### PR TITLE
Fix tenant current lease actions projection

### DIFF
--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   fetchTenantTenanciesMock: vi.fn(),
   updateTenantRecordMock: vi.fn(),
   updateTenancyMock: vi.fn(),
+  useTenantDetailMock: vi.fn(),
   createTenantEventMock: vi.fn(),
   hydrateTenantSummariesBatchMock: vi.fn(),
   getCachedTenantSummaryMock: vi.fn(),
@@ -51,6 +52,10 @@ vi.mock("@/api/tenantsApi", () => ({
   fetchTenantTenancies: mocks.fetchTenantTenanciesMock,
   updateTenantRecord: mocks.updateTenantRecordMock,
   updateTenancy: mocks.updateTenancyMock,
+}));
+
+vi.mock("@/hooks/useTenantDetail", () => ({
+  useTenantDetail: mocks.useTenantDetailMock,
 }));
 
 vi.mock("@/api/tenantEventsWriteApi", () => ({
@@ -123,6 +128,7 @@ describe("TenantsPage", () => {
     mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
     mocks.updateTenantRecordMock.mockResolvedValue({});
     mocks.updateTenancyMock.mockResolvedValue({});
+    mocks.useTenantDetailMock.mockReturnValue({ bundle: null, loading: false, error: null });
     mocks.createTenantEventMock.mockResolvedValue({ ok: true });
     mocks.hydrateTenantSummariesBatchMock.mockResolvedValue(undefined);
     mocks.getCachedTenantSummaryMock.mockReturnValue(null);
@@ -176,6 +182,95 @@ describe("TenantsPage", () => {
     expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send tenant invite" })).toBeInTheDocument();
     expect(screen.getByText("lease-1")).toBeInTheDocument();
+  });
+
+  it("shows the current lease from tenant detail when the list row has no currentLeaseId", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyName: "Main Street",
+        propertyId: "property-1",
+        unit: "Unit 4",
+        unitId: "unit-4",
+        currentLeaseId: null,
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([
+      { id: "tenancy-1", tenantId: "tenant-1", status: "active", unitLabel: "Unit 4" },
+    ]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      bundle: {
+        tenant: { id: "tenant-1", fullName: "Taylor Tenant" },
+        currentLease: {
+          id: "lease-active-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          propertyName: "Main Street",
+          unitId: "unit-4",
+          unit: "Unit 4",
+          leaseStart: "2026-01-01",
+          leaseEnd: null,
+          monthlyRent: 1850,
+          status: "active",
+        },
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    expect(screen.getByText("lease-active-1")).toBeInTheDocument();
+    expect(screen.queryByText("No current lease linked")).not.toBeInTheDocument();
+  });
+
+  it("shows no current lease linked when neither list nor detail has a current lease", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyName: "Main Street",
+        propertyId: "property-1",
+        unit: "Unit 4",
+        unitId: "unit-4",
+        currentLeaseId: null,
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([
+      { id: "tenancy-1", tenantId: "tenant-1", status: "active", unitLabel: "Unit 4" },
+    ]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      bundle: {
+        tenant: { id: "tenant-1", fullName: "Taylor Tenant" },
+        currentLease: null,
+        lease: null,
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    expect(screen.getByText("No current lease linked")).toBeInTheDocument();
   });
 
   it("fails closed by hiding the targeted cleanup tenant ids from the landlord list", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -22,8 +22,10 @@ import { TenantScorePill } from "../components/tenant/TenantScorePill";
 import { hydrateTenantSummariesBatch, getCachedTenantSummary } from "../lib/tenantSummaryCache";
 import { track } from "../lib/analytics";
 import { useCapabilities } from "@/hooks/useCapabilities";
+import { useTenantDetail } from "@/hooks/useTenantDetail";
 import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import { isTargetedHiddenTenantId } from "@/lib/testDataVisibilityTargets";
+import type { TenantLeaseSummary } from "@/api/tenantDetail";
 import "./TenantsPage.css";
 
 type TenantWithTenancies = TenantApiModel & { tenancies?: TenancyApiModel[] };
@@ -137,12 +139,16 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
-function describeTenantLinkage(tenant: TenantApiModel & { tenancies?: TenancyApiModel[] }) {
+function describeTenantLinkage(
+  tenant: TenantApiModel & { tenancies?: TenancyApiModel[] },
+  currentLease?: TenantLeaseSummary | null
+) {
   const tenancies = Array.isArray(tenant.tenancies) ? tenant.tenancies : [];
   const activeTenancies = tenancies.filter((tenancy) => tenancy.status !== "inactive");
   const primaryProperty = tenant.propertyName || tenant.propertyId || "No property linked";
   const primaryUnit = tenant.unit || tenant.unitLabel || tenant.unitId || "No unit linked";
-  const leaseState = tenant.currentLeaseId ? tenant.currentLeaseId : "No current lease linked";
+  const currentLeaseId = String(currentLease?.id || tenant.currentLeaseId || "").trim();
+  const leaseState = currentLeaseId || "No current lease linked";
 
   return {
     propertyLabel: primaryProperty,
@@ -150,7 +156,7 @@ function describeTenantLinkage(tenant: TenantApiModel & { tenancies?: TenancyApi
     leaseLabel: leaseState,
     activeTenancyCount: activeTenancies.length,
     linkageNote:
-      !tenant.propertyId && !tenant.unitId && !tenant.currentLeaseId
+      !tenant.propertyId && !tenant.unitId && !currentLeaseId
         ? "This tenant record has no canonical property, unit, or current lease linkage yet."
         : activeTenancies.length === 0
         ? "No active tenancy registrations are linked to this tenant."
@@ -444,7 +450,12 @@ const loadTenants = useCallback(async () => {
     ? tenants.find((t) => t.id === selectedTenantId) || null
     : null;
   const tenantExists = Boolean(selectedTenant);
-  const selectedTenantLinkage = selectedTenant ? describeTenantLinkage(selectedTenant) : null;
+  const { bundle: selectedTenantDetailBundle } = useTenantDetail(tenantExists ? selectedTenantId : null);
+  const selectedCurrentLease =
+    selectedTenantDetailBundle?.currentLease || selectedTenantDetailBundle?.lease || null;
+  const selectedTenantLinkage = selectedTenant
+    ? describeTenantLinkage(selectedTenant, selectedCurrentLease)
+    : null;
 
   const filteredTenants = useMemo(() => {
     const base = tenants || [];


### PR DESCRIPTION
## Summary
- Update the `/tenants` Tenant Actions current lease display to use the selected tenant detail bundle's `currentLease || lease` source before falling back to the list row `tenant.currentLeaseId`.
- Add focused frontend coverage for active/current lease display when the list record is missing `currentLeaseId`, and for the no-current-lease state.
- Leave backend list/detail projection, Firestore data, migrations, lease lifecycle behavior, and unrelated tenant workflows unchanged.

## Root Cause
The Tenant Actions card previously read only `tenant.currentLeaseId` from the `/tenants` list record. The lower tenant profile and lease panels resolve current lease state through selected tenant detail / active lease lookup, so they could show an active lease while Tenant Actions incorrectly showed `No current lease linked`.

## Projection Strategy
Use the existing selected tenant detail bundle source already aligned with the profile panel: `bundle.currentLease || bundle.lease`. If the detail bundle has no current lease, the display falls back to `tenant.currentLeaseId`, then to `No current lease linked`.

## Validation
- `npm test -- TenantsPage.test.tsx` in `rentchain-frontend`: passed
- `npm test -- tenantDetailsService.test.ts tenantsRoutes.test.ts` in `rentchain-api` with Node 20: passed
- `npm run build` in `rentchain-frontend` with Node 20.20.2: passed
- `git diff --check`: passed

## Preview QA Required Before Merge
- Tenant Actions no longer shows `No current lease linked` for a selected tenant with an active/current lease.
- Lower tenant profile/lease panels agree with Tenant Actions on current lease state.
- Selected tenant without an active/current lease still shows `No current lease linked`.
- No duplicate tenant rows return.
- Lease dates remain correct after PR #887.
- No raw unitId issue is addressed in this PR; track separately.

## Remaining Risk
The selected tenant detail may be fetched twice because `TenantsPage` now reads the same detail bundle source that `TenantDetailPanel` also loads. This keeps the fix narrow and avoids backend projection or cache changes.