### PR TITLE
feat: add jurisdiction-aware lease workflow foundations

### DIFF
--- a/rentchain-api/src/config/__tests__/leaseNoticeRules.test.ts
+++ b/rentchain-api/src/config/__tests__/leaseNoticeRules.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  listSupportedLeaseNoticeRules,
+  resolveLeaseNoticeRule,
+  resolveLeaseWorkflowConfig,
+} from "../leaseNoticeRules";
+
+describe("leaseNoticeRules", () => {
+  it("resolves Nova Scotia rules through the jurisdiction workflow registry", () => {
+    expect(resolveLeaseNoticeRule({ province: "Nova Scotia", leaseType: "fixed_term" })).toMatchObject({
+      province: "NS",
+      leaseType: "fixed_term",
+      noticeLeadDays: 90,
+      templateKey: "ns.fixed_term.renewal_offer.v1",
+      ruleVersion: "ns-v1",
+    });
+    expect(resolveLeaseNoticeRule({ province: "NS", leaseType: "month_to_month" })).toMatchObject({
+      province: "NS",
+      leaseType: "month_to_month",
+      noticeLeadDays: 30,
+    });
+  });
+
+  it("adds Ontario workflow-review rules without enabling autonomous legal enforcement", () => {
+    expect(resolveLeaseNoticeRule({ province: "ON", leaseType: "fixed_term" })).toMatchObject({
+      province: "ON",
+      leaseType: "fixed_term",
+      noticeLeadDays: 60,
+      templateKey: "on.fixed_term.workflow_review.v1",
+      ruleVersion: "on-v1",
+      requireTermDates: false,
+    });
+    expect(resolveLeaseWorkflowConfig({ province: "ON" })).toMatchObject({
+      province: "ON",
+      legalAdviceDisclaimer: expect.stringContaining("does not provide legal advice"),
+    });
+  });
+
+  it("fails closed for unsupported or missing provinces", () => {
+    expect(resolveLeaseNoticeRule({ province: "BC", leaseType: "fixed_term" })).toBeNull();
+    expect(resolveLeaseNoticeRule({ province: "", leaseType: "fixed_term" })).toBeNull();
+    expect(resolveLeaseWorkflowConfig({ province: "BC" })).toBeNull();
+    expect(listSupportedLeaseNoticeRules().map((rule) => `${rule.province}:${rule.leaseType}`)).toEqual([
+      "NS:fixed_term",
+      "NS:year_to_year",
+      "NS:month_to_month",
+      "ON:fixed_term",
+      "ON:month_to_month",
+    ]);
+  });
+});

