### PR TITLE
feat: add jurisdiction-aware operational policy engine

### DIFF
--- a/rentchain-api/src/lib/jurisdiction/__tests__/operationalPolicyEvaluator.test.ts
+++ b/rentchain-api/src/lib/jurisdiction/__tests__/operationalPolicyEvaluator.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { evaluateJurisdictionPolicy } from "../operationalPolicyEvaluator";
+
+describe("evaluateJurisdictionPolicy", () => {
+  it("returns Nova Scotia lease renewal review guidance inside the configured window", () => {
+    const evaluation = evaluateJurisdictionPolicy({
+      province: "NS",
+      leaseStatus: "active",
+      leaseExecutionStatus: "fully_executed",
+      leaseEndDate: "2026-07-15",
+      leaseLifecycleStatus: "expiring_soon",
+      today: "2026-05-17",
+    });
+
+    expect(evaluation.jurisdiction).toBe("NS");
+    expect(evaluation.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          jurisdiction: "NS",
+          policyKey: "lease_renewal_review",
+          status: "review",
+          legalAdvice: false,
+          disclaimer: expect.stringContaining("does not provide legal advice"),
+        }),
+      ])
+    );
+  });
+
+  it("returns Ontario lease renewal review guidance inside the configured window", () => {
+    const evaluation = evaluateJurisdictionPolicy({
+      propertyProvince: "Ontario",
+      leaseStatus: "active",
+      leaseExecutionStatus: "fully_executed",
+      leaseEndDate: "2026-07-01",
+      leaseLifecycleStatus: "expiring_soon",
+      today: "2026-05-17",
+    });
+
+    expect(evaluation.jurisdiction).toBe("ON");
+    expect(evaluation.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          jurisdiction: "ON",
+          policyKey: "lease_renewal_review",
+          sourceRuleKey: "ON.lease_renewal_review",
+        }),
+      ])
+    );
+  });
+
+  it("returns a missing jurisdiction policy when no province is available", () => {
+    const evaluation = evaluateJurisdictionPolicy({
+      leaseStatus: "active",
+      leaseEndDate: "2026-07-01",
+    });
+
+    expect(evaluation.jurisdiction).toBe("UNKNOWN");
+    expect(evaluation.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          policyKey: "missing_jurisdiction",
+          severity: "warning",
+        }),
+        expect.objectContaining({
+          policyKey: "missing_province_property_data",
+          severity: "warning",
+        }),
+      ])
+    );
+  });
+
+  it("returns an unsupported jurisdiction policy for provinces outside the v1 registry", () => {
+    const evaluation = evaluateJurisdictionPolicy({
+      province: "BC",
+      leaseStatus: "active",
+      leaseEndDate: "2026-07-01",
+    });
+
+    expect(evaluation).toEqual({
+      jurisdiction: "UNSUPPORTED",
+      results: [
+        expect.objectContaining({
+          jurisdiction: "UNSUPPORTED",
+          policyKey: "unsupported_jurisdiction",
+          legalAdvice: false,
+        }),
+      ],
+    });
+  });
+
+  it("handles missing or unknown lease dates without crashing", () => {
+    const evaluation = evaluateJurisdictionPolicy({
+      province: "NS",
+      leaseStatus: "active",
+      leaseExecutionStatus: "fully_executed",
+      leaseEndDate: null,
+    });
+
+    expect(evaluation.jurisdiction).toBe("NS");
+    expect(evaluation.results.length).toBeGreaterThan(0);
+    expect(evaluation.results.some((result) => result.policyKey === "lease_renewal_review")).toBe(false);
+  });
+
+  it("surfaces execution readiness review without mutating input", () => {
+    const input = {
+      province: "ON",
+      leaseStatus: "active",
+      leaseExecutionStatus: "draft",
+      leaseEndDate: "2026-12-31",
+      stateCoherence: {
+        coherenceStatus: "review_required",
+        flags: {
+          requiresReview: true,
+          leaseMarkedActiveBeforeExecution: true,
+        },
+      },
+    };
+    const before = JSON.stringify(input);
+    const evaluation = evaluateJurisdictionPolicy(input);
+
+    expect(JSON.stringify(input)).toBe(before);
+    expect(evaluation.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          policyKey: "lease_execution_readiness",
+          status: "review",
+          severity: "warning",
+        }),
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/jurisdiction/leaseWorkflowRegistry.ts
+++ b/rentchain-api/src/lib/jurisdiction/leaseWorkflowRegistry.ts
@@ -66,7 +66,7 @@ export type JurisdictionWorkflowSummary = Pick<
   | "confidence"
 >;
 
-const LEGAL_ADVICE_DISCLAIMER =
+export const LEGAL_ADVICE_DISCLAIMER =
   "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.";
 
 const WORKFLOW_REGISTRY: Record<SupportedLeaseWorkflowProvince, JurisdictionWorkflowConfig> = {

--- a/rentchain-api/src/lib/jurisdiction/operationalPolicyEvaluator.ts
+++ b/rentchain-api/src/lib/jurisdiction/operationalPolicyEvaluator.ts
@@ -1,0 +1,288 @@
+import {
+  getJurisdictionWorkflowConfig,
+  LEGAL_ADVICE_DISCLAIMER,
+  normalizeLeaseWorkflowProvince,
+  type SupportedLeaseWorkflowProvince,
+} from "./leaseWorkflowRegistry";
+
+export type JurisdictionPolicyStatus = "ok" | "review" | "not_applicable" | "unknown";
+export type JurisdictionPolicySeverity = "info" | "warning" | "critical";
+export type JurisdictionPolicyConfidence = "high" | "medium" | "low";
+
+export type JurisdictionPolicyKey =
+  | "lease_renewal_review"
+  | "rent_increase_workflow_availability"
+  | "notice_workflow_readiness"
+  | "move_out_preparation"
+  | "deposit_workflow_review"
+  | "lease_execution_readiness"
+  | "missing_jurisdiction"
+  | "unsupported_jurisdiction"
+  | "missing_province_property_data";
+
+export type JurisdictionPolicyResult = {
+  jurisdiction: SupportedLeaseWorkflowProvince | "UNKNOWN" | "UNSUPPORTED";
+  policyKey: JurisdictionPolicyKey;
+  status: JurisdictionPolicyStatus;
+  severity: JurisdictionPolicySeverity;
+  label: string;
+  reason: string;
+  recommendation: string;
+  sourceRuleKey: string;
+  confidence: JurisdictionPolicyConfidence;
+  legalAdvice: false;
+  disclaimer: string;
+};
+
+export type EvaluateJurisdictionPolicyInput = {
+  province?: unknown;
+  propertyProvince?: unknown;
+  jurisdictionProvince?: unknown;
+  leaseStatus?: unknown;
+  leaseStartDate?: unknown;
+  leaseEndDate?: unknown;
+  leaseExecutionStatus?: unknown;
+  leaseLifecycleStatus?: unknown;
+  occupancyStatus?: unknown;
+  stateCoherence?: {
+    coherenceStatus?: unknown;
+    flags?: {
+      requiresReview?: unknown;
+      leaseMarkedActiveBeforeExecution?: unknown;
+      activeLeaseOnVacantUnit?: unknown;
+      hasStateConflict?: unknown;
+    } | null;
+  } | null;
+  today?: Date | string | number | null;
+};
+
+export type JurisdictionPolicyEvaluation = {
+  jurisdiction: SupportedLeaseWorkflowProvince | "UNKNOWN" | "UNSUPPORTED";
+  results: JurisdictionPolicyResult[];
+};
+
+function rawProvince(input: EvaluateJurisdictionPolicyInput): string {
+  return String(input.jurisdictionProvince || input.propertyProvince || input.province || "").trim();
+}
+
+function normalizedString(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function parseDateOnly(value: unknown): Date | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate()));
+}
+
+function daysUntil(dateValue: unknown, todayValue: EvaluateJurisdictionPolicyInput["today"]): number | null {
+  const target = parseDateOnly(dateValue);
+  const today = parseDateOnly(todayValue || new Date());
+  if (!target || !today) return null;
+  return Math.ceil((target.getTime() - today.getTime()) / 86_400_000);
+}
+
+function result(
+  jurisdiction: JurisdictionPolicyResult["jurisdiction"],
+  policyKey: JurisdictionPolicyKey,
+  input: Omit<JurisdictionPolicyResult, "jurisdiction" | "policyKey" | "legalAdvice" | "disclaimer">
+): JurisdictionPolicyResult {
+  return {
+    jurisdiction,
+    policyKey,
+    ...input,
+    legalAdvice: false,
+    disclaimer: LEGAL_ADVICE_DISCLAIMER,
+  };
+}
+
+export function evaluateJurisdictionPolicy(
+  input: EvaluateJurisdictionPolicyInput
+): JurisdictionPolicyEvaluation {
+  const provinceInput = rawProvince(input);
+  if (!provinceInput) {
+    return {
+      jurisdiction: "UNKNOWN",
+      results: [
+        result("UNKNOWN", "missing_jurisdiction", {
+          status: "review",
+          severity: "warning",
+          label: "Jurisdiction review needed",
+          reason: "No province is available from the lease or property context.",
+          recommendation: "Add or verify the property province before relying on province-aware workflow guidance.",
+          sourceRuleKey: "jurisdiction.missing_province",
+          confidence: "high",
+        }),
+        result("UNKNOWN", "missing_province_property_data", {
+          status: "review",
+          severity: "warning",
+          label: "Property province missing",
+          reason: "Province-aware operational guidance depends on property jurisdiction metadata.",
+          recommendation: "Confirm the property province in the property profile.",
+          sourceRuleKey: "jurisdiction.property_province_missing",
+          confidence: "high",
+        }),
+      ],
+    };
+  }
+
+  const province = normalizeLeaseWorkflowProvince(provinceInput);
+  if (!province) {
+    return {
+      jurisdiction: "UNSUPPORTED",
+      results: [
+        result("UNSUPPORTED", "unsupported_jurisdiction", {
+          status: "review",
+          severity: "warning",
+          label: "Jurisdiction workflow not configured",
+          reason: "This province is not part of the current jurisdiction workflow registry.",
+          recommendation: "Use general lease operations and verify local requirements outside RentChain.",
+          sourceRuleKey: "jurisdiction.unsupported_province",
+          confidence: "high",
+        }),
+      ],
+    };
+  }
+
+  const config = getJurisdictionWorkflowConfig(province);
+  if (!config) {
+    return { jurisdiction: "UNSUPPORTED", results: [] };
+  }
+
+  const results: JurisdictionPolicyResult[] = [];
+  const leaseStatus = normalizedString(input.leaseStatus);
+  const executionStatus = normalizedString(input.leaseExecutionStatus);
+  const lifecycleStatus = normalizedString(input.leaseLifecycleStatus);
+  const coherenceRequiresReview =
+    input.stateCoherence?.coherenceStatus === "review_required" ||
+    Boolean(input.stateCoherence?.flags?.requiresReview);
+  const markedActiveBeforeExecution = Boolean(input.stateCoherence?.flags?.leaseMarkedActiveBeforeExecution);
+  const endDateDays = daysUntil(input.leaseEndDate, input.today);
+  const hasLeaseEndDate = endDateDays !== null;
+  const executionIncomplete =
+    Boolean(executionStatus) &&
+    executionStatus !== "fully_executed" &&
+    executionStatus !== "executed" &&
+    executionStatus !== "landlord_signed";
+
+  if (config.leaseLifecycleExpectations.activeRequiresExecutionReview && (markedActiveBeforeExecution || (leaseStatus === "active" && executionIncomplete))) {
+    results.push(
+      result(province, "lease_execution_readiness", {
+        status: "review",
+        severity: "warning",
+        label: "Lease execution review recommended",
+        reason: "The lease appears operationally active while execution signals are not complete.",
+        recommendation: "Review the lease package and signature readiness before treating execution as complete.",
+        sourceRuleKey: `${province}.lease_execution_readiness`,
+        confidence: "medium",
+      })
+    );
+  }
+
+  if (hasLeaseEndDate && endDateDays! >= 0 && endDateDays! <= config.defaultWorkflow.leaseRenewalReminderDays) {
+    results.push(
+      result(province, "lease_renewal_review", {
+        status: "review",
+        severity: "info",
+        label: "Lease renewal review recommended",
+        reason: `The lease end date is within the configured ${config.defaultWorkflow.leaseRenewalReminderDays}-day review window.`,
+        recommendation: "Review renewal, continuation, or move-out workflow next steps with the current jurisdiction context.",
+        sourceRuleKey: `${province}.lease_renewal_review`,
+        confidence: config.confidence,
+      })
+    );
+  }
+
+  if (hasLeaseEndDate && endDateDays! >= 0 && endDateDays! <= config.defaultWorkflow.moveOutPreparationDays) {
+    results.push(
+      result(province, "move_out_preparation", {
+        status: "review",
+        severity: "info",
+        label: "Move-out preparation review available",
+        reason: `The lease end date is within the configured ${config.defaultWorkflow.moveOutPreparationDays}-day move-out preparation window.`,
+        recommendation: "Review move-out preparation tasks without assuming legal notice validity from this guidance.",
+        sourceRuleKey: `${province}.move_out_preparation`,
+        confidence: config.confidence,
+      })
+    );
+  }
+
+  if (config.supportedNoticeTypes.includes("rent_increase")) {
+    results.push(
+      result(province, "rent_increase_workflow_availability", {
+        status: "ok",
+        severity: "info",
+        label: "Rent increase workflow metadata available",
+        reason: "This jurisdiction has rent increase workflow metadata configured for operational review.",
+        recommendation: "Use the guided workflow as a review aid and verify current local requirements before sending notices.",
+        sourceRuleKey: `${province}.rent_increase_workflow`,
+        confidence: config.confidence,
+      })
+    );
+  }
+
+  if (config.supportedNoticeTypes.length > 0) {
+    results.push(
+      result(province, "notice_workflow_readiness", {
+        status: "ok",
+        severity: "info",
+        label: "Notice workflow guidance available",
+        reason: "Province-aware notice workflow metadata is available for landlord review.",
+        recommendation: "Prepare notice workflow steps manually and verify local legal requirements before delivery.",
+        sourceRuleKey: `${province}.notice_workflow_readiness`,
+        confidence: config.confidence,
+      })
+    );
+  }
+
+  if (config.requiresDepositRules) {
+    results.push(
+      result(province, "deposit_workflow_review", {
+        status: "review",
+        severity: "info",
+        label: "Deposit workflow review available",
+        reason: "This jurisdiction has deposit workflow metadata flagged for operational review.",
+        recommendation: "Review deposit handling as part of the lease workflow without treating this as a compliance determination.",
+        sourceRuleKey: `${province}.deposit_workflow_review`,
+        confidence: config.confidence,
+      })
+    );
+  }
+
+  if (coherenceRequiresReview && !results.some((entry) => entry.policyKey === "lease_execution_readiness")) {
+    results.unshift(
+      result(province, "lease_execution_readiness", {
+        status: "review",
+        severity: "warning",
+        label: "Operational state review recommended",
+        reason: "Lease, occupancy, tenant, or payment readiness signals require review.",
+        recommendation: "Review the lease operations page before relying on downstream workflow guidance.",
+        sourceRuleKey: `${province}.state_coherence_review`,
+        confidence: "medium",
+      })
+    );
+  }
+
+  if (results.length === 0 && !lifecycleStatus) {
+    results.push(
+      result(province, "notice_workflow_readiness", {
+        status: "unknown",
+        severity: "info",
+        label: "Jurisdiction workflow available",
+        reason: "Province metadata is available, but lease lifecycle inputs are incomplete.",
+        recommendation: "Review lease dates and status before using jurisdiction-aware workflow guidance.",
+        sourceRuleKey: `${province}.workflow_available_inputs_incomplete`,
+        confidence: "low",
+      })
+    );
+  }
+
+  return { jurisdiction: province, results };
+}

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -167,7 +167,7 @@ describe("leaseRoutes GET /active", () => {
   });
 
   it("returns landlord-scoped active leases with tenant and document details", async () => {
-    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
     seedDoc("leaseDrafts", "draft-1", { landlordId: "landlord-1", lastGeneratedSnapshotId: "snapshot-1" });
     seedDoc("leaseSnapshots", "snapshot-1", {
@@ -282,6 +282,14 @@ describe("leaseRoutes GET /active", () => {
           lifecycleLabel: "Active",
           requiredNextAction: "none",
         }),
+        jurisdictionProvince: "NS",
+        jurisdictionPolicies: expect.arrayContaining([
+          expect.objectContaining({
+            jurisdiction: "NS",
+            policyKey: "rent_increase_workflow_availability",
+            legalAdvice: false,
+          }),
+        ]),
         derivedLifecycleState: "active",
         derivedLifecycleReasons: ["signed_current_term"],
         derivedLifecycleRequiresReview: false,

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -68,6 +68,7 @@ import { computeNoResponseState } from "../services/leaseNoticeWorkflowService";
 import { deriveLeaseLifecycleSummary } from "../services/leaseLifecycle/deriveLeaseLifecycleSummary";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
 import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupancyCoherence";
+import { evaluateJurisdictionPolicy } from "../lib/jurisdiction/operationalPolicyEvaluator";
 import { formatInternalReference, slugifyOperationalReference } from "../lib/identityReferences";
 import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
 
@@ -1019,10 +1020,22 @@ async function enrichLeaseRow(raw: any) {
     loadLeaseDocumentUrlForLease(raw),
   ]);
 
+  const propertyData = propertySnap?.exists ? propertySnap.data() : null;
   const propertyName =
-    propertySnap?.exists
-      ? String(propertySnap.data()?.name || propertySnap.data()?.addressLine1 || "Property").trim() || "Property"
+    propertyData
+      ? String(propertyData?.name || propertyData?.addressLine1 || "Property").trim() || "Property"
       : "Property";
+  const propertyProvince =
+    String(
+      raw?.jurisdictionProvince ||
+        raw?.province ||
+        raw?.provinceState ||
+        propertyData?.jurisdictionProvince ||
+        propertyData?.province ||
+        propertyData?.provinceState ||
+        propertyData?.state ||
+        ""
+    ).trim() || null;
   const tenantName =
     tenantSnap?.exists
       ? String(tenantSnap.data()?.fullName || tenantSnap.data()?.name || "").trim() || null
@@ -1076,6 +1089,7 @@ async function enrichLeaseRow(raw: any) {
   return {
     ...(await hydrateLeaseUnitDisplayFields(lease, landlordId)),
     propertyName,
+    jurisdictionProvince: propertyProvince,
     tenantName,
     tenantEmail,
     documentUrl,
@@ -1127,18 +1141,30 @@ async function listLandlordLeaseRows(landlordId: string, opts?: { archived?: boo
   return mergedLeases.map((lease: any) => {
     const rawLease = rawLeaseById.get(String(lease?.id || "").trim()) || null;
     const latestNotice = latestNoticeByLeaseId.get(String(lease?.id || "").trim()) || null;
+    const leaseLifecycleSummary = deriveLeaseLifecycleSummary({
+      lease: {
+        status: lease?.status,
+        leaseStartDate: lease?.startDate,
+        leaseEndDate: lease?.endDate,
+        nextNoticeDueAt: rawLease?.nextNoticeDueAt,
+      },
+      latestNotice,
+      noResponse: latestNotice ? computeNoResponseState(latestNotice) : false,
+    });
     return {
       ...lease,
-      leaseLifecycleSummary: deriveLeaseLifecycleSummary({
-        lease: {
-          status: lease?.status,
-          leaseStartDate: lease?.startDate,
-          leaseEndDate: lease?.endDate,
-          nextNoticeDueAt: rawLease?.nextNoticeDueAt,
-        },
-        latestNotice,
-        noResponse: latestNotice ? computeNoResponseState(latestNotice) : false,
-      }),
+      leaseLifecycleSummary,
+      jurisdictionPolicies: evaluateJurisdictionPolicy({
+        province: rawLease?.province || rawLease?.provinceState || null,
+        propertyProvince: lease?.jurisdictionProvince || null,
+        jurisdictionProvince: rawLease?.jurisdictionProvince || null,
+        leaseStatus: lease?.status,
+        leaseStartDate: lease?.startDate,
+        leaseEndDate: lease?.endDate,
+        leaseExecutionStatus: lease?.leaseExecution?.executionStatus,
+        leaseLifecycleStatus: leaseLifecycleSummary.lifecycleStatus,
+        stateCoherence: lease?.stateCoherence || null,
+      }).results,
     };
   });
 }

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -105,6 +105,20 @@ export type LeaseStateCoherence = {
   };
 };
 
+export type JurisdictionPolicyGuidance = {
+  jurisdiction: "NS" | "ON" | "UNKNOWN" | "UNSUPPORTED";
+  policyKey: string;
+  status: "ok" | "review" | "not_applicable" | "unknown";
+  severity: "info" | "warning" | "critical";
+  label: string;
+  reason: string;
+  recommendation: string;
+  sourceRuleKey: string;
+  confidence: "high" | "medium" | "low";
+  legalAdvice: false;
+  disclaimer: string;
+};
+
 export interface LandlordActiveLease extends Lease {
   propertyName: string;
   tenantName?: string | null;
@@ -181,6 +195,8 @@ export interface LandlordActiveLease extends Lease {
   } | null;
   leaseLifecycleSummary?: LeaseLifecycleSummary;
   stateCoherence?: LeaseStateCoherence | null;
+  jurisdictionProvince?: string | null;
+  jurisdictionPolicies?: JurisdictionPolicyGuidance[];
   hiddenFromActiveLists?: boolean;
   cleanupReason?: string | null;
   cleanupBatch?: string | null;

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -121,6 +121,22 @@ describe("LandlordActiveLeasesPage", () => {
             daysUntilExpiry: 30,
             history: [{ type: "lease_started", label: "Lease started", occurredAt: "2026-01-01T00:00:00.000Z" }],
           },
+          jurisdictionPolicies: [
+            {
+              jurisdiction: "NS",
+              policyKey: "lease_renewal_review",
+              status: "review",
+              severity: "info",
+              label: "Lease renewal review recommended",
+              reason: "The lease end date is within the configured review window.",
+              recommendation: "Review the lease and prepare next-step workflow guidance.",
+              sourceRuleKey: "NS.lease_renewal_review",
+              confidence: "medium",
+              legalAdvice: false,
+              disclaimer:
+                "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.",
+            },
+          ],
         },
       ],
     });
@@ -178,6 +194,9 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getAllByText("Lease fully executed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);
     expect(screen.getByText(/Prepare renewal notice/i)).toBeInTheDocument();
+    expect(screen.getByText("NS workflow guidance")).toBeInTheDocument();
+    expect(screen.getByText("Lease renewal review recommended")).toBeInTheDocument();
+    expect(screen.getByText("Workflow guidance only — verify local legal requirements.")).toBeInTheDocument();
     expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View lease" })).toHaveAttribute("href", "https://example.com/lease.pdf");

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -229,6 +229,44 @@ function renderLifecycleSummary(lease: LandlordActiveLease) {
   );
 }
 
+function renderJurisdictionPolicyGuidance(lease: LandlordActiveLease) {
+  const policies = Array.isArray(lease.jurisdictionPolicies) ? lease.jurisdictionPolicies : [];
+  if (policies.length === 0) return null;
+  const visiblePolicies = policies.slice(0, 3);
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 6,
+        marginTop: 8,
+        padding: "8px 10px",
+        border: "1px solid #bfdbfe",
+        borderRadius: 10,
+        background: "#eff6ff",
+        color: "#1e3a8a",
+        fontSize: 12,
+      }}
+    >
+      <div style={{ fontWeight: 800 }}>
+        {policies[0]?.jurisdiction === "NS"
+          ? "NS workflow guidance"
+          : policies[0]?.jurisdiction === "ON"
+          ? "ON workflow guidance"
+          : "Jurisdiction workflow guidance"}
+      </div>
+      {visiblePolicies.map((policy) => (
+        <div key={`${policy.policyKey}:${policy.sourceRuleKey}`} style={{ display: "grid", gap: 2 }}>
+          <div style={{ fontWeight: policy.severity === "warning" || policy.severity === "critical" ? 800 : 700 }}>
+            {policy.label}
+          </div>
+          <div>{policy.recommendation}</div>
+        </div>
+      ))}
+      <div style={{ color: "#475569" }}>Workflow guidance only — verify local legal requirements.</div>
+    </div>
+  );
+}
+
 export default function LandlordActiveLeasesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get("view") === "archived" ? "archived" : "active";
