### PR TITLE
fix: clarify lease ledger decision workflow actions

### DIFF
--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
@@ -36,7 +36,7 @@ describe("DecisionContextPanel", () => {
     cleanup();
   });
 
-  it("renders context links, evidence, and review trail", () => {
+  it("renders context links, evidence, and review workflow trail", () => {
     render(
       <MemoryRouter>
         <DecisionContextPanel decision={baseDecision} includeAdminReviewLink />
@@ -51,7 +51,9 @@ describe("DecisionContextPanel", () => {
     expect(screen.getByText("Decision reason")).toBeInTheDocument();
     expect(screen.getByText("Rent past due date")).toBeInTheDocument();
     expect(screen.getByText("$1,450.00")).toBeInTheDocument();
-    expect(screen.getByText(/Current status:/)).toBeInTheDocument();
+    expect(screen.getByText("Review workflow trail")).toBeInTheDocument();
+    expect(screen.getByText("Tracks operational review actions only.")).toBeInTheDocument();
+    expect(screen.getByText(/Workflow status:/)).toBeInTheDocument();
     expect(screen.getByText(/Last action:/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
@@ -75,9 +75,10 @@ export function DecisionContextPanel({
       </div>
 
       <div style={{ display: "grid", gap: 4 }}>
-        <div style={{ color: "#334155", fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>Review trail</div>
+        <div style={{ color: "#334155", fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>Review workflow trail</div>
+        <div style={{ color: "#64748b", fontSize: 12 }}>Tracks operational review actions only.</div>
         <div style={{ color: "#475569", fontSize: 12 }}>
-          Current status: <strong>{decisionStatusCopy[decision.status || "detected"]}</strong>
+          Workflow status: <strong>{decisionStatusCopy[decision.status || "detected"]}</strong>
         </div>
         {latestAction ? (
           <div style={{ color: "#475569", fontSize: 12 }}>
@@ -93,4 +94,3 @@ export function DecisionContextPanel({
 }
 
 export default DecisionContextPanel;
-

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -530,7 +530,15 @@ describe("LeaseLedgerPage", () => {
 
     expect(await screen.findByText("Decisions")).toBeInTheDocument();
     expect(screen.getByText("Read-only decisions derived from detected lease and payment signals.")).toBeInTheDocument();
+    expect(
+      screen.getByText("These actions manage operational review workflow only. They do not change lease balances, payment records, or ledger history.")
+    ).toBeInTheDocument();
     expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /Mark reviewed: Marks this issue as reviewed by staff/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: /Snooze: Temporarily hides this issue until later review/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: /Assign: Assigns this review item to a team\/person/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: /Dismiss: Dismisses this signal from active review/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: /Resolve: Marks the operational review task as resolved/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Rent past due date").length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: "Lease ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-1/ledger")).toBe(true);
     expect(screen.getAllByRole("link", { name: "Harbour View · Unit 101" }).some((link) => link.getAttribute("href") === "/properties?propertyId=prop-1&unitId=unit-1")).toBe(true);
@@ -585,7 +593,7 @@ describe("LeaseLedgerPage", () => {
     );
 
     expect(await screen.findByText("Overdue Rent")).toBeInTheDocument();
-    fireEvent.click(screen.getAllByRole("button", { name: "Mark reviewed" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Mark reviewed:/ })[0]);
 
     await waitFor(() => expect(mocks.patchDecisionAction).toHaveBeenCalledWith("decision-overdue", expect.objectContaining({ actionType: "reviewed" })));
     await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledTimes(2));

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -223,12 +223,32 @@ function DecisionActionControls({
   pending: boolean;
   onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
 }) {
-  const actions: Array<{ actionType: DecisionActionType; label: string }> = [
-    { actionType: "reviewed", label: "Mark reviewed" },
-    { actionType: "snoozed", label: "Snooze" },
-    { actionType: "assigned", label: "Assign" },
-    { actionType: "dismissed", label: "Dismiss" },
-    { actionType: "resolved", label: "Resolve" },
+  const actions: Array<{ actionType: DecisionActionType; label: string; description: string }> = [
+    {
+      actionType: "reviewed",
+      label: "Mark reviewed",
+      description: "Marks this issue as reviewed by staff. Does not change balances or payment records.",
+    },
+    {
+      actionType: "snoozed",
+      label: "Snooze",
+      description: "Temporarily hides this issue until later review. Does not affect ledger or delinquency calculations.",
+    },
+    {
+      actionType: "assigned",
+      label: "Assign",
+      description: "Assigns this review item to a team/person. Does not change financial records.",
+    },
+    {
+      actionType: "dismissed",
+      label: "Dismiss",
+      description: "Dismisses this signal from active review. Does not delete ledger/payment history.",
+    },
+    {
+      actionType: "resolved",
+      label: "Resolve",
+      description: "Marks the operational review task as resolved. Does not automatically modify balances or obligations.",
+    },
   ];
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
@@ -237,6 +257,8 @@ function DecisionActionControls({
           key={action.actionType}
           type="button"
           disabled={pending}
+          title={action.description}
+          aria-label={`${action.label}: ${action.description}`}
           onClick={() => onAction(decision, action.actionType)}
           style={{ border: "1px solid #cbd5e1", background: "#fff", borderRadius: 8, padding: "6px 9px", fontWeight: 700 }}
         >
@@ -781,6 +803,9 @@ export default function LeaseLedgerPage() {
           <h2 style={{ margin: 0, fontSize: "1rem" }}>Decisions</h2>
           <div style={{ color: "#64748b", fontSize: 13, marginTop: 3 }}>
             Read-only decisions derived from detected lease and payment signals.
+          </div>
+          <div style={{ color: "#475569", fontSize: 13, marginTop: 4 }}>
+            These actions manage operational review workflow only. They do not change lease balances, payment records, or ledger history.
           </div>
         </div>
         {decisions.length === 0 ? (


### PR DESCRIPTION
## Summary

Clarifies that lease ledger decision actions manage operational review workflow only and do not change balances, payment records, obligations, or ledger history.

## UX Copy Added

- Decisions helper text: “These actions manage operational review workflow only. They do not change lease balances, payment records, or ledger history.”
- Action descriptions/tooltips for:
  - Mark reviewed
  - Snooze
  - Assign
  - Dismiss
  - Resolve
- Review trail relabeled to “Review workflow trail.”
- Status label changed from “Current status” to “Workflow status.”
- Review trail helper text: “Tracks operational review actions only.”

## Guardrails

- Frontend governance UX only.
- No backend decision action changes.
- No payment reconciliation changes.
- No payment obligation changes.
- No ledger entry or balance behavior changes.
- No CSV import, lifecycle, occupancy, or jurisdiction workflow changes.

## Tests Run

- `rentchain-frontend`: `npm run test:single -- src/pages/LeaseLedgerPage.test.tsx src/components/decisions/DecisionContextPanel.test.tsx src/pages/DashboardPage.test.tsx`
- `rentchain-frontend`: `npm run build`

## QA Notes

Preview QA should verify the lease ledger decision section copy, action tooltips/accessibility labels, and review workflow trail labels while confirming action behavior remains unchanged.