### PR TITLE
Add trust export lifecycle controls

### DIFF
--- a/rentchain-api/src/lib/institutionTrustExports/__tests__/deriveInstitutionalTrustExportPackage.test.ts
+++ b/rentchain-api/src/lib/institutionTrustExports/__tests__/deriveInstitutionalTrustExportPackage.test.ts
@@ -83,6 +83,15 @@ describe("deriveInstitutionalTrustExportPackage", () => {
         purpose: "insurance_review",
         status: "export_ready",
         lifecycle: "policy_evaluated",
+        lifecycleControl: expect.objectContaining({
+          schemaVersion: "institutional_trust_export_lifecycle_control.v1",
+          state: "active",
+          active: true,
+          shareable: true,
+          metadataOnly: true,
+          publicAccessEnabled: false,
+          externalSubmissionEnabled: false,
+        }),
         metadataOnly: true,
         consentScoped: true,
         policyGated: true,
@@ -124,6 +133,8 @@ describe("deriveInstitutionalTrustExportPackage", () => {
       ])
     );
     expect(pkg.auditMetadata.blockedAttestationCount).toBe(3);
+    expect(pkg.lifecycleControl.state).toBe("reverification_required");
+    expect(pkg.lifecycleControl.active).toBe(false);
   });
 
   it("enforces audience restrictions and excludes raw/internal references from export payloads", () => {

--- a/rentchain-api/src/lib/institutionTrustExports/deriveInstitutionalTrustExportPackage.ts
+++ b/rentchain-api/src/lib/institutionTrustExports/deriveInstitutionalTrustExportPackage.ts
@@ -8,6 +8,7 @@ import type {
   DeriveInstitutionalTrustExportPackageInput,
   InstitutionalTrustExportAudience,
   InstitutionalTrustExportAudienceMapping,
+  InstitutionalTrustExportLifecycleControl,
   InstitutionalTrustExportPackage,
   InstitutionalTrustExportPurpose,
   InstitutionalTrustExportRedaction,
@@ -131,6 +132,44 @@ function policyReasonLines(decisions: AttestationPolicyDecision[]) {
   );
 }
 
+function lifecycleControlFor(params: {
+  status: InstitutionalTrustExportPackage["status"];
+  lifecycle: InstitutionalTrustExportPackage["lifecycle"];
+  generatedAt: string;
+  blockedReasons: string[];
+  exportSummaryCount: number;
+}): InstitutionalTrustExportLifecycleControl {
+  const joined = params.blockedReasons.join(" ");
+  const state: InstitutionalTrustExportLifecycleControl["state"] =
+    params.status === "export_ready" && params.exportSummaryCount > 0
+      ? "active"
+      : params.lifecycle === "empty"
+      ? "empty"
+      : joined.includes("reverification_required")
+      ? "reverification_required"
+      : joined.includes("revoked")
+      ? "revoked"
+      : joined.includes("superseded")
+      ? "superseded"
+      : joined.includes("expired")
+      ? "expired"
+      : joined.includes("raw_payload_blocked") || joined.includes("support_metadata_blocked")
+      ? "invalidated"
+      : "blocked";
+  const active = state === "active";
+  return {
+    schemaVersion: "institutional_trust_export_lifecycle_control.v1",
+    state,
+    reasons: active ? ["export_active"] : params.blockedReasons,
+    active,
+    shareable: active,
+    evaluatedAt: params.generatedAt,
+    metadataOnly: true,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+  };
+}
+
 export function deriveInstitutionalTrustExportPackage(
   input: DeriveInstitutionalTrustExportPackageInput
 ): InstitutionalTrustExportPackage {
@@ -170,6 +209,13 @@ export function deriveInstitutionalTrustExportPackage(
   const uniqueBlockedReasons = Array.from(new Set(blockedReasons));
   const status = exportSummaries.length ? "export_ready" : uniqueBlockedReasons.length ? "blocked" : "unavailable";
   const lifecycle = status === "export_ready" ? "policy_evaluated" : attestations.length ? "blocked" : "empty";
+  const lifecycleControl = lifecycleControlFor({
+    status,
+    lifecycle,
+    generatedAt,
+    blockedReasons: uniqueBlockedReasons,
+    exportSummaryCount: exportSummaries.length,
+  });
 
   return {
     exportId,
@@ -179,6 +225,7 @@ export function deriveInstitutionalTrustExportPackage(
     status,
     lifecycle,
     generatedAt,
+    lifecycleControl,
     metadataOnly: true,
     consentScoped: true,
     policyGated: true,

--- a/rentchain-api/src/lib/institutionTrustExports/institutionTrustExportTypes.ts
+++ b/rentchain-api/src/lib/institutionTrustExports/institutionTrustExportTypes.ts
@@ -29,6 +29,18 @@ export type InstitutionalTrustExportStatus = "export_ready" | "blocked" | "unava
 
 export type InstitutionalTrustExportLifecycle = "policy_evaluated" | "blocked" | "empty";
 
+export type InstitutionalTrustExportLifecycleControl = {
+  schemaVersion: "institutional_trust_export_lifecycle_control.v1";
+  state: "active" | "blocked" | "empty" | "expired" | "revoked" | "superseded" | "reverification_required" | "invalidated";
+  reasons: string[];
+  active: boolean;
+  shareable: boolean;
+  evaluatedAt: string;
+  metadataOnly: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+};
+
 export type InstitutionalTrustExportRedaction = {
   fieldCategory: string;
   reason: string;
@@ -65,6 +77,7 @@ export type InstitutionalTrustExportPackage = {
   status: InstitutionalTrustExportStatus;
   lifecycle: InstitutionalTrustExportLifecycle;
   generatedAt: string;
+  lifecycleControl: InstitutionalTrustExportLifecycleControl;
   metadataOnly: true;
   consentScoped: true;
   policyGated: true;

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts
@@ -125,6 +125,26 @@ describe("tenantTrustExportService", () => {
     });
 
     expect(prepared?.lifecycle).toBe("prepared");
+    expect(prepared?.lifecycleControl).toEqual(
+      expect.objectContaining({
+        schemaVersion: "trust_export_lifecycle_control.v1",
+        state: "prepared",
+        reason: "export_active",
+        active: true,
+        shareable: true,
+        metadataOnly: true,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+      })
+    );
+    expect(prepared?.lifecycleEvents?.[0]).toEqual(
+      expect.objectContaining({
+        eventType: "trust_export_prepared",
+        reason: "export_active",
+        metadataOnly: true,
+      })
+    );
+    expect(prepared?.downloadEnabled).toBe(true);
     expect(prepared?.consent.granted).toBe(true);
     expect(prepared?.package.status).toBe("export_ready");
     expect(prepared?.includedClaims.map((claim) => claim.claimCategory)).toEqual(
@@ -147,6 +167,112 @@ describe("tenantTrustExportService", () => {
     expect(payload).not.toContain("tenant-1");
     expect(ensureCollection("tenantTrustExports").size).toBe(1);
     expect(Array.from(ensureCollection("tenantTrustExports").values())[0]?.tenantId).toBe("tenant-1");
+  });
+
+  it("supersedes older active exports when a tenant prepares a replacement for the same audience and purpose", async () => {
+    const service = await import("../tenantTrustExportService");
+
+    const first = await service.prepareTenantTrustExport({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      consentAccepted: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    const second = await service.prepareTenantTrustExport({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      consentAccepted: true,
+    });
+
+    expect(first?.exportId).toBeTruthy();
+    expect(second?.exportId).toBeTruthy();
+    expect(second?.exportId).not.toBe(first?.exportId);
+
+    const listed = await service.listTenantTrustExports({ tenantId: "tenant-1" });
+    const oldExport = listed.find((item) => item.exportId === first?.exportId);
+    const replacement = listed.find((item) => item.exportId === second?.exportId);
+    expect(oldExport?.lifecycle).toBe("superseded");
+    expect(oldExport?.lifecycleControl).toEqual(
+      expect.objectContaining({
+        state: "superseded",
+        reason: "export_superseded",
+        active: false,
+        shareable: false,
+        supersededByExportId: second?.exportId,
+        replacedByExportId: second?.exportId,
+      })
+    );
+    expect(oldExport?.downloadEnabled).toBe(false);
+    expect(oldExport?.lifecycleEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["trust_export_superseded", "trust_export_replaced"])
+    );
+    expect(replacement?.lifecycle).toBe("prepared");
+  });
+
+  it("invalidates stored exports when source summaries expire, revoke, supersede, or require reverification", async () => {
+    const service = await import("../tenantTrustExportService");
+
+    const prepared = await service.prepareTenantTrustExport({
+      tenantId: "tenant-1",
+      audience: "tenant_portability",
+      consentAccepted: true,
+    });
+    const stored = ensureCollection("tenantTrustExports").get(prepared?.exportId || "");
+    ensureCollection("tenantTrustExports").set(prepared?.exportId || "", {
+      ...stored,
+      package: {
+        ...stored.package,
+        exportSummaries: [
+          {
+            ...stored.package.exportSummaries[0],
+            status: "revoked",
+            revokedAt: "2026-05-10T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const listed = await service.listTenantTrustExports({ tenantId: "tenant-1" });
+    expect(listed[0]?.lifecycle).toBe("invalidated");
+    expect(listed[0]?.lifecycleControl).toEqual(
+      expect.objectContaining({
+        state: "invalidated",
+        reason: "source_attestation_revoked",
+        active: false,
+        shareable: false,
+      })
+    );
+    expect(listed[0]?.lifecycleEvents.map((event) => event.eventType)).toContain("trust_export_invalidation_detected");
+    expect(JSON.stringify(listed[0])).not.toContain("supportMetadataIncluded\":true");
+    expect(JSON.stringify(listed[0])).not.toContain("rawProviderPayloadIncluded\":true");
+  });
+
+  it("keeps archived exports audit-visible but inactive and non-shareable", async () => {
+    const service = await import("../tenantTrustExportService");
+
+    const prepared = await service.prepareTenantTrustExport({
+      tenantId: "tenant-1",
+      audience: "auditor",
+      consentAccepted: true,
+    });
+    const archived = await service.archiveTenantTrustExport({
+      tenantId: "tenant-1",
+      exportId: prepared?.exportId || "",
+    });
+
+    expect(archived && archived.lifecycle).toBe("archived");
+    expect(archived && archived.downloadEnabled).toBe(false);
+    expect(archived && archived.lifecycleControl).toEqual(
+      expect.objectContaining({
+        state: "archived",
+        reason: "export_archived",
+        active: false,
+        shareable: false,
+      })
+    );
+    const listed = await service.listTenantTrustExports({ tenantId: "tenant-1" });
+    expect(listed[0]?.lifecycle).toBe("archived");
+    expect(listed[0]?.lifecycleEvents.map((event) => event.eventType)).toContain("trust_export_archived");
   });
 
   it("requires consent before preparation and lets the owning tenant revoke the record", async () => {

--- a/rentchain-api/src/services/tenantPortal/tenantTrustExportService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantTrustExportService.ts
@@ -47,7 +47,62 @@ export type TenantTrustExportLifecycle =
   | "revoked"
   | "expired"
   | "blocked"
-  | "consent_required";
+  | "consent_required"
+  | "superseded"
+  | "archived"
+  | "reverification_required"
+  | "invalidated"
+  | "replaced";
+
+export type TrustExportLifecycleReason =
+  | "export_active"
+  | "export_expired"
+  | "export_revoked"
+  | "export_superseded"
+  | "export_archived"
+  | "export_replaced"
+  | "export_blocked"
+  | "source_attestation_revoked"
+  | "source_attestation_expired"
+  | "source_attestation_superseded"
+  | "source_reverification_required"
+  | "policy_gate_blocked";
+
+export type TrustExportLifecycleControl = {
+  schemaVersion: "trust_export_lifecycle_control.v1";
+  state: Exclude<TenantTrustExportLifecycle, "preview" | "consent_required">;
+  reason: TrustExportLifecycleReason;
+  active: boolean;
+  shareable: boolean;
+  evaluatedAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  supersededAt: string | null;
+  supersededByExportId: string | null;
+  archivedAt: string | null;
+  replacedByExportId: string | null;
+  invalidatedAt: string | null;
+  sourceAttestationIds: string[];
+  metadataOnly: true;
+  publicAccessEnabled: false;
+  downloadEnabled: false;
+};
+
+export type TrustExportLifecycleEvent = {
+  eventType:
+    | "trust_export_prepared"
+    | "trust_export_expired"
+    | "trust_export_revoked"
+    | "trust_export_superseded"
+    | "trust_export_archived"
+    | "trust_export_replaced"
+    | "trust_export_invalidation_detected"
+    | "trust_export_reverification_required";
+  occurredAt: string;
+  actorType: "tenant" | "system";
+  reason: TrustExportLifecycleReason;
+  metadataOnly: true;
+};
 
 export type TenantTrustExportConsentState = {
   required: true;
@@ -73,9 +128,17 @@ export type TenantTrustExportPreview = {
   consent: TenantTrustExportConsentState;
   expiresAt: string | null;
   revokedAt: string | null;
+  supersededAt: string | null;
+  supersededByExportId: string | null;
+  archivedAt: string | null;
+  replacedByExportId: string | null;
+  invalidatedAt: string | null;
   generatedAt: string;
+  lifecycleControl: TrustExportLifecycleControl;
+  lifecycleEvents: TrustExportLifecycleEvent[];
   metadataOnly: true;
   publicAccessEnabled: false;
+  downloadEnabled: boolean;
   externalSubmissionEnabled: false;
   policyGated: true;
   package: InstitutionalTrustExportPackage;
@@ -98,7 +161,7 @@ export type TenantTrustExportPreview = {
 
 export type TenantTrustExportRecord = TenantTrustExportPreview & {
   exportId: string;
-  lifecycle: "prepared" | "revoked" | "expired" | "blocked";
+  lifecycle: Exclude<TenantTrustExportLifecycle, "preview" | "consent_required">;
   createdAt: string;
   updatedAt: string;
 };
@@ -131,6 +194,13 @@ function nowIso() {
 
 function addDaysIso(start: string, days: number) {
   return new Date(Date.parse(start) + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function timestampAtOrBefore(value: string | null | undefined, comparedAt: string) {
+  if (!value) return false;
+  const candidate = Date.parse(value);
+  const now = Date.parse(comparedAt);
+  return Number.isFinite(candidate) && Number.isFinite(now) && candidate <= now;
 }
 
 function clampExpiresInDays(value: unknown) {
@@ -214,6 +284,125 @@ function exportIdFor(params: {
   ]
     .join(":")
     .replace(/[^a-zA-Z0-9_.:-]+/g, "_");
+}
+
+function sourceAttestationIds(record: Pick<TenantTrustExportPreview, "package">) {
+  return Array.from(
+    new Set((record.package?.exportSummaries || []).map((summary: any) => asString(summary?.attestationId)).filter(Boolean) as string[])
+  );
+}
+
+function lifecycleEvent(params: {
+  eventType: TrustExportLifecycleEvent["eventType"];
+  occurredAt: string;
+  reason: TrustExportLifecycleReason;
+  actorType?: TrustExportLifecycleEvent["actorType"];
+}): TrustExportLifecycleEvent {
+  return {
+    eventType: params.eventType,
+    occurredAt: params.occurredAt,
+    actorType: params.actorType || "system",
+    reason: params.reason,
+    metadataOnly: true,
+  };
+}
+
+function lifecycleControl(params: {
+  state: TrustExportLifecycleControl["state"];
+  reason: TrustExportLifecycleReason;
+  evaluatedAt: string;
+  record: Partial<TenantTrustExportPreview>;
+  supersededByExportId?: string | null;
+  replacedByExportId?: string | null;
+  invalidatedAt?: string | null;
+}): TrustExportLifecycleControl {
+  const active = params.state === "prepared";
+  return {
+    schemaVersion: "trust_export_lifecycle_control.v1",
+    state: params.state,
+    reason: params.reason,
+    active,
+    shareable: active,
+    evaluatedAt: params.evaluatedAt,
+    expiresAt: params.record.expiresAt || null,
+    revokedAt: params.record.revokedAt || null,
+    supersededAt: params.record.supersededAt || null,
+    supersededByExportId: params.supersededByExportId ?? params.record.supersededByExportId ?? null,
+    archivedAt: params.record.archivedAt || null,
+    replacedByExportId: params.replacedByExportId ?? params.record.replacedByExportId ?? null,
+    invalidatedAt: params.invalidatedAt ?? params.record.invalidatedAt ?? null,
+    sourceAttestationIds: params.record.package ? sourceAttestationIds(params.record as TenantTrustExportPreview) : [],
+    metadataOnly: true,
+    publicAccessEnabled: false,
+    downloadEnabled: false,
+  };
+}
+
+function evaluateStoredExportLifecycle(
+  record: TenantTrustExportStoredRecord,
+  evaluatedAt = nowIso()
+): { state: TrustExportLifecycleControl["state"]; reason: TrustExportLifecycleReason; invalidatedAt: string | null } {
+  if (record.lifecycle === "revoked" || record.revokedAt || record.consent?.revokedAt) {
+    return { state: "revoked", reason: "export_revoked", invalidatedAt: record.revokedAt || record.consent?.revokedAt || evaluatedAt };
+  }
+  if (record.lifecycle === "archived" || record.archivedAt) {
+    return { state: "archived", reason: "export_archived", invalidatedAt: record.archivedAt || evaluatedAt };
+  }
+  if (record.lifecycle === "superseded" || record.supersededAt) {
+    return { state: "superseded", reason: "export_superseded", invalidatedAt: record.supersededAt || evaluatedAt };
+  }
+  if (record.lifecycle === "replaced" || record.replacedByExportId) {
+    return { state: "replaced", reason: "export_replaced", invalidatedAt: evaluatedAt };
+  }
+  if (timestampAtOrBefore(record.expiresAt, evaluatedAt) || timestampAtOrBefore(record.consent?.expiresAt, evaluatedAt)) {
+    return { state: "expired", reason: "export_expired", invalidatedAt: record.expiresAt || record.consent?.expiresAt || evaluatedAt };
+  }
+
+  for (const summary of record.package?.exportSummaries || []) {
+    if (summary?.status === "revoked" || summary?.revokedAt) {
+      return { state: "invalidated", reason: "source_attestation_revoked", invalidatedAt: summary.revokedAt || evaluatedAt };
+    }
+    if (summary?.status === "superseded" || summary?.supersededAt || summary?.lifecycleState === "superseded") {
+      return { state: "superseded", reason: "source_attestation_superseded", invalidatedAt: summary.supersededAt || evaluatedAt };
+    }
+    if (
+      summary?.status === "expired" ||
+      summary?.lifecycleState === "expired" ||
+      timestampAtOrBefore(summary?.expiresAt, evaluatedAt) ||
+      timestampAtOrBefore(summary?.consentExpiresAt, evaluatedAt)
+    ) {
+      return { state: "expired", reason: "source_attestation_expired", invalidatedAt: summary?.expiresAt || summary?.consentExpiresAt || evaluatedAt };
+    }
+    if (
+      summary?.status === "reverification_required" ||
+      summary?.lifecycleState === "reverification_required" ||
+      timestampAtOrBefore(summary?.nextReverificationAt, evaluatedAt)
+    ) {
+      return { state: "reverification_required", reason: "source_reverification_required", invalidatedAt: summary?.nextReverificationAt || evaluatedAt };
+    }
+  }
+
+  if (record.package?.status !== "export_ready") {
+    return { state: "blocked", reason: "policy_gate_blocked", invalidatedAt: evaluatedAt };
+  }
+
+  return { state: "prepared", reason: "export_active", invalidatedAt: null };
+}
+
+function lifecycleEventTypeForDecision(
+  state: TrustExportLifecycleControl["state"],
+  reason: TrustExportLifecycleReason
+): TrustExportLifecycleEvent["eventType"] | null {
+  if (state === "prepared") return null;
+  if (state === "expired") return "trust_export_expired";
+  if (state === "revoked") return "trust_export_revoked";
+  if (state === "superseded") return "trust_export_superseded";
+  if (state === "archived") return "trust_export_archived";
+  if (state === "replaced") return "trust_export_replaced";
+  if (state === "reverification_required" || reason === "source_reverification_required") {
+    return "trust_export_reverification_required";
+  }
+  return "trust_export_invalidation_detected";
 }
 
 async function resolveTenantTrustContext(tenantId: string): Promise<TenantTrustContext | null> {
@@ -552,9 +741,31 @@ function tenantPreviewFromPackage(params: {
     }),
     expiresAt: params.expiresAt,
     revokedAt: null,
+    supersededAt: null,
+    supersededByExportId: null,
+    archivedAt: null,
+    replacedByExportId: null,
+    invalidatedAt: null,
     generatedAt: params.generatedAt,
+    lifecycleControl: lifecycleControl({
+      state: lifecycle === "preview" ? "prepared" : "blocked",
+      reason: lifecycle === "preview" ? "export_active" : "policy_gate_blocked",
+      evaluatedAt: params.generatedAt,
+      record: {
+        expiresAt: params.expiresAt,
+        revokedAt: null,
+        supersededAt: null,
+        supersededByExportId: null,
+        archivedAt: null,
+        replacedByExportId: null,
+        invalidatedAt: null,
+        package: params.package,
+      },
+    }),
+    lifecycleEvents: [],
     metadataOnly: true,
     publicAccessEnabled: false,
+    downloadEnabled: lifecycle === "preview",
     externalSubmissionEnabled: false,
     policyGated: true,
     package: params.package,
@@ -570,6 +781,7 @@ function tenantPreviewFromPackage(params: {
       "This export is prepared for tenant review and manual use only.",
       "No institution receives this package automatically.",
       "Revocation affects RentChain-controlled state and future preparation, not files already downloaded.",
+      "Expired, revoked, superseded, archived, or reverification-required exports are not active or shareable.",
       "This package is not a credit, insurance, subsidy, ownership, or automated eligibility decision.",
     ],
   };
@@ -629,26 +841,115 @@ async function buildTenantTrustExportPreview(params: {
 }
 
 function asRecord(id: string, data: any): TenantTrustExportStoredRecord {
-  const expiresAt = asString(data?.expiresAt);
-  const now = Date.now();
-  const lifecycle =
-    data?.lifecycle === "revoked"
-      ? "revoked"
-      : expiresAt && Date.parse(expiresAt) <= now
-      ? "expired"
-      : data?.package?.status === "export_ready"
-      ? "prepared"
-      : "blocked";
-  return {
+  const base = {
     ...(data || {}),
     exportId: id,
-    lifecycle,
+    supersededAt: asString(data?.supersededAt),
+    supersededByExportId: asString(data?.supersededByExportId),
+    archivedAt: asString(data?.archivedAt),
+    replacedByExportId: asString(data?.replacedByExportId),
+    invalidatedAt: asString(data?.invalidatedAt),
+    lifecycleEvents: Array.isArray(data?.lifecycleEvents) ? data.lifecycleEvents : [],
+    downloadEnabled: data?.downloadEnabled === true,
+  } as TenantTrustExportStoredRecord;
+  const decision = evaluateStoredExportLifecycle(base);
+  const eventType = lifecycleEventTypeForDecision(decision.state, decision.reason);
+  const lifecycleEvents =
+    eventType && !(base.lifecycleEvents || []).some((event) => event.eventType === eventType && event.reason === decision.reason)
+      ? [
+          ...(base.lifecycleEvents || []),
+          lifecycleEvent({
+            eventType,
+            occurredAt: decision.invalidatedAt || nowIso(),
+            reason: decision.reason,
+          }),
+        ].slice(-50)
+      : base.lifecycleEvents || [];
+  return {
+    ...base,
+    lifecycle: decision.state,
+    invalidatedAt: base.invalidatedAt || decision.invalidatedAt,
+    lifecycleEvents,
+    lifecycleControl: lifecycleControl({
+      state: decision.state,
+      reason: decision.reason,
+      evaluatedAt: nowIso(),
+      record: {
+        ...base,
+        invalidatedAt: base.invalidatedAt || decision.invalidatedAt,
+      },
+    }),
+    downloadEnabled: decision.state === "prepared",
   } as TenantTrustExportStoredRecord;
 }
 
 function publicRecord(record: TenantTrustExportStoredRecord): TenantTrustExportRecord {
   const { tenantId: _tenantId, ...rest } = record;
   return rest;
+}
+
+async function supersedeActiveTenantTrustExports(params: {
+  tenantId: string;
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  replacementExportId: string;
+  occurredAt: string;
+}) {
+  const snap = await db.collection(COLLECTION).where("tenantId", "==", params.tenantId).limit(50).get();
+  await Promise.all(
+    (snap.docs || []).map(async (doc: any) => {
+      const current = asRecord(String(doc.id || ""), doc.data?.() || {});
+      if (
+        current.exportId === params.replacementExportId ||
+        current.audience !== params.audience ||
+        current.purpose !== params.purpose ||
+        current.lifecycle !== "prepared"
+      ) {
+        return;
+      }
+      const events = [
+        ...(Array.isArray(current.lifecycleEvents) ? current.lifecycleEvents : []),
+        lifecycleEvent({
+          eventType: "trust_export_superseded",
+          occurredAt: params.occurredAt,
+          reason: "export_superseded",
+        }),
+        lifecycleEvent({
+          eventType: "trust_export_replaced",
+          occurredAt: params.occurredAt,
+          reason: "export_replaced",
+        }),
+      ].slice(-50);
+      const nextControl = lifecycleControl({
+        state: "superseded",
+        reason: "export_superseded",
+        evaluatedAt: params.occurredAt,
+        record: {
+          ...current,
+          supersededAt: params.occurredAt,
+          supersededByExportId: params.replacementExportId,
+          replacedByExportId: params.replacementExportId,
+        },
+        supersededByExportId: params.replacementExportId,
+        replacedByExportId: params.replacementExportId,
+        invalidatedAt: params.occurredAt,
+      });
+      await db.collection(COLLECTION).doc(current.exportId).set(
+        {
+          lifecycle: "superseded",
+          supersededAt: params.occurredAt,
+          supersededByExportId: params.replacementExportId,
+          replacedByExportId: params.replacementExportId,
+          invalidatedAt: params.occurredAt,
+          updatedAt: params.occurredAt,
+          downloadEnabled: false,
+          lifecycleControl: nextControl,
+          lifecycleEvents: events,
+        },
+        { merge: true }
+      );
+    })
+  );
 }
 
 export async function previewTenantTrustExport(params: {
@@ -687,11 +988,42 @@ export async function prepareTenantTrustExport(params: {
   });
   if (!preview) return null;
 
+  await supersedeActiveTenantTrustExports({
+    tenantId,
+    audience,
+    purpose,
+    replacementExportId: exportId,
+    occurredAt: generatedAt,
+  });
+
+  const initialLifecycle: TenantTrustExportRecord["lifecycle"] =
+    preview.package.status === "export_ready" ? "prepared" : "blocked";
+  const initialReason: TrustExportLifecycleReason =
+    initialLifecycle === "prepared" ? "export_active" : "policy_gate_blocked";
   const record: TenantTrustExportStoredRecord = {
     ...preview,
     exportId,
     tenantId,
-    lifecycle: preview.package.status === "export_ready" ? "prepared" : "blocked",
+    lifecycle: initialLifecycle,
+    lifecycleControl: lifecycleControl({
+      state: initialLifecycle,
+      reason: initialReason,
+      evaluatedAt: generatedAt,
+      record: {
+        ...preview,
+        exportId,
+        lifecycle: initialLifecycle,
+      },
+    }),
+    lifecycleEvents: [
+      lifecycleEvent({
+        eventType: "trust_export_prepared",
+        occurredAt: generatedAt,
+        reason: initialReason,
+        actorType: "tenant",
+      }),
+    ],
+    downloadEnabled: initialLifecycle === "prepared",
     createdAt: generatedAt,
     updatedAt: generatedAt,
   };
@@ -719,11 +1051,35 @@ export async function revokeTenantTrustExport(params: { tenantId: string; export
   const current = asRecord(exportId, snap.data?.() || {});
   if (current.tenantId !== tenantId) return false;
   const updatedAt = nowIso();
+  const lifecycleEvents = [
+    ...(Array.isArray(current.lifecycleEvents) ? current.lifecycleEvents : []),
+    lifecycleEvent({
+      eventType: "trust_export_revoked",
+      occurredAt: updatedAt,
+      reason: "export_revoked",
+      actorType: "tenant",
+    }),
+  ].slice(-50);
+  const nextControl = lifecycleControl({
+    state: "revoked",
+    reason: "export_revoked",
+    evaluatedAt: updatedAt,
+    record: {
+      ...current,
+      revokedAt: updatedAt,
+      invalidatedAt: updatedAt,
+    },
+    invalidatedAt: updatedAt,
+  });
   await ref.set(
     {
       lifecycle: "revoked",
       revokedAt: updatedAt,
+      invalidatedAt: updatedAt,
       updatedAt,
+      downloadEnabled: false,
+      lifecycleControl: nextControl,
+      lifecycleEvents,
       consent: {
         ...current.consent,
         granted: false,
@@ -736,11 +1092,69 @@ export async function revokeTenantTrustExport(params: { tenantId: string; export
     ...current,
     lifecycle: "revoked" as const,
     revokedAt: updatedAt,
+    invalidatedAt: updatedAt,
     updatedAt,
+    downloadEnabled: false,
+    lifecycleControl: nextControl,
+    lifecycleEvents,
     consent: {
       ...current.consent,
       granted: false,
       revokedAt: updatedAt,
     },
+  });
+}
+
+export async function archiveTenantTrustExport(params: { tenantId: string; exportId: string }) {
+  const tenantId = asString(params.tenantId);
+  const exportId = asString(params.exportId);
+  if (!tenantId || !exportId) return null;
+  const ref = db.collection(COLLECTION).doc(exportId);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const current = asRecord(exportId, snap.data?.() || {});
+  if (current.tenantId !== tenantId) return false;
+  const archivedAt = nowIso();
+  const lifecycleEvents = [
+    ...(Array.isArray(current.lifecycleEvents) ? current.lifecycleEvents : []),
+    lifecycleEvent({
+      eventType: "trust_export_archived",
+      occurredAt: archivedAt,
+      reason: "export_archived",
+      actorType: "tenant",
+    }),
+  ].slice(-50);
+  const nextControl = lifecycleControl({
+    state: "archived",
+    reason: "export_archived",
+    evaluatedAt: archivedAt,
+    record: {
+      ...current,
+      archivedAt,
+      invalidatedAt: archivedAt,
+    },
+    invalidatedAt: archivedAt,
+  });
+  await ref.set(
+    {
+      lifecycle: "archived",
+      archivedAt,
+      invalidatedAt: archivedAt,
+      updatedAt: archivedAt,
+      downloadEnabled: false,
+      lifecycleControl: nextControl,
+      lifecycleEvents,
+    },
+    { merge: true }
+  );
+  return publicRecord({
+    ...current,
+    lifecycle: "archived" as const,
+    archivedAt,
+    invalidatedAt: archivedAt,
+    updatedAt: archivedAt,
+    downloadEnabled: false,
+    lifecycleControl: nextControl,
+    lifecycleEvents,
   });
 }

--- a/rentchain-frontend/src/api/tenantTrustExports.ts
+++ b/rentchain-frontend/src/api/tenantTrustExports.ts
@@ -20,7 +20,12 @@ export type TenantTrustExportLifecycle =
   | "revoked"
   | "expired"
   | "blocked"
-  | "consent_required";
+  | "consent_required"
+  | "superseded"
+  | "archived"
+  | "reverification_required"
+  | "invalidated"
+  | "replaced";
 
 export type TenantTrustExportPreview = {
   exportId: string | null;
@@ -43,15 +48,58 @@ export type TenantTrustExportPreview = {
   };
   expiresAt: string | null;
   revokedAt: string | null;
+  supersededAt: string | null;
+  supersededByExportId: string | null;
+  archivedAt: string | null;
+  replacedByExportId: string | null;
+  invalidatedAt: string | null;
   generatedAt: string;
+  lifecycleControl: {
+    schemaVersion: "trust_export_lifecycle_control.v1";
+    state: Exclude<TenantTrustExportLifecycle, "preview" | "consent_required">;
+    reason: string;
+    active: boolean;
+    shareable: boolean;
+    evaluatedAt: string;
+    expiresAt: string | null;
+    revokedAt: string | null;
+    supersededAt: string | null;
+    supersededByExportId: string | null;
+    archivedAt: string | null;
+    replacedByExportId: string | null;
+    invalidatedAt: string | null;
+    sourceAttestationIds: string[];
+    metadataOnly: true;
+    publicAccessEnabled: false;
+    downloadEnabled: false;
+  };
+  lifecycleEvents: Array<{
+    eventType: string;
+    occurredAt: string;
+    actorType: "tenant" | "system";
+    reason: string;
+    metadataOnly: true;
+  }>;
   metadataOnly: true;
   publicAccessEnabled: false;
+  downloadEnabled: boolean;
   externalSubmissionEnabled: false;
   policyGated: true;
   package: {
     exportId: string;
     status: "export_ready" | "blocked" | "unavailable";
     lifecycle: "policy_evaluated" | "blocked" | "empty";
+    lifecycleControl?: {
+      schemaVersion: "institutional_trust_export_lifecycle_control.v1";
+      state: string;
+      reasons: string[];
+      active: boolean;
+      shareable: boolean;
+      evaluatedAt: string;
+      metadataOnly: true;
+      publicAccessEnabled: false;
+      externalSubmissionEnabled: false;
+    };
     blockedReasons: string[];
     exportSummaries: Array<{
       attestationId: string;
@@ -98,7 +146,7 @@ export type TenantTrustExportPreview = {
 
 export type TenantTrustExportRecord = TenantTrustExportPreview & {
   exportId: string;
-  lifecycle: "prepared" | "revoked" | "expired" | "blocked";
+  lifecycle: Exclude<TenantTrustExportLifecycle, "preview" | "consent_required">;
   createdAt: string;
   updatedAt: string;
 };

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -175,6 +175,16 @@ function prettyTrustExportLifecycle(value: string | null | undefined) {
       return "Expired";
     case "blocked":
       return "Blocked";
+    case "superseded":
+      return "Superseded";
+    case "archived":
+      return "Archived";
+    case "reverification_required":
+      return "Reverification required";
+    case "invalidated":
+      return "Invalidated";
+    case "replaced":
+      return "Replaced";
     case "consent_required":
       return "Consent required";
     case "preview":
@@ -1660,6 +1670,10 @@ export default function TenantWorkspacePage() {
                     { label: "Audience", value: prettyTrustExportAudience(trustExportPreview.audience) },
                     { label: "Consent", value: trustExportPreview.consent.granted ? "Granted for this package" : "Required" },
                     { label: "Policy status", value: prettyStatus(trustExportPreview.package.status) },
+                    {
+                      label: "Lifecycle control",
+                      value: prettyTrustExportLifecycle(trustExportPreview.lifecycleControl?.state || trustExportPreview.lifecycle),
+                    },
                     { label: "Included claims", value: String(trustExportPreview.includedClaims.length) },
                     { label: "Blocked claims", value: String(trustExportPreview.excludedClaims.length) },
                     { label: "Public access", value: trustExportPreview.publicAccessEnabled ? "Enabled" : "Disabled" },
@@ -1712,15 +1726,24 @@ export default function TenantWorkspacePage() {
                       rows={[
                         { label: "Audience", value: prettyTrustExportAudience(entry.audience) },
                         { label: "Status", value: prettyTrustExportLifecycle(entry.lifecycle) },
+                        { label: "Lifecycle reason", value: entry.lifecycleControl?.reason ? prettyPolicyReason(entry.lifecycleControl.reason) : "Not available" },
                         { label: "Prepared", value: formatDate(entry.createdAt) },
                         { label: "Expires", value: formatDate(entry.expiresAt) },
+                        { label: "Invalidated", value: entry.invalidatedAt ? formatDate(entry.invalidatedAt) : "Not invalidated" },
                         { label: "Claims", value: String(entry.includedClaims.length) },
                       ]}
                     />
+                    {entry.lifecycle !== "prepared" ? (
+                      <div style={{ color: textTokens.secondary }}>
+                        This export is retained for audit history only and is not active or shareable.
+                      </div>
+                    ) : null}
                     <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-                      <button type="button" onClick={() => handleDownloadTrustExportJson(entry)}>
-                        Download JSON
-                      </button>
+                      {entry.lifecycle === "prepared" && entry.downloadEnabled ? (
+                        <button type="button" onClick={() => handleDownloadTrustExportJson(entry)}>
+                          Download JSON
+                        </button>
+                      ) : null}
                       {entry.lifecycle === "prepared" ? (
                         <button type="button" onClick={() => void handleRevokeTrustExport(entry.exportId)} disabled={trustExportBusy}>
                           Revoke export


### PR DESCRIPTION
## Summary
- Introduces deterministic trust export lifecycle controls for tenant-prepared trust exports, including expired, revoked, superseded, archived, replaced, reverification-required, invalidated, and blocked states.
- Adds package-level lifecycle control metadata to institutional trust export derivation so export readiness is explicitly active/shareable or blocked with machine-readable reasons.
- Propagates source attestation revocation, expiration, supersession, and reverification requirements into stored tenant export state and tenant-visible lifecycle status.
- Adds replacement/supersession handling for newer exports with the same tenant/audience/purpose, metadata-only lifecycle events, and conservative tenant UI status/download gating.

## Audit Summary
- Current portable attestation policy already blocked revoked, expired, superseded, and reverification-required attestations at package derivation time.
- Prepared tenant exports persisted snapshots but lacked deterministic replacement, archival, stale-source invalidation, lifecycle-control metadata, and lifecycle event summaries.
- Tenant-mediated access and recipient review already denied non-active grants/packages and remained metadata-only/non-public; this change keeps adoption points unchanged and strengthens export lifecycle state beneath them.

## Governance and Privacy
- No public export URLs, recipient downloads, institution/provider integrations, share-package widening, or automated decisioning were added.
- Lifecycle controls remain metadata-only and explicitly mark public access disabled.
- Inactive exports are audit-visible only and no longer tenant-downloadable from the workspace.

## Tests
- rentchain-api: `npm run test`
- rentchain-api: `npm run build`
- rentchain-api targeted:
  - `npm run test:single -- src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts`
  - `npm run test:single -- src/routes/__tests__/tenantPortalRoutes.test.ts`
  - `npm run test:single -- src/lib/institutionTrustExports/__tests__/deriveInstitutionalTrustExportPackage.test.ts`
  - `npm run test:single -- src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts`
  - `npm run test:single -- src/lib/portableAttestations/__tests__/attestationPolicyGate.test.ts`
  - `npm run test:single -- src/routes/__tests__/recipientTrustReviewRoutes.test.ts`
- rentchain-frontend: `npm run test`
- rentchain-frontend: `npm run build`
- rentchain-frontend targeted:
  - `npm run test:single -- src/pages/tenant/TenantWorkspacePage.test.tsx`
- `git diff --check`
