### PR TITLE
Add institution review session observability

### DIFF
--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -413,6 +413,36 @@ describe("supportConsoleRoutes", () => {
             downloadEnabled: false,
           }),
         }),
+        observability: expect.objectContaining({
+          schemaVersion: "institution_review_observability.v1",
+          operationalHealth: "attention_required",
+          lifecycleMetrics: expect.objectContaining({
+            blockedReviewCount: 1,
+            openedReviewCount: 0,
+          }),
+          sessionHealth: expect.objectContaining({
+            continuityState: "not_started",
+            staleSessionDetected: false,
+          }),
+          bottlenecks: expect.objectContaining({
+            unresolvedBlockedReview: true,
+            reviewNeverOpened: false,
+            policyDenied: false,
+          }),
+          escalation: expect.objectContaining({
+            followUpRequired: true,
+            primaryReason: "recipient_access_issue",
+            nextOperationalAction: "recipient_followup",
+          }),
+          visibility: expect.objectContaining({
+            supportSafe: true,
+            recipientVisible: false,
+            trustPayloadIncluded: false,
+            providerPayloadIncluded: false,
+            publicAccessEnabled: false,
+            downloadEnabled: false,
+          }),
+        }),
       })
     );
     const payload = JSON.stringify(response.body);

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -503,6 +503,35 @@ describe("tenantInstitutionAccessService", () => {
           blockedReviewCount: 1,
           reasonCategories: expect.arrayContaining(["access_granted", "recipient_email_mismatch", "review_available"]),
         }),
