### PR TITLE
feat: add provider-agnostic screening workflow UI

### DIFF
--- a/rentchain-frontend/src/components/applications/ApplicationDetailPanel.tsx
+++ b/rentchain-frontend/src/components/applications/ApplicationDetailPanel.tsx
@@ -12,6 +12,7 @@ import { updateApplicationDetails, updateApplicationReferences } from "@/api/app
 import { useToast } from "../ui/ToastProvider";
 import { ConvertToTenantButton } from "./ConvertToTenantButton";
 import { getUiLocale, SCREENING_ENABLED, screeningComingSoonLabel, screeningComingSoonNotice } from "../../config/screening";
+import { ScreeningWorkflowPanel } from "@/components/screening/ScreeningWorkflowPanel";
 
 type ApplicationDetailPanelProps = {
   application: Application | null;
@@ -1176,6 +1177,12 @@ export const ApplicationDetailPanel: React.FC<ApplicationDetailPanelProps> = ({
       </div>
 
       {/* Screening */}
+      <ScreeningWorkflowPanel
+        compact
+        screeningEnabled={SCREENING_ENABLED}
+        workflowStatus={(application as any)?.screeningStatus || (application as any)?.screening?.status || null}
+      />
+
       {!SCREENING_ENABLED ? (
         <div
           style={{

--- a/rentchain-frontend/src/components/dashboard/ActionRequiredPanel.tsx
+++ b/rentchain-frontend/src/components/dashboard/ActionRequiredPanel.tsx
@@ -31,7 +31,7 @@ export function ActionRequiredPanel({
     const href = String(item?.href || "").toLowerCase();
     const isScreening = title.includes("screening") || title.includes("transunion") || href.includes("opentransunionaccess");
     if (isScreening) {
-      return "Connect TransUnion access from Applications, then open an application review to run screening once the applicant has provided the required consent.";
+      return "Open the screening workflow from Applications, review provider availability, then run or record screening once the applicant has provided the required consent.";
     }
     return "Open this action to continue the related workflow. RentChain keeps these items here when there is a clear next step for the landlord.";
   }

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
@@ -13,21 +13,21 @@ describe("ConnectTransUnionModal", () => {
       />
     );
 
-    expect(screen.getByText("Connect Your TransUnion Account")).toBeInTheDocument();
+    expect(screen.getByText("Configure screening provider")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Connect your TransUnion membership by entering the member code and passcode issued to your business. Screening requests are initiated under your TransUnion credentials within RentChain."
+        "Configure the live provider path for tenant screening. TransUnion is the current live provider in RentChain, and screening requests use the member code and passcode issued to your business."
       )
     ).toBeInTheDocument();
     expect(
       screen.getByText(/If connection details are not available yet, use the access flow first/i)
     ).toBeInTheDocument();
-    expect(screen.getByText("Need TransUnion access?")).toBeInTheDocument();
+    expect(screen.getByText("Need provider access?")).toBeInTheDocument();
     expect(screen.getByText("Already credentialed?")).toBeInTheDocument();
     expect(screen.getByText("Choose path")).toBeInTheDocument();
-    expect(screen.getByText("Connect membership")).toBeInTheDocument();
+    expect(screen.getByText("Connect provider")).toBeInTheDocument();
     expect(screen.getByText("Ready to screen")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Get TransUnion Access" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start provider setup" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "I Already Have Credentials" })).toBeInTheDocument();
     expect(screen.queryByText("Member code")).not.toBeInTheDocument();
   });
@@ -45,7 +45,7 @@ describe("ConnectTransUnionModal", () => {
     );
 
     const dialog = screen.getAllByRole("dialog").find((node) =>
-      node.getAttribute("aria-label") === "Connect Your TransUnion Account"
+      node.getAttribute("aria-label") === "Configure screening provider"
     ) as HTMLElement;
     const dialogQueries = within(dialog);
 
@@ -80,12 +80,12 @@ describe("ConnectTransUnionModal", () => {
     );
 
     const dialog = screen.getAllByRole("dialog").find((node) =>
-      node.getAttribute("aria-label") === "Connect Your TransUnion Account"
+      node.getAttribute("aria-label") === "Configure screening provider"
     ) as HTMLElement;
     const dialogQueries = within(dialog);
 
     await waitFor(() => {
-      expect(dialogQueries.getByText("Membership credentials")).toBeInTheDocument();
+      expect(dialogQueries.getByText("Live provider details")).toBeInTheDocument();
     });
     expect(dialogQueries.getByText("Business details required for setup")).toBeInTheDocument();
     expect(dialogQueries.queryByRole("button", { name: "I Already Have Credentials" })).not.toBeInTheDocument();
@@ -109,7 +109,7 @@ describe("ConnectTransUnionModal", () => {
     );
 
     const dialog = screen.getAllByRole("dialog").find((node) =>
-      node.getAttribute("aria-label") === "Connect Your TransUnion Account"
+      node.getAttribute("aria-label") === "Configure screening provider"
     ) as HTMLElement;
     const dialogQueries = within(dialog);
     const credentialButton = dialogQueries.queryByRole("button", {
@@ -142,9 +142,9 @@ describe("ConnectTransUnionModal", () => {
 
     fireEvent.click(dialogQueries.getAllByRole("button", { name: "Connect Account" })[0]);
 
-    expect(await screen.findByText("TransUnion Connected")).toBeInTheDocument();
+    expect(await screen.findByText("Screening provider connected")).toBeInTheDocument();
     const successDialog = screen.getAllByRole("dialog").find((node) =>
-      node.getAttribute("aria-label") === "TransUnion Connected"
+      node.getAttribute("aria-label") === "Screening provider connected"
     ) as HTMLElement;
     expect(within(successDialog).getByRole("button", { name: "Continue to Screening" })).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
@@ -96,7 +96,7 @@ export function ConnectTransUnionModal({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label="TransUnion Connected"
+        aria-label="Screening provider connected"
         style={{
           position: "fixed",
           inset: 0,
@@ -120,10 +120,10 @@ export function ConnectTransUnionModal({
           }}
         >
           <div style={{ display: "grid", gap: spacing.sm }}>
-            <h2 style={{ margin: 0, fontSize: "1.2rem" }}>TransUnion Connected</h2>
+            <h2 style={{ margin: 0, fontSize: "1.2rem" }}>Screening provider connected</h2>
             <p style={{ margin: 0, color: text.muted, lineHeight: 1.6 }}>
-              Your TransUnion membership is now connected to RentChain. You can continue screening
-              applicants without leaving this workflow.
+              Your live screening provider membership is now connected to RentChain. TransUnion is
+              the active provider path for this connection.
             </p>
           </div>
           <div
@@ -163,7 +163,7 @@ export function ConnectTransUnionModal({
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Connect Your TransUnion Account"
+      aria-label="Configure screening provider"
       style={{
         position: "fixed",
         inset: 0,
@@ -191,11 +191,11 @@ export function ConnectTransUnionModal({
         }}
       >
         <div style={{ display: "grid", gap: spacing.xs }}>
-          <h2 style={{ margin: 0, fontSize: "1.2rem" }}>Connect Your TransUnion Account</h2>
+          <h2 style={{ margin: 0, fontSize: "1.2rem" }}>Configure screening provider</h2>
           <p style={{ margin: 0, color: text.muted }}>
-            Connect your TransUnion membership by entering the member code and passcode issued to
-            your business. Screening requests are initiated under your TransUnion credentials within
-            RentChain.
+            Configure the live provider path for tenant screening. TransUnion is the current live
+            provider in RentChain, and screening requests use the member code and passcode issued to
+            your business.
           </p>
           <p style={{ margin: 0, color: text.subtle, fontSize: "0.92rem" }}>
             If connection details are not available yet, use the access flow first. If the connection window does not open on mobile, try again or continue on desktop.
@@ -218,7 +218,7 @@ export function ConnectTransUnionModal({
               },
               {
                 key: "connect",
-                label: "Connect membership",
+                label: "Connect provider",
                 active: showCredentials,
                 complete: success,
               },
@@ -266,11 +266,11 @@ export function ConnectTransUnionModal({
                   gap: 10,
                 }}
               >
-                <div style={{ fontWeight: 700 }}>Need TransUnion access?</div>
+                <div style={{ fontWeight: 700 }}>Need provider access?</div>
                 <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
-                  Don&apos;t have TransUnion yet? We&apos;ll guide you through the external onboarding
-                  path first. Once TransUnion issues your member code and passcode, come back here to
-                  finish setup in RentChain.
+                  Need live screening credentials? We&apos;ll guide you through the current provider
+                  onboarding path first. Once TransUnion issues your member code and passcode, come
+                  back here to finish setup in RentChain.
                 </div>
                 <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
                   Outcome: your account moves into a credentialing-in-progress state until you receive
@@ -279,7 +279,7 @@ export function ConnectTransUnionModal({
                 {onGetAccess ? (
                   <div>
                     <Button type="button" variant="secondary" onClick={onGetAccess}>
-                      Get TransUnion Access
+                      Start provider setup
                     </Button>
                   </div>
                 ) : null}
@@ -330,7 +330,7 @@ export function ConnectTransUnionModal({
                   gap: 6,
                 }}
               >
-                <div style={{ fontWeight: 700 }}>Membership credentials</div>
+                <div style={{ fontWeight: 700 }}>Live provider details</div>
                 <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
                   Enter the member code and passcode exactly as TransUnion provided them.
                 </div>

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
@@ -79,6 +79,28 @@ describe("GetTransUnionAccessModal", () => {
     expect(onPhoneClick).toHaveBeenCalledTimes(1);
   });
 
+  it("presents provider options before provider-specific contact details", () => {
+    render(
+      <GetTransUnionAccessModal
+        open
+        onClose={vi.fn()}
+        onMarkInProgress={vi.fn()}
+        onEnterCredentials={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Choose or manage a screening workflow provider before ordering reports. Provider availability can vary by setup status, consent requirements, and integration readiness.")).toBeInTheDocument();
+    expect(screen.getByText("Provider options")).toBeInTheDocument();
+    expect(screen.getByText("TransUnion")).toBeInTheDocument();
+    expect(screen.getByText("Live provider path")).toBeInTheDocument();
+    expect(screen.getByText("Manual/offline screening")).toBeInTheDocument();
+    expect(screen.getByText("Available fallback")).toBeInTheDocument();
+    expect(screen.getByText("Certn")).toBeInTheDocument();
+    expect(screen.getAllByText("Candidate provider")).toHaveLength(2);
+    expect(screen.getByText("Equifax")).toBeInTheDocument();
+    expect(screen.getByText("TransUnion provider contact details")).toBeInTheDocument();
+  });
+
   it("debounces rapid email clicks so tracking and opening happen once", () => {
     const onEmailClick = vi.fn();
 

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
@@ -164,10 +164,10 @@ describe("GetTransUnionAccessModal", () => {
       />
     );
 
-    const dialog = screen.getByRole("dialog", { name: "Get TransUnion Access" });
+    const dialog = screen.getByRole("dialog", { name: "Screening provider setup" });
     const card = dialog.firstElementChild as HTMLElement;
     expect(dialog).toHaveStyle({ overflowY: "auto" });
     expect(card).toHaveStyle({ maxHeight: "calc(100dvh - 24px)", overflowY: "auto" });
-    expect(screen.getByRole("button", { name: "Get TransUnion Access" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start provider setup" })).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
@@ -31,6 +31,28 @@ Subject: ${MAILTO_SUBJECT}
 
 ${MAILTO_BODY}`;
 const EMAIL_HANDOFF_COOLDOWN_MS = 1500;
+const PROVIDER_OPTIONS = [
+  {
+    label: "TransUnion",
+    status: "Live provider path",
+    detail: "Requires provider credentialing before live screening can begin.",
+  },
+  {
+    label: "Manual/offline screening",
+    status: "Available fallback",
+    detail: "Use manual review when live provider screening is unavailable or not appropriate.",
+  },
+  {
+    label: "Certn",
+    status: "Candidate provider",
+    detail: "Workflow-ready candidate. Integration is not active yet.",
+  },
+  {
+    label: "Equifax",
+    status: "Candidate provider",
+    detail: "Future provider path candidate. Integration is not active yet.",
+  },
+] as const;
 
 type Props = {
   open: boolean;
@@ -124,10 +146,37 @@ export function GetTransUnionAccessModal({
         <div style={{ display: "grid", gap: spacing.sm }}>
           <h2 style={{ margin: 0, fontSize: "1.2rem" }}>Screening provider setup</h2>
           <p style={{ margin: 0, color: text.muted, lineHeight: 1.6 }}>
-            Configure your screening workflow before ordering reports. TransUnion is the current
-            live provider path in RentChain, and your business must be credentialed by TransUnion
-            before live screening can begin.
+            Choose or manage a screening workflow provider before ordering reports. Provider
+            availability can vary by setup status, consent requirements, and integration readiness.
           </p>
+        </div>
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ fontWeight: 700, color: text.primary }}>Provider options</div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+              gap: spacing.sm,
+            }}
+          >
+            {PROVIDER_OPTIONS.map((provider) => (
+              <div
+                key={provider.label}
+                style={{
+                  border: `1px solid ${provider.label === "TransUnion" ? colors.accent : colors.border}`,
+                  background: provider.label === "TransUnion" ? colors.accentSoft : "#fff",
+                  borderRadius: radius.md,
+                  padding: spacing.sm,
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ fontWeight: 700 }}>{provider.label}</div>
+                <div style={{ color: text.primary, fontSize: "0.9rem", fontWeight: 700 }}>{provider.status}</div>
+                <div style={{ color: text.muted, fontSize: "0.9rem", lineHeight: 1.45 }}>{provider.detail}</div>
+              </div>
+            ))}
+          </div>
         </div>
         <div
           style={{
@@ -171,93 +220,101 @@ export function GetTransUnionAccessModal({
         >
           <div style={{ fontWeight: 700, color: text.primary, marginBottom: 8 }}>How credentialing works</div>
           <ol style={{ margin: 0, paddingLeft: 18, display: "grid", gap: 6 }}>
-            <li>Choose the live provider path for this workflow.</li>
-            <li>Get credentialed for your business with the provider.</li>
-            <li>Receive your member code and passcode.</li>
+            <li>Choose the provider path or manual workflow that fits the applicant review.</li>
+            <li>For live provider screening, complete provider credentialing for your business.</li>
+            <li>Receive any provider-issued member code and passcode.</li>
             <li>Return to RentChain and connect your credentials.</li>
           </ol>
         </div>
-        <div
+        <details
           style={{
             border: `1px solid ${colors.border}`,
             borderRadius: radius.md,
             padding: spacing.sm,
             background: "#fff",
-            display: "grid",
-            gridTemplateColumns: "minmax(0, 1fr) minmax(220px, 0.75fr)",
-            gap: 8,
           }}
         >
-          <div style={{ display: "grid", gap: 8, minWidth: 0 }}>
-            <div style={{ fontWeight: 700, color: text.primary }}>TransUnion contact</div>
-            <div style={{ color: text.primary, lineHeight: 1.6, overflowWrap: "anywhere" }}>
-              <div>Chhavi Kumar</div>
-              <div>Account Executive, Inside Sales</div>
-              <div>{CHHAVI_EMAIL}</div>
-              <div>{CHHAVI_PHONE}</div>
-              <div>Customer Support: {CUSTOMER_SUPPORT_PHONE}</div>
-              <div>Tech Support: {TECH_SUPPORT_PHONE}</div>
-              <div>{TECH_SUPPORT_EMAIL}</div>
+          <summary style={{ cursor: "pointer", fontWeight: 700, color: text.primary }}>
+            TransUnion provider contact details
+          </summary>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(0, 1fr) minmax(220px, 0.75fr)",
+              gap: 8,
+              marginTop: spacing.sm,
+            }}
+          >
+            <div style={{ display: "grid", gap: 8, minWidth: 0 }}>
+              <div style={{ color: text.primary, lineHeight: 1.6, overflowWrap: "anywhere" }}>
+                <div>Chhavi Kumar</div>
+                <div>Account Executive, Inside Sales</div>
+                <div>{CHHAVI_EMAIL}</div>
+                <div>{CHHAVI_PHONE}</div>
+                <div>Customer Support: {CUSTOMER_SUPPORT_PHONE}</div>
+                <div>Tech Support: {TECH_SUPPORT_PHONE}</div>
+                <div>{TECH_SUPPORT_EMAIL}</div>
+              </div>
+            </div>
+            <div style={{ display: "grid", gap: spacing.sm, alignContent: "start", minWidth: 0 }}>
+              <a
+                href={CHHAVI_MAILTO}
+                onClick={handleEmailClick}
+                aria-disabled={emailOpening}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  padding: "10px 14px",
+                  borderRadius: radius.pill,
+                  border: `1px solid ${colors.border}`,
+                  background: emailOpening ? colors.bg : colors.accentSoft,
+                  color: text.primary,
+                  textDecoration: "none",
+                  fontWeight: 600,
+                  fontSize: "0.95rem",
+                  pointerEvents: emailOpening ? "none" : "auto",
+                  opacity: emailOpening ? 0.7 : 1,
+                }}
+              >
+                Email Chhavi Kumar
+              </a>
+              <a
+                href={CHHAVI_TEL}
+                onClick={onPhoneClick}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  padding: "10px 14px",
+                  borderRadius: radius.pill,
+                  border: `1px solid ${colors.border}`,
+                  background: "transparent",
+                  color: text.primary,
+                  textDecoration: "none",
+                  fontWeight: 600,
+                  fontSize: "0.95rem",
+                }}
+              >
+                Call Chhavi Kumar
+              </a>
+              <Button type="button" variant="secondary" onClick={() => void handleCopyTemplate()}>
+                Copy email template
+              </Button>
+            </div>
+            <div style={{ gridColumn: "1 / -1" }}>
+              {emailStatus ? (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  style={{ color: text.muted, fontSize: "0.9rem", lineHeight: 1.5 }}
+                >
+                  {emailStatus}
+                </div>
+              ) : null}
             </div>
           </div>
-          <div style={{ display: "grid", gap: spacing.sm, alignContent: "start", minWidth: 0 }}>
-            <a
-              href={CHHAVI_MAILTO}
-              onClick={handleEmailClick}
-              aria-disabled={emailOpening}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                padding: "10px 14px",
-                borderRadius: radius.pill,
-                border: `1px solid ${colors.border}`,
-                background: emailOpening ? colors.bg : colors.accentSoft,
-                color: text.primary,
-                textDecoration: "none",
-                fontWeight: 600,
-                fontSize: "0.95rem",
-                pointerEvents: emailOpening ? "none" : "auto",
-                opacity: emailOpening ? 0.7 : 1,
-              }}
-            >
-              Email Chhavi Kumar
-            </a>
-            <a
-              href={CHHAVI_TEL}
-              onClick={onPhoneClick}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                padding: "10px 14px",
-                borderRadius: radius.pill,
-                border: `1px solid ${colors.border}`,
-                background: "transparent",
-                color: text.primary,
-                textDecoration: "none",
-                fontWeight: 600,
-                fontSize: "0.95rem",
-              }}
-            >
-              Call Chhavi Kumar
-            </a>
-            <Button type="button" variant="secondary" onClick={() => void handleCopyTemplate()}>
-              Copy email template
-            </Button>
-          </div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            {emailStatus ? (
-              <div
-                role="status"
-                aria-live="polite"
-                style={{ color: text.muted, fontSize: "0.9rem", lineHeight: 1.5 }}
-              >
-                {emailStatus}
-              </div>
-            ) : null}
-          </div>
-        </div>
+        </details>
         <div
           style={{
             border: `1px solid ${colors.border}`,

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
@@ -94,7 +94,7 @@ export function GetTransUnionAccessModal({
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Get TransUnion Access"
+      aria-label="Screening provider setup"
       style={{
         position: "fixed",
         inset: 0,
@@ -122,11 +122,11 @@ export function GetTransUnionAccessModal({
         }}
       >
         <div style={{ display: "grid", gap: spacing.sm }}>
-          <h2 style={{ margin: 0, fontSize: "1.2rem" }}>Get TransUnion Access</h2>
+          <h2 style={{ margin: 0, fontSize: "1.2rem" }}>Screening provider setup</h2>
           <p style={{ margin: 0, color: text.muted, lineHeight: 1.6 }}>
-            To use TransUnion screening through RentChain, your business must first be credentialed
-            by TransUnion. Once approved, you’ll receive a member code and passcode to enter in
-            RentChain.
+            Configure your screening workflow before ordering reports. TransUnion is the current
+            live provider path in RentChain, and your business must be credentialed by TransUnion
+            before live screening can begin.
           </p>
         </div>
         <div
@@ -138,7 +138,7 @@ export function GetTransUnionAccessModal({
         >
           {[
             { label: "Not connected", state: "complete" },
-            { label: "Get access", state: "current" },
+            { label: "Provider access", state: "current" },
             { label: "Return to connect", state: "upcoming" },
           ].map((step) => (
             <div
@@ -171,8 +171,8 @@ export function GetTransUnionAccessModal({
         >
           <div style={{ fontWeight: 700, color: text.primary, marginBottom: 8 }}>How credentialing works</div>
           <ol style={{ margin: 0, paddingLeft: 18, display: "grid", gap: 6 }}>
-            <li>Contact TransUnion.</li>
-            <li>Get credentialed for your business.</li>
+            <li>Choose the live provider path for this workflow.</li>
+            <li>Get credentialed for your business with the provider.</li>
             <li>Receive your member code and passcode.</li>
             <li>Return to RentChain and connect your credentials.</li>
           </ol>
@@ -269,8 +269,8 @@ export function GetTransUnionAccessModal({
             lineHeight: 1.6,
           }}
         >
-          Expected outcome: your account will be marked as credentialing in progress so you always
-          know the next step is to return and connect the issued membership details.
+          Expected outcome: your screening workflow will be marked as credentialing in progress so
+          you always know the next step is to return and connect the issued membership details.
         </div>
         <div
           style={{
@@ -317,7 +317,7 @@ export function GetTransUnionAccessModal({
             Close
           </Button>
           <Button type="button" onClick={() => void onMarkInProgress()} disabled={submitting}>
-            {submitting ? "Saving..." : "Get TransUnion Access"}
+            {submitting ? "Saving..." : "Start provider setup"}
           </Button>
         </div>
       </Card>

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
@@ -34,7 +34,7 @@ describe("TransUnionConnectionCard", () => {
     expect(screen.getAllByText("Not connected")).toHaveLength(2);
     expect(screen.getByText("Connect or get access")).toBeInTheDocument();
     expect(screen.getByText("Ready to screen")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Get TransUnion Access" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start provider setup" }));
     expect(onGetAccess).toHaveBeenCalledTimes(1);
   });
 

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
@@ -130,7 +130,7 @@ export function TransUnionConnectionCard({
       "Use the guided access path first if your business still needs TransUnion approval. If you already have credentials, connect them directly here.";
     nextStep = "Next step: get TransUnion access first, or connect your existing membership details.";
     actions = [
-      { label: "Get TransUnion Access", onClick: onGetAccess, variant: "primary" },
+      { label: "Start provider setup", onClick: onGetAccess, variant: "primary" },
       { label: "Connect Existing Membership", onClick: onConnectExisting },
     ];
   }

--- a/rentchain-frontend/src/components/screening/ScreeningWorkflowPanel.test.tsx
+++ b/rentchain-frontend/src/components/screening/ScreeningWorkflowPanel.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ScreeningWorkflowPanel } from "./ScreeningWorkflowPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ScreeningWorkflowPanel", () => {
+  it("renders provider-agnostic screening options without making TransUnion the only path", () => {
+    render(<ScreeningWorkflowPanel transUnionConnected={false} workflowStatus="not_started" />);
+
+    expect(screen.getByText("Screening workflow")).toBeInTheDocument();
+    expect(screen.getByText("TransUnion")).toBeInTheDocument();
+    expect(screen.getByText("Certn")).toBeInTheDocument();
+    expect(screen.getByText("Equifax")).toBeInTheDocument();
+    expect(screen.getByText("Manual/offline review")).toBeInTheDocument();
+    expect(screen.getByText("Future provider")).toBeInTheDocument();
+    expect(screen.getByText("Workflow state: Not started")).toBeInTheDocument();
+  });
+
+  it("labels unavailable providers as non-live and keeps them disabled", () => {
+    render(<ScreeningWorkflowPanel transUnionConnected={false} />);
+
+    const disabledButtons = screen.getAllByRole("button", { name: "Not live yet" });
+    expect(disabledButtons.length).toBeGreaterThanOrEqual(3);
+    expect(disabledButtons[0]).toBeDisabled();
+    expect(screen.getAllByText("Coming soon").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses requires-setup for TransUnion until credentials are connected", () => {
+    const onSetup = vi.fn();
+    render(<ScreeningWorkflowPanel transUnionConnected={false} onTransUnionSetup={onSetup} />);
+
+    expect(screen.getByText("Requires setup")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Set up provider" }));
+    expect(onSetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows manual review as a safe fallback without starting a live provider", () => {
+    const onManualReview = vi.fn();
+    render(<ScreeningWorkflowPanel transUnionConnected={false} onManualReview={onManualReview} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Use manual review" }));
+    expect(onManualReview).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/do not upload or store raw bureau reports here/i)).toBeInTheDocument();
+  });
+
+  it("shows consent and provider requirements guidance", () => {
+    render(<ScreeningWorkflowPanel transUnionConnected workflowStatus="requested" onTransUnionStart={vi.fn()} />);
+
+    expect(screen.getByText("Workflow state: Awaiting applicant")).toBeInTheDocument();
+    expect(screen.getByText(/Verify consent and provider requirements before ordering reports/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Use TransUnion" })).toBeEnabled();
+  });
+});

--- a/rentchain-frontend/src/components/screening/ScreeningWorkflowPanel.tsx
+++ b/rentchain-frontend/src/components/screening/ScreeningWorkflowPanel.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { Button } from "@/components/ui/Ui";
+import {
+  getScreeningProviderOptions,
+  normalizeScreeningWorkflowState,
+  screeningProviderAvailabilityLabel,
+  screeningWorkflowStateLabel,
+  type ScreeningProviderAvailability,
+  type ScreeningProviderKey,
+} from "@/lib/screeningWorkflowProviders";
+import { colors, radius, spacing, text } from "@/styles/tokens";
+
+type ScreeningWorkflowPanelProps = {
+  screeningEnabled?: boolean;
+  transUnionConnected?: boolean;
+  workflowStatus?: string | null;
+  compact?: boolean;
+  onTransUnionSetup?: () => void;
+  onTransUnionStart?: () => void;
+  onManualReview?: () => void;
+};
+
+function availabilityTone(value: ScreeningProviderAvailability): React.CSSProperties {
+  switch (value) {
+    case "available":
+      return { background: "rgba(16,185,129,0.12)", borderColor: "rgba(16,185,129,0.35)", color: "#047857" };
+    case "manual":
+      return { background: "rgba(37,99,235,0.12)", borderColor: "rgba(37,99,235,0.35)", color: colors.accent };
+    case "requires_setup":
+      return { background: "rgba(234,179,8,0.14)", borderColor: "rgba(234,179,8,0.38)", color: "#92400e" };
+    default:
+      return { background: "rgba(148,163,184,0.14)", borderColor: "rgba(148,163,184,0.32)", color: text.muted };
+  }
+}
+
+function actionForProvider(
+  key: ScreeningProviderKey,
+  availability: ScreeningProviderAvailability,
+  props: ScreeningWorkflowPanelProps,
+) {
+  if (key === "transunion" && availability === "available" && props.onTransUnionStart) {
+    return { label: "Use TransUnion", onClick: props.onTransUnionStart, disabled: false };
+  }
+  if (key === "transunion" && availability === "requires_setup" && props.onTransUnionSetup) {
+    return { label: "Set up provider", onClick: props.onTransUnionSetup, disabled: false };
+  }
+  if (key === "manual_offline" && availability === "manual" && props.onManualReview) {
+    return { label: "Use manual review", onClick: props.onManualReview, disabled: false };
+  }
+  return {
+    label: availability === "coming_soon" ? "Not live yet" : screeningProviderAvailabilityLabel(availability),
+    onClick: undefined,
+    disabled: true,
+  };
+}
+
+export function ScreeningWorkflowPanel(props: ScreeningWorkflowPanelProps) {
+  const options = getScreeningProviderOptions({
+    screeningEnabled: props.screeningEnabled,
+    transUnionConnected: props.transUnionConnected,
+  });
+  const workflowState = normalizeScreeningWorkflowState(props.workflowStatus);
+  const cardPadding = props.compact ? spacing.md : spacing.lg;
+
+  return (
+    <section
+      data-testid="screening-workflow-panel"
+      style={{
+        display: "grid",
+        gap: spacing.md,
+        padding: cardPadding,
+        border: `1px solid ${colors.border}`,
+        background: props.compact ? colors.panel : colors.card,
+        borderRadius: radius.lg,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <div style={{ fontWeight: 800, fontSize: props.compact ? 14 : 16 }}>Screening workflow</div>
+          <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.55 }}>
+            Choose a provider path, confirm consent, then review results or manual evidence inside the applicant workflow.
+          </div>
+        </div>
+        <span
+          style={{
+            alignSelf: "flex-start",
+            display: "inline-flex",
+            padding: "5px 10px",
+            borderRadius: radius.pill,
+            border: `1px solid ${colors.border}`,
+            background: colors.bg,
+            color: text.secondary,
+            fontSize: 12,
+            fontWeight: 800,
+            whiteSpace: "nowrap",
+          }}
+        >
+          Workflow state: {screeningWorkflowStateLabel(workflowState)}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gap: spacing.sm,
+          gridTemplateColumns: props.compact ? "1fr" : "repeat(auto-fit, minmax(210px, 1fr))",
+        }}
+      >
+        {options.map((option) => {
+          const tone = availabilityTone(option.availability);
+          const action = actionForProvider(option.key, option.availability, props);
+          return (
+            <div
+              key={option.key}
+              style={{
+                border: `1px solid ${colors.border}`,
+                borderRadius: radius.md,
+                background: colors.card,
+                padding: spacing.sm,
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "flex-start" }}>
+                <div>
+                  <div style={{ color: text.primary, fontWeight: 800, fontSize: 14 }}>{option.label}</div>
+                  <div style={{ color: text.subtle, fontSize: 12, marginTop: 2 }}>{option.capability}</div>
+                </div>
+                <span
+                  style={{
+                    border: `1px solid ${tone.borderColor}`,
+                    borderRadius: radius.pill,
+                    background: tone.background,
+                    color: tone.color,
+                    padding: "3px 8px",
+                    fontSize: 11,
+                    fontWeight: 800,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {screeningProviderAvailabilityLabel(option.availability)}
+                </span>
+              </div>
+              <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.5 }}>{option.description}</div>
+              <div>
+                <Button
+                  type="button"
+                  variant={action.disabled ? "ghost" : option.availability === "manual" ? "secondary" : "primary"}
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  aria-disabled={action.disabled}
+                  style={{ padding: "7px 10px", fontSize: 12 }}
+                >
+                  {action.label}
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        style={{
+          border: `1px solid ${colors.border}`,
+          borderRadius: radius.md,
+          background: colors.bg,
+          padding: spacing.sm,
+          color: text.muted,
+          fontSize: 12,
+          lineHeight: 1.55,
+          display: "grid",
+          gap: 4,
+        }}
+      >
+        <div>
+          Consent required: confirm applicant authorization and provider requirements before ordering or recording screening.
+        </div>
+        <div>Screening provider availability may vary. Verify consent and provider requirements before ordering reports.</div>
+        <div>RentChain stores workflow metadata and review summaries only; do not upload or store raw bureau reports here.</div>
+      </div>
+    </section>
+  );
+}

--- a/rentchain-frontend/src/lib/screeningWorkflowProviders.test.ts
+++ b/rentchain-frontend/src/lib/screeningWorkflowProviders.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  getScreeningProviderOptions,
+  normalizeScreeningWorkflowState,
+  screeningProviderAvailabilityLabel,
+} from "./screeningWorkflowProviders";
+
+describe("screeningWorkflowProviders", () => {
+  it("returns deterministic provider options with only configured paths marked live", () => {
+    const options = getScreeningProviderOptions({ screeningEnabled: true, transUnionConnected: true });
+
+    expect(options.map((option) => option.key)).toEqual([
+      "transunion",
+      "certn",
+      "equifax",
+      "manual_offline",
+      "future_provider",
+    ]);
+    expect(options.find((option) => option.key === "transunion")).toMatchObject({
+      availability: "available",
+      live: true,
+    });
+    expect(options.find((option) => option.key === "certn")).toMatchObject({
+      availability: "coming_soon",
+      live: false,
+    });
+    expect(options.find((option) => option.key === "equifax")).toMatchObject({
+      availability: "coming_soon",
+      live: false,
+    });
+    expect(options.find((option) => option.key === "manual_offline")).toMatchObject({
+      availability: "manual",
+      live: true,
+    });
+  });
+
+  it("requires setup for TransUnion when credentials are not connected", () => {
+    const options = getScreeningProviderOptions({ screeningEnabled: true, transUnionConnected: false });
+
+    expect(options.find((option) => option.key === "transunion")).toMatchObject({
+      availability: "requires_setup",
+      live: false,
+    });
+  });
+
+  it("normalizes legacy screening status names into provider-agnostic states", () => {
+    expect(normalizeScreeningWorkflowState("requested")).toBe("awaiting_applicant");
+    expect(normalizeScreeningWorkflowState("processing")).toBe("in_progress");
+    expect(normalizeScreeningWorkflowState("complete")).toBe("completed");
+    expect(normalizeScreeningWorkflowState("blocked_transunion_not_connected")).toBe("blocked");
+    expect(screeningProviderAvailabilityLabel("requires_setup")).toBe("Requires setup");
+  });
+});

--- a/rentchain-frontend/src/lib/screeningWorkflowProviders.ts
+++ b/rentchain-frontend/src/lib/screeningWorkflowProviders.ts
@@ -1,0 +1,152 @@
+export type ScreeningProviderKey = "transunion" | "certn" | "equifax" | "manual_offline" | "future_provider";
+
+export type ScreeningProviderAvailability = "available" | "coming_soon" | "manual" | "requires_setup" | "unavailable";
+
+export type ScreeningWorkflowState =
+  | "not_started"
+  | "consent_needed"
+  | "provider_selected"
+  | "awaiting_applicant"
+  | "in_progress"
+  | "completed"
+  | "manual_review"
+  | "blocked"
+  | "unavailable";
+
+export type ScreeningProviderOption = {
+  key: ScreeningProviderKey;
+  label: string;
+  availability: ScreeningProviderAvailability;
+  capability: string;
+  description: string;
+  live: boolean;
+};
+
+const PROVIDER_BASE: Record<ScreeningProviderKey, Omit<ScreeningProviderOption, "availability" | "live">> = {
+  transunion: {
+    key: "transunion",
+    label: "TransUnion",
+    capability: "Credit and identity screening",
+    description: "Existing configured provider path. Availability depends on landlord credentials and environment setup.",
+  },
+  certn: {
+    key: "certn",
+    label: "Certn",
+    capability: "Background and identity workflow candidate",
+    description: "Workflow-ready provider candidate. Integration is not active yet.",
+  },
+  equifax: {
+    key: "equifax",
+    label: "Equifax",
+    capability: "Credit bureau workflow candidate",
+    description: "Provider candidate for a future integration path. Integration is not active yet.",
+  },
+  manual_offline: {
+    key: "manual_offline",
+    label: "Manual/offline review",
+    capability: "Offline document and reference review",
+    description: "Use a review workflow when provider screening is unavailable or not appropriate.",
+  },
+  future_provider: {
+    key: "future_provider",
+    label: "Future provider",
+    capability: "Additional screening provider slot",
+    description: "Placeholder for future provider expansion without changing landlord workflow structure.",
+  },
+};
+
+export function getScreeningProviderOptions(input?: {
+  screeningEnabled?: boolean;
+  transUnionConnected?: boolean;
+}): ScreeningProviderOption[] {
+  const screeningEnabled = input?.screeningEnabled !== false;
+  const transUnionConnected = Boolean(input?.transUnionConnected);
+  const transUnionAvailability: ScreeningProviderAvailability = !screeningEnabled
+    ? "unavailable"
+    : transUnionConnected
+      ? "available"
+      : "requires_setup";
+
+  return [
+    {
+      ...PROVIDER_BASE.transunion,
+      availability: transUnionAvailability,
+      live: transUnionAvailability === "available",
+    },
+    {
+      ...PROVIDER_BASE.certn,
+      availability: "coming_soon",
+      live: false,
+    },
+    {
+      ...PROVIDER_BASE.equifax,
+      availability: "coming_soon",
+      live: false,
+    },
+    {
+      ...PROVIDER_BASE.manual_offline,
+      availability: "manual",
+      live: screeningEnabled,
+    },
+    {
+      ...PROVIDER_BASE.future_provider,
+      availability: "coming_soon",
+      live: false,
+    },
+  ];
+}
+
+export function normalizeScreeningWorkflowState(value?: string | null): ScreeningWorkflowState {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "requested") return "awaiting_applicant";
+  if (normalized === "processing") return "in_progress";
+  if (normalized === "complete") return "completed";
+  if (normalized === "completed") return "completed";
+  if (normalized === "failed" || normalized === "cancelled") return "manual_review";
+  if (normalized === "blocked_transunion_not_connected") return "blocked";
+  if (normalized === "pending" || normalized === "provider_selected") return "provider_selected";
+  if (normalized === "consent_required" || normalized === "consent_needed") return "consent_needed";
+  if (normalized === "unavailable") return "unavailable";
+  if (normalized === "in_progress") return "in_progress";
+  return "not_started";
+}
+
+export function screeningProviderAvailabilityLabel(value: ScreeningProviderAvailability): string {
+  switch (value) {
+    case "available":
+      return "Available";
+    case "coming_soon":
+      return "Coming soon";
+    case "manual":
+      return "Manual";
+    case "requires_setup":
+      return "Requires setup";
+    case "unavailable":
+      return "Unavailable";
+    default:
+      return "Unavailable";
+  }
+}
+
+export function screeningWorkflowStateLabel(value: ScreeningWorkflowState): string {
+  switch (value) {
+    case "consent_needed":
+      return "Consent needed";
+    case "provider_selected":
+      return "Provider selected";
+    case "awaiting_applicant":
+      return "Awaiting applicant";
+    case "in_progress":
+      return "In progress";
+    case "completed":
+      return "Completed";
+    case "manual_review":
+      return "Manual review";
+    case "blocked":
+      return "Blocked";
+    case "unavailable":
+      return "Unavailable";
+    default:
+      return "Not started";
+  }
+}

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -532,7 +532,7 @@ describe("ApplicationsPage", () => {
     });
 
     expect(screen.getByRole("button", { name: "Send screening invite" })).toBeInTheDocument();
-    expect(screen.getAllByText("Tenant Screening Setup").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Screening provider setup").length).toBeGreaterThan(0);
     expect(screen.getByText("Screening Provider")).toBeInTheDocument();
     expect(screen.getAllByText("Screening workflow").length).toBeGreaterThan(0);
     expect(screen.getAllByText("TransUnion").length).toBeGreaterThan(0);
@@ -541,7 +541,8 @@ describe("ApplicationsPage", () => {
     expect(screen.getAllByText("Manual/offline review").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Verify consent and provider requirements before ordering reports/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Screening provider not connected").length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("button", { name: "Provider credentials" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Screening provider setup" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Manage screening providers" }).length).toBeGreaterThan(0);
     expect(screen.queryByText("TransUnion Connection")).not.toBeInTheDocument();
     expect(screen.getByText("Application Funnel")).toBeInTheDocument();
     expect(screen.getByText("40%")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -534,6 +534,12 @@ describe("ApplicationsPage", () => {
     expect(screen.getByRole("button", { name: "Send screening invite" })).toBeInTheDocument();
     expect(screen.getAllByText("Tenant Screening Setup").length).toBeGreaterThan(0);
     expect(screen.getByText("Screening Provider")).toBeInTheDocument();
+    expect(screen.getAllByText("Screening workflow").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("TransUnion").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Certn").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Equifax").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual/offline review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Verify consent and provider requirements before ordering reports/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Screening provider not connected").length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: "Provider credentials" }).length).toBeGreaterThan(0);
     expect(screen.queryByText("TransUnion Connection")).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -251,23 +251,23 @@ function ScreeningProviderSetupCard({
         ? "Screening Provider is connected and ready for the selected application."
         : "Screening Provider is connected. Choose an applicant to start the tenant screening workflow."
       : pending
-        ? "Tenant Screening Setup is in progress. Finish provider credentialing, then return to enter Provider credentials."
+        ? "Screening provider setup is in progress. Finish provider credentialing, then return to configure provider details."
         : error
-          ? "Screening provider not connected. Review Provider credentials and try again."
-          : "Screening provider not connected. Start setup or enter Provider credentials before requesting tenant screening.";
+          ? "Screening provider not connected. Review provider details and try again."
+          : "Screening provider not connected. Start setup or enter provider details before requesting tenant screening.";
   const nextStep = connected
     ? readyToScreen
       ? `Next step: start screening${safeSelectedApplicationLabel ? ` for ${safeSelectedApplicationLabel}` : ""}.`
       : "Next step: choose an applicant, then start screening from that application."
     : pending
-      ? "Next step: complete Tenant Screening Setup, then enter Provider credentials."
-      : "Next step: connect Provider credentials or start Tenant Screening Setup.";
+      ? "Next step: complete screening provider setup, then enter provider details."
+      : "Next step: connect provider details or start screening provider setup.";
 
   return (
     <Card elevated data-testid="screening-provider-setup-card" style={{ display: "grid", gap: spacing.md }}>
       <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
         <div style={{ display: "grid", gap: spacing.xs }}>
-          <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Tenant Screening Setup</div>
+          <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Screening provider setup</div>
           <div style={{ color: text.subtle, fontSize: "0.88rem", fontWeight: 700 }}>Screening Provider</div>
           <div style={{ color: text.muted, lineHeight: 1.6 }}>{body}</div>
         </div>
@@ -288,13 +288,13 @@ function ScreeningProviderSetupCard({
         >
           {connected ? (
             <>
-              <div>Provider credentials: Stored securely</div>
+              <div>Provider details: Stored securely</div>
               <div>Last updated date: {updatedAt ? new Date(updatedAt).toLocaleDateString() : "Not available"}</div>
               {completedCount != null ? <div>Screenings completed: {completedCount}</div> : null}
               {formattedLastScreeningDate ? <div>Last screening date: {formattedLastScreeningDate}</div> : null}
             </>
           ) : (
-            <div>Provider credentials are required before screening can begin.</div>
+            <div>Provider setup is required before live screening can begin.</div>
           )}
           <div>{nextStep}</div>
         </div>
@@ -317,7 +317,7 @@ function ScreeningProviderSetupCard({
           {connected ? (
             <>
               <Button type="button" variant="secondary" onClick={onUpdateCredentials}>
-                Provider credentials
+                Manage screening providers
               </Button>
               <Button type="button" variant="ghost" onClick={onDisconnect}>
                 Disconnect
@@ -335,19 +335,19 @@ function ScreeningProviderSetupCard({
           ) : pending ? (
             <>
               <Button type="button" onClick={onEnterDetails}>
-                Provider credentials
+                Configure screening workflow
               </Button>
               <Button type="button" variant="secondary" onClick={onViewInstructions}>
-                Tenant Screening Setup
+                Screening provider setup
               </Button>
             </>
           ) : (
             <>
               <Button type="button" onClick={onGetAccess}>
-                Tenant Screening Setup
+                Screening provider setup
               </Button>
               <Button type="button" variant="secondary" onClick={onConnectExisting}>
-                Provider credentials
+                Manage screening providers
               </Button>
             </>
           )}

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -50,6 +50,7 @@ import "./ApplicationsPage.css";
 import { SendScreeningInviteModal } from "../components/screening/SendScreeningInviteModal";
 import { ScreeningStatusBadge } from "../components/screening/ScreeningStatusBadge";
 import { ScreeningStatusCard } from "@/components/screening/ScreeningStatusCard";
+import { ScreeningWorkflowPanel } from "@/components/screening/ScreeningWorkflowPanel";
 import {
   ScreeningReportView,
   type ScreeningReportAction,
@@ -199,6 +200,8 @@ function ScreeningProviderSetupCard({
   loading,
   readyToScreen,
   selectedApplicationLabel,
+  workflowStatus,
+  screeningEnabled = true,
   screeningsCompletedCount,
   lastScreeningDate,
   onGetAccess,
@@ -214,6 +217,8 @@ function ScreeningProviderSetupCard({
   loading: boolean;
   readyToScreen: boolean;
   selectedApplicationLabel?: string | null;
+  workflowStatus?: string | null;
+  screeningEnabled?: boolean;
   screeningsCompletedCount?: number | null;
   lastScreeningDate?: string | number | null;
   onGetAccess: () => void;
@@ -293,6 +298,18 @@ function ScreeningProviderSetupCard({
           )}
           <div>{nextStep}</div>
         </div>
+      ) : null}
+
+      {!loading ? (
+        <ScreeningWorkflowPanel
+          compact
+          screeningEnabled={screeningEnabled}
+          transUnionConnected={connected}
+          workflowStatus={workflowStatus}
+          onTransUnionSetup={connected ? undefined : onGetAccess}
+          onTransUnionStart={connected && readyToScreen && onStartScreening ? onStartScreening : undefined}
+          onManualReview={onChooseApplicant}
+        />
       ) : null}
 
       {!loading ? (
@@ -2285,6 +2302,8 @@ const ApplicationsPage: React.FC = () => {
         integration={transUnionIntegration}
         loading={transUnionLoading}
         readyToScreen={Boolean(detail)}
+        screeningEnabled={SCREENING_ENABLED}
+        workflowStatus={displayScreeningStatus || manualScreeningStatus?.status || null}
         selectedApplicationLabel={buildApplicantLabel(detail)}
         onChooseApplicant={guideToApplicationsForScreening}
         screeningsCompletedCount={

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -577,7 +577,7 @@ describe("DashboardPage", () => {
       </ToastProvider>
     );
 
-    expect(await screen.findByText("TransUnion Setup Funnel")).toBeInTheDocument();
+    expect(await screen.findByText("Provider setup funnel")).toBeInTheDocument();
     screen.getAllByRole("button", { name: "Open" })[0].click();
     expect(assignMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
     expect(screen.getByText("Started → Connected 50%")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -530,7 +530,7 @@ describe("DashboardPage", () => {
     expect(screen.getAllByText("Info")).toHaveLength(1);
     screen.getByRole("button", { name: "Info about Run your first screening" }).click();
     await waitFor(() => expect(screen.getByRole("dialog", { name: "Action information" })).toBeInTheDocument());
-    expect(screen.getByText(/Connect TransUnion access from Applications/i)).toBeInTheDocument();
+    expect(screen.getByText(/Open the screening workflow from Applications/i)).toBeInTheDocument();
     screen.getByRole("button", { name: "Open" }).click();
     expect(assignMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
   });
@@ -637,8 +637,8 @@ describe("DashboardPage", () => {
       </ToastProvider>
     );
 
-    expect(await screen.findAllByRole("button", { name: "Get TransUnion Access" })).not.toHaveLength(0);
-    screen.getAllByRole("button", { name: "Get TransUnion Access" })[0].click();
+    expect(await screen.findAllByRole("button", { name: "Set up screening workflow" })).not.toHaveLength(0);
+    screen.getAllByRole("button", { name: "Set up screening workflow" })[0].click();
     expect(mocks.navigateMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
 
     mocks.navigateMock.mockReset();

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -594,7 +594,7 @@ const DashboardPage: React.FC = () => {
     if (SCREENING_ENABLED && canManualScreen && (kpis.screeningsCount ?? 0) === 0) {
       items.push({
         id: "run-first-screening",
-        title: "Get TransUnion access",
+        title: "Set up screening workflow",
         severity: "info",
         href: "/applications?openTransUnionAccess=1",
       });
@@ -1013,7 +1013,7 @@ const DashboardPage: React.FC = () => {
                   </Button>
                 ) : (
                   <Button variant="primary" onClick={() => navigate("/applications?openTransUnionAccess=1")}>
-                    Get TransUnion Access
+                    Set up screening workflow
                   </Button>
                 )}
               </div>
@@ -1128,13 +1128,13 @@ const DashboardPage: React.FC = () => {
             <div style={{ color: text.muted, marginBottom: 12 }}>
               {SCREENING_ENABLED
                 ? screeningSetupComplete
-                  ? "Your screening setup is connected. Go to Applications to start screening."
-                  : "Start the TransUnion onboarding path, then return to RentChain to connect your credentials and screen applicants."
+                  ? "Your configured screening provider is connected. Go to Applications to start screening."
+                  : "Open the screening workflow to review provider setup, consent requirements, and manual/offline options."
                 : screeningLabel}
             </div>
             {SCREENING_ENABLED ? (
               <Button onClick={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}>
-                {screeningSetupComplete ? "Run screening" : "Get TransUnion Access"}
+                {screeningSetupComplete ? "Run screening" : "Set up screening workflow"}
               </Button>
             ) : (
               <Button disabled>{screeningLabel}</Button>

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -30,7 +30,7 @@ import { listReferrals } from "../api/referralsApi";
 import { markDashboardVisit } from "@/features/upgradeNudges/nudgeStore";
 import { GettingStartedCard } from "../components/onboarding/GettingStartedCard";
 import { LandlordWelcomeModal } from "../components/onboarding/LandlordWelcomeModal";
-import { SCREENING_ENABLED, getUiLocale, screeningComingSoonLabel } from "../config/screening";
+import { SCREENING_ENABLED } from "../config/screening";
 import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import { UpgradeNudgeInlineCard } from "@/features/upgradeNudges/UpgradeNudgeInlineCard";
 import { canUseTimeline, normalizeTimelinePlan } from "@/features/automation/timeline/timelineEntitlements";
@@ -258,8 +258,7 @@ const DashboardPage: React.FC = () => {
   const [showTimelineNudge, setShowTimelineNudge] = React.useState(false);
   const timelineNudgeViewedRef = React.useRef(false);
   const canManualScreen = isAdmin || features?.screening_pay_per_use !== false;
-  const uiLocale = getUiLocale();
-  const screeningLabel = screeningComingSoonLabel(uiLocale);
+  const screeningWorkflowLabel = "Screening workflow setup";
   const openActionsRef = React.useRef<HTMLDivElement | null>(null);
   const canUseReferrals = isLandlord || isAdmin;
   const [properties, setProperties] = React.useState<any[]>([]);
@@ -1004,8 +1003,8 @@ const DashboardPage: React.FC = () => {
                   Add Expense
                 </Button>
                 {!SCREENING_ENABLED ? (
-                  <Button variant="primary" disabled>
-                    {screeningLabel}
+                  <Button variant="primary" onClick={() => navigate("/applications")}>
+                    {screeningWorkflowLabel}
                   </Button>
                 ) : screeningSetupComplete ? (
                   <Button variant="primary" onClick={() => navigate("/applications")}>
@@ -1124,27 +1123,23 @@ const DashboardPage: React.FC = () => {
 
         {dataReady ? (
           <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Credit screening</div>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>Screening workflow</div>
             <div style={{ color: text.muted, marginBottom: 12 }}>
               {SCREENING_ENABLED
                 ? screeningSetupComplete
                   ? "Your configured screening provider is connected. Go to Applications to start screening."
                   : "Open the screening workflow to review provider setup, consent requirements, and manual/offline options."
-                : screeningLabel}
+                : "Open the screening workflow to review provider paths, consent requirements, and manual/offline options."}
             </div>
-            {SCREENING_ENABLED ? (
-              <Button onClick={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}>
-                {screeningSetupComplete ? "Run screening" : "Set up screening workflow"}
-              </Button>
-            ) : (
-              <Button disabled>{screeningLabel}</Button>
-            )}
+            <Button onClick={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}>
+              {screeningSetupComplete ? "Run screening" : "Set up screening workflow"}
+            </Button>
           </Card>
         ) : null}
 
         {dataReady && SCREENING_ENABLED ? (
           <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>TransUnion Setup Funnel</div>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>Provider setup funnel</div>
             <div style={{ color: text.muted, marginBottom: 12 }}>
               {transUnionFunnelLoading
                 ? "Loading onboarding funnel..."


### PR DESCRIPTION
## Summary

Adds a provider-agnostic screening workflow UI foundation without adding any new live provider integration.

## Audit Summary

Inspected existing screening workflow surfaces and provider assumptions across:

- `rentchain-frontend/src/pages/ApplicationsPage.tsx`
- `rentchain-frontend/src/components/applications/ApplicationDetailPanel.tsx`
- `rentchain-frontend/src/pages/DashboardPage.tsx`
- `rentchain-frontend/src/components/dashboard/ActionRequiredPanel.tsx`
- `rentchain-frontend/src/components/screening/ScreeningStatusCard.tsx`
- `rentchain-frontend/src/api/screeningOpsApi.ts`
- `rentchain-frontend/src/config/screening.ts`
- Existing screening tests for Applications, Dashboard, and screening components

## Provider Assumptions Found

- Application and dashboard CTAs still routed through the existing TransUnion setup path.
- The existing manual screening status card already used more provider-neutral copy in some places.
- Provider status types remain TransUnion/manual-oriented in current API types.
- Some TransUnion-specific admin/integration screens remain intentionally provider-specific because they manage the existing TransUnion path.

## Files Changed

- `rentchain-frontend/src/lib/screeningWorkflowProviders.ts`
- `rentchain-frontend/src/lib/screeningWorkflowProviders.test.ts`
- `rentchain-frontend/src/components/screening/ScreeningWorkflowPanel.tsx`
- `rentchain-frontend/src/components/screening/ScreeningWorkflowPanel.test.tsx`
- `rentchain-frontend/src/pages/ApplicationsPage.tsx`
- `rentchain-frontend/src/pages/ApplicationsPage.test.tsx`
- `rentchain-frontend/src/components/applications/ApplicationDetailPanel.tsx`
- `rentchain-frontend/src/pages/DashboardPage.tsx`
- `rentchain-frontend/src/pages/DashboardPage.test.tsx`
- `rentchain-frontend/src/components/dashboard/ActionRequiredPanel.tsx`

## UI Surfaces Updated

- Applications screening setup card now shows a provider-agnostic workflow panel.
- Applicant detail screening section now shows the same provider workflow foundation.
- Dashboard screening CTA copy now points to screening workflow setup instead of TransUnion-only language.
- Action-required screening guidance now describes provider availability and consent review instead of TransUnion-only setup.

## Provider Options Added as Metadata

- TransUnion: available only when existing credentials are connected; otherwise requires setup.
- Certn: coming soon, disabled.
- Equifax: coming soon, disabled.
- Manual/offline review: visible as manual fallback.
- Future provider: coming soon, disabled.

## Guardrails

- No backend routes changed.
- No new live provider integration added.
- No raw credit, bureau, or background report payload storage added.
- No approval/rejection automation added.
- Existing TransUnion flow remains intact.
- Payment, lease, lifecycle, occupancy, and tenant workspace logic untouched.

## Tests Run

- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/components/screening/ScreeningWorkflowPanel.test.tsx src/lib/screeningWorkflowProviders.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationsPage.test.tsx src/pages/DashboardPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`

## Known Follow-ups

- Backend provider registry/types can be generalized later once there is a provider integration mission.
- TransUnion-specific admin analytics/integration pages remain intentionally provider-specific.
- Future provider activation should require explicit consent, storage, and provider-specific backend guardrails before any live ordering is enabled.