@@ -731,6 +769,7 @@ export default function LandlordActiveLeasesPage() {
                       ) : null}
                       {renderLifecycleSummary(lease)}
                       {renderStateCoherence(lease)}
+                      {renderJurisdictionPolicyGuidance(lease)}
                       {lease.archivedAt ? (
                         <div style={{ color: "#64748b", fontSize: 12, marginTop: 4 }}>
                           Archived {formatDate(lease.archivedAt)}
@@ -859,6 +898,7 @@ export default function LandlordActiveLeasesPage() {
                 <div style={{ color: "#64748b", fontSize: 12 }}>{paymentReadinessChecklist(lease)}</div>
               ) : null}
               {renderStateCoherence(lease)}
+              {renderJurisdictionPolicyGuidance(lease)}
               {renderLeaseActions(lease)}
             </div>
           ))}


### PR DESCRIPTION
## Summary

Adds the first read-only jurisdiction-aware operational policy evaluator on top of the lease workflow registry from PR #917.

## Audit Summary

Current policy/action infrastructure already supports action-oriented outcomes for screening, maintenance, and lease notices, including allow/block/review decisions. This PR keeps the jurisdiction work separate as a pure guidance evaluator so it does not become an action engine or enforcement layer.

Lease operations already aggregate lease execution readiness, lifecycle summaries, occupancy/payment coherence, tenant/property context, and province metadata. This PR attaches province-aware policy guidance to that existing read model only.

