### PR TITLE
fix: send email notifications for landlord-to-tenant messages

### DIFF
--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -181,6 +181,90 @@ describe("messagesRoutes notifications", () => {
 
     expect(res.status).toBe(201);
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ["tenant@example.com"],
+        subject: expect.stringContaining("New message from your landlord"),
+      })
+    );
+  });
+
+  it("emails tenant when landlord replies to an auth-id conversation hydrated by tenant email", async () => {
+    ensureCollection("conversations").set("conv-auth-email", {
+      landlordId: "landlord-1",
+      tenantId: "auth-user-1",
+      tenantEmail: "tenant@example.com",
+      unitId: "unit-1",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations/conv-auth-email",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+      body: { body: "Your landlord reply is ready." },
+    });
+
+    expect(res.status).toBe(201);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ["tenant@example.com"],
+      })
+    );
+  });
+
+  it("emails tenant when landlord replies to a unit-linked conversation resolved through an active lease", async () => {
+    ensureCollection("conversations").set("conv-unit-only", {
+      landlordId: "landlord-1",
+      tenantId: null,
+      propertyId: null,
+      unitId: "unit-1",
+    });
+    ensureCollection("leases").set("lease-unit-only", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations/conv-unit-only",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+      body: { body: "Unit-linked reply." },
+    });
+
+    expect(res.status).toBe(201);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ["tenant@example.com"],
+      })
+    );
+  });
+
+  it("does not fail landlord send when tenant email is missing", async () => {
+    ensureCollection("conversations").set("conv-no-email", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-no-email",
+    });
+    ensureCollection("tenants").set("tenant-no-email", {
+      fullName: "No Email Tenant",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations/conv-no-email",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+      body: { body: "This should persist without email." },
+    });
+
+    expect(res.status).toBe(201);
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("emails landlord when tenant sends a message", async () => {

--- a/rentchain-api/src/routes/__tests__/publicRoutes.messages.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicRoutes.messages.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { sendEmailMock } = vi.hoisted(() => ({
+  sendEmailMock: vi.fn(),
+}));
+
 const collections = new Map<string, Map<string, any>>();
 
 function ensureCollection(name: string) {
@@ -102,7 +106,7 @@ vi.mock("../../services/capabilityGuard", () => ({
   requireCapability: vi.fn(async () => ({ ok: true })),
 }));
 vi.mock("../../services/emailService", () => ({
-  sendEmail: vi.fn(),
+  sendEmail: sendEmailMock,
   sendWaitlistConfirmation: vi.fn(),
 }));
 vi.mock("../../services/tenantDetailsService", () => ({
@@ -185,6 +189,9 @@ async function invokeRouter(router: any, options: {
 describe("publicRoutes message endpoints", () => {
   beforeEach(() => {
     collections.clear();
+    sendEmailMock.mockReset();
+    sendEmailMock.mockResolvedValue(undefined);
+    process.env.EMAIL_FROM = "noreply@example.com";
     ensureCollection("conversations").set("conv-unit-only", {
       landlordId: "landlord-1",
       tenantId: null,
@@ -210,6 +217,9 @@ describe("publicRoutes message endpoints", () => {
       propertyId: "prop-1",
       unitNumber: "2A",
     });
+    ensureCollection("users").set("landlord-1", {
+      email: "landlord@example.com",
+    });
   });
 
   it("serves landlord messages through publicRoutes with active lease labels", async () => {
@@ -234,5 +244,52 @@ describe("publicRoutes message endpoints", () => {
         }),
       ])
     );
+  });
+
+  it("sends tenant email notifications for landlord replies on unit-linked conversations", async () => {
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations/conv-unit-only",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          landlordId: "landlord-1",
+          role: "landlord",
+          email: "landlord@example.com",
+        }),
+      },
+      body: { body: "Please review the latest message." },
+    });
+
+    expect(res.status).toBe(201);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "tenant@example.com",
+        subject: "New message on RentChain",
+      })
+    );
+  });
+
+  it("does not send tenant notifications to the landlord request user email", async () => {
+    const router = (await import("../publicRoutes")).default;
+    await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations/conv-unit-only",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          landlordId: "landlord-1",
+          role: "landlord",
+          email: "landlord@example.com",
+        }),
+      },
+      body: { body: "Recipient should be the tenant." },
+    });
+
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock.mock.calls[0]?.[0]?.to).toBe("tenant@example.com");
+    expect(sendEmailMock.mock.calls[0]?.[0]?.to).not.toBe("landlord@example.com");
   });
 });

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -76,6 +76,15 @@ function buildTenantLabel(tenant: any) {
   return stringOrNull(tenant?.fullName) || stringOrNull(tenant?.name) || stringOrNull(tenant?.email) || null;
 }
 
