### PR TITLE
feat: confirm AI-assisted payment CSV imports

### DIFF
--- a/rentchain-api/src/routes/__tests__/ledgerPaymentImportRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/ledgerPaymentImportRoutes.test.ts
@@ -5,11 +5,28 @@ import { routeSource } from "../../middleware/routeSource";
 
 const { fakeDb, resetFakeDb, seedDoc, writeTracker } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
-  const writeTracker = { writes: 0 };
+  let nextId = 1;
+  const writeTracker = { writes: 0, paymentWrites: 0, ledgerEntryWrites: 0 };
 
   function ensureCollection(name: string) {
     if (!store.has(name)) store.set(name, new Map());
     return store.get(name)!;
+  }
+
+  function makeDocRef(name: string, id = `${name}-${nextId++}`) {
+    return {
+      id,
+      get: async () => {
+        const data = ensureCollection(name).get(id);
+        return { id, exists: Boolean(data), data: () => data };
+      },
+      set: async (data: any) => {
+        writeTracker.writes += 1;
+        if (name === "payments") writeTracker.paymentWrites += 1;
+        if (name === "ledgerEntries") writeTracker.ledgerEntryWrites += 1;
+        ensureCollection(name).set(id, data);
+      },
+    };
   }
 
   function makeQuery(name: string, filters: Array<{ field: string; value: any }> = []) {
@@ -21,15 +38,12 @@ const { fakeDb, resetFakeDb, seedDoc, writeTracker } = vi.hoisted(() => {
           .map(([id, data]) => ({ id, exists: true, data: () => data }));
         return { docs, empty: docs.length === 0, size: docs.length };
       },
-      doc: (id: string) => ({
-        id,
-        set: async () => {
-          writeTracker.writes += 1;
-        },
-      }),
+      doc: (id?: string) => makeDocRef(name, id),
       add: async () => {
         writeTracker.writes += 1;
-        return { id: "new-doc" };
+        const ref = makeDocRef(name);
+        ensureCollection(name).set(ref.id, {});
+        return { id: ref.id };
       },
     };
   }
