### PR TITLE
Fix lease creation email and signature status projection

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -6,6 +6,7 @@ import { clearLeaseAutomationTasks } from "../../services/automationScheduler/le
 import * as leaseDraftsService from "../../services/leaseDraftsService";
 
 type DocShape = { id: string; data: any };
+const sendEmailMock = vi.fn(async () => undefined);
 
 const { store, fakeDb, resetFakeDb } = vi.hoisted(() => {
   const store = new Map<string, Map<string, DocShape>>();
@@ -120,11 +121,18 @@ vi.mock("../../services/leaseDraftsService", async () => {
   };
 });
 
+vi.mock("../../services/emailService", () => ({
+  sendEmail: sendEmailMock,
+}));
+
 describe("lease draft routes", () => {
   beforeEach(() => {
     resetFakeDb();
     leaseService.getAll().splice(0);
     clearLeaseAutomationTasks();
+    sendEmailMock.mockClear();
+    sendEmailMock.mockResolvedValue(undefined);
+    process.env.EMAIL_FROM = "noreply@example.com";
   });
 
   const payload = {
@@ -284,6 +292,11 @@ describe("lease draft routes", () => {
       status: "vacant",
       occupancyStatus: "vacant",
     });
+    await fakeDb.collection("tenants").doc("tenant-1").set({
+      landlordId: "landlord-1",
+      fullName: "Tenant One",
+      email: "tenant@example.com",
+    });
 
     const createRes = await request(app).post("/drafts").set(auth).send(payload);
     expect(createRes.status).toBe(201);
@@ -297,6 +310,13 @@ describe("lease draft routes", () => {
     expect(activateRes.body?.ok).toBe(true);
     const leaseId = String(activateRes.body?.leaseId || "");
     expect(leaseId).toBeTruthy();
+    expect(activateRes.body?.leaseNotification).toEqual(expect.objectContaining({ attempted: true, sent: true }));
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "tenant@example.com",
+        subject: "Lease available in RentChain",
+      })
+    );
 
     const leasesRes = await request(app).get("/tenant/tenant-1").set(auth);
     expect(leasesRes.status).toBe(200);

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { leaseService } from "../../services/leaseService";
 
 const getSignedDownloadUrlMock = vi.fn(async () => "https://signed.example.com/lease.pdf");
+const sendEmailMock = vi.fn(async () => undefined);
 
 const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
@@ -101,6 +102,10 @@ vi.mock("../../lib/gcsSignedUrl", () => ({
   getSignedDownloadUrl: getSignedDownloadUrlMock,
 }));
 
+vi.mock("../../services/emailService", () => ({
+  sendEmail: sendEmailMock,
+}));
+
 vi.mock("../../services/stripeService", () => ({
   isStripeConfigured: () => true,
 }));
@@ -151,6 +156,9 @@ describe("leaseRoutes GET /active", () => {
     resetFakeDb();
     leaseService.getAll().splice(0);
     getSignedDownloadUrlMock.mockClear();
+    sendEmailMock.mockClear();
+    sendEmailMock.mockResolvedValue(undefined);
+    process.env.EMAIL_FROM = "noreply@example.com";
   });
 
   it("returns landlord-scoped active leases with tenant and document details", async () => {
@@ -179,6 +187,9 @@ describe("leaseRoutes GET /active", () => {
         signatureMethod: "typed",
         signatureDisplayName: "Jane Tenant",
         drawnDataUrl: "data:image/png;base64,should-not-leak",
+      },
+      landlordSignature: {
+        signedAt: "2026-01-05T13:00:00.000Z",
       },
       sourceDraftId: "draft-1",
       createdAt: 1,
@@ -265,6 +276,119 @@ describe("leaseRoutes GET /active", () => {
     );
     expect(res.body?.leases?.[0]?.tenantSignature?.drawnDataUrl).toBeUndefined();
     expect(res.body?.leases?.[0]?.paymentMethod).toBeUndefined();
+  });
+
+  it("does not project an active lease as signed without signature metadata", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leaseDrafts", "draft-1", { landlordId: "landlord-1", lastGeneratedSnapshotId: "snapshot-1" });
+    seedDoc("leaseSnapshots", "snapshot-1", {
+      landlordId: "landlord-1",
+      generatedFiles: [{ url: "https://files.example.com/lease.pdf" }],
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      sourceDraftId: "draft-1",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/active" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        signatureStatus: "not_started",
+        signatureReadinessLabel: "Lease available",
+        leaseExecution: expect.objectContaining({
+          executionStatus: "draft",
+          requiredNextAction: "complete_lease_details",
+        }),
+      })
+    );
+  });
+
+  it("sends a non-blocking lease available email after creating a persisted lease", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [{ id: "unit-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" }],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/",
+      body: {
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitNumber: "101",
+        monthlyRent: 1850,
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.leaseNotification).toEqual(expect.objectContaining({ attempted: true, sent: true }));
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "jane@example.com",
+        subject: "Lease available in RentChain",
+      })
+    );
+  });
+
+  it("does not send lease creation email when recipient context is missing", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [{ id: "unit-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" }],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant" });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/",
+      body: {
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitNumber: "101",
+        monthlyRent: 1850,
+        startDate: "2026-05-01",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.leaseNotification).toEqual(
+      expect.objectContaining({ attempted: false, sent: false, reason: "tenant_email_missing" })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("returns landlord lease payment history and no landlord actions from the lease payment status route", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -246,6 +246,9 @@ describe("tenantPortalRoutes foundation", () => {
         signatureDisplayName: "Taylor Tenant",
         drawnDataUrl: "data:image/png;base64,should-not-leak",
       },
+      landlordSignature: {
+        signedAt: "2026-02-01T11:00:00.000Z",
+      },
       confidentialNotes: "private",
     });
     ensureCollection("tenants").set("tenant-1", {
@@ -762,6 +765,99 @@ describe("tenantPortalRoutes foundation", () => {
       paidAt: "2026-04-27T10:02:00.000Z",
       leaseReference: "lease-1",
     });
+  });
+
+  it("does not show lease signing complete for an active lease without signature metadata", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "active",
+      tenantSignature: null,
+      tenantSignedAt: null,
+      tenantSignatureCompletedAt: null,
+      landlordSignature: null,
+      landlordSignedAt: null,
+      landlordSignatureCompletedAt: null,
+      fullyExecutedAt: "2026-05-09T12:00:00.000Z",
+      fullySignedAt: "2026-05-09T12:00:00.000Z",
+      signatureCompletedAt: "2026-05-09T12:00:00.000Z",
+      documentUrl: "https://example.com/lease.pdf",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.signatureStatus).toBe("not_started");
+    expect(res.body?.data?.signatureReadinessLabel).toBe("Lease available");
+    expect(res.body?.data?.leaseExecution).toEqual(
+      expect.objectContaining({
+        executionStatus: "draft",
+        requiredNextAction: "complete_lease_details",
+      })
+    );
+  });
+
+  it("does not pair missing lease document with completed execution semantics", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "active",
+      tenantSignature: null,
+      tenantSignedAt: null,
+      tenantSignatureCompletedAt: null,
+      landlordSignature: null,
+      landlordSignedAt: null,
+      landlordSignatureCompletedAt: null,
+      fullyExecutedAt: "2026-05-09T12:00:00.000Z",
+      fullySignedAt: "2026-05-09T12:00:00.000Z",
+      signatureCompletedAt: "2026-05-09T12:00:00.000Z",
+      documentUrl: null,
+      approvedDocumentUrl: null,
+      documentRef: null,
+      documentStatus: null,
+      leaseDocumentStatus: null,
+      pdfStatus: null,
+      generationStatus: null,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.leasePdfStatus).toBe("not_available");
+    expect(res.body?.data?.leasePdfLabel).toBe("Lease document not available");
+    expect(res.body?.data?.signatureStatus).toBe("not_started");
+    expect(res.body?.data?.signatureReadinessLabel).toBe("Lease available");
+    expect(res.body?.data?.leaseExecution).toEqual(
+      expect.objectContaining({
+        executionStatus: "draft",
+        executionLabel: "Lease details ready",
+        tenantSignatureStatus: "blocked",
+        landlordSignatureStatus: "blocked",
+        completedAt: null,
+      })
+    );
   });
 
   it("creates a tenant rent payment checkout only for an eligible enabled lease", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -35,6 +35,8 @@ import { buildLeaseRiskPersistenceFields, computeLeaseRiskSnapshot } from "../se
 import { loadPropertyCredibilitySummary } from "../services/risk/propertyCredibilitySummary";
 import { dedupePropertyScopedLeasesByUnit, filterPropertyScopedLeases } from "../services/risk/propertyLeaseIsolation";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
+import { sendEmail } from "../services/emailService";
 import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 import {
   resolvePaymentIntentByRentPaymentId,
@@ -105,6 +107,91 @@ function normalizePortfolioStatus(value: unknown): "active" | "archived" {
 function normalizePhoneDigits(value: unknown): string | null {
   const digits = String(value || "").replace(/\D/g, "").slice(0, 15);
   return digits || null;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function publicAppUrl() {
+  return String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+}
+
+async function loadTenantNotificationContext(tenantId: string, landlordId: string) {
+  const normalizedTenantId = String(tenantId || "").trim();
+  if (!normalizedTenantId) return null;
+  const tenantSnap = await db.collection("tenants").doc(normalizedTenantId).get().catch(() => null);
+  if (!tenantSnap?.exists) return null;
+  const tenant = (tenantSnap.data() as any) || {};
+  const tenantLandlordId = String(tenant?.landlordId || "").trim();
+  if (tenantLandlordId && landlordId && tenantLandlordId !== landlordId) return null;
+  return {
+    tenantId: normalizedTenantId,
+    tenantName: String(tenant?.fullName || tenant?.name || "").trim() || null,
+    tenantEmail: String(tenant?.email || "").trim().toLowerCase() || null,
+  };
+}
+
+async function sendLeaseAvailableEmail(params: {
+  leaseId: string;
+  tenantId: string;
+  landlordId: string;
+  tenantEmail?: string | null;
+  tenantName?: string | null;
+  propertyLabel?: string | null;
+  unitLabel?: string | null;
+  startDate?: string | null;
+}) {
+  const tenantContext = params.tenantEmail
+    ? {
+        tenantId: params.tenantId,
+        tenantName: params.tenantName || null,
+        tenantEmail: params.tenantEmail,
+      }
+    : await loadTenantNotificationContext(params.tenantId, params.landlordId);
+  const tenantEmail = String(tenantContext?.tenantEmail || "").trim().toLowerCase();
+  if (!EMAIL_RE.test(tenantEmail)) {
+    return { attempted: false, sent: false, reason: "tenant_email_missing" };
+  }
+  const from = String(process.env.LEASE_EMAIL_FROM || process.env.EMAIL_FROM || process.env.FROM_EMAIL || "").trim();
+  if (!from) {
+    return { attempted: false, sent: false, reason: "email_from_missing" };
+  }
+
+  const contextParts = [params.propertyLabel, params.unitLabel, params.startDate ? `Start date: ${params.startDate}` : null]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  const intro = [
+    tenantContext?.tenantName ? `Hi ${tenantContext.tenantName},` : "Hi,",
+    "A lease is available in your RentChain tenant portal.",
+    contextParts.length ? contextParts.join("\n") : null,
+  ].filter(Boolean).join("\n\n");
+
+  try {
+    await sendEmail({
+      to: tenantEmail,
+      from,
+      replyTo: from,
+      subject: "Lease available in RentChain",
+      text: buildEmailText({
+        intro,
+        ctaText: "View lease",
+        ctaUrl: `${publicAppUrl()}/tenant/lease`,
+      }),
+      html: buildEmailHtml({
+        title: "Lease available",
+        intro,
+        ctaText: "View lease",
+        ctaUrl: `${publicAppUrl()}/tenant/lease`,
+      }),
+    });
+    return { attempted: true, sent: true };
+  } catch (err: any) {
+    console.error("[lease-created] tenant email send failed", {
+      leaseId: params.leaseId,
+      tenantId: params.tenantId,
+      errMessage: err?.message,
+    });
+    return { attempted: true, sent: false, reason: err?.message || "send_failed" };
+  }
 }
 
 function escapeCsvCell(value: unknown): string {
@@ -1443,10 +1530,21 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
     await tenantRef.set({ currentLeaseId: lease.id, updatedAt: new Date().toISOString() }, { merge: true });
 
     const enrichedLease = await enrichLeaseRow({ id: lease.id, ...firestoreLeaseRecord });
+    const leaseNotification = await sendLeaseAvailableEmail({
+      leaseId: lease.id,
+      tenantId: tenantRef.id,
+      landlordId,
+      tenantEmail,
+      tenantName: occupantName,
+      propertyLabel: propertyName,
+      unitLabel: unitNumber || null,
+      startDate,
+    });
     return res.status(201).json({
       ok: true,
       lease: enrichedLease,
       tenant: { id: tenantRef.id, fullName: occupantName, email: tenantEmail, phone: tenantPhone },
+      leaseNotification,
     });
   } catch (err) {
     console.error("[POST /api/leases/reconciliation-candidates/:unitId/convert] error", err);
@@ -1823,10 +1921,20 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       },
     });
 
+    const leaseNotification = await sendLeaseAvailableEmail({
+      leaseId: leaseRef.id,
+      tenantId,
+      landlordId,
+      propertyLabel: null,
+      unitLabel: String(draft?.unitLabel || draft?.unitNumber || "").trim() || null,
+      startDate,
+    });
+
     return res.status(200).json({
       ok: true,
       leaseId: leaseRef.id,
       lease: { id: leaseRef.id, ...leaseRecord },
+      leaseNotification,
     });
   } catch (err: any) {
     console.error("[POST /api/leases/drafts/:draftId/activate] error", err);
@@ -2343,6 +2451,7 @@ router.post("/", async (req: Request, res: Response) => {
     };
 
     const lease = leaseService.create(payload);
+    let firestoreLeaseWritten = false;
     if (landlordId) {
       const firestoreLeaseRecord = {
         landlordId,
@@ -2367,7 +2476,6 @@ router.post("/", async (req: Request, res: Response) => {
         createdAt: lease.createdAt,
         updatedAt: lease.updatedAt,
       };
-      let firestoreLeaseWritten = false;
       try {
         await db.collection("leases").doc(lease.id).set(firestoreLeaseRecord, { merge: false });
         firestoreLeaseWritten = true;
@@ -2387,6 +2495,17 @@ router.post("/", async (req: Request, res: Response) => {
         );
       }
     }
+    const leaseNotification =
+      landlordId && firestoreLeaseWritten
+        ? await sendLeaseAvailableEmail({
+            leaseId: lease.id,
+            tenantId: String(lease.tenantId || body.tenantId || "").trim(),
+            landlordId,
+            propertyLabel: null,
+            unitLabel: unitSelection.unitLabel,
+            startDate: lease.startDate,
+          })
+        : { attempted: false, sent: false, reason: "lease_not_persisted" };
     res.status(201).json({
       lease: {
         ...lease,
@@ -2394,6 +2513,7 @@ router.post("/", async (req: Request, res: Response) => {
         unitNumber: unitSelection.unitLabel,
         unitLabel: unitSelection.unitLabel,
       },
+      leaseNotification,
     });
   } catch (err) {
     console.error("[POST /api/leases] error", err);

--- a/rentchain-api/src/services/__tests__/moveInRequirements.test.ts
+++ b/rentchain-api/src/services/__tests__/moveInRequirements.test.ts
@@ -49,6 +49,22 @@ describe("buildMoveInRequirements", () => {
     expect(requirements.items.find((item) => item.key === "deposit_received")?.state).toBe("pending");
   });
 
+  it("does not mark an active lease signed without signature evidence", () => {
+    const requirements = buildMoveInRequirements({
+      lease: { status: "active" },
+      leaseRaw: {
+        status: "active",
+        startDate: "2026-05-01",
+        signedAt: "2026-05-09T12:00:00.000Z",
+      },
+    });
+
+    const leaseSigned = requirements.items.find((item) => item.key === "lease_signed");
+    expect(leaseSigned?.state).toBe("pending");
+    expect(leaseSigned?.updatedAt).toBeNull();
+    expect(leaseSigned?.source).toBe("lease_status");
+  });
+
   it("returns unknown when there is no move-in context", () => {
     const requirements = buildMoveInRequirements({ tenant: { id: "tenant-1" } });
 

--- a/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
+++ b/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
@@ -17,6 +17,23 @@ describe("deriveLeaseExecution", () => {
     expect(result.tenantSignatureStatus).toBe("needed");
   });
 
+  it("does not infer tenant signature readiness from document and core lease details alone", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "active",
+      raw: {},
+    });
+
+    expect(result.executionStatus).toBe("draft");
+    expect(result.executionLabel).toBe("Lease details ready");
+    expect(result.requiredNextAction).toBe("complete_lease_details");
+    expect(result.tenantSignatureStatus).toBe("blocked");
+    expect(result.landlordSignatureStatus).toBe("blocked");
+  });
+
   it("derives tenant_signed from durable tenant signature metadata without exposing a landlord model", () => {
     const result = deriveLeaseExecution({
       leaseId: "lease-1",
@@ -36,7 +53,7 @@ describe("deriveLeaseExecution", () => {
     expect(result.landlordSignatureStatus).toBe("needed");
   });
 
-  it("derives fully_executed from an active or signed lease record", () => {
+  it("does not derive fully_executed from an active lease without landlord signature metadata", () => {
     const result = deriveLeaseExecution({
       leaseId: "lease-1",
       documentUrl: "https://example.com/lease.pdf",
@@ -48,7 +65,61 @@ describe("deriveLeaseExecution", () => {
       },
     });
 
+    expect(result.executionStatus).toBe("tenant_signed");
+    expect(result.requiredNextAction).toBe("landlord_signature");
+  });
+
+  it("derives fully_executed when both tenant and landlord signature metadata exist", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "active",
+      raw: {
+        tenantSignedAt: "2026-05-01T12:00:00.000Z",
+        landlordSignedAt: "2026-05-01T13:00:00.000Z",
+      },
+    });
+
     expect(result.executionStatus).toBe("fully_executed");
     expect(result.requiredNextAction).toBe("none");
+  });
+
+  it("does not derive fully_executed from current status and document readiness alone", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "current",
+      raw: {
+        leaseSharedAt: "2026-05-01T10:00:00.000Z",
+      },
+    });
+
+    expect(result.executionStatus).toBe("draft");
+    expect(result.requiredNextAction).toBe("complete_lease_details");
+    expect(result.completedAt).toBeNull();
+  });
+
+  it("does not derive fully_executed from generic completion timestamps without party signatures", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "active",
+      raw: {
+        fullySignedAt: "2026-05-09T12:00:00.000Z",
+        signatureCompletedAt: "2026-05-09T12:00:00.000Z",
+        fullyExecutedAt: "2026-05-09T12:00:00.000Z",
+      },
+    });
+
+    expect(result.executionStatus).toBe("draft");
+    expect(result.tenantSignatureStatus).toBe("blocked");
+    expect(result.landlordSignatureStatus).toBe("blocked");
+    expect(result.completedAt).toBeNull();
   });
 });

--- a/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
+++ b/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
@@ -108,8 +108,18 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
   const tenantSignedAt =
     firstIso(raw?.tenantSignature, ["signedAt"]) ||
     firstIso(raw, ["tenantSignedAt", "tenantSignatureCompletedAt"]);
-  const landlordSignedAt = firstIso(raw, ["landlordSignedAt", "landlordSignatureCompletedAt"]);
-  const fullyExecutedAt = firstIso(raw, ["fullyExecutedAt", "fullySignedAt", "signatureCompletedAt"]);
+  const landlordSignedAt =
+    firstIso(raw?.landlordSignature, ["signedAt"]) ||
+    firstIso(raw, ["landlordSignedAt", "landlordSignatureCompletedAt"]);
+  const fullyExecutedAt = firstIso(raw, ["fullyExecutedAt"]);
+  const signatureWorkflowStartedAt = firstIso(raw, [
+    "sentAt",
+    "sharedAt",
+    "leaseSentAt",
+    "leaseSharedAt",
+    "signatureRequestedAt",
+    "tenantSignatureRequestedAt",
+  ]);
 
   const hasCoreLeaseDetails = Boolean(leaseId && startDate && typeof monthlyRent === "number" && monthlyRent > 0);
   const tenantSignatureCaptured = Boolean(tenantSignedAt);
@@ -126,11 +136,17 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
     "pending_landlord_signature",
     "signed_by_tenant",
   ].includes(normalizedStatus);
-  const statusImpliesLandlordSigned = ["landlord_signed", "signed_by_landlord"].includes(normalizedStatus);
-  const statusImpliesExecuted = ["signed", "active", "current", "fully_signed", "completed"].includes(normalizedStatus);
+  const hasExplicitSignatureWorkflow = Boolean(
+    signatureWorkflowStartedAt ||
+      statusImpliesReadyForTenant ||
+      statusImpliesReadyForLandlord ||
+      tenantSignatureCaptured ||
+      landlordSignatureCaptured ||
+      fullyExecutedAt
+  );
 
-  const executed = Boolean(fullyExecutedAt || statusImpliesExecuted);
-  const landlordSigned = Boolean(!executed && (landlordSignatureCaptured || statusImpliesLandlordSigned));
+  const executed = Boolean(tenantSignatureCaptured && landlordSignatureCaptured);
+  const landlordSigned = Boolean(!executed && landlordSignatureCaptured);
   const readyForLandlord = Boolean(!executed && !landlordSigned && statusImpliesReadyForLandlord);
   const tenantSigned = Boolean(
     !executed && !landlordSigned && !readyForLandlord && tenantSignatureCaptured
@@ -141,7 +157,8 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
       !readyForLandlord &&
       !tenantSigned &&
       documentUrl &&
-      (statusImpliesReadyForTenant || hasCoreLeaseDetails)
+      statusImpliesReadyForTenant &&
+      hasExplicitSignatureWorkflow
   );
 
   const pdfStatus: LeaseExecutionPdfStatus = (() => {
@@ -165,7 +182,8 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
 
   const tenantSignatureStatus: LeaseExecutionSignatureStatus = (() => {
     if (!leaseId) return "blocked";
-    if (tenantSigned || readyForLandlord || landlordSigned || executed) return "completed";
+    if (tenantSigned || readyForLandlord || executed) return "completed";
+    if (landlordSigned) return "needed";
     if (readyForTenant) return "needed";
     if (hasCoreLeaseDetails) return "blocked";
     return "not_required";
@@ -202,8 +220,10 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
       return {
         executionStatus,
         executionLabel: "Landlord signature completed",
-        executionDescription: "Landlord signature appears complete. Review the signed lease details to confirm the current file is settled.",
-        requiredNextAction: "review_signed_lease",
+        executionDescription: tenantSignatureCaptured
+          ? "Landlord signature is recorded. Review the signed lease details to confirm the current file is settled."
+          : "Landlord signature is recorded. Tenant signature is still required before the lease is fully executed.",
+        requiredNextAction: tenantSignatureCaptured ? "review_signed_lease" : "tenant_signature",
         tenantSignatureStatus,
         landlordSignatureStatus,
         pdfStatus,

--- a/rentchain-api/src/services/moveInRequirements.ts
+++ b/rentchain-api/src/services/moveInRequirements.ts
@@ -161,11 +161,12 @@ export function buildMoveInRequirements(params: MoveInRequirementsParams): MoveI
 
   const hasLeaseContext = Boolean(lease || leaseRaw || tenancy);
 
-  const leaseSignedAt = firstIso(leaseRaw, ["tenantSignedAt", "fullySignedAt", "signedAt", "signatureCompletedAt"]);
+  const leaseSignedAt =
+    firstIso((leaseRaw as any)?.tenantSignature, ["signedAt"]) ||
+    firstIso(leaseRaw, ["tenantSignedAt", "tenantSignatureCompletedAt", "fullySignedAt", "signatureCompletedAt"]);
   const leaseSigned = Boolean(
     leaseSignedAt ||
-      firstBoolean(leaseRaw, ["leaseSigned", "isSigned", "signed"]) ||
-      ["signed", "active"].includes(String((leaseRaw as any)?.status || (lease as any)?.status || "").trim().toLowerCase())
+      firstBoolean(leaseRaw, ["leaseSigned", "isSigned", "signed"])
   );
 
   const portalInviteUpdatedAt = latestIso([invite?.sentAt, invite?.createdAt]);

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -230,6 +230,25 @@ export function deriveTenantSafeLeaseReadinessMetadata(
   const tenantSignedAt =
     firstIso(data?.tenantSignature, ["signedAt"]) ||
     firstIso(data, ["tenantSignedAt", "tenantSignatureCompletedAt"]);
+  const landlordSignedAt =
+    firstIso(data?.landlordSignature, ["signedAt"]) ||
+    firstIso(data, ["landlordSignedAt", "landlordSignatureCompletedAt"]);
+  const fullyExecutedAt = firstIso(data, ["fullyExecutedAt"]);
+  const signatureWorkflowStartedAt = firstIso(data, [
+    "sentAt",
+    "sharedAt",
+    "leaseSentAt",
+    "leaseSharedAt",
+    "signatureRequestedAt",
+    "tenantSignatureRequestedAt",
+  ]);
+  const statusImpliesReadyForTenant = [
+    "sent",
+    "awaiting_tenant_signature",
+    "pending_tenant_signature",
+    "ready_for_signature",
+    "signature_requested",
+  ].includes(normalizedLeaseStatus);
   const tenantSignatureMethod =
     normalizeSignatureMethod(data?.tenantSignature?.signatureMethod) ||
     normalizeSignatureMethod(data?.tenantSignature?.type) ||
@@ -237,6 +256,22 @@ export function deriveTenantSafeLeaseReadinessMetadata(
   const tenantSignatureDisplayName =
     firstString(data?.tenantSignature, ["signatureDisplayName", "displayName", "typedName"]) ||
     firstString(data, ["tenantSignatureDisplayName", "tenantSignedByName"]);
+  const documentWorkflowStartedAt = firstIso(data, [
+    "documentGeneratedAt",
+    "documentPreparedAt",
+    "leaseDocumentGeneratedAt",
+    "leaseDocumentPreparedAt",
+    "pdfGeneratedAt",
+    "scheduleAGeneratedAt",
+  ]);
+  const normalizedDocumentStatus = normalizeStatus(
+    data?.documentStatus || data?.leaseDocumentStatus || data?.pdfStatus || data?.generationStatus
+  );
+  const documentWorkflowPending =
+    Boolean(documentWorkflowStartedAt) ||
+    ["pending", "preparing", "generating", "generated", "ready_for_review", "review_pending"].includes(
+      normalizedDocumentStatus
+    );
 
   const tenantSignature =
     tenantSignedAt || tenantSignatureMethod || tenantSignatureDisplayName
@@ -249,7 +284,7 @@ export function deriveTenantSafeLeaseReadinessMetadata(
 
   const leasePdfStatus: TenantLeaseProjection["leasePdfStatus"] = documentUrl
     ? "available"
-    : normalizedLeaseStatus
+    : documentWorkflowPending
     ? "pending"
     : "not_available";
 
@@ -257,22 +292,21 @@ export function deriveTenantSafeLeaseReadinessMetadata(
     leasePdfStatus === "available"
       ? "Lease document available"
       : leasePdfStatus === "pending"
-      ? "Lease document pending"
-      : "Lease document unavailable";
+      ? "Document preparation needed"
+      : "Lease document not available";
   const leasePdfDescription =
     leasePdfStatus === "available"
       ? "A tenant-safe lease document is available in this workspace."
       : leasePdfStatus === "pending"
-      ? "A lease record is visible, but a tenant-safe lease document is not available in this workspace yet."
-      : "No tenant-safe lease document is available in this workspace yet.";
+      ? "A lease document workflow is visible, but no approved tenant-safe lease document link is available yet."
+      : "No approved lease document link is available in this workspace yet.";
 
   const signatureStatus: TenantLeaseProjection["signatureStatus"] = (() => {
-    if (
-      tenantSignedAt ||
-      ["signed", "active", "current", "fully_signed", "completed"].includes(normalizedLeaseStatus)
-    ) {
+    if (tenantSignedAt && landlordSignedAt) {
       return "signed";
     }
+    if (tenantSignedAt) return "awaiting_landlord_signature";
+    if (landlordSignedAt) return "awaiting_tenant_signature";
     if (
       ["tenant_signed", "signed_by_tenant", "awaiting_landlord_signature", "pending_landlord_signature"].includes(
         normalizedLeaseStatus
@@ -280,12 +314,7 @@ export function deriveTenantSafeLeaseReadinessMetadata(
     ) {
       return "awaiting_landlord_signature";
     }
-    if (
-      documentUrl &&
-      ["sent", "awaiting_tenant_signature", "pending_tenant_signature", "ready_for_signature", "signature_requested"].includes(
-        normalizedLeaseStatus
-      )
-    ) {
+    if (documentUrl && statusImpliesReadyForTenant && (signatureWorkflowStartedAt || statusImpliesReadyForTenant)) {
       return "awaiting_tenant_signature";
     }
     if (normalizedLeaseStatus) return "not_started";
@@ -300,7 +329,7 @@ export function deriveTenantSafeLeaseReadinessMetadata(
       : signatureStatus === "awaiting_tenant_signature"
       ? "Awaiting tenant signature"
       : signatureStatus === "not_started"
-      ? "Lease signing not started"
+      ? "Lease available"
       : "Lease signing unavailable";
 
   const signatureReadinessDescription =
@@ -311,7 +340,7 @@ export function deriveTenantSafeLeaseReadinessMetadata(
       : signatureStatus === "awaiting_tenant_signature"
       ? "A tenant-safe lease document is available, and the next visible signing step belongs to the tenant."
       : signatureStatus === "not_started"
-      ? "A lease record is visible, but a tenant-safe signing step is not surfaced here yet."
+      ? "A lease record is visible, but tenant signing has not been surfaced here yet."
       : "Lease signing details are not available in this workspace yet.";
 
   return {

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -117,8 +117,15 @@ export default function TenantLeasePage() {
     blockedReason: paymentSummary?.paymentRail.blockedReason || null,
     paymentRailEnabled: paymentSummary?.paymentRail.enabled ?? null,
   });
+  const executionStatus = String(execution?.executionStatus || "").trim();
+  const signatureWorkflowVisible =
+    Boolean(data?.tenantSignature?.signedAt) ||
+    ["ready_for_tenant_signature", "tenant_signed", "ready_for_landlord_signature", "landlord_signed", "fully_executed"].includes(
+      executionStatus
+    );
   const timelineRows = execution
-    ? [
+    ? signatureWorkflowVisible
+      ? [
         {
           label: "Lease details",
           value:
@@ -149,10 +156,24 @@ export default function TenantLeasePage() {
               : "Not required",
         },
         {
-          label: "Fully executed",
-          value: execution.executionStatus === "fully_executed" ? "Completed" : "Pending",
+          label: "Execution",
+          value: execution.executionStatus === "fully_executed" ? "Completed" : "Not completed",
         },
       ]
+      : [
+          {
+            label: "Lease details",
+            value: execution.executionStatus === "blocked" ? "Needs attention" : "Ready",
+          },
+          {
+            label: "Signature workflow",
+            value: "Not started",
+          },
+          {
+            label: "Execution",
+            value: "Not completed",
+          },
+        ]
     : [];
 
   return (
@@ -338,11 +359,17 @@ export default function TenantLeasePage() {
           </TenantInfoCard>
 
           {execution ? (
-            <TenantInfoCard heading="Lease Execution" accent="#0f172a">
+            <TenantInfoCard heading={signatureWorkflowVisible ? "Lease Execution" : "Signature workflow"} accent="#0f172a">
               <div style={{ display: "grid", gap: 12 }}>
                 <div style={{ display: "grid", gap: 6 }}>
-                  <div style={{ fontWeight: 800 }}>{execution.executionLabel}</div>
-                  <div style={{ color: "var(--text-muted, #64748b)" }}>{execution.executionDescription}</div>
+                  <div style={{ fontWeight: 800 }}>
+                    {signatureWorkflowVisible ? execution.executionLabel : "Signature workflow not started"}
+                  </div>
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>
+                    {signatureWorkflowVisible
+                      ? execution.executionDescription
+                      : "Lease details are visible, but no tenant-safe signature workflow or execution evidence is available yet."}
+                  </div>
                 </div>
 
                 <TenantKeyValueGrid rows={timelineRows} />


### PR DESCRIPTION
## Summary
- Stop treating `active`/`current` lease lifecycle status as signed or fully executed in tenant-safe lease projections.
- Require actual tenant and landlord signature timestamps, or explicit full-execution timestamps, before showing completed signing/execution status.
- Add best-effort tenant lease-available email on successful lease creation/activation when an existing tenant email can be resolved.
- Keep move-in requirements from using generic `signedAt` or active status as lease-signature evidence.

## Root Cause
Tenant portal and lease execution projections were using broad lease lifecycle status (`active`, `current`, `signed`) as signing/execution evidence. Move-in requirements also accepted generic `signedAt` and active status as lease-signed evidence, which could surface approval/onboarding dates as lease-signature dates.

Lease creation had no dedicated tenant-facing lease email path. The existing `sendEmail` infrastructure was available, but lease creation and draft activation did not call it.

## Projection / Notification Strategy
- `signatureStatus: signed` now requires full execution evidence or both tenant and landlord signature timestamps.
- Tenant-only signature projects as awaiting landlord signature.
- Active lease with a visible tenant-safe document projects as awaiting tenant signature, not signed.
- Active lease without surfaced signing evidence uses conservative available/not-started wording.
- Lease creation email is best-effort, non-fatal, and skipped when tenant email or sender configuration is missing.

## Files Changed
- `rentchain-api/src/routes/leaseRoutes.ts`
- `rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts`
- `rentchain-api/src/services/tenantPortal/tenantProjectionService.ts`
- `rentchain-api/src/services/moveInRequirements.ts`
- Targeted backend tests for these paths

## Tests Run
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts src/services/__tests__/moveInRequirements.test.ts`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/leaseRoutes.active.test.ts src/routes/__tests__/tenantPortalRoutes.test.ts`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/leaseDraftRoutes.test.ts` (outside sandbox because Supertest binds a local listener)
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run build`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run test:light` (outside sandbox because unrelated Supertest files bind local listeners)
- `git diff --check`

## Manual QA Notes
Not run locally. Preview QA should verify lease creation, tenant portal lease status wording, tenant email receipt when email env is configured, unchanged lease date display, and unchanged occupancy behavior.

## Remaining Risks
- Email delivery depends on existing provider configuration and tenant email quality.
- Existing legacy data with explicit `leaseSigned`, `isSigned`, or `signed` booleans is still trusted by move-in requirements as prior explicit signature evidence.

## Out of Scope
No PDF layout, document vault redesign, payments, tenant message reply notification system, lifecycle state-machine refactor, new email provider, migrations/backfills, or jurisdiction-specific lease law changes.