### PR TITLE
Institution review invite flow v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1599,6 +1599,95 @@ describe("tenantPortalRoutes foundation", () => {
     expect(revoked.body?.data?.recipientAccess?.enabled).toBe(false);
   });
 
+  it("creates institution review invites with conservative email and authenticated review linkage", async () => {
+    process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+      }),
+    };
+
+    const missingConsent = await invokeRouter(router, {
+      method: "POST",
+      url: "/institution-access/invites",
+      body: {
+        audience: "insurer",
+        recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+        expiresInDays: 7,
+        consentAccepted: false,
+      },
+      headers,
+    });
+    expect(missingConsent.status).toBe(400);
+    expect(missingConsent.body?.error).toBe("TENANT_INSTITUTION_ACCESS_CONSENT_REQUIRED");
+
+    const invited = await invokeRouter(router, {
+      method: "POST",
+      url: "/institution-access/invites",
+      body: {
+        audience: "insurer",
+        recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+        expiresInDays: 7,
+        consentAccepted: true,
+      },
+      headers,
+    });
+
+    expect(invited.status).toBe(200);
+    expect(invited.body?.data?.lifecycle).toBe("active");
+    expect(invited.body?.data?.institutionReviewInvite).toEqual(
+      expect.objectContaining({
+        status: "invited",
+        recipientAuthenticationRequired: true,
+        inviteTokenIssued: false,
+        bearerAccessEnabled: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        metadataOnly: true,
+      })
+    );
+    expect(invited.body?.data?.recipientAccess).toEqual(
+      expect.objectContaining({
+        enabled: true,
+        accessTokenIssued: false,
+        recipientAuthenticationRequired: true,
+        sessionBound: true,
+        downloadEnabled: false,
+      })
+    );
+    expect(invited.body?.data?.institutionReviewSession).toEqual(
+      expect.objectContaining({
+        accessGrantId: invited.body?.data?.grantId,
+        lifecycle: "pending",
+        metadataOnly: true,
+        downloadEnabled: false,
+      })
+    );
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const email = sendEmailMock.mock.calls[0]?.[0] || {};
+    expect(email.to).toBe("reviewer@example.com");
+    expect(email.subject).toMatch(/trust review invitation/i);
+    const emailPayload = JSON.stringify(email);
+    expect(emailPayload).toContain("/recipient/trust-review/");
+    expect(emailPayload).toContain("must sign in");
+    expect(emailPayload).toContain("metadata-only");
+    expect(emailPayload).not.toContain("verified tenant");
+    expect(emailPayload).toContain("not an approval");
+    expect(emailPayload).not.toContain("prop-1");
+    expect(emailPayload).not.toContain("rawProviderPayload");
+    expect(invited.body?.data?.auditTimeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "institution_review_invite_sent", reason: "invite_sent" }),
+        expect.objectContaining({ eventType: "institution_review_invite_created", reason: "invite_created" }),
+      ])
+    );
+    expect(ensureCollection("tenantSharePackages").size).toBe(0);
+  });
+
   it("creates a tenant-owned metadata-only institutional handoff draft safely", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -69,6 +69,7 @@ import {
   revokeTenantTrustExport,
 } from "../services/tenantPortal/tenantTrustExportService";
 import {
+  createInstitutionReviewInvite,
   createTenantInstitutionAccessGrant,
   listTenantInstitutionAccessGrants,
   previewTenantInstitutionAccess,
@@ -3413,6 +3414,49 @@ router.post("/institution-access/grants", requireTenantWorkspaceIdentity, async 
       message: err?.message || "failed",
     });
     return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_CREATE_FAILED" });
+  }
+});
+
+router.post("/institution-access/invites", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const invite = await createInstitutionReviewInvite({
+      tenantId,
+      audience: req.body?.audience,
+      purpose: req.body?.purpose,
+      recipient: req.body?.recipient,
+      expiresInDays: req.body?.expiresInDays,
+      consentAccepted: req.body?.consentAccepted === true,
+    });
+    if (!invite) {
+      return res.status(404).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_UNAVAILABLE" });
+    }
+    return res.json({ ok: true, data: invite });
+  } catch (err: any) {
+    if (err?.message === "tenant_institution_access_consent_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_CONSENT_REQUIRED" });
+    }
+    if (err?.message === "tenant_institution_access_recipient_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_RECIPIENT_REQUIRED" });
+    }
+    if (err?.message === "tenant_institution_access_expiration_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_EXPIRATION_REQUIRED" });
+    }
+    if (err?.message === "tenant_institution_access_policy_blocked") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_POLICY_BLOCKED" });
+    }
+    console.error("[tenant/institution-access:invite] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_INVITE_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { db } from "../../config/firebase";
+import { buildEmailHtml, buildEmailText } from "../../email/templates/baseEmailTemplate";
 import {
   deriveInstitutionReviewSession,
   type InstitutionReviewSessionSummary,
@@ -12,6 +13,7 @@ import {
   type TenantTrustExportAudience,
   type TenantTrustExportPurpose,
 } from "./tenantTrustExportService";
+import { sendEmail } from "../emailService";
 
 const COLLECTION = "tenantInstitutionAccessGrants";
 const SESSION_COLLECTION = "recipientTrustReviewSessions";
@@ -79,14 +81,13 @@ export type TenantInstitutionAccessPreview = {
   providerIntegrationEnabled: false;
   automatedDecisioningEnabled: false;
   recipientAccess: {
-    enabled: false;
-    accessUrl: null;
+    enabled: boolean;
+    accessUrl: string | null;
     accessTokenIssued: false;
     recipientAuthenticationRequired: true;
     sessionBound: true;
     downloadEnabled: false;
-    summary:
-      "Recipient access is modeled for controlled future review only; no public link or external delivery is created by this grant.";
+    summary: string;
   };
   package: InstitutionalTrustExportPackage;
   includedClaims: Array<{
@@ -106,6 +107,40 @@ export type TenantInstitutionAccessPreview = {
   disclaimers: string[];
 };
 
+export type InstitutionReviewInviteStatus =
+  | "not_created"
+  | "invited"
+  | "viewed"
+  | "authenticated"
+  | "expired"
+  | "revoked"
+  | "blocked"
+  | "send_failed";
+
+export type InstitutionReviewInviteSummary = {
+  schemaVersion: "institution_review_invite.v1";
+  status: InstitutionReviewInviteStatus;
+  recipientEmail: string;
+  redactedRecipientEmail: string;
+  organizationName: string | null;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  reviewUrl: string | null;
+  createdAt: string | null;
+  sentAt: string | null;
+  openedAt: string | null;
+  authenticatedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  recipientAuthenticationRequired: true;
+  inviteTokenIssued: false;
+  bearerAccessEnabled: false;
+  publicAccessEnabled: false;
+  downloadEnabled: false;
+  metadataOnly: true;
+  summary: string;
+};
+
 export type TenantInstitutionAccessGrantEvent = {
   eventType:
     | "tenant_institution_access_granted"
@@ -120,13 +155,39 @@ export type TenantInstitutionAccessGrantEvent = {
     | "recipient_review_session_expired"
     | "recipient_review_session_revoked"
     | "recipient_review_session_blocked"
-    | "recipient_review_session_reauthenticated";
+    | "recipient_review_session_reauthenticated"
+    | "institution_review_invite_created"
+    | "institution_review_invite_sent"
+    | "institution_review_invite_opened"
+    | "institution_review_invite_authenticated"
+    | "institution_review_invite_revoked"
+    | "institution_review_invite_expired"
+    | "institution_review_invite_blocked";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   metadataOnly: true;
-  outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated";
-  reason?: RecipientTrustReviewAccessDecision["reason"] | "access_granted" | "access_revoked" | "session_started";
-  status?: RecipientTrustReviewStatus | "granted" | "active";
+  outcome?:
+    | "invite_created"
+    | "invite_sent"
+    | "invite_opened"
+    | "invite_authenticated"
+    | "granted"
+    | "opened"
+    | "blocked"
+    | "revoked"
+    | "expired"
+    | "session_started"
+    | "reauthenticated";
+  reason?:
+    | RecipientTrustReviewAccessDecision["reason"]
+    | "access_granted"
+    | "access_revoked"
+    | "session_started"
+    | "invite_created"
+    | "invite_sent"
+    | "invite_opened"
+    | "invite_authenticated";
+  status?: RecipientTrustReviewStatus | "granted" | "active" | "invited" | "viewed" | "authenticated" | "send_failed";
 };
 
 type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessPreview & {
@@ -136,11 +197,13 @@ type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessPreview & {
   updatedAt: string;
   events: TenantInstitutionAccessGrantEvent[];
   tenantId: string;
+  institutionReviewInvite?: InstitutionReviewInviteSummary;
 };
 
 export type TenantInstitutionAccessGrant = Omit<TenantInstitutionAccessStoredGrant, "tenantId"> & {
   auditSummary: TenantInstitutionAccessAuditSummary;
   auditTimeline: TenantInstitutionAccessAuditEvent[];
+  institutionReviewSession: InstitutionReviewSessionSummary;
 };
 
 export type RecipientTrustReviewStatus =
@@ -250,6 +313,10 @@ export type RecipientTrustReviewResult = {
 };
 
 export type TenantInstitutionAccessAuditOutcome =
+  | "invite_created"
+  | "invite_sent"
+  | "invite_opened"
+  | "invite_authenticated"
   | "granted"
   | "opened"
   | "blocked"
@@ -263,13 +330,27 @@ export type TenantInstitutionAccessAuditEvent = {
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   outcome: TenantInstitutionAccessAuditOutcome;
-  status: RecipientTrustReviewStatus | "granted" | "revoked" | "expired" | "blocked" | "active";
+  status:
+    | RecipientTrustReviewStatus
+    | "granted"
+    | "revoked"
+    | "expired"
+    | "blocked"
+    | "active"
+    | "invited"
+    | "viewed"
+    | "authenticated"
+    | "send_failed";
   reason:
     | RecipientTrustReviewAccessDecision["reason"]
     | "access_granted"
     | "access_revoked"
     | "access_expired"
     | "access_blocked"
+    | "invite_created"
+    | "invite_sent"
+    | "invite_opened"
+    | "invite_authenticated"
     | "session_started"
     | "recipient_session_expired"
     | "recipient_session_revoked"
@@ -617,13 +698,67 @@ function accessPreviewFromTrustPackage(params: {
   };
 }
 
+function institutionReviewUrl(grantId: string) {
+  const base = String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(
+    /\/$/,
+    ""
+  );
+  return `${base}/recipient/trust-review/${encodeURIComponent(grantId)}`;
+}
+
+function inviteSummaryForGrant(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  status?: InstitutionReviewInviteStatus;
+  reviewUrl?: string | null;
+  createdAt?: string | null;
+  sentAt?: string | null;
+  openedAt?: string | null;
+  authenticatedAt?: string | null;
+}) {
+  const existing = params.grant.institutionReviewInvite || null;
+  const revoked = params.grant.lifecycle === "revoked" || Boolean(params.grant.revokedAt || params.grant.consent?.revokedAt);
+  const expired = params.grant.lifecycle === "expired" || Boolean(params.grant.expiresAt && Date.parse(params.grant.expiresAt) <= Date.now());
+  const status =
+    params.status ||
+    (revoked ? "revoked" : expired ? "expired" : existing?.status && existing.status !== "not_created" ? existing.status : "invited");
+  return {
+    schemaVersion: "institution_review_invite.v1" as const,
+    status,
+    recipientEmail: params.grant.recipient?.email || "",
+    redactedRecipientEmail: redactEmail(params.grant.recipient?.email),
+    organizationName: params.grant.recipient?.organizationName || null,
+    audience: params.grant.audience,
+    purpose: params.grant.purpose,
+    reviewUrl: params.reviewUrl === undefined ? existing?.reviewUrl || institutionReviewUrl(params.grant.grantId) : params.reviewUrl,
+    createdAt: params.createdAt === undefined ? existing?.createdAt || params.grant.createdAt || null : params.createdAt,
+    sentAt: params.sentAt === undefined ? existing?.sentAt || null : params.sentAt,
+    openedAt: params.openedAt === undefined ? existing?.openedAt || null : params.openedAt,
+    authenticatedAt: params.authenticatedAt === undefined ? existing?.authenticatedAt || null : params.authenticatedAt,
+    expiresAt: params.grant.expiresAt || null,
+    revokedAt: params.grant.revokedAt || params.grant.consent?.revokedAt || null,
+    recipientAuthenticationRequired: true as const,
+    inviteTokenIssued: false as const,
+    bearerAccessEnabled: false as const,
+    publicAccessEnabled: false as const,
+    downloadEnabled: false as const,
+    metadataOnly: true as const,
+    summary:
+      "This invitation points the recipient to an authenticated, tenant-authorized, metadata-only trust review. The invite link is not bearer authorization.",
+  };
+}
+
 function outcomeForEventType(eventType: TenantInstitutionAccessAuditEvent["eventType"]): TenantInstitutionAccessAuditOutcome {
+  if (eventType === "institution_review_invite_created") return "invite_created";
+  if (eventType === "institution_review_invite_sent") return "invite_sent";
+  if (eventType === "institution_review_invite_opened") return "invite_opened";
+  if (eventType === "institution_review_invite_authenticated") return "invite_authenticated";
   if (eventType === "tenant_institution_access_granted") return "granted";
   if (eventType === "tenant_institution_access_revoked" || eventType === "recipient_trust_review_revoked") return "revoked";
   if (
     eventType === "tenant_institution_access_expired" ||
     eventType === "recipient_trust_review_expired" ||
-    eventType === "recipient_review_session_expired"
+    eventType === "recipient_review_session_expired" ||
+    eventType === "institution_review_invite_expired"
   ) {
     return "expired";
   }
@@ -635,12 +770,22 @@ function outcomeForEventType(eventType: TenantInstitutionAccessAuditEvent["event
 
 function statusForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"][number]): TenantInstitutionAccessAuditEvent["status"] {
   if (event.status) return event.status as TenantInstitutionAccessAuditEvent["status"];
+  if (event.eventType === "institution_review_invite_created" || event.eventType === "institution_review_invite_sent") return "invited";
+  if (event.eventType === "institution_review_invite_opened") return "viewed";
+  if (event.eventType === "institution_review_invite_authenticated") return "authenticated";
   if (event.eventType === "tenant_institution_access_granted") return "granted";
-  if (event.eventType === "tenant_institution_access_revoked" || event.eventType === "recipient_trust_review_revoked") return "revoked";
+  if (
+    event.eventType === "tenant_institution_access_revoked" ||
+    event.eventType === "recipient_trust_review_revoked" ||
+    event.eventType === "institution_review_invite_revoked"
+  ) {
+    return "revoked";
+  }
   if (
     event.eventType === "tenant_institution_access_expired" ||
     event.eventType === "recipient_trust_review_expired" ||
-    event.eventType === "recipient_review_session_expired"
+    event.eventType === "recipient_review_session_expired" ||
+    event.eventType === "institution_review_invite_expired"
   ) {
     return "expired";
   }
@@ -652,8 +797,16 @@ function statusForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
 
 function reasonForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"][number]): TenantInstitutionAccessAuditEvent["reason"] {
   if (event.reason) return event.reason as TenantInstitutionAccessAuditEvent["reason"];
+  if (event.eventType === "institution_review_invite_created") return "invite_created";
+  if (event.eventType === "institution_review_invite_sent") return "invite_sent";
+  if (event.eventType === "institution_review_invite_opened") return "invite_opened";
+  if (event.eventType === "institution_review_invite_authenticated") return "invite_authenticated";
   if (event.eventType === "tenant_institution_access_granted") return "access_granted";
-  if (event.eventType === "tenant_institution_access_revoked" || event.eventType === "recipient_trust_review_revoked") {
+  if (
+    event.eventType === "tenant_institution_access_revoked" ||
+    event.eventType === "recipient_trust_review_revoked" ||
+    event.eventType === "institution_review_invite_revoked"
+  ) {
     return "access_revoked";
   }
   if (event.eventType === "recipient_review_session_revoked") return "recipient_session_revoked";
@@ -662,7 +815,8 @@ function reasonForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
   if (event.eventType === "recipient_review_session_started") return "session_started";
   if (
     event.eventType === "tenant_institution_access_expired" ||
-    event.eventType === "recipient_trust_review_expired"
+    event.eventType === "recipient_trust_review_expired" ||
+    event.eventType === "institution_review_invite_expired"
   ) {
     return "access_expired";
   }
@@ -736,7 +890,19 @@ function buildAccessAudit(record: TenantInstitutionAccessStoredGrant): {
 function publicGrant(record: TenantInstitutionAccessStoredGrant): TenantInstitutionAccessGrant {
   const { tenantId: _tenantId, ...rest } = record;
   const { auditSummary, auditTimeline } = buildAccessAudit(record);
-  return { ...rest, auditSummary, auditTimeline };
+  const normalizedRecord = {
+    ...rest,
+    institutionReviewInvite: record.institutionReviewInvite || inviteSummaryForGrant({ grant: record, status: "not_created", reviewUrl: null }),
+  };
+  return {
+    ...normalizedRecord,
+    auditSummary,
+    auditTimeline,
+    institutionReviewSession: deriveInstitutionReviewSession({
+      accessGrant: record,
+      generatedAt: record.updatedAt || record.generatedAt,
+    }),
+  };
 }
 
 function supportDiagnosticFromGrant(record: TenantInstitutionAccessStoredGrant): SupportInstitutionAccessDiagnosticSummary {
@@ -1305,6 +1471,24 @@ export async function getRecipientTrustReview(params: {
     status: "available",
     reason: "review_available",
   });
+  if (grant.institutionReviewInvite) {
+    await appendGrantEvent({
+      grant,
+      eventType: "institution_review_invite_authenticated",
+      occurredAt: reviewedAt,
+      status: "authenticated",
+      reason: "invite_authenticated",
+      outcome: "invite_authenticated",
+    });
+    const invite = inviteSummaryForGrant({
+      grant,
+      status: "authenticated",
+      openedAt: grant.institutionReviewInvite.openedAt || reviewedAt,
+      authenticatedAt: reviewedAt,
+    });
+    await db.collection(COLLECTION).doc(grant.grantId).set({ institutionReviewInvite: invite, updatedAt: reviewedAt }, { merge: true });
+    grant.institutionReviewInvite = invite;
+  }
 
   return {
     decision: {
@@ -1415,6 +1599,204 @@ export async function createTenantInstitutionAccessGrant(params: {
   return publicGrant(record);
 }
 
+async function findReusableInviteGrant(params: {
+  tenantId: string;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  recipientEmail: string;
+}) {
+  const snap = await db.collection(COLLECTION).where("tenantId", "==", params.tenantId).limit(25).get();
+  const now = Date.now();
+  const match = (snap.docs || [])
+    .map((doc: any) => asGrant(String(doc.id || ""), doc.data?.() || {}))
+    .find((grant) => {
+      const expiresAt = grant.expiresAt ? Date.parse(grant.expiresAt) : 0;
+      return (
+        grant.audience === params.audience &&
+        grant.purpose === params.purpose &&
+        normalizeEmail(grant.recipient?.email) === params.recipientEmail &&
+        grant.lifecycle === "active" &&
+        grant.consent?.granted === true &&
+        (!expiresAt || expiresAt > now) &&
+        grant.package?.status === "export_ready"
+      );
+    });
+  return match || null;
+}
+
+async function sendInstitutionReviewInviteEmail(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  reviewUrl: string;
+}) {
+  const audienceLabel = params.grant.audience.replace(/_/g, " ");
+  const purposeLabel = params.grant.purpose.replace(/_/g, " ");
+  const organization = params.grant.recipient.organizationName
+    ? ` for ${params.grant.recipient.organizationName}`
+    : "";
+  const intro = `A RentChain tenant has authorized a limited institution trust review${organization}. You must sign in with ${params.grant.recipient.email} before any review summary can be shown.`;
+  const bullets = [
+    `Audience: ${audienceLabel}`,
+    `Purpose: ${purposeLabel}`,
+    `Expires: ${params.grant.expiresAt || "Time-bound access"}`,
+    "The review is metadata-only, view-only, and tenant-mediated.",
+    "This is not an approval, eligibility decision, credit report, public profile, or automated decision.",
+    "Raw identity documents, provider payloads, support/internal notes, and downloads are not included.",
+  ];
+  await sendEmail({
+    to: params.grant.recipient.email,
+    from: process.env.EMAIL_FROM || process.env.FROM_EMAIL,
+    subject: "RentChain tenant-authorized trust review invitation",
+    text: buildEmailText({
+      intro,
+      bullets,
+      ctaText: "Sign in to review",
+      ctaUrl: params.reviewUrl,
+      footerNote:
+        "This invitation does not grant access by itself. Recipient authentication and tenant authorization are required before review.",
+    }),
+    html: buildEmailHtml({
+      title: "Tenant-authorized trust review",
+      intro,
+      bullets,
+      ctaText: "Sign in to review",
+      ctaUrl: params.reviewUrl,
+      preheader: "A tenant has authorized a limited metadata-only RentChain trust review.",
+      footerNote:
+        "This invitation does not grant access by itself. Recipient authentication and tenant authorization are required before review.",
+    }),
+  });
+}
+
+export async function createInstitutionReviewInvite(params: {
+  tenantId: string;
+  audience?: unknown;
+  purpose?: unknown;
+  recipient?: unknown;
+  expiresInDays?: unknown;
+  consentAccepted?: boolean;
+}) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return null;
+  if (params.consentAccepted !== true) throw new Error("tenant_institution_access_consent_required");
+  const recipient = normalizeRecipient(params.recipient);
+  if (!recipient) throw new Error("tenant_institution_access_recipient_required");
+  const expiresInDays = clampExpiresInDays(params.expiresInDays);
+  if (!expiresInDays) throw new Error("tenant_institution_access_expiration_required");
+  const audience = sanitizeAudience(params.audience);
+  const purpose = purposeForAudience(audience);
+  const reusable = await findReusableInviteGrant({ tenantId, audience, purpose, recipientEmail: recipient.email });
+  const created = reusable || (await createTenantInstitutionAccessGrant({ ...params, tenantId, consentAccepted: true }));
+  if (!created) return null;
+
+  const ref = db.collection(COLLECTION).doc(created.grantId);
+  const snap = await ref.get();
+  const grant = asGrant(created.grantId, snap.data?.() || created);
+  if (grant.lifecycle !== "active" || grant.package?.status !== "export_ready") {
+    throw new Error("tenant_institution_access_policy_blocked");
+  }
+
+  const now = nowIso();
+  const reviewUrl = institutionReviewUrl(grant.grantId);
+  const createdInvite = inviteSummaryForGrant({
+    grant,
+    status: "invited",
+    reviewUrl,
+    createdAt: grant.institutionReviewInvite?.createdAt || now,
+  });
+  const createdEvent: TenantInstitutionAccessGrantEvent = {
+    eventType: "institution_review_invite_created",
+    occurredAt: now,
+    actorType: "tenant",
+    metadataOnly: true,
+    outcome: "invite_created",
+    status: "invited",
+    reason: "invite_created",
+  };
+  const eventsBeforeSend = [...(Array.isArray(grant.events) ? grant.events : []), createdEvent].slice(-50);
+  await ref.set(
+    {
+      institutionReviewInvite: createdInvite,
+      recipientAccess: {
+        ...grant.recipientAccess,
+        enabled: true,
+        accessUrl: reviewUrl,
+        accessTokenIssued: false,
+        recipientAuthenticationRequired: true,
+        sessionBound: true,
+        downloadEnabled: false,
+        summary:
+          "Recipient access requires authentication and matching recipient identity; the invite link is not bearer authorization.",
+      },
+      events: eventsBeforeSend,
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+  grant.institutionReviewInvite = createdInvite;
+  grant.recipientAccess = {
+    ...grant.recipientAccess,
+    enabled: true,
+    accessUrl: reviewUrl,
+    accessTokenIssued: false,
+    recipientAuthenticationRequired: true,
+    sessionBound: true,
+    downloadEnabled: false,
+    summary:
+      "Recipient access requires authentication and matching recipient identity; the invite link is not bearer authorization.",
+  };
+  grant.events = eventsBeforeSend;
+  grant.updatedAt = now;
+
+  try {
+    await sendInstitutionReviewInviteEmail({ grant, reviewUrl });
+  } catch (error) {
+    const failedAt = nowIso();
+    const failedInvite = inviteSummaryForGrant({ grant, status: "send_failed", reviewUrl, createdAt: createdInvite.createdAt });
+    const failedEvents = [
+      ...eventsBeforeSend,
+      {
+        eventType: "institution_review_invite_blocked" as const,
+        occurredAt: failedAt,
+        actorType: "system" as const,
+        metadataOnly: true as const,
+        outcome: "blocked" as const,
+        status: "send_failed" as const,
+        reason: "grant_blocked" as const,
+      },
+    ].slice(-50);
+    await ref.set({ institutionReviewInvite: failedInvite, events: failedEvents, updatedAt: failedAt }, { merge: true });
+    throw error;
+  }
+
+  const sentAt = nowIso();
+  const sentInvite = inviteSummaryForGrant({
+    grant,
+    status: "invited",
+    reviewUrl,
+    createdAt: createdInvite.createdAt,
+    sentAt,
+  });
+  const sentEvents = [
+    ...eventsBeforeSend,
+    {
+      eventType: "institution_review_invite_sent" as const,
+      occurredAt: sentAt,
+      actorType: "system" as const,
+      metadataOnly: true as const,
+      outcome: "invite_sent" as const,
+      status: "invited" as const,
+      reason: "invite_sent" as const,
+    },
+  ].slice(-50);
+  await ref.set({ institutionReviewInvite: sentInvite, events: sentEvents, updatedAt: sentAt }, { merge: true });
+  return publicGrant({
+    ...grant,
+    institutionReviewInvite: sentInvite,
+    events: sentEvents,
+    updatedAt: sentAt,
+  });
+}
+
 export async function listTenantInstitutionAccessGrants(params: { tenantId: string }) {
   const tenantId = asString(params.tenantId);
   if (!tenantId) return [];
@@ -1446,13 +1828,26 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
       status: "revoked" as const,
       reason: "access_revoked" as const,
     },
+    {
+      eventType: "institution_review_invite_revoked" as const,
+      occurredAt: updatedAt,
+      actorType: "tenant" as const,
+      metadataOnly: true as const,
+      outcome: "revoked" as const,
+      status: "revoked" as const,
+      reason: "access_revoked" as const,
+    },
   ];
+  const institutionReviewInvite = current.institutionReviewInvite
+    ? inviteSummaryForGrant({ grant: { ...current, lifecycle: "revoked", revokedAt: updatedAt }, status: "revoked" })
+    : undefined;
   await ref.set(
     {
       lifecycle: "revoked",
       revokedAt: updatedAt,
       updatedAt,
       events,
+      ...(institutionReviewInvite ? { institutionReviewInvite } : {}),
       consent: {
         ...current.consent,
         granted: false,
@@ -1475,6 +1870,7 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
     revokedAt: updatedAt,
     updatedAt,
     events,
+    ...(institutionReviewInvite ? { institutionReviewInvite } : {}),
     consent: {
       ...current.consent,
       granted: false,

--- a/rentchain-frontend/src/api/tenantInstitutionAccess.ts
+++ b/rentchain-frontend/src/api/tenantInstitutionAccess.ts
@@ -56,8 +56,8 @@ export type TenantInstitutionAccessPreview = {
   providerIntegrationEnabled: false;
   automatedDecisioningEnabled: false;
   recipientAccess: {
-    enabled: false;
-    accessUrl: null;
+    enabled: boolean;
+    accessUrl: string | null;
     accessTokenIssued: false;
     recipientAuthenticationRequired: true;
     sessionBound: true;
@@ -110,16 +110,62 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
       | "recipient_trust_review_opened"
       | "recipient_trust_review_blocked"
       | "recipient_trust_review_expired"
-      | "recipient_trust_review_revoked";
+      | "recipient_trust_review_revoked"
+      | "recipient_review_session_started"
+      | "recipient_review_session_expired"
+      | "recipient_review_session_revoked"
+      | "recipient_review_session_blocked"
+      | "recipient_review_session_reauthenticated"
+      | "institution_review_invite_created"
+      | "institution_review_invite_sent"
+      | "institution_review_invite_opened"
+      | "institution_review_invite_authenticated"
+      | "institution_review_invite_revoked"
+      | "institution_review_invite_expired"
+      | "institution_review_invite_blocked";
     occurredAt: string;
     actorType: "tenant" | "system" | "recipient";
     metadataOnly: true;
-    outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated";
+    outcome?:
+      | "invite_created"
+      | "invite_sent"
+      | "invite_opened"
+      | "invite_authenticated"
+      | "granted"
+      | "opened"
+      | "blocked"
+      | "revoked"
+      | "expired"
+      | "session_started"
+      | "reauthenticated";
     reason?: string;
     status?: string;
   }>;
   auditSummary: TenantInstitutionAccessAuditSummary;
   auditTimeline: TenantInstitutionAccessAuditEvent[];
+  institutionReviewInvite?: {
+    schemaVersion: "institution_review_invite.v1";
+    status: "not_created" | "invited" | "viewed" | "authenticated" | "expired" | "revoked" | "blocked" | "send_failed";
+    recipientEmail: string;
+    redactedRecipientEmail: string;
+    organizationName: string | null;
+    audience: TenantInstitutionAccessAudience;
+    purpose: TenantInstitutionAccessPurpose;
+    reviewUrl: string | null;
+    createdAt: string | null;
+    sentAt: string | null;
+    openedAt: string | null;
+    authenticatedAt: string | null;
+    expiresAt: string | null;
+    revokedAt: string | null;
+    recipientAuthenticationRequired: true;
+    inviteTokenIssued: false;
+    bearerAccessEnabled: false;
+    publicAccessEnabled: false;
+    downloadEnabled: false;
+    metadataOnly: true;
+    summary: string;
+  };
 };
 
 export type TenantInstitutionAccessAuditEvent = {
@@ -136,10 +182,28 @@ export type TenantInstitutionAccessAuditEvent = {
     | "recipient_review_session_expired"
     | "recipient_review_session_revoked"
     | "recipient_review_session_blocked"
-    | "recipient_review_session_reauthenticated";
+    | "recipient_review_session_reauthenticated"
+    | "institution_review_invite_created"
+    | "institution_review_invite_sent"
+    | "institution_review_invite_opened"
+    | "institution_review_invite_authenticated"
+    | "institution_review_invite_revoked"
+    | "institution_review_invite_expired"
+    | "institution_review_invite_blocked";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
-  outcome: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated";
+  outcome:
+    | "invite_created"
+    | "invite_sent"
+    | "invite_opened"
+    | "invite_authenticated"
+    | "granted"
+    | "opened"
+    | "blocked"
+    | "revoked"
+    | "expired"
+    | "session_started"
+    | "reauthenticated";
   status: string;
   reason: string;
   metadataOnly: true;
@@ -158,7 +222,19 @@ export type TenantInstitutionAccessAuditSummary = {
   lastActivityAt: string | null;
   lastOpenedAt: string | null;
   lastBlockedAt: string | null;
-  lastOutcome: "granted" | "opened" | "blocked" | "revoked" | "expired" | "session_started" | "reauthenticated" | null;
+  lastOutcome:
+    | "invite_created"
+    | "invite_sent"
+    | "invite_opened"
+    | "invite_authenticated"
+    | "granted"
+    | "opened"
+    | "blocked"
+    | "revoked"
+    | "expired"
+    | "session_started"
+    | "reauthenticated"
+    | null;
   lastReason: string | null;
   recipientIdentifier: {
     email: string;
@@ -213,6 +289,19 @@ export async function createTenantInstitutionAccessGrant(
 ): Promise<TenantInstitutionAccessGrant> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantInstitutionAccessGrant }>(
     "/tenant/institution-access/grants",
+    {
+      method: "POST",
+      body: request,
+    }
+  );
+  return res.data;
+}
+
+export async function createInstitutionReviewInvite(
+  request: TenantInstitutionAccessRequest
+): Promise<TenantInstitutionAccessGrant> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantInstitutionAccessGrant }>(
+    "/tenant/institution-access/invites",
     {
       method: "POST",
       body: request,

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -75,7 +75,7 @@ const tenantTrustExportsApi = vi.hoisted(() => ({
 const tenantInstitutionAccessApi = vi.hoisted(() => ({
   listTenantInstitutionAccessGrants: vi.fn(),
   previewTenantInstitutionAccess: vi.fn(),
-  createTenantInstitutionAccessGrant: vi.fn(),
+  createInstitutionReviewInvite: vi.fn(),
   revokeTenantInstitutionAccessGrant: vi.fn(),
 }));
 
@@ -874,7 +874,32 @@ describe("tenant workspace frontend shell", () => {
       ],
     };
     tenantInstitutionAccessApi.previewTenantInstitutionAccess.mockResolvedValue(institutionAccessPreview);
-    tenantInstitutionAccessApi.createTenantInstitutionAccessGrant.mockResolvedValue(institutionAccessGrant);
+    tenantInstitutionAccessApi.createInstitutionReviewInvite.mockResolvedValue({
+      ...institutionAccessGrant,
+      institutionReviewInvite: {
+        schemaVersion: "institution_review_invite.v1",
+        status: "invited",
+        recipientEmail: "reviewer@example.com",
+        redactedRecipientEmail: "re***@example.com",
+        organizationName: "Example Insurance",
+        audience: "insurer",
+        purpose: "insurance_review",
+        reviewUrl: "https://www.rentchain.test/recipient/trust-review/grant-1",
+        createdAt: "2026-05-09T00:00:00.000Z",
+        sentAt: "2026-05-09T00:01:00.000Z",
+        openedAt: null,
+        authenticatedAt: null,
+        expiresAt: "2026-05-16T00:00:00.000Z",
+        revokedAt: null,
+        recipientAuthenticationRequired: true,
+        inviteTokenIssued: false,
+        bearerAccessEnabled: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        metadataOnly: true,
+        summary: "This invitation points the recipient to an authenticated review.",
+      },
+    });
     tenantInstitutionAccessApi.revokeTenantInstitutionAccessGrant.mockImplementation(async (grantId: string) => ({
       ...institutionAccessGrant,
       grantId,
@@ -1554,15 +1579,15 @@ describe("tenant workspace frontend shell", () => {
     });
   });
 
-  it("requires tenant consent before creating institution access grants", async () => {
+  it("requires tenant consent before creating institution review invites", async () => {
     render(
       <MemoryRouter>
         <TenantWorkspacePage />
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Tenant-mediated institution access/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Create access grant/i })).toBeDisabled();
+    expect((await screen.findAllByText(/Institution review invites/i)).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Send review invite/i })).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText(/Recipient email/i), {
       target: { value: "reviewer@example.com" },
@@ -1584,10 +1609,10 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText(/No claims are accessible until consent and policy checks pass/i)).toBeInTheDocument();
     expect(screen.getByText(/Public trust profiles and public links are not created/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText(/I consent to preparing metadata-only institution access/i));
-    fireEvent.click(screen.getByRole("button", { name: /Create access grant/i }));
+    fireEvent.click(screen.getByLabelText(/I consent to inviting this recipient/i));
+    fireEvent.click(screen.getByRole("button", { name: /Send review invite/i }));
     await waitFor(() => {
-      expect(tenantInstitutionAccessApi.createTenantInstitutionAccessGrant).toHaveBeenCalledWith(
+      expect(tenantInstitutionAccessApi.createInstitutionReviewInvite).toHaveBeenCalledWith(
         expect.objectContaining({
           audience: "insurer",
           consentAccepted: true,
@@ -1596,7 +1621,7 @@ describe("tenant workspace frontend shell", () => {
       );
     });
     expect(await screen.findByText(/Tenant portability metadata available/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/Not created/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Invited/i)).toBeInTheDocument();
     expect(screen.getByText(/Access activity/i)).toBeInTheDocument();
     expect(screen.getByText(/re\*\*\*@example.com/i)).toBeInTheDocument();
     expect(screen.getByText(/Opened reviews/i)).toBeInTheDocument();
@@ -1628,7 +1653,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getAllByText(/No data is sent automatically/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Institution connections are not enabled yet/i)).toBeInTheDocument();
     expect(screen.getByText(/tenant-managed manual-release preparation only/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /send/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /send to institution/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /submit to bank/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /connect institution/i })).not.toBeInTheDocument();
 

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -37,7 +37,7 @@ import {
   type TenantTrustExportRecord,
 } from "../../api/tenantTrustExports";
 import {
-  createTenantInstitutionAccessGrant,
+  createInstitutionReviewInvite,
   listTenantInstitutionAccessGrants,
   previewTenantInstitutionAccess,
   revokeTenantInstitutionAccessGrant,
@@ -220,6 +220,14 @@ function prettyPolicyReason(value: string) {
 
 function prettyAccessAuditOutcome(value: string | null | undefined) {
   switch (value) {
+    case "invite_created":
+      return "Invite created";
+    case "invite_sent":
+      return "Invite sent";
+    case "invite_opened":
+      return "Invite opened";
+    case "invite_authenticated":
+      return "Invite authenticated";
     case "opened":
       return "Review opened";
     case "blocked":
@@ -720,7 +728,7 @@ export default function TenantWorkspacePage() {
     try {
       setInstitutionAccessBusy(true);
       setInstitutionAccessError(null);
-      const created = await createTenantInstitutionAccessGrant(institutionAccessRequest(institutionAccessConsentAccepted));
+      const created = await createInstitutionReviewInvite(institutionAccessRequest(institutionAccessConsentAccepted));
       setInstitutionAccessPreview(created);
       setInstitutionAccessGrants((current) => [created, ...current.filter((entry) => entry.grantId !== created.grantId)]);
     } catch (err: any) {
@@ -728,8 +736,8 @@ export default function TenantWorkspacePage() {
         err?.payload?.error === "TENANT_INSTITUTION_ACCESS_CONSENT_REQUIRED"
           ? "Confirm consent before creating institution access."
           : err?.payload?.error === "TENANT_INSTITUTION_ACCESS_RECIPIENT_REQUIRED"
-          ? "Enter a recipient email before creating institution access."
-          : err?.payload?.error || err?.message || "Unable to create institution access right now."
+          ? "Enter a recipient email before creating the review invite."
+          : err?.payload?.error || err?.message || "Unable to create institution review invite right now."
       );
     } finally {
       setInstitutionAccessBusy(false);
@@ -1769,9 +1777,9 @@ export default function TenantWorkspacePage() {
               gap: 10,
             }}
           >
-            <div style={{ fontWeight: 700, color: textTokens.primary }}>Tenant-mediated institution access</div>
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Institution review invites</div>
             <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
-              Prepare a controlled, non-public access grant for a specific recipient. This does not create a public profile, does not send data to an institution, and does not enable automatic decisions.
+              Invite a specific recipient to an authenticated, non-public, metadata-only trust review. This does not create a public profile, downloadable export, or automatic decision.
             </div>
 
             <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
@@ -1830,7 +1838,7 @@ export default function TenantWorkspacePage() {
                 style={{ marginTop: 4 }}
               />
               <span>
-                I consent to preparing metadata-only institution access for {prettyInstitutionAccessAudience(institutionAccessAudience)}. I understand recipient access requires controlled future authentication, no public link is created, and this is not an eligibility or approval decision.
+                I consent to inviting this recipient to a metadata-only trust review for {prettyInstitutionAccessAudience(institutionAccessAudience)}. I understand the recipient must authenticate, access is time-bound and revocable, and this is not an eligibility or approval decision.
               </span>
             </label>
 
@@ -1843,7 +1851,7 @@ export default function TenantWorkspacePage() {
                 onClick={() => void handleCreateInstitutionAccessGrant()}
                 disabled={institutionAccessBusy || !institutionAccessConsentAccepted}
               >
-                Create access grant
+                Send review invite
               </button>
             </div>
 
@@ -1852,7 +1860,7 @@ export default function TenantWorkspacePage() {
             {institutionAccessPreview ? (
               <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 10 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
-                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Institution access preview</div>
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Institution review invite preview</div>
                   <div style={{ color: textTokens.secondary }}>{prettyTrustExportLifecycle(institutionAccessPreview.lifecycle)}</div>
                 </div>
                 <TenantKeyValueGrid
@@ -1863,7 +1871,7 @@ export default function TenantWorkspacePage() {
                     { label: "Policy status", value: prettyStatus(institutionAccessPreview.package.status) },
                     { label: "Included claims", value: String(institutionAccessPreview.includedClaims.length) },
                     { label: "Public access", value: institutionAccessPreview.publicAccessEnabled ? "Enabled" : "Disabled" },
-                    { label: "Recipient URL", value: institutionAccessPreview.recipientAccess.accessUrl || "Not created" },
+                    { label: "Recipient review", value: institutionAccessPreview.recipientAccess.accessUrl || "Created only after invite is sent" },
                     { label: "Expires", value: formatDate(institutionAccessPreview.expiresAt) },
                   ]}
                 />
@@ -1891,7 +1899,7 @@ export default function TenantWorkspacePage() {
             ) : null}
 
             <div style={{ display: "grid", gap: 8 }}>
-              <div style={{ fontWeight: 700, color: textTokens.primary }}>Institution access grants</div>
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Institution review invites</div>
               {institutionAccessGrants.length ? (
                 institutionAccessGrants.map((entry) => (
                   <div key={entry.grantId} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 8 }}>
@@ -1900,9 +1908,11 @@ export default function TenantWorkspacePage() {
                         { label: "Recipient", value: entry.recipient.email },
                         { label: "Audience", value: prettyInstitutionAccessAudience(entry.audience) },
                         { label: "Status", value: prettyTrustExportLifecycle(entry.lifecycle) },
+                        { label: "Invite", value: entry.institutionReviewInvite?.status ? prettyStatus(entry.institutionReviewInvite.status) : "Not created" },
                         { label: "Created", value: formatDate(entry.createdAt) },
                         { label: "Expires", value: formatDate(entry.expiresAt) },
-                        { label: "Access URL", value: entry.recipientAccess.accessUrl || "Not created" },
+                        { label: "Authentication", value: "Required before review" },
+                        { label: "Downloads", value: entry.institutionReviewInvite?.downloadEnabled ? "Enabled" : "Disabled" },
                       ]}
                     />
                     <div style={{ borderTop: "1px solid rgba(15,23,42,0.08)", paddingTop: 8, display: "grid", gap: 8 }}>
@@ -1963,7 +1973,7 @@ export default function TenantWorkspacePage() {
                 ))
               ) : (
                 <div style={{ color: textTokens.secondary }}>
-                  Institution access grants will appear here. They stay tenant-controlled, time-bound, and non-public.
+                  Institution review invites will appear here. They stay tenant-controlled, authenticated, time-bound, and non-public.
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Add tenant-created institution review invites on top of existing tenant-mediated access grants and institution review sessions.
- Require recipient email, audience, purpose, expiration, and explicit consent before invite creation.
- Send conservative metadata-only invite email and keep recipient review authenticated, email-bound, policy-gated, revocable, and view-only.

## Validation
- API npm run test under Node 20.20.2
- API npm run build under Node 20.20.2
- Frontend npm run test under Node 20.20.2
- Frontend npm run build under Node 20.20.2
- git diff --check

## Governance Notes
- No public trust profile or bearer-token-only authorization was introduced.
- No institution/provider integrations, downloadable institution exports, share-package widening, or trust payload exposure were introduced.
- Browser/manual QA was not run.