### PR TITLE
Hydrate property lease risk unit labels

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -615,6 +615,47 @@ describe("leaseRoutes GET /active", () => {
     expect(res.body?.lease?.id).toBeTruthy();
   });
 
+  it("hydrates property lease rows with canonical unit labels for display", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [{ id: "unit-raw-id-123456", unitNumber: "101", label: "Unit 101", status: "occupied" }],
+    });
+    seedDoc("units", "unit-raw-id-123456", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      label: "Unit 101",
+      status: "occupied",
+      occupancyStatus: "occupied",
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-raw-id-123456",
+      unitNumber: "unit-raw-id-123456",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/property/prop-1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        unitId: "unit-raw-id-123456",
+        unitNumber: "101",
+        unitLabel: "101",
+      })
+    );
+  });
+
   it("enables rent collection for an owned eligible lease", async () => {
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -719,6 +719,25 @@ async function hydrateLeaseUnitDisplayFields<T extends Record<string, any>>(
   };
 }
 
+function hydrateLeaseUnitDisplayFieldsFromUnits<T extends Record<string, any>>(
+  lease: T,
+  units: any[]
+): T {
+  const propertyId = String(lease?.propertyId || "").trim();
+  const unitReference = String(lease?.unitId || lease?.unitNumber || lease?.unitLabel || lease?.unit || "").trim();
+  if (!propertyId || !unitReference) return lease;
+  const resolution = resolveUnitReference(units, unitReference);
+  if (resolution.ambiguous || !resolution.unit) return lease;
+  const unitLabel = getCanonicalUnitLabel(resolution.unit);
+  if (!unitLabel) return lease;
+  return {
+    ...lease,
+    unitId: String(lease?.unitId || resolution.unit.id || "").trim() || resolution.unit.id,
+    unitNumber: unitLabel,
+    unitLabel,
+  };
+}
+
 async function enrichLeaseRow(raw: any) {
   const lease = normalizeLeaseRow(raw.id, raw);
   const propertyId = String(lease.propertyId || "").trim();
@@ -2361,7 +2380,8 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
 
     // Occupancy and rent roll consumers must operate on lease agreements, not per-tenant rows.
     const summaryLeases = mergeLeaseRows(combinedRows.filter((lease) => winnerIds.has(lease.id)));
-    const response: any = { leases: summaryLeases };
+    const displayLeases = summaryLeases.map((lease) => hydrateLeaseUnitDisplayFieldsFromUnits(lease, units));
+    const response: any = { leases: displayLeases };
     response.credibilitySummary = await loadPropertyCredibilitySummary({
       firestore: db as any,
       propertyId,

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -32,6 +32,7 @@ export interface Lease {
   propertyName?: string | null;
   propertyLabel?: string | null;
   unitId?: string | null;
+  unitLabel?: string | null;
   unitNumber: string;
   monthlyRent: number;
   startDate: string;

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -383,6 +383,108 @@ describe("PropertyDetailPanel", () => {
     expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
   });
 
+  it("hydrates lease risk unit labels from property units instead of showing raw unit ids", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      {
+        id: "wzECCdkACeLm2yWdV9b3",
+        unitNumber: "101",
+        status: "occupied",
+        rent: 1850,
+      },
+    ]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "wzECCdkACeLm2yWdV9b3",
+          unitNumber: "wzECCdkACeLm2yWdV9b3",
+          monthlyRent: 1850,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          riskScore: 72,
+          riskGrade: "B",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      credibilitySummary: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            totalUnits: 1,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Lease risk overview")).toBeInTheDocument();
+    expect(screen.getAllByText("Unit 101").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Unit wzECCdkACeLm2yWdV9b3")).not.toBeInTheDocument();
+  });
+
+  it("uses a conservative lease risk fallback when no unit label exists", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "t9Xs0CLL7erK1j3pWQVa",
+          unitNumber: "t9Xs0CLL7erK1j3pWQVa",
+          monthlyRent: 1850,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      credibilitySummary: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            totalUnits: 1,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Assigned unit")).toBeInTheDocument();
+    expect(screen.queryByText("Unit t9Xs0CLL7erK1j3pWQVa")).not.toBeInTheDocument();
+  });
+
   it("shows upcoming and notice-period occupancy from lease lifecycle", async () => {
     mocks.fetchUnitsForProperty.mockResolvedValue([
       {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -58,6 +58,51 @@ import { safeLocaleNumber } from "@/utils/format";
 
 const formatCurrency = (value: number): string => `$${safeLocaleNumber(value)}`;
 
+const RAW_ID_PATTERN = /^[A-Za-z0-9_-]{16,}$/;
+
+function cleanLabel(value: unknown): string {
+  return String(value || "").trim();
+}
+
+function isRawUnitIdLabel(value: string, rawIds: string[]) {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  if (rawIds.some((id) => id && id.toLowerCase() === normalized)) return true;
+  return RAW_ID_PATTERN.test(value) && /[A-Za-z]/.test(value) && /\d/.test(value);
+}
+
+function resolveLeaseRiskUnitLabel(lease: Lease, unitsForDisplay: any[]): string {
+  const rawIds = [cleanLabel(lease.unitId), cleanLabel((lease as any).id)].filter(Boolean);
+  const unitReference = cleanLabel(lease.unitId || lease.unitNumber || lease.unitLabel);
+  const matchedUnit = unitsForDisplay.find((unit: any) => {
+    const candidates = [
+      unit?.id,
+      unit?.unitId,
+      unit?.uid,
+      unit?.unitNumber,
+      unit?.label,
+      unit?.name,
+      unit?.unit,
+    ]
+      .map(cleanLabel)
+      .filter(Boolean);
+    return candidates.some((candidate) => candidate.toLowerCase() === unitReference.toLowerCase());
+  });
+  const candidates = [
+    matchedUnit?.unitNumber,
+    matchedUnit?.label,
+    matchedUnit?.name,
+    matchedUnit?.unit,
+    lease.unitLabel,
+    lease.unitNumber,
+  ]
+    .map(cleanLabel)
+    .filter((value) => value && !isRawUnitIdLabel(value, rawIds));
+  const label = candidates[0];
+  if (!label) return "Assigned unit";
+  return /^unit\b/i.test(label) ? label : `Unit ${label}`;
+}
+
 function unitOccupancyTone(status: UnitOccupancyStatus) {
   if (status === "occupied") {
     return { background: "rgba(34,197,94,0.1)", color: "#166534", dot: "#22c55e" };
@@ -1260,7 +1305,9 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                 }}
               >
                 <div style={{ display: "grid", gap: 2 }}>
-                  <div style={{ color: "#0f172a", fontWeight: 700 }}>Unit {lease.unitNumber || lease.unitId || "--"}</div>
+                  <div style={{ color: "#0f172a", fontWeight: 700 }}>
+                    {resolveLeaseRiskUnitLabel(lease, displayedUnits)}
+                  </div>
                   <div style={{ color: "#475569", fontSize: 12 }}>
                     {formatCurrency(lease.monthlyRent)} / month
                     {lease.riskConfidence != null ? " • " + Math.round(lease.riskConfidence * 100) + "% confidence" : ""}


### PR DESCRIPTION
## Summary
- Hydrate `/leases/property/:propertyId` response rows with canonical unit display labels from the units already loaded by the property lease route.
- Update `/properties` lease risk overview to resolve unit labels from fetched/embedded property units before using lease fields.
- Replace raw unit-id fallback display with conservative `Assigned unit` when no safe label exists.

## Audit Summary
Reviewed the property lease risk overview in `PropertyDetailPanel`, the `getLeasesForProperty` client path, the backend property lease route, unit fetch API, property/unit types, and existing lease route/property detail tests. The raw display came from `Unit {lease.unitNumber || lease.unitId || "--"}` in the risk overview.

## Root Cause
The property lease risk card trusted `lease.unitNumber` from the property lease list. Legacy/canonicalized lease rows can carry the raw Firestore unit id in `unitNumber`, so the UI rendered `Unit <rawId>` instead of resolving the existing canonical unit label.

## Hydration Strategy
- Backend: display-only hydration for property lease response rows using existing `loadUnitsForProperty`, `resolveUnitReference`, and canonical unit label logic. Risk/credibility calculations still use the original summary lease rows.
- Frontend: defensive label resolution from `displayedUnits`, then safe lease labels, then `Assigned unit`; raw id-shaped values are not rendered as labels.

## Tests Run
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/leaseRoutes.active.test.ts` in `rentchain-api`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:single -- src/components/properties/PropertyDetailPanel.test.tsx` in `rentchain-frontend`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run build` in `rentchain-api`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build` in `rentchain-frontend`
- `git diff --check`

## Manual QA Notes
Not run locally. Preview QA should verify `/properties` lease risk overview shows human-readable unit labels, no raw unit IDs where unit records exist, occupancy status remains correct, and PR #890 lease execution/signature states remain corrected.

## Remaining Risks
- If no unit record or safe lease label exists, the card intentionally shows `Assigned unit` instead of a raw id.
- Other property surfaces were not refactored; this PR is limited to lease risk unit-label projection/display.

## Out of Scope
No lease execution/signature changes, occupancy lifecycle changes, tenant identity changes, document vault, payments, PDF layout, migrations/backfills, Firestore rules, or package/lockfile changes.