### PR TITLE
[codex] Fix lease document attachment dedupe

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -275,6 +275,55 @@ describe("lease draft routes", () => {
     );
   });
 
+  it("updates a legacy same-url Lease attachment instead of creating a visible duplicate", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    await fakeDb.collection("ledgerAttachments").doc("legacy-same-url-lease").set({
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      ledgerItemId: "legacy-ledger-item",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.invalid/schedule-a.pdf",
+      createdAt: 100,
+      source: "lease_pdf_generation",
+    });
+
+    const createRes = await request(app).post("/drafts").set(auth).send(payload);
+    expect(createRes.status).toBe(201);
+    const draftId = String(createRes.body?.draftId || "");
+
+    const generateRes = await request(app)
+      .post(`/drafts/${encodeURIComponent(draftId)}/generate`)
+      .set(auth)
+      .send({
+        tenantNames: ["Tenant One"],
+        propertyAddress: "123 Main St, Halifax, NS",
+        unitLabel: "Unit 2A",
+      });
+    expect(generateRes.status).toBe(201);
+
+    const attachmentDocs = Array.from(store.get("ledgerAttachments")?.entries() || []);
+    expect(attachmentDocs).toHaveLength(1);
+    expect(attachmentDocs[0][0]).toBe("legacy-same-url-lease");
+    expect(attachmentDocs[0][1].data).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        leaseId: null,
+        draftId,
+        category: "Lease",
+        purpose: "LEASE",
+        url: "https://example.invalid/schedule-a.pdf",
+      })
+    );
+  });
+
   it("activates a draft using the latest durable generated snapshot when the draft pointer is missing", async () => {
     const router = (await import("../leaseRoutes")).default;
     const app = express();

--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -230,6 +230,51 @@ describe("lease draft routes", () => {
     );
   }, 30000);
 
+  it("updates one visible Lease attachment across repeated draft PDF generation", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    const createRes = await request(app).post("/drafts").set(auth).send(payload);
+    expect(createRes.status).toBe(201);
+    const draftId = String(createRes.body?.draftId || "");
+
+    const firstGenerateRes = await request(app)
+      .post(`/drafts/${encodeURIComponent(draftId)}/generate`)
+      .set(auth)
+      .send({
+        tenantNames: ["Tenant One"],
+        propertyAddress: "123 Main St, Halifax, NS",
+        unitLabel: "Unit 2A",
+      });
+    expect(firstGenerateRes.status).toBe(201);
+
+    const secondGenerateRes = await request(app)
+      .post(`/drafts/${encodeURIComponent(draftId)}/generate`)
+      .set(auth)
+      .send({
+        tenantNames: ["Tenant One"],
+        propertyAddress: "123 Main St, Halifax, NS",
+        unitLabel: "Unit 2A",
+      });
+    expect(secondGenerateRes.status).toBe(201);
+
+    const attachmentDocs = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
+    expect(attachmentDocs).toHaveLength(1);
+    expect(attachmentDocs[0]).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        leaseId: null,
+        draftId,
+        leaseSnapshotId: String(secondGenerateRes.body?.snapshotId || ""),
+        category: "Lease",
+        purpose: "LEASE",
+        url: "https://example.invalid/schedule-a.pdf",
+      })
+    );
+  });
+
   it("activates a draft using the latest durable generated snapshot when the draft pointer is missing", async () => {
     const router = (await import("../leaseRoutes")).default;
     const app = express();
@@ -336,6 +381,15 @@ describe("lease draft routes", () => {
       })
     );
 
+    await fakeDb.collection("leaseSnapshots").doc("snapshot-existing-new").set({
+      ...payload,
+      landlordId: "landlord-1",
+      draftId,
+      sourceDraftId: draftId,
+      generatedAt: 400,
+      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/existing-schedule-a-new.pdf" }],
+    });
+
     const secondRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
     expect(secondRes.status).toBe(200);
     expect(secondRes.body?.leaseId).toBe(leaseId);
@@ -347,9 +401,9 @@ describe("lease draft routes", () => {
         tenantId: "tenant-1",
         leaseId,
         draftId,
-        leaseSnapshotId: "snapshot-existing",
+        leaseSnapshotId: "snapshot-existing-new",
         category: "Lease",
-        url: "https://example.invalid/existing-schedule-a.pdf",
+        url: "https://example.invalid/existing-schedule-a-new.pdf",
       })
     );
   });

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -2992,6 +2992,69 @@ describe("tenantPortalRoutes foundation", () => {
     ).toBe(true);
   });
 
