### PR TITLE
Security session telemetry foundations v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
@@ -67,6 +67,11 @@ async function invokeRouter(router: any, options: { method: string; url: string;
       path: options.url,
       params: {},
       headers: options.headers || {},
+      ip: "203.0.113.30",
+      socket: { remoteAddress: "203.0.113.31" },
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
     };
     const match = options.url.match(/^\/trust-reviews\/([^/?#]+)/);
     if (match) req.params.grantId = decodeURIComponent(match[1]);
@@ -199,7 +204,7 @@ describe("recipientTrustReviewRoutes", () => {
     const res = await invokeRouter(router, {
       method: "GET",
       url: "/trust-reviews/grant-1",
-      headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
+    headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
     });
 
     expect(res.status).toBe(200);
@@ -249,6 +254,38 @@ describe("recipientTrustReviewRoutes", () => {
         }),
       ])
     );
+    const securityTelemetry = stored.events
+      .map((event: any) => event.securityTelemetry)
+      .filter(Boolean);
+    expect(securityTelemetry).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          schemaVersion: "security_session_telemetry.v1",
+          workflow: "recipient_trust_review",
+          signal: "recipient_review_opened",
+          retention: expect.objectContaining({
+            classification: "security_session_internal",
+            internalOnly: true,
+            portableVisible: false,
+            exportable: false,
+          }),
+          request: expect.objectContaining({
+            ipHash: expect.any(String),
+            ipFamily: "ipv4",
+            userAgentFamily: "unknown",
+          }),
+          payloadSafety: expect.objectContaining({
+            trustPayloadIncluded: false,
+            preciseGeolocationIncluded: false,
+            deviceFingerprintingIncluded: false,
+            behavioralProfileIncluded: false,
+            riskScoreIncluded: false,
+          }),
+        }),
+      ])
+    );
+    expect(JSON.stringify(res.body?.data || {})).not.toContain("securityTelemetry");
+    expect(JSON.stringify(securityTelemetry)).not.toContain("203.0.113");
   });
 
   it("requires reauthentication for expired or mismatched recipient review sessions", async () => {

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -53,7 +53,7 @@ vi.mock("../../middleware/requireAuth", () => ({
 
 async function invokeRouter(
   router: any,
-  options: { method: string; url: string; user?: Record<string, unknown> | null }
+  options: { method: string; url: string; user?: Record<string, unknown> | null; headers?: Record<string, string> }
 ) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const [path, queryString] = options.url.split("?");
@@ -66,7 +66,9 @@ async function invokeRouter(
       user: options.user ?? null,
       query: Object.fromEntries(query.entries()),
       params: {},
-      headers: {},
+      headers: options.headers || {},
+      ip: "203.0.113.40",
+      socket: { remoteAddress: "203.0.113.41" },
       get(name: string) {
         return this.headers[String(name).toLowerCase()];
       },
@@ -186,9 +188,24 @@ describe("supportConsoleRoutes", () => {
           metadataOnly: true,
           redactionApplied: true,
           retentionCategory: "support_diagnostics",
+          securityTelemetry: expect.objectContaining({
+            schemaVersion: "security_session_telemetry.v1",
+            workflow: "support_diagnostics",
+            signal: "operator_diagnostics_access",
+            internalOnly: true,
+            metadataOnly: true,
+            ipHash: expect.any(String),
+            userAgentFamily: "unknown",
+            rawIpVisible: false,
+            rawUserAgentVisible: false,
+            portableVisible: false,
+            exportable: false,
+            riskScoreIncluded: false,
+          }),
         }),
       }),
     ]);
+    expect(JSON.stringify(auditEvents)).not.toContain("203.0.113.40");
   });
 
   it("returns maintenance data without reconciliation", async () => {

--- a/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
+++ b/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
@@ -4,6 +4,17 @@ import { getRecipientTrustReview } from "../services/tenantPortal/tenantInstitut
 
 const router = Router();
 
+function requestSecurityContext(req: any) {
+  const forwardedFor = String(req.headers?.["x-forwarded-for"] || "")
+    .split(",")[0]
+    .trim();
+  return {
+    ipAddress: forwardedFor || String(req.ip || req.socket?.remoteAddress || "").trim() || null,
+    userAgent: String(req.get?.("user-agent") || req.headers?.["user-agent"] || "").trim() || null,
+    requestId: String(req.headers?.["x-request-id"] || req.headers?.["x-correlation-id"] || "").trim() || null,
+  };
+}
+
 function statusForDecision(status: string) {
   if (status === "unauthenticated") return 401;
   if (status === "session_expired" || status === "reauthentication_required") return 401;
@@ -24,7 +35,13 @@ router.get("/trust-reviews/:grantId", requireAuth, async (req: any, res) => {
   ).trim();
 
   try {
-    const result = await getRecipientTrustReview({ grantId, recipientEmail, recipientUserId, recipientSessionId });
+    const result = await getRecipientTrustReview({
+      grantId,
+      recipientEmail,
+      recipientUserId,
+      recipientSessionId,
+      requestContext: requestSecurityContext(req),
+    });
     if (!result.decision.allowed) {
       return res.status(statusForDecision(result.decision.status)).json({
         ok: false,

--- a/rentchain-api/src/routes/supportConsoleRoutes.ts
+++ b/rentchain-api/src/routes/supportConsoleRoutes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import crypto from "crypto";
 import { requireAuth } from "../middleware/requireAuth";
 import { requirePermission } from "../middleware/requireAuthz";
 import { buildSupportConsoleResource } from "../lib/supportConsole/buildSupportConsoleResource";
@@ -9,6 +10,50 @@ const router = Router();
 
 function asString(value: unknown, max = 240) {
   return String(value || "").trim().slice(0, max);
+}
+
+function telemetryHash(value: unknown) {
+  const raw = asString(value, 500);
+  if (!raw) return null;
+  return crypto.createHash("sha256").update(raw).digest("hex").slice(0, 20);
+}
+
+function requestSecurityTelemetry(req: any) {
+  const ip = String(req.headers?.["x-forwarded-for"] || "")
+    .split(",")[0]
+    .trim() || asString(req.ip || req.socket?.remoteAddress, 120);
+  const userAgent = asString(req.get?.("user-agent") || req.headers?.["user-agent"], 500);
+  const userAgentLower = String(userAgent || "").toLowerCase();
+  const userAgentFamily = userAgentLower.includes("edg/")
+    ? "edge"
+    : userAgentLower.includes("chrome/")
+    ? "chrome"
+    : userAgentLower.includes("safari/")
+    ? "safari"
+    : userAgentLower.includes("firefox/")
+    ? "firefox"
+    : userAgentLower
+    ? "other"
+    : "unknown";
+  return {
+    schemaVersion: "security_session_telemetry.v1",
+    workflow: "support_diagnostics",
+    signal: "operator_diagnostics_access",
+    internalOnly: true,
+    metadataOnly: true,
+    ipHash: telemetryHash(ip),
+    userAgentHash: telemetryHash(userAgent),
+    userAgentFamily,
+    retentionClassification: "security_session_internal",
+    rawIpVisible: false,
+    rawUserAgentVisible: false,
+    preciseGeolocationIncluded: false,
+    deviceFingerprintingIncluded: false,
+    behavioralProfileIncluded: false,
+    riskScoreIncluded: false,
+    portableVisible: false,
+    exportable: false,
+  };
 }
 
 function isInstitutionAccessResourceType(value: unknown) {
@@ -53,6 +98,7 @@ async function recordSupportConsoleAccess(req: any, input: { resourceType: strin
         trustPayloadIncluded: false,
         rawProviderPayloadIncluded: false,
         downloadEnabled: false,
+        securityTelemetry: requestSecurityTelemetry(req),
       },
       tags: institutionAccess
         ? ["support_console", "institution_access_diagnostics", "governance"]

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -244,6 +244,7 @@ describe("tenantInstitutionAccessService", () => {
     const wrongRecipient = await service.getRecipientTrustReview({
       grantId: grant?.grantId || "",
       recipientEmail: "other@example.com",
+      requestContext: { ipAddress: "203.0.113.10", userAgent: "Mozilla/5.0 Chrome/120.0", requestId: "req-1" },
     });
     expect(wrongRecipient.decision.allowed).toBe(false);
     expect(wrongRecipient.decision.status).toBe("recipient_mismatch");
@@ -251,6 +252,8 @@ describe("tenantInstitutionAccessService", () => {
     const review = await service.getRecipientTrustReview({
       grantId: grant?.grantId || "",
       recipientEmail: "Reviewer@Example.com",
+      recipientUserId: "recipient-1",
+      requestContext: { ipAddress: "203.0.113.10", userAgent: "Mozilla/5.0 Chrome/120.0", requestId: "req-2" },
     });
     expect(review.decision.allowed).toBe(true);
     expect(review.summary?.schemaVersion).toBe("recipient_trust_review.v1");
@@ -312,6 +315,9 @@ describe("tenantInstitutionAccessService", () => {
       auditTimeline: listed[0].auditTimeline,
     });
     expect(auditPayload).not.toContain("tenant-1");
+    expect(auditPayload).not.toContain("securityTelemetry");
+    expect(auditPayload).not.toContain("203.0.113.10");
+    expect(auditPayload).not.toContain("Mozilla");
     expect(auditPayload).not.toContain("policyDecisions");
     expect(auditPayload).not.toContain("supportMetadataIncluded\":true");
     expect(auditPayload).not.toContain("rawProviderPayloadIncluded\":true");
@@ -319,6 +325,9 @@ describe("tenantInstitutionAccessService", () => {
     expect(auditPayload).not.toContain("downloadEnabled\":true");
     const payload = JSON.stringify(review.summary || {});
     expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("securityTelemetry");
+    expect(payload).not.toContain("203.0.113.10");
+    expect(payload).not.toContain("Mozilla");
     expect(payload).not.toContain("policyDecisions");
     expect(payload).not.toContain("rawProviderPayloadIncluded\":true");
     expect(payload).not.toContain("rawEvidenceIncluded\":true");
@@ -471,10 +480,13 @@ describe("tenantInstitutionAccessService", () => {
     await service.getRecipientTrustReview({
       grantId: grant?.grantId || "",
       recipientEmail: "other@example.com",
+      requestContext: { ipAddress: "198.51.100.20", userAgent: "Mozilla/5.0 Firefox/120.0" },
     });
     await service.getRecipientTrustReview({
       grantId: grant?.grantId || "",
       recipientEmail: "reviewer@example.com",
+      recipientUserId: "recipient-1",
+      requestContext: { ipAddress: "198.51.100.20", userAgent: "Mozilla/5.0 Firefox/120.0" },
     });
 
     const diagnostic = await service.getSupportInstitutionAccessDiagnostic({ grantId: grant?.grantId || "" });
@@ -502,6 +514,37 @@ describe("tenantInstitutionAccessService", () => {
           openedReviewCount: 1,
           blockedReviewCount: 1,
           reasonCategories: expect.arrayContaining(["access_granted", "recipient_email_mismatch", "review_available"]),
+        }),
+        securityTelemetry: expect.objectContaining({
+          schemaVersion: "support_safe_security_session_telemetry.v1",
+          internalOnly: true,
+          metadataOnly: true,
+          eventCount: 3,
+          blockedAttemptCount: 1,
+          wrongRecipientAttemptCount: 1,
+          uniqueIpHashCount: 1,
+          userAgentFamilies: ["firefox"],
+          signals: expect.arrayContaining(["recipient_review_opened", "recipient_session_started", "wrong_recipient_attempt"]),
+          retention: expect.objectContaining({
+            classification: "security_session_internal",
+            nonPortable: true,
+            nonExportable: true,
+          }),
+          redaction: expect.objectContaining({
+            ipAddressMode: "hash_only",
+            rawIpVisible: false,
+            rawUserAgentVisible: false,
+            preciseGeolocationIncluded: false,
+            deviceFingerprintingIncluded: false,
+            riskScoreIncluded: false,
+          }),
+          visibility: expect.objectContaining({
+            supportSafe: true,
+            tenantVisible: false,
+            recipientVisible: false,
+            portableVisible: false,
+            trustPayloadIncluded: false,
+          }),
         }),
         observability: expect.objectContaining({
           schemaVersion: "institution_review_observability.v1",
@@ -548,6 +591,9 @@ describe("tenantInstitutionAccessService", () => {
     const payload = JSON.stringify(diagnostic || {});
     expect(payload).not.toContain("tenant-1");
     expect(payload).not.toContain("reviewer@example.com");
+    expect(payload).not.toContain("198.51.100.20");
+    expect(payload).not.toContain("Mozilla");
+    expect(payload).not.toContain("Firefox/120.0");
     expect(payload).not.toContain("includedClaims");
     expect(payload).not.toContain("exportSummaries");
     expect(payload).not.toContain("policyDecisions");

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -23,6 +23,114 @@ const MAX_EXPIRES_DAYS = 30;
 const RECIPIENT_REVIEW_SESSION_TTL_MS = 30 * 60 * 1000;
 const RECIPIENT_REVIEW_SESSION_STALE_MS = 15 * 60 * 1000;
 
+export type SecuritySessionTelemetryActorType = "recipient" | "operator" | "system";
+
+export type SecuritySessionTelemetrySignal =
+  | "recipient_review_opened"
+  | "recipient_review_blocked"
+  | "wrong_recipient_attempt"
+  | "revoked_access_attempt"
+  | "expired_access_attempt"
+  | "policy_denied_attempt"
+  | "stale_session_attempt"
+  | "replay_blocked_attempt"
+  | "recipient_session_started"
+  | "operator_diagnostics_access";
+
+export type SecuritySessionRequestContext = {
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  requestId?: string | null;
+};
+
+export type SecuritySessionTelemetryEvent = {
+  schemaVersion: "security_session_telemetry.v1";
+  recordedAt: string;
+  actorType: SecuritySessionTelemetryActorType;
+  workflow: "recipient_trust_review" | "support_diagnostics";
+  signal: SecuritySessionTelemetrySignal;
+  lifecycleState: string | null;
+  reasonCode: string | null;
+  subject: {
+    grantIdRedacted: string | null;
+    recipientReferenceRedacted: string | null;
+    sessionReferenceRedacted: string | null;
+    userReferenceRedacted: string | null;
+  };
+  request: {
+    ipHash: string | null;
+    ipFamily: "ipv4" | "ipv6" | "unknown";
+    userAgentHash: string | null;
+    userAgentFamily: string;
+    requestReferenceRedacted: string | null;
+  };
+  retention: {
+    classification: "security_session_internal";
+    internalOnly: true;
+    portableVisible: false;
+    tenantVisible: false;
+    recipientVisible: false;
+    publicVisible: false;
+    exportable: false;
+  };
+  payloadSafety: {
+    metadataOnly: true;
+    trustPayloadIncluded: false;
+    rawProviderPayloadIncluded: false;
+    rawIdentityPayloadIncluded: false;
+    rawPropertyPayloadIncluded: false;
+    preciseGeolocationIncluded: false;
+    deviceFingerprintingIncluded: false;
+    behavioralProfileIncluded: false;
+    riskScoreIncluded: false;
+  };
+};
+
+export type SupportSafeSecuritySessionTelemetrySummary = {
+  schemaVersion: "support_safe_security_session_telemetry.v1";
+  internalOnly: true;
+  metadataOnly: true;
+  eventCount: number;
+  blockedAttemptCount: number;
+  wrongRecipientAttemptCount: number;
+  revokedAttemptCount: number;
+  expiredAttemptCount: number;
+  replayBlockedCount: number;
+  staleSessionCount: number;
+  uniqueIpHashCount: number;
+  userAgentFamilies: string[];
+  lastSignal: SecuritySessionTelemetrySignal | null;
+  lastRecordedAt: string | null;
+  signals: SecuritySessionTelemetrySignal[];
+  retention: {
+    classification: "security_session_internal";
+    nonPortable: true;
+    nonExportable: true;
+  };
+  redaction: {
+    ipAddressMode: "hash_only";
+    userAgentMode: "family_and_hash";
+    rawIpVisible: false;
+    rawUserAgentVisible: false;
+    preciseGeolocationIncluded: false;
+    deviceFingerprintingIncluded: false;
+    behavioralProfileIncluded: false;
+    riskScoreIncluded: false;
+  };
+  visibility: {
+    supportSafe: true;
+    operatorVisible: true;
+    tenantVisible: false;
+    recipientVisible: false;
+    portableVisible: false;
+    publicVisible: false;
+    trustPayloadIncluded: false;
+    providerPayloadIncluded: false;
+    rawIdentityPayloadIncluded: false;
+    rawPropertyPayloadIncluded: false;
+  };
+};
+
 export type TenantInstitutionAccessAudience = "insurer" | "lender" | "institutional_landlord" | "auditor";
 
 export type TenantInstitutionAccessPurpose =
@@ -435,6 +543,7 @@ export type TenantInstitutionAccessGrantEvent = {
     | "authenticated"
     | "send_failed"
     | InstitutionReviewDeliveryStatus;
+  securityTelemetry?: SecuritySessionTelemetryEvent;
 };
 
 type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessPreview & {
@@ -725,6 +834,7 @@ export type SupportInstitutionAccessDiagnosticSummary = {
     lastReason: TenantInstitutionAccessAuditSummary["lastReason"];
     reasonCategories: string[];
   };
+  securityTelemetry: SupportSafeSecuritySessionTelemetrySummary;
   pilotOperation: PilotInstitutionReviewOperation;
   observability: InstitutionReviewObservabilitySummary;
   payloadSafety: {
@@ -828,6 +938,168 @@ function redactEmail(value: string | null | undefined) {
   const [local, domain] = email.split("@");
   const visible = local.length <= 2 ? local.slice(0, 1) : `${local.slice(0, 2)}***`;
   return `${visible}@${domain}`;
+}
+
+function telemetryHash(value: unknown) {
+  const raw = asString(value, 500);
+  if (!raw) return null;
+  return crypto.createHash("sha256").update(raw).digest("hex").slice(0, 20);
+}
+
+function ipFamily(value: unknown): SecuritySessionTelemetryEvent["request"]["ipFamily"] {
+  const raw = asString(value, 120) || "";
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(raw)) return "ipv4";
+  if (raw.includes(":")) return "ipv6";
+  return "unknown";
+}
+
+function userAgentFamily(value: unknown) {
+  const raw = (asString(value, 500) || "").toLowerCase();
+  if (!raw) return "unknown";
+  if (raw.includes("edg/") || raw.includes("edge/")) return "edge";
+  if (raw.includes("chrome/") || raw.includes("chromium/")) return "chrome";
+  if (raw.includes("safari/") && !raw.includes("chrome/")) return "safari";
+  if (raw.includes("firefox/")) return "firefox";
+  if (raw.includes("bot") || raw.includes("crawler") || raw.includes("spider")) return "automated_client";
+  return "other";
+}
+
+function signalForGrantEvent(params: {
+  eventType: TenantInstitutionAccessGrantEvent["eventType"];
+  reason: TenantInstitutionAccessGrantEvent["reason"];
+}): SecuritySessionTelemetrySignal {
+  if (params.eventType === "recipient_trust_review_opened") return "recipient_review_opened";
+  if (params.eventType === "recipient_review_session_started") return "recipient_session_started";
+  if (params.reason === "recipient_email_mismatch") return "wrong_recipient_attempt";
+  if (params.reason === "grant_revoked" || params.eventType === "recipient_trust_review_revoked") return "revoked_access_attempt";
+  if (params.reason === "grant_expired" || params.eventType === "recipient_trust_review_expired") return "expired_access_attempt";
+  if (params.reason === "recipient_session_replay_blocked") return "replay_blocked_attempt";
+  if (params.reason === "recipient_session_stale") return "stale_session_attempt";
+  if (params.reason === "policy_gated_summary_unavailable" || params.reason === "trust_export_lifecycle_inactive") {
+    return "policy_denied_attempt";
+  }
+  return "recipient_review_blocked";
+}
+
+function buildSecurityTelemetryEvent(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  eventType: TenantInstitutionAccessGrantEvent["eventType"];
+  occurredAt: string;
+  actorType?: TenantInstitutionAccessGrantEvent["actorType"];
+  status: TenantInstitutionAccessGrantEvent["status"];
+  reason: TenantInstitutionAccessGrantEvent["reason"];
+  recipientEmail?: string | null;
+  recipientUserId?: string | null;
+  recipientSessionId?: string | null;
+  requestContext?: SecuritySessionRequestContext | null;
+}): SecuritySessionTelemetryEvent | undefined {
+  const signal = signalForGrantEvent({ eventType: params.eventType, reason: params.reason });
+  if (!params.requestContext && signal !== "wrong_recipient_attempt" && signal !== "revoked_access_attempt" && signal !== "expired_access_attempt") {
+    return undefined;
+  }
+  const ip = asString(params.requestContext?.ipAddress, 120);
+  const userAgent = asString(params.requestContext?.userAgent, 500);
+  return {
+    schemaVersion: "security_session_telemetry.v1",
+    recordedAt: params.occurredAt,
+    actorType: params.actorType === "system" ? "system" : "recipient",
+    workflow: "recipient_trust_review",
+    signal,
+    lifecycleState: asString(params.status, 80),
+    reasonCode: asString(params.reason, 120),
+    subject: {
+      grantIdRedacted: redactIdentifier(params.grant.grantId),
+      recipientReferenceRedacted: redactIdentifier(params.recipientEmail || params.grant.recipient?.email || null),
+      sessionReferenceRedacted: redactIdentifier(params.recipientSessionId || null),
+      userReferenceRedacted: redactIdentifier(params.recipientUserId || null),
+    },
+    request: {
+      ipHash: telemetryHash(ip),
+      ipFamily: ipFamily(ip),
+      userAgentHash: telemetryHash(userAgent),
+      userAgentFamily: userAgentFamily(userAgent),
+      requestReferenceRedacted: redactIdentifier(params.requestContext?.requestId || null),
+    },
+    retention: {
+      classification: "security_session_internal",
+      internalOnly: true,
+      portableVisible: false,
+      tenantVisible: false,
+      recipientVisible: false,
+      publicVisible: false,
+      exportable: false,
+    },
+    payloadSafety: {
+      metadataOnly: true,
+      trustPayloadIncluded: false,
+      rawProviderPayloadIncluded: false,
+      rawIdentityPayloadIncluded: false,
+      rawPropertyPayloadIncluded: false,
+      preciseGeolocationIncluded: false,
+      deviceFingerprintingIncluded: false,
+      behavioralProfileIncluded: false,
+      riskScoreIncluded: false,
+    },
+  };
+}
+
+function publicGrantEvent(event: TenantInstitutionAccessGrantEvent): TenantInstitutionAccessGrantEvent {
+  const { securityTelemetry: _securityTelemetry, ...safeEvent } = event;
+  return safeEvent;
+}
+
+function buildSupportSafeSecurityTelemetrySummary(record: TenantInstitutionAccessStoredGrant): SupportSafeSecuritySessionTelemetrySummary {
+  const telemetry = (Array.isArray(record.events) ? record.events : [])
+    .map((event) => event.securityTelemetry)
+    .filter(Boolean) as SecuritySessionTelemetryEvent[];
+  telemetry.sort((left, right) => Date.parse(right.recordedAt) - Date.parse(left.recordedAt));
+  const signals = Array.from(new Set(telemetry.map((event) => event.signal))).sort() as SecuritySessionTelemetrySignal[];
+  const ipHashes = new Set(telemetry.map((event) => event.request.ipHash).filter(Boolean));
+  const userAgentFamilies = Array.from(new Set(telemetry.map((event) => event.request.userAgentFamily).filter(Boolean))).sort();
+  return {
+    schemaVersion: "support_safe_security_session_telemetry.v1",
+    internalOnly: true,
+    metadataOnly: true,
+    eventCount: telemetry.length,
+    blockedAttemptCount: telemetry.filter((event) => event.signal.endsWith("_attempt") || event.signal === "recipient_review_blocked").length,
+    wrongRecipientAttemptCount: telemetry.filter((event) => event.signal === "wrong_recipient_attempt").length,
+    revokedAttemptCount: telemetry.filter((event) => event.signal === "revoked_access_attempt").length,
+    expiredAttemptCount: telemetry.filter((event) => event.signal === "expired_access_attempt").length,
+    replayBlockedCount: telemetry.filter((event) => event.signal === "replay_blocked_attempt").length,
+    staleSessionCount: telemetry.filter((event) => event.signal === "stale_session_attempt").length,
+    uniqueIpHashCount: ipHashes.size,
+    userAgentFamilies,
+    lastSignal: telemetry[0]?.signal || null,
+    lastRecordedAt: telemetry[0]?.recordedAt || null,
+    signals,
+    retention: {
+      classification: "security_session_internal",
+      nonPortable: true,
+      nonExportable: true,
+    },
+    redaction: {
+      ipAddressMode: "hash_only",
+      userAgentMode: "family_and_hash",
+      rawIpVisible: false,
+      rawUserAgentVisible: false,
+      preciseGeolocationIncluded: false,
+      deviceFingerprintingIncluded: false,
+      behavioralProfileIncluded: false,
+      riskScoreIncluded: false,
+    },
+    visibility: {
+      supportSafe: true,
+      operatorVisible: true,
+      tenantVisible: false,
+      recipientVisible: false,
+      portableVisible: false,
+      publicVisible: false,
+      trustPayloadIncluded: false,
+      providerPayloadIncluded: false,
+      rawIdentityPayloadIncluded: false,
+      rawPropertyPayloadIncluded: false,
+    },
+  };
 }
 
 function grantIdFor(params: {
@@ -1603,6 +1875,7 @@ function publicGrant(record: TenantInstitutionAccessStoredGrant): TenantInstitut
   const { auditSummary, auditTimeline } = buildAccessAudit(record);
   const normalizedRecord = {
     ...rest,
+    events: (Array.isArray(record.events) ? record.events : []).map(publicGrantEvent),
     institutionReviewInvite: record.institutionReviewInvite || inviteSummaryForGrant({ grant: record, status: "not_created", reviewUrl: null }),
     institutionReviewDelivery:
       record.institutionReviewDelivery ||
@@ -1711,6 +1984,7 @@ function supportDiagnosticFromGrant(record: TenantInstitutionAccessStoredGrant):
       lastReason: auditSummary.lastReason,
       reasonCategories,
     },
+    securityTelemetry: buildSupportSafeSecurityTelemetrySummary(record),
     pilotOperation,
     observability,
     payloadSafety: {
@@ -1881,8 +2155,24 @@ async function appendGrantEvent(params: {
   outcome?: TenantInstitutionAccessGrantEvent["outcome"];
   status: TenantInstitutionAccessGrantEvent["status"];
   reason: TenantInstitutionAccessGrantEvent["reason"];
+  recipientEmail?: string | null;
+  recipientUserId?: string | null;
+  recipientSessionId?: string | null;
+  requestContext?: SecuritySessionRequestContext | null;
 }) {
   const ref = db.collection(COLLECTION).doc(params.grant.grantId);
+  const securityTelemetry = buildSecurityTelemetryEvent({
+    grant: params.grant,
+    eventType: params.eventType,
+    occurredAt: params.occurredAt,
+    actorType: params.actorType,
+    status: params.status,
+    reason: params.reason,
+    recipientEmail: params.recipientEmail,
+    recipientUserId: params.recipientUserId,
+    recipientSessionId: params.recipientSessionId,
+    requestContext: params.requestContext,
+  });
   const events = [
     ...(Array.isArray(params.grant.events) ? params.grant.events : []),
     {
@@ -1893,6 +2183,7 @@ async function appendGrantEvent(params: {
       outcome: params.outcome || outcomeForEventType(params.eventType),
       status: params.status,
       reason: params.reason,
+      ...(securityTelemetry ? { securityTelemetry } : {}),
     },
   ].slice(-50);
   await ref.set({ events, updatedAt: params.occurredAt }, { merge: true });
@@ -2009,6 +2300,7 @@ async function startRecipientReviewSession(params: {
   recipientEmail: string;
   recipientUserId?: string | null;
   now: string;
+  requestContext?: SecuritySessionRequestContext | null;
 }) {
   const emailHash = recipientEmailHash(params.recipientEmail);
   await invalidateActiveSessionsForGrant({
@@ -2054,6 +2346,10 @@ async function startRecipientReviewSession(params: {
     status: "active",
     reason: "session_started",
     outcome: "session_started",
+    recipientEmail: params.recipientEmail,
+    recipientUserId: params.recipientUserId,
+    recipientSessionId: session.sessionId,
+    requestContext: params.requestContext,
   });
   return sessionSummaryFromRecord(session);
 }
@@ -2105,6 +2401,7 @@ async function validateRecipientReviewSession(params: {
   recipientUserId?: string | null;
   sessionId?: unknown;
   now: string;
+  requestContext?: SecuritySessionRequestContext | null;
 }): Promise<
   | { ok: true; session: RecipientReviewSessionSummary }
   | {
@@ -2122,6 +2419,7 @@ async function validateRecipientReviewSession(params: {
       recipientEmail: params.recipientEmail,
       recipientUserId: params.recipientUserId,
       now: params.now,
+      requestContext: params.requestContext,
     });
     return { ok: true, session };
   }
@@ -2237,6 +2535,7 @@ export async function getRecipientTrustReview(params: {
   recipientEmail?: unknown;
   recipientUserId?: unknown;
   recipientSessionId?: unknown;
+  requestContext?: SecuritySessionRequestContext | null;
 }): Promise<RecipientTrustReviewResult> {
   const grantId = asString(params.grantId);
   const recipientEmail = normalizeRecipientEmailForReview(params.recipientEmail);
@@ -2257,6 +2556,10 @@ export async function getRecipientTrustReview(params: {
       occurredAt: reviewedAt,
       status: "recipient_mismatch",
       reason: "recipient_email_mismatch",
+      recipientEmail,
+      recipientUserId: asString(params.recipientUserId, 160),
+      recipientSessionId: asString(params.recipientSessionId, 180),
+      requestContext: params.requestContext,
     });
     return denyRecipientReview("recipient_mismatch", "recipient_email_mismatch");
   }
@@ -2281,7 +2584,17 @@ export async function getRecipientTrustReview(params: {
         await invalidateActiveSessionsForGrant({ grantId: grant.grantId, lifecycle: sessionLifecycle, now: reviewedAt, reason });
       }
     }
-    await appendGrantEvent({ grant, eventType, occurredAt: reviewedAt, status, reason });
+    await appendGrantEvent({
+      grant,
+      eventType,
+      occurredAt: reviewedAt,
+      status,
+      reason,
+      recipientEmail,
+      recipientUserId: asString(params.recipientUserId, 160),
+      recipientSessionId: sessionId || asString(params.recipientSessionId, 180),
+      requestContext: params.requestContext,
+    });
     return denyRecipientReview(status, reason);
   };
 
@@ -2332,6 +2645,7 @@ export async function getRecipientTrustReview(params: {
     recipientUserId: asString(params.recipientUserId, 160),
     sessionId: params.recipientSessionId,
     now: reviewedAt,
+    requestContext: params.requestContext,
   });
   if (!sessionDecision.ok) {
     return denyWithEvent(
@@ -2349,6 +2663,10 @@ export async function getRecipientTrustReview(params: {
     occurredAt: reviewedAt,
     status: "available",
     reason: "review_available",
+    recipientEmail,
+    recipientUserId: asString(params.recipientUserId, 160),
+    recipientSessionId: sessionDecision.session.sessionId,
+    requestContext: params.requestContext,
   });
   if (grant.institutionReviewInvite) {
     await appendGrantEvent({

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -193,6 +193,50 @@ export type SupportInstitutionAccessDiagnosticSummary = {
     lastReason: string | null;
     reasonCategories: string[];
   };
+  securityTelemetry?: {
+    schemaVersion: "support_safe_security_session_telemetry.v1";
+    internalOnly: true;
+    metadataOnly: true;
+    eventCount: number;
+    blockedAttemptCount: number;
+    wrongRecipientAttemptCount: number;
+    revokedAttemptCount: number;
+    expiredAttemptCount: number;
+    replayBlockedCount: number;
+    staleSessionCount: number;
+    uniqueIpHashCount: number;
+    userAgentFamilies: string[];
+    lastSignal: string | null;
+    lastRecordedAt: string | null;
+    signals: string[];
+    retention: {
+      classification: string;
+      nonPortable: true;
+      nonExportable: true;
+    };
+    redaction: {
+      ipAddressMode: string;
+      userAgentMode: string;
+      rawIpVisible: false;
+      rawUserAgentVisible: false;
+      preciseGeolocationIncluded: false;
+      deviceFingerprintingIncluded: false;
+      behavioralProfileIncluded: false;
+      riskScoreIncluded: false;
+    };
+    visibility: {
+      supportSafe: true;
+      operatorVisible: true;
+      tenantVisible: false;
+      recipientVisible: false;
+      portableVisible: false;
+      publicVisible: false;
+      trustPayloadIncluded: false;
+      providerPayloadIncluded: false;
+      rawIdentityPayloadIncluded: false;
+      rawPropertyPayloadIncluded: false;
+    };
+  };
   pilotOperation?: {
     schemaVersion: "pilot_institution_review_operation.v1";
     status: string;

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -303,12 +303,58 @@ describe("SupportDebugConsolePage", () => {
           blockedReviewCount: 1,
           revokedAccessCount: 0,
           expiredAccessCount: 0,
+          sessionStartedCount: 1,
+          sessionExpiredCount: 0,
           lastActivityAt: "2026-05-02T00:00:00.000Z",
           lastOpenedAt: "2026-05-02T00:00:00.000Z",
           lastBlockedAt: "2026-05-01T00:00:00.000Z",
           lastOutcome: "opened",
           lastReason: "review_available",
           reasonCategories: ["recipient_email_mismatch", "review_available"],
+        },
+        securityTelemetry: {
+          schemaVersion: "support_safe_security_session_telemetry.v1",
+          internalOnly: true,
+          metadataOnly: true,
+          eventCount: 3,
+          blockedAttemptCount: 1,
+          wrongRecipientAttemptCount: 1,
+          revokedAttemptCount: 0,
+          expiredAttemptCount: 0,
+          replayBlockedCount: 0,
+          staleSessionCount: 0,
+          uniqueIpHashCount: 1,
+          userAgentFamilies: ["chrome"],
+          lastSignal: "recipient_review_opened",
+          lastRecordedAt: "2026-05-02T00:00:00.000Z",
+          signals: ["recipient_review_opened", "recipient_session_started", "wrong_recipient_attempt"],
+          retention: {
+            classification: "security_session_internal",
+            nonPortable: true,
+            nonExportable: true,
+          },
+          redaction: {
+            ipAddressMode: "hash_only",
+            userAgentMode: "family_and_hash",
+            rawIpVisible: false,
+            rawUserAgentVisible: false,
+            preciseGeolocationIncluded: false,
+            deviceFingerprintingIncluded: false,
+            behavioralProfileIncluded: false,
+            riskScoreIncluded: false,
+          },
+          visibility: {
+            supportSafe: true,
+            operatorVisible: true,
+            tenantVisible: false,
+            recipientVisible: false,
+            portableVisible: false,
+            publicVisible: false,
+            trustPayloadIncluded: false,
+            providerPayloadIncluded: false,
+            rawIdentityPayloadIncluded: false,
+            rawPropertyPayloadIncluded: false,
+          },
         },
         pilotOperation: {
           schemaVersion: "pilot_institution_review_operation.v1",
@@ -588,7 +634,10 @@ describe("SupportDebugConsolePage", () => {
     expect(screen.getByText(/recipient_followup/i)).toBeInTheDocument();
     expect(screen.getByText(/Review health/i)).toBeInTheDocument();
     expect(screen.getByText(/attention_required/i)).toBeInTheDocument();
-    expect(screen.getByText(/Replay blocks/i)).toBeInTheDocument();
+    expect(screen.getByText(/Security events/i)).toBeInTheDocument();
+    expect(screen.getByText(/Wrong recipient attempts/i)).toBeInTheDocument();
+    expect(screen.getByText(/Internal-only security telemetry/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Replay blocks/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Completion evidence/i)).toBeInTheDocument();
     expect(screen.getByText(/Trust payloads, portable attestation contents, provider payloads/i)).toBeInTheDocument();
     expect(screen.getByText(/Operator audit timeline/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -62,6 +62,23 @@ function renderInstitutionAccessDiagnostics(payload: SupportConsoleResourceRespo
           <strong>Reason categories</strong>:{" "}
           {diagnostic.audit.reasonCategories.length ? diagnostic.audit.reasonCategories.join(", ") : "None"}
         </div>
+        {diagnostic.securityTelemetry ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+              <div><strong>Security events</strong>: {diagnostic.securityTelemetry.eventCount}</div>
+              <div><strong>Blocked attempts</strong>: {diagnostic.securityTelemetry.blockedAttemptCount}</div>
+              <div><strong>Wrong recipient attempts</strong>: {diagnostic.securityTelemetry.wrongRecipientAttemptCount}</div>
+              <div><strong>Revoked attempts</strong>: {diagnostic.securityTelemetry.revokedAttemptCount}</div>
+              <div><strong>Expired attempts</strong>: {diagnostic.securityTelemetry.expiredAttemptCount}</div>
+              <div><strong>Replay blocks</strong>: {diagnostic.securityTelemetry.replayBlockedCount}</div>
+              <div><strong>Unique request origins</strong>: {diagnostic.securityTelemetry.uniqueIpHashCount}</div>
+              <div><strong>Last signal</strong>: {diagnostic.securityTelemetry.lastSignal || "None"}</div>
+            </div>
+            <div style={{ color: "#475569" }}>
+              Internal-only security telemetry. IP addresses are hash-only, user agents are reduced to family/hash form, and telemetry is non-portable and non-exportable.
+            </div>
+          </div>
+        ) : null}
         {diagnostic.pilotOperation ? (
           <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
             <div><strong>Pilot status</strong>: {diagnostic.pilotOperation.statusLabel}</div>


### PR DESCRIPTION
## Summary
- Added internal-only security/session telemetry primitives for recipient trust review access attempts.
- Captures hash-only IP references, user-agent family/hash, redacted grant/session/user references, lifecycle state, and conservative signal descriptors.
- Adds support-safe security telemetry summaries to institution access diagnostics and support-console UI.
- Enriches support console access audit metadata with redacted operator diagnostics telemetry.

## Guardrails
- Telemetry is internal-only, non-portable, and non-exportable.
- Recipient review summaries and tenant-facing audit payloads strip telemetry.
- No trust payloads, provider payloads, raw identity/property data, precise geolocation, device fingerprinting, behavioral profiling, risk scoring, public exposure, institution/provider integrations, or automated decisions were introduced.

## Validation
- API targeted: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- tenantInstitutionAccessService.test.ts recipientTrustReviewRoutes.test.ts supportConsoleRoutes.test.ts`
- Frontend targeted: `npm test -- SupportDebugConsolePage.test.tsx`
- API build: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Frontend build: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- API full: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test` outside sandbox after sandbox Supertest port binding failed with EPERM
- Frontend full: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test`
- `git diff --check`