### PR TITLE
fix: normalize tenant workspace lease document linkage

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -860,6 +860,153 @@ describe("tenantPortalRoutes foundation", () => {
     );
   });
 
+  it("links tenant lease workspace to generated unsigned lease package attachments", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "ready_for_signature",
+      documentUrl: null,
+      approvedDocumentUrl: null,
+      documentRef: null,
+      tenantSignature: null,
+      landlordSignature: null,
+    });
+    ensureCollection("ledgerAttachments").set("lease-generated-current", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      ledgerItemId: "lease-1",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.com/generated-current.pdf",
+      createdAt: 900,
+      source: "lease_pdf_generation",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.documentUrl).toBe("https://example.com/generated-current.pdf");
+    expect(res.body?.data?.leasePdfStatus).toBe("available");
+    expect(res.body?.data?.leaseDocumentContext).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        documentStatus: "generated",
+        documentUrl: "https://example.com/generated-current.pdf",
+        displayLabel: "Generated lease package",
+        source: "ledgerAttachments",
+        confidence: "high",
+      })
+    );
+  });
+
+  it("prefers the current active lease document over an archived tenant lease reference", async () => {
+    ensureCollection("tenants").set("tenant-1", {
+      ...(ensureCollection("tenants").get("tenant-1") || {}),
+      leaseId: "archived-lease",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+    });
+    ensureCollection("leases").set("archived-lease", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "archived",
+      documentUrl: "https://example.com/archived.pdf",
+      updatedAt: 1000,
+    });
+    ensureCollection("leases").set("active-lease", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2026-06-01",
+      endDate: "2027-05-31",
+      monthlyRent: 1800,
+      documentUrl: "https://example.com/current.pdf",
+      updatedAt: 500,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.leaseId).toBe("active-lease");
+    expect(res.body?.data?.documentUrl).toBe("https://example.com/current.pdf");
+    expect(res.body?.data?.leaseDocumentContext?.documentUrl).toBe("https://example.com/current.pdf");
+  });
+
+  it("does not expose another tenant's lease attachment as current lease document", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "ready_for_signature",
+      documentUrl: null,
+      approvedDocumentUrl: null,
+      documentRef: null,
+    });
+    ensureCollection("ledgerAttachments").set("lease-generated-other-tenant", {
+      tenantId: "tenant-2",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      ledgerItemId: "lease-1",
+      title: "Lease document",
+      fileName: "schedule-a-v1.pdf",
+      category: "Lease",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      url: "https://example.com/other-tenant.pdf",
+      createdAt: 900,
+      source: "lease_pdf_generation",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(res.body)).not.toContain("other-tenant.pdf");
+    expect(res.body?.data?.leaseDocumentContext?.documentStatus).toBe("pending");
+  });
+
   it("creates a tenant rent payment checkout only for an eligible enabled lease", async () => {
     ensureCollection("leases").set("lease-1", {
       ...(ensureCollection("leases").get("lease-1") || {}),
@@ -2971,8 +3118,8 @@ describe("tenantPortalRoutes foundation", () => {
         expect.objectContaining({
           label: "LEASE — Lease",
           category: "Lease",
-          fileName: "schedule-a-v1.pdf",
-          url: "https://example.com/generated-lease.pdf",
+          fileName: "signed-lease.pdf",
+          url: "https://example.com/lease.pdf",
         }),
       ])
     );
@@ -2993,6 +3140,20 @@ describe("tenantPortalRoutes foundation", () => {
   });
 
   it("dedupes duplicate visible Lease attachments in the tenant document vault", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "ready_for_signature",
+      documentUrl: null,
+      approvedDocumentUrl: null,
+      documentRef: null,
+      tenantSignature: null,
+      landlordSignature: null,
+      tenantSignedAt: null,
+      landlordSignedAt: null,
+      fullyExecutedAt: null,
+      fullySignedAt: null,
+      signatureCompletedAt: null,
+    });
     ensureCollection("ledgerAttachments").set("lease-generated-draft-only", {
       tenantId: "tenant-1",
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2308,6 +2308,51 @@ async function queryFirstApplicationDocument(field: string, value: string | null
   return null;
 }
 
+function leaseSelectionRank(record: { id: string; data: any }): number {
+  const status = String(record.data?.status || "").trim().toLowerCase();
+  const archived = Boolean(record.data?.archivedAt || record.data?.deletedAt) || ["archived", "past", "ended", "inactive", "void"].includes(status);
+  if (archived) return -100;
+  if (["active", "current", "signed", "fully_executed"].includes(status)) return 100;
+  if (["sent", "awaiting_tenant_signature", "pending_tenant_signature", "ready_for_signature", "lease_sent"].includes(status)) return 80;
+  if (["draft", "pending", "lease_pending"].includes(status)) return 50;
+  return 20;
+}
+
+async function findBestTenantLease(params: {
+  current: { id: string; data: any } | null;
+  tenantId: string | null;
+  propertyId: string | null;
+}) {
+  const tenantId = String(params.tenantId || "").trim();
+  const propertyId = String(params.propertyId || "").trim();
+  const candidates = new Map<string, { id: string; data: any }>();
+  if (params.current?.id) candidates.set(params.current.id, params.current);
+  if (tenantId) {
+    for (const query of [
+      () => db.collection("leases").where("tenantId", "==", tenantId).limit(20).get(),
+      () => db.collection("leases").where("tenantIds", "array-contains", tenantId).limit(20).get(),
+    ]) {
+      try {
+        const snap = await query();
+        snap.docs.forEach((doc) => candidates.set(doc.id, { id: doc.id, data: doc.data() as any }));
+      } catch {
+        // Keep the explicitly linked lease if one of the compatibility queries is unavailable.
+      }
+    }
+  }
+
+  const ranked = Array.from(candidates.values())
+    .filter((candidate) => !propertyId || String(candidate.data?.propertyId || "").trim() === propertyId)
+    .filter((candidate) => !tenantId || leaseHasTenant(candidate.data, tenantId))
+    .sort((left, right) => {
+      const rankDelta = leaseSelectionRank(right) - leaseSelectionRank(left);
+      if (rankDelta !== 0) return rankDelta;
+      return timestampToSort(right.data?.updatedAt || right.data?.createdAt) - timestampToSort(left.data?.updatedAt || left.data?.createdAt);
+    });
+
+  return ranked[0] || params.current;
+}
+
 async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolveTenancyContext>>) {
   const propertyDoc = await loadDocument("properties", context.propertyId);
 
@@ -2329,30 +2374,7 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
   }
 
   let leaseDoc = await loadDocument("leases", context.leaseId);
-  if (!leaseDoc && context.tenantId) {
-    try {
-      const directSnap = await db.collection("leases").where("tenantId", "==", context.tenantId).limit(5).get();
-      const directMatch = directSnap.docs.find((doc) => {
-        const data = doc.data() as any;
-        return String(data?.propertyId || "") === String(context.propertyId || "");
-      });
-      if (directMatch) leaseDoc = { id: directMatch.id, data: directMatch.data() as any };
-    } catch {
-      leaseDoc = null;
-    }
-  }
-  if (!leaseDoc && context.tenantId) {
-    try {
-      const snap = await db.collection("leases").where("tenantIds", "array-contains", context.tenantId).limit(5).get();
-      const match = snap.docs.find((doc) => {
-        const data = doc.data() as any;
-        return String(data?.propertyId || "") === String(context.propertyId || "");
-      });
-      if (match) leaseDoc = { id: match.id, data: match.data() as any };
-    } catch {
-      leaseDoc = null;
-    }
-  }
+  leaseDoc = await findBestTenantLease({ current: leaseDoc, tenantId: context.tenantId, propertyId: context.propertyId });
 
   const maintenanceItems: Array<{ id: string; data: any }> = [];
   if (context.tenantId) {
@@ -2368,7 +2390,24 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
     }
   }
 
-  const lease = leaseDoc ? projectTenantLease(leaseDoc.id, leaseDoc.data) : null;
+  const leaseDocumentContext = leaseDoc
+    ? await getTenantLeaseDocumentContext({
+        leaseId: leaseDoc.id,
+        tenantId: context.tenantId,
+        propertyId: String(leaseDoc.data?.propertyId || context.propertyId || "").trim() || null,
+        unitId: String(leaseDoc.data?.unitId || context.unitId || "").trim() || null,
+        leaseData: leaseDoc.data,
+      })
+    : null;
+  const leaseProjectionData =
+    leaseDoc && leaseDocumentContext?.documentUrl
+      ? {
+          ...leaseDoc.data,
+          documentUrl: leaseDocumentContext.documentUrl,
+          approvedDocumentUrl: leaseDocumentContext.documentUrl,
+        }
+      : leaseDoc?.data;
+  const lease = leaseDoc ? projectTenantLease(leaseDoc.id, leaseProjectionData) : null;
   const rentPaymentSummary = lease
     ? (
         await buildLeasePaymentProjection({
@@ -2396,7 +2435,7 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
   return {
     property: propertyDoc ? projectTenantProperty(propertyDoc.id, propertyDoc.data) : null,
     application: applicationDoc ? projectTenantApplication(applicationDoc.id, applicationDoc.data) : null,
-    lease: lease ? { ...lease, rentPaymentSummary } : null,
+    lease: lease ? { ...lease, leaseDocumentContext, rentPaymentSummary } : null,
     maintenance: maintenanceItems
       .map((item) => projectTenantMaintenance(item.id, item.data))
       .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0)),
@@ -2727,6 +2766,37 @@ function shapeTenantProfileResponse(profile: Awaited<ReturnType<typeof loadTenan
   };
 }
 
+async function withTenantLeaseDocumentContext(profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>) {
+  const lease = profile?.profile?.lease;
+  const leaseId = String(lease?.leaseId || profile?.context?.leaseId || "").trim();
+  const tenantId = String(profile?.context?.tenantId || "").trim();
+  if (!leaseId || !tenantId) return profile;
+  const leaseSnap = await db.collection("leases").doc(leaseId).get();
+  if (!leaseSnap.exists) return profile;
+  const leaseData = leaseSnap.data() as any;
+  const leaseDocumentContext = await getTenantLeaseDocumentContext({
+    leaseId,
+    tenantId,
+    propertyId: String(profile?.context?.propertyId || leaseData?.propertyId || "").trim() || null,
+    unitId: String(profile?.context?.unitId || leaseData?.unitId || "").trim() || null,
+    leaseData,
+  });
+  const nextLease = leaseDocumentContext.documentUrl
+    ? projectTenantLease(leaseId, {
+        ...leaseData,
+        documentUrl: leaseDocumentContext.documentUrl,
+        approvedDocumentUrl: leaseDocumentContext.documentUrl,
+      })
+    : lease;
+  return {
+    ...profile,
+    profile: {
+      ...profile.profile,
+      lease: nextLease ? { ...nextLease, leaseDocumentContext } : lease,
+    },
+  };
+}
+
 function normalizeDocumentKey(value: unknown): string {
   return String(value || "")
     .trim()
@@ -2839,12 +2909,281 @@ function dedupeTenantVisibleLeaseAttachments(attachments: any[]): any[] {
   return output;
 }
 
+type TenantLeaseDocumentContext = {
+  leaseId?: string;
+  tenantId?: string;
+  propertyId?: string;
+  unitId?: string;
+  leaseStatus?: string;
+  signingStatus?: string;
+  documentStatus: "signed" | "generated" | "pending" | "missing";
+  documentId?: string;
+  documentUrl?: string;
+  displayLabel: string;
+  source: string;
+  confidence: "high" | "medium" | "low";
+  warnings: string[];
+};
+
+function firstLeaseDocumentUrl(raw: any, fields: string[]): string | null {
+  for (const field of fields) {
+    const value = String(raw?.[field] || "").trim();
+    if (value.startsWith("https://")) return value;
+  }
+  return null;
+}
+
+function leaseHasTenant(raw: any, tenantId: string): boolean {
+  const normalizedTenantId = String(tenantId || "").trim();
+  if (!normalizedTenantId) return false;
+  if (String(raw?.tenantId || "").trim() === normalizedTenantId) return true;
+  if (String(raw?.primaryTenantId || "").trim() === normalizedTenantId) return true;
+  return Array.isArray(raw?.tenantIds) && raw.tenantIds.map((value: any) => String(value || "").trim()).includes(normalizedTenantId);
+}
+
+function isLeaseSigned(raw: any): boolean {
+  const status = String(raw?.status || "").trim().toLowerCase();
+  return Boolean(
+    raw?.fullyExecutedAt ||
+      raw?.fullySignedAt ||
+      raw?.signatureCompletedAt ||
+      (raw?.tenantSignature?.signedAt && raw?.landlordSignature?.signedAt) ||
+      (raw?.tenantSignedAt && raw?.landlordSignedAt) ||
+      ["signed", "executed", "fully_executed"].includes(status)
+  );
+}
+
+function isLeaseDocumentWorkflowPending(raw: any): boolean {
+  const status = String(raw?.status || "").trim().toLowerCase();
+  const documentStatus = String(raw?.documentStatus || raw?.leaseDocumentStatus || raw?.pdfStatus || raw?.generationStatus || "")
+    .trim()
+    .toLowerCase();
+  return Boolean(
+    raw?.documentGeneratedAt ||
+      raw?.documentPreparedAt ||
+      raw?.leaseDocumentGeneratedAt ||
+      raw?.leaseDocumentPreparedAt ||
+      raw?.pdfGeneratedAt ||
+      raw?.scheduleAGeneratedAt ||
+      ["sent", "awaiting_tenant_signature", "pending_tenant_signature", "ready_for_signature", "signature_requested"].includes(status) ||
+      ["pending", "preparing", "generating", "generated", "ready_for_review", "review_pending"].includes(documentStatus)
+  );
+}
+
+function bestTenantLeaseAttachment(params: {
+  attachments: any[];
+  leaseId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+}) {
+  const leaseId = String(params.leaseId || "").trim();
+  const propertyId = String(params.propertyId || "").trim();
+  const unitId = String(params.unitId || "").trim();
+
+  const candidates = (Array.isArray(params.attachments) ? params.attachments : [])
+    .filter((item) => isVisibleLeaseDocumentAttachment(item) && String(item?.url || "").trim().startsWith("https://"))
+    .map((item) => {
+      const candidateLeaseId = String(item?.leaseId || "").trim();
+      const candidateLedgerItemId = String(item?.ledgerItemId || "").trim();
+      const candidatePropertyId = String(item?.propertyId || "").trim();
+      const candidateUnitId = String(item?.unitId || "").trim();
+      const exactLease = leaseId && (candidateLeaseId === leaseId || candidateLedgerItemId === leaseId) ? 4 : 0;
+      const propertyMatch = propertyId && candidatePropertyId === propertyId ? 2 : 0;
+      const unitMatch = unitId && candidateUnitId === unitId ? 1 : 0;
+      return {
+        item,
+        score: exactLease + propertyMatch + unitMatch,
+        createdAt: Number(item?.createdAt || 0) || 0,
+      };
+    })
+    .filter((entry) => entry.score > 0 || !leaseId);
+
+  candidates.sort((left, right) => right.score - left.score || right.createdAt - left.createdAt);
+  return candidates[0]?.item || null;
+}
+
+async function loadTenantLeaseAttachments(tenantId: string): Promise<any[]> {
+  const normalizedTenantId = String(tenantId || "").trim();
+  if (!normalizedTenantId) return [];
+  const snap = await db.collection("ledgerAttachments").where("tenantId", "==", normalizedTenantId).limit(50).get();
+  return snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
+}
+
+async function getTenantLeaseDocumentContext(params: {
+  leaseId: string | null;
+  tenantId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  leaseData: any;
+  attachments?: any[];
+}): Promise<TenantLeaseDocumentContext> {
+  const leaseId = String(params.leaseId || "").trim();
+  const tenantId = String(params.tenantId || "").trim();
+  const propertyId = String(params.propertyId || params.leaseData?.propertyId || "").trim();
+  const unitId = String(params.unitId || params.leaseData?.unitId || params.leaseData?.unit || "").trim();
+  const leaseStatus = String(params.leaseData?.status || "").trim() || undefined;
+  const warnings: string[] = [];
+
+  if (!leaseId || !params.leaseData) {
+    return {
+      tenantId: tenantId || undefined,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      documentStatus: "missing",
+      displayLabel: "No lease document available yet",
+      source: "missing_lease",
+      confidence: "low",
+      warnings: ["No current lease record is available for this tenant workspace."],
+    };
+  }
+
+  if (tenantId && !leaseHasTenant(params.leaseData, tenantId)) {
+    return {
+      leaseId,
+      tenantId,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      documentStatus: "missing",
+      displayLabel: "No lease document available yet",
+      source: "tenant_mismatch",
+      confidence: "low",
+      warnings: ["The visible lease record is not linked to this tenant workspace."],
+    };
+  }
+
+  const signed = isLeaseSigned(params.leaseData);
+  const signedUrl = firstLeaseDocumentUrl(params.leaseData, [
+    "signedDocumentUrl",
+    "signedLeaseDocumentUrl",
+    "executedDocumentUrl",
+    "finalDocumentUrl",
+    "fullyExecutedDocumentUrl",
+    "documentUrl",
+    "approvedDocumentUrl",
+    "documentRef",
+  ]);
+  if (signed && signedUrl) {
+    return {
+      leaseId,
+      tenantId: tenantId || undefined,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      signingStatus: "signed",
+      documentStatus: "signed",
+      documentId: String(params.leaseData?.signedDocumentId || params.leaseData?.documentId || params.leaseData?.latestLeaseSnapshotId || "").trim() || undefined,
+      documentUrl: signedUrl,
+      displayLabel: "Signed lease document",
+      source: "lease_signed_document",
+      confidence: "high",
+      warnings,
+    };
+  }
+
+  const generatedUrl = firstLeaseDocumentUrl(params.leaseData, ["documentUrl", "approvedDocumentUrl", "documentRef"]);
+  if (generatedUrl) {
+    return {
+      leaseId,
+      tenantId: tenantId || undefined,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      signingStatus: signed ? "signed" : "unsigned",
+      documentStatus: signed ? "signed" : "generated",
+      documentId: String(params.leaseData?.documentId || params.leaseData?.latestLeaseSnapshotId || "").trim() || undefined,
+      documentUrl: generatedUrl,
+      displayLabel: signed ? "Signed lease document" : "Generated lease package",
+      source: "lease_document_fields",
+      confidence: "high",
+      warnings,
+    };
+  }
+
+  const attachments = params.attachments || (tenantId ? await loadTenantLeaseAttachments(tenantId) : []);
+  const attachment = bestTenantLeaseAttachment({ attachments, leaseId, propertyId, unitId });
+  if (attachment) {
+    return {
+      leaseId,
+      tenantId: tenantId || undefined,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      signingStatus: signed ? "signed" : "unsigned",
+      documentStatus: signed ? "signed" : "generated",
+      documentId: String(attachment?.id || "").trim() || undefined,
+      documentUrl: String(attachment.url || "").trim(),
+      displayLabel: signed ? "Signed lease document" : "Generated lease package",
+      source: "ledgerAttachments",
+      confidence: "high",
+      warnings,
+    };
+  }
+
+  if (isLeaseDocumentWorkflowPending(params.leaseData)) {
+    return {
+      leaseId,
+      tenantId: tenantId || undefined,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      signingStatus: signed ? "signed" : "unsigned",
+      documentStatus: "pending",
+      displayLabel: "Lease document pending",
+      source: "lease_document_workflow",
+      confidence: "medium",
+      warnings: ["A lease workflow is visible, but no tenant-safe document link is available yet."],
+    };
+  }
+
+  return {
+    leaseId,
+    tenantId: tenantId || undefined,
+    propertyId: propertyId || undefined,
+    unitId: unitId || undefined,
+    leaseStatus,
+    signingStatus: signed ? "signed" : "unsigned",
+    documentStatus: "missing",
+    displayLabel: "No lease document available yet",
+    source: "missing_document",
+    confidence: "medium",
+    warnings: ["No tenant-safe lease document link is available yet."],
+  };
+}
+
 function buildTenantDocumentWorkspace(params: {
   attachments: Array<any>;
   profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>;
+  leaseDocumentContext?: TenantLeaseDocumentContext | null;
 }) {
   const checklist = Array.isArray(params.profile?.identity?.documentChecklist) ? params.profile.identity.documentChecklist : [];
-  const attachments = dedupeTenantVisibleLeaseAttachments(Array.isArray(params.attachments) ? params.attachments : []);
+  const leaseDocumentContext = params.leaseDocumentContext || null;
+  const contextAttachment =
+    leaseDocumentContext?.documentUrl &&
+    leaseDocumentContext.documentStatus !== "missing" &&
+    leaseDocumentContext.source !== "ledgerAttachments"
+      ? {
+          id: leaseDocumentContext.documentId || `lease-document-context-${leaseDocumentContext.leaseId || "current"}`,
+          tenantId: leaseDocumentContext.tenantId || null,
+          leaseId: leaseDocumentContext.leaseId || null,
+          propertyId: leaseDocumentContext.propertyId || null,
+          unitId: leaseDocumentContext.unitId || null,
+          ledgerItemId: leaseDocumentContext.leaseId || null,
+          title: leaseDocumentContext.displayLabel,
+          fileName: leaseDocumentContext.documentStatus === "signed" ? "signed-lease.pdf" : "lease-package.pdf",
+          category: "Lease",
+          purpose: "LEASE",
+          purposeLabel: "Lease",
+          url: leaseDocumentContext.documentUrl,
+          createdAt: 0,
+          source: leaseDocumentContext.source,
+        }
+      : null;
+  const attachments = dedupeTenantVisibleLeaseAttachments([
+    ...(contextAttachment ? [contextAttachment] : []),
+    ...(Array.isArray(params.attachments) ? params.attachments : []),
+  ]);
 
   const normalizedAttachmentMap = new Map<string, any[]>();
   attachments.forEach((item) => {
@@ -4105,11 +4444,11 @@ router.get("/profile", requireTenantWorkspaceIdentity, async (req: any, res) => 
   if (!context) return;
 
   try {
-    const profile = await loadTenantProfileProjection({
+    const profile = await withTenantLeaseDocumentContext(await loadTenantProfileProjection({
       context,
       userId: String(req.user?.id || "").trim(),
       userEmail: String(req.user?.email || "").trim() || null,
-    });
+    }));
 
     await recordTenantEvent({
       eventType: "tenant_profile_viewed",
@@ -6349,29 +6688,32 @@ router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res)
     const tenantId = String(context.tenantId || "").trim();
     if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
 
-    const [snap, profile] = await Promise.all([
+    const [snap, profile, workspaceData] = await Promise.all([
       db.collection("ledgerAttachments").where("tenantId", "==", tenantId).limit(50).get(),
       loadTenantProfileProjection({
         context,
         userId: String(req.user?.id || "").trim(),
         userEmail: String(req.user?.email || "").trim() || null,
-      }),
+      }).then((profile) => withTenantLeaseDocumentContext(profile)),
+      loadTenantWorkspaceData(context),
     ]);
 
     const rawAttachments = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
     rawAttachments.sort((a, b) => (Number(b.createdAt || 0) || 0) - (Number(a.createdAt || 0) || 0));
 
-    const workspace = buildTenantDocumentWorkspace({
+    const documentWorkspace = buildTenantDocumentWorkspace({
       attachments: rawAttachments,
       profile,
+      leaseDocumentContext: workspaceData.lease?.leaseDocumentContext || (profile.profile?.lease as any)?.leaseDocumentContext || null,
     });
 
     return res.json({
       ok: true,
-      data: workspace.items,
-      summary: workspace.summary,
-      guidance: workspace.guidance,
-      updatedAt: workspace.updatedAt,
+      data: documentWorkspace.items,
+      summary: documentWorkspace.summary,
+      guidance: documentWorkspace.guidance,
+      updatedAt: documentWorkspace.updatedAt,
+      leaseDocumentContext: workspaceData.lease?.leaseDocumentContext || (profile.profile?.lease as any)?.leaseDocumentContext || null,
     });
   } catch (err) {
     console.error("[tenant/attachments] failed", {
@@ -6430,20 +6772,14 @@ router.get("/lease", requireTenant, async (req: any, res) => {
         leaseRecord = leaseSnap.data() as any;
       }
     }
-    if (!leaseRecord) {
-      const leaseSnap = await db.collection("leases").where("tenantId", "==", tenantId).limit(20).get();
-      const ranked = leaseSnap.docs
-        .map((doc) => ({ id: doc.id, ...(doc.data() as any) }))
-        .sort((a, b) => {
-          const aActive = ["signed", "active", "current"].includes(String(a?.status || "").toLowerCase()) ? 1 : 0;
-          const bActive = ["signed", "active", "current"].includes(String(b?.status || "").toLowerCase()) ? 1 : 0;
-          if (aActive !== bActive) return bActive - aActive;
-          return Number(b?.updatedAt || b?.createdAt || 0) - Number(a?.updatedAt || a?.createdAt || 0);
-        });
-      if (ranked.length > 0) {
-        leaseRecord = ranked[0];
-        leaseId = leaseId || String(leaseRecord.id || "").trim() || null;
-      }
+    const bestLease = await findBestTenantLease({
+      current: leaseRecord && leaseId ? { id: leaseId, data: leaseRecord } : null,
+      tenantId,
+      propertyId,
+    });
+    if (bestLease) {
+      leaseRecord = bestLease.data;
+      leaseId = bestLease.id;
     }
 
     propertyId = propertyId || String(leaseRecord?.propertyId || "").trim() || null;
@@ -6473,9 +6809,25 @@ router.get("/lease", requireTenant, async (req: any, res) => {
       }
     }
 
+    const leaseDocumentContext =
+      leaseId && leaseRecord
+        ? await getTenantLeaseDocumentContext({
+            leaseId,
+            tenantId,
+            propertyId,
+            unitId,
+            leaseData: leaseRecord,
+          })
+        : null;
     const projectedLease = leaseId
       ? projectTenantLease(leaseId, {
           ...(leaseRecord || {}),
+          ...(leaseDocumentContext?.documentUrl
+            ? {
+                documentUrl: leaseDocumentContext.documentUrl,
+                approvedDocumentUrl: leaseDocumentContext.documentUrl,
+              }
+            : {}),
           startDate: leaseRecord?.startDate || leaseRecord?.leaseStart || tenantData?.leaseStart || tenantData?.leaseStartDate || null,
           endDate: leaseRecord?.endDate || tenantData?.leaseEnd || null,
           monthlyRent:
@@ -6534,6 +6886,7 @@ router.get("/lease", requireTenant, async (req: any, res) => {
       rentAmount: projectedLease?.monthlyRent ?? null,
       leaseStart: projectedLease?.startDate ?? null,
       leaseEnd: projectedLease?.endDate ?? null,
+      leaseDocumentContext,
     };
 
     return res.json({ ok: true, data: lease, lease, ...lease });

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -45,6 +45,7 @@ export type TenantWorkspaceLease = {
   dueDay?: number | null;
   status: string | null;
   documentUrl: string | null;
+  leaseDocumentContext?: TenantLeaseDocumentContext | null;
   signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
   signatureReadinessLabel?: string | null;
   signatureReadinessDescription?: string | null;
@@ -105,6 +106,22 @@ export type TenantWorkspaceLease = {
     } | null;
     paymentExperience: PaymentExperience;
   } | null;
+};
+
+export type TenantLeaseDocumentContext = {
+  leaseId?: string | null;
+  tenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  leaseStatus?: string | null;
+  signingStatus?: string | null;
+  documentStatus: "signed" | "generated" | "pending" | "missing";
+  documentId?: string | null;
+  documentUrl?: string | null;
+  displayLabel: string;
+  source: string;
+  confidence: "high" | "medium" | "low";
+  warnings: string[];
 };
 
 export type RentPaymentHistoryItem = {

--- a/rentchain-frontend/src/api/tenantPortalApi.ts
+++ b/rentchain-frontend/src/api/tenantPortalApi.ts
@@ -22,6 +22,7 @@ export interface TenantLease {
   leaseEnd: string | null;
   status: string | null;
   documentUrl?: string | null;
+  leaseDocumentContext?: TenantLeaseDocumentContext | null;
   signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
   signatureReadinessLabel?: string | null;
   signatureReadinessDescription?: string | null;
@@ -73,6 +74,22 @@ export interface TenantLease {
       storedPaymentMethod: false;
     };
   } | null;
+}
+
+export interface TenantLeaseDocumentContext {
+  leaseId?: string | null;
+  tenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  leaseStatus?: string | null;
+  signingStatus?: string | null;
+  documentStatus: "signed" | "generated" | "pending" | "missing";
+  documentId?: string | null;
+  documentUrl?: string | null;
+  displayLabel: string;
+  source: string;
+  confidence: "high" | "medium" | "low";
+  warnings: string[];
 }
 
 export interface TenantPayment {

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -197,7 +197,10 @@ describe("TenantsPage", () => {
     expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send tenant invite" })).toBeInTheDocument();
     expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("lease-1").length).toBeGreaterThan(0);
+    const leaseLinks = screen.getAllByRole("link", { name: "Main Street · Unit 4 · Lease" });
+    expect(leaseLinks.length).toBeGreaterThan(0);
+    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.getByText("Lease ledger")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View ledger" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Record payment" })).toBeEnabled();
@@ -250,7 +253,10 @@ describe("TenantsPage", () => {
     );
 
     expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
-    expect(screen.getAllByText("lease-active-1").length).toBeGreaterThan(0);
+    const leaseLinks = screen.getAllByRole("link", { name: "Main Street · Unit 4 · Lease" });
+    expect(leaseLinks.length).toBeGreaterThan(0);
+    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-active-1/summary");
+    expect(screen.queryByText("lease-active-1")).not.toBeInTheDocument();
     expect(screen.queryByText("No current lease linked")).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useToast } from "../components/ui/ToastProvider";
 import { useAuth } from "../context/useAuth";
 import { TenantDetailPanel } from "../components/tenants/TenantDetailPanel";
@@ -152,12 +152,17 @@ function describeTenantLinkage(
   const primaryProperty = tenant.propertyName || tenant.propertyId || "No property linked";
   const primaryUnit = tenant.unit || tenant.unitLabel || tenant.unitId || "No unit linked";
   const currentLeaseId = String(currentLease?.id || tenant.currentLeaseId || "").trim();
-  const leaseState = currentLeaseId || "No current lease linked";
+  const leaseLabel = currentLeaseId
+    ? [primaryProperty !== "No property linked" ? primaryProperty : null, primaryUnit !== "No unit linked" ? primaryUnit : null, "Lease"]
+        .filter(Boolean)
+        .join(" · ")
+    : "No current lease linked";
 
   return {
     propertyLabel: primaryProperty,
     unitLabel: primaryUnit,
-    leaseLabel: leaseState,
+    leaseLabel,
+    leaseId: currentLeaseId || null,
     activeTenancyCount: activeTenancies.length,
     linkageNote:
       !tenant.propertyId && !tenant.unitId && !currentLeaseId
@@ -470,6 +475,9 @@ const loadTenants = useCallback(async () => {
     : null;
   const selectedLeaseLedgerPath = selectedCurrentLeaseId
     ? `/leases/${encodeURIComponent(selectedCurrentLeaseId)}/ledger`
+    : null;
+  const selectedLeaseSummaryPath = selectedCurrentLeaseId
+    ? `/leases/${encodeURIComponent(selectedCurrentLeaseId)}/summary`
     : null;
 
   const filteredTenants = useMemo(() => {
@@ -957,7 +965,13 @@ const loadTenants = useCallback(async () => {
                       <Card>
                         <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Current lease link</div>
                         <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
-                          {selectedTenantLinkage.leaseLabel}
+                          {selectedLeaseSummaryPath ? (
+                            <Link to={selectedLeaseSummaryPath} style={{ fontWeight: 700, color: "#2563eb" }}>
+                              {selectedTenantLinkage.leaseLabel}
+                            </Link>
+                          ) : (
+                            selectedTenantLinkage.leaseLabel
+                          )}
                         </div>
                       </Card>
                       <Card>
@@ -1041,7 +1055,13 @@ const loadTenants = useCallback(async () => {
                         <div>
                           <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Current lease</div>
                           <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
-                            {selectedTenantLinkage.leaseLabel}
+                            {selectedLeaseSummaryPath ? (
+                              <Link to={selectedLeaseSummaryPath} style={{ fontWeight: 700, color: "#2563eb" }}>
+                                {selectedTenantLinkage.leaseLabel}
+                              </Link>
+                            ) : (
+                              selectedTenantLinkage.leaseLabel
+                            )}
                           </div>
                         </div>
                       </div>

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -102,6 +102,10 @@ export default function TenantLeasePage() {
   }
 
   const execution = data?.leaseExecution || null;
+  const leaseDocumentContext = data?.leaseDocumentContext || null;
+  const leaseDocumentUrl = leaseDocumentContext?.documentUrl || data?.documentUrl || null;
+  const leaseDocumentLabel = leaseDocumentContext?.displayLabel || data?.leasePdfLabel || null;
+  const leaseDocumentWarnings = Array.isArray(leaseDocumentContext?.warnings) ? leaseDocumentContext.warnings : [];
   const paymentReadiness = data?.paymentReadiness || null;
   const paymentSummary = rentPaymentDetails || data?.rentPaymentSummary || null;
   const latestPaymentStatus =
@@ -310,16 +314,24 @@ export default function TenantLeasePage() {
           ) : null}
 
           <TenantInfoCard heading="Lease Document" accent="#0f766e">
-            {data.leasePdfLabel ? (
+            {leaseDocumentLabel ? (
               <div style={{ display: "grid", gap: 6 }}>
-                <div style={{ fontWeight: 800 }}>{data.leasePdfLabel}</div>
+                <div style={{ fontWeight: 800 }}>{leaseDocumentLabel}</div>
                 {data.leasePdfDescription ? (
                   <div style={{ color: "var(--text-muted, #64748b)" }}>{data.leasePdfDescription}</div>
                 ) : null}
+                {leaseDocumentContext?.documentStatus ? (
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>
+                    Document status: {prettyStatus(leaseDocumentContext.documentStatus)}
+                  </div>
+                ) : null}
+                {leaseDocumentWarnings.length > 0 ? (
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>{leaseDocumentWarnings[0]}</div>
+                ) : null}
               </div>
             ) : null}
-            {data.documentUrl ? (
-              <a href={data.documentUrl} target="_blank" rel="noreferrer">
+            {leaseDocumentUrl ? (
+              <a href={leaseDocumentUrl} target="_blank" rel="noreferrer">
                 Open lease document
               </a>
             ) : (

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -323,7 +323,9 @@ export default function TenantProfilePage() {
               { label: "Lease end", value: formatDate(data?.profile?.lease?.endDate) },
               {
                 label: "Lease document",
-                value: data?.profile?.lease?.documentUrl ? "Available" : "Not shared yet",
+                value:
+                  data?.profile?.lease?.leaseDocumentContext?.displayLabel ||
+                  (data?.profile?.lease?.documentUrl ? "Available" : "Not shared yet"),
               },
             ]}
           />

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2165,6 +2165,21 @@ describe("tenant workspace frontend shell", () => {
       monthlyRent: 1800,
       status: "active",
       documentUrl: "https://example.com/lease.pdf",
+      leaseDocumentContext: {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        leaseStatus: "active",
+        signingStatus: "signed",
+        documentStatus: "signed",
+        documentId: "snapshot-1",
+        documentUrl: "https://example.com/lease.pdf",
+        displayLabel: "Signed lease document",
+        source: "lease_signed_document",
+        confidence: "high",
+        warnings: [],
+      },
       signatureStatus: "signed",
       signatureReadinessLabel: "Lease signing complete",
       signatureReadinessDescription: "The visible lease record shows the current signing stage as complete.",
@@ -2225,7 +2240,8 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText(/^Lease Summary$/i)).toBeInTheDocument();
     expect(screen.getByText(/\$1,800/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease signing complete$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Lease document available$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Signed lease document$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Document status: Signed/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease fully executed$/i)).toBeInTheDocument();
     expect(screen.getByText(/Rent terms ready for future setup/i)).toBeInTheDocument();
     expect(screen.getByText(/Payment processed by Stripe\. RentChain does not store card or bank payment details\./i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -1012,8 +1012,14 @@ export default function TenantWorkspacePage() {
           <TenantKeyValueGrid
             rows={[
               { label: "Status", value: activeTenancy.label },
-              { label: "Lease reference", value: data?.lease?.leaseId || "Not visible yet" },
+              { label: "Internal Lease ID", value: data?.lease?.leaseId || "Not visible yet" },
               { label: "Lease status", value: prettyStatus(data?.lease?.status) },
+              {
+                label: "Lease document",
+                value:
+                  data?.lease?.leaseDocumentContext?.displayLabel ||
+                  (data?.lease?.documentUrl ? "Lease document available" : "No lease document available yet"),
+              },
               { label: "Monthly rent", value: formatMoney(data?.lease?.monthlyRent) },
             ]}
           />


### PR DESCRIPTION
## Summary

Normalizes tenant-facing lease document linkage so tenant workspace, tenant lease/profile pages, and tenant document vault resolve the same canonical current lease/document context.

## Audit Summary

- Tenant `/lease` and workspace lease projections primarily read document fields directly from `leases`.
- Tenant document vault independently read lease PDFs from `ledgerAttachments`.
- Generated lease PDF creation already writes tenant-visible `ledgerAttachments` and often updates the lease document fields, but the tenant UI paths did not share a deterministic resolver.
- Tenant profile lease document display only showed a generic available/not-shared state.

## Linkage Rules Implemented

1. Prefer the best active/current tenant lease over stale archived references.
2. Prefer signed/executed lease document fields when present.
3. Fall back to generated unsigned lease package links from lease fields.
4. Fall back to tenant-visible lease `ledgerAttachments` linked to the same lease/property/unit.
5. Return pending/missing context safely when no tenant-safe document is available.
6. Never expose another tenant's attachment as the current lease document.

## UI Surfaces Updated

- Tenant lease page document card now uses `leaseDocumentContext` and shows document status.
- Tenant workspace active tenancy card shows the lease document context and labels the lease ID as `Internal Lease ID`.
- Tenant profile rental record uses the normalized lease document display label.
- Tenant document vault can surface a current lease document context when the document exists only on the lease record.

## Tests Run

- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- --run src/routes/__tests__/tenantPortalRoutes.test.ts` from `rentchain-api`
- `npm test -- --run src/pages/tenant/TenantWorkspacePage.test.tsx` from `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` from `rentchain-frontend`

Note: forcing Node 20.11.1 for frontend Vitest hits an existing Vitest/jsdom `html-encoding-sniffer` ESM worker issue. The same frontend test passes under the current shell Node, and the frontend production build passes under Node 20.11.1.

## Guardrails

- No document generation changes.
- No lease signing write behavior changes.
- No signed document mutation.
- No payment, ledger, lifecycle, occupancy, or jurisdiction behavior changes.
- No Firestore migration.

## Known Follow-ups

- Landlord lease operations can later expose the same normalized document context object explicitly; this PR keeps landlord behavior stable while aligning tenant read paths.