### PR TITLE
Enforce security telemetry retention lifecycle

### DIFF
--- a/docs/operations/security-telemetry-retention-enforcement-v1.md
+++ b/docs/operations/security-telemetry-retention-enforcement-v1.md
@@ -1,0 +1,84 @@
+# Security Telemetry Retention Enforcement V1
+
+## Purpose
+
+This document defines the first operational retention boundary for RentChain security/session telemetry and support-safe access forensics.
+
+The retention layer exists to preserve security accountability while preventing internal telemetry from becoming an uncontrolled archive. It applies to `security_session_internal` telemetry used for recipient review sessions, institution review invites, tenant-mediated delivery, support diagnostics, operator timelines, and access forensics.
+
+## Audit Summary
+
+Current telemetry is persisted as metadata-only security events on tenant institution access grant event records. Those records include redacted grant, recipient, session, user, request, and lifecycle references. Raw IP addresses, full user agents, trust payloads, provider payloads, raw identity data, raw property data, precise geolocation, fingerprinting data, behavioral profiles, and risk scores are not stored.
+
+Before this mission, telemetry had an internal-only classification but no deterministic lifecycle decision. Support-safe diagnostics and forensics could summarize all available telemetry as active operational signal, and the support console still displayed retention enforcement as a future follow-up.
+
+## Retention Model
+
+`security_session_internal` telemetry is evaluated by policy version `security_telemetry_retention.v1`.
+
+The lifecycle states are:
+
+- `active`: telemetry can contribute to active support-safe security summaries and forensics.
+- `archived`: telemetry can remain visible as archived support-safe continuity, but it no longer contributes to active operational signals.
+- `retention_expired`: telemetry is no longer included in support-safe summaries or forensic chains and is eligible for purge handling.
+- `purge_pending`: telemetry is past retention plus grace period and should be handled by future destructive cleanup.
+- `purged`: telemetry must not appear in support-safe summaries or forensic chains.
+
+Initial policy windows:
+
+- Active retention: 180 days
+- Archive after: 180 days
+- Retention expiry: 365 days
+- Purge-pending grace: 30 days after retention expiry
+
+This mission does not run destructive cleanup jobs or mutate historical records. It introduces deterministic retention evaluation and TTL-compatible lifecycle metadata so future cleanup can be implemented safely.
+
+## Purge And Archive Semantics
+
+Archived telemetry is not treated as active. It can support operational continuity without increasing active incident counts, active request-origin counts, or current support signals.
+
+Retention-expired, purge-pending, and purged telemetry must not influence active support metrics, incident summaries, request-origin summaries, or forensic chains.
+
+Future destructive enforcement should be implemented under `feat/security-telemetry-retention-enforcement-v2` or a narrowly scoped cleanup mission only after legal/compliance review confirms exact retention windows and deletion obligations.
+
+## Support/Admin Visibility
+
+Support/admin operators may see support-safe retention counts:
+
+- active count
+- archived count
+- retention-expired count
+- purge-pending count
+- purged count
+
+Operators must not see raw IP values, full user agents, raw identity/property/provider payloads, trust payloads, or exportable telemetry artifacts.
+
+Telemetry retention state is internal operational metadata. It must not appear in tenant views, recipient review payloads, institution review payloads, trust exports, portable attestations, public pages, or downloadable artifacts.
+
+## Audit And Forensic Continuity
+
+Forensics remain support-safe and metadata-only.
+
+Active telemetry can contribute to active forensic incidents. Archived telemetry can remain part of continuity where still retained, but it is marked by retention state and does not become an active incident signal. Retention-expired, purge-pending, and purged telemetry is excluded from reconstructed chains.
+
+Operator audit timelines remain metadata-only. Retention enforcement must not erase operator accountability; future destructive cleanup should retain immutable audit records needed for compliance while avoiding raw telemetry persistence.
+
+## Prohibited Uses
+
+Telemetry retention must not be used for:
+
+- tenant scoring
+- recipient scoring
+- behavioral profiling
+- risk scoring
+- automated fraud decisions
+- automated institutional decisions
+- institution-visible analytics
+- public security dashboards
+- portable trust artifacts
+
+## Remaining Risks
+
+- No destructive purge job is implemented in this mission.
+- Final retention windows require legal/compliance confirmation before production cleanup automation.
+- Existing grant event storage remains the persistence location; future cleanup will need careful handling to preserve immutable audit integrity while removing expired telemetry details.