@@ -38,13 +52,20 @@ const { fakeDb, resetFakeDb, seedDoc, writeTracker } = vi.hoisted(() => {
     writeTracker,
     resetFakeDb: () => {
       store.clear();
+      nextId = 1;
       writeTracker.writes = 0;
+      writeTracker.paymentWrites = 0;
+      writeTracker.ledgerEntryWrites = 0;
     },
     seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, data),
     fakeDb: {
       collection: (name: string) => makeQuery(name),
-      runTransaction: async () => {
-        writeTracker.writes += 1;
+      runTransaction: async (fn: any) => {
+        const transaction = {
+          get: (ref: any) => ref.get(),
+          set: (ref: any, data: any) => ref.set(data),
+        };
+        await fn(transaction);
       },
     },
   };
@@ -74,6 +95,7 @@ vi.mock("../../services/capabilityGuard", () => ({
 
 function buildApp(router: any) {
   const app = express();
+  app.use(express.json());
   app.use("/api/ledger", routeSource("ledgerRoutes.ts"), router);
   return app;
 }
@@ -144,7 +166,11 @@ describe("ledger payment CSV import routes", () => {
       leaseId: "lease-1",
       confidence: "high",
     });
-    expect(writeTracker.writes).toBe(0);
+    expect(writeTracker.paymentWrites).toBe(0);
+    expect(writeTracker.ledgerEntryWrites).toBe(0);
+    const batches = await fakeDb.collection("ledgerImportBatches").get();
+    expect(batches.docs).toHaveLength(1);
+    expect(JSON.stringify(batches.docs[0].data())).not.toContain("tenantName,property,unit");
   });
 
   it("keeps payment CSV preview route ahead of broad screening fallback routes", async () => {
@@ -166,7 +192,8 @@ describe("ledger payment CSV import routes", () => {
       matchStatus: "matched",
       confidence: "high",
     });
-    expect(writeTracker.writes).toBe(0);
+    expect(writeTracker.paymentWrites).toBe(0);
+    expect(writeTracker.ledgerEntryWrites).toBe(0);
   });
 
   it("does not match tenants outside the authenticated landlord scope", async () => {
@@ -187,6 +214,169 @@ describe("ledger payment CSV import routes", () => {
       matchedTenantId: null,
       preselected: false,
     });
-    expect(writeTracker.writes).toBe(0);
+    expect(writeTracker.paymentWrites).toBe(0);
+    expect(writeTracker.ledgerEntryWrites).toBe(0);
+  });
+
+  it("confirms selected high-confidence rows into linked payments and ledger entries", async () => {
+    const router = (await import("../ledgerRoutes")).default;
+    const app = buildApp(router);
+    const csv = "tenantName,property,unit,amount,paymentDate,method,reference\nBailey Blinkers,Harbour View,1,150,2026-05-15,etransfer,may";
+
+    const preview = await request(app)
+      .post("/api/ledger/imports/payment-csv/preview")
+      .attach("file", Buffer.from(csv), {
+        filename: "payments.csv",
+        contentType: "text/csv",
+      });
+
+    const res = await request(app).post("/api/ledger/imports/payment-csv/confirm").send({
+      importBatchId: preview.body.importBatchId,
+      selectedRowIds: [preview.body.rows[0].rowId],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-payment-import-mode"]).toBe("confirm");
+    expect(res.body).toMatchObject({ ok: true, importedCount: 1, duplicateCount: 0, failedCount: 0 });
+    const payments = await fakeDb.collection("payments").get();
+    const ledgerEntries = await fakeDb.collection("ledgerEntries").get();
+    expect(payments.docs).toHaveLength(1);
+    expect(ledgerEntries.docs).toHaveLength(1);
+    const paymentDoc = payments.docs[0];
+    const entryDoc = ledgerEntries.docs[0];
+    expect(paymentDoc.data()).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        amountCents: 15000,
+        amount: 150,
+        status: "recorded",
+        paidAt: "2026-05-15",
+        effectiveDate: "2026-05-15",
+        method: "etransfer",
+        reference: "may",
+        ledgerEntryId: entryDoc.id,
+        source: "payment_csv_import",
+      })
+    );
+    expect(entryDoc.data()).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        entryType: "payment",
+        category: "payment",
+        amountCents: 15000,
+        paymentDocumentId: paymentDoc.id,
+        source: "payment_csv_import",
+      })
+    );
+  });
+
+  it("rejects unmatched selected rows and does not create payment records", async () => {
+    const router = (await import("../ledgerRoutes")).default;
+    const app = buildApp(router);
+    const csv = "tenantName,amount,paymentDate\nUnknown Tenant,150,2026-05-15";
+
+    const preview = await request(app)
+      .post("/api/ledger/imports/payment-csv/preview")
+      .attach("file", Buffer.from(csv), {
+        filename: "payments.csv",
+        contentType: "text/csv",
+      });
+    const res = await request(app).post("/api/ledger/imports/payment-csv/confirm").send({
+      importBatchId: preview.body.importBatchId,
+      selectedRowIds: [preview.body.rows[0].rowId],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ importedCount: 0, failedCount: 1 });
+    expect(res.body.results[0]).toMatchObject({ status: "failed" });
+    expect(writeTracker.paymentWrites).toBe(0);
+    expect(writeTracker.ledgerEntryWrites).toBe(0);
+  });
+
+  it("skips exact duplicates without mutating existing records", async () => {
+    seedDoc("payments", "existing-payment", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      leaseId: "lease-1",
+      amountCents: 15000,
+      paidAt: "2026-05-15",
+      effectiveDate: "2026-05-15",
+      method: "etransfer",
+      reference: "may",
+    });
+    const router = (await import("../ledgerRoutes")).default;
+    const app = buildApp(router);
+    const csv = "tenantName,property,unit,amount,paymentDate,method,reference\nBailey Blinkers,Harbour View,1,150,2026-05-15,etransfer,may";
+
+    const preview = await request(app)
+      .post("/api/ledger/imports/payment-csv/preview")
+      .attach("file", Buffer.from(csv), {
+        filename: "payments.csv",
+        contentType: "text/csv",
+      });
+    const res = await request(app).post("/api/ledger/imports/payment-csv/confirm").send({
+      importBatchId: preview.body.importBatchId,
+      selectedRowFingerprints: [preview.body.rows[0].rowFingerprint],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ importedCount: 0, duplicateCount: 1, failedCount: 0 });
+    expect(res.body.results[0]).toMatchObject({ status: "duplicate" });
+    const payments = await fakeDb.collection("payments").get();
+    expect(payments.docs).toHaveLength(1);
+    expect(writeTracker.ledgerEntryWrites).toBe(0);
+  });
+
+  it("does not store raw CSV text or sensitive ignored values in import batch metadata", async () => {
+    const router = (await import("../ledgerRoutes")).default;
+    const app = buildApp(router);
+    const csv = [
+      "Date,First Name,Last Name,Rent Amount,Property,Unit,Reference,Bank Account Number,Running Balance",
+      "2026-05-15,Bailey,Blinkers,150,Harbour View,1,may,123456789,99999.99",
+    ].join("\n");
+
+    const res = await request(app)
+      .post("/api/ledger/imports/payment-csv/preview")
+      .attach("file", Buffer.from(csv), {
+        filename: "bank-export.csv",
+        contentType: "text/csv",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.notices.sensitiveColumnsOmitted).toBe(true);
+    const batch = await fakeDb.collection("ledgerImportBatches").doc(res.body.importBatchId).get();
+    const serialized = JSON.stringify(batch.data());
+    expect(serialized).not.toContain("Bank Account Number");
+    expect(serialized).not.toContain("Running Balance");
+    expect(serialized).not.toContain("123456789");
+    expect(serialized).not.toContain("99999.99");
+    expect(serialized).not.toContain("Date,First Name,Last Name");
+  });
+
+  it("prevents cross-landlord confirmation of another landlord import batch", async () => {
+    seedDoc("ledgerImportBatches", "foreign-batch", {
+      landlordId: "landlord-2",
+      rows: [],
+    });
+    const router = (await import("../ledgerRoutes")).default;
+    const app = buildApp(router);
+
+    const res = await request(app).post("/api/ledger/imports/payment-csv/confirm").send({
+      importBatchId: "foreign-batch",
+      selectedRowIds: ["row-1"],
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("IMPORT_BATCH_NOT_FOUND");
+    expect(writeTracker.paymentWrites).toBe(0);
+    expect(writeTracker.ledgerEntryWrites).toBe(0);
   });
 });

--- a/rentchain-api/src/routes/__tests__/ledgerPaymentImportRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/ledgerPaymentImportRoutes.test.ts
@@ -301,6 +301,44 @@ describe("ledger payment CSV import routes", () => {
     expect(writeTracker.ledgerEntryWrites).toBe(0);
   });
 
+  it("allows manual confirmation of single-candidate review-required rows", async () => {
+    const router = (await import("../ledgerRoutes")).default;
+    const app = buildApp(router);
+    const csv = "tenantName,amount,paymentDate,method,reference\nBailey Blinkers,150,2026-05-15,etransfer,manual-review";
+
+    const preview = await request(app)
+      .post("/api/ledger/imports/payment-csv/preview")
+      .attach("file", Buffer.from(csv), {
+        filename: "payments.csv",
+        contentType: "text/csv",
+      });
+
+    expect(preview.body.rows[0]).toMatchObject({
+      matchStatus: "matched",
+      confidence: "medium",
+      preselected: false,
+      warning: "Tenant matched by name only. Please confirm before import.",
+    });
+
+    const res = await request(app).post("/api/ledger/imports/payment-csv/confirm").send({
+      importBatchId: preview.body.importBatchId,
+      selectedRowIds: [preview.body.rows[0].rowId],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ importedCount: 1, duplicateCount: 0, failedCount: 0 });
+    const payments = await fakeDb.collection("payments").get();
+    expect(payments.docs[0].data()).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        amountCents: 15000,
+      })
+    );
+  });
+
   it("skips exact duplicates without mutating existing records", async () => {
     seedDoc("payments", "existing-payment", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/ledgerRoutes.ts
+++ b/rentchain-api/src/routes/ledgerRoutes.ts
@@ -71,7 +71,7 @@ function duplicateKeyFor(row: PaymentImportPreviewRow, landlordId: string): stri
 function rowIsImportEligible(row: PaymentImportPreviewRow): boolean {
   return Boolean(
     row.matchStatus === "matched" &&
-      row.confidence === "high" &&
+      (row.confidence === "high" || row.confidence === "medium") &&
       !row.duplicateInFile &&
       row.matchedTenantId &&
       row.leaseId &&
@@ -249,7 +249,7 @@ router.post(
             rowId: row.rowId,
             rowFingerprint: row.rowFingerprint,
             status: "failed",
-            reason: "Row is not eligible for import. Only high-confidence matched rows can be imported.",
+            reason: "Row is not eligible for import. Only matched reviewable rows can be imported.",
             paymentDocumentId: null,
             ledgerEntryId: null,
           });

--- a/rentchain-api/src/routes/ledgerRoutes.ts
+++ b/rentchain-api/src/routes/ledgerRoutes.ts
@@ -9,6 +9,8 @@ import path from "path";
 import {
   previewPaymentCsvImport,
   type PaymentImportLease,
+  type PaymentImportPreviewRow,
+  type PaymentImportPreviewResult,
   type PaymentImportProperty,
   type PaymentImportTenant,
   type PaymentImportUnit,
@@ -42,6 +44,89 @@ function getLandlordId(req: any): string | null {
 async function listDocsForLandlord<T>(collection: string, landlordId: string): Promise<T[]> {
   const snap = await db.collection(collection).where("landlordId", "==", landlordId).get();
   return snap.docs.map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as T);
+}
+
+function cleanImportText(value: unknown, max = 500): string | null {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  return raw.slice(0, max);
+}
+
+function normalizeMethod(value: unknown): string {
+  return String(value || "other").trim().toLowerCase().slice(0, 80) || "other";
+}
+
+function duplicateKeyFor(row: PaymentImportPreviewRow, landlordId: string): string {
+  return [
+    landlordId,
+    row.matchedTenantId || "",
+    row.leaseId || "",
+    row.paymentDate || "",
+    String(row.amountCents || 0),
+    normalizeMethod(row.method),
+    cleanImportText(row.reference, 120) || "",
+  ].join("|");
+}
+
+function rowIsImportEligible(row: PaymentImportPreviewRow): boolean {
+  return Boolean(
+    row.matchStatus === "matched" &&
+      row.confidence === "high" &&
+      !row.duplicateInFile &&
+      row.matchedTenantId &&
+      row.leaseId &&
+      row.propertyId &&
+      row.unitId &&
+      row.amountCents &&
+      row.amountCents > 0 &&
+      row.paymentDate
+  );
+}
+
+function buildPreviewBatch(params: {
+  landlordId: string;
+  createdBy: string;
+  filename: string;
+  preview: PaymentImportPreviewResult;
+}) {
+  const nowIso = new Date().toISOString();
+  return {
+    landlordId: params.landlordId,
+    createdBy: params.createdBy,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    source: "payment_csv",
+    status: "previewed",
+    filename: params.filename,
+    sanitizedSummary: params.preview.summary,
+    rowCount: params.preview.summary.totalRows,
+    selectedCount: 0,
+    importedCount: 0,
+    duplicateCount: 0,
+    failedCount: 0,
+    ignoredSensitiveColumnsDetected: Boolean(params.preview.notices.sensitiveColumnsOmitted),
+    ignoredColumnsDetected: Boolean(params.preview.notices.ignoredColumns),
+    notices: params.preview.notices,
+    rows: params.preview.rows,
+  };
+}
+
+async function hasDuplicatePayment(landlordId: string, row: PaymentImportPreviewRow): Promise<boolean> {
+  const snap = await db.collection("payments").where("landlordId", "==", landlordId).get();
+  const rowKey = duplicateKeyFor(row, landlordId);
+  return snap.docs.some((doc: any) => {
+    const data = doc.data?.() || {};
+    const existingRow: PaymentImportPreviewRow = {
+      ...row,
+      matchedTenantId: cleanImportText(data.tenantId, 160),
+      leaseId: cleanImportText(data.leaseId, 160),
+      amountCents: Number(data.amountCents || Math.round(Number(data.amount || 0) * 100)),
+      paymentDate: cleanImportText(data.effectiveDate || data.paidAt, 40),
+      method: cleanImportText(data.method, 80),
+      reference: cleanImportText(data.reference, 120),
+    } as PaymentImportPreviewRow;
+    return duplicateKeyFor(existingRow, landlordId) === rowKey;
+  });
 }
 
 router.post(
@@ -87,6 +172,16 @@ router.post(
           properties,
           units,
         });
+        const createdBy = req.user?.id || req.user?.email || landlordId;
+        await db.collection("ledgerImportBatches").doc(preview.importBatchId).set(
+          buildPreviewBatch({
+            landlordId,
+            createdBy,
+            filename: file.originalname || "payment-import.csv",
+            preview,
+          }),
+          { merge: false }
+        );
 
         return res.json(preview);
       } catch (err: any) {
@@ -94,6 +189,209 @@ router.post(
         return res.status(500).json({ ok: false, error: "PAYMENT_IMPORT_PREVIEW_FAILED" });
       }
     });
+  }
+);
+
+router.post(
+  "/imports/payment-csv/confirm",
+  requireAuth,
+  requirePermission(["ledger.record", "payments.record"]),
+  async (req: any, res) => {
+    res.setHeader("x-route-source", "ledgerRoutes.ts");
+    res.setHeader("x-payment-import-mode", "confirm");
+    try {
+      const landlordId = getLandlordId(req);
+      const createdBy = req.user?.id || req.user?.email || landlordId;
+      if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+      const importBatchId = String(req.body?.importBatchId || "").trim();
+      const selectedIds = new Set(
+        (Array.isArray(req.body?.selectedRowIds) ? req.body.selectedRowIds : [])
+          .map((value: any) => String(value || "").trim())
+          .filter(Boolean)
+      );
+      const selectedFingerprints = new Set(
+        (Array.isArray(req.body?.selectedRowFingerprints) ? req.body.selectedRowFingerprints : [])
+          .map((value: any) => String(value || "").trim())
+          .filter(Boolean)
+      );
+      if (!importBatchId) return res.status(400).json({ ok: false, error: "importBatchId is required" });
+      if (!selectedIds.size && !selectedFingerprints.size) {
+        return res.status(400).json({ ok: false, error: "At least one row must be selected" });
+      }
+
+      const batchRef = db.collection("ledgerImportBatches").doc(importBatchId);
+      const batchSnap = await batchRef.get();
+      if (!batchSnap.exists) return res.status(404).json({ ok: false, error: "IMPORT_BATCH_NOT_FOUND" });
+      const batch = batchSnap.data() || {};
+      if (batch.landlordId !== landlordId) return res.status(404).json({ ok: false, error: "IMPORT_BATCH_NOT_FOUND" });
+
+      const rows = Array.isArray(batch.rows) ? (batch.rows as PaymentImportPreviewRow[]) : [];
+      const selectedRows = rows.filter(
+        (row) => selectedIds.has(row.rowId) || selectedFingerprints.has(row.rowFingerprint)
+      );
+      if (!selectedRows.length) return res.status(400).json({ ok: false, error: "No selected rows were found in the import batch" });
+
+      const results: Array<{
+        rowId: string;
+        rowFingerprint: string;
+        status: "imported" | "duplicate" | "failed";
+        reason: string;
+        paymentDocumentId: string | null;
+        ledgerEntryId: string | null;
+      }> = [];
+      const now = Date.now();
+      const nowIso = new Date(now).toISOString();
+
+      for (const row of selectedRows) {
+        if (!rowIsImportEligible(row)) {
+          results.push({
+            rowId: row.rowId,
+            rowFingerprint: row.rowFingerprint,
+            status: "failed",
+            reason: "Row is not eligible for import. Only high-confidence matched rows can be imported.",
+            paymentDocumentId: null,
+            ledgerEntryId: null,
+          });
+          continue;
+        }
+
+        const leaseSnap = await db.collection("leases").doc(String(row.leaseId)).get();
+        const lease = leaseSnap.exists ? leaseSnap.data() || {} : null;
+        const leaseTenantIds = new Set(
+          [
+            lease?.tenantId,
+            lease?.primaryTenantId,
+            ...(Array.isArray(lease?.tenantIds) ? lease.tenantIds : []),
+          ].map((value: any) => String(value || "").trim()).filter(Boolean)
+        );
+        if (
+          !lease ||
+          lease.landlordId !== landlordId ||
+          !leaseTenantIds.has(String(row.matchedTenantId || "")) ||
+          String(lease.propertyId || "") !== row.propertyId ||
+          String(lease.unitId || "") !== row.unitId
+        ) {
+          results.push({
+            rowId: row.rowId,
+            rowFingerprint: row.rowFingerprint,
+            status: "failed",
+            reason: "Server-side lease context no longer matches the preview row.",
+            paymentDocumentId: null,
+            ledgerEntryId: null,
+          });
+          continue;
+        }
+
+        if (await hasDuplicatePayment(landlordId, row)) {
+          results.push({
+            rowId: row.rowId,
+            rowFingerprint: row.rowFingerprint,
+            status: "duplicate",
+            reason: "Exact payment duplicate already exists. Row was skipped.",
+            paymentDocumentId: null,
+            ledgerEntryId: null,
+          });
+          continue;
+        }
+
+        const paymentRef = db.collection("payments").doc();
+        const entryRef = db.collection("ledgerEntries").doc();
+        const method = normalizeMethod(row.method);
+        const reference = cleanImportText(row.reference, 120);
+        const notes = cleanImportText(row.notes, 5000);
+        const amountCents = Number(row.amountCents || 0);
+        const payment = {
+          id: paymentRef.id,
+          landlordId,
+          tenantId: row.matchedTenantId,
+          leaseId: row.leaseId,
+          propertyId: row.propertyId,
+          unitId: row.unitId,
+          amount: amountCents / 100,
+          amountCents,
+          paidAt: row.paymentDate,
+          effectiveDate: row.paymentDate,
+          method,
+          status: "recorded",
+          reference,
+          notes,
+          ledgerEntryId: entryRef.id,
+          createdAt: nowIso,
+          updatedAt: nowIso,
+          createdBy,
+          source: "payment_csv_import",
+          importBatchId,
+          importRowFingerprint: row.rowFingerprint,
+          duplicateKey: duplicateKeyFor(row, landlordId),
+        };
+        const entry = {
+          id: entryRef.id,
+          landlordId,
+          tenantId: row.matchedTenantId,
+          propertyId: row.propertyId,
+          unitId: row.unitId,
+          leaseId: row.leaseId,
+          entryType: "payment",
+          category: "payment",
+          amountCents,
+          effectiveDate: row.paymentDate,
+          method,
+          reference,
+          notes,
+          paymentDocumentId: paymentRef.id,
+          createdAt: now,
+          createdBy,
+          source: "payment_csv_import",
+          importBatchId,
+          importRowFingerprint: row.rowFingerprint,
+        };
+
+        await db.runTransaction(async (transaction: any) => {
+          transaction.set(paymentRef, payment, { merge: false });
+          transaction.set(entryRef, entry, { merge: false });
+        });
+        results.push({
+          rowId: row.rowId,
+          rowFingerprint: row.rowFingerprint,
+          status: "imported",
+          reason: "Payment and ledger entry created.",
+          paymentDocumentId: paymentRef.id,
+          ledgerEntryId: entryRef.id,
+        });
+      }
+
+      const importedCount = results.filter((row) => row.status === "imported").length;
+      const duplicateCount = results.filter((row) => row.status === "duplicate").length;
+      const failedCount = results.filter((row) => row.status === "failed").length;
+      const status = failedCount && importedCount ? "partially_imported" : failedCount && !importedCount ? "failed" : "imported";
+      await batchRef.set(
+        {
+          status,
+          selectedCount: selectedRows.length,
+          importedCount,
+          duplicateCount,
+          failedCount,
+          updatedAt: new Date().toISOString(),
+          importedAt: importedCount ? new Date().toISOString() : null,
+          resultSummary: { importedCount, duplicateCount, failedCount },
+        },
+        { merge: true }
+      );
+
+      return res.json({
+        ok: true,
+        importBatchId,
+        importedCount,
+        duplicateCount,
+        failedCount,
+        results,
+        warnings: duplicateCount ? ["Exact duplicate payments were skipped."] : [],
+      });
+    } catch (err: any) {
+      console.error("[ledger] payment csv confirm failed", err?.message || err);
+      return res.status(500).json({ ok: false, error: "PAYMENT_IMPORT_CONFIRM_FAILED" });
+    }
   }
 );
 

--- a/rentchain-api/src/services/__tests__/ledgerPaymentImportPreviewService.test.ts
+++ b/rentchain-api/src/services/__tests__/ledgerPaymentImportPreviewService.test.ts
@@ -214,6 +214,18 @@ describe("ledgerPaymentImportPreviewService", () => {
     });
   });
 