## Policy Evaluator Location

- `rentchain-api/src/lib/jurisdiction/operationalPolicyEvaluator.ts`
- Pure helper: `evaluateJurisdictionPolicy(input)`
- No Firestore writes, no workflow actions, no legal conclusions

## Policy Categories Added

- `lease_renewal_review`
- `rent_increase_workflow_availability`
- `notice_workflow_readiness`
- `move_out_preparation`
- `deposit_workflow_review`
- `lease_execution_readiness`
- `missing_jurisdiction`
- `unsupported_jurisdiction`
- `missing_province_property_data`

## UI Surfaces Updated

- Lease operations active/archived lease rows now render jurisdiction-aware guidance when present.
- UI includes: `Workflow guidance only — verify local legal requirements.`

## Guardrails

- No legal automation
- No legal advice
- No notice generation or sending
- No workflow blocking
- No Firestore migration
- No payment, ledger, tenant, occupancy, messaging, or lease write behavior changes

## Tests Run

- `rentchain-api`: `npm run test:single -- src/lib/jurisdiction/__tests__/operationalPolicyEvaluator.test.ts src/routes/__tests__/leaseRoutes.active.test.ts`
- `rentchain-api`: `npm run build`
- `rentchain-frontend` with Node 22: `npm test -- --run src/pages/LandlordActiveLeasesPage.test.tsx`
- `rentchain-frontend`: `npm run build`

Note: frontend Vitest failed to start under Node 20 due the existing Vitest/jsdom `ERR_REQUIRE_ESM` dependency issue, then passed under Node 22.

## Known Follow-ups

- Add property-page jurisdiction hints for missing/unsupported provinces if needed.
- Add dashboard/open-action aggregation only after lease operations QA confirms guidance is useful.
- Continue keeping legal form selection and notice validation as explicit human-reviewed workflows.