### PR TITLE
fix: normalize property occupancy display

### DIFF
--- a/rentchain-frontend/src/components/properties/PropertyCredibilitySummaryCard.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyCredibilitySummaryCard.tsx
@@ -5,6 +5,7 @@ import { colors, radius, shadows, spacing, text } from "@/styles/tokens";
 
 interface PropertyCredibilitySummaryCardProps {
   summary?: PropertyCredibilitySummary | null;
+  leaseHref?: string;
 }
 
 function healthTone(status?: PropertyCredibilitySummary["healthStatus"] | null) {
@@ -48,7 +49,7 @@ const MetricTile: React.FC<{ label: string; value: React.ReactNode; caption?: Re
   </div>
 );
 
-export const PropertyCredibilitySummaryCard: React.FC<PropertyCredibilitySummaryCardProps> = ({ summary }) => {
+export const PropertyCredibilitySummaryCard: React.FC<PropertyCredibilitySummaryCardProps> = ({ summary, leaseHref = "/leases" }) => {
   if (!summary || summary.healthStatus === "unknown") {
     return (
       <section
@@ -67,6 +68,9 @@ export const PropertyCredibilitySummaryCard: React.FC<PropertyCredibilitySummary
           <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.6 }}>
             This summary reflects current lease and tenant credibility signals for this property. Decision support only.
           </div>
+          <a href={leaseHref} style={{ color: "#2563eb", fontSize: 13, fontWeight: 700 }}>
+            View related leases
+          </a>
         </div>
         <div
           style={{
@@ -105,6 +109,9 @@ export const PropertyCredibilitySummaryCard: React.FC<PropertyCredibilitySummary
           <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.6 }}>
             This summary reflects current lease and tenant credibility signals for this property. Decision support only.
           </div>
+          <a href={leaseHref} style={{ color: "#2563eb", fontSize: 13, fontWeight: 700 }}>
+            View related leases
+          </a>
         </div>
         <span
           style={{

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -84,7 +84,13 @@ vi.mock("./UnitsCsvPreviewModal", () => ({
 }));
 
 vi.mock("./UnitEditModal", () => ({
-  UnitEditModal: () => null,
+  UnitEditModal: ({ open, unit }: any) =>
+    open ? (
+      <div data-testid="unit-edit-modal">
+        <div>modal tenant: {unit?.occupantName || ""}</div>
+        <div>modal lease end: {unit?.leaseEndDate || ""}</div>
+      </div>
+    ) : null,
 }));
 
 vi.mock("./SendApplicationModal", () => ({
@@ -96,7 +102,7 @@ vi.mock("@/components/leases/RiskScoreBadge", () => ({
 }));
 
 vi.mock("@/components/properties/PropertyCredibilitySummaryCard", () => ({
-  PropertyCredibilitySummaryCard: () => null,
+  PropertyCredibilitySummaryCard: ({ leaseHref }: any) => <a href={leaseHref}>View related leases</a>,
 }));
 
 describe("PropertyDetailPanel", () => {
@@ -434,9 +440,65 @@ describe("PropertyDetailPanel", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Lease risk overview")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("Lease risk overview").length).toBeGreaterThan(0));
     expect(screen.getAllByText("Unit 101").length).toBeGreaterThan(0);
     expect(screen.queryByText("Unit wzECCdkACeLm2yWdV9b3")).not.toBeInTheDocument();
+  });
+
+  it("uses configured unit rent in lease risk overview when matched unit data is fresher than lease rent", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      {
+        id: "unit-102",
+        unitNumber: "102",
+        status: "occupied",
+        rent: 1540,
+      },
+    ]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-102",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-102",
+          unitNumber: "102",
+          monthlyRent: 1400,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          riskScore: 72,
+          riskGrade: "B",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      credibilitySummary: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            totalUnits: 1,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getAllByText("Lease risk overview").length).toBeGreaterThan(0));
+    expect(screen.getAllByText("$1,540 / month").length).toBeGreaterThan(0);
+    expect(screen.queryByText("$1,400 / month")).not.toBeInTheDocument();
   });
 
   it("uses a conservative lease risk fallback when no unit label exists", async () => {
@@ -507,6 +569,7 @@ describe("PropertyDetailPanel", () => {
           unitId: "unit-future",
           unitNumber: "201",
           monthlyRent: 1800,
+          tenantName: "Future Tenant",
           startDate: "2026-06-01",
           endDate: "2027-05-31",
           status: "active",
@@ -521,6 +584,7 @@ describe("PropertyDetailPanel", () => {
           unitId: "unit-notice",
           unitNumber: "202",
           monthlyRent: 1900,
+          tenantName: "Current Tenant",
           startDate: "2026-01-01",
           endDate: "2026-12-31",
           status: "move_out_pending",
@@ -553,8 +617,70 @@ describe("PropertyDetailPanel", () => {
     );
 
     expect((await screen.findAllByText("Upcoming")).length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Notice period").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Occupied").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Future Tenant · Ends May 31, 2027/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Current Tenant · Ends Dec 31, 2026/).length).toBeGreaterThan(0);
     expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("hydrates the unit edit modal from lease-derived occupancy instead of stale unit fields", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      {
+        id: "unit-occupied",
+        unitNumber: "101",
+        rent: 1800,
+        status: "occupied",
+        occupantName: "Stale Occupant",
+        leaseEndDate: "2026-08-30",
+      },
+    ]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-occupied",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-occupied",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          tenantName: "John Smith",
+          startDate: "2026-01-01",
+          endDate: "2027-05-29",
+          status: "active",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      credibilitySummary: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            totalUnits: 1,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getAllByText(/John Smith · Ends May 29, 2027/).length).toBeGreaterThan(0));
+    expect(screen.getAllByRole("link", { name: "View related leases" })[0]).toHaveAttribute("href", "/leases?propertyId=prop-1");
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
+
+    expect(screen.getByText("modal tenant: John Smith")).toBeInTheDocument();
+    expect(screen.getByText("modal lease end: 2027-05-29")).toBeInTheDocument();
   });
 
   it("uses the updated archive confirmation copy before archiving", async () => {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -39,6 +39,7 @@ import { calculateConfiguredUnitRentTotal, resolveConfiguredUnitRent } from "@/l
 import { buildPropertySummaryMetrics } from "@/lib/propertySummaryMetrics";
 import {
   deriveUnitOccupancyFromLeases,
+  type UnitOccupancy,
   type UnitOccupancyStatus,
 } from "@/lib/leases/leaseLifecycle";
 import { getUnitsNeedingOccupancySetup } from "./occupancyPrompt";
@@ -71,10 +72,10 @@ function isRawUnitIdLabel(value: string, rawIds: string[]) {
   return RAW_ID_PATTERN.test(value) && /[A-Za-z]/.test(value) && /\d/.test(value);
 }
 
-function resolveLeaseRiskUnitLabel(lease: Lease, unitsForDisplay: any[]): string {
+function findLeaseRiskUnit(lease: Lease, unitsForDisplay: any[]): any | null {
   const rawIds = [cleanLabel(lease.unitId), cleanLabel((lease as any).id)].filter(Boolean);
   const unitReference = cleanLabel(lease.unitId || lease.unitNumber || lease.unitLabel);
-  const matchedUnit = unitsForDisplay.find((unit: any) => {
+  return unitsForDisplay.find((unit: any) => {
     const candidates = [
       unit?.id,
       unit?.unitId,
@@ -87,7 +88,12 @@ function resolveLeaseRiskUnitLabel(lease: Lease, unitsForDisplay: any[]): string
       .map(cleanLabel)
       .filter(Boolean);
     return candidates.some((candidate) => candidate.toLowerCase() === unitReference.toLowerCase());
-  });
+  }) || null;
+}
+
+function resolveLeaseRiskUnitLabel(lease: Lease, unitsForDisplay: any[]): string {
+  const rawIds = [cleanLabel(lease.unitId), cleanLabel((lease as any).id)].filter(Boolean);
+  const matchedUnit = findLeaseRiskUnit(lease, unitsForDisplay);
   const candidates = [
     matchedUnit?.unitNumber,
     matchedUnit?.label,
@@ -103,21 +109,79 @@ function resolveLeaseRiskUnitLabel(lease: Lease, unitsForDisplay: any[]): string
   return /^unit\b/i.test(label) ? label : `Unit ${label}`;
 }
 
+function resolveLeaseRiskRent(lease: Lease, unitsForDisplay: any[]): number {
+  const matchedUnit = findLeaseRiskUnit(lease, unitsForDisplay);
+  return resolveConfiguredUnitRent(matchedUnit || {}) ?? lease.monthlyRent ?? 0;
+}
+
+function formatDateInputValue(value: unknown): string {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})/.exec(raw);
+  if (dateOnly) return `${dateOnly[1]}-${dateOnly[2]}-${dateOnly[3]}`;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toISOString().slice(0, 10);
+}
+
+function resolveOccupancyTenantName(unit: any, occupancy: UnitOccupancy): string {
+  const lease = occupancy.lease as any;
+  return String(
+    lease?.tenantName ||
+      lease?.tenantDisplayName ||
+      lease?.primaryTenantName ||
+      lease?.occupantName ||
+      unit?.occupantName ||
+      unit?.tenantName ||
+      ""
+  ).trim();
+}
+
+function resolveOccupancyLeaseEndDate(unit: any, occupancy: UnitOccupancy): string {
+  const lease = occupancy.lease as any;
+  return String(lease?.endDate || lease?.leaseEndDate || unit?.leaseEndDate || unit?.leaseEnd || "").trim();
+}
+
+function buildUnitOccupancyView(unit: any, occupancy: UnitOccupancy) {
+  const tenantName = occupancy.status === "occupied" || occupancy.status === "upcoming"
+    ? resolveOccupancyTenantName(unit, occupancy)
+    : "";
+  const leaseEndDate = occupancy.status === "occupied" || occupancy.status === "upcoming"
+    ? resolveOccupancyLeaseEndDate(unit, occupancy)
+    : "";
+  const leaseId = String((occupancy.lease as any)?.id || (occupancy.lease as any)?.leaseId || "").trim();
+  return {
+    status: occupancy.status,
+    label: occupancy.label,
+    tenantName,
+    leaseEndDate,
+    leaseId,
+    reviewReason: occupancy.status === "review_required" ? occupancy.reason || "Occupancy data needs review." : "",
+    ledgerHref: leaseId ? `/leases/${encodeURIComponent(leaseId)}/ledger` : "",
+  };
+}
+
 function unitOccupancyTone(status: UnitOccupancyStatus) {
   if (status === "occupied") {
     return { background: "rgba(34,197,94,0.1)", color: "#166534", dot: "#22c55e" };
   }
-  if (status === "notice_period") {
+  if (status === "review_required") {
     return { background: "rgba(245,158,11,0.12)", color: "#92400e", dot: "#f59e0b" };
   }
   if (status === "upcoming") {
     return { background: "rgba(59,130,246,0.1)", color: "#1d4ed8", dot: "#3b82f6" };
   }
+  if (status === "archived") {
+    return { background: "rgba(100,116,139,0.1)", color: "#475569", dot: "#64748b" };
+  }
   return { background: "rgba(248,113,113,0.08)", color: "#b91c1c", dot: "#f87171" };
 }
 
 const formatDate = (iso: string): string => {
-  const d = new Date(iso);
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(iso || "").trim());
+  const d = dateOnly
+    ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+    : new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString(undefined, {
     month: "short",
@@ -653,6 +717,24 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   const getUnitOccupancy = useCallback(
     (unit: any) => deriveUnitOccupancyFromLeases(unit, leases),
     [leases]
+  );
+  const getUnitOccupancyView = useCallback(
+    (unit: any) => buildUnitOccupancyView(unit, getUnitOccupancy(unit)),
+    [getUnitOccupancy]
+  );
+  const getUnitForEdit = useCallback(
+    (unit: any) => {
+      const view = getUnitOccupancyView(unit);
+      const hasLeaseDerivedOccupancy = Boolean(view.leaseId) && (view.status === "occupied" || view.status === "upcoming");
+      if (!hasLeaseDerivedOccupancy) return unit;
+      return {
+        ...unit,
+        status: "occupied",
+        occupantName: view.tenantName || unit?.occupantName || "",
+        leaseEndDate: formatDateInputValue(view.leaseEndDate) || unit?.leaseEndDate || "",
+      };
+    },
+    [getUnitOccupancyView]
   );
 
   const unitsNeedingOccupancySetup = useMemo(
@@ -1268,7 +1350,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         </div>
       )}
 
-      <PropertyCredibilitySummaryCard summary={credibilitySummary} />
+      <PropertyCredibilitySummaryCard
+        summary={credibilitySummary}
+        leaseHref={property?.id ? `/leases?propertyId=${encodeURIComponent(String(property.id))}` : "/leases"}
+      />
       <PropertyRegistryStatusCard property={property} onOpenSubmissionAssistant={() => setSubmissionAssistantOpen(true)} />
 
       {activeLeases.length > 0 && (
@@ -1309,11 +1394,31 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                     {resolveLeaseRiskUnitLabel(lease, displayedUnits)}
                   </div>
                   <div style={{ color: "#475569", fontSize: 12 }}>
-                    {formatCurrency(lease.monthlyRent)} / month
+                    {formatCurrency(resolveLeaseRiskRent(lease, displayedUnits))} / month
                     {lease.riskConfidence != null ? " • " + Math.round(lease.riskConfidence * 100) + "% confidence" : ""}
                   </div>
                 </div>
-                <RiskScoreBadge grade={(lease.riskGrade as any) || lease.risk?.grade || null} score={lease.riskScore ?? lease.risk?.score ?? null} compact />
+                <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                  <RiskScoreBadge grade={(lease.riskGrade as any) || lease.risk?.grade || null} score={lease.riskScore ?? lease.risk?.score ?? null} compact />
+                  {lease.id ? (
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/leases/${encodeURIComponent(String(lease.id))}/ledger`)}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 8,
+                        border: "1px solid #dbeafe",
+                        background: "#eff6ff",
+                        color: "#1d4ed8",
+                        fontWeight: 700,
+                        cursor: "pointer",
+                        fontSize: "0.8rem",
+                      }}
+                    >
+                      Ledger
+                    </button>
+                  ) : null}
+                </div>
               </div>
             ))}
           </div>
@@ -1376,7 +1481,8 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                 <button
                   type="button"
                   onClick={() => {
-                    setEditingUnit(unitsNeedingOccupancySetup[0] || displayedUnits[0] || null);
+                    const targetUnit = unitsNeedingOccupancySetup[0] || displayedUnits[0] || null;
+                    setEditingUnit(targetUnit ? getUnitForEdit(targetUnit) : null);
                     dismissOccupancyPrompt();
                   }}
                   style={{
@@ -1499,21 +1605,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                   const rentVal = resolveConfiguredUnitRent(u);
                   const sqftVal = (u as any).sqft ?? null;
                   const occupancy = getUnitOccupancy(u);
+                  const occupancyView = buildUnitOccupancyView(u, occupancy);
                   const occupancyTone = unitOccupancyTone(occupancy.status);
-                  const isLeased = occupancy.status === "occupied" || occupancy.status === "notice_period";
-                  const occupantName =
-                    isLeased || occupancy.status === "upcoming"
-                      ? String((u as any).occupantName || (occupancy.lease as any)?.tenantName || "").trim()
-                      : "";
-                  const leaseEndDate =
-                    isLeased || occupancy.status === "upcoming"
-                      ? String(
-                          (occupancy.lease as any)?.endDate ||
-                            (occupancy.lease as any)?.leaseEndDate ||
-                            (u as any).leaseEndDate ||
-                            ""
-                        ).trim()
-                      : "";
+                  const occupantName = occupancyView.tenantName;
+                  const leaseEndDate = occupancyView.leaseEndDate;
                   const rentDisplay =
                     rentVal !== null && rentVal !== undefined
                       ? formatCurrency(Number(rentVal) || 0)
@@ -1595,6 +1690,17 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                             <div style={{ fontSize: "0.8rem", color: "#475569" }}>
                               {occupantName}
                               {leaseEndDate ? ` · Ends ${formatDate(leaseEndDate)}` : ""}
+                              {occupancyView.ledgerHref ? (
+                                <>
+                                  {" · "}
+                                  <a href={occupancyView.ledgerHref}>Ledger</a>
+                                </>
+                              ) : null}
+                            </div>
+                          ) : null}
+                          {occupancyView.reviewReason ? (
+                            <div style={{ fontSize: "0.78rem", color: "#92400e" }}>
+                              {occupancyView.reviewReason}
                             </div>
                           ) : null}
                           {(u as any).leaseDocument?.fileName ? (
@@ -1614,7 +1720,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                         <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
                           <button
                             type="button"
-                            onClick={() => setEditingUnit(u)}
+                            onClick={() => setEditingUnit(getUnitForEdit(u))}
                             style={{
                               padding: "6px 10px",
                               borderRadius: 8,
@@ -1678,20 +1784,9 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             const rentVal = resolveConfiguredUnitRent(u);
             const sqftVal = (u as any).sqft ?? null;
             const occupancy = getUnitOccupancy(u);
-            const isLeased = occupancy.status === "occupied" || occupancy.status === "notice_period";
-            const occupantName =
-              isLeased || occupancy.status === "upcoming"
-                ? String((u as any).occupantName || (occupancy.lease as any)?.tenantName || "").trim()
-                : "";
-            const leaseEndDate =
-              isLeased || occupancy.status === "upcoming"
-                ? String(
-                    (occupancy.lease as any)?.endDate ||
-                      (occupancy.lease as any)?.leaseEndDate ||
-                      (u as any).leaseEndDate ||
-                      ""
-                  ).trim()
-                : "";
+            const occupancyView = buildUnitOccupancyView(u, occupancy);
+            const occupantName = occupancyView.tenantName;
+            const leaseEndDate = occupancyView.leaseEndDate;
             const rentDisplay =
               rentVal !== null && rentVal !== undefined
                 ? formatCurrency(Number(rentVal) || 0)
@@ -1734,6 +1829,17 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                       <div style={{ fontSize: "0.8rem", color: "#475569", marginTop: 4 }}>
                         {occupantName}
                         {leaseEndDate ? ` · Ends ${formatDate(leaseEndDate)}` : ""}
+                        {occupancyView.ledgerHref ? (
+                          <>
+                            {" · "}
+                            <a href={occupancyView.ledgerHref}>Ledger</a>
+                          </>
+                        ) : null}
+                      </div>
+                    ) : null}
+                    {occupancyView.reviewReason ? (
+                      <div style={{ fontSize: "0.78rem", color: "#92400e", marginTop: 4 }}>
+                        {occupancyView.reviewReason}
                       </div>
                     ) : null}
                     {(u as any).leaseDocument?.fileName ? (
@@ -1778,7 +1884,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                 <div className="rc-unit-actions">
                   <button
                     type="button"
-                    onClick={() => setEditingUnit(u)}
+                    onClick={() => setEditingUnit(getUnitForEdit(u))}
                     style={{
                       padding: "6px 10px",
                       borderRadius: 8,

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
@@ -154,4 +154,30 @@ describe("TenantLeasePanel", () => {
     expect(screen.queryByText(/Apr 30, 2026/)).not.toBeInTheDocument();
     expect(screen.queryByText(/May 31, 2026/)).not.toBeInTheDocument();
   });
+
+  it("surfaces a signed future lease as upcoming instead of showing no current lease", async () => {
+    mocks.getLeaseAutomationTasks.mockResolvedValue({ tasks: [] });
+    mocks.getLeasesForTenant.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-future",
+          propertyId: "prop-1",
+          propertyName: "North Towers",
+          unitNumber: "103",
+          monthlyRent: 1640,
+          startDate: "2026-07-01",
+          endDate: "2027-06-30",
+          status: "active",
+          signatureStatus: "signed",
+          automationEnabled: true,
+        },
+      ],
+    });
+
+    render(<TenantLeasePanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("Upcoming Lease")).toBeInTheDocument();
+    expect(screen.getByText("Property: North Towers - Unit 103")).toBeInTheDocument();
+    expect(mocks.getLeaseAutomationTasks).not.toHaveBeenCalled();
+  });
 });

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -12,6 +12,7 @@ import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
 import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
 import { LeaseRiskCard } from "@/components/leases/LeaseRiskCard";
+import { deriveLeaseLifecycleStatus, isLeaseCurrentlyActive } from "@/lib/leases/leaseLifecycle";
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
@@ -167,12 +168,23 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
   }, [loadLeases, tenantId]);
 
   const activeLease = useMemo(
-    () => leases.find((l) => l.status === "active") ?? null,
+    () => leases.find((l) => isLeaseCurrentlyActive(l)) ?? null,
     [leases]
   );
 
+  const upcomingLease = useMemo(
+    () => leases.find((l) => deriveLeaseLifecycleStatus(l) === "signed_future") ?? null,
+    [leases]
+  );
+
+  const displayedLease = activeLease || upcomingLease;
+
   const endedLeases = useMemo(
-    () => leases.filter((l) => l.status === "ended"),
+    () =>
+      leases.filter((l) => {
+        const lifecycle = deriveLeaseLifecycleStatus(l);
+        return lifecycle === "expired" || lifecycle === "terminated" || lifecycle === "renewed" || l.status === "ended" || l.status === "archived";
+      }),
     [leases]
   );
 
@@ -354,7 +366,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
   } else {
     content = (
       <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-        {activeLease && (
+        {displayedLease && (
           <div
             style={{
               ...panelSurface,
@@ -362,21 +374,22 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
             }}
           >
             <div style={{ color: "#64748b", fontSize: 12, marginBottom: 4, fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.6 }}>
-              Current Lease
+              {activeLease ? "Current Lease" : "Upcoming Lease"}
             </div>
             <div style={{ color: "#0f172a", fontWeight: 700 }}>
-              Property: {formatLeaseLabel(activeLease)}
+              Property: {formatLeaseLabel(displayedLease)}
             </div>
             <div style={{ color: "#334155", fontSize: 13, marginTop: 4, fontWeight: 600 }}>
-              Rent: {formatCurrency(activeLease.monthlyRent)} / month
+              Rent: {formatCurrency(displayedLease.monthlyRent)} / month
             </div>
             <div style={{ color: "#64748b", fontSize: 12, marginTop: 4 }}>
-              {formatDate(activeLease.startDate)} →{" "}
-              {activeLease.endDate ? formatDate(activeLease.endDate) : "Ongoing"}
+              {formatDate(displayedLease.startDate)} →{" "}
+              {displayedLease.endDate ? formatDate(displayedLease.endDate) : "Ongoing"}
             </div>
             <div style={{ marginTop: 12 }}>
-              <LeaseRiskCard risk={activeLease.risk ?? null} compact />
+              <LeaseRiskCard risk={displayedLease.risk ?? null} compact />
             </div>
+            {activeLease ? (
             <div
               style={{
                 ...insetPanelSurface,
@@ -406,7 +419,9 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                 {automationSaving ? "Saving..." : activeLease.automationEnabled !== false ? "On" : "Off"}
               </label>
             </div>
+            ) : null}
 
+            {activeLease ? (
             <div
               style={{
                 ...insetPanelSurface,
@@ -480,8 +495,9 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                 </div>
               ) : null}
             </div>
+            ) : null}
             <div style={{ marginTop: 8, display: "grid", gap: 8 }}>
-              {confirmingLeaseId === activeLease.id ? (
+              {activeLease && confirmingLeaseId === activeLease.id ? (
                 <div
                   style={{
                     borderRadius: 12,
@@ -538,6 +554,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                   </div>
                 </div>
               ) : null}
+              {activeLease ? (
               <div style={{ display: "flex", justifyContent: "flex-end" }}>
                 <button
                   type="button"
@@ -558,6 +575,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                   End lease
                 </button>
               </div>
+              ) : null}
             </div>
           </div>
         )}

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
@@ -70,7 +70,7 @@ describe("leaseLifecycle", () => {
         ],
         today
       )
-    ).toMatchObject({ status: "notice_period", label: "Notice period" });
+    ).toMatchObject({ status: "occupied", label: "Occupied" });
 
     expect(
       deriveUnitOccupancyFromLeases(
@@ -181,6 +181,63 @@ describe("leaseLifecycle", () => {
         ],
         today
       )
-    ).toMatchObject({ status: "review_required", label: "Review required" });
+    ).toMatchObject({ status: "review_required", label: "Review needed" });
+  });
+
+  it("keeps archived leases out of occupied display", () => {
+    expect(
+      deriveLeaseLifecycleStatus(
+        {
+          id: "lease-archived-derived",
+          unitId: "unit-archived",
+          status: "active",
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          derivedLifecycleState: "archived",
+        },
+        today
+      )
+    ).toBe("archived");
+
+    expect(
+      deriveUnitOccupancyFromLeases(
+        { id: "unit-archived", unitNumber: "106" },
+        [
+          {
+            id: "lease-archived",
+            unitId: "unit-archived",
+            status: "archived",
+            startDate: "2025-01-01",
+            endDate: "2026-12-31",
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "archived", label: "Archived" });
+  });
+
+  it("flags multiple current leases for one unit as review needed", () => {
+    expect(
+      deriveUnitOccupancyFromLeases(
+        { id: "unit-conflict", unitNumber: "107" },
+        [
+          {
+            id: "lease-active-1",
+            unitId: "unit-conflict",
+            status: "active",
+            startDate: "2026-01-01",
+            endDate: "2026-12-31",
+          },
+          {
+            id: "lease-active-2",
+            unitId: "unit-conflict",
+            status: "active",
+            startDate: "2026-02-01",
+            endDate: "2026-11-30",
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "review_required", label: "Review needed" });
   });
 });

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
@@ -8,14 +8,16 @@ export type LeaseLifecycleStatus =
   | "renewed"
   | "terminated"
   | "cancelled"
+  | "archived"
   | "unknown";
 
-export type UnitOccupancyStatus = "vacant" | "occupied" | "notice_period" | "upcoming" | "review_required";
+export type UnitOccupancyStatus = "vacant" | "occupied" | "upcoming" | "archived" | "review_required";
 
 export type UnitOccupancy = {
   status: UnitOccupancyStatus;
-  label: "Vacant" | "Occupied" | "Notice period" | "Upcoming" | "Review required";
+  label: "Vacant" | "Occupied" | "Upcoming" | "Archived" | "Review needed";
   lease: LeaseLike | null;
+  reason?: string | null;
 };
 
 export type LeaseLike = {
@@ -90,6 +92,7 @@ const CANONICAL_LIFECYCLE_STATUSES = new Set<LeaseLifecycleStatus>([
   "renewed",
   "terminated",
   "cancelled",
+  "archived",
   "unknown",
 ]);
 
@@ -176,6 +179,7 @@ export function deriveLeaseLifecycleStatus(
   const endDay = leaseEndDay(lease);
 
   if (CANCELLED_STATUSES.has(status)) return "cancelled";
+  if (status === "archived" || lifecycleStatus === "archived") return "archived";
   if (TERMINATED_STATUSES.has(status) || (lease.terminationDate && (toDay(lease.terminationDate) ?? Infinity) <= currentDay)) {
     return "terminated";
   }
@@ -244,6 +248,15 @@ function hasManualCurrentOccupancy(unit: UnitLike, today: string | number | Date
   return status === "occupied" && hasManualOccupant(unit) && hasCurrentManualLeaseEnd(unit, today);
 }
 
+function hasUnitArchivedSignal(unit: UnitLike): boolean {
+  const status = normalize(unit.occupancyStatus || unit.status);
+  return status === "archived" || status === "deleted" || status === "inactive";
+}
+
+function hasLeaseArchivedSignal(lease: LeaseLike): boolean {
+  return deriveLeaseLifecycleStatus(lease) === "archived";
+}
+
 export function leasesForUnit(unit: UnitLike, leases: LeaseLike[]): LeaseLike[] {
   const ids = new Set(unitIdentifiers(unit));
   if (!ids.size) return [];
@@ -264,12 +277,28 @@ export function deriveUnitOccupancyFromLeases(
   }));
 
   const review = withLifecycle.find((item) => item.status === "unknown" || item.lease.derivedLifecycleRequiresReview === true);
-  if (review) return { status: "review_required", label: "Review required", lease: review.lease };
+  if (review) {
+    return {
+      status: "review_required",
+      label: "Review needed",
+      lease: review.lease,
+      reason: Array.isArray(review.lease.derivedLifecycleReasons) && review.lease.derivedLifecycleReasons.length
+        ? review.lease.derivedLifecycleReasons.join(", ")
+        : "Lifecycle data needs review.",
+    };
+  }
 
-  const notice = withLifecycle.find((item) => item.status === "notice_period");
-  if (notice) return { status: "notice_period", label: "Notice period", lease: notice.lease };
+  const currentLeases = withLifecycle.filter((item) => item.status === "active" || item.status === "notice_period");
+  if (currentLeases.length > 1) {
+    return {
+      status: "review_required",
+      label: "Review needed",
+      lease: currentLeases[0]?.lease ?? null,
+      reason: "Multiple current leases match this unit.",
+    };
+  }
 
-  const active = withLifecycle.find((item) => item.status === "active");
+  const active = currentLeases[0];
   if (active) return { status: "occupied", label: "Occupied", lease: active.lease };
 
   const upcoming = withLifecycle.find((item) => item.status === "signed_future");
@@ -277,6 +306,10 @@ export function deriveUnitOccupancyFromLeases(
 
   if (hasManualCurrentOccupancy(unit, today)) {
     return { status: "occupied", label: "Occupied", lease: null };
+  }
+
+  if (hasUnitArchivedSignal(unit) || matchedLeases.some(hasLeaseArchivedSignal)) {
+    return { status: "archived", label: "Archived", lease: matchedLeases[0] ?? null };
   }
 
   return { status: "vacant", label: "Vacant", lease: null };

--- a/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
+++ b/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
@@ -181,4 +181,53 @@ describe("buildPropertySummaryMetrics", () => {
     expect(metrics.occupancyRate).toBe(0);
     expect(metrics.currentOccupiedRentTotal).toBe(0);
   });
+
+  it("does not count review-needed occupancy conflicts as occupied", () => {
+    const metrics = buildPropertySummaryMetrics(
+      [
+        {
+          id: "unit-1",
+          unitNumber: "101",
+          status: "occupied",
+          occupantName: "Conflicted Tenant",
+          leaseEndDate: "2026-12-31",
+          rent: 1800,
+        },
+      ],
+      [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "lease-2",
+          tenantId: "tenant-2",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2026-02-01",
+          endDate: "2026-11-30",
+          status: "active",
+          createdAt: "2026-02-01T00:00:00.000Z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ],
+      1,
+      "2026-05-04"
+    );
+
+    expect(metrics.leasedUnits).toHaveLength(0);
+    expect(metrics.occupancyRate).toBe(0);
+    expect(metrics.currentOccupiedRentTotal).toBe(0);
+  });
 });

--- a/rentchain-frontend/src/lib/propertySummaryMetrics.ts
+++ b/rentchain-frontend/src/lib/propertySummaryMetrics.ts
@@ -29,7 +29,7 @@ export function buildPropertySummaryMetrics(
     occupancy: deriveUnitOccupancyFromLeases(unit, leases, today),
   }));
   const occupiedUnits = occupancyByUnit
-    .filter((item) => item.occupancy.status === "occupied" || item.occupancy.status === "notice_period")
+    .filter((item) => item.occupancy.status === "occupied")
     .map((item) => item.unit);
   const leasedUnits = occupiedUnits;
   const occupancyRate = unitCount > 0 ? (occupiedUnits.length / unitCount) * 100 : 0;
@@ -38,7 +38,7 @@ export function buildPropertySummaryMetrics(
     0
   );
   const currentOccupiedRentTotal = occupancyByUnit.reduce((sum, item) => {
-    if (item.occupancy.status !== "occupied" && item.occupancy.status !== "notice_period") return sum;
+    if (item.occupancy.status !== "occupied") return sum;
     const rentFromLease =
       typeof item.occupancy.lease?.monthlyRent === "number"
         ? item.occupancy.lease.monthlyRent

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -380,7 +380,8 @@ describe("LandlordActiveLeasesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Needs review: Draft lease · Review Required occupancy/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Needs review: Draft lease · Review needed occupancy/i)).toBeInTheDocument();
+    expect(screen.getByText("Review needed")).toBeInTheDocument();
     expect(screen.getByText("Recorded ledger payment activity present")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-review/ledger");
   });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -126,6 +126,29 @@ function formatCoherenceToken(value: string | null | undefined) {
   return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function occupancyDisplayLabel(lease: LandlordActiveLease) {
+  const coherence = lease.stateCoherence;
+  if (!coherence) return null;
+  if (coherence.flags?.requiresReview || coherence.occupancyState === "review_required" || coherence.occupancyState === "unknown") {
+    return "Review needed";
+  }
+  if (coherence.leaseOperationalState === "archived") return "Archived";
+  if (coherence.occupancyState === "upcoming") return "Upcoming";
+  if (coherence.occupancyState === "occupied" || coherence.occupancyState === "notice_period") return "Occupied";
+  if (coherence.occupancyState === "vacant") return "Vacant";
+  return "Review needed";
+}
+
+function renderOccupancyDisplay(lease: LandlordActiveLease) {
+  const label = occupancyDisplayLabel(lease);
+  if (!label) return null;
+  return (
+    <div style={{ color: label === "Review needed" ? "#92400e" : "#64748b", fontSize: 12, marginTop: 6 }}>
+      Occupancy: <strong>{label}</strong>
+    </div>
+  );
+}
+
 function renderStateCoherence(lease: LandlordActiveLease) {
   const coherence = lease.stateCoherence;
   if (!coherence) return null;
@@ -147,8 +170,7 @@ function renderStateCoherence(lease: LandlordActiveLease) {
     >
       {needsReview ? (
         <div style={{ fontWeight: 800 }}>
-          Needs review: {formatCoherenceToken(coherence.leaseOperationalState)} lease ·{" "}
-          {formatCoherenceToken(coherence.occupancyState)} occupancy
+          Needs review: {formatCoherenceToken(coherence.leaseOperationalState)} lease · Review needed occupancy
         </div>
       ) : null}
       {paymentActivityLabel ? <div>{paymentActivityLabel}</div> : null}
@@ -757,6 +779,7 @@ export default function LandlordActiveLeasesPage() {
                     </td>
                     <td style={{ padding: 12 }}>
                       <div>{statusBadge(lease.status)}</div>
+                      {renderOccupancyDisplay(lease)}
                       {lease.leaseExecution ? (
                         <div style={{ display: "grid", gap: 4, marginTop: 6 }}>
                           <div style={{ fontSize: 12, fontWeight: 700, color: "#0f172a" }}>
@@ -865,6 +888,7 @@ export default function LandlordActiveLeasesPage() {
                 <div>
                   <div style={{ color: "#64748b", fontSize: 12 }}>Status</div>
                   <div style={{ marginTop: 6 }}>{statusBadge(lease.status)}</div>
+                  {renderOccupancyDisplay(lease)}
                 </div>
                 <div>
                   <div style={{ color: "#64748b", fontSize: 12 }}>Rent</div>


### PR DESCRIPTION
## Summary

Normalizes read-only property/unit occupancy display across the low-risk landlord surfaces touched by this branch.

## Audit Summary

Current occupancy display was split across several frontend paths:

- Property unit tables used `deriveUnitOccupancyFromLeases`, but still exposed `Notice period` / `Review required` display states instead of the current canonical display vocabulary.
- Property occupancy counts were tied to the helper but counted notice-period occupancy separately.
- Tenant profile lease info selected `status === "active"` directly, which could miss signed future/upcoming leases and archived/past handling.
- Lease operations had state-coherence warnings, but did not surface a normalized occupancy display label alongside status.

## Changes

- Extended the existing lease lifecycle helper to normalize unit occupancy display states to:
  - Occupied
  - Vacant
  - Upcoming
  - Archived
  - Review needed
- Treats active and notice-period leases as `Occupied` for property/unit display.
- Treats signed future leases as `Upcoming`.
- Treats archived lease/unit signals as `Archived`, not occupied.
- Flags multiple current leases for the same unit as `Review needed`.
- Updates property summary metrics so only normalized `Occupied` units count toward occupied-unit totals.
- Updates property unit table badges and mobile unit cards to use the normalized labels.
- Updates tenant lease panel to use lifecycle derivation for current/upcoming/history display instead of raw `status === "active"` only.
- Adds a read-only normalized occupancy label to lease operations when state coherence is available.

## Guardrails

- No Firestore migration.
- No lease write behavior changed.
- No tenant/property/unit records mutated.
- No payment, ledger, CSV import, messaging, jurisdiction, or lease lifecycle state-machine writes changed.
- Display-only normalization from existing signals.

## Tests Run

- `npm run test:single -- src/lib/leases/leaseLifecycle.test.ts src/lib/propertySummaryMetrics.test.ts src/components/properties/PropertyDetailPanel.test.tsx src/components/tenants/TenantLeasePanel.test.tsx src/pages/LandlordActiveLeasesPage.test.tsx`
- `npm run build`

## Known Follow-ups

- Backend portfolio/admin summary services still have older occupancy count derivations in some aggregate paths; this PR keeps the implementation to low-risk landlord-facing display surfaces.
- Broader backend occupancy read-model normalization can be handled separately if dashboard/admin aggregate drift is observed in QA.