### PR TITLE
Link draft activation to generated lease documents

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -178,6 +178,18 @@ describe("lease draft routes", () => {
     expect(generateRes.body?.ok).toBe(true);
     expect(generateRes.body?.scheduleAUrl).toContain("https://example.invalid");
     expect(String(generateRes.body?.snapshotId || "")).toBeTruthy();
+    const generatedSnapshot = store.get("leaseSnapshots")?.get(String(generateRes.body?.snapshotId || ""))?.data;
+    expect(generatedSnapshot).toEqual(
+      expect.objectContaining({
+        draftId,
+        sourceDraftId: draftId,
+        generatedFiles: [
+          expect.objectContaining({
+            url: "https://example.invalid/schedule-a.pdf",
+          }),
+        ],
+      })
+    );
 
     const attachmentDocsAfterGenerate = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
     expect(attachmentDocsAfterGenerate).toEqual([
@@ -217,6 +229,130 @@ describe("lease draft routes", () => {
       })
     );
   }, 30000);
+
+  it("activates a draft using the latest durable generated snapshot when the draft pointer is missing", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    const draftId = "draft_without_pointer";
+    await fakeDb.collection("leaseDrafts").doc(draftId).set({
+      ...payload,
+      landlordId: "landlord-1",
+      status: "generated",
+      updatedAt: 100,
+    });
+    await fakeDb.collection("leaseSnapshots").doc("snapshot-old").set({
+      ...payload,
+      landlordId: "landlord-1",
+      draftId,
+      sourceDraftId: draftId,
+      generatedAt: 100,
+      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/old-schedule-a.pdf" }],
+    });
+    await fakeDb.collection("leaseSnapshots").doc("snapshot-new").set({
+      ...payload,
+      landlordId: "landlord-1",
+      draftId,
+      sourceDraftId: draftId,
+      generatedAt: 200,
+      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/new-schedule-a.pdf" }],
+    });
+
+    const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    expect(activateRes.status).toBe(200);
+    expect(activateRes.body?.lease).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://example.invalid/new-schedule-a.pdf",
+        approvedDocumentUrl: "https://example.invalid/new-schedule-a.pdf",
+        documentRef: "https://example.invalid/new-schedule-a.pdf",
+        latestLeaseSnapshotId: "snapshot-new",
+      })
+    );
+
+    const attachmentDocs = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
+    expect(attachmentDocs).toHaveLength(1);
+    expect(attachmentDocs[0]).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        leaseId: String(activateRes.body?.leaseId || ""),
+        draftId,
+        leaseSnapshotId: "snapshot-new",
+        category: "Lease",
+        purpose: "LEASE",
+        purposeLabel: "Lease",
+        title: "Lease document",
+        fileName: "schedule-a-v1.pdf",
+        url: "https://example.invalid/new-schedule-a.pdf",
+        source: "lease_pdf_generation",
+      })
+    );
+  });
+
+  it("repairs existing activated draft document linkage without duplicating the Lease attachment", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    const draftId = "draft_existing_lease";
+    const leaseId = "lease-existing";
+    await fakeDb.collection("leaseDrafts").doc(draftId).set({
+      ...payload,
+      landlordId: "landlord-1",
+      leaseId,
+      status: "active",
+    });
+    await fakeDb.collection("leases").doc(leaseId).set({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+      sourceDraftId: draftId,
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+    });
+    await fakeDb.collection("leaseSnapshots").doc("snapshot-existing").set({
+      ...payload,
+      landlordId: "landlord-1",
+      draftId,
+      sourceDraftId: draftId,
+      generatedAt: 300,
+      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/existing-schedule-a.pdf" }],
+    });
+
+    const firstRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    expect(firstRes.status).toBe(200);
+    expect(firstRes.body?.leaseId).toBe(leaseId);
+    expect(firstRes.body?.lease).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://example.invalid/existing-schedule-a.pdf",
+        approvedDocumentUrl: "https://example.invalid/existing-schedule-a.pdf",
+        documentRef: "https://example.invalid/existing-schedule-a.pdf",
+        latestLeaseSnapshotId: "snapshot-existing",
+      })
+    );
+
+    const secondRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    expect(secondRes.status).toBe(200);
+    expect(secondRes.body?.leaseId).toBe(leaseId);
+
+    const attachmentDocs = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
+    expect(attachmentDocs).toHaveLength(1);
+    expect(attachmentDocs[0]).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        leaseId,
+        draftId,
+        leaseSnapshotId: "snapshot-existing",
+        category: "Lease",
+        url: "https://example.invalid/existing-schedule-a.pdf",
+      })
+    );
+  });
 
   it("returns inline PDF when storage upload is unavailable", async () => {
     vi.spyOn(leaseDraftsService, "generateScheduleA").mockResolvedValueOnce({

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -654,6 +654,90 @@ function firstGeneratedLeasePdfFile(generatedFiles: any[]): any | null {
   );
 }
 
+type GeneratedLeaseDocument = {
+  url: string;
+  snapshotId: string | null;
+  file: any;
+};
+
+async function loadGeneratedLeaseDocumentForDraft(draftId: string, draft: any): Promise<GeneratedLeaseDocument | null> {
+  const normalizedDraftId = String(draftId || "").trim();
+  if (!normalizedDraftId) return null;
+
+  const candidates: Array<GeneratedLeaseDocument & { generatedAt: number }> = [];
+  const seenSnapshotIds = new Set<string>();
+
+  const addCandidate = (snapshotId: string | null, file: any, generatedAt: number) => {
+    const leaseFile = firstGeneratedLeasePdfFile([file]);
+    const url = String(leaseFile?.url || "").trim();
+    if (!url.startsWith("https://")) return;
+    candidates.push({
+      url,
+      snapshotId: snapshotId || null,
+      file: leaseFile,
+      generatedAt: Number(generatedAt || 0) || 0,
+    });
+  };
+
+  const loadSnapshot = async (snapshotId: string | null) => {
+    const normalizedSnapshotId = String(snapshotId || "").trim();
+    if (!normalizedSnapshotId || seenSnapshotIds.has(normalizedSnapshotId)) return;
+    seenSnapshotIds.add(normalizedSnapshotId);
+    const snapshotSnap = await db.collection("leaseSnapshots").doc(normalizedSnapshotId).get().catch(() => null as any);
+    if (!snapshotSnap?.exists) return;
+    const snapshot = (snapshotSnap.data() as any) || {};
+    const generatedFiles = Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : [];
+    const leaseFile = firstGeneratedLeasePdfFile(generatedFiles);
+    if (!leaseFile) return;
+    addCandidate(
+      normalizedSnapshotId,
+      leaseFile,
+      Number(snapshot?.generatedAt || snapshot?.createdAt || snapshot?.updatedAt || 0)
+    );
+  };
+
+  await loadSnapshot(String(draft?.lastGeneratedSnapshotId || "").trim() || null);
+  await loadSnapshot(String(draft?.latestLeaseSnapshotId || "").trim() || null);
+
+  const directUrl = String(draft?.lastGeneratedDocumentUrl || draft?.documentUrl || draft?.approvedDocumentUrl || draft?.documentRef || "").trim();
+  if (directUrl.startsWith("https://")) {
+    addCandidate(
+      String(draft?.lastGeneratedSnapshotId || draft?.latestLeaseSnapshotId || "").trim() || null,
+      { kind: "schedule-a-pdf", url: directUrl },
+      Number(draft?.generatedAt || draft?.updatedAt || draft?.createdAt || 0)
+    );
+  }
+
+  const queryGeneratedSnapshots = async (field: string) => {
+    const snap = await db.collection("leaseSnapshots").where(field, "==", normalizedDraftId).get().catch(() => null as any);
+    const docs = Array.isArray(snap?.docs) ? snap.docs : [];
+    for (const doc of docs) {
+      if (!doc?.id || seenSnapshotIds.has(doc.id)) continue;
+      seenSnapshotIds.add(doc.id);
+      const snapshot = (doc.data() as any) || {};
+      const leaseFile = firstGeneratedLeasePdfFile(Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : []);
+      if (!leaseFile) continue;
+      addCandidate(
+        doc.id,
+        leaseFile,
+        Number(snapshot?.generatedAt || snapshot?.createdAt || snapshot?.updatedAt || 0)
+      );
+    }
+  };
+
+  await queryGeneratedSnapshots("sourceDraftId");
+  await queryGeneratedSnapshots("draftId");
+
+  candidates.sort((left, right) => right.generatedAt - left.generatedAt);
+  const latest = candidates[0];
+  if (!latest) return null;
+  return {
+    url: latest.url,
+    snapshotId: latest.snapshotId,
+    file: latest.file,
+  };
+}
+
 function safeAttachmentDocumentId(parts: string[]) {
   return parts
     .map((part) => String(part || "").trim().replace(/[^A-Za-z0-9_-]+/g, "_"))
@@ -1774,6 +1858,8 @@ router.post("/drafts/:id/generate", requireLandlord, async (req: any, res: Respo
     const generatedFiles = [file];
     const snapshotDoc = {
       ...draft,
+      draftId: id,
+      sourceDraftId: id,
       status: "generated",
       generatedAt: now,
       generatedFiles,
@@ -1883,6 +1969,36 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       return res.status(400).json({ ok: false, error: "payment_method_required" });
     }
 
+    const generatedLeaseDocument = await loadGeneratedLeaseDocumentForDraft(draftId, draft);
+
+    if (String(draft?.leaseId || "").trim()) {
+      const existingLeaseId = String(draft.leaseId).trim();
+      const existingLeaseSnap = await db.collection("leases").doc(existingLeaseId).get();
+      if (existingLeaseSnap.exists) {
+        if (generatedLeaseDocument) {
+          await linkGeneratedLeasePdfToTenantWorkspace({
+            draft: { ...draft, leaseId: existingLeaseId },
+            draftId,
+            landlordId,
+            snapshotId: generatedLeaseDocument.snapshotId || `activated_${existingLeaseId}`,
+            file: generatedLeaseDocument.file,
+            actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
+          });
+          const repairedLeaseSnap = await db.collection("leases").doc(existingLeaseId).get();
+          return res.status(200).json({
+            ok: true,
+            leaseId: existingLeaseId,
+            lease: { id: existingLeaseId, ...(repairedLeaseSnap.data() as any) },
+          });
+        }
+        return res.status(200).json({
+          ok: true,
+          leaseId: existingLeaseId,
+          lease: { id: existingLeaseId, ...(existingLeaseSnap.data() as any) },
+        });
+      }
+    }
+
     const conflicts = await assertNoConflictingActiveAgreement({
       landlordId,
       propertyId,
@@ -1894,18 +2010,6 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
     });
     if (conflicts.length) {
       return res.status(409).json({ ok: false, error: "conflicting_active_lease_agreement", conflictLeaseIds: conflicts.map((entry: any) => entry.lease.id) });
-    }
-
-    if (String(draft?.leaseId || "").trim()) {
-      const existingLeaseId = String(draft.leaseId).trim();
-      const existingLeaseSnap = await db.collection("leases").doc(existingLeaseId).get();
-      if (existingLeaseSnap.exists) {
-        return res.status(200).json({
-          ok: true,
-          leaseId: existingLeaseId,
-          lease: { id: existingLeaseId, ...(existingLeaseSnap.data() as any) },
-        });
-      }
     }
 
     const now = Date.now();
@@ -1955,28 +2059,22 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       createdAt: now,
       updatedAt: now,
     };
-    const draftDocumentUrl = await loadLeaseDocumentUrlForLease({ sourceDraftId: draftId });
-    if (draftDocumentUrl) {
-      leaseRecord.documentUrl = draftDocumentUrl;
-      leaseRecord.approvedDocumentUrl = draftDocumentUrl;
-      leaseRecord.documentRef = draftDocumentUrl;
+    if (generatedLeaseDocument) {
+      leaseRecord.documentUrl = generatedLeaseDocument.url;
+      leaseRecord.approvedDocumentUrl = generatedLeaseDocument.url;
+      leaseRecord.documentRef = generatedLeaseDocument.url;
       leaseRecord.documentGeneratedAt = now;
       leaseRecord.leaseDocumentGeneratedAt = now;
-      leaseRecord.latestLeaseSnapshotId = String(draft?.lastGeneratedSnapshotId || "").trim() || null;
+      leaseRecord.latestLeaseSnapshotId = generatedLeaseDocument.snapshotId;
     }
     await leaseRef.set(leaseRecord, { merge: false });
-    if (draftDocumentUrl) {
-      const snapshotId = String(draft?.lastGeneratedSnapshotId || "").trim();
-      const generatedFile = {
-        kind: "schedule-a-pdf",
-        url: draftDocumentUrl,
-      };
+    if (generatedLeaseDocument) {
       await linkGeneratedLeasePdfToTenantWorkspace({
         draft: { ...draft, leaseId: leaseRef.id },
         draftId,
         landlordId,
-        snapshotId: snapshotId || `activated_${leaseRef.id}`,
-        file: generatedFile,
+        snapshotId: generatedLeaseDocument.snapshotId || `activated_${leaseRef.id}`,
+        file: generatedLeaseDocument.file,
         actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
       });
     }


### PR DESCRIPTION
## Summary
- Resolve the latest durable generated Schedule A PDF for a lease draft during activation, even when `lastGeneratedSnapshotId` is missing.
- Carry that durable PDF URL onto activated leases via existing fields: `documentUrl`, `approvedDocumentUrl`, `documentRef`, and `latestLeaseSnapshotId`.
- Reuse the existing Lease `ledgerAttachments` linkage helper so tenant document workspace visibility is populated without changing vault projection behavior.
- Repair the existing-lease activation retry path so a draft with `leaseId` can still backfill document references and the Lease attachment without duplicating attachments.

## Root Cause
Draft activation previously depended on `leaseDrafts.lastGeneratedSnapshotId` to locate the generated document. If a draft retained `sourceDraftId` on the activated lease but lacked that generated snapshot pointer, activation could create an active lease with no `documentUrl`, `approvedDocumentUrl`, `documentRef`, `latestLeaseSnapshotId`, or Lease `ledgerAttachment`. The existing retry path for drafts with `leaseId` returned before attempting document linkage repair.

## Durable URL Source Used
Activation now resolves generated documents from:
- explicit draft snapshot pointers: `lastGeneratedSnapshotId` and `latestLeaseSnapshotId`;
- durable draft URL fields already present on the draft;
- matching `leaseSnapshots` rows by `sourceDraftId` or `draftId`, choosing the newest generated snapshot by timestamp.

Only durable `https://` generated PDF URLs are eligible. Inline PDF output remains unlinked because it is not a durable tenant-safe document URL.

## Activation Linkage Behavior
When a durable generated PDF is found, activation writes existing lease document fields:
- `documentUrl`
- `approvedDocumentUrl`
- `documentRef`
- `documentGeneratedAt`
- `leaseDocumentGeneratedAt`
- `latestLeaseSnapshotId`

It then calls the existing Lease attachment linkage helper to create/update the tenant-visible `ledgerAttachments` record.

## LedgerAttachment Idempotency
The linkage helper uses the deterministic attachment ID based on `lease`, snapshot ID, and tenant ID. Repeated activation/repair for the same generated snapshot updates the same Lease attachment instead of creating duplicates.

## Files Changed
- `rentchain-api/src/routes/leaseRoutes.ts`
- `rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts`

## Tests Run
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/leaseDraftRoutes.test.ts` (outside sandbox because Supertest binds a local listener)
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm test -- --run src/routes/__tests__/tenantPortalRoutes.test.ts src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run build`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.11.1/bin:$PATH npm run test:light` (first run had one unrelated timeout in `leaseRoutes.integrity.test.ts`; targeted rerun passed; second full run passed: 349 files / 1554 tests)
- `git diff --check`

## Remaining Risks
- No historical backfill is performed; activation/retry must run after this patch to repair an existing draft-linked lease.
- If no durable generated PDF URL exists in the draft or related `leaseSnapshots`, no document fields or Lease attachment are created.
- Direct lease creation remains out of scope and still does not auto-generate or link lease PDFs.
- Duplicate lease document attachments remain follow-up work in `fix/lease-document-attachment-deduplication-v1`.
- Lease signing state semantics cleanup remains follow-up work in `fix/lease-signing-state-semantics-v1`.

## Out of Scope
No direct lease PDF auto-generation, PDF system consolidation, document vault redesign, e-signature workflow, historical backfill, payments changes, package/lockfile changes, attachment deduplication cleanup, signing semantics cleanup, or broad lease lifecycle redesign.