### PR TITLE
Pilot institution operations runbooks v1

### DIFF
--- a/docs/operations/pilot-institution-operations-runbooks-v1.md
+++ b/docs/operations/pilot-institution-operations-runbooks-v1.md
@@ -1,0 +1,703 @@
+# Pilot Institution Operations Runbooks v1
+
+Branch: `strategy/pilot-institution-operations-runbooks-v1`
+Scope: documentation-first operational runbooks and governance procedures for controlled pilot institution review operations
+
+## Executive Summary
+
+RentChain is approaching readiness for controlled pilot institution review operations under a narrow operating model:
+
+- tenant-mediated institution delivery
+- explicit tenant consent
+- authenticated recipient review
+- audience and purpose scope
+- revocable and expiration-aware access
+- lifecycle-governed trust export continuity
+- metadata-only, view-only institution review
+- support-safe diagnostics
+- operator audit timeline reconstruction
+- internal-only security telemetry and access forensics
+
+This runbook layer is required before live pilot institution workflows. The current product surface is technically mature enough for controlled pilots, but pilot operations still need written procedures for support intake, lifecycle troubleshooting, escalation, institution communication, incident handling, operator accountability, and governance-safe support boundaries.
+
+RentChain is not ready for institution APIs, provider integrations, downloadable institution exports, public trust profiles, public interoperability, automated institution delivery, institution-controlled workflows, or automated eligibility decisions.
+
+Recommended next mission:
+
+`feat/security-telemetry-retention-enforcement-v1`
+
+Reason: support-safe diagnostics, operator timelines, observability, telemetry, and access forensics now provide the operational visibility needed for pilots. The next governance gap is retention enforcement for internal security/session telemetry so that pilot operations have explicit lifecycle, retention, and deletion controls before real partner operations scale.
+
+## Operational Review Plan
+
+This mission is documentation-first and operations-first.
+
+1. Review the institution review invite, delivery, session, lifecycle, support, audit, telemetry, observability, and forensics surfaces.
+2. Identify operational strengths and support gaps.
+3. Define support procedures for authentication, revocation, expiration, lifecycle invalidation, wrong-recipient events, replay/stale-session events, and delivery issues.
+4. Define escalation paths and institution-facing communication standards.
+5. Define support/admin boundaries and prohibited disclosures.
+6. Produce a pilot readiness checklist and next mission recommendation.
+7. Do not implement institution integrations, APIs, downloadable exports, public trust visibility, blockchain/tokenization, automated decisions, or product behavior changes.
+
+## Audit Scope Completed
+
+Reviewed strategy and readiness artifacts:
+
+- `docs/strategy/institution-review-invite-operational-qa-v1.md`
+- `docs/strategy/institution-partner-readiness-v1.md`
+- `docs/strategy/institution-interoperability-readiness-audit-v1.md`
+- `docs/strategy/institution-access-operational-qa-v1.md`
+- `docs/strategy/institution-access-support-admin-readiness-audit-v1.md`
+
+Reviewed operational and support-safe implementation surfaces:
+
+- `rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts`
+- `rentchain-api/src/routes/recipientTrustReviewRoutes.ts`
+- `rentchain-api/src/routes/tenantPortalRoutes.ts`
+- `rentchain-api/src/lib/supportConsole/operatorAuditTimeline.ts`
+- `rentchain-api/src/lib/supportConsole/securityAccessForensics.ts`
+- `rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts`
+- `rentchain-api/src/routes/supportConsoleRoutes.ts`
+- `rentchain-api/src/lib/institutionReviewSessions/*`
+- `rentchain-api/src/lib/institutionTrustExports/*`
+- `rentchain-api/src/lib/portableAttestations/attestationPolicyGate.ts`
+- `rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx`
+- `rentchain-frontend/src/pages/RecipientTrustReviewPage.tsx`
+- `rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx`
+
+Reviewed existing runbook pattern:
+
+- `docs/runbooks/admin-production-verification-v1.md`
+
+## Operational Readiness Audit Summary
+
+### Current Operational Strengths
+
+Tenant-mediated control is established. Institution review begins with tenant action, explicit consent, recipient email, audience, purpose, and expiration. Institutions do not initiate or own trust access.
+
+Recipient review is authenticated and email-bound. Possession of an invite or delivery link is not sufficient authorization.
+
+Review remains metadata-only and view-only. Recipient downloads, public profiles, public trust URLs, institution APIs, provider integrations, and automated decisioning are disabled.
+
+Lifecycle governance is strong inside RentChain-controlled surfaces. Revoked, expired, blocked, superseded, archived, invalidated, policy-denied, and reverification-required states block active review.
+
+Support-safe diagnostics, operator audit timelines, observability summaries, security telemetry summaries, and access forensics now provide operational reconstruction without raw trust payloads.
+
+### Current Support Gaps
+
+Support procedures were not yet formalized before this document. Operators had safe visibility but no standard operating procedure for triage, escalation, communications, and closure.
+
+Pilot partner support expectations are not yet codified into partner-facing terms, support hours, escalation contacts, or incident response obligations.
+
+Retention enforcement for security/session telemetry is classified but not yet implemented as an operational retention job or deletion/archival procedure.
+
+### Current Escalation Gaps
+
+Escalation states exist in pilot operations and observability summaries, but escalation ownership and response procedures were not yet documented.
+
+Wrong-recipient, repeated blocked attempt, revoked/expired access, replay-blocked, stale-session, and operator diagnostic access patterns are visible through forensics, but operator response levels were not yet standardized.
+
+### Current Incident Handling Gaps
+
+Security/access forensics can reconstruct support-safe incident chains, but incident severity, containment, communication, evidence capture, and closure criteria needed a written runbook.
+
+No partner-facing incident acknowledgement process exists. This is acceptable for narrow pilots where review remains RentChain-hosted, view-only, and non-downloadable, but it is not sufficient for institution APIs or downloadable exports.
+
+### Current Lifecycle Troubleshooting Gaps
+
+Lifecycle state is visible across grants, review sessions, delivery, trust exports, operator timelines, and observability summaries. Operators still need a deterministic troubleshooting order so they do not over-disclose or misinterpret lifecycle blocks.
+
+### Current Institution Communication Gaps
+
+Safe institution-facing language exists in invite and review copy, but support teams need standard wording for revoked access, expired access, authentication requirements, policy-denied review, lifecycle invalidation, and non-decision disclaimers.
+
+### Current Governance Boundaries
+
+Governance boundaries are strong and must remain permanent:
+
+- institution review is tenant-mediated
+- access is authenticated, revocable, expiration-aware, audience-scoped, and purpose-scoped
+- review is metadata-only, view-only, non-public, and policy-gated
+- support diagnostics are operational-only, redacted, metadata-only, and non-portable
+- security telemetry and forensics are internal-only and must not appear in tenant, recipient, institution, or export payloads
+
+## Operating Principles
+
+Pilot institution operations must remain:
+
+- tenant-mediated
+- consent-scoped
+- authenticated
+- revocable
+- expiration-aware
+- lifecycle-governed
+- metadata-only
+- view-only
+- policy-gated
+- support-safe
+- audit-safe
+- non-public
+
+Pilot institution operations must never become:
+
+- institution-controlled trust ownership
+- public trust sharing
+- downloadable trust portability
+- automated eligibility review
+- hidden scoring
+- behavioral profiling
+- broad trust browsing
+- a public credential registry
+
+## Roles And Responsibilities
+
+### Tenant
+
+The tenant authorizes institution review, selects the intended recipient, grants consent, and may revoke access.
+
+### Institution-Facing Recipient
+
+The recipient authenticates with the invited email and views only the tenant-authorized, metadata-only review summary while access remains active.
+
+### Support Operator
+
+The support operator diagnoses operational issues using support-safe diagnostics, observability, operator timelines, and access forensics. Operators must not browse or disclose raw trust payloads.
+
+### Support Lead
+
+The support lead owns escalations involving repeated blocked attempts, wrong-recipient patterns, suspected replay/stale-session issues, disputed revocations, policy-denied review confusion, or institution-facing communications.
+
+### Security/Governance Reviewer
+
+The security/governance reviewer handles suspected unauthorized access, telemetry/forensics review, support overexposure risk, legal/compliance concerns, and retention policy questions.
+
+### Product/Engineering
+
+Product/engineering handles defects in lifecycle propagation, session invalidation, policy-gate enforcement, tenant status rendering, email delivery, or support-console reconstruction.
+
+## Support Intake Procedure
+
+Use this procedure for every pilot institution review support request.
+
+1. Confirm requester type:
+   - tenant
+   - institution-facing recipient
+   - internal operator
+   - partner contact
+2. Confirm the workflow context:
+   - access grant reference if available
+   - tenant-reported institution recipient
+   - audience and purpose if known
+   - approximate time of issue
+3. Use support-safe search and diagnostics only.
+4. Open the support console institution access diagnostic for the relevant grant.
+5. Review:
+   - grant lifecycle
+   - consent state
+   - expiration timestamp
+   - invite/delivery status
+   - recipient review state
+   - institution review session state
+   - trust export lifecycle state
+   - policy-denied status
+   - observability health
+   - security access forensics summary
+   - operator audit timeline
+6. Do not request or paste raw documents, raw provider payloads, screenshots of trust content, or internal telemetry values into support notes.
+7. Classify the issue using the categories below.
+8. Apply the relevant runbook.
+9. Record operator action through existing support/audit tooling.
+10. Close only when the lifecycle state, user-facing message, and next action are clear.
+
+## Issue Categories
+
+| Category | Examples | Primary Owner | Initial SLA |
+| --- | --- | --- | --- |
+| Authentication issue | recipient cannot sign in, email mismatch, wrong account | Support operator | same business day |
+| Revoked access | tenant revoked access, recipient asks why unavailable | Support operator | same business day |
+| Expired access | review expired, session expired, stale tab | Support operator | same business day |
+| Lifecycle invalidation | superseded export, reverification required, policy denied | Support lead | 1 business day |
+| Delivery issue | email not received, resend unclear, delivery failed | Support operator | same business day |
+| Suspicious access | repeated blocked attempts, replay, stale session, wrong-recipient pattern | Security/governance reviewer | immediate triage |
+| Institution semantics issue | recipient asks if review means approval/eligibility | Support lead | same business day |
+| Product defect | state mismatch, incorrect status, broken support view | Product/engineering | severity-based |
+
+## Revoked Review Access Runbook
+
+Use when an institution-facing recipient reports that access was previously available but is now blocked or unavailable.
+
+1. Confirm the grant lifecycle is `revoked` or consent `revokedAt` is present.
+2. Confirm tenant revocation event exists in the operator audit timeline.
+3. Confirm recipient review is blocked and no active trust summary is returned.
+4. Confirm delivery/invite status is revoked when available.
+5. Do not restore access unless the tenant creates a new tenant-mediated authorization.
+6. Do not disclose tenant-private rationale beyond safe wording.
+7. Institution-facing response:
+   - "This tenant-authorized review is no longer active. RentChain can only show review metadata while tenant authorization is active. Please contact the tenant if a new review is needed."
+8. Tenant-facing response:
+   - "Access has been revoked in RentChain-controlled review surfaces. Future review attempts are blocked unless you authorize a new review."
+9. Escalate to support lead if:
+   - recipient disputes revocation
+   - revocation did not propagate to recipient review
+   - tenant reports revocation but support diagnostics show active access
+   - operator timeline lacks revocation evidence
+
+## Expired Review Or Session Runbook
+
+Use when recipient review is blocked because the grant, invite, delivery, or session expired.
+
+1. Confirm expiration timestamp.
+2. Confirm whether the expired state is grant expiration, invite/delivery expiration, or recipient session expiration.
+3. Confirm no active summary is returned after expiration.
+4. Confirm whether the tenant can authorize a new review using the current product flow.
+5. Do not extend expiration manually.
+6. Do not bypass reauthentication.
+7. Institution-facing response:
+   - "This tenant-authorized review is time-bound and has expired. RentChain requires a current tenant authorization before review metadata can be shown again."
+8. Tenant-facing response:
+   - "The prior review window has expired. A new institution review should be authorized only if you still want this recipient to review the metadata-only summary."
+9. Escalate to product/engineering if:
+   - expired review still renders active metadata
+   - expiration displays incorrectly
+   - stale tabs continue review without revalidation
+
+## Recipient Authentication Issue Runbook
+
+Use when the intended recipient cannot access a review after receiving an invite or delivery email.
+
+1. Confirm recipient is signed in.
+2. Confirm authenticated email matches the tenant-authorized recipient email.
+3. Confirm the grant is active, unexpired, and not revoked.
+4. Confirm policy gate and trust export lifecycle allow review.
+5. Confirm recipient review session is active or reauthentication is required.
+6. Do not change recipient email on behalf of an institution without tenant authorization.
+7. If the wrong email was invited, direct the tenant to create a corrected review invite.
+8. Institution-facing response:
+   - "Review access requires sign-in with the tenant-authorized recipient email. Possession of the invite email or link alone does not authorize review."
+9. Escalate to security/governance reviewer if:
+   - repeated wrong-recipient attempts are visible
+   - access attempts come from multiple request-origin references
+   - recipient claims access without matching email
+
+## Wrong-Recipient Access Incident Runbook
+
+Use when support-safe forensics show wrong-recipient attempts.
+
+1. Review security access forensics for:
+   - wrong-recipient incident count
+   - repeated blocked attempt count
+   - last observed timestamp
+   - request-origin reference count
+   - user-agent families
+2. Confirm recipient review blocked the attempt.
+3. Confirm no active trust summary was returned.
+4. Confirm operator audit timeline and recipient access chain are coherent.
+5. Do not expose raw IP addresses, full user agents, or raw telemetry to the tenant, recipient, or institution.
+6. If one-off:
+   - classify as authentication mismatch
+   - provide sign-in guidance
+7. If repeated or distributed:
+   - escalate to security/governance reviewer
+   - preserve support-safe forensic summary
+   - confirm tenant authorization still points to the intended recipient
+8. Safe external wording:
+   - "RentChain requires the authenticated recipient to match the tenant-authorized recipient. Access attempts from non-matching accounts are blocked."
+
+## Replay Or Stale-Session Incident Runbook
+
+Use when forensics or observability show replay-blocked or stale-session attempts.
+
+1. Confirm the replay/stale-session signal in security access forensics.
+2. Confirm recipient session governance blocked review continuity.
+3. Confirm current grant, invite, delivery, consent, and trust export lifecycle states.
+4. Require reauthentication through the normal recipient review flow.
+5. Do not rehydrate or manually mark sessions active.
+6. Do not treat invite link possession as authorization.
+7. Escalate to security/governance reviewer if:
+   - replay attempts repeat
+   - stale sessions appear after revocation or expiration
+   - multiple session/device attempts cluster around revoked or expired access
+8. Safe external wording:
+   - "For security, RentChain requires a fresh authenticated review session when access state changes or a session becomes stale."
+
+## Trust Export Lifecycle Invalidation Runbook
+
+Use when review is blocked by trust export lifecycle state, policy gate, supersession, reverification requirement, archival, revocation, or expiration.
+
+1. Confirm package lifecycle state.
+2. Confirm whether the block is caused by:
+   - source attestation revoked
+   - source attestation expired
+   - reverification required
+   - export superseded
+   - export archived
+   - policy gate denied summary
+   - unsafe payload indicator
+3. Confirm recipient review returns no active trust summary.
+4. Do not expose policy internals or raw trust payloads.
+5. Do not tell an institution the tenant is "verified", "unverified", "eligible", or "ineligible".
+6. Tenant-facing response:
+   - "The prior trust review package is no longer active for review. A new review package may be required after the underlying trust information is current and policy-eligible."
+7. Institution-facing response:
+   - "This review is unavailable because the tenant-authorized review package is no longer active under RentChain lifecycle controls."
+8. Escalate to product/engineering if:
+   - lifecycle state appears inconsistent between tenant status, recipient review, support diagnostics, and operator timeline
+
+## Delivery Failure Or Resend Runbook
+
+Use when a tenant or recipient reports that the institution review email was not received or resend behavior is unclear.
+
+1. Confirm delivery status:
+   - prepared
+   - sent
+   - failed
+   - blocked
+   - resent
+   - revoked
+   - expired
+2. Confirm invite/access grant is still active and policy-eligible.
+3. Confirm recipient email is correct and tenant-authorized.
+4. If active and resend is supported by current product behavior, resend through the intended tenant-mediated workflow.
+5. If expired or revoked, require a new tenant authorization rather than resending the old delivery.
+6. If policy-denied or lifecycle-invalid, block resend and explain current state.
+7. Do not copy trust metadata into email.
+8. Do not send review links manually outside the product flow.
+
+## Suspicious Access Handling Runbook
+
+Use for repeated blocked attempts, wrong-recipient clusters, revoked/expired access attempts, replay-blocked attempts, stale-session clusters, or unusual operator diagnostic access patterns.
+
+1. Open support-safe security access forensics.
+2. Record the incident types, counts, and last observed timestamps.
+3. Review operator audit timeline for diagnostic access correlation.
+4. Confirm no active trust payload was returned.
+5. Confirm tenant/recipient/institution views do not show telemetry.
+6. Escalate to security/governance reviewer.
+7. Preserve only support-safe metadata in operational notes.
+8. Do not create risk scores, recipient labels, tenant labels, behavioral profiles, or fraud conclusions.
+9. Use conservative incident wording:
+   - "Repeated blocked access attempts observed"
+   - "Wrong-recipient attempts observed"
+   - "Revoked access attempted"
+   - "Expired access attempted"
+   - "Replay or stale-session attempt observed"
+10. Close only when:
+   - deterministic access controls are confirmed
+   - no active trust data was exposed
+   - tenant-facing and institution-facing communications are complete if required
+   - follow-up engineering work is filed if a product defect is found
+
+## Operator Audit Review Procedure
+
+Operators should use the audit timeline to reconstruct:
+
+- access grant lifecycle
+- invite lifecycle
+- delivery lifecycle
+- recipient review lifecycle
+- recipient session lifecycle
+- institution review session lifecycle
+- trust export lifecycle
+- policy denial
+- operator diagnostic access
+
+Operators must not use the audit timeline to infer:
+
+- tenant quality
+- recipient intent
+- institution risk
+- eligibility
+- approval
+- creditworthiness
+- insurance suitability
+- subsidy eligibility
+
+If audit events are missing or inconsistent, escalate to product/engineering. Do not fill gaps with unsupported narrative.
+
+## Support-Safe Diagnostics Procedure
+
+Support diagnostics may be used to view:
+
+- lifecycle state
+- audience
+- purpose
+- redacted recipient reference
+- organization label if provided
+- expiration/revocation state
+- opened/blocked/revoked/expired counts
+- reason categories
+- support-safe telemetry counts
+- support-safe forensic summaries
+- operator audit timeline events
+
+Support diagnostics must not be used to view, request, or disclose:
+
+- raw identity documents
+- raw provider payloads
+- raw property payloads
+- raw registry payloads
+- raw IP addresses
+- full user agents
+- precise geolocation
+- device fingerprints
+- behavioral profiles
+- risk scores
+- trust payload contents
+- portable attestation contents
+- support/internal notes externally
+- internal policy rule internals
+- downloadable artifacts
+
+## Institution Communication Standards
+
+Use safe language:
+
+- "tenant-authorized review"
+- "metadata-only review"
+- "view-only review"
+- "authenticated recipient"
+- "time-bound access"
+- "revocable access in RentChain-controlled surfaces"
+- "audience-scoped"
+- "purpose-scoped"
+- "policy-gated"
+- "lifecycle-governed"
+- "not an approval or eligibility decision"
+- "not a credit report"
+- "not a public profile"
+- "not an automated decision"
+
+Do not use unsafe language:
+
+- "approved tenant"
+- "eligible tenant"
+- "verified tenant"
+- "creditworthy"
+- "insurable"
+- "government verified"
+- "provider verified"
+- "risk score"
+- "tenant score"
+- "institution approved"
+- "permanent credential"
+- "source of truth"
+- "guaranteed acceptance"
+- "automated decision"
+
+## Standard External Responses
+
+### Recipient Must Authenticate
+
+"For privacy and security, RentChain requires the invited recipient to sign in before any tenant-authorized review metadata can be shown. The invite or delivery email is not a bearer authorization."
+
+### Wrong Recipient
+
+"The authenticated account does not match the tenant-authorized recipient for this review. RentChain blocks review access when the recipient does not match the tenant's authorization."
+
+### Revoked Access
+
+"This tenant-authorized review is no longer active. RentChain can only show review metadata while tenant authorization remains active."
+
+### Expired Access
+
+"This tenant-authorized review was time-bound and has expired. A current tenant authorization is required before review metadata can be shown again."
+
+### Lifecycle Blocked
+
+"This review is unavailable because the underlying tenant-authorized review package is not active under RentChain lifecycle controls."
+
+### No Decisioning
+
+"RentChain provides a tenant-authorized, metadata-only review context. It is not an approval, eligibility decision, credit report, insurance decision, subsidy decision, government determination, or automated institutional decision."
+
+## Incident Severity Guidance
+
+| Severity | Criteria | Response |
+| --- | --- | --- |
+| Low | One-off sign-in or expired-session issue, no suspicious pattern | support operator handles with standard guidance |
+| Medium | Repeated blocked attempts, wrong-recipient mismatch, delivery failure affecting pilot workflow | support lead reviews and documents |
+| High | Replay/stale-session cluster, revoked/expired access attempts after tenant revocation, inconsistent lifecycle enforcement | security/governance reviewer and product/engineering review |
+| Critical | Evidence that active trust metadata was shown to unauthorized recipient or public surface | immediate incident response, product/engineering escalation, governance/legal review |
+
+## Escalation Matrix
+
+| Trigger | Escalate To | Required Evidence |
+| --- | --- | --- |
+| Revocation did not block review | product/engineering, security/governance | grant lifecycle, recipient review result, operator timeline |
+| Expired access still renders metadata | product/engineering | expiration timestamp, review result, session state |
+| Wrong-recipient attempts repeat | security/governance | forensic summary, request-origin count, timestamps |
+| Replay/stale-session attempts repeat | security/governance, product/engineering | forensic summary, session state, lifecycle state |
+| Policy-denied state unclear | support lead, product/engineering | package state, reason category, support diagnostic |
+| Institution asks for eligibility/approval interpretation | support lead, legal/compliance if needed | communication record, exact request |
+| Operator access appears unusual | security/governance | operator audit timeline, diagnostic access count |
+| External partner asks for data export | support lead, governance/legal | request details; deny unless future approved product exists |
+
+## Pilot Readiness Checklist
+
+Before starting a controlled pilot institution review workflow, confirm:
+
+- Tenant consent copy is current.
+- Institution-facing recipient email is known and tenant-authorized.
+- Audience and purpose are specific.
+- Expiration is set and tenant-visible.
+- Recipient review requires authentication.
+- Invite/delivery copy avoids approval, eligibility, credit, insurance, subsidy, government, or verification overclaims.
+- Review remains metadata-only and view-only.
+- Downloads are disabled.
+- Public links and public profiles are disabled.
+- Trust export lifecycle is active.
+- Policy gate allows the metadata summary.
+- Revocation path is available to tenant.
+- Support-safe diagnostics are available.
+- Operator audit timeline is available.
+- Security/session telemetry summary is available where applicable.
+- Security access forensics are available where applicable.
+- Support operators have this runbook.
+- Partner communications use approved language.
+- Legal/compliance review is complete for the pilot partner category.
+- Pilot exit criteria are defined.
+
+## Pilot Workflows Safe Today
+
+Operationally safe today:
+
+- tenant-mediated institution review invite
+- tenant-mediated controlled delivery email
+- authenticated matching-recipient metadata-only review
+- tenant revocation of active review access
+- expiration-aware recipient review
+- support-safe operational diagnostics
+- operator audit timeline reconstruction
+- support-safe access forensics
+
+Operationally moderate risk and requiring manual governance:
+
+- insurer/lender/subsidy/government exploratory pilot discussions
+- advocate/caseworker-assisted review where recipient authority is manually validated
+- repeated resend/retry scenarios
+- partner support requests involving disputed recipient identity
+
+Not operationally safe yet:
+
+- institution APIs
+- provider APIs
+- downloadable institution exports
+- public trust profiles
+- institution-controlled workflows
+- automated eligibility/approval decisions
+- automated delivery without tenant intent
+- public verification
+- institution-visible telemetry
+- raw provider payload review
+
+## Legal And Compliance Awareness
+
+Support and pilot operators must not suggest that RentChain is:
+
+- a credit bureau
+- an insurer
+- a lender
+- a government verifier
+- a subsidy eligibility system
+- a public credential registry
+- an automated decision engine
+- a public reputation network
+
+Legal/compliance review is required before:
+
+- any live institution partnership
+- partner-specific data processing terms
+- institution reliance language
+- any use case involving insurance, lending, subsidy, or government housing decisions
+- partner retention terms
+- partner incident response terms
+- data export or API planning
+
+## Metadata Never To Expose Operationally
+
+Support/admin operators must never expose these to tenants, recipients, institutions, or public channels:
+
+- raw trust payloads
+- raw identity documents
+- raw provider payloads
+- raw property records
+- raw registry payloads
+- support-console internals
+- internal policy rule internals
+- security telemetry values
+- raw IP addresses
+- full user agents
+- precise geolocation
+- device fingerprints
+- behavioral profiles
+- risk scores
+- hidden confidence calculations
+- tenant scoring or rankings
+- downloadable trust artifacts
+- access tokens
+- public trust URLs
+
+## Operational Closure Criteria
+
+Close a pilot support case only when:
+
+- current lifecycle state is known
+- recipient authentication status is known where relevant
+- access is confirmed active, revoked, expired, blocked, or policy-denied
+- tenant-facing next action is clear
+- institution-facing wording is conservative and approved
+- support-safe diagnostic evidence is recorded without raw payloads
+- operator audit trail exists for support access
+- product/engineering follow-up is filed for defects
+- security/governance follow-up is filed for suspicious access patterns
+
+## Governance And Privacy Findings
+
+The governance foundation is strong for controlled pilots:
+
+- tenant consent controls review initiation
+- recipient authentication blocks bearer-link-only access
+- lifecycle controls block stale, revoked, expired, policy-denied, and invalidated review packages
+- support diagnostics are redacted and operational-only
+- operator audit timeline supports accountability
+- security telemetry and access forensics provide incident reconstruction without raw payloads
+
+The primary remaining privacy/governance gap is retention enforcement for internal security/session telemetry. Current telemetry is internal-only, non-portable, and non-exportable, but operational pilot maturity requires explicit retention enforcement and review procedures.
+
+## Operational Readiness Finding
+
+RentChain is ready to prepare controlled pilot institution operations under manual governance, limited partner scope, tenant-mediated consent, authenticated recipient review, and support-safe operational procedures.
+
+RentChain is not ready for automated partner onboarding, institution APIs, downloadable exports, institution-controlled workflows, automated eligibility decisions, or public trust sharing.
+
+## Recommended Next Mission
+
+Recommended next mission:
+
+`feat/security-telemetry-retention-enforcement-v1`
+
+Rationale:
+
+- security/session telemetry and access forensics now exist
+- pilot operations will rely on internal telemetry for accountability and incident review
+- retention classes are defined but enforcement is not yet implemented
+- retention enforcement is a governance prerequisite before operational scale
+
+Acceptable alternate follow-up:
+
+`strategy/pilot-institution-partner-engagement-v1`
+
+Use this only if RentChain needs partner-facing pilot eligibility, operating terms, and communication templates before implementing retention enforcement. Do not proceed next with institution APIs, downloadable exports, automated institution delivery, or institution-controlled workflows.
+
+## Remaining Risks
+
+- Manual pilot operations still require legal/compliance review before real partner use.
+- Partner organization identity is not yet verified beyond authenticated recipient email.
+- External revocation acknowledgement is not modeled because review remains RentChain-hosted and non-downloadable.
+- Retention enforcement for security/session telemetry is not implemented in this mission.
+- Browser/manual QA of these runbooks was not applicable in this documentation-only mission.
+
+## PR Readiness Notes
+
+This document is a strategy/operations artifact only. It does not change product behavior, routes, services, frontend screens, dependencies, lockfiles, institution integrations, provider integrations, public access, exports, scoring, profiling, or automated decisioning.


### PR DESCRIPTION
## Summary
- Adds the first pilot institution operations runbook artifact under `docs/operations`.
- Documents support intake, escalation, lifecycle troubleshooting, revocation/expiration handling, wrong-recipient and replay/stale-session incident procedures, support-safe diagnostics usage, operator audit review, institution communication standards, and pilot readiness checklist.
- Recommends `feat/security-telemetry-retention-enforcement-v1` as the next mission.

## Governance boundaries
- Documentation-only mission.
- No product behavior changes, institution integrations, APIs, downloads, public trust exposure, provider integrations, scoring, profiling, blockchain/tokenization, or automated decisions.
- Reinforces tenant-mediated, authenticated, revocable, expiration-aware, metadata-only, lifecycle-governed, support-safe pilot operations.

## Verification
- `git diff --check --cached`
- Confirmed staged diff is one documentation file only: `docs/operations/pilot-institution-operations-runbooks-v1.md`
- Confirmed no production code changes
- Confirmed no lockfile/dependency drift
- No markdown/documentation checker is configured in this repo.

## Remaining risks
- Manual pilot operations still require legal/compliance review before real partner use.
- Partner organization identity remains email-session based at this stage.
- Security/session telemetry retention enforcement is documented as follow-up, not implemented here.