### PR TITLE
fix: separate financial and workflow status on lease ledger

### DIFF
--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -468,6 +468,13 @@ describe("LeaseLedgerPage", () => {
 
     expect(await screen.findByText("Payment obligations")).toBeInTheDocument();
     expect(screen.getByText("Read-only view of expected rent, execution records, and reconciliation evidence.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Obligation status is financial truth from payments and reconciliation. Decision workflow actions do not change these values.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Financial status" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Financial signal" })).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Status" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Delinquency" })).not.toBeInTheDocument();
     expect(screen.getAllByText("Expected").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Paid").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Outstanding").length).toBeGreaterThan(0);
@@ -503,7 +510,7 @@ describe("LeaseLedgerPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Delinquency overview")).toBeInTheDocument();
+    expect(await screen.findByText("Financial delinquency summary")).toBeInTheDocument();
     expect(screen.getByText("Read-only detection based on obligation ledger signals.")).toBeInTheDocument();
     expect(screen.getAllByText("Overdue").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Outstanding").length).toBeGreaterThan(0);
@@ -534,6 +541,14 @@ describe("LeaseLedgerPage", () => {
       screen.getByText("These actions manage operational review workflow only. They do not change lease balances, payment records, or ledger history.")
     ).toBeInTheDocument();
     expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
+    expect(screen.getAllByText("Financial signal").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Workflow status").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Workflow actions update review handling only. Financial status is derived from payments, obligations, and reconciliation evidence.").length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Active critical decisions")).toBeInTheDocument();
+    expect(screen.getByText("Active warning decisions")).toBeInTheDocument();
+    expect(screen.getByText("Active decision count")).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /Mark reviewed: Marks this issue as reviewed by staff/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: /Snooze: Temporarily hides this issue until later review/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: /Assign: Assigns this review item to a team\/person/i }).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -336,13 +336,20 @@ function DecisionRow({
   return (
     <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, background: "#fff", display: "grid", gap: 6 }}>
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <strong>{copy.label}</strong>
+      </div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <span style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Financial signal</span>
         <DecisionBadge severity={decision.severity} label={copy.badge} />
+        <span style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Workflow status</span>
         <span style={{ border: "1px solid #cbd5e1", borderRadius: 999, padding: "3px 8px", fontSize: 12, fontWeight: 800 }}>
           {decisionStatusCopy[decision.status || "detected"]}
         </span>
-        <strong>{copy.label}</strong>
       </div>
       <div style={{ color: "#475569" }}>{decision.reason}</div>
+      <div style={{ color: "#64748b", fontSize: 12 }}>
+        Workflow actions update review handling only. Financial status is derived from payments, obligations, and reconciliation evidence.
+      </div>
       {context.length ? <div style={{ color: "#64748b", fontSize: 12 }}>{context.join(" · ")}</div> : null}
       {decision.latestAction ? (
         <div style={{ color: "#64748b", fontSize: 12 }}>Last action: {decisionStatusCopy[decision.latestAction.nextStatus]}</div>
@@ -816,15 +823,15 @@ export default function LeaseLedgerPage() {
           <>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8 }}>
               <div style={{ border: "1px solid #fecaca", borderRadius: 10, padding: 10, background: "#fef2f2" }}>
-                <div style={{ fontSize: 12, color: "#991b1b" }}>Critical</div>
+                <div style={{ fontSize: 12, color: "#991b1b" }}>Active critical decisions</div>
                 <strong>{decisionSummary.critical}</strong>
               </div>
               <div style={{ border: "1px solid #fed7aa", borderRadius: 10, padding: 10, background: "#fff7ed" }}>
-                <div style={{ fontSize: 12, color: "#9a3412" }}>Warning</div>
+                <div style={{ fontSize: 12, color: "#9a3412" }}>Active warning decisions</div>
                 <strong>{decisionSummary.warning}</strong>
               </div>
               <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
-                <div style={{ fontSize: 12, color: "#64748b" }}>Active</div>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Active decision count</div>
                 <strong>{decisionSummary.total}</strong>
               </div>
             </div>
@@ -847,7 +854,7 @@ export default function LeaseLedgerPage() {
 
       <section style={{ display: "grid", gap: 10 }}>
         <div>
-          <h2 style={{ margin: 0, fontSize: "1rem" }}>Delinquency overview</h2>
+          <h2 style={{ margin: 0, fontSize: "1rem" }}>Financial delinquency summary</h2>
           <div style={{ color: "#64748b", fontSize: 13, marginTop: 3 }}>
             Read-only detection based on obligation ledger signals.
           </div>
@@ -883,6 +890,9 @@ export default function LeaseLedgerPage() {
           <div style={{ color: "#64748b", fontSize: 13, marginTop: 3 }}>
             Read-only view of expected rent, execution records, and reconciliation evidence.
           </div>
+          <div style={{ color: "#475569", fontSize: 13, marginTop: 4 }}>
+            Obligation status is financial truth from payments and reconciliation. Decision workflow actions do not change these values.
+          </div>
         </div>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 8 }}>
           <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
@@ -911,7 +921,7 @@ export default function LeaseLedgerPage() {
             <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 1080 }}>
               <thead>
                 <tr style={{ background: "#f8fafc" }}>
-                  {["Period", "Due date", "Expected", "Paid", "Outstanding", "Status", "Delinquency", "Evidence"].map((h) => (
+                  {["Period", "Due date", "Expected", "Paid", "Outstanding", "Financial status", "Financial signal", "Evidence"].map((h) => (
                     <th key={h} style={{ textAlign: "left", padding: 10, borderBottom: "1px solid #e2e8f0" }}>{h}</th>
                   ))}
                 </tr>


### PR DESCRIPTION
## Summary

Separates financial/obligation status from operational review workflow status on the lease ledger decision and payment obligation surfaces.

## Audit Summary

The lease ledger already receives separate data fields:

- `row.obligationStatus` for financial/obligation truth from payments, obligations, reconciliation, and delinquency rules.
- `decision.status` for operational review workflow state from operator actions.

The issue was presentation: the payment obligations table used generic `Status` / `Delinquency` labels, and decision cards placed financial signal badges next to workflow status without naming the distinction.

## UI Labels / Copy Changed

- Payment obligations table column `Status` is now `Financial status`.
- Payment obligations table column `Delinquency` is now `Financial signal`.
- Delinquency section title is now `Financial delinquency summary`.
- Payment obligations helper copy now states obligation status is financial truth and decision workflow actions do not change it.
- Decision cards now show separate labels for:
  - `Financial signal`
  - `Workflow status`
- Decision cards now state: “Workflow actions update review handling only. Financial status is derived from payments, obligations, and reconciliation evidence.”
- Decision summary cards now use `Active critical decisions`, `Active warning decisions`, and `Active decision count`.

## Guardrails

- Frontend UI copy/label changes only.
- No backend decision action changes.
- No payment reconciliation changes.
- No obligation derivation changes.
- No ledger entry or balance behavior changes.
- No CSV import, lifecycle, occupancy, or jurisdiction workflow changes.

## Tests Run

- `rentchain-frontend`: `npm run test:single -- src/pages/LeaseLedgerPage.test.tsx src/components/decisions/DecisionContextPanel.test.tsx src/pages/DashboardPage.test.tsx`
- `rentchain-frontend`: `npm run build`

## QA Notes

Preview QA should verify `/leases/:leaseId/ledger` clearly distinguishes financial status from workflow status, and that decision actions still do not change payment obligations, balances, ledger entries, or payment records.

## Known Follow-ups

- Next planned mission: `fix/tenant-document-workspace-lease-linkage-v1`.