### PR TITLE
Fix tenant document workspace lease attachment lookup

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -450,7 +450,7 @@ describe("tenantPortalRoutes foundation", () => {
           id: "user-1",
           email: "tenant@example.com",
           role: "tenant",
-          tenantId: "tenant-1",
+          tenantId: "auth-tenant-claim",
         }),
       },
     });
@@ -2962,6 +2962,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body?.data)).toBe(true);
     expect(res.body?.summary?.total).toBeGreaterThan(0);
+    expect(res.body?.summary?.uploaded).toBeGreaterThanOrEqual(2);
     expect(res.body?.summary?.pendingReview).toBeTypeOf("number");
     expect(res.body?.guidance?.headline).toBeTypeOf("string");
     expect(res.body?.data?.[0]?.internalNotes).toBeUndefined();
@@ -2972,6 +2973,15 @@ describe("tenantPortalRoutes foundation", () => {
           category: "Lease",
           fileName: "schedule-a-v1.pdf",
           url: "https://example.com/generated-lease.pdf",
+        }),
+      ])
+    );
+    expect(res.body?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Government ID",
+          fileName: "id-card.pdf",
+          url: "https://example.com/id-card.pdf",
         }),
       ])
     );

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -6226,7 +6226,7 @@ router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res)
   if (!context) return;
 
   try {
-    const tenantId = req.user?.tenantId;
+    const tenantId = String(context.tenantId || "").trim();
     if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
 
     const [snap, profile] = await Promise.all([
@@ -6255,7 +6255,7 @@ router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res)
     });
   } catch (err) {
     console.error("[tenant/attachments] failed", {
-      tenantId: req.user?.tenantId,
+      tenantId: context.tenantId,
       err: (err as any)?.message,
       code: (err as any)?.code,
     });


### PR DESCRIPTION
## Summary
- Align `/tenant/attachments` with the server-resolved canonical tenancy context when querying `ledgerAttachments`.
- Keep `buildTenantDocumentWorkspace()` unchanged; it already displays returned lease attachments correctly.
- Extend tenant portal attachment coverage to reproduce an auth-claim tenant ID mismatch while still returning the generated lease PDF attachment and existing non-lease attachments.

## Root Cause
PR #892 created generated lease PDF `ledgerAttachments` using the canonical tenant ID from the lease draft. The tenant document workspace endpoint resolved the canonical tenancy context, but then queried `ledgerAttachments` using `req.user.tenantId`. When the tenant auth claim ID differed from the canonical tenant document ID, the generated lease attachment existed but was not returned to the workspace projection.

## TenantId Alignment
`/tenant/attachments` now queries attachments with `context.tenantId`, the same server-side canonical tenant ID produced by `resolveTenancyContext()`. Authorization remains handled by `requireTenantWorkspaceIdentity` plus `resolveWorkspaceContextOrRespond()`.

## Required Attachment Fields
No change was needed to PR #892 attachment creation. The generated lease attachment already stores the required fields: `tenantId`, `landlordId`, `leaseId` when available, `draftId`, `leaseSnapshotId`, `propertyId`, `unitId`, `purpose: "LEASE"`, `purposeLabel: "Lease"`, `category: "Lease"`, `title: "Lease document"`, `fileName`, `url`, and `source: "lease_pdf_generation"`.

## Files Changed
- `rentchain-api/src/routes/tenantPortalRoutes.ts`
- `rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts`

## Tests Run
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/tenantPortalRoutes.test.ts`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/leaseDraftRoutes.test.ts` (outside sandbox because Supertest binds a local listener)
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run build`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run test:light` (outside sandbox because route tests bind local listeners)
- `git diff --check`

## Remaining Risks
- Existing historical generated lease PDFs are not backfilled.
- This only fixes tenant workspace retrieval for already-created `ledgerAttachments`; any missing production attachment records still require regenerating/linking through the existing generation flow or a separately approved mission.
- Direct lease creation and draft activation document reference linkage remain follow-up work in `fix/draft-activation-document-reference-linkage-v1`.

## Out of Scope
No document vault redesign, PDF template/layout work, PDF system consolidation, e-signature workflow, execution/signature semantics changes, payments changes, tenant identity refactor, migrations/backfills, package/lockfile changes, direct/draft activation document linkage changes, or broad logging changes.