### PR TITLE
Add institution review onboarding flow

### DIFF
--- a/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
@@ -204,7 +204,10 @@ describe("recipientTrustReviewRoutes", () => {
     const res = await invokeRouter(router, {
       method: "GET",
       url: "/trust-reviews/grant-1",
-    headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
+      headers: {
+        "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }),
+        "x-institution-review-onboarding-acknowledged": "true",
+      },
     });
 
     expect(res.status).toBe(200);
@@ -286,6 +289,61 @@ describe("recipientTrustReviewRoutes", () => {
     );
     expect(JSON.stringify(res.body?.data || {})).not.toContain("securityTelemetry");
     expect(JSON.stringify(securityTelemetry)).not.toContain("203.0.113");
+  });
+
+  it("returns onboarding orientation before exposing review claim metadata", async () => {
+    const router = (await import("../recipientTrustReviewRoutes")).default;
+    seedGrant();
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.decision).toEqual(
+      expect.objectContaining({
+        allowed: true,
+        status: "onboarding_required",
+        reason: "institution_review_onboarding_required",
+        metadataOnly: true,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+      })
+    );
+    expect(res.body?.data?.summary?.onboarding).toEqual(
+      expect.objectContaining({
+        schemaVersion: "institution_review_onboarding.v1",
+        status: "required",
+        acknowledgementRequired: true,
+        acknowledged: false,
+        tenantMediated: true,
+        authenticatedRecipientRequired: true,
+        metadataOnly: true,
+        viewOnly: true,
+        revocable: true,
+        timeBound: true,
+        policyGated: true,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        institutionAccountCreated: false,
+        automatedDecisioningEnabled: false,
+      })
+    );
+    expect(res.body?.data?.summary?.includedClaims).toEqual([]);
+    expect(JSON.stringify(res.body?.data || {})).not.toContain("attestation-1");
+    expect(JSON.stringify(res.body?.data || {})).not.toContain("policyDecisions");
+    expect(ensureCollection("tenantInstitutionAccessGrants").get("grant-1")?.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "institution_review_onboarding_started",
+          metadataOnly: true,
+          status: "onboarding_required",
+          reason: "institution_review_onboarding_required",
+        }),
+      ])
+    );
   });
 
   it("requires reauthentication for expired or mismatched recipient review sessions", async () => {

--- a/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
+++ b/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
@@ -33,6 +33,10 @@ router.get("/trust-reviews/:grantId", requireAuth, async (req: any, res) => {
       req.query?.recipientSessionId ||
       ""
   ).trim();
+  const onboardingAcknowledged =
+    String(req.headers?.["x-institution-review-onboarding-acknowledged"] || req.query?.onboardingAcknowledged || "")
+      .trim()
+      .toLowerCase() === "true";
 
   try {
     const result = await getRecipientTrustReview({
@@ -40,6 +44,7 @@ router.get("/trust-reviews/:grantId", requireAuth, async (req: any, res) => {
       recipientEmail,
       recipientUserId,
       recipientSessionId,
+      onboardingAcknowledged,
       requestContext: requestSecurityContext(req),
     });
     if (!result.decision.allowed) {

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -253,6 +253,7 @@ describe("tenantInstitutionAccessService", () => {
       grantId: grant?.grantId || "",
       recipientEmail: "Reviewer@Example.com",
       recipientUserId: "recipient-1",
+      onboardingAcknowledged: true,
       requestContext: { ipAddress: "203.0.113.10", userAgent: "Mozilla/5.0 Chrome/120.0", requestId: "req-2" },
     });
     expect(review.decision.allowed).toBe(true);
@@ -365,6 +366,7 @@ describe("tenantInstitutionAccessService", () => {
       grantId: grant?.grantId || "",
       recipientEmail: "reviewer@example.com",
       recipientUserId: "recipient-1",
+      onboardingAcknowledged: true,
       recipientSessionId: sessionId,
     });
     expect(expiredSession.decision.allowed).toBe(false);
@@ -387,6 +389,7 @@ describe("tenantInstitutionAccessService", () => {
       grantId: grant?.grantId || "",
       recipientEmail: "reviewer@example.com",
       recipientUserId: "recipient-1",
+      onboardingAcknowledged: true,
       recipientSessionId: activeSessionId,
     });
     expect(revoked.decision.allowed).toBe(false);
@@ -486,6 +489,7 @@ describe("tenantInstitutionAccessService", () => {
       grantId: grant?.grantId || "",
       recipientEmail: "reviewer@example.com",
       recipientUserId: "recipient-1",
+      onboardingAcknowledged: true,
       requestContext: { ipAddress: "198.51.100.20", userAgent: "Mozilla/5.0 Firefox/120.0" },
     });
 
@@ -513,13 +517,19 @@ describe("tenantInstitutionAccessService", () => {
         audit: expect.objectContaining({
           openedReviewCount: 1,
           blockedReviewCount: 1,
-          reasonCategories: expect.arrayContaining(["access_granted", "recipient_email_mismatch", "review_available"]),
+          reasonCategories: expect.arrayContaining([
+            "access_granted",
+            "institution_review_onboarding_acknowledged",
+            "institution_review_onboarding_completed",
+            "recipient_email_mismatch",
+            "review_available",
+          ]),
         }),
         securityTelemetry: expect.objectContaining({
           schemaVersion: "support_safe_security_session_telemetry.v1",
           internalOnly: true,
           metadataOnly: true,
-          eventCount: 3,
+          eventCount: 5,
           blockedAttemptCount: 1,
           wrongRecipientAttemptCount: 1,
           uniqueIpHashCount: 1,

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -513,7 +513,11 @@ export type TenantInstitutionAccessGrantEvent = {
     | "institution_review_delivery_blocked"
     | "institution_review_delivery_resent"
     | "institution_review_delivery_revoked"
-    | "institution_review_delivery_expired";
+    | "institution_review_delivery_expired"
+    | "institution_review_onboarding_started"
+    | "institution_review_onboarding_acknowledged"
+    | "institution_review_onboarding_blocked"
+    | "institution_review_onboarding_completed";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   metadataOnly: true;
@@ -526,6 +530,10 @@ export type TenantInstitutionAccessGrantEvent = {
     | "delivery_sent"
     | "delivery_failed"
     | "delivery_resent"
+    | "onboarding_started"
+    | "onboarding_acknowledged"
+    | "onboarding_blocked"
+    | "onboarding_completed"
     | "granted"
     | "opened"
     | "blocked"
@@ -546,6 +554,9 @@ export type TenantInstitutionAccessGrantEvent = {
     | "delivery_sent"
     | "delivery_failed"
     | "delivery_resent"
+    | "institution_review_onboarding_required"
+    | "institution_review_onboarding_acknowledged"
+    | "institution_review_onboarding_completed"
     | InstitutionReviewDeliveryFailureReason;
   status?:
     | RecipientTrustReviewStatus
@@ -590,7 +601,8 @@ export type RecipientTrustReviewStatus =
   | "policy_denied"
   | "session_expired"
   | "session_revoked"
-  | "reauthentication_required";
+  | "reauthentication_required"
+  | "onboarding_required";
 
 export type RecipientTrustReviewAccessDecision = {
   allowed: boolean;
@@ -611,7 +623,8 @@ export type RecipientTrustReviewAccessDecision = {
     | "recipient_session_reauthentication_required"
     | "recipient_session_stale"
     | "recipient_session_replay_blocked"
-    | "trust_export_lifecycle_inactive";
+    | "trust_export_lifecycle_inactive"
+    | "institution_review_onboarding_required";
   metadataOnly: true;
   publicAccessEnabled: false;
   downloadEnabled: false;
@@ -645,6 +658,31 @@ export type RecipientReviewSessionSummary = {
   };
 };
 
+export type InstitutionReviewOnboardingSummary = {
+  schemaVersion: "institution_review_onboarding.v1";
+  status: "required" | "acknowledged";
+  acknowledgementRequired: true;
+  acknowledged: boolean;
+  tenantMediated: true;
+  authenticatedRecipientRequired: true;
+  metadataOnly: true;
+  viewOnly: true;
+  timeBound: true;
+  revocable: true;
+  policyGated: true;
+  publicAccessEnabled: false;
+  downloadEnabled: false;
+  institutionAccountCreated: false;
+  automatedDecisioningEnabled: false;
+  copy: {
+    title: string;
+    intro: string;
+    bullets: string[];
+    acknowledgement: string;
+    supportGuidance: string[];
+  };
+};
+
 export type RecipientTrustReviewSummary = {
   schemaVersion: "recipient_trust_review.v1";
   grantId: string;
@@ -672,6 +710,7 @@ export type RecipientTrustReviewSummary = {
   reviewedAt: string;
   session: RecipientReviewSessionSummary;
   institutionReviewSession: InstitutionReviewSessionSummary;
+  onboarding: InstitutionReviewOnboardingSummary;
   metadataOnly: true;
   policyGated: true;
   includedClaims: Array<{
@@ -703,6 +742,10 @@ export type TenantInstitutionAccessAuditOutcome =
   | "delivery_sent"
   | "delivery_failed"
   | "delivery_resent"
+  | "onboarding_started"
+  | "onboarding_acknowledged"
+  | "onboarding_blocked"
+  | "onboarding_completed"
   | "granted"
   | "opened"
   | "blocked"
@@ -742,6 +785,9 @@ export type TenantInstitutionAccessAuditEvent = {
     | "delivery_sent"
     | "delivery_failed"
     | "delivery_resent"
+    | "institution_review_onboarding_required"
+    | "institution_review_onboarding_acknowledged"
+    | "institution_review_onboarding_completed"
     | InstitutionReviewDeliveryFailureReason
     | "session_started"
     | "recipient_session_expired"
@@ -983,6 +1029,13 @@ function signalForGrantEvent(params: {
 }): SecuritySessionTelemetrySignal {
   if (params.eventType === "recipient_trust_review_opened") return "recipient_review_opened";
   if (params.eventType === "recipient_review_session_started") return "recipient_session_started";
+  if (
+    params.eventType === "institution_review_onboarding_started" ||
+    params.eventType === "institution_review_onboarding_acknowledged" ||
+    params.eventType === "institution_review_onboarding_completed"
+  ) {
+    return "recipient_review_opened";
+  }
   if (params.reason === "recipient_email_mismatch") return "wrong_recipient_attempt";
   if (params.reason === "grant_revoked" || params.eventType === "recipient_trust_review_revoked") return "revoked_access_attempt";
   if (params.reason === "grant_expired" || params.eventType === "recipient_trust_review_expired") return "expired_access_attempt";
@@ -1383,6 +1436,10 @@ function outcomeForEventType(eventType: TenantInstitutionAccessAuditEvent["event
   if (eventType === "institution_review_delivery_sent") return "delivery_sent";
   if (eventType === "institution_review_delivery_failed") return "delivery_failed";
   if (eventType === "institution_review_delivery_resent") return "delivery_resent";
+  if (eventType === "institution_review_onboarding_started") return "onboarding_started";
+  if (eventType === "institution_review_onboarding_acknowledged") return "onboarding_acknowledged";
+  if (eventType === "institution_review_onboarding_completed") return "onboarding_completed";
+  if (eventType === "institution_review_onboarding_blocked") return "onboarding_blocked";
   if (eventType === "tenant_institution_access_granted") return "granted";
   if (
     eventType === "tenant_institution_access_revoked" ||
@@ -1437,6 +1494,10 @@ function statusForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
   if (event.eventType === "recipient_review_session_revoked") return "session_revoked";
   if (event.eventType === "recipient_review_session_started") return "active";
   if (event.eventType === "recipient_trust_review_opened") return "available";
+  if (event.eventType === "institution_review_onboarding_started") return "onboarding_required";
+  if (event.eventType === "institution_review_onboarding_acknowledged" || event.eventType === "institution_review_onboarding_completed") {
+    return "available";
+  }
   return "blocked";
 }
 
@@ -1464,6 +1525,9 @@ function reasonForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"]
   if (event.eventType === "recipient_review_session_expired") return "recipient_session_expired";
   if (event.eventType === "recipient_review_session_blocked") return "recipient_session_reauthentication_required";
   if (event.eventType === "recipient_review_session_started") return "session_started";
+  if (event.eventType === "institution_review_onboarding_started") return "institution_review_onboarding_required";
+  if (event.eventType === "institution_review_onboarding_acknowledged") return "institution_review_onboarding_acknowledged";
+  if (event.eventType === "institution_review_onboarding_completed") return "institution_review_onboarding_completed";
   if (
     event.eventType === "tenant_institution_access_expired" ||
     event.eventType === "recipient_trust_review_expired" ||
@@ -2265,7 +2329,8 @@ function hasUnsafeRecipientPayload(grant: TenantInstitutionAccessStoredGrant) {
 function recipientSummaryFromGrant(
   grant: TenantInstitutionAccessStoredGrant,
   reviewedAt: string,
-  session: RecipientReviewSessionSummary
+  session: RecipientReviewSessionSummary,
+  options: { onboardingAcknowledged?: boolean } = {}
 ): RecipientTrustReviewSummary {
   const institutionReviewSession = deriveInstitutionReviewSession({
     accessGrant: grant,
@@ -2307,14 +2372,51 @@ function recipientSummaryFromGrant(
     reviewedAt,
     session,
     institutionReviewSession,
+    onboarding: {
+      schemaVersion: "institution_review_onboarding.v1",
+      status: options.onboardingAcknowledged ? "acknowledged" : "required",
+      acknowledgementRequired: true,
+      acknowledged: options.onboardingAcknowledged === true,
+      tenantMediated: true,
+      authenticatedRecipientRequired: true,
+      metadataOnly: true,
+      viewOnly: true,
+      timeBound: true,
+      revocable: true,
+      policyGated: true,
+      publicAccessEnabled: false,
+      downloadEnabled: false,
+      institutionAccountCreated: false,
+      automatedDecisioningEnabled: false,
+      copy: {
+        title: "Institution review orientation",
+        intro:
+          "A tenant authorized this limited RentChain review for the invited recipient, audience, and purpose shown here.",
+        bullets: [
+          "You must remain signed in with the invited recipient email before review metadata can be shown.",
+          "The review is metadata-only and view-only; raw trust payloads, provider payloads, identity documents, support/internal notes, public profiles, and downloads are excluded.",
+          "Access is time-bound, policy-gated, lifecycle-governed, and may be revoked by the tenant.",
+          "RentChain is not making an approval, eligibility, credit, insurance, subsidy, government, or automated decision.",
+        ],
+        acknowledgement:
+          "I understand this is a tenant-authorized, metadata-only, revocable, time-bound review and not an approval or eligibility decision.",
+        supportGuidance: [
+          "If you are not the intended recipient, ask the tenant to send a new invitation to the correct email.",
+          "If access is expired or revoked, the tenant must re-authorize review before metadata can be shown again.",
+          "If authentication fails, sign in with the invited recipient email before retrying.",
+        ],
+      },
+    },
     metadataOnly: true,
     policyGated: true,
-    includedClaims: (grant.includedClaims || []).map((claim) => ({
-      claimCategory: claim.claimCategory,
-      claimLabel: claim.claimLabel,
-      lifecycleState: claim.lifecycleState,
-      consentExpiresAt: claim.consentExpiresAt,
-    })),
+    includedClaims: options.onboardingAcknowledged
+      ? (grant.includedClaims || []).map((claim) => ({
+          claimCategory: claim.claimCategory,
+          claimLabel: claim.claimLabel,
+          lifecycleState: claim.lifecycleState,
+          consentExpiresAt: claim.consentExpiresAt,
+        }))
+      : [],
     excludedClaims: (grant.excludedClaims || []).map((claim) => ({
       claimCategory: claim.claimCategory,
       claimLabel: claim.claimLabel,
@@ -2570,6 +2672,7 @@ export async function getRecipientTrustReview(params: {
   recipientEmail?: unknown;
   recipientUserId?: unknown;
   recipientSessionId?: unknown;
+  onboardingAcknowledged?: boolean;
   requestContext?: SecuritySessionRequestContext | null;
 }): Promise<RecipientTrustReviewResult> {
   const grantId = asString(params.grantId);
@@ -2692,6 +2795,44 @@ export async function getRecipientTrustReview(params: {
     );
   }
 
+  if (params.onboardingAcknowledged !== true) {
+    await appendGrantEvent({
+      grant,
+      eventType: "institution_review_onboarding_started",
+      occurredAt: reviewedAt,
+      status: "onboarding_required",
+      reason: "institution_review_onboarding_required",
+      outcome: "onboarding_started",
+      recipientEmail,
+      recipientUserId: asString(params.recipientUserId, 160),
+      recipientSessionId: sessionDecision.session.sessionId,
+      requestContext: params.requestContext,
+    });
+    return {
+      decision: {
+        allowed: true,
+        status: "onboarding_required",
+        reason: "institution_review_onboarding_required",
+        metadataOnly: true,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+      },
+      summary: recipientSummaryFromGrant(grant, reviewedAt, sessionDecision.session, { onboardingAcknowledged: false }),
+    };
+  }
+
+  await appendGrantEvent({
+    grant,
+    eventType: "institution_review_onboarding_acknowledged",
+    occurredAt: reviewedAt,
+    status: "available",
+    reason: "institution_review_onboarding_acknowledged",
+    outcome: "onboarding_acknowledged",
+    recipientEmail,
+    recipientUserId: asString(params.recipientUserId, 160),
+    recipientSessionId: sessionDecision.session.sessionId,
+    requestContext: params.requestContext,
+  });
   await appendGrantEvent({
     grant,
     eventType: "recipient_trust_review_opened",
@@ -2721,6 +2862,18 @@ export async function getRecipientTrustReview(params: {
     await db.collection(COLLECTION).doc(grant.grantId).set({ institutionReviewInvite: invite, updatedAt: reviewedAt }, { merge: true });
     grant.institutionReviewInvite = invite;
   }
+  await appendGrantEvent({
+    grant,
+    eventType: "institution_review_onboarding_completed",
+    occurredAt: reviewedAt,
+    status: "available",
+    reason: "institution_review_onboarding_completed",
+    outcome: "onboarding_completed",
+    recipientEmail,
+    recipientUserId: asString(params.recipientUserId, 160),
+    recipientSessionId: sessionDecision.session.sessionId,
+    requestContext: params.requestContext,
+  });
 
   return {
     decision: {
@@ -2731,7 +2884,7 @@ export async function getRecipientTrustReview(params: {
       publicAccessEnabled: false,
       downloadEnabled: false,
     },
-    summary: recipientSummaryFromGrant(grant, reviewedAt, sessionDecision.session),
+    summary: recipientSummaryFromGrant(grant, reviewedAt, sessionDecision.session, { onboardingAcknowledged: true }),
   };
 }
 

--- a/rentchain-frontend/src/api/recipientTrustReview.ts
+++ b/rentchain-frontend/src/api/recipientTrustReview.ts
@@ -13,7 +13,8 @@ export type RecipientTrustReviewStatus =
   | "policy_denied"
   | "session_expired"
   | "session_revoked"
-  | "reauthentication_required";
+  | "reauthentication_required"
+  | "onboarding_required";
 
 export type RecipientTrustReviewDecision = {
   allowed: boolean;
@@ -103,6 +104,30 @@ export type RecipientTrustReviewSummary = {
     automatedDecisioningEnabled: false;
     downloadEnabled: false;
   };
+  onboarding: {
+    schemaVersion: "institution_review_onboarding.v1";
+    status: "required" | "acknowledged";
+    acknowledgementRequired: true;
+    acknowledged: boolean;
+    tenantMediated: true;
+    authenticatedRecipientRequired: true;
+    metadataOnly: true;
+    viewOnly: true;
+    timeBound: true;
+    revocable: true;
+    policyGated: true;
+    publicAccessEnabled: false;
+    downloadEnabled: false;
+    institutionAccountCreated: false;
+    automatedDecisioningEnabled: false;
+    copy: {
+      title: string;
+      intro: string;
+      bullets: string[];
+      acknowledgement: string;
+      supportGuidance: string[];
+    };
+  };
   metadataOnly: true;
   policyGated: true;
   includedClaims: Array<{
@@ -127,12 +152,15 @@ export type RecipientTrustReviewResponse = {
 
 export async function getRecipientTrustReview(
   grantId: string,
-  recipientSessionId?: string | null
+  recipientSessionId?: string | null,
+  onboardingAcknowledged = false
 ): Promise<RecipientTrustReviewResponse> {
-  const headers = recipientSessionId ? { "x-recipient-review-session-id": recipientSessionId } : undefined;
+  const headers: Record<string, string> = {};
+  if (recipientSessionId) headers["x-recipient-review-session-id"] = recipientSessionId;
+  if (onboardingAcknowledged) headers["x-institution-review-onboarding-acknowledged"] = "true";
   const res = await apiFetch<{ ok: boolean; data: RecipientTrustReviewResponse }>(
     `/recipient/trust-reviews/${encodeURIComponent(grantId)}`,
-    headers ? { headers } : undefined
+    Object.keys(headers).length ? { headers } : undefined
   );
   return res.data;
 }

--- a/rentchain-frontend/src/api/tenantInstitutionAccess.ts
+++ b/rentchain-frontend/src/api/tenantInstitutionAccess.ts
@@ -131,7 +131,11 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
       | "institution_review_delivery_blocked"
       | "institution_review_delivery_resent"
       | "institution_review_delivery_revoked"
-      | "institution_review_delivery_expired";
+      | "institution_review_delivery_expired"
+      | "institution_review_onboarding_started"
+      | "institution_review_onboarding_acknowledged"
+      | "institution_review_onboarding_blocked"
+      | "institution_review_onboarding_completed";
     occurredAt: string;
     actorType: "tenant" | "system" | "recipient";
     metadataOnly: true;
@@ -144,6 +148,10 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
       | "delivery_sent"
       | "delivery_failed"
       | "delivery_resent"
+      | "onboarding_started"
+      | "onboarding_acknowledged"
+      | "onboarding_blocked"
+      | "onboarding_completed"
       | "granted"
       | "opened"
       | "blocked"
@@ -289,7 +297,11 @@ export type TenantInstitutionAccessAuditEvent = {
     | "institution_review_delivery_blocked"
     | "institution_review_delivery_resent"
     | "institution_review_delivery_revoked"
-    | "institution_review_delivery_expired";
+    | "institution_review_delivery_expired"
+    | "institution_review_onboarding_started"
+    | "institution_review_onboarding_acknowledged"
+    | "institution_review_onboarding_blocked"
+    | "institution_review_onboarding_completed";
   occurredAt: string;
   actorType: "tenant" | "system" | "recipient";
   outcome:
@@ -301,6 +313,10 @@ export type TenantInstitutionAccessAuditEvent = {
     | "delivery_sent"
     | "delivery_failed"
     | "delivery_resent"
+    | "onboarding_started"
+    | "onboarding_acknowledged"
+    | "onboarding_blocked"
+    | "onboarding_completed"
     | "granted"
     | "opened"
     | "blocked"
@@ -331,6 +347,10 @@ export type TenantInstitutionAccessAuditSummary = {
     | "invite_sent"
     | "invite_opened"
     | "invite_authenticated"
+    | "onboarding_started"
+    | "onboarding_acknowledged"
+    | "onboarding_blocked"
+    | "onboarding_completed"
     | "granted"
     | "opened"
     | "blocked"

--- a/rentchain-frontend/src/pages/RecipientTrustReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/RecipientTrustReviewPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import RecipientTrustReviewPage from "./RecipientTrustReviewPage";
 
@@ -87,6 +87,30 @@ describe("RecipientTrustReviewPage", () => {
           publicAccessEnabled: false,
           reauthenticationRequiredAt: "2026-05-02T00:30:00.000Z",
         },
+        onboarding: {
+          schemaVersion: "institution_review_onboarding.v1",
+          status: "acknowledged",
+          acknowledgementRequired: true,
+          acknowledged: true,
+          tenantMediated: true,
+          authenticatedRecipientRequired: true,
+          metadataOnly: true,
+          viewOnly: true,
+          timeBound: true,
+          revocable: true,
+          policyGated: true,
+          publicAccessEnabled: false,
+          downloadEnabled: false,
+          institutionAccountCreated: false,
+          automatedDecisioningEnabled: false,
+          copy: {
+            title: "Institution review orientation",
+            intro: "A tenant authorized this limited RentChain review.",
+            bullets: ["The review is metadata-only and view-only."],
+            acknowledgement: "I understand this is not an approval or eligibility decision.",
+            supportGuidance: ["Ask the tenant to re-authorize expired access."],
+          },
+        },
         metadataOnly: true,
         policyGated: true,
         includedClaims: [
@@ -112,6 +136,139 @@ describe("RecipientTrustReviewPage", () => {
     expect(screen.getByText(/Recipient downloads are disabled/i)).toBeInTheDocument();
     expect(screen.getByText(/Public profiles and public trust URLs are not created/i)).toBeInTheDocument();
     expect(screen.getByText(/not an approval, eligibility, credit, insurance, subsidy, ownership, government, or automated decision/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Verified tenant/i)).not.toBeInTheDocument();
+  });
+
+  it("requires lightweight onboarding acknowledgement before showing included metadata", async () => {
+    const baseSummary: any = {
+      schemaVersion: "recipient_trust_review.v1",
+      grantId: "grant-1",
+      audience: "insurer",
+      purpose: "insurance_review",
+      lifecycle: "active",
+      recipient: { email: "reviewer@example.com", displayName: "Reviewer", organizationName: "Example Insurance" },
+      consent: {
+        granted: true,
+        consentVersion: "tenant_institution_access_consent.v1",
+        grantedAt: "2026-05-01T00:00:00.000Z",
+        expiresAt: "2026-06-01T00:00:00.000Z",
+        audience: "insurer",
+        purpose: "insurance_review",
+      },
+      access: {
+        authenticated: true,
+        sessionBound: true,
+        viewOnly: true,
+        downloadEnabled: false,
+        publicAccessEnabled: false,
+        publicProfileEnabled: false,
+        externalSubmissionEnabled: false,
+        providerIntegrationEnabled: false,
+        automatedDecisioningEnabled: false,
+      },
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-06-01T00:00:00.000Z",
+      reviewedAt: "2026-05-02T00:00:00.000Z",
+      session: {
+        schemaVersion: "recipient_review_session.v1",
+        sessionId: "session-1",
+        lifecycle: "active",
+        issuedAt: "2026-05-02T00:00:00.000Z",
+        expiresAt: "2026-05-02T00:30:00.000Z",
+        lastValidatedAt: "2026-05-02T00:00:00.000Z",
+        grantId: "grant-1",
+        audience: "insurer",
+        purpose: "insurance_review",
+        metadataOnly: true,
+        authenticated: true,
+        viewOnly: true,
+        downloadEnabled: false,
+        publicAccessEnabled: false,
+        reauthenticationRequiredAt: "2026-05-02T00:30:00.000Z",
+      },
+      onboarding: {
+        schemaVersion: "institution_review_onboarding.v1",
+        status: "required",
+        acknowledgementRequired: true,
+        acknowledged: false,
+        tenantMediated: true,
+        authenticatedRecipientRequired: true,
+        metadataOnly: true,
+        viewOnly: true,
+        timeBound: true,
+        revocable: true,
+        policyGated: true,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+        institutionAccountCreated: false,
+        automatedDecisioningEnabled: false,
+        copy: {
+          title: "Institution review orientation",
+          intro: "A tenant authorized this limited RentChain review.",
+          bullets: [
+            "You must remain signed in with the invited recipient email before review metadata can be shown.",
+            "The review is metadata-only and view-only.",
+            "Access is time-bound and may be revoked by the tenant.",
+            "RentChain is not making an approval or eligibility decision.",
+          ],
+          acknowledgement:
+            "I understand this is a tenant-authorized, metadata-only, revocable, time-bound review and not an approval or eligibility decision.",
+          supportGuidance: ["If access is expired or revoked, the tenant must re-authorize review before metadata can be shown again."],
+        },
+      },
+      metadataOnly: true,
+      policyGated: true,
+      includedClaims: [],
+      excludedClaims: [],
+      redactions: ["Support/internal metadata is excluded."],
+      disclaimers: ["This review is not an automated eligibility decision."],
+    };
+    recipientTrustReviewApi.getRecipientTrustReview
+      .mockResolvedValueOnce({
+        decision: {
+          allowed: true,
+          status: "onboarding_required",
+          reason: "institution_review_onboarding_required",
+          metadataOnly: true,
+          publicAccessEnabled: false,
+          downloadEnabled: false,
+        },
+        summary: baseSummary,
+      })
+      .mockResolvedValueOnce({
+        decision: {
+          allowed: true,
+          status: "available",
+          reason: "review_available",
+          metadataOnly: true,
+          publicAccessEnabled: false,
+          downloadEnabled: false,
+        },
+        summary: {
+          ...baseSummary,
+          onboarding: { ...baseSummary.onboarding, status: "acknowledged", acknowledged: true },
+          includedClaims: [
+            {
+              claimCategory: "account_trust",
+              claimLabel: "Account trust",
+              lifecycleState: "export_ready",
+              consentExpiresAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        },
+      });
+
+    renderPage();
+
+    expect(await screen.findByText(/Institution review orientation/i)).toBeInTheDocument();
+    expect(screen.queryByText("Account trust")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Continue to metadata review/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText(/tenant-authorized, metadata-only, revocable/i));
+    fireEvent.click(screen.getByRole("button", { name: /Continue to metadata review/i }));
+
+    expect(await screen.findByText("Account trust")).toBeInTheDocument();
+    expect(recipientTrustReviewApi.getRecipientTrustReview).toHaveBeenLastCalledWith("grant-1", "session-1", true);
     expect(screen.queryByText(/Verified tenant/i)).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/RecipientTrustReviewPage.tsx
+++ b/rentchain-frontend/src/pages/RecipientTrustReviewPage.tsx
@@ -93,11 +93,13 @@ export default function RecipientTrustReviewPage() {
     data: RecipientTrustReviewResponse | null;
     error: string | null;
   }>({ loading: true, data: null, error: null });
+  const [acknowledged, setAcknowledged] = React.useState(false);
+  const [acknowledging, setAcknowledging] = React.useState(false);
 
   React.useEffect(() => {
     let cancelled = false;
     setState({ loading: true, data: null, error: null });
-    getRecipientTrustReview(grantId, loadStoredSessionId(grantId))
+    getRecipientTrustReview(grantId, loadStoredSessionId(grantId), false)
       .then((data) => {
         if (!cancelled) {
           storeSessionId(grantId, data.summary?.session?.sessionId);
@@ -124,6 +126,29 @@ export default function RecipientTrustReviewPage() {
   }, [grantId]);
 
   const summary = state.data?.summary || null;
+  const onboardingRequired = summary?.onboarding?.acknowledgementRequired && !summary.onboarding.acknowledged;
+
+  function acknowledgeOnboarding() {
+    setAcknowledging(true);
+    getRecipientTrustReview(grantId, loadStoredSessionId(grantId), true)
+      .then((data) => {
+        storeSessionId(grantId, data.summary?.session?.sessionId);
+        setState({ loading: false, data, error: null });
+      })
+      .catch((err: any) => {
+        const decision = err?.body?.decision;
+        const reason = decision?.reason || err?.body?.error || err?.message || "Unable to complete this onboarding step.";
+        if (
+          decision?.status === "session_expired" ||
+          decision?.status === "session_revoked" ||
+          decision?.status === "reauthentication_required"
+        ) {
+          clearStoredSessionId(grantId);
+        }
+        setState({ loading: false, data: null, error: pretty(reason) });
+      })
+      .finally(() => setAcknowledging(false));
+  }
 
   return (
     <main style={pageStyle}>
@@ -148,6 +173,34 @@ export default function RecipientTrustReviewPage() {
           </section>
         ) : summary ? (
           <>
+            {onboardingRequired ? (
+              <section style={panelStyle}>
+                <h2 style={{ marginTop: 0, fontSize: 20 }}>{summary.onboarding.copy.title}</h2>
+                <p style={{ marginTop: 0, color: "#475569", lineHeight: 1.6 }}>{summary.onboarding.copy.intro}</p>
+                <ul style={{ margin: 0, paddingLeft: 20, color: "#475569", lineHeight: 1.7 }}>
+                  {summary.onboarding.copy.bullets.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+                <div style={{ marginTop: 16, display: "grid", gap: 12 }}>
+                  <label style={{ display: "flex", gap: 10, alignItems: "flex-start", color: "#334155", lineHeight: 1.5 }}>
+                    <input
+                      type="checkbox"
+                      checked={acknowledged}
+                      onChange={(event) => setAcknowledged(event.target.checked)}
+                      style={{ marginTop: 4 }}
+                    />
+                    <span>{summary.onboarding.copy.acknowledgement}</span>
+                  </label>
+                  <button type="button" disabled={!acknowledged || acknowledging} onClick={acknowledgeOnboarding}>
+                    {acknowledging ? "Preparing review..." : "Continue to metadata review"}
+                  </button>
+                </div>
+                <div style={{ marginTop: 16, color: "#64748b", lineHeight: 1.6 }}>
+                  {summary.onboarding.copy.supportGuidance.join(" ")}
+                </div>
+              </section>
+            ) : null}
             <section style={panelStyle}>
               <h2 style={{ marginTop: 0, fontSize: 20 }}>Review scope</h2>
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
@@ -174,10 +227,12 @@ export default function RecipientTrustReviewPage() {
               </div>
             </section>
 
-            <section style={panelStyle}>
-              <h2 style={{ marginTop: 0, fontSize: 20 }}>Included metadata</h2>
-              <MetadataList summary={summary} />
-            </section>
+            {!onboardingRequired ? (
+              <section style={panelStyle}>
+                <h2 style={{ marginTop: 0, fontSize: 20 }}>Included metadata</h2>
+                <MetadataList summary={summary} />
+              </section>
+            ) : null}
 
             <section style={panelStyle}>
               <h2 style={{ marginTop: 0, fontSize: 20 }}>Excluded metadata</h2>


### PR DESCRIPTION
## Summary
- Adds a controlled institution review onboarding summary to authenticated recipient trust review responses.
- Gates included review metadata behind a lightweight recipient acknowledgement while keeping review scope, redactions, and support guidance visible.
- Records metadata-only onboarding started/acknowledged/completed audit events and keeps frontend/API event unions aligned.

## Governance boundaries
- No institution accounts, APIs, provider integrations, downloads, public profiles, or public trust URLs added.
- Recipient review remains authenticated, tenant-mediated, audience/purpose scoped, policy-gated, lifecycle-governed, metadata-only, and view-only.
- Onboarding copy explicitly says RentChain is not making approval, eligibility, credit, insurance, subsidy, government, or automated decisions.

## Validation
- API targeted: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- recipientTrustReviewRoutes.test.ts tenantInstitutionAccessService.test.ts`
- Frontend targeted: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- RecipientTrustReviewPage.test.tsx`
- API build: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Frontend build: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- API full suite: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test` (rerun outside sandbox after sandbox `listen EPERM`)
- Frontend full suite: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test`
- `git diff --check`

## Manual QA
- Browser/manual QA not run in this environment.
- Verified through route/service/page tests that onboarding appears before included metadata, acknowledgement unlocks metadata, wrong recipient/auth/lifecycle blocks remain enforced, and no raw trust payload markers are exposed.