+        observability: expect.objectContaining({
+          schemaVersion: "institution_review_observability.v1",
+          operationalHealth: "attention_required",
+          lifecycleMetrics: expect.objectContaining({
+            openedReviewCount: 1,
+            blockedReviewCount: 1,
+          }),
+          sessionHealth: expect.objectContaining({
+            sessionStartedCount: 1,
+            continuityState: "active",
+            staleSessionDetected: false,
+          }),
+          bottlenecks: expect.objectContaining({
+            unresolvedBlockedReview: true,
+            reviewNeverOpened: false,
+          }),
+          escalation: expect.objectContaining({
+            followUpRequired: true,
+            primaryReason: "recipient_access_issue",
+            nextOperationalAction: "recipient_followup",
+          }),
+          visibility: expect.objectContaining({
+            supportSafe: true,
+            recipientVisible: false,
+            trustPayloadIncluded: false,
+            publicAccessEnabled: false,
+            downloadEnabled: false,
+          }),
+        }),
         payloadSafety: expect.objectContaining({
           metadataOnly: true,
           supportSafe: true,

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -293,6 +293,75 @@ export type PilotInstitutionReviewOperation = {
   events: PilotInstitutionReviewEvent[];
 };
 
+export type InstitutionReviewObservabilitySummary = {
+  schemaVersion: "institution_review_observability.v1";
+  operationalHealth: "healthy" | "attention_required" | "blocked" | "inactive";
+  lifecycleMetrics: {
+    pendingReviewCount: number;
+    activeReviewCount: number;
+    awaitingAuthenticationCount: number;
+    openedReviewCount: number;
+    blockedReviewCount: number;
+    expiredReviewCount: number;
+    revokedReviewCount: number;
+    supersededReviewCount: number;
+    completedReviewCount: number;
+  };
+  sessionHealth: {
+    sessionStartedCount: number;
+    sessionExpiredCount: number;
+    staleSessionDetected: boolean;
+    replayBlockedCount: number;
+    reauthenticationRequiredCount: number;
+    invalidatedSessionCount: number;
+    continuityState: "not_started" | "active" | "stale" | "invalidated";
+  };
+  bottlenecks: {
+    awaitingAuthentication: boolean;
+    reviewNeverOpened: boolean;
+    deliveryNotSent: boolean;
+    unresolvedBlockedReview: boolean;
+    lifecycleBlocked: boolean;
+    policyDenied: boolean;
+    staleReview: boolean;
+  };
+  escalation: {
+    followUpRequired: boolean;
+    primaryReason: PilotInstitutionReviewEscalation;
+    reasons: PilotInstitutionReviewEscalation[];
+    nextOperationalAction: PilotInstitutionReviewOperation["coordination"]["nextOperationalAction"];
+  };
+  conversion: {
+    deliveryAttemptCount: number;
+    deliverySent: boolean;
+    reviewOpened: boolean;
+    authenticatedReviewObserved: boolean;
+    completionEvidence: "none" | "opened_only" | "explicit_completion";
+  };
+  auditAlignment: {
+    sourceEventCount: number;
+    pilotEventCount: number;
+    lastActivityAt: string | null;
+    lastObservedReason: TenantInstitutionAccessAuditEvent["reason"] | PilotInstitutionReviewEscalation | null;
+    metadataOnly: true;
+  };
+  visibility: {
+    supportSafe: true;
+    operatorVisible: true;
+    tenantVisible: false;
+    recipientVisible: false;
+    portableVisible: false;
+    metadataOnly: true;
+    trustPayloadIncluded: false;
+    providerPayloadIncluded: false;
+    rawIdentityPayloadIncluded: false;
+    rawPropertyPayloadIncluded: false;
+    supportMetadataIncluded: false;
+    publicAccessEnabled: false;
+    downloadEnabled: false;
+  };
+};
+
 export type TenantInstitutionAccessGrantEvent = {
   eventType:
     | "tenant_institution_access_granted"
@@ -657,6 +726,7 @@ export type SupportInstitutionAccessDiagnosticSummary = {
     reasonCategories: string[];
   };
   pilotOperation: PilotInstitutionReviewOperation;
+  observability: InstitutionReviewObservabilitySummary;
   payloadSafety: {
     metadataOnly: true;
     supportSafe: true;
@@ -1413,6 +1483,121 @@ function buildPilotOperation(record: TenantInstitutionAccessStoredGrant): PilotI
   };
 }
 
+function observabilityHealth(params: {
+  pilotOperation: PilotInstitutionReviewOperation;
+  lifecycleBlocked: boolean;
+}): InstitutionReviewObservabilitySummary["operationalHealth"] {
+  if (
+    params.pilotOperation.status === "review_revoked" ||
+    params.pilotOperation.status === "review_expired" ||
+    params.pilotOperation.status === "review_superseded"
+  ) {
+    return "inactive";
+  }
+  if (params.lifecycleBlocked || params.pilotOperation.status === "review_blocked") return "blocked";
+  if (params.pilotOperation.escalation.required || params.pilotOperation.continuity.sessionState === "stale") {
+    return "attention_required";
+  }
+  return "healthy";
+}
+
+function buildInstitutionReviewObservability(params: {
+  record: TenantInstitutionAccessStoredGrant;
+  auditSummary: TenantInstitutionAccessAuditSummary;
+  auditTimeline: TenantInstitutionAccessAuditEvent[];
+  pilotOperation: PilotInstitutionReviewOperation;
+}): InstitutionReviewObservabilitySummary {
+  const replayBlockedCount = params.auditTimeline.filter((event) => event.reason === "recipient_session_replay_blocked").length;
+  const reauthenticationRequiredCount = params.auditTimeline.filter(
+    (event) => event.reason === "recipient_session_reauthentication_required" || event.reason === "recipient_session_stale"
+  ).length;
+  const invalidatedSessionCount = params.auditTimeline.filter(
+    (event) => event.eventType === "recipient_review_session_revoked" || event.eventType === "recipient_review_session_blocked"
+  ).length;
+  const authenticatedReviewObserved = params.auditTimeline.some(
+    (event) => event.eventType === "institution_review_invite_authenticated" || event.outcome === "opened"
+  );
+  const lifecycleState = asString(params.record.package?.lifecycleControl?.state, 120);
+  const lifecycleBlocked =
+    params.record.lifecycle === "blocked" ||
+    params.record.package?.status === "blocked" ||
+    lifecycleState === "blocked" ||
+    params.pilotOperation.continuity.policyDeniedVisible;
+  const deliveryStatus = params.pilotOperation.continuity.deliveryStatus;
+  const deliverySent = deliveryStatus === "sent" || deliveryStatus === "resent";
+  const reviewOpened = params.auditSummary.openedReviewCount > 0;
+  const status = params.pilotOperation.status;
+
+  return {
+    schemaVersion: "institution_review_observability.v1",
+    operationalHealth: observabilityHealth({ pilotOperation: params.pilotOperation, lifecycleBlocked }),
+    lifecycleMetrics: {
+      pendingReviewCount: status === "pending_review" ? 1 : 0,
+      activeReviewCount: status === "active_review" ? 1 : 0,
+      awaitingAuthenticationCount: status === "awaiting_authentication" ? 1 : 0,
+      openedReviewCount: params.auditSummary.openedReviewCount,
+      blockedReviewCount: params.auditSummary.blockedReviewCount,
+      expiredReviewCount: status === "review_expired" || params.auditSummary.expiredAccessCount > 0 ? 1 : 0,
+      revokedReviewCount: status === "review_revoked" || params.auditSummary.revokedAccessCount > 0 ? 1 : 0,
+      supersededReviewCount: status === "review_superseded" ? 1 : 0,
+      completedReviewCount: status === "review_completed" ? 1 : 0,
+    },
+    sessionHealth: {
+      sessionStartedCount: params.auditSummary.sessionStartedCount,
+      sessionExpiredCount: params.auditSummary.sessionExpiredCount,
+      staleSessionDetected: params.pilotOperation.continuity.sessionState === "stale",
+      replayBlockedCount,
+      reauthenticationRequiredCount,
+      invalidatedSessionCount,
+      continuityState: params.pilotOperation.continuity.sessionState,
+    },
+    bottlenecks: {
+      awaitingAuthentication: status === "awaiting_authentication",
+      reviewNeverOpened: deliverySent && !reviewOpened,
+      deliveryNotSent: params.pilotOperation.reporting.deliveryAttemptCount === 0 || deliveryStatus === "failed",
+      unresolvedBlockedReview: params.auditSummary.blockedReviewCount > 0 && params.pilotOperation.escalation.required,
+      lifecycleBlocked,
+      policyDenied: params.pilotOperation.continuity.policyDeniedVisible,
+      staleReview: params.pilotOperation.continuity.sessionState === "stale",
+    },
+    escalation: {
+      followUpRequired: params.pilotOperation.coordination.reviewNeedsFollowUp,
+      primaryReason: params.pilotOperation.escalation.primaryReason,
+      reasons: params.pilotOperation.escalation.reasons,
+      nextOperationalAction: params.pilotOperation.coordination.nextOperationalAction,
+    },
+    conversion: {
+      deliveryAttemptCount: params.pilotOperation.reporting.deliveryAttemptCount,
+      deliverySent,
+      reviewOpened,
+      authenticatedReviewObserved,
+      completionEvidence: status === "review_completed" ? "explicit_completion" : reviewOpened ? "opened_only" : "none",
+    },
+    auditAlignment: {
+      sourceEventCount: params.auditSummary.totalEvents,
+      pilotEventCount: params.pilotOperation.events.length,
+      lastActivityAt: params.auditSummary.lastActivityAt || params.pilotOperation.reporting.lastActivityAt,
+      lastObservedReason: params.auditSummary.lastReason || params.pilotOperation.escalation.primaryReason,
+      metadataOnly: true,
+    },
+    visibility: {
+      supportSafe: true,
+      operatorVisible: true,
+      tenantVisible: false,
+      recipientVisible: false,
+      portableVisible: false,
+      metadataOnly: true,
+      trustPayloadIncluded: false,
+      providerPayloadIncluded: false,
+      rawIdentityPayloadIncluded: false,
+      rawPropertyPayloadIncluded: false,
+      supportMetadataIncluded: false,
+      publicAccessEnabled: false,
+      downloadEnabled: false,
+    },
+  };
+}
+
 function publicGrant(record: TenantInstitutionAccessStoredGrant): TenantInstitutionAccessGrant {
   const { tenantId: _tenantId, ...rest } = record;
   const { auditSummary, auditTimeline } = buildAccessAudit(record);
@@ -1465,6 +1650,12 @@ function supportDiagnosticFromGrant(record: TenantInstitutionAccessStoredGrant):
     },
   }));
   const pilotOperation = buildPilotOperation(record);
