### PR TITLE
Fix application approval and tenant onboarding flow

### DIFF
--- a/rentchain-api/src/routes/__tests__/authOnboardTenantInvites.test.ts
+++ b/rentchain-api/src/routes/__tests__/authOnboardTenantInvites.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone(value: any) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function applyWhereFilter(data: any, field: string, op: string, value: any) {
+  if (op === "==") return data?.[field] === value;
+  return false;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+        },
+      };
+    },
+    where: (field: string, op: string, value: any) => ({
+      limit: (_count: number) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).entries())
+            .filter(([, data]) => applyWhereFilter(data, field, op, value))
+            .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).entries())
+          .filter(([, data]) => applyWhereFilter(data, field, op, value))
+          .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+        return { docs, empty: docs.length === 0 };
+      },
+    }),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../../auth/jwt", () => ({
+  signAuthToken: vi.fn(() => "auth-token"),
+  verifyAuthToken: vi.fn(() => {
+    throw new Error("no auth");
+  }),
+}));
+
+vi.mock("../../services/tenantPortal/tenantEventLogService", () => ({
+  recordTenantEvent: vi.fn(async () => ({ id: "event-1" })),
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [pathWithQuery, queryRaw = ""] = options.url.split("?");
+    const query = Object.fromEntries(new URLSearchParams(queryRaw));
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: pathWithQuery,
+      body: options.body ?? {},
+      headers: {},
+      query,
+      get() {
+        return undefined;
+      },
+      header() {
+        return undefined;
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("auth onboard tenant invites", () => {
+  beforeEach(() => {
+    collections.clear();
+    process.env.JWT_SECRET = "test-secret";
+  });
+
+  it("resolves and accepts hashed tenancy_invites tokens from tenant invite links", async () => {
+    const { createTenancyInvite } = await import("../../services/tenantPortal/tenantInviteService");
+    const created = await createTenancyInvite({
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      applicationId: "app-1",
+      unitId: "unit-1",
+      invitedEmail: "tenant@example.com",
+      invitedName: "Tenant Name",
+      createdBy: "landlord-1",
+    });
+
+    const router = (await import("../authRoutes")).default;
+
+    const resolveRes = await invokeRouter(router, {
+      method: "GET",
+      url: `/onboard/resolve?source=tenant&token=${created.token}`,
+    });
+    expect(resolveRes.status).toBe(200);
+    expect(resolveRes.body).toMatchObject({
+      ok: true,
+      inviteType: "tenant",
+      status: "valid",
+      email: "tenant@example.com",
+      propertyId: "property-1",
+    });
+
+    const acceptRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/onboard/accept",
+      body: { source: "tenant", token: created.token },
+    });
+    expect(acceptRes.status).toBe(200);
+    expect(acceptRes.body).toMatchObject({
+      ok: true,
+      accepted: true,
+      role: "tenant",
+      redirectTo: "/tenant",
+      propertyId: "property-1",
+    });
+    expect(acceptRes.body?.tenantToken).toBeTruthy();
+
+    const storedInvite = ensureCollection("tenancy_invites").get(created.invite.id);
+    expect(storedInvite?.status).toBe("redeemed");
+    expect(storedInvite?.token).toBeUndefined();
+  });
+
+  it("reports replaced tenancy_invites tokens as expired instead of not found", async () => {
+    const { createReplacementTenancyInvite } = await import("../../services/tenantPortal/tenantInviteService");
+    const first = await createReplacementTenancyInvite({
+      landlordId: "landlord-2",
+      propertyId: "property-2",
+      applicationId: "app-2",
+      unitId: "unit-2",
+      invitedEmail: "tenant2@example.com",
+      createdBy: "landlord-2",
+    });
+    await createReplacementTenancyInvite({
+      landlordId: "landlord-2",
+      propertyId: "property-2",
+      applicationId: "app-2",
+      unitId: "unit-2",
+      invitedEmail: "tenant2@example.com",
+      createdBy: "landlord-2",
+    });
+
+    const router = (await import("../authRoutes")).default;
+
+    const resolveRes = await invokeRouter(router, {
+      method: "GET",
+      url: `/onboard/resolve?source=tenant&token=${first.token}`,
+    });
+    expect(resolveRes.status).toBe(410);
+    expect(resolveRes.body).toMatchObject({
+      ok: false,
+      inviteType: "tenant",
+      status: "expired",
+    });
+  });
+});

--- a/rentchain-api/src/routes/__tests__/publicApplicationLinksRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicApplicationLinksRoutes.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = { id: string; data: any };
 
-const { dbMock, resetDb, seedCollection, savedDocs } = vi.hoisted(() => {
+const { dbMock, resetDb, seedCollection, savedDocs, sendEmailMock, buildEmailTextMock, buildEmailHtmlMock } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
   let generatedId = 0;
 
@@ -58,15 +58,26 @@ const { dbMock, resetDb, seedCollection, savedDocs } = vi.hoisted(() => {
     resetDb: () => {
       collections.clear();
       generatedId = 0;
+      sendEmailMock.mockReset();
+      buildEmailTextMock.mockReset();
+      buildEmailHtmlMock.mockReset();
     },
     seedCollection: (name: string, id: string, data: any) => {
       ensureCollection(name).set(id, { id, data });
     },
     savedDocs: collections,
+    sendEmailMock: vi.fn(async () => undefined),
+    buildEmailTextMock: vi.fn(() => "email-text"),
+    buildEmailHtmlMock: vi.fn(() => "<p>email</p>"),
   };
 });
 
 vi.mock("../../config/firebase", () => ({ db: dbMock }));
+vi.mock("../../services/emailService", () => ({ sendEmail: sendEmailMock }));
+vi.mock("../../email/templates/baseEmailTemplate", () => ({
+  buildEmailText: buildEmailTextMock,
+  buildEmailHtml: buildEmailHtmlMock,
+}));
 vi.mock("../../middleware/rateLimit", () => ({
   rateLimitPublicApply: (_req: any, _res: any, next: any) => next(),
 }));
@@ -184,6 +195,20 @@ describe("publicApplicationLinksRoutes", () => {
       propertyId: "property-1",
       unitId: "unit-1",
     });
+    seedCollection("landlords", "landlord-1", {
+      id: "landlord-1",
+      email: "owner@example.com",
+    });
+    seedCollection("properties", "property-1", {
+      id: "property-1",
+      name: "Harbour View",
+    });
+    seedCollection("units", "unit-1", {
+      id: "unit-1",
+      unitNumber: "4B",
+    });
+    process.env.EMAIL_FROM = "noreply@rentchain.test";
+    process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
   });
 
   it("persists currentLeaseStatus on application create", async () => {
@@ -225,6 +250,35 @@ describe("publicApplicationLinksRoutes", () => {
     const rentalApplications = savedDocs.get("rentalApplications");
     const stored = Array.from(rentalApplications?.values() || [])[0]?.data;
     expect(stored.currentLeaseStatus).toBeNull();
+  });
+
+  it("notifies the landlord when an applicant completes an application", async () => {
+    const router = await createApp();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications",
+      body: buildBody(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.landlordNotification).toEqual({ emailed: true, error: null });
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "owner@example.com",
+        subject: "Application completed — Jordan Lee",
+      })
+    );
+    expect(buildEmailTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intro: expect.stringContaining("Harbour View, Unit 4B"),
+        ctaUrl: expect.stringContaining("/applications?applicationId="),
+      })
+    );
+    expect(buildEmailTextMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        intro: expect.stringContaining("property-1"),
+      })
+    );
   });
 
   it("stores only safe partial progress metadata", async () => {

--- a/rentchain-api/src/routes/__tests__/rentalApplicationsDecisionActions.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsDecisionActions.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = { id: string; data: any };
 
-const { dbMock, resetDb, upsertDoc, sendEmailMock, buildEmailHtmlMock, buildEmailTextMock, recordRiskDecisionAuditMock } = vi.hoisted(() => {
+const { dbMock, resetDb, upsertDoc, sendEmailMock, buildEmailHtmlMock, buildEmailTextMock, recordRiskDecisionAuditMock, convertApplicationToTenantMock } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
   let autoId = 0;
 
@@ -85,6 +85,12 @@ const { dbMock, resetDb, upsertDoc, sendEmailMock, buildEmailHtmlMock, buildEmai
       id: "audit-1",
       createdAt: "2026-04-01T00:00:00.000Z",
       ...payload,
+    })),
+    convertApplicationToTenantMock: vi.fn(async () => ({
+      tenantId: "tenant-1",
+      alreadyConverted: false,
+      inviteUrl: "https://www.rentchain.test/tenant/invite/token-1",
+      inviteEmailed: true,
     })),
   };
 });
