### PR TITLE
feat: add tenant profile button to landlord messages

### DIFF
--- a/rentchain-frontend/src/pages/MessagesPage.css
+++ b/rentchain-frontend/src/pages/MessagesPage.css
@@ -85,6 +85,34 @@
   overflow-wrap: anywhere;
 }
 
+.rc-messages-tenant-profile-button {
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 5px 9px;
+  white-space: nowrap;
+}
+
+.rc-messages-tenant-profile-button:hover,
+.rc-messages-tenant-profile-button:focus-visible {
+  background: rgba(37, 99, 235, 0.14);
+  outline: 2px solid rgba(37, 99, 235, 0.25);
+  outline-offset: 2px;
+}
+
+.rc-messages-thread-title-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .rc-messages-list-item-meta {
   font-size: 0.8rem;
   color: #64748b;

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -1,5 +1,5 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MessagesPage from "./MessagesPage";
 
@@ -39,6 +39,11 @@ vi.mock("@/components/layout/ResponsiveMasterDetail", () => ({
   ),
 }));
 
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
 describe("MessagesPage", () => {
   afterEach(() => {
     cleanup();
@@ -59,6 +64,7 @@ describe("MessagesPage", () => {
     mocks.fetchLandlordConversationsMock.mockResolvedValue([
       {
         id: "conv-1",
+        tenantId: "tenant-1",
         tenantDisplayName: "Taylor Tenant",
         propertyDisplayLabel: "Harbour View",
         unitDisplayLabel: "Unit 2A",
@@ -67,6 +73,7 @@ describe("MessagesPage", () => {
     mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
       conversation: {
         id: "conv-1",
+        tenantId: "tenant-1",
         tenantDisplayName: "Taylor Tenant",
         propertyDisplayLabel: "Harbour View",
         unitDisplayLabel: "Unit 2A",
@@ -99,8 +106,8 @@ describe("MessagesPage", () => {
     );
 
     await flushAsync();
-    expect(screen.getByText("Taylor Tenant")).toBeInTheDocument();
-    expect(screen.getByText("Harbour View / Unit 2A")).toBeInTheDocument();
+    expect(screen.getAllByText("Taylor Tenant").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Harbour View / Unit 2A").length).toBeGreaterThan(0);
     expect(screen.getByText("TT")).toBeInTheDocument();
     expect(screen.queryByText(/Tenant tenant-/i)).not.toBeInTheDocument();
   });
@@ -233,6 +240,109 @@ describe("MessagesPage", () => {
     expect(screen.getAllByText("Tenant • Linked property / linked unit").length).toBeGreaterThan(0);
     expect(screen.queryByText(/tenant-raw-5|prop-raw-5|unit-raw-5/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unavailable/i)).not.toBeInTheDocument();
+  });
+
+  it("renders profile buttons that navigate to the tenant profile when tenantId is present", async () => {
+    render(
+      <MemoryRouter>
+        <LocationProbe />
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await flushAsync();
+    expect(screen.queryByRole("link", { name: "Taylor Tenant" })).not.toBeInTheDocument();
+    const buttons = screen.getAllByRole("button", { name: "Profile" });
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+
+    fireEvent.click(buttons[0]);
+    expect(screen.getByTestId("location")).toHaveTextContent("/tenants?tenantId=tenant-1");
+  });
+
+  it("keeps landlord message tenant names as plain text when tenantId is missing", async () => {
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([
+      {
+        id: "conv-missing-tenant",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      },
+    ]);
+    mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
+      conversation: {
+        id: "conv-missing-tenant",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      },
+      messages: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await flushAsync();
+    expect(screen.getAllByText("Taylor Tenant").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link", { name: "Taylor Tenant" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Profile" })).not.toBeInTheDocument();
+  });
+
+  it("keeps profile buttons from reselecting the message thread", async () => {
+    render(
+      <MemoryRouter>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await flushAsync();
+    fireEvent.click(screen.getAllByRole("button", { name: "Profile" })[0]);
+
+    expect(mocks.fetchLandlordConversationMessagesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the rest of a conversation row selectable when the profile button is present", async () => {
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([
+      {
+        id: "conv-1",
+        tenantId: "tenant-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      },
+      {
+        id: "conv-2",
+        tenantId: "tenant-2",
+        tenantDisplayName: "Jordan Tenant",
+        propertyDisplayLabel: "North Point",
+        unitDisplayLabel: "Unit 3",
+      },
+    ]);
+    mocks.fetchLandlordConversationMessagesMock.mockImplementation(async (id: string) => ({
+      conversation: {
+        id,
+        tenantId: id === "conv-2" ? "tenant-2" : "tenant-1",
+        tenantDisplayName: id === "conv-2" ? "Jordan Tenant" : "Taylor Tenant",
+        propertyDisplayLabel: id === "conv-2" ? "North Point" : "Harbour View",
+        unitDisplayLabel: id === "conv-2" ? "Unit 3" : "Unit 2A",
+      },
+      messages: [],
+    }));
+
+    render(
+      <MemoryRouter>
+        <LocationProbe />
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await flushAsync();
+    fireEvent.click(screen.getByText("North Point / Unit 3"));
+
+    expect(screen.getByTestId("location")).toHaveTextContent("/messages?threadId=conv-2");
+    expect(mocks.fetchLandlordConversationMessagesMock).toHaveBeenCalledWith("conv-2");
   });
 
   it("preserves the selected conversation across background refresh without blanking the thread", async () => {

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -104,6 +104,60 @@ function buildConversationMeta(conversation: Conversation) {
   return displayConversationContext(conversation);
 }
 
+function tenantProfilePath(conversation: Conversation | null) {
+  const tenantId = String(conversation?.tenantId || "").trim();
+  return tenantId ? `/tenants?tenantId=${encodeURIComponent(tenantId)}` : null;
+}
+
+function TenantNameLabel({
+  conversation,
+  className,
+}: {
+  conversation: Conversation | null;
+  className?: string;
+}) {
+  const tenantName = displayTenantName(conversation);
+  return <span className={className}>{tenantName}</span>;
+}
+
+function TenantProfileButton({
+  conversation,
+  onClick,
+}: {
+  conversation: Conversation | null;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}) {
+  const navigate = useNavigate();
+  const path = tenantProfilePath(conversation);
+  if (!path) return null;
+  return (
+    <button
+      type="button"
+      className="rc-messages-tenant-profile-button"
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        event.stopPropagation();
+        navigate(path);
+      }}
+    >
+      Profile
+    </button>
+  );
+}
+
+function ConversationHeaderTitle({ conversation }: { conversation: Conversation | null }) {
+  if (!conversation) return <>Conversation</>;
+  const locationLabel = displayConversationContext(conversation);
+  return (
+    <span className="rc-messages-thread-title-content">
+      <TenantNameLabel conversation={conversation} />
+      {locationLabel ? <span> • {locationLabel}</span> : null}
+      <TenantProfileButton conversation={conversation} />
+    </span>
+  );
+}
+
 export default function MessagesPage() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -390,10 +444,18 @@ export default function MessagesPage() {
                 conversations.map((c) => {
                   const isActive = c.id === selectedId;
                   return (
-                    <button
+                    <div
                       key={c.id}
                       className="rc-messages-list-item"
+                      role="button"
+                      tabIndex={0}
                       onClick={() => {
+                        setSelectedId(c.id);
+                        navigate(`/messages?threadId=${c.id}`);
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key !== "Enter" && event.key !== " ") return;
+                        event.preventDefault();
                         setSelectedId(c.id);
                         navigate(`/messages?threadId=${c.id}`);
                       }}
@@ -413,8 +475,9 @@ export default function MessagesPage() {
                         <div className="rc-messages-list-item-content">
                           <div className="rc-messages-list-item-row">
                             <div className="rc-messages-list-item-title">
-                              {displayTenantName(c)}
+                              <TenantNameLabel conversation={c} />
                             </div>
+                            <TenantProfileButton conversation={c} />
                             {c.hasUnread ? (
                               <span className="rc-messages-unread-dot" />
                             ) : null}
@@ -424,7 +487,7 @@ export default function MessagesPage() {
                           </div>
                         </div>
                       </div>
-                    </button>
+                    </div>
                   );
                 })
               )}
@@ -436,7 +499,7 @@ export default function MessagesPage() {
                 <>
                   <div className="rc-messages-thread-header">
                     <div className="rc-messages-thread-title">
-                      {selectedConversationTitle}
+                      <ConversationHeaderTitle conversation={selectedConversation} />
                     </div>
                   </div>
                   <div className="rc-messages-thread-body">


### PR DESCRIPTION
## Summary

- Add explicit Profile buttons to landlord /messages conversation rows when tenantId is present.
- Add the same Profile button to the selected conversation header when tenantId is present.
- Keep tenant names as plain text, and keep profile navigation out of rows that do not have tenantId.

## Scope

- Frontend-only landlord /messages navigation.
- No backend messaging changes.
- No tenant workspace communications changes.
- No message send/reply behavior changes.
- No route redesign; buttons navigate to existing landlord tenant profile route /tenants?tenantId=<id>.

## Dependency

This PR targets fix/raw-firestore-id-operational-leakage-v1 because PR #905 is still open and this branch was built on top of that messaging normalization work. Retarget to main after #905 merges if needed.

## Tests

- npm test -- --run src/pages/MessagesPage.test.tsx
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build

Note: the frontend build completes, with the existing Vite warning that Node 20.11.1 is below Vite's preferred 20.19+ runtime.