### PR TITLE
fix: normalize payment obligation due dates from lease terms

### DIFF
--- a/rentchain-api/src/lib/decisions/__tests__/decisionEngine.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/decisionEngine.test.ts
@@ -205,6 +205,42 @@ describe("decisionEngine", () => {
     );
   });
 
+  it("falls back to obligation row due date for manual review decision metadata", () => {
+    const decisions = deriveDecisions({
+      delinquencySignals: [
+        signal({
+          signalId: "delinquency:manual_review_required:canonical-review",
+          paymentIntentId: null,
+          rentPaymentId: null,
+          signalType: "manual_review_required",
+          severity: "warning",
+          dueDate: null,
+          reasons: ["obligation_requires_manual_review"],
+        }),
+      ],
+      obligationRows: [
+        row({
+          rowId: "canonical_payment:lease-103:payment-1",
+          paymentIntentId: null,
+          rentPaymentId: null,
+          paymentDocumentId: "payment-1",
+          obligationStatus: "manual_review_required",
+          evidenceStatus: "manual_review_required",
+          source: "canonical_payment",
+          dueDate: "2026-07-01",
+        }),
+      ],
+      today: "2026-07-15T00:00:00.000Z",
+    });
+
+    expect(decisions[0].metadata).toEqual(
+      expect.objectContaining({
+        obligationRowId: "canonical_payment:lease-103:payment-1",
+        dueDate: "2026-07-01",
+      })
+    );
+  });
+
   it("does not create decisions for informational rent_due signals", () => {
     const decisions = deriveDecisions({
       delinquencySignals: [

--- a/rentchain-api/src/lib/decisions/decisionEngine.ts
+++ b/rentchain-api/src/lib/decisions/decisionEngine.ts
@@ -182,7 +182,7 @@ function decisionFromDelinquencySignal(
       expectedAmountCents: signal.expectedAmountCents,
       paidAmountCents: signal.paidAmountCents,
       outstandingAmountCents: signal.outstandingAmountCents,
-      dueDate: signal.dueDate || null,
+      dueDate: signal.dueDate || row?.dueDate || null,
       obligationRowId: row?.rowId || null,
       obligationStatus: row?.obligationStatus || null,
     },

--- a/rentchain-api/src/lib/payments/__tests__/delinquencySignals.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/delinquencySignals.test.ts
@@ -196,6 +196,31 @@ describe("delinquencySignals", () => {
     expect(signals[1].reasons).toEqual(["obligation_status_unknown"]);
   });
 
+  it("carries normalized due date into manual review signals for canonical payment rows", () => {
+    const signals = deriveDelinquencySignals(
+      [
+        row({
+          rowId: "canonical-review",
+          paymentIntentId: null,
+          rentPaymentId: null,
+          paymentDocumentId: "payment-1",
+          obligationStatus: "manual_review_required",
+          evidenceStatus: "manual_review_required",
+          source: "canonical_payment",
+          dueDate: "2026-07-01",
+        }),
+      ],
+      "2026-07-15T00:00:00.000Z"
+    );
+
+    expect(signals[0]).toEqual(
+      expect.objectContaining({
+        signalType: "manual_review_required",
+        dueDate: "2026-07-01T00:00:00.000Z",
+      })
+    );
+  });
+
   it("summarizes signal counts and outstanding rent", () => {
     const signals = deriveDelinquencySignals(
       [

--- a/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
@@ -101,6 +101,45 @@ describe("paymentObligationLedger", () => {
     );
   });
 
+  it("derives due date from legacy lease start aliases before stale due date fallback", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [
+        {
+          ...lease,
+          startDate: null,
+          leaseStartDate: "2026-05-31",
+          dueDate: "2026-05-05",
+        },
+      ],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        periodStart: "2026-05-31T00:00:00.000Z",
+        dueDate: "2026-06-01",
+      })
+    );
+  });
+
+  it("derives due date from nested rent schedule due day", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [
+        {
+          ...lease,
+          startDate: "2026-07-01",
+          dueDay: null,
+          rentSchedule: { dueDay: 5 },
+        },
+      ],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        dueDate: "2026-07-05",
+      })
+    );
+  });
+
   it("derives monthly obligation due date from a custom lease due day", () => {
     const rows = buildPaymentObligationLedgerRows({
       leases: [{ ...lease, startDate: "2026-05-01", dueDay: 5, dueDate: "2026-05-01" }],

--- a/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
@@ -96,7 +96,7 @@ describe("paymentObligationLedger", () => {
     expect(rows[0]).toEqual(
       expect.objectContaining({
         periodStart: "2026-05-31T00:00:00.000Z",
-        dueDate: "2026-05-01T00:00:00.000Z",
+        dueDate: "2026-06-01",
       })
     );
   });
@@ -108,19 +108,19 @@ describe("paymentObligationLedger", () => {
 
     expect(rows[0]).toEqual(
       expect.objectContaining({
-        dueDate: "2026-05-05T00:00:00.000Z",
+        dueDate: "2026-05-05",
       })
     );
   });
 
-  it("falls back to the first day of the obligation month when due day is missing", () => {
+  it("falls back to the next first day when due day is missing", () => {
     const rows = buildPaymentObligationLedgerRows({
       leases: [{ ...lease, startDate: "2026-06-15", dueDate: null }],
     });
 
     expect(rows[0]).toEqual(
       expect.objectContaining({
-        dueDate: "2026-06-01T00:00:00.000Z",
+        dueDate: "2026-07-01",
       })
     );
   });
@@ -179,7 +179,7 @@ describe("paymentObligationLedger", () => {
       expect.objectContaining({
         leaseId: "lease-1",
         paymentDocumentId: "payment-import-1",
-        dueDate: "2026-04-01T00:00:00.000Z",
+        dueDate: "2026-04-01",
         expectedAmountCents: 180000,
         paidAmountCents: 180000,
         obligationStatus: "paid",
@@ -215,7 +215,7 @@ describe("paymentObligationLedger", () => {
 
     expect(rows[0]).toEqual(
       expect.objectContaining({
-        dueDate: "2026-05-05T00:00:00.000Z",
+        dueDate: "2026-05-05",
         paidAmountCents: 180000,
         obligationStatus: "paid",
         evidenceStatus: "reconciled",
@@ -237,7 +237,7 @@ describe("paymentObligationLedger", () => {
 
     expect(rows[0]).toEqual(
       expect.objectContaining({
-        dueDate: "2026-05-05T00:00:00.000Z",
+        dueDate: "2026-05-05",
         paidAmountCents: 180000,
         obligationStatus: "paid",
       })
@@ -310,7 +310,7 @@ describe("paymentObligationLedger", () => {
     expect(rows[0]).toEqual(
       expect.objectContaining({
         expectedAmountCents: 164000,
-        dueDate: "2026-05-01T00:00:00.000Z",
+        dueDate: "2026-06-01",
         paidAmountCents: 328000,
         obligationStatus: "overpaid",
         evidenceStatus: "reconciled",

--- a/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
@@ -88,6 +88,43 @@ describe("paymentObligationLedger", () => {
     ]);
   });
 
+  it("derives monthly obligation due date from lease due day 1", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [{ ...lease, startDate: "2026-05-31", dueDay: 1, dueDate: "2026-05-31" }],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        periodStart: "2026-05-31T00:00:00.000Z",
+        dueDate: "2026-05-01T00:00:00.000Z",
+      })
+    );
+  });
+
+  it("derives monthly obligation due date from a custom lease due day", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [{ ...lease, startDate: "2026-05-01", dueDay: 5, dueDate: "2026-05-01" }],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        dueDate: "2026-05-05T00:00:00.000Z",
+      })
+    );
+  });
+
+  it("falls back to the first day of the obligation month when due day is missing", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [{ ...lease, startDate: "2026-06-15", dueDate: null }],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        dueDate: "2026-06-01T00:00:00.000Z",
+      })
+    );
+  });
+
   it("derives paid when paid amount matches expected", () => {
     const rows = buildPaymentObligationLedgerRows({
       leases: [lease],
@@ -120,7 +157,7 @@ describe("paymentObligationLedger", () => {
 
   it("reconciles imported canonical payments against matching lease obligations", () => {
     const rows = buildPaymentObligationLedgerRows({
-      leases: [lease],
+      leases: [{ ...lease, dueDay: 1 }],
       canonicalPayments: [
         {
           id: "payment-import-1",
@@ -142,6 +179,7 @@ describe("paymentObligationLedger", () => {
       expect.objectContaining({
         leaseId: "lease-1",
         paymentDocumentId: "payment-import-1",
+        dueDate: "2026-04-01T00:00:00.000Z",
         expectedAmountCents: 180000,
         paidAmountCents: 180000,
         obligationStatus: "paid",
@@ -155,6 +193,53 @@ describe("paymentObligationLedger", () => {
         expectedAmountCents: 180000,
         paidAmountCents: 180000,
         outstandingAmountCents: 0,
+      })
+    );
+  });
+
+  it("keeps canonical payment evidence date separate from obligation due date", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [{ ...lease, startDate: "2026-05-01", dueDay: 5 }],
+      canonicalPayments: [
+        {
+          id: "payment-import-late",
+          leaseId: "lease-1",
+          amountCents: 180000,
+          status: "recorded",
+          effectiveDate: "2026-05-17",
+          paidAt: "2026-05-17",
+          source: "payment_csv_import",
+        },
+      ],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        dueDate: "2026-05-05T00:00:00.000Z",
+        paidAmountCents: 180000,
+        obligationStatus: "paid",
+        evidenceStatus: "reconciled",
+      })
+    );
+  });
+
+  it("keeps manual rent payment evidence date separate from obligation due date", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [{ ...lease, startDate: "2026-05-01", dueDay: 5 }],
+      rentPayments: [
+        rentPayment({
+          id: "rp-manual-1",
+          paymentIntentId: null,
+          paidAt: "2026-05-20T12:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        dueDate: "2026-05-05T00:00:00.000Z",
+        paidAmountCents: 180000,
+        obligationStatus: "paid",
       })
     );
   });
@@ -197,6 +282,7 @@ describe("paymentObligationLedger", () => {
           ...lease,
           startDate: "2026-05-31",
           endDate: "2027-05-29",
+          dueDay: 1,
           monthlyRent: 164000,
           amountCents: 164000,
         },
@@ -224,6 +310,7 @@ describe("paymentObligationLedger", () => {
     expect(rows[0]).toEqual(
       expect.objectContaining({
         expectedAmountCents: 164000,
+        dueDate: "2026-05-01T00:00:00.000Z",
         paidAmountCents: 328000,
         obligationStatus: "overpaid",
         evidenceStatus: "reconciled",

--- a/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
@@ -121,6 +121,27 @@ describe("paymentObligationLedger", () => {
     );
   });
 
+  it("derives due date from period start when lease metadata is unavailable", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      paymentIntents: [
+        intent({
+          leaseId: "lease-missing",
+          periodStart: "2026-06-01",
+          periodEnd: "2027-05-30",
+          dueDate: "2026-05-05",
+        }),
+      ],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-missing",
+        periodStart: "2026-06-01T00:00:00.000Z",
+        dueDate: "2026-06-01",
+      })
+    );
+  });
+
   it("derives due date from nested rent schedule due day", () => {
     const rows = buildPaymentObligationLedgerRows({
       leases: [

--- a/rentchain-api/src/lib/payments/paymentObligationLedger.ts
+++ b/rentchain-api/src/lib/payments/paymentObligationLedger.ts
@@ -256,6 +256,15 @@ function daysInUtcMonth(year: number, month: number): number {
   return new Date(Date.UTC(year, month, 0)).getUTCDate();
 }
 
+function formatDateOnly(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function nextMonth(year: number, month: number): { year: number; month: number } {
+  if (month < 12) return { year, month: month + 1 };
+  return { year: year + 1, month: 1 };
+}
+
 function normalizeDueDay(value: unknown): number | null {
   const day = Number(value);
   if (!Number.isInteger(day) || day < 1 || day > 31) return null;
@@ -276,8 +285,13 @@ function deriveLeaseTermDueDate(lease: PaymentObligationLeaseInput | null | unde
   if (!lease) return normalizeDate(fallbackDueDate);
   const anchor = dateOnlyParts(periodStart || lease.startDate || fallbackDueDate || lease.dueDate);
   if (!anchor) return normalizeDate(fallbackDueDate || lease.dueDate);
-  const dueDay = Math.min(leaseDueDay(lease), daysInUtcMonth(anchor.year, anchor.month));
-  return new Date(Date.UTC(anchor.year, anchor.month - 1, dueDay)).toISOString();
+  const configuredDueDay = leaseDueDay(lease);
+  const dueMonth =
+    anchor.day > configuredDueDay
+      ? nextMonth(anchor.year, anchor.month)
+      : { year: anchor.year, month: anchor.month };
+  const dueDay = Math.min(configuredDueDay, daysInUtcMonth(dueMonth.year, dueMonth.month));
+  return formatDateOnly(dueMonth.year, dueMonth.month, dueDay);
 }
 
 function paymentFallsWithinLeaseTerm(payment: PaymentObligationCanonicalPaymentInput, lease: PaymentObligationLeaseInput | null): boolean {

--- a/rentchain-api/src/lib/payments/paymentObligationLedger.ts
+++ b/rentchain-api/src/lib/payments/paymentObligationLedger.ts
@@ -68,6 +68,11 @@ export type PaymentObligationLeaseInput = {
   startDate?: string | null;
   endDate?: string | null;
   dueDate?: string | null;
+  dueDay?: number | string | null;
+  rentDueDay?: number | string | null;
+  paymentDueDay?: number | string | null;
+  rentDueDayOfMonth?: number | string | null;
+  paymentFrequency?: string | null;
   derivedLifecycleState?: LeaseLifecycleState | null;
   derivedLifecycleRequiresReview?: boolean | null;
   status?: string | null;
@@ -233,6 +238,48 @@ function dateOnlyMillis(value: unknown): number | null {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 }
 
+function dateOnlyParts(value: unknown): { year: number; month: number; day: number } | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return { year: Number(year), month: Number(month), day: Number(day) };
+  }
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  const date = new Date(parsed);
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
+}
+
+function daysInUtcMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function normalizeDueDay(value: unknown): number | null {
+  const day = Number(value);
+  if (!Number.isInteger(day) || day < 1 || day > 31) return null;
+  return day;
+}
+
+function leaseDueDay(lease: PaymentObligationLeaseInput | null | undefined): number {
+  return (
+    normalizeDueDay(lease?.dueDay) ??
+    normalizeDueDay(lease?.rentDueDay) ??
+    normalizeDueDay(lease?.paymentDueDay) ??
+    normalizeDueDay(lease?.rentDueDayOfMonth) ??
+    1
+  );
+}
+
+function deriveLeaseTermDueDate(lease: PaymentObligationLeaseInput | null | undefined, periodStart?: unknown, fallbackDueDate?: unknown): string | null {
+  if (!lease) return normalizeDate(fallbackDueDate);
+  const anchor = dateOnlyParts(periodStart || lease.startDate || fallbackDueDate || lease.dueDate);
+  if (!anchor) return normalizeDate(fallbackDueDate || lease.dueDate);
+  const dueDay = Math.min(leaseDueDay(lease), daysInUtcMonth(anchor.year, anchor.month));
+  return new Date(Date.UTC(anchor.year, anchor.month - 1, dueDay)).toISOString();
+}
+
 function paymentFallsWithinLeaseTerm(payment: PaymentObligationCanonicalPaymentInput, lease: PaymentObligationLeaseInput | null): boolean {
   if (!lease) return false;
   const paymentDate = dateOnlyMillis(payment.effectiveDate || payment.paidAt);
@@ -390,7 +437,7 @@ export function buildPaymentObligationLedgerRows(
       tenantId: intent.tenantId || lease?.tenantId || lease?.primaryTenantId || null,
       periodStart: normalizeDate(intent.periodStart || lease?.startDate),
       periodEnd: normalizeDate(intent.periodEnd || lease?.endDate),
-      dueDate: normalizeDate(intent.dueDate || lease?.dueDate),
+      dueDate: deriveLeaseTermDueDate(lease, intent.periodStart || lease?.startDate, intent.dueDate || lease?.dueDate),
       expectedAmountCents: normalizeAmountCents(intent.amountCents),
       paidAmountCents,
       currency: normalizeCurrency(intent.currency || lease?.currency),
@@ -431,7 +478,7 @@ export function buildPaymentObligationLedgerRows(
       tenantId: rentPayment.tenantId || lease?.tenantId || lease?.primaryTenantId || null,
       periodStart: normalizeDate(lease?.startDate),
       periodEnd: normalizeDate(lease?.endDate),
-      dueDate: normalizeDate(lease?.dueDate),
+      dueDate: deriveLeaseTermDueDate(lease, lease?.startDate, lease?.dueDate),
       expectedAmountCents: normalizeAmountCents(rentPayment.amountCents),
       paidAmountCents,
       currency: normalizeCurrency(rentPayment.currency || lease?.currency),
@@ -475,7 +522,7 @@ export function buildPaymentObligationLedgerRows(
       tenantId: inWindowPayments[0]?.tenantId || lease.tenantId || lease.primaryTenantId || null,
       periodStart: normalizeDate(lease.startDate),
       periodEnd: normalizeDate(lease.endDate),
-      dueDate: normalizeDate(inWindowPayments[0]?.effectiveDate || inWindowPayments[0]?.paidAt || lease.dueDate),
+      dueDate: deriveLeaseTermDueDate(lease, lease.startDate, lease.dueDate),
       expectedAmountCents,
       paidAmountCents,
       currency: normalizeCurrency(inWindowPayments[0]?.currency || lease.currency),
@@ -512,7 +559,7 @@ export function buildPaymentObligationLedgerRows(
       tenantId: lease.tenantId || lease.primaryTenantId || null,
       periodStart: normalizeDate(lease.startDate),
       periodEnd: normalizeDate(lease.endDate),
-      dueDate: normalizeDate(lease.dueDate),
+      dueDate: deriveLeaseTermDueDate(lease, lease.startDate, lease.dueDate),
       expectedAmountCents,
       paidAmountCents: 0,
       currency: normalizeCurrency(lease.currency),

--- a/rentchain-api/src/lib/payments/paymentObligationLedger.ts
+++ b/rentchain-api/src/lib/payments/paymentObligationLedger.ts
@@ -304,10 +304,9 @@ function leaseEndDate(lease: PaymentObligationLeaseInput | null | undefined): st
 }
 
 function deriveLeaseTermDueDate(lease: PaymentObligationLeaseInput | null | undefined, periodStart?: unknown, fallbackDueDate?: unknown): string | null {
-  if (!lease) return normalizeDate(fallbackDueDate);
-  const anchor = dateOnlyParts(periodStart || leaseStartDate(lease) || fallbackDueDate || lease.dueDate);
-  if (!anchor) return normalizeDate(fallbackDueDate || lease.dueDate);
-  const configuredDueDay = leaseDueDay(lease);
+  const anchor = dateOnlyParts(periodStart || leaseStartDate(lease) || fallbackDueDate || lease?.dueDate);
+  if (!anchor) return null;
+  const configuredDueDay = lease ? leaseDueDay(lease) : 1;
   const dueMonth =
     anchor.day > configuredDueDay
       ? nextMonth(anchor.year, anchor.month)

--- a/rentchain-api/src/lib/payments/paymentObligationLedger.ts
+++ b/rentchain-api/src/lib/payments/paymentObligationLedger.ts
@@ -66,12 +66,18 @@ export type PaymentObligationLeaseInput = {
   amountCents?: number | null;
   currency?: string | null;
   startDate?: string | null;
+  leaseStartDate?: string | null;
+  leaseStart?: string | null;
   endDate?: string | null;
+  leaseEndDate?: string | null;
+  leaseEnd?: string | null;
   dueDate?: string | null;
   dueDay?: number | string | null;
   rentDueDay?: number | string | null;
   paymentDueDay?: number | string | null;
   rentDueDayOfMonth?: number | string | null;
+  rentSchedule?: Record<string, unknown> | null;
+  paymentTerms?: Record<string, unknown> | null;
   paymentFrequency?: string | null;
   derivedLifecycleState?: LeaseLifecycleState | null;
   derivedLifecycleRequiresReview?: boolean | null;
@@ -277,13 +283,29 @@ function leaseDueDay(lease: PaymentObligationLeaseInput | null | undefined): num
     normalizeDueDay(lease?.rentDueDay) ??
     normalizeDueDay(lease?.paymentDueDay) ??
     normalizeDueDay(lease?.rentDueDayOfMonth) ??
+    normalizeDueDay(lease?.rentSchedule?.dueDay) ??
+    normalizeDueDay(lease?.rentSchedule?.rentDueDay) ??
+    normalizeDueDay(lease?.rentSchedule?.paymentDueDay) ??
+    normalizeDueDay(lease?.rentSchedule?.dayOfMonth) ??
+    normalizeDueDay(lease?.paymentTerms?.dueDay) ??
+    normalizeDueDay(lease?.paymentTerms?.rentDueDay) ??
+    normalizeDueDay(lease?.paymentTerms?.paymentDueDay) ??
+    normalizeDueDay(lease?.paymentTerms?.dayOfMonth) ??
     1
   );
 }
 
+function leaseStartDate(lease: PaymentObligationLeaseInput | null | undefined): string | null {
+  return asString(lease?.startDate || lease?.leaseStartDate || lease?.leaseStart, 120);
+}
+
+function leaseEndDate(lease: PaymentObligationLeaseInput | null | undefined): string | null {
+  return asString(lease?.endDate || lease?.leaseEndDate || lease?.leaseEnd, 120);
+}
+
 function deriveLeaseTermDueDate(lease: PaymentObligationLeaseInput | null | undefined, periodStart?: unknown, fallbackDueDate?: unknown): string | null {
   if (!lease) return normalizeDate(fallbackDueDate);
-  const anchor = dateOnlyParts(periodStart || lease.startDate || fallbackDueDate || lease.dueDate);
+  const anchor = dateOnlyParts(periodStart || leaseStartDate(lease) || fallbackDueDate || lease.dueDate);
   if (!anchor) return normalizeDate(fallbackDueDate || lease.dueDate);
   const configuredDueDay = leaseDueDay(lease);
   const dueMonth =
@@ -298,8 +320,8 @@ function paymentFallsWithinLeaseTerm(payment: PaymentObligationCanonicalPaymentI
   if (!lease) return false;
   const paymentDate = dateOnlyMillis(payment.effectiveDate || payment.paidAt);
   if (paymentDate === null) return true;
-  const start = dateOnlyMillis(lease.startDate);
-  const end = dateOnlyMillis(lease.endDate);
+  const start = dateOnlyMillis(leaseStartDate(lease));
+  const end = dateOnlyMillis(leaseEndDate(lease));
   if (start !== null && paymentDate < start - PREPAID_RENT_WINDOW_DAYS * 86_400_000) return false;
   if (end !== null && paymentDate > end) return false;
   return true;
@@ -449,9 +471,9 @@ export function buildPaymentObligationLedgerRows(
       propertyId: intent.propertyId || lease?.propertyId || null,
       unitId: intent.unitId || lease?.unitId || null,
       tenantId: intent.tenantId || lease?.tenantId || lease?.primaryTenantId || null,
-      periodStart: normalizeDate(intent.periodStart || lease?.startDate),
-      periodEnd: normalizeDate(intent.periodEnd || lease?.endDate),
-      dueDate: deriveLeaseTermDueDate(lease, intent.periodStart || lease?.startDate, intent.dueDate || lease?.dueDate),
+      periodStart: normalizeDate(intent.periodStart || leaseStartDate(lease)),
+      periodEnd: normalizeDate(intent.periodEnd || leaseEndDate(lease)),
+      dueDate: deriveLeaseTermDueDate(lease, intent.periodStart || leaseStartDate(lease), intent.dueDate || lease?.dueDate),
       expectedAmountCents: normalizeAmountCents(intent.amountCents),
       paidAmountCents,
       currency: normalizeCurrency(intent.currency || lease?.currency),
@@ -490,9 +512,9 @@ export function buildPaymentObligationLedgerRows(
       propertyId: rentPayment.propertyId || lease?.propertyId || null,
       unitId: rentPayment.unitId || lease?.unitId || null,
       tenantId: rentPayment.tenantId || lease?.tenantId || lease?.primaryTenantId || null,
-      periodStart: normalizeDate(lease?.startDate),
-      periodEnd: normalizeDate(lease?.endDate),
-      dueDate: deriveLeaseTermDueDate(lease, lease?.startDate, lease?.dueDate),
+      periodStart: normalizeDate(leaseStartDate(lease)),
+      periodEnd: normalizeDate(leaseEndDate(lease)),
+      dueDate: deriveLeaseTermDueDate(lease, leaseStartDate(lease), lease?.dueDate),
       expectedAmountCents: normalizeAmountCents(rentPayment.amountCents),
       paidAmountCents,
       currency: normalizeCurrency(rentPayment.currency || lease?.currency),
@@ -534,9 +556,9 @@ export function buildPaymentObligationLedgerRows(
       propertyId: inWindowPayments[0]?.propertyId || lease.propertyId || null,
       unitId: inWindowPayments[0]?.unitId || lease.unitId || null,
       tenantId: inWindowPayments[0]?.tenantId || lease.tenantId || lease.primaryTenantId || null,
-      periodStart: normalizeDate(lease.startDate),
-      periodEnd: normalizeDate(lease.endDate),
-      dueDate: deriveLeaseTermDueDate(lease, lease.startDate, lease.dueDate),
+      periodStart: normalizeDate(leaseStartDate(lease)),
+      periodEnd: normalizeDate(leaseEndDate(lease)),
+      dueDate: deriveLeaseTermDueDate(lease, leaseStartDate(lease), lease.dueDate),
       expectedAmountCents,
       paidAmountCents,
       currency: normalizeCurrency(inWindowPayments[0]?.currency || lease.currency),
@@ -571,9 +593,9 @@ export function buildPaymentObligationLedgerRows(
       propertyId: lease.propertyId || null,
       unitId: lease.unitId || null,
       tenantId: lease.tenantId || lease.primaryTenantId || null,
-      periodStart: normalizeDate(lease.startDate),
-      periodEnd: normalizeDate(lease.endDate),
-      dueDate: deriveLeaseTermDueDate(lease, lease.startDate, lease.dueDate),
+      periodStart: normalizeDate(leaseStartDate(lease)),
+      periodEnd: normalizeDate(leaseEndDate(lease)),
+      dueDate: deriveLeaseTermDueDate(lease, leaseStartDate(lease), lease.dueDate),
       expectedAmountCents,
       paidAmountCents: 0,
       currency: normalizeCurrency(lease.currency),

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -465,6 +465,7 @@ describe("leaseRoutes integrity repairs", () => {
       expect.objectContaining({
         leaseId: "lease-1",
         paymentDocumentId: "payment-import-1",
+        dueDate: "2026-05-01T00:00:00.000Z",
         expectedAmountCents: 198000,
         paidAmountCents: 198000,
         obligationStatus: "paid",
@@ -551,6 +552,7 @@ describe("leaseRoutes integrity repairs", () => {
     expect(res.body?.obligationRows).toEqual([
       expect.objectContaining({
         leaseId: "lease-1",
+        dueDate: "2026-05-01T00:00:00.000Z",
         expectedAmountCents: 164000,
         paidAmountCents: 492000,
         obligationStatus: "overpaid",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -465,7 +465,7 @@ describe("leaseRoutes integrity repairs", () => {
       expect.objectContaining({
         leaseId: "lease-1",
         paymentDocumentId: "payment-import-1",
-        dueDate: "2026-05-01T00:00:00.000Z",
+        dueDate: "2026-05-01",
         expectedAmountCents: 198000,
         paidAmountCents: 198000,
         obligationStatus: "paid",
@@ -552,7 +552,7 @@ describe("leaseRoutes integrity repairs", () => {
     expect(res.body?.obligationRows).toEqual([
       expect.objectContaining({
         leaseId: "lease-1",
-        dueDate: "2026-05-01T00:00:00.000Z",
+        dueDate: "2026-06-01",
         expectedAmountCents: 164000,
         paidAmountCents: 492000,
         obligationStatus: "overpaid",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -572,6 +572,81 @@ describe("leaseRoutes integrity repairs", () => {
     expect(res.body?.delinquencySignals).toEqual([]);
   });
 
+  it("derives lease ledger obligation due date from legacy lease term aliases before stale due date", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-101",
+      unitNumber: "101",
+      monthlyRent: 1640,
+      leaseStartDate: "2026-05-31",
+      leaseEndDate: "2027-05-29",
+      dueDate: "2026-05-05",
+      status: "active",
+    });
+    seedDoc("ledgerEntries", "entry-prepaid-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      leaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: "unit-101",
+      entryType: "payment",
+      category: "payment",
+      amountCents: 164000,
+      effectiveDate: "2026-05-05",
+      method: "etransfer",
+      createdAt: 20,
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/lease-1/ledger");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.obligationRows).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-1",
+        periodStart: "2026-05-31T00:00:00.000Z",
+        periodEnd: "2027-05-29T00:00:00.000Z",
+        dueDate: "2026-06-01",
+        paidAmountCents: 164000,
+        obligationStatus: "paid",
+        evidenceStatus: "reconciled",
+      }),
+    ]);
+  });
+
+  it("derives lease ledger obligation due date from lease start alias when due date is missing", async () => {
+    seedDoc("leases", "lease-103", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-3",
+      unitId: "unit-103",
+      unitNumber: "103",
+      monthlyRent: 1725,
+      leaseStartDate: "2026-07-01",
+      leaseEndDate: "2027-06-30",
+      status: "active",
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/lease-103/ledger");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.obligationRows).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-103",
+        periodStart: "2026-07-01T00:00:00.000Z",
+        periodEnd: "2027-06-30T00:00:00.000Z",
+        dueDate: "2026-07-01",
+        expectedAmountCents: 172500,
+        paidAmountCents: 0,
+        obligationStatus: "missing",
+        evidenceStatus: "none",
+      }),
+    ]);
+  });
+
   it("exports lease ledger csv with property and unit labels instead of raw ids", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -647,6 +647,63 @@ describe("leaseRoutes integrity repairs", () => {
     ]);
   });
 
+  it("keeps normalized due date on manual review payloads for canonical payment obligations", async () => {
+    seedDoc("leases", "lease-103", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-3",
+      unitId: "unit-103",
+      unitNumber: "103",
+      monthlyRent: 1725,
+      leaseStartDate: "2026-07-01",
+      leaseEndDate: "2027-06-30",
+      status: "active",
+    });
+    seedDoc("payments", "payment-outside-window", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-3",
+      leaseId: "lease-103",
+      propertyId: "prop-1",
+      unitId: "unit-103",
+      amountCents: 172500,
+      status: "recorded",
+      paidAt: "2026-05-01",
+      effectiveDate: "2026-05-01",
+      source: "payment_csv_import",
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/lease-103/ledger");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.obligationRows).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-103",
+        dueDate: "2026-07-01",
+        obligationStatus: "manual_review_required",
+        evidenceStatus: "manual_review_required",
+        source: "canonical_payment",
+      }),
+    ]);
+    expect(res.body?.delinquencySignals).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-103",
+        dueDate: "2026-07-01T00:00:00.000Z",
+        signalType: "manual_review_required",
+      }),
+    ]);
+    expect(res.body?.decisions).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-103",
+        decisionType: "review_manual_payment_issue",
+        metadata: expect.objectContaining({
+          dueDate: "2026-07-01T00:00:00.000Z",
+          obligationStatus: "manual_review_required",
+        }),
+      }),
+    ]);
+  });
+
   it("exports lease ledger csv with property and unit labels instead of raw ids", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -119,6 +119,7 @@ describe("LeaseLedgerPage", () => {
           leaseId: "lease-1",
           paymentIntentId: "pi-underpaid",
           propertyId: "prop-1",
+          dueDate: "2026-05-05T00:00:00.000Z",
           expectedAmountCents: 145000,
           paidAmountCents: 10000,
           currency: "cad",
@@ -490,6 +491,7 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Reconciled").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual Review Required").length).toBeGreaterThan(0);
+    expect(screen.getByText(new Date(2026, 4, 5).toLocaleDateString())).toBeInTheDocument();
   });
 
   it("renders delinquency summary cards and row-level signal reasons", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -68,6 +68,11 @@ function formatSignedCurrencyCents(cents: number, entryType: LeaseLedgerEntry["e
 
 function formatDate(value: string | null | undefined) {
   if (!value) return "—";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString();
+  }
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleDateString();


### PR DESCRIPTION
## Summary

Payment obligation due dates now derive from lease rent terms instead of payment evidence dates or reconciliation timing, including actual `/api/leases/:leaseId/ledger` payloads, canonical payment rows, and manual-review/decision metadata.

## Audit Summary

- The Payment obligations table is powered by `GET /api/leases/:leaseId/ledger`.
- The frontend renders `obligationRows[].dueDate` in `rentchain-frontend/src/pages/LeaseLedgerPage.tsx`.
- Obligation rows are built in `rentchain-api/src/lib/payments/paymentObligationLedger.ts`.
- Delinquency signals copy `row.dueDate` in `rentchain-api/src/lib/payments/delinquencySignals.ts`.
- Decision/action metadata copies delinquency signal dates in `rentchain-api/src/lib/decisions/decisionEngine.ts`.
- QA found canonical/manual-review paths could still surface stale `2026-05-05` or `null`. The remaining gap was that partial/missing lease metadata could force fallback dates, and decision metadata did not fall back to a matched obligation row due date when a signal date was absent.

## Due Date Derivation Rule

- Due date is the next configured lease due day on or after the obligation period anchor.
- Period anchor precedence supports `startDate`, `leaseStartDate`, and `leaseStart`.
- Period end supports `endDate`, `leaseEndDate`, and `leaseEnd`.
- Due day precedence: `dueDay`, `rentDueDay`, `paymentDueDay`, `rentDueDayOfMonth`, then nested `rentSchedule`/`paymentTerms` due-day fields.
- Missing or invalid due day falls back to day 1.
- If lease metadata is unavailable but a row period exists, the period start still wins over stale fallback due dates.
- The chosen day is clamped to the target month length.
- Due dates are returned as date-only operational dates so payment evidence dates stay separate.
- Lease ledger UI renders date-only/ISO date prefixes without timezone day-shift.

## API Regression Coverage Added

- Unit 101-style payload: `leaseStartDate: 2026-05-31`, stale `dueDate: 2026-05-05`, payment evidence on `2026-05-05` now returns `obligationRows[0].dueDate: 2026-06-01`.
- Unit 103-style payload: `leaseStartDate: 2026-07-01`, missing `dueDate`, no payment evidence now returns `obligationRows[0].dueDate: 2026-07-01`.
- Canonical/manual-review payload: outside-window canonical payment returns normalized `obligationRows[].dueDate`, `delinquencySignals[].dueDate`, and `decisions[].metadata.dueDate`.
- Missing lease metadata with valid `periodStart` no longer falls back to stale payment/evidence `dueDate`.

## Files Changed

- `rentchain-api/src/lib/payments/paymentObligationLedger.ts`
- `rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts`
- `rentchain-api/src/lib/payments/delinquencySignals.ts`
- `rentchain-api/src/lib/payments/__tests__/delinquencySignals.test.ts`
- `rentchain-api/src/lib/decisions/decisionEngine.ts`
- `rentchain-api/src/lib/decisions/__tests__/decisionEngine.test.ts`
- `rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts`
- `rentchain-frontend/src/pages/LeaseLedgerPage.tsx`
- `rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx`

## Tests Run

- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/lib/payments/__tests__/paymentObligationLedger.test.ts src/lib/payments/__tests__/delinquencySignals.test.ts src/lib/decisions/__tests__/decisionEngine.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/routes/__tests__/leaseRoutes.integrity.test.ts` *(passed with local listener permissions; sandbox run fails with Supertest `listen EPERM`)*
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- LeaseLedgerPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`

## Guardrails

- No payment import logic changed.
- No ledger write behavior changed.
- No append-only ledger behavior changed.
- No reconciliation behavior changed.
- No jurisdiction/legal automation added.

## Preview QA

Pending preview deployment from latest head.