+  const observability = buildInstitutionReviewObservability({
+    record,
+    auditSummary,
+    auditTimeline,
+    pilotOperation,
+  });
 
   return {
     schemaVersion: "support_institution_access_diagnostics.v1",
@@ -1521,6 +1712,7 @@ function supportDiagnosticFromGrant(record: TenantInstitutionAccessStoredGrant):
       reasonCategories,
     },
     pilotOperation,
+    observability,
     payloadSafety: {
       metadataOnly: true,
       supportSafe: true,

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -240,6 +240,74 @@ export type SupportInstitutionAccessDiagnosticSummary = {
       downloadEnabled: false;
     };
   };
+  observability?: {
+    schemaVersion: "institution_review_observability.v1";
+    operationalHealth: string;
+    lifecycleMetrics: {
+      pendingReviewCount: number;
+      activeReviewCount: number;
+      awaitingAuthenticationCount: number;
+      openedReviewCount: number;
+      blockedReviewCount: number;
+      expiredReviewCount: number;
+      revokedReviewCount: number;
+      supersededReviewCount: number;
+      completedReviewCount: number;
+    };
+    sessionHealth: {
+      sessionStartedCount: number;
+      sessionExpiredCount: number;
+      staleSessionDetected: boolean;
+      replayBlockedCount: number;
+      reauthenticationRequiredCount: number;
+      invalidatedSessionCount: number;
+      continuityState: string;
+    };
+    bottlenecks: {
+      awaitingAuthentication: boolean;
+      reviewNeverOpened: boolean;
+      deliveryNotSent: boolean;
+      unresolvedBlockedReview: boolean;
+      lifecycleBlocked: boolean;
+      policyDenied: boolean;
+      staleReview: boolean;
+    };
+    escalation: {
+      followUpRequired: boolean;
+      primaryReason: string;
+      reasons: string[];
+      nextOperationalAction: string;
+    };
+    conversion: {
+      deliveryAttemptCount: number;
+      deliverySent: boolean;
+      reviewOpened: boolean;
+      authenticatedReviewObserved: boolean;
+      completionEvidence: string;
+    };
+    auditAlignment: {
+      sourceEventCount: number;
+      pilotEventCount: number;
+      lastActivityAt: string | null;
+      lastObservedReason: string | null;
+      metadataOnly: true;
+    };
+    visibility: {
+      supportSafe: true;
+      operatorVisible: true;
+      tenantVisible: false;
+      recipientVisible: false;
+      portableVisible: false;
+      metadataOnly: true;
+      trustPayloadIncluded: false;
+      providerPayloadIncluded: false;
+      rawIdentityPayloadIncluded: false;
+      rawPropertyPayloadIncluded: false;
+      supportMetadataIncluded: false;
+      publicAccessEnabled: false;
+      downloadEnabled: false;
+    };
+  };
   payloadSafety: {
     metadataOnly: true;
     supportSafe: true;

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -357,6 +357,74 @@ describe("SupportDebugConsolePage", () => {
             downloadEnabled: false,
           },
         },
+        observability: {
+          schemaVersion: "institution_review_observability.v1",
+          operationalHealth: "attention_required",
+          lifecycleMetrics: {
+            pendingReviewCount: 0,
+            activeReviewCount: 0,
+            awaitingAuthenticationCount: 0,
+            openedReviewCount: 1,
+            blockedReviewCount: 1,
+            expiredReviewCount: 0,
+            revokedReviewCount: 0,
+            supersededReviewCount: 0,
+            completedReviewCount: 0,
+          },
+          sessionHealth: {
+            sessionStartedCount: 1,
+            sessionExpiredCount: 0,
+            staleSessionDetected: false,
+            replayBlockedCount: 0,
+            reauthenticationRequiredCount: 0,
+            invalidatedSessionCount: 0,
+            continuityState: "active",
+          },
+          bottlenecks: {
+            awaitingAuthentication: false,
+            reviewNeverOpened: false,
+            deliveryNotSent: false,
+            unresolvedBlockedReview: true,
+            lifecycleBlocked: false,
+            policyDenied: false,
+            staleReview: false,
+          },
+          escalation: {
+            followUpRequired: true,
+            primaryReason: "recipient_access_issue",
+            reasons: ["recipient_access_issue"],
+            nextOperationalAction: "recipient_followup",
+          },
+          conversion: {
+            deliveryAttemptCount: 1,
+            deliverySent: true,
+            reviewOpened: true,
+            authenticatedReviewObserved: true,
+            completionEvidence: "opened_only",
+          },
+          auditAlignment: {
+            sourceEventCount: 2,
+            pilotEventCount: 2,
+            lastActivityAt: "2026-05-02T00:00:00.000Z",
+            lastObservedReason: "review_available",
+            metadataOnly: true,
+          },
+          visibility: {
+            supportSafe: true,
+            operatorVisible: true,
+            tenantVisible: false,
+            recipientVisible: false,
+            portableVisible: false,
+            metadataOnly: true,
+            trustPayloadIncluded: false,
+            providerPayloadIncluded: false,
+            rawIdentityPayloadIncluded: false,
+            rawPropertyPayloadIncluded: false,
+            supportMetadataIncluded: false,
+            publicAccessEnabled: false,
+            downloadEnabled: false,
+          },
+        },
         payloadSafety: {
           metadataOnly: true,
           supportSafe: true,
@@ -518,6 +586,10 @@ describe("SupportDebugConsolePage", () => {
     expect(screen.getByText(/Pilot status/i)).toBeInTheDocument();
     expect(screen.getByText(/Review escalated/i)).toBeInTheDocument();
     expect(screen.getByText(/recipient_followup/i)).toBeInTheDocument();
+    expect(screen.getByText(/Review health/i)).toBeInTheDocument();
+    expect(screen.getByText(/attention_required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Replay blocks/i)).toBeInTheDocument();
+    expect(screen.getByText(/Completion evidence/i)).toBeInTheDocument();
     expect(screen.getByText(/Trust payloads, portable attestation contents, provider payloads/i)).toBeInTheDocument();
     expect(screen.getByText(/Operator audit timeline/i)).toBeInTheDocument();
     expect(screen.getByText(/trust_export_superseded/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -72,6 +72,23 @@ function renderInstitutionAccessDiagnostics(payload: SupportConsoleResourceRespo
             <div><strong>Delivery status</strong>: {diagnostic.pilotOperation.continuity.deliveryStatus}</div>
           </div>
         ) : null}
+        {diagnostic.observability ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+              <div><strong>Review health</strong>: {diagnostic.observability.operationalHealth}</div>
+              <div><strong>Stale session</strong>: {diagnostic.observability.sessionHealth.staleSessionDetected ? "Detected" : "Not detected"}</div>
+              <div><strong>Replay blocks</strong>: {diagnostic.observability.sessionHealth.replayBlockedCount}</div>
+              <div><strong>Reauthentication required</strong>: {diagnostic.observability.sessionHealth.reauthenticationRequiredCount}</div>
+              <div><strong>Lifecycle blocked</strong>: {diagnostic.observability.bottlenecks.lifecycleBlocked ? "Yes" : "No"}</div>
+              <div><strong>Review never opened</strong>: {diagnostic.observability.bottlenecks.reviewNeverOpened ? "Yes" : "No"}</div>
+              <div><strong>Delivery attempts</strong>: {diagnostic.observability.conversion.deliveryAttemptCount}</div>
+              <div><strong>Completion evidence</strong>: {diagnostic.observability.conversion.completionEvidence}</div>
+            </div>
+            <div style={{ color: "#475569" }}>
+              Observability is support-safe operational metadata only. It does not include trust payloads, provider payloads, raw identity or property data, public access, or downloads.
+            </div>
+          </div>
+        ) : null}
         <div style={{ color: "#475569" }}>
           Metadata-only diagnostic. Trust payloads, portable attestation contents, provider payloads, raw identity or property data, support metadata, public links, and downloads are excluded.
         </div>


### PR DESCRIPTION
## Summary

Implements the first support-safe observability layer for institution review sessions and pilot institution review operations.

- Adds `institution_review_observability.v1` as a derived, metadata-only support diagnostic summary.
- Captures lifecycle distribution, session health, stale/replay/reauthentication indicators, bottlenecks, escalation/follow-up signals, delivery/review conversion signals, and audit alignment.
- Surfaces the observability summary in the support console institution access diagnostic view.
- Adds backend and frontend regression coverage for observability aggregation and payload safety.

## Implementation Audit Summary

Existing institution review state is already centralized through tenant-mediated access grants, recipient review events, pilot operation summaries, support-safe diagnostics, and the operator audit timeline. The main gap was that support operators had event timelines and per-grant diagnostics but no normalized health summary for review continuity, stale sessions, blocked/revoked/expired states, or follow-up bottlenecks.

This PR derives observability from existing safe summaries only. It does not introduce a new event source, public route, trust payload projection, export, institution integration, provider integration, or automated decisioning.

## Governance Boundaries

Observability remains support-safe and operationally scoped:

- no trust payloads
- no portable attestation contents
- no raw identity/property/provider payloads
- no support metadata exposed externally
- no recipient/institution visibility widening
- no public dashboards
- no downloads/exports
- no scoring or automated institutional decision semantics

## Validation

- Targeted API tests passed: tenant institution access service, support console routes, operator audit timeline, recipient trust review routes, institution review sessions.
- Targeted frontend tests passed: support debug console, recipient trust review page.
- API typecheck passed: `tsc -p tsconfig.build.json --noEmit`.
- Frontend typecheck passed: `tsc -p tsconfig.json --noEmit`.
- Full API test suite passed under Node 20 outside sandbox: `npm run test`.
- Full frontend test suite passed under Node 20: `npm run test`.
- API build passed under Node 20: `npm run build`.
- Frontend build passed under Node 20: `npm run build`.
- `git diff --check` passed.

## QA

Manual browser QA was not run. Automated coverage verifies the observability payload is metadata-only, redacted, support-safe, and rendered in the support console without exposing raw recipient email, included claims, export summaries, or trust payload data.