--- a/rentchain-api/src/lib/securityTelemetry/__tests__/securityTelemetryRetention.test.ts
+++ b/rentchain-api/src/lib/securityTelemetry/__tests__/securityTelemetryRetention.test.ts
@@ -1,0 +1,88 @@
+import {
+  evaluateSecurityTelemetryRetention,
+  summarizeSecurityTelemetryRetention,
+} from "../securityTelemetryRetention";
+import { describe, expect, it } from "vitest";
+
+describe("security telemetry retention", () => {
+  const evaluatedAt = "2026-05-10T12:00:00.000Z";
+
+  it("keeps recent telemetry active and support-visible", () => {
+    const decision = evaluateSecurityTelemetryRetention({
+      recordedAt: "2026-05-01T12:00:00.000Z",
+      evaluatedAt,
+    });
+
+    expect(decision).toEqual(
+      expect.objectContaining({
+        classification: "security_session_internal",
+        lifecycleState: "active",
+        reason: "within_active_retention",
+        activeSupportSignalsIncluded: true,
+        forensicChainIncluded: true,
+        supportSummaryIncluded: true,
+        purgeEligible: false,
+        nonPortable: true,
+        nonExportable: true,
+      })
+    );
+  });
+
+  it("archives telemetry after the active window without counting it as active", () => {
+    const decision = evaluateSecurityTelemetryRetention({
+      recordedAt: "2025-09-01T12:00:00.000Z",
+      evaluatedAt,
+    });
+
+    expect(decision).toEqual(
+      expect.objectContaining({
+        lifecycleState: "archived",
+        reason: "archive_window_reached",
+        activeSupportSignalsIncluded: false,
+        forensicChainIncluded: true,
+        supportSummaryIncluded: true,
+        purgeEligible: false,
+      })
+    );
+  });
+
+  it("marks expired telemetry purge eligible and excludes it from summaries", () => {
+    const decision = evaluateSecurityTelemetryRetention({
+      recordedAt: "2025-04-15T12:00:00.000Z",
+      evaluatedAt,
+    });
+
+    expect(decision).toEqual(
+      expect.objectContaining({
+        lifecycleState: "retention_expired",
+        reason: "retention_window_expired",
+        activeSupportSignalsIncluded: false,
+        forensicChainIncluded: false,
+        supportSummaryIncluded: false,
+        purgeEligible: true,
+      })
+    );
+  });
+
+  it("summarizes lifecycle counts deterministically", () => {
+    const decisions = [
+      evaluateSecurityTelemetryRetention({ recordedAt: "2026-05-01T12:00:00.000Z", evaluatedAt }),
+      evaluateSecurityTelemetryRetention({ recordedAt: "2025-09-01T12:00:00.000Z", evaluatedAt }),
+      evaluateSecurityTelemetryRetention({ recordedAt: "2025-04-15T12:00:00.000Z", evaluatedAt }),
+    ];
+
+    expect(summarizeSecurityTelemetryRetention(decisions, evaluatedAt)).toEqual(
+      expect.objectContaining({
+        policyVersion: "security_telemetry_retention.v1",
+        classification: "security_session_internal",
+        activeCount: 1,
+        archivedCount: 1,
+        retentionExpiredCount: 1,
+        purgePendingCount: 0,
+        purgedCount: 0,
+        totalEvaluatedCount: 3,
+        destructivePurgeJobImplemented: false,
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/securityTelemetry/securityTelemetryRetention.ts
+++ b/rentchain-api/src/lib/securityTelemetry/securityTelemetryRetention.ts
@@ -1,0 +1,223 @@
+export type SecurityTelemetryRetentionClass = "security_session_internal";
+
+export type SecurityTelemetryLifecycleState =
+  | "active"
+  | "archived"
+  | "retention_expired"
+  | "purge_pending"
+  | "purged";
+
+export type SecurityTelemetryRetentionPolicy = {
+  schemaVersion: "security_telemetry_retention_policy.v1";
+  policyVersion: "security_telemetry_retention.v1";
+  classification: SecurityTelemetryRetentionClass;
+  activeRetentionDays: number;
+  archiveAfterDays: number;
+  purgeAfterDays: number;
+  purgePendingGraceDays: number;
+  internalOnly: true;
+  nonPortable: true;
+  nonExportable: true;
+  supportSafe: true;
+};
+
+export type SecurityTelemetryRetentionDecision = {
+  schemaVersion: "security_telemetry_retention_decision.v1";
+  policyVersion: SecurityTelemetryRetentionPolicy["policyVersion"];
+  classification: SecurityTelemetryRetentionClass;
+  lifecycleState: SecurityTelemetryLifecycleState;
+  reason:
+    | "within_active_retention"
+    | "archive_window_reached"
+    | "retention_window_expired"
+    | "purge_grace_elapsed"
+    | "already_purged"
+    | "invalid_recorded_at";
+  recordedAt: string | null;
+  evaluatedAt: string;
+  archiveAfter: string | null;
+  purgeAfter: string | null;
+  purgePendingAfter: string | null;
+  activeSupportSignalsIncluded: boolean;
+  forensicChainIncluded: boolean;
+  supportSummaryIncluded: boolean;
+  purgeEligible: boolean;
+  internalOnly: true;
+  nonPortable: true;
+  nonExportable: true;
+};
+
+export type SecurityTelemetryRetentionCounts = {
+  activeCount: number;
+  archivedCount: number;
+  retentionExpiredCount: number;
+  purgePendingCount: number;
+  purgedCount: number;
+  totalEvaluatedCount: number;
+};
+
+export type SecurityTelemetryRetentionSummary = SecurityTelemetryRetentionCounts & {
+  schemaVersion: "security_telemetry_retention_summary.v1";
+  policyVersion: SecurityTelemetryRetentionPolicy["policyVersion"];
+  classification: SecurityTelemetryRetentionClass;
+  activeRetentionDays: number;
+  archiveAfterDays: number;
+  purgeAfterDays: number;
+  purgePendingGraceDays: number;
+  evaluatedAt: string;
+  nonPortable: true;
+  nonExportable: true;
+  internalOnly: true;
+  destructivePurgeJobImplemented: false;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const SECURITY_TELEMETRY_RETENTION_POLICY: SecurityTelemetryRetentionPolicy = {
+  schemaVersion: "security_telemetry_retention_policy.v1",
+  policyVersion: "security_telemetry_retention.v1",
+  classification: "security_session_internal",
+  activeRetentionDays: 180,
+  archiveAfterDays: 180,
+  purgeAfterDays: 365,
+  purgePendingGraceDays: 30,
+  internalOnly: true,
+  nonPortable: true,
+  nonExportable: true,
+  supportSafe: true,
+};
+
+function addDays(value: Date, days: number) {
+  return new Date(value.getTime() + days * DAY_MS).toISOString();
+}
+
+function parseTimestamp(value: unknown) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const time = Date.parse(text);
+  return Number.isFinite(time) ? new Date(time) : null;
+}
+
+export function evaluateSecurityTelemetryRetention(input: {
+  recordedAt?: string | null;
+  evaluatedAt?: string | Date | null;
+  lifecycleState?: SecurityTelemetryLifecycleState | null;
+}): SecurityTelemetryRetentionDecision {
+  const evaluatedAtDate = parseTimestamp(input.evaluatedAt) || new Date();
+  const evaluatedAt = evaluatedAtDate.toISOString();
+  const recordedAtDate = parseTimestamp(input.recordedAt);
+  const recordedAt = recordedAtDate?.toISOString() || null;
+  const policy = SECURITY_TELEMETRY_RETENTION_POLICY;
+
+  if (input.lifecycleState === "purged") {
+    return {
+      schemaVersion: "security_telemetry_retention_decision.v1",
+      policyVersion: policy.policyVersion,
+      classification: policy.classification,
+      lifecycleState: "purged",
+      reason: "already_purged",
+      recordedAt,
+      evaluatedAt,
+      archiveAfter: recordedAtDate ? addDays(recordedAtDate, policy.archiveAfterDays) : null,
+      purgeAfter: recordedAtDate ? addDays(recordedAtDate, policy.purgeAfterDays) : null,
+      purgePendingAfter: recordedAtDate ? addDays(recordedAtDate, policy.purgeAfterDays + policy.purgePendingGraceDays) : null,
+      activeSupportSignalsIncluded: false,
+      forensicChainIncluded: false,
+      supportSummaryIncluded: false,
+      purgeEligible: false,
+      internalOnly: true,
+      nonPortable: true,
+      nonExportable: true,
+    };
+  }
+
+  if (!recordedAtDate) {
+    return {
+      schemaVersion: "security_telemetry_retention_decision.v1",
+      policyVersion: policy.policyVersion,
+      classification: policy.classification,
+      lifecycleState: "retention_expired",
+      reason: "invalid_recorded_at",
+      recordedAt: null,
+      evaluatedAt,
+      archiveAfter: null,
+      purgeAfter: null,
+      purgePendingAfter: null,
+      activeSupportSignalsIncluded: false,
+      forensicChainIncluded: false,
+      supportSummaryIncluded: false,
+      purgeEligible: true,
+      internalOnly: true,
+      nonPortable: true,
+      nonExportable: true,
+    };
+  }
+
+  const ageMs = Math.max(0, evaluatedAtDate.getTime() - recordedAtDate.getTime());
+  const activeMs = policy.activeRetentionDays * DAY_MS;
+  const purgeMs = policy.purgeAfterDays * DAY_MS;
+  const purgePendingMs = (policy.purgeAfterDays + policy.purgePendingGraceDays) * DAY_MS;
+
+  let lifecycleState: SecurityTelemetryLifecycleState = "active";
+  let reason: SecurityTelemetryRetentionDecision["reason"] = "within_active_retention";
+  if (ageMs >= purgePendingMs) {
+    lifecycleState = "purge_pending";
+    reason = "purge_grace_elapsed";
+  } else if (ageMs >= purgeMs) {
+    lifecycleState = "retention_expired";
+    reason = "retention_window_expired";
+  } else if (ageMs >= activeMs) {
+    lifecycleState = "archived";
+    reason = "archive_window_reached";
+  }
+
+  const active = lifecycleState === "active";
+  const archived = lifecycleState === "archived";
+  return {
+    schemaVersion: "security_telemetry_retention_decision.v1",
+    policyVersion: policy.policyVersion,
+    classification: policy.classification,
+    lifecycleState,
+    reason,
+    recordedAt,
+    evaluatedAt,
+    archiveAfter: addDays(recordedAtDate, policy.archiveAfterDays),
+    purgeAfter: addDays(recordedAtDate, policy.purgeAfterDays),
+    purgePendingAfter: addDays(recordedAtDate, policy.purgeAfterDays + policy.purgePendingGraceDays),
+    activeSupportSignalsIncluded: active,
+    forensicChainIncluded: active || archived,
+    supportSummaryIncluded: active || archived,
+    purgeEligible: lifecycleState === "retention_expired" || lifecycleState === "purge_pending",
+    internalOnly: true,
+    nonPortable: true,
+    nonExportable: true,
+  };
+}
+
+export function summarizeSecurityTelemetryRetention(
+  decisions: SecurityTelemetryRetentionDecision[],
+  evaluatedAt: string | Date | null = null
+): SecurityTelemetryRetentionSummary {
+  const policy = SECURITY_TELEMETRY_RETENTION_POLICY;
+  const evaluatedAtDate = parseTimestamp(evaluatedAt) || new Date();
+  return {
+    schemaVersion: "security_telemetry_retention_summary.v1",
+    policyVersion: policy.policyVersion,
+    classification: policy.classification,
+    activeRetentionDays: policy.activeRetentionDays,
+    archiveAfterDays: policy.archiveAfterDays,
+    purgeAfterDays: policy.purgeAfterDays,
+    purgePendingGraceDays: policy.purgePendingGraceDays,
+    evaluatedAt: evaluatedAtDate.toISOString(),
+    activeCount: decisions.filter((decision) => decision.lifecycleState === "active").length,
+    archivedCount: decisions.filter((decision) => decision.lifecycleState === "archived").length,
+    retentionExpiredCount: decisions.filter((decision) => decision.lifecycleState === "retention_expired").length,
+    purgePendingCount: decisions.filter((decision) => decision.lifecycleState === "purge_pending").length,
+    purgedCount: decisions.filter((decision) => decision.lifecycleState === "purged").length,
+    totalEvaluatedCount: decisions.length,
+    nonPortable: true,
+    nonExportable: true,
+    internalOnly: true,
+    destructivePurgeJobImplemented: false,
+  };
+}

--- a/rentchain-api/src/lib/supportConsole/__tests__/securityAccessForensics.test.ts
+++ b/rentchain-api/src/lib/supportConsole/__tests__/securityAccessForensics.test.ts
@@ -97,6 +97,33 @@ function diagnostic(): SupportInstitutionAccessDiagnosticSummary {
         classification: "security_session_internal",
         nonPortable: true,
         nonExportable: true,
+        policyVersion: "security_telemetry_retention.v1",
+        activeRetentionDays: 180,
+        archiveAfterDays: 180,
+        purgeAfterDays: 365,
+        purgePendingGraceDays: 30,
+        retentionEnforced: true,
+        destructivePurgeJobImplemented: false,
+      },
+      retentionLifecycle: {
+        schemaVersion: "security_telemetry_retention_summary.v1",
+        policyVersion: "security_telemetry_retention.v1",
+        classification: "security_session_internal",
+        activeRetentionDays: 180,
+        archiveAfterDays: 180,
+        purgeAfterDays: 365,
+        purgePendingGraceDays: 30,
+        evaluatedAt: "2026-05-10T00:00:00.000Z",
+        activeCount: 6,
+        archivedCount: 0,
+        retentionExpiredCount: 0,
+        purgePendingCount: 0,
+        purgedCount: 0,
+        totalEvaluatedCount: 6,
+        nonPortable: true,
+        nonExportable: true,
+        internalOnly: true,
+        destructivePurgeJobImplemented: false,
       },
       redaction: {
         ipAddressMode: "hash_only",
@@ -283,8 +310,18 @@ describe("buildSecurityAccessForensics", () => {
           userAgentFamilies: ["chrome", "safari"],
         }),
         retention: expect.objectContaining({
-          futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
-          retentionJobImplemented: false,
+          retentionEnforced: true,
+          retentionJobImplemented: true,
+          destructivePurgeJobImplemented: false,
+          retentionLifecycle: expect.objectContaining({
+            policyVersion: "security_telemetry_retention.v1",
+            classification: "security_session_internal",
+            activeCount: expect.any(Number),
+            archivedCount: expect.any(Number),
+            retentionExpiredCount: expect.any(Number),
+            nonPortable: true,
+            nonExportable: true,
+          }),
         }),
         visibility: expect.objectContaining({
           tenantVisible: false,
@@ -321,5 +358,50 @@ describe("buildSecurityAccessForensics", () => {
     expect(payload).not.toContain("provider-secret");
     expect(payload).not.toContain('"score"');
     expect(payload).not.toContain('"profile"');
+  });
+
+  it("excludes retention-expired telemetry from forensic chains", () => {
+    const nextDiagnostic = diagnostic();
+    nextDiagnostic.timeline = [
+      {
+        schemaVersion: "support_institution_access_diagnostic_event.v1",
+        eventType: "recipient_trust_review_blocked",
+        occurredAt: "2025-01-01T00:00:00.000Z",
+        actorType: "recipient",
+        metadataOnly: true,
+        outcome: "blocked",
+        reason: "recipient_email_mismatch",
+        status: "recipient_mismatch",
+        visibility,
+      },
+    ];
+    nextDiagnostic.securityTelemetry = {
+      ...nextDiagnostic.securityTelemetry,
+      eventCount: 0,
+      blockedAttemptCount: 0,
+      wrongRecipientAttemptCount: 0,
+      uniqueIpHashCount: 0,
+      userAgentFamilies: [],
+      signals: [],
+      lastSignal: null,
+      lastRecordedAt: null,
+      retentionLifecycle: {
+        ...nextDiagnostic.securityTelemetry.retentionLifecycle,
+        activeCount: 0,
+        archivedCount: 0,
+        retentionExpiredCount: 1,
+        totalEvaluatedCount: 1,
+      },
+    };
+
+    const summary = buildSecurityAccessForensics({
+      grantId: "grant-sensitive-1",
+      diagnostic: nextDiagnostic,
+      operatorAuditTimeline: null,
+    });
+
+    expect(summary?.chains.find((item) => item.type === "recipient_access_chain")?.eventCount).toBe(0);
+    expect(summary?.incidents.find((item) => item.type === "wrong_recipient_attempts_observed")?.observed).toBe(false);
+    expect(summary?.retention.retentionLifecycle.retentionExpiredCount).toBe(1);
   });
 });

--- a/rentchain-api/src/lib/supportConsole/securityAccessForensics.ts
+++ b/rentchain-api/src/lib/supportConsole/securityAccessForensics.ts
@@ -1,5 +1,11 @@
 import type { SupportInstitutionAccessDiagnosticSummary } from "../../services/tenantPortal/tenantInstitutionAccessService";
 import { redactIdentifier } from "../governance/platformGovernance";
+import {
+  evaluateSecurityTelemetryRetention,
+  summarizeSecurityTelemetryRetention,
+  type SecurityTelemetryRetentionDecision,
+  type SecurityTelemetryRetentionSummary,
+} from "../securityTelemetry/securityTelemetryRetention";
 import type { OperatorAuditTimelineEvent, OperatorAuditTimelineSummary } from "./operatorAuditTimeline";
 
 type ForensicIncidentType =
@@ -46,6 +52,7 @@ export type SecurityAccessForensicEvent = {
     userAgentFamily: string | null;
     rawUserAgentVisible: false;
   };
+  retention: SecurityTelemetryRetentionDecision;
   metadataOnly: true;
   visibility: SecurityAccessForensicVisibility;
 };
@@ -112,8 +119,10 @@ export type SecurityAccessForensicSummary = {
     classification: "security_session_internal";
     nonPortable: true;
     nonExportable: true;
-    retentionJobImplemented: false;
-    futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1";
+    retentionEnforced: true;
+    retentionJobImplemented: true;
+    destructivePurgeJobImplemented: false;
+    retentionLifecycle: SecurityTelemetryRetentionSummary;
   };
   prohibitedFields: {
     rawTrustPayloads: false;
@@ -193,6 +202,8 @@ function eventFromAccessTimeline(params: {
   const eventType = asString(params.event.eventType, 160);
   const occurredAt = asString(params.event.occurredAt, 120);
   if (!category || !eventType || !occurredAt || params.event.metadataOnly !== true) return null;
+  const retention = evaluateSecurityTelemetryRetention({ recordedAt: occurredAt });
+  if (!retention.forensicChainIncluded) return null;
   return {
     schemaVersion: "security_access_forensic_event.v1",
     eventId: `recipient:${params.grantId}:${eventType}:${occurredAt}:${asString(params.event.reason, 160) || "none"}`,
@@ -208,6 +219,7 @@ function eventFromAccessTimeline(params: {
       type: "tenant_institution_access_grant",
       redactedId: redactIdentifier(params.grantId),
     },
+    retention,
     metadataOnly: true,
     visibility: visibility(),
   };
@@ -226,6 +238,8 @@ function eventFromOperatorTimeline(event: OperatorAuditTimelineEvent): SecurityA
   const eventType = asString(event.eventType, 160);
   const occurredAt = asString(event.occurredAt, 120);
   if (!eventType || !occurredAt) return null;
+  const retention = evaluateSecurityTelemetryRetention({ recordedAt: occurredAt });
+  if (!retention.forensicChainIncluded) return null;
   const category = categoryFromOperatorEvent(event);
   if (category !== "operator_access" && category !== "revoked_access" && category !== "expired_access" && category !== "lifecycle_context") {
     return null;
@@ -245,6 +259,7 @@ function eventFromOperatorTimeline(event: OperatorAuditTimelineEvent): SecurityA
       type: event.resource.type,
       redactedId: event.resource.redactedId,
     },
+    retention,
     metadataOnly: true,
     visibility: visibility(),
   };
@@ -301,6 +316,8 @@ export function buildSecurityAccessForensics(input: {
   const replayEvents = accessEvents.filter((event) => event.category === "replay_blocked");
   const staleEvents = accessEvents.filter((event) => event.category === "stale_session");
   const operatorDiagnosticEvents = operatorEvents.filter((event) => event.category === "operator_access");
+  const retentionLifecycle =
+    telemetry?.retentionLifecycle || summarizeSecurityTelemetryRetention([...accessEvents, ...operatorEvents].map((event) => event.retention));
 
   const blockedCount = Math.max(telemetry?.blockedAttemptCount || 0, input.diagnostic?.audit.blockedReviewCount || 0, blockedEvents.length);
   const wrongRecipientCount = Math.max(telemetry?.wrongRecipientAttemptCount || 0, wrongRecipientEvents.length);
@@ -391,8 +408,10 @@ export function buildSecurityAccessForensics(input: {
       classification: "security_session_internal",
       nonPortable: true,
       nonExportable: true,
-      retentionJobImplemented: false,
-      futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
+      retentionEnforced: true,
+      retentionJobImplemented: true,
+      destructivePurgeJobImplemented: false,
+      retentionLifecycle,
     },
     prohibitedFields: {
       rawTrustPayloads: false,

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -577,8 +577,17 @@ describe("supportConsoleRoutes", () => {
         }),
         retention: expect.objectContaining({
           classification: "security_session_internal",
-          retentionJobImplemented: false,
-          futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
+          retentionEnforced: true,
+          retentionJobImplemented: true,
+          destructivePurgeJobImplemented: false,
+          retentionLifecycle: expect.objectContaining({
+            policyVersion: "security_telemetry_retention.v1",
+            activeCount: expect.any(Number),
+            archivedCount: expect.any(Number),
+            retentionExpiredCount: expect.any(Number),
+            nonPortable: true,
+            nonExportable: true,
+          }),
         }),
         visibility: expect.objectContaining({
           tenantVisible: false,

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -9,6 +9,11 @@ import type { InstitutionalTrustExportPackage } from "../../lib/institutionTrust
 import type { PortableAttestationClaimCategory } from "../../lib/portableAttestations";
 import { redactIdentifier } from "../../lib/governance/platformGovernance";
 import {
+  evaluateSecurityTelemetryRetention,
+  summarizeSecurityTelemetryRetention,
+  type SecurityTelemetryRetentionSummary,
+} from "../../lib/securityTelemetry/securityTelemetryRetention";
+import {
   previewTenantTrustExport,
   type TenantTrustExportAudience,
   type TenantTrustExportPurpose,
@@ -106,7 +111,15 @@ export type SupportSafeSecuritySessionTelemetrySummary = {
     classification: "security_session_internal";
     nonPortable: true;
     nonExportable: true;
+    policyVersion: "security_telemetry_retention.v1";
+    activeRetentionDays: number;
+    archiveAfterDays: number;
+    purgeAfterDays: number;
+    purgePendingGraceDays: number;
+    retentionEnforced: true;
+    destructivePurgeJobImplemented: false;
   };
+  retentionLifecycle: SecurityTelemetryRetentionSummary;
   redaction: {
     ipAddressMode: "hash_only";
     userAgentMode: "family_and_hash";
@@ -1053,29 +1066,51 @@ function buildSupportSafeSecurityTelemetrySummary(record: TenantInstitutionAcces
     .map((event) => event.securityTelemetry)
     .filter(Boolean) as SecuritySessionTelemetryEvent[];
   telemetry.sort((left, right) => Date.parse(right.recordedAt) - Date.parse(left.recordedAt));
-  const signals = Array.from(new Set(telemetry.map((event) => event.signal))).sort() as SecuritySessionTelemetrySignal[];
-  const ipHashes = new Set(telemetry.map((event) => event.request.ipHash).filter(Boolean));
-  const userAgentFamilies = Array.from(new Set(telemetry.map((event) => event.request.userAgentFamily).filter(Boolean))).sort();
+  const evaluatedAt = new Date();
+  const telemetryWithRetention = telemetry.map((event) => ({
+    event,
+    decision: evaluateSecurityTelemetryRetention({ recordedAt: event.recordedAt, evaluatedAt }),
+  }));
+  const retentionLifecycle = summarizeSecurityTelemetryRetention(
+    telemetryWithRetention.map((entry) => entry.decision),
+    evaluatedAt
+  );
+  const activeTelemetry = telemetryWithRetention
+    .filter((entry) => entry.decision.activeSupportSignalsIncluded)
+    .map((entry) => entry.event);
+  const signals = Array.from(new Set(activeTelemetry.map((event) => event.signal))).sort() as SecuritySessionTelemetrySignal[];
+  const ipHashes = new Set(activeTelemetry.map((event) => event.request.ipHash).filter(Boolean));
+  const userAgentFamilies = Array.from(new Set(activeTelemetry.map((event) => event.request.userAgentFamily).filter(Boolean))).sort();
   return {
     schemaVersion: "support_safe_security_session_telemetry.v1",
     internalOnly: true,
     metadataOnly: true,
-    eventCount: telemetry.length,
-    blockedAttemptCount: telemetry.filter((event) => event.signal.endsWith("_attempt") || event.signal === "recipient_review_blocked").length,
-    wrongRecipientAttemptCount: telemetry.filter((event) => event.signal === "wrong_recipient_attempt").length,
-    revokedAttemptCount: telemetry.filter((event) => event.signal === "revoked_access_attempt").length,
-    expiredAttemptCount: telemetry.filter((event) => event.signal === "expired_access_attempt").length,
-    replayBlockedCount: telemetry.filter((event) => event.signal === "replay_blocked_attempt").length,
-    staleSessionCount: telemetry.filter((event) => event.signal === "stale_session_attempt").length,
+    eventCount: activeTelemetry.length,
+    blockedAttemptCount: activeTelemetry.filter((event) => event.signal.endsWith("_attempt") || event.signal === "recipient_review_blocked").length,
+    wrongRecipientAttemptCount: activeTelemetry.filter((event) => event.signal === "wrong_recipient_attempt").length,
+    revokedAttemptCount: activeTelemetry.filter((event) => event.signal === "revoked_access_attempt").length,
+    expiredAttemptCount: activeTelemetry.filter((event) => event.signal === "expired_access_attempt").length,
+    replayBlockedCount: activeTelemetry.filter((event) => event.signal === "replay_blocked_attempt").length,
+    staleSessionCount: activeTelemetry.filter((event) => event.signal === "stale_session_attempt").length,
     uniqueIpHashCount: ipHashes.size,
     userAgentFamilies,
-    lastSignal: telemetry[0]?.signal || null,
-    lastRecordedAt: telemetry[0]?.recordedAt || null,
+    lastSignal: activeTelemetry[0]?.signal || null,
+    lastRecordedAt: activeTelemetry[0]?.recordedAt || null,
     signals,
     retention: {
       classification: "security_session_internal",
       nonPortable: true,
       nonExportable: true,
+      policyVersion: retentionLifecycle.policyVersion,
+      activeRetentionDays: retentionLifecycle.activeRetentionDays,
+      archiveAfterDays: retentionLifecycle.archiveAfterDays,
+      purgeAfterDays: retentionLifecycle.purgeAfterDays,
+      purgePendingGraceDays: retentionLifecycle.purgePendingGraceDays,
+      retentionEnforced: true,
+      destructivePurgeJobImplemented: false,
+    },
+    retentionLifecycle: {
+      ...retentionLifecycle,
     },
     redaction: {
       ipAddressMode: "hash_only",

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -96,6 +96,20 @@ export type SecurityAccessForensicSummary = {
         type: string;
         redactedId: string | null;
       };
+      retention: {
+        schemaVersion: "security_telemetry_retention_decision.v1";
+        policyVersion: "security_telemetry_retention.v1";
+        classification: "security_session_internal";
+        lifecycleState: "active" | "archived" | "retention_expired" | "purge_pending" | "purged";
+        reason: string;
+        activeSupportSignalsIncluded: boolean;
+        forensicChainIncluded: boolean;
+        supportSummaryIncluded: boolean;
+        purgeEligible: boolean;
+        internalOnly: true;
+        nonPortable: true;
+        nonExportable: true;
+      };
       metadataOnly: true;
       visibility: {
         supportVisible: true;
@@ -133,8 +147,29 @@ export type SecurityAccessForensicSummary = {
     classification: "security_session_internal";
     nonPortable: true;
     nonExportable: true;
-    retentionJobImplemented: false;
-    futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1";
+    retentionEnforced: true;
+    retentionJobImplemented: true;
+    destructivePurgeJobImplemented: false;
+    retentionLifecycle: {
+      schemaVersion: "security_telemetry_retention_summary.v1";
+      policyVersion: "security_telemetry_retention.v1";
+      classification: "security_session_internal";
+      activeRetentionDays: number;
+      archiveAfterDays: number;
+      purgeAfterDays: number;
+      purgePendingGraceDays: number;
+      evaluatedAt: string;
+      activeCount: number;
+      archivedCount: number;
+      retentionExpiredCount: number;
+      purgePendingCount: number;
+      purgedCount: number;
+      totalEvaluatedCount: number;
+      nonPortable: true;
+      nonExportable: true;
+      internalOnly: true;
+      destructivePurgeJobImplemented: false;
+    };
   };
   prohibitedFields: Record<string, false>;
 };
@@ -293,6 +328,33 @@ export type SupportInstitutionAccessDiagnosticSummary = {
       classification: string;
       nonPortable: true;
       nonExportable: true;
+      policyVersion?: "security_telemetry_retention.v1";
+      activeRetentionDays?: number;
+      archiveAfterDays?: number;
+      purgeAfterDays?: number;
+      purgePendingGraceDays?: number;
+      retentionEnforced?: true;
+      destructivePurgeJobImplemented?: false;
+    };
+    retentionLifecycle?: {
+      schemaVersion: "security_telemetry_retention_summary.v1";
+      policyVersion: "security_telemetry_retention.v1";
+      classification: "security_session_internal";
+      activeRetentionDays: number;
+      archiveAfterDays: number;
+      purgeAfterDays: number;
+      purgePendingGraceDays: number;
+      evaluatedAt: string;
+      activeCount: number;
+      archivedCount: number;
+      retentionExpiredCount: number;
+      purgePendingCount: number;
+      purgedCount: number;
+      totalEvaluatedCount: number;
+      nonPortable: true;
+      nonExportable: true;
+      internalOnly: true;
+      destructivePurgeJobImplemented: false;
     };
     redaction: {
       ipAddressMode: string;

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -332,6 +332,33 @@ describe("SupportDebugConsolePage", () => {
             classification: "security_session_internal",
             nonPortable: true,
             nonExportable: true,
+            policyVersion: "security_telemetry_retention.v1",
+            activeRetentionDays: 180,
+            archiveAfterDays: 180,
+            purgeAfterDays: 365,
+            purgePendingGraceDays: 30,
+            retentionEnforced: true,
+            destructivePurgeJobImplemented: false,
+          },
+          retentionLifecycle: {
+            schemaVersion: "security_telemetry_retention_summary.v1",
+            policyVersion: "security_telemetry_retention.v1",
+            classification: "security_session_internal",
+            activeRetentionDays: 180,
+            archiveAfterDays: 180,
+            purgeAfterDays: 365,
+            purgePendingGraceDays: 30,
+            evaluatedAt: "2026-05-10T00:00:00.000Z",
+            activeCount: 3,
+            archivedCount: 0,
+            retentionExpiredCount: 0,
+            purgePendingCount: 0,
+            purgedCount: 0,
+            totalEvaluatedCount: 3,
+            nonPortable: true,
+            nonExportable: true,
+            internalOnly: true,
+            destructivePurgeJobImplemented: false,
           },
           redaction: {
             ipAddressMode: "hash_only",
@@ -737,8 +764,29 @@ describe("SupportDebugConsolePage", () => {
           classification: "security_session_internal",
           nonPortable: true,
           nonExportable: true,
-          retentionJobImplemented: false,
-          futureEnforcementMission: "feat/security-telemetry-retention-enforcement-v1",
+          retentionEnforced: true,
+          retentionJobImplemented: true,
+          destructivePurgeJobImplemented: false,
+          retentionLifecycle: {
+            schemaVersion: "security_telemetry_retention_summary.v1",
+            policyVersion: "security_telemetry_retention.v1",
+            classification: "security_session_internal",
+            activeRetentionDays: 180,
+            archiveAfterDays: 180,
+            purgeAfterDays: 365,
+            purgePendingGraceDays: 30,
+            evaluatedAt: "2026-05-10T00:00:00.000Z",
+            activeCount: 2,
+            archivedCount: 0,
+            retentionExpiredCount: 0,
+            purgePendingCount: 0,
+            purgedCount: 0,
+            totalEvaluatedCount: 2,
+            nonPortable: true,
+            nonExportable: true,
+            internalOnly: true,
+            destructivePurgeJobImplemented: false,
+          },
         },
         prohibitedFields: {
           rawTrustPayloads: false,
@@ -785,7 +833,7 @@ describe("SupportDebugConsolePage", () => {
     expect(screen.getByText(/Wrong recipient attempts observed/i)).toBeInTheDocument();
     expect(screen.getByText(/Operator diagnostic access observed/i)).toBeInTheDocument();
     expect(screen.getByText(/Request origins are summarized as hash counts/i)).toBeInTheDocument();
-    expect(screen.getByText(/feat\/security-telemetry-retention-enforcement-v1/i)).toBeInTheDocument();
+    expect(screen.getByText(/Retention enforcement active/i)).toBeInTheDocument();
     expect(screen.getByText(/trust_export_superseded/i)).toBeInTheDocument();
     expect(screen.getByText(/Operator: \*\*\*or-1 · admin/i)).toBeInTheDocument();
     expect(screen.queryByText(/reviewer@example\.com/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -77,6 +77,11 @@ function renderInstitutionAccessDiagnostics(payload: SupportConsoleResourceRespo
             <div style={{ color: "#475569" }}>
               Internal-only security telemetry. IP addresses are hash-only, user agents are reduced to family/hash form, and telemetry is non-portable and non-exportable.
             </div>
+            {diagnostic.securityTelemetry.retentionLifecycle ? (
+              <div style={{ color: "#475569" }}>
+                Retention: {diagnostic.securityTelemetry.retentionLifecycle.activeCount} active, {diagnostic.securityTelemetry.retentionLifecycle.archivedCount} archived, {diagnostic.securityTelemetry.retentionLifecycle.retentionExpiredCount + diagnostic.securityTelemetry.retentionLifecycle.purgePendingCount + diagnostic.securityTelemetry.retentionLifecycle.purgedCount} expired or purged.
+              </div>
+            ) : null}
           </div>
         ) : null}
         {diagnostic.pilotOperation ? (
@@ -130,6 +135,7 @@ function renderSecurityAccessForensics(payload: SupportConsoleResourceResponse) 
   const forensics = payload.securityAccessForensics;
   if (!forensics) return null;
   const observedIncidents = forensics.incidents.filter((incident) => incident.observed);
+  const retentionLifecycle = forensics.retention.retentionLifecycle;
   return (
     <SupportConsoleSection title="Security access forensics">
       <div style={{ display: "grid", gap: 12 }}>
@@ -145,7 +151,9 @@ function renderSecurityAccessForensics(payload: SupportConsoleResourceResponse) 
           Support-only forensic reconstruction. Request origins are summarized as hash counts, raw IP addresses and full user agents are hidden, and telemetry is non-portable and non-exportable.
         </div>
         <div style={{ color: "#475569" }}>
-          Retention follow-up: {forensics.retention.futureEnforcementMission}.
+          {retentionLifecycle
+            ? `Retention enforcement active: ${retentionLifecycle.activeCount} active, ${retentionLifecycle.archivedCount} archived, ${retentionLifecycle.retentionExpiredCount + retentionLifecycle.purgePendingCount + retentionLifecycle.purgedCount} expired or purged. Destructive purge job: ${forensics.retention.destructivePurgeJobImplemented ? "enabled" : "not enabled"}.`
+            : "Retention enforcement pending."}
         </div>
         <div style={{ display: "grid", gap: 8 }}>
           {observedIncidents.length ? (


### PR DESCRIPTION
## Summary
- Add `security_telemetry_retention.v1` lifecycle decisions for active, archived, retention-expired, purge-pending, and purged security/session telemetry.
- Apply retention enforcement to support-safe security telemetry summaries and access forensics so expired/purged telemetry does not influence active support signals or forensic chains.
- Update support console API/UI to show retention enforcement counts and add operational documentation for retention boundaries.

## Audit Summary
- Current telemetry persisted as metadata-only grant event metadata with redacted request/session/user references.
- Previous gap: telemetry was classified as `security_session_internal`, but active/archive/purge lifecycle decisions were not enforced.
- This PR keeps telemetry internal-only/non-portable and adds deterministic retention lifecycle evaluation without destructive migrations.

## Guardrails
- No public telemetry exposure.
- No telemetry added to tenant/recipient/institution review payloads or exports.
- No raw IPs, full user agents, trust payloads, provider payloads, identity/property payloads, scoring, or profiling.
- No institution/provider integrations.

## Tests
- API targeted: `npm test -- securityTelemetryRetention.test.ts securityAccessForensics.test.ts tenantInstitutionAccessService.test.ts supportConsoleRoutes.test.ts recipientTrustReviewRoutes.test.ts`
- API full: `npm run test`
- API build: `npm run build`
- Frontend targeted: `npm test -- SupportDebugConsolePage.test.tsx`
- Frontend full: `npm run test`
- Frontend build: `npm run build`
- `git diff --check`

## Remaining Risk
- This mission does not implement a destructive purge job; it adds deterministic lifecycle enforcement and TTL-compatible metadata. Final deletion automation should follow legal/compliance confirmation of retention windows.