### PR TITLE
fix: normalize lease date-only display

### DIFF
--- a/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
@@ -9,9 +9,22 @@ function formatCurrency(value: number | null | undefined) {
 
 function formatDate(value: string | null | undefined) {
   if (!value) return "—";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-CA", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleDateString();
+  return parsed.toLocaleDateString("en-CA", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 }
 
 function prettyLeaseStatus(value: string | null | undefined) {

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -239,4 +239,44 @@ describe("TenantDetailPanel", () => {
     await waitFor(() => expect(mocks.fetchLedger).toHaveBeenCalledWith({ tenantId: "tenant-1", limit: 50 }));
     await waitFor(() => expect(mocks.fetchTenantFinancialActivity).toHaveBeenCalledWith("tenant-1"));
   });
+
+  it("formats current lease date-only values without shifting to the previous day", async () => {
+    mocks.useTenantDetail.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: {
+        tenant: {
+          id: "tenant-1",
+          fullName: "Taylor Tenant",
+          propertyName: "Harbour View",
+          unit: "101",
+        },
+        currentLease: {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyName: "Harbour View",
+          unit: "101",
+          leaseStart: "2026-05-01",
+          leaseEnd: "2027-04-30",
+          monthlyRent: 1850,
+          status: "active",
+        },
+        property: { id: "prop-1", name: "Harbour View", addressLine1: "123 Harbour St", city: "Halifax", province: "NS" },
+        unit: { id: "unit-1", unitNumber: "101" },
+        moveInReadiness: null,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantDetailPanel tenantId="tenant-1" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("May 1, 2026")).toBeInTheDocument();
+    expect(screen.getByText("Apr 30, 2027")).toBeInTheDocument();
+    expect(screen.queryByText("Apr 30, 2026")).not.toBeInTheDocument();
+    expect(screen.queryByText("Apr 29, 2027")).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledWith("lease-1"));
+  });
 });

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -48,12 +48,24 @@ const riskBorderMap: Record<string, string> = {
 };
 
 const RECENT_LEASE_LEDGER_ENTRY_LIMIT = 10;
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 function formatDateLabel(value?: string | number | null) {
   if (!value) return "--";
+  if (typeof value === "string") {
+    const dateOnlyMatch = DATE_ONLY_PATTERN.exec(value.trim());
+    if (dateOnlyMatch) {
+      const [, year, month, day] = dateOnlyMatch;
+      return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-CA", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+    }
+  }
   const parsed = new Date(typeof value === "number" ? value : String(value));
   if (Number.isNaN(parsed.getTime())) return String(value);
-  return parsed.toLocaleDateString(undefined, {
+  return parsed.toLocaleDateString("en-CA", {
     month: "short",
     day: "numeric",
     year: "numeric",

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
@@ -128,4 +128,30 @@ describe("TenantLeasePanel", () => {
     expect(screen.queryByText(/prop-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/prop-raw-2/i)).not.toBeInTheDocument();
   });
+
+  it("formats lease date-only values without shifting to the previous day", async () => {
+    mocks.getLeaseAutomationTasks.mockResolvedValue({ tasks: [] });
+    mocks.getLeasesForTenant.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          propertyId: "prop-1",
+          propertyName: "Harbour View",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2026-05-01",
+          endDate: "2026-06-01",
+          status: "active",
+          automationEnabled: true,
+        },
+      ],
+    });
+
+    render(<TenantLeasePanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText(/May 1, 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/Jun 1, 2026/)).toBeInTheDocument();
+    expect(screen.queryByText(/Apr 30, 2026/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/May 31, 2026/)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -13,6 +13,13 @@ import { useUpgrade } from "@/context/UpgradeContext";
 import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
 import { LeaseRiskCard } from "@/components/leases/LeaseRiskCard";
 
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+};
+
 function isNotFound(err: any): boolean {
   return (
     err?.status === 404 ||
@@ -203,9 +210,14 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
 
   const formatDate = (value?: string) => {
     if (!value) return "--";
+    const dateOnlyMatch = DATE_ONLY_PATTERN.exec(value.trim());
+    if (dateOnlyMatch) {
+      const [, year, month, day] = dateOnlyMatch;
+      return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-CA", DATE_FORMAT_OPTIONS);
+    }
     const d = new Date(value);
     if (Number.isNaN(d.getTime())) return value;
-    return d.toLocaleDateString();
+    return d.toLocaleDateString("en-CA", DATE_FORMAT_OPTIONS);
   };
 
   const formatCurrency = (value: number) =>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -195,6 +195,48 @@ describe("LandlordActiveLeasesPage", () => {
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 
+  it("renders date-only lease dates without shifting them backward across timezones", async () => {
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-may",
+          propertyId: "prop-1",
+          propertyName: "Harbour View",
+          unitNumber: "101",
+          monthlyRent: 1850,
+          startDate: "2026-05-01",
+          endDate: "2026-06-01",
+          status: "active",
+          tenantName: "Jane Tenant",
+          tenantEmail: "jane@example.com",
+        },
+        {
+          id: "lease-iso",
+          propertyId: "prop-2",
+          propertyName: "Dockside",
+          unitNumber: "202",
+          monthlyRent: 1950,
+          startDate: "2026-05-01T12:00:00.000Z",
+          endDate: "2026-06-01T12:00:00.000Z",
+          status: "active",
+          tenantName: "Mark Harbor",
+          tenantEmail: "mark@example.com",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findAllByText("May 1, 2026")).not.toHaveLength(0);
+    expect(screen.getAllByText(/June 1, 2026/)).not.toHaveLength(0);
+    expect(screen.queryByText("April 30, 2026")).not.toBeInTheDocument();
+    expect(screen.queryByText("May 31, 2026")).not.toBeInTheDocument();
+  });
+
   it("shows landlord-safe payment visibility without retry or receipt actions", async () => {
     mocks.getActiveLeasesForLandlord.mockResolvedValue({
       leases: [

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -28,9 +28,22 @@ function formatCurrency(value: number | null | undefined) {
 
 function formatDate(value: string | null | undefined) {
   if (!value) return "—";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-CA", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleDateString();
+  return parsed.toLocaleDateString("en-CA", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 }
 
 function prettyLeaseStatus(value: string | null | undefined) {

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -95,6 +95,66 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
   });
 
+  it("renders date-only lease summary dates without UTC timezone rollback", async () => {
+    mocks.getLeaseById.mockResolvedValue({
+      lease: {
+        id: "lease-1",
+        propertyId: "prop-1",
+        propertyName: "Coburg Rd",
+        unitNumber: "3",
+        monthlyRent: 2100,
+        startDate: "2026-05-01",
+        endDate: "2026-06-01",
+        status: "active",
+        tenantName: "Tony Wenpeng",
+        tenantEmail: "tony@example.com",
+        documentUrl: null,
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/summary"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("May 1, 2026")).toBeInTheDocument();
+    expect(screen.getByText("June 1, 2026")).toBeInTheDocument();
+    expect(screen.queryByText("April 30, 2026")).not.toBeInTheDocument();
+    expect(screen.queryByText("May 31, 2026")).not.toBeInTheDocument();
+  });
+
+  it("continues to render ISO datetime lease summary dates", async () => {
+    mocks.getLeaseById.mockResolvedValue({
+      lease: {
+        id: "lease-1",
+        propertyId: "prop-1",
+        propertyName: "Coburg Rd",
+        unitNumber: "3",
+        monthlyRent: 2100,
+        startDate: "2026-05-01T12:00:00.000Z",
+        endDate: "2026-06-01T12:00:00.000Z",
+        status: "active",
+        tenantName: "Tony Wenpeng",
+        tenantEmail: "tony@example.com",
+        documentUrl: null,
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/summary"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("May 1, 2026")).toBeInTheDocument();
+    expect(screen.getByText("June 1, 2026")).toBeInTheDocument();
+  });
+
   it("saves missing-document lease summaries as PDFs instead of raw text", async () => {
     const realCreateElement = document.createElement.bind(document);
     const createdAnchors: HTMLAnchorElement[] = [];

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -14,13 +14,6 @@ function formatCurrency(value: number | null | undefined) {
   return amount.toLocaleString(undefined, { style: "currency", currency: "CAD" });
 }
 
-function formatDate(value: string | null | undefined) {
-  if (!value) return "—";
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleDateString();
-}
-
 function prettyLeaseStatus(value: string | null | undefined) {
   const normalized = String(value || "").trim().toLowerCase();
   if (!normalized) return "Unknown";


### PR DESCRIPTION
## Summary
- Normalizes date-only lease start/end display so values like `2026-05-01` render as May 1, 2026 instead of rolling back in UTC-negative timezones.
- Keeps ISO datetime values on the existing `Date` parsing path.
- Adds targeted lease page tests for May 1 / June 1 date-only rendering and ISO datetime rendering.
- Extends the same date-only normalization to tenant lease/profile surfaces after preview QA found remaining Apr 30 / Apr 29 displays.

## Scope confirmation
- Frontend display-only change.
- `LeaseDocumentView.tsx` change only affects date display normalization.
- No PDF utility/template/layout changes.
- No backend lease date schema changes.
- No email, tenant document vault, payments, messaging, or broad raw unitId fixes included.
- No package or lockfile changes.

## Validation
- `npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx src/pages/LandlordLeaseSummaryPage.test.tsx` passed on Node `20.20.2`: `2` files, `16` tests.
- `npm --prefix rentchain-frontend test -- TenantDetailPanel.test.tsx TenantLeasePanel.test.tsx --pool=forks` passed on Node `20.20.2`: `2` files, `7` tests.
- `npm run build` passed on Node `20.11.1`; Vite emitted the existing Node `20.19+` recommendation warning.
- `npm --prefix rentchain-frontend run build` passed.
- `git diff --check` passed.
- GitHub checks passed: `ci`, `merge-gate`, `codex-pr-review`, Vercel, Terraform Cloud.

## Remaining risks / follow-ups
- Tenant Actions current lease card still relies on `tenant.currentLeaseId`; active lease projection consistency remains out of scope.
- Tenant portal raw unitId display remains follow-up scope.
- `strategy/lease-pdf-template-compliance-review-v1`
- `fix/tenant-portal-documents-and-payments-routes-v1`
- `fix/tenant-portal-unit-label-and-message-identity-v1`
- `fix/tenant-message-notification-delivery-v1`
- `fix/tenant-dashboard-redeem-invite-ux-v1`