### PR TITLE
Link generated lease PDFs to tenant vault

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -178,6 +178,44 @@ describe("lease draft routes", () => {
     expect(generateRes.body?.ok).toBe(true);
     expect(generateRes.body?.scheduleAUrl).toContain("https://example.invalid");
     expect(String(generateRes.body?.snapshotId || "")).toBeTruthy();
+
+    const attachmentDocsAfterGenerate = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
+    expect(attachmentDocsAfterGenerate).toEqual([
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        leaseId: null,
+        draftId,
+        propertyId: "prop-1",
+        category: "Lease",
+        purpose: "LEASE",
+        purposeLabel: "Lease",
+        url: "https://example.invalid/schedule-a.pdf",
+      }),
+    ]);
+
+    const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    expect(activateRes.status).toBe(200);
+    expect(activateRes.body?.lease).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://example.invalid/schedule-a.pdf",
+        approvedDocumentUrl: "https://example.invalid/schedule-a.pdf",
+        documentRef: "https://example.invalid/schedule-a.pdf",
+      })
+    );
+
+    const attachmentDocsAfterActivate = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
+    expect(attachmentDocsAfterActivate).toHaveLength(1);
+    expect(attachmentDocsAfterActivate[0]).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        leaseId: String(activateRes.body?.leaseId || ""),
+        draftId,
+        propertyId: "prop-1",
+        category: "Lease",
+      })
+    );
   }, 30000);
 
   it("returns inline PDF when storage upload is unavailable", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -2926,6 +2926,25 @@ describe("tenantPortalRoutes foundation", () => {
   });
 
   it("returns tenant-safe document states and completion guidance", async () => {
+    ensureCollection("ledgerAttachments").set("lease-generated-attachment", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      draftId: "draft-1",
+      leaseSnapshotId: "snapshot-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      ledgerItemId: "lease-1",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.com/generated-lease.pdf",
+      createdAt: 600,
+      source: "lease_pdf_generation",
+    });
+
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {
       method: "GET",
@@ -2946,6 +2965,16 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.summary?.pendingReview).toBeTypeOf("number");
     expect(res.body?.guidance?.headline).toBeTypeOf("string");
     expect(res.body?.data?.[0]?.internalNotes).toBeUndefined();
+    expect(res.body?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "LEASE — Lease",
+          category: "Lease",
+          fileName: "schedule-a-v1.pdf",
+          url: "https://example.com/generated-lease.pdf",
+        }),
+      ])
+    );
     expect(
       res.body?.data?.some((item: any) =>
         ["uploaded", "missing", "pending_review", "verified", "needs_attention", "reupload_requested"].includes(item.status)

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -644,6 +644,101 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
   }
 }
 
