### PR TITLE
fix: normalize lease ledger decision actions

### DIFF
--- a/rentchain-api/src/routes/__tests__/decisionRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/decisionRoutes.test.ts
@@ -135,6 +135,12 @@ describe("decisionRoutes", () => {
         }),
       ])
     );
+    expect(res.body.summary).toEqual(
+      expect.objectContaining({
+        allTotal: res.body.decisions.length,
+        inactiveTotal: 0,
+      })
+    );
   });
 
   it("persists decision action records without mutating lease documents", async () => {
@@ -166,6 +172,91 @@ describe("decisionRoutes", () => {
         status: "active",
       }),
     ]);
+  });
+
+  it("reports reviewed decisions as inactive in route summaries", async () => {
+    seedLease();
+    const app = await makeApp();
+
+    const listRes = await request(app).get("/api/decisions?leaseId=lease-1");
+    const decision = listRes.body.decisions.find((row: any) => row.decisionType === "review_missing_payment");
+    expect(decision).toBeTruthy();
+
+    await request(app)
+      .patch(`/api/decisions/${encodeURIComponent(decision.decisionId)}/action`)
+      .send({ leaseId: "lease-1", actionType: "reviewed", note: "Reviewed by operator" })
+      .expect(200);
+
+    const res = await request(app).get("/api/decisions?leaseId=lease-1");
+
+    expect(res.body.summary).toEqual(
+      expect.objectContaining({
+        allTotal: res.body.decisions.length,
+        inactiveTotal: 1,
+        total: res.body.decisions.length - 1,
+      })
+    );
+  });
+
+  it.each([
+    ["reviewed", { note: "Reviewed by operator" }, "reviewed"],
+    ["snoozed", { snoozedUntil: "2026-05-12T00:00:00.000Z" }, "snoozed"],
+    ["assigned", { assignedTo: "operations" }, "assigned"],
+    ["dismissed", { note: "Not actionable" }, "dismissed"],
+    ["resolved", { note: "Resolved from ledger review" }, "resolved"],
+  ])("persists deterministic %s action transitions", async (actionType, extraPayload, expectedStatus) => {
+    seedLease();
+    const app = await makeApp();
+
+    const listRes = await request(app).get("/api/decisions?leaseId=lease-1");
+    const decision = listRes.body.decisions.find((row: any) => row.decisionType === "review_missing_payment");
+    expect(decision).toBeTruthy();
+
+    const res = await request(app)
+      .patch(`/api/decisions/${encodeURIComponent(decision.decisionId)}/action`)
+      .send({ leaseId: "lease-1", actionType, ...extraPayload });
+
+    expect(res.status).toBe(200);
+    expect(res.body.decision).toEqual(
+      expect.objectContaining({
+        decisionId: decision.decisionId,
+        status: expectedStatus,
+        latestAction: expect.objectContaining({
+          actionType,
+          previousStatus: "detected",
+          nextStatus: expectedStatus,
+        }),
+      })
+    );
+    expect(listDocs("decisionActions")).toHaveLength(1);
+  });
+
+  it("records repeated decision actions with the current overlaid status as previousStatus", async () => {
+    seedLease();
+    const app = await makeApp();
+
+    const listRes = await request(app).get("/api/decisions?leaseId=lease-1");
+    const decision = listRes.body.decisions.find((row: any) => row.decisionType === "review_missing_payment");
+    expect(decision).toBeTruthy();
+
+    await request(app)
+      .patch(`/api/decisions/${encodeURIComponent(decision.decisionId)}/action`)
+      .send({ leaseId: "lease-1", actionType: "reviewed" })
+      .expect(200);
+
+    const res = await request(app)
+      .patch(`/api/decisions/${encodeURIComponent(decision.decisionId)}/action`)
+      .send({ leaseId: "lease-1", actionType: "resolved", note: "Resolved after review" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.action).toEqual(
+      expect.objectContaining({
+        actionType: "resolved",
+        previousStatus: "reviewed",
+        nextStatus: "resolved",
+      })
+    );
+    expect(listDocs("decisionActions")).toHaveLength(2);
   });
 
   it("blocks landlord access to leases outside their scope", async () => {

--- a/rentchain-api/src/routes/decisionRoutes.ts
+++ b/rentchain-api/src/routes/decisionRoutes.ts
@@ -43,6 +43,11 @@ function actorEmailFromReq(req: any) {
   return asString(req.user?.email, 320) || null;
 }
 
+function isActiveDecisionStatus(status: unknown) {
+  const normalized = asString(status || "detected", 40);
+  return !["reviewed", "snoozed", "accepted", "dismissed", "resolved"].includes(normalized);
+}
+
 async function loadLeaseForDecisionAccess(req: any, leaseId: string) {
   const snap = await db.collection("leases").doc(leaseId).get();
   if (!snap.exists) return { ok: false as const, status: 404, error: "decision_lease_not_found" };
@@ -209,10 +214,12 @@ router.get("/", requireAuth, async (req: any, res: Response) => {
       decisions: model.decisions,
       actions: model.actions,
       summary: {
-        total: model.decisions.length,
-        critical: model.decisions.filter((decision) => decision.severity === "critical").length,
-        warning: model.decisions.filter((decision) => decision.severity === "warning").length,
-        info: model.decisions.filter((decision) => decision.severity === "info").length,
+        total: model.decisions.filter((decision) => isActiveDecisionStatus(decision.status)).length,
+        allTotal: model.decisions.length,
+        inactiveTotal: model.decisions.filter((decision) => !isActiveDecisionStatus(decision.status)).length,
+        critical: model.decisions.filter((decision) => isActiveDecisionStatus(decision.status) && decision.severity === "critical").length,
+        warning: model.decisions.filter((decision) => isActiveDecisionStatus(decision.status) && decision.severity === "warning").length,
+        info: model.decisions.filter((decision) => isActiveDecisionStatus(decision.status) && decision.severity === "info").length,
       },
     });
   } catch (err: any) {

--- a/rentchain-frontend/src/lib/decisions/decisionDisplay.test.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionDisplay.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isDecisionActive, summarizeDecisionItems, type DecisionItem } from "./decisionDisplay";
+
+function decision(overrides: Partial<DecisionItem> = {}): DecisionItem {
+  return {
+    decisionId: "decision-1",
+    leaseId: "lease-1",
+    decisionType: "review_missing_payment",
+    severity: "critical",
+    status: "detected",
+    reason: "Expected rent payment is missing.",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("decisionDisplay", () => {
+  it("treats assigned decisions as active and reviewed/snoozed/dismissed/resolved decisions as inactive", () => {
+    expect(isDecisionActive(decision({ status: "detected" }))).toBe(true);
+    expect(isDecisionActive(decision({ status: "assigned" }))).toBe(true);
+    expect(isDecisionActive(decision({ status: "reviewed" }))).toBe(false);
+    expect(isDecisionActive(decision({ status: "snoozed" }))).toBe(false);
+    expect(isDecisionActive(decision({ status: "dismissed" }))).toBe(false);
+    expect(isDecisionActive(decision({ status: "resolved" }))).toBe(false);
+  });
+
+  it("summarizes active decisions without losing the inactive audit count", () => {
+    const summary = summarizeDecisionItems([
+      decision({ decisionId: "critical-active", severity: "critical", status: "detected" }),
+      decision({ decisionId: "warning-active", severity: "warning", decisionType: "review_underpaid_rent", status: "assigned" }),
+      decision({ decisionId: "critical-reviewed", severity: "critical", status: "reviewed" }),
+      decision({ decisionId: "warning-resolved", severity: "warning", status: "resolved" }),
+    ]);
+
+    expect(summary.total).toBe(2);
+    expect(summary.allTotal).toBe(4);
+    expect(summary.inactiveTotal).toBe(2);
+    expect(summary.critical).toBe(1);
+    expect(summary.warning).toBe(1);
+    expect(summary.underpaid).toBe(1);
+  });
+});

--- a/rentchain-frontend/src/lib/decisions/decisionDisplay.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionDisplay.ts
@@ -55,6 +55,8 @@ export type DecisionItem = {
 
 export type DecisionSummary = {
   total: number;
+  allTotal: number;
+  inactiveTotal: number;
   critical: number;
   warning: number;
   info: number;
@@ -92,6 +94,13 @@ export const decisionStatusCopy: Record<DecisionStatus, string> = {
   dismissed: "Dismissed",
   resolved: "Resolved",
 };
+
+const INACTIVE_DECISION_STATUSES = new Set<DecisionStatus>(["reviewed", "snoozed", "accepted", "dismissed", "resolved"]);
+
+export function isDecisionActive(decision: Pick<DecisionItem, "status">): boolean {
+  const status = decision.status || "detected";
+  return !INACTIVE_DECISION_STATUSES.has(status);
+}
 
 const delinquencyDecisionMap: Record<
   DelinquencySignalType,
@@ -230,9 +239,12 @@ export function decisionFromLifecycleReviewItem(item: {
 }
 
 export function summarizeDecisionItems(decisions: DecisionItem[] | null | undefined): DecisionSummary {
-  const rows = decisions || [];
+  const allRows = decisions || [];
+  const rows = allRows.filter(isDecisionActive);
   return {
     total: rows.length,
+    allTotal: allRows.length,
+    inactiveTotal: allRows.length - rows.length,
     critical: rows.filter((item) => item.severity === "critical").length,
     warning: rows.filter((item) => item.severity === "warning").length,
     info: rows.filter((item) => item.severity === "info").length,

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -161,7 +161,7 @@ function DashboardDecisionSummaryPanel({
           Open decision inbox
         </Link>
       </div>
-      {summary.total === 0 ? (
+      {summary.allTotal === 0 ? (
         <div style={{ color: "#166534", background: "#f0fdf4", border: "1px solid #bbf7d0", borderRadius: 10, padding: 10 }}>
           No issues detected. Everything is up to date.
         </div>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -552,6 +552,30 @@ describe("LeaseLedgerPage", () => {
   });
 
   it("updates lease decision status from human actions", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger
+      .mockResolvedValueOnce(baseLedgerResponse)
+      .mockResolvedValueOnce({
+        ...baseLedgerResponse,
+        decisions: baseLedgerResponse.decisions.map((decision: any) =>
+          decision.decisionId === "decision-overdue"
+            ? {
+                ...decision,
+                status: "reviewed",
+                latestAction: {
+                  actionId: "action-1",
+                  decisionId: "decision-overdue",
+                  actionType: "reviewed",
+                  previousStatus: "detected",
+                  nextStatus: "reviewed",
+                  createdAt: "2026-05-05T12:00:00.000Z",
+                },
+              }
+            : decision
+        ),
+      });
+
     render(
       <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
         <Routes>
@@ -564,7 +588,10 @@ describe("LeaseLedgerPage", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Mark reviewed" })[0]);
 
     await waitFor(() => expect(mocks.patchDecisionAction).toHaveBeenCalledWith("decision-overdue", expect.objectContaining({ actionType: "reviewed" })));
+    await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledTimes(2));
     expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Outstanding").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$4,200.00").length).toBeGreaterThan(0);
   });
 
   it("renders an empty obligation state while preserving existing ledger entries", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -478,9 +478,10 @@ export default function LeaseLedgerPage() {
     return Object.entries(monthlyTotals).sort((a, b) => (a[0] < b[0] ? 1 : -1));
   }, [monthlyTotals]);
 
-  const loadLedger = async () => {
+  const loadLedger = async (options: { showLoading?: boolean } = {}) => {
     if (!leaseId) return;
-    setLoading(true);
+    const showLoading = options.showLoading ?? true;
+    if (showLoading) setLoading(true);
     setError(null);
     try {
       const res = await fetchLeaseLedger(leaseId, from || undefined, to || undefined);
@@ -495,7 +496,7 @@ export default function LeaseLedgerPage() {
     } catch (err: unknown) {
       setError(errorMessage(err, "Failed to load lease ledger"));
     } finally {
-      setLoading(false);
+      if (showLoading) setLoading(false);
     }
   };
 
@@ -513,6 +514,7 @@ export default function LeaseLedgerPage() {
       });
       const nextDecision = result?.decision || decisionWithStatus(decision, actionType);
       setDecisions((current) => current.map((item) => (item.decisionId === decision.decisionId ? nextDecision : item)));
+      await loadLedger({ showLoading: false });
     } catch (err: unknown) {
       setError(errorMessage(err, "Failed to update decision"));
     } finally {
@@ -797,7 +799,7 @@ export default function LeaseLedgerPage() {
                 <strong>{decisionSummary.warning}</strong>
               </div>
               <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
-                <div style={{ fontSize: 12, color: "#64748b" }}>Total</div>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Active</div>
                 <strong>{decisionSummary.total}</strong>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Repairs the lease ledger decision action workflow so review actions persist deterministically and the UI refreshes derived decision state after actions.

## Changes

- Normalizes active decision summaries so reviewed, snoozed, dismissed, resolved, and accepted decisions no longer inflate active critical/warning counts.
- Keeps decision rows visible with their latest status/action trail while active counts reflect actionable decisions.
- Refreshes the lease ledger read model after decision actions so cards, counts, delinquency context, and payment obligations stay in sync without a hard reload.
- Adds backend coverage for reviewed, snoozed, assigned, dismissed, and resolved transitions, including repeated-action previousStatus handling.
- Adds frontend coverage for active/inactive summary behavior and lease ledger action refresh behavior.

## Guardrails

- No payment reconciliation changes.
- No payment obligation derivation changes.
- No ledger entry mutation behavior changes.
- No CSV import changes.
- Decision action records remain append-only.

## Tests Run

- `rentchain-api`: `npm run test:single -- src/routes/__tests__/decisionRoutes.test.ts src/lib/decisions/__tests__/decisionActions.test.ts`
- `rentchain-api`: `npm run build`
- `rentchain-frontend`: `npm run test:single -- src/pages/LeaseLedgerPage.test.tsx src/lib/decisions/decisionDisplay.test.ts`
- `rentchain-frontend`: `npm run build`

## QA Notes

Preview QA should verify Mark reviewed, Snooze, Assign, Dismiss, and Resolve on `/leases/:leaseId/ledger`, then confirm visible statuses and active counts update without changing payment obligation values.