### PR TITLE
Recipient session governance

### DIFF
--- a/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
@@ -14,6 +14,19 @@ function clone(value: any) {
 
 const dbMock = {
   collection: (name: string) => ({
+    where: (field: string, op: string, expected: any) => ({
+      limit: (_count: number) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries())
+            .filter(([, value]) => op === "==" && value?.[field] === expected)
+            .map(([id, value]) => ({
+              id,
+              data: () => clone(value),
+            }));
+          return { docs };
+        },
+      }),
+    }),
     doc: (id?: string) => {
       const docId = id || `doc_${ensureCollection(name).size + 1}`;
       return {
@@ -201,6 +214,16 @@ describe("recipientTrustReviewRoutes", () => {
         externalSubmissionEnabled: false,
       })
     );
+    expect(res.body?.data?.summary?.session).toEqual(
+      expect.objectContaining({
+        schemaVersion: "recipient_review_session.v1",
+        lifecycle: "active",
+        authenticated: true,
+        viewOnly: true,
+        downloadEnabled: false,
+        publicAccessEnabled: false,
+      })
+    );
     const payload = JSON.stringify(res.body?.data || {});
     expect(payload).not.toContain("tenant-1");
     expect(payload).not.toContain("policyDecisions");
@@ -218,8 +241,80 @@ describe("recipientTrustReviewRoutes", () => {
           status: "available",
           reason: "review_available",
         }),
+        expect.objectContaining({
+          eventType: "recipient_review_session_started",
+          metadataOnly: true,
+          status: "active",
+          reason: "session_started",
+        }),
       ])
     );
