### PR TITLE
Tenant-mediated institution delivery v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1650,6 +1650,18 @@ describe("tenantPortalRoutes foundation", () => {
         metadataOnly: true,
       })
     );
+    expect(invited.body?.data?.institutionReviewDelivery).toEqual(
+      expect.objectContaining({
+        schemaVersion: "institution_review_delivery.v1",
+        status: "sent",
+        attemptCount: 1,
+        recipientAuthenticationRequired: true,
+        bearerAccessEnabled: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        metadataOnly: true,
+      })
+    );
     expect(invited.body?.data?.recipientAccess).toEqual(
       expect.objectContaining({
         enabled: true,
@@ -1683,9 +1695,87 @@ describe("tenantPortalRoutes foundation", () => {
       expect.arrayContaining([
         expect.objectContaining({ eventType: "institution_review_invite_sent", reason: "invite_sent" }),
         expect.objectContaining({ eventType: "institution_review_invite_created", reason: "invite_created" }),
+        expect.objectContaining({ eventType: "institution_review_delivery_sent", reason: "delivery_sent" }),
+        expect.objectContaining({ eventType: "institution_review_delivery_prepared", reason: "delivery_prepared" }),
       ])
     );
     expect(ensureCollection("tenantSharePackages").size).toBe(0);
+  });
+
+  it("resends institution review delivery deterministically and blocks revoked delivery", async () => {
+    process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+      }),
+    };
+
+    const invited = await invokeRouter(router, {
+      method: "POST",
+      url: "/institution-access/invites",
+      body: {
+        audience: "lender",
+        recipient: { email: "underwriter@example.com", organizationName: "Example Lender" },
+        expiresInDays: 7,
+        consentAccepted: true,
+      },
+      headers,
+    });
+    const grantId = invited.body?.data?.grantId;
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+
+    const resent = await invokeRouter(router, {
+      method: "POST",
+      url: `/institution-access/grants/${encodeURIComponent(grantId)}/delivery/resend`,
+      headers,
+    });
+    expect(resent.status).toBe(200);
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+    expect(resent.body?.data?.institutionReviewDelivery).toEqual(
+      expect.objectContaining({
+        status: "resent",
+        attemptCount: 2,
+        recipientAuthenticationRequired: true,
+        bearerAccessEnabled: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        metadataOnly: true,
+      })
+    );
+    expect(resent.body?.data?.auditTimeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "institution_review_delivery_resent", reason: "delivery_resent" }),
+        expect.objectContaining({ eventType: "institution_review_delivery_prepared", reason: "delivery_prepared" }),
+      ])
+    );
+
+    const revoked = await invokeRouter(router, {
+      method: "POST",
+      url: `/institution-access/grants/${encodeURIComponent(grantId)}/revoke`,
+      headers,
+    });
+    expect(revoked.status).toBe(200);
+    expect(revoked.body?.data?.institutionReviewDelivery).toEqual(
+      expect.objectContaining({
+        status: "revoked",
+        bearerAccessEnabled: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+      })
+    );
+
+    const blocked = await invokeRouter(router, {
+      method: "POST",
+      url: `/institution-access/grants/${encodeURIComponent(grantId)}/delivery/resend`,
+      headers,
+    });
+    expect(blocked.status).toBe(400);
+    expect(blocked.body?.error).toBe("TENANT_INSTITUTION_DELIVERY_BLOCKED");
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
   });
 
   it("creates a tenant-owned metadata-only institutional handoff draft safely", async () => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -73,6 +73,7 @@ import {
   createTenantInstitutionAccessGrant,
   listTenantInstitutionAccessGrants,
   previewTenantInstitutionAccess,
+  resendInstitutionReviewDelivery,
   revokeTenantInstitutionAccessGrant,
 } from "../services/tenantPortal/tenantInstitutionAccessService";
 import { recordSystemObservabilityEvent } from "../services/observability/recordSystemObservabilityEvent";
@@ -3409,6 +3410,9 @@ router.post("/institution-access/grants", requireTenantWorkspaceIdentity, async 
     if (err?.message === "tenant_institution_access_policy_blocked") {
       return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_POLICY_BLOCKED" });
     }
+    if (String(err?.message || "").startsWith("tenant_institution_delivery_blocked")) {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_DELIVERY_BLOCKED" });
+    }
     console.error("[tenant/institution-access:create] failed", {
       tenantId,
       message: err?.message || "failed",
@@ -3452,11 +3456,49 @@ router.post("/institution-access/invites", requireTenantWorkspaceIdentity, async
     if (err?.message === "tenant_institution_access_policy_blocked") {
       return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_POLICY_BLOCKED" });
     }
+    if (String(err?.message || "").startsWith("tenant_institution_delivery_blocked")) {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_DELIVERY_BLOCKED" });
+    }
     console.error("[tenant/institution-access:invite] failed", {
       tenantId,
       message: err?.message || "failed",
     });
     return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_INVITE_FAILED" });
+  }
+});
+
+router.post("/institution-access/grants/:id/delivery/resend", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  const grantId = String(req.params?.id || "").trim();
+  if (!tenantId || !grantId) {
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+
+  try {
+    const delivered = await resendInstitutionReviewDelivery({ tenantId, grantId });
+    if (!delivered) {
+      return res.status(404).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_NOT_FOUND" });
+    }
+    if ((delivered as unknown) === false) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    return res.json({ ok: true, data: delivered });
+  } catch (err: any) {
+    if (err?.message === "tenant_institution_delivery_invite_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_DELIVERY_INVITE_REQUIRED" });
+    }
+    if (String(err?.message || "").startsWith("tenant_institution_delivery_blocked")) {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_DELIVERY_BLOCKED" });
+    }
+    console.error("[tenant/institution-access:delivery-resend] failed", {
+      tenantId,
+      grantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_DELIVERY_RESEND_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -142,6 +142,52 @@ export type InstitutionReviewInviteSummary = {
   summary: string;
 };
 
+export type InstitutionReviewDeliveryStatus =
+  | "not_prepared"
+  | "prepared"
+  | "sent"
+  | "failed"
+  | "blocked"
+  | "resent"
+  | "revoked"
+  | "expired";
+
+export type InstitutionReviewDeliveryFailureReason =
+  | "none"
+  | "tenant_intent_required"
+  | "invite_not_active"
+  | "access_grant_not_active"
+  | "recipient_email_required"
+  | "recipient_authentication_required"
+  | "trust_export_lifecycle_inactive"
+  | "policy_gated_summary_unavailable"
+  | "tenant_consent_missing"
+  | "grant_expired"
+  | "grant_revoked"
+  | "email_delivery_failed";
+
+export type InstitutionReviewDeliverySummary = {
+  schemaVersion: "institution_review_delivery.v1";
+  status: InstitutionReviewDeliveryStatus;
+  attemptCount: number;
+  lastAttemptAt: string | null;
+  lastSentAt: string | null;
+  lastFailedAt: string | null;
+  lastFailureReason: InstitutionReviewDeliveryFailureReason | null;
+  recipientEmail: string;
+  redactedRecipientEmail: string;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  reviewUrl: string | null;
+  tenantAuthorized: true;
+  recipientAuthenticationRequired: true;
+  bearerAccessEnabled: false;
+  publicAccessEnabled: false;
+  downloadEnabled: false;
+  metadataOnly: true;
+  summary: string;
+};
+
 export type TenantInstitutionAccessGrantEvent = {
   eventType:
     | "tenant_institution_access_granted"
@@ -165,7 +211,14 @@ export type TenantInstitutionAccessGrantEvent = {
     | "institution_review_invite_authenticated"
     | "institution_review_invite_revoked"
     | "institution_review_invite_expired"
-    | "institution_review_invite_blocked";
+    | "institution_review_invite_blocked"
+    | "institution_review_delivery_prepared"
+    | "institution_review_delivery_sent"
+    | "institution_review_delivery_failed"
+    | "institution_review_delivery_blocked"
+    | "institution_review_delivery_resent"
+    | "institution_review_delivery_revoked"
+    | "institution_review_delivery_expired";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   metadataOnly: true;
@@ -174,6 +227,10 @@ export type TenantInstitutionAccessGrantEvent = {
     | "invite_sent"
     | "invite_opened"
     | "invite_authenticated"
+    | "delivery_prepared"
+    | "delivery_sent"
+    | "delivery_failed"
+    | "delivery_resent"
     | "granted"
     | "opened"
     | "blocked"
@@ -189,8 +246,21 @@ export type TenantInstitutionAccessGrantEvent = {
     | "invite_created"
     | "invite_sent"
     | "invite_opened"
-    | "invite_authenticated";
-  status?: RecipientTrustReviewStatus | "granted" | "active" | "invited" | "viewed" | "authenticated" | "send_failed";
+    | "invite_authenticated"
+    | "delivery_prepared"
+    | "delivery_sent"
+    | "delivery_failed"
+    | "delivery_resent"
+    | InstitutionReviewDeliveryFailureReason;
+  status?:
+    | RecipientTrustReviewStatus
+    | "granted"
+    | "active"
+    | "invited"
+    | "viewed"
+    | "authenticated"
+    | "send_failed"
+    | InstitutionReviewDeliveryStatus;
 };
 
 type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessPreview & {
@@ -201,6 +271,7 @@ type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessPreview & {
   events: TenantInstitutionAccessGrantEvent[];
   tenantId: string;
   institutionReviewInvite?: InstitutionReviewInviteSummary;
+  institutionReviewDelivery?: InstitutionReviewDeliverySummary;
 };
 
 export type TenantInstitutionAccessGrant = Omit<TenantInstitutionAccessStoredGrant, "tenantId"> & {
@@ -331,6 +402,10 @@ export type TenantInstitutionAccessAuditOutcome =
   | "invite_sent"
   | "invite_opened"
   | "invite_authenticated"
+  | "delivery_prepared"
+  | "delivery_sent"
+  | "delivery_failed"
+  | "delivery_resent"
   | "granted"
   | "opened"
   | "blocked"
@@ -354,7 +429,8 @@ export type TenantInstitutionAccessAuditEvent = {
     | "invited"
     | "viewed"
     | "authenticated"
-    | "send_failed";
+    | "send_failed"
+    | InstitutionReviewDeliveryStatus;
   reason:
     | RecipientTrustReviewAccessDecision["reason"]
     | "access_granted"
@@ -365,6 +441,11 @@ export type TenantInstitutionAccessAuditEvent = {
     | "invite_sent"
     | "invite_opened"
     | "invite_authenticated"
+    | "delivery_prepared"
+    | "delivery_sent"
+    | "delivery_failed"
+    | "delivery_resent"
+    | InstitutionReviewDeliveryFailureReason
     | "session_started"
     | "recipient_session_expired"
     | "recipient_session_revoked"
@@ -764,18 +845,74 @@ function inviteSummaryForGrant(params: {
   };
 }
 
+function deliverySummaryForGrant(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  status?: InstitutionReviewDeliveryStatus;
+  reviewUrl?: string | null;
+  attemptedAt?: string | null;
+  sentAt?: string | null;
+  failedAt?: string | null;
+  failureReason?: InstitutionReviewDeliveryFailureReason | null;
+  incrementAttempt?: boolean;
+}) {
+  const existing = params.grant.institutionReviewDelivery || null;
+  const revoked = params.grant.lifecycle === "revoked" || Boolean(params.grant.revokedAt || params.grant.consent?.revokedAt);
+  const expired = params.grant.lifecycle === "expired" || Boolean(params.grant.expiresAt && Date.parse(params.grant.expiresAt) <= Date.now());
+  const status =
+    params.status ||
+    (revoked ? "revoked" : expired ? "expired" : existing?.status && existing.status !== "not_prepared" ? existing.status : "prepared");
+  const attemptCount = Math.max(0, Number(existing?.attemptCount || 0)) + (params.incrementAttempt ? 1 : 0);
+  return {
+    schemaVersion: "institution_review_delivery.v1" as const,
+    status,
+    attemptCount,
+    lastAttemptAt: params.attemptedAt === undefined ? existing?.lastAttemptAt || null : params.attemptedAt,
+    lastSentAt: params.sentAt === undefined ? existing?.lastSentAt || null : params.sentAt,
+    lastFailedAt: params.failedAt === undefined ? existing?.lastFailedAt || null : params.failedAt,
+    lastFailureReason:
+      params.failureReason === undefined ? existing?.lastFailureReason || null : params.failureReason,
+    recipientEmail: params.grant.recipient?.email || "",
+    redactedRecipientEmail: redactEmail(params.grant.recipient?.email),
+    audience: params.grant.audience,
+    purpose: params.grant.purpose,
+    reviewUrl:
+      params.reviewUrl === undefined
+        ? existing?.reviewUrl || params.grant.institutionReviewInvite?.reviewUrl || institutionReviewUrl(params.grant.grantId)
+        : params.reviewUrl,
+    tenantAuthorized: true as const,
+    recipientAuthenticationRequired: true as const,
+    bearerAccessEnabled: false as const,
+    publicAccessEnabled: false as const,
+    downloadEnabled: false as const,
+    metadataOnly: true as const,
+    summary:
+      "Delivery is tenant-authorized and points only to an authenticated, metadata-only RentChain review. The delivery link is not bearer authorization.",
+  };
+}
+
 function outcomeForEventType(eventType: TenantInstitutionAccessAuditEvent["eventType"]): TenantInstitutionAccessAuditOutcome {
   if (eventType === "institution_review_invite_created") return "invite_created";
   if (eventType === "institution_review_invite_sent") return "invite_sent";
   if (eventType === "institution_review_invite_opened") return "invite_opened";
   if (eventType === "institution_review_invite_authenticated") return "invite_authenticated";
+  if (eventType === "institution_review_delivery_prepared") return "delivery_prepared";
+  if (eventType === "institution_review_delivery_sent") return "delivery_sent";
+  if (eventType === "institution_review_delivery_failed") return "delivery_failed";
+  if (eventType === "institution_review_delivery_resent") return "delivery_resent";
   if (eventType === "tenant_institution_access_granted") return "granted";
-  if (eventType === "tenant_institution_access_revoked" || eventType === "recipient_trust_review_revoked") return "revoked";
+  if (
+    eventType === "tenant_institution_access_revoked" ||
+    eventType === "recipient_trust_review_revoked" ||
+    eventType === "institution_review_delivery_revoked"
+  ) {
+    return "revoked";
+  }
   if (
     eventType === "tenant_institution_access_expired" ||
     eventType === "recipient_trust_review_expired" ||
     eventType === "recipient_review_session_expired" ||
-    eventType === "institution_review_invite_expired"
+    eventType === "institution_review_invite_expired" ||
+    eventType === "institution_review_delivery_expired"
   ) {
     return "expired";
   }
@@ -788,13 +925,19 @@ function outcomeForEventType(eventType: TenantInstitutionAccessAuditEvent["event
 function statusForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"][number]): TenantInstitutionAccessAuditEvent["status"] {
   if (event.status) return event.status as TenantInstitutionAccessAuditEvent["status"];
   if (event.eventType === "institution_review_invite_created" || event.eventType === "institution_review_invite_sent") return "invited";
+  if (event.eventType === "institution_review_delivery_prepared") return "prepared";
+  if (event.eventType === "institution_review_delivery_sent") return "sent";
+  if (event.eventType === "institution_review_delivery_resent") return "resent";
+  if (event.eventType === "institution_review_delivery_failed") return "failed";
+  if (event.eventType === "institution_review_delivery_blocked") return "blocked";
   if (event.eventType === "institution_review_invite_opened") return "viewed";
   if (event.eventType === "institution_review_invite_authenticated") return "authenticated";
   if (event.eventType === "tenant_institution_access_granted") return "granted";
   if (
     event.eventType === "tenant_institution_access_revoked" ||
     event.eventType === "recipient_trust_review_revoked" ||
-    event.eventType === "institution_review_invite_revoked"
+    event.eventType === "institution_review_invite_revoked" ||
+    event.eventType === "institution_review_delivery_revoked"
   ) {
     return "revoked";
   }
@@ -802,7 +945,8 @@ function statusForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
     event.eventType === "tenant_institution_access_expired" ||
     event.eventType === "recipient_trust_review_expired" ||
     event.eventType === "recipient_review_session_expired" ||
-    event.eventType === "institution_review_invite_expired"
+    event.eventType === "institution_review_invite_expired" ||
+    event.eventType === "institution_review_delivery_expired"
   ) {
     return "expired";
   }
@@ -818,11 +962,17 @@ function reasonForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
   if (event.eventType === "institution_review_invite_sent") return "invite_sent";
   if (event.eventType === "institution_review_invite_opened") return "invite_opened";
   if (event.eventType === "institution_review_invite_authenticated") return "invite_authenticated";
+  if (event.eventType === "institution_review_delivery_prepared") return "delivery_prepared";
+  if (event.eventType === "institution_review_delivery_sent") return "delivery_sent";
+  if (event.eventType === "institution_review_delivery_resent") return "delivery_resent";
+  if (event.eventType === "institution_review_delivery_failed") return "email_delivery_failed";
+  if (event.eventType === "institution_review_delivery_blocked") return "trust_export_lifecycle_inactive";
   if (event.eventType === "tenant_institution_access_granted") return "access_granted";
   if (
     event.eventType === "tenant_institution_access_revoked" ||
     event.eventType === "recipient_trust_review_revoked" ||
-    event.eventType === "institution_review_invite_revoked"
+    event.eventType === "institution_review_invite_revoked" ||
+    event.eventType === "institution_review_delivery_revoked"
   ) {
     return "access_revoked";
   }
@@ -833,7 +983,8 @@ function reasonForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
   if (
     event.eventType === "tenant_institution_access_expired" ||
     event.eventType === "recipient_trust_review_expired" ||
-    event.eventType === "institution_review_invite_expired"
+    event.eventType === "institution_review_invite_expired" ||
+    event.eventType === "institution_review_delivery_expired"
   ) {
     return "access_expired";
   }
@@ -910,6 +1061,9 @@ function publicGrant(record: TenantInstitutionAccessStoredGrant): TenantInstitut
   const normalizedRecord = {
     ...rest,
     institutionReviewInvite: record.institutionReviewInvite || inviteSummaryForGrant({ grant: record, status: "not_created", reviewUrl: null }),
+    institutionReviewDelivery:
+      record.institutionReviewDelivery ||
+      deliverySummaryForGrant({ grant: record, status: "not_prepared", reviewUrl: null, failureReason: null }),
   };
   return {
     ...normalizedRecord,
@@ -1069,6 +1223,7 @@ function addMsIso(start: string, ms: number) {
 function continuityFingerprintForGrant(grant: TenantInstitutionAccessStoredGrant) {
   const lifecycleControl = grant.package?.lifecycleControl || {};
   const invite = grant.institutionReviewInvite || null;
+  const delivery = grant.institutionReviewDelivery || null;
   return crypto
     .createHash("sha256")
     .update(
@@ -1101,6 +1256,12 @@ function continuityFingerprintForGrant(grant: TenantInstitutionAccessStoredGrant
           revokedAt: invite?.revokedAt || null,
           bearerAccessEnabled: Boolean((invite as any)?.bearerAccessEnabled),
           inviteTokenIssued: Boolean((invite as any)?.inviteTokenIssued),
+        },
+        delivery: {
+          status: delivery?.status || null,
+          attemptCount: delivery?.attemptCount || 0,
+          lastSentAt: delivery?.lastSentAt || null,
+          lastFailureReason: delivery?.lastFailureReason || null,
         },
       })
     )
@@ -1832,6 +1993,159 @@ async function sendInstitutionReviewInviteEmail(params: {
   });
 }
 
+function evaluateInstitutionReviewDeliveryEligibility(grant: TenantInstitutionAccessStoredGrant): InstitutionReviewDeliveryFailureReason | null {
+  if (!normalizeEmail(grant.recipient?.email)) return "recipient_email_required";
+  if (grant.recipient?.authenticationRequirement !== "recipient_email_session_required") {
+    return "recipient_authentication_required";
+  }
+  if (grant.lifecycle === "revoked" || grant.revokedAt || grant.consent?.revokedAt) return "grant_revoked";
+  if (grant.lifecycle === "expired" || (grant.expiresAt && Date.parse(grant.expiresAt) <= Date.now())) return "grant_expired";
+  if (grant.lifecycle !== "active") return "access_grant_not_active";
+  if (grant.consent?.granted !== true || !grant.consent?.consentId) return "tenant_consent_missing";
+  const lifecycleBlockReason = lifecycleControlBlocksReview(grant);
+  if (lifecycleBlockReason === "grant_expired") return "grant_expired";
+  if (lifecycleBlockReason === "grant_revoked") return "grant_revoked";
+  if (lifecycleBlockReason) return "trust_export_lifecycle_inactive";
+  if (grant.package?.status !== "export_ready" || !Array.isArray(grant.package?.exportSummaries) || !grant.package.exportSummaries.length) {
+    return "policy_gated_summary_unavailable";
+  }
+  if (hasUnsafeRecipientPayload(grant)) return "policy_gated_summary_unavailable";
+  return null;
+}
+
+async function deliverInstitutionReviewInvite(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  reviewUrl: string;
+  resend?: boolean;
+}) {
+  const ref = db.collection(COLLECTION).doc(params.grant.grantId);
+  const attemptedAt = nowIso();
+  const eligibilityFailure = evaluateInstitutionReviewDeliveryEligibility(params.grant);
+  const baseEvents = Array.isArray(params.grant.events) ? params.grant.events : [];
+  const preparedEvent: TenantInstitutionAccessGrantEvent = {
+    eventType: "institution_review_delivery_prepared",
+    occurredAt: attemptedAt,
+    actorType: "tenant",
+    metadataOnly: true,
+    outcome: "delivery_prepared",
+    status: "prepared",
+    reason: "delivery_prepared",
+  };
+
+  if (eligibilityFailure) {
+    const blockedDelivery = deliverySummaryForGrant({
+      grant: params.grant,
+      status: eligibilityFailure === "grant_expired" ? "expired" : eligibilityFailure === "grant_revoked" ? "revoked" : "blocked",
+      reviewUrl: params.reviewUrl,
+      attemptedAt,
+      failureReason: eligibilityFailure,
+      incrementAttempt: true,
+    });
+    const blockedInvite = inviteSummaryForGrant({
+      grant: params.grant,
+      status: eligibilityFailure === "grant_expired" ? "expired" : eligibilityFailure === "grant_revoked" ? "revoked" : "blocked",
+      reviewUrl: params.reviewUrl,
+    });
+    const events = [
+      ...baseEvents,
+      preparedEvent,
+      {
+        eventType: "institution_review_delivery_blocked" as const,
+        occurredAt: attemptedAt,
+        actorType: "system" as const,
+        metadataOnly: true as const,
+        outcome: "blocked" as const,
+        status: blockedDelivery.status,
+        reason: eligibilityFailure,
+      },
+    ].slice(-50);
+    await ref.set(
+      {
+        institutionReviewInvite: blockedInvite,
+        institutionReviewDelivery: blockedDelivery,
+        events,
+        updatedAt: attemptedAt,
+      },
+      { merge: true }
+    );
+    throw new Error(`tenant_institution_delivery_blocked:${eligibilityFailure}`);
+  }
+
+  const preparedDelivery = deliverySummaryForGrant({
+    grant: params.grant,
+    status: "prepared",
+    reviewUrl: params.reviewUrl,
+    attemptedAt,
+    failureReason: null,
+    incrementAttempt: true,
+  });
+  const eventsBeforeSend = [...baseEvents, preparedEvent].slice(-50);
+  await ref.set(
+    {
+      institutionReviewDelivery: preparedDelivery,
+      events: eventsBeforeSend,
+      updatedAt: attemptedAt,
+    },
+    { merge: true }
+  );
+  params.grant.institutionReviewDelivery = preparedDelivery;
+  params.grant.events = eventsBeforeSend;
+  params.grant.updatedAt = attemptedAt;
+
+  try {
+    await sendInstitutionReviewInviteEmail({ grant: params.grant, reviewUrl: params.reviewUrl });
+  } catch (error) {
+    const failedAt = nowIso();
+    const failedDelivery = deliverySummaryForGrant({
+      grant: params.grant,
+      status: "failed",
+      reviewUrl: params.reviewUrl,
+      failedAt,
+      failureReason: "email_delivery_failed",
+    });
+    const events = [
+      ...eventsBeforeSend,
+      {
+        eventType: "institution_review_delivery_failed" as const,
+        occurredAt: failedAt,
+        actorType: "system" as const,
+        metadataOnly: true as const,
+        outcome: "delivery_failed" as const,
+        status: "failed" as const,
+        reason: "email_delivery_failed" as const,
+      },
+    ].slice(-50);
+    await ref.set({ institutionReviewDelivery: failedDelivery, events, updatedAt: failedAt }, { merge: true });
+    throw error;
+  }
+
+  const sentAt = nowIso();
+  const delivery = deliverySummaryForGrant({
+    grant: params.grant,
+    status: params.resend ? "resent" : "sent",
+    reviewUrl: params.reviewUrl,
+    sentAt,
+    failureReason: null,
+  });
+  const events = [
+    ...eventsBeforeSend,
+    {
+      eventType: params.resend ? ("institution_review_delivery_resent" as const) : ("institution_review_delivery_sent" as const),
+      occurredAt: sentAt,
+      actorType: "system" as const,
+      metadataOnly: true as const,
+      outcome: params.resend ? ("delivery_resent" as const) : ("delivery_sent" as const),
+      status: params.resend ? ("resent" as const) : ("sent" as const),
+      reason: params.resend ? ("delivery_resent" as const) : ("delivery_sent" as const),
+    },
+  ].slice(-50);
+  await ref.set({ institutionReviewDelivery: delivery, events, updatedAt: sentAt }, { merge: true });
+  params.grant.institutionReviewDelivery = delivery;
+  params.grant.events = events;
+  params.grant.updatedAt = sentAt;
+  return delivery;
+}
+
 export async function createInstitutionReviewInvite(params: {
   tenantId: string;
   audience?: unknown;
@@ -1856,7 +2170,7 @@ export async function createInstitutionReviewInvite(params: {
   const ref = db.collection(COLLECTION).doc(created.grantId);
   const snap = await ref.get();
   const grant = asGrant(created.grantId, snap.data?.() || created);
-  if (grant.lifecycle !== "active" || grant.package?.status !== "export_ready") {
+  if (grant.lifecycle !== "active" || grant.package?.status !== "export_ready" || lifecycleControlBlocksReview(grant)) {
     throw new Error("tenant_institution_access_policy_blocked");
   }
 
@@ -1912,13 +2226,16 @@ export async function createInstitutionReviewInvite(params: {
   grant.events = eventsBeforeSend;
   grant.updatedAt = now;
 
+  let delivery: InstitutionReviewDeliverySummary;
   try {
-    await sendInstitutionReviewInviteEmail({ grant, reviewUrl });
+    delivery = await deliverInstitutionReviewInvite({ grant, reviewUrl });
   } catch (error) {
     const failedAt = nowIso();
     const failedInvite = inviteSummaryForGrant({ grant, status: "send_failed", reviewUrl, createdAt: createdInvite.createdAt });
+    const currentSnap = await ref.get();
+    const current = asGrant(created.grantId, currentSnap.data?.() || grant);
     const failedEvents = [
-      ...eventsBeforeSend,
+      ...(Array.isArray(current.events) ? current.events : []),
       {
         eventType: "institution_review_invite_blocked" as const,
         occurredAt: failedAt,
@@ -1933,7 +2250,7 @@ export async function createInstitutionReviewInvite(params: {
     throw error;
   }
 
-  const sentAt = nowIso();
+  const sentAt = delivery.lastSentAt || nowIso();
   const sentInvite = inviteSummaryForGrant({
     grant,
     status: "invited",
@@ -1942,7 +2259,7 @@ export async function createInstitutionReviewInvite(params: {
     sentAt,
   });
   const sentEvents = [
-    ...eventsBeforeSend,
+    ...(Array.isArray(grant.events) ? grant.events : []),
     {
       eventType: "institution_review_invite_sent" as const,
       occurredAt: sentAt,
@@ -1957,9 +2274,32 @@ export async function createInstitutionReviewInvite(params: {
   return publicGrant({
     ...grant,
     institutionReviewInvite: sentInvite,
+    institutionReviewDelivery: delivery,
     events: sentEvents,
     updatedAt: sentAt,
   });
+}
+
+export async function resendInstitutionReviewDelivery(params: { tenantId: string; grantId: string }) {
+  const tenantId = asString(params.tenantId);
+  const grantId = asString(params.grantId);
+  if (!tenantId || !grantId) return null;
+  const ref = db.collection(COLLECTION).doc(grantId);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const grant = asGrant(grantId, snap.data?.() || {});
+  if (grant.tenantId !== tenantId) return false;
+  if (!grant.institutionReviewInvite || grant.institutionReviewInvite.status === "not_created") {
+    throw new Error("tenant_institution_delivery_invite_required");
+  }
+  if (grant.institutionReviewInvite.status === "revoked" || grant.institutionReviewInvite.status === "expired") {
+    throw new Error("tenant_institution_delivery_blocked");
+  }
+  const reviewUrl = grant.institutionReviewInvite.reviewUrl || institutionReviewUrl(grant.grantId);
+  await deliverInstitutionReviewInvite({ grant, reviewUrl, resend: true });
+  const currentSnap = await ref.get();
+  const current = asGrant(grantId, currentSnap.data?.() || grant);
+  return publicGrant(current);
 }
 
 export async function listTenantInstitutionAccessGrants(params: { tenantId: string }) {
@@ -2002,9 +2342,21 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
       status: "revoked" as const,
       reason: "access_revoked" as const,
     },
+    {
+      eventType: "institution_review_delivery_revoked" as const,
+      occurredAt: updatedAt,
+      actorType: "tenant" as const,
+      metadataOnly: true as const,
+      outcome: "revoked" as const,
+      status: "revoked" as const,
+      reason: "access_revoked" as const,
+    },
   ];
   const institutionReviewInvite = current.institutionReviewInvite
     ? inviteSummaryForGrant({ grant: { ...current, lifecycle: "revoked", revokedAt: updatedAt }, status: "revoked" })
+    : undefined;
+  const institutionReviewDelivery = current.institutionReviewDelivery
+    ? deliverySummaryForGrant({ grant: { ...current, lifecycle: "revoked", revokedAt: updatedAt }, status: "revoked" })
     : undefined;
   await ref.set(
     {
@@ -2013,6 +2365,7 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
       updatedAt,
       events,
       ...(institutionReviewInvite ? { institutionReviewInvite } : {}),
+      ...(institutionReviewDelivery ? { institutionReviewDelivery } : {}),
       consent: {
         ...current.consent,
         granted: false,
@@ -2036,6 +2389,7 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
     updatedAt,
     events,
     ...(institutionReviewInvite ? { institutionReviewInvite } : {}),
+    ...(institutionReviewDelivery ? { institutionReviewDelivery } : {}),
     consent: {
       ...current.consent,
       granted: false,

--- a/rentchain-frontend/src/api/tenantInstitutionAccess.ts
+++ b/rentchain-frontend/src/api/tenantInstitutionAccess.ts
@@ -124,7 +124,14 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
       | "institution_review_invite_authenticated"
       | "institution_review_invite_revoked"
       | "institution_review_invite_expired"
-      | "institution_review_invite_blocked";
+      | "institution_review_invite_blocked"
+      | "institution_review_delivery_prepared"
+      | "institution_review_delivery_sent"
+      | "institution_review_delivery_failed"
+      | "institution_review_delivery_blocked"
+      | "institution_review_delivery_resent"
+      | "institution_review_delivery_revoked"
+      | "institution_review_delivery_expired";
     occurredAt: string;
     actorType: "tenant" | "system" | "recipient";
     metadataOnly: true;
@@ -133,6 +140,10 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
       | "invite_sent"
       | "invite_opened"
       | "invite_authenticated"
+      | "delivery_prepared"
+      | "delivery_sent"
+      | "delivery_failed"
+      | "delivery_resent"
       | "granted"
       | "opened"
       | "blocked"
@@ -168,6 +179,27 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
     metadataOnly: true;
     summary: string;
   };
+  institutionReviewDelivery?: {
+    schemaVersion: "institution_review_delivery.v1";
+    status: "not_prepared" | "prepared" | "sent" | "failed" | "blocked" | "resent" | "revoked" | "expired";
+    attemptCount: number;
+    lastAttemptAt: string | null;
+    lastSentAt: string | null;
+    lastFailedAt: string | null;
+    lastFailureReason: string | null;
+    recipientEmail: string;
+    redactedRecipientEmail: string;
+    audience: TenantInstitutionAccessAudience;
+    purpose: TenantInstitutionAccessPurpose;
+    reviewUrl: string | null;
+    tenantAuthorized: true;
+    recipientAuthenticationRequired: true;
+    bearerAccessEnabled: false;
+    publicAccessEnabled: false;
+    downloadEnabled: false;
+    metadataOnly: true;
+    summary: string;
+  };
 };
 
 export type TenantInstitutionAccessAuditEvent = {
@@ -193,7 +225,14 @@ export type TenantInstitutionAccessAuditEvent = {
     | "institution_review_invite_authenticated"
     | "institution_review_invite_revoked"
     | "institution_review_invite_expired"
-    | "institution_review_invite_blocked";
+    | "institution_review_invite_blocked"
+    | "institution_review_delivery_prepared"
+    | "institution_review_delivery_sent"
+    | "institution_review_delivery_failed"
+    | "institution_review_delivery_blocked"
+    | "institution_review_delivery_resent"
+    | "institution_review_delivery_revoked"
+    | "institution_review_delivery_expired";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   outcome:
@@ -201,6 +240,10 @@ export type TenantInstitutionAccessAuditEvent = {
     | "invite_sent"
     | "invite_opened"
     | "invite_authenticated"
+    | "delivery_prepared"
+    | "delivery_sent"
+    | "delivery_failed"
+    | "delivery_resent"
     | "granted"
     | "opened"
     | "blocked"
@@ -309,6 +352,16 @@ export async function createInstitutionReviewInvite(
     {
       method: "POST",
       body: request,
+    }
+  );
+  return res.data;
+}
+
+export async function resendInstitutionReviewDelivery(grantId: string): Promise<TenantInstitutionAccessGrant> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantInstitutionAccessGrant }>(
+    `/tenant/institution-access/grants/${encodeURIComponent(grantId)}/delivery/resend`,
+    {
+      method: "POST",
     }
   );
   return res.data;

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -76,6 +76,7 @@ const tenantInstitutionAccessApi = vi.hoisted(() => ({
   listTenantInstitutionAccessGrants: vi.fn(),
   previewTenantInstitutionAccess: vi.fn(),
   createInstitutionReviewInvite: vi.fn(),
+  resendInstitutionReviewDelivery: vi.fn(),
   revokeTenantInstitutionAccessGrant: vi.fn(),
 }));
 
@@ -899,7 +900,53 @@ describe("tenant workspace frontend shell", () => {
         metadataOnly: true,
         summary: "This invitation points the recipient to an authenticated review.",
       },
+      institutionReviewDelivery: {
+        schemaVersion: "institution_review_delivery.v1",
+        status: "sent",
+        attemptCount: 1,
+        lastAttemptAt: "2026-05-09T00:00:30.000Z",
+        lastSentAt: "2026-05-09T00:01:00.000Z",
+        lastFailedAt: null,
+        lastFailureReason: null,
+        recipientEmail: "reviewer@example.com",
+        redactedRecipientEmail: "re***@example.com",
+        audience: "insurer",
+        purpose: "insurance_review",
+        reviewUrl: "https://www.rentchain.test/recipient/trust-review/grant-1",
+        tenantAuthorized: true,
+        recipientAuthenticationRequired: true,
+        bearerAccessEnabled: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        metadataOnly: true,
+        summary: "Delivery is tenant-authorized and metadata-only.",
+      },
     });
+    tenantInstitutionAccessApi.resendInstitutionReviewDelivery.mockImplementation(async (grantId: string) => ({
+      ...institutionAccessGrant,
+      grantId,
+      institutionReviewDelivery: {
+        schemaVersion: "institution_review_delivery.v1",
+        status: "resent",
+        attemptCount: 2,
+        lastAttemptAt: "2026-05-09T03:00:00.000Z",
+        lastSentAt: "2026-05-09T03:00:05.000Z",
+        lastFailedAt: null,
+        lastFailureReason: null,
+        recipientEmail: "reviewer@example.com",
+        redactedRecipientEmail: "re***@example.com",
+        audience: "insurer",
+        purpose: "insurance_review",
+        reviewUrl: "https://www.rentchain.test/recipient/trust-review/grant-1",
+        tenantAuthorized: true,
+        recipientAuthenticationRequired: true,
+        bearerAccessEnabled: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        metadataOnly: true,
+        summary: "Delivery is tenant-authorized and metadata-only.",
+      },
+    }));
     tenantInstitutionAccessApi.revokeTenantInstitutionAccessGrant.mockImplementation(async (grantId: string) => ({
       ...institutionAccessGrant,
       grantId,
@@ -1622,6 +1669,10 @@ describe("tenant workspace frontend shell", () => {
     });
     expect(await screen.findByText(/Tenant portability metadata available/i)).toBeInTheDocument();
     expect(screen.getByText(/Invited/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Delivery/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Sent/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Delivery attempts/i)).toBeInTheDocument();
+    expect(screen.getByText(/Delivery emails contain only the review context and sign-in requirement/i)).toBeInTheDocument();
     expect(screen.getByText(/Access activity/i)).toBeInTheDocument();
     expect(screen.getByText(/re\*\*\*@example.com/i)).toBeInTheDocument();
     expect(screen.getByText(/Opened reviews/i)).toBeInTheDocument();
@@ -1635,6 +1686,12 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.queryByText(/verified tenant/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/reputation/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /send to institution/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Resend delivery/i }));
+    await waitFor(() => {
+      expect(tenantInstitutionAccessApi.resendInstitutionReviewDelivery).toHaveBeenCalledWith("grant-1");
+    });
+    expect(await screen.findByText(/^Resent$/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Revoke access/i }));
     await waitFor(() => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -40,6 +40,7 @@ import {
   createInstitutionReviewInvite,
   listTenantInstitutionAccessGrants,
   previewTenantInstitutionAccess,
+  resendInstitutionReviewDelivery,
   revokeTenantInstitutionAccessGrant,
   type TenantInstitutionAccessAudience,
   type TenantInstitutionAccessGrant,
@@ -228,6 +229,14 @@ function prettyAccessAuditOutcome(value: string | null | undefined) {
       return "Invite opened";
     case "invite_authenticated":
       return "Invite authenticated";
+    case "delivery_prepared":
+      return "Delivery prepared";
+    case "delivery_sent":
+      return "Delivery sent";
+    case "delivery_failed":
+      return "Delivery failed";
+    case "delivery_resent":
+      return "Delivery resent";
     case "opened":
       return "Review opened";
     case "blocked":
@@ -753,6 +762,24 @@ export default function TenantWorkspacePage() {
       setInstitutionAccessPreview((current) => (current?.grantId === grantId ? revoked : current));
     } catch (err: any) {
       setInstitutionAccessError(err?.payload?.error || err?.message || "Unable to revoke institution access right now.");
+    } finally {
+      setInstitutionAccessBusy(false);
+    }
+  }, []);
+
+  const handleResendInstitutionDelivery = React.useCallback(async (grantId: string) => {
+    try {
+      setInstitutionAccessBusy(true);
+      setInstitutionAccessError(null);
+      const delivered = await resendInstitutionReviewDelivery(grantId);
+      setInstitutionAccessGrants((current) => current.map((entry) => (entry.grantId === grantId ? delivered : entry)));
+      setInstitutionAccessPreview((current) => (current?.grantId === grantId ? delivered : current));
+    } catch (err: any) {
+      setInstitutionAccessError(
+        err?.payload?.error === "TENANT_INSTITUTION_DELIVERY_BLOCKED"
+          ? "This delivery cannot be resent because access is revoked, expired, policy-blocked, or lifecycle-invalid."
+          : err?.payload?.error || err?.message || "Unable to resend this institution review delivery right now."
+      );
     } finally {
       setInstitutionAccessBusy(false);
     }
@@ -1909,6 +1936,18 @@ export default function TenantWorkspacePage() {
                         { label: "Audience", value: prettyInstitutionAccessAudience(entry.audience) },
                         { label: "Status", value: prettyTrustExportLifecycle(entry.lifecycle) },
                         { label: "Invite", value: entry.institutionReviewInvite?.status ? prettyStatus(entry.institutionReviewInvite.status) : "Not created" },
+                        {
+                          label: "Delivery",
+                          value: entry.institutionReviewDelivery?.status ? prettyStatus(entry.institutionReviewDelivery.status) : "Not prepared",
+                        },
+                        {
+                          label: "Delivery attempts",
+                          value: String(entry.institutionReviewDelivery?.attemptCount || 0),
+                        },
+                        {
+                          label: "Last sent",
+                          value: entry.institutionReviewDelivery?.lastSentAt ? formatDate(entry.institutionReviewDelivery.lastSentAt) : "Not sent",
+                        },
                         { label: "Created", value: formatDate(entry.createdAt) },
                         { label: "Expires", value: formatDate(entry.expiresAt) },
                         { label: "Authentication", value: "Required before review" },
@@ -1963,11 +2002,24 @@ export default function TenantWorkspacePage() {
                           Recipient review activity will appear here after authenticated review attempts. Trust payloads and support/internal metadata are never shown in this activity summary.
                         </div>
                       )}
+                      <div style={{ color: textTokens.secondary, lineHeight: 1.5 }}>
+                        Delivery emails contain only the review context and sign-in requirement. They do not include
+                        trust payloads, raw IDs, downloads, approval language, or bearer-token access.
+                      </div>
                     </div>
                     {entry.lifecycle === "active" ? (
-                      <button type="button" onClick={() => void handleRevokeInstitutionAccessGrant(entry.grantId)} disabled={institutionAccessBusy}>
-                        Revoke access
-                      </button>
+                      <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+                        <button
+                          type="button"
+                          onClick={() => void handleResendInstitutionDelivery(entry.grantId)}
+                          disabled={institutionAccessBusy}
+                        >
+                          Resend delivery
+                        </button>
+                        <button type="button" onClick={() => void handleRevokeInstitutionAccessGrant(entry.grantId)} disabled={institutionAccessBusy}>
+                          Revoke access
+                        </button>
+                      </div>
                     ) : null}
                   </div>
                 ))


### PR DESCRIPTION
## Summary
- Added a metadata-only institution review delivery model on top of the existing tenant-mediated access grant and institution review invite stack.
- Added controlled resend delivery semantics with lifecycle/policy/consent checks before email delivery and safe tenant-visible delivery status/history.
- Preserved recipient-authenticated, non-public, view-only review: no institution APIs, provider integrations, public profiles, downloads, share-package widening, or trust payload exposure.

## Audit Summary
Current institution review invites created tenant-mediated access grants, created review invite summaries, sent conservative email, and reused recipient-authenticated review/session/lifecycle controls. Gaps were that delivery state was implicit in invite status, resend/retry behavior was not first-class, and delivery attempts were not independently audit-visible. This PR adds explicit delivery status and delivery events without creating a parallel access system.

## Delivery Model
- `institution_review_delivery.v1` tracks prepared/sent/failed/blocked/resent/revoked/expired states, attempt count, safe recipient labels, last sent/failed timestamps, and safe failure categories.
- Delivery and resend require active tenant access, active consent, active export lifecycle controls, policy-ready package summaries, recipient email binding, and recipient authentication requirement.
- Delivery emails remain conservative and contain no trust payloads, downloads, public trust profile language, approval/eligibility claims, or bearer-token authorization.

## Verification
- Targeted API tests: `npx vitest run src/routes/__tests__/tenantPortalRoutes.test.ts src/routes/__tests__/recipientTrustReviewRoutes.test.ts src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts`
- Targeted frontend tests: `npx vitest run src/pages/tenant/TenantWorkspacePage.test.tsx src/pages/RecipientTrustReviewPage.test.tsx`
- API TypeScript: `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit`
- Frontend TypeScript: `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- API `npm run test` under Node 20.20.2 outside sandbox after sandbox-local supertest bind failures
- API `npm run build` under Node 20.20.2
- Frontend `npm run test` under Node 20.20.2
- Frontend `npm run build` under Node 20.20.2
- `git diff --check`
- Confirmed no lockfile/dependency drift

## Remaining Risks
- Browser/manual QA was not run.
- Delivery remains email-based and tenant-triggered; institution identity verification and institution APIs remain out of scope.