### PR TITLE
test: add lifecycle continuity fixtures

### DIFF
--- a/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts
+++ b/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLifecycleContinuityLease,
+  buildLifecycleContinuityScenario,
+  buildLifecycleContinuityTenant,
+  lifecycleContinuityDates,
+  lifecycleContinuityIds,
+} from "./lifecycleContinuityFixtures";
+
+describe("lifecycle continuity fixtures", () => {
+  it("builds deterministic cross-system records for the canonical lifecycle scenario", () => {
+    const scenario = buildLifecycleContinuityScenario();
+
+    expect(scenario.property.id).toBe(lifecycleContinuityIds.propertyId);
+    expect(scenario.activeLease.id).toBe(lifecycleContinuityIds.activeLeaseId);
+    expect(scenario.activeLease.tenantId).toBe(scenario.activeTenant.id);
+    expect(scenario.activeLease.propertyId).toBe(scenario.property.id);
+    expect(scenario.payment.ledgerEntryId).toBe(scenario.ledgerEntry.id);
+    expect(scenario.ledgerEntry.paymentDocumentId).toBe(scenario.payment.id);
+    expect(scenario.obligation.dueDate).toBe(lifecycleContinuityDates.obligationDueDate);
+    expect(scenario.obligation.evidence).toEqual([
+      {
+        paymentDocumentId: scenario.payment.id,
+        ledgerEntryId: scenario.ledgerEntry.id,
+        amountCents: 164000,
+        paymentDate: lifecycleContinuityDates.paymentDate,
+      },
+    ]);
+    expect(scenario.decision.metadata).toMatchObject({
+      obligationId: scenario.obligation.id,
+      dueDate: lifecycleContinuityDates.obligationDueDate,
+      paymentDocumentId: scenario.payment.id,
+      ledgerEntryId: scenario.ledgerEntry.id,
+    });
+    expect(scenario.signedDocument.leaseId).toBe(scenario.activeLease.id);
+    expect(scenario.generatedDocument.leaseId).toBe(scenario.upcomingLease.id);
+  });
+
+  it("keeps builder overrides isolated from later fixture calls", () => {
+    const changedTenant = buildLifecycleContinuityTenant("active", {
+      fullName: "Changed Tenant",
+    });
+    const unchangedTenant = buildLifecycleContinuityTenant("active");
+    const changedLease = buildLifecycleContinuityLease("active", {
+      rentCents: 175000,
+    });
+    const unchangedLease = buildLifecycleContinuityLease("active");
+
+    expect(changedTenant.fullName).toBe("Changed Tenant");
+    expect(unchangedTenant.fullName).toBe("John Smith");
+    expect(changedLease.rentCents).toBe(175000);
+    expect(unchangedLease.rentCents).toBe(164000);
+  });
+});

