### PR TITLE
Security and access forensics v1

### DIFF
--- a/rentchain-api/src/lib/supportConsole/__tests__/securityAccessForensics.test.ts
+++ b/rentchain-api/src/lib/supportConsole/__tests__/securityAccessForensics.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from "vitest";
+import { buildSecurityAccessForensics } from "../securityAccessForensics";
+import type { OperatorAuditTimelineSummary } from "../operatorAuditTimeline";
+import type { SupportInstitutionAccessDiagnosticSummary } from "../../../services/tenantPortal/tenantInstitutionAccessService";
+
+const visibility = {
+  supportVisible: true,
+  tenantVisible: false,
+  recipientVisible: false,
+  portableVisible: false,
+  trustPayloadIncluded: false,
+  providerPayloadIncluded: false,
+  rawIdentityPayloadIncluded: false,
+  rawPropertyPayloadIncluded: false,
+  supportMetadataIncluded: false,
+  downloadEnabled: false,
+  publicAccessEnabled: false,
+} as const;
+
+function diagnostic(): SupportInstitutionAccessDiagnosticSummary {
+  return {
+    schemaVersion: "support_institution_access_diagnostics.v1",
+    grantId: "grant-sensitive-1",
+    lifecycle: "active",
+    audience: "insurer",
+    purpose: "insurance_review",
+    recipient: {
+      redactedEmail: "re***@example.com",
+      organizationName: "Example Insurance",
+      authenticationRequirement: "recipient_email_session_required",
+    },
+    tenant: { redactedTenantId: "***nt-1" },
+    consent: {
+      granted: true,
+      consentVersion: "tenant_institution_access_consent.v1",
+      grantedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-06-01T00:00:00.000Z",
+      revokedAt: null,
+    },
+    access: {
+      recipientAuthenticationRequired: true,
+      sessionBound: true,
+      publicAccessEnabled: false,
+      publicProfileEnabled: false,
+      externalSubmissionEnabled: false,
+      downloadEnabled: false,
+    },
+    package: {
+      status: "export_ready",
+      blockedReasonCount: 0,
+      exportSummaryCount: 1,
+    },
+    audit: {
+      totalEvents: 5,
+      openedReviewCount: 0,
+      blockedReviewCount: 3,
+      revokedAccessCount: 1,
+      expiredAccessCount: 1,
+      sessionStartedCount: 1,
+      sessionExpiredCount: 1,
+      lastActivityAt: "2026-05-06T00:00:00.000Z",
+      lastOpenedAt: null,
+      lastBlockedAt: "2026-05-06T00:00:00.000Z",
+      lastOutcome: "blocked",
+      lastReason: "recipient_session_stale",
+      reasonCategories: [
+        "recipient_email_mismatch",
+        "access_revoked",
+        "access_expired",
+        "recipient_session_replay_blocked",
+        "recipient_session_stale",
+      ],
+    },
+    securityTelemetry: {
+      schemaVersion: "support_safe_security_session_telemetry.v1",
+      internalOnly: true,
+      metadataOnly: true,
+      eventCount: 6,
+      blockedAttemptCount: 5,
+      wrongRecipientAttemptCount: 2,
+      revokedAttemptCount: 1,
+      expiredAttemptCount: 1,
+      replayBlockedCount: 1,
+      staleSessionCount: 1,
+      uniqueIpHashCount: 2,
+      userAgentFamilies: ["chrome", "safari"],
+      lastSignal: "stale_session_attempt",
+      lastRecordedAt: "2026-05-06T00:00:00.000Z",
+      signals: [
+        "wrong_recipient_attempt",
+        "revoked_access_attempt",
+        "expired_access_attempt",
+        "replay_blocked_attempt",
+        "stale_session_attempt",
+      ],
+      retention: {
+        classification: "security_session_internal",
+        nonPortable: true,
+        nonExportable: true,
+      },
+      redaction: {
+        ipAddressMode: "hash_only",
+        userAgentMode: "family_and_hash",
+        rawIpVisible: false,
+        rawUserAgentVisible: false,
+        preciseGeolocationIncluded: false,
+        deviceFingerprintingIncluded: false,
+        behavioralProfileIncluded: false,
+        riskScoreIncluded: false,
+      },
+      visibility: {
+        supportSafe: true,
+        operatorVisible: true,
+        tenantVisible: false,
+        recipientVisible: false,
+        portableVisible: false,
+        publicVisible: false,
+        trustPayloadIncluded: false,
+        providerPayloadIncluded: false,
+        rawIdentityPayloadIncluded: false,
+        rawPropertyPayloadIncluded: false,
+      },
+    },
+    payloadSafety: {
+      metadataOnly: true,
+      supportSafe: true,
+      trustPayloadIncluded: false,
+      portableAttestationContentsIncluded: false,
+      rawProviderPayloadIncluded: false,
+      rawIdentityPayloadIncluded: false,
+      rawPropertyPayloadIncluded: false,
+      supportMetadataIncluded: false,
+      unsafePortablePayloadDetected: false,
+    },
+    timeline: [
+      {
+        eventType: "recipient_trust_review_blocked",
+        occurredAt: "2026-05-02T00:00:00.000Z",
+        actorType: "recipient",
+        metadataOnly: true,
+        outcome: "blocked",
+        status: "recipient_mismatch",
+        reason: "recipient_email_mismatch",
+      },
+      {
+        eventType: "recipient_trust_review_revoked",
+        occurredAt: "2026-05-03T00:00:00.000Z",
+        actorType: "recipient",
+        metadataOnly: true,
+        outcome: "blocked",
+        status: "revoked",
+        reason: "access_revoked",
+      },
+      {
+        eventType: "recipient_trust_review_expired",
+        occurredAt: "2026-05-04T00:00:00.000Z",
+        actorType: "recipient",
+        metadataOnly: true,
+        outcome: "blocked",
+        status: "expired",
+        reason: "access_expired",
+      },
+      {
+        eventType: "institution_review_session_replay_blocked",
+        occurredAt: "2026-05-05T00:00:00.000Z",
+        actorType: "recipient",
+        metadataOnly: true,
+        outcome: "blocked",
+        status: "blocked",
+        reason: "recipient_session_replay_blocked",
+      },
+      {
+        eventType: "recipient_review_session_blocked",
+        occurredAt: "2026-05-06T00:00:00.000Z",
+        actorType: "recipient",
+        metadataOnly: true,
+        outcome: "blocked",
+        status: "blocked",
+        reason: "recipient_session_stale",
+      },
+    ],
+  };
+}
+
+function operatorTimeline(): OperatorAuditTimelineSummary {
+  return {
+    schemaVersion: "operator_audit_timeline.v1",
+    metadataOnly: true,
+    supportSafe: true,
+    eventCount: 2,
+    lifecycleTransitionCount: 1,
+    revocationCount: 0,
+    expirationCount: 0,
+    supersessionCount: 1,
+    policyDeniedCount: 0,
+    sessionEventCount: 0,
+    operatorInteractionCount: 1,
+    firstEventAt: "2026-05-07T00:00:00.000Z",
+    lastEventAt: "2026-05-08T00:00:00.000Z",
+    events: [
+      {
+        schemaVersion: "operator_audit_timeline_event.v1",
+        eventId: "operator-event-1",
+        source: "operator_interaction",
+        category: "operator_access",
+        eventType: "system.institution_access_diagnostics_opened",
+        occurredAt: "2026-05-08T00:00:00.000Z",
+        actorType: "operator",
+        status: "completed",
+        outcome: "completed",
+        reason: "support_diagnostics",
+        lifecycleState: null,
+        audience: null,
+        purpose: null,
+        resource: {
+          type: "tenant_institution_access_grant",
+          id: "grant-sensitive-1",
+          redactedId: "***ve-1",
+        },
+        operator: {
+          redactedOperatorId: "***or-1",
+          role: "admin",
+        },
+        metadataOnly: true,
+        visibility,
+      },
+      {
+        schemaVersion: "operator_audit_timeline_event.v1",
+        eventId: "export-event-1",
+        source: "tenant_trust_export",
+        category: "trust_export_lifecycle",
+        eventType: "trust_export_superseded",
+        occurredAt: "2026-05-07T00:00:00.000Z",
+        actorType: "system",
+        status: "superseded",
+        outcome: "inactive",
+        reason: "export_superseded",
+        lifecycleState: "superseded",
+        audience: "insurer",
+        purpose: "insurance_review",
+        resource: {
+          type: "tenant_trust_export",
+          id: "export-sensitive-1",
+          redactedId: "***ve-1",
+        },
+        metadataOnly: true,
+        visibility,
+      },
+    ],
+    payloadSafety: {
+      trustPayloadIncluded: false,
+      portableAttestationContentsIncluded: false,
+      rawProviderPayloadIncluded: false,
+      rawIdentityPayloadIncluded: false,
+      rawPropertyPayloadIncluded: false,
+      supportMetadataIncluded: false,
+      downloadableArtifactIncluded: false,
+      publicAccessEnabled: false,
+    },
+  };
+}
+
+describe("buildSecurityAccessForensics", () => {
+  it("summarizes suspicious access chains without scores or raw telemetry", () => {
+    const summary = buildSecurityAccessForensics({
+      grantId: "grant-sensitive-1",
+      diagnostic: diagnostic(),
+      operatorAuditTimeline: operatorTimeline(),
+    });
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        schemaVersion: "security_access_forensics.v1",
+        internalOnly: true,
+        supportSafe: true,
+        metadataOnly: true,
+        incidentCount: 7,
+        requestOriginSummary: expect.objectContaining({
+          uniqueIpHashCount: 2,
+          ipHashValuesVisible: false,
+          rawIpVisible: false,
+          rawUserAgentVisible: false,
+          userAgentFamilies: ["chrome", "safari"],
+        }),
+        retention: expect.objectContaining({
+          futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
+          retentionJobImplemented: false,
+        }),
+        visibility: expect.objectContaining({
+          tenantVisible: false,
+          recipientVisible: false,
+          institutionVisible: false,
+          rawIpIncluded: false,
+          riskScoreIncluded: false,
+        }),
+      })
+    );
+    expect(summary?.incidents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "repeated_blocked_attempts_observed", count: 5 }),
+        expect.objectContaining({ type: "wrong_recipient_attempts_observed", count: 2 }),
+        expect.objectContaining({ type: "revoked_access_attempt_observed", count: 1 }),
+        expect.objectContaining({ type: "expired_access_attempt_observed", count: 1 }),
+        expect.objectContaining({ type: "replay_attempt_observed", count: 1 }),
+        expect.objectContaining({ type: "stale_session_attempt_observed", count: 1 }),
+        expect.objectContaining({ type: "operator_diagnostic_access_observed", count: 1 }),
+      ])
+    );
+    expect(summary?.chains).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "recipient_access_chain", eventCount: 5 }),
+        expect.objectContaining({ type: "operator_diagnostic_chain", eventCount: 1 }),
+        expect.objectContaining({ type: "lifecycle_context_chain", eventCount: 1 }),
+      ])
+    );
+
+    const payload = JSON.stringify(summary);
+    expect(payload).not.toContain("203.0.113");
+    expect(payload).not.toContain("Mozilla/");
+    expect(payload).not.toContain("includedClaims");
+    expect(payload).not.toContain("provider-secret");
+    expect(payload).not.toContain('"score"');
+    expect(payload).not.toContain('"profile"');
+  });
+});

