### PR TITLE
fix: reconcile occupancy on active lease creation

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -16,26 +16,57 @@ const { store, fakeDb, resetFakeDb } = vi.hoisted(() => {
     return store.get(name)!;
   }
 
-  const fakeDb = {
-    collection: (name: string) => ({
-      doc: (id?: string) => {
-        const actualId = id || `doc_${++idSeq}`;
-        const col = ensureCollection(name);
+  function matches(doc: DocShape, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      if (op === "array-contains") return Array.isArray(actual) && actual.includes(value);
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      orderBy: () => makeQuery(name, filters),
+      limit: () => makeQuery(name, filters),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id?: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id?: string) {
+    const actualId = id || `doc_${++idSeq}`;
+    const col = ensureCollection(name);
+    return {
+      id: actualId,
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = col.get(actualId)?.data || {};
+        col.set(actualId, { id: actualId, data: options?.merge ? { ...current, ...value } : value });
+      },
+      get: async () => {
+        const entry = col.get(actualId);
         return {
           id: actualId,
-          set: async (value: any) => {
-            col.set(actualId, { id: actualId, data: value });
-          },
-          get: async () => {
-            const entry = col.get(actualId);
-            return {
-              id: actualId,
-              exists: Boolean(entry),
-              data: () => entry?.data,
-            };
-          },
+          exists: Boolean(entry),
+          data: () => entry?.data,
         };
       },
+    };
+  }
+
+  const fakeDb = {
+    collection: (name: string) => ({
+      where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+      orderBy: () => makeQuery(name),
+      limit: () => makeQuery(name),
+      get: async () => makeQuery(name).get(),
+      doc: (id?: string) => makeDoc(name, id),
     }),
   };
 
@@ -238,6 +269,21 @@ describe("lease draft routes", () => {
     const app = express();
     app.use(express.json());
     app.use(router);
+    await fakeDb.collection("properties").doc("prop-1").set({
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [
+        { id: "unit-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" },
+        { id: "unit-2", unitNumber: "102", status: "vacant", occupancyStatus: "vacant" },
+      ],
+    });
+    await fakeDb.collection("units").doc("unit-1").set({
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
 
     const createRes = await request(app).post("/drafts").set(auth).send(payload);
     expect(createRes.status).toBe(201);
@@ -249,13 +295,36 @@ describe("lease draft routes", () => {
       .send({});
     expect(activateRes.status).toBe(200);
     expect(activateRes.body?.ok).toBe(true);
-    expect(String(activateRes.body?.leaseId || "")).toBeTruthy();
+    const leaseId = String(activateRes.body?.leaseId || "");
+    expect(leaseId).toBeTruthy();
 
     const leasesRes = await request(app).get("/tenant/tenant-1").set(auth);
     expect(leasesRes.status).toBe(200);
     expect(leasesRes.body?.ok).toBe(true);
     expect(Array.isArray(leasesRes.body?.leases)).toBe(true);
     expect(leasesRes.body.leases.length).toBeGreaterThan(0);
+
+    const propertySnap = await fakeDb.collection("properties").doc("prop-1").get();
+    expect(propertySnap.data()?.units).toEqual([
+      expect.objectContaining({
+        id: "unit-1",
+        status: "occupied",
+        occupancyStatus: "occupied",
+        currentTenantId: "tenant-1",
+        currentLeaseId: leaseId,
+      }),
+      expect.objectContaining({ id: "unit-2", status: "vacant" }),
+    ]);
+    const unitSnap = await fakeDb.collection("units").doc("unit-1").get();
+    expect(unitSnap.data()).toEqual(
+      expect.objectContaining({
+        status: "occupied",
+        occupancyStatus: "occupied",
+        currentTenantId: "tenant-1",
+        currentLeaseId: leaseId,
+        occupancySource: "canonical_lease",
+      })
+    );
   });
 
   it("returns 401 for activate when unauthorized", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -380,8 +380,14 @@ describe("leaseRoutes GET /active", () => {
       landlordId: "landlord-1",
       propertyId: "prop-1",
       unitNumber: "101",
+      label: "Unit 101",
       status: "vacant",
       occupancyStatus: "vacant",
+    });
+    seedDoc("tenants", "tenant-1", {
+      landlordId: "landlord-1",
+      fullName: "Jane Tenant",
+      email: "jane@example.com",
     });
 
     const router = (await import("../leaseRoutes")).default;
@@ -400,6 +406,44 @@ describe("leaseRoutes GET /active", () => {
     expect(res.status).toBe(201);
     const leaseId = String(res.body?.lease?.id || "");
     expect(leaseId).toBeTruthy();
+    expect(res.body?.lease).toEqual(
+      expect.objectContaining({
+        unitId: "unit-1",
+        unitNumber: "101",
+        unitLabel: "101",
+      })
+    );
+
+    const leaseSnap = await fakeDb.collection("leases").doc(leaseId).get();
+    expect(leaseSnap.data()).toEqual(
+      expect.objectContaining({
+        unitId: "unit-1",
+        unitNumber: "101",
+        unitLabel: "101",
+      })
+    );
+
+    const summaryRes = await invokeRouter(router, { method: "GET", url: `/${leaseId}` });
+    expect(summaryRes.status).toBe(200);
+    expect(summaryRes.body?.lease).toEqual(
+      expect.objectContaining({
+        unitId: "unit-1",
+        unitNumber: "101",
+        unitLabel: "101",
+      })
+    );
+    expect(JSON.stringify(summaryRes.body?.lease || {})).not.toContain("Unit unit-1");
+
+    const tenantLeasesRes = await invokeRouter(router, { method: "GET", url: "/tenant/tenant-1" });
+    expect(tenantLeasesRes.status).toBe(200);
+    expect(tenantLeasesRes.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        unitId: "unit-1",
+        unitNumber: "101",
+        unitLabel: "101",
+      })
+    );
+
     const propertySnap = await fakeDb.collection("properties").doc("prop-1").get();
     expect(propertySnap.data()?.units).toEqual([
       expect.objectContaining({
@@ -408,6 +452,9 @@ describe("leaseRoutes GET /active", () => {
         occupancyStatus: "occupied",
         currentTenantId: "tenant-1",
         currentLeaseId: leaseId,
+        tenantName: "Jane Tenant",
+        tenantFullName: "Jane Tenant",
+        currentTenantName: "Jane Tenant",
       }),
       expect.objectContaining({ id: "unit-2", status: "vacant" }),
     ]);
@@ -418,6 +465,9 @@ describe("leaseRoutes GET /active", () => {
         occupancyStatus: "occupied",
         currentTenantId: "tenant-1",
         currentLeaseId: leaseId,
+        tenantName: "Jane Tenant",
+        tenantFullName: "Jane Tenant",
+        currentTenantName: "Jane Tenant",
         occupancySource: "canonical_lease",
       })
     );

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { leaseService } from "../../services/leaseService";
 
 const getSignedDownloadUrlMock = vi.fn(async () => "https://signed.example.com/lease.pdf");
 
@@ -148,6 +149,7 @@ async function invokeRouter(router: any, options: {
 describe("leaseRoutes GET /active", () => {
   beforeEach(() => {
     resetFakeDb();
+    leaseService.getAll().splice(0);
     getSignedDownloadUrlMock.mockClear();
   });
 
@@ -365,6 +367,80 @@ describe("leaseRoutes GET /active", () => {
     expect(res.body?.leases.map((lease: { id: string }) => lease.id)).toEqual(["lease-visible"]);
   });
 
+  it("marks a direct created active lease unit occupied in embedded and standalone storage", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [
+        { id: "unit-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" },
+        { id: "unit-2", unitNumber: "102", status: "vacant", occupancyStatus: "vacant" },
+      ],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/",
+      body: {
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitNumber: "unit-1",
+        monthlyRent: 1850,
+        startDate: "2026-01-01",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    const leaseId = String(res.body?.lease?.id || "");
+    expect(leaseId).toBeTruthy();
+    const propertySnap = await fakeDb.collection("properties").doc("prop-1").get();
+    expect(propertySnap.data()?.units).toEqual([
+      expect.objectContaining({
+        id: "unit-1",
+        status: "occupied",
+        occupancyStatus: "occupied",
+        currentTenantId: "tenant-1",
+        currentLeaseId: leaseId,
+      }),
+      expect.objectContaining({ id: "unit-2", status: "vacant" }),
+    ]);
+    const unitSnap = await fakeDb.collection("units").doc("unit-1").get();
+    expect(unitSnap.data()).toEqual(
+      expect.objectContaining({
+        status: "occupied",
+        occupancyStatus: "occupied",
+        currentTenantId: "tenant-1",
+        currentLeaseId: leaseId,
+        occupancySource: "canonical_lease",
+      })
+    );
+  });
+
+  it("does not block direct lease creation when occupancy sync cannot find a unit", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/",
+      body: {
+        tenantId: "tenant-1",
+        propertyId: "prop-missing",
+        unitNumber: "unit-missing",
+        monthlyRent: 1850,
+        startDate: "2026-01-01",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.lease?.id).toBeTruthy();
+  });
+
   it("enables rent collection for an owned eligible lease", async () => {
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",
@@ -553,6 +629,17 @@ describe("leaseRoutes GET /active", () => {
       createdAt: 1,
       updatedAt: 2,
     });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: "tenant-1",
+      currentTenantId: "tenant-1",
+      leaseId: "lease-1",
+      currentLeaseId: "lease-1",
+    });
 
     const router = (await import("../leaseRoutes")).default;
     const res = await invokeRouter(router, { method: "POST", url: "/lease-1/end", body: {} });
@@ -563,6 +650,18 @@ describe("leaseRoutes GET /active", () => {
       expect.objectContaining({ id: "unit-1", unitNumber: "101", status: "vacant" }),
       expect.objectContaining({ id: "unit-2", unitNumber: "102", status: "occupied" }),
     ]);
+    const unitSnap = await fakeDb.collection("units").doc("unit-1").get();
+    expect(unitSnap.data()).toEqual(
+      expect.objectContaining({
+        status: "vacant",
+        occupancyStatus: "vacant",
+        tenantId: null,
+        currentTenantId: null,
+        leaseId: null,
+        currentLeaseId: null,
+        occupancySource: "lease_end",
+      })
+    );
   });
 
   it("restores an ended firestore lease and marks the matched unit occupied", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -116,6 +116,20 @@ vi.mock("../../services/leaseCanonicalizationService", () => ({
       label: String(doc.data()?.unitNumber || "").trim(),
     }));
   }),
+  resolveUnitReference: vi.fn((units: any[], reference: any) => {
+    const target = String(reference || "").trim().toLowerCase();
+    const unit = units.find((candidate) =>
+      [candidate.id, candidate.unitNumber, candidate.label]
+        .map((value) => String(value || "").trim().toLowerCase())
+        .includes(target)
+    );
+    return {
+      unit: unit || null,
+      matchedBy: unit ? "test" : null,
+      ambiguous: false,
+      candidateIds: unit ? [unit.id] : [],
+    };
+  }),
   toCanonicalLeaseRecord: vi.fn((id: string, raw: any) => ({
     id,
     status: String(raw?.status || "").trim().toLowerCase(),

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -22,7 +22,13 @@ import {
   getLeaseAutomationTasks,
   regenerateLeaseAutomationTasks,
 } from "../services/automationScheduler/leaseAutomationTaskStore";
-import { CURRENT_LEASE_STATUSES, loadCanonicalPropertyLeases, loadUnitsForProperty, toCanonicalLeaseRecord } from "../services/leaseCanonicalizationService";
+import {
+  CURRENT_LEASE_STATUSES,
+  loadCanonicalPropertyLeases,
+  loadUnitsForProperty,
+  resolveUnitReference,
+  toCanonicalLeaseRecord,
+} from "../services/leaseCanonicalizationService";
 import { evaluateSameLeaseAgreement, groupLeaseAgreementCandidates, pickAgreementWinner } from "../services/leasePartyConsolidationService";
 import { loadPropertyLeaseIntegrityDiagnostics } from "../services/leaseIntegrityService";
 import { buildLeaseRiskPersistenceFields, computeLeaseRiskSnapshot } from "../services/risk/recomputeLeaseRisk";
@@ -58,6 +64,7 @@ import { buildLeasePaymentProjection } from "../services/projections/buildLeaseP
 import { computeNoResponseState } from "../services/leaseNoticeWorkflowService";
 import { deriveLeaseLifecycleSummary } from "../services/leaseLifecycle/deriveLeaseLifecycleSummary";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
+import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
@@ -305,16 +312,79 @@ async function resolvePropertyUnitForLease(lease: any, errorPrefix: string) {
 
 async function reconcilePropertyUnitVacancyForLeaseEnd(lease: any) {
   const { propertyRef, units, unitIndex } = await resolvePropertyUnitForLease(lease, "lease_end");
+  const nowIso = new Date().toISOString();
   const nextUnits = units.map((unit: any, index: number) =>
     index === unitIndex ? { ...unit, status: "vacant" } : unit
   );
   await propertyRef.set(
     {
       units: nextUnits,
-      updatedAt: new Date().toISOString(),
+      updatedAt: nowIso,
     },
     { merge: true }
   );
+
+  const unitDocId = await resolveStandaloneUnitDocIdForLeaseEnd(lease);
+  if (unitDocId) {
+    await db.collection("units").doc(unitDocId).set(
+      {
+        status: "vacant",
+        occupancyStatus: "vacant",
+        tenantId: null,
+        currentTenantId: null,
+        leaseId: null,
+        currentLeaseId: null,
+        occupancySource: "lease_end",
+        occupancyUpdatedAt: nowIso,
+        updatedAt: nowIso,
+      },
+      { merge: true }
+    );
+  }
+}
+
+async function resolveStandaloneUnitDocIdForLeaseEnd(lease: any): Promise<string | null> {
+  const propertyId = String(lease?.propertyId || "").trim();
+  const landlordId = String(lease?.landlordId || "").trim();
+  if (!propertyId) return null;
+
+  const canonicalUnits = await loadUnitsForProperty(db as any, propertyId, landlordId || null);
+  const leaseUnitId = String(lease?.unitId || "").trim();
+  const leaseUnitNumber = String(lease?.unitNumber || lease?.unit || "").trim();
+  const byId = resolveUnitReference(canonicalUnits, leaseUnitId);
+  if (byId.ambiguous) return null;
+  if (byId.unit) return byId.unit.id;
+
+  const byLabel = resolveUnitReference(canonicalUnits, leaseUnitNumber);
+  if (byLabel.ambiguous) return null;
+  return byLabel.unit?.id || null;
+}
+
+async function syncOccupancyAfterActiveLeaseWrite(
+  input: {
+    tenantId: string;
+    leaseId: string;
+    landlordId: string;
+    propertyId: string;
+    unitId: string;
+  },
+  logPrefix: string
+) {
+  try {
+    const result = await syncPropertyUnitOccupancyForTenantContext(input);
+    if (!result.updated) {
+      console.warn(`${logPrefix} occupancy sync skipped`, {
+        leaseId: input.leaseId,
+        tenantId: input.tenantId,
+        landlordId: input.landlordId,
+        propertyId: input.propertyId,
+        unitId: input.unitId,
+        reason: result.reason,
+      });
+    }
+  } catch (syncErr) {
+    console.warn(`${logPrefix} occupancy sync failed`, syncErr);
+  }
 }
 
 async function reconcilePropertyUnitOccupancyForLeaseRestore(lease: any) {
@@ -1605,6 +1675,16 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       updatedAt: now,
     };
     await leaseRef.set(leaseRecord, { merge: false });
+    await syncOccupancyAfterActiveLeaseWrite(
+      {
+        tenantId,
+        leaseId: leaseRef.id,
+        landlordId,
+        propertyId,
+        unitId,
+      },
+      "[POST /api/leases/drafts/:draftId/activate]"
+    );
 
     // Keep in-memory lease service in sync for existing automation/toggle flows.
     leaseService.getAll().push({
@@ -2223,9 +2303,25 @@ router.post("/", async (req: Request, res: Response) => {
         createdAt: lease.createdAt,
         updatedAt: lease.updatedAt,
       };
-      await db.collection("leases").doc(lease.id).set(firestoreLeaseRecord, { merge: false }).catch((error: any) => {
+      let firestoreLeaseWritten = false;
+      try {
+        await db.collection("leases").doc(lease.id).set(firestoreLeaseRecord, { merge: false });
+        firestoreLeaseWritten = true;
+      } catch (error: any) {
         console.warn("[POST /api/leases] firestore lease write failed", error);
-      });
+      }
+      if (firestoreLeaseWritten) {
+        await syncOccupancyAfterActiveLeaseWrite(
+          {
+            tenantId: String(lease.tenantId || body.tenantId || "").trim(),
+            leaseId: lease.id,
+            landlordId,
+            propertyId: String(lease.propertyId || body.propertyId || "").trim(),
+            unitId: String(body.unitNumber || lease.unitNumber || "").trim(),
+          },
+          "[POST /api/leases]"
+        );
+      }
     }
     res.status(201).json({ lease });
   } catch (err) {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -577,6 +577,61 @@ async function loadUnitLeaseDocumentForResponse(raw: any) {
   }
 }
 
+function getCanonicalUnitLabel(unit: any): string | null {
+  const unitId = String(unit?.id || "").trim().toLowerCase();
+  const candidates = [
+    unit?.unitNumber,
+    unit?.label,
+    unit?.raw?.unitNumber,
+    unit?.raw?.label,
+    unit?.raw?.displayLabel,
+    unit?.raw?.unitLabel,
+    unit?.raw?.name,
+  ]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  return candidates.find((value) => value.toLowerCase() !== unitId) || candidates[0] || null;
+}
+
+async function resolveLeaseUnitSelection(input: {
+  landlordId: string;
+  propertyId: string;
+  unitReference: string;
+}): Promise<{ unitId: string; unitLabel: string }> {
+  const units = await loadUnitsForProperty(db as any, input.propertyId, input.landlordId || null).catch(() => []);
+  const resolution = resolveUnitReference(units, input.unitReference);
+  if (!resolution.ambiguous && resolution.unit) {
+    return {
+      unitId: resolution.unit.id,
+      unitLabel: getCanonicalUnitLabel(resolution.unit) || input.unitReference,
+    };
+  }
+  return {
+    unitId: input.unitReference,
+    unitLabel: input.unitReference,
+  };
+}
+
+async function hydrateLeaseUnitDisplayFields<T extends Record<string, any>>(
+  lease: T,
+  landlordId: string | null
+): Promise<T> {
+  const propertyId = String(lease?.propertyId || "").trim();
+  const unitReference = String(lease?.unitId || lease?.unitNumber || lease?.unit || "").trim();
+  if (!propertyId || !unitReference) return lease;
+  const units = await loadUnitsForProperty(db as any, propertyId, landlordId || null).catch(() => []);
+  const resolution = resolveUnitReference(units, unitReference);
+  if (resolution.ambiguous || !resolution.unit) return lease;
+  const unitLabel = getCanonicalUnitLabel(resolution.unit);
+  if (!unitLabel) return lease;
+  return {
+    ...lease,
+    unitId: String(lease?.unitId || resolution.unit.id || "").trim() || resolution.unit.id,
+    unitNumber: unitLabel,
+    unitLabel,
+  };
+}
+
 async function enrichLeaseRow(raw: any) {
   const lease = normalizeLeaseRow(raw.id, raw);
   const propertyId = String(lease.propertyId || "").trim();
@@ -623,7 +678,7 @@ async function enrichLeaseRow(raw: any) {
   const rentPaymentSummary = leasePaymentProjection.rentPaymentSummary;
 
   return {
-    ...lease,
+    ...(await hydrateLeaseUnitDisplayFields(lease, String(lease.landlordId || "").trim() || null)),
     propertyName,
     tenantName,
     tenantEmail,
@@ -2116,18 +2171,21 @@ router.get("/tenant/:tenantId", requireLandlord, async (req: any, res: Response)
     const propertyMap = new Map<string, { propertyName: string | null; propertyAddress: string | null } | null>(
       propertyEntries
     );
-    const displayLeases = firestoreLeases.map((lease: any) => {
-      const propertyData = propertyMap.get(String(lease.propertyId || "").trim()) || null;
-      const propertyName = lease._rawPropertyName || propertyData?.propertyName || null;
-      const propertyAddress = lease._rawPropertyAddress || propertyData?.propertyAddress || null;
-      const { _rawPropertyName, _rawPropertyAddress, ...rest } = lease;
-      return {
-        ...rest,
-        propertyName,
-        propertyAddress,
-        propertyLabel: propertyName,
-      };
-    });
+    const displayLeases = await Promise.all(
+      firestoreLeases.map(async (lease: any) => {
+        const propertyData = propertyMap.get(String(lease.propertyId || "").trim()) || null;
+        const propertyName = lease._rawPropertyName || propertyData?.propertyName || null;
+        const propertyAddress = lease._rawPropertyAddress || propertyData?.propertyAddress || null;
+        const { _rawPropertyName, _rawPropertyAddress, ...rest } = lease;
+        const hydrated = await hydrateLeaseUnitDisplayFields(rest, landlordId || null);
+        return {
+          ...hydrated,
+          propertyName,
+          propertyAddress,
+          propertyLabel: propertyName,
+        };
+      })
+    );
     return res.status(200).json({ ok: true, leases: mergeLeaseRows([...memoryLeases, ...displayLeases]) });
   } catch {
     return res.status(200).json({ ok: true, leases: memoryLeases });
@@ -2236,11 +2294,16 @@ router.post("/", async (req: Request, res: Response) => {
     const tenantIds = Array.isArray((body as any)?.tenantIds)
       ? (body as any).tenantIds.map((value: any) => String(value || "").trim()).filter(Boolean)
       : [String(body.tenantId || "").trim()].filter(Boolean);
+    const unitSelection = await resolveLeaseUnitSelection({
+      landlordId,
+      propertyId: String(body.propertyId || "").trim(),
+      unitReference: String(body.unitNumber || "").trim(),
+    });
 
     const conflicts = await assertNoConflictingActiveAgreement({
       landlordId,
       propertyId: body.propertyId,
-      unitId: body.unitNumber,
+      unitId: unitSelection.unitId,
       tenantIds,
       startDate: body.startDate,
       endDate: body.endDate,
@@ -2257,7 +2320,7 @@ router.post("/", async (req: Request, res: Response) => {
     const riskSnapshot = await computeLeaseRiskSnapshot({
       landlordId,
       propertyId: body.propertyId,
-      unitId: body.unitNumber,
+      unitId: unitSelection.unitId,
       tenantIds,
       monthlyRent: Number(body.monthlyRent),
     });
@@ -2271,7 +2334,7 @@ router.post("/", async (req: Request, res: Response) => {
       tenantIds,
       primaryTenantId: tenantIds[0] || body.tenantId,
       propertyId: body.propertyId,
-      unitNumber: body.unitNumber,
+      unitNumber: unitSelection.unitLabel,
       monthlyRent: Number(body.monthlyRent),
       startDate: body.startDate,
       endDate: body.endDate,
@@ -2287,8 +2350,9 @@ router.post("/", async (req: Request, res: Response) => {
         tenantIds,
         primaryTenantId: tenantIds[0] || body.tenantId,
         propertyId: lease.propertyId,
-        unitId: body.unitNumber,
-        unitNumber: lease.unitNumber,
+        unitId: unitSelection.unitId,
+        unitNumber: unitSelection.unitLabel,
+        unitLabel: unitSelection.unitLabel,
         monthlyRent: lease.monthlyRent,
         startDate: lease.startDate,
         endDate: lease.endDate ?? null,
@@ -2317,13 +2381,20 @@ router.post("/", async (req: Request, res: Response) => {
             leaseId: lease.id,
             landlordId,
             propertyId: String(lease.propertyId || body.propertyId || "").trim(),
-            unitId: String(body.unitNumber || lease.unitNumber || "").trim(),
+            unitId: unitSelection.unitId,
           },
           "[POST /api/leases]"
         );
       }
     }
-    res.status(201).json({ lease });
+    res.status(201).json({
+      lease: {
+        ...lease,
+        unitId: unitSelection.unitId,
+        unitNumber: unitSelection.unitLabel,
+        unitLabel: unitSelection.unitLabel,
+      },
+    });
   } catch (err) {
     console.error("[POST /api/leases] error", err);
     res.status(500).json({ error: "Failed to process lease" });

--- a/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
+++ b/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
@@ -89,6 +89,17 @@ describe("applicationConversionService", () => {
       },
       status: "APPROVED",
     });
+    ensureCollection("properties").set("property-1", {
+      landlordId: "landlord-1",
+      units: [{ id: "unit-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" }],
+    });
+    ensureCollection("units").set("unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
 
     const { convertApplicationToTenant } = await import("../applicationConversionService");
     const result = await convertApplicationToTenant({
@@ -115,6 +126,12 @@ describe("applicationConversionService", () => {
       source: "application_conversion",
     });
     expect(ensureCollection("rentalApplications").get("app-1")?.convertedTenantId).toBe(result.tenantId);
+    expect(ensureCollection("properties").get("property-1")?.units).toEqual([
+      expect.objectContaining({ id: "unit-1", status: "vacant", occupancyStatus: "vacant" }),
+    ]);
+    expect(ensureCollection("units").get("unit-1")).toEqual(
+      expect.objectContaining({ status: "vacant", occupancyStatus: "vacant" })
+    );
   });
 
   it("does not create another tenant when conversion is repeated for the same application", async () => {

--- a/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
@@ -82,9 +82,9 @@ async function findUnitDoc(propertyId: string, landlordId: string | null, unitId
   const snap = await db.collection("units").where("propertyId", "==", propertyId).get();
   const matches = snap.docs
     .map((doc: any) => ({ id: doc.id, data: doc.data() || {} }))
-    .filter(({ data }: any) => {
+    .filter(({ id, data }: any) => {
       if (landlordId && asString(data?.landlordId) && asString(data?.landlordId) !== landlordId) return false;
-      return unitMatches({ id: data?.id || data?.unitId, ...data }, unitId);
+      return unitMatches({ ...data, id: data?.id || data?.unitId || id }, unitId);
     });
   if (matches.length !== 1) return null;
   return matches[0];

--- a/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
@@ -107,6 +107,24 @@ async function updateEmbeddedPropertyUnit(propertyId: string, unitId: string, pa
   return true;
 }
 
+async function loadTenantDisplayFields(tenantId: string): Promise<Record<string, string>> {
+  const snap = await db.collection("tenants").doc(tenantId).get().catch(() => null);
+  if (!snap?.exists) return {};
+  const tenant = snap.data() || {};
+  const displayName = asString(
+    (tenant as any)?.fullName ||
+      (tenant as any)?.name ||
+      (tenant as any)?.tenantName ||
+      (tenant as any)?.displayName
+  );
+  if (!displayName) return {};
+  return {
+    tenantName: displayName,
+    tenantFullName: displayName,
+    currentTenantName: displayName,
+  };
+}
+
 export async function syncPropertyUnitOccupancyForTenantContext(
   input: OccupancySyncInput
 ): Promise<OccupancySyncResult> {
@@ -135,6 +153,7 @@ export async function syncPropertyUnitOccupancyForTenantContext(
   const unitReference = leaseUnitId || unitId;
 
   const now = Date.now();
+  const tenantDisplayFields = await loadTenantDisplayFields(tenantId);
   const occupancyPatch = {
     status: "occupied",
     occupancyStatus: "occupied",
@@ -143,6 +162,7 @@ export async function syncPropertyUnitOccupancyForTenantContext(
     leaseId,
     currentLeaseId: leaseId,
     applicationId: asString(input.applicationId),
+    ...tenantDisplayFields,
     occupancySource: "canonical_lease",
     occupancyUpdatedAt: now,
     updatedAt: now,


### PR DESCRIPTION
## Summary
- Reconcile unit occupancy after active lease records are written from draft activation.
- Reconcile unit occupancy after direct active lease creation when the Firestore lease write succeeds.
- Update lease-end vacancy reconciliation to mark both embedded `properties/{propertyId}.units[]` and standalone `units/{unitId}` records vacant when a canonical unit doc can be resolved.
- Preserve non-fatal occupancy sync behavior for lease creation/activation failures.

## Scope
- Backend lease route occupancy insertion points only.
- Tenant occupancy sync matching fix for standalone unit document IDs.
- Targeted backend route/service tests only.
- No frontend files changed.
- No Firestore rules, package/lockfile, migration, backfill, or broad lease status refactor changes.
- Application conversion and invite redemption without lease context remain non-occupancy events.

## Explicitly Out of Scope
- `PUT /api/leases/:id` status-change reconciliation.
- Historical occupancy backfill or migration.
- `reconcileUnitOccupancyFromLeases`.
- Tenant identity/deduping behavior.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/routes/__tests__/leaseRoutes.active.test.ts src/routes/__tests__/leaseDraftRoutes.test.ts src/services/__tests__/applicationConversionService.test.ts src/routes/__tests__/authOnboardTenantInvites.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:light` passed after approving local Supertest server binding; the initial sandboxed run failed with `listen EPERM`.
- `git diff --check`

## Preview QA Focus
- Create lease from tenant profile and confirm `/properties` unit changes to occupied.
- End lease and confirm unit returns to vacant.
- Confirm application approval alone still does not mark occupied.

Do not merge until CI and preview QA pass.