+function buildTenantEmail(tenant: any) {
+  return (
+    stringOrNull(tenant?.email) ||
+    stringOrNull(tenant?.applicantEmail) ||
+    stringOrNull(tenant?.tenantEmail) ||
+    null
+  );
+}
+
 async function lookupPropertyIdForUnit(unitId: string | null) {
   const target = stringOrNull(unitId);
   if (!target) return null;
@@ -248,6 +257,7 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
       id: string | null;
       raw: any;
       label: string | null;
+      email: string | null;
       unitLabel: string | null;
       unitId: string | null;
       propertyId: string | null;
@@ -260,6 +270,7 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
         id: tenant?.id || null,
         raw: tenant?.raw || null,
         label: tenant?.raw ? buildTenantLabel(tenant.raw) : null,
+        email: tenant?.raw ? buildTenantEmail(tenant.raw) : null,
         unitLabel: tenant?.raw ? normalizeUnitLabel(tenant.raw?.unitLabel || tenant.raw?.unitNumber || tenant.raw?.unit) : null,
         unitId: tenant?.raw ? stringOrNull(tenant.raw?.unitId) : null,
         propertyId: tenant?.raw ? stringOrNull(tenant.raw?.propertyId) : null,
@@ -378,6 +389,14 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
 
     return {
       ...conversation,
+      tenantId:
+        stringOrNull(conversation.tenantId) ||
+        stringOrNull(resolvedTenant?.id) ||
+        stringOrNull(resolvedLease?.raw?.tenantId),
+      tenantEmail:
+        stringOrNull(conversation.tenantEmail) ||
+        stringOrNull(resolvedTenant?.email) ||
+        buildTenantEmail(resolvedLease?.raw),
       tenantDisplayName: resolvedTenant?.label || stringOrNull(conversation.tenantName) || stringOrNull(conversation.tenantEmail),
       propertyDisplayLabel: buildPropertyLabel(property) || stringOrNull(conversation.propertySnapshotLabel),
       unitDisplayLabel:
@@ -456,6 +475,46 @@ async function lookupTenantEmail(tenantId: string | null) {
   return null;
 }
 
+async function lookupTenantEmailByAlternateId(tenantId: string | null) {
+  const id = stringOrNull(tenantId);
+  if (!id) return null;
+  for (const field of ["tenantId", "userId", "uid"]) {
+    try {
+      const snap = await db.collection("tenants").where(field, "==", id).limit(2).get();
+      const doc = snap.docs?.[0];
+      const email = doc ? buildTenantEmail(doc.data() as any) : null;
+      if (email) return email;
+    } catch {
+      // continue through alternate tenant identifiers
+    }
+  }
+  return null;
+}
+
+async function lookupApplicationTenantEmail(applicationId: string | null) {
+  const id = stringOrNull(applicationId);
+  if (!id) return null;
+  try {
+    const snap = await db.collection("rentalApplications").doc(id).get();
+    if (snap.exists) return buildTenantEmail(snap.data() as any);
+  } catch {
+    // ignore lookup failures
+  }
+  return null;
+}
+
+async function lookupTenantRecipientEmail(conversation: any) {
+  const direct = buildTenantEmail(conversation);
+  if (direct) return direct;
+  const byTenantDoc = await lookupTenantEmail(conversation?.tenantId);
+  if (byTenantDoc) return byTenantDoc;
+  const byAlternateTenantId = await lookupTenantEmailByAlternateId(conversation?.tenantId);
+  if (byAlternateTenantId) return byAlternateTenantId;
+  const byApplication = await lookupApplicationTenantEmail(conversation?.applicationId);
+  if (byApplication) return byApplication;
+  return null;
+}
+
 async function sendConversationMessageEmail(params: {
   conversation: any;
   senderRole: Role;
@@ -470,9 +529,31 @@ async function sendConversationMessageEmail(params: {
 
   const recipientEmail =
     params.senderRole === "landlord"
-      ? await lookupTenantEmail(params.conversation.tenantId)
+      ? await lookupTenantRecipientEmail(params.conversation)
       : await lookupLandlordEmail(params.conversation.landlordId);
-  if (!recipientEmail || !emailRegex.test(recipientEmail)) return;
+  if (!recipientEmail || !emailRegex.test(recipientEmail)) {
+    console.info("[messages] message email skipped", {
+      conversationId: params.conversation?.id,
+      recipientRole: params.senderRole === "landlord" ? "tenant" : "landlord",
+      reason: "recipient_email_missing",
+    });
+    return;
+  }
+
+  const recipientRole = params.senderRole === "landlord" ? "tenant" : "landlord";
+  const lastNotified =
+    recipientRole === "tenant"
+      ? toMillis(params.conversation?.lastNotifiedAtTenantMs)
+      : toMillis(params.conversation?.lastNotifiedAtLandlordMs);
+  const now = Date.now();
+  if (lastNotified && now - lastNotified < 10 * 60 * 1000) {
+    console.info("[messages] message email skipped", {
+      conversationId: params.conversation?.id,
+      recipientRole,
+      reason: "recently_notified",
+    });
+    return;
+  }
 
   const baseUrl = (process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
   const threadPath = params.senderRole === "landlord" ? "/tenant/messages" : "/messages";
@@ -500,6 +581,13 @@ async function sendConversationMessageEmail(params: {
       ctaUrl: `${baseUrl}${threadPath}`,
     }),
   });
+
+  await db.collection("conversations").doc(params.conversation.id).set(
+    recipientRole === "tenant"
+      ? { lastNotifiedAtTenantMs: now }
+      : { lastNotifiedAtLandlordMs: now },
+    { merge: true }
+  );
 }
 
 async function addMessage(params: {

--- a/rentchain-api/src/routes/publicRoutes.ts
+++ b/rentchain-api/src/routes/publicRoutes.ts
@@ -579,6 +579,10 @@ function stringOrNull(value: any) {
   return next || null;
 }
 
+function isValidEmail(value: any) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value || "").trim());
+}
+
 function normalizeUnitLabel(value: any) {
   const raw = String(value || "").trim();
   if (!raw) return null;
@@ -598,6 +602,15 @@ function buildPropertyLabel(property: any) {
 
 function buildTenantLabel(tenant: any) {
   return stringOrNull(tenant?.fullName) || stringOrNull(tenant?.name) || stringOrNull(tenant?.email) || null;
+}
+
+function buildTenantEmail(tenant: any) {
+  return (
+    stringOrNull(tenant?.email) ||
+    stringOrNull(tenant?.applicantEmail) ||
+    stringOrNull(tenant?.tenantEmail) ||
+    null
+  );
 }
 
 function normalizeConversation(doc: any) {
@@ -830,6 +843,14 @@ async function enrichPublicConversationDisplay<T extends ReturnType<typeof norma
         buildTenantLabel(tenant?.raw) ||
         stringOrNull(conversation.tenantName) ||
         stringOrNull(conversation.tenantEmail),
+      tenantId:
+        stringOrNull(conversation.tenantId) ||
+        stringOrNull(tenant?.id) ||
+        stringOrNull(lease?.raw?.tenantId),
+      tenantEmail:
+        stringOrNull(conversation.tenantEmail) ||
+        buildTenantEmail(tenant?.raw) ||
+        buildTenantEmail(lease?.raw),
       propertyId: propertyId || conversation.propertyId,
       unitId: unitId || conversation.unitId,
       leaseId: stringOrNull(conversation.leaseId) || stringOrNull(lease?.id),
@@ -863,6 +884,76 @@ async function addMessage(params: { conversationId: string; senderRole: "landlor
   return { id: docRef.id, conversationId, senderRole, body, createdAt: now, createdAtMs: now };
 }
 
+async function lookupUserEmail(userId: string | null) {
+  const id = stringOrNull(userId);
+  if (!id) return null;
+  try {
+    const userSnap = await db.collection("users").doc(id).get();
+    if (userSnap.exists) return stringOrNull((userSnap.data() as any)?.email);
+  } catch {
+    // ignore lookup failures
+  }
+  return null;
+}
+
+async function lookupLandlordRecipientEmail(landlordId: string | null) {
+  const direct = await lookupUserEmail(landlordId);
+  if (direct) return direct;
+  const id = stringOrNull(landlordId);
+  if (!id) return null;
+  try {
+    const landlordSnap = await db.collection("landlords").doc(id).get();
+    if (landlordSnap.exists) return stringOrNull((landlordSnap.data() as any)?.email);
+  } catch {
+    // ignore lookup failures
+  }
+  return null;
+}
+
+async function lookupTenantEmailById(tenantId: string | null) {
+  const id = stringOrNull(tenantId);
+  if (!id) return null;
+  try {
+    const tenantSnap = await db.collection("tenants").doc(id).get();
+    if (tenantSnap.exists) return buildTenantEmail(tenantSnap.data() as any);
+  } catch {
+    // continue through alternate tenant identifiers
+  }
+  for (const field of ["tenantId", "userId", "uid"]) {
+    try {
+      const snap = await db.collection("tenants").where(field, "==", id).limit(2).get();
+      const doc = snap.docs?.[0];
+      const email = doc ? buildTenantEmail(doc.data() as any) : null;
+      if (email) return email;
+    } catch {
+      // continue through alternate tenant identifiers
+    }
+  }
+  return null;
+}
+
+async function lookupApplicationTenantEmail(applicationId: string | null) {
+  const id = stringOrNull(applicationId);
+  if (!id) return null;
+  try {
+    const snap = await db.collection("rentalApplications").doc(id).get();
+    if (snap.exists) return buildTenantEmail(snap.data() as any);
+  } catch {
+    // ignore lookup failures
+  }
+  return null;
+}
+
+async function lookupTenantRecipientEmail(convo: any) {
+  const direct = buildTenantEmail(convo);
+  if (direct) return direct;
+  const byTenantId = await lookupTenantEmailById(convo?.tenantId);
+  if (byTenantId) return byTenantId;
+  const byApplication = await lookupApplicationTenantEmail(convo?.applicationId);
+  if (byApplication) return byApplication;
+  return null;
+}
+
 async function notifyMessageRecipient(params: {
   convo: any;
   senderRole: "landlord" | "tenant";
@@ -874,14 +965,6 @@ async function notifyMessageRecipient(params: {
     const recipientRole = senderRole === "landlord" ? "tenant" : "landlord";
     const now = Date.now();
 
-    const lastRead =
-      recipientRole === "tenant"
-        ? convo.lastReadAtTenant
-        : convo.lastReadAtLandlord;
-    if (lastRead && now - lastRead < 2 * 60 * 1000) {
-      return;
-    }
-
     const lastNotified =
       recipientRole === "tenant"
         ? convo.lastNotifiedAtTenantMs
@@ -890,42 +973,28 @@ async function notifyMessageRecipient(params: {
       return;
     }
 
-    const from =
-      String(process.env.SENDGRID_FROM_EMAIL || "").trim() ||
-      String(process.env.WAITLIST_FROM_EMAIL || "").trim();
+    const from = resolveEmailFromAddress() || String(process.env.WAITLIST_FROM_EMAIL || "").trim();
     if (!from) {
       return;
     }
 
     let toEmail: string | null = null;
     if (recipientRole === "tenant") {
-      toEmail = requestUser?.tenantEmail || requestUser?.email || null;
-      if (!toEmail && convo?.tenantId) {
-        try {
-          const tenSnap = await db.collection("tenants").doc(convo.tenantId).get();
-          if (tenSnap.exists) {
-            const data = tenSnap.data() as any;
-            toEmail = data?.email || data?.applicantEmail || null;
-          }
-        } catch {
-          // ignore lookup error
-        }
-      }
+      toEmail = await lookupTenantRecipientEmail(convo);
     } else {
-      toEmail = requestUser?.email || null;
-      if (!toEmail && convo?.landlordId) {
-        try {
-          const userSnap = await db.collection("users").doc(convo.landlordId).get();
-          if (userSnap.exists) {
-            const udata = userSnap.data() as any;
-            toEmail = udata?.email || null;
-          }
-        } catch {
-          // ignore
-        }
+      toEmail = await lookupLandlordRecipientEmail(convo?.landlordId);
+      if (!toEmail && requestUser?.role === "landlord") {
+        toEmail = stringOrNull(requestUser?.email);
       }
     }
-    if (!toEmail) return;
+    if (!toEmail || !isValidEmail(toEmail)) {
+      console.info("[messages notify] skipped", {
+        conversationId: convo?.id,
+        recipientRole,
+        reason: "recipient_email_missing",
+      });
+      return;
+    }
 
     const snippet = String(messageBody || "").slice(0, 140);
     const conversationId = convo.id;


### PR DESCRIPTION
## Summary

- Fix landlord-to-tenant message notification routing so landlord replies can email the tenant recipient.
- Resolve tenant recipient email from conversation email, canonical tenant record, alternate tenant identifiers, active lease/unit context, or rental application context.
- Preserve tenant-to-landlord message notification behavior.
- Keep message persistence, tenant inbox retrieval, and frontend messaging behavior unchanged.

## Audit Findings

- Tenant-to-landlord notifications already used the existing email service path and were working in QA.
- Landlord-to-tenant notifications were not intentionally omitted, but recipient resolution was too narrow.
- The canonical messages route only looked up `tenants/{conversation.tenantId}`, missing auth-id, unit-linked, and application-linked conversations.
- The public route messaging surface could use sender request context as the recipient fallback, which risked landlord email being considered for tenant notifications.

## Guardrails

- No message persistence behavior changed.
- No tenant inbox retrieval changes.
- No frontend changes.
- Missing tenant email skips notification safely and does not fail message send.
- Notification dedupe remains based on recent `lastNotifiedAt*Ms` metadata.

## Tests

- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- --run src/routes/__tests__/messagesRoutes.test.ts src/routes/__tests__/publicRoutes.messages.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