--- a/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
+++ b/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
@@ -12,6 +12,7 @@ import { canonicalEventToTimelineItem } from "../timeline/timelineAdapter";
 import { redactIdentifier, redactIdentifierMap } from "../governance/platformGovernance";
 import { getSupportInstitutionAccessDiagnostic } from "../../services/tenantPortal/tenantInstitutionAccessService";
 import { buildOperatorAuditTimeline } from "./operatorAuditTimeline";
+import { buildSecurityAccessForensics } from "./securityAccessForensics";
 import type {
   SupportConsoleAutomationItem,
   SupportConsolePolicyDecision,
@@ -408,6 +409,11 @@ export async function buildSupportConsoleResource(input: {
       canonicalEvents: sortedEvents,
       tenantTrustExports,
     });
+    const securityAccessForensics = buildSecurityAccessForensics({
+      grantId: resourceId,
+      diagnostic,
+      operatorAuditTimeline,
+    });
     return {
       resource: buildInstitutionAccessHeader(resourceId, doc, diagnostic),
       timeline: sortedEvents.map(canonicalEventToTimelineItem),
@@ -429,6 +435,7 @@ export async function buildSupportConsoleResource(input: {
       watch: null,
       institutionAccessDiagnostic: diagnostic,
       operatorAuditTimeline,
+      securityAccessForensics,
       debug: {
         canonicalEventCount: relatedEvents.length,
         domainsPresent: domainsPresent(relatedEvents),

--- a/rentchain-api/src/lib/supportConsole/securityAccessForensics.ts
+++ b/rentchain-api/src/lib/supportConsole/securityAccessForensics.ts
@@ -1,0 +1,410 @@
+import type { SupportInstitutionAccessDiagnosticSummary } from "../../services/tenantPortal/tenantInstitutionAccessService";
+import { redactIdentifier } from "../governance/platformGovernance";
+import type { OperatorAuditTimelineEvent, OperatorAuditTimelineSummary } from "./operatorAuditTimeline";
+
+type ForensicIncidentType =
+  | "repeated_blocked_attempts_observed"
+  | "wrong_recipient_attempts_observed"
+  | "revoked_access_attempt_observed"
+  | "expired_access_attempt_observed"
+  | "replay_attempt_observed"
+  | "stale_session_attempt_observed"
+  | "operator_diagnostic_access_observed";
+
+type ForensicChainType =
+  | "recipient_access_chain"
+  | "operator_diagnostic_chain"
+  | "lifecycle_context_chain";
+
+export type SecurityAccessForensicEvent = {
+  schemaVersion: "security_access_forensic_event.v1";
+  eventId: string;
+  source: "recipient_access_timeline" | "operator_audit_timeline";
+  category:
+    | "blocked_access"
+    | "wrong_recipient"
+    | "revoked_access"
+    | "expired_access"
+    | "replay_blocked"
+    | "stale_session"
+    | "operator_access"
+    | "lifecycle_context";
+  eventType: string;
+  occurredAt: string;
+  actorType: string;
+  outcome: string | null;
+  reason: string | null;
+  lifecycleState: string | null;
+  resource: {
+    type: string;
+    redactedId: string | null;
+  };
+  requestContext?: {
+    ipHashPresent: boolean;
+    ipHashValueVisible: false;
+    rawIpVisible: false;
+    userAgentFamily: string | null;
+    rawUserAgentVisible: false;
+  };
+  metadataOnly: true;
+  visibility: SecurityAccessForensicVisibility;
+};
+
+export type SecurityAccessForensicIncidentSummary = {
+  type: ForensicIncidentType;
+  label: string;
+  count: number;
+  observed: boolean;
+  followUpSuggested: boolean;
+  lastObservedAt: string | null;
+};
+
+export type SecurityAccessForensicChain = {
+  type: ForensicChainType;
+  label: string;
+  eventCount: number;
+  lastEventAt: string | null;
+  events: SecurityAccessForensicEvent[];
+};
+
+export type SecurityAccessForensicVisibility = {
+  supportVisible: true;
+  operatorVisible: true;
+  tenantVisible: false;
+  recipientVisible: false;
+  institutionVisible: false;
+  portableVisible: false;
+  publicVisible: false;
+  exportable: false;
+  downloadable: false;
+  trustPayloadIncluded: false;
+  providerPayloadIncluded: false;
+  rawIdentityPayloadIncluded: false;
+  rawPropertyPayloadIncluded: false;
+  rawIpIncluded: false;
+  fullUserAgentIncluded: false;
+  behavioralProfileIncluded: false;
+  riskScoreIncluded: false;
+};
+
+export type SecurityAccessForensicSummary = {
+  schemaVersion: "security_access_forensics.v1";
+  internalOnly: true;
+  supportSafe: true;
+  metadataOnly: true;
+  grantId: string;
+  incidentCount: number;
+  chainEventCount: number;
+  incidents: SecurityAccessForensicIncidentSummary[];
+  chains: SecurityAccessForensicChain[];
+  requestOriginSummary: {
+    uniqueIpHashCount: number;
+    ipHashValuesVisible: false;
+    rawIpVisible: false;
+    userAgentFamilies: string[];
+    rawUserAgentVisible: false;
+  };
+  operatorCorrelation: {
+    operatorDiagnosticAccessCount: number;
+    lastOperatorAccessAt: string | null;
+  };
+  retention: {
+    classification: "security_session_internal";
+    nonPortable: true;
+    nonExportable: true;
+    retentionJobImplemented: false;
+    futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1";
+  };
+  prohibitedFields: {
+    rawTrustPayloads: false;
+    rawProviderPayloads: false;
+    rawIdentityDocuments: false;
+    rawPropertyPayloads: false;
+    rawIpAddresses: false;
+    fullUserAgents: false;
+    preciseGeolocation: false;
+    behavioralProfiles: false;
+    riskScores: false;
+  };
+  visibility: SecurityAccessForensicVisibility;
+};
+
+function asString(value: unknown, max = 240) {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function eventTimestamp(value: { occurredAt?: string | null }) {
+  const parsed = Date.parse(asString(value.occurredAt, 120) || "");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function visibility(): SecurityAccessForensicVisibility {
+  return {
+    supportVisible: true,
+    operatorVisible: true,
+    tenantVisible: false,
+    recipientVisible: false,
+    institutionVisible: false,
+    portableVisible: false,
+    publicVisible: false,
+    exportable: false,
+    downloadable: false,
+    trustPayloadIncluded: false,
+    providerPayloadIncluded: false,
+    rawIdentityPayloadIncluded: false,
+    rawPropertyPayloadIncluded: false,
+    rawIpIncluded: false,
+    fullUserAgentIncluded: false,
+    behavioralProfileIncluded: false,
+    riskScoreIncluded: false,
+  };
+}
+
+function lastTimestamp(events: Array<{ occurredAt?: string | null }>) {
+  const sorted = [...events].filter((event) => asString(event.occurredAt, 120)).sort((a, b) => eventTimestamp(b) - eventTimestamp(a));
+  return sorted[0]?.occurredAt || null;
+}
+
+function includesAny(value: string | null, needles: string[]) {
+  const haystack = String(value || "").toLowerCase();
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function classifyAccessEvent(event: SupportInstitutionAccessDiagnosticSummary["timeline"][number]): SecurityAccessForensicEvent["category"] | null {
+  const reason = asString(event.reason, 160);
+  const eventType = asString(event.eventType, 160);
+  const outcome = asString(event.outcome, 120);
+  const status = asString(event.status, 120);
+  if (includesAny(reason, ["recipient_email_mismatch", "wrong_recipient"])) return "wrong_recipient";
+  if (includesAny(reason, ["replay"]) || includesAny(eventType, ["replay"])) return "replay_blocked";
+  if (includesAny(reason, ["stale"]) || includesAny(eventType, ["stale"])) return "stale_session";
+  if (includesAny(reason, ["revoked"]) || includesAny(eventType, ["revoked"]) || includesAny(status, ["revoked"])) return "revoked_access";
+  if (includesAny(reason, ["expired"]) || includesAny(eventType, ["expired"]) || includesAny(status, ["expired"])) return "expired_access";
+  if (outcome === "blocked" || includesAny(eventType, ["blocked"])) return "blocked_access";
+  return null;
+}
+
+function eventFromAccessTimeline(params: {
+  grantId: string;
+  event: SupportInstitutionAccessDiagnosticSummary["timeline"][number];
+}): SecurityAccessForensicEvent | null {
+  const category = classifyAccessEvent(params.event);
+  const eventType = asString(params.event.eventType, 160);
+  const occurredAt = asString(params.event.occurredAt, 120);
+  if (!category || !eventType || !occurredAt || params.event.metadataOnly !== true) return null;
+  return {
+    schemaVersion: "security_access_forensic_event.v1",
+    eventId: `recipient:${params.grantId}:${eventType}:${occurredAt}:${asString(params.event.reason, 160) || "none"}`,
+    source: "recipient_access_timeline",
+    category,
+    eventType,
+    occurredAt,
+    actorType: asString(params.event.actorType, 80) || "system",
+    outcome: asString(params.event.outcome, 120),
+    reason: asString(params.event.reason, 160),
+    lifecycleState: asString(params.event.status, 120),
+    resource: {
+      type: "tenant_institution_access_grant",
+      redactedId: redactIdentifier(params.grantId),
+    },
+    metadataOnly: true,
+    visibility: visibility(),
+  };
+}
+
+function categoryFromOperatorEvent(event: OperatorAuditTimelineEvent): SecurityAccessForensicEvent["category"] {
+  if (event.category === "operator_access") return "operator_access";
+  if (includesAny(event.reason, ["revoked"]) || includesAny(event.eventType, ["revoked"])) return "revoked_access";
+  if (includesAny(event.reason, ["expired"]) || includesAny(event.eventType, ["expired"])) return "expired_access";
+  if (includesAny(event.reason, ["superseded", "policy"]) || event.category === "policy_denial") return "lifecycle_context";
+  return "lifecycle_context";
+}
+
+function eventFromOperatorTimeline(event: OperatorAuditTimelineEvent): SecurityAccessForensicEvent | null {
+  if (event.metadataOnly !== true) return null;
+  const eventType = asString(event.eventType, 160);
+  const occurredAt = asString(event.occurredAt, 120);
+  if (!eventType || !occurredAt) return null;
+  const category = categoryFromOperatorEvent(event);
+  if (category !== "operator_access" && category !== "revoked_access" && category !== "expired_access" && category !== "lifecycle_context") {
+    return null;
+  }
+  return {
+    schemaVersion: "security_access_forensic_event.v1",
+    eventId: `operator:${event.eventId}`,
+    source: "operator_audit_timeline",
+    category,
+    eventType,
+    occurredAt,
+    actorType: event.actorType,
+    outcome: event.outcome,
+    reason: event.reason,
+    lifecycleState: event.lifecycleState || event.status,
+    resource: {
+      type: event.resource.type,
+      redactedId: event.resource.redactedId,
+    },
+    metadataOnly: true,
+    visibility: visibility(),
+  };
+}
+
+function incident(params: {
+  type: ForensicIncidentType;
+  label: string;
+  count: number;
+  events: Array<{ occurredAt?: string | null }>;
+  followUpThreshold?: number;
+}): SecurityAccessForensicIncidentSummary {
+  const threshold = params.followUpThreshold ?? 1;
+  return {
+    type: params.type,
+    label: params.label,
+    count: params.count,
+    observed: params.count > 0,
+    followUpSuggested: params.count >= threshold,
+    lastObservedAt: lastTimestamp(params.events),
+  };
+}
+
+function chain(type: ForensicChainType, label: string, events: SecurityAccessForensicEvent[]): SecurityAccessForensicChain {
+  const sorted = [...events].sort((a, b) => eventTimestamp(b) - eventTimestamp(a)).slice(0, 25);
+  return {
+    type,
+    label,
+    eventCount: sorted.length,
+    lastEventAt: sorted[0]?.occurredAt || null,
+    events: sorted,
+  };
+}
+
+export function buildSecurityAccessForensics(input: {
+  grantId: string;
+  diagnostic: SupportInstitutionAccessDiagnosticSummary | null;
+  operatorAuditTimeline: OperatorAuditTimelineSummary | null;
+}): SecurityAccessForensicSummary | null {
+  if (!input.diagnostic && !input.operatorAuditTimeline) return null;
+  const grantId = asString(input.grantId, 240) || "unknown";
+  const telemetry = input.diagnostic?.securityTelemetry;
+  const accessEvents = (input.diagnostic?.timeline || [])
+    .map((event) => eventFromAccessTimeline({ grantId, event }))
+    .filter((event): event is SecurityAccessForensicEvent => Boolean(event));
+  const operatorEvents = (input.operatorAuditTimeline?.events || [])
+    .map(eventFromOperatorTimeline)
+    .filter((event): event is SecurityAccessForensicEvent => Boolean(event));
+
+  const blockedEvents = accessEvents.filter((event) => event.category === "blocked_access" || event.category === "wrong_recipient");
+  const wrongRecipientEvents = accessEvents.filter((event) => event.category === "wrong_recipient");
+  const revokedEvents = [...accessEvents, ...operatorEvents].filter((event) => event.category === "revoked_access");
+  const expiredEvents = [...accessEvents, ...operatorEvents].filter((event) => event.category === "expired_access");
+  const replayEvents = accessEvents.filter((event) => event.category === "replay_blocked");
+  const staleEvents = accessEvents.filter((event) => event.category === "stale_session");
+  const operatorDiagnosticEvents = operatorEvents.filter((event) => event.category === "operator_access");
+
+  const blockedCount = Math.max(telemetry?.blockedAttemptCount || 0, input.diagnostic?.audit.blockedReviewCount || 0, blockedEvents.length);
+  const wrongRecipientCount = Math.max(telemetry?.wrongRecipientAttemptCount || 0, wrongRecipientEvents.length);
+  const revokedCount = Math.max(telemetry?.revokedAttemptCount || 0, revokedEvents.length);
+  const expiredCount = Math.max(telemetry?.expiredAttemptCount || 0, expiredEvents.length);
+  const replayCount = Math.max(telemetry?.replayBlockedCount || 0, replayEvents.length);
+  const staleCount = Math.max(telemetry?.staleSessionCount || 0, staleEvents.length);
+  const operatorDiagnosticCount = Math.max(input.operatorAuditTimeline?.operatorInteractionCount || 0, operatorDiagnosticEvents.length);
+
+  const incidents = [
+    incident({
+      type: "repeated_blocked_attempts_observed",
+      label: "Repeated blocked attempts observed",
+      count: blockedCount >= 2 ? blockedCount : 0,
+      events: blockedEvents,
+      followUpThreshold: 2,
+    }),
+    incident({
+      type: "wrong_recipient_attempts_observed",
+      label: "Wrong recipient attempts observed",
+      count: wrongRecipientCount,
+      events: wrongRecipientEvents,
+    }),
+    incident({
+      type: "revoked_access_attempt_observed",
+      label: "Revoked access attempted",
+      count: revokedCount,
+      events: revokedEvents,
+    }),
+    incident({
+      type: "expired_access_attempt_observed",
+      label: "Expired access attempted",
+      count: expiredCount,
+      events: expiredEvents,
+    }),
+    incident({
+      type: "replay_attempt_observed",
+      label: "Replay or stale invite/session attempt observed",
+      count: replayCount,
+      events: replayEvents,
+    }),
+    incident({
+      type: "stale_session_attempt_observed",
+      label: "Stale session attempt observed",
+      count: staleCount,
+      events: staleEvents,
+    }),
+    incident({
+      type: "operator_diagnostic_access_observed",
+      label: "Operator diagnostic access observed",
+      count: operatorDiagnosticCount,
+      events: operatorDiagnosticEvents,
+    }),
+  ];
+
+  const chains = [
+    chain("recipient_access_chain", "Recipient access chain", accessEvents),
+    chain("operator_diagnostic_chain", "Operator diagnostic access chain", operatorDiagnosticEvents),
+    chain(
+      "lifecycle_context_chain",
+      "Lifecycle context chain",
+      operatorEvents.filter((event) => event.category !== "operator_access")
+    ),
+  ];
+
+  return {
+    schemaVersion: "security_access_forensics.v1",
+    internalOnly: true,
+    supportSafe: true,
+    metadataOnly: true,
+    grantId,
+    incidentCount: incidents.filter((item) => item.observed).length,
+    chainEventCount: chains.reduce((total, item) => total + item.eventCount, 0),
+    incidents,
+    chains,
+    requestOriginSummary: {
+      uniqueIpHashCount: telemetry?.uniqueIpHashCount || 0,
+      ipHashValuesVisible: false,
+      rawIpVisible: false,
+      userAgentFamilies: telemetry?.userAgentFamilies || [],
+      rawUserAgentVisible: false,
+    },
+    operatorCorrelation: {
+      operatorDiagnosticAccessCount: operatorDiagnosticCount,
+      lastOperatorAccessAt: lastTimestamp(operatorDiagnosticEvents),
+    },
+    retention: {
+      classification: "security_session_internal",
+      nonPortable: true,
+      nonExportable: true,
+      retentionJobImplemented: false,
+      futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
+    },
+    prohibitedFields: {
+      rawTrustPayloads: false,
+      rawProviderPayloads: false,
+      rawIdentityDocuments: false,
+      rawPropertyPayloads: false,
+      rawIpAddresses: false,
+      fullUserAgents: false,
+      preciseGeolocation: false,
+      behavioralProfiles: false,
+      riskScores: false,
+    },
+    visibility: visibility(),
+  };
+}

--- a/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
+++ b/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
@@ -5,6 +5,7 @@ import type { SlaEvaluationV1 } from "../sla/slaTypes";
 import type { WatchlistEntryV1 } from "../watchlist/watchlistTypes";
 import type { SupportInstitutionAccessDiagnosticSummary } from "../../services/tenantPortal/tenantInstitutionAccessService";
 import type { OperatorAuditTimelineSummary } from "./operatorAuditTimeline";
+import type { SecurityAccessForensicSummary } from "./securityAccessForensics";
 
 export type SupportConsoleResourceSummary = {
   type: string;
@@ -48,6 +49,7 @@ export type SupportConsoleResourceResponse = {
   watch?: WatchlistEntryV1 | null;
   institutionAccessDiagnostic?: SupportInstitutionAccessDiagnosticSummary | null;
   operatorAuditTimeline?: OperatorAuditTimelineSummary | null;
+  securityAccessForensics?: SecurityAccessForensicSummary | null;
   debug: {
     canonicalEventCount: number;
     domainsPresent: string[];

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -322,6 +322,50 @@ describe("supportConsoleRoutes", () => {
           outcome: "blocked",
           status: "recipient_mismatch",
           reason: "recipient_email_mismatch",
+          securityTelemetry: {
+            schemaVersion: "security_session_telemetry.v1",
+            recordedAt: "2026-05-02T00:00:00.000Z",
+            actorType: "recipient",
+            workflow: "recipient_trust_review",
+            signal: "wrong_recipient_attempt",
+            lifecycleState: "active",
+            reasonCode: "recipient_email_mismatch",
+            subject: {
+              grantIdRedacted: "***nt-1",
+              recipientReferenceRedacted: "re***@example.com",
+              sessionReferenceRedacted: "***on-1",
+              userReferenceRedacted: "***er-1",
+            },
+            request: {
+              ipHash: "hash-only-reference",
+              ipFamily: "ipv4",
+              userAgentHash: "ua-hash-only-reference",
+              userAgentFamily: "chrome",
+              requestReferenceRedacted: "***st-1",
+            },
+            retention: {
+              classification: "security_session_internal",
+              internalOnly: true,
+              portableVisible: false,
+              tenantVisible: false,
+              recipientVisible: false,
+              publicVisible: false,
+              exportable: false,
+            },
+            payloadSafety: {
+              metadataOnly: true,
+              trustPayloadIncluded: false,
+              rawProviderPayloadIncluded: false,
+              rawIdentityPayloadIncluded: false,
+              rawPropertyPayloadIncluded: false,
+              rawIpIncluded: false,
+              fullUserAgentIncluded: false,
+              preciseGeolocationIncluded: false,
+              deviceFingerprintingIncluded: false,
+              behavioralProfileIncluded: false,
+              riskScoreIncluded: false,
+            },
+          },
         },
       ],
     });
@@ -514,6 +558,51 @@ describe("supportConsoleRoutes", () => {
         }),
       ])
     );
+    expect(response.body?.securityAccessForensics).toEqual(
+      expect.objectContaining({
+        schemaVersion: "security_access_forensics.v1",
+        internalOnly: true,
+        supportSafe: true,
+        metadataOnly: true,
+        incidentCount: expect.any(Number),
+        requestOriginSummary: expect.objectContaining({
+          uniqueIpHashCount: 1,
+          ipHashValuesVisible: false,
+          rawIpVisible: false,
+          userAgentFamilies: ["chrome"],
+          rawUserAgentVisible: false,
+        }),
+        operatorCorrelation: expect.objectContaining({
+          operatorDiagnosticAccessCount: 1,
+        }),
+        retention: expect.objectContaining({
+          classification: "security_session_internal",
+          retentionJobImplemented: false,
+          futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
+        }),
+        visibility: expect.objectContaining({
+          tenantVisible: false,
+          recipientVisible: false,
+          institutionVisible: false,
+          portableVisible: false,
+          rawIpIncluded: false,
+          trustPayloadIncluded: false,
+          riskScoreIncluded: false,
+        }),
+      })
+    );
+    expect(response.body?.securityAccessForensics?.incidents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "wrong_recipient_attempts_observed", count: 1 }),
+        expect.objectContaining({ type: "operator_diagnostic_access_observed", count: 1 }),
+      ])
+    );
+    expect(response.body?.securityAccessForensics?.chains).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "recipient_access_chain", eventCount: 1 }),
+        expect.objectContaining({ type: "operator_diagnostic_chain", eventCount: 1 }),
+      ])
+    );
 
     const auditEvents = Array.from(collections.get("canonicalEvents")?.values() || []).filter(
       (event: any) => event.type === "system.institution_access_diagnostics_opened" && event.actor?.id === "admin-1"
@@ -536,6 +625,9 @@ describe("supportConsoleRoutes", () => {
         }),
       }),
     ]);