@@ -247,6 +253,10 @@ vi.mock("../../services/riskAgent/riskDecisionAuditService", () => ({
   recordRiskDecisionAudit: recordRiskDecisionAuditMock,
 }));
 
+vi.mock("../../services/applicationConversionService", () => ({
+  convertApplicationToTenant: convertApplicationToTenantMock,
+}));
+
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any; headers?: Record<string, string> }) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const req: any = {
@@ -302,6 +312,7 @@ describe("rentalApplications decision actions", () => {
     buildEmailHtmlMock.mockReturnValue("<p>email</p>");
     buildEmailTextMock.mockReset();
     buildEmailTextMock.mockReturnValue("email");
+    convertApplicationToTenantMock.mockClear();
     process.env.EMAIL_FROM = "noreply@rentchain.test";
     process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
     upsertDoc("rentalApplications", "app-1", {
@@ -309,6 +320,8 @@ describe("rentalApplications decision actions", () => {
       landlordId: "landlord-1",
       propertyId: "prop-1",
       propertyName: "Harbour View",
+      unitId: "unit-1",
+      monthlyRent: 2200,
       status: "SUBMITTED",
       applicant: {
         firstName: "Jamie",
@@ -319,6 +332,11 @@ describe("rentalApplications decision actions", () => {
     upsertDoc("landlords", "landlord-1", {
       id: "landlord-1",
       email: "payments@example.com",
+    });
+    upsertDoc("units", "unit-1", {
+      id: "unit-1",
+      unitNumber: "4B",
+      monthlyRent: 2200,
     });
   });
 
@@ -351,7 +369,7 @@ describe("rentalApplications decision actions", () => {
     );
   });
 
-  it("approves the application and includes the configured landlord payment email", async () => {
+  it("approves the application, sends hardened approval email, and creates tenant invite", async () => {
     const router = await createRouter();
     const res = await invokeRouter(router, {
       method: "POST",
@@ -366,11 +384,38 @@ describe("rentalApplications decision actions", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data?.status).toBe("APPROVED");
     expect(res.body?.action?.paymentEmail).toBe("payments@example.com");
+    expect(res.body?.action?.tenantInviteUrl).toContain("/tenant/invite/");
+    expect(res.body?.action?.tenantInviteEmailed).toBe(true);
     expect(sendEmailMock).toHaveBeenCalledWith(
       expect.objectContaining({
         to: "jamie@example.com",
         replyTo: "payments@example.com",
         subject: expect.stringMatching(/approved/i),
+      })
+    );
+    expect(buildEmailTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intro: expect.stringContaining("Harbour View, Unit 4B"),
+      })
+    );
+    expect(buildEmailTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intro: expect.stringContaining("$1,100"),
+        bullets: expect.arrayContaining([
+          expect.stringContaining("tenant onboarding invite"),
+        ]),
+      })
+    );
+    expect(buildEmailTextMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        intro: expect.stringContaining("prop-1"),
+      })
+    );
+    expect(convertApplicationToTenantMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        applicationId: "app-1",
+        runScreening: false,
       })
     );
   });

--- a/rentchain-api/src/routes/__tests__/tenantInvitesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantInvitesRoutes.test.ts
@@ -22,8 +22,8 @@ const dbMock = {
     if (name === "tenancy_invites") {
       return {
         doc: (id: string) => ({
-          set: async (value: any) => {
-            invites.set(id, value);
+          set: async (value: any, opts?: { merge?: boolean }) => {
+            invites.set(id, opts?.merge ? { ...(invites.get(id) || {}), ...value } : value);
           },
           get: async () => ({
             exists: invites.has(id),
@@ -31,14 +31,18 @@ const dbMock = {
             id,
           }),
         }),
-        where: (field: string, op: string, value: any) => ({
-          get: async () => {
-            const docs = Array.from(invites.entries())
-              .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
-              .map(([docId, data]) => ({ id: docId, data: () => data, exists: true }));
-            return { docs, empty: docs.length === 0 };
-          },
-        }),
+        where: (field: string, op: string, value: any) => {
+          const query = {
+            get: async () => {
+              const docs = Array.from(invites.entries())
+                .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
+                .map(([docId, data]) => ({ id: docId, data: () => data, exists: true }));
+              return { docs, empty: docs.length === 0 };
+            },
+            limit: (_count: number) => query,
+          };
+          return query;
+        },
       };
     }
     if (name === "event_log") {
@@ -163,5 +167,39 @@ describe("POST /api/tenant-invites", () => {
     expect(String(res.body?.inviteUrl || "")).toContain("/tenant/invite/");
     expect(res.body?.error).toBeUndefined();
     expect(invites.size).toBe(1);
+  }, 30000);
+
+  it("replaces an active duplicate invite deterministically", async () => {
+    const router = (await import("../tenantInvitesRoutes")).default;
+    const first = await invokeRouter(router, {
+      method: "POST",
+      url: "/",
+      body: {
+        tenantEmail: "tenant@example.com",
+        tenantName: "Tenant Name",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        applicationId: "app-1",
+      },
+    });
+    const second = await invokeRouter(router, {
+      method: "POST",
+      url: "/",
+      body: {
+        tenantEmail: "tenant@example.com",
+        tenantName: "Tenant Name",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        applicationId: "app-1",
+      },
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body?.replacedInviteId).toBeTruthy();
+    expect(String(second.body?.inviteUrl || "")).toContain("/tenant/invite/");
+    expect(invites.size).toBe(2);
+    const oldInvite = invites.get(second.body.replacedInviteId);
+    expect(oldInvite?.status).toBe("superseded");
   }, 30000);
 });

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -28,6 +28,10 @@ import { rateLimitAuth, rateLimitSimple } from "../middleware/rateLimit";
 import { requireAuth } from "../middleware/requireAuth";
 import { buildCanonicalSessionUserFromClaims } from "../services/sessionUserService";
 import { sendEmail, sendLandlordWelcomeEmail } from "../services/emailService";
+import {
+  redeemTenancyInvite,
+  resolveTenancyInviteByToken,
+} from "../services/tenantPortal/tenantInviteService";
 
 const router = Router();
 const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
@@ -247,6 +251,50 @@ async function resolveOnboardToken(token: string, sourceHint = ""): Promise<Onbo
     }
 
     if (source === "tenant") {
+      const tenancyInvite = await resolveTenancyInviteByToken(tokenValue);
+      if (tenancyInvite) {
+        const expired = Boolean(tenancyInvite.expiresAt && now >= tenancyInvite.expiresAt);
+        const accepted = tenancyInvite.status === "redeemed";
+        const unavailable = tenancyInvite.status === "superseded" || tenancyInvite.status === "expired";
+        const status = accepted ? "accepted" : expired || unavailable ? "expired" : "valid";
+        return {
+          ok: status === "valid" || status === "accepted",
+          token: tokenValue,
+          inviteType: "tenant",
+          role: "tenant",
+          email: tenancyInvite.invitedEmail,
+          maskedEmail: tenancyInvite.invitedEmail ? maskEmail(tenancyInvite.invitedEmail) : null,
+          status,
+          requiresAuth: false,
+          requiresSignup: false,
+          requiresExistingAccount: false,
+          alreadyAccepted: status === "accepted",
+          workspaceId: tenancyInvite.landlordId || null,
+          propertyId: tenancyInvite.propertyId || null,
+          inviteId: tenancyInvite.id,
+          redirectTo: "/tenant",
+          suggestedAuthMethod: "password_or_magic",
+          copy:
+            status === "expired"
+              ? {
+                  title: "Invite expired",
+                  description: "This invite has expired or was replaced. Request a new invite to continue.",
+                  cta: "Request a new invite",
+                }
+              : status === "accepted"
+              ? {
+                  title: "Invite already accepted",
+                  description: "This tenant invite has already been accepted.",
+                  cta: "Continue",
+                }
+              : {
+                  title: "You’re invited to join RentChain",
+                  description: "Accept this invite to access your tenant portal.",
+                  cta: "Accept invite",
+                },
+        };
+      }
+
       const doc = await db.collection("tenantInvites").doc(tokenValue).get();
       if (doc.exists) {
         const item = doc.data() as any;
@@ -1071,6 +1119,129 @@ router.post("/onboard/accept", async (req: any, res) => {
           expectedEmail: resolved.email,
           maskedExpectedEmail: resolved.maskedEmail,
           message: "This invite belongs to a different exact email address.",
+        });
+      }
+
+      const tenancyInvite = await resolveTenancyInviteByToken(token);
+      if (tenancyInvite) {
+        const email = String(tenancyInvite.invitedEmail || "").trim().toLowerCase();
+        if (!email || !ONBOARD_EMAIL_RE.test(email)) {
+          return res.status(400).json({ ok: false, code: "invite_invalid", message: "Invite invalid." });
+        }
+        const requestEmail = String(requestUser?.email || "").trim().toLowerCase();
+        if (requestEmail && email !== requestEmail) {
+          return res.status(409).json({
+            ok: false,
+            code: "wrong_account",
+            expectedEmail: email,
+            maskedExpectedEmail: maskEmail(email),
+            message: "This invite belongs to a different exact email address.",
+          });
+        }
+
+        const tenantId =
+          String(tenancyInvite.redeemedByUid || "").trim() ||
+          crypto
+            .createHash("sha256")
+            .update(`${tenancyInvite.landlordId}:${email}`.toLowerCase())
+            .digest("hex")
+            .slice(0, 24);
+
+        if (tenancyInvite.status === "redeemed") {
+          const tenantToken = signTenantJwt({
+            sub: tenantId,
+            role: "tenant",
+            tenantId,
+            landlordId: tenancyInvite.landlordId,
+            email,
+            propertyId: tenancyInvite.propertyId || null,
+            unitId: tenancyInvite.unitId || null,
+            leaseId: tenancyInvite.leaseId || null,
+          });
+          return res.json({
+            ok: true,
+            accepted: true,
+            role: "tenant",
+            redirectTo: "/tenant",
+            workspaceId: tenancyInvite.landlordId || null,
+            propertyId: tenancyInvite.propertyId || null,
+            tenantToken,
+            message: "Invite already accepted.",
+          });
+        }
+
+        const redeemed = await redeemTenancyInvite({
+          token,
+          redeemedByUid: String(requestUser?.id || tenantId).trim() || tenantId,
+          redeemedByEmail: requestEmail || email,
+        });
+        if (!redeemed.ok) {
+          const status =
+            redeemed.error === "invite_not_found" ? 404 : redeemed.error === "invite_used" ? 409 : 410;
+          const code =
+            redeemed.error === "invite_expired"
+              ? "expired"
+              : redeemed.error === "invite_used"
+              ? "accepted"
+              : "invalid";
+          return res.status(status).json({
+            ok: false,
+            code,
+            message:
+              redeemed.error === "invite_expired"
+                ? "Invite expired."
+                : redeemed.error === "invite_used"
+                ? "Invite already accepted."
+                : "Invite not found.",
+          });
+        }
+
+        await db.collection("tenants").doc(tenantId).set(
+          {
+            id: tenantId,
+            tenantId,
+            landlordId: tenancyInvite.landlordId,
+            email,
+            fullName: tenancyInvite.invitedName || null,
+            propertyId: tenancyInvite.propertyId || null,
+            unitId: tenancyInvite.unitId || null,
+            leaseId: tenancyInvite.leaseId || null,
+            applicationId: tenancyInvite.applicationId || null,
+            source: "invite",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+          { merge: true }
+        );
+
+        const tenantToken = signTenantJwt({
+          sub: tenantId,
+          role: "tenant",
+          tenantId,
+          landlordId: tenancyInvite.landlordId,
+          email,
+          propertyId: tenancyInvite.propertyId || null,
+          unitId: tenancyInvite.unitId || null,
+          leaseId: tenancyInvite.leaseId || null,
+        });
+        onboardLog("tenant_session_issued", {
+          token: tokenFingerprint(token),
+          inviteType: "tenant",
+          inviteStatus: "tenancy_invite_redeemed",
+          tenantId,
+          issuedRole: "tenant",
+          hasTenantToken: true,
+        });
+        onboardLog("accept_succeeded", { token: tokenFingerprint(token), inviteType: "tenant", inviteId: tenancyInvite.id });
+        return res.json({
+          ok: true,
+          accepted: true,
+          role: "tenant",
+          redirectTo: "/tenant",
+          workspaceId: tenancyInvite.landlordId || null,
+          propertyId: tenancyInvite.propertyId || null,
+          tenantToken,
+          message: "Invite accepted successfully.",
         });
       }
 

--- a/rentchain-api/src/routes/publicApplicationLinksRoutes.ts
+++ b/rentchain-api/src/routes/publicApplicationLinksRoutes.ts
@@ -2,6 +2,8 @@ import { Router } from "express";
 import { createHash } from "crypto";
 import { db } from "../config/firebase";
 import { rateLimitPublicApply } from "../middleware/rateLimit";
+import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
+import { sendEmail } from "../services/emailService";
 
 const router = Router();
 
@@ -103,6 +105,94 @@ function sanitizePartialProgressInput(input: any) {
       viewingChoice,
     },
   };
+}
+
+function buildContextLabel(propertyName?: string | null, unitLabel?: string | null) {
+  const property = String(propertyName || "").trim();
+  const unit = String(unitLabel || "").trim();
+  const normalizedUnit = /^unit\s+/i.test(unit) ? unit : unit ? `Unit ${unit}` : "";
+  if (property && normalizedUnit) return `${property}, ${normalizedUnit}`;
+  if (property) return property;
+  if (normalizedUnit) return normalizedUnit;
+  return "your property";
+}
+
+async function loadApplicationContextLabel(link: any) {
+  let propertyName: string | null = null;
+  let unitLabel: string | null = null;
+
+  if (link?.propertyId) {
+    try {
+      const propSnap = await db.collection("properties").doc(String(link.propertyId)).get();
+      if (propSnap.exists) {
+        const data = propSnap.data() as any;
+        propertyName = data?.name || data?.addressLine1 || data?.address || null;
+      }
+    } catch {
+      propertyName = null;
+    }
+  }
+
+  if (link?.unitId) {
+    try {
+      const unitSnap = await db.collection("units").doc(String(link.unitId)).get();
+      if (unitSnap.exists) {
+        const data = unitSnap.data() as any;
+        unitLabel = data?.unitNumber || data?.name || data?.label || null;
+      }
+    } catch {
+      unitLabel = null;
+    }
+  }
+
+  return buildContextLabel(propertyName, unitLabel);
+}
+
+async function notifyLandlordApplicationSubmitted(params: {
+  landlordId?: string | null;
+  applicationId: string;
+  applicantName: string;
+  propertyLabel: string;
+}) {
+  const landlordId = String(params.landlordId || "").trim();
+  if (!landlordId) return { emailed: false, error: "LANDLORD_MISSING" };
+
+  const from = String(process.env.EMAIL_FROM || process.env.FROM_EMAIL || "").trim();
+  if (!from) return { emailed: false, error: "EMAIL_NOT_CONFIGURED" };
+
+  let landlordEmail = "";
+  try {
+    const landlordSnap = await db.collection("landlords").doc(landlordId).get();
+    const landlord = landlordSnap.exists ? (landlordSnap.data() as any) : null;
+    landlordEmail = String(landlord?.email || "").trim();
+  } catch {
+    landlordEmail = "";
+  }
+  if (!landlordEmail) return { emailed: false, error: "LANDLORD_EMAIL_MISSING" };
+
+  const baseUrl = String(process.env.PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+  const applicationUrl = `${baseUrl}/applications?applicationId=${encodeURIComponent(params.applicationId)}`;
+  await sendEmail({
+    to: landlordEmail,
+    from,
+    subject: `Application completed — ${params.applicantName}`,
+    text: buildEmailText({
+      intro: `${params.applicantName} completed a rental application for ${params.propertyLabel}.`,
+      bullets: ["Open the Applications dashboard to review the submission."],
+      ctaText: "Review application",
+      ctaUrl: applicationUrl,
+      footerNote: "This notification was generated after the applicant submitted the application.",
+    }),
+    html: buildEmailHtml({
+      title: "Application completed",
+      intro: `${params.applicantName} completed a rental application for ${params.propertyLabel}.`,
+      bullets: ["Open the Applications dashboard to review the submission."],
+      ctaText: "Review application",
+      ctaUrl: applicationUrl,
+      footerNote: "This notification was generated after the applicant submitted the application.",
+    }),
+  });
+  return { emailed: true, error: null };
 }
 
 function normalizeStoredPartialProgress(input: any): StoredPartialProgress {
@@ -492,6 +582,22 @@ router.post("/rental-applications", rateLimitPublicApply, async (req: any, res) 
     };
 
     await appRef.set(payload, { merge: true });
+    let landlordNotification: { emailed: boolean; error: string | null } = { emailed: false, error: null };
+    try {
+      landlordNotification = await notifyLandlordApplicationSubmitted({
+        landlordId: link.landlordId || null,
+        applicationId,
+        applicantName: `${firstName} ${lastName}`.trim(),
+        propertyLabel: await loadApplicationContextLabel(link),
+      });
+    } catch (err: any) {
+      landlordNotification = { emailed: false, error: String(err?.message || "SEND_FAILED") };
+      console.error("[public applications] landlord notification failed", {
+        applicationId,
+        landlordId: link.landlordId || null,
+        error: landlordNotification.error,
+      });
+    }
     await db.collection("applicationLinks").doc(link.id).set(
       {
         partialProgress: buildPartialProgressPatch(link.partialProgress, {
@@ -510,7 +616,7 @@ router.post("/rental-applications", rateLimitPublicApply, async (req: any, res) 
       { merge: true }
     );
 
-    return res.json({ ok: true, data: { applicationId } });
+    return res.json({ ok: true, data: { applicationId, landlordNotification } });
   } catch (err: any) {
     console.error("[public applications] create failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "Failed to submit application" });

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -47,6 +47,7 @@ import { recordRiskDecisionAudit } from "../services/riskAgent/riskDecisionAudit
 import { rateLimitScreeningIp, rateLimitScreeningUser } from "../middleware/rateLimit";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
+import { convertApplicationToTenant } from "../services/applicationConversionService";
 import { recordScreeningPaymentInitiated } from "../services/screeningPaymentTransactionService";
 import {
   executeScreeningCheckout,
@@ -181,6 +182,107 @@ async function resolveLandlordContactEmail(landlordId: string, fallbackEmail?: s
   }
 }
 
+function centsFromValue(value: unknown): number | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  if (n > 10_000) return Math.round(n);
+  return Math.round(n * 100);
+}
+
+function formatCadAmount(cents: number | null): string | null {
+  if (!cents || cents <= 0) return null;
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+    minimumFractionDigits: cents % 100 === 0 ? 0 : 2,
+  }).format(cents / 100);
+}
+
+function resolveApplicationDepositCents(application: any): number | null {
+  const direct =
+    centsFromValue(application?.holdingDepositCents) ||
+    centsFromValue(application?.depositCents) ||
+    centsFromValue(application?.requiredDepositCents) ||
+    centsFromValue(application?.holdingDepositAmountCents) ||
+    centsFromValue(application?.depositAmountCents);
+  if (direct) return direct;
+
+  const amount =
+    centsFromValue(application?.holdingDepositAmount) ||
+    centsFromValue(application?.depositAmount) ||
+    centsFromValue(application?.requiredDepositAmount);
+  if (amount) return amount;
+
+  const rent =
+    centsFromValue(application?.monthlyRent) ||
+    centsFromValue(application?.requestedRent) ||
+    centsFromValue(application?.rentAmount) ||
+    centsFromValue(application?.rent);
+  return rent ? Math.round(rent / 2) : null;
+}
+
+function buildPropertyUnitLabel(application: any): string {
+  const propertyName = String(
+    application?.propertyName ||
+      application?.property?.name ||
+      application?.propertyAddress ||
+      application?.address ||
+      ""
+  ).trim();
+  const unitLabel = String(
+    application?.unitLabel ||
+      application?.unitName ||
+      application?.unitNumber ||
+      application?.unitApplied ||
+      application?.unit ||
+      ""
+  ).trim();
+  const normalizedUnit = /^unit\s+/i.test(unitLabel) ? unitLabel : unitLabel ? `Unit ${unitLabel}` : "";
+  if (propertyName && normalizedUnit) return `${propertyName}, ${normalizedUnit}`;
+  if (propertyName) return propertyName;
+  if (normalizedUnit) return normalizedUnit;
+  return "the property";
+}
+
+async function hydrateApplicationDisplayContext(application: any) {
+  const next = { ...(application || {}) };
+  if (!next.propertyName && next.propertyId) {
+    try {
+      const propSnap = await db.collection("properties").doc(String(next.propertyId)).get();
+      if (propSnap.exists) {
+        const prop = propSnap.data() as any;
+        next.propertyName = prop?.name || prop?.addressLine1 || prop?.address || null;
+      }
+    } catch {
+      // best-effort display context only
+    }
+  }
+  const unitId = String(next.unitId || next.unitApplied || next.unit || "").trim();
+  if (!next.unitLabel && unitId) {
+    try {
+      const unitSnap = await db.collection("units").doc(unitId).get();
+      if (unitSnap.exists) {
+        const unit = unitSnap.data() as any;
+        next.unitLabel = unit?.unitNumber || unit?.name || unit?.label || unitId;
+      }
+    } catch {
+      next.unitLabel = next.unitLabel || unitId;
+    }
+  }
+  if (!next.monthlyRent && !next.requestedRent && unitId) {
+    try {
+      const unitSnap = await db.collection("units").doc(unitId).get();
+      if (unitSnap.exists) {
+        const unit = unitSnap.data() as any;
+        next.monthlyRent = unit?.monthlyRent || unit?.rent || unit?.marketRent || null;
+      }
+    } catch {
+      // best-effort display context only
+    }
+  }
+  return next;
+}
+
 async function sendRentalApplicationDecisionEmail(params: {
   action: (typeof APPLICATION_DECISION_ACTIONS)[number];
   application: any;
@@ -196,7 +298,7 @@ async function sendRentalApplicationDecisionEmail(params: {
   const applicantFirstName = String(params.application?.applicant?.firstName || "").trim() || "there";
   const applicantLastName = String(params.application?.applicant?.lastName || "").trim();
   const applicantName = `${applicantFirstName} ${applicantLastName}`.trim();
-  const propertyLabel = String(params.application?.propertyName || params.application?.propertyId || "the property").trim();
+  const propertyLabel = buildPropertyUnitLabel(params.application);
   const publicAppBaseUrl = getPublicAppBaseUrl();
   const ctaUrl = params.landlordEmail ? `mailto:${encodeURIComponent(params.landlordEmail)}` : `${publicAppBaseUrl}/login`;
   const replyTo = params.landlordEmail || undefined;
@@ -212,11 +314,16 @@ async function sendRentalApplicationDecisionEmail(params: {
     if (!paymentEmail) {
       throw new Error("LANDLORD_PAYMENT_EMAIL_MISSING");
     }
-    const intro = `Hi ${applicantFirstName}, your rental application for ${propertyLabel} has been approved. To hold the unit, please send an e-transfer for one half of one month's rent to ${paymentEmail}.`;
+    const depositAmount = formatCadAmount(resolveApplicationDepositCents(params.application));
+    const depositText = depositAmount
+      ? `The required holding deposit is ${depositAmount}.`
+      : "The landlord will confirm the required holding deposit amount.";
+    const intro = `Hi ${applicantFirstName}, your rental application for ${propertyLabel} has been approved. ${depositText}`;
     const bullets = [
-      `Send the e-transfer to ${paymentEmail}.`,
-      "Include your full name and the property or unit reference in the transfer note.",
-      "Reply to this email if you need to confirm the next leasing steps.",
+      `If your landlord has asked for an e-transfer, send it to ${paymentEmail}.`,
+      `Include your full name and ${propertyLabel} in the transfer note.`,
+      "You will receive a separate RentChain tenant onboarding invite for the next leasing step.",
+      "Reply to this email before sending funds if you need to confirm payment instructions.",
     ];
     await sendEmail({
       to: applicantEmail,
@@ -1431,11 +1538,21 @@ router.post("/rental-applications/:id/decision-action", async (req: any, res) =>
 
     const emailResult = await sendRentalApplicationDecisionEmail({
       action: action as (typeof APPLICATION_DECISION_ACTIONS)[number],
-      application: data,
+      application: await hydrateApplicationDisplayContext(data),
       landlordEmail,
       requestInfoItems: requestedItems,
       customMessage: note,
     });
+
+    let tenantInviteResult: Awaited<ReturnType<typeof convertApplicationToTenant>> | null = null;
+    if (action === "approve") {
+      tenantInviteResult = await convertApplicationToTenant({
+        landlordId: applicationLandlordId || fallbackLandlordId,
+        applicationId: id,
+        runScreening: false,
+        actorUserId: actorUserId || undefined,
+      });
+    }
 
     const now = Date.now();
     const nextStatus =
@@ -1451,6 +1568,8 @@ router.post("/rental-applications/:id/decision-action", async (req: any, res) =>
         actorRole: role,
         emailSentAt: now,
         paymentEmail: emailResult?.paymentEmail || null,
+        tenantInviteUrl: tenantInviteResult?.inviteUrl || null,
+        tenantInviteEmailed: tenantInviteResult?.inviteEmailed ?? null,
         note,
         requestedItems: action === "request_info" ? requestedItems : [],
       },
@@ -1487,6 +1606,8 @@ router.post("/rental-applications/:id/decision-action", async (req: any, res) =>
         status: nextStatus,
         emailSent: true,
         paymentEmail: emailResult?.paymentEmail || null,
+        tenantInviteUrl: tenantInviteResult?.inviteUrl || null,
+        tenantInviteEmailed: tenantInviteResult?.inviteEmailed ?? null,
       },
     });
   } catch (err: any) {

--- a/rentchain-api/src/routes/tenantInvitesRoutes.ts
+++ b/rentchain-api/src/routes/tenantInvitesRoutes.ts
@@ -7,7 +7,7 @@ import { sendEmail } from "../services/emailService";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { requireCapability } from "../services/capabilityGuard";
 import {
-  createTenancyInvite,
+  createReplacementTenancyInvite,
   listTenancyInvitesForLandlord,
   redeemTenancyInvite,
 } from "../services/tenantPortal/tenantInviteService";
@@ -73,7 +73,7 @@ router.post("/", requireAuth, requireLandlordOrAdmin, rateLimitTenantInvitesUser
       rcPropId = null;
     }
 
-    const created = await createTenancyInvite({
+    const created = await createReplacementTenancyInvite({
       landlordId,
       rcPropId,
       propertyId: String(propertyId),
@@ -95,6 +95,7 @@ router.post("/", requireAuth, requireLandlordOrAdmin, rateLimitTenantInvitesUser
         inviteUrl,
         expiresAt: created.invite.expiresAt,
         invite: created.invite,
+        replacedInviteId: created.replacedInviteId,
         emailed: false,
         emailError: "EMAIL_NOT_CONFIGURED",
       });
@@ -136,6 +137,7 @@ router.post("/", requireAuth, requireLandlordOrAdmin, rateLimitTenantInvitesUser
       inviteUrl,
       expiresAt: created.invite.expiresAt,
       invite: created.invite,
+      replacedInviteId: created.replacedInviteId,
       emailed,
       emailError,
     });

--- a/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
+++ b/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone(value: any) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+const { sendEmailMock, addConvertedTenantMock, logAuditEventMock, createTenancyIfMissingMock } = vi.hoisted(() => ({
+  sendEmailMock: vi.fn(async () => undefined),
+  addConvertedTenantMock: vi.fn(),
+  logAuditEventMock: vi.fn(async () => undefined),
+  createTenancyIfMissingMock: vi.fn(async () => undefined),
+}));
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+        },
+      };
+    },
+    where: (field: string, op: string, value: any) => ({
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).entries())
+          .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
+          .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+        return { docs, empty: docs.length === 0 };
+      },
+    }),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../tenantDetailsService", () => ({ addConvertedTenant: addConvertedTenantMock }));
+vi.mock("../propertyService", () => ({ propertyService: { getById: vi.fn(() => null) } }));
+vi.mock("../screeningsService", () => ({ runScreeningWithCredits: vi.fn() }));
+vi.mock("../auditEventsService", () => ({ logAuditEvent: logAuditEventMock }));
+vi.mock("../emailService", () => ({ sendEmail: sendEmailMock }));
+vi.mock("../../email/templates/baseEmailTemplate", () => ({
+  buildEmailHtml: vi.fn(() => "<p>invite</p>"),
+  buildEmailText: vi.fn(() => "invite"),
+}));
+vi.mock("../tenanciesService", () => ({ createTenancyIfMissing: createTenancyIfMissingMock }));
+vi.mock("../tenantPortal/tenantEventLogService", () => ({
+  recordTenantEvent: vi.fn(async () => ({ id: "event-1" })),
+}));
+
+describe("applicationConversionService", () => {
+  beforeEach(() => {
+    collections.clear();
+    sendEmailMock.mockClear();
+    addConvertedTenantMock.mockClear();
+    logAuditEventMock.mockClear();
+    createTenancyIfMissingMock.mockClear();
+    process.env.EMAIL_FROM = "noreply@rentchain.test";
+    process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
+  });
+
+  it("converts rentalApplications records and creates a hashed tenant invite", async () => {
+    ensureCollection("rentalApplications").set("app-1", {
+      id: "app-1",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      applicant: {
+        firstName: "Jamie",
+        lastName: "Stone",
+        email: "jamie@example.com",
+      },
+      status: "APPROVED",
+    });
+
+    const { convertApplicationToTenant } = await import("../applicationConversionService");
+    const result = await convertApplicationToTenant({
+      landlordId: "landlord-1",
+      applicationId: "app-1",
+      runScreening: false,
+      actorUserId: "landlord-1",
+    });
+
+    expect(result.inviteUrl).toContain("/tenant/invite/");
+    expect(result.inviteEmailed).toBe(true);
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({ to: "jamie@example.com" }));
+    const invites = Array.from(ensureCollection("tenancy_invites").values());
+    expect(invites).toHaveLength(1);
+    expect(invites[0]?.token_hash).toBeTruthy();
+    expect(invites[0]?.token).toBeUndefined();
+    expect(invites[0]?.application_id).toBe("app-1");
+    expect(ensureCollection("rentalApplications").get("app-1")?.convertedTenantId).toBe(result.tenantId);
+  });
+});

--- a/rentchain-api/src/services/__tests__/tenantInviteService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantInviteService.test.ts
@@ -37,6 +37,14 @@ const dbMock = {
       };
     },
     where: (field: string, op: string, value: any) => ({
+      limit: (_count: number) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).entries())
+            .filter(([, data]) => applyWhereFilter(data, field, op, value))
+            .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
       get: async () => {
         const docs = Array.from(ensureCollection(name).entries())
           .filter(([, data]) => applyWhereFilter(data, field, op, value))
@@ -120,5 +128,44 @@ describe("tenantInviteService", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toBe("invite_expired");
+  });
+
+  it("replaces an active matching invite without retaining the raw token", async () => {
+    const { createReplacementTenancyInvite, redeemTenancyInvite } = await import("../tenantPortal/tenantInviteService");
+    const first = await createReplacementTenancyInvite({
+      landlordId: "landlord-4",
+      propertyId: "prop-4",
+      applicationId: "app-4",
+      unitId: "unit-4",
+      invitedEmail: "tenant4@example.com",
+      createdBy: "landlord-4",
+    });
+    const second = await createReplacementTenancyInvite({
+      landlordId: "landlord-4",
+      propertyId: "prop-4",
+      applicationId: "app-4",
+      unitId: "unit-4",
+      invitedEmail: "tenant4@example.com",
+      createdBy: "landlord-4",
+    });
+
+    expect(second.replacedInviteId).toBe(first.invite.id);
+    expect(ensureCollection("tenancy_invites").get(first.invite.id)?.status).toBe("superseded");
+    expect(ensureCollection("tenancy_invites").get(first.invite.id)?.token).toBeUndefined();
+
+    const oldRedeem = await redeemTenancyInvite({
+      token: first.token,
+      redeemedByUid: "user-4",
+      redeemedByEmail: "tenant4@example.com",
+    });
+    const newRedeem = await redeemTenancyInvite({
+      token: second.token,
+      redeemedByUid: "user-4",
+      redeemedByEmail: "tenant4@example.com",
+    });
+
+    expect(oldRedeem.ok).toBe(false);
+    expect(oldRedeem.error).toBe("invite_expired");
+    expect(newRedeem.ok).toBe(true);
   });
 });

--- a/rentchain-api/src/services/applicationConversionService.ts
+++ b/rentchain-api/src/services/applicationConversionService.ts
@@ -1,9 +1,5 @@
 // @ts-nocheck
 import crypto from "crypto";
-import {
-  getApplicationByIdAsync,
-  saveApplicationAsync,
-} from "./applicationsService";
 import { addConvertedTenant } from "./tenantDetailsService";
 import { propertyService } from "./propertyService";
 import { runScreeningWithCredits } from "./screeningsService";
@@ -12,6 +8,26 @@ import { db } from "../config/firebase";
 import { sendEmail } from "./emailService";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { createTenancyIfMissing } from "./tenanciesService";
+import { createReplacementTenancyInvite } from "./tenantPortal/tenantInviteService";
+
+async function loadApplicationForConversion(applicationId: string): Promise<{ application: any; collectionName: string } | null> {
+  const rentalSnap = await db.collection("rentalApplications").doc(applicationId).get();
+  if (rentalSnap.exists) {
+    return { application: { id: rentalSnap.id, ...(rentalSnap.data() as any) }, collectionName: "rentalApplications" };
+  }
+  const legacySnap = await db.collection("applications").doc(applicationId).get();
+  if (legacySnap.exists) {
+    return { application: { id: legacySnap.id, ...(legacySnap.data() as any) }, collectionName: "applications" };
+  }
+  return null;
+}
+
+async function saveConvertedApplication(collectionName: string, updated: any) {
+  await db.collection(collectionName).doc(String(updated.id)).set(updated, { merge: true });
+  if (collectionName !== "applications") {
+    await db.collection("applications").doc(String(updated.id)).set(updated, { merge: true });
+  }
+}
 
 export async function convertApplicationToTenant(params: {
   landlordId: string;
@@ -25,13 +41,22 @@ export async function convertApplicationToTenant(params: {
   inviteUrl?: string | null;
   inviteEmailed?: boolean;
 }> {
-  const application = await getApplicationByIdAsync(params.applicationId);
-  if (!application) {
+  const loaded = await loadApplicationForConversion(params.applicationId);
+  if (!loaded) {
     throw new Error("Application not found");
   }
+  const application = loaded.application;
   if (application.landlordId && application.landlordId !== params.landlordId) {
     throw new Error("Forbidden");
   }
+  const applicantFirstName = String(application?.applicant?.firstName || application?.firstName || "").trim();
+  const applicantLastName = String(application?.applicant?.lastName || application?.lastName || "").trim();
+  const applicantFullName =
+    String(application?.applicantFullName || application?.fullName || "").trim() ||
+    `${applicantFirstName} ${applicantLastName}`.trim();
+  const applicantEmail = String(application?.applicantEmail || application?.email || application?.applicant?.email || "").trim().toLowerCase();
+  const applicantPhone = String(application?.applicantPhone || application?.phone || application?.applicant?.phoneHome || application?.applicant?.phoneWork || "").trim();
+  const unitId = application.unitId ?? application.unitApplied ?? application.unit ?? null;
 
   if (application.convertedTenantId) {
     await logAuditEvent({
@@ -60,15 +85,14 @@ export async function convertApplicationToTenant(params: {
     id: tenantId,
     landlordId: params.landlordId,
     fullName:
-      application.applicantFullName ||
-      application.fullName ||
+      applicantFullName ||
       "Converted Applicant",
-    email: application.applicantEmail ?? application.email ?? null,
-    phone: application.applicantPhone ?? application.phone ?? null,
+    email: applicantEmail || null,
+    phone: applicantPhone || null,
     propertyName: application.propertyName ?? null,
     propertyId: application.propertyId ?? null,
-    unitId: application.unitApplied ?? application.unit ?? null,
-    unit: application.unitApplied ?? application.unit ?? null,
+    unitId,
+    unit: unitId,
     leaseStart: application.leaseStartDate ?? application.moveInDate ?? null,
     leaseEnd: null,
     monthlyRent: application.requestedRent ?? null,
@@ -93,19 +117,19 @@ export async function convertApplicationToTenant(params: {
       tenantId,
       landlordId: params.landlordId,
       propertyId: application.propertyId ?? null,
-      unitId: application.unitApplied ?? application.unit ?? null,
-      unitLabel: application.unitApplied ?? application.unit ?? null,
+      unitId,
+      unitLabel: unitId,
       moveInAt: application.leaseStartDate ?? application.moveInDate ?? null,
     });
   } catch (err) {
     console.warn("[applicationConversion] tenancy backfill failed", err);
   }
 
-  if (application.propertyId && application.unitApplied) {
+  if (application.propertyId && unitId) {
     const property = propertyService.getById(application.propertyId);
     if (property?.units) {
       const unit = property.units.find(
-        (u) => u.unitNumber === application.unitApplied
+        (u) => u.unitNumber === unitId
       );
       if (unit) {
         unit.status = "occupied";
@@ -117,9 +141,11 @@ export async function convertApplicationToTenant(params: {
     landlordId: params.landlordId,
     tenantId,
     propertyId: application.propertyId ?? null,
-    unitId: application.unitApplied ?? application.unit ?? null,
-    tenantEmail: application.applicantEmail ?? application.email ?? null,
-    tenantName: application.applicantFullName ?? application.fullName ?? null,
+    unitId,
+    applicationId: application.id,
+    tenantEmail: applicantEmail || null,
+    tenantName: applicantFullName || null,
+    createdBy: params.actorUserId || params.landlordId,
   });
 
   const updated = {
@@ -162,7 +188,7 @@ export async function convertApplicationToTenant(params: {
     }
   }
 
-  await saveApplicationAsync(updated);
+  await saveConvertedApplication(loaded.collectionName, updated);
 
   await logAuditEvent({
     landlordId: params.landlordId,
@@ -188,29 +214,29 @@ async function createAndEmailInvite(opts: {
   tenantId: string;
   propertyId?: string | null;
   unitId?: string | null;
+  applicationId?: string | null;
   tenantEmail?: string | null;
   tenantName?: string | null;
+  createdBy?: string | null;
 }): Promise<{ inviteUrl: string | null; inviteEmailed: boolean }> {
   const tenantEmail = (opts.tenantEmail || "").trim();
   const hasEmail = !!tenantEmail;
-  const token = crypto.randomBytes(24).toString("hex");
-  const now = Date.now();
-  const expiresAt = now + 1000 * 60 * 60 * 24 * 7;
-  const baseUrl = (process.env.PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
-  const inviteUrl = `${baseUrl}/tenant/invite/${token}`;
-
-  await db.collection("tenantInvites").doc(token).set({
-    token,
+  if (!opts.propertyId) {
+    console.warn("[applicationConversion] missing propertyId, skipping tenant invite");
+    return { inviteUrl: null, inviteEmailed: false };
+  }
+  const created = await createReplacementTenancyInvite({
     landlordId: opts.landlordId,
-    tenantEmail: hasEmail ? tenantEmail : null,
-    tenantName: opts.tenantName || null,
-    propertyId: opts.propertyId || null,
+    propertyId: opts.propertyId,
+    applicationId: opts.applicationId || null,
+    invitedEmail: tenantEmail || null,
+    invitedName: opts.tenantName || null,
     unitId: opts.unitId || null,
-    tenantId: opts.tenantId || null,
-    status: "pending",
-    createdAt: now,
-    expiresAt,
+    leaseId: null,
+    createdBy: opts.createdBy || opts.landlordId,
   });
+  const baseUrl = (process.env.PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+  const inviteUrl = `${baseUrl}/tenant/invite/${created.token}`;
 
   if (!hasEmail) {
     return { inviteUrl, inviteEmailed: false };

--- a/rentchain-api/src/services/tenantPortal/tenantInviteService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInviteService.ts
@@ -33,7 +33,7 @@ export type TenancyInviteRecord = {
   leaseId: string | null;
   invitedEmail: string | null;
   invitedName: string | null;
-  status: "pending" | "redeemed" | "expired";
+  status: "pending" | "redeemed" | "expired" | "superseded";
   createdAt: number | null;
   expiresAt: number | null;
   redeemedAt: number | null;
@@ -71,12 +71,75 @@ function mapInvite(docId: string, data: any): TenancyInviteRecord {
     leaseId: String(data?.lease_id || data?.leaseId || "").trim() || null,
     invitedEmail: normalizeEmail(data?.invited_email || data?.invitedEmail),
     invitedName: String(data?.invited_name || data?.invitedName || "").trim() || null,
-    status: data?.status === "redeemed" ? "redeemed" : data?.status === "expired" ? "expired" : "pending",
+    status:
+      data?.status === "redeemed"
+        ? "redeemed"
+        : data?.status === "expired"
+        ? "expired"
+        : data?.status === "superseded"
+        ? "superseded"
+        : "pending",
     createdAt: typeof data?.created_at === "number" ? data.created_at : typeof data?.createdAt === "number" ? data.createdAt : null,
     expiresAt: typeof data?.expires_at === "number" ? data.expires_at : typeof data?.expiresAt === "number" ? data.expiresAt : null,
     redeemedAt: typeof data?.redeemed_at === "number" ? data.redeemed_at : typeof data?.redeemedAt === "number" ? data.redeemedAt : null,
     redeemedByUid: String(data?.redeemed_by_uid || data?.redeemedByUid || "").trim() || null,
   };
+}
+
+async function findPendingInviteForContext(input: CreateTenancyInviteInput): Promise<TenancyInviteRecord | null> {
+  const landlordId = String(input.landlordId || "").trim();
+  const propertyId = String(input.propertyId || "").trim();
+  const invitedEmail = normalizeEmail(input.invitedEmail);
+  if (!landlordId || !propertyId || !invitedEmail) return null;
+
+  const snap = await db.collection("tenancy_invites").where("landlord_id", "==", landlordId).get();
+  const now = nowMillis();
+  const matches = snap.docs
+    .map((doc: any) => mapInvite(doc.id, doc.data() as any))
+    .filter((invite) => {
+      if (invite.status !== "pending") return false;
+      if (invite.expiresAt && invite.expiresAt <= now) return false;
+      return (
+        invite.propertyId === propertyId &&
+        invite.invitedEmail === invitedEmail &&
+        String(invite.applicationId || "") === String(input.applicationId || "") &&
+        String(invite.unitId || "") === String(input.unitId || "") &&
+        String(invite.leaseId || "") === String(input.leaseId || "")
+      );
+    })
+    .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0));
+
+  return matches[0] || null;
+}
+
+async function supersedeInvite(invite: TenancyInviteRecord, replacementTokenPreview: string, actorId: string) {
+  const now = nowMillis();
+  await db.collection("tenancy_invites").doc(invite.id).set(
+    {
+      status: "superseded",
+      superseded_at: now,
+      superseded_by_token_preview: replacementTokenPreview,
+      updated_at: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  await recordTenantEvent({
+    eventType: "tenant_invite_superseded",
+    entityType: "tenancy_invite",
+    entityId: invite.id,
+    createdBy: actorId,
+    context: {
+      rc_prop_id: invite.rc_prop_id,
+      propertyId: invite.propertyId,
+      applicationId: invite.applicationId,
+    },
+    payload: {
+      invitedEmail: invite.invitedEmail,
+      tokenPreview: invite.tokenPreview,
+      replacementTokenPreview,
+    },
+  });
 }
 
 export async function createTenancyInvite(input: CreateTenancyInviteInput): Promise<{
@@ -132,6 +195,26 @@ export async function createTenancyInvite(input: CreateTenancyInviteInput): Prom
   };
 }
 
+export async function createReplacementTenancyInvite(input: CreateTenancyInviteInput): Promise<{
+  token: string;
+  invite: TenancyInviteRecord;
+  replacedInviteId: string | null;
+}> {
+  const existing = await findPendingInviteForContext(input);
+  const created = await createTenancyInvite(input);
+  if (existing) {
+    await supersedeInvite(existing, created.invite.tokenPreview, String(input.createdBy || input.landlordId || "system"));
+  }
+  return { ...created, replacedInviteId: existing?.id || null };
+}
+
+export async function resolveTenancyInviteByToken(token: string): Promise<TenancyInviteRecord | null> {
+  const tokenHash = hashTenancyInviteToken(token);
+  const snap = await db.collection("tenancy_invites").doc(tokenHash).get();
+  if (!snap.exists) return null;
+  return mapInvite(snap.id, snap.data() as any);
+}
+
 export async function listTenancyInvitesForLandlord(landlordId: string): Promise<TenancyInviteRecord[]> {
   const snap = await db.collection("tenancy_invites").where("landlord_id", "==", String(landlordId || "").trim()).get();
   return snap.docs
@@ -158,6 +241,9 @@ export async function redeemTenancyInvite(input: RedeemTenancyInviteInput): Prom
   }
   if (invite.status === "redeemed") {
     return { ok: false, error: "invite_used" };
+  }
+  if (invite.status === "superseded" || invite.status === "expired") {
+    return { ok: false, error: "invite_expired" };
   }
 
   const redeemedEmail = normalizeEmail(input.redeemedByEmail);


### PR DESCRIPTION
## Summary
- Notifies landlords when public applicants complete rental applications, using readable applicant/property context and the applications dashboard path.
- Hardens application approval email copy to avoid raw Firestore IDs, show calculated/fallback holding deposit wording, and keep e-transfer instructions accurate without implying payment automation.
- Aligns application approval with tenant invite creation by automatically creating/replacing hashed tenancy invites and emailing applicants after approval.
- Repairs tenant invite onboarding by resolving and accepting hashed `tenancy_invites` tokens through `/auth/onboard`, while preserving legacy raw-token invite compatibility.
- Adds deterministic duplicate/resend behavior by superseding active matching invites and issuing a new valid token.

## Audit / Root Cause
- Manual tenant invites were written to hashed `tenancy_invites`, but `/auth/onboard/resolve` and `/auth/onboard/accept` only looked up legacy raw-token `tenantInvites`, which produced the observed "Invite not found" state.
- Application approval conversion also used legacy application storage assumptions, while landlord approval operates on `rentalApplications`, so automatic conversion/invite creation was not reliable.
- Approval email rendering could fall back to raw property IDs and hardcoded a generic deposit phrase instead of deriving a dollar amount where possible.
- Public application submission did not send landlord completion notification.

## Validation
- `git diff --check`
- API targeted tests for application approval, public application notification, tenant invites, auth onboarding invite resolution, application conversion, tenant portal, application apply, notification derivation
- API full test suite: `Test Files 346 passed (346)`, `Tests 1508 passed (1508)`
- API build passed
- Frontend targeted route test passed: `42 passed`
- Frontend full test suite: `Test Files 257 passed (257)`, `Tests 947 passed (947)`
- Frontend build passed with existing Vite chunk-size warning only

## Scope Boundaries
- No payment rail or bank request integration added.
- No tenant onboarding redesign or auth-core rewrite.
- No public access widening.
- No raw invite tokens stored in hashed tenancy invite records.
- No unrelated institution trust systems changed.