### PR TITLE
feat: make screening workflow copy provider agnostic

### DIFF
--- a/rentchain-frontend/src/components/applications/ApplicationDetailPanel.tsx
+++ b/rentchain-frontend/src/components/applications/ApplicationDetailPanel.tsx
@@ -11,7 +11,7 @@ import { colors, text, radius, shadows, spacing } from "../../styles/tokens";
 import { updateApplicationDetails, updateApplicationReferences } from "@/api/applicationsApi";
 import { useToast } from "../ui/ToastProvider";
 import { ConvertToTenantButton } from "./ConvertToTenantButton";
-import { SCREENING_ENABLED } from "../../config/screening";
+import { getUiLocale, SCREENING_ENABLED, screeningComingSoonLabel, screeningComingSoonNotice } from "../../config/screening";
 
 type ApplicationDetailPanelProps = {
   application: Application | null;
@@ -77,6 +77,7 @@ export const ApplicationDetailPanel: React.FC<ApplicationDetailPanelProps> = ({
   const [selectedApplicantIndex, setSelectedApplicantIndex] = useState(0);
   const { features } = useSubscription();
   const canUseAiScreening = features.hasTenantAI;
+  const uiLocale = getUiLocale();
   const [timelineOpen, setTimelineOpen] = useState(false);
   const [requiredFields, setRequiredFields] = useState({
     unitApplied: "",
@@ -1176,29 +1177,30 @@ export const ApplicationDetailPanel: React.FC<ApplicationDetailPanelProps> = ({
 
       {/* Screening */}
       {!SCREENING_ENABLED ? (
-<div
-  style={{
-    marginTop: 12,
-    borderRadius: 14,
-    padding: 12,
-    background: colors.panel,
-    border: `1px solid ${colors.border}`,
-  }}
->
-  <div
-    style={{
-      fontSize: 13,
-      color: text.primary,
-      fontWeight: 600,
-      marginBottom: 6,
-    }}
-  >
-    Credit screening — coming soon
-  </div>
-  <div style={{ fontSize: 13, color: text.muted }}>
-    Screening will be available soon. You&apos;ll be able to request tenant consent and run screening from here.
-  </div>
-</div>
+        <div
+          style={{
+            marginTop: 12,
+            borderRadius: 14,
+            padding: 12,
+            background: colors.panel,
+            border: `1px solid ${colors.border}`,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 13,
+              color: text.primary,
+              fontWeight: 600,
+              marginBottom: 6,
+            }}
+          >
+            {screeningComingSoonLabel(uiLocale)}
+          </div>
+          <div style={{ fontSize: 13, color: text.muted }}>{screeningComingSoonNotice(uiLocale)}</div>
+        </div>
+      ) : canUseAiScreening ? (
+        <div
+          style={{
             borderRadius: 14,
             padding: 12,
             background: colors.panel,

--- a/rentchain-frontend/src/components/screening/ScreeningReportView.test.tsx
+++ b/rentchain-frontend/src/components/screening/ScreeningReportView.test.tsx
@@ -42,4 +42,21 @@ describe("ScreeningReportView", () => {
     expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
     expect(screen.getByText(/Completed:/i)).toBeInTheDocument();
   });
+
+  it("uses provider-neutral fallback copy when no provider is present", () => {
+    render(
+      <ScreeningReportView
+        applicantName="Jordan Lee"
+        status="pending"
+        provider={null}
+        recommendation="Pending"
+        findings={[]}
+        flags={[]}
+        recommendedActions={[]}
+      />
+    );
+
+    expect(screen.getByText("Provider: Configured screening provider")).toBeInTheDocument();
+    expect(screen.queryByText(/TransUnion manual/i)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/screening/ScreeningReportView.tsx
+++ b/rentchain-frontend/src/components/screening/ScreeningReportView.tsx
@@ -86,6 +86,13 @@ function statusLabel(value: string) {
   return value.replace(/_/g, " ");
 }
 
+function providerLabel(value?: string | null) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "Configured screening provider";
+  if (normalized === "transunion" || normalized === "transunion_manual") return "TransUnion";
+  return value || "Configured screening provider";
+}
+
 export function ScreeningReportView({
   applicantName,
   propertyLabel,
@@ -132,7 +139,7 @@ export function ScreeningReportView({
           </div>
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap", fontSize: 12, color: text.subtle }}>
             <span>Status: {statusLabel(status)}</span>
-            <span>Provider: {provider || "TransUnion manual"}</span>
+            <span>Provider: {providerLabel(provider)}</span>
             {completedLabel ? <span>Completed: {completedLabel}</span> : null}
           </div>
         </div>

--- a/rentchain-frontend/src/components/screening/ScreeningStatusCard.test.tsx
+++ b/rentchain-frontend/src/components/screening/ScreeningStatusCard.test.tsx
@@ -28,7 +28,7 @@ describe("ScreeningStatusCard", () => {
     cleanup();
   });
 
-  it("renders blocked TransUnion state", () => {
+  it("renders provider-neutral blocked setup state", () => {
     render(
       <ScreeningStatusCard
         status={buildStatus({
@@ -39,8 +39,10 @@ describe("ScreeningStatusCard", () => {
     );
 
     expect(screen.getByText("Next step required")).toBeInTheDocument();
-    expect(screen.getByText(/We'll help you complete screening step by step/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Connect TransUnion" })).toBeInTheDocument();
+    expect(screen.getByText(/Connect the configured screening provider to continue/i)).toBeInTheDocument();
+    expect(screen.getByText(/Connect provider access, request screening/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect screening provider" })).toBeInTheDocument();
+    expect(screen.queryByText(/Connect TransUnion/i)).not.toBeInTheDocument();
   });
 
   it("renders requested state", () => {

--- a/rentchain-frontend/src/components/screening/ScreeningStatusCard.tsx
+++ b/rentchain-frontend/src/components/screening/ScreeningStatusCard.tsx
@@ -38,7 +38,7 @@ function getBadge(status: ScreeningStatusView["status"]) {
 function getDescription(status: ScreeningStatusView["status"]) {
   switch (status) {
     case "blocked_transunion_not_connected":
-      return "Connect TransUnion to continue. We'll help you complete screening step by step once your membership is linked.";
+      return "Connect the configured screening provider to continue. We'll help you complete screening step by step once provider access is linked.";
     case "requested":
       return "Your screening request is in the queue. We’ll guide it through the remaining internal review steps.";
     case "in_progress":
@@ -50,6 +50,11 @@ function getDescription(status: ScreeningStatusView["status"]) {
     default:
       return "Start screening when you're ready. We’ll help you complete each step from request to review.";
   }
+}
+
+function getActionLabel(status: ScreeningStatusView): string {
+  if (status.status === "blocked_transunion_not_connected") return "Connect screening provider";
+  return status.actionLabel;
 }
 
 export function ScreeningStatusCard({
@@ -109,7 +114,7 @@ export function ScreeningStatusCard({
         ) : null}
         {status.status === "blocked_transunion_not_connected" ? (
           <div style={{ color: text.primary }}>
-            <strong>Step-by-step:</strong> Connect TransUnion, request screening, then review the completed result here.
+            <strong>Step-by-step:</strong> Connect provider access, request screening, then review the completed result here.
           </div>
         ) : null}
         {status.reportAvailable ? (
@@ -119,7 +124,7 @@ export function ScreeningStatusCard({
 
       <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
         <Button type="button" onClick={onPrimaryAction} disabled={actionLoading}>
-          {actionLoading ? "Working..." : status.actionLabel}
+          {actionLoading ? "Working..." : getActionLabel(status)}
         </Button>
       </div>
     </Card>

--- a/rentchain-frontend/src/components/screening/SendScreeningInviteModal.test.tsx
+++ b/rentchain-frontend/src/components/screening/SendScreeningInviteModal.test.tsx
@@ -58,6 +58,9 @@ describe("SendScreeningInviteModal", () => {
 
     render(<SendScreeningInviteModal open onClose={vi.fn()} />);
 
+    expect(screen.getByText("Powered by RentChain screening workflow")).toBeInTheDocument();
+    expect(screen.queryByText("Powered by TransUnion")).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "Send invite" }));
 
     expect(openUpgrade).toHaveBeenCalled();

--- a/rentchain-frontend/src/components/screening/SendScreeningInviteModal.tsx
+++ b/rentchain-frontend/src/components/screening/SendScreeningInviteModal.tsx
@@ -273,7 +273,7 @@ export function SendScreeningInviteModal({
             width: "fit-content",
           }}
         >
-          Powered by TransUnion
+          Powered by RentChain screening workflow
           <span style={{ fontWeight: 400, color: text.subtle }}>Soft inquiry (no score impact)</span>
         </div>
         <div style={{ fontSize: 12, color: text.subtle }}>

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -250,6 +250,7 @@ vi.mock("../config/screening", () => ({
   SCREENING_ENABLED: true,
   getUiLocale: () => "en",
   screeningComingSoonLabel: () => "Credit screening - coming soon.",
+  screeningComingSoonNotice: () => "Credit screening is coming soon. We'll notify you when it's available.",
   screeningUnavailableMessage: () => "Screening unavailable.",
 }));
 

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -61,6 +61,7 @@ import {
   SCREENING_ENABLED,
   getUiLocale,
   screeningComingSoonLabel,
+  screeningComingSoonNotice,
   screeningUnavailableMessage,
 } from "../config/screening";
 import { ApplicationDecisionSummaryCard } from "@/components/applications/ApplicationDecisionSummaryCard";
@@ -185,6 +186,13 @@ const REQUEST_INFO_OPTIONS: Array<{ value: RequestInfoChecklistItem; label: stri
 const formatScreeningStatus = (value?: string | null) => {
   if (!value) return "unknown";
   return value.replace(/_/g, " ");
+};
+
+const formatScreeningProviderLabel = (value?: string | null) => {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "Configured screening provider";
+  if (normalized === "transunion" || normalized === "transunion_manual") return "TransUnion";
+  return String(value);
 };
 
 const formatUnitLabel = (value?: string | null) => {
@@ -421,10 +429,7 @@ const ApplicationsPage: React.FC = () => {
   }, []);
   const uiLocale = getUiLocale();
   const screeningComingSoonText = screeningComingSoonLabel(uiLocale);
-  const screeningComingSoonDetailText =
-    uiLocale === "fr"
-      ? "Verification de credit - bientot disponible."
-      : "Credit screening - coming soon.";
+  const screeningComingSoonDetailText = screeningComingSoonNotice(uiLocale);
   const CONSENT_VERSION = "v1.0";
   const onboarding = useOnboardingState();
   const propertiesCount = propertyRecords.length;
@@ -560,7 +565,7 @@ const ApplicationsPage: React.FC = () => {
       setTransUnionIntegration(data);
     } catch (err: any) {
       showToast({
-        message: "Unable to load TransUnion connection",
+        message: "Unable to load screening provider connection",
         description: err?.message || "",
         variant: "error",
       });
@@ -1840,8 +1845,8 @@ const ApplicationsPage: React.FC = () => {
     } catch (err: any) {
       if (String(err?.message || "").includes("transunion_not_connected")) {
         showToast({
-          message: "Connect TransUnion",
-          description: "Connect your TransUnion membership before starting screening.",
+          message: "Connect screening provider",
+          description: "Connect the configured screening provider before starting screening.",
           variant: "warning",
         });
         setTransUnionConnectOpen(true);
@@ -2412,8 +2417,8 @@ const ApplicationsPage: React.FC = () => {
                         Ready to start your first screening
                       </div>
                       <div style={{ color: text.muted, lineHeight: 1.6 }}>
-                        Your TransUnion connection is active. Next step: choose an applicant from this
-                        list, then open screening from that application.
+                        Your screening provider connection is active. Next step: choose an applicant
+                        from this list, then open screening from that application.
                       </div>
                       <div style={{ color: text.subtle, fontSize: "0.9rem" }}>
                         Start with the most review-ready applicant to reach your first completed
@@ -2849,7 +2854,7 @@ const ApplicationsPage: React.FC = () => {
                         width: "fit-content",
                       }}
                     >
-                      Powered by TransUnion
+                      Powered by RentChain screening workflow
                       <span style={{ fontWeight: 400, color: text.subtle }}>Soft inquiry (no score impact)</span>
                     </div>
                     <div className="rc-wrap-row">
@@ -2866,7 +2871,9 @@ const ApplicationsPage: React.FC = () => {
                         <span style={{ fontSize: 12, color: text.subtle }}>Refreshing…</span>
                       ) : null}
                       {screeningStatus?.provider ? (
-                        <span style={{ fontSize: 12, color: text.subtle }}>Provider: {screeningStatus.provider}</span>
+                        <span style={{ fontSize: 12, color: text.subtle }}>
+                          Provider: {formatScreeningProviderLabel(screeningStatus.provider)}
+                        </span>
                       ) : null}
                     </div>
                     <div style={{ fontSize: 13, color: text.muted }}>
@@ -2956,7 +2963,7 @@ const ApplicationsPage: React.FC = () => {
                     Screening is unavailable on your current plan.
                   </div>
                 ) : transUnionLoading ? (
-                  <div style={{ color: text.muted }}>Loading TransUnion connection…</div>
+                  <div style={{ color: text.muted }}>Loading screening provider connection...</div>
                 ) : !isTransUnionConnected ? (
                   <Card
                     style={{
@@ -2967,19 +2974,19 @@ const ApplicationsPage: React.FC = () => {
                     }}
                   >
                     <div style={{ fontWeight: 700, fontSize: "1rem" }}>
-                      Connect TransUnion to continue
+                      Connect screening provider to continue
                     </div>
                     <div style={{ color: text.muted, lineHeight: 1.6 }}>
-                      Before you can screen a tenant in RentChain, connect your TransUnion
-                      membership credentials. If you are still waiting on credentialing, start with
+                      Before you can screen a tenant in RentChain, connect the configured screening
+                      provider credentials. If you are still waiting on provider access, start with
                       the guided access steps here.
                     </div>
                     <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
                       <Button type="button" onClick={() => setTransUnionConnectOpen(true)}>
-                        Connect TransUnion to Continue
+                        Connect provider to continue
                       </Button>
                       <Button type="button" variant="secondary" onClick={() => openTransUnionAccess("applications_page")}>
-                        Get TransUnion Access
+                        Get provider access
                       </Button>
                     </div>
                   </Card>
@@ -3168,7 +3175,7 @@ const ApplicationsPage: React.FC = () => {
                   <div style={{ display: "grid", gap: 6, fontSize: 12 }}>
                     <div style={{ fontWeight: 700, fontSize: 13 }}>Screening receipt</div>
                     {receiptStatusLabel ? <div>Status: {receiptStatusLabel}</div> : null}
-                    <div>Provider: {screeningReceipt.provider || "TransUnion"}</div>
+                    <div>Provider: {formatScreeningProviderLabel(screeningReceipt.provider)}</div>
                     <div>Inquiry type: {screeningReceipt.inquiryType || "Soft inquiry (no score impact)"}</div>
                     <div>
                       Consent: {screeningReceipt.consentVersion || CONSENT_VERSION}

--- a/rentchain-frontend/src/pages/screening/ScreeningStartPage.test.tsx
+++ b/rentchain-frontend/src/pages/screening/ScreeningStartPage.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../api/apiFetch", () => ({
   apiFetch: vi.fn(async () => ({
     error: "transunion_not_connected",
-    message: "Connect your TransUnion membership before starting screening.",
+    message: "Connect the configured screening provider before starting screening.",
   })),
 }));
 
@@ -42,21 +42,22 @@ afterEach(() => {
 });
 
 describe("ScreeningStartPage", () => {
-  it("shows the TransUnion interstitial when TransUnion is not connected", async () => {
+  it("shows the provider-neutral interstitial when provider access is not connected", async () => {
     render(
       <MemoryRouter initialEntries={["/screening/start?applicationId=app-1"]}>
         <ScreeningStartPage />
       </MemoryRouter>
     );
 
-    expect((await screen.findAllByText("Connect TransUnion to start screening")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Connect screening provider to start screening")).length).toBeGreaterThan(0);
     expect(
       screen.getByText(
-        "Before you can screen a tenant in RentChain, connect your TransUnion membership credentials."
+        "Before you can screen a tenant in RentChain, connect the configured screening provider credentials."
       )
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Connect TransUnion" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Get Access" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect provider" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Get provider access" })).toBeInTheDocument();
+    expect(screen.queryByText(/Connect TransUnion/i)).not.toBeInTheDocument();
   });
 });
 

--- a/rentchain-frontend/src/pages/screening/ScreeningStartPage.tsx
+++ b/rentchain-frontend/src/pages/screening/ScreeningStartPage.tsx
@@ -87,7 +87,7 @@ const mapErrorMessage = (code?: string | null) => {
     return "This application isn't ready for screening yet.";
   }
   if (normalized === "transunion_not_connected") {
-    return "Connect your TransUnion membership before starting screening.";
+    return "Connect the configured screening provider before starting screening.";
   }
   return "Unable to start screening checkout. Please try again.";
 };
@@ -110,7 +110,7 @@ const mapErrorTitle = (code?: string | null) => {
     return "Screening unavailable";
   }
   if (normalized === "transunion_not_connected") {
-    return "Connect TransUnion to start screening";
+    return "Connect screening provider to start screening";
   }
   return "Unable to start screening checkout";
 };
@@ -466,25 +466,25 @@ const ScreeningStartPage: React.FC = () => {
                 }}
               >
                 <div style={{ fontWeight: 700, fontSize: "1rem" }}>
-                  Connect TransUnion to start screening
+                  Connect screening provider to start screening
                 </div>
                 <div style={{ color: text.muted, fontSize: "0.95rem" }}>
-                  Before you can screen a tenant in RentChain, connect your TransUnion membership
-                  credentials.
+                  Before you can screen a tenant in RentChain, connect the configured screening
+                  provider credentials.
                 </div>
                 <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
                   <Button
                     type="button"
                     onClick={() => navigate("/applications?openTransUnionConnect=1")}
                   >
-                    Connect TransUnion
+                    Connect provider
                   </Button>
                   <Button
                     type="button"
                     variant="secondary"
                     onClick={() => navigate("/applications?openTransUnionAccess=1")}
                   >
-                    Get Access
+                    Get provider access
                   </Button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Updates generic screening workflow UX copy so RentChain reads as a provider-neutral tenant screening workflow rather than a TransUnion front-end.
- Applies provider abstraction only to generic workflow surfaces: screening CTAs, blocked states, provider labels, powered-by labels, and generic unavailable/error copy.
- Updates `ApplicationDetailPanel.tsx` to use `screeningComingSoonLabel()` and `screeningComingSoonNotice()`.
- Adds targeted assertions for provider-neutral copy in screening/application UI tests.

## Explicit Scope Notes
- Backend untouched.
- Provider logic untouched.
- TransUnion credential/setup flows intentionally preserved.
- Provider abstraction applied only to generic workflow UX.
- No dependency upgrades, package version changes, or Vitest/jsdom dependency changes.

## Out of Scope Preserved
- Did not change TransUnion credential modals/cards.
- Did not rename backend error codes.
- Did not wire SingleKey into `getBureauProvider()`.
- Did not modify marketing/legal i18n copy.
- Did not change billing, auth, Firestore rules, analytics events, or provider credential storage.

## Testing
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Frontend build passed on Node 20.11.1 via `npm run build`.
- Targeted Vitest execution was blocked locally by a jsdom/ESM dependency loader issue: `html-encoding-sniffer` requiring ESM `@exodus/bytes/encoding-lite.js` before tests imported. This appears environmental/tooling-related, not implementation-specific.

## Remaining Risk
- Future workspace maintenance may require aligning frontend runtime/tooling toward Node 20.19+ compatibility, since Vite warns that it requires Node 20.19+ or 22.12+ even though the build completed under Node 20.11.1.

## Merge
Do not merge automatically until remote CI is green.