--- a/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.ts
+++ b/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.ts
@@ -1,0 +1,458 @@
+export type LifecycleContinuityRecord = Record<string, unknown>;
+
+export type LifecycleContinuityLeaseKind = "active" | "upcoming" | "archived";
+
+export type LifecycleContinuityTenantKind =
+  | "applicant"
+  | "active"
+  | "upcoming"
+  | "archived";
+
+export type LifecycleContinuityDocumentKind = "signed" | "generated";
+
+export const lifecycleContinuityIds = {
+  landlordId: "lc_landlord_001",
+  propertyId: "lc_property_north_towers",
+  unit101Id: "lc_unit_101",
+  unit102Id: "lc_unit_102",
+  unit103Id: "lc_unit_103",
+  applicantId: "lc_applicant_001",
+  activeTenantId: "lc_tenant_active_001",
+  upcomingTenantId: "lc_tenant_upcoming_001",
+  archivedTenantId: "lc_tenant_archived_001",
+  activeLeaseId: "lc_lease_active_001",
+  upcomingLeaseId: "lc_lease_upcoming_001",
+  archivedLeaseId: "lc_lease_archived_001",
+  paymentId: "lc_payment_import_001",
+  ledgerEntryId: "lc_ledger_payment_001",
+  obligationId: "lc_obligation_2026_06",
+  decisionId: "lc_decision_manual_review_001",
+  signedDocumentId: "lc_doc_signed_lease_001",
+  generatedDocumentId: "lc_doc_generated_lease_001",
+  importBatchId: "lc_import_batch_001",
+} as const;
+
+export const lifecycleContinuityDates = {
+  now: "2026-05-18T12:00:00.000Z",
+  applicationSubmittedAt: "2026-04-10T14:00:00.000Z",
+  approvedAt: "2026-04-15T14:00:00.000Z",
+  activeLeaseStart: "2026-06-01",
+  activeLeaseEnd: "2027-05-31",
+  upcomingLeaseStart: "2026-07-01",
+  upcomingLeaseEnd: "2027-06-30",
+  archivedLeaseStart: "2025-06-01",
+  archivedLeaseEnd: "2026-05-31",
+  paymentDate: "2026-06-01",
+  obligationDueDate: "2026-06-01T00:00:00.000Z",
+  decisionCreatedAt: "2026-06-02T10:00:00.000Z",
+} as const;
+
+export const lifecycleContinuityLabels = {
+  propertyName: "North Towers",
+  propertyAddress: "10 Harbour Road, Halifax, NS",
+  unit101: "Unit 101",
+  unit102: "Unit 102",
+  unit103: "Unit 103",
+  applicantName: "Avery Applicant",
+  activeTenantName: "John Smith",
+  upcomingTenantName: "Bailey Blinkers",
+  archivedTenantName: "Casey Past",
+  activeLeaseLabel: "North Towers - Unit 101 Lease",
+  upcomingLeaseLabel: "North Towers - Unit 103 Lease",
+} as const;
+
+function cloneRecord<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function withOverrides<T extends LifecycleContinuityRecord>(
+  base: T,
+  overrides?: Partial<T>,
+): T {
+  return {
+    ...cloneRecord(base),
+    ...(overrides ?? {}),
+  };
+}
+
+export function buildLifecycleContinuityProperty(
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityIds.propertyId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      name: lifecycleContinuityLabels.propertyName,
+      address: lifecycleContinuityLabels.propertyAddress,
+      province: "NS",
+      jurisdictionProvince: "NS",
+      status: "active",
+      createdAt: lifecycleContinuityDates.now,
+      updatedAt: lifecycleContinuityDates.now,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityUnits(): LifecycleContinuityRecord[] {
+  return [
+    {
+      id: lifecycleContinuityIds.unit101Id,
+      landlordId: lifecycleContinuityIds.landlordId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      label: lifecycleContinuityLabels.unit101,
+      unitNumber: "101",
+      configuredRentCents: 164000,
+      occupancyDisplayStatus: "occupied",
+      activeLeaseId: lifecycleContinuityIds.activeLeaseId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+    },
+    {
+      id: lifecycleContinuityIds.unit102Id,
+      landlordId: lifecycleContinuityIds.landlordId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      label: lifecycleContinuityLabels.unit102,
+      unitNumber: "102",
+      configuredRentCents: 154000,
+      occupancyDisplayStatus: "vacant",
+    },
+    {
+      id: lifecycleContinuityIds.unit103Id,
+      landlordId: lifecycleContinuityIds.landlordId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      label: lifecycleContinuityLabels.unit103,
+      unitNumber: "103",
+      configuredRentCents: 198000,
+      occupancyDisplayStatus: "upcoming",
+      activeLeaseId: lifecycleContinuityIds.upcomingLeaseId,
+      tenantId: lifecycleContinuityIds.upcomingTenantId,
+    },
+  ];
+}
+
+export function buildLifecycleContinuityApplication(
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityIds.applicantId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.applicantId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit102Id,
+      fullName: lifecycleContinuityLabels.applicantName,
+      email: "avery.applicant@example.test",
+      status: "approved",
+      screeningStatus: "screening_completed",
+      submittedAt: lifecycleContinuityDates.applicationSubmittedAt,
+      approvedAt: lifecycleContinuityDates.approvedAt,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityTenant(
+  kind: LifecycleContinuityTenantKind = "active",
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  const baseByKind: Record<LifecycleContinuityTenantKind, LifecycleContinuityRecord> = {
+    applicant: {
+      id: lifecycleContinuityIds.applicantId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      fullName: lifecycleContinuityLabels.applicantName,
+      email: "avery.applicant@example.test",
+      status: "approved",
+      lifecycleState: "approved",
+      applicationId: lifecycleContinuityIds.applicantId,
+    },
+    active: {
+      id: lifecycleContinuityIds.activeTenantId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      fullName: lifecycleContinuityLabels.activeTenantName,
+      email: "john.smith@example.test",
+      status: "active",
+      lifecycleState: "active",
+      currentLeaseId: lifecycleContinuityIds.activeLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+    },
+    upcoming: {
+      id: lifecycleContinuityIds.upcomingTenantId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      fullName: lifecycleContinuityLabels.upcomingTenantName,
+      email: "bailey.blinkers@example.test",
+      status: "lease_signed",
+      lifecycleState: "lease_signed",
+      currentLeaseId: lifecycleContinuityIds.upcomingLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit103Id,
+    },
+    archived: {
+      id: lifecycleContinuityIds.archivedTenantId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      fullName: lifecycleContinuityLabels.archivedTenantName,
+      email: "casey.past@example.test",
+      status: "archived",
+      lifecycleState: "past",
+      archived: true,
+      previousLeaseId: lifecycleContinuityIds.archivedLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+    },
+  };
+
+  return withOverrides(baseByKind[kind], overrides);
+}
+
+export function buildLifecycleContinuityLease(
+  kind: LifecycleContinuityLeaseKind = "active",
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  const baseByKind: Record<LifecycleContinuityLeaseKind, LifecycleContinuityRecord> = {
+    active: {
+      id: lifecycleContinuityIds.activeLeaseId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+      status: "active",
+      signingStatus: "signed",
+      startDate: lifecycleContinuityDates.activeLeaseStart,
+      endDate: lifecycleContinuityDates.activeLeaseEnd,
+      rentCents: 164000,
+      rentDueDay: 1,
+      paymentFrequency: "monthly",
+      label: lifecycleContinuityLabels.activeLeaseLabel,
+    },
+    upcoming: {
+      id: lifecycleContinuityIds.upcomingLeaseId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.upcomingTenantId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit103Id,
+      status: "signed",
+      signingStatus: "signed",
+      startDate: lifecycleContinuityDates.upcomingLeaseStart,
+      endDate: lifecycleContinuityDates.upcomingLeaseEnd,
+      rentCents: 198000,
+      rentDueDay: 1,
+      paymentFrequency: "monthly",
+      label: lifecycleContinuityLabels.upcomingLeaseLabel,
+    },
+    archived: {
+      id: lifecycleContinuityIds.archivedLeaseId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.archivedTenantId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+      status: "archived",
+      signingStatus: "signed",
+      startDate: lifecycleContinuityDates.archivedLeaseStart,
+      endDate: lifecycleContinuityDates.archivedLeaseEnd,
+      rentCents: 150000,
+      rentDueDay: 1,
+      paymentFrequency: "monthly",
+      label: "North Towers - Unit 101 Archived Lease",
+      archived: true,
+    },
+  };
+
+  return withOverrides(baseByKind[kind], overrides);
+}
+
+export function buildLifecycleContinuityPayment(
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityIds.paymentId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+      leaseId: lifecycleContinuityIds.activeLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+      amountCents: 164000,
+      paidAt: lifecycleContinuityDates.paymentDate,
+      effectiveDate: lifecycleContinuityDates.paymentDate,
+      method: "etransfer",
+      reference: "LC-CSV-1001",
+      status: "recorded",
+      source: "payment_csv_import",
+      importBatchId: lifecycleContinuityIds.importBatchId,
+      ledgerEntryId: lifecycleContinuityIds.ledgerEntryId,
+      createdBy: lifecycleContinuityIds.landlordId,
+      createdAt: lifecycleContinuityDates.now,
+      updatedAt: lifecycleContinuityDates.now,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityLedgerEntry(
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityIds.ledgerEntryId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+      leaseId: lifecycleContinuityIds.activeLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+      entryType: "payment",
+      category: "payment",
+      amountCents: 164000,
+      signedAmountCents: -164000,
+      effectiveDate: lifecycleContinuityDates.paymentDate,
+      method: "etransfer",
+      reference: "LC-CSV-1001",
+      paymentDocumentId: lifecycleContinuityIds.paymentId,
+      immutable: true,
+      createdBy: lifecycleContinuityIds.landlordId,
+      createdAt: lifecycleContinuityDates.now,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityObligation(
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityIds.obligationId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+      leaseId: lifecycleContinuityIds.activeLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+      periodStart: lifecycleContinuityDates.activeLeaseStart,
+      periodEnd: "2026-06-30",
+      dueDate: lifecycleContinuityDates.obligationDueDate,
+      expectedAmountCents: 164000,
+      paidAmountCents: 164000,
+      outstandingAmountCents: 0,
+      status: "current",
+      evidence: [
+        {
+          paymentDocumentId: lifecycleContinuityIds.paymentId,
+          ledgerEntryId: lifecycleContinuityIds.ledgerEntryId,
+          amountCents: 164000,
+          paymentDate: lifecycleContinuityDates.paymentDate,
+        },
+      ],
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityDecision(
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityIds.decisionId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+      leaseId: lifecycleContinuityIds.activeLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+      type: "manual_review_required",
+      severity: "warning",
+      financialSignal: "Manual review required",
+      workflowStatus: "unreviewed",
+      metadata: {
+        obligationId: lifecycleContinuityIds.obligationId,
+        dueDate: lifecycleContinuityDates.obligationDueDate,
+        paymentDocumentId: lifecycleContinuityIds.paymentId,
+        ledgerEntryId: lifecycleContinuityIds.ledgerEntryId,
+      },
+      reviewTrail: [
+        {
+          action: "created",
+          actorId: "system",
+          createdAt: lifecycleContinuityDates.decisionCreatedAt,
+        },
+      ],
+      createdAt: lifecycleContinuityDates.decisionCreatedAt,
+      updatedAt: lifecycleContinuityDates.decisionCreatedAt,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityLeaseDocument(
+  kind: LifecycleContinuityDocumentKind = "signed",
+  overrides?: Partial<LifecycleContinuityRecord>,
+): LifecycleContinuityRecord {
+  const baseByKind: Record<LifecycleContinuityDocumentKind, LifecycleContinuityRecord> = {
+    signed: {
+      id: lifecycleContinuityIds.signedDocumentId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+      leaseId: lifecycleContinuityIds.activeLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit101Id,
+      documentStatus: "signed",
+      signingStatus: "signed",
+      displayLabel: "Signed lease package - North Towers Unit 101",
+      documentUrl: "https://example.test/docs/lc_doc_signed_lease_001.pdf",
+      source: "leaseDocuments",
+      createdAt: lifecycleContinuityDates.now,
+    },
+    generated: {
+      id: lifecycleContinuityIds.generatedDocumentId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.upcomingTenantId,
+      leaseId: lifecycleContinuityIds.upcomingLeaseId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      unitId: lifecycleContinuityIds.unit103Id,
+      documentStatus: "generated",
+      signingStatus: "pending",
+      displayLabel: "Generated lease package - North Towers Unit 103",
+      documentUrl: "https://example.test/docs/lc_doc_generated_lease_001.pdf",
+      source: "leaseDocuments",
+      createdAt: lifecycleContinuityDates.now,
+    },
+  };
+
+  return withOverrides(baseByKind[kind], overrides);
+}
+
+export function buildLifecycleContinuityScenario(): {
+  property: LifecycleContinuityRecord;
+  units: LifecycleContinuityRecord[];
+  application: LifecycleContinuityRecord;
+  applicant: LifecycleContinuityRecord;
+  activeTenant: LifecycleContinuityRecord;
+  upcomingTenant: LifecycleContinuityRecord;
+  archivedTenant: LifecycleContinuityRecord;
+  activeLease: LifecycleContinuityRecord;
+  upcomingLease: LifecycleContinuityRecord;
+  archivedLease: LifecycleContinuityRecord;
+  payment: LifecycleContinuityRecord;
+  ledgerEntry: LifecycleContinuityRecord;
+  obligation: LifecycleContinuityRecord;
+  decision: LifecycleContinuityRecord;
+  signedDocument: LifecycleContinuityRecord;
+  generatedDocument: LifecycleContinuityRecord;
+} {
+  return {
+    property: buildLifecycleContinuityProperty(),
+    units: buildLifecycleContinuityUnits(),
+    application: buildLifecycleContinuityApplication(),
+    applicant: buildLifecycleContinuityTenant("applicant"),
+    activeTenant: buildLifecycleContinuityTenant("active"),
+    upcomingTenant: buildLifecycleContinuityTenant("upcoming"),
+    archivedTenant: buildLifecycleContinuityTenant("archived"),
+    activeLease: buildLifecycleContinuityLease("active"),
+    upcomingLease: buildLifecycleContinuityLease("upcoming"),
+    archivedLease: buildLifecycleContinuityLease("archived"),
+    payment: buildLifecycleContinuityPayment(),
+    ledgerEntry: buildLifecycleContinuityLedgerEntry(),
+    obligation: buildLifecycleContinuityObligation(),
+    decision: buildLifecycleContinuityDecision(),
+    signedDocument: buildLifecycleContinuityLeaseDocument("signed"),
+    generatedDocument: buildLifecycleContinuityLeaseDocument("generated"),
+  };
+}

--- a/rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.test.ts
+++ b/rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLifecycleContinuityFrontendScenario,
+  buildLifecycleContinuityPaymentRow,
+  lifecycleContinuityUiDates,
+  lifecycleContinuityUiIds,
+} from "./lifecycleContinuityFixtures";
+
+describe("frontend lifecycle continuity fixtures", () => {
+  it("builds operational labels and routes without using raw IDs as primary labels", () => {
+    const scenario = buildLifecycleContinuityFrontendScenario();
+    const currentLease = scenario.tenantRow.currentLease as {
+      label: string;
+      href: string;
+    };
+
+    expect(currentLease.label).toBe("North Towers - Unit 101 Lease");
+    expect(currentLease.label).not.toContain(lifecycleContinuityUiIds.activeLeaseId);
+    expect(currentLease.href).toBe(
+      `/leases/${lifecycleContinuityUiIds.activeLeaseId}/summary`,
+    );
+    expect(scenario.tenantWorkspaceDocumentContext).toMatchObject({
+      leaseId: lifecycleContinuityUiIds.activeLeaseId,
+      documentStatus: "signed",
+      confidence: "high",
+    });
+  });
+
+  it("keeps payment, ledger, and obligation references aligned for UI regression tests", () => {
+    const scenario = buildLifecycleContinuityFrontendScenario();
+    const ledgerEntries = scenario.leaseLedger.ledgerEntries as Array<{
+      id: string;
+      paymentDocumentId: string;
+      effectiveDate: string;
+    }>;
+    const obligations = scenario.leaseLedger.obligations as Array<{
+      dueDate: string;
+      paidAmount: string;
+      outstandingAmount: string;
+    }>;
+    const paymentRow = buildLifecycleContinuityPaymentRow({
+      amount: "$1,700.00",
+    });
+
+    expect(scenario.paymentRow.ledgerEntryId).toBe(ledgerEntries[0].id);
+    expect(ledgerEntries[0].paymentDocumentId).toBe(scenario.paymentRow.id);
+    expect(ledgerEntries[0].effectiveDate).toBe(
+      lifecycleContinuityUiDates.paymentDate,
+    );
+    expect(obligations[0]).toMatchObject({
+      dueDate: lifecycleContinuityUiDates.obligationDueDate,
+      paidAmount: "$1,640.00",
+      outstandingAmount: "$0.00",
+    });
+    expect(paymentRow.amount).toBe("$1,700.00");
+    expect(buildLifecycleContinuityPaymentRow().amount).toBe("$1,640.00");
+  });
+});

--- a/rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.ts
+++ b/rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.ts
@@ -1,0 +1,204 @@
+export type LifecycleContinuityUiRecord = Record<string, unknown>;
+
+export const lifecycleContinuityUiIds = {
+  landlordId: "lc_landlord_001",
+  propertyId: "lc_property_north_towers",
+  unit101Id: "lc_unit_101",
+  unit103Id: "lc_unit_103",
+  activeTenantId: "lc_tenant_active_001",
+  upcomingTenantId: "lc_tenant_upcoming_001",
+  activeLeaseId: "lc_lease_active_001",
+  upcomingLeaseId: "lc_lease_upcoming_001",
+  paymentId: "lc_payment_import_001",
+  ledgerEntryId: "lc_ledger_payment_001",
+  obligationId: "lc_obligation_2026_06",
+  decisionId: "lc_decision_manual_review_001",
+  signedDocumentId: "lc_doc_signed_lease_001",
+} as const;
+
+export const lifecycleContinuityUiDates = {
+  now: "2026-05-18T12:00:00.000Z",
+  activeLeaseStart: "2026-06-01",
+  activeLeaseEnd: "2027-05-31",
+  upcomingLeaseStart: "2026-07-01",
+  upcomingLeaseEnd: "2027-06-30",
+  paymentDate: "2026-06-01",
+  obligationDueDate: "2026-06-01T00:00:00.000Z",
+} as const;
+
+function cloneRecord<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function withOverrides<T extends LifecycleContinuityUiRecord>(
+  base: T,
+  overrides?: Partial<T>,
+): T {
+  return {
+    ...cloneRecord(base),
+    ...(overrides ?? {}),
+  };
+}
+
+export function buildLifecycleContinuityTenantRow(
+  overrides?: Partial<LifecycleContinuityUiRecord>,
+): LifecycleContinuityUiRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityUiIds.activeTenantId,
+      displayName: "John Smith",
+      email: "john.smith@example.test",
+      lifecycleState: "active",
+      lifecycleLabel: "Active",
+      propertyLabel: "North Towers",
+      unitLabel: "Unit 101",
+      currentLease: {
+        leaseId: lifecycleContinuityUiIds.activeLeaseId,
+        label: "North Towers - Unit 101 Lease",
+        href: `/leases/${lifecycleContinuityUiIds.activeLeaseId}/summary`,
+      },
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityLeaseSummary(
+  overrides?: Partial<LifecycleContinuityUiRecord>,
+): LifecycleContinuityUiRecord {
+  return withOverrides(
+    {
+      leaseId: lifecycleContinuityUiIds.activeLeaseId,
+      label: "North Towers - Unit 101 Lease",
+      tenantName: "John Smith",
+      propertyLabel: "North Towers",
+      unitLabel: "Unit 101",
+      startDate: lifecycleContinuityUiDates.activeLeaseStart,
+      endDate: lifecycleContinuityUiDates.activeLeaseEnd,
+      status: "active",
+      signingStatus: "signed",
+      href: `/leases/${lifecycleContinuityUiIds.activeLeaseId}/summary`,
+      ledgerHref: `/leases/${lifecycleContinuityUiIds.activeLeaseId}/ledger`,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityPropertyUnitRows(): LifecycleContinuityUiRecord[] {
+  return [
+    {
+      unitId: lifecycleContinuityUiIds.unit101Id,
+      unitLabel: "Unit 101",
+      propertyLabel: "North Towers",
+      configuredRent: "$1,640.00",
+      occupancyStatus: "Occupied",
+      occupancyDetail: "John Smith - Ends May 31, 2027",
+      leaseId: lifecycleContinuityUiIds.activeLeaseId,
+      leaseHref: `/leases/${lifecycleContinuityUiIds.activeLeaseId}/summary`,
+      ledgerHref: `/leases/${lifecycleContinuityUiIds.activeLeaseId}/ledger`,
+    },
+    {
+      unitId: lifecycleContinuityUiIds.unit103Id,
+      unitLabel: "Unit 103",
+      propertyLabel: "North Towers",
+      configuredRent: "$1,980.00",
+      occupancyStatus: "Upcoming",
+      occupancyDetail: "Bailey Blinkers - Ends Jun 30, 2027",
+      leaseId: lifecycleContinuityUiIds.upcomingLeaseId,
+      leaseHref: `/leases/${lifecycleContinuityUiIds.upcomingLeaseId}/summary`,
+      ledgerHref: `/leases/${lifecycleContinuityUiIds.upcomingLeaseId}/ledger`,
+    },
+  ];
+}
+
+export function buildLifecycleContinuityPaymentRow(
+  overrides?: Partial<LifecycleContinuityUiRecord>,
+): LifecycleContinuityUiRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityUiIds.paymentId,
+      paymentDocumentId: lifecycleContinuityUiIds.paymentId,
+      tenantName: "John Smith",
+      propertyLabel: "North Towers",
+      unitLabel: "Unit 101",
+      amount: "$1,640.00",
+      amountCents: 164000,
+      paymentDate: lifecycleContinuityUiDates.paymentDate,
+      method: "etransfer",
+      reference: "LC-CSV-1001",
+      status: "recorded",
+      canEdit: true,
+      ledgerEntryId: lifecycleContinuityUiIds.ledgerEntryId,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityLeaseLedgerResponse(): LifecycleContinuityUiRecord {
+  return {
+    lease: buildLifecycleContinuityLeaseSummary(),
+    ledgerEntries: [
+      {
+        id: lifecycleContinuityUiIds.ledgerEntryId,
+        type: "payment",
+        category: "payment",
+        amount: "-$1,640.00",
+        amountCents: 164000,
+        signedAmountCents: -164000,
+        effectiveDate: lifecycleContinuityUiDates.paymentDate,
+        paymentDocumentId: lifecycleContinuityUiIds.paymentId,
+      },
+    ],
+    obligations: [
+      {
+        id: lifecycleContinuityUiIds.obligationId,
+        financialStatus: "Current",
+        dueDate: lifecycleContinuityUiDates.obligationDueDate,
+        expectedAmount: "$1,640.00",
+        paidAmount: "$1,640.00",
+        outstandingAmount: "$0.00",
+        evidence: "Reconciled",
+      },
+    ],
+    decisions: [
+      {
+        id: lifecycleContinuityUiIds.decisionId,
+        financialSignal: "Manual review required",
+        workflowStatus: "Unreviewed",
+        obligationId: lifecycleContinuityUiIds.obligationId,
+      },
+    ],
+  };
+}
+
+export function buildLifecycleContinuityTenantWorkspaceDocumentContext(): LifecycleContinuityUiRecord {
+  return {
+    leaseId: lifecycleContinuityUiIds.activeLeaseId,
+    tenantId: lifecycleContinuityUiIds.activeTenantId,
+    propertyLabel: "North Towers",
+    unitLabel: "Unit 101",
+    leaseLabel: "North Towers - Unit 101 Lease",
+    documentStatus: "signed",
+    documentId: lifecycleContinuityUiIds.signedDocumentId,
+    documentUrl: "https://example.test/docs/lc_doc_signed_lease_001.pdf",
+    confidence: "high",
+    warnings: [],
+  };
+}
+
+export function buildLifecycleContinuityFrontendScenario(): {
+  tenantRow: LifecycleContinuityUiRecord;
+  leaseSummary: LifecycleContinuityUiRecord;
+  propertyUnitRows: LifecycleContinuityUiRecord[];
+  paymentRow: LifecycleContinuityUiRecord;
+  leaseLedger: LifecycleContinuityUiRecord;
+  tenantWorkspaceDocumentContext: LifecycleContinuityUiRecord;
+} {
+  return {
+    tenantRow: buildLifecycleContinuityTenantRow(),
+    leaseSummary: buildLifecycleContinuityLeaseSummary(),
+    propertyUnitRows: buildLifecycleContinuityPropertyUnitRows(),
+    paymentRow: buildLifecycleContinuityPaymentRow(),
+    leaseLedger: buildLifecycleContinuityLeaseLedgerResponse(),
+    tenantWorkspaceDocumentContext: buildLifecycleContinuityTenantWorkspaceDocumentContext(),
+  };
+}


### PR DESCRIPTION
## Summary

Adds the first reusable lifecycle continuity fixture foundation recommended by `docs/testing/lifecycle-continuity-readiness-v1.md`.

## Audit Summary

Current test coverage is broad but mostly uses local inline records and route-specific mocks. There was no shared canonical fixture module for cross-system lifecycle scenarios spanning tenant lifecycle, lease/occupancy, payments, ledger entries, obligations, decisions, and tenant document linkage.

## Fixtures Added

- `rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.ts`
- `rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.ts`

The fixtures use deterministic IDs, dates, amounts, labels, and builders for:

- applicant / approved applicant
- active tenant with lease
- upcoming lease / upcoming occupancy
- archived/past lease
- canonical imported payment
- linked immutable ledger payment row
- payment obligation evidence
- manual review decision workflow state
- signed/generated lease document context
- property occupancy display rows

## Tests Added

- `rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts`
- `rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.test.ts`

These verify fixture cross-links, stable due dates/evidence, operational labels/routes, and isolated override behavior.

## Guardrails

- Test infrastructure only.
- No product behavior changes.
- No Firestore schema changes.
- No route, payment, ledger, lifecycle, occupancy, document, or seed data changes.

## Validation

- `rentchain-api`: `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- --run src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts`
- `rentchain-frontend`: `npm run test:single -- --run src/test/fixtures/lifecycleContinuityFixtures.test.ts`
- `rentchain-api`: `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `rentchain-frontend`: `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`

Note: frontend Vitest under Node 20.11.1 hit the existing jsdom/html-encoding-sniffer ESM worker issue before loading tests; the same narrow test passed under the local default Node v25.8.1. The production frontend build with Node 20.11.1 completed successfully, with the existing Vite warning that Vite prefers Node 20.19+ or 22.12+.

## Known Follow-ups

- `test/payment-ledger-obligation-e2e-v1`
- `test/tenant-workspace-lease-linkage-e2e-v1`
- `test/property-occupancy-regression-suite-v1`
- `test/decision-workflow-regression-suite-v1`
- Add route-level integration tests that consume these fixtures as each continuity path is hardened.