### PR TITLE
fix: normalize operational references and internal ID labeling

### DIFF
--- a/rentchain-api/src/lib/__tests__/identityReferences.test.ts
+++ b/rentchain-api/src/lib/__tests__/identityReferences.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatInternalReference,
+  formatOperationalReference,
+  shortenInternalId,
+  slugifyOperationalReference,
+} from "../identityReferences";
+
+describe("identityReferences", () => {
+  it("shortens long internal ids for display-only references", () => {
+    expect(shortenInternalId("38r6fSwiPSDke0rEGKkx")).toBe("38r6fSwi...GKkx");
+    expect(shortenInternalId("t1")).toBe("t1");
+  });
+
+  it("labels internal ids explicitly in support/debug contexts", () => {
+    expect(formatInternalReference("lease", "y7XM6BFXIzWW0fV3mu1L")).toBe(
+      "Internal lease ID: y7XM6BFX...mu1L"
+    );
+  });
+
+  it("formats operational references and safe export slugs", () => {
+    expect(formatOperationalReference("tenant", "38r6fSwiPSDke0rEGKkx")).toBe("Tenant ref 38r6fSwi...GKkx");
+    expect(slugifyOperationalReference(["Tenant report", "Bailey Blinkers"])).toBe("tenant-report-bailey-blinkers");
+  });
+});

