### PR TITLE
feat: add operational command center foundation

### DIFF
--- a/rentchain-api/src/lib/automatedWorkflows/__tests__/deriveAutomatedWorkflowTransitions.test.ts
+++ b/rentchain-api/src/lib/automatedWorkflows/__tests__/deriveAutomatedWorkflowTransitions.test.ts
@@ -159,4 +159,26 @@ describe("deriveAutomatedWorkflowTransitions", () => {
 
     expect(source).toEqual(before);
   });
+
+  it("uses readable operational reasons instead of raw decision identifiers", () => {
+    const result = deriveAutomatedWorkflowTransitions({
+      decisions: [
+        decision({
+          id: "reduce_vacancy_risk:ZaeL9oqpJCSZPguWa6wR",
+          title: "Decision reduce_vacancy_risk:ZaeL9oqpJCSZPguWa6wR",
+          workflow: {
+            queue: "lease_review",
+            workflowState: "new",
+            ownershipType: "landlord",
+            reviewPriority: "medium",
+            escalationLevel: "none",
+            manualOnly: true,
+          },
+        }),
+      ],
+    });
+
+    expect(result.workflows[0].reasons[0]).toBe("Vacancy pressure review is routed to Lease readiness review.");
+    expect(result.workflows[0].reasons.join(" ")).not.toMatch(/ZaeL9oqpJCSZPguWa6wR|reduce_vacancy_risk:/);
+  });
 });

--- a/rentchain-api/src/lib/automatedWorkflows/deriveAutomatedWorkflowTransitions.ts
+++ b/rentchain-api/src/lib/automatedWorkflows/deriveAutomatedWorkflowTransitions.ts
@@ -62,6 +62,7 @@ function workflowQueueLabel(queue: DecisionWorkflowQueue): string {
 function looksLikeInternalId(value: unknown): boolean {
   const raw = asString(value, 240);
   if (!raw) return false;
+  if (/^[a-z]+:[A-Za-z0-9:_-]{8,}$/i.test(raw)) return true;
   if (/^[a-z]+_[a-z]+:/i.test(raw)) return true;
   if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw)) return true;
   if (/^[A-Za-z0-9_-]{18,}$/.test(raw) && /[A-Z]/.test(raw) && /[a-z]/.test(raw) && /\d/.test(raw)) return true;