+    expect(JSON.stringify(response.body?.securityAccessForensics)).not.toContain("hash-only-reference");
+    expect(JSON.stringify(response.body?.securityAccessForensics)).not.toContain("ua-hash-only-reference");
+    expect(JSON.stringify(response.body?.securityAccessForensics)).not.toContain("203.0.113");
   });
 
   it("extracts policy and automation histories", async () => {

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -37,6 +37,7 @@ export type SupportConsoleResourceResponse = {
   resolution?: ResolutionRecordV1 | null;
   institutionAccessDiagnostic?: SupportInstitutionAccessDiagnosticSummary | null;
   operatorAuditTimeline?: OperatorAuditTimelineSummary | null;
+  securityAccessForensics?: SecurityAccessForensicSummary | null;
   watch?: {
     version: "v1";
     id: string;
@@ -57,6 +58,85 @@ export type SupportConsoleResourceResponse = {
     domainsPresent: string[];
     identifiers?: Record<string, string | null | undefined>;
   };
+};
+
+export type SecurityAccessForensicSummary = {
+  schemaVersion: "security_access_forensics.v1";
+  internalOnly: true;
+  supportSafe: true;
+  metadataOnly: true;
+  grantId: string;
+  incidentCount: number;
+  chainEventCount: number;
+  incidents: Array<{
+    type: string;
+    label: string;
+    count: number;
+    observed: boolean;
+    followUpSuggested: boolean;
+    lastObservedAt: string | null;
+  }>;
+  chains: Array<{
+    type: string;
+    label: string;
+    eventCount: number;
+    lastEventAt: string | null;
+    events: Array<{
+      schemaVersion: "security_access_forensic_event.v1";
+      eventId: string;
+      source: string;
+      category: string;
+      eventType: string;
+      occurredAt: string;
+      actorType: string;
+      outcome: string | null;
+      reason: string | null;
+      lifecycleState: string | null;
+      resource: {
+        type: string;
+        redactedId: string | null;
+      };
+      metadataOnly: true;
+      visibility: {
+        supportVisible: true;
+        operatorVisible: true;
+        tenantVisible: false;
+        recipientVisible: false;
+        institutionVisible: false;
+        portableVisible: false;
+        publicVisible: false;
+        exportable: false;
+        downloadable: false;
+        trustPayloadIncluded: false;
+        providerPayloadIncluded: false;
+        rawIdentityPayloadIncluded: false;
+        rawPropertyPayloadIncluded: false;
+        rawIpIncluded: false;
+        fullUserAgentIncluded: false;
+        behavioralProfileIncluded: false;
+        riskScoreIncluded: false;
+      };
+    }>;
+  }>;
+  requestOriginSummary: {
+    uniqueIpHashCount: number;
+    ipHashValuesVisible: false;
+    rawIpVisible: false;
+    userAgentFamilies: string[];
+    rawUserAgentVisible: false;
+  };
+  operatorCorrelation: {
+    operatorDiagnosticAccessCount: number;
+    lastOperatorAccessAt: string | null;
+  };
+  retention: {
+    classification: "security_session_internal";
+    nonPortable: true;
+    nonExportable: true;
+    retentionJobImplemented: false;
+    futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1";
+  };
+  prohibitedFields: Record<string, false>;
 };
 
 export type OperatorAuditTimelineSummary = {

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -612,6 +612,146 @@ describe("SupportDebugConsolePage", () => {
           publicAccessEnabled: false,
         },
       },
+      securityAccessForensics: {
+        schemaVersion: "security_access_forensics.v1",
+        internalOnly: true,
+        supportSafe: true,
+        metadataOnly: true,
+        grantId: "grant-1",
+        incidentCount: 2,
+        chainEventCount: 2,
+        incidents: [
+          {
+            type: "wrong_recipient_attempts_observed",
+            label: "Wrong recipient attempts observed",
+            count: 1,
+            observed: true,
+            followUpSuggested: true,
+            lastObservedAt: "2026-05-01T00:00:00.000Z",
+          },
+          {
+            type: "operator_diagnostic_access_observed",
+            label: "Operator diagnostic access observed",
+            count: 1,
+            observed: true,
+            followUpSuggested: true,
+            lastObservedAt: "2026-05-04T00:00:00.000Z",
+          },
+        ],
+        chains: [
+          {
+            type: "recipient_access_chain",
+            label: "Recipient access chain",
+            eventCount: 1,
+            lastEventAt: "2026-05-01T00:00:00.000Z",
+            events: [
+              {
+                schemaVersion: "security_access_forensic_event.v1",
+                eventId: "recipient-1",
+                source: "recipient_access_timeline",
+                category: "wrong_recipient",
+                eventType: "recipient_trust_review_blocked",
+                occurredAt: "2026-05-01T00:00:00.000Z",
+                actorType: "recipient",
+                outcome: "blocked",
+                reason: "recipient_email_mismatch",
+                lifecycleState: "recipient_mismatch",
+                resource: { type: "tenant_institution_access_grant", redactedId: "***nt-1" },
+                metadataOnly: true,
+                visibility: {
+                  supportVisible: true,
+                  operatorVisible: true,
+                  tenantVisible: false,
+                  recipientVisible: false,
+                  institutionVisible: false,
+                  portableVisible: false,
+                  publicVisible: false,
+                  exportable: false,
+                  downloadable: false,
+                  trustPayloadIncluded: false,
+                  providerPayloadIncluded: false,
+                  rawIdentityPayloadIncluded: false,
+                  rawPropertyPayloadIncluded: false,
+                  rawIpIncluded: false,
+                  fullUserAgentIncluded: false,
+                  behavioralProfileIncluded: false,
+                  riskScoreIncluded: false,
+                },
+              },
+            ],
+          },
+          {
+            type: "operator_diagnostic_chain",
+            label: "Operator diagnostic access chain",
+            eventCount: 1,
+            lastEventAt: "2026-05-04T00:00:00.000Z",
+            events: [
+              {
+                schemaVersion: "security_access_forensic_event.v1",
+                eventId: "operator-1",
+                source: "operator_audit_timeline",
+                category: "operator_access",
+                eventType: "system.institution_access_diagnostics_opened",
+                occurredAt: "2026-05-04T00:00:00.000Z",
+                actorType: "operator",
+                outcome: "completed",
+                reason: "support_diagnostics",
+                lifecycleState: null,
+                resource: { type: "tenant_institution_access_grant", redactedId: "***nt-1" },
+                metadataOnly: true,
+                visibility: {
+                  supportVisible: true,
+                  operatorVisible: true,
+                  tenantVisible: false,
+                  recipientVisible: false,
+                  institutionVisible: false,
+                  portableVisible: false,
+                  publicVisible: false,
+                  exportable: false,
+                  downloadable: false,
+                  trustPayloadIncluded: false,
+                  providerPayloadIncluded: false,
+                  rawIdentityPayloadIncluded: false,
+                  rawPropertyPayloadIncluded: false,
+                  rawIpIncluded: false,
+                  fullUserAgentIncluded: false,
+                  behavioralProfileIncluded: false,
+                  riskScoreIncluded: false,
+                },
+              },
+            ],
+          },
+        ],
+        requestOriginSummary: {
+          uniqueIpHashCount: 1,
+          ipHashValuesVisible: false,
+          rawIpVisible: false,
+          userAgentFamilies: ["chrome"],
+          rawUserAgentVisible: false,
+        },
+        operatorCorrelation: {
+          operatorDiagnosticAccessCount: 1,
+          lastOperatorAccessAt: "2026-05-04T00:00:00.000Z",
+        },
+        retention: {
+          classification: "security_session_internal",
+          nonPortable: true,
+          nonExportable: true,
+          retentionJobImplemented: false,
+          futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
+        },
+        prohibitedFields: {
+          rawTrustPayloads: false,
+          rawProviderPayloads: false,
+          rawIdentityDocuments: false,
+          rawPropertyPayloads: false,
+          rawIpAddresses: false,
+          fullUserAgents: false,
+          preciseGeolocation: false,
+          behavioralProfiles: false,
+          riskScores: false,
+        },
+      },
       debug: {
         canonicalEventCount: 0,
         domainsPresent: [],
@@ -635,12 +775,17 @@ describe("SupportDebugConsolePage", () => {
     expect(screen.getByText(/Review health/i)).toBeInTheDocument();
     expect(screen.getByText(/attention_required/i)).toBeInTheDocument();
     expect(screen.getByText(/Security events/i)).toBeInTheDocument();
-    expect(screen.getByText(/Wrong recipient attempts/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Wrong recipient attempts/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Internal-only security telemetry/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Replay blocks/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Completion evidence/i)).toBeInTheDocument();
     expect(screen.getByText(/Trust payloads, portable attestation contents, provider payloads/i)).toBeInTheDocument();
     expect(screen.getByText(/Operator audit timeline/i)).toBeInTheDocument();
+    expect(screen.getByText(/Security access forensics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Wrong recipient attempts observed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Operator diagnostic access observed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Request origins are summarized as hash counts/i)).toBeInTheDocument();
+    expect(screen.getByText(/feat\/security-telemetry-retention-enforcement-v1/i)).toBeInTheDocument();
     expect(screen.getByText(/trust_export_superseded/i)).toBeInTheDocument();
     expect(screen.getByText(/Operator: \*\*\*or-1 · admin/i)).toBeInTheDocument();
     expect(screen.queryByText(/reviewer@example\.com/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -126,6 +126,59 @@ function renderInstitutionAccessDiagnostics(payload: SupportConsoleResourceRespo
   );
 }
 
+function renderSecurityAccessForensics(payload: SupportConsoleResourceResponse) {
+  const forensics = payload.securityAccessForensics;
+  if (!forensics) return null;
+  const observedIncidents = forensics.incidents.filter((incident) => incident.observed);
+  return (
+    <SupportConsoleSection title="Security access forensics">
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+          <div><strong>Observed incident types</strong>: {forensics.incidentCount}</div>
+          <div><strong>Forensic chain events</strong>: {forensics.chainEventCount}</div>
+          <div><strong>Request origin references</strong>: {forensics.requestOriginSummary.uniqueIpHashCount}</div>
+          <div><strong>User-agent families</strong>: {forensics.requestOriginSummary.userAgentFamilies.length ? forensics.requestOriginSummary.userAgentFamilies.join(", ") : "None"}</div>
+          <div><strong>Operator diagnostic accesses</strong>: {forensics.operatorCorrelation.operatorDiagnosticAccessCount}</div>
+          <div><strong>Last operator access</strong>: {forensics.operatorCorrelation.lastOperatorAccessAt || "None"}</div>
+        </div>
+        <div style={{ color: "#475569" }}>
+          Support-only forensic reconstruction. Request origins are summarized as hash counts, raw IP addresses and full user agents are hidden, and telemetry is non-portable and non-exportable.
+        </div>
+        <div style={{ color: "#475569" }}>
+          Retention follow-up: {forensics.retention.futureEnforcementMission}.
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          {observedIncidents.length ? (
+            observedIncidents.map((incident) => (
+              <div key={incident.type} style={{ borderTop: "1px solid #e2e8f0", paddingTop: 8 }}>
+                <strong>{incident.label}</strong> · {incident.count}
+                <div style={{ color: "#64748b" }}>
+                  {incident.followUpSuggested ? "Follow-up suggested" : "Monitor"} · Last observed {incident.lastObservedAt || "unknown"}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div style={{ color: "#64748b" }}>No security-relevant access incidents are currently summarized.</div>
+          )}
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          {forensics.chains.map((chain) => (
+            <div key={chain.type} style={{ borderTop: "1px solid #e2e8f0", paddingTop: 8 }}>
+              <strong>{chain.label}</strong> · {chain.eventCount} events
+              <div style={{ color: "#64748b" }}>Last event {chain.lastEventAt || "none"}</div>
+              {chain.events.slice(0, 5).map((event) => (
+                <div key={event.eventId} style={{ color: "#475569", marginTop: 4 }}>
+                  {event.eventType} · {event.category} · {event.reason || event.outcome || "no reason"}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </SupportConsoleSection>
+  );
+}
+
 function renderOperatorAuditTimeline(payload: SupportConsoleResourceResponse) {
   const timeline = payload.operatorAuditTimeline;
   if (!timeline) return null;
@@ -278,6 +331,7 @@ export default function SupportDebugConsolePage() {
             <SupportConsoleHeader resource={payload.resource} />
 
             {renderInstitutionAccessDiagnostics(payload)}
+            {renderSecurityAccessForensics(payload)}
             {renderOperatorAuditTimeline(payload)}
 
             <SupportConsoleSection title="Derived insight">


### PR DESCRIPTION
## Summary
- Adds a support-console-only security access forensics model derived from existing redacted security telemetry, institution access diagnostics, and operator audit timelines.
- Surfaces support-safe forensic incident summaries for wrong-recipient, repeated blocked, revoked/expired, replay/stale-session, and operator diagnostic access chains.
- Extends the admin support/debug console with metadata-only forensic summaries, request-origin count summaries, operator correlation, and the retention follow-up marker `feat/security-telemetry-retention-enforcement-v1`.

## Governance and privacy boundaries
- No raw trust payloads, provider payloads, identity documents, property payloads, raw IP addresses, full user agents, public dashboards, downloads, or portable telemetry are exposed.
- No risk scoring, behavioral profiling, automated enforcement, institution/provider integrations, or tenant/recipient/institution telemetry visibility is introduced.
- Forensics remain support-safe, internal-only, redacted, non-portable, and non-exportable.

## Validation
- API targeted: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- securityAccessForensics.test.ts supportConsoleRoutes.test.ts`
- Frontend targeted: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- SupportDebugConsolePage.test.tsx`
- API build: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Frontend build: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Frontend full test: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test`
- API full test: rerun outside sandbox due Supertest `listen EPERM`; passed `348` files / `1522` tests
- `git diff --check`

## Notes
- Browser/manual QA was not run in this environment.
- Local `gh auth status` reports the GitHub CLI token is invalid, so PR creation used the GitHub connector instead of `gh`.