### PR TITLE
fix: create canonical payments from lease ledger payments

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -856,6 +856,10 @@ describe("leaseRoutes GET /active", () => {
 
     expect(res.status).toBe(201);
     expect(res.body?.ok).toBe(true);
+    expect(res.headers["x-route-source"]).toBe("leaseRoutes.ts");
+    expect(res.headers["x-lease-payment-write-version"]).toBe("canonical-payments-ledger-link-v1");
+    expect(res.body?.routeSource).toBe("leaseRoutes.ts");
+    expect(res.body?.writeVersion).toBe("canonical-payments-ledger-link-v1");
 
     const paymentsSnap = await fakeDb.collection("payments").get();
     const ledgerSnap = await fakeDb.collection("ledgerEntries").get();

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -61,6 +61,11 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
     },
     seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
     fakeDb: {
+      runTransaction: async (callback: any) =>
+        callback({
+          get: async (ref: any) => ref.get(),
+          set: async (ref: any, value: any, options?: any) => ref.set(value, options),
+        }),
       collection: (name: string) => ({
         where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
         orderBy: () => makeQuery(name),
@@ -818,6 +823,87 @@ describe("leaseRoutes GET /active", () => {
         },
       },
     });
+  });
+
+  it("records lease payments as linked canonical payments and immutable ledger entries", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      dueDay: 1,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/ledger/payment",
+      body: {
+        amountCents: 185000,
+        date: "2026-05-14",
+        method: "etransfer",
+        reference: "May rent",
+        notes: "Received in full",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.ok).toBe(true);
+
+    const paymentsSnap = await fakeDb.collection("payments").get();
+    const ledgerSnap = await fakeDb.collection("ledgerEntries").get();
+    expect(paymentsSnap.docs).toHaveLength(1);
+    expect(ledgerSnap.docs).toHaveLength(1);
+
+    const paymentDoc = paymentsSnap.docs[0];
+    const ledgerDoc = ledgerSnap.docs[0];
+    const payment = paymentDoc.data();
+    const entry = ledgerDoc.data();
+
+    expect(paymentDoc.id).toBe(res.body.payment.id);
+    expect(ledgerDoc.id).toBe(res.body.entry.id);
+    expect(payment).toEqual(
+      expect.objectContaining({
+        id: paymentDoc.id,
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        amount: 1850,
+        amountCents: 185000,
+        method: "etransfer",
+        paidAt: "2026-05-14",
+        effectiveDate: "2026-05-14",
+        status: "recorded",
+        ledgerEntryId: ledgerDoc.id,
+        createdBy: "landlord-1",
+      })
+    );
+    expect(entry).toEqual(
+      expect.objectContaining({
+        id: ledgerDoc.id,
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        entryType: "payment",
+        category: "payment",
+        amountCents: 185000,
+        effectiveDate: "2026-05-14",
+        method: "etransfer",
+        paymentDocumentId: paymentDoc.id,
+        createdBy: "landlord-1",
+      })
+    );
   });
 
   it("reconciles the affected property unit to vacant when ending a lease", async () => {

--- a/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
@@ -921,6 +921,54 @@ describe("paymentsRoutes exports", () => {
     );
   });
 
+  it("surfaces cents-native canonical payments with editable document ids", async () => {
+    ensureCollection("payments").set("canonical-cents-payment", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      leaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      amountCents: 185000,
+      paidAt: "2026-05-14",
+      effectiveDate: "2026-05-14",
+      method: "etransfer",
+      status: "recorded",
+      ledgerEntryId: "ledger-linked-payment",
+    });
+    ensureCollection("ledgerEntries").set("ledger-linked-payment", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      leaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "payment",
+      category: "payment",
+      amountCents: 185000,
+      effectiveDate: "2026-05-14",
+      method: "etransfer",
+      paymentDocumentId: "canonical-cents-payment",
+      createdAt: 1778716800000,
+    });
+
+    const router = (await import("../paymentsRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/payments?tenantId=tenant-1" });
+
+    expect(res.status).toBe(200);
+    const duplicateRows = res.body.filter((payment: any) =>
+      ["canonical-cents-payment", "ledger-linked-payment"].includes(payment.id)
+    );
+    expect(duplicateRows).toHaveLength(1);
+    expect(duplicateRows[0]).toEqual(
+      expect.objectContaining({
+        id: "canonical-cents-payment",
+        canonicalPaymentId: "canonical-cents-payment",
+        paymentDocumentId: "canonical-cents-payment",
+        amount: 1850,
+        source: "payments",
+      })
+    );
+  });
+
   it("normalizes rentPayments with missing optional fields without crashing", async () => {
     ensureCollection("rentPayments").set("rent-payment-minimal", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/tenantEventsWriteRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantEventsWriteRoutes.test.ts
@@ -130,4 +130,34 @@ describe("tenantEventsWriteRoutes", () => {
     expect(createdEvents[0]?.severity).toBe("neutral");
     expect(createdEvents[0]?.title).toBe("Note added");
   });
+
+  it("keeps tenant payment activity separate from ledger and payments writes", async () => {
+    const router = (await import("../tenantEventsWriteRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "POST",
+      url: "/tenant-events",
+      body: {
+        tenantId: "tenant-1",
+        type: "RENT_PAID",
+        amountCents: 185000,
+        currency: "CAD",
+        purpose: "RENT",
+        description: "Timeline note only.",
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body?.ok).toBe(true);
+    expect(createdEvents).toHaveLength(1);
+    expect(createdEvents[0]).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        type: "RENT_PAID",
+        title: "Rent paid",
+        amountCents: 185000,
+        currency: "CAD",
+      })
+    );
+  });
 });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -3188,6 +3188,8 @@ router.post("/:leaseId/ledger/charge", async (req: any, res: Response) => {
 });
 
 router.post("/:leaseId/ledger/payment", async (req: any, res: Response) => {
+  res.setHeader("x-route-source", "leaseRoutes.ts");
+  res.setHeader("x-lease-payment-write-version", "canonical-payments-ledger-link-v1");
   try {
     const landlordId = req.user?.landlordId || req.user?.id;
     const createdBy = req.user?.id || req.user?.email || landlordId;
@@ -3262,7 +3264,13 @@ router.post("/:leaseId/ledger/payment", async (req: any, res: Response) => {
       transaction.set(paymentRef, payment, { merge: false });
       transaction.set(entryRef, entry, { merge: false });
     });
-    return res.status(201).json({ ok: true, payment, entry });
+    return res.status(201).json({
+      ok: true,
+      routeSource: "leaseRoutes.ts",
+      writeVersion: "canonical-payments-ledger-link-v1",
+      payment,
+      entry,
+    });
   } catch (err) {
     console.error("[POST /api/leases/:leaseId/ledger/payment] error", err);
     return res.status(500).json({ ok: false, error: "Failed to record payment" });
@@ -3382,7 +3390,6 @@ router.get("/:leaseId/ledger/export.pdf", async (req: any, res: Response) => {
 });
 
 export default router;
-
 
 
 

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -3208,14 +3208,44 @@ router.post("/:leaseId/ledger/payment", async (req: any, res: Response) => {
     }
 
     const lease = leaseCheck.lease as any;
+    const tenantIds = Array.isArray(lease?.tenantIds) ? lease.tenantIds : [];
+    const tenantId = String(lease?.tenantId || lease?.primaryTenantId || tenantIds[0] || "").trim();
+    if (!tenantId) {
+      return res.status(409).json({ ok: false, error: "Lease is missing tenant context" });
+    }
+
     const now = Date.now();
+    const nowIso = new Date(now).toISOString();
+    const propertyId = String(req.body?.propertyId || lease?.propertyId || "").trim() || null;
+    const unitId = String(req.body?.unitId || lease?.unitId || lease?.unitNumber || "").trim() || null;
+    const paymentRef = db.collection("payments").doc();
     const entryRef = db.collection(LEDGER_COLLECTION).doc();
+    const payment = {
+      id: paymentRef.id,
+      landlordId,
+      tenantId,
+      leaseId,
+      propertyId,
+      unitId,
+      amount: amountCents / 100,
+      amountCents,
+      paidAt: effectiveDate,
+      effectiveDate,
+      method,
+      status: "recorded",
+      reference: req.body?.reference ? String(req.body.reference).trim().slice(0, 120) : null,
+      notes: req.body?.notes ? String(req.body.notes).trim().slice(0, 5000) : null,
+      ledgerEntryId: entryRef.id,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+      createdBy,
+    };
     const entry = {
       id: entryRef.id,
       landlordId,
-      propertyId: String(req.body?.propertyId || lease?.propertyId || "").trim() || null,
-      unitId:
-        String(req.body?.unitId || lease?.unitId || lease?.unitNumber || "").trim() || null,
+      tenantId,
+      propertyId,
+      unitId,
       leaseId,
       entryType: "payment" as LedgerEntryType,
       category: "payment",
@@ -3224,11 +3254,15 @@ router.post("/:leaseId/ledger/payment", async (req: any, res: Response) => {
       method,
       reference: req.body?.reference ? String(req.body.reference).trim().slice(0, 120) : null,
       notes: req.body?.notes ? String(req.body.notes).trim().slice(0, 5000) : null,
+      paymentDocumentId: paymentRef.id,
       createdAt: now,
       createdBy,
     };
-    await entryRef.set(entry, { merge: false });
-    return res.status(201).json({ ok: true, entry });
+    await db.runTransaction(async (transaction: any) => {
+      transaction.set(paymentRef, payment, { merge: false });
+      transaction.set(entryRef, entry, { merge: false });
+    });
+    return res.status(201).json({ ok: true, payment, entry });
   } catch (err) {
     console.error("[POST /api/leases/:leaseId/ledger/payment] error", err);
     return res.status(500).json({ ok: false, error: "Failed to record payment" });
@@ -3348,7 +3382,6 @@ router.get("/:leaseId/ledger/export.pdf", async (req: any, res: Response) => {
 });
 
 export default router;
-
 
 
 

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -141,6 +141,14 @@ function normalizePersistedPayment(
   createdAt?: string | null;
   updatedAt?: string | null;
 } {
+  const rawAmount = Number(raw?.amount);
+  const rawAmountCents = Number(raw?.amountCents);
+  const amount =
+    Number.isFinite(rawAmount) && rawAmount > 0
+      ? rawAmount
+      : Number.isFinite(rawAmountCents) && rawAmountCents > 0
+      ? rawAmountCents / 100
+      : 0;
   return {
     id: docId,
     canonicalPaymentId: docId,
@@ -148,7 +156,7 @@ function normalizePersistedPayment(
     landlordId: resolvedLandlordIdForRecord(raw, landlordId, ownership),
     tenantId: String(raw?.tenantId || "").trim(),
     propertyId: String(raw?.propertyId || "").trim() || null,
-    amount: Number(raw?.amount ?? 0),
+    amount,
     paidAt: String(toIsoString(raw?.paidAt) || "").trim(),
     method: String(raw?.method || "").trim(),
     notes: raw?.notes ?? null,
@@ -336,6 +344,8 @@ function normalizeLedgerEntryPayment(
 
   return {
     id: docId,
+    canonicalPaymentId: String(raw?.canonicalPaymentId || raw?.paymentDocumentId || "").trim(),
+    paymentDocumentId: String(raw?.paymentDocumentId || raw?.canonicalPaymentId || "").trim(),
     landlordId,
     tenantId,
     propertyId,

--- a/rentchain-frontend/src/api/leaseLedgerApi.test.ts
+++ b/rentchain-frontend/src/api/leaseLedgerApi.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("./apiFetch", () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+describe("leaseLedgerApi", () => {
+  beforeEach(() => {
+    mocks.apiFetch.mockReset();
+    mocks.apiFetch.mockResolvedValue({ ok: true });
+  });
+
+  it("records lease payments through the canonical lease ledger payment endpoint", async () => {
+    const { addLeasePayment } = await import("./leaseLedgerApi");
+
+    await addLeasePayment("lease-1", {
+      amountCents: 15000,
+      date: "2026-05-15",
+      method: "etransfer",
+      reference: "May payment",
+      notes: "QA payment",
+    });
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/leases/lease-1/ledger/payment", {
+      method: "POST",
+      body: {
+        amountCents: 15000,
+        date: "2026-05-15",
+        method: "etransfer",
+        reference: "May payment",
+        notes: "QA payment",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Lease ledger payment recording now creates a canonical `/payments` document alongside the immutable `/ledgerEntries` payment row.

## Key Changes

- `POST /api/leases/:leaseId/ledger/payment` now transactionally creates both records.
- Ledger entries remain append-only payment rows.
- Payments and ledger entries are cross-linked:
  - `ledgerEntries.paymentDocumentId = payments doc ID`
  - `payments.ledgerEntryId = ledger entry ID`
- Canonical payment docs include landlord, tenant, lease, property, unit, cents amount, method, paid/effective date, recorded status, and audit metadata.
- `/payments` can now surface editable canonical payment rows through explicit `paymentDocumentId` / `canonicalPaymentId` identity.
- Tenant activity payment notes remain tenant-event-only and do not create ledger or payments records.
- Legacy ledger-only rows do not become editable.

## Dependency

This PR depends on PR #898 (`fix/payments-edit-route-and-ledger-activity-sync-v1`) for the payment edit route safety work, canonical edit guard, and payments list normalization behavior. It intentionally targets that branch while PR #898 remains open. After #898 merges, this PR should be retargeted or rebased onto `main`.

## Tests Run

- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm test -- --run src/routes/__tests__/leaseRoutes.active.test.ts src/routes/__tests__/paymentsRoutes.test.ts src/routes/__tests__/tenantEventsWriteRoutes.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm test -- --run src/api/paymentsApi.test.ts src/pages/PaymentsPage.test.tsx src/components/tenants/TenantPaymentsPanel.test.tsx`

## QA Notes

- Record a real lease ledger payment.
- Confirm one canonical `/payments` doc is created.
- Confirm one immutable `/ledgerEntries` payment row is created.
- Confirm both records contain cross-links.
- Confirm `/payments` shows Edit only for the linked canonical payment row.
- Confirm tenant activity notes remain timeline-only.