@@ -72,7 +73,7 @@ function hasRawReferenceLabel(value: unknown): boolean {
   const raw = asString(value, 240);
   if (!raw) return false;
   if (looksLikeInternalId(raw)) return true;
-  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]{8,}$/i.test(raw);
+  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]+$/i.test(raw);
 }
 
 function operationalDecisionLabel(decision: DecisionInboxItem): string {

--- a/rentchain-api/src/lib/automatedWorkflows/deriveAutomatedWorkflowTransitions.ts
+++ b/rentchain-api/src/lib/automatedWorkflows/deriveAutomatedWorkflowTransitions.ts
@@ -45,6 +45,50 @@ function generatedAt(value: unknown): string {
   return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
 }
 
+function titleCase(value: string): string {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function workflowQueueLabel(queue: DecisionWorkflowQueue): string {
+  if (queue === "lease_review") return "Lease readiness review";
+  if (queue === "delinquency_review") return "Delinquency review";
+  if (queue === "screening_review") return "Screening workflow review";
+  if (queue === "maintenance_review") return "Maintenance review";
+  if (queue === "compliance_review") return "Compliance review";
+  if (queue === "admin_review") return "Admin review";
+  return "General review";
+}
+
+function looksLikeInternalId(value: unknown): boolean {
+  const raw = asString(value, 240);
+  if (!raw) return false;
+  if (/^[a-z]+_[a-z]+:/i.test(raw)) return true;
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw)) return true;
+  if (/^[A-Za-z0-9_-]{18,}$/.test(raw) && /[A-Z]/.test(raw) && /[a-z]/.test(raw) && /\d/.test(raw)) return true;
+  return false;
+}
+
+function hasRawReferenceLabel(value: unknown): boolean {
+  const raw = asString(value, 240);
+  if (!raw) return false;
+  if (looksLikeInternalId(raw)) return true;
+  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]{8,}$/i.test(raw);
+}
+
+function operationalDecisionLabel(decision: DecisionInboxItem): string {
+  const title = asString(decision.title, 160);
+  if (title && !hasRawReferenceLabel(title)) return title;
+  const raw = asString(decision.id, 240).toLowerCase();
+  if (raw.includes("reduce_vacancy_risk") || raw.includes("vacancy")) return "Vacancy pressure review";
+  if (raw.includes("revenue")) return "Revenue pressure review";
+  if (raw.includes("missing_payment") || raw.includes("delinquency") || decision.workflow.queue === "delinquency_review") {
+    return "Delinquency review";
+  }
+  if (raw.includes("lease") || decision.workflow.queue === "lease_review") return "Lease readiness review";
+  if (raw.includes("screening") || decision.workflow.queue === "screening_review") return "Screening workflow review";
+  return "Operational review";
+}
+
 function workflowTypeForDecision(decision: DecisionInboxItem): AutomatedWorkflowType {
   if (decision.workflow.queue === "delinquency_review") return "delinquency";
   if (decision.workflow.queue === "maintenance_review") return "maintenance";
@@ -65,9 +109,9 @@ function transitionForState(state: DecisionWorkflowState): { toState: DecisionWo
 
 function reasonsForDecision(decision: DecisionInboxItem, toState: DecisionWorkflowState): string[] {
   const reasons = [
-    `Decision ${decision.id} is routed to ${decision.workflow.queue}.`,
-    `Current workflow state is ${decision.workflow.workflowState}.`,
-    `Derived internal review state is ${toState}.`,
+    `${operationalDecisionLabel(decision)} is routed to ${workflowQueueLabel(decision.workflow.queue)}.`,
+    `Current workflow state is ${titleCase(decision.workflow.workflowState)}.`,
+    `Derived internal review state is ${titleCase(toState)}.`,
     "Manual review remains required before any operational action.",
   ];
   if (decision.workflow.escalationLevel !== "none") {

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -131,4 +131,41 @@ describe("deriveEvidencePack", () => {
     expect(pack.status).toBe("unavailable");
     expect(pack.manualReviewRequired).toBe(true);
   });
+
+  it("uses operational evidence labels instead of raw lease and decision identifiers", () => {
+    const pack = deriveEvidencePack({
+      scope: "lease",
+      scopeId: "JK6S7JQ2HsMj8m8RFI76",
+      landlordId: "landlord-1",
+      decisions: [
+        {
+          ...decision,
+          id: "reduce_vacancy_risk:ZaeL9oqpJCSZPguWa6wR",
+          title: "Decision reduce_vacancy_risk:ZaeL9oqpJCSZPguWa6wR",
+          workflow: { ...decision.workflow, queue: "lease_review" },
+        },
+      ],
+      leases: [
+        {
+          id: "JK6S7JQ2HsMj8m8RFI76",
+          propertyName: "North Towers",
+          unitNumber: "103",
+          tenantName: "James Smith",
+        },
+      ],
+      properties: [{ id: "ZaeL9oqpJCSZPguWa6wR", name: "North Towers" }],
+    });
+
+    const leaseContext = pack.sections.find((section) => section.sectionKey === "lease_context");
+    const decisionLineage = pack.sections.find((section) => section.sectionKey === "decision_lineage");
+
+    expect(leaseContext?.items[0]?.label).toBe("North Towers · Unit 103 · James Smith");
+    expect(decisionLineage?.items[0]?.label).toBe("Vacancy pressure review");
+    expect(pack.sections.flatMap((section) => section.items.map((item) => item.label))).not.toContain(
+      "Lease JK6S7JQ2HsMj8m8RFI76"
+    );
+    expect(pack.sections.flatMap((section) => section.items.map((item) => item.label))).not.toContain(
+      "Decision reduce_vacancy_risk:ZaeL9oqpJCSZPguWa6wR"
+    );
+  });
 });

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -51,6 +51,7 @@ function normalizeTimestamp(value: unknown): string | null {
 function looksLikeInternalId(value: unknown): boolean {
   const raw = asString(value, 240);
   if (!raw) return false;
+  if (/^[a-z]+:[A-Za-z0-9:_-]{8,}$/i.test(raw)) return true;
   if (/^[a-z]+_[a-z]+:/i.test(raw)) return true;
   if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw)) return true;
   if (/^[A-Za-z0-9_-]{18,}$/.test(raw) && /[A-Z]/.test(raw) && /[a-z]/.test(raw) && /\d/.test(raw)) return true;
@@ -61,7 +62,7 @@ function hasRawReferenceLabel(value: unknown): boolean {
   const raw = asString(value, 240);
   if (!raw) return false;
   if (looksLikeInternalId(raw)) return true;
-  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]{8,}$/i.test(raw);
+  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]+$/i.test(raw);
 }
 
 function unitLabel(value: unknown): string {

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -48,6 +48,61 @@ function normalizeTimestamp(value: unknown): string | null {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
+function looksLikeInternalId(value: unknown): boolean {
+  const raw = asString(value, 240);
+  if (!raw) return false;
+  if (/^[a-z]+_[a-z]+:/i.test(raw)) return true;
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw)) return true;
+  if (/^[A-Za-z0-9_-]{18,}$/.test(raw) && /[A-Z]/.test(raw) && /[a-z]/.test(raw) && /\d/.test(raw)) return true;
+  return false;
+}
+
+function hasRawReferenceLabel(value: unknown): boolean {
+  const raw = asString(value, 240);
+  if (!raw) return false;
+  if (looksLikeInternalId(raw)) return true;
+  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]{8,}$/i.test(raw);
+}
+
+function unitLabel(value: unknown): string {
+  const raw = asString(value, 80);
+  if (!raw || looksLikeInternalId(raw)) return "";
+  return /^unit\s+/i.test(raw) ? raw : `Unit ${raw}`;
+}
+
+function leaseContextLabel(lease: Record<string, any>): string {
+  const property = asString(
+    lease.propertyName || lease.propertyLabel || lease.property?.name || lease.propertyAddress || lease.address,
+    120
+  );
+  const unit = unitLabel(lease.unitLabel || lease.unitNumber || lease.unitName || lease.unit);
+  const tenant = asString(lease.tenantName || lease.primaryTenantName || lease.tenant?.name, 120);
+  const parts = [property, unit].filter(Boolean);
+  if (parts.length) return tenant ? `${parts.join(" · ")} · ${tenant}` : parts.join(" · ");
+  if (tenant) return `${tenant} lease`;
+  return "Lease context review";
+}
+
+function propertyContextLabel(property: Record<string, any>): string {
+  const name = asString(property.name || property.propertyName || property.address || property.addressLine1, 160);
+  return name && !hasRawReferenceLabel(name) ? name : "Property review";
+}
+
+function operationalDecisionLabel(decision: Record<string, any>): string {
+  const title = asString(decision.title, 160);
+  if (title && !hasRawReferenceLabel(title)) return title;
+  const raw = asString(decision.id || decision.decisionId || decision.decisionType || decision.type, 240).toLowerCase();
+  const queue = asString(decision.workflow?.queue, 120).toLowerCase();
+  if (raw.includes("reduce_vacancy_risk") || raw.includes("vacancy")) return "Vacancy pressure review";
+  if (raw.includes("revenue")) return "Revenue pressure review";
+  if (raw.includes("missing_payment") || raw.includes("delinquency") || queue === "delinquency_review") {
+    return "Delinquency review";
+  }
+  if (raw.includes("lease") || queue === "lease_review") return "Lease readiness review";
+  if (raw.includes("screening") || queue === "screening_review") return "Screening workflow review";
+  return "Operational review";
+}
+
 function evidenceItem(input: {
   itemType: EvidenceItemType;
   label: string;
@@ -149,7 +204,7 @@ function decisionSections(input: DeriveEvidencePackInput): EvidencePackSection[]
   const decisionItems = target.map((decision) =>
     evidenceItem({
       itemType: "decision",
-      label: decision.title,
+      label: operationalDecisionLabel(decision),
       description: decision.description,
       source: "decision_inbox",
       sourceId: decision.id,
@@ -285,7 +340,7 @@ function contextSections(input: DeriveEvidencePackInput): EvidencePackSection[] 
     .map((lease) =>
       evidenceItem({
         itemType: "lease_summary",
-        label: `Lease ${asString(lease.id || lease.leaseId, 120) || "summary"}`,
+        label: leaseContextLabel(lease),
         description: `Lease context includes property and unit linkage without private tenant documents.`,
         source: "lease_ledger",
         sourceId: asString(lease.id || lease.leaseId, 240) || null,
@@ -299,7 +354,7 @@ function contextSections(input: DeriveEvidencePackInput): EvidencePackSection[] 
     .map((property) =>
       evidenceItem({
         itemType: "property_summary",
-        label: asString(property.name || property.address || property.id || "Property summary", 160),
+        label: propertyContextLabel(property),
         description: "Landlord-scoped property context is available.",
         source: "registry",
         sourceId: asString(property.id || property.propertyId, 240) || null,
@@ -354,7 +409,7 @@ function delinquencySection(input: DeriveEvidencePackInput): EvidencePackSection
     items: delinquency.slice(0, 8).map((decision) =>
       evidenceItem({
         itemType: "ledger_summary",
-        label: decision.title,
+        label: operationalDecisionLabel(decision),
         description: decision.description,
         source: "lease_ledger",
         sourceId: decision.id,

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -126,6 +126,7 @@ const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScor
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
 const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
 const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"));
+const OperationalCommandCenterPage = lazy(() => import("./pages/OperationalCommandCenterPage"));
 const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
 const AgentSupervisionPage = lazy(() => import("./pages/AgentSupervisionPage"));
 const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage"));
@@ -521,6 +522,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <LandlordAnalyticsPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/operations"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <OperationalCommandCenterPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/components/agentActions/AgentActionPanel.test.tsx
+++ b/rentchain-frontend/src/components/agentActions/AgentActionPanel.test.tsx
@@ -59,4 +59,27 @@ describe("AgentActionPanel", () => {
     expect(screen.getByText("Blocked")).toBeInTheDocument();
     expect(screen.getByText("Required workflow context is missing or incomplete.")).toBeInTheDocument();
   });
+
+  it("renders workflow explanation reasons without raw decision route identifiers", () => {
+    render(
+      <AgentActionPanel
+        actions={[
+          action({
+            explanation: {
+              summary: "Escalation review is recommended based on workflow severity.",
+              reasons: [
+                "Decision decision:review_overdue_rent:delinquency:overdue:lease_lifecycle:jjua9wfkdv19d5y5sdv7 is routed to delinquency_review.",
+              ],
+              blockedReasons: [],
+            },
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Overdue rent review is routed to delinquency review.")).toBeInTheDocument();
+    expect(screen.queryByText(/Decision decision:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/lease_lifecycle:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/delinquency_review/)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/agentActions/AgentActionPanel.tsx
+++ b/rentchain-frontend/src/components/agentActions/AgentActionPanel.tsx
@@ -5,6 +5,40 @@ function label(value: string) {
   return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function workflowQueueLabel(queue: string) {
+  if (queue === "delinquency_review") return "delinquency review";
+  if (queue === "lease_review") return "lease readiness review";
+  if (queue === "screening_review") return "screening workflow review";
+  if (queue === "maintenance_review") return "maintenance review";
+  if (queue === "compliance_review") return "compliance review";
+  if (queue === "admin_review") return "admin review";
+  return label(queue).toLowerCase();
+}
+
+function operationalReviewLabel(value: string, queue?: string) {
+  const raw = value.toLowerCase();
+  if (raw.includes("review_overdue_rent") || raw.includes("overdue_rent") || raw.includes("overdue")) {
+    return "Overdue rent review";
+  }
+  if (raw.includes("review_missing_payment") || raw.includes("missing_payment")) return "Missing payment review";
+  if (raw.includes("reduce_vacancy_risk") || raw.includes("vacancy")) return "Vacancy pressure review";
+  if (raw.includes("revenue")) return "Revenue pressure review";
+  if (raw.includes("delinquency") || queue === "delinquency_review") return "Delinquency review";
+  if (raw.includes("screening") || queue === "screening_review") return "Screening workflow review";
+  if (raw.includes("lease") || queue === "lease_review") return "Lease readiness review";
+  return "Operational review";
+}
+
+function safeExplanationReason(reason: string, action: PolicyGatedAgentAction) {
+  const routedMatch = reason.match(/^Decision\s+(.+?)\s+is routed to\s+([a-z_]+)\.?$/i);
+  if (routedMatch) {
+    return `${operationalReviewLabel(routedMatch[1], action.queue)} is routed to ${workflowQueueLabel(routedMatch[2])}.`;
+  }
+  return reason.replace(/\b(lease_lifecycle|decision|property|lease):[A-Za-z0-9:_-]+\b/gi, (match) =>
+    operationalReviewLabel(match, action.queue)
+  );
+}
+
 function statusTone(status: AgentActionStatus) {
   if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
   if (status === "suggested") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
@@ -74,7 +108,7 @@ export function AgentActionPanel({ actions }: { actions?: PolicyGatedAgentAction
             <strong style={{ color: "#312e81", fontSize: 13 }}>Review explanation</strong>
             {action.explanation.reasons.slice(0, 4).map((reason) => (
               <span key={reason} style={{ color: "#475569", fontSize: 13 }}>
-                {reason}
+                {safeExplanationReason(reason, action)}
               </span>
             ))}
             {action.explanation.blockedReasons.map((reason) => (

--- a/rentchain-frontend/src/components/evidence/EvidencePackPanel.test.tsx
+++ b/rentchain-frontend/src/components/evidence/EvidencePackPanel.test.tsx
@@ -87,4 +87,68 @@ describe("EvidencePackPanel", () => {
     expect(screen.getByText("Payment Account Details")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /submit|send|share externally|certify|file|upload|auto-report|legal approval/i })).not.toBeInTheDocument();
   });
+
+  it("does not render raw decision or lease identifiers as primary evidence labels", () => {
+    render(
+      <MemoryRouter>
+        <EvidencePackPanel
+          evidencePack={evidencePack({
+            scope: "lease",
+            scopeId: "JK6S7JQ2HsMj8m8RFI76",
+            sections: [
+              {
+                sectionKey: "lease_context",
+                label: "Lease context",
+                status: "included",
+                itemsCount: 1,
+                items: [{
+                  evidenceItemId: "lease-item",
+                  itemType: "lease_summary",
+                  label: "Lease JK6S7JQ2HsMj8m8RFI76",
+                  description: "Lease context includes property and unit linkage.",
+                  status: "included",
+                  source: "lease_ledger",
+                  sourceId: "JK6S7JQ2HsMj8m8RFI76",
+                  destination: "/leases/JK6S7JQ2HsMj8m8RFI76/ledger",
+                  timestamp: null,
+                  redacted: false,
+                  redactionReason: null,
+                  blockedReason: null,
+                }],
+                missingEvidence: [],
+                blockedReasons: [],
+              },
+              {
+                sectionKey: "decision_lineage",
+                label: "Decision lineage",
+                status: "included",
+                itemsCount: 1,
+                items: [{
+                  evidenceItemId: "decision-item",
+                  itemType: "decision",
+                  label: "Decision decision:review_missing_payment:delinquency:missing_payment:lease_lifecycle:jjua9wfkdv19d5y5sdv7",
+                  description: "Expected rent payment is missing.",
+                  status: "included",
+                  source: "decision_inbox",
+                  sourceId: "decision:review_missing_payment:delinquency:missing_payment:lease_lifecycle:jjua9wfkdv19d5y5sdv7",
+                  destination: "/leases/jjua9wfkdv19d5y5sdv7/ledger",
+                  timestamp: null,
+                  redacted: false,
+                  redactionReason: null,
+                  blockedReason: null,
+                }],
+                missingEvidence: [],
+                blockedReasons: [],
+              },
+            ],
+          }) as any}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText("Lease context review").length).toBeGreaterThan(0);
+    expect(screen.getByText("Missing payment review")).toBeInTheDocument();
+    expect(screen.queryByText(/Lease JK6S7JQ2HsMj8m8RFI76/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Decision decision:/)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/evidence/EvidencePackPanel.test.tsx
+++ b/rentchain-frontend/src/components/evidence/EvidencePackPanel.test.tsx
@@ -76,6 +76,8 @@ describe("EvidencePackPanel", () => {
     expect(screen.getByText("Total items")).toBeInTheDocument();
     expect(screen.getByText("Decision lineage")).toBeInTheDocument();
     expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getByText("Decision · Review missing payment")).toBeInTheDocument();
+    expect(screen.queryByText("Decision · decision-1")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "View timeline" })).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
+++ b/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
@@ -8,6 +8,50 @@ function label(value: string) {
   return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function looksLikeInternalId(value: string) {
+  const raw = value.trim();
+  if (!raw) return false;
+  if (/^[a-z]+:[A-Za-z0-9:_-]{8,}$/i.test(raw)) return true;
+  if (/^[a-z]+_[a-z]+:[A-Za-z0-9:_-]{8,}$/i.test(raw)) return true;
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw)) return true;
+  if (/^[A-Za-z0-9_-]{18,}$/.test(raw) && /[A-Z]/.test(raw) && /[a-z]/.test(raw) && /\d/.test(raw)) return true;
+  return false;
+}
+
+function hasRawReferenceLabel(value: string) {
+  const raw = value.trim();
+  if (!raw) return false;
+  if (looksLikeInternalId(raw)) return true;
+  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]+$/i.test(raw);
+}
+
+function workflowFallbackLabel(value: string) {
+  const raw = value.toLowerCase();
+  if (raw.includes("review_missing_payment") || raw.includes("missing_payment")) return "Missing payment review";
+  if (raw.includes("reduce_vacancy_risk") || raw.includes("vacancy")) return "Vacancy pressure review";
+  if (raw.includes("revenue")) return "Revenue pressure review";
+  if (raw.includes("delinquency")) return "Delinquency review";
+  if (raw.includes("screening")) return "Screening workflow review";
+  if (raw.includes("lease")) return "Lease context review";
+  return "Operational review";
+}
+
+function safeEvidenceLabel(input: {
+  label: string;
+  sectionKey?: string;
+  itemType?: string;
+  scope?: string;
+}) {
+  if (input.label && !hasRawReferenceLabel(input.label)) return input.label;
+  if (input.itemType === "lease_summary" || input.sectionKey === "lease_context") {
+    return "Lease context review";
+  }
+  if (input.itemType === "property_summary" || input.sectionKey === "property_context") {
+    return "Property review";
+  }
+  return workflowFallbackLabel(input.label);
+}
+
 function operationalScopeLabel(evidencePack: EvidencePack) {
   const preferredSections = [
     "lease_context",
@@ -20,7 +64,14 @@ function operationalScopeLabel(evidencePack: EvidencePack) {
   for (const sectionKey of preferredSections) {
     const section = evidencePack.sections.find((item) => item.sectionKey === sectionKey);
     const item = section?.items.find((entry) => entry.label?.trim());
-    if (item?.label) return item.label;
+    if (item?.label) {
+      return safeEvidenceLabel({
+        label: item.label,
+        sectionKey: section?.sectionKey,
+        itemType: item.itemType,
+        scope: evidencePack.scope,
+      });
+    }
   }
   if (evidencePack.scope === "lease") return "Lease context review";
   if (evidencePack.scope === "property") return "Property review";
@@ -124,7 +175,14 @@ export function EvidencePackPanel({ evidencePack }: { evidencePack: EvidencePack
             {section.items.slice(0, 5).map((item) => (
               <div key={item.evidenceItemId} style={{ borderTop: "1px solid #e2e8f0", paddingTop: 8, display: "grid", gap: 4 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
-                  <strong style={{ color: "#0f172a", fontSize: 13 }}>{item.label}</strong>
+                  <strong style={{ color: "#0f172a", fontSize: 13 }}>
+                    {safeEvidenceLabel({
+                      label: item.label,
+                      sectionKey: section.sectionKey,
+                      itemType: item.itemType,
+                      scope: evidencePack.scope,
+                    })}
+                  </strong>
                   <Badge status={item.status}>{label(item.status)}</Badge>
                 </div>
                 <div style={{ color: "#475569", fontSize: 13 }}>{item.description}</div>

--- a/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
+++ b/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
@@ -8,6 +8,27 @@ function label(value: string) {
   return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function operationalScopeLabel(evidencePack: EvidencePack) {
+  const preferredSections = [
+    "lease_context",
+    "property_context",
+    "delinquency_context",
+    "decision_lineage",
+    "workflow_routing",
+    "maintenance_context",
+  ];
+  for (const sectionKey of preferredSections) {
+    const section = evidencePack.sections.find((item) => item.sectionKey === sectionKey);
+    const item = section?.items.find((entry) => entry.label?.trim());
+    if (item?.label) return item.label;
+  }
+  if (evidencePack.scope === "lease") return "Lease context review";
+  if (evidencePack.scope === "property") return "Property review";
+  if (evidencePack.scope === "delinquency") return "Delinquency review";
+  if (evidencePack.scope === "decision" || evidencePack.scope === "workflow") return "Operational review";
+  return `${label(evidencePack.scope)} review`;
+}
+
 function statusTone(status: string) {
   if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
   if (status === "incomplete" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
@@ -45,7 +66,7 @@ export function EvidencePackPanel({ evidencePack }: { evidencePack: EvidencePack
             <div>
               <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Evidence details</h2>
               <div style={{ color: "#64748b", fontSize: 13 }}>
-                {label(evidencePack.scope)} · {evidencePack.scopeId}
+                {label(evidencePack.scope)} · {operationalScopeLabel(evidencePack)}
               </div>
             </div>
             <Badge status={evidencePack.status}>{label(evidencePack.status)}</Badge>

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText, BarChart3, Inbox } from "lucide-react";
+import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText, BarChart3, Inbox, ClipboardList } from "lucide-react";
 import { SCREENING_ENABLED } from "../../config/screening";
 
 export type NavItem = {
@@ -37,6 +37,14 @@ export const NAV_ITEMS: NavItem[] = [
     icon: LayoutDashboard,
     showInDrawer: true,
     showInTabs: true,
+  },
+  {
+    id: "operations",
+    label: "Operations",
+    to: "/operations",
+    icon: ClipboardList,
+    showInDrawer: true,
+    requiresLandlordOrAdmin: true,
   },
   {
     id: "properties",

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -369,7 +369,9 @@ describe("DecisionInboxPage", () => {
     expect(screen.getByText("Draft only. Review local legal requirements before use.")).toBeInTheDocument();
     expect(screen.getByText(/no tenant communication will be sent/i)).toBeInTheDocument();
     expect(screen.getByText("Source: Lease Ledger")).toBeInTheDocument();
-    expect(screen.getByText("Related: Lease lease-1")).toBeInTheDocument();
+    expect(screen.getByText("Related: Lease context review")).toBeInTheDocument();
+    expect(screen.getByText("Missing payment review is routed to delinquency review.")).toBeInTheDocument();
+    expect(screen.queryByText(/Decision decision:review_missing_payment/)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByText("Open cost approval")).toBeInTheDocument();
     expect(screen.getByText("No context link available")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -146,6 +146,65 @@ function Badge({ children, tone }: { children: React.ReactNode; tone: { color: s
   );
 }
 
+function looksLikeInternalId(value: string) {
+  const raw = value.trim();
+  if (!raw) return false;
+  if (/^[a-z]+:[A-Za-z0-9:_-]{8,}$/i.test(raw)) return true;
+  if (/^[a-z]+_[a-z]+:[A-Za-z0-9:_-]{8,}$/i.test(raw)) return true;
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw)) return true;
+  if (/^[A-Za-z0-9_-]{18,}$/.test(raw) && /[A-Z]/.test(raw) && /[a-z]/.test(raw) && /\d/.test(raw)) return true;
+  return false;
+}
+
+function hasRawReferenceLabel(value: string) {
+  const raw = value.trim();
+  if (!raw) return false;
+  if (looksLikeInternalId(raw)) return true;
+  return /^(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]+$/i.test(raw);
+}
+
+function workflowQueueLabel(queue: string) {
+  if (queue === "delinquency_review") return "delinquency review";
+  if (queue === "lease_review") return "lease readiness review";
+  if (queue === "screening_review") return "screening workflow review";
+  if (queue === "maintenance_review") return "maintenance review";
+  if (queue === "compliance_review") return "compliance review";
+  if (queue === "admin_review") return "admin review";
+  return label(queue).toLowerCase();
+}
+
+function operationalReviewLabel(input: { value: string; queue?: string }) {
+  const raw = input.value.toLowerCase();
+  if (raw.includes("review_missing_payment") || raw.includes("missing_payment")) return "Missing payment review";
+  if (raw.includes("reduce_vacancy_risk") || raw.includes("vacancy")) return "Vacancy pressure review";
+  if (raw.includes("revenue")) return "Revenue pressure review";
+  if (raw.includes("delinquency") || input.queue === "delinquency_review") return "Delinquency review";
+  if (raw.includes("screening") || input.queue === "screening_review") return "Screening workflow review";
+  if (raw.includes("lease") || input.queue === "lease_review") return "Lease readiness review";
+  return "Operational review";
+}
+
+function safeRelatedLabel(item: DecisionInboxItem) {
+  const raw = item.relatedEntity?.label || "";
+  if (raw && !hasRawReferenceLabel(raw)) return raw;
+  if (item.destination?.startsWith("/leases/")) return "Lease context review";
+  return operationalReviewLabel({ value: raw || item.id, queue: item.workflow.queue });
+}
+
+function safeAutomationReason(reason: string, item: DecisionInboxItem) {
+  const routedMatch = reason.match(/^Decision\s+(.+?)\s+is routed to\s+([a-z_]+)\.?$/i);
+  if (routedMatch) {
+    return `${operationalReviewLabel({ value: routedMatch[1], queue: item.workflow.queue })} is routed to ${workflowQueueLabel(
+      routedMatch[2]
+    )}.`;
+  }
+  return reason.replace(/\b(Lease|Property|Decision|Tenant|Unit)\s+[A-Za-z0-9:_-]{8,}\b/gi, (_, kind: string) => {
+    if (String(kind).toLowerCase() === "lease") return "Lease context review";
+    if (String(kind).toLowerCase() === "property") return "Property review";
+    return operationalReviewLabel({ value: item.id, queue: item.workflow.queue });
+  });
+}
+
 function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
   const delinquencyActions = item.delinquencyActions || [];
   const automatedWorkflow = item.automatedWorkflow;
@@ -185,7 +244,7 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         <span style={{ color: "#64748b", fontSize: 13 }}>
-          Related: {item.relatedEntity?.label || "Context unavailable"}
+          Related: {safeRelatedLabel(item)}
         </span>
         {item.destination ? (
           <Link to={item.destination} style={{ color: "#2563eb", fontWeight: 800 }}>
@@ -300,7 +359,7 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
             <strong style={{ color: "#1e3a8a", fontSize: 13 }}>Review automation reasoning</strong>
             {automatedWorkflow.reasons.slice(0, 3).map((reason) => (
               <span key={reason} style={{ color: "#334155", fontSize: 13 }}>
-                {reason}
+                {safeAutomationReason(reason, item)}
               </span>
             ))}
             {automatedWorkflow.blockedReasons.map((reason) => (

--- a/rentchain-frontend/src/pages/EvidencePackPage.test.tsx
+++ b/rentchain-frontend/src/pages/EvidencePackPage.test.tsx
@@ -81,7 +81,7 @@ describe("EvidencePackPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.change(screen.getByLabelText("Scope ID"), { target: { value: "lease-1" } });
+    fireEvent.change(screen.getByLabelText(/Internal scope reference/i), { target: { value: "lease-1" } });
     fireEvent.change(screen.getByLabelText("Scope"), { target: { value: "lease" } });
     fireEvent.click(screen.getByRole("button", { name: "Preview evidence" }));
 

--- a/rentchain-frontend/src/pages/EvidencePackPage.tsx
+++ b/rentchain-frontend/src/pages/EvidencePackPage.tsx
@@ -48,7 +48,7 @@ export default function EvidencePackPage() {
 
   const loadPreview = React.useCallback(async () => {
     if (!scopeId.trim()) {
-      setError("Scope ID is required for evidence preview.");
+      setError("Internal scope reference is required for evidence preview.");
       setData(null);
       return;
     }
@@ -101,12 +101,15 @@ export default function EvidencePackPage() {
             </select>
           </label>
           <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
-            Scope ID
+            Internal scope reference
             <input
               value={scopeId}
               onChange={(event) => setScopeId(event.target.value)}
               style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 260 }}
             />
+            <span style={{ color: "#64748b", fontSize: 12, fontWeight: 600 }}>
+              Internal routing reference. Evidence labels below use operational context when available.
+            </span>
           </label>
           <button
             type="button"

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -205,6 +205,51 @@ describe("deriveCommandCenterSignals", () => {
 
     expect(signals).toEqual([]);
   });
+
+  it("normalizes raw decision context labels with operational lease and property references", () => {
+    const signals = deriveCommandCenterSignals({
+      decisions: [
+        decision({
+          id: "decision-lease",
+          relatedEntity: { kind: "lease", id: "lease-1", label: "Lease jjua9wFKDV19d5y5sdV7" },
+          destination: "/leases/lease-1/ledger",
+        }),
+        decision({
+          id: "decision-property",
+          type: "property",
+          workflow: {
+            queue: "general_review",
+            workflowState: "new",
+            ownershipType: "operations",
+            reviewPriority: "medium",
+            escalationLevel: "attention",
+            manualOnly: true,
+          },
+          relatedEntity: { kind: "property", id: "property-1", label: "Property ZaeL9oqpJCSZPguWa6wR" },
+          destination: "/properties?propertyId=property-1",
+        }),
+      ],
+      leases: [lease()],
+      properties: [
+        {
+          id: "property-1",
+          name: "Center Suites",
+          addressLine1: "2 Main",
+          city: "Halifax",
+          totalUnits: 1,
+          units: [],
+          createdAt: "2026-01-01T00:00:00.000Z",
+        } as any,
+      ],
+    });
+
+    expect(signals.find((signal) => signal.id === "decision:decision-lease")?.contextLabel).toBe(
+      "North Towers · 101 · John Smith"
+    );
+    expect(signals.find((signal) => signal.id === "decision:decision-property")?.contextLabel).toBe("Center Suites");
+    expect(signals.map((signal) => signal.contextLabel).join(" ")).not.toContain("jjua9wFKDV19d5y5sdV7");
+    expect(signals.map((signal) => signal.contextLabel).join(" ")).not.toContain("ZaeL9oqpJCSZPguWa6wR");
+  });
 });
 
 describe("OperationalCommandCenterPage", () => {
@@ -268,6 +313,9 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Lease lifecycle").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Documents / workspace").length).toBeGreaterThan(0);
     expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getAllByText("Context: North Towers · 101 · John Smith").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Lease jjua9wFKDV19d5y5sdV7/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Property ZaeL9oqpJCSZPguWa6wR/i)).not.toBeInTheDocument();
     expect(screen.getAllByText("Open source workflow").length).toBeGreaterThan(0);
     expect(mocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ title: "Operational command center" }));
   });

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -1,0 +1,295 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OperationalCommandCenterPage, { deriveCommandCenterSignals } from "./OperationalCommandCenterPage";
+
+const mocks = vi.hoisted(() => ({
+  fetchDecisionInbox: vi.fn(),
+  fetchDashboardSummary: vi.fn(),
+  getActiveLeasesForLandlord: vi.fn(),
+  fetchProperties: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/decisionInboxApi", async () => {
+  const actual = await vi.importActual<any>("@/api/decisionInboxApi");
+  return {
+    ...actual,
+    fetchDecisionInbox: mocks.fetchDecisionInbox,
+  };
+});
+
+vi.mock("@/api/dashboard", () => ({
+  fetchDashboardSummary: mocks.fetchDashboardSummary,
+}));
+
+vi.mock("@/api/leasesApi", async () => {
+  const actual = await vi.importActual<any>("@/api/leasesApi");
+  return {
+    ...actual,
+    getActiveLeasesForLandlord: mocks.getActiveLeasesForLandlord,
+  };
+});
+
+vi.mock("@/api/propertiesApi", async () => {
+  const actual = await vi.importActual<any>("@/api/propertiesApi");
+  return {
+    ...actual,
+    fetchProperties: mocks.fetchProperties,
+  };
+});
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode }) => {
+    mocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function decision(overrides: Record<string, any> = {}) {
+  return {
+    id: "decision-1",
+    title: "Review missing payment",
+    description: "Expected rent payment needs review.",
+    severity: "critical",
+    status: "open",
+    type: "billing",
+    source: "lease_ledger",
+    relatedEntity: { kind: "lease", id: "lease-1", label: "North Towers · Unit 101" },
+    destination: "/leases/lease-1/ledger",
+    automationEligible: false,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "new",
+      ownershipType: "operations",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+    },
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function lease(overrides: Record<string, any> = {}) {
+  return {
+    id: "lease-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    propertyName: "North Towers",
+    unitId: "unit-101",
+    unitNumber: "101",
+    tenantName: "John Smith",
+    monthlyRent: 1640,
+    startDate: "2026-06-01",
+    endDate: "2026-07-15",
+    status: "active",
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+    leaseExecution: {
+      executionStatus: "blocked",
+      executionLabel: "Lease execution blocked",
+      executionDescription: "Missing landlord signature.",
+      requiredNextAction: "landlord_signature",
+      tenantSignatureStatus: "completed",
+      landlordSignatureStatus: "needed",
+      pdfStatus: "ready",
+      completedAt: null,
+    },
+    stateCoherence: {
+      coherenceStatus: "review_required",
+      coherenceLabel: "Occupancy review needed",
+      coherenceReason: "Lease is active but occupancy state conflicts.",
+      leaseExecutionState: "blocked",
+      leaseOperationalState: "review_required",
+      occupancyState: "review_required",
+      tenantOperationalState: "review_required",
+      paymentReadinessState: "review_required",
+      sourceFields: {},
+      flags: {
+        leaseMarkedActiveBeforeExecution: true,
+        activeLeaseOnVacantUnit: true,
+        occupiedUnitWithoutActiveExecutedLease: false,
+        tenantActiveWithoutExecutedOccupancy: false,
+        paymentActivityWithoutProviderSetup: false,
+        hasStateConflict: true,
+        requiresReview: true,
+      },
+    },
+    paymentReadiness: {
+      readinessStatus: "blocked",
+      readinessLabel: "Payment setup blocked",
+      readinessDescription: "Review rent terms before payment setup.",
+      requiredNextAction: "review_rent_terms",
+      rentTerms: {
+        rentAmountAvailable: true,
+        dueDateAvailable: false,
+        leaseDatesAvailable: true,
+        tenantLinked: true,
+        leaseExecuted: false,
+      },
+      paymentSetup: {
+        processorConnected: false,
+        moneyMovementEnabled: false,
+        storedPaymentMethod: false,
+      },
+    },
+    signatureStatus: "awaiting_landlord_signature",
+    signatureReadinessLabel: "Landlord signature pending",
+    signatureReadinessDescription: "Landlord signature is required before execution completes.",
+    leasePdfStatus: "pending",
+    leasePdfLabel: "Lease package pending",
+    leasePdfDescription: "Generated lease package is not ready yet.",
+    jurisdictionPolicies: [
+      {
+        jurisdiction: "NS",
+        policyKey: "lease_renewal_review",
+        status: "review",
+        severity: "warning",
+        label: "Lease renewal review recommended",
+        reason: "Lease end date is approaching.",
+        recommendation: "Review workflow timing.",
+        sourceRuleKey: "lease_renewal_review",
+        confidence: "medium",
+        legalAdvice: false,
+        disclaimer: "Workflow guidance only — verify local legal requirements.",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("deriveCommandCenterSignals", () => {
+  it("aggregates decision, lease, occupancy, document, and payment readiness signals without actions", () => {
+    const signals = deriveCommandCenterSignals({
+      decisions: [decision()],
+      leases: [lease()],
+      properties: [
+        {
+          id: "property-1",
+          name: "North Towers",
+          addressLine1: "1 Main",
+          city: "Halifax",
+          totalUnits: 2,
+          units: [{ id: "unit-102", unitNumber: "102", rent: 1540, status: "vacant" }],
+          createdAt: "2026-01-01T00:00:00.000Z",
+        } as any,
+      ],
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    });
+
+    expect(signals.map((signal) => signal.category)).toEqual(
+      expect.arrayContaining(["payments", "lease_lifecycle", "occupancy", "documents"])
+    );
+    expect(signals.find((signal) => signal.id === "decision:decision-1")).toMatchObject({
+      category: "payments",
+      severity: "critical",
+      destination: "/leases/lease-1/ledger",
+    });
+    expect(signals.some((signal) => signal.title === "Lease ending soon")).toBe(true);
+    expect(signals.some((signal) => signal.title === "Vacant units visible")).toBe(true);
+  });
+
+  it("keeps resolved and dismissed decisions out of the active command center queue", () => {
+    const signals = deriveCommandCenterSignals({
+      decisions: [decision({ id: "resolved-1", status: "resolved" }), decision({ id: "dismissed-1", status: "dismissed" })],
+      leases: [],
+      properties: [],
+    });
+
+    expect(signals).toEqual([]);
+  });
+});
+
+describe("OperationalCommandCenterPage", () => {
+  beforeEach(() => {
+    mocks.fetchDecisionInbox.mockResolvedValue({
+      items: [decision()],
+      filters: { severity: [], status: [], type: [], queue: [], workflowState: [], escalationLevel: [] },
+      summary: { total: 1, critical: 1, high: 0, open: 1, blocked: 0 },
+      workflowSummary: { new: 1, underReview: 0, escalated: 0, critical: 1 },
+      automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+      agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
+    });
+    mocks.fetchDashboardSummary.mockResolvedValue({
+      kpis: {
+        propertiesCount: 1,
+        unitsCount: 2,
+        tenantsCount: 1,
+        openActionsCount: 3,
+        delinquentCount: 1,
+        screeningsCount: 0,
+      },
+      rent: { month: "2026-06", collectedCents: 0, expectedCents: 0, delinquentCents: 0 },
+      actions: [],
+      properties: [],
+      events: [],
+    });
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({ leases: [lease()] });
+    mocks.fetchProperties.mockResolvedValue({
+      properties: [
+        {
+          id: "property-1",
+          name: "North Towers",
+          addressLine1: "1 Main",
+          city: "Halifax",
+          totalUnits: 2,
+          units: [{ id: "unit-102", unitNumber: "102", rent: 1540, status: "vacant" }],
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("renders a read-only operational coordination surface with source workflow links", async () => {
+    render(
+      <MemoryRouter>
+        <OperationalCommandCenterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Operational command center" })).toBeInTheDocument();
+    expect(screen.getByText(/does not execute actions, enforce legal timelines, or modify records/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mocks.fetchDecisionInbox).toHaveBeenCalled();
+      expect(mocks.getActiveLeasesForLandlord).toHaveBeenCalled();
+      expect(mocks.fetchDashboardSummary).toHaveBeenCalled();
+      expect(mocks.fetchProperties).toHaveBeenCalledWith({ status: "active" });
+    });
+
+    expect(screen.getAllByText("Payments / obligations").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Lease lifecycle").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Documents / workspace").length).toBeGreaterThan(0);
+    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getAllByText("Open source workflow").length).toBeGreaterThan(0);
+    expect(mocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ title: "Operational command center" }));
+  });
+
+  it("shows a safe empty state when no signals are visible", async () => {
+    mocks.fetchDecisionInbox.mockResolvedValueOnce({
+      items: [],
+      filters: { severity: [], status: [], type: [], queue: [], workflowState: [], escalationLevel: [] },
+      summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+      workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
+      automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+      agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
+    });
+    mocks.getActiveLeasesForLandlord.mockResolvedValueOnce({ leases: [] });
+    mocks.fetchProperties.mockResolvedValueOnce({ properties: [] });
+
+    render(
+      <MemoryRouter>
+        <OperationalCommandCenterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No high-signal operational issues are currently visible.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -125,7 +125,90 @@ function decisionCategory(item: DecisionInboxItem): CommandCenterCategory {
 function leaseLabel(lease: LandlordActiveLease) {
   const property = lease.propertyName || lease.propertyLabel || "Property";
   const unit = lease.unitLabel || lease.unitNumber || "Unit";
-  return `${property} · ${unit}`;
+  const tenant = lease.tenantName ? ` · ${lease.tenantName}` : "";
+  return `${property} · ${unit}${tenant}`;
+}
+
+function propertyLabel(property: Property) {
+  return property.name || property.addressLine1 || "Property";
+}
+
+function looksLikeInternalId(value: unknown) {
+  const text = String(value || "").trim();
+  if (!text) return false;
+  if (/^[A-Za-z0-9_-]{16,}$/.test(text)) return true;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(text);
+}
+
+function hasRawReferenceLabel(value: unknown) {
+  const text = String(value || "").trim();
+  if (!text) return false;
+  return /^(Lease|Property|Tenant|Unit)\s+[A-Za-z0-9_-]{12,}$/i.test(text);
+}
+
+function leaseIdFromDestination(value: unknown) {
+  const text = String(value || "");
+  const match = text.match(/\/leases\/([^/?#]+)/);
+  if (!match?.[1]) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+function buildLeaseLookup(leases: LandlordActiveLease[]) {
+  const lookup = new Map<string, LandlordActiveLease>();
+  for (const lease of leases) {
+    [lease.id, (lease as any).leaseId, lease.unitId, lease.tenantId, lease.propertyId]
+      .map((value) => String(value || "").trim())
+      .filter(Boolean)
+      .forEach((key) => lookup.set(key, lease));
+  }
+  return lookup;
+}
+
+function buildPropertyLookup(properties: Property[]) {
+  const lookup = new Map<string, Property>();
+  for (const property of properties) {
+    String(property.id || "").trim() && lookup.set(String(property.id), property);
+    for (const unit of property.units || []) {
+      const unitId = String((unit as any)?.id || "").trim();
+      if (unitId) lookup.set(unitId, property);
+    }
+  }
+  return lookup;
+}
+
+function resolveDecisionContextLabel(
+  item: DecisionInboxItem,
+  lookups: { leases: Map<string, LandlordActiveLease>; properties: Map<string, Property> }
+) {
+  const relatedId = String(item.relatedEntity?.id || "").trim();
+  const destinationLeaseId = leaseIdFromDestination(item.destination);
+  if (item.relatedEntity?.kind === "property") {
+    const property = relatedId ? lookups.properties.get(relatedId) : null;
+    if (property) return propertyLabel(property);
+  }
+  const lease = [relatedId, destinationLeaseId]
+    .filter(Boolean)
+    .map((id) => lookups.leases.get(String(id)))
+    .find(Boolean);
+  if (lease) return leaseLabel(lease);
+
+  const property = relatedId ? lookups.properties.get(relatedId) : null;
+  if (property) return propertyLabel(property);
+
+  const existingLabel = String(item.relatedEntity?.label || "").trim();
+  if (existingLabel && !looksLikeInternalId(existingLabel) && !hasRawReferenceLabel(existingLabel)) return existingLabel;
+
+  if (item.workflow?.queue === "delinquency_review") return "Lease ledger review";
+  if (item.workflow?.queue === "screening_review") return "Screening workflow review";
+  if (item.workflow?.queue === "lease_review") return "Lease workflow review";
+  if (item.relatedEntity?.kind === "property") return "Property review";
+  if (item.relatedEntity?.kind === "tenant") return "Tenant review";
+  if (item.relatedEntity?.kind === "lease") return "Lease review";
+  return "Operational review";
 }
 
 export function deriveCommandCenterSignals(input: {
@@ -136,6 +219,12 @@ export function deriveCommandCenterSignals(input: {
 }): CommandCenterSignal[] {
   const now = input.now || new Date();
   const signals: CommandCenterSignal[] = [];
+  const leases = input.leases || [];
+  const properties = input.properties || [];
+  const lookups = {
+    leases: buildLeaseLookup(leases),
+    properties: buildPropertyLookup(properties),
+  };
 
   for (const item of input.decisions || []) {
     if (INACTIVE_DECISION_STATUSES.has(String(item.status))) continue;
@@ -146,13 +235,13 @@ export function deriveCommandCenterSignals(input: {
       severity: severityFromDecision(item),
       title: item.title || "Operational review item",
       description: item.description || "Review the source workflow before taking any action.",
-      contextLabel: item.relatedEntity?.label || "Context unavailable",
+      contextLabel: resolveDecisionContextLabel(item, lookups),
       destination: item.destination || CATEGORY_CONFIG[category].destination,
       source: `Decision inbox · ${label(item.workflow?.queue || "general_review")}`,
     });
   }
 
-  for (const lease of input.leases || []) {
+  for (const lease of leases) {
     const baseLabel = leaseLabel(lease);
     const leaseDestination = `/leases/${encodeURIComponent(lease.id)}/ledger`;
     const endingIn = daysUntil(lease.endDate, now);
@@ -252,7 +341,7 @@ export function deriveCommandCenterSignals(input: {
     }
   }
 
-  for (const property of input.properties || []) {
+  for (const property of properties) {
     const units = Array.isArray(property.units) ? property.units : [];
     const vacantUnits = units.filter((unit: any) => String(unit?.status || "").toLowerCase() === "vacant").length;
     if (vacantUnits > 0) {
@@ -262,7 +351,7 @@ export function deriveCommandCenterSignals(input: {
         severity: "info",
         title: "Vacant units visible",
         description: `${vacantUnits} vacant unit${vacantUnits === 1 ? "" : "s"} may need listing, lease, or follow-up review.`,
-        contextLabel: property.name || property.addressLine1 || "Property",
+        contextLabel: propertyLabel(property),
         destination: "/properties",
         source: "Properties · occupancy display",
       });

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -1,0 +1,475 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { AlertTriangle, Building2, ClipboardList, FileText, Home, ReceiptText, ShieldCheck } from "lucide-react";
+import { fetchDashboardSummary, type DashboardSummaryData } from "@/api/dashboard";
+import {
+  fetchDecisionInbox,
+  type DecisionInboxItem,
+  type DecisionInboxResponse,
+} from "@/api/decisionInboxApi";
+import { getActiveLeasesForLandlord, type LandlordActiveLease } from "@/api/leasesApi";
+import { fetchProperties, type Property } from "@/api/propertiesApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+
+type CommandCenterCategory =
+  | "lease_lifecycle"
+  | "payments"
+  | "occupancy"
+  | "screening"
+  | "documents"
+  | "review_workflow";
+
+type CommandCenterSeverity = "critical" | "warning" | "info";
+
+export type CommandCenterSignal = {
+  id: string;
+  category: CommandCenterCategory;
+  severity: CommandCenterSeverity;
+  title: string;
+  description: string;
+  contextLabel: string;
+  destination: string;
+  source: string;
+};
+
+type CategoryConfig = {
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+  destination: string;
+};
+
+const CATEGORY_CONFIG: Record<CommandCenterCategory, CategoryConfig> = {
+  lease_lifecycle: {
+    label: "Lease lifecycle",
+    description: "Lease execution, ending-soon, and readiness signals.",
+    icon: ClipboardList,
+    destination: "/leases",
+  },
+  payments: {
+    label: "Payments / obligations",
+    description: "Delinquency, unmatched evidence, and obligation review signals.",
+    icon: ReceiptText,
+    destination: "/payments",
+  },
+  occupancy: {
+    label: "Occupancy",
+    description: "Vacancy, upcoming occupancy, and review-needed state conflicts.",
+    icon: Home,
+    destination: "/properties",
+  },
+  screening: {
+    label: "Screening",
+    description: "Consent, provider setup, and manual screening workflow signals.",
+    icon: ShieldCheck,
+    destination: "/applications",
+  },
+  documents: {
+    label: "Documents / workspace",
+    description: "Lease package, signature, and tenant workspace document readiness.",
+    icon: FileText,
+    destination: "/leases",
+  },
+  review_workflow: {
+    label: "Operational review",
+    description: "Decision workflow items requiring human review or ownership.",
+    icon: AlertTriangle,
+    destination: "/decision-inbox",
+  },
+};
+
+const CATEGORY_ORDER: CommandCenterCategory[] = [
+  "lease_lifecycle",
+  "payments",
+  "occupancy",
+  "screening",
+  "documents",
+  "review_workflow",
+];
+
+const INACTIVE_DECISION_STATUSES = new Set(["resolved", "dismissed"]);
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "date unavailable";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "date unavailable";
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+function daysUntil(value?: string | null, now = new Date()) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return Math.ceil((date.getTime() - now.getTime()) / 86_400_000);
+}
+
+function severityFromDecision(item: DecisionInboxItem): CommandCenterSeverity {
+  if (item.severity === "critical" || item.severity === "high" || item.status === "blocked") return "critical";
+  if (item.severity === "medium" || item.workflow?.escalationLevel === "attention") return "warning";
+  return "info";
+}
+
+function decisionCategory(item: DecisionInboxItem): CommandCenterCategory {
+  if (item.workflow?.queue === "delinquency_review" || item.type === "billing") return "payments";
+  if (item.workflow?.queue === "screening_review" || item.type === "screening") return "screening";
+  if (item.type === "property") return "occupancy";
+  if (item.type === "lease" || item.workflow?.queue === "lease_review") return "lease_lifecycle";
+  return "review_workflow";
+}
+
+function leaseLabel(lease: LandlordActiveLease) {
+  const property = lease.propertyName || lease.propertyLabel || "Property";
+  const unit = lease.unitLabel || lease.unitNumber || "Unit";
+  return `${property} · ${unit}`;
+}
+
+export function deriveCommandCenterSignals(input: {
+  decisions?: DecisionInboxItem[];
+  leases?: LandlordActiveLease[];
+  properties?: Property[];
+  now?: Date;
+}): CommandCenterSignal[] {
+  const now = input.now || new Date();
+  const signals: CommandCenterSignal[] = [];
+
+  for (const item of input.decisions || []) {
+    if (INACTIVE_DECISION_STATUSES.has(String(item.status))) continue;
+    const category = decisionCategory(item);
+    signals.push({
+      id: `decision:${item.id}`,
+      category,
+      severity: severityFromDecision(item),
+      title: item.title || "Operational review item",
+      description: item.description || "Review the source workflow before taking any action.",
+      contextLabel: item.relatedEntity?.label || "Context unavailable",
+      destination: item.destination || CATEGORY_CONFIG[category].destination,
+      source: `Decision inbox · ${label(item.workflow?.queue || "general_review")}`,
+    });
+  }
+
+  for (const lease of input.leases || []) {
+    const baseLabel = leaseLabel(lease);
+    const leaseDestination = `/leases/${encodeURIComponent(lease.id)}/ledger`;
+    const endingIn = daysUntil(lease.endDate, now);
+    const executionStatus = lease.leaseExecution?.executionStatus;
+    const signatureStatus = lease.signatureStatus;
+
+    if (lease.stateCoherence?.flags?.requiresReview || lease.stateCoherence?.flags?.hasStateConflict) {
+      signals.push({
+        id: `lease-coherence:${lease.id}`,
+        category: "occupancy",
+        severity: "warning",
+        title: lease.stateCoherence.coherenceLabel || "Occupancy review needed",
+        description: lease.stateCoherence.coherenceReason || "Lease and occupancy signals need human review.",
+        contextLabel: baseLabel,
+        destination: "/leases",
+        source: "Lease operations · occupancy coherence",
+      });
+    }
+
+    if (executionStatus && executionStatus !== "fully_executed" && executionStatus !== "landlord_signed") {
+      signals.push({
+        id: `lease-execution:${lease.id}`,
+        category: "lease_lifecycle",
+        severity: executionStatus === "blocked" ? "critical" : "warning",
+        title: lease.leaseExecution?.executionLabel || "Lease execution needs review",
+        description: lease.leaseExecution?.executionDescription || "Lease execution is not complete.",
+        contextLabel: baseLabel,
+        destination: "/leases",
+        source: "Lease operations · execution readiness",
+      });
+    }
+
+    if (signatureStatus && signatureStatus !== "signed" && signatureStatus !== "unavailable") {
+      signals.push({
+        id: `lease-signature:${lease.id}`,
+        category: "documents",
+        severity: "warning",
+        title: lease.signatureReadinessLabel || "Lease signature pending",
+        description: lease.signatureReadinessDescription || "Lease package has a pending signature step.",
+        contextLabel: baseLabel,
+        destination: leaseDestination,
+        source: "Lease operations · document readiness",
+      });
+    }
+
+    if (lease.leasePdfStatus === "not_available" || lease.leasePdfStatus === "pending") {
+      signals.push({
+        id: `lease-document:${lease.id}`,
+        category: "documents",
+        severity: lease.leasePdfStatus === "not_available" ? "warning" : "info",
+        title: lease.leasePdfLabel || "Lease document package not ready",
+        description: lease.leasePdfDescription || "The tenant-facing lease package is not yet available.",
+        contextLabel: baseLabel,
+        destination: "/leases",
+        source: "Lease operations · tenant workspace linkage",
+      });
+    }
+
+    if (lease.paymentReadiness && lease.paymentReadiness.readinessStatus !== "ready_to_configure") {
+      signals.push({
+        id: `payment-readiness:${lease.id}`,
+        category: "payments",
+        severity: lease.paymentReadiness.readinessStatus === "blocked" ? "critical" : "warning",
+        title: lease.paymentReadiness.readinessLabel || "Payment readiness needs review",
+        description: lease.paymentReadiness.readinessDescription || "Review lease payment setup before relying on collection workflow.",
+        contextLabel: baseLabel,
+        destination: leaseDestination,
+        source: "Lease operations · payment readiness",
+      });
+    }
+
+    if (endingIn != null && endingIn >= 0 && endingIn <= 90) {
+      signals.push({
+        id: `lease-ending:${lease.id}`,
+        category: "lease_lifecycle",
+        severity: endingIn <= 30 ? "warning" : "info",
+        title: "Lease ending soon",
+        description: `Lease ends ${formatDate(lease.endDate)}. Review renewal, notice, or move-out workflow timing.`,
+        contextLabel: baseLabel,
+        destination: "/leases",
+        source: "Lease operations · lifecycle timing",
+      });
+    }
+
+    for (const policy of lease.jurisdictionPolicies || []) {
+      if (policy.status !== "review") continue;
+      signals.push({
+        id: `policy:${lease.id}:${policy.policyKey}`,
+        category: "lease_lifecycle",
+        severity: policy.severity === "critical" ? "critical" : policy.severity === "warning" ? "warning" : "info",
+        title: policy.label,
+        description: `${policy.reason} ${policy.disclaimer}`,
+        contextLabel: baseLabel,
+        destination: "/leases",
+        source: `Jurisdiction workflow · ${policy.jurisdiction}`,
+      });
+    }
+  }
+
+  for (const property of input.properties || []) {
+    const units = Array.isArray(property.units) ? property.units : [];
+    const vacantUnits = units.filter((unit: any) => String(unit?.status || "").toLowerCase() === "vacant").length;
+    if (vacantUnits > 0) {
+      signals.push({
+        id: `property-vacancy:${property.id}`,
+        category: "occupancy",
+        severity: "info",
+        title: "Vacant units visible",
+        description: `${vacantUnits} vacant unit${vacantUnits === 1 ? "" : "s"} may need listing, lease, or follow-up review.`,
+        contextLabel: property.name || property.addressLine1 || "Property",
+        destination: "/properties",
+        source: "Properties · occupancy display",
+      });
+    }
+  }
+
+  return signals.sort((a, b) => {
+    const severityRank = { critical: 0, warning: 1, info: 2 };
+    return severityRank[a.severity] - severityRank[b.severity] || CATEGORY_ORDER.indexOf(a.category) - CATEGORY_ORDER.indexOf(b.category);
+  });
+}
+
+function summarizeByCategory(signals: CommandCenterSignal[]) {
+  return CATEGORY_ORDER.map((category) => ({
+    category,
+    config: CATEGORY_CONFIG[category],
+    total: signals.filter((signal) => signal.category === category).length,
+    critical: signals.filter((signal) => signal.category === category && signal.severity === "critical").length,
+    warning: signals.filter((signal) => signal.category === category && signal.severity === "warning").length,
+    info: signals.filter((signal) => signal.category === category && signal.severity === "info").length,
+  }));
+}
+
+function severityTone(severity: CommandCenterSeverity) {
+  if (severity === "critical") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (severity === "warning") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  return { color: "#075985", background: "#e0f2fe", border: "#bae6fd" };
+}
+
+function Badge({ children, severity }: { children: React.ReactNode; severity: CommandCenterSeverity }) {
+  const tone = severityTone(severity);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        background: tone.background,
+        color: tone.color,
+        borderRadius: 999,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label(String(children))}
+    </span>
+  );
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Unable to load operational command center";
+}
+
+export default function OperationalCommandCenterPage() {
+  const [decisionData, setDecisionData] = React.useState<DecisionInboxResponse | null>(null);
+  const [dashboardData, setDashboardData] = React.useState<DashboardSummaryData | null>(null);
+  const [leases, setLeases] = React.useState<LandlordActiveLease[]>([]);
+  const [properties, setProperties] = React.useState<Property[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const [decisionResponse, dashboardResponse, leaseResponse, propertyResponse] = await Promise.all([
+          fetchDecisionInbox(),
+          fetchDashboardSummary(),
+          getActiveLeasesForLandlord(),
+          fetchProperties({ status: "active" }),
+        ]);
+        if (!mounted) return;
+        setDecisionData(decisionResponse);
+        setDashboardData(dashboardResponse);
+        setLeases(leaseResponse.leases || []);
+        setProperties(propertyResponse.properties || propertyResponse.items || []);
+      } catch (err) {
+        if (!mounted) return;
+        setError(errorMessage(err));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const signals = React.useMemo(
+    () => deriveCommandCenterSignals({ decisions: decisionData?.items || [], leases, properties }),
+    [decisionData?.items, leases, properties]
+  );
+  const categorySummary = React.useMemo(() => summarizeByCategory(signals), [signals]);
+  const criticalCount = signals.filter((signal) => signal.severity === "critical").length;
+  const warningCount = signals.filter((signal) => signal.severity === "warning").length;
+
+  return (
+    <MacShell title="Operational command center" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, flexWrap: "wrap", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: 6, maxWidth: 920 }}>
+              <h1 style={{ margin: 0, fontSize: "1.55rem", color: "#0f172a" }}>Operational command center</h1>
+              <div style={{ color: "#475569", lineHeight: 1.55 }}>
+                Centralized operational visibility across leases, payments, occupancy, screening, documents, and review workflows.
+                This page prioritizes source workflow issues only; it does not execute actions, enforce legal timelines, or modify records.
+              </div>
+            </div>
+            <Link to="/decision-inbox" style={{ color: "#2563eb", fontWeight: 900 }}>
+              Open decision inbox
+            </Link>
+          </div>
+        </Section>
+
+        <Section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10 }}>
+          {[
+            ["Signals", signals.length],
+            ["Critical", criticalCount],
+            ["Warnings", warningCount],
+            ["Open decisions", decisionData?.summary?.open ?? 0],
+            ["Delinquent", dashboardData?.kpis?.delinquentCount ?? 0],
+            ["Open actions", dashboardData?.kpis?.openActionsCount ?? 0],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 900 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 24 }}>{value}</strong>
+            </Card>
+          ))}
+        </Section>
+
+        <Section style={{ display: "grid", gap: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+            <div>
+              <div style={{ fontWeight: 900, color: "#0f172a" }}>Coordination lanes</div>
+              <div style={{ color: "#64748b", fontSize: 13 }}>Each lane links back to the source workflow for manual review.</div>
+            </div>
+            <div style={{ color: "#64748b", fontSize: 13 }}>Read-only coordination layer</div>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 10 }}>
+            {categorySummary.map(({ category, config, total, critical, warning, info }) => {
+              const Icon = config.icon;
+              return (
+                <Link
+                  key={category}
+                  to={config.destination}
+                  style={{ color: "inherit", textDecoration: "none" }}
+                >
+                  <Card style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8, height: "100%" }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <Icon size={18} />
+                      <strong style={{ color: "#0f172a" }}>{config.label}</strong>
+                    </div>
+                    <div style={{ color: "#64748b", fontSize: 13, lineHeight: 1.45 }}>{config.description}</div>
+                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", fontSize: 12, color: "#475569" }}>
+                      <span>{total} total</span>
+                      <span>{critical} critical</span>
+                      <span>{warning} warning</span>
+                      <span>{info} info</span>
+                    </div>
+                  </Card>
+                </Link>
+              );
+            })}
+          </div>
+        </Section>
+
+        <Section style={{ display: "grid", gap: 12 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <Building2 size={18} />
+            <strong style={{ color: "#0f172a" }}>High-signal queue</strong>
+            <span style={{ color: "#64748b", fontSize: 13 }}>Prioritized by severity and source workflow.</span>
+          </div>
+          {loading ? <Card>Loading operational signals...</Card> : null}
+          {!loading && error ? <Card style={{ color: "#b91c1c" }}>{error}</Card> : null}
+          {!loading && !error && signals.length === 0 ? (
+            <Card style={{ color: "#64748b" }}>No high-signal operational issues are currently visible.</Card>
+          ) : null}
+          {!loading && !error && signals.length ? (
+            <div style={{ display: "grid", gap: 10 }}>
+              {signals.slice(0, 12).map((signal) => (
+                <Card key={signal.id} style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                    <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                      <Badge severity={signal.severity}>{signal.severity}</Badge>
+                      <span style={{ color: "#64748b", fontSize: 13, fontWeight: 800 }}>
+                        {CATEGORY_CONFIG[signal.category].label}
+                      </span>
+                      <span style={{ color: "#64748b", fontSize: 13 }}>{signal.source}</span>
+                    </div>
+                    <Link to={signal.destination} style={{ color: "#2563eb", fontWeight: 900 }}>
+                      Open source workflow
+                    </Link>
+                  </div>
+                  <div style={{ display: "grid", gap: 4 }}>
+                    <strong style={{ color: "#0f172a", fontSize: 16 }}>{signal.title}</strong>
+                    <span style={{ color: "#475569", lineHeight: 1.5 }}>{signal.description}</span>
+                    <span style={{ color: "#64748b", fontSize: 13 }}>Context: {signal.contextLabel}</span>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          ) : null}
+        </Section>
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the first read-only Operational Command Center foundation at `/operations`.

## Audit Summary

Inspected existing operational surfaces and reused current read paths instead of adding a new action engine:

- Dashboard summary API for portfolio action/delinquency counts
- Decision inbox API for lease, delinquency, screening, and review workflow signals
- Lease operations API for execution, document, payment readiness, jurisdiction policy, and occupancy-coherence signals
- Properties API for basic visible occupancy/vacancy signals
- Existing landlord route/nav patterns in `App.tsx` and `navConfig.ts`

## What Changed

- Added `/operations` as a landlord/admin route.
- Added an Operations navigation item.
- Added a read-only command center page that aggregates high-signal workflow issues across:
  - lease lifecycle
  - payments / obligations
  - occupancy
  - screening
  - documents / workspace
  - operational review workflow
- Added source workflow links back to existing pages such as `/decision-inbox`, `/leases`, `/leases/:leaseId/ledger`, `/payments`, `/properties`, and `/applications`.
- Added focused tests for signal derivation and page rendering.

## Guardrails

- No backend routes added.
- No write paths added.
- No autonomous workflow execution.
- No legal automation or enforcement.
- No payment, ledger, lease, occupancy, screening, tenant workspace, or decision action behavior changed.

## Tests Run

- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/OperationalCommandCenterPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`

## Known Follow-ups

- Add a backend aggregate endpoint if the command center needs server-side pagination or cross-collection ranking.
- Add workflow-owner filters once team assignment metadata is standardized across operational sources.
- Add Playwright smoke coverage for `/operations` after broader E2E harness work resumes.