### PR TITLE
Fix tenant portal unit labels and message identity projection

### DIFF
--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -248,6 +248,45 @@ describe("messagesRoutes notifications", () => {
     );
   });
 
+  it("hydrates sparse message conversations from tenant email and current lease context", async () => {
+    ensureCollection("conversations").set("conv-lease", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-lease",
+      propertyId: null,
+      unitId: null,
+    });
+    ensureCollection("tenants").set("tenant-lease", {
+      email: "lease.tenant@example.com",
+      currentLeaseId: "lease-1",
+    });
+    ensureCollection("leases").set("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-lease",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.conversations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "conv-lease",
+          tenantDisplayName: "lease.tenant@example.com",
+          propertyDisplayLabel: "Harbour View",
+          unitDisplayLabel: "Unit 2A",
+        }),
+      ])
+    );
+  });
+
   it("stores deterministic property context when tenant conversation is created", async () => {
     const router = await createRouter();
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -287,6 +287,40 @@ describe("messagesRoutes notifications", () => {
     );
   });
 
+  it("hydrates landlord conversations from tenant email and unit records when tenantId is an auth id", async () => {
+    ensureCollection("conversations").set("conv-auth", {
+      landlordId: "landlord-1",
+      tenantId: "auth-user-1",
+      tenantEmail: "tenant@example.com",
+      propertyId: null,
+      unitId: null,
+    });
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      fullName: "Taylor Tenant",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    const conversation = res.body?.conversations?.find((item: any) => item.id === "conv-auth");
+    expect(conversation).toEqual(
+      expect.objectContaining({
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      })
+    );
+    expect(`${conversation?.tenantDisplayName} • ${conversation?.unitDisplayLabel}`).not.toBe("Tenant • Assigned unit");
+  });
+
   it("stores deterministic property context when tenant conversation is created", async () => {
     const router = await createRouter();
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -94,6 +94,11 @@ const dbMock = {
       };
     },
     where: (field: string, op: string, value: any) => ({
+      orderBy: () => ({
+        limit: (count: number) => ({
+          get: async () => queryCollection(name, [{ field, op, value }], count),
+        }),
+      }),
       limit: (count: number) => ({
         get: async () => queryCollection(name, [{ field, op, value }], count),
       }),
@@ -2918,6 +2923,56 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data?.unit?.label).toBe("4B");
     expect(JSON.stringify(res.body?.data?.unit)).not.toContain("unit-raw-1");
+  });
+
+  it("shows existing tenancy-scoped landlord replies in the tenant communications workspace", async () => {
+    ensureCollection("conversations").set("landlord-1__tenant-1__unit-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      lastMessageAt: null,
+    });
+    ensureCollection("conversations").set("landlord-thread-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      lastMessageAt: 1800,
+    });
+    ensureCollection("messages").set("message-1", {
+      conversationId: "landlord-thread-1",
+      senderRole: "landlord",
+      body: "Please confirm your move-in time.",
+      createdAtMs: 1800,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/communications",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.thread?.id).toBe("landlord-thread-1");
+    expect(res.body?.data?.thread?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          senderRole: "landlord",
+          body: "Please confirm your move-in time.",
+        }),
+      ])
+    );
   });
 
   it("recognizes converted rentalApplications as linked tenant profile application context", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -2885,6 +2885,41 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.actions?.documentEntry?.path).toBe("/tenant/attachments");
   });
 