--- a/rentchain-api/src/config/leaseNoticeRules.ts
+++ b/rentchain-api/src/config/leaseNoticeRules.ts
@@ -1,3 +1,9 @@
+import {
+  getJurisdictionWorkflowConfig,
+  listJurisdictionWorkflowConfigs,
+  normalizeLeaseWorkflowProvince,
+} from "../lib/jurisdiction/leaseWorkflowRegistry";
+
 export type LeaseNoticeWorkflowFlag = {
   enabled: boolean;
   source: string;
@@ -31,38 +37,73 @@ export type LeaseNoticeRule = {
   ruleVersion: string;
 };
 
-const RULES: LeaseNoticeRule[] = [
-  {
-    province: "NS",
-    leaseType: "fixed_term",
-    noticeLeadDays: 90,
-    templateKey: "ns.fixed_term.renewal_offer.v1",
-    allowedNoticeTypes: ["renewal_offer", "end_of_term_notice"],
-    allowUndecidedRent: true,
-    requireTermDates: true,
-    ruleVersion: "ns-v1",
-  },
-  {
-    province: "NS",
-    leaseType: "year_to_year",
-    noticeLeadDays: 90,
-    templateKey: "ns.year_to_year.notice.v1",
-    allowedNoticeTypes: ["renewal_offer", "end_of_term_notice"],
-    allowUndecidedRent: true,
-    requireTermDates: true,
-    ruleVersion: "ns-v1",
-  },
-  {
-    province: "NS",
-    leaseType: "month_to_month",
-    noticeLeadDays: 30,
-    templateKey: "ns.month_to_month.notice.v1",
-    allowedNoticeTypes: ["month_to_month_notice", "non_renewal"],
-    allowUndecidedRent: true,
-    requireTermDates: false,
-    ruleVersion: "ns-v1",
-  },
-];
+function buildRules(): LeaseNoticeRule[] {
+  const rules: LeaseNoticeRule[] = [];
+  for (const workflow of listJurisdictionWorkflowConfigs()) {
+    if (workflow.province === "NS") {
+      rules.push(
+        {
+          province: "NS",
+          leaseType: "fixed_term",
+          noticeLeadDays: workflow.defaultWorkflow.leaseRenewalReminderDays,
+          templateKey: "ns.fixed_term.renewal_offer.v1",
+          allowedNoticeTypes: ["renewal_offer", "end_of_term_notice"],
+          allowUndecidedRent: true,
+          requireTermDates: true,
+          ruleVersion: "ns-v1",
+        },
+        {
+          province: "NS",
+          leaseType: "year_to_year",
+          noticeLeadDays: workflow.noticePeriods.leaseTerminationByLeaseType.year_to_year || 90,
+          templateKey: "ns.year_to_year.notice.v1",
+          allowedNoticeTypes: ["renewal_offer", "end_of_term_notice"],
+          allowUndecidedRent: true,
+          requireTermDates: true,
+          ruleVersion: "ns-v1",
+        },
+        {
+          province: "NS",
+          leaseType: "month_to_month",
+          noticeLeadDays: workflow.noticePeriods.leaseTerminationByLeaseType.month_to_month || 30,
+          templateKey: "ns.month_to_month.notice.v1",
+          allowedNoticeTypes: ["month_to_month_notice", "non_renewal"],
+          allowUndecidedRent: true,
+          requireTermDates: false,
+          ruleVersion: "ns-v1",
+        }
+      );
+    }
+
+    if (workflow.province === "ON") {
+      rules.push(
+        {
+          province: "ON",
+          leaseType: "fixed_term",
+          noticeLeadDays: workflow.defaultWorkflow.leaseRenewalReminderDays,
+          templateKey: "on.fixed_term.workflow_review.v1",
+          allowedNoticeTypes: ["renewal_offer", "end_of_term_notice"],
+          allowUndecidedRent: true,
+          requireTermDates: false,
+          ruleVersion: "on-v1",
+        },
+        {
+          province: "ON",
+          leaseType: "month_to_month",
+          noticeLeadDays: workflow.noticePeriods.leaseTerminationByLeaseType.month_to_month || 60,
+          templateKey: "on.month_to_month.workflow_review.v1",
+          allowedNoticeTypes: ["month_to_month_notice", "non_renewal"],
+          allowUndecidedRent: true,
+          requireTermDates: false,
+          ruleVersion: "on-v1",
+        }
+      );
+    }
+  }
+  return rules;
+}
+
+const RULES: LeaseNoticeRule[] = buildRules();
 
 export function getLeaseNoticeWorkflowFlag(): LeaseNoticeWorkflowFlag {
   const raw = String(process.env.LEASE_NOTICE_WORKFLOW_ENABLED || "").trim().toLowerCase();
@@ -76,7 +117,7 @@ export function resolveLeaseNoticeRule(input: {
   province?: string | null;
   leaseType?: string | null;
 }): LeaseNoticeRule | null {
-  const province = String(input.province || "").trim().toUpperCase();
+  const province = normalizeLeaseWorkflowProvince(input.province);
   const leaseType = String(input.leaseType || "").trim().toLowerCase();
   if (!province || !leaseType) return null;
   return (
@@ -86,4 +127,8 @@ export function resolveLeaseNoticeRule(input: {
 
 export function listSupportedLeaseNoticeRules() {
   return [...RULES];
+}
+
+export function resolveLeaseWorkflowConfig(input: { province?: string | null }) {
+  return getJurisdictionWorkflowConfig(input.province);
 }

--- a/rentchain-api/src/lib/jurisdiction/__tests__/leaseWorkflowRegistry.test.ts
+++ b/rentchain-api/src/lib/jurisdiction/__tests__/leaseWorkflowRegistry.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  getJurisdictionWorkflow,
+  getJurisdictionWorkflowConfig,
+  getLeaseWorkflowConfig,
+  getProvinceOperationalRules,
+  listSupportedJurisdictionWorkflowProvinces,
+  normalizeLeaseWorkflowProvince,
+  toJurisdictionWorkflowSummary,
+} from "../leaseWorkflowRegistry";
+
+describe("leaseWorkflowRegistry", () => {
+  it("normalizes only the supported v1 provinces", () => {
+    expect(normalizeLeaseWorkflowProvince("Nova Scotia")).toBe("NS");
+    expect(normalizeLeaseWorkflowProvince("on")).toBe("ON");
+    expect(normalizeLeaseWorkflowProvince("BC")).toBeNull();
+    expect(listSupportedJurisdictionWorkflowProvinces()).toEqual(["NS", "ON"]);
+  });
+
+  it("derives Nova Scotia workflow metadata without legal automation", () => {
+    const config = getJurisdictionWorkflowConfig("NS");
+    expect(config).toMatchObject({
+      province: "NS",
+      leaseTemplateType: "standard_residential_ns_form_p",
+      noticePeriods: {
+        rentIncreaseDays: 120,
+        entryNoticeHours: 24,
+        leaseTerminationByLeaseType: {
+          fixed_term: 0,
+          year_to_year: 90,
+          month_to_month: 30,
+        },
+      },
+      leaseLifecycleExpectations: {
+        fixedTermContinuation: "ends_on_term_end",
+        activeRequiresExecutionReview: true,
+      },
+      confidence: "medium",
+    });
+    expect(config?.legalAdviceDisclaimer).toContain("does not provide legal advice");
+    expect(config?.supportedNoticeTypes).toContain("renewal_review");
+  });
+
+  it("derives Ontario workflow metadata and keeps fixed-term continuation distinct", () => {
+    const config = getJurisdictionWorkflowConfig("ON");
+    expect(config).toMatchObject({
+      province: "ON",
+      leaseTemplateType: "standard_residential_on",
+      noticePeriods: {
+        rentIncreaseDays: 90,
+        entryNoticeHours: 24,
+        leaseTerminationByLeaseType: {
+          fixed_term: 60,
+          month_to_month: 60,
+        },
+      },
+      leaseLifecycleExpectations: {
+        fixedTermContinuation: "continues_periodic",
+        activeRequiresExecutionReview: true,
+      },
+      confidence: "medium",
+    });
+  });
+
+  it("returns a source-free operational summary for API payloads", () => {
+    const config = getJurisdictionWorkflowConfig("ON");
+    expect(config).toBeTruthy();
+    const summary = toJurisdictionWorkflowSummary(config!);
+    expect(summary).toEqual(
+      expect.objectContaining({
+        province: "ON",
+        legalAdviceDisclaimer: expect.any(String),
+        guidance: expect.any(Object),
+      })
+    );
+    expect(summary).not.toHaveProperty("sources");
+  });
+
+  it("exposes mission-named helper aliases for downstream workflow callers", () => {
+    expect(getJurisdictionWorkflow("NS")?.province).toBe("NS");
+    expect(getLeaseWorkflowConfig("ON")?.province).toBe("ON");
+    expect(getProvinceOperationalRules("Ontario")).toMatchObject({
+      province: "ON",
+      leaseTemplateType: "standard_residential_on",
+    });
+    expect(getProvinceOperationalRules("BC")).toBeNull();
+  });
+});

--- a/rentchain-api/src/lib/jurisdiction/leaseWorkflowRegistry.ts
+++ b/rentchain-api/src/lib/jurisdiction/leaseWorkflowRegistry.ts
@@ -1,0 +1,248 @@
+export type SupportedLeaseWorkflowProvince = "NS" | "ON";
+
+export type JurisdictionWorkflowConfidence = "high" | "medium" | "low";
+
+export type JurisdictionNoticeType =
+  | "rent_increase"
+  | "termination"
+  | "inspection"
+  | "renewal_review";
+
+export type JurisdictionLeaseType = "fixed_term" | "year_to_year" | "month_to_month";
+
+export type JurisdictionWorkflowConfig = {
+  province: SupportedLeaseWorkflowProvince;
+  provinceLabel: string;
+  country: "CA";
+  workflowVersion: "jurisdiction-workflow-v1";
+  leaseTemplateType: "standard_residential_ns_form_p" | "standard_residential_on";
+  legalAdviceDisclaimer: string;
+  noticePeriods: {
+    rentIncreaseDays: number;
+    entryNoticeHours: number;
+    leaseTerminationDays: number;
+    leaseTerminationByLeaseType: Partial<Record<JurisdictionLeaseType, number>>;
+  };
+  supportsDigitalSigning: boolean;
+  requiresDepositRules: boolean;
+  defaultWorkflow: {
+    leaseRenewalReminderDays: number;
+    moveOutPreparationDays: number;
+  };
+  leaseLifecycleExpectations: {
+    fixedTermContinuation: "ends_on_term_end" | "continues_periodic";
+    periodicContinuation: "continues_until_notice";
+    activeRequiresExecutionReview: boolean;
+  };
+  supportedNoticeTypes: JurisdictionNoticeType[];
+  guidance: {
+    leaseCreation: string[];
+    renewalReview: string[];
+    moveOutReview: string[];
+  };
+  sources: Array<{
+    label: string;
+    url: string;
+    accessedAt: "2026-05-17";
+  }>;
+  confidence: JurisdictionWorkflowConfidence;
+};
+
+export type JurisdictionWorkflowSummary = Pick<
+  JurisdictionWorkflowConfig,
+  | "province"
+  | "provinceLabel"
+  | "country"
+  | "workflowVersion"
+  | "leaseTemplateType"
+  | "legalAdviceDisclaimer"
+  | "noticePeriods"
+  | "supportsDigitalSigning"
+  | "requiresDepositRules"
+  | "defaultWorkflow"
+  | "leaseLifecycleExpectations"
+  | "supportedNoticeTypes"
+  | "guidance"
+  | "confidence"
+>;
+
+const LEGAL_ADVICE_DISCLAIMER =
+  "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.";
+
+const WORKFLOW_REGISTRY: Record<SupportedLeaseWorkflowProvince, JurisdictionWorkflowConfig> = {
+  NS: {
+    province: "NS",
+    provinceLabel: "Nova Scotia",
+    country: "CA",
+    workflowVersion: "jurisdiction-workflow-v1",
+    leaseTemplateType: "standard_residential_ns_form_p",
+    legalAdviceDisclaimer: LEGAL_ADVICE_DISCLAIMER,
+    noticePeriods: {
+      rentIncreaseDays: 120,
+      entryNoticeHours: 24,
+      leaseTerminationDays: 90,
+      leaseTerminationByLeaseType: {
+        fixed_term: 0,
+        year_to_year: 90,
+        month_to_month: 30,
+      },
+    },
+    supportsDigitalSigning: true,
+    requiresDepositRules: true,
+    defaultWorkflow: {
+      leaseRenewalReminderDays: 90,
+      moveOutPreparationDays: 30,
+    },
+    leaseLifecycleExpectations: {
+      fixedTermContinuation: "ends_on_term_end",
+      periodicContinuation: "continues_until_notice",
+      activeRequiresExecutionReview: true,
+    },
+    supportedNoticeTypes: ["rent_increase", "termination", "inspection", "renewal_review"],
+    guidance: {
+      leaseCreation: [
+        "Use the Nova Scotia standard form lease workflow metadata for lease package selection.",
+        "Treat fixed-term continuation as requiring explicit written follow-through before assuming renewal.",
+      ],
+      renewalReview: [
+        "Review renewal or move-out workflow before the lease end date.",
+        "Do not automatically generate or send formal notices from this metadata alone.",
+      ],
+      moveOutReview: [
+        "Surface move-out preparation as an operational reminder.",
+        "Keep notice validation and legal form selection as human-reviewed steps.",
+      ],
+    },
+    sources: [
+      {
+        label: "Nova Scotia rent cap facts",
+        url: "https://novascotia.ca/residential-tenancies-tenants-and-landlords/docs/rent-cap-facts-en.pdf",
+        accessedAt: "2026-05-17",
+      },
+      {
+        label: "Nova Scotia Standard Form of Lease (Form P)",
+        url: "https://www.novascotia.ca/standard-form-lease-form-p",
+        accessedAt: "2026-05-17",
+      },
+    ],
+    confidence: "medium",
+  },
+  ON: {
+    province: "ON",
+    provinceLabel: "Ontario",
+    country: "CA",
+    workflowVersion: "jurisdiction-workflow-v1",
+    leaseTemplateType: "standard_residential_on",
+    legalAdviceDisclaimer: LEGAL_ADVICE_DISCLAIMER,
+    noticePeriods: {
+      rentIncreaseDays: 90,
+      entryNoticeHours: 24,
+      leaseTerminationDays: 60,
+      leaseTerminationByLeaseType: {
+        fixed_term: 60,
+        month_to_month: 60,
+      },
+    },
+    supportsDigitalSigning: true,
+    requiresDepositRules: true,
+    defaultWorkflow: {
+      leaseRenewalReminderDays: 60,
+      moveOutPreparationDays: 30,
+    },
+    leaseLifecycleExpectations: {
+      fixedTermContinuation: "continues_periodic",
+      periodicContinuation: "continues_until_notice",
+      activeRequiresExecutionReview: true,
+    },
+    supportedNoticeTypes: ["rent_increase", "termination", "inspection", "renewal_review"],
+    guidance: {
+      leaseCreation: [
+        "Use Ontario standard lease workflow metadata for lease package selection.",
+        "Do not treat the end of a fixed term as automatic tenant move-out.",
+      ],
+      renewalReview: [
+        "Surface lease end review as an operational checkpoint, not as a legal conclusion.",
+        "Keep formal notice selection and delivery human-reviewed.",
+      ],
+      moveOutReview: [
+        "Surface tenant move-out planning as a review workflow.",
+        "Do not automatically infer vacant possession from lease end dates.",
+      ],
+    },
+    sources: [
+      {
+        label: "Ontario residential rent increases",
+        url: "https://www.ontario.ca/page/residential-rent-increases",
+        accessedAt: "2026-05-17",
+      },
+      {
+        label: "Landlord and Tenant Board guide to the Residential Tenancies Act",
+        url: "https://tm2.tribunalsontario.ca/documents/ltb/Brochures/Guide%20to%20RTA%20%28English%29.html",
+        accessedAt: "2026-05-17",
+      },
+    ],
+    confidence: "medium",
+  },
+};
+
+function normalizeProvinceValue(input: unknown): string {
+  const value = String(input || "").trim().toUpperCase();
+  if (value === "NOVA SCOTIA") return "NS";
+  if (value === "ONTARIO") return "ON";
+  return value;
+}
+
+export function normalizeLeaseWorkflowProvince(input: unknown): SupportedLeaseWorkflowProvince | null {
+  const normalized = normalizeProvinceValue(input);
+  if (normalized === "NS" || normalized === "ON") return normalized;
+  return null;
+}
+
+export function getJurisdictionWorkflowConfig(
+  provinceInput: unknown
+): JurisdictionWorkflowConfig | null {
+  const province = normalizeLeaseWorkflowProvince(provinceInput);
+  return province ? WORKFLOW_REGISTRY[province] : null;
+}
+
+export function getJurisdictionWorkflow(provinceInput: unknown): JurisdictionWorkflowConfig | null {
+  return getJurisdictionWorkflowConfig(provinceInput);
+}
+
+export function getLeaseWorkflowConfig(provinceInput: unknown): JurisdictionWorkflowConfig | null {
+  return getJurisdictionWorkflowConfig(provinceInput);
+}
+
+export function getProvinceOperationalRules(provinceInput: unknown): JurisdictionWorkflowSummary | null {
+  const config = getJurisdictionWorkflowConfig(provinceInput);
+  return config ? toJurisdictionWorkflowSummary(config) : null;
+}
+
+export function listJurisdictionWorkflowConfigs(): JurisdictionWorkflowConfig[] {
+  return Object.values(WORKFLOW_REGISTRY);
+}
+
+export function listSupportedJurisdictionWorkflowProvinces(): SupportedLeaseWorkflowProvince[] {
+  return Object.keys(WORKFLOW_REGISTRY) as SupportedLeaseWorkflowProvince[];
+}
+
+export function toJurisdictionWorkflowSummary(
+  config: JurisdictionWorkflowConfig
+): JurisdictionWorkflowSummary {
+  return {
+    province: config.province,
+    provinceLabel: config.provinceLabel,
+    country: config.country,
+    workflowVersion: config.workflowVersion,
+    leaseTemplateType: config.leaseTemplateType,
+    legalAdviceDisclaimer: config.legalAdviceDisclaimer,
+    noticePeriods: config.noticePeriods,
+    supportsDigitalSigning: config.supportsDigitalSigning,
+    requiresDepositRules: config.requiresDepositRules,
+    defaultWorkflow: config.defaultWorkflow,
+    leaseLifecycleExpectations: config.leaseLifecycleExpectations,
+    supportedNoticeTypes: config.supportedNoticeTypes,
+    guidance: config.guidance,
+    confidence: config.confidence,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/complianceRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/complianceRoutes.test.ts
@@ -37,11 +37,24 @@ describe("compliance routes", () => {
     const app = await makeApp("allow");
     const res = await request(app).get("/api/compliance/rules?province=ON");
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
+    expect(res.body).toMatchObject({
       ok: true,
       province: "ON",
       complianceVersion: "v1",
-      rules: expect.any(Object),
+      rules: {
+        rentIncrease: {
+          noticeDays: 90,
+        },
+        workflow: {
+          leaseTemplateType: "standard_residential_on",
+          fixedTermContinuation: "continues_periodic",
+        },
+      },
+      jurisdictionWorkflow: {
+        province: "ON",
+        leaseTemplateType: "standard_residential_on",
+        legalAdviceDisclaimer: expect.stringContaining("does not provide legal advice"),
+      },
     });
   });
 
@@ -78,5 +91,14 @@ describe("compliance routes", () => {
     const res = await request(app).get("/api/compliance/rules?province=Nova%20Scotia");
     expect(res.status).toBe(200);
     expect(res.body?.province).toBe("NS");
+    expect(res.body?.jurisdictionWorkflow).toMatchObject({
+      province: "NS",
+      noticePeriods: {
+        rentIncreaseDays: 120,
+      },
+      leaseLifecycleExpectations: {
+        fixedTermContinuation: "ends_on_term_end",
+      },
+    });
   });
 });

--- a/rentchain-api/src/routes/complianceRoutes.ts
+++ b/rentchain-api/src/routes/complianceRoutes.ts
@@ -5,6 +5,10 @@ import {
   getComplianceRules,
   listComplianceProvinces,
 } from "../services/complianceEngine";
+import {
+  getJurisdictionWorkflowConfig,
+  toJurisdictionWorkflowSummary,
+} from "../lib/jurisdiction/leaseWorkflowRegistry";
 
 const router = Router();
 
@@ -35,6 +39,7 @@ router.get("/rules", requireAuth, (req: any, res) => {
 
   const province = normalized as "ON" | "NS";
   const rules = getComplianceRules(province);
+  const workflow = getJurisdictionWorkflowConfig(province);
   return res.status(200).json({
     ok: true,
     province,
@@ -43,7 +48,9 @@ router.get("/rules", requireAuth, (req: any, res) => {
       rentIncrease: rules.rentIncrease,
       leaseEnd: rules.leaseEnd,
       notices: rules.notices,
+      workflow: rules.workflow,
     },
+    jurisdictionWorkflow: workflow ? toJurisdictionWorkflowSummary(workflow) : null,
   });
 });
 

--- a/rentchain-api/src/services/__tests__/complianceEngine.test.ts
+++ b/rentchain-api/src/services/__tests__/complianceEngine.test.ts
@@ -10,15 +10,28 @@ describe("complianceEngine", () => {
     const rules = getComplianceRules("ON");
     expect(rules.province).toBe("ON");
     expect(rules.complianceVersion).toBe("v1");
-    expect(rules.rentIncrease.minMonthsBetweenIncreases).toBeGreaterThan(0);
-    expect(rules.rentIncrease.noticeDays).toBeGreaterThan(0);
-    expect(rules.notices.entryNoticeMinHours).toBeGreaterThan(0);
+    expect(rules.rentIncrease).toMatchObject({
+      minMonthsBetweenIncreases: 12,
+      noticeDays: 90,
+    });
+    expect(rules.notices.entryNoticeMinHours).toBe(24);
+    expect(rules.workflow).toMatchObject({
+      leaseTemplateType: "standard_residential_on",
+      fixedTermContinuation: "continues_periodic",
+      legalAdviceDisclaimer: expect.stringContaining("does not provide legal advice"),
+    });
   });
 
-  it("loads NS stub rules", () => {
+  it("loads Nova Scotia workflow rules", () => {
     const rules = getComplianceRules("NS");
     expect(rules.province).toBe("NS");
     expect(rules.complianceVersion).toBe("v1");
+    expect(rules.rentIncrease.noticeDays).toBe(120);
+    expect(rules.leaseEnd.renewalWindowDays).toBe(90);
+    expect(rules.workflow).toMatchObject({
+      leaseTemplateType: "standard_residential_ns_form_p",
+      fixedTermContinuation: "ends_on_term_end",
+    });
   });
 
   it("normalizes and validates province codes", () => {

--- a/rentchain-api/src/services/complianceEngine/provinces/ns.ts
+++ b/rentchain-api/src/services/complianceEngine/provinces/ns.ts
@@ -1,17 +1,28 @@
 import { ComplianceRules } from "../types";
+import { getJurisdictionWorkflowConfig } from "../../../lib/jurisdiction/leaseWorkflowRegistry";
+
+const workflow = getJurisdictionWorkflowConfig("NS")!;
 
 export const nsComplianceRules: ComplianceRules = {
   province: "NS",
   complianceVersion: "v1",
   rentIncrease: {
     minMonthsBetweenIncreases: 12,
-    noticeDays: 4,
+    noticeDays: workflow.noticePeriods.rentIncreaseDays,
   },
   leaseEnd: {
-    renewalWindowDays: 60,
-    fixedTermBehavior: "stub_v1_review_required_before_automation",
+    renewalWindowDays: workflow.defaultWorkflow.leaseRenewalReminderDays,
+    fixedTermBehavior: workflow.leaseLifecycleExpectations.fixedTermContinuation,
   },
   notices: {
-    entryNoticeMinHours: 24,
+    entryNoticeMinHours: workflow.noticePeriods.entryNoticeHours,
+  },
+  workflow: {
+    leaseTemplateType: workflow.leaseTemplateType,
+    leaseRenewalReminderDays: workflow.defaultWorkflow.leaseRenewalReminderDays,
+    moveOutPreparationDays: workflow.defaultWorkflow.moveOutPreparationDays,
+    fixedTermContinuation: workflow.leaseLifecycleExpectations.fixedTermContinuation,
+    supportedNoticeTypes: workflow.supportedNoticeTypes,
+    legalAdviceDisclaimer: workflow.legalAdviceDisclaimer,
   },
 };

--- a/rentchain-api/src/services/complianceEngine/provinces/on.ts
+++ b/rentchain-api/src/services/complianceEngine/provinces/on.ts
@@ -1,18 +1,29 @@
 import { ComplianceRules } from "../types";
+import { getJurisdictionWorkflowConfig } from "../../../lib/jurisdiction/leaseWorkflowRegistry";
+
+const workflow = getJurisdictionWorkflowConfig("ON")!;
 
 export const onComplianceRules: ComplianceRules = {
   province: "ON",
   complianceVersion: "v1",
   rentIncrease: {
     minMonthsBetweenIncreases: 12,
-    noticeDays: 90,
+    noticeDays: workflow.noticePeriods.rentIncreaseDays,
     exemptions: ["new_unit_exemption_window"],
   },
   leaseEnd: {
-    renewalWindowDays: 60,
-    fixedTermBehavior: "continues_as_month_to_month_unless_ended_by_valid_notice",
+    renewalWindowDays: workflow.defaultWorkflow.leaseRenewalReminderDays,
+    fixedTermBehavior: workflow.leaseLifecycleExpectations.fixedTermContinuation,
   },
   notices: {
-    entryNoticeMinHours: 24,
+    entryNoticeMinHours: workflow.noticePeriods.entryNoticeHours,
+  },
+  workflow: {
+    leaseTemplateType: workflow.leaseTemplateType,
+    leaseRenewalReminderDays: workflow.defaultWorkflow.leaseRenewalReminderDays,
+    moveOutPreparationDays: workflow.defaultWorkflow.moveOutPreparationDays,
+    fixedTermContinuation: workflow.leaseLifecycleExpectations.fixedTermContinuation,
+    supportedNoticeTypes: workflow.supportedNoticeTypes,
+    legalAdviceDisclaimer: workflow.legalAdviceDisclaimer,
   },
 };

--- a/rentchain-api/src/services/complianceEngine/types.ts
+++ b/rentchain-api/src/services/complianceEngine/types.ts
@@ -21,4 +21,12 @@ export type ComplianceRules = {
   rentIncrease: RentIncreaseRules;
   leaseEnd: LeaseEndRules;
   notices: NoticeRules;
+  workflow: {
+    leaseTemplateType: string;
+    leaseRenewalReminderDays: number;
+    moveOutPreparationDays: number;
+    fixedTermContinuation: string;
+    supportedNoticeTypes: string[];
+    legalAdviceDisclaimer: string;
+  };
 };

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -8,6 +8,11 @@ import {
   type RentChangeMode,
   resolveLeaseNoticeRule,
 } from "../config/leaseNoticeRules";
+import {
+  getJurisdictionWorkflowConfig,
+  toJurisdictionWorkflowSummary,
+  type JurisdictionWorkflowSummary,
+} from "../lib/jurisdiction/leaseWorkflowRegistry";
 import { toAutopilotPolicySummary } from "../lib/policy/policyEvaluator";
 import { loadUnitsForProperty, resolveUnitReference } from "./leaseCanonicalizationService";
 import { isTargetedHiddenLeaseId } from "../lib/testDataVisibilityTargets";
@@ -61,6 +66,7 @@ export type LeaseWorkflowLease = {
   unitLabel: string | null;
   propertyLabel: string | null;
   propertyAddress: string | null;
+  jurisdictionWorkflow: JurisdictionWorkflowSummary | null;
 };
 
 export type LeaseNoticePreviewInput = {
@@ -244,7 +250,8 @@ export function normalizeLeaseRecord(id: string, raw: any): LeaseWorkflowLease {
   const leaseEndDate =
     toDateOnly(raw?.leaseEndDate || raw?.endDate || raw?.leaseEnd || raw?.end_date || null) || null;
   const leaseType = asLeaseType(raw?.leaseType || raw?.termType || raw?.lease_type || null);
-  const province = String(raw?.province || raw?.jurisdiction || "").trim().toUpperCase() || "NS";
+  const workflowConfig = getJurisdictionWorkflowConfig(raw?.province || raw?.jurisdiction || null);
+  const province = workflowConfig?.province || String(raw?.province || raw?.jurisdiction || "").trim().toUpperCase() || "UNSET";
   const rule = resolveLeaseNoticeRule({ province, leaseType });
   const nextNoticeDueAt =
     toMillis(raw?.nextNoticeDueAt) || (leaseEndDate && rule ? minusDays(leaseEndDate, rule.noticeLeadDays) : null);
@@ -296,6 +303,7 @@ export function normalizeLeaseRecord(id: string, raw: any): LeaseWorkflowLease {
     unitLabel: String(raw?.unitLabel || raw?.unitNumber || raw?.unit || "").trim() || null,
     propertyLabel: String(raw?.propertyLabel || raw?.propertyName || "").trim() || null,
     propertyAddress: String(raw?.propertyAddress || raw?.propertyAddressLine1 || raw?.addressLine1 || raw?.propertyAddress1 || raw?.address || "").trim() || null,
+    jurisdictionWorkflow: workflowConfig ? toJurisdictionWorkflowSummary(workflowConfig) : null,
   };
 }
 

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LeasePackWizardModal } from "./LeasePackWizardModal";
+
+vi.mock("@/api/leasePacksApi", () => ({
+  activateLeaseDraft: vi.fn(),
+  createLeaseDraft: vi.fn(),
+  generateLeaseDraftPdf: vi.fn(),
+  getLeaseSnapshot: vi.fn(),
+  updateLeaseDraft: vi.fn(),
+}));
+
+vi.mock("@/api/http", () => ({
+  apiJson: vi.fn(async () => ({ items: [] })),
+}));
+
+vi.mock("../ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock("@/components/leases/LeaseRiskCard", () => ({
+  LeaseRiskCard: () => null,
+}));
+
+describe("LeasePackWizardModal jurisdiction workflow guidance", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders Nova Scotia jurisdiction badge and workflow guidance", () => {
+    render(
+      <LeasePackWizardModal
+        open
+        onClose={vi.fn()}
+        landlordName="Landlord"
+        tenant={{
+          id: "tenant-1",
+          fullName: "Tenant One",
+          propertyId: "property-1",
+          propertyName: "Harbour Place",
+          unitId: "unit-1",
+          unit: "1",
+          province: "NS",
+        }}
+        lease={{}}
+      />
+    );
+
+    expect(screen.getByText("NS Residential")).toBeInTheDocument();
+    expect(screen.getByText("Workflow guidance only - verify local legal requirements.")).toBeInTheDocument();
+    expect(screen.getByText(/standard residential ns form p/i)).toBeInTheDocument();
+  });
+
+  it("renders Ontario jurisdiction badge without enabling Schedule A generation", () => {
+    render(
+      <LeasePackWizardModal
+        open
+        onClose={vi.fn()}
+        landlordName="Landlord"
+        tenant={{
+          id: "tenant-1",
+          fullName: "Tenant One",
+          propertyId: "property-1",
+          propertyName: "King Street",
+          unitId: "unit-1",
+          unit: "1",
+          province: "ON",
+        }}
+        lease={{}}
+      />
+    );
+
+    expect(screen.getByText("ON Residential")).toBeInTheDocument();
+    expect(screen.getByText(/Ontario lease pack documents are available/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Generate Schedule A PDF/i })).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
@@ -14,6 +14,7 @@ import { useToast } from "../ui/ToastProvider";
 import { apiJson } from "@/api/http";
 import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "@/lib/pdfExportObservability";
 import { normalizeProvinceCode, provinceLabelFromCode, type ProvinceCode } from "@/lib/provinces";
+import { getJurisdictionWorkflow } from "@/lib/jurisdictionLeaseWorkflow";
 import { LeaseRiskCard } from "@/components/leases/LeaseRiskCard";
 
 interface Props {
@@ -154,6 +155,7 @@ export const LeasePackWizardModal: React.FC<Props> = ({
 
   const isNsProvince = provinceCode === "NS";
   const isOntario = provinceCode === "ON";
+  const jurisdictionWorkflow = getJurisdictionWorkflow(provinceCode);
   const provinceUnset = !provinceCode || provinceCode === "UNSET";
   const blockingProvinceError =
     !provinceLoading && provinceUnset ? "Set property province to generate lease pack" : "";
@@ -364,6 +366,41 @@ export const LeasePackWizardModal: React.FC<Props> = ({
           <a href="/help/templates" style={{ color: "#2563eb", textDecoration: "underline" }}>
             Templates
           </a>
+        </div>
+
+        <div
+          style={{
+            border: "1px solid #bfdbfe",
+            background: "#eff6ff",
+            color: "#1e3a8a",
+            padding: 10,
+            borderRadius: 8,
+            fontSize: 13,
+            display: "grid",
+            gap: 4,
+          }}
+        >
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+            <span
+              style={{
+                display: "inline-flex",
+                borderRadius: 999,
+                background: "#dbeafe",
+                color: "#1d4ed8",
+                padding: "3px 8px",
+                fontWeight: 800,
+                fontSize: 12,
+              }}
+            >
+              {jurisdictionWorkflow?.badgeLabel || "Jurisdiction review"}
+            </span>
+            <span>{jurisdictionWorkflow?.guidanceCopy || "Set property province to show workflow guidance."}</span>
+          </div>
+          {jurisdictionWorkflow ? (
+            <div style={{ color: "#475569" }}>
+              Template workflow: {jurisdictionWorkflow.leaseTemplateType.replace(/_/g, " ")}
+            </div>
+          ) : null}
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))", gap: 10 }}>

--- a/rentchain-frontend/src/lib/jurisdictionLeaseWorkflow.test.ts
+++ b/rentchain-frontend/src/lib/jurisdictionLeaseWorkflow.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  getJurisdictionWorkflow,
+  getLeaseWorkflowConfig,
+  getProvinceOperationalRules,
+} from "./jurisdictionLeaseWorkflow";
+
+describe("jurisdictionLeaseWorkflow", () => {
+  it("derives NS and ON operational workflow UI config", () => {
+    expect(getJurisdictionWorkflow("Nova Scotia")).toMatchObject({
+      province: "NS",
+      badgeLabel: "NS Residential",
+      supportsLeaseGeneration: true,
+      guidanceCopy: expect.stringContaining("Workflow guidance only"),
+    });
+    expect(getLeaseWorkflowConfig("ON")).toMatchObject({
+      province: "ON",
+      badgeLabel: "ON Residential",
+      supportsLeaseGeneration: false,
+    });
+  });
+
+  it("falls back safely for unsupported or missing province", () => {
+    expect(getProvinceOperationalRules("BC")).toBeNull();
+    expect(getJurisdictionWorkflow(null)).toBeNull();
+  });
+});

--- a/rentchain-frontend/src/lib/jurisdictionLeaseWorkflow.ts
+++ b/rentchain-frontend/src/lib/jurisdictionLeaseWorkflow.ts
@@ -1,0 +1,44 @@
+import { normalizeProvinceCode } from "./provinces";
+
+export type LeaseWorkflowProvince = "NS" | "ON";
+
+export type LeaseWorkflowUiConfig = {
+  province: LeaseWorkflowProvince;
+  badgeLabel: string;
+  leaseTemplateType: "standard_residential_ns_form_p" | "standard_residential_on";
+  guidanceCopy: string;
+  supportsLeaseGeneration: boolean;
+};
+
+const GUIDANCE_COPY = "Workflow guidance only - verify local legal requirements.";
+
+const WORKFLOW_UI_CONFIG: Record<LeaseWorkflowProvince, LeaseWorkflowUiConfig> = {
+  NS: {
+    province: "NS",
+    badgeLabel: "NS Residential",
+    leaseTemplateType: "standard_residential_ns_form_p",
+    guidanceCopy: GUIDANCE_COPY,
+    supportsLeaseGeneration: true,
+  },
+  ON: {
+    province: "ON",
+    badgeLabel: "ON Residential",
+    leaseTemplateType: "standard_residential_on",
+    guidanceCopy: GUIDANCE_COPY,
+    supportsLeaseGeneration: false,
+  },
+};
+
+export function getJurisdictionWorkflow(input?: string | null): LeaseWorkflowUiConfig | null {
+  const province = normalizeProvinceCode(input);
+  if (province === "NS" || province === "ON") return WORKFLOW_UI_CONFIG[province];
+  return null;
+}
+
+export function getLeaseWorkflowConfig(input?: string | null): LeaseWorkflowUiConfig | null {
+  return getJurisdictionWorkflow(input);
+}
+
+export function getProvinceOperationalRules(input?: string | null): LeaseWorkflowUiConfig | null {
+  return getJurisdictionWorkflow(input);
+}


### PR DESCRIPTION
## Summary

Adds the foundation for jurisdiction-aware lease and operational workflow handling for Nova Scotia and Ontario.

This is workflow metadata and operational guidance infrastructure only. It does not generate legal conclusions, auto-send notices, enforce timelines, file anything externally, or change payment/lease write behavior.

## Audit Summary

Current lifecycle/workflow handling already had several province-related fragments:

- `complianceEngine` supported `ON` and `NS` but used a small standalone rule shape.
- `leaseNoticeRules` was Nova Scotia-only and encoded renewal/notice timing directly.
- `leaseNoticeWorkflowService.normalizeLeaseRecord` defaulted missing province to `NS`, which could make unknown or Ontario records appear Nova Scotia-scoped.
- Lease draft generation is currently Nova Scotia Schedule A/Form P only.
- Frontend lease pack catalog already has province-specific NS and ON template packs.
- Lease lifecycle/coherence helpers are deterministic but not jurisdiction-specific.

## Workflow Assumptions Found

- Nova Scotia lease package generation is the only active backend lease generation path.
- Ontario lease pack assets exist on the frontend, but backend generation/activation remains NS-only.
- Existing notice workflow remains feature-flagged and landlord-reviewed.
- Lease status, execution, occupancy, and payment readiness are derived elsewhere and were not changed.
- Property/tenant/lease province data is already present in multiple shapes and is normalized where touched.

## Province Config Structure

Added `rentchain-api/src/lib/jurisdiction/leaseWorkflowRegistry.ts` with:

- supported provinces: `NS`, `ON`
- lease template type
- operational notice timing metadata
- digital signing/deposit workflow flags
- default renewal and move-out reminder windows
- lease lifecycle expectations
- supported notice workflow categories
- safe operational guidance copy
- source metadata and non-legal-advice disclaimer

Exposed helper names:

- `getJurisdictionWorkflow`
- `getLeaseWorkflowConfig`
- `getProvinceOperationalRules`

## UI Surfaces Updated

Low-risk lease creation surface only:

- `LeasePackWizardModal` now shows a jurisdiction badge such as `NS Residential` or `ON Residential`.
- It shows safe copy: `Workflow guidance only - verify local legal requirements.`
- Ontario remains non-generative in this modal; Schedule A generation stays NS-only.

## Backend Surfaces Updated

- `complianceRoutes` now returns `jurisdictionWorkflow` metadata alongside existing compliance rules.
- `complianceEngine` derives workflow metadata from the canonical registry.
- `leaseNoticeRules` now resolves NS/ON workflow-review rules from the canonical registry.
- Unknown or unsupported provinces fail closed instead of silently resolving to NS for notice workflow metadata.
- `leaseNoticeWorkflowService` projects `jurisdictionWorkflow` metadata into normalized lease workflow records.

## Tests Added / Updated

Backend:

- jurisdiction workflow registry tests
- lease notice rule resolution tests
- compliance engine tests
- compliance route tests
- existing lease notice workflow/composition tests

Frontend:

- jurisdiction workflow helper tests
- lease pack modal jurisdiction badge tests

## Validation

- Backend focused tests passed: 24/24
- Frontend focused tests passed: 4/4
- Backend build passed
- Frontend build passed

Note: frontend build emits the existing Vite warning that Node 20.11.1 is below Vite's recommended 20.19+/22.12+ range, but the repo preflight requires Node 20.11.1 and the build completed successfully.

## Guardrails Preserved

- No Firestore migration
- No payment logic changes
- No lease write behavior changes
- No lifecycle/coherence write behavior changes
- No notice auto-send changes
- No eviction/legal automation
- No legal compliance certification claims
- No broad UI redesign

## Known Follow-ups

- Ontario backend lease generation/activation flow remains future work.
- Province-specific workflow QA should expand to property profile and lease profile surfaces once UX scope is defined.
- Future notice workflow work should keep formal notice selection human-reviewed.
- Add a jurisdiction source/audit viewer if legal operations metadata needs admin review.