### PR TITLE
[codex] Fix tenant shell unit label hydration

### DIFF
--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -23,6 +23,11 @@ export type TenantWorkspaceProperty = {
   features: string[];
 };
 
+export type TenantWorkspaceUnit = {
+  unitId?: string | null;
+  label: string | null;
+};
+
 export type TenantWorkspaceApplication = {
   applicationId: string;
   status: string | null;
@@ -503,6 +508,7 @@ export type InstitutionalHandoffSummary = {
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
   property: TenantWorkspaceProperty | null;
+  unit: TenantWorkspaceUnit | null;
   application: TenantWorkspaceApplication | null;
   lease: TenantWorkspaceLease | null;
   maintenance: TenantWorkspaceMaintenance[];

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -40,7 +40,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
         const workspace = await getTenantWorkspace();
         const name = String(workspace?.context?.invitedEmail || "").trim();
         const email = String(workspace?.context?.invitedEmail || "").trim();
-        const unit = String(workspace?.context?.unitId || "").trim();
+        const unit = String(workspace?.unit?.label || "").trim();
         if (!cancelled) {
           setTenantName(name ? name.split("@")[0] : "Tenant workspace");
           setTenantEmail(email || null);

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -54,8 +54,12 @@ describe("tenant profile and communications pages", () => {
         applicationId: "app-1",
         leaseId: "lease-1",
         tenantId: "tenant-1",
-        unitId: "unit-2",
+        unitId: "iXHTFgm8ay3iuUptfI4I",
         invitedEmail: "tenant@example.com",
+      },
+      unit: {
+        unitId: "iXHTFgm8ay3iuUptfI4I",
+        label: "1",
       },
     });
     tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
@@ -110,6 +114,47 @@ describe("tenant profile and communications pages", () => {
     expect(screen.getByRole("link", { name: /Profile/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Access/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /History/i })).toBeInTheDocument();
+  });
+
+  it("tenant nav shows the hydrated unit label instead of the raw unit id", async () => {
+    render(
+      <MemoryRouter>
+        <TenantNav>
+          <div>Tenant content</div>
+        </TenantNav>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText((content) => content.includes("tenant@example.com") && content.includes("Unit 1"))).toBeInTheDocument();
+    expect(screen.queryByText(/iXHTFgm8ay3iuUptfI4I/)).not.toBeInTheDocument();
+  });
+
+  it("tenant nav omits the unit when the hydrated label is missing", async () => {
+    tenantPortalApi.getTenantWorkspace.mockResolvedValueOnce({
+      context: {
+        authority: "active_tenant",
+        propertyId: "prop-1",
+        rc_prop_id: "rc-prop-1",
+        applicationId: "app-1",
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        unitId: "raw-internal-unit-id",
+        invitedEmail: "tenant@example.com",
+      },
+      unit: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantNav>
+          <div>Tenant content</div>
+        </TenantNav>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("tenant@example.com")).toBeInTheDocument();
+    expect(screen.queryByText(/raw-internal-unit-id/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unit raw-internal-unit-id/)).not.toBeInTheDocument();
   });
 
   it("tenant profile page renders safe projected profile data and identity states", async () => {


### PR DESCRIPTION
## Summary
- Add the hydrated tenant workspace unit projection type to the frontend API contract.
- Update the tenant shell/header to display `workspace.unit.label` instead of the raw internal `context.unitId`.
- Add targeted TenantNav coverage for hydrated labels, raw unit ID suppression, and missing unit labels.

## Root Cause
The backend `/tenant/workspace` response already includes the tenant-facing hydrated unit label, but the frontend summary type did not model `unit` and `TenantNav` rendered the internal Firestore unit ID from `workspace.context.unitId`.

## Validation
- `npm run test -- TenantProfileCommunicationsPages.test.tsx`
- `npm run build`
- `git diff --check`

## Merge Gate
Do not merge until CI passes and preview QA confirms the tenant shell/header shows the human-readable unit label, does not show raw Firestore unit IDs, and missing labels do not fall back to raw IDs.