+function firstGeneratedLeasePdfFile(generatedFiles: any[]): any | null {
+  return (
+    (Array.isArray(generatedFiles) ? generatedFiles : []).find((item: any) => {
+      const url = String(item?.url || "").trim();
+      const kind = String(item?.kind || "").trim().toLowerCase();
+      return url.startsWith("https://") && (!kind || kind.includes("pdf") || kind.includes("schedule"));
+    }) || null
+  );
+}
+
+function safeAttachmentDocumentId(parts: string[]) {
+  return parts
+    .map((part) => String(part || "").trim().replace(/[^A-Za-z0-9_-]+/g, "_"))
+    .filter(Boolean)
+    .join("_")
+    .slice(0, 240);
+}
+
+async function linkGeneratedLeasePdfToTenantWorkspace(params: {
+  draft: any;
+  draftId: string;
+  landlordId: string;
+  snapshotId: string;
+  file: any;
+  actorId: string | null;
+}) {
+  const url = String(params.file?.url || "").trim();
+  if (!url.startsWith("https://")) return;
+
+  const leaseId = String(params.draft?.leaseId || "").trim() || null;
+  const propertyId = String(params.draft?.propertyId || "").trim() || null;
+  const unitId = String(params.draft?.unitId || "").trim() || null;
+  const tenantIds = Array.isArray(params.draft?.tenantIds)
+    ? params.draft.tenantIds.map((value: any) => String(value || "").trim()).filter(Boolean)
+    : [];
+  const now = Date.now();
+  const fileName = "schedule-a-v1.pdf";
+
+  if (leaseId) {
+    await db
+      .collection("leases")
+      .doc(leaseId)
+      .set(
+        {
+          documentUrl: url,
+          approvedDocumentUrl: url,
+          documentRef: url,
+          documentGeneratedAt: now,
+          leaseDocumentGeneratedAt: now,
+          latestLeaseSnapshotId: params.snapshotId,
+          updatedAt: now,
+        },
+        { merge: true }
+      );
+  }
+
+  await Promise.all(
+    tenantIds.map(async (tenantId: string) => {
+      const attachmentId = safeAttachmentDocumentId([
+        "lease",
+        params.snapshotId,
+        tenantId,
+      ]);
+      await db
+        .collection("ledgerAttachments")
+        .doc(attachmentId)
+        .set(
+          {
+            landlordId: params.landlordId,
+            tenantId,
+            leaseId,
+            draftId: params.draftId,
+            leaseSnapshotId: params.snapshotId,
+            propertyId,
+            unitId,
+            ledgerItemId: leaseId || `leaseDraft:${params.draftId}`,
+            url,
+            title: "Lease document",
+            fileName,
+            category: "Lease",
+            purpose: "LEASE",
+            purposeLabel: "Lease",
+            source: "lease_pdf_generation",
+            generatedFileKind: String(params.file?.kind || "schedule-a-pdf"),
+            sha256: String(params.file?.sha256 || "").trim() || null,
+            sizeBytes: Number(params.file?.sizeBytes || 0) || null,
+            createdAt: now,
+            createdBy: params.actorId,
+          },
+          { merge: true }
+        );
+    })
+  );
+}
+
 async function loadUnitLeaseDocumentForResponse(raw: any) {
   const leaseDocument = raw?.leaseDocument;
   if (!leaseDocument || typeof leaseDocument !== "object") return raw;
@@ -1676,13 +1771,26 @@ router.post("/drafts/:id/generate", requireLandlord, async (req: any, res: Respo
 
     const now = Date.now();
     const snapshotRef = db.collection("leaseSnapshots").doc();
+    const generatedFiles = [file];
     const snapshotDoc = {
       ...draft,
       status: "generated",
       generatedAt: now,
-      generatedFiles: [file],
+      generatedFiles,
     };
     await snapshotRef.set(snapshotDoc, { merge: false });
+
+    const generatedLeaseFile = firstGeneratedLeasePdfFile(generatedFiles);
+    if (generatedLeaseFile) {
+      await linkGeneratedLeasePdfToTenantWorkspace({
+        draft,
+        draftId: id,
+        landlordId,
+        snapshotId: snapshotRef.id,
+        file: generatedLeaseFile,
+        actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
+      });
+    }
 
     await ref.set(
       {
@@ -1690,6 +1798,7 @@ router.post("/drafts/:id/generate", requireLandlord, async (req: any, res: Respo
         status: "generated",
         updatedAt: now,
         lastGeneratedSnapshotId: snapshotRef.id,
+        lastGeneratedDocumentUrl: generatedLeaseFile ? String(generatedLeaseFile.url || "").trim() : null,
       },
       { merge: false }
     );
@@ -1709,7 +1818,7 @@ router.post("/drafts/:id/generate", requireLandlord, async (req: any, res: Respo
       ok: true,
       snapshotId: snapshotRef.id,
       scheduleAUrl: generated.file?.url || file.url,
-      generatedFiles: [file],
+      generatedFiles,
     });
   } catch (err: any) {
     console.error("[POST /api/leases/drafts/:id/generate] error", {
@@ -1846,7 +1955,31 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       createdAt: now,
       updatedAt: now,
     };
+    const draftDocumentUrl = await loadLeaseDocumentUrlForLease({ sourceDraftId: draftId });
+    if (draftDocumentUrl) {
+      leaseRecord.documentUrl = draftDocumentUrl;
+      leaseRecord.approvedDocumentUrl = draftDocumentUrl;
+      leaseRecord.documentRef = draftDocumentUrl;
+      leaseRecord.documentGeneratedAt = now;
+      leaseRecord.leaseDocumentGeneratedAt = now;
+      leaseRecord.latestLeaseSnapshotId = String(draft?.lastGeneratedSnapshotId || "").trim() || null;
+    }
     await leaseRef.set(leaseRecord, { merge: false });
+    if (draftDocumentUrl) {
+      const snapshotId = String(draft?.lastGeneratedSnapshotId || "").trim();
+      const generatedFile = {
+        kind: "schedule-a-pdf",
+        url: draftDocumentUrl,
+      };
+      await linkGeneratedLeasePdfToTenantWorkspace({
+        draft: { ...draft, leaseId: leaseRef.id },
+        draftId,
+        landlordId,
+        snapshotId: snapshotId || `activated_${leaseRef.id}`,
+        file: generatedFile,
+        actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
+      });
+    }
     await syncOccupancyAfterActiveLeaseWrite(
       {
         tenantId,

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -159,7 +159,7 @@ describe("tenant profile and communications pages", () => {
 
     expect(await screen.findByText(/Tenant Profile/i)).toBeInTheDocument();
     expect(screen.getByText(/rental profile space|tenant-safe projections only/i)).toBeInTheDocument();
-    expect(screen.getByText(/Profile completion/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Profile completion/i)).toBeInTheDocument();
     expect(await screen.findByDisplayValue(/Taylor Tenant/i)).toBeInTheDocument();
     expect((await screen.findAllByText(/Verification is still in progress/i)).length).toBeGreaterThan(0);
     expect(screen.getByRole("textbox", { name: /Display name/i })).toBeInTheDocument();
@@ -177,6 +177,55 @@ describe("tenant profile and communications pages", () => {
   it("formats tenant rental record date-only lease dates without shifting backward", () => {
     expect(formatDate("2026-05-01")).toBe("May 1, 2026");
     expect(formatDate("2027-04-30")).toBe("Apr 30, 2027");
+  });
+
+  it("shows generated lease documents as available in the rental record", async () => {
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        application: { status: "converted" },
+        lease: {
+          status: "active",
+          monthlyRent: 1800,
+          startDate: "2026-05-01",
+          endDate: "2027-04-30",
+          documentUrl: "https://example.com/generated-lease.pdf",
+        },
+      },
+      identity: {
+        overallStatus: "verified",
+        identityVerification: {
+          status: "verified",
+          label: "Verified",
+          note: "Verified.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: true,
+          path: "/tenant/attachments",
+          label: "Open documents",
+          note: "Open your tenant documents area.",
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Rental record/i)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Not shared yet")).not.toBeInTheDocument();
   });
 
   it("tenant profile page saves bounded profile edits safely", async () => {


### PR DESCRIPTION
## Summary
- Link generated Schedule A lease PDFs from `POST /api/leases/drafts/:id/generate` into existing `ledgerAttachments` tenant document workspace records.
- Carry generated lease PDF URLs into existing lease document fields (`documentUrl`, `approvedDocumentUrl`, `documentRef`) when an activated lease exists or a generated draft is later activated.
- Add targeted tests for vault visibility, tenant profile document availability, and unchanged lease execution semantics.

## Files Changed
- `rentchain-api/src/routes/leaseRoutes.ts`
- `rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts`
- `rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts`
- `rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx`

## Lease Document Lifecycle Linkage
Generation still writes `leaseSnapshots.generatedFiles` as before. This patch adds read/write continuity around the generated file:
- after a valid HTTPS generated PDF exists, create/update tenant-visible `ledgerAttachments` records for draft tenants;
- when the draft is activated, carry the latest generated file URL onto the created lease record;
- if a draft already has a leaseId and is regenerated, update that lease’s document fields directly.

This does not create execution, signature, or acceptance semantics.

## ledgerAttachment Linkage
Generated lease PDFs now create deterministic `ledgerAttachments` documents keyed by snapshot and tenant. The attachment includes:
- `category: "Lease"`
- `purpose: "LEASE"`
- `purposeLabel: "Lease"`
- `tenantId`, `landlordId`, `draftId`, `leaseSnapshotId`
- `leaseId` when available
- `propertyId` and `unitId` when present on the draft
- generated file URL, file name, source, SHA, and size metadata when available

The tenant document workspace already reads `ledgerAttachments`, so generated lease PDFs become visible through the existing vault path.

## documentUrl Linkage
Activated leases now receive the latest generated draft PDF URL in existing supported fields:
- `documentUrl`
- `approvedDocumentUrl`
- `documentRef`

The tenant lease/profile projections already use those fields, so the tenant profile rental record can show `Available` instead of `Not shared yet` after a valid generated document is linked.

## Tests Run
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/leaseDraftRoutes.test.ts` in `rentchain-api` (outside sandbox because Supertest binds a local listener)
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/tenantPortalRoutes.test.ts src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts` in `rentchain-api`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:single -- src/pages/tenant/TenantProfileCommunicationsPages.test.tsx src/pages/tenant/TenantAttachmentsPage.test.tsx` in `rentchain-frontend`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run build` in `rentchain-api`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build` in `rentchain-frontend`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run test:light` in `rentchain-api` (outside sandbox because route tests bind local listeners)
- `git diff --check`

## Remaining Risks
- Inline PDF responses without an HTTPS uploaded file are not linked into the vault, because there is no durable tenant-safe URL to show.
- Existing historical generated PDFs are not backfilled; this is read/write linkage for new generation or activation flows only.
- The backend Schedule A PDF generator and frontend lease summary PDF generator remain separate systems.

## Future Architecture Follow-up Notes
Track separately, not in this PR:
- `strategy/canonical-lease-document-generation-readiness-v1`
- `feat/canonical-lease-document-orchestration-v1`

## Out of Scope
No e-signature workflow, lease execution redesign, PDF template consolidation, PDF layout redesign, automatic PDF generation during lease creation, document vault redesign, payments changes, package/lockfile changes, migrations/backfills, or screening/provider changes.