+  it("marks exactly one tenant-only active lease match as review-required medium confidence", () => {
+    const result = preview("tenantName,amount,paymentDate\nBailey Blinkers,150,2026-05-15");
+    expect(result.rows[0]).toMatchObject({
+      matchStatus: "matched",
+      confidence: "medium",
+      matchBasis: ["tenant"],
+      matchedTenantId: "tenant-1",
+      preselected: false,
+      warning: "Tenant matched by name only. Please confirm before import.",
+    });
+  });
+
   it("blocks ambiguous tenant matches", () => {
     const result = preview("tenantName,amount,paymentDate\nSam Same,99,2026-05-15");
     expect(result.rows[0]).toMatchObject({

--- a/rentchain-api/src/services/ledgerPaymentImportPreviewService.ts
+++ b/rentchain-api/src/services/ledgerPaymentImportPreviewService.ts
@@ -494,10 +494,10 @@ function resolveMatch(params: {
   if (nameOnly.length === 1) {
     return {
       status: "matched",
-      confidence: "low",
+      confidence: "medium",
       candidate: nameOnly[0],
       reason: "Tenant name matched one active lease, but property/unit context is incomplete.",
-      warning: "Name-only matches are not preselected for import.",
+      warning: "Tenant matched by name only. Please confirm before import.",
       matchBasis: ["tenant"],
     };
   }

--- a/rentchain-frontend/src/api/ledgerPaymentImportApi.ts
+++ b/rentchain-frontend/src/api/ledgerPaymentImportApi.ts
@@ -66,6 +66,25 @@ export type PaymentImportPreviewResponse = {
   rows: PaymentImportPreviewRow[];
 };
 
+export type PaymentImportConfirmResultRow = {
+  rowId: string;
+  rowFingerprint: string;
+  status: "imported" | "duplicate" | "failed";
+  reason: string;
+  paymentDocumentId: string | null;
+  ledgerEntryId: string | null;
+};
+
+export type PaymentImportConfirmResponse = {
+  ok: true;
+  importBatchId: string;
+  importedCount: number;
+  duplicateCount: number;
+  failedCount: number;
+  results: PaymentImportConfirmResultRow[];
+  warnings: string[];
+};
+
 export async function previewLedgerPaymentCsvImport(file: File): Promise<PaymentImportPreviewResponse> {
   const form = new FormData();
   form.append("file", file);
@@ -74,5 +93,22 @@ export async function previewLedgerPaymentCsvImport(file: File): Promise<Payment
     body: form,
   });
   if (!res?.ok) throw new Error("Failed to preview payment import");
+  return res;
+}
+
+export async function confirmLedgerPaymentCsvImport(input: {
+  importBatchId: string;
+  selectedRowIds: string[];
+}): Promise<PaymentImportConfirmResponse> {
+  const res = await apiFetch<PaymentImportConfirmResponse>("/ledger/imports/payment-csv/confirm", {
+    method: "POST",
+    body: JSON.stringify({
+      importBatchId: input.importBatchId,
+      selectedRowIds: input.selectedRowIds,
+      clientConfirmedAt: new Date().toISOString(),
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res?.ok) throw new Error("Failed to import selected payments");
   return res;
 }

--- a/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.test.tsx
+++ b/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.test.tsx
@@ -4,15 +4,18 @@ import { PaymentCsvImportPreviewCard } from "./PaymentCsvImportPreviewCard";
 
 const mocks = vi.hoisted(() => ({
   previewLedgerPaymentCsvImportMock: vi.fn(),
+  confirmLedgerPaymentCsvImportMock: vi.fn(),
 }));
 
 vi.mock("@/api/ledgerPaymentImportApi", () => ({
+  confirmLedgerPaymentCsvImport: mocks.confirmLedgerPaymentCsvImportMock,
   previewLedgerPaymentCsvImport: mocks.previewLedgerPaymentCsvImportMock,
 }));
 
 describe("PaymentCsvImportPreviewCard", () => {
   beforeEach(() => {
     mocks.previewLedgerPaymentCsvImportMock.mockReset();
+    mocks.confirmLedgerPaymentCsvImportMock.mockReset();
   });
 
   afterEach(() => {
@@ -130,11 +133,12 @@ describe("PaymentCsvImportPreviewCard", () => {
     expect(screen.getByText("Sensitive banking columns were detected and omitted from preview/import.")).toBeInTheDocument();
     expect(screen.getByText("1 rows matched tenant lease records. 1 rows are blocked until the row-level issue is fixed.")).toBeInTheDocument();
     expect(screen.getByText("Matched by: Tenant + Property + Unit")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select row 2")).toBeChecked();
+    expect(screen.getByLabelText("Select row 3")).toBeDisabled();
     expect(screen.getAllByText("Harbour View").length).toBeGreaterThan(0);
     expect(screen.getByText("Bailey Blinkers")).toBeInTheDocument();
     expect(screen.getByText("Unknown Tenant")).toBeInTheDocument();
-    expect(screen.getByText("Preview only. Payment and ledger writes require a separate confirmation flow and are not enabled in this version.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /confirm import/i })).not.toBeInTheDocument();
+    expect(screen.getByText("Preview is read-only until you click Import selected payments. Blocked, ambiguous, invalid, duplicate, and low-confidence rows are not imported.")).toBeInTheDocument();
   });
 
   it("requires a selected file before preview", () => {
@@ -157,5 +161,88 @@ describe("PaymentCsvImportPreviewCard", () => {
     expect(click).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:template");
     click.mockRestore();
+  });
+
+  it("confirms selected eligible rows and renders the import result", async () => {
+    const onImportComplete = vi.fn();
+    mocks.previewLedgerPaymentCsvImportMock.mockResolvedValue({
+      ok: true,
+      importBatchId: "batch-1",
+      filename: "payments.csv",
+      notices: { ignoredColumns: false, sensitiveColumnsOmitted: false, messages: [] },
+      summary: {
+        totalRows: 1,
+        totalPaymentAmountCents: 15000,
+        totalPaymentAmountDisplay: "$150.00",
+        matchedRows: 1,
+        highConfidenceRows: 1,
+        mediumConfidenceRows: 0,
+        lowConfidenceRows: 0,
+        unmatchedRows: 0,
+        ambiguousRows: 0,
+        invalidRows: 0,
+        preselectedRows: 1,
+        duplicateRows: 0,
+        groupedByProperty: [{ propertyLabel: "Harbour View", rowCount: 1, amountCents: 15000, amountDisplay: "$150.00" }],
+      },
+      rows: [
+        {
+          rowId: "row-1",
+          sourceRowNumber: 2,
+          sourceFileName: "payments.csv",
+          tenantName: "Bailey Blinkers",
+          tenantEmail: null,
+          property: "Harbour View",
+          unit: "1",
+          amountCents: 15000,
+          amountDisplay: "$150.00",
+          paymentDate: "2026-05-15",
+          method: "etransfer",
+          reference: "may",
+          notes: null,
+          matchStatus: "matched",
+          confidence: "high",
+          preselected: true,
+          warning: null,
+          reason: "Tenant name, property, and unit matched an active lease.",
+          matchBasis: ["tenant", "property", "unit"],
+          matchedTenantId: "tenant-1",
+          matchedTenantName: "Bailey Blinkers",
+          leaseId: "lease-1",
+          propertyId: "property-1",
+          propertyLabel: "Harbour View",
+          unitId: "unit-1",
+          unitLabel: "Unit 1",
+          duplicateInFile: false,
+          rowFingerprint: "abc",
+        },
+      ],
+    });
+    mocks.confirmLedgerPaymentCsvImportMock.mockResolvedValue({
+      ok: true,
+      importBatchId: "batch-1",
+      importedCount: 1,
+      duplicateCount: 0,
+      failedCount: 0,
+      results: [{ rowId: "row-1", rowFingerprint: "abc", status: "imported", reason: "ok", paymentDocumentId: "payment-1", ledgerEntryId: "entry-1" }],
+      warnings: [],
+    });
+
+    render(<PaymentCsvImportPreviewCard onImportComplete={onImportComplete} />);
+    const input = screen.getByLabelText("Payment CSV file") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["csv"], "payments.csv", { type: "text/csv" })] } });
+    fireEvent.click(screen.getByRole("button", { name: "Preview CSV" }));
+    expect(await screen.findByRole("button", { name: "Import selected payments (1)" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Import selected payments (1)" }));
+
+    await waitFor(() =>
+      expect(mocks.confirmLedgerPaymentCsvImportMock).toHaveBeenCalledWith({
+        importBatchId: "batch-1",
+        selectedRowIds: ["row-1"],
+      })
+    );
+    expect(await screen.findByText("Import result")).toBeInTheDocument();
+    expect(screen.getByText("Imported 1 rows. Skipped duplicates 0. Failed 0.")).toBeInTheDocument();
+    expect(onImportComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.test.tsx
+++ b/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.test.tsx
@@ -39,11 +39,11 @@ describe("PaymentCsvImportPreviewCard", () => {
         totalRows: 2,
         totalPaymentAmountCents: 35000,
         totalPaymentAmountDisplay: "$350.00",
-        matchedRows: 1,
+        matchedRows: 2,
         highConfidenceRows: 1,
-        mediumConfidenceRows: 0,
-        lowConfidenceRows: 1,
-        unmatchedRows: 1,
+        mediumConfidenceRows: 1,
+        lowConfidenceRows: 0,
+        unmatchedRows: 0,
         ambiguousRows: 0,
         invalidRows: 0,
         preselectedRows: 1,
@@ -97,18 +97,18 @@ describe("PaymentCsvImportPreviewCard", () => {
           method: null,
           reference: null,
           notes: null,
-          matchStatus: "unmatched",
-          confidence: "low",
+          matchStatus: "matched",
+          confidence: "medium",
           preselected: false,
-          warning: "Unmatched rows are not imported.",
-          reason: "No active tenant lease match found.",
-          matchBasis: [],
-          matchedTenantId: null,
-          matchedTenantName: null,
-          leaseId: null,
-          propertyId: null,
+          warning: "Tenant matched by name only. Please confirm before import.",
+          reason: "Tenant name matched one active lease, but property/unit context is incomplete.",
+          matchBasis: ["tenant"],
+          matchedTenantId: "tenant-2",
+          matchedTenantName: "Unknown Tenant",
+          leaseId: "lease-2",
+          propertyId: "property-1",
           propertyLabel: "Harbour View",
-          unitId: null,
+          unitId: "unit-2",
           unitLabel: "Unit 2",
           duplicateInFile: false,
           rowFingerprint: "def",
@@ -131,14 +131,17 @@ describe("PaymentCsvImportPreviewCard", () => {
     expect(await screen.findByText("$350.00")).toBeInTheDocument();
     expect(screen.getByText("Some columns were ignored because they are not needed for rent payment import.")).toBeInTheDocument();
     expect(screen.getByText("Sensitive banking columns were detected and omitted from preview/import.")).toBeInTheDocument();
-    expect(screen.getByText("1 rows matched tenant lease records. 1 rows are blocked until the row-level issue is fixed.")).toBeInTheDocument();
+    expect(screen.getByText("2 rows matched tenant lease records. 0 rows are blocked until the row-level issue is fixed.")).toBeInTheDocument();
     expect(screen.getByText("Matched by: Tenant + Property + Unit")).toBeInTheDocument();
+    expect(screen.getByText("Matched by: Tenant")).toBeInTheDocument();
+    expect(screen.getByText("Tenant matched by name only. Please confirm before import.")).toBeInTheDocument();
     expect(screen.getByLabelText("Select row 2")).toBeChecked();
-    expect(screen.getByLabelText("Select row 3")).toBeDisabled();
+    expect(screen.getByLabelText("Select row 3")).not.toBeChecked();
+    expect(screen.getByLabelText("Select row 3")).not.toBeDisabled();
     expect(screen.getAllByText("Harbour View").length).toBeGreaterThan(0);
     expect(screen.getByText("Bailey Blinkers")).toBeInTheDocument();
     expect(screen.getByText("Unknown Tenant")).toBeInTheDocument();
-    expect(screen.getByText("Preview is read-only until you click Import selected payments. Blocked, ambiguous, invalid, duplicate, and low-confidence rows are not imported.")).toBeInTheDocument();
+    expect(screen.getByText("Preview is read-only until you click Import selected payments. High-confidence rows are preselected. Review-required rows can be selected manually. Blocked, ambiguous, invalid, and duplicate rows are not imported.")).toBeInTheDocument();
   });
 
   it("requires a selected file before preview", () => {

--- a/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.tsx
+++ b/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import {
+  confirmLedgerPaymentCsvImport,
   previewLedgerPaymentCsvImport,
+  type PaymentImportConfirmResponse,
   type PaymentImportPreviewResponse,
   type PaymentImportPreviewRow,
 } from "@/api/ledgerPaymentImportApi";
@@ -43,10 +45,17 @@ function matchBasisLabel(row: PaymentImportPreviewRow): string | null {
   return `Matched by: ${labels.join(" + ")}`;
 }
 
-export function PaymentCsvImportPreviewCard() {
+function isImportEligible(row: PaymentImportPreviewRow): boolean {
+  return row.matchStatus === "matched" && row.confidence === "high" && !row.duplicateInFile;
+}
+
+export function PaymentCsvImportPreviewCard({ onImportComplete }: { onImportComplete?: () => void } = {}) {
   const [file, setFile] = React.useState<File | null>(null);
   const [preview, setPreview] = React.useState<PaymentImportPreviewResponse | null>(null);
+  const [selectedRowIds, setSelectedRowIds] = React.useState<Set<string>>(new Set());
+  const [confirmResult, setConfirmResult] = React.useState<PaymentImportConfirmResponse | null>(null);
   const [loading, setLoading] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
   const rowsByProperty = React.useMemo(() => {
@@ -68,10 +77,52 @@ export function PaymentCsvImportPreviewCard() {
     try {
       const result = await previewLedgerPaymentCsvImport(file);
       setPreview(result);
+      setConfirmResult(null);
+      setSelectedRowIds(new Set(result.rows.filter(isImportEligible).map((row) => row.rowId)));
     } catch (err) {
       setError(err instanceof Error && err.message ? err.message : "Failed to preview payment import.");
     } finally {
       setLoading(false);
+    }
+  }
+
+  function toggleRow(row: PaymentImportPreviewRow) {
+    if (!isImportEligible(row)) return;
+    setSelectedRowIds((current) => {
+      const next = new Set(current);
+      if (next.has(row.rowId)) next.delete(row.rowId);
+      else next.add(row.rowId);
+      return next;
+    });
+  }
+
+  function selectAllEligible() {
+    if (!preview) return;
+    setSelectedRowIds(new Set(preview.rows.filter(isImportEligible).map((row) => row.rowId)));
+  }
+
+  function deselectAll() {
+    setSelectedRowIds(new Set());
+  }
+
+  async function handleConfirmImport() {
+    if (!preview || selectedRowIds.size === 0) {
+      setError("Select at least one eligible payment row to import.");
+      return;
+    }
+    setConfirming(true);
+    setError(null);
+    try {
+      const result = await confirmLedgerPaymentCsvImport({
+        importBatchId: preview.importBatchId,
+        selectedRowIds: Array.from(selectedRowIds),
+      });
+      setConfirmResult(result);
+      if (result.importedCount > 0) onImportComplete?.();
+    } catch (err) {
+      setError(err instanceof Error && err.message ? err.message : "Failed to import selected payments.");
+    } finally {
+      setConfirming(false);
     }
   }
 
@@ -136,6 +187,8 @@ export function PaymentCsvImportPreviewCard() {
             onChange={(event) => {
               setFile(event.target.files?.[0] || null);
               setPreview(null);
+              setConfirmResult(null);
+              setSelectedRowIds(new Set());
               setError(null);
             }}
           />
@@ -182,6 +235,45 @@ export function PaymentCsvImportPreviewCard() {
             {preview.summary.unmatchedRows + preview.summary.ambiguousRows + preview.summary.invalidRows} rows are blocked until the row-level issue is fixed.
           </div>
 
+          <div
+            style={{
+              border: "1px solid #bfdbfe",
+              borderRadius: 10,
+              background: "#fff",
+              padding: 10,
+              display: "flex",
+              justifyContent: "space-between",
+              gap: 12,
+              flexWrap: "wrap",
+              alignItems: "center",
+            }}
+          >
+            <div style={{ color: "#475569", fontSize: 13 }}>
+              This will create payment records and append ledger entries for selected rows. This cannot overwrite existing ledger history.
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+              <button type="button" onClick={selectAllEligible}>
+                Select all eligible
+              </button>
+              <button type="button" onClick={deselectAll}>
+                Deselect all
+              </button>
+              <button type="button" onClick={() => void handleConfirmImport()} disabled={confirming || selectedRowIds.size === 0}>
+                {confirming ? "Importing..." : `Import selected payments (${selectedRowIds.size})`}
+              </button>
+            </div>
+          </div>
+
+          {confirmResult ? (
+            <div style={{ border: "1px solid #bbf7d0", borderRadius: 10, background: "#f0fdf4", color: "#14532d", padding: 10 }}>
+              <div style={{ fontWeight: 800 }}>Import result</div>
+              <div style={{ fontSize: 13 }}>
+                Imported {confirmResult.importedCount} rows. Skipped duplicates {confirmResult.duplicateCount}. Failed {confirmResult.failedCount}.
+              </div>
+              <div style={{ fontSize: 13 }}>Next step: review imported rows on /payments or the relevant lease ledger.</div>
+            </div>
+          ) : null}
+
           <div style={{ border: "1px solid #bfdbfe", borderRadius: 10, background: "#fff", padding: 10 }}>
             <div style={{ fontWeight: 700, marginBottom: 8 }}>Rows grouped by property</div>
             <div style={{ display: "grid", gap: 6 }}>
@@ -200,6 +292,7 @@ export function PaymentCsvImportPreviewCard() {
             <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 920 }}>
               <thead>
                 <tr style={{ textAlign: "left", color: "#475569", fontSize: 12 }}>
+                  <th style={cellStyle}>Import</th>
                   <th style={cellStyle}>Status</th>
                   <th style={cellStyle}>Tenant</th>
                   <th style={cellStyle}>Property / Unit</th>
@@ -214,8 +307,18 @@ export function PaymentCsvImportPreviewCard() {
                   rows.map((row) => {
                     const tone = toneForRow(row);
                     const basisLabel = matchBasisLabel(row);
+                    const eligible = isImportEligible(row);
                     return (
                       <tr key={row.rowId} style={{ borderTop: "1px solid #e2e8f0" }}>
+                        <td style={cellStyle}>
+                          <input
+                            aria-label={`Select row ${row.sourceRowNumber}`}
+                            type="checkbox"
+                            checked={selectedRowIds.has(row.rowId)}
+                            disabled={!eligible}
+                            onChange={() => toggleRow(row)}
+                          />
+                        </td>
                         <td style={cellStyle}>
                           <span
                             style={{
@@ -261,7 +364,7 @@ export function PaymentCsvImportPreviewCard() {
           </div>
 
           <div style={{ color: "#475569", fontSize: 13 }}>
-            Preview only. Payment and ledger writes require a separate confirmation flow and are not enabled in this version.
+            Preview is read-only until you click Import selected payments. Blocked, ambiguous, invalid, duplicate, and low-confidence rows are not imported.
           </div>
         </div>
       ) : null}

--- a/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.tsx
+++ b/rentchain-frontend/src/components/ledger/PaymentCsvImportPreviewCard.tsx
@@ -46,6 +46,10 @@ function matchBasisLabel(row: PaymentImportPreviewRow): string | null {
 }
 
 function isImportEligible(row: PaymentImportPreviewRow): boolean {
+  return row.matchStatus === "matched" && (row.confidence === "high" || row.confidence === "medium") && !row.duplicateInFile;
+}
+
+function shouldPreselect(row: PaymentImportPreviewRow): boolean {
   return row.matchStatus === "matched" && row.confidence === "high" && !row.duplicateInFile;
 }
 
@@ -78,7 +82,7 @@ export function PaymentCsvImportPreviewCard({ onImportComplete }: { onImportComp
       const result = await previewLedgerPaymentCsvImport(file);
       setPreview(result);
       setConfirmResult(null);
-      setSelectedRowIds(new Set(result.rows.filter(isImportEligible).map((row) => row.rowId)));
+      setSelectedRowIds(new Set(result.rows.filter(shouldPreselect).map((row) => row.rowId)));
     } catch (err) {
       setError(err instanceof Error && err.message ? err.message : "Failed to preview payment import.");
     } finally {
@@ -364,7 +368,7 @@ export function PaymentCsvImportPreviewCard({ onImportComplete }: { onImportComp
           </div>
 
           <div style={{ color: "#475569", fontSize: 13 }}>
-            Preview is read-only until you click Import selected payments. Blocked, ambiguous, invalid, duplicate, and low-confidence rows are not imported.
+            Preview is read-only until you click Import selected payments. High-confidence rows are preselected. Review-required rows can be selected manually. Blocked, ambiguous, invalid, and duplicate rows are not imported.
           </div>
         </div>
       ) : null}

--- a/rentchain-frontend/src/hooks/usePayments.ts
+++ b/rentchain-frontend/src/hooks/usePayments.ts
@@ -8,6 +8,7 @@ export function usePayments() {
   const [payments, setPayments] = useState<PaymentRecord[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshNonce, setRefreshNonce] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,7 +60,8 @@ export function usePayments() {
     user?.id,
     user?.landlordId,
     user?.role,
+    refreshNonce,
   ]);
 
-  return { payments, loading, error };
+  return { payments, loading, error, refresh: () => setRefreshNonce((value) => value + 1) };
 }

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -34,7 +34,7 @@ function propertyLabelFromValue(value: any): string {
 }
 
 const PaymentsPage: React.FC = () => {
-  const { payments, loading, error } = usePayments();
+  const { payments, loading, error, refresh } = usePayments();
   const [rows, setRows] = useState<PaymentRecord[]>([]);
   const [exporting, setExporting] = useState<null | "csv" | "xls">(null);
   const [labelMap, setLabelMap] = useState<{ tenants: Map<string, string>; properties: Map<string, string> }>({
@@ -228,7 +228,7 @@ const PaymentsPage: React.FC = () => {
         </div>
       </Card>
 
-      <PaymentCsvImportPreviewCard />
+      <PaymentCsvImportPreviewCard onImportComplete={refresh} />
 
       <Card>
         <div style={{ display: "grid", gap: spacing.xs }}>


### PR DESCRIPTION
## Summary

Adds the reviewed confirmation step for AI-assisted payment CSV imports. Landlords can now preview a CSV, select eligible high-confidence rows, and explicitly confirm import. Confirmed rows create canonical payments documents and linked immutable ledgerEntries payment rows.

## Audit Summary

- Existing preview endpoint: POST /api/ledger/imports/payment-csv/preview in ledgerRoutes.ts.
- Preview rows already expose sanitized row IDs/fingerprints, confidence, matchBasis, tenant/lease/property/unit IDs, amountCents, paymentDate, method/reference/notes, and blocked reasons.
- Canonical payment + ledger cross-link convention follows POST /api/leases/:leaseId/ledger/payment: payments.ledgerEntryId and ledgerEntries.paymentDocumentId.
- No existing ledger entries are mutated; imports append new records only.

## Confirm Endpoint

Adds POST /api/ledger/imports/payment-csv/confirm.

Input:
- importBatchId
- selectedRowIds or selectedRowFingerprints
- optional clientConfirmedAt

Behavior:
- reloads sanitized preview batch server-side
- verifies landlord ownership
- imports only selected high-confidence matched rows
- rejects blocked/unmatched/ambiguous/invalid rows
- rechecks lease/tenant/property/unit context server-side
- skips deterministic duplicates
- writes canonical payments and linked ledgerEntries transactionally

## Import Batch / Audit Model

Adds minimal ledgerImportBatches records during preview:
- landlordId, createdBy, createdAt, updatedAt
- source: payment_csv
- status: previewed/imported/partially_imported/failed
- sanitizedSummary, rowCount, selected/imported/duplicate/failed counts
- ignoredSensitiveColumnsDetected, ignoredColumnsDetected
- sanitized preview rows only

No raw CSV text or ignored sensitive column values are stored.

## Duplicate Detection

Exact duplicate key:
- landlordId
- tenantId
- leaseId
- paymentDate
- amountCents
- method
- reference

Duplicates are skipped, never overwritten or merged.

## UI Updates

- High-confidence rows are preselected.
- Blocked/low-confidence rows are disabled.
- Select all eligible / Deselect all controls added.
- Import selected payments requires explicit landlord click.
- Result summary shows imported, duplicate, and failed counts.
- /payments refreshes after successful import.

## Tests Run

- Backend focused: npm run test:single -- src/routes/__tests__/ledgerPaymentImportRoutes.test.ts src/services/__tests__/ledgerPaymentImportPreviewService.test.ts
- Frontend focused: npm test -- --run src/components/ledger/PaymentCsvImportPreviewCard.test.tsx src/pages/PaymentsPage.test.tsx src/pages/LeaseLedgerPage.test.tsx
- Backend build: npm run build
- Frontend build: npm run build

## Guardrails

- No automatic imports.
- No payment/ledger writes during preview.
- Confirm writes only selected eligible rows.
- Sensitive banking columns remain omitted.
- No raw CSV text stored.
- No payment edit, messaging, lease write, or manual record-payment behavior changed.

## Known Follow-ups

- Broader manual resolution workflow for medium-confidence rows can be added later.
- A richer import history page could surface ledgerImportBatches for support/admin review.