+  it("dedupes duplicate visible Lease attachments in the tenant document vault", async () => {
+    ensureCollection("ledgerAttachments").set("lease-generated-old", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      draftId: "draft-1",
+      leaseSnapshotId: "snapshot-old",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      ledgerItemId: "lease-1",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.com/generated-lease-old.pdf",
+      createdAt: 600,
+      source: "lease_pdf_generation",
+    });
+    ensureCollection("ledgerAttachments").set("lease-generated-new", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      draftId: "draft-1",
+      leaseSnapshotId: "snapshot-new",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      ledgerItemId: "lease-1",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.com/generated-lease-new.pdf",
+      createdAt: 700,
+      source: "lease_pdf_generation",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/attachments",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const visibleLeaseItems = res.body?.data?.filter((item: any) => item.category === "Lease" && item.purpose === "LEASE");
+    expect(visibleLeaseItems).toHaveLength(1);
+    expect(visibleLeaseItems[0]).toEqual(
+      expect.objectContaining({
+        fileName: "schedule-a-v1.pdf",
+        url: "https://example.com/generated-lease-new.pdf",
+      })
+    );
+  });
+
   it("rejects unauthorized tenant attachments access", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -3047,6 +3047,23 @@ describe("tenantPortalRoutes foundation", () => {
       createdAt: 700,
       source: "lease_pdf_generation",
     });
+    ensureCollection("ledgerAttachments").set("lease-generated-lease-only", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      leaseSnapshotId: "snapshot-lease-only",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      ledgerItemId: "lease-1",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.com/generated-lease-current.pdf",
+      createdAt: 800,
+      source: "lease_pdf_generation",
+    });
 
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {
@@ -3068,7 +3085,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(visibleLeaseItems[0]).toEqual(
       expect.objectContaining({
         fileName: "schedule-a-v1.pdf",
-        url: "https://example.com/generated-lease-new.pdf",
+        url: "https://example.com/generated-lease-current.pdf",
       })
     );
     expect(res.body?.summary).toEqual(

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -2993,6 +2993,24 @@ describe("tenantPortalRoutes foundation", () => {
   });
 
   it("dedupes duplicate visible Lease attachments in the tenant document vault", async () => {
+    ensureCollection("ledgerAttachments").set("lease-generated-draft-only", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: null,
+      draftId: "draft-1",
+      leaseSnapshotId: "snapshot-draft",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      ledgerItemId: "leaseDraft:draft-1",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.com/generated-lease-draft.pdf",
+      createdAt: 500,
+      source: "lease_pdf_generation",
+    });
     ensureCollection("ledgerAttachments").set("lease-generated-old", {
       tenantId: "tenant-1",
       landlordId: "landlord-1",
@@ -3052,6 +3070,21 @@ describe("tenantPortalRoutes foundation", () => {
         fileName: "schedule-a-v1.pdf",
         url: "https://example.com/generated-lease-new.pdf",
       })
+    );
+    expect(res.body?.summary).toEqual(
+      expect.objectContaining({
+        total: 2,
+        uploaded: 2,
+      })
+    );
+    expect(res.body?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Government ID",
+          fileName: "id-card.pdf",
+          url: "https://example.com/id-card.pdf",
+        }),
+      ])
     );
   });
 

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -758,10 +758,12 @@ async function resolveLeaseAttachmentRef(params: {
   tenantId: string;
   leaseId: string | null;
   draftId: string;
+  url: string;
 }) {
   const tenantId = String(params.tenantId || "").trim();
   const leaseId = String(params.leaseId || "").trim();
   const draftId = String(params.draftId || "").trim();
+  const url = String(params.url || "").trim();
 
   const existingSnap = await db
     .collection("ledgerAttachments")
@@ -776,8 +778,12 @@ async function resolveLeaseAttachmentRef(params: {
     if (!isVisibleLeaseAttachment(data)) return false;
     const candidateLeaseId = String(data?.leaseId || "").trim();
     const candidateDraftId = String(data?.draftId || "").trim();
+    const candidateLedgerItemId = String(data?.ledgerItemId || "").trim();
+    const candidateUrl = String(data?.url || "").trim();
     if (leaseId && candidateLeaseId === leaseId) return true;
+    if (leaseId && candidateLedgerItemId === leaseId) return true;
     if (draftId && candidateDraftId === draftId) return true;
+    if (url && candidateUrl === url) return true;
     return false;
   });
 
@@ -838,6 +844,7 @@ async function linkGeneratedLeasePdfToTenantWorkspace(params: {
         tenantId,
         leaseId,
         draftId: params.draftId,
+        url,
       });
       await attachmentRef.set(
         {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -746,6 +746,54 @@ function safeAttachmentDocumentId(parts: string[]) {
     .slice(0, 240);
 }
 
+function isVisibleLeaseAttachment(raw: any): boolean {
+  const category = String(raw?.category || "").trim().toLowerCase();
+  const purpose = String(raw?.purpose || "").trim().toUpperCase();
+  const purposeLabel = String(raw?.purposeLabel || "").trim().toLowerCase();
+  const title = String(raw?.title || "").trim().toLowerCase();
+  return category === "lease" || purpose === "LEASE" || purposeLabel === "lease" || title === "lease document";
+}
+
+async function resolveLeaseAttachmentRef(params: {
+  tenantId: string;
+  leaseId: string | null;
+  draftId: string;
+}) {
+  const tenantId = String(params.tenantId || "").trim();
+  const leaseId = String(params.leaseId || "").trim();
+  const draftId = String(params.draftId || "").trim();
+
+  const existingSnap = await db
+    .collection("ledgerAttachments")
+    .where("tenantId", "==", tenantId)
+    .limit(50)
+    .get()
+    .catch(() => null as any);
+
+  const existingDocs = Array.isArray(existingSnap?.docs) ? existingSnap.docs : [];
+  const matchingDoc = existingDocs.find((doc: any) => {
+    const data = (doc.data() as any) || {};
+    if (!isVisibleLeaseAttachment(data)) return false;
+    const candidateLeaseId = String(data?.leaseId || "").trim();
+    const candidateDraftId = String(data?.draftId || "").trim();
+    if (leaseId && candidateLeaseId === leaseId) return true;
+    if (draftId && candidateDraftId === draftId) return true;
+    return false;
+  });
+
+  if (matchingDoc?.id) {
+    return db.collection("ledgerAttachments").doc(matchingDoc.id);
+  }
+
+  const attachmentId = safeAttachmentDocumentId([
+    "lease",
+    tenantId,
+    leaseId || draftId,
+    "LEASE",
+  ]);
+  return db.collection("ledgerAttachments").doc(attachmentId);
+}
+
 async function linkGeneratedLeasePdfToTenantWorkspace(params: {
   draft: any;
   draftId: string;
@@ -786,39 +834,36 @@ async function linkGeneratedLeasePdfToTenantWorkspace(params: {
 
   await Promise.all(
     tenantIds.map(async (tenantId: string) => {
-      const attachmentId = safeAttachmentDocumentId([
-        "lease",
-        params.snapshotId,
+      const attachmentRef = await resolveLeaseAttachmentRef({
         tenantId,
-      ]);
-      await db
-        .collection("ledgerAttachments")
-        .doc(attachmentId)
-        .set(
-          {
-            landlordId: params.landlordId,
-            tenantId,
-            leaseId,
-            draftId: params.draftId,
-            leaseSnapshotId: params.snapshotId,
-            propertyId,
-            unitId,
-            ledgerItemId: leaseId || `leaseDraft:${params.draftId}`,
-            url,
-            title: "Lease document",
-            fileName,
-            category: "Lease",
-            purpose: "LEASE",
-            purposeLabel: "Lease",
-            source: "lease_pdf_generation",
-            generatedFileKind: String(params.file?.kind || "schedule-a-pdf"),
-            sha256: String(params.file?.sha256 || "").trim() || null,
-            sizeBytes: Number(params.file?.sizeBytes || 0) || null,
-            createdAt: now,
-            createdBy: params.actorId,
-          },
-          { merge: true }
-        );
+        leaseId,
+        draftId: params.draftId,
+      });
+      await attachmentRef.set(
+        {
+          landlordId: params.landlordId,
+          tenantId,
+          leaseId,
+          draftId: params.draftId,
+          leaseSnapshotId: params.snapshotId,
+          propertyId,
+          unitId,
+          ledgerItemId: leaseId || `leaseDraft:${params.draftId}`,
+          url,
+          title: "Lease document",
+          fileName,
+          category: "Lease",
+          purpose: "LEASE",
+          purposeLabel: "Lease",
+          source: "lease_pdf_generation",
+          generatedFileKind: String(params.file?.kind || "schedule-a-pdf"),
+          sha256: String(params.file?.sha256 || "").trim() || null,
+          sizeBytes: Number(params.file?.sizeBytes || 0) || null,
+          createdAt: now,
+          createdBy: params.actorId,
+        },
+        { merge: true }
+      );
     })
   );
 }

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2771,14 +2771,27 @@ function visibleLeaseDocumentDedupeKeys(raw: any): string[] {
 }
 
 function dedupeTenantVisibleLeaseAttachments(attachments: any[]): any[] {
-  const seen = new Set<string>();
-  return attachments.filter((item) => {
+  const output: any[] = [];
+  const leaseKeySets: Set<string>[] = [];
+
+  attachments.forEach((item) => {
     const keys = visibleLeaseDocumentDedupeKeys(item);
-    if (!keys.length) return true;
-    if (keys.some((key) => seen.has(key))) return false;
-    keys.forEach((key) => seen.add(key));
-    return true;
+    if (!keys.length) {
+      output.push(item);
+      return;
+    }
+
+    const existingIndex = leaseKeySets.findIndex((knownKeys) => keys.some((key) => knownKeys.has(key)));
+    if (existingIndex >= 0) {
+      keys.forEach((key) => leaseKeySets[existingIndex].add(key));
+      return;
+    }
+
+    output.push(item);
+    leaseKeySets.push(new Set(keys));
   });
+
+  return output;
 }
 
 function buildTenantDocumentWorkspace(params: {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2747,25 +2747,36 @@ function isVisibleLeaseDocumentAttachment(raw: any): boolean {
   return category === "lease" || purpose === "LEASE" || purposeLabel === "lease" || title === "lease document";
 }
 
-function visibleLeaseDocumentDedupeKey(raw: any): string | null {
-  if (!isVisibleLeaseDocumentAttachment(raw)) return null;
+function visibleLeaseDocumentDedupeKeys(raw: any): string[] {
+  if (!isVisibleLeaseDocumentAttachment(raw)) return [];
   const tenantId = String(raw?.tenantId || "").trim();
+  if (!tenantId) return [];
+
   const leaseId = String(raw?.leaseId || "").trim();
   const draftId = String(raw?.draftId || "").trim();
   const ledgerItemId = String(raw?.ledgerItemId || "").trim();
   const url = String(raw?.url || "").trim();
-  const visibleLeaseId = leaseId || draftId || ledgerItemId || url;
-  if (!tenantId || !visibleLeaseId) return null;
-  return [tenantId, visibleLeaseId, "LEASE"].join("|");
+  const sha256 = String(raw?.sha256 || "").trim();
+  const fileName = String(raw?.fileName || "").trim();
+  const keys = [
+    leaseId ? `${tenantId}|lease:${leaseId}|LEASE` : null,
+    draftId ? `${tenantId}|draft:${draftId}|LEASE` : null,
+    ledgerItemId ? `${tenantId}|ledger:${ledgerItemId}|LEASE` : null,
+    url ? `${tenantId}|url:${url}|LEASE` : null,
+    sha256 ? `${tenantId}|sha256:${sha256}|LEASE` : null,
+    !leaseId && !draftId && !ledgerItemId && !url && fileName ? `${tenantId}|file:${fileName}|LEASE` : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return keys.length ? keys : [`${tenantId}|unidentified|LEASE`];
 }
 
 function dedupeTenantVisibleLeaseAttachments(attachments: any[]): any[] {
   const seen = new Set<string>();
   return attachments.filter((item) => {
-    const key = visibleLeaseDocumentDedupeKey(item);
-    if (!key) return true;
-    if (seen.has(key)) return false;
-    seen.add(key);
+    const keys = visibleLeaseDocumentDedupeKeys(item);
+    if (!keys.length) return true;
+    if (keys.some((key) => seen.has(key))) return false;
+    keys.forEach((key) => seen.add(key));
     return true;
   });
 }

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2739,12 +2739,43 @@ function documentNextActionCopy(status: TenantDocumentStatus, nextAction: string
   }
 }
 
+function isVisibleLeaseDocumentAttachment(raw: any): boolean {
+  const category = String(raw?.category || "").trim().toLowerCase();
+  const purpose = String(raw?.purpose || "").trim().toUpperCase();
+  const purposeLabel = String(raw?.purposeLabel || "").trim().toLowerCase();
+  const title = String(raw?.title || "").trim().toLowerCase();
+  return category === "lease" || purpose === "LEASE" || purposeLabel === "lease" || title === "lease document";
+}
+
+function visibleLeaseDocumentDedupeKey(raw: any): string | null {
+  if (!isVisibleLeaseDocumentAttachment(raw)) return null;
+  const tenantId = String(raw?.tenantId || "").trim();
+  const leaseId = String(raw?.leaseId || "").trim();
+  const draftId = String(raw?.draftId || "").trim();
+  const ledgerItemId = String(raw?.ledgerItemId || "").trim();
+  const url = String(raw?.url || "").trim();
+  const visibleLeaseId = leaseId || draftId || ledgerItemId || url;
+  if (!tenantId || !visibleLeaseId) return null;
+  return [tenantId, visibleLeaseId, "LEASE"].join("|");
+}
+
+function dedupeTenantVisibleLeaseAttachments(attachments: any[]): any[] {
+  const seen = new Set<string>();
+  return attachments.filter((item) => {
+    const key = visibleLeaseDocumentDedupeKey(item);
+    if (!key) return true;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 function buildTenantDocumentWorkspace(params: {
   attachments: Array<any>;
   profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>;
 }) {
   const checklist = Array.isArray(params.profile?.identity?.documentChecklist) ? params.profile.identity.documentChecklist : [];
-  const attachments = Array.isArray(params.attachments) ? params.attachments : [];
+  const attachments = dedupeTenantVisibleLeaseAttachments(Array.isArray(params.attachments) ? params.attachments : []);
 
   const normalizedAttachmentMap = new Map<string, any[]>();
   attachments.forEach((item) => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -231,6 +231,10 @@ type TenantDocumentItem = {
   title: string | null;
   purpose: string | null;
   purposeLabel: string | null;
+  tenantId: string | null;
+  leaseId: string | null;
+  draftId: string | null;
+  ledgerItemId: string | null;
   url: string | null;
   uploadedAt: number | null;
   nextAction: string | null;
@@ -2753,21 +2757,10 @@ function visibleLeaseDocumentDedupeKeys(raw: any): string[] {
   if (!tenantId) return [];
 
   const leaseId = String(raw?.leaseId || "").trim();
-  const draftId = String(raw?.draftId || "").trim();
-  const ledgerItemId = String(raw?.ledgerItemId || "").trim();
-  const url = String(raw?.url || "").trim();
-  const sha256 = String(raw?.sha256 || "").trim();
-  const fileName = String(raw?.fileName || "").trim();
-  const keys = [
+  return [
+    `${tenantId}|lease:current|LEASE`,
     leaseId ? `${tenantId}|lease:${leaseId}|LEASE` : null,
-    draftId ? `${tenantId}|draft:${draftId}|LEASE` : null,
-    ledgerItemId ? `${tenantId}|ledger:${ledgerItemId}|LEASE` : null,
-    url ? `${tenantId}|url:${url}|LEASE` : null,
-    sha256 ? `${tenantId}|sha256:${sha256}|LEASE` : null,
-    !leaseId && !draftId && !ledgerItemId && !url && fileName ? `${tenantId}|file:${fileName}|LEASE` : null,
   ].filter((value): value is string => Boolean(value));
-
-  return keys.length ? keys : [`${tenantId}|unidentified|LEASE`];
 }
 
 function dedupeTenantVisibleLeaseAttachments(attachments: any[]): any[] {
@@ -2846,6 +2839,10 @@ function buildTenantDocumentWorkspace(params: {
       title: matchedAttachment?.title ? String(matchedAttachment.title) : null,
       purpose: matchedAttachment?.purpose ? String(matchedAttachment.purpose) : null,
       purposeLabel: matchedAttachment?.purposeLabel ? String(matchedAttachment.purposeLabel) : null,
+      tenantId: matchedAttachment?.tenantId ? String(matchedAttachment.tenantId) : null,
+      leaseId: matchedAttachment?.leaseId ? String(matchedAttachment.leaseId) : null,
+      draftId: matchedAttachment?.draftId ? String(matchedAttachment.draftId) : null,
+      ledgerItemId: matchedAttachment?.ledgerItemId ? String(matchedAttachment.ledgerItemId) : null,
       url: matchedAttachment?.url ? String(matchedAttachment.url) : null,
       uploadedAt: Number(matchedAttachment?.createdAt || 0) || null,
       nextAction: documentNextActionCopy(status, String(entry?.nextStep || ""), Boolean(matchedAttachment?.url)),
@@ -2869,6 +2866,10 @@ function buildTenantDocumentWorkspace(params: {
       title: item?.title ? String(item.title) : null,
       purpose: item?.purpose ? String(item.purpose) : null,
       purposeLabel: item?.purposeLabel ? String(item.purposeLabel) : null,
+      tenantId: item?.tenantId ? String(item.tenantId) : null,
+      leaseId: item?.leaseId ? String(item.leaseId) : null,
+      draftId: item?.draftId ? String(item.draftId) : null,
+      ledgerItemId: item?.ledgerItemId ? String(item.ledgerItemId) : null,
       url: item?.url ? String(item.url) : null,
       uploadedAt: Number(item?.createdAt || 0) || null,
       nextAction: "This file has been added to your record.",

--- a/rentchain-frontend/src/api/tenantAttachmentsApi.ts
+++ b/rentchain-frontend/src/api/tenantAttachmentsApi.ts
@@ -3,12 +3,15 @@ import { tenantApiFetch } from "./tenantApiFetch";
 export type TenantAttachment = {
   id: string;
   tenantId?: string | null;
+  leaseId?: string | null;
+  draftId?: string | null;
   ledgerItemId?: string | null;
   title?: string | null;
   url?: string | null;
   purpose?: string | null;
   purposeLabel?: string | null;
   fileName?: string | null;
+  sha256?: string | null;
   createdAt?: number | null;
   label?: string | null;
   category?: string | null;

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
@@ -89,4 +89,102 @@ describe("buildTenantDocumentVaultView", () => {
       }),
     ]);
   });
+
+  it("collapses duplicate visible Lease attachments before metrics and sections are assembled", () => {
+    const sourceItems = [
+      {
+        id: "lease-generated-draft",
+        tenantId: "tenant-1",
+        draftId: "draft-1",
+        ledgerItemId: "leaseDraft:draft-1",
+        label: "LEASE — Lease",
+        title: "Lease document",
+        category: "Lease",
+        purpose: "LEASE",
+        purposeLabel: "Lease",
+        fileName: "schedule-a-v1.pdf",
+        url: "https://example.com/lease-draft.pdf",
+        status: "uploaded" as const,
+        uploadedAt: 100,
+      },
+      {
+        id: "lease-generated-old",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        draftId: "draft-1",
+        ledgerItemId: "lease-1",
+        label: "LEASE — Lease",
+        title: "Lease document",
+        category: "Lease",
+        purpose: "LEASE",
+        purposeLabel: "Lease",
+        fileName: "schedule-a-v1.pdf",
+        url: "https://example.com/lease-old.pdf",
+        status: "uploaded" as const,
+        uploadedAt: 200,
+      },
+      {
+        id: "lease-generated-new",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        draftId: "draft-1",
+        ledgerItemId: "lease-1",
+        label: "LEASE — Lease",
+        title: "Lease document",
+        category: "Lease",
+        purpose: "LEASE",
+        purposeLabel: "Lease",
+        fileName: "schedule-a-v1.pdf",
+        url: "https://example.com/lease-new.pdf",
+        status: "uploaded" as const,
+        uploadedAt: 300,
+      },
+      {
+        id: "lease-generated-url",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        label: "LEASE — Lease",
+        title: "Lease document",
+        category: "Lease",
+        purpose: "LEASE",
+        purposeLabel: "Lease",
+        fileName: "schedule-a-v1.pdf",
+        url: "https://example.com/lease-url.pdf",
+        status: "uploaded" as const,
+        uploadedAt: 400,
+      },
+      {
+        id: "identity-doc",
+        tenantId: "tenant-1",
+        label: "Government ID",
+        title: "Government ID",
+        category: "Identity",
+        purpose: "identity",
+        purposeLabel: "Upload Id",
+        fileName: "id-card.pdf",
+        url: "https://example.com/id-card.pdf",
+        status: "uploaded" as const,
+        uploadedAt: 250,
+      },
+    ];
+
+    const result = buildTenantDocumentVaultView({
+      items: sourceItems,
+      summary: {
+        total: 5,
+        missing: 0,
+        uploaded: 5,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+    });
+
+    expect(sourceItems).toHaveLength(5);
+    expect(result.metrics.map((item) => item.value).slice(0, 3)).toEqual([2, 2, 0]);
+    expect(result.readyItems.map((item) => item.id)).toEqual(["lease-generated-url", "identity-doc"]);
+    expect(result.groupedItems.find((group) => group.category === "Lease")?.items).toHaveLength(1);
+    expect(result.groupedItems.find((group) => group.category === "Identity")?.items).toHaveLength(1);
+    expect(result.recentItems.map((item) => item.id)).toEqual(["lease-generated-url", "identity-doc"]);
+  });
 });

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
@@ -187,4 +187,65 @@ describe("buildTenantDocumentVaultView", () => {
     expect(result.groupedItems.find((group) => group.category === "Identity")?.items).toHaveLength(1);
     expect(result.recentItems.map((item) => item.id)).toEqual(["lease-generated-url", "identity-doc"]);
   });
+
+  it("collapses generated Lease rows that only differ by URL when lease metadata is absent", () => {
+    const result = buildTenantDocumentVaultView({
+      items: [
+        {
+          id: "lease-snapshot-1",
+          label: "LEASE — Lease",
+          title: "Lease document",
+          category: "Lease",
+          purpose: "LEASE",
+          purposeLabel: "Lease",
+          fileName: "schedule-a-v1.pdf",
+          url: "https://example.com/snapshot-1.pdf",
+          status: "uploaded",
+          uploadedAt: 100,
+        },
+        {
+          id: "lease-snapshot-2",
+          label: "LEASE — Lease",
+          title: "Lease document",
+          category: "Lease",
+          purpose: "LEASE",
+          purposeLabel: "Lease",
+          fileName: "schedule-a-v1.pdf",
+          url: "https://example.com/snapshot-2.pdf",
+          status: "uploaded",
+          uploadedAt: 200,
+        },
+        {
+          id: "lease-snapshot-3",
+          label: "LEASE — Lease",
+          title: "Lease document",
+          category: "Lease",
+          purpose: "LEASE",
+          purposeLabel: "Lease",
+          fileName: "schedule-a-v1.pdf",
+          url: "https://example.com/snapshot-3.pdf",
+          status: "uploaded",
+          uploadedAt: 300,
+        },
+        {
+          id: "lease-snapshot-4",
+          label: "LEASE — Lease",
+          title: "Lease document",
+          category: "Lease",
+          purpose: "LEASE",
+          purposeLabel: "Lease",
+          fileName: "schedule-a-v1.pdf",
+          url: "https://example.com/snapshot-4.pdf",
+          status: "uploaded",
+          uploadedAt: 400,
+        },
+      ],
+    });
+
+    expect(result.metrics.map((item) => item.value).slice(0, 3)).toEqual([1, 1, 0]);
+    expect(result.readyItems.map((item) => item.id)).toEqual(["lease-snapshot-4"]);
+    expect(result.groupedItems).toHaveLength(1);
+    expect(result.groupedItems[0].items.map((item) => item.id)).toEqual(["lease-snapshot-4"]);
+    expect(result.recentItems.map((item) => item.id)).toEqual(["lease-snapshot-4"]);
+  });
 });

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
@@ -52,20 +52,10 @@ function visibleLeaseKeys(item: TenantAttachment): string[] {
   if (!isVisibleLeaseAttachment(item)) return [];
   const tenantId = String(item.tenantId || "").trim() || "tenant";
   const leaseId = String(item.leaseId || "").trim();
-  const draftId = String(item.draftId || "").trim();
-  const ledgerItemId = String(item.ledgerItemId || "").trim();
-  const url = String(item.url || "").trim();
-  const sha256 = String(item.sha256 || "").trim();
-  const fileName = String(item.fileName || "").trim();
-  const keys = [
+  return [
+    `${tenantId}|lease:current|LEASE`,
     leaseId ? `${tenantId}|lease:${leaseId}|LEASE` : null,
-    draftId ? `${tenantId}|draft:${draftId}|LEASE` : null,
-    ledgerItemId ? `${tenantId}|ledger:${ledgerItemId}|LEASE` : null,
-    url ? `${tenantId}|url:${url}|LEASE` : null,
-    sha256 ? `${tenantId}|sha256:${sha256}|LEASE` : null,
-    !leaseId && !draftId && !ledgerItemId && !url && fileName ? `${tenantId}|file:${fileName}|LEASE` : null,
   ].filter((value): value is string => Boolean(value));
-  return keys.length ? keys : [`${tenantId}|unidentified|LEASE`];
 }
 
 function dedupeVisibleLeaseItems(items: TenantAttachment[]): TenantAttachment[] {

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
@@ -39,6 +39,60 @@ function needsAttention(item: TenantAttachment): boolean {
   return item.status === "missing" || item.status === "needs_attention" || item.status === "reupload_requested";
 }
 
+function isVisibleLeaseAttachment(item: TenantAttachment): boolean {
+  const category = String(item.category || "").trim().toLowerCase();
+  const purpose = String(item.purpose || "").trim().toUpperCase();
+  const purposeLabel = String(item.purposeLabel || "").trim().toLowerCase();
+  const title = String(item.title || "").trim().toLowerCase();
+  const label = String(item.label || "").trim().toLowerCase();
+  return category === "lease" || purpose === "LEASE" || purposeLabel === "lease" || title === "lease document" || label.includes("lease");
+}
+
+function visibleLeaseKeys(item: TenantAttachment): string[] {
+  if (!isVisibleLeaseAttachment(item)) return [];
+  const tenantId = String(item.tenantId || "").trim() || "tenant";
+  const leaseId = String(item.leaseId || "").trim();
+  const draftId = String(item.draftId || "").trim();
+  const ledgerItemId = String(item.ledgerItemId || "").trim();
+  const url = String(item.url || "").trim();
+  const sha256 = String(item.sha256 || "").trim();
+  const fileName = String(item.fileName || "").trim();
+  const keys = [
+    leaseId ? `${tenantId}|lease:${leaseId}|LEASE` : null,
+    draftId ? `${tenantId}|draft:${draftId}|LEASE` : null,
+    ledgerItemId ? `${tenantId}|ledger:${ledgerItemId}|LEASE` : null,
+    url ? `${tenantId}|url:${url}|LEASE` : null,
+    sha256 ? `${tenantId}|sha256:${sha256}|LEASE` : null,
+    !leaseId && !draftId && !ledgerItemId && !url && fileName ? `${tenantId}|file:${fileName}|LEASE` : null,
+  ].filter((value): value is string => Boolean(value));
+  return keys.length ? keys : [`${tenantId}|unidentified|LEASE`];
+}
+
+function dedupeVisibleLeaseItems(items: TenantAttachment[]): TenantAttachment[] {
+  const sortedItems = [...items].sort((a, b) => Number(b.uploadedAt || b.createdAt || 0) - Number(a.uploadedAt || a.createdAt || 0));
+  const output: TenantAttachment[] = [];
+  const leaseKeySets: Set<string>[] = [];
+
+  sortedItems.forEach((item) => {
+    const keys = visibleLeaseKeys(item);
+    if (!keys.length) {
+      output.push(item);
+      return;
+    }
+
+    const existingIndex = leaseKeySets.findIndex((knownKeys) => keys.some((key) => knownKeys.has(key)));
+    if (existingIndex >= 0) {
+      keys.forEach((key) => leaseKeySets[existingIndex].add(key));
+      return;
+    }
+
+    output.push(item);
+    leaseKeySets.push(new Set(keys));
+  });
+
+  return output;
+}
+
 function statusRank(status?: TenantAttachment["status"]): number {
   switch (status) {
     case "reupload_requested":
@@ -107,8 +161,7 @@ export function buildTenantDocumentVaultView(params: {
   updatedAt?: number | null;
   access?: TenantAccessWorkspace | null;
 }): TenantDocumentVaultView {
-  const items = Array.isArray(params.items) ? [...params.items] : [];
-  const summary = params.summary;
+  const items = dedupeVisibleLeaseItems(Array.isArray(params.items) ? [...params.items] : []);
   const readyItems = items.filter(isReadyToShare);
   const missingItems = items.filter(needsAttention);
   const recentItems = [...items]
@@ -141,7 +194,7 @@ export function buildTenantDocumentVaultView(params: {
   const metrics: VaultMetric[] = [
     {
       label: "In your vault",
-      value: summary?.total ?? items.length,
+      value: items.length,
       accent: "#0f766e",
       hint: "Documents already connected to your tenant profile.",
     },


### PR DESCRIPTION
## Summary

Fixes duplicate tenant-visible Lease documents caused by repeated Schedule A generation, draft activation, or linkage repair creating multiple `ledgerAttachments` for the same visible Lease document.

## Root Cause

Lease attachment IDs were derived from `snapshotId`, so repeated generation or repair could create separate tenant-visible Lease attachment rows for the same tenant and lease/draft. Historical attachment records should be preserved, but the tenant document vault should show only one visible Lease document for a tenant + lease/draft Lease identity.

## Changes

- Reuse an existing visible Lease `ledgerAttachments` record for the same tenant plus `leaseId` or `draftId` before writing a generated Lease PDF link.
- Use a stable deterministic fallback attachment ID based on tenant + lease/draft + Lease purpose instead of snapshot ID.
- Add tenant vault read-time dedupe for visible Lease attachments as a safety guard.
- Preserve historical `ledgerAttachments`; no deletion or migration is included.
- Add regression coverage for repeated generation, repeated activation repair with a new snapshot, and tenant vault visible dedupe.

## Explicit Non-Goals

- No package or lockfile changes.
- No PDF system consolidation.
- No document vault redesign.
- No lease execution or signature semantics changes.
- No deletion of historical attachment data.

## Validation

- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:single -- src/routes/__tests__/leaseDraftRoutes.test.ts`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:single -- src/routes/__tests__/tenantPortalRoutes.test.ts`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- `git diff --check`

## Preview QA

1. Generate Schedule A PDF.
2. Activate draft.
3. Open tenant document vault.
4. Confirm only one Lease document appears.
5. Repeat generation/activation repair if possible.
6. Confirm vault still shows one visible Lease document.
7. Confirm non-Lease documents remain visible.

Do not merge until CI and preview QA pass.