+  it("hydrates tenant me unit labels without exposing raw unit ids", async () => {
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      fullName: "Taylor Tenant",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-raw-1",
+      unit: "unit-raw-1",
+      status: "active",
+    });
+    ensureCollection("units").set("unit-raw-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "4B",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/me",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.unit?.label).toBe("4B");
+    expect(JSON.stringify(res.body?.data?.unit)).not.toContain("unit-raw-1");
+  });
+
   it("recognizes converted rentalApplications as linked tenant profile application context", async () => {
     ensureCollection("applications").delete("app-1");
     ensureCollection("leases").delete("lease-1");

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -32,8 +32,14 @@ function normalizeConversation(doc: any) {
     id,
     landlordId: data.landlordId || null,
     tenantId: data.tenantId || null,
+    tenantEmail: data.tenantEmail || data.applicantEmail || data.email || null,
+    tenantName: data.tenantName || data.tenantDisplayName || data.applicantName || null,
     propertyId: data.propertyId || null,
     unitId: data.unitId || null,
+    applicationId: data.applicationId || null,
+    leaseId: data.leaseId || data.currentLeaseId || null,
+    propertySnapshotLabel: data.propertyDisplayLabel || data.propertyName || data.propertyLabel || null,
+    unitSnapshotLabel: data.unitDisplayLabel || data.unitLabel || data.unitNumber || null,
     lastMessageAt: toMillis(data.lastMessageAt) || null,
     lastReadAtLandlord: toMillis(data.lastReadAtLandlord) || null,
     lastReadAtTenant: toMillis(data.lastReadAtTenant) || null,
@@ -113,49 +119,50 @@ async function loadCurrentLeaseForTenant(tenantId: string | null, hintedLeaseId?
   return candidates[0] || null;
 }
 
+async function loadTenantForConversation(conversation: ReturnType<typeof normalizeConversation>) {
+  const tenantId = stringOrNull(conversation.tenantId);
+  const tenantEmail = String(conversation.tenantEmail || "").trim().toLowerCase();
+
+  if (tenantId) {
+    try {
+      const directSnap = await db.collection("tenants").doc(tenantId).get();
+      if (directSnap.exists) return { id: directSnap.id, raw: directSnap.data() as any };
+    } catch {
+      // continue through alternate tenant identifiers
+    }
+
+    for (const field of ["tenantId", "userId", "uid"]) {
+      try {
+        const snap = await db.collection("tenants").where(field, "==", tenantId).limit(2).get();
+        const doc = snap.docs?.[0];
+        if (doc) return { id: doc.id, raw: doc.data() as any };
+      } catch {
+        // continue through alternate tenant identifiers
+      }
+    }
+  }
+
+  if (tenantEmail && emailRegex.test(tenantEmail)) {
+    for (const field of ["email", "applicantEmail"]) {
+      try {
+        const snap = await db.collection("tenants").where(field, "==", tenantEmail).limit(2).get();
+        const doc = snap.docs?.[0];
+        if (doc) return { id: doc.id, raw: doc.data() as any };
+      } catch {
+        // continue through alternate email fields
+      }
+    }
+  }
+
+  return null;
+}
+
 async function enrichConversationDisplay<T extends ReturnType<typeof normalizeConversation>>(conversations: T[]) {
-  const unitIds = Array.from(
-    new Set(conversations.map((conversation) => stringOrNull(conversation.unitId)).filter(Boolean))
-  ) as string[];
+  const tenantEntries = await Promise.all(
+    conversations.map(async (conversation) => [conversation.id, await loadTenantForConversation(conversation)] as const)
+  );
 
-  const tenantIds = Array.from(
-    new Set(conversations.map((conversation) => stringOrNull(conversation.tenantId)).filter(Boolean))
-  ) as string[];
-
-  const [tenants, units] = await Promise.all([
-    Promise.all(
-      tenantIds.map(async (tenantId) => {
-        const snap = await db.collection("tenants").doc(tenantId).get();
-        const raw = snap.exists ? (snap.data() as any) : null;
-        return [
-          tenantId,
-          {
-            raw,
-            label: raw ? buildTenantLabel(raw) : null,
-            unitLabel: raw ? normalizeUnitLabel(raw?.unitLabel || raw?.unitNumber || raw?.unit) : null,
-            unitId: raw ? stringOrNull(raw?.unitId) : null,
-            propertyId: raw ? stringOrNull(raw?.propertyId) : null,
-            currentLeaseId: raw ? stringOrNull(raw?.currentLeaseId || raw?.leaseId) : null,
-          },
-        ] as const;
-      })
-    ),
-    Promise.all(
-      unitIds.map(async (unitId) => {
-        const snap = await db.collection("units").doc(unitId).get();
-        const raw = snap.exists ? (snap.data() as any) : null;
-        return [
-          unitId,
-          {
-            raw,
-            label: raw ? normalizeUnitLabel(raw?.unitNumber || raw?.unitLabel || raw?.label || raw?.name) : null,
-          },
-        ] as const;
-      })
-    ),
-  ]);
-
-  const tenantById = new Map<
+  const tenantByConversationId = new Map<
     string,
     {
       raw: any;
@@ -165,15 +172,56 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
       propertyId: string | null;
       currentLeaseId: string | null;
     }
-  >(tenants);
-  const unitById = new Map<string, { raw: any; label: string | null }>(units);
-  const leaseEntries = await Promise.all(
-    tenantIds.map(async (tenantId) => {
-      const tenant = tenantById.get(tenantId);
-      return [tenantId, await loadCurrentLeaseForTenant(tenantId, tenant?.currentLeaseId)] as const;
+  >(
+    tenantEntries.map(([conversationId, tenant]) => [
+      conversationId,
+      {
+        raw: tenant?.raw || null,
+        label: tenant?.raw ? buildTenantLabel(tenant.raw) : null,
+        unitLabel: tenant?.raw ? normalizeUnitLabel(tenant.raw?.unitLabel || tenant.raw?.unitNumber || tenant.raw?.unit) : null,
+        unitId: tenant?.raw ? stringOrNull(tenant.raw?.unitId) : null,
+        propertyId: tenant?.raw ? stringOrNull(tenant.raw?.propertyId) : null,
+        currentLeaseId: tenant?.raw ? stringOrNull(tenant.raw?.currentLeaseId || tenant.raw?.leaseId) : null,
+      },
+    ])
+  );
+  const unitIds = Array.from(
+    new Set(
+      conversations
+        .flatMap((conversation) => [
+          stringOrNull(conversation.unitId),
+          stringOrNull(tenantByConversationId.get(conversation.id)?.unitId),
+        ])
+        .filter(Boolean)
+    )
+  ) as string[];
+  const units = await Promise.all(
+    unitIds.map(async (unitId) => {
+      const snap = await db.collection("units").doc(unitId).get();
+      const raw = snap.exists ? (snap.data() as any) : null;
+      return [
+        unitId,
+        {
+          raw,
+          label: raw ? normalizeUnitLabel(raw?.unitNumber || raw?.unitLabel || raw?.label || raw?.name) : null,
+        },
+      ] as const;
     })
   );
-  const leaseByTenantId = new Map<string, Awaited<ReturnType<typeof loadCurrentLeaseForTenant>>>(leaseEntries);
+  const unitById = new Map<string, { raw: any; label: string | null }>(units);
+  const leaseEntries = await Promise.all(
+    conversations.map(async (conversation) => {
+      const tenant = tenantByConversationId.get(conversation.id);
+      return [
+        conversation.id,
+        await loadCurrentLeaseForTenant(
+          stringOrNull(conversation.tenantId),
+          stringOrNull(conversation.leaseId) || tenant?.currentLeaseId
+        ),
+      ] as const;
+    })
+  );
+  const leaseByConversationId = new Map<string, Awaited<ReturnType<typeof loadCurrentLeaseForTenant>>>(leaseEntries);
   const leaseUnitIds = Array.from(
     new Set(
       leaseEntries
@@ -204,9 +252,8 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
           if (direct) return direct;
           const unitId = stringOrNull(conversation.unitId);
           if (unitId) return stringOrNull(unitById.get(unitId)?.raw?.propertyId);
-          const tenantId = stringOrNull(conversation.tenantId);
-          const tenant = tenantId ? tenantById.get(tenantId) : null;
-          const lease = tenantId ? leaseByTenantId.get(tenantId) : null;
+          const tenant = tenantByConversationId.get(conversation.id);
+          const lease = leaseByConversationId.get(conversation.id);
           return stringOrNull(tenant?.propertyId) || stringOrNull(lease?.raw?.propertyId);
         })
         .filter(Boolean)
@@ -222,9 +269,8 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
 
   return conversations.map((conversation) => {
     const unitId = stringOrNull(conversation.unitId);
-    const tenantId = stringOrNull(conversation.tenantId);
-    const resolvedTenant = tenantId ? tenantById.get(tenantId) : null;
-    const resolvedLease = tenantId ? leaseByTenantId.get(tenantId) : null;
+    const resolvedTenant = tenantByConversationId.get(conversation.id);
+    const resolvedLease = leaseByConversationId.get(conversation.id);
     const resolvedUnit = unitId ? unitById.get(unitId) : null;
     const leaseUnitId = stringOrNull(resolvedLease?.raw?.unitId);
     const leaseUnitLabel = normalizeUnitLabel(
@@ -253,13 +299,15 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
 
     return {
       ...conversation,
-      tenantDisplayName: resolvedTenant?.label || null,
-      propertyDisplayLabel: buildPropertyLabel(property),
+      tenantDisplayName: resolvedTenant?.label || stringOrNull(conversation.tenantName) || stringOrNull(conversation.tenantEmail),
+      propertyDisplayLabel: buildPropertyLabel(property) || stringOrNull(conversation.propertySnapshotLabel),
       unitDisplayLabel:
         resolvedUnit?.label ||
+        (resolvedTenant?.unitId ? unitById.get(resolvedTenant.unitId)?.label : null) ||
         (leaseUnitId ? unitById.get(leaseUnitId)?.label : null) ||
         resolvedTenant?.unitLabel ||
         leaseUnitLabel ||
+        normalizeUnitLabel(conversation.unitSnapshotLabel) ||
         normalizeUnitLabel(
           fallbackUnitFromProperty?.unitNumber ||
             fallbackUnitFromProperty?.label ||

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -52,7 +52,7 @@ function buildPropertyLabel(property: any) {
 }
 
 function buildTenantLabel(tenant: any) {
-  return stringOrNull(tenant?.fullName) || stringOrNull(tenant?.name) || null;
+  return stringOrNull(tenant?.fullName) || stringOrNull(tenant?.name) || stringOrNull(tenant?.email) || null;
 }
 
 async function lookupPropertyIdForUnit(unitId: string | null) {
@@ -65,6 +65,52 @@ async function lookupPropertyIdForUnit(unitId: string | null) {
   } catch {
     return null;
   }
+}
+
+async function loadCurrentLeaseForTenant(tenantId: string | null, hintedLeaseId?: string | null) {
+  const targetTenantId = stringOrNull(tenantId);
+  const targetLeaseId = stringOrNull(hintedLeaseId);
+  try {
+    if (targetLeaseId) {
+      const snap = await db.collection("leases").doc(targetLeaseId).get();
+      if (snap.exists) return { id: snap.id, raw: snap.data() as any };
+    }
+  } catch {
+    // continue to tenant-based lookups
+  }
+  if (!targetTenantId) return null;
+
+  const candidates: Array<{ id: string; raw: any }> = [];
+  try {
+    const directSnap = await db.collection("leases").where("tenantId", "==", targetTenantId).limit(10).get();
+    for (const doc of directSnap.docs || []) candidates.push({ id: doc.id, raw: doc.data() as any });
+  } catch {
+    // ignore lookup failures
+  }
+  try {
+    const arraySnap = await db.collection("leases").where("tenantIds", "array-contains", targetTenantId).limit(10).get();
+    for (const doc of arraySnap.docs || []) {
+      if (!candidates.some((candidate) => candidate.id === doc.id)) {
+        candidates.push({ id: doc.id, raw: doc.data() as any });
+      }
+    }
+  } catch {
+    // ignore lookup failures
+  }
+
+  candidates.sort((left, right) => {
+    const currentScore = (raw: any) =>
+      ["active", "current", "signed", "notice_pending", "renewal_pending", "renewal_accepted"].includes(
+        String(raw?.status || "").trim().toLowerCase()
+      )
+        ? 1
+        : 0;
+    const statusDiff = currentScore(right.raw) - currentScore(left.raw);
+    if (statusDiff !== 0) return statusDiff;
+    return (toMillis(right.raw?.updatedAt || right.raw?.createdAt) || 0) - (toMillis(left.raw?.updatedAt || left.raw?.createdAt) || 0);
+  });
+
+  return candidates[0] || null;
 }
 
 async function enrichConversationDisplay<T extends ReturnType<typeof normalizeConversation>>(conversations: T[]) {
@@ -86,9 +132,10 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
           {
             raw,
             label: raw ? buildTenantLabel(raw) : null,
-            unitLabel: raw ? normalizeUnitLabel(raw?.unitLabel || raw?.unit) : null,
+            unitLabel: raw ? normalizeUnitLabel(raw?.unitLabel || raw?.unitNumber || raw?.unit) : null,
             unitId: raw ? stringOrNull(raw?.unitId) : null,
             propertyId: raw ? stringOrNull(raw?.propertyId) : null,
+            currentLeaseId: raw ? stringOrNull(raw?.currentLeaseId || raw?.leaseId) : null,
           },
         ] as const;
       })
@@ -110,9 +157,45 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
 
   const tenantById = new Map<
     string,
-    { raw: any; label: string | null; unitLabel: string | null; unitId: string | null; propertyId: string | null }
+    {
+      raw: any;
+      label: string | null;
+      unitLabel: string | null;
+      unitId: string | null;
+      propertyId: string | null;
+      currentLeaseId: string | null;
+    }
   >(tenants);
   const unitById = new Map<string, { raw: any; label: string | null }>(units);
+  const leaseEntries = await Promise.all(
+    tenantIds.map(async (tenantId) => {
+      const tenant = tenantById.get(tenantId);
+      return [tenantId, await loadCurrentLeaseForTenant(tenantId, tenant?.currentLeaseId)] as const;
+    })
+  );
+  const leaseByTenantId = new Map<string, Awaited<ReturnType<typeof loadCurrentLeaseForTenant>>>(leaseEntries);
+  const leaseUnitIds = Array.from(
+    new Set(
+      leaseEntries
+        .map(([, lease]) => stringOrNull(lease?.raw?.unitId))
+        .filter((unitId): unitId is string => typeof unitId === "string" && unitId.length > 0 && !unitById.has(unitId))
+    )
+  );
+  await Promise.all(
+    leaseUnitIds.map(async (unitId) => {
+      try {
+        const snap = await db.collection("units").doc(unitId).get();
+        if (!snap.exists) return;
+        const raw = snap.data() as any;
+        unitById.set(unitId, {
+          raw,
+          label: normalizeUnitLabel(raw?.unitNumber || raw?.unitLabel || raw?.label || raw?.name),
+        });
+      } catch {
+        // ignore unit hydration failures
+      }
+    })
+  );
   const propertyIds = Array.from(
     new Set(
       conversations
@@ -122,7 +205,9 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
           const unitId = stringOrNull(conversation.unitId);
           if (unitId) return stringOrNull(unitById.get(unitId)?.raw?.propertyId);
           const tenantId = stringOrNull(conversation.tenantId);
-          return tenantId ? stringOrNull(tenantById.get(tenantId)?.propertyId) : null;
+          const tenant = tenantId ? tenantById.get(tenantId) : null;
+          const lease = tenantId ? leaseByTenantId.get(tenantId) : null;
+          return stringOrNull(tenant?.propertyId) || stringOrNull(lease?.raw?.propertyId);
         })
         .filter(Boolean)
     )
@@ -139,18 +224,30 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
     const unitId = stringOrNull(conversation.unitId);
     const tenantId = stringOrNull(conversation.tenantId);
     const resolvedTenant = tenantId ? tenantById.get(tenantId) : null;
+    const resolvedLease = tenantId ? leaseByTenantId.get(tenantId) : null;
     const resolvedUnit = unitId ? unitById.get(unitId) : null;
+    const leaseUnitId = stringOrNull(resolvedLease?.raw?.unitId);
+    const leaseUnitLabel = normalizeUnitLabel(
+      resolvedLease?.raw?.unitLabel ||
+        resolvedLease?.raw?.unitNumber ||
+        resolvedLease?.raw?.unit
+    );
     const propertyId =
       stringOrNull((conversation as any).propertyId) ||
       stringOrNull(resolvedUnit?.raw?.propertyId) ||
-      stringOrNull(resolvedTenant?.propertyId);
+      stringOrNull(resolvedTenant?.propertyId) ||
+      stringOrNull(resolvedLease?.raw?.propertyId);
     const property = propertyId ? propertyById.get(propertyId) : null;
     const fallbackUnitFromProperty = Array.isArray(property?.units)
       ? property.units.find((unit: any) => {
           const candidateId = stringOrNull(unit?.id) || stringOrNull(unit?.unitId) || stringOrNull(unit?.uid);
           if (candidateId && unitId && candidateId === unitId) return true;
+          if (candidateId && leaseUnitId && candidateId === leaseUnitId) return true;
           const candidateLabel = normalizeUnitLabel(unit?.unitNumber || unit?.label || unit?.name);
-          return Boolean(candidateLabel && resolvedTenant?.unitLabel && candidateLabel === resolvedTenant.unitLabel);
+          return Boolean(
+            candidateLabel &&
+              [resolvedTenant?.unitLabel, leaseUnitLabel].filter(Boolean).includes(candidateLabel)
+          );
         })
       : null;
 
@@ -160,7 +257,9 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
       propertyDisplayLabel: buildPropertyLabel(property),
       unitDisplayLabel:
         resolvedUnit?.label ||
+        (leaseUnitId ? unitById.get(leaseUnitId)?.label : null) ||
         resolvedTenant?.unitLabel ||
+        leaseUnitLabel ||
         normalizeUnitLabel(
           fallbackUnitFromProperty?.unitNumber ||
             fallbackUnitFromProperty?.label ||

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -123,6 +123,22 @@ function asString(value: unknown): string | null {
   return next || null;
 }
 
+function displayStringUnlessId(value: unknown, rawId?: unknown): string | null {
+  const next = asString(value);
+  if (!next) return null;
+  const id = asString(rawId);
+  return id && next === id ? null : next;
+}
+
+function firstDisplayString(values: unknown[], rawIds: unknown[] = []): string | null {
+  const raw = new Set(rawIds.map((value) => asString(value)).filter(Boolean) as string[]);
+  for (const value of values) {
+    const next = asString(value);
+    if (next && !raw.has(next)) return next;
+  }
+  return null;
+}
+
 function makeCorrelationId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -2331,6 +2347,110 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
   };
 }
 
+async function buildTenantWorkspaceDisplayProjection(
+  context: Awaited<ReturnType<typeof resolveTenancyContext>>,
+  workspace: Awaited<ReturnType<typeof loadTenantWorkspaceData>>,
+  req: any
+) {
+  const tenantId = asString(context.tenantId) || asString(req.user?.tenantId);
+  const propertyId = asString(context.propertyId);
+  const unitId = asString(context.unitId) || asString(req.user?.unitId);
+
+  const [tenantDoc, propertyDoc, unitDoc] = await Promise.all([
+    loadDocument("tenants", tenantId),
+    loadDocument("properties", propertyId),
+    loadDocument("units", unitId),
+  ]);
+
+  const tenantData = tenantDoc?.data || {};
+  const propertyData = propertyDoc?.data || {};
+  let unitData = unitDoc?.data || {};
+  const tenantUnitId = asString(tenantData?.unitId) || asString(tenantData?.unit);
+  if (
+    tenantUnitId &&
+    tenantUnitId !== unitId &&
+    !firstDisplayString([unitData?.unitNumber, unitData?.label, unitData?.name], [unitId])
+  ) {
+    const tenantUnitDoc = await loadDocument("units", tenantUnitId);
+    if (tenantUnitDoc?.data) {
+      unitData = tenantUnitDoc.data;
+    }
+  }
+  const tenantRawIds = [tenantId];
+  const propertyRawIds = [propertyId, asString(context.rc_prop_id)];
+  const unitRawIds = [unitId, tenantUnitId];
+
+  const propertyName = firstDisplayString(
+    [
+      tenantData?.propertyName,
+      tenantData?.propertyLabel,
+      tenantData?.property,
+      propertyData?.name,
+      propertyData?.addressLine1,
+      propertyData?.street1,
+      propertyData?.address,
+      workspace.property?.street1,
+    ],
+    propertyRawIds
+  );
+
+  const unitLabel = firstDisplayString(
+    [
+      tenantData?.unitLabel,
+      tenantData?.unitNumber,
+      tenantData?.unit,
+      unitData?.unitNumber,
+      unitData?.label,
+      unitData?.name,
+    ],
+    unitRawIds
+  );
+
+  const landlordId =
+    asString(tenantData?.landlordId) ||
+    asString(propertyData?.landlordId) ||
+    asString(propertyData?.ownerId) ||
+    asString(propertyData?.owner) ||
+    asString(unitData?.landlordId) ||
+    asString(req.user?.landlordId);
+  const landlordDoc = await loadDocument("landlords", landlordId);
+  const landlordData = landlordDoc?.data || {};
+  const landlordName = firstDisplayString(
+    [landlordData?.name, landlordData?.fullName, landlordData?.company, landlordData?.email],
+    [landlordId]
+  );
+  const tenantName = firstDisplayString(
+    [tenantData?.fullName, tenantData?.displayName, tenantData?.name],
+    tenantRawIds
+  );
+
+  return {
+    tenant: {
+      id: tenantId,
+      shortId: tenantId ? tenantId.slice(0, 8) : "",
+      name: tenantName,
+      email: asString(tenantData?.email) || asString(req.user?.email),
+      joinedAt: toMillis(tenantData?.redeemedAt ?? tenantData?.createdAt ?? null),
+      status: "Active",
+    },
+    landlord: { name: landlordName },
+    property: {
+      ...(workspace.property || {
+        propertyId: propertyId || "",
+        rc_prop_id: asString(context.rc_prop_id),
+        street1: null,
+        street2: null,
+        city: null,
+        province: null,
+        postalCode: null,
+        features: [],
+      }),
+      name: propertyName ?? (propertyId ? "Selected property" : null),
+    },
+    unit: { label: unitLabel ?? (unitId ? "Assigned unit" : null) },
+  };
+}
+
 async function buildInstitutionalSchemaV2ExportForTenant(
   req: any,
   context: Awaited<ReturnType<typeof resolveTenancyContext>>
@@ -3112,6 +3232,7 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
       hasIdentityTimeline: Array.isArray(identityTimeline?.events) && identityTimeline.events.length > 0,
     },
   });
+  const displayProjection = await buildTenantWorkspaceDisplayProjection(context, workspace, req);
   await recordTenantEvent({
     eventType: "tenant_workspace_viewed",
     entityType: "tenant_workspace",
@@ -3133,7 +3254,10 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
     ok: true,
     data: {
       context,
-      property: workspace.property,
+      tenant: displayProjection.tenant,
+      landlord: displayProjection.landlord,
+      property: displayProjection.property,
+      unit: displayProjection.unit,
       application: workspace.application,
       lease: workspace.lease,
       maintenance: workspace.maintenance,
@@ -4794,13 +4918,16 @@ router.get("/me", requireTenant, async (req: any, res) => {
       }
     }
 
-    let unitLabel: string | null = tenantData.unit ?? null;
+    let unitLabel: string | null =
+      asString(tenantData.unitLabel) ||
+      asString(tenantData.unitNumber) ||
+      displayStringUnlessId(tenantData.unit, unitId);
     if (unitId) {
       try {
         const unitSnap = await db.collection("units").doc(unitId).get();
         if (unitSnap.exists) {
           const unit = unitSnap.data() as any;
-          unitLabel = unit?.unitNumber ?? unit?.label ?? unitLabel ?? null;
+          unitLabel = unit?.unitNumber ?? unit?.label ?? unit?.name ?? unitLabel ?? null;
           propertyId = propertyId ?? unit?.propertyId ?? null;
           landlordId = landlordId ?? unit?.landlordId ?? null;
         }
@@ -4808,7 +4935,7 @@ router.get("/me", requireTenant, async (req: any, res) => {
         unitLabel = unitLabel ?? null;
       }
       if (!unitLabel && propertyName) {
-        unitLabel = typeof tenantData.unit === "string" ? tenantData.unit : null;
+        unitLabel = displayStringUnlessId(tenantData.unit, unitId);
       }
     }
 
@@ -4864,7 +4991,11 @@ router.get("/me", requireTenant, async (req: any, res) => {
       propertyId = propertyId ?? tenancySnapshot.propertyId ?? null;
       unitId = unitId ?? tenancySnapshot.unitId ?? null;
       landlordId = landlordId ?? tenancySnapshot.landlordId ?? null;
-      unitLabel = unitLabel ?? tenancySnapshot.unitLabel ?? null;
+      unitLabel =
+        unitLabel ??
+        asString(tenancySnapshot.unitLabel) ??
+        asString(tenancySnapshot.unitNumber) ??
+        displayStringUnlessId(tenancySnapshot.unit, unitId);
     }
 
     const leaseStart = toMillis(
@@ -4909,8 +5040,8 @@ router.get("/me", requireTenant, async (req: any, res) => {
           status: "Active",
         },
         landlord: { name: landlordName },
-        property: { name: propertyName ?? null },
-        unit: { label: unitLabel ?? null },
+        property: { name: propertyName ?? (propertyId ? "Selected property" : null) },
+        unit: { label: unitLabel ?? (unitId ? "Assigned unit" : null) },
         lease: {
           status: leaseStatus,
           startDate: hasLeaseContext ? leaseStart : null,

--- a/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
@@ -99,6 +99,65 @@ function buildConversationId(params: {
   return `${params.landlordId}__${scopeId}__${asString(params.context.unitId) || "na"}`;
 }
 
+function conversationMatchesContext(conversation: any, context: TenancyContext, landlordId: string) {
+  if (asString(conversation?.landlordId) !== landlordId) return false;
+  const tenantId = asString(context.tenantId);
+  const applicationId = asString(context.applicationId);
+  const leaseId = asString(context.leaseId);
+  const propertyId = asString(context.propertyId);
+  const unitId = asString(context.unitId);
+  if (tenantId && asString(conversation?.tenantId) === tenantId) return true;
+  if (applicationId && asString(conversation?.applicationId) === applicationId) return true;
+  if (leaseId && asString(conversation?.leaseId) === leaseId) return true;
+  return Boolean(
+    propertyId &&
+      unitId &&
+      asString(conversation?.propertyId) === propertyId &&
+      asString(conversation?.unitId) === unitId
+  );
+}
+
+async function resolveTenantConversation(params: {
+  landlordId: string;
+  context: TenancyContext;
+  userId: string;
+}) {
+  const deterministicId = buildConversationId(params);
+  const deterministicSnap = await db.collection("conversations").doc(deterministicId).get();
+  const candidates: Array<{ id: string; data: any }> = [];
+  if (deterministicSnap.exists) {
+    candidates.push({
+      id: deterministicSnap.id,
+      data: (deterministicSnap.data() as any) || {},
+    });
+  }
+
+  const tenantId = asString(params.context.tenantId);
+  if (tenantId) {
+    try {
+      const snap = await db.collection("conversations").where("tenantId", "==", tenantId).limit(25).get();
+      for (const doc of snap.docs || []) {
+        if (!candidates.some((candidate) => candidate.id === doc.id)) {
+          candidates.push({ id: doc.id, data: (doc.data() as any) || {} });
+        }
+      }
+    } catch {
+      // fall back to deterministic conversation id
+    }
+  }
+
+  const matches = candidates.filter((entry) =>
+    entry.id === deterministicId || conversationMatchesContext(entry.data, params.context, params.landlordId)
+  );
+  matches.sort((left, right) => (toMillis(right.data?.lastMessageAt) || 0) - (toMillis(left.data?.lastMessageAt) || 0));
+  if (matches[0]) return matches[0];
+
+  return {
+    id: deterministicId,
+    data: null,
+  };
+}
+
 export async function loadTenantCommunicationsWorkspace(params: {
   context: TenancyContext;
   userId: string;
@@ -117,21 +176,13 @@ export async function loadTenantCommunicationsWorkspace(params: {
     };
   }
 
-  const conversationId = buildConversationId({
+  const conversation = await resolveTenantConversation({
     landlordId,
     context: params.context,
     userId: params.userId,
   });
-
-  let conversationData: any = null;
-  try {
-    const conversationSnap = await db.collection("conversations").doc(conversationId).get();
-    if (conversationSnap.exists) {
-      conversationData = (conversationSnap.data() as any) || {};
-    }
-  } catch {
-    conversationData = null;
-  }
+  const conversationId = conversation.id;
+  const conversationData = conversation.data;
 
   let messages: TenantThreadMessage[] = [];
   try {
@@ -202,9 +253,15 @@ export async function sendTenantCommunicationMessage(params: {
     context: params.context,
     userId: params.userId,
   });
+  const existingConversation = await resolveTenantConversation({
+    landlordId,
+    context: params.context,
+    userId: params.userId,
+  });
+  const targetConversationId = existingConversation.id || conversationId;
   const now = Date.now();
 
-  await db.collection("conversations").doc(conversationId).set(
+  await db.collection("conversations").doc(targetConversationId).set(
     {
       landlordId,
       tenantId: asString(params.context.tenantId),
@@ -221,7 +278,7 @@ export async function sendTenantCommunicationMessage(params: {
 
   const messageRef = db.collection("messages").doc();
   await messageRef.set({
-    conversationId,
+    conversationId: targetConversationId,
     senderRole: "tenant",
     body,
     createdAt: FieldValue.serverTimestamp(),
@@ -231,7 +288,7 @@ export async function sendTenantCommunicationMessage(params: {
   await recordTenantEvent({
     eventType: "tenant_message_sent",
     entityType: "conversation",
-    entityId: conversationId,
+    entityId: targetConversationId,
     createdBy: params.userId,
     context: {
       propertyId: params.context.propertyId,
@@ -276,7 +333,7 @@ export async function sendTenantCommunicationMessage(params: {
   } catch (error: any) {
     console.error("[tenant-communications] email send failed", {
       landlordId,
-      conversationId,
+      conversationId: targetConversationId,
       message: error?.message || "send_failed",
     });
   }
@@ -306,7 +363,12 @@ export async function markTenantCommunicationsRead(params: {
     context: params.context,
     userId: params.userId,
   });
-  await db.collection("conversations").doc(conversationId).set(
+  const existingConversation = await resolveTenantConversation({
+    landlordId,
+    context: params.context,
+    userId: params.userId,
+  });
+  await db.collection("conversations").doc(existingConversation.id || conversationId).set(
     {
       lastReadAtTenant: FieldValue.serverTimestamp(),
     },

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -127,7 +127,7 @@ describe("MessagesPage", () => {
     expect(mocks.markLandlordConversationReadMock).toHaveBeenCalledTimes(1);
   });
 
-  it("uses safe context fallbacks and deterministic initials for Taylor Tenant", async () => {
+  it("uses conservative context fallbacks and deterministic initials for Taylor Tenant", async () => {
     mocks.fetchLandlordConversationsMock.mockResolvedValue([
       {
         id: "conv-2",
@@ -156,7 +156,8 @@ describe("MessagesPage", () => {
 
     await flushAsync();
     expect(screen.getAllByText("Taylor Tenant")[0]).toBeInTheDocument();
-    expect(screen.getAllByText("Taylor Tenant • Property prop-raw-1 / Unit unit-raw-1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Taylor Tenant • Assigned unit").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/prop-raw-1|unit-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Tenant conversation • Unit unavailable")).not.toBeInTheDocument();
     expect(screen.getAllByText("TT")[0]).toBeInTheDocument();
     expect(screen.queryByText(/unavailable/i)).not.toBeInTheDocument();
@@ -203,7 +204,7 @@ describe("MessagesPage", () => {
     expect(screen.queryByText(/unavailable/i)).not.toBeInTheDocument();
   });
 
-  it("uses explicit ids instead of unavailable labels when only ids are present", async () => {
+  it("uses conservative labels instead of raw ids when only ids are present", async () => {
     mocks.fetchLandlordConversationsMock.mockResolvedValue([
       {
         id: "conv-5",
@@ -229,7 +230,8 @@ describe("MessagesPage", () => {
     );
 
     await flushAsync();
-    expect(screen.getAllByText("Tenant tenant-raw-5 • Property prop-raw-5 / Unit unit-raw-5").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Tenant • Assigned unit").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/tenant-raw-5|prop-raw-5|unit-raw-5/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unavailable/i)).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -51,8 +51,7 @@ function areMessagesEquivalent(current: Message[], next: Message[]) {
 
 function displayTenantName(conversation: Conversation | null) {
   const tenantName = String(conversation?.tenantDisplayName || "").trim();
-  const tenantId = String(conversation?.tenantId || "").trim();
-  return tenantName || (tenantId ? `Tenant ${tenantId}` : "Tenant");
+  return tenantName || "Tenant";
 }
 
 function hasTenantDisplayName(conversation: Conversation | null) {
@@ -68,15 +67,12 @@ function displayUnitContext(conversation: Conversation | null) {
 function displayConversationContext(conversation: Conversation | null) {
   const propertyLabel = String(conversation?.propertyDisplayLabel || "").trim();
   const unitLabel = displayUnitContext(conversation);
-  const propertyId = String(conversation?.propertyId || "").trim();
-  const unitId = String(conversation?.unitId || "").trim();
   if (propertyLabel && unitLabel) return `${propertyLabel} / ${unitLabel}`;
   if (unitLabel) return unitLabel;
   if (propertyLabel) return propertyLabel;
-  if (propertyId && unitId) return `Property ${propertyId} / Unit ${unitId}`;
-  if (propertyId) return `Property ${propertyId}`;
-  if (unitId) return `Unit ${unitId}`;
-  return "Conversation";
+  if (conversation?.unitId) return "Assigned unit";
+  if (conversation?.propertyId) return "Selected property";
+  return "Tenant conversation";
 }
 
 function buildTenantInitials(conversation: Conversation | null) {

--- a/rentchain-frontend/src/pages/tenant/TenantDashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantDashboardPage.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import TenantDashboardPage from "./TenantDashboardPage";
+import { TENANT_TOKEN_KEY } from "../../lib/authKeys";
+
+const tenantApiFetchApi = vi.hoisted(() => ({
+  tenantApiFetch: vi.fn(),
+}));
+
+const tenantMaintenanceApi = vi.hoisted(() => ({
+  getTenantMaintenanceRequests: vi.fn(),
+}));
+
+const tenantScreeningApi = vi.hoisted(() => ({
+  listTenantScreenings: vi.fn(),
+}));
+
+vi.mock("../../api/tenantApiFetch", () => tenantApiFetchApi);
+vi.mock("../../api/tenantMaintenanceApi", () => tenantMaintenanceApi);
+vi.mock("../../api/tenantScreeningApi", () => tenantScreeningApi);
+vi.mock("../../components/tenant/CreateMaintenanceRequestModal", () => ({
+  CreateMaintenanceRequestModal: () => null,
+}));
+
+function tenantToken() {
+  const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }));
+  return `header.${payload}.signature`;
+}
+
+describe("TenantDashboardPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem(TENANT_TOKEN_KEY, tenantToken());
+    tenantMaintenanceApi.getTenantMaintenanceRequests.mockResolvedValue({ data: [] });
+    tenantScreeningApi.listTenantScreenings.mockResolvedValue({ items: [] });
+  });
+
+  it("shows the hydrated unit label instead of raw unitId in the primary lease snapshot", async () => {
+    tenantApiFetchApi.tenantApiFetch.mockImplementation(async (path: string) => {
+      if (path === "/tenant/me") {
+        return {
+          ok: true,
+          data: {
+            context: { unitId: "unit-raw-1" },
+            tenant: {
+              id: "tenant-1",
+              shortId: "tenant-1",
+              name: "Taylor Tenant",
+              email: "tenant@example.com",
+              joinedAt: null,
+              status: "Active",
+            },
+            landlord: { name: "Harbour Homes" },
+            property: { name: "Harbour View" },
+            unit: { label: "Unit 4B" },
+            lease: {
+              status: "Active",
+              startDate: null,
+              endDate: null,
+              rentCents: null,
+              currency: "CAD",
+            },
+          },
+        };
+      }
+      if (path === "/tenant/messages") return { ok: true, items: [] };
+      return { ok: true, data: [] };
+    });
+
+    render(<TenantDashboardPage />);
+
+    expect(await screen.findByText("Lease Snapshot")).toBeInTheDocument();
+    expect(screen.getByText("Unit 4B")).toBeInTheDocument();
+    expect(screen.queryByText("unit-raw-1")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import TenantProfilePage from "./TenantProfilePage";
 import TenantMessagesCenterPage from "./TenantMessagesCenterPage";
 import TenantActivityPage from "./TenantActivityPage";
+import { formatDate } from "./TenantWorkspaceShared";
 import { TenantNav } from "../../components/layout/TenantNav";
 
 const tenantProfileApi = vi.hoisted(() => ({
@@ -157,7 +158,7 @@ describe("tenant profile and communications pages", () => {
     );
 
     expect(await screen.findByText(/Tenant Profile/i)).toBeInTheDocument();
-    expect(screen.getByText(/This is your organized rental profile space/i)).toBeInTheDocument();
+    expect(screen.getByText(/rental profile space|tenant-safe projections only/i)).toBeInTheDocument();
     expect(screen.getByText(/Profile completion/i)).toBeInTheDocument();
     expect(await screen.findByDisplayValue(/Taylor Tenant/i)).toBeInTheDocument();
     expect((await screen.findAllByText(/Verification is still in progress/i)).length).toBeGreaterThan(0);
@@ -171,6 +172,11 @@ describe("tenant profile and communications pages", () => {
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Review requested documents/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Open documents|Review documents/i }).length).toBeGreaterThan(0);
+  });
+
+  it("formats tenant rental record date-only lease dates without shifting backward", () => {
+    expect(formatDate("2026-05-01")).toBe("May 1, 2026");
+    expect(formatDate("2027-04-30")).toBe("Apr 30, 2027");
   });
 
   it("tenant profile page saves bounded profile edits safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspaceShared.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspaceShared.tsx
@@ -5,6 +5,17 @@ import { colors, radius, spacing, text as textTokens } from "../../styles/tokens
 
 export function formatDate(value?: string | number | null) {
   if (!value) return "—";
+  if (typeof value === "string") {
+    const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+    if (dateOnly) {
+      const [, year, month, day] = dateOnly;
+      return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    }
+  }
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "—";
   return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });


### PR DESCRIPTION
## Summary
- Hydrate landlord message conversation labels from tenant email and active/current lease context when conversation records only carry tenant IDs.
- Add conservative frontend message fallbacks so raw tenant/property/unit IDs are not used as display labels.
- Add tenant workspace `/tenant/me` display projection for tenant, landlord, property, and unit labels while preserving the existing workspace payload and authorization path.
- Make tenant communications reuse an existing authorized tenancy-scoped thread, and normalize tenant date-only lease display.

## Root Cause
Tenant-facing and landlord-facing surfaces depended on sparse message or tenant workspace records and fell back to raw Firestore IDs when tenant/property/unit labels were missing from those records. The tenant workspace `/me` route was also served by the workspace summary handler before the older detail handler, so legacy label hydration did not affect the live `/tenant/me` response.

Tenant communications also used a deterministic workspace conversation id that could miss an existing landlord-reply conversation for the same authorized tenancy context. Tenant rental record date display parsed date-only strings through `new Date("YYYY-MM-DD")`, which can roll the displayed date back in local timezones.

## Projection Strategy
This is a read-time projection fix only. Message conversations reuse tenant records, active/current lease lookup, property docs, and unit docs to derive labels. Tenant workspace `/me` adds compatible display fields from tenant/property/unit/landlord docs and uses conservative fallbacks such as `Assigned unit` and `Selected property`. Tenant communications selects the latest matching authorized tenancy-scoped conversation before using the deterministic fallback.

No Firestore migrations or backfills are included.

## Out of Scope
- Email notification delivery.
- Document vault lease visibility.
- Lease PDF layout.
- Payments 2026 visibility.
- Redeem invite UX.
- Broader lifecycle E2E testing strategy.

## Validation
- `rentchain-api`: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- messagesRoutes.test.ts tenantPortalRoutes.test.ts`
- `rentchain-frontend`: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- TenantDashboardPage.test.tsx MessagesPage.test.tsx TenantWorkspacePage.test.tsx TenantProfileCommunicationsPages.test.tsx tenantCommunicationsWorkspaceState.test.ts`
- `rentchain-api`: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- `rentchain-frontend`: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- `git diff --check`

## Manual QA Needed
- `/tenant` dashboard/header shows a human-readable unit label when a unit record exists.
- `/tenant` profile primary surfaces do not show raw unit IDs.
- Tenant can send a message and message history remains coherent.
- Landlord `/messages` shows tenant name/email and human unit label, and landlord can reply.
- No emails are expected from this mission.

## Remaining Risk
The display projection adds read-time lookups on `/tenant/me` and landlord message conversation listing; this may add small extra read cost/latency on those views.