+  });
+
+  it("requires reauthentication for expired or mismatched recipient review sessions", async () => {
+    const router = (await import("../recipientTrustReviewRoutes")).default;
+    seedGrant();
+    ensureCollection("recipientTrustReviewSessions").set("session-1", {
+      schemaVersion: "recipient_review_session.v1",
+      sessionId: "session-1",
+      grantId: "grant-1",
+      recipientEmailHash: "wrong",
+      recipientUserId: "recipient-1",
+      audience: "insurer",
+      purpose: "insurance_review",
+      lifecycle: "active",
+      issuedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-06-01T00:00:00.000Z",
+      lastValidatedAt: "2026-05-01T00:00:00.000Z",
+      metadataOnly: true,
+      authenticated: true,
+      viewOnly: true,
+      downloadEnabled: false,
+      publicAccessEnabled: false,
+    });
+
+    const mismatched = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }),
+        "x-recipient-review-session-id": "session-1",
+      },
+    });
+    expect(mismatched.status).toBe(401);
+    expect(mismatched.body?.decision?.status).toBe("reauthentication_required");
+    expect(mismatched.body?.decision?.reason).toBe("recipient_session_reauthentication_required");
+
+    ensureCollection("recipientTrustReviewSessions").set("session-2", {
+      schemaVersion: "recipient_review_session.v1",
+      sessionId: "session-2",
+      grantId: "grant-1",
+      recipientEmailHash: "18717f7f1f60f92207bd02972c16aec92f52b31c2a8442444df988d8e8503c5e",
+      recipientUserId: "recipient-1",
+      audience: "insurer",
+      purpose: "insurance_review",
+      lifecycle: "active",
+      issuedAt: "2020-01-01T00:00:00.000Z",
+      expiresAt: "2020-01-01T00:00:00.000Z",
+      lastValidatedAt: "2020-01-01T00:00:00.000Z",
+      metadataOnly: true,
+      authenticated: true,
+      viewOnly: true,
+      downloadEnabled: false,
+      publicAccessEnabled: false,
+    });
+    const expired = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }),
+        "x-recipient-review-session-id": "session-2",
+      },
+    });
+    expect(expired.status).toBe(401);
+    expect(expired.body?.decision?.status).toBe("session_expired");
+    expect(expired.body?.decision?.reason).toBe("recipient_session_expired");
+    expect(ensureCollection("recipientTrustReviewSessions").get("session-2")?.lifecycle).toBe("expired");
   });
 
   it("blocks revoked, expired, and policy-denied grants", async () => {

--- a/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
+++ b/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
@@ -6,17 +6,25 @@ const router = Router();
 
 function statusForDecision(status: string) {
   if (status === "unauthenticated") return 401;
+  if (status === "session_expired" || status === "reauthentication_required") return 401;
   if (status === "not_found" || status === "recipient_mismatch") return 404;
-  if (status === "expired" || status === "revoked") return 410;
+  if (status === "expired" || status === "revoked" || status === "session_revoked") return 410;
   return 403;
 }
 
 router.get("/trust-reviews/:grantId", requireAuth, async (req: any, res) => {
   const grantId = String(req.params?.grantId || "").trim();
   const recipientEmail = String(req.user?.email || "").trim();
+  const recipientUserId = String(req.user?.id || req.user?.uid || req.user?.sub || "").trim();
+  const recipientSessionId = String(
+    req.headers?.["x-recipient-review-session-id"] ||
+      req.headers?.["X-Recipient-Review-Session-Id"] ||
+      req.query?.recipientSessionId ||
+      ""
+  ).trim();
 
   try {
-    const result = await getRecipientTrustReview({ grantId, recipientEmail });
+    const result = await getRecipientTrustReview({ grantId, recipientEmail, recipientUserId, recipientSessionId });
     if (!result.decision.allowed) {
       return res.status(statusForDecision(result.decision.status)).json({
         ok: false,

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -254,6 +254,16 @@ describe("tenantInstitutionAccessService", () => {
     });
     expect(review.decision.allowed).toBe(true);
     expect(review.summary?.schemaVersion).toBe("recipient_trust_review.v1");
+    expect(review.summary?.session).toEqual(
+      expect.objectContaining({
+        schemaVersion: "recipient_review_session.v1",
+        lifecycle: "active",
+        authenticated: true,
+        viewOnly: true,
+        downloadEnabled: false,
+        publicAccessEnabled: false,
+      })
+    );
     expect(review.summary?.access).toEqual(
       expect.objectContaining({
         authenticated: true,
@@ -268,8 +278,9 @@ describe("tenantInstitutionAccessService", () => {
     const listed = await service.listTenantInstitutionAccessGrants({ tenantId: "tenant-1" });
     expect(listed[0].auditSummary.openedReviewCount).toBe(1);
     expect(listed[0].auditSummary.blockedReviewCount).toBe(1);
+    expect(listed[0].auditSummary.sessionStartedCount).toBe(1);
     expect(listed[0].auditTimeline.map((event) => event.reason)).toEqual(
-      expect.arrayContaining(["review_available", "recipient_email_mismatch", "access_granted"])
+      expect.arrayContaining(["review_available", "recipient_email_mismatch", "access_granted", "session_started"])
     );
     expect(listed[0].auditSummary.recipientIdentifier.redactedEmail).toBe("re***@example.com");
     const auditPayload = JSON.stringify({
@@ -291,6 +302,63 @@ describe("tenantInstitutionAccessService", () => {
     expect(payload).not.toContain("publicAccessEnabled\":true");
     expect(payload).not.toContain("downloadEnabled\":true");
     expect(payload).not.toContain("accessTokenIssued");
+  });
+
+  it("enforces recipient review session expiration and revocation", async () => {
+    const service = await import("../tenantInstitutionAccessService");
+
+    const grant = await service.createTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+      expiresInDays: 7,
+      consentAccepted: true,
+    });
+
+    const firstReview = await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "reviewer@example.com",
+      recipientUserId: "recipient-1",
+    });
+    const sessionId = firstReview.summary?.session.sessionId || "";
+    expect(sessionId).toBeTruthy();
+
+    ensureCollection("recipientTrustReviewSessions").set(sessionId, {
+      ...ensureCollection("recipientTrustReviewSessions").get(sessionId),
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    const expiredSession = await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "reviewer@example.com",
+      recipientUserId: "recipient-1",
+      recipientSessionId: sessionId,
+    });
+    expect(expiredSession.decision.allowed).toBe(false);
+    expect(expiredSession.decision.status).toBe("session_expired");
+    expect(expiredSession.decision.reason).toBe("recipient_session_expired");
+    expect(ensureCollection("recipientTrustReviewSessions").get(sessionId)?.lifecycle).toBe("expired");
+
+    const secondReview = await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "reviewer@example.com",
+      recipientUserId: "recipient-1",
+    });
+    const activeSessionId = secondReview.summary?.session.sessionId || "";
+    expect(activeSessionId).toBeTruthy();
+
+    await service.revokeTenantInstitutionAccessGrant({ tenantId: "tenant-1", grantId: grant?.grantId || "" });
+    expect(ensureCollection("recipientTrustReviewSessions").get(activeSessionId)?.lifecycle).toBe("revoked");
+
+    const revoked = await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "reviewer@example.com",
+      recipientUserId: "recipient-1",
+      recipientSessionId: activeSessionId,
+    });
+    expect(revoked.decision.allowed).toBe(false);
+    expect(revoked.decision.status).toBe("revoked");
+    expect(revoked.summary).toBeNull();
   });
 
   it("blocks recipient review for revoked, expired, and policy-denied grants", async () => {

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -10,9 +10,11 @@ import {
 } from "./tenantTrustExportService";
 
 const COLLECTION = "tenantInstitutionAccessGrants";
+const SESSION_COLLECTION = "recipientTrustReviewSessions";
 const CONSENT_VERSION = "tenant_institution_access_consent.v1";
 const DEFAULT_EXPIRES_DAYS = 14;
 const MAX_EXPIRES_DAYS = 30;
+const RECIPIENT_REVIEW_SESSION_TTL_MS = 30 * 60 * 1000;
 
 export type TenantInstitutionAccessAudience = "insurer" | "lender" | "institutional_landlord" | "auditor";
 
@@ -109,13 +111,18 @@ export type TenantInstitutionAccessGrantEvent = {
     | "recipient_trust_review_opened"
     | "recipient_trust_review_blocked"
     | "recipient_trust_review_expired"
-    | "recipient_trust_review_revoked";
+    | "recipient_trust_review_revoked"
+    | "recipient_review_session_started"
+    | "recipient_review_session_expired"
+    | "recipient_review_session_revoked"
+    | "recipient_review_session_blocked"
+    | "recipient_review_session_reauthenticated";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   metadataOnly: true;
-  outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired";
-  reason?: RecipientTrustReviewAccessDecision["reason"] | "access_granted" | "access_revoked";
-  status?: RecipientTrustReviewStatus | "granted";
+  outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated";
+  reason?: RecipientTrustReviewAccessDecision["reason"] | "access_granted" | "access_revoked" | "session_started";
+  status?: RecipientTrustReviewStatus | "granted" | "active";
 };
 
 type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessPreview & {
@@ -142,7 +149,10 @@ export type RecipientTrustReviewStatus =
   | "blocked"
   | "consent_required"
   | "reverification_required"
-  | "policy_denied";
+  | "policy_denied"
+  | "session_expired"
+  | "session_revoked"
+  | "reauthentication_required";
 
 export type RecipientTrustReviewAccessDecision = {
   allowed: boolean;
@@ -157,10 +167,33 @@ export type RecipientTrustReviewAccessDecision = {
     | "grant_blocked"
     | "tenant_consent_missing"
     | "trust_reverification_required"
-    | "policy_gated_summary_unavailable";
+    | "policy_gated_summary_unavailable"
+    | "recipient_session_expired"
+    | "recipient_session_revoked"
+    | "recipient_session_reauthentication_required";
   metadataOnly: true;
   publicAccessEnabled: false;
   downloadEnabled: false;
+};
+
+export type RecipientReviewSessionLifecycle = "active" | "expired" | "revoked" | "blocked";
+
+export type RecipientReviewSessionSummary = {
+  schemaVersion: "recipient_review_session.v1";
+  sessionId: string;
+  lifecycle: RecipientReviewSessionLifecycle;
+  issuedAt: string;
+  expiresAt: string;
+  lastValidatedAt: string;
+  grantId: string;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  metadataOnly: true;
+  authenticated: true;
+  viewOnly: true;
+  downloadEnabled: false;
+  publicAccessEnabled: false;
+  reauthenticationRequiredAt: string;
 };
 
 export type RecipientTrustReviewSummary = {
@@ -188,6 +221,7 @@ export type RecipientTrustReviewSummary = {
   generatedAt: string;
   expiresAt: string | null;
   reviewedAt: string;
+  session: RecipientReviewSessionSummary;
   metadataOnly: true;
   policyGated: true;
   includedClaims: Array<{
@@ -210,20 +244,31 @@ export type RecipientTrustReviewResult = {
   summary: RecipientTrustReviewSummary | null;
 };
 
-export type TenantInstitutionAccessAuditOutcome = "granted" | "opened" | "blocked" | "revoked" | "expired";
+export type TenantInstitutionAccessAuditOutcome =
+  | "granted"
+  | "opened"
+  | "blocked"
+  | "revoked"
+  | "expired"
+  | "session_started"
+  | "reauthenticated";
 
 export type TenantInstitutionAccessAuditEvent = {
   eventType: TenantInstitutionAccessGrantEvent["eventType"];
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   outcome: TenantInstitutionAccessAuditOutcome;
-  status: RecipientTrustReviewStatus | "granted" | "revoked" | "expired" | "blocked";
+  status: RecipientTrustReviewStatus | "granted" | "revoked" | "expired" | "blocked" | "active";
   reason:
     | RecipientTrustReviewAccessDecision["reason"]
     | "access_granted"
     | "access_revoked"
     | "access_expired"
-    | "access_blocked";
+    | "access_blocked"
+    | "session_started"
+    | "recipient_session_expired"
+    | "recipient_session_revoked"
+    | "recipient_session_reauthentication_required";
   metadataOnly: true;
 };
 
@@ -235,17 +280,13 @@ export type TenantInstitutionAccessAuditSummary = {
   blockedReviewCount: number;
   revokedAccessCount: number;
   expiredAccessCount: number;
+  sessionStartedCount: number;
+  sessionExpiredCount: number;
   lastActivityAt: string | null;
   lastOpenedAt: string | null;
   lastBlockedAt: string | null;
   lastOutcome: TenantInstitutionAccessAuditOutcome | null;
-  lastReason:
-    | RecipientTrustReviewAccessDecision["reason"]
-    | "access_granted"
-    | "access_revoked"
-    | "access_expired"
-    | "access_blocked"
-    | null;
+  lastReason: TenantInstitutionAccessAuditEvent["reason"] | null;
   recipientIdentifier: {
     email: string;
     redactedEmail: string;
@@ -318,6 +359,8 @@ export type SupportInstitutionAccessDiagnosticSummary = {
     blockedReviewCount: number;
     revokedAccessCount: number;
     expiredAccessCount: number;
+    sessionStartedCount: number;
+    sessionExpiredCount: number;
     lastActivityAt: string | null;
     lastOpenedAt: string | null;
     lastBlockedAt: string | null;
@@ -337,6 +380,27 @@ export type SupportInstitutionAccessDiagnosticSummary = {
     unsafePortablePayloadDetected: boolean;
   };
   timeline: SupportInstitutionAccessDiagnosticEvent[];
+};
+
+type RecipientReviewSessionRecord = {
+  schemaVersion: "recipient_review_session.v1";
+  sessionId: string;
+  grantId: string;
+  recipientEmailHash: string;
+  recipientUserId: string | null;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  lifecycle: RecipientReviewSessionLifecycle;
+  issuedAt: string;
+  expiresAt: string;
+  lastValidatedAt: string;
+  revokedAt: string | null;
+  blockedAt: string | null;
+  metadataOnly: true;
+  authenticated: true;
+  viewOnly: true;
+  downloadEnabled: false;
+  publicAccessEnabled: false;
 };
 
 function asString(value: unknown, max = 240): string | null {
@@ -550,8 +614,16 @@ function accessPreviewFromTrustPackage(params: {
 function outcomeForEventType(eventType: TenantInstitutionAccessAuditEvent["eventType"]): TenantInstitutionAccessAuditOutcome {
   if (eventType === "tenant_institution_access_granted") return "granted";
   if (eventType === "tenant_institution_access_revoked" || eventType === "recipient_trust_review_revoked") return "revoked";
-  if (eventType === "tenant_institution_access_expired" || eventType === "recipient_trust_review_expired") return "expired";
+  if (
+    eventType === "tenant_institution_access_expired" ||
+    eventType === "recipient_trust_review_expired" ||
+    eventType === "recipient_review_session_expired"
+  ) {
+    return "expired";
+  }
   if (eventType === "recipient_trust_review_opened") return "opened";
+  if (eventType === "recipient_review_session_started") return "session_started";
+  if (eventType === "recipient_review_session_reauthenticated") return "reauthenticated";
   return "blocked";
 }
 
@@ -559,7 +631,15 @@ function statusForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
   if (event.status) return event.status as TenantInstitutionAccessAuditEvent["status"];
   if (event.eventType === "tenant_institution_access_granted") return "granted";
   if (event.eventType === "tenant_institution_access_revoked" || event.eventType === "recipient_trust_review_revoked") return "revoked";
-  if (event.eventType === "tenant_institution_access_expired" || event.eventType === "recipient_trust_review_expired") return "expired";
+  if (
+    event.eventType === "tenant_institution_access_expired" ||
+    event.eventType === "recipient_trust_review_expired" ||
+    event.eventType === "recipient_review_session_expired"
+  ) {
+    return "expired";
+  }
+  if (event.eventType === "recipient_review_session_revoked") return "session_revoked";
+  if (event.eventType === "recipient_review_session_started") return "active";
   if (event.eventType === "recipient_trust_review_opened") return "available";
   return "blocked";
 }
@@ -570,7 +650,14 @@ function reasonForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
   if (event.eventType === "tenant_institution_access_revoked" || event.eventType === "recipient_trust_review_revoked") {
     return "access_revoked";
   }
-  if (event.eventType === "tenant_institution_access_expired" || event.eventType === "recipient_trust_review_expired") {
+  if (event.eventType === "recipient_review_session_revoked") return "recipient_session_revoked";
+  if (event.eventType === "recipient_review_session_expired") return "recipient_session_expired";
+  if (event.eventType === "recipient_review_session_blocked") return "recipient_session_reauthentication_required";
+  if (event.eventType === "recipient_review_session_started") return "session_started";
+  if (
+    event.eventType === "tenant_institution_access_expired" ||
+    event.eventType === "recipient_trust_review_expired"
+  ) {
     return "access_expired";
   }
   if (event.eventType === "recipient_trust_review_opened") return "review_available";
@@ -613,6 +700,10 @@ function buildAccessAudit(record: TenantInstitutionAccessStoredGrant): {
       blockedReviewCount: auditTimeline.filter((event) => event.outcome === "blocked").length,
       revokedAccessCount: auditTimeline.filter((event) => event.outcome === "revoked").length,
       expiredAccessCount: auditTimeline.filter((event) => event.outcome === "expired").length,
+      sessionStartedCount: auditTimeline.filter((event) => event.outcome === "session_started").length,
+      sessionExpiredCount: auditTimeline.filter(
+        (event) => event.eventType === "recipient_review_session_expired"
+      ).length,
       lastActivityAt: last?.occurredAt || null,
       lastOpenedAt: lastOpened?.occurredAt || null,
       lastBlockedAt: lastBlocked?.occurredAt || null,
@@ -695,6 +786,8 @@ function supportDiagnosticFromGrant(record: TenantInstitutionAccessStoredGrant):
       blockedReviewCount: auditSummary.blockedReviewCount,
       revokedAccessCount: auditSummary.revokedAccessCount,
       expiredAccessCount: auditSummary.expiredAccessCount,
+      sessionStartedCount: auditSummary.sessionStartedCount,
+      sessionExpiredCount: auditSummary.sessionExpiredCount,
       lastActivityAt: auditSummary.lastActivityAt,
       lastOpenedAt: auditSummary.lastOpenedAt,
       lastBlockedAt: auditSummary.lastBlockedAt,
@@ -738,6 +831,82 @@ function normalizeRecipientEmailForReview(value: unknown) {
   return normalizeEmail(value);
 }
 
+function recipientEmailHash(value: unknown) {
+  const email = normalizeRecipientEmailForReview(value) || "";
+  return crypto.createHash("sha256").update(email).digest("hex");
+}
+
+function recipientReviewSessionId(params: {
+  grantId: string;
+  recipientEmail: string;
+  recipientUserId?: string | null;
+  issuedAt: string;
+}) {
+  const entropy = crypto.randomUUID();
+  const digest = crypto
+    .createHash("sha256")
+    .update([params.grantId, params.recipientEmail, params.recipientUserId || "", params.issuedAt, entropy].join(":"))
+    .digest("hex")
+    .slice(0, 24);
+  return `recipient_review_session:${digest}`;
+}
+
+function sessionSummaryFromRecord(record: RecipientReviewSessionRecord): RecipientReviewSessionSummary {
+  return {
+    schemaVersion: "recipient_review_session.v1",
+    sessionId: record.sessionId,
+    lifecycle: record.lifecycle,
+    issuedAt: record.issuedAt,
+    expiresAt: record.expiresAt,
+    lastValidatedAt: record.lastValidatedAt,
+    grantId: record.grantId,
+    audience: record.audience,
+    purpose: record.purpose,
+    metadataOnly: true,
+    authenticated: true,
+    viewOnly: true,
+    downloadEnabled: false,
+    publicAccessEnabled: false,
+    reauthenticationRequiredAt: record.expiresAt,
+  };
+}
+
+function sessionExpiryForGrant(grant: TenantInstitutionAccessStoredGrant, issuedAt: string) {
+  const candidates = [Date.parse(issuedAt) + RECIPIENT_REVIEW_SESSION_TTL_MS];
+  const grantExpiry = grant.expiresAt ? Date.parse(grant.expiresAt) : NaN;
+  if (Number.isFinite(grantExpiry)) candidates.push(grantExpiry);
+  const consentExpiry = grant.consent?.expiresAt ? Date.parse(grant.consent.expiresAt) : NaN;
+  if (Number.isFinite(consentExpiry)) candidates.push(consentExpiry);
+  return new Date(Math.min(...candidates)).toISOString();
+}
+
+async function appendGrantEvent(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  eventType: TenantInstitutionAccessGrantEvent["eventType"];
+  occurredAt: string;
+  actorType?: TenantInstitutionAccessGrantEvent["actorType"];
+  outcome?: TenantInstitutionAccessGrantEvent["outcome"];
+  status: TenantInstitutionAccessGrantEvent["status"];
+  reason: TenantInstitutionAccessGrantEvent["reason"];
+}) {
+  const ref = db.collection(COLLECTION).doc(params.grant.grantId);
+  const events = [
+    ...(Array.isArray(params.grant.events) ? params.grant.events : []),
+    {
+      eventType: params.eventType,
+      occurredAt: params.occurredAt,
+      actorType: params.actorType || ("recipient" as const),
+      metadataOnly: true as const,
+      outcome: params.outcome || outcomeForEventType(params.eventType),
+      status: params.status,
+      reason: params.reason,
+    },
+  ].slice(-50);
+  await ref.set({ events, updatedAt: params.occurredAt }, { merge: true });
+  params.grant.events = events;
+  params.grant.updatedAt = params.occurredAt;
+}
+
 function denyRecipientReview(
   status: RecipientTrustReviewStatus,
   reason: RecipientTrustReviewAccessDecision["reason"]
@@ -776,7 +945,8 @@ function hasUnsafeRecipientPayload(grant: TenantInstitutionAccessStoredGrant) {
 
 function recipientSummaryFromGrant(
   grant: TenantInstitutionAccessStoredGrant,
-  reviewedAt: string
+  reviewedAt: string,
+  session: RecipientReviewSessionSummary
 ): RecipientTrustReviewSummary {
   return {
     schemaVersion: "recipient_trust_review.v1",
@@ -811,6 +981,7 @@ function recipientSummaryFromGrant(
     generatedAt: grant.generatedAt,
     expiresAt: grant.expiresAt,
     reviewedAt,
+    session,
     metadataOnly: true,
     policyGated: true,
     includedClaims: (grant.includedClaims || []).map((claim) => ({
@@ -834,36 +1005,180 @@ function recipientSummaryFromGrant(
   };
 }
 
-async function appendRecipientReviewEvent(params: {
+async function startRecipientReviewSession(params: {
   grant: TenantInstitutionAccessStoredGrant;
-  eventType:
-    | "recipient_trust_review_opened"
-    | "recipient_trust_review_blocked"
-    | "recipient_trust_review_expired"
-    | "recipient_trust_review_revoked";
-  occurredAt: string;
-  status: RecipientTrustReviewStatus;
-  reason: RecipientTrustReviewAccessDecision["reason"];
+  recipientEmail: string;
+  recipientUserId?: string | null;
+  now: string;
 }) {
-  const ref = db.collection(COLLECTION).doc(params.grant.grantId);
-  const events = [
-    ...(Array.isArray(params.grant.events) ? params.grant.events : []),
-    {
-      eventType: params.eventType,
-      occurredAt: params.occurredAt,
-      actorType: "recipient" as const,
-      metadataOnly: true as const,
-      outcome: outcomeForEventType(params.eventType),
-      status: params.status,
-      reason: params.reason,
-    },
-  ].slice(-50);
-  await ref.set({ events, updatedAt: params.occurredAt }, { merge: true });
+  const session: RecipientReviewSessionRecord = {
+    schemaVersion: "recipient_review_session.v1",
+    sessionId: recipientReviewSessionId({
+      grantId: params.grant.grantId,
+      recipientEmail: params.recipientEmail,
+      recipientUserId: params.recipientUserId,
+      issuedAt: params.now,
+    }),
+    grantId: params.grant.grantId,
+    recipientEmailHash: recipientEmailHash(params.recipientEmail),
+    recipientUserId: asString(params.recipientUserId, 160),
+    audience: params.grant.audience,
+    purpose: params.grant.purpose,
+    lifecycle: "active",
+    issuedAt: params.now,
+    expiresAt: sessionExpiryForGrant(params.grant, params.now),
+    lastValidatedAt: params.now,
+    revokedAt: null,
+    blockedAt: null,
+    metadataOnly: true,
+    authenticated: true,
+    viewOnly: true,
+    downloadEnabled: false,
+    publicAccessEnabled: false,
+  };
+  await db.collection(SESSION_COLLECTION).doc(session.sessionId).set(session);
+  await appendGrantEvent({
+    grant: params.grant,
+    eventType: "recipient_review_session_started",
+    occurredAt: params.now,
+    status: "active",
+    reason: "session_started",
+    outcome: "session_started",
+  });
+  return sessionSummaryFromRecord(session);
+}
+
+async function blockRecipientReviewSession(params: {
+  sessionId: string | null;
+  lifecycle: Exclude<RecipientReviewSessionLifecycle, "active">;
+  now: string;
+}) {
+  if (!params.sessionId) return;
+  const patch: Partial<RecipientReviewSessionRecord> = {
+    lifecycle: params.lifecycle,
+    lastValidatedAt: params.now,
+  };
+  if (params.lifecycle === "expired") patch.expiresAt = params.now;
+  if (params.lifecycle === "revoked") patch.revokedAt = params.now;
+  if (params.lifecycle === "blocked") patch.blockedAt = params.now;
+  await db.collection(SESSION_COLLECTION).doc(params.sessionId).set(patch, { merge: true });
+}
+
+async function invalidateActiveSessionsForGrant(params: { grantId: string; lifecycle: "revoked" | "expired" | "blocked"; now: string }) {
+  const snap = await db.collection(SESSION_COLLECTION).where("grantId", "==", params.grantId).limit(50).get();
+  await Promise.all(
+    (snap.docs || []).map(async (doc: any) => {
+      const data = doc.data?.() || {};
+      if (data.lifecycle !== "active") return;
+      await blockRecipientReviewSession({
+        sessionId: String(doc.id || data.sessionId || ""),
+        lifecycle: params.lifecycle,
+        now: params.now,
+      });
+    })
+  );
+}
+
+async function validateRecipientReviewSession(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  recipientEmail: string;
+  recipientUserId?: string | null;
+  sessionId?: unknown;
+  now: string;
+}): Promise<
+  | { ok: true; session: RecipientReviewSessionSummary }
+  | {
+      ok: false;
+      status: RecipientTrustReviewStatus;
+      reason: RecipientTrustReviewAccessDecision["reason"];
+      eventType: "recipient_review_session_expired" | "recipient_review_session_revoked" | "recipient_review_session_blocked";
+      sessionId: string | null;
+    }
+> {
+  const sessionId = asString(params.sessionId, 180);
+  if (!sessionId) {
+    const session = await startRecipientReviewSession({
+      grant: params.grant,
+      recipientEmail: params.recipientEmail,
+      recipientUserId: params.recipientUserId,
+      now: params.now,
+    });
+    return { ok: true, session };
+  }
+
+  const snap = await db.collection(SESSION_COLLECTION).doc(sessionId).get();
+  if (!snap.exists) {
+    return {
+      ok: false,
+      status: "reauthentication_required",
+      reason: "recipient_session_reauthentication_required",
+      eventType: "recipient_review_session_blocked",
+      sessionId,
+    };
+  }
+
+  const session = { sessionId, ...(snap.data?.() || {}) } as RecipientReviewSessionRecord;
+  const expectedEmailHash = recipientEmailHash(params.recipientEmail);
+  const userId = asString(params.recipientUserId, 160);
+  if (
+    session.grantId !== params.grant.grantId ||
+    session.recipientEmailHash !== expectedEmailHash ||
+    (session.recipientUserId || null) !== (userId || null) ||
+    session.audience !== params.grant.audience ||
+    session.purpose !== params.grant.purpose
+  ) {
+    await blockRecipientReviewSession({ sessionId, lifecycle: "blocked", now: params.now });
+    return {
+      ok: false,
+      status: "reauthentication_required",
+      reason: "recipient_session_reauthentication_required",
+      eventType: "recipient_review_session_blocked",
+      sessionId,
+    };
+  }
+
+  if (session.lifecycle === "revoked") {
+    return {
+      ok: false,
+      status: "session_revoked",
+      reason: "recipient_session_revoked",
+      eventType: "recipient_review_session_revoked",
+      sessionId,
+    };
+  }
+  if (session.lifecycle === "expired" || Date.parse(session.expiresAt) <= Date.parse(params.now)) {
+    await blockRecipientReviewSession({ sessionId, lifecycle: "expired", now: params.now });
+    return {
+      ok: false,
+      status: "session_expired",
+      reason: "recipient_session_expired",
+      eventType: "recipient_review_session_expired",
+      sessionId,
+    };
+  }
+  if (session.lifecycle === "blocked") {
+    return {
+      ok: false,
+      status: "reauthentication_required",
+      reason: "recipient_session_reauthentication_required",
+      eventType: "recipient_review_session_blocked",
+      sessionId,
+    };
+  }
+
+  const refreshed = {
+    ...session,
+    lastValidatedAt: params.now,
+  };
+  await db.collection(SESSION_COLLECTION).doc(sessionId).set({ lastValidatedAt: params.now }, { merge: true });
+  return { ok: true, session: sessionSummaryFromRecord(refreshed) };
 }
 
 export async function getRecipientTrustReview(params: {
   grantId: string;
   recipientEmail?: unknown;
+  recipientUserId?: unknown;
+  recipientSessionId?: unknown;
 }): Promise<RecipientTrustReviewResult> {
   const grantId = asString(params.grantId);
   const recipientEmail = normalizeRecipientEmailForReview(params.recipientEmail);
@@ -878,7 +1193,7 @@ export async function getRecipientTrustReview(params: {
   const grant = asGrant(grantId, snap.data?.() || {});
   const reviewedAt = nowIso();
   if (normalizeRecipientEmailForReview(grant.recipient?.email) !== recipientEmail) {
-    await appendRecipientReviewEvent({
+    await appendGrantEvent({
       grant,
       eventType: "recipient_trust_review_blocked",
       occurredAt: reviewedAt,
@@ -894,21 +1209,33 @@ export async function getRecipientTrustReview(params: {
     eventType:
       | "recipient_trust_review_blocked"
       | "recipient_trust_review_expired"
-      | "recipient_trust_review_revoked" = "recipient_trust_review_blocked"
+      | "recipient_trust_review_revoked"
+      | "recipient_review_session_expired"
+      | "recipient_review_session_revoked"
+      | "recipient_review_session_blocked" = "recipient_trust_review_blocked",
+    sessionLifecycle?: Exclude<RecipientReviewSessionLifecycle, "active">,
+    sessionId?: string | null
   ) => {
-    await appendRecipientReviewEvent({ grant, eventType, occurredAt: reviewedAt, status, reason });
+    if (sessionLifecycle) {
+      if (sessionId) {
+        await blockRecipientReviewSession({ sessionId, lifecycle: sessionLifecycle, now: reviewedAt });
+      } else {
+        await invalidateActiveSessionsForGrant({ grantId: grant.grantId, lifecycle: sessionLifecycle, now: reviewedAt });
+      }
+    }
+    await appendGrantEvent({ grant, eventType, occurredAt: reviewedAt, status, reason });
     return denyRecipientReview(status, reason);
   };
 
   if (grant.lifecycle === "revoked" || grant.revokedAt || grant.consent?.revokedAt) {
-    return denyWithEvent("revoked", "grant_revoked", "recipient_trust_review_revoked");
+    return denyWithEvent("revoked", "grant_revoked", "recipient_trust_review_revoked", "revoked");
   }
   if (grant.lifecycle === "expired" || (grant.expiresAt && Date.parse(grant.expiresAt) <= Date.now())) {
-    return denyWithEvent("expired", "grant_expired", "recipient_trust_review_expired");
+    return denyWithEvent("expired", "grant_expired", "recipient_trust_review_expired", "expired");
   }
-  if (grant.lifecycle === "blocked") return denyWithEvent("blocked", "grant_blocked");
+  if (grant.lifecycle === "blocked") return denyWithEvent("blocked", "grant_blocked", "recipient_trust_review_blocked", "blocked");
   if (grant.lifecycle === "reverification_required") {
-    return denyWithEvent("reverification_required", "trust_reverification_required");
+    return denyWithEvent("reverification_required", "trust_reverification_required", "recipient_trust_review_blocked", "blocked");
   }
   if (grant.consent?.granted !== true || !grant.consent?.consentId) {
     return denyWithEvent("consent_required", "tenant_consent_missing");
@@ -920,7 +1247,24 @@ export async function getRecipientTrustReview(params: {
     return denyWithEvent("policy_denied", "policy_gated_summary_unavailable");
   }
 
-  await appendRecipientReviewEvent({
+  const sessionDecision = await validateRecipientReviewSession({
+    grant,
+    recipientEmail,
+    recipientUserId: asString(params.recipientUserId, 160),
+    sessionId: params.recipientSessionId,
+    now: reviewedAt,
+  });
+  if (!sessionDecision.ok) {
+    return denyWithEvent(
+      sessionDecision.status,
+      sessionDecision.reason,
+      sessionDecision.eventType,
+      sessionDecision.status === "session_expired" ? "expired" : sessionDecision.status === "session_revoked" ? "revoked" : "blocked",
+      sessionDecision.sessionId
+    );
+  }
+
+  await appendGrantEvent({
     grant,
     eventType: "recipient_trust_review_opened",
     occurredAt: reviewedAt,
@@ -937,7 +1281,7 @@ export async function getRecipientTrustReview(params: {
       publicAccessEnabled: false,
       downloadEnabled: false,
     },
-    summary: recipientSummaryFromGrant(grant, reviewedAt),
+    summary: recipientSummaryFromGrant(grant, reviewedAt, sessionDecision.session),
   };
 }
 
@@ -1090,6 +1434,7 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
     },
     { merge: true }
   );
+  await invalidateActiveSessionsForGrant({ grantId, lifecycle: "revoked", now: updatedAt });
   return publicGrant({
     ...current,
     lifecycle: "revoked",

--- a/rentchain-frontend/src/api/recipientTrustReview.ts
+++ b/rentchain-frontend/src/api/recipientTrustReview.ts
@@ -10,7 +10,10 @@ export type RecipientTrustReviewStatus =
   | "blocked"
   | "consent_required"
   | "reverification_required"
-  | "policy_denied";
+  | "policy_denied"
+  | "session_expired"
+  | "session_revoked"
+  | "reauthentication_required";
 
 export type RecipientTrustReviewDecision = {
   allowed: boolean;
@@ -54,6 +57,23 @@ export type RecipientTrustReviewSummary = {
   generatedAt: string;
   expiresAt: string | null;
   reviewedAt: string;
+  session: {
+    schemaVersion: "recipient_review_session.v1";
+    sessionId: string;
+    lifecycle: "active" | "expired" | "revoked" | "blocked";
+    issuedAt: string;
+    expiresAt: string;
+    lastValidatedAt: string;
+    grantId: string;
+    audience: string;
+    purpose: string;
+    metadataOnly: true;
+    authenticated: true;
+    viewOnly: true;
+    downloadEnabled: false;
+    publicAccessEnabled: false;
+    reauthenticationRequiredAt: string;
+  };
   metadataOnly: true;
   policyGated: true;
   includedClaims: Array<{
@@ -76,9 +96,14 @@ export type RecipientTrustReviewResponse = {
   summary: RecipientTrustReviewSummary | null;
 };
 
-export async function getRecipientTrustReview(grantId: string): Promise<RecipientTrustReviewResponse> {
+export async function getRecipientTrustReview(
+  grantId: string,
+  recipientSessionId?: string | null
+): Promise<RecipientTrustReviewResponse> {
+  const headers = recipientSessionId ? { "x-recipient-review-session-id": recipientSessionId } : undefined;
   const res = await apiFetch<{ ok: boolean; data: RecipientTrustReviewResponse }>(
-    `/recipient/trust-reviews/${encodeURIComponent(grantId)}`
+    `/recipient/trust-reviews/${encodeURIComponent(grantId)}`,
+    headers ? { headers } : undefined
   );
   return res.data;
 }

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -98,6 +98,8 @@ export type SupportInstitutionAccessDiagnosticSummary = {
     blockedReviewCount: number;
     revokedAccessCount: number;
     expiredAccessCount: number;
+    sessionStartedCount: number;
+    sessionExpiredCount: number;
     lastActivityAt: string | null;
     lastOpenedAt: string | null;
     lastBlockedAt: string | null;

--- a/rentchain-frontend/src/api/tenantInstitutionAccess.ts
+++ b/rentchain-frontend/src/api/tenantInstitutionAccess.ts
@@ -114,7 +114,7 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
     occurredAt: string;
     actorType: "tenant" | "system" | "recipient";
     metadataOnly: true;
-    outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired";
+    outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated";
     reason?: string;
     status?: string;
   }>;
@@ -131,10 +131,15 @@ export type TenantInstitutionAccessAuditEvent = {
     | "recipient_trust_review_opened"
     | "recipient_trust_review_blocked"
     | "recipient_trust_review_expired"
-    | "recipient_trust_review_revoked";
+    | "recipient_trust_review_revoked"
+    | "recipient_review_session_started"
+    | "recipient_review_session_expired"
+    | "recipient_review_session_revoked"
+    | "recipient_review_session_blocked"
+    | "recipient_review_session_reauthenticated";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
-  outcome: "granted" | "opened" | "blocked" | "revoked" | "expired";
+  outcome: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated";
   status: string;
   reason: string;
   metadataOnly: true;
@@ -148,10 +153,12 @@ export type TenantInstitutionAccessAuditSummary = {
   blockedReviewCount: number;
   revokedAccessCount: number;
   expiredAccessCount: number;
+  sessionStartedCount: number;
+  sessionExpiredCount: number;
   lastActivityAt: string | null;
   lastOpenedAt: string | null;
   lastBlockedAt: string | null;
-  lastOutcome: "granted" | "opened" | "blocked" | "revoked" | "expired" | null;
+  lastOutcome: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated" | null;
   lastReason: string | null;
   recipientIdentifier: {
     email: string;

--- a/rentchain-frontend/src/pages/RecipientTrustReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/RecipientTrustReviewPage.test.tsx
@@ -24,6 +24,7 @@ describe("RecipientTrustReviewPage", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   it("renders a conservative metadata-only view-only trust review", async () => {
@@ -69,6 +70,23 @@ describe("RecipientTrustReviewPage", () => {
         generatedAt: "2026-05-01T00:00:00.000Z",
         expiresAt: "2026-06-01T00:00:00.000Z",
         reviewedAt: "2026-05-02T00:00:00.000Z",
+        session: {
+          schemaVersion: "recipient_review_session.v1",
+          sessionId: "session-1",
+          lifecycle: "active",
+          issuedAt: "2026-05-02T00:00:00.000Z",
+          expiresAt: "2026-05-02T00:30:00.000Z",
+          lastValidatedAt: "2026-05-02T00:00:00.000Z",
+          grantId: "grant-1",
+          audience: "insurer",
+          purpose: "insurance_review",
+          metadataOnly: true,
+          authenticated: true,
+          viewOnly: true,
+          downloadEnabled: false,
+          publicAccessEnabled: false,
+          reauthenticationRequiredAt: "2026-05-02T00:30:00.000Z",
+        },
         metadataOnly: true,
         policyGated: true,
         includedClaims: [
@@ -90,6 +108,7 @@ describe("RecipientTrustReviewPage", () => {
     expect(await screen.findByText(/Metadata-only recipient review/i)).toBeInTheDocument();
     expect(screen.getByText("reviewer@example.com")).toBeInTheDocument();
     expect(screen.getByText("Account trust")).toBeInTheDocument();
+    expect(screen.getByText(/Review session expires/i)).toBeInTheDocument();
     expect(screen.getByText(/Recipient downloads are disabled/i)).toBeInTheDocument();
     expect(screen.getByText(/Public profiles and public trust URLs are not created/i)).toBeInTheDocument();
     expect(screen.getByText(/not an approval, eligibility, credit, insurance, subsidy, ownership, government, or automated decision/i)).toBeInTheDocument();
@@ -108,5 +127,23 @@ describe("RecipientTrustReviewPage", () => {
     await waitFor(() => {
       expect(screen.queryByText(/Account trust/i)).not.toBeInTheDocument();
     });
+  });
+
+  it("clears stored recipient review session when reauthentication is required", async () => {
+    window.sessionStorage.setItem("recipientTrustReviewSession:grant-1", "session-1");
+    const err: any = new Error("reauthentication");
+    err.body = {
+      decision: {
+        status: "session_expired",
+        reason: "recipient_session_expired",
+      },
+    };
+    recipientTrustReviewApi.getRecipientTrustReview.mockRejectedValue(err);
+
+    renderPage();
+
+    expect(await screen.findByText(/Review unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/recipient session expired/i)).toBeInTheDocument();
+    expect(window.sessionStorage.getItem("recipientTrustReviewSession:grant-1")).toBeNull();
   });
 });

--- a/rentchain-frontend/src/pages/RecipientTrustReviewPage.tsx
+++ b/rentchain-frontend/src/pages/RecipientTrustReviewPage.tsx
@@ -39,6 +39,25 @@ function dateValue(value: string | null | undefined) {
   return parsed.toLocaleString();
 }
 
+function sessionStorageKey(grantId: string) {
+  return `recipientTrustReviewSession:${grantId}`;
+}
+
+function loadStoredSessionId(grantId: string) {
+  if (typeof window === "undefined") return null;
+  return window.sessionStorage.getItem(sessionStorageKey(grantId));
+}
+
+function storeSessionId(grantId: string, sessionId: string | null | undefined) {
+  if (typeof window === "undefined" || !sessionId) return;
+  window.sessionStorage.setItem(sessionStorageKey(grantId), sessionId);
+}
+
+function clearStoredSessionId(grantId: string) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(sessionStorageKey(grantId));
+}
+
 function MetadataList({ summary }: { summary: RecipientTrustReviewSummary }) {
   if (!summary.includedClaims.length) {
     return <div style={{ color: "#64748b" }}>No active trust metadata is available for this review.</div>;
@@ -78,14 +97,26 @@ export default function RecipientTrustReviewPage() {
   React.useEffect(() => {
     let cancelled = false;
     setState({ loading: true, data: null, error: null });
-    getRecipientTrustReview(grantId)
+    getRecipientTrustReview(grantId, loadStoredSessionId(grantId))
       .then((data) => {
-        if (!cancelled) setState({ loading: false, data, error: null });
+        if (!cancelled) {
+          storeSessionId(grantId, data.summary?.session?.sessionId);
+          setState({ loading: false, data, error: null });
+        }
       })
       .catch((err: any) => {
         const decision = err?.body?.decision;
         const reason = decision?.reason || err?.body?.error || err?.message || "Unable to load this trust review.";
-        if (!cancelled) setState({ loading: false, data: null, error: pretty(reason) });
+        if (!cancelled) {
+          if (
+            decision?.status === "session_expired" ||
+            decision?.status === "session_revoked" ||
+            decision?.status === "reauthentication_required"
+          ) {
+            clearStoredSessionId(grantId);
+          }
+          setState({ loading: false, data: null, error: pretty(reason) });
+        }
       });
     return () => {
       cancelled = true;
@@ -135,6 +166,10 @@ export default function RecipientTrustReviewPage() {
                 <div>
                   <div style={{ color: "#64748b", fontSize: 13 }}>Expires</div>
                   <div style={{ fontWeight: 700 }}>{dateValue(summary.expiresAt)}</div>
+                </div>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 13 }}>Review session expires</div>
+                  <div style={{ fontWeight: 700 }}>{dateValue(summary.session.expiresAt)}</div>
                 </div>
               </div>
             </section>


### PR DESCRIPTION
## Implementation audit summary
- Current recipient trust review used authenticated recipient email matching plus access-grant lifecycle checks, but did not model a first-class recipient review session.
- Grant revocation/expiration blocked new requests, while stale active review continuity lacked explicit session invalidation and audit reasons.
- Recipient review remained metadata-only and tenant-mediated; this change preserves those boundaries and adds session lifecycle governance under the existing policy-gated access flow.

## Changes
- Added metadata-only `recipientTrustReviewSessions` records with 30-minute TTL bounded by grant/consent expiration.
- Bound recipient sessions to grant, recipient email hash, recipient user id, audience, and purpose.
- Enforced stale-session blocking, session expiration, revocation propagation, and reauthentication-required outcomes.
- Added session audit events/reasons for started, expired, revoked, blocked, and reauthentication-required review flows.
- Returned session summaries to recipient review UI and stored the non-authorizing session id in `sessionStorage` for continuity.
- Preserved no public URLs, no downloads, no provider/institution integrations, and metadata-only review surfaces.

## Tests / verification
- `npm run test:single -- src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts`
- `npm run test:single -- src/routes/__tests__/recipientTrustReviewRoutes.test.ts`
- `npm run test:single -- src/pages/RecipientTrustReviewPage.test.tsx`
- `npm run test` in `rentchain-api` (rerun outside sandbox because Supertest local port binding is blocked by sandbox `listen EPERM`)
- `npm run test` in `rentchain-frontend`
- `npm run build` in `rentchain-api`
- `npm run build` in `rentchain-frontend`
- `git diff --check`

## QA notes
- Verified recipient review remains authenticated, view-only, metadata-only, and non-public.
- Verified expired/mismatched sessions require reauthentication.
- Verified revoked grants invalidate active recipient review sessions.
- Verified frontend clears stale stored session ids on session expiration/revocation/reauthentication errors.

## Remaining risks
- Session governance is backend-enforced per request; no live push invalidation is introduced in this mission.
- Recipient sessions are narrow internal records, not institution accounts or provider-backed recipient identity verification.