--- a/rentchain-api/src/lib/identityReferences.ts
+++ b/rentchain-api/src/lib/identityReferences.ts
@@ -1,0 +1,58 @@
+export type IdentityReferenceKind =
+  | "application"
+  | "event"
+  | "ledgerEntry"
+  | "lease"
+  | "payment"
+  | "property"
+  | "record"
+  | "tenant"
+  | "unit";
+
+const KIND_LABELS: Record<IdentityReferenceKind, string> = {
+  application: "application",
+  event: "event",
+  ledgerEntry: "ledger entry",
+  lease: "lease",
+  payment: "payment",
+  property: "property",
+  record: "record",
+  tenant: "tenant",
+  unit: "unit",
+};
+
+function cleanString(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function titleCase(value: string): string {
+  return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function shortenInternalId(value: unknown, visiblePrefix = 8, visibleSuffix = 4): string {
+  const text = cleanString(value);
+  if (!text) return "not available";
+  const minimumLength = visiblePrefix + visibleSuffix + 2;
+  if (text.length <= minimumLength) return text;
+  return `${text.slice(0, visiblePrefix)}...${text.slice(-visibleSuffix)}`;
+}
+
+export function formatInternalReference(kind: IdentityReferenceKind, value: unknown): string {
+  return `Internal ${KIND_LABELS[kind]} ID: ${shortenInternalId(value)}`;
+}
+
+export function formatOperationalReference(kind: IdentityReferenceKind, value: unknown): string {
+  return `${titleCase(KIND_LABELS[kind])} ref ${shortenInternalId(value)}`;
+}
+
+export function slugifyOperationalReference(parts: unknown[], fallback = "rentchain-export"): string {
+  const slug = parts
+    .map(cleanString)
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return slug || fallback;
+}

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -224,8 +224,22 @@ describe("leaseRoutes integrity repairs", () => {
       propertyId: "prop-1",
       tenantId: "tenant-1",
       unitId: "unit-1",
-      unitNumber: "101",
       status: "active",
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
     });
     seedDoc("ledgerEntries", "entry-1", {
       landlordId: "landlord-1",
@@ -406,8 +420,12 @@ describe("leaseRoutes integrity repairs", () => {
       propertyId: "prop-1",
       tenantId: "tenant-1",
       unitId: "unit-1",
-      unitNumber: "101",
       status: "active",
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
     });
     seedDoc("ledgerEntries", "entry-1", {
       landlordId: "landlord-1",
@@ -426,9 +444,16 @@ describe("leaseRoutes integrity repairs", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toContain("text/csv");
-    expect(res.text).toContain("property,unit");
+    expect(res.text).toContain("Date,Type,Category,Amount,Balance,Method,Reference,Notes,Property,Unit");
+    expect(res.text).toContain("Charge");
+    expect(res.text).toContain("Rent");
+    expect(res.text).toContain("$1,800.00");
     expect(res.text).toContain("123 Main St");
     expect(res.text).toContain("101");
+    expect(res.text).not.toContain("amountCents");
+    expect(res.text).not.toContain("signedAmountCents");
+    expect(res.text).not.toContain("balanceCents");
+    expect(res.text).not.toContain("createdAt");
     expect(res.text).not.toContain("propertyId");
     expect(res.text).not.toContain("unitId");
     expect(res.text).not.toContain("prop-1");
@@ -446,8 +471,12 @@ describe("leaseRoutes integrity repairs", () => {
       propertyId: "prop-1",
       tenantId: "tenant-1",
       unitId: "unit-1",
-      unitNumber: "101",
       status: "active",
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
     });
     seedDoc("ledgerEntries", "entry-1", {
       landlordId: "landlord-1",
@@ -475,7 +504,7 @@ describe("leaseRoutes integrity repairs", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toContain("application/pdf");
-    expect(res.headers["content-disposition"]).toContain("lease-ledger-lease-1.pdf");
+    expect(res.headers["content-disposition"]).toContain("lease-ledger-123-main-st-101.pdf");
     expect(Buffer.isBuffer(res.body)).toBe(true);
     expect(res.body.length).toBeGreaterThan(500);
   });

--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -321,6 +321,40 @@ describe("messagesRoutes notifications", () => {
     expect(`${conversation?.tenantDisplayName} • ${conversation?.unitDisplayLabel}`).not.toBe("Tenant • Assigned unit");
   });
 
+  it("hydrates unit-linked landlord conversations from active lease context", async () => {
+    ensureCollection("conversations").set("conv-unit-only", {
+      landlordId: "landlord-1",
+      tenantId: null,
+      propertyId: null,
+      unitId: "unit-1",
+    });
+    ensureCollection("leases").set("lease-unit-only", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    const conversation = res.body?.conversations?.find((item: any) => item.id === "conv-unit-only");
+    expect(conversation).toEqual(
+      expect.objectContaining({
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      })
+    );
+    expect(`${conversation?.tenantDisplayName} • ${conversation?.unitDisplayLabel}`).not.toBe("Tenant • Linked unit");
+  });
+
   it("stores deterministic property context when tenant conversation is created", async () => {
     const router = await createRouter();
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/__tests__/publicRoutes.messages.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicRoutes.messages.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function applyFilters(rows: Array<[string, any]>, filters: Array<{ field: string; op: string; value: any }>) {
+  return rows.filter(([, data]) =>
+    filters.every((filter) => {
+      const current = data?.[filter.field];
+      if (filter.op === "==") return current === filter.value;
+      if (filter.op === "array-contains") return Array.isArray(current) && current.includes(filter.value);
+      return false;
+    })
+  );
+}
+
+function createQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+  const api: any = {
+    where(field: string, op: string, value: any) {
+      return createQuery(name, [...filters, { field, op, value }]);
+    },
+    orderBy() {
+      return api;
+    },
+    limit(count: number) {
+      return {
+        get: async () => {
+          const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters)
+            .slice(0, count)
+            .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+          return { docs, empty: docs.length === 0 };
+        },
+      };
+    },
+    async get() {
+      const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters).map(([id, data]) => ({
+        id,
+        exists: true,
+        data: () => clone(data),
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
+  };
+  return api;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+        },
+      };
+    },
+    where: (field: string, op: string, value: any) => createQuery(name, [{ field, op, value }]),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) req.user = JSON.parse(header);
+    next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    return next();
+  },
+}));
+vi.mock("../../services/capabilityGuard", () => ({
+  requireCapability: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("../../services/emailService", () => ({
+  sendEmail: vi.fn(),
+  sendWaitlistConfirmation: vi.fn(),
+}));
+vi.mock("../../services/tenantDetailsService", () => ({
+  getTenantsList: vi.fn(),
+  getTenantDetailBundle: vi.fn(),
+}));
+vi.mock("../../services/stripeService", () => ({
+  getStripeClient: vi.fn(),
+  isStripeConfigured: vi.fn(() => false),
+  STRIPE_API_VERSION: "2024-06-20",
+}));
+vi.mock("../onboardingRoutes", () => ({
+  default: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock("../../services/screening/providerHealth", () => ({
+  getScreeningProviderHealth: vi.fn(() => ({ ok: true })),
+}));
+vi.mock("../../services/screening/inviteTokens", () => ({
+  hashInviteToken: vi.fn((value: string) => value),
+}));
+vi.mock("../../services/screening/screeningEvents", () => ({
+  writeScreeningEvent: vi.fn(),
+}));
+vi.mock("../../services/screening/providers/bureauProvider", () => ({
+  getBureauProvider: vi.fn(() => null),
+}));
+vi.mock("../../config/planMatrix", () => ({
+  getPricingHealth: vi.fn(() => ({ ok: true })),
+}));
+vi.mock("../../config/requiredEnv", () => ({
+  getEnvFlags: vi.fn(() => ({})),
+}));
+vi.mock("../../email/templates/baseEmailTemplate", () => ({
+  buildEmailHtml: vi.fn(() => "<p>email</p>"),
+  buildEmailText: vi.fn(() => "email"),
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      query: {},
+      params: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      setHeader(name: string, value: string) {
+        headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("publicRoutes message endpoints", () => {
+  beforeEach(() => {
+    collections.clear();
+    ensureCollection("conversations").set("conv-unit-only", {
+      landlordId: "landlord-1",
+      tenantId: null,
+      propertyId: null,
+      unitId: "unit-1",
+      lastMessageAt: 2000,
+    });
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      fullName: "Taylor Tenant",
+    });
+    ensureCollection("leases").set("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+    });
+    ensureCollection("properties").set("prop-1", {
+      name: "Harbour View",
+    });
+    ensureCollection("units").set("unit-1", {
+      propertyId: "prop-1",
+      unitNumber: "2A",
+    });
+  });
+
+  it("serves landlord messages through publicRoutes with active lease labels", async () => {
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("publicRoutes.ts");
+    expect(res.body?.conversations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "conv-unit-only",
+          tenantDisplayName: "Taylor Tenant",
+          propertyDisplayLabel: "Harbour View",
+          unitDisplayLabel: "Unit 2A",
+        }),
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
@@ -219,6 +219,13 @@ describe("tenant communications routes", () => {
   });
 
   it("loads landlord messages from property and unit linked conversations without tenant ids", async () => {
+    ensureCollection("conversations").set("landlord-1__tenant-1__unit-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      lastMessageAt: "2026-01-06T00:00:00.000Z",
+    });
     ensureCollection("conversations").set("conv-linked-unit", {
       landlordId: "landlord-1",
       unitId: "unit-1",
@@ -263,6 +270,80 @@ describe("tenant communications routes", () => {
         }),
       ])
     );
+  });
+
+  it("keeps tenant and landlord replies on the same resolved conversation thread", async () => {
+    ensureCollection("conversations").set("conv-linked-unit", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      lastMessageAt: "2026-01-05T00:00:00.000Z",
+      lastReadAtTenant: "2026-01-04T00:00:00.000Z",
+    });
+    ensureCollection("leases").set("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+    });
+    ensureCollection("messages").set("msg-landlord-1", {
+      conversationId: "conv-linked-unit",
+      senderRole: "landlord",
+      body: "Can you confirm receipt?",
+      createdAtMs: Date.parse("2026-01-05T00:00:00.000Z"),
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+      }),
+    };
+    const sendRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/communications/messages",
+      headers,
+      body: {
+        body: "I received it.",
+      },
+    });
+    expect(sendRes.status).toBe(201);
+    const tenantMessage = Array.from(ensureCollection("messages").values()).find(
+      (entry) => entry?.body === "I received it."
+    );
+    expect(tenantMessage?.conversationId).toBe("conv-linked-unit");
+
+    ensureCollection("messages").set("msg-landlord-2", {
+      conversationId: "conv-linked-unit",
+      senderRole: "landlord",
+      body: "Thanks for confirming.",
+      createdAtMs: Date.parse("2026-01-06T00:00:00.000Z"),
+    });
+    ensureCollection("conversations").set("conv-linked-unit", {
+      ...ensureCollection("conversations").get("conv-linked-unit"),
+      lastMessageAt: "2026-01-06T00:00:00.000Z",
+    });
+
+    const loadRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/communications",
+      headers,
+    });
+
+    expect(loadRes.status).toBe(200);
+    expect(loadRes.body?.data?.thread?.id).toBe("conv-linked-unit");
+    expect(loadRes.body?.data?.thread?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ senderRole: "landlord", body: "Can you confirm receipt?" }),
+        expect.objectContaining({ senderRole: "tenant", body: "I received it." }),
+        expect.objectContaining({ senderRole: "landlord", body: "Thanks for confirming." }),
+      ])
+    );
+    expect(loadRes.body?.data?.thread?.unreadCount).toBe(2);
   });
 
   it("send path respects authority context and records a scoped message", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
@@ -221,7 +221,6 @@ describe("tenant communications routes", () => {
   it("loads landlord messages from property and unit linked conversations without tenant ids", async () => {
     ensureCollection("conversations").set("conv-linked-unit", {
       landlordId: "landlord-1",
-      propertyId: "prop-1",
       unitId: "unit-1",
       lastMessageAt: "2026-01-05T00:00:00.000Z",
       lastReadAtTenant: "2026-01-04T00:00:00.000Z",

--- a/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
@@ -218,6 +218,54 @@ describe("tenant communications routes", () => {
     expect(res.body?.data?.thread?.unreadCount).toBe(1);
   });
 
+  it("loads landlord messages from property and unit linked conversations without tenant ids", async () => {
+    ensureCollection("conversations").set("conv-linked-unit", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      lastMessageAt: "2026-01-05T00:00:00.000Z",
+      lastReadAtTenant: "2026-01-04T00:00:00.000Z",
+    });
+    ensureCollection("leases").set("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+    });
+    ensureCollection("messages").set("msg-linked-unit", {
+      conversationId: "conv-linked-unit",
+      senderRole: "landlord",
+      body: "This landlord message should appear in the tenant workspace.",
+      createdAtMs: Date.parse("2026-01-05T00:00:00.000Z"),
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/communications",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.thread?.id).toBe("conv-linked-unit");
+    expect(res.body?.data?.thread?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          body: "This landlord message should appear in the tenant workspace.",
+          senderRole: "landlord",
+        }),
+      ])
+    );
+  });
+
   it("send path respects authority context and records a scoped message", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -3223,6 +3223,93 @@ describe("tenantPortalRoutes foundation", () => {
     );
   });
 
+  it("summarizes unit-linked tenant messages without requiring a Firestore composite index", async () => {
+    ensureCollection("conversations").set("landlord-1__tenant-1__unit-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      lastMessageAt: 1900,
+    });
+    ensureCollection("conversations").set("landlord-thread-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      lastMessageAt: 2200,
+    });
+    ensureCollection("conversations").set("other-unit-thread", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-other",
+      lastMessageAt: 2400,
+    });
+    ensureCollection("messages").set("message-1", {
+      conversationId: "landlord-thread-1",
+      senderRole: "landlord",
+      body: "Please confirm your move-in time.",
+      createdAtMs: 2200,
+    });
+    ensureCollection("messages").set("message-other", {
+      conversationId: "other-unit-thread",
+      senderRole: "landlord",
+      body: "Should not leak",
+      createdAtMs: 2400,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/communication/summary",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        unreadMessages: 1,
+        latestMessagePreview: "Please confirm your move-in time.",
+        latestMessageAt: new Date(2200).toISOString(),
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("Should not leak");
+
+    const messagesRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/messages",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(messagesRes.status).toBe(200);
+    expect(messagesRes.body?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          body: "Please confirm your move-in time.",
+          type: "message",
+        }),
+      ])
+    );
+    expect(JSON.stringify(messagesRes.body)).not.toContain("Should not leak");
+  });
+
   it("recognizes converted rentalApplications as linked tenant profile application context", async () => {
     ensureCollection("applications").delete("app-1");
     ensureCollection("leases").delete("lease-1");

--- a/rentchain-api/src/routes/landlordCreditHistoryRoutes.ts
+++ b/rentchain-api/src/routes/landlordCreditHistoryRoutes.ts
@@ -85,7 +85,7 @@ router.get("/tenants/:tenantId/credit-history/export", async (req: any, res) => 
         "\n"
       );
       res.setHeader("Content-Type", "text/csv");
-      res.setHeader("Content-Disposition", `attachment; filename="credit-history-${tenantId}.csv"`);
+      res.setHeader("Content-Disposition", "attachment; filename=\"credit-history.csv\"");
       return res.send(csv);
     }
     res.setHeader("Content-Type", "application/json");

--- a/rentchain-api/src/routes/landlordMicroLiveRoutes.ts
+++ b/rentchain-api/src/routes/landlordMicroLiveRoutes.ts
@@ -34,7 +34,7 @@ router.get("/tenants/:tenantId/credit-history/export", (req: any, res) => {
   res.setHeader("Content-Type", "text/csv; charset=utf-8");
   res.setHeader(
     "Content-Disposition",
-    `attachment; filename="credit-history-${req.params.tenantId}.csv"`
+    "attachment; filename=\"credit-history.csv\""
   );
   return res.status(200).send(csv);
 });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -67,6 +67,7 @@ import { computeNoResponseState } from "../services/leaseNoticeWorkflowService";
 import { deriveLeaseLifecycleSummary } from "../services/leaseLifecycle/deriveLeaseLifecycleSummary";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
 import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupancyCoherence";
+import { formatInternalReference, slugifyOperationalReference } from "../lib/identityReferences";
 import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
 
 const router = Router();
@@ -1404,10 +1405,28 @@ function enrichLeaseLedgerEntryWithPaymentIntent(
 
 async function resolveLeaseLedgerExportLabels(lease: any) {
   const propertyId = String(lease?.propertyId || "").trim();
+  const unitId = String(lease?.unitId || "").trim();
   const propertySnap = propertyId
     ? await db.collection("properties").doc(propertyId).get().catch(() => null)
     : null;
+  const unitSnap = unitId
+    ? await db.collection("units").doc(unitId).get().catch(() => null)
+    : null;
+  const unitQuerySnap =
+    propertyId && unitId && !unitSnap?.exists
+      ? await db.collection("units").where("propertyId", "==", propertyId).get().catch(() => null)
+      : null;
   const propertyData = propertySnap?.exists ? (propertySnap.data() as any) : null;
+  const unitData = unitSnap?.exists
+    ? (unitSnap.data() as any)
+    : (unitQuerySnap?.docs || [])
+        .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+        .find((unit: any) => {
+          const candidates = [unit?.id, unit?.unitId, unit?.uid, unit?.unitNumber, unit?.unitLabel, unit?.label, unit?.name]
+            .map((value) => String(value || "").trim())
+            .filter(Boolean);
+          return candidates.includes(unitId);
+        }) || null;
   const property =
     String(propertyData?.propertyAddress || lease?.propertyAddress || "").trim() ||
     String(propertyData?.addressLine1 || propertyData?.address || lease?.addressLine1 || lease?.address || "").trim() ||
@@ -1415,9 +1434,17 @@ async function resolveLeaseLedgerExportLabels(lease: any) {
     String(propertyData?.name || lease?.name || "").trim() ||
     "Property";
   const unit =
+    String(unitData?.unitNumber || unitData?.unitLabel || unitData?.label || unitData?.name || "").trim() ||
     String(lease?.unitLabel || lease?.unitNumber || lease?.unit || "").trim() ||
     "Unit";
-  return { property, unit };
+  const filenameSlug = slugifyOperationalReference(["lease-ledger", property, unit], "lease-ledger");
+  return { property, unit, filenameSlug };
+}
+
+function formatUnitLabel(value: unknown): string {
+  const label = String(value || "").trim();
+  if (!label) return "Unit";
+  return /^unit\b/i.test(label) ? label : `Unit ${label}`;
 }
 
 function formatLedgerCurrency(centsValue: unknown): string {
@@ -1428,6 +1455,21 @@ function formatLedgerCurrency(centsValue: unknown): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })}`;
+}
+
+function formatLedgerExportLabel(value: unknown): string {
+  const raw = String(value || "").trim();
+  if (!raw) return "-";
+  return raw
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function signedLedgerAmountCents(entry: any): number {
+  if (entry?.entryType === "payment") return -Math.abs(Number(entry?.amountCents || 0));
+  if (entry?.entryType === "adjustment") return Number(entry?.amountCents || 0);
+  return Math.abs(Number(entry?.amountCents || 0));
 }
 
 async function renderLeaseLedgerPdf(params: {
@@ -1448,8 +1490,9 @@ async function renderLeaseLedgerPdf(params: {
   const rangeLabel = [params.from, params.to].filter(Boolean).join(" to ") || "All dates";
   doc.font("Helvetica-Bold").fontSize(18).fillColor("#0f172a").text("Lease Ledger");
   doc.moveDown(0.25);
-  doc.font("Helvetica").fontSize(10).fillColor("#475569").text(`${params.labels.property} · Unit ${params.labels.unit}`);
-  doc.text(`Lease ${params.leaseId} · ${rangeLabel} · ${params.rows.length} entries`);
+  doc.font("Helvetica").fontSize(10).fillColor("#475569").text(`${params.labels.property} · ${formatUnitLabel(params.labels.unit)}`);
+  doc.text(`${rangeLabel} · ${params.rows.length} entries`);
+  doc.text(`Support reference: ${formatInternalReference("lease", params.leaseId)}`);
   doc.moveDown(0.75);
 
   const tableX = 42;
@@ -1487,19 +1530,15 @@ async function renderLeaseLedgerPdf(params: {
   let runningBalance = 0;
 
   for (const row of params.rows) {
-    const signedAmount = row?.entryType === "payment"
-      ? -Math.abs(Number(row?.amountCents || 0))
-      : row?.entryType === "adjustment"
-      ? Number(row?.amountCents || 0) // Adjustments can be positive or negative
-      : Math.abs(Number(row?.amountCents || 0));
+    const signedAmount = signedLedgerAmountCents(row);
     runningBalance += signedAmount;
     const description =
       String(row?.notes || "").trim() ||
-      [row?.category, row?.method, row?.reference].map((value) => String(value || "").trim()).filter(Boolean).join(" · ") ||
+      [formatLedgerExportLabel(row?.category), row?.method, row?.reference].map((value) => String(value || "").trim()).filter((value) => value && value !== "-").join(" · ") ||
       "-";
     const values: Record<string, string> = {
       date: String(row?.effectiveDate || "-"),
-      type: String(row?.entryType || "-").replace(/_/g, " "),
+      type: formatLedgerExportLabel(row?.entryType),
       description,
       amount: formatLedgerCurrency(signedAmount),
       balance: formatLedgerCurrency(runningBalance),
@@ -3351,39 +3390,31 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
     const labels = await resolveLeaseLedgerExportLabels(leaseCheck.lease);
     let runningBalance = 0;
     const header = [
-      "date",
-      "entryType",
-      "category",
-      "amountCents",
-      "signedAmountCents",
-      "balanceCents",
-      "method",
-      "reference",
-      "notes",
-      "property",
-      "unit",
-      "createdAt",
+      "Date",
+      "Type",
+      "Category",
+      "Amount",
+      "Balance",
+      "Method",
+      "Reference",
+      "Notes",
+      "Property",
+      "Unit",
     ];
     const rows = entries.map((entry: any) => {
-      const signed = entry.entryType === "payment"
-        ? -Math.abs(Number(entry.amountCents || 0))
-        : entry.entryType === "adjustment"
-        ? Number(entry.amountCents || 0) // Adjustments can be positive or negative
-        : Math.abs(Number(entry.amountCents || 0));
+      const signed = signedLedgerAmountCents(entry);
       runningBalance += signed;
       return [
-        entry.effectiveDate,
-        entry.entryType,
-        entry.category,
-        entry.amountCents,
-        signed,
-        runningBalance,
+        entry.effectiveDate || "",
+        formatLedgerExportLabel(entry.entryType),
+        formatLedgerExportLabel(entry.category),
+        formatLedgerCurrency(signed),
+        formatLedgerCurrency(runningBalance),
         entry.method || "",
         entry.reference || "",
         entry.notes || "",
         labels.property,
-        labels.unit,
-        entry.createdAt || "",
+        formatUnitLabel(labels.unit),
       ]
         .map(escapeCsvCell)
         .join(",");
@@ -3392,7 +3423,7 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
     res.setHeader("Content-Type", "text/csv; charset=utf-8");
     res.setHeader(
       "Content-Disposition",
-      `attachment; filename=\"lease-ledger-${leaseId}.csv\"`
+      `attachment; filename=\"${labels.filenameSlug}.csv\"`
     );
     return res.status(200).send(csv);
   } catch (err) {
@@ -3420,7 +3451,7 @@ router.get("/:leaseId/ledger/export.pdf", async (req: any, res: Response) => {
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader(
       "Content-Disposition",
-      `attachment; filename=\"lease-ledger-${leaseId}.pdf\"`
+      `attachment; filename=\"${labels.filenameSlug}.pdf\"`
     );
     void recordPdfExportTelemetry({
       eventName: "pdf_export_completed",
@@ -3448,5 +3479,3 @@ router.get("/:leaseId/ledger/export.pdf", async (req: any, res: Response) => {
 });
 
 export default router;
-
-

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -54,7 +54,14 @@ function normalizeUnitLabel(value: any) {
 }
 
 function buildPropertyLabel(property: any) {
-  return stringOrNull(property?.name) || stringOrNull(property?.addressLine1) || null;
+  return (
+    stringOrNull(property?.name) ||
+    stringOrNull(property?.propertyName) ||
+    stringOrNull(property?.propertyAddress) ||
+    stringOrNull(property?.addressLine1) ||
+    stringOrNull(property?.address) ||
+    null
+  );
 }
 
 function buildTenantLabel(tenant: any) {

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -12,6 +12,14 @@ router.use(authenticateJwt);
 
 type Role = "landlord" | "tenant";
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CURRENT_LEASE_STATUSES = new Set([
+  "active",
+  "current",
+  "signed",
+  "notice_pending",
+  "renewal_pending",
+  "renewal_accepted",
+]);
 
 function toMillis(v: any): number | null {
   if (!v) return null;
@@ -126,6 +134,60 @@ async function loadCurrentLeaseForTenant(tenantId: string | null, hintedLeaseId?
   return candidates[0] || null;
 }
 
+function scoreLeaseForMessages(raw: any) {
+  return CURRENT_LEASE_STATUSES.has(String(raw?.status || "").trim().toLowerCase()) ? 1 : 0;
+}
+
+async function loadCurrentLeaseForConversation(
+  conversation: ReturnType<typeof normalizeConversation>,
+  tenant:
+    | {
+        id?: string | null;
+        raw: any;
+        currentLeaseId?: string | null;
+      }
+    | null
+) {
+  const tenantId =
+    stringOrNull(conversation.tenantId) ||
+    stringOrNull(tenant?.id) ||
+    stringOrNull(tenant?.raw?.tenantId) ||
+    stringOrNull(tenant?.raw?.userId) ||
+    stringOrNull(tenant?.raw?.uid);
+  const hintedLeaseId =
+    stringOrNull(conversation.leaseId) ||
+    stringOrNull(tenant?.currentLeaseId) ||
+    stringOrNull(tenant?.raw?.currentLeaseId) ||
+    stringOrNull(tenant?.raw?.leaseId);
+
+  const tenantLease = await loadCurrentLeaseForTenant(tenantId, hintedLeaseId);
+  if (tenantLease) return tenantLease;
+
+  const unitId = stringOrNull(conversation.unitId);
+  if (!unitId) return null;
+
+  try {
+    const snap = await db.collection("leases").where("unitId", "==", unitId).limit(10).get();
+    const candidates = (snap.docs || [])
+      .map((doc: any) => ({ id: doc.id, raw: doc.data() as any }))
+      .filter((lease: any) => {
+        const leaseLandlordId = stringOrNull(lease.raw?.landlordId);
+        const leasePropertyId = stringOrNull(lease.raw?.propertyId);
+        if (leaseLandlordId && leaseLandlordId !== conversation.landlordId) return false;
+        if (conversation.propertyId && leasePropertyId && leasePropertyId !== conversation.propertyId) return false;
+        return true;
+      });
+    candidates.sort((left, right) => {
+      const statusDiff = scoreLeaseForMessages(right.raw) - scoreLeaseForMessages(left.raw);
+      if (statusDiff !== 0) return statusDiff;
+      return (toMillis(right.raw?.updatedAt || right.raw?.createdAt) || 0) - (toMillis(left.raw?.updatedAt || left.raw?.createdAt) || 0);
+    });
+    return candidates[0] || null;
+  } catch {
+    return null;
+  }
+}
+
 async function loadTenantForConversation(conversation: ReturnType<typeof normalizeConversation>) {
   const tenantId = stringOrNull(conversation.tenantId);
   const tenantEmail = String(conversation.tenantEmail || "").trim().toLowerCase();
@@ -161,6 +223,17 @@ async function loadTenantForConversation(conversation: ReturnType<typeof normali
     }
   }
 
+  const lease = await loadCurrentLeaseForConversation(conversation, null);
+  const leaseTenantId = stringOrNull(lease?.raw?.tenantId);
+  if (leaseTenantId) {
+    try {
+      const tenantSnap = await db.collection("tenants").doc(leaseTenantId).get();
+      if (tenantSnap.exists) return { id: tenantSnap.id, raw: tenantSnap.data() as any };
+    } catch {
+      // fall back to unresolved tenant display
+    }
+  }
+
   return null;
 }
 
@@ -172,6 +245,7 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
   const tenantByConversationId = new Map<
     string,
     {
+      id: string | null;
       raw: any;
       label: string | null;
       unitLabel: string | null;
@@ -183,6 +257,7 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
     tenantEntries.map(([conversationId, tenant]) => [
       conversationId,
       {
+        id: tenant?.id || null,
         raw: tenant?.raw || null,
         label: tenant?.raw ? buildTenantLabel(tenant.raw) : null,
         unitLabel: tenant?.raw ? normalizeUnitLabel(tenant.raw?.unitLabel || tenant.raw?.unitNumber || tenant.raw?.unit) : null,
@@ -221,10 +296,7 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
       const tenant = tenantByConversationId.get(conversation.id);
       return [
         conversation.id,
-        await loadCurrentLeaseForTenant(
-          stringOrNull(conversation.tenantId),
-          stringOrNull(conversation.leaseId) || tenant?.currentLeaseId
-        ),
+        await loadCurrentLeaseForConversation(conversation, tenant || null),
       ] as const;
     })
   );

--- a/rentchain-api/src/routes/publicRoutes.ts
+++ b/rentchain-api/src/routes/publicRoutes.ts
@@ -565,6 +565,41 @@ function toMillis(v: any): number | null {
   return null;
 }
 
+const MESSAGE_CURRENT_LEASE_STATUSES = new Set([
+  "active",
+  "current",
+  "signed",
+  "notice_pending",
+  "renewal_pending",
+  "renewal_accepted",
+]);
+
+function stringOrNull(value: any) {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function normalizeUnitLabel(value: any) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  return /^unit\b/i.test(raw) ? raw : `Unit ${raw}`;
+}
+
+function buildPropertyLabel(property: any) {
+  return (
+    stringOrNull(property?.name) ||
+    stringOrNull(property?.propertyName) ||
+    stringOrNull(property?.propertyAddress) ||
+    stringOrNull(property?.addressLine1) ||
+    stringOrNull(property?.address) ||
+    null
+  );
+}
+
+function buildTenantLabel(tenant: any) {
+  return stringOrNull(tenant?.fullName) || stringOrNull(tenant?.name) || stringOrNull(tenant?.email) || null;
+}
+
 function normalizeConversation(doc: any) {
   const data = doc.data() as any;
   const id = doc.id;
@@ -572,7 +607,14 @@ function normalizeConversation(doc: any) {
     id,
     landlordId: data.landlordId || null,
     tenantId: data.tenantId || null,
+    tenantEmail: data.tenantEmail || data.applicantEmail || data.email || null,
+    tenantName: data.tenantName || data.tenantDisplayName || data.applicantName || null,
+    propertyId: data.propertyId || null,
     unitId: data.unitId || null,
+    applicationId: data.applicationId || null,
+    leaseId: data.leaseId || data.currentLeaseId || null,
+    propertySnapshotLabel: data.propertyDisplayLabel || data.propertyName || data.propertyLabel || null,
+    unitSnapshotLabel: data.unitDisplayLabel || data.unitLabel || data.unitNumber || null,
     lastMessageAt: toMillis(data.lastMessageAt) || null,
     lastReadAtLandlord: toMillis(data.lastReadAtLandlord) || null,
     lastReadAtTenant: toMillis(data.lastReadAtTenant) || null,
@@ -580,6 +622,225 @@ function normalizeConversation(doc: any) {
     lastNotifiedAtLandlordMs: toMillis(data.lastNotifiedAtLandlordMs) || null,
     lastNotifiedAtTenantMs: toMillis(data.lastNotifiedAtTenantMs) || null,
   };
+}
+
+function scoreMessageLease(raw: any) {
+  return MESSAGE_CURRENT_LEASE_STATUSES.has(String(raw?.status || "").trim().toLowerCase()) ? 1 : 0;
+}
+
+async function loadCurrentLeaseForPublicConversation(conversation: ReturnType<typeof normalizeConversation>) {
+  const leaseId = stringOrNull(conversation.leaseId);
+  if (leaseId) {
+    try {
+      const snap = await db.collection("leases").doc(leaseId).get();
+      if (snap.exists) return { id: snap.id, raw: snap.data() as any };
+    } catch {
+      // continue through tenant and unit lookups
+    }
+  }
+
+  const candidates: Array<{ id: string; raw: any }> = [];
+  const tenantId = stringOrNull(conversation.tenantId);
+  if (tenantId) {
+    try {
+      const snap = await db.collection("leases").where("tenantId", "==", tenantId).limit(10).get();
+      for (const doc of snap.docs || []) candidates.push({ id: doc.id, raw: doc.data() as any });
+    } catch {
+      // continue through unit lookup
+    }
+    try {
+      const snap = await db.collection("leases").where("tenantIds", "array-contains", tenantId).limit(10).get();
+      for (const doc of snap.docs || []) {
+        if (!candidates.some((candidate) => candidate.id === doc.id)) {
+          candidates.push({ id: doc.id, raw: doc.data() as any });
+        }
+      }
+    } catch {
+      // continue through unit lookup
+    }
+  }
+
+  const unitId = stringOrNull(conversation.unitId);
+  if (unitId) {
+    try {
+      const snap = await db.collection("leases").where("unitId", "==", unitId).limit(10).get();
+      for (const doc of snap.docs || []) {
+        if (!candidates.some((candidate) => candidate.id === doc.id)) {
+          candidates.push({ id: doc.id, raw: doc.data() as any });
+        }
+      }
+    } catch {
+      // ignore lease lookup failures
+    }
+  }
+
+  const filtered = candidates.filter((lease) => {
+    const leaseLandlordId = stringOrNull(lease.raw?.landlordId);
+    const leasePropertyId = stringOrNull(lease.raw?.propertyId);
+    if (leaseLandlordId && leaseLandlordId !== conversation.landlordId) return false;
+    if (conversation.propertyId && leasePropertyId && leasePropertyId !== conversation.propertyId) return false;
+    return true;
+  });
+  filtered.sort((left, right) => {
+    const statusDiff = scoreMessageLease(right.raw) - scoreMessageLease(left.raw);
+    if (statusDiff !== 0) return statusDiff;
+    return (toMillis(right.raw?.updatedAt || right.raw?.createdAt) || 0) - (toMillis(left.raw?.updatedAt || left.raw?.createdAt) || 0);
+  });
+  return filtered[0] || null;
+}
+
+async function loadTenantForPublicConversation(
+  conversation: ReturnType<typeof normalizeConversation>,
+  lease?: { id: string; raw: any } | null
+) {
+  const tenantIds = [
+    stringOrNull(conversation.tenantId),
+    stringOrNull(lease?.raw?.tenantId),
+  ].filter(Boolean) as string[];
+
+  for (const tenantId of tenantIds) {
+    try {
+      const directSnap = await db.collection("tenants").doc(tenantId).get();
+      if (directSnap.exists) return { id: directSnap.id, raw: directSnap.data() as any };
+    } catch {
+      // continue through alternate tenant identifiers
+    }
+    for (const field of ["tenantId", "userId", "uid"]) {
+      try {
+        const snap = await db.collection("tenants").where(field, "==", tenantId).limit(2).get();
+        const doc = snap.docs?.[0];
+        if (doc) return { id: doc.id, raw: doc.data() as any };
+      } catch {
+        // continue through alternate tenant identifiers
+      }
+    }
+  }
+
+  const tenantEmail = String(conversation.tenantEmail || "").trim().toLowerCase();
+  if (tenantEmail) {
+    for (const field of ["email", "applicantEmail"]) {
+      try {
+        const snap = await db.collection("tenants").where(field, "==", tenantEmail).limit(2).get();
+        const doc = snap.docs?.[0];
+        if (doc) return { id: doc.id, raw: doc.data() as any };
+      } catch {
+        // continue through alternate email fields
+      }
+    }
+  }
+
+  return null;
+}
+
+async function enrichPublicConversationDisplay<T extends ReturnType<typeof normalizeConversation>>(conversations: T[]) {
+  const leaseEntries = await Promise.all(
+    conversations.map(async (conversation) => [conversation.id, await loadCurrentLeaseForPublicConversation(conversation)] as const)
+  );
+  const leaseByConversationId = new Map<string, Awaited<ReturnType<typeof loadCurrentLeaseForPublicConversation>>>(leaseEntries);
+  const tenantEntries = await Promise.all(
+    conversations.map(async (conversation) => [
+      conversation.id,
+      await loadTenantForPublicConversation(conversation, leaseByConversationId.get(conversation.id)),
+    ] as const)
+  );
+  const tenantByConversationId = new Map<string, { id: string | null; raw: any }>(
+    tenantEntries.map(([conversationId, tenant]) => [
+      conversationId,
+      {
+        id: tenant?.id || null,
+        raw: tenant?.raw || null,
+      },
+    ])
+  );
+
+  const unitIds = Array.from(
+    new Set(
+      conversations
+        .flatMap((conversation) => {
+          const tenant = tenantByConversationId.get(conversation.id);
+          const lease = leaseByConversationId.get(conversation.id);
+          return [
+            stringOrNull(conversation.unitId),
+            stringOrNull(tenant?.raw?.unitId),
+            stringOrNull(lease?.raw?.unitId),
+          ];
+        })
+        .filter(Boolean)
+    )
+  ) as string[];
+  const units = await Promise.all(
+    unitIds.map(async (unitId) => {
+      try {
+        const snap = await db.collection("units").doc(unitId).get();
+        return [unitId, snap.exists ? (snap.data() as any) : null] as const;
+      } catch {
+        return [unitId, null] as const;
+      }
+    })
+  );
+  const unitById = new Map<string, any>(units);
+
+  const propertyIds = Array.from(
+    new Set(
+      conversations
+        .flatMap((conversation) => {
+          const tenant = tenantByConversationId.get(conversation.id);
+          const lease = leaseByConversationId.get(conversation.id);
+          const unit = stringOrNull(conversation.unitId) ? unitById.get(String(conversation.unitId)) : null;
+          return [
+            stringOrNull(conversation.propertyId),
+            stringOrNull(unit?.propertyId),
+            stringOrNull(tenant?.raw?.propertyId),
+            stringOrNull(lease?.raw?.propertyId),
+          ];
+        })
+        .filter(Boolean)
+    )
+  ) as string[];
+  const properties = await Promise.all(
+    propertyIds.map(async (propertyId) => {
+      try {
+        const snap = await db.collection("properties").doc(propertyId).get();
+        return [propertyId, snap.exists ? (snap.data() as any) : null] as const;
+      } catch {
+        return [propertyId, null] as const;
+      }
+    })
+  );
+  const propertyById = new Map<string, any>(properties);
+
+  return conversations.map((conversation) => {
+    const tenant = tenantByConversationId.get(conversation.id);
+    const lease = leaseByConversationId.get(conversation.id);
+    const unitId =
+      stringOrNull(conversation.unitId) ||
+      stringOrNull(tenant?.raw?.unitId) ||
+      stringOrNull(lease?.raw?.unitId);
+    const unit = unitId ? unitById.get(unitId) : null;
+    const propertyId =
+      stringOrNull(conversation.propertyId) ||
+      stringOrNull(unit?.propertyId) ||
+      stringOrNull(tenant?.raw?.propertyId) ||
+      stringOrNull(lease?.raw?.propertyId);
+    const property = propertyId ? propertyById.get(propertyId) : null;
+
+    return {
+      ...conversation,
+      tenantDisplayName:
+        buildTenantLabel(tenant?.raw) ||
+        stringOrNull(conversation.tenantName) ||
+        stringOrNull(conversation.tenantEmail),
+      propertyId: propertyId || conversation.propertyId,
+      unitId: unitId || conversation.unitId,
+      leaseId: stringOrNull(conversation.leaseId) || stringOrNull(lease?.id),
+      propertyDisplayLabel: buildPropertyLabel(property) || stringOrNull(conversation.propertySnapshotLabel),
+      unitDisplayLabel:
+        normalizeUnitLabel(unit?.unitNumber || unit?.unitLabel || unit?.label || unit?.name) ||
+        normalizeUnitLabel(tenant?.raw?.unitLabel || tenant?.raw?.unitNumber || tenant?.raw?.unit) ||
+        normalizeUnitLabel(lease?.raw?.unitLabel || lease?.raw?.unitNumber || lease?.raw?.unit) ||
+        normalizeUnitLabel(conversation.unitSnapshotLabel),
+    };
+  });
 }
 
 async function addMessage(params: { conversationId: string; senderRole: "landlord" | "tenant"; body: string }) {
@@ -796,7 +1057,7 @@ router.get("/landlord/messages/conversations", authenticateJwt, requireLandlord,
   try {
     const snap = await db.collection("conversations").where("landlordId", "==", landlordId).get();
 
-    const items = snap.docs.map(normalizeConversation);
+    const items = await enrichPublicConversationDisplay(snap.docs.map(normalizeConversation));
     items.sort((a: any, b: any) => {
       const aKey = a.lastMessageAt || a.createdAt || 0;
       const bKey = b.lastMessageAt || b.createdAt || 0;
@@ -833,7 +1094,7 @@ router.get("/landlord/messages/conversations/:id", authenticateJwt, requireLandl
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichPublicConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.landlordId !== landlordId) return res.status(403).json({ ok: false, error: "Forbidden" });
 
     const msgSnap = await db.collection("messages").where("conversationId", "==", id).get();
@@ -868,7 +1129,7 @@ router.post("/landlord/messages/conversations/:id", authenticateJwt, requireLand
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichPublicConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.landlordId !== landlordId) return res.status(403).json({ ok: false, error: "Forbidden" });
 
     const msg = await addMessage({ conversationId: id, senderRole: "landlord", body });
@@ -889,7 +1150,7 @@ router.post("/landlord/messages/conversations/:id/read", authenticateJwt, requir
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichPublicConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.landlordId !== landlordId) return res.status(403).json({ ok: false, error: "Forbidden" });
 
     await db
@@ -930,9 +1191,11 @@ router.get("/tenant/messages/conversation", authenticateJwt, requireTenant, asyn
         lastNotifiedAtTenantMs: null,
       });
       const created = await ref.get();
-      return res.json({ ok: true, conversation: normalizeConversation(created) });
+      const createdConversation = (await enrichPublicConversationDisplay([normalizeConversation(created)]))[0];
+      return res.json({ ok: true, conversation: createdConversation });
     }
-    return res.json({ ok: true, conversation: normalizeConversation(snap) });
+    const conversation = (await enrichPublicConversationDisplay([normalizeConversation(snap)]))[0];
+    return res.json({ ok: true, conversation });
   } catch (err: any) {
     console.error("[publicRoutes] tenant get/create conversation error", err);
     return res.status(500).json({ ok: false, error: "Failed to load conversation" });
@@ -952,7 +1215,7 @@ router.get("/tenant/messages/conversation/:id", authenticateJwt, requireTenant, 
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichPublicConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.tenantId !== ctx.tenantId || convo.landlordId !== ctx.landlordId) {
       return res.status(403).json({ ok: false, error: "Forbidden" });
     }
@@ -990,7 +1253,7 @@ router.post("/tenant/messages/conversation/:id", authenticateJwt, requireTenant,
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichPublicConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.tenantId !== ctx.tenantId || convo.landlordId !== ctx.landlordId) {
       return res.status(403).json({ ok: false, error: "Forbidden" });
     }
@@ -1014,7 +1277,7 @@ router.post("/tenant/messages/conversation/:id/read", authenticateJwt, requireTe
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichPublicConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.tenantId !== ctx.tenantId || convo.landlordId !== ctx.landlordId) {
       return res.status(403).json({ ok: false, error: "Forbidden" });
     }

--- a/rentchain-api/src/routes/tenantDetailsRoutes.ts
+++ b/rentchain-api/src/routes/tenantDetailsRoutes.ts
@@ -80,7 +80,7 @@ router.get("/tenants/:tenantId/report", async (req, res) => {
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader(
       "Content-Disposition",
-      `attachment; filename=\"tenant-report-${tenantId}.pdf\"`
+      "attachment; filename=\"tenant-report.pdf\""
     );
     res.send(buffer);
   } catch (err) {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -1228,13 +1228,63 @@ async function writeScreeningConsentCanonicalEvent(input: {
   });
 }
 
-async function getTenantConversationIds(tenantId: string): Promise<string[]> {
-  const snap = await db
-    .collection("conversations")
-    .where("tenantId", "==", tenantId)
-    .limit(20)
-    .get();
-  return snap.docs.map((doc) => doc.id);
+function tenantConversationMatchesContext(conversation: any, context: Awaited<ReturnType<typeof resolveTenancyContext>> | null) {
+  if (!context?.ok) return true;
+  const conversationTenantId = String(conversation?.tenantId || "").trim();
+  const conversationLeaseId = String(conversation?.leaseId || "").trim();
+  const conversationApplicationId = String(conversation?.applicationId || "").trim();
+  const conversationPropertyId = String(conversation?.propertyId || "").trim();
+  const conversationUnitId = String(conversation?.unitId || "").trim();
+  const tenantId = String(context.tenantId || "").trim();
+  const leaseId = String(context.leaseId || "").trim();
+  const applicationId = String(context.applicationId || "").trim();
+  const propertyId = String(context.propertyId || "").trim();
+  const unitId = String(context.unitId || "").trim();
+
+  if (tenantId && conversationTenantId === tenantId) return true;
+  if (leaseId && conversationLeaseId === leaseId) return true;
+  if (applicationId && conversationApplicationId === applicationId) return true;
+  if (unitId && conversationUnitId === unitId) {
+    return !propertyId || !conversationPropertyId || conversationPropertyId === propertyId;
+  }
+  return false;
+}
+
+async function addTenantConversationCandidates(
+  candidates: Map<string, any>,
+  field: string,
+  value: string | null | undefined,
+  context: Awaited<ReturnType<typeof resolveTenancyContext>> | null
+) {
+  const normalized = String(value || "").trim();
+  if (!normalized) return;
+  try {
+    const snap = await db.collection("conversations").where(field, "==", normalized).limit(25).get();
+    for (const doc of snap.docs || []) {
+      const data = (doc.data() as any) || {};
+      if (tenantConversationMatchesContext(data, context)) {
+        candidates.set(doc.id, data);
+      }
+    }
+  } catch {
+    // Keep the communications summary best-effort; a failed optional lookup must not break the tenant shell.
+  }
+}
+
+async function getTenantConversationIds(
+  tenantId: string,
+  context: Awaited<ReturnType<typeof resolveTenancyContext>> | null = null
+): Promise<string[]> {
+  const candidates = new Map<string, any>();
+  await addTenantConversationCandidates(candidates, "tenantId", tenantId, context);
+
+  if (context?.ok) {
+    await addTenantConversationCandidates(candidates, "unitId", context.unitId, context);
+    await addTenantConversationCandidates(candidates, "leaseId", context.leaseId, context);
+    await addTenantConversationCandidates(candidates, "applicationId", context.applicationId, context);
+  }
+
+  return Array.from(candidates.keys());
 }
 
 async function getMessageReadMap(tenantId: string): Promise<Map<string, number>> {
@@ -2064,9 +2114,12 @@ async function buildTenantNoticeItems(tenantId: string): Promise<TenantCommunica
     .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
 }
 
-async function buildTenantMessageItems(tenantId: string): Promise<TenantCommunicationItem[]> {
+async function buildTenantMessageItems(
+  tenantId: string,
+  context: Awaited<ReturnType<typeof resolveTenancyContext>> | null = null
+): Promise<TenantCommunicationItem[]> {
   const [conversationIds, readMap] = await Promise.all([
-    getTenantConversationIds(tenantId),
+    getTenantConversationIds(tenantId, context),
     getMessageReadMap(tenantId),
   ]);
 
@@ -2077,7 +2130,6 @@ async function buildTenantMessageItems(tenantId: string): Promise<TenantCommunic
       db
         .collection("messages")
         .where("conversationId", "==", conversationId)
-        .orderBy("createdAt", "desc")
         .limit(50)
         .get()
     )
@@ -5119,11 +5171,17 @@ router.get("/messages", requireTenant, async (req: any, res) => {
   try {
     const tenantId = String(req.user?.tenantId || "").trim();
     if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const context = await resolveTenancyContext({
+      uid: String(req.user?.id || "").trim(),
+      email: String(req.user?.email || "").trim() || null,
+      tenantId,
+      leaseId: String(req.user?.leaseId || "").trim() || null,
+    });
 
     const includeMaintenance = String(req.query?.includeMaintenance ?? "1") !== "0";
     const includeScreening = String(req.query?.includeScreening ?? "1") !== "0";
     const [messageItems, maintenanceItems, screeningItems] = await Promise.all([
-      buildTenantMessageItems(tenantId),
+      buildTenantMessageItems(tenantId, context),
       includeMaintenance ? buildTenantMaintenanceUpdateItems(tenantId) : Promise.resolve([]),
       includeScreening ? buildTenantScreeningItems(tenantId) : Promise.resolve([]),
     ]);
@@ -5151,9 +5209,15 @@ router.post("/messages/read-all", requireTenant, async (req: any, res) => {
   try {
     const tenantId = String(req.user?.tenantId || "").trim();
     if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const context = await resolveTenancyContext({
+      uid: String(req.user?.id || "").trim(),
+      email: String(req.user?.email || "").trim() || null,
+      tenantId,
+      leaseId: String(req.user?.leaseId || "").trim() || null,
+    });
 
     const [messageItems, maintenanceItems, screeningItems] = await Promise.all([
-      buildTenantMessageItems(tenantId),
+      buildTenantMessageItems(tenantId, context),
       buildTenantMaintenanceUpdateItems(tenantId),
       buildTenantScreeningItems(tenantId),
     ]);
@@ -6590,8 +6654,14 @@ router.get("/communication/summary", requireTenant, async (req: any, res) => {
   try {
     const tenantId = String(req.user?.tenantId || "").trim();
     if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const context = await resolveTenancyContext({
+      uid: String(req.user?.id || "").trim(),
+      email: String(req.user?.email || "").trim() || null,
+      tenantId,
+      leaseId: String(req.user?.leaseId || "").trim() || null,
+    });
     const [messages, notices, maintenance, screening] = await Promise.all([
-      buildTenantMessageItems(tenantId),
+      buildTenantMessageItems(tenantId, context),
       buildTenantNoticeItems(tenantId),
       buildTenantMaintenanceUpdateItems(tenantId),
       buildTenantScreeningItems(tenantId),
@@ -6600,6 +6670,7 @@ router.get("/communication/summary", requireTenant, async (req: any, res) => {
     const unreadNotices = notices.filter((item) => !item.read).length;
     const unreadMaintenanceUpdates = maintenance.filter((item) => !item.read).length;
     const unreadScreeningUpdates = screening.filter((item) => !item.read).length;
+    const latestMessage = messages[0] || null;
     return res.json({
       ok: true,
       unreadMessages,
@@ -6607,6 +6678,8 @@ router.get("/communication/summary", requireTenant, async (req: any, res) => {
       unreadMaintenanceUpdates,
       unreadScreeningUpdates,
       unreadTotal: unreadMessages + unreadNotices + unreadMaintenanceUpdates + unreadScreeningUpdates,
+      latestMessagePreview: latestMessage?.body || null,
+      latestMessageAt: latestMessage?.createdAt || null,
     });
   } catch (err: any) {
     console.error("[tenant/communication/summary] failed", {

--- a/rentchain-api/src/routes/tenantsRoutes.ts
+++ b/rentchain-api/src/routes/tenantsRoutes.ts
@@ -16,6 +16,7 @@ import {
   updateMoveInReadinessItems,
 } from "../services/tenantMoveInReadinessService";
 import { requireCapability } from "../services/capabilityGuard";
+import { slugifyOperationalReference } from "../lib/identityReferences";
 
 const router = Router();
 
@@ -248,11 +249,15 @@ router.get("/:tenantId/report", async (req: any, res) => {
     }
 
     const buffer = await generateTenantReportPdfBuffer(tenantId);
+    const tenantName =
+      String((bundle.tenant as any)?.fullName || (bundle.tenant as any)?.name || (bundle.tenant as any)?.displayName || "").trim() ||
+      "tenant";
+    const filenameSlug = slugifyOperationalReference(["tenant-report", tenantName], "tenant-report");
 
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader(
       "Content-Disposition",
-      `attachment; filename=\"tenant-report-${tenantId}.pdf\"`
+      `attachment; filename=\"${filenameSlug}.pdf\"`
     );
     res.send(buffer);
   } catch (err: any) {

--- a/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
@@ -116,6 +116,25 @@ function conversationMatchesContext(conversation: any, context: TenancyContext, 
   );
 }
 
+async function loadLatestMessageMillis(conversationId: string): Promise<number | null> {
+  const id = asString(conversationId);
+  if (!id) return null;
+  try {
+    const snap = await db
+      .collection("messages")
+      .where("conversationId", "==", id)
+      .orderBy("createdAt", "desc")
+      .limit(1)
+      .get();
+    const doc = snap.docs?.[0];
+    if (!doc) return null;
+    const data = (doc.data() as any) || {};
+    return toMillis(data?.createdAt) || toMillis(data?.createdAtMs);
+  } catch {
+    return null;
+  }
+}
+
 async function resolveTenantConversation(params: {
   landlordId: string;
   context: TenancyContext;
@@ -159,11 +178,59 @@ async function resolveTenantConversation(params: {
     }
   }
 
+  const leaseId = asString(params.context.leaseId);
+  if (leaseId) {
+    try {
+      const snap = await db.collection("conversations").where("leaseId", "==", leaseId).limit(25).get();
+      for (const doc of snap.docs || []) {
+        if (!candidates.some((candidate) => candidate.id === doc.id)) {
+          candidates.push({ id: doc.id, data: (doc.data() as any) || {} });
+        }
+      }
+    } catch {
+      // fall back to deterministic conversation id
+    }
+  }
+
+  const applicationId = asString(params.context.applicationId);
+  if (applicationId) {
+    try {
+      const snap = await db.collection("conversations").where("applicationId", "==", applicationId).limit(25).get();
+      for (const doc of snap.docs || []) {
+        if (!candidates.some((candidate) => candidate.id === doc.id)) {
+          candidates.push({ id: doc.id, data: (doc.data() as any) || {} });
+        }
+      }
+    } catch {
+      // fall back to deterministic conversation id
+    }
+  }
+
   const matches = candidates.filter((entry) =>
     entry.id === deterministicId || conversationMatchesContext(entry.data, params.context, params.landlordId)
   );
-  matches.sort((left, right) => (toMillis(right.data?.lastMessageAt) || 0) - (toMillis(left.data?.lastMessageAt) || 0));
-  if (matches[0]) return matches[0];
+  const scoredMatches = await Promise.all(
+    matches.map(async (entry) => {
+      const latestMessageAt = await loadLatestMessageMillis(entry.id);
+      return {
+        ...entry,
+        latestMessageAt,
+        latestConversationAt: toMillis(entry.data?.lastMessageAt),
+      };
+    })
+  );
+  scoredMatches.sort((left, right) => {
+    const messagePresenceDiff = Number(Boolean(right.latestMessageAt)) - Number(Boolean(left.latestMessageAt));
+    if (messagePresenceDiff !== 0) return messagePresenceDiff;
+    const activityDiff =
+      (right.latestMessageAt || right.latestConversationAt || 0) -
+      (left.latestMessageAt || left.latestConversationAt || 0);
+    if (activityDiff !== 0) return activityDiff;
+    if (left.id === deterministicId) return -1;
+    if (right.id === deterministicId) return 1;
+    return left.id.localeCompare(right.id);
+  });
+  if (scoredMatches[0]) return scoredMatches[0];
 
   return {
     id: deterministicId,

--- a/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
@@ -146,6 +146,20 @@ async function resolveTenantConversation(params: {
     }
   }
 
+  const unitId = asString(params.context.unitId);
+  if (unitId) {
+    try {
+      const snap = await db.collection("conversations").where("unitId", "==", unitId).limit(25).get();
+      for (const doc of snap.docs || []) {
+        if (!candidates.some((candidate) => candidate.id === doc.id)) {
+          candidates.push({ id: doc.id, data: (doc.data() as any) || {} });
+        }
+      }
+    } catch {
+      // fall back to deterministic conversation id
+    }
+  }
+
   const matches = candidates.filter((entry) =>
     entry.id === deterministicId || conversationMatchesContext(entry.data, params.context, params.landlordId)
   );

--- a/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
@@ -110,10 +110,9 @@ function conversationMatchesContext(conversation: any, context: TenancyContext, 
   if (applicationId && asString(conversation?.applicationId) === applicationId) return true;
   if (leaseId && asString(conversation?.leaseId) === leaseId) return true;
   return Boolean(
-    propertyId &&
-      unitId &&
-      asString(conversation?.propertyId) === propertyId &&
-      asString(conversation?.unitId) === unitId
+    unitId &&
+      asString(conversation?.unitId) === unitId &&
+      (!propertyId || !asString(conversation?.propertyId) || asString(conversation?.propertyId) === propertyId)
   );
 }
 

--- a/rentchain-api/src/services/tenantReportService.ts
+++ b/rentchain-api/src/services/tenantReportService.ts
@@ -7,6 +7,7 @@ import {
 } from "./financialProjectionService";
 import { getTenantLedger } from "./tenantLedgerService";
 import { getTenantDetailBundle } from "./tenantDetailsService";
+import { formatInternalReference } from "../lib/identityReferences";
 
 export type TenantPaymentBehaviorSummary = {
   onTimeRate: number | null;
@@ -426,7 +427,7 @@ export async function generateTenantReportPdfBuffer(
       .fontSize(12)
       .fillColor("#000000")
       .text(`Tenant: ${data.tenantName}`, { continued: true })
-      .text(`   (ID: ${data.tenantId})`)
+      .text(`   (${formatInternalReference("tenant", data.tenantId)})`)
       .moveDown(0.25);
 
     if (data.propertyName || data.unitLabel) {

--- a/rentchain-frontend/src/api/creditHistoryApi.ts
+++ b/rentchain-frontend/src/api/creditHistoryApi.ts
@@ -41,7 +41,7 @@ export async function downloadCreditHistory(tenantId: string, format: "csv" | "j
   const blob = await res.blob();
   const a = document.createElement("a");
   a.href = URL.createObjectURL(blob);
-  a.download = `credit-history-${tenantId}.${format}`;
+  a.download = `credit-history.${format}`;
   document.body.appendChild(a);
   a.click();
   a.remove();

--- a/rentchain-frontend/src/api/tenantCommunicationsApi.ts
+++ b/rentchain-frontend/src/api/tenantCommunicationsApi.ts
@@ -23,6 +23,8 @@ export type TenantCommunicationSummary = {
   unreadMaintenanceUpdates: number;
   unreadScreeningUpdates?: number;
   unreadTotal: number;
+  latestMessagePreview?: string | null;
+  latestMessageAt?: string | null;
 };
 
 export type TenantThreadMessage = {

--- a/rentchain-frontend/src/api/tenantsApi.ts
+++ b/rentchain-frontend/src/api/tenantsApi.ts
@@ -161,7 +161,7 @@ export async function downloadTenantReport(tenantId: string): Promise<{ filename
     const blob = await response.blob();
     const disposition = response.headers.get("content-disposition") || "";
     const match = disposition.match(/filename="?([^"]+)"?/i);
-    const filename = match?.[1] || `tenant-summary-${tenantId}.pdf`;
+    const filename = match?.[1] || "tenant-summary.pdf";
     recordPdfExportEvent("pdf_export_completed", {
       exportType: "tenant_report",
       renderingPath: "backend_pdfkit",

--- a/rentchain-frontend/src/components/dashboard/ActionRequiredPanel.tsx
+++ b/rentchain-frontend/src/components/dashboard/ActionRequiredPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card, Button } from "../ui/Ui";
 import { spacing, colors, text } from "../../styles/tokens";
+import { formatOperationalReference } from "@/lib/identityReferences";
 
 type Props = {
   items: any[];
@@ -67,8 +68,8 @@ export function ActionRequiredPanel({
             const title = item?.title || item?.type || "Action";
             const severity = String(item?.severity || "info").toLowerCase();
             const subtitleParts = [];
-            if (item?.propertyId) subtitleParts.push(`Property: ${item.propertyId}`);
-            if (item?.tenantId) subtitleParts.push(`Tenant: ${item.tenantId}`);
+            if (item?.propertyId) subtitleParts.push(formatOperationalReference("property", item.propertyId));
+            if (item?.tenantId) subtitleParts.push(formatOperationalReference("tenant", item.tenantId));
             return (
               <div
                 key={item?.id || idx}

--- a/rentchain-frontend/src/components/dashboard/MonthlyOpsSnapshotPanel.tsx
+++ b/rentchain-frontend/src/components/dashboard/MonthlyOpsSnapshotPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { getMonthlyOpsSnapshot, type OpsMonthlySnapshot } from "../../api/opsSnapshot";
 import { TenantScorePill } from "../tenant/TenantScorePill";
+import { formatOperationalReference } from "@/lib/identityReferences";
 
 const TENANT_DETAIL_PATH = (tenantId: string) => `/tenants/${tenantId}`;
 
@@ -208,7 +209,7 @@ export default function MonthlyOpsSnapshotPanel() {
                       style={{ fontWeight: 950, color: "inherit", textDecoration: "underline", textUnderlineOffset: 3 }}
                       title="Open tenant"
                     >
-                      {t.tenantId}
+                      {formatOperationalReference("tenant", t.tenantId)}
                     </a>
 
                     <TenantScorePill score={t.scoreV1} tier={t.tierV1} compact />

--- a/rentchain-frontend/src/components/ledger/LedgerEventDrawer.tsx
+++ b/rentchain-frontend/src/components/ledger/LedgerEventDrawer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { getLedgerEventV2, LedgerEventV2 } from "../../api/ledgerV2";
 import { LedgerEventTypeBadge } from "./LedgerEventTypeBadge";
+import { formatInternalReference } from "@/lib/identityReferences";
 
 interface Props {
   eventId: string | null;
@@ -66,7 +67,8 @@ export const LedgerEventDrawer: React.FC<Props> = ({ eventId, onClose }) => {
           </div>
           {item.summary ? <div style={{ marginTop: 8 }}>{item.summary}</div> : null}
           <div style={{ marginTop: 10, fontSize: 12, color: "#4b5563" }}>
-            Property: {item.propertyId || "-"} • Tenant: {item.tenantId || "-"}
+            {item.propertyId ? formatInternalReference("property", item.propertyId) : "Property unavailable"} •{" "}
+            {item.tenantId ? formatInternalReference("tenant", item.tenantId) : "Tenant unavailable"}
           </div>
           <pre
             style={{

--- a/rentchain-frontend/src/components/ledger/LedgerTimeline.tsx
+++ b/rentchain-frontend/src/components/ledger/LedgerTimeline.tsx
@@ -3,6 +3,7 @@ import type { LedgerEventStored } from "@/api/ledgerApi";
 import { IntegrityBadge } from "./IntegrityBadge";
 import { AttachDocumentLinkModal } from "./AttachDocumentLinkModal";
 import { useToast } from "../ui/ToastProvider";
+import { formatInternalReference } from "@/lib/identityReferences";
 
 type Props = {
   items: LedgerEventStored[];
@@ -131,8 +132,8 @@ export function LedgerTimeline({ items, compact }: Props) {
                 }}
               >
                 <div>seq: {ev.seq}</div>
-                {ev.tenantId ? <div>tenantId: {ev.tenantId}</div> : null}
-                {ev.propertyId ? <div>propertyId: {ev.propertyId}</div> : null}
+                {ev.tenantId ? <div>{formatInternalReference("tenant", ev.tenantId)}</div> : null}
+                {ev.propertyId ? <div>{formatInternalReference("property", ev.propertyId)}</div> : null}
                 <div>hash: {ev.hash}</div>
                 <div>prevHash: {ev.prevHash ?? "null"}</div>
                 <div>payloadHash: {ev.payloadHash}</div>

--- a/rentchain-frontend/src/components/property/PropertyLedgerPanel.tsx
+++ b/rentchain-frontend/src/components/property/PropertyLedgerPanel.tsx
@@ -7,6 +7,7 @@ import {
   PropertyLedgerResponse,
 } from "../../types/ledger";
 import { API_BASE_URL } from "../../config/api";
+import { formatInternalReference } from "@/lib/identityReferences";
 
 interface PropertyLedgerPanelProps {
   propertyId: string;
@@ -96,7 +97,7 @@ export const PropertyLedgerPanel: React.FC<PropertyLedgerPanelProps> = ({
             whiteSpace: "nowrap",
           }}
         >
-          Property ID: {propertyId}
+          {formatInternalReference("property", propertyId)}
         </span>
       </div>
 

--- a/rentchain-frontend/src/components/tenants/TenantBalanceSummary.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantBalanceSummary.tsx
@@ -5,6 +5,7 @@ import {
   fetchTenantBalance,
   TenantBalanceSummary as BalanceSummary,
 } from "../../services/tenantBalanceApi";
+import { formatInternalReference } from "@/lib/identityReferences";
 
 interface TenantBalanceSummaryProps {
   tenantId: string | null;
@@ -179,7 +180,7 @@ export const TenantBalanceSummary: React.FC<TenantBalanceSummaryProps> = ({
             textAlign: "right",
           }}
         >
-          Tenant: {tenantId}
+          {formatInternalReference("tenant", tenantId)}
           {summary && (
             <div
               style={{

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -321,7 +321,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
       const url = URL.createObjectURL(report.blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = report.filename || `tenant-summary-${tenantId}.pdf`;
+      a.download = report.filename || "tenant-summary.pdf";
       document.body.appendChild(a);
       a.click();
       a.remove();

--- a/rentchain-frontend/src/features/automation/timeline/AutomationTimelinePage.tsx
+++ b/rentchain-frontend/src/features/automation/timeline/AutomationTimelinePage.tsx
@@ -7,6 +7,7 @@ import { useAutomationTimeline } from "./useAutomationTimeline";
 import type { AutomationEvent, AutomationEventType } from "./automationTimeline.types";
 import { canUseTimeline, canUseTimelineCsv, normalizeTimelinePlan } from "./timelineEntitlements";
 import { computeTimelineAnalytics } from "./timelineAnalytics";
+import { formatOperationalReference, type IdentityReferenceKind } from "@/lib/identityReferences";
 
 type FilterValue = "all" | AutomationEventType;
 
@@ -56,6 +57,36 @@ const entityOrder: Array<keyof NonNullable<AutomationEvent["entity"]>> = [
   "leaseId",
   "paymentId",
 ];
+
+const entityReferenceKinds: Record<keyof NonNullable<AutomationEvent["entity"]>, IdentityReferenceKind> = {
+  propertyId: "property",
+  unitId: "unit",
+  tenantId: "tenant",
+  applicationId: "application",
+  leaseId: "lease",
+  paymentId: "payment",
+};
+
+const entityReferenceLabels: Record<keyof NonNullable<AutomationEvent["entity"]>, string> = {
+  propertyId: "Property",
+  unitId: "Unit",
+  tenantId: "Tenant",
+  applicationId: "Application",
+  leaseId: "Lease",
+  paymentId: "Payment",
+};
+
+function formatEntityReference(key: keyof NonNullable<AutomationEvent["entity"]>, value: unknown): string {
+  return formatOperationalReference(entityReferenceKinds[key], value);
+}
+
+function normalizedEntityReferences(entity: AutomationEvent["entity"] | undefined) {
+  return Object.fromEntries(
+    entityOrder
+      .map((key) => [key.replace(/Id$/, "Reference"), entity?.[key] ? formatEntityReference(key, entity[key]) : ""] as const)
+      .filter((entry) => entry[1])
+  );
+}
 
 export default function AutomationTimelinePage() {
   const { user } = useAuth();
@@ -165,7 +196,16 @@ export default function AutomationTimelinePage() {
   const analytics = useMemo(() => computeTimelineAnalytics(visibleEvents), [visibleEvents]);
 
   const handleExport = () => {
-    const payload = JSON.stringify(visibleEvents, null, 2);
+    const exportEvents = visibleEvents.map((event) => ({
+      eventReference: formatOperationalReference("event", event.id),
+      type: event.type,
+      occurredAt: event.occurredAt,
+      title: event.title,
+      summary: event.summary || "",
+      entityReferences: normalizedEntityReferences(event.entity),
+      source: String((event.metadata as Record<string, unknown> | undefined)?.source || ""),
+    }));
+    const payload = JSON.stringify(exportEvents, null, 2);
     const blob = new Blob([payload], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
@@ -185,34 +225,34 @@ export default function AutomationTimelinePage() {
   const handleCsvExport = () => {
     try {
       const headers = [
-        "id",
+        "eventReference",
         "type",
         "occurredAt",
         "title",
         "summary",
-        "propertyId",
-        "unitId",
-        "tenantId",
-        "applicationId",
-        "leaseId",
-        "paymentId",
+        "propertyReference",
+        "unitReference",
+        "tenantReference",
+        "applicationReference",
+        "leaseReference",
+        "paymentReference",
         "source",
       ];
       const lines = [
         headers.join(","),
         ...visibleEvents.map((event) =>
           [
-            event.id,
+            formatOperationalReference("event", event.id),
             event.type,
             event.occurredAt,
             event.title,
             event.summary || "",
-            event.entity?.propertyId || "",
-            event.entity?.unitId || "",
-            event.entity?.tenantId || "",
-            event.entity?.applicationId || "",
-            event.entity?.leaseId || "",
-            event.entity?.paymentId || "",
+            event.entity?.propertyId ? formatEntityReference("propertyId", event.entity.propertyId) : "",
+            event.entity?.unitId ? formatEntityReference("unitId", event.entity.unitId) : "",
+            event.entity?.tenantId ? formatEntityReference("tenantId", event.entity.tenantId) : "",
+            event.entity?.applicationId ? formatEntityReference("applicationId", event.entity.applicationId) : "",
+            event.entity?.leaseId ? formatEntityReference("leaseId", event.entity.leaseId) : "",
+            event.entity?.paymentId ? formatEntityReference("paymentId", event.entity.paymentId) : "",
             String((event.metadata as Record<string, unknown> | undefined)?.source || ""),
           ]
             .map(csvEscape)
@@ -513,7 +553,7 @@ export default function AutomationTimelinePage() {
             <option value="">All properties</option>
             {propertyIds.map((id) => (
               <option key={id} value={id}>
-                {id}
+                {formatOperationalReference("property", id)}
               </option>
             ))}
           </select>
@@ -525,7 +565,7 @@ export default function AutomationTimelinePage() {
             <option value="">All units</option>
             {unitIds.map((id) => (
               <option key={id} value={id}>
-                {id}
+                {formatOperationalReference("unit", id)}
               </option>
             ))}
           </select>
@@ -537,7 +577,7 @@ export default function AutomationTimelinePage() {
             <option value="">All tenants</option>
             {tenantIds.map((id) => (
               <option key={id} value={id}>
-                {id}
+                {formatOperationalReference("tenant", id)}
               </option>
             ))}
           </select>
@@ -757,7 +797,7 @@ export default function AutomationTimelinePage() {
                             padding: "3px 8px",
                           }}
                         >
-                          {key}: {String(value)}
+                          {entityReferenceLabels[key]}: {formatEntityReference(key, value)}
                         </span>
                       ))}
                     </div>

--- a/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
@@ -93,12 +93,11 @@ describe("decisionContext", () => {
         { label: "Severity", value: "Critical" },
         { label: "Related delinquency signal", value: "Overdue" },
         { label: "Outstanding amount", value: "$1,450.00" },
-        { label: "Payment intent reference", value: "pi-1" },
-        { label: "Rent payment reference", value: "rp-1" },
+        { label: "Provider payment reference", value: "Internal payment ID: pi-1" },
+        { label: "Internal rent payment reference", value: "Internal payment ID: rp-1" },
         { label: "Last action", value: "Assigned by ops@example.com" },
       ])
     );
     expect(items.map((item) => item.value)).not.toContain("undefined");
   });
 });
-

--- a/rentchain-frontend/src/lib/decisions/decisionContext.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.ts
@@ -1,4 +1,5 @@
 import type { LeaseDelinquencySignal, LeaseObligationLedgerRow } from "@/api/leaseLedgerApi";
+import { formatInternalReference } from "@/lib/identityReferences";
 import type { DecisionItem } from "./decisionDisplay";
 
 export type DecisionContextLink = {
@@ -185,8 +186,12 @@ export function buildDecisionEvidenceItems(
   }
   if (lifecycleState) items.push({ label: "Lease lifecycle state", value: titleCase(lifecycleState) });
   if (lifecycleReasons) items.push({ label: "Lifecycle reason", value: lifecycleReasons });
-  if (decision.paymentIntentId) items.push({ label: "Payment intent reference", value: decision.paymentIntentId });
-  if (decision.rentPaymentId) items.push({ label: "Rent payment reference", value: decision.rentPaymentId });
+  if (decision.paymentIntentId) {
+    items.push({ label: "Provider payment reference", value: formatInternalReference("payment", decision.paymentIntentId) });
+  }
+  if (decision.rentPaymentId) {
+    items.push({ label: "Internal rent payment reference", value: formatInternalReference("payment", decision.rentPaymentId) });
+  }
   if (decision.latestAction) {
     items.push({
       label: "Last action",
@@ -196,4 +201,3 @@ export function buildDecisionEvidenceItems(
 
   return items;
 }
-

--- a/rentchain-frontend/src/lib/identityReferences.test.ts
+++ b/rentchain-frontend/src/lib/identityReferences.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatInternalReference,
+  formatOperationalLabel,
+  formatOperationalReference,
+  shortenInternalId,
+  slugifyOperationalReference,
+} from "./identityReferences";
+
+describe("identityReferences", () => {
+  it("shortens long internal ids without changing storage identity", () => {
+    expect(shortenInternalId("38r6fSwiPSDke0rEGKkx")).toBe("38r6fSwi...GKkx");
+    expect(shortenInternalId("t1")).toBe("t1");
+  });
+
+  it("labels internal ids explicitly for support and debug contexts", () => {
+    expect(formatInternalReference("tenant", "38r6fSwiPSDke0rEGKkx")).toBe(
+      "Internal tenant ID: 38r6fSwi...GKkx"
+    );
+  });
+
+  it("uses operational labels before falling back to references", () => {
+    expect(formatOperationalLabel({ kind: "tenant", label: "Bailey Blinkers", internalId: "abc123" })).toBe(
+      "Bailey Blinkers"
+    );
+    expect(formatOperationalLabel({ kind: "tenant", internalId: "38r6fSwiPSDke0rEGKkx" })).toBe(
+      "Tenant ref 38r6fSwi...GKkx"
+    );
+  });
+
+  it("formats export-safe slugs from human-readable parts", () => {
+    expect(slugifyOperationalReference(["Lease ledger", "Bailey House", "Unit 4"])).toBe(
+      "lease-ledger-bailey-house-unit-4"
+    );
+    expect(slugifyOperationalReference(["", null], "fallback-name")).toBe("fallback-name");
+  });
+
+  it("formats operational references without raw field names", () => {
+    expect(formatOperationalReference("lease", "lease_1234567890abcdef")).toBe("Lease ref lease_12...cdef");
+  });
+});

--- a/rentchain-frontend/src/lib/identityReferences.ts
+++ b/rentchain-frontend/src/lib/identityReferences.ts
@@ -1,0 +1,72 @@
+export type IdentityReferenceKind =
+  | "application"
+  | "event"
+  | "ledgerEntry"
+  | "lease"
+  | "payment"
+  | "property"
+  | "record"
+  | "tenant"
+  | "unit";
+
+const KIND_LABELS: Record<IdentityReferenceKind, string> = {
+  application: "application",
+  event: "event",
+  ledgerEntry: "ledger entry",
+  lease: "lease",
+  payment: "payment",
+  property: "property",
+  record: "record",
+  tenant: "tenant",
+  unit: "unit",
+};
+
+function cleanString(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function titleCase(value: string): string {
+  return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function shortenInternalId(value: unknown, visiblePrefix = 8, visibleSuffix = 4): string {
+  const text = cleanString(value);
+  if (!text) return "not available";
+  const minimumLength = visiblePrefix + visibleSuffix + 2;
+  if (text.length <= minimumLength) return text;
+  return `${text.slice(0, visiblePrefix)}...${text.slice(-visibleSuffix)}`;
+}
+
+export function formatInternalReference(kind: IdentityReferenceKind, value: unknown): string {
+  return `Internal ${KIND_LABELS[kind]} ID: ${shortenInternalId(value)}`;
+}
+
+export function formatOperationalReference(kind: IdentityReferenceKind, value: unknown): string {
+  return `${titleCase(KIND_LABELS[kind])} ref ${shortenInternalId(value)}`;
+}
+
+export function formatOperationalLabel(input: {
+  kind: IdentityReferenceKind;
+  label?: unknown;
+  fallbackLabel?: unknown;
+  internalId?: unknown;
+}): string {
+  const label = cleanString(input.label);
+  if (label) return label;
+  const fallbackLabel = cleanString(input.fallbackLabel);
+  if (fallbackLabel) return fallbackLabel;
+  if (cleanString(input.internalId)) return formatOperationalReference(input.kind, input.internalId);
+  return `${titleCase(KIND_LABELS[input.kind])} unavailable`;
+}
+
+export function slugifyOperationalReference(parts: unknown[], fallback = "rentchain-export"): string {
+  const slug = parts
+    .map(cleanString)
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return slug || fallback;
+}

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -656,7 +656,7 @@ describe("LeaseLedgerPage", () => {
       );
       expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
     });
-    expect(createdAnchors[createdAnchors.length - 1]?.download).toBe("lease-ledger-lease-1.pdf");
+    expect(createdAnchors[createdAnchors.length - 1]?.download).toBe("lease-ledger-harbour-view-unit-101.pdf");
     expect(global.URL.createObjectURL).toHaveBeenCalled();
     expect(global.URL.revokeObjectURL).toHaveBeenCalled();
   });

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -24,6 +24,7 @@ import {
   type LandlordActiveLease,
   type LeaseNote,
 } from "@/api/leasesApi";
+import { formatInternalReference, formatOperationalLabel, formatOperationalReference, slugifyOperationalReference } from "@/lib/identityReferences";
 import {
   decisionDisplayCopy,
   decisionSeverityStyle,
@@ -255,8 +256,8 @@ function DecisionRow({
 }) {
   const copy = decisionDisplayCopy[decision.decisionType];
   const context = [
-    decision.unitId ? `Unit ${decision.unitId}` : null,
-    decision.tenantId ? `Tenant ${decision.tenantId}` : null,
+    decision.unitId ? formatOperationalReference("unit", decision.unitId) : null,
+    decision.tenantId ? formatOperationalReference("tenant", decision.tenantId) : null,
   ].filter(Boolean);
   return (
     <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, background: "#fff", display: "grid", gap: 6 }}>
@@ -612,9 +613,17 @@ export default function LeaseLedgerPage() {
       if (to) query.set("to", to);
       const queryString = query.toString();
       const path = `/leases/${encodeURIComponent(leaseId)}/ledger/export.${format}${queryString ? `?${queryString}` : ""}`;
+      const exportSlug = slugifyOperationalReference(
+        [
+          "lease-ledger",
+          lease?.propertyName || lease?.propertyAddress || "property",
+          lease?.unitNumber ? `unit-${lease.unitNumber}` : lease?.unitLabel || "unit",
+        ],
+        "lease-ledger"
+      );
       const { blob, filename } = await downloadAuthenticatedExport({
         path,
-        fallbackFilename: `lease-ledger-${leaseId}.${format}`,
+        fallbackFilename: `${exportSlug}.${format}`,
         errorMessage: `Failed to export ${format.toUpperCase()}`,
         observability: isPdf
           ? {
@@ -634,12 +643,14 @@ export default function LeaseLedgerPage() {
       <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", justifyContent: "space-between" }}>
         <div>
           <h1 style={{ margin: 0, fontSize: "1.2rem" }}>Lease Ledger</h1>
-          <div style={{ color: "#475569", marginTop: 4 }}>Lease ID: {leaseId}</div>
+          <div style={{ color: "#475569", marginTop: 4 }}>
+            {lease
+              ? `${formatOperationalLabel({ kind: "property", label: lease.propertyName || lease.propertyAddress, fallbackLabel: "Property", internalId: lease.propertyId })} · ${formatOperationalLabel({ kind: "unit", label: lease.unitNumber ? `Unit ${lease.unitNumber}` : lease.unitLabel, fallbackLabel: "Unit", internalId: lease.unitId })}`
+              : "Lease ledger"}
+          </div>
+          <div style={{ color: "#64748b", marginTop: 2, fontSize: 12 }}>{formatInternalReference("lease", leaseId)}</div>
           {lease ? (
             <div style={{ color: "#334155", marginTop: 6, display: "grid", gap: 2 }}>
-              <div>
-                {lease.propertyName || "Property"} · Unit {lease.unitNumber || "—"}
-              </div>
               <div>
                 {lease.tenantName || "Tenant not linked"} · {prettyStatus(lease.status)}
                 {lease.archivedAt ? ` · Archived ${formatDate(lease.archivedAt)}` : ""}

--- a/rentchain-frontend/src/pages/LedgerV2Page.tsx
+++ b/rentchain-frontend/src/pages/LedgerV2Page.tsx
@@ -4,6 +4,7 @@ import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
 import { colors, spacing } from "@/styles/tokens";
 import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
+import { formatInternalReference } from "@/lib/identityReferences";
 
 type Filters = {
   eventType: string;
@@ -262,7 +263,8 @@ export default function LedgerV2Page() {
             Occurred: {new Date(detail.occurredAt).toLocaleString()}
           </div>
           <div style={{ marginTop: 8, fontSize: 12 }}>
-            Property: {detail.propertyId || "-"} | Tenant: {detail.tenantId || "-"}
+            {detail.propertyId ? formatInternalReference("property", detail.propertyId) : "Property unavailable"} |{" "}
+            {detail.tenantId ? formatInternalReference("tenant", detail.tenantId) : "Tenant unavailable"}
           </div>
           <pre style={{ marginTop: 12, background: "#f9f9f9", padding: 8, borderRadius: 8, fontSize: 12 }}>
             {JSON.stringify(detail.metadata || {}, null, 2)}

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -156,7 +156,7 @@ describe("MessagesPage", () => {
 
     await flushAsync();
     expect(screen.getAllByText("Taylor Tenant")[0]).toBeInTheDocument();
-    expect(screen.getAllByText("Taylor Tenant • Assigned unit").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Taylor Tenant • Linked property / linked unit").length).toBeGreaterThan(0);
     expect(screen.queryByText(/prop-raw-1|unit-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Tenant conversation • Unit unavailable")).not.toBeInTheDocument();
     expect(screen.getAllByText("TT")[0]).toBeInTheDocument();
@@ -230,7 +230,7 @@ describe("MessagesPage", () => {
     );
 
     await flushAsync();
-    expect(screen.getAllByText("Tenant • Assigned unit").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Tenant • Linked property / linked unit").length).toBeGreaterThan(0);
     expect(screen.queryByText(/tenant-raw-5|prop-raw-5|unit-raw-5/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unavailable/i)).not.toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -70,8 +70,11 @@ function displayConversationContext(conversation: Conversation | null) {
   if (propertyLabel && unitLabel) return `${propertyLabel} / ${unitLabel}`;
   if (unitLabel) return unitLabel;
   if (propertyLabel) return propertyLabel;
-  if (conversation?.unitId) return "Assigned unit";
-  if (conversation?.propertyId) return "Selected property";
+  const propertyId = String(conversation?.propertyId || "").trim();
+  const unitId = String(conversation?.unitId || "").trim();
+  if (propertyId && unitId) return "Linked property / linked unit";
+  if (unitId) return "Linked unit";
+  if (propertyId) return "Linked property";
   return "Tenant conversation";
 }
 

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -134,7 +134,7 @@ describe("PaymentsPage", () => {
     click.mockRestore();
   });
 
-  it("falls back to explicit IDs instead of unavailable labels when API labels are absent", async () => {
+  it("falls back to operational references instead of unavailable labels when API labels are absent", async () => {
     mocks.usePayments.mockReturnValue({
       payments: [
         {
@@ -157,8 +157,8 @@ describe("PaymentsPage", () => {
 
     render(<PaymentsPage />);
 
-    expect((await screen.findAllByText("Tenant tenant-2")).length).toBeGreaterThan(0);
-    expect((await screen.findAllByText("Property prop-2")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Tenant ref tenant-2")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Property ref prop-2")).length).toBeGreaterThan(0);
     expect(screen.queryByText(/unavailable/i)).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -14,6 +14,7 @@ import { fetchTenants } from "../api/tenantsApi";
 import { printSummaryDocument } from "../utils/printSummary";
 import { triggerBlobDownload } from "../utils/downloadBlob";
 import { buildCsvBlob } from "../utils/csvExport";
+import { formatOperationalReference } from "@/lib/identityReferences";
 
 function tenantLabelFromValue(value: any): string {
   return (
@@ -92,7 +93,7 @@ const PaymentsPage: React.FC = () => {
       tenantLabelFromValue(record.tenantProfile) ||
       String(record.tenantName || record.tenantDisplayName || record.applicantName || "").trim() ||
       labelMap.tenants.get(String(payment.tenantId || "").trim()) ||
-      (payment.tenantId ? `Tenant ${payment.tenantId}` : "Tenant")
+      (payment.tenantId ? formatOperationalReference("tenant", payment.tenantId) : "Tenant")
     );
   };
   const getPropertyLabel = (payment: PaymentRecord) => {
@@ -108,9 +109,9 @@ const PaymentsPage: React.FC = () => {
     const propertyId = String(payment.propertyId || "").trim();
     const unitId = String(record.unitId || "").trim();
     if (propertyLabel || formattedUnit) return propertyLabel || formattedUnit;
-    if (propertyId && unitId) return `Property ${propertyId} / Unit ${unitId}`;
-    if (propertyId) return `Property ${propertyId}`;
-    if (unitId) return `Unit ${unitId}`;
+    if (propertyId && unitId) return `${formatOperationalReference("property", propertyId)} / ${formatOperationalReference("unit", unitId)}`;
+    if (propertyId) return formatOperationalReference("property", propertyId);
+    if (unitId) return formatOperationalReference("unit", unitId);
     return "Property";
   };
 
@@ -118,7 +119,7 @@ const PaymentsPage: React.FC = () => {
     try {
       setExporting(format);
       const blob = buildCsvBlob(
-        ["tenant", "property", "amount", "paid_date", "method", "notes"],
+        ["tenant", "property_unit", "amount", "paid_date", "method", "notes"],
         rows.map((payment) => [
           getTenantLabel(payment),
           getPropertyLabel(payment),
@@ -268,7 +269,7 @@ const PaymentsPage: React.FC = () => {
                   }}
                 >
                   <th style={{ padding: "0.5rem 0.4rem" }}>Tenant</th>
-                  <th style={{ padding: "0.5rem 0.4rem" }}>Property</th>
+                  <th style={{ padding: "0.5rem 0.4rem" }}>Property / Unit</th>
                   <th style={{ padding: "0.5rem 0.4rem", textAlign: "right" }}>Amount</th>
                   <th style={{ padding: "0.5rem 0.4rem" }}>Paid Date</th>
                   <th style={{ padding: "0.5rem 0.4rem", textAlign: "right" }}>Method</th>
@@ -341,7 +342,7 @@ const PaymentsPage: React.FC = () => {
           <thead>
             <tr>
               <th>Tenant</th>
-              <th>Property</th>
+              <th>Property / Unit</th>
               <th>Amount</th>
               <th>Paid date</th>
               <th>Method</th>

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   useToastMock: vi.fn(),
   useAuthMock: vi.fn(),
   useCapabilitiesMock: vi.fn(),
+  printSummaryDocumentMock: vi.fn(),
 }));
 
 vi.mock("../api/propertiesApi", () => ({
@@ -99,6 +100,10 @@ vi.mock("../hooks/useCapabilities", () => ({
   useCapabilities: mocks.useCapabilitiesMock,
 }));
 
+vi.mock("../utils/printSummary", () => ({
+  printSummaryDocument: mocks.printSummaryDocumentMock,
+}));
+
 vi.mock("../lib/analytics", () => ({
   track: vi.fn(),
 }));
@@ -121,6 +126,7 @@ describe("PropertiesPage", () => {
       features: { tenant_invites: false },
       loading: false,
     });
+    mocks.printSummaryDocumentMock.mockResolvedValue(undefined);
   });
 
   it("renders active and archived property filters", async () => {
@@ -153,6 +159,21 @@ describe("PropertiesPage", () => {
     await waitFor(() => {
       expect(screen.getAllByRole("button", { name: "Print / Save PDF" }).length).toBeGreaterThan(0);
     });
+  });
+
+  it("routes property print through the shared summary print helper", async () => {
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Print / Save PDF" }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Print / Save PDF" })[0]);
+
+    expect(mocks.printSummaryDocumentMock).toHaveBeenCalledWith("summary");
   });
 
   it("shows a guided first-property empty state for new users", async () => {

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -34,6 +34,7 @@ import { track } from "../lib/analytics";
 import { resolveReturnToParam } from "../lib/propertyGate";
 import { useCapabilities } from "../hooks/useCapabilities";
 import { deriveUnitOccupancyFromLeases } from "../lib/leases/leaseLifecycle";
+import { printSummaryDocument } from "../utils/printSummary";
 
 const PropertiesPage: React.FC = () => {
   const [properties, setProperties] = useState<Property[]>([]);
@@ -874,7 +875,7 @@ const PropertiesPage: React.FC = () => {
                     <Button
                       type="button"
                       className="no-print"
-                      onClick={() => window.print()}
+                      onClick={() => void printSummaryDocument("summary")}
                     >
                       Print / Save PDF
                     </Button>

--- a/rentchain-frontend/src/pages/admin/AdminIntegrityPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminIntegrityPage.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Pill, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
 import { exportAdminIntegrityCsv, fetchAdminIntegrity, type AdminIntegrity } from "../../api/adminApi";
 import { AdminSavedFilters } from "../../components/admin/AdminSavedFilters";
+import { formatOperationalReference } from "@/lib/identityReferences";
 
 const EMPTY_INTEGRITY: AdminIntegrity = {
   sections: [
@@ -204,9 +205,9 @@ export const AdminIntegrityPage: React.FC = () => {
                             <div style={{ fontWeight: 600 }}>{sample.label}</div>
                             <div style={{ color: "#64748b", fontSize: 13 }}>
                               {sample.type}
-                              {sample.propertyId ? ` · Property ${sample.propertyId}` : ""}
-                              {sample.leaseId ? ` · Lease ${sample.leaseId}` : ""}
-                              {sample.tenantId ? ` · Tenant ${sample.tenantId}` : ""}
+                              {sample.propertyId ? ` · ${formatOperationalReference("property", sample.propertyId)}` : ""}
+                              {sample.leaseId ? ` · ${formatOperationalReference("lease", sample.leaseId)}` : ""}
+                              {sample.tenantId ? ` · ${formatOperationalReference("tenant", sample.tenantId)}` : ""}
                             </div>
                             {sample.relatedAdminPath ? (
                               <Link to={sample.relatedAdminPath} style={{ color: "#2563eb", fontWeight: 600, textDecoration: "none" }}>

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
@@ -121,7 +121,7 @@ describe("AdminLeaseLifecycleReviewPage", () => {
     expect(screen.getByText(/Expired lease conflicts with manual occupancy/i)).toBeInTheDocument();
     expect(screen.getByText(/unknown lifecycle/i)).toBeInTheDocument();
     expect(screen.getByText(/expired occupancy conflict/i)).toBeInTheDocument();
-    expect(screen.getByText(/Open lease record/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Open lease record/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Confirm occupancy manually/i)).toBeInTheDocument();
     expect(screen.getAllByText(/reviewed/i).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: /Mark reviewed/i }).length).toBeGreaterThan(0);
@@ -139,7 +139,11 @@ describe("AdminLeaseLifecycleReviewPage", () => {
     expect(screen.getAllByText("Evidence").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Occupancy/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Lease lifecycle indicates an occupancy conflict that needs review/i).length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: "lease-1" })).toHaveAttribute("href", "/admin/leases?q=lease-1");
+    expect(
+      screen
+        .getAllByRole("link", { name: "Open lease record" })
+        .some((link) => link.getAttribute("href") === "/admin/leases?q=lease-1")
+    ).toBe(true);
     expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/Fix automatically/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /accept/i })).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/decisions/decisionDisplay";
 import { patchDecisionAction } from "@/api/decisionApi";
 import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
+import { formatInternalReference, formatOperationalReference } from "@/lib/identityReferences";
 
 const emptySummary: AdminLeaseLifecycleReviewSummary = {
   total: 0,
@@ -115,9 +116,11 @@ function QueueItemRow({
       </td>
       <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
         <div style={{ display: "grid", gap: 4 }}>
-          <Link to={`/admin/leases?q=${encodeURIComponent(item.leaseId)}`}>{item.leaseId}</Link>
+          <Link to={`/admin/leases?q=${encodeURIComponent(item.leaseId)}`}>Open lease record</Link>
+          <span style={{ color: "#64748b", fontSize: "0.85rem" }}>{formatInternalReference("lease", item.leaseId)}</span>
           <span style={{ color: "#64748b", fontSize: "0.9rem" }}>
-            Property {item.propertyId || "-"} - Unit {item.unitId || "-"}
+            {item.propertyId ? formatOperationalReference("property", item.propertyId) : "Property unavailable"} -{" "}
+            {item.unitId ? formatOperationalReference("unit", item.unitId) : "Unit unavailable"}
           </span>
         </div>
       </td>


### PR DESCRIPTION
## Summary

Phase 1 only for raw Firestore ID operational leakage hardening.

This PR separates internal storage identity from operational human-readable references across low-risk UI, support/debug, and export surfaces. Internal Firestore IDs remain preserved internally; route params, backend storage, and API behavior are unchanged.

## What Changed

- Added shared identity/reference formatting helpers for frontend and API.
- Replaced low-risk raw ID display with operational references where safe.
- Labeled support/debug contexts explicitly as Internal tenant/property/lease/payment IDs.
- Normalized export/download filenames where safe to prefer tenant, property/unit, lease, or generic report references over raw Firestore IDs.
- Updated automation timeline exports to use normalized operational references instead of raw entity maps.
- Normalized lease ledger CSV exports from datastore-style fields to landlord-facing columns and formatted currency values.
- Lease ledger CSV now omits datastore headers such as `amountCents`, `signedAmountCents`, `balanceCents`, and `createdAt`.
- Lease ledger CSV/PDF resolve unit labels from the `units` document when the lease only carries an internal `unitId`.
- Tightened lease ledger PDF row labels so entry type/category values render as operational labels.
- Updated payments print/export labels to use Property / Unit context.
- Expanded messages backend display hydration for property address labels and replaced ID-only frontend fallbacks with non-ID linked-property/unit copy.
- Routed /properties Print / Save PDF through the shared summary print helper.
- Added helper tests and updated expectations for normalized export/display behavior.

## Explicit Non-Goals

- No route/API redesign.
- No Firestore migrations.
- No public ID system introduced.
- No global Firestore ID replacement.
- No payment, lifecycle, lease, or occupancy behavior changes.
- Internal IDs are still preserved and used internally.
- No telemetry infrastructure changes.
- No lease document/template generation changes.

## Tests Run

- `rentchain-api npm run test:single -- src/routes/__tests__/leaseRoutes.integrity.test.ts src/routes/__tests__/messagesRoutes.test.ts src/lib/__tests__/identityReferences.test.ts`
- `rentchain-frontend npm run test:single -- src/pages/MessagesPage.test.tsx src/pages/PaymentsPage.test.tsx src/pages/PropertiesPage.test.tsx src/pages/LeaseLedgerPage.test.tsx`
- `rentchain-api npm run build`
- `rentchain-frontend npm run build`
- `rentchain-frontend npm run lint`
- Earlier full Phase 1 pass before this QA follow-up: `rentchain-frontend npm run test:light` and `rentchain-api npm run test:light`
- `git diff --check`

## Known Limitations / Follow-ups

- `rentchain-frontend/src/pages/reports/MonthlyOpsReportPage.tsx` has an invalid UTF-8 issue and was intentionally deferred to avoid broadening Phase 1 scope. Track separately if that page still leaks raw IDs.
- `/api/telemetry` 404 noise during PDF export remains a telemetry follow-up, not part of this PR’s identity/export normalization scope.
- `/leases` View Lease showing Schedule A/fallback-style content instead of a full lease template is a separate lease document/template generation follow-up. PR #905 did not change lease document generation.

## QA Notes

Preview QA should focus on confirming operational labels and exports remain understandable while support/debug contexts still expose explicitly labeled internal references where needed. Lease ledger CSV/PDF are API-backed; QA must run against a backend deployment containing this PR head to validate those API export changes.