### PR TITLE
feat: add operational command center priority routing

### DIFF
--- a/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
@@ -36,7 +36,7 @@ describe("KpiStrip", () => {
     );
 
     const grid = container.firstElementChild as HTMLElement;
-    expect(grid).toHaveStyle({ gridTemplateColumns: "1fr", gap: "16px", minWidth: "0" });
+    expect(grid).toHaveStyle({ gridTemplateColumns: "1fr", gap: "16px", minWidth: "0", width: "100%", boxSizing: "border-box" });
     expect(screen.getByText("Properties")).toBeInTheDocument();
     expect(screen.getByText("Units")).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
@@ -36,7 +36,7 @@ describe("KpiStrip", () => {
     );
 
     const grid = container.firstElementChild as HTMLElement;
-    expect(grid).toHaveStyle({ gridTemplateColumns: "1fr", gap: "16px" });
+    expect(grid).toHaveStyle({ gridTemplateColumns: "1fr", gap: "16px", minWidth: "0" });
     expect(screen.getByText("Properties")).toBeInTheDocument();
     expect(screen.getByText("Units")).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
@@ -46,6 +46,8 @@ export function KpiStrip({ kpis, loading, links }: Props) {
         gap: isMobile ? 16 : spacing.sm,
         alignItems: "stretch",
         minWidth: 0,
+        width: "100%",
+        boxSizing: "border-box",
       }}
     >
       {itemsOrder.map((item) => {
@@ -59,6 +61,7 @@ export function KpiStrip({ kpis, loading, links }: Props) {
               minHeight: isMobile ? 0 : 80,
               height: "100%",
               minWidth: 0,
+              boxSizing: "border-box",
               overflowWrap: "anywhere",
             }}
           >

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
@@ -45,6 +45,7 @@ export function KpiStrip({ kpis, loading, links }: Props) {
         gridTemplateColumns: isMobile ? "1fr" : "repeat(auto-fit, minmax(140px, 1fr))",
         gap: isMobile ? 16 : spacing.sm,
         alignItems: "stretch",
+        minWidth: 0,
       }}
     >
       {itemsOrder.map((item) => {
@@ -57,6 +58,8 @@ export function KpiStrip({ kpis, loading, links }: Props) {
               border: `1px solid ${colors.border}`,
               minHeight: isMobile ? 0 : 80,
               height: "100%",
+              minWidth: 0,
+              overflowWrap: "anywhere",
             }}
           >
             {loading ? (

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -151,7 +151,7 @@ function DashboardDecisionSummaryPanel({
     { label: "Manual Review", value: summary.manualReview, severity: "warning" as const },
   ];
   return (
-    <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}`, display: "grid", gap: spacing.sm }}>
+    <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}`, display: "grid", gap: spacing.sm, minWidth: 0, overflow: "hidden" }}>
       <div>
         <div style={{ fontWeight: 800 }}>Decision summary</div>
         <div style={{ color: text.muted, fontSize: 13, marginTop: 3 }}>
@@ -183,7 +183,7 @@ function DashboardDecisionSummaryPanel({
               const copy = decisionDisplayCopy[decision.decisionType];
               const tone = decisionSeverityStyle[decision.severity];
               return (
-                <div key={decision.decisionId} style={{ display: "grid", gap: 6, color: text.primary, borderTop: `1px solid ${colors.border}`, paddingTop: 8 }}>
+                <div key={decision.decisionId} style={{ display: "grid", gap: 6, color: text.primary, borderTop: `1px solid ${colors.border}`, paddingTop: 8, minWidth: 0 }}>
                   <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
                   <span style={{ border: `1px solid ${tone.border}`, background: tone.bg, color: tone.color, borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
                     {copy.badge}
@@ -192,7 +192,7 @@ function DashboardDecisionSummaryPanel({
                       {decisionStatusCopy[decision.status || "detected"]}
                     </span>
                   <span>{copy.label}</span>
-                  <span style={{ color: text.muted }}>{decision.reason}</span>
+                  <span style={{ color: text.muted, overflowWrap: "anywhere" }}>{decision.reason}</span>
                   </div>
                   <DecisionContextPanel decision={decision} compact />
                   <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
@@ -792,24 +792,24 @@ const DashboardPage: React.FC = () => {
         ) : null}
 
         {dataReady ? (
-          <KpiStrip
-            kpis={kpis}
-            loading={loading}
-            links={{
-              propertiesCount: "/properties",
-              unitsCount: "/properties",
-              tenantsCount: "/tenants",
-              openActionsCount: "/dashboard#open-actions",
-              delinquentCount: "/payments?filter=delinquent",
-            }}
-          />
-        ) : null}
-        {dataReady ? (
-          <DashboardDecisionSummaryPanel
-            decisions={dashboardDecisions}
-            pendingId={decisionActionPendingId}
-            onAction={handleDashboardDecisionAction}
-          />
+          <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
+            <KpiStrip
+              kpis={kpis}
+              loading={loading}
+              links={{
+                propertiesCount: "/properties",
+                unitsCount: "/properties",
+                tenantsCount: "/tenants",
+                openActionsCount: "/dashboard#open-actions",
+                delinquentCount: "/payments?filter=delinquent",
+              }}
+            />
+            <DashboardDecisionSummaryPanel
+              decisions={dashboardDecisions}
+              pendingId={decisionActionPendingId}
+              onAction={handleDashboardDecisionAction}
+            />
+          </div>
         ) : null}
         {dataReady ? (
           <div style={{ marginTop: spacing.md }}>

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -151,7 +151,18 @@ function DashboardDecisionSummaryPanel({
     { label: "Manual Review", value: summary.manualReview, severity: "warning" as const },
   ];
   return (
-    <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}`, display: "grid", gap: spacing.sm, minWidth: 0, overflow: "hidden" }}>
+    <Card
+      style={{
+        padding: spacing.md,
+        border: `1px solid ${colors.border}`,
+        display: "grid",
+        gap: spacing.sm,
+        minWidth: 0,
+        width: "100%",
+        boxSizing: "border-box",
+        overflow: "hidden",
+      }}
+    >
       <div>
         <div style={{ fontWeight: 800 }}>Decision summary</div>
         <div style={{ color: text.muted, fontSize: 13, marginTop: 3 }}>
@@ -183,7 +194,18 @@ function DashboardDecisionSummaryPanel({
               const copy = decisionDisplayCopy[decision.decisionType];
               const tone = decisionSeverityStyle[decision.severity];
               return (
-                <div key={decision.decisionId} style={{ display: "grid", gap: 6, color: text.primary, borderTop: `1px solid ${colors.border}`, paddingTop: 8, minWidth: 0 }}>
+                <div
+                  key={decision.decisionId}
+                  style={{
+                    display: "grid",
+                    gap: 6,
+                    color: text.primary,
+                    borderTop: `1px solid ${colors.border}`,
+                    paddingTop: 8,
+                    minWidth: 0,
+                    boxSizing: "border-box",
+                  }}
+                >
                   <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
                   <span style={{ border: `1px solid ${tone.border}`, background: tone.bg, color: tone.color, borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
                     {copy.badge}
@@ -792,7 +814,7 @@ const DashboardPage: React.FC = () => {
         ) : null}
 
         {dataReady ? (
-          <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
+          <div style={{ display: "grid", gap: spacing.lg, minWidth: 0, width: "100%", boxSizing: "border-box", clear: "both" }}>
             <KpiStrip
               kpis={kpis}
               loading={loading}

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import OperationalCommandCenterPage, { deriveCommandCenterSignals } from "./OperationalCommandCenterPage";
+import OperationalCommandCenterPage, { deriveCommandCenterSignals, prioritizeOperationalItems } from "./OperationalCommandCenterPage";
 
 const mocks = vi.hoisted(() => ({
   fetchDecisionInbox: vi.fn(),
@@ -190,10 +190,54 @@ describe("deriveCommandCenterSignals", () => {
     expect(signals.find((signal) => signal.id === "decision:decision-1")).toMatchObject({
       category: "payments",
       severity: "critical",
+      priorityGroup: "critical",
       destination: "/leases/lease-1/ledger",
+      workflowStatus: "New",
+      reviewStatus: "Open",
+      financialStatus: "Review required",
+      nextActionLabel: "Review payment evidence",
     });
     expect(signals.some((signal) => signal.title === "Lease ending soon")).toBe(true);
     expect(signals.some((signal) => signal.title === "Vacant units visible")).toBe(true);
+  });
+
+  it("routes operational items into deterministic priority groups highest priority first", () => {
+    const signals = deriveCommandCenterSignals({
+      decisions: [
+        decision({ id: "info-1", severity: "info", type: "admin", workflow: { ...decision().workflow, queue: "general_review", escalationLevel: "none" } }),
+        decision({ id: "critical-payment", severity: "medium", type: "billing", workflow: { ...decision().workflow, queue: "delinquency_review" } }),
+      ],
+      leases: [
+        lease({
+          id: "upcoming-lease",
+          endDate: "2026-08-01",
+          leaseExecution: { ...lease().leaseExecution, executionStatus: "fully_executed" },
+          stateCoherence: { ...lease().stateCoherence, flags: { ...lease().stateCoherence.flags, requiresReview: false, hasStateConflict: false } },
+          paymentReadiness: { ...lease().paymentReadiness, readinessStatus: "ready_to_configure" },
+          signatureStatus: "signed",
+          leasePdfStatus: "ready",
+          jurisdictionPolicies: [],
+        }),
+      ],
+      properties: [
+        {
+          id: "property-1",
+          name: "North Towers",
+          addressLine1: "1 Main",
+          city: "Halifax",
+          totalUnits: 1,
+          units: [{ id: "unit-102", unitNumber: "102", rent: 1540, status: "vacant" }],
+          createdAt: "2026-01-01T00:00:00.000Z",
+        } as any,
+      ],
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    });
+
+    expect(signals.map((signal) => signal.priorityGroup)).toEqual(
+      expect.arrayContaining(["critical", "upcoming", "informational"])
+    );
+    expect(signals[0]).toMatchObject({ id: "decision:critical-payment", priorityGroup: "critical" });
+    expect(prioritizeOperationalItems([...signals].reverse()).map((signal) => signal.id)).toEqual(signals.map((signal) => signal.id));
   });
 
   it("keeps resolved and dismissed decisions out of the active command center queue", () => {
@@ -312,8 +356,18 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Payments / obligations").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lease lifecycle").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Documents / workspace").length).toBeGreaterThan(0);
+    expect(screen.getByText("Priority routing queue")).toBeInTheDocument();
+    expect(screen.getByText(/Highest priority first by urgency, severity, and source workflow/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Critical").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Needs review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Upcoming").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Informational").length).toBeGreaterThan(0);
     expect(screen.getByText("Review missing payment")).toBeInTheDocument();
     expect(screen.getAllByText("Context: North Towers · 101 · John Smith").length).toBeGreaterThan(0);
+    expect(screen.getByText("Workflow status: New")).toBeInTheDocument();
+    expect(screen.getByText("Review status: Open")).toBeInTheDocument();
+    expect(screen.getAllByText("Financial status: Review required").length).toBeGreaterThan(0);
+    expect(screen.getByText("Next action: Review payment evidence")).toBeInTheDocument();
     expect(screen.queryByText(/Lease jjua9wFKDV19d5y5sdV7/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Property ZaeL9oqpJCSZPguWa6wR/i)).not.toBeInTheDocument();
     expect(screen.getAllByText("Open source workflow").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OperationalCommandCenterPage, { deriveCommandCenterSignals, prioritizeOperationalItems } from "./OperationalCommandCenterPage";
 
@@ -395,6 +395,29 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.queryByText(/Property ZaeL9oqpJCSZPguWa6wR/i)).not.toBeInTheDocument();
     expect(screen.getAllByText("Open source workflow").length).toBeGreaterThan(0);
     expect(mocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ title: "Operational command center" }));
+  });
+
+  it("filters and searches visible operational items without changing priority sorting", async () => {
+    render(
+      <MemoryRouter>
+        <OperationalCommandCenterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getByText("Lease ending soon")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Upcoming" }));
+    expect(screen.queryByText("Review missing payment")).not.toBeInTheDocument();
+    expect(screen.getByText("Lease ending soon")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    fireEvent.change(screen.getByLabelText("Search operational items"), { target: { value: "North Towers 101" } });
+    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.queryByText("Vacant units visible")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search operational items"), { target: { value: "no matching workflow" } });
+    expect(screen.getByText("No operational items match the current search or filter.")).toBeInTheDocument();
   });
 
   it("shows a safe empty state when no signals are visible", async () => {

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -240,6 +240,28 @@ describe("deriveCommandCenterSignals", () => {
     expect(prioritizeOperationalItems([...signals].reverse()).map((signal) => signal.id)).toEqual(signals.map((signal) => signal.id));
   });
 
+  it("normalizes machine reason labels into operator-readable copy", () => {
+    const signals = deriveCommandCenterSignals({
+      leases: [
+        lease({
+          stateCoherence: {
+            ...lease().stateCoherence,
+            coherenceLabel: "Needs review",
+            coherenceReason: "lease_status_active_but_execution_incomplete",
+          },
+        }),
+      ],
+      properties: [],
+    });
+
+    const coherenceSignal = signals.find((signal) => signal.id === "lease-coherence:lease-1");
+    expect(coherenceSignal).toMatchObject({
+      title: "Active lease needs execution review",
+      description: "Lease is marked active, but signing or execution is incomplete.",
+    });
+    expect(JSON.stringify(signals)).not.toContain("lease_status_active_but_execution_incomplete");
+  });
+
   it("keeps resolved and dismissed decisions out of the active command center queue", () => {
     const signals = deriveCommandCenterSignals({
       decisions: [decision({ id: "resolved-1", status: "resolved" }), decision({ id: "dismissed-1", status: "dismissed" })],
@@ -364,6 +386,7 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Informational").length).toBeGreaterThan(0);
     expect(screen.getByText("Review missing payment")).toBeInTheDocument();
     expect(screen.getAllByText("Context: North Towers · 101 · John Smith").length).toBeGreaterThan(0);
+    expect(screen.getByText("Why: Lease is active but occupancy state conflicts.")).toBeInTheDocument();
     expect(screen.getByText("Workflow status: New")).toBeInTheDocument();
     expect(screen.getByText("Review status: Open")).toBeInTheDocument();
     expect(screen.getAllByText("Financial status: Review required").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -21,16 +21,22 @@ type CommandCenterCategory =
   | "review_workflow";
 
 type CommandCenterSeverity = "critical" | "warning" | "info";
+type CommandCenterPriorityGroup = "critical" | "needs_review" | "upcoming" | "informational";
 
 export type CommandCenterSignal = {
   id: string;
   category: CommandCenterCategory;
   severity: CommandCenterSeverity;
+  priorityGroup: CommandCenterPriorityGroup;
   title: string;
   description: string;
   contextLabel: string;
   destination: string;
   source: string;
+  workflowStatus: string;
+  reviewStatus: string;
+  financialStatus?: string | null;
+  nextActionLabel: string;
 };
 
 type CategoryConfig = {
@@ -88,6 +94,38 @@ const CATEGORY_ORDER: CommandCenterCategory[] = [
   "review_workflow",
 ];
 
+const PRIORITY_GROUPS: Array<{
+  group: CommandCenterPriorityGroup;
+  label: string;
+  description: string;
+  tone: CommandCenterSeverity;
+}> = [
+  {
+    group: "critical",
+    label: "Critical",
+    description: "Highest-priority items that need prompt human review.",
+    tone: "critical",
+  },
+  {
+    group: "needs_review",
+    label: "Needs review",
+    description: "Operational issues that need staff review before the source workflow progresses.",
+    tone: "warning",
+  },
+  {
+    group: "upcoming",
+    label: "Upcoming",
+    description: "Forward-looking lease, occupancy, and workflow timing signals.",
+    tone: "info",
+  },
+  {
+    group: "informational",
+    label: "Informational",
+    description: "Lower-risk visibility signals and non-urgent operational context.",
+    tone: "info",
+  },
+];
+
 const INACTIVE_DECISION_STATUSES = new Set(["resolved", "dismissed"]);
 
 function label(value: string) {
@@ -112,6 +150,43 @@ function severityFromDecision(item: DecisionInboxItem): CommandCenterSeverity {
   if (item.severity === "critical" || item.severity === "high" || item.status === "blocked") return "critical";
   if (item.severity === "medium" || item.workflow?.escalationLevel === "attention") return "warning";
   return "info";
+}
+
+function priorityRank(group: CommandCenterPriorityGroup) {
+  return PRIORITY_GROUPS.findIndex((item) => item.group === group);
+}
+
+function severityRank(severity: CommandCenterSeverity) {
+  return { critical: 0, warning: 1, info: 2 }[severity];
+}
+
+function priorityFromDecision(item: DecisionInboxItem, category: CommandCenterCategory): CommandCenterPriorityGroup {
+  if (
+    item.status === "blocked" ||
+    item.workflow?.workflowState === "escalated" ||
+    item.workflow?.escalationLevel === "critical" ||
+    category === "payments"
+  ) {
+    return "critical";
+  }
+  if (
+    item.severity === "high" ||
+    item.severity === "medium" ||
+    item.workflow?.workflowState === "waiting_context" ||
+    item.workflow?.escalationLevel === "urgent" ||
+    item.workflow?.escalationLevel === "attention"
+  ) {
+    return "needs_review";
+  }
+  return "informational";
+}
+
+function nextActionForDecision(item: DecisionInboxItem, category: CommandCenterCategory) {
+  if (category === "payments") return "Review payment evidence";
+  if (category === "screening") return "Review screening workflow";
+  if (category === "lease_lifecycle") return "Review lease readiness";
+  if (category === "occupancy") return "Review occupancy context";
+  return "Review source workflow";
 }
 
 function decisionCategory(item: DecisionInboxItem): CommandCenterCategory {
@@ -211,6 +286,18 @@ function resolveDecisionContextLabel(
   return "Operational review";
 }
 
+export function prioritizeOperationalItems(signals: CommandCenterSignal[]): CommandCenterSignal[] {
+  return [...signals].sort((a, b) => {
+    return (
+      priorityRank(a.priorityGroup) - priorityRank(b.priorityGroup) ||
+      severityRank(a.severity) - severityRank(b.severity) ||
+      CATEGORY_ORDER.indexOf(a.category) - CATEGORY_ORDER.indexOf(b.category) ||
+      a.title.localeCompare(b.title) ||
+      a.id.localeCompare(b.id)
+    );
+  });
+}
+
 export function deriveCommandCenterSignals(input: {
   decisions?: DecisionInboxItem[];
   leases?: LandlordActiveLease[];
@@ -233,11 +320,16 @@ export function deriveCommandCenterSignals(input: {
       id: `decision:${item.id}`,
       category,
       severity: severityFromDecision(item),
+      priorityGroup: priorityFromDecision(item, category),
       title: item.title || "Operational review item",
       description: item.description || "Review the source workflow before taking any action.",
       contextLabel: resolveDecisionContextLabel(item, lookups),
       destination: item.destination || CATEGORY_CONFIG[category].destination,
       source: `Decision inbox · ${label(item.workflow?.queue || "general_review")}`,
+      workflowStatus: label(item.workflow?.workflowState || "new"),
+      reviewStatus: label(item.status || "open"),
+      financialStatus: category === "payments" ? "Review required" : null,
+      nextActionLabel: nextActionForDecision(item, category),
     });
   }
 
@@ -253,11 +345,16 @@ export function deriveCommandCenterSignals(input: {
         id: `lease-coherence:${lease.id}`,
         category: "occupancy",
         severity: "warning",
+        priorityGroup: lease.stateCoherence?.flags?.hasStateConflict ? "critical" : "needs_review",
         title: lease.stateCoherence.coherenceLabel || "Occupancy review needed",
         description: lease.stateCoherence.coherenceReason || "Lease and occupancy signals need human review.",
         contextLabel: baseLabel,
         destination: "/leases",
         source: "Lease operations · occupancy coherence",
+        workflowStatus: label(lease.stateCoherence.leaseOperationalState || "review_required"),
+        reviewStatus: "Review needed",
+        financialStatus: null,
+        nextActionLabel: "Review occupancy context",
       });
     }
 
@@ -266,11 +363,16 @@ export function deriveCommandCenterSignals(input: {
         id: `lease-execution:${lease.id}`,
         category: "lease_lifecycle",
         severity: executionStatus === "blocked" ? "critical" : "warning",
+        priorityGroup: executionStatus === "blocked" ? "critical" : "needs_review",
         title: lease.leaseExecution?.executionLabel || "Lease execution needs review",
         description: lease.leaseExecution?.executionDescription || "Lease execution is not complete.",
         contextLabel: baseLabel,
         destination: "/leases",
         source: "Lease operations · execution readiness",
+        workflowStatus: label(executionStatus),
+        reviewStatus: "Review needed",
+        financialStatus: null,
+        nextActionLabel: "Review lease execution",
       });
     }
 
@@ -279,11 +381,16 @@ export function deriveCommandCenterSignals(input: {
         id: `lease-signature:${lease.id}`,
         category: "documents",
         severity: "warning",
+        priorityGroup: "needs_review",
         title: lease.signatureReadinessLabel || "Lease signature pending",
         description: lease.signatureReadinessDescription || "Lease package has a pending signature step.",
         contextLabel: baseLabel,
         destination: leaseDestination,
         source: "Lease operations · document readiness",
+        workflowStatus: label(signatureStatus),
+        reviewStatus: "Review needed",
+        financialStatus: null,
+        nextActionLabel: "Review lease package",
       });
     }
 
@@ -292,11 +399,16 @@ export function deriveCommandCenterSignals(input: {
         id: `lease-document:${lease.id}`,
         category: "documents",
         severity: lease.leasePdfStatus === "not_available" ? "warning" : "info",
+        priorityGroup: lease.leasePdfStatus === "not_available" ? "needs_review" : "informational",
         title: lease.leasePdfLabel || "Lease document package not ready",
         description: lease.leasePdfDescription || "The tenant-facing lease package is not yet available.",
         contextLabel: baseLabel,
         destination: "/leases",
         source: "Lease operations · tenant workspace linkage",
+        workflowStatus: label(lease.leasePdfStatus),
+        reviewStatus: lease.leasePdfStatus === "not_available" ? "Review needed" : "Informational",
+        financialStatus: null,
+        nextActionLabel: "Review document context",
       });
     }
 
@@ -305,11 +417,16 @@ export function deriveCommandCenterSignals(input: {
         id: `payment-readiness:${lease.id}`,
         category: "payments",
         severity: lease.paymentReadiness.readinessStatus === "blocked" ? "critical" : "warning",
+        priorityGroup: lease.paymentReadiness.readinessStatus === "blocked" ? "critical" : "needs_review",
         title: lease.paymentReadiness.readinessLabel || "Payment readiness needs review",
         description: lease.paymentReadiness.readinessDescription || "Review lease payment setup before relying on collection workflow.",
         contextLabel: baseLabel,
         destination: leaseDestination,
         source: "Lease operations · payment readiness",
+        workflowStatus: label(lease.paymentReadiness.readinessStatus),
+        reviewStatus: "Review needed",
+        financialStatus: label(lease.paymentReadiness.readinessStatus),
+        nextActionLabel: "Review payment setup",
       });
     }
 
@@ -318,11 +435,16 @@ export function deriveCommandCenterSignals(input: {
         id: `lease-ending:${lease.id}`,
         category: "lease_lifecycle",
         severity: endingIn <= 30 ? "warning" : "info",
+        priorityGroup: "upcoming",
         title: "Lease ending soon",
         description: `Lease ends ${formatDate(lease.endDate)}. Review renewal, notice, or move-out workflow timing.`,
         contextLabel: baseLabel,
         destination: "/leases",
         source: "Lease operations · lifecycle timing",
+        workflowStatus: "Upcoming",
+        reviewStatus: endingIn <= 30 ? "Needs review" : "Upcoming",
+        financialStatus: null,
+        nextActionLabel: "Review renewal timing",
       });
     }
 
@@ -332,11 +454,17 @@ export function deriveCommandCenterSignals(input: {
         id: `policy:${lease.id}:${policy.policyKey}`,
         category: "lease_lifecycle",
         severity: policy.severity === "critical" ? "critical" : policy.severity === "warning" ? "warning" : "info",
+        priorityGroup:
+          policy.severity === "critical" ? "critical" : policy.policyKey.includes("renewal") ? "upcoming" : "needs_review",
         title: policy.label,
         description: `${policy.reason} ${policy.disclaimer}`,
         contextLabel: baseLabel,
         destination: "/leases",
         source: `Jurisdiction workflow · ${policy.jurisdiction}`,
+        workflowStatus: label(policy.status),
+        reviewStatus: "Review needed",
+        financialStatus: null,
+        nextActionLabel: "Review jurisdiction guidance",
       });
     }
   }
@@ -349,19 +477,21 @@ export function deriveCommandCenterSignals(input: {
         id: `property-vacancy:${property.id}`,
         category: "occupancy",
         severity: "info",
+        priorityGroup: "informational",
         title: "Vacant units visible",
         description: `${vacantUnits} vacant unit${vacantUnits === 1 ? "" : "s"} may need listing, lease, or follow-up review.`,
         contextLabel: propertyLabel(property),
         destination: "/properties",
         source: "Properties · occupancy display",
+        workflowStatus: "Informational",
+        reviewStatus: "Informational",
+        financialStatus: null,
+        nextActionLabel: "Review property occupancy",
       });
     }
   }
 
-  return signals.sort((a, b) => {
-    const severityRank = { critical: 0, warning: 1, info: 2 };
-    return severityRank[a.severity] - severityRank[b.severity] || CATEGORY_ORDER.indexOf(a.category) - CATEGORY_ORDER.indexOf(b.category);
-  });
+  return prioritizeOperationalItems(signals);
 }
 
 function summarizeByCategory(signals: CommandCenterSignal[]) {
@@ -372,6 +502,13 @@ function summarizeByCategory(signals: CommandCenterSignal[]) {
     critical: signals.filter((signal) => signal.category === category && signal.severity === "critical").length,
     warning: signals.filter((signal) => signal.category === category && signal.severity === "warning").length,
     info: signals.filter((signal) => signal.category === category && signal.severity === "info").length,
+  }));
+}
+
+function summarizeByPriority(signals: CommandCenterSignal[]) {
+  return PRIORITY_GROUPS.map((group) => ({
+    ...group,
+    signals: signals.filter((signal) => signal.priorityGroup === group.group),
   }));
 }
 
@@ -448,6 +585,7 @@ export default function OperationalCommandCenterPage() {
     [decisionData?.items, leases, properties]
   );
   const categorySummary = React.useMemo(() => summarizeByCategory(signals), [signals]);
+  const prioritySummary = React.useMemo(() => summarizeByPriority(signals), [signals]);
   const criticalCount = signals.filter((signal) => signal.severity === "critical").length;
   const warningCount = signals.filter((signal) => signal.severity === "warning").length;
 
@@ -474,9 +612,10 @@ export default function OperationalCommandCenterPage() {
             ["Signals", signals.length],
             ["Critical", criticalCount],
             ["Warnings", warningCount],
+            ["Needs review", signals.filter((signal) => signal.priorityGroup === "needs_review").length],
+            ["Upcoming", signals.filter((signal) => signal.priorityGroup === "upcoming").length],
             ["Open decisions", decisionData?.summary?.open ?? 0],
             ["Delinquent", dashboardData?.kpis?.delinquentCount ?? 0],
-            ["Open actions", dashboardData?.kpis?.openActionsCount ?? 0],
           ].map(([name, value]) => (
             <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
               <div style={{ color: "#64748b", fontSize: 12, fontWeight: 900 }}>{name}</div>
@@ -524,8 +663,8 @@ export default function OperationalCommandCenterPage() {
         <Section style={{ display: "grid", gap: 12 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             <Building2 size={18} />
-            <strong style={{ color: "#0f172a" }}>High-signal queue</strong>
-            <span style={{ color: "#64748b", fontSize: 13 }}>Prioritized by severity and source workflow.</span>
+            <strong style={{ color: "#0f172a" }}>Priority routing queue</strong>
+            <span style={{ color: "#64748b", fontSize: 13 }}>Highest priority first by urgency, severity, and source workflow.</span>
           </div>
           {loading ? <Card>Loading operational signals...</Card> : null}
           {!loading && error ? <Card style={{ color: "#b91c1c" }}>{error}</Card> : null}
@@ -533,27 +672,52 @@ export default function OperationalCommandCenterPage() {
             <Card style={{ color: "#64748b" }}>No high-signal operational issues are currently visible.</Card>
           ) : null}
           {!loading && !error && signals.length ? (
-            <div style={{ display: "grid", gap: 10 }}>
-              {signals.slice(0, 12).map((signal) => (
-                <Card key={signal.id} style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8 }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
-                    <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-                      <Badge severity={signal.severity}>{signal.severity}</Badge>
-                      <span style={{ color: "#64748b", fontSize: 13, fontWeight: 800 }}>
-                        {CATEGORY_CONFIG[signal.category].label}
-                      </span>
-                      <span style={{ color: "#64748b", fontSize: 13 }}>{signal.source}</span>
+            <div style={{ display: "grid", gap: 14 }}>
+              {prioritySummary.map((group) => (
+                <div key={group.group} style={{ display: "grid", gap: 8 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+                    <div style={{ display: "grid", gap: 3 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                        <Badge severity={group.tone}>{group.label}</Badge>
+                        <strong style={{ color: "#0f172a" }}>{group.signals.length} item{group.signals.length === 1 ? "" : "s"}</strong>
+                      </div>
+                      <span style={{ color: "#64748b", fontSize: 13 }}>{group.description}</span>
                     </div>
-                    <Link to={signal.destination} style={{ color: "#2563eb", fontWeight: 900 }}>
-                      Open source workflow
-                    </Link>
                   </div>
-                  <div style={{ display: "grid", gap: 4 }}>
-                    <strong style={{ color: "#0f172a", fontSize: 16 }}>{signal.title}</strong>
-                    <span style={{ color: "#475569", lineHeight: 1.5 }}>{signal.description}</span>
-                    <span style={{ color: "#64748b", fontSize: 13 }}>Context: {signal.contextLabel}</span>
-                  </div>
-                </Card>
+                  {group.signals.length ? (
+                    <div style={{ display: "grid", gap: 10 }}>
+                      {group.signals.map((signal) => (
+                        <Card key={signal.id} style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8 }}>
+                          <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                              <Badge severity={signal.severity}>{signal.severity}</Badge>
+                              <span style={{ color: "#64748b", fontSize: 13, fontWeight: 800 }}>
+                                {CATEGORY_CONFIG[signal.category].label}
+                              </span>
+                              <span style={{ color: "#64748b", fontSize: 13 }}>{signal.source}</span>
+                            </div>
+                            <Link to={signal.destination} style={{ color: "#2563eb", fontWeight: 900 }}>
+                              Open source workflow
+                            </Link>
+                          </div>
+                          <div style={{ display: "grid", gap: 4 }}>
+                            <strong style={{ color: "#0f172a", fontSize: 16 }}>{signal.title}</strong>
+                            <span style={{ color: "#475569", lineHeight: 1.5 }}>{signal.description}</span>
+                            <span style={{ color: "#64748b", fontSize: 13 }}>Context: {signal.contextLabel}</span>
+                          </div>
+                          <div style={{ display: "flex", gap: 10, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 800 }}>
+                            <span>Workflow status: {signal.workflowStatus}</span>
+                            <span>Review status: {signal.reviewStatus}</span>
+                            {signal.financialStatus ? <span>Financial status: {signal.financialStatus}</span> : null}
+                            <span>Next action: {signal.nextActionLabel}</span>
+                          </div>
+                        </Card>
+                      ))}
+                    </div>
+                  ) : (
+                    <Card style={{ color: "#64748b", borderRadius: 8 }}>No {group.label.toLowerCase()} items currently visible.</Card>
+                  )}
+                </div>
               ))}
             </div>
           ) : null}

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -132,6 +132,32 @@ function label(value: string) {
   return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function operationalCopy(value: string | null | undefined, fallback: string) {
+  const raw = String(value || "").trim();
+  if (!raw) return fallback;
+  const normalized = raw.toLowerCase();
+  const known: Record<string, string> = {
+    lease_status_active_but_execution_incomplete: "Lease is marked active, but signing or execution is incomplete.",
+    ledger_payment_activity_without_provider_payment_setup:
+      "Payment activity exists, but payment setup still needs operational review.",
+    active_lease_on_vacant_unit: "Lease and unit occupancy signals conflict and need review.",
+    occupied_unit_without_active_executed_lease: "Unit appears occupied without a fully executed active lease.",
+    tenant_active_without_executed_occupancy: "Tenant and lease occupancy signals need review.",
+  };
+  if (known[normalized]) return known[normalized];
+  if (/^[a-z0-9]+(?:_[a-z0-9]+){2,}$/.test(normalized)) return label(normalized);
+  return raw;
+}
+
+function operationalTitle(value: string | null | undefined, fallback: string) {
+  const raw = String(value || "").trim();
+  const normalized = raw.toLowerCase();
+  if (!raw || normalized === "needs review") return fallback;
+  if (normalized === "lease_status_active_but_execution_incomplete") return "Active lease needs execution review";
+  if (normalized === "ledger_payment_activity_without_provider_payment_setup") return "Payment setup needs review";
+  return operationalCopy(raw, fallback);
+}
+
 function formatDate(value?: string | null) {
   if (!value) return "date unavailable";
   const date = new Date(value);
@@ -346,8 +372,8 @@ export function deriveCommandCenterSignals(input: {
         category: "occupancy",
         severity: "warning",
         priorityGroup: lease.stateCoherence?.flags?.hasStateConflict ? "critical" : "needs_review",
-        title: lease.stateCoherence.coherenceLabel || "Occupancy review needed",
-        description: lease.stateCoherence.coherenceReason || "Lease and occupancy signals need human review.",
+        title: operationalTitle(lease.stateCoherence.coherenceReason || lease.stateCoherence.coherenceLabel, "Occupancy review needed"),
+        description: operationalCopy(lease.stateCoherence.coherenceReason, "Lease and occupancy signals need human review."),
         contextLabel: baseLabel,
         destination: "/leases",
         source: "Lease operations · occupancy coherence",
@@ -702,14 +728,16 @@ export default function OperationalCommandCenterPage() {
                           </div>
                           <div style={{ display: "grid", gap: 4 }}>
                             <strong style={{ color: "#0f172a", fontSize: 16 }}>{signal.title}</strong>
-                            <span style={{ color: "#475569", lineHeight: 1.5 }}>{signal.description}</span>
                             <span style={{ color: "#64748b", fontSize: 13 }}>Context: {signal.contextLabel}</span>
+                            <span style={{ color: "#475569", lineHeight: 1.5 }}>Why: {signal.description}</span>
+                            <span style={{ color: "#0f172a", fontSize: 13, fontWeight: 900 }}>
+                              Next action: {signal.nextActionLabel}
+                            </span>
                           </div>
                           <div style={{ display: "flex", gap: 10, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 800 }}>
                             <span>Workflow status: {signal.workflowStatus}</span>
                             <span>Review status: {signal.reviewStatus}</span>
                             {signal.financialStatus ? <span>Financial status: {signal.financialStatus}</span> : null}
-                            <span>Next action: {signal.nextActionLabel}</span>
                           </div>
                         </Card>
                       ))}

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -22,6 +22,15 @@ type CommandCenterCategory =
 
 type CommandCenterSeverity = "critical" | "warning" | "info";
 type CommandCenterPriorityGroup = "critical" | "needs_review" | "upcoming" | "informational";
+type CommandCenterFilter =
+  | "all"
+  | "critical"
+  | "warnings"
+  | "needs_review"
+  | "upcoming"
+  | "open_decisions"
+  | "delinquent"
+  | "informational";
 
 export type CommandCenterSignal = {
   id: string;
@@ -127,6 +136,16 @@ const PRIORITY_GROUPS: Array<{
 ];
 
 const INACTIVE_DECISION_STATUSES = new Set(["resolved", "dismissed"]);
+const COMMAND_CENTER_FILTERS: Array<{ value: CommandCenterFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "critical", label: "Critical" },
+  { value: "warnings", label: "Warnings" },
+  { value: "needs_review", label: "Needs review" },
+  { value: "upcoming", label: "Upcoming" },
+  { value: "open_decisions", label: "Open decisions" },
+  { value: "delinquent", label: "Delinquent" },
+  { value: "informational", label: "Informational" },
+];
 
 function label(value: string) {
   return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
@@ -538,6 +557,53 @@ function summarizeByPriority(signals: CommandCenterSignal[]) {
   }));
 }
 
+function normalizeSearchText(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function signalSearchText(signal: CommandCenterSignal) {
+  return [
+    signal.title,
+    signal.description,
+    signal.contextLabel,
+    CATEGORY_CONFIG[signal.category].label,
+    signal.category,
+    signal.source,
+    signal.workflowStatus,
+    signal.reviewStatus,
+    signal.financialStatus,
+    signal.nextActionLabel,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function matchesCommandCenterFilter(signal: CommandCenterSignal, filter: CommandCenterFilter) {
+  if (filter === "all") return true;
+  if (filter === "critical") return signal.priorityGroup === "critical" || signal.severity === "critical";
+  if (filter === "warnings") return signal.severity === "warning";
+  if (filter === "needs_review") return signal.priorityGroup === "needs_review";
+  if (filter === "upcoming") return signal.priorityGroup === "upcoming";
+  if (filter === "open_decisions") return signal.id.startsWith("decision:");
+  if (filter === "delinquent") return signal.category === "payments" || /delinqu|payment evidence/i.test(signal.source);
+  if (filter === "informational") return signal.priorityGroup === "informational";
+  return true;
+}
+
+export function filterOperationalItems(
+  signals: CommandCenterSignal[],
+  options: { search?: string; filter?: CommandCenterFilter }
+) {
+  const query = normalizeSearchText(String(options.search || ""));
+  const filter = options.filter || "all";
+  return signals.filter((signal) => {
+    if (!matchesCommandCenterFilter(signal, filter)) return false;
+    if (!query) return true;
+    return normalizeSearchText(signalSearchText(signal)).includes(query);
+  });
+}
+
 function severityTone(severity: CommandCenterSeverity) {
   if (severity === "critical") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
   if (severity === "warning") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
@@ -574,6 +640,8 @@ export default function OperationalCommandCenterPage() {
   const [dashboardData, setDashboardData] = React.useState<DashboardSummaryData | null>(null);
   const [leases, setLeases] = React.useState<LandlordActiveLease[]>([]);
   const [properties, setProperties] = React.useState<Property[]>([]);
+  const [search, setSearch] = React.useState("");
+  const [activeFilter, setActiveFilter] = React.useState<CommandCenterFilter>("all");
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -610,8 +678,12 @@ export default function OperationalCommandCenterPage() {
     () => deriveCommandCenterSignals({ decisions: decisionData?.items || [], leases, properties }),
     [decisionData?.items, leases, properties]
   );
-  const categorySummary = React.useMemo(() => summarizeByCategory(signals), [signals]);
-  const prioritySummary = React.useMemo(() => summarizeByPriority(signals), [signals]);
+  const visibleSignals = React.useMemo(
+    () => filterOperationalItems(signals, { search, filter: activeFilter }),
+    [activeFilter, search, signals]
+  );
+  const categorySummary = React.useMemo(() => summarizeByCategory(visibleSignals), [visibleSignals]);
+  const prioritySummary = React.useMemo(() => summarizeByPriority(visibleSignals), [visibleSignals]);
   const criticalCount = signals.filter((signal) => signal.severity === "critical").length;
   const warningCount = signals.filter((signal) => signal.severity === "warning").length;
 
@@ -650,7 +722,7 @@ export default function OperationalCommandCenterPage() {
           ))}
         </Section>
 
-        <Section style={{ display: "grid", gap: 12 }}>
+        <Section style={{ display: "grid", gap: 12, minWidth: 0 }}>
           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
             <div>
               <div style={{ fontWeight: 900, color: "#0f172a" }}>Coordination lanes</div>
@@ -658,16 +730,16 @@ export default function OperationalCommandCenterPage() {
             </div>
             <div style={{ color: "#64748b", fontSize: 13 }}>Read-only coordination layer</div>
           </div>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 10 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 10, minWidth: 0 }}>
             {categorySummary.map(({ category, config, total, critical, warning, info }) => {
               const Icon = config.icon;
               return (
                 <Link
                   key={category}
                   to={config.destination}
-                  style={{ color: "inherit", textDecoration: "none" }}
+                  style={{ color: "inherit", textDecoration: "none", minWidth: 0 }}
                 >
-                  <Card style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8, height: "100%" }}>
+                  <Card style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8, height: "100%", minWidth: 0, overflowWrap: "anywhere" }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                       <Icon size={18} />
                       <strong style={{ color: "#0f172a" }}>{config.label}</strong>
@@ -686,18 +758,66 @@ export default function OperationalCommandCenterPage() {
           </div>
         </Section>
 
-        <Section style={{ display: "grid", gap: 12 }}>
+        <Section style={{ display: "grid", gap: 12, minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             <Building2 size={18} />
             <strong style={{ color: "#0f172a" }}>Priority routing queue</strong>
             <span style={{ color: "#64748b", fontSize: 13 }}>Highest priority first by urgency, severity, and source workflow.</span>
+          </div>
+          <div style={{ display: "grid", gap: 10 }}>
+            <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Search operational items
+              <input
+                aria-label="Search operational items"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search by tenant, property, unit, workflow, category, or status"
+                style={{
+                  width: "100%",
+                  minWidth: 0,
+                  border: "1px solid #cbd5e1",
+                  borderRadius: 8,
+                  padding: "10px 12px",
+                  fontSize: 14,
+                  color: "#0f172a",
+                  boxSizing: "border-box",
+                }}
+              />
+            </label>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }} aria-label="Operational item filters">
+              {COMMAND_CENTER_FILTERS.map((filter) => {
+                const selected = activeFilter === filter.value;
+                return (
+                  <button
+                    key={filter.value}
+                    type="button"
+                    onClick={() => setActiveFilter(filter.value)}
+                    style={{
+                      border: selected ? "1px solid #1d4ed8" : "1px solid #cbd5e1",
+                      background: selected ? "#dbeafe" : "#fff",
+                      color: selected ? "#1d4ed8" : "#334155",
+                      borderRadius: 999,
+                      padding: "7px 11px",
+                      fontSize: 13,
+                      fontWeight: 900,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {filter.label}
+                  </button>
+                );
+              })}
+            </div>
           </div>
           {loading ? <Card>Loading operational signals...</Card> : null}
           {!loading && error ? <Card style={{ color: "#b91c1c" }}>{error}</Card> : null}
           {!loading && !error && signals.length === 0 ? (
             <Card style={{ color: "#64748b" }}>No high-signal operational issues are currently visible.</Card>
           ) : null}
-          {!loading && !error && signals.length ? (
+          {!loading && !error && signals.length > 0 && visibleSignals.length === 0 ? (
+            <Card style={{ color: "#64748b" }}>No operational items match the current search or filter.</Card>
+          ) : null}
+          {!loading && !error && visibleSignals.length ? (
             <div style={{ display: "grid", gap: 14 }}>
               {prioritySummary.map((group) => (
                 <div key={group.group} style={{ display: "grid", gap: 8 }}>
@@ -713,7 +833,7 @@ export default function OperationalCommandCenterPage() {
                   {group.signals.length ? (
                     <div style={{ display: "grid", gap: 10 }}>
                       {group.signals.map((signal) => (
-                        <Card key={signal.id} style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8 }}>
+                        <Card key={signal.id} style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8, minWidth: 0, overflowWrap: "anywhere" }}>
                           <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
                             <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
                               <Badge severity={signal.severity}>{signal.severity}</Badge>

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -705,7 +705,7 @@ export default function OperationalCommandCenterPage() {
           </div>
         </Section>
 
-        <Section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10 }}>
+        <Section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10, minWidth: 0 }}>
           {[
             ["Signals", signals.length],
             ["Critical", criticalCount],
@@ -715,7 +715,7 @@ export default function OperationalCommandCenterPage() {
             ["Open decisions", decisionData?.summary?.open ?? 0],
             ["Delinquent", dashboardData?.kpis?.delinquentCount ?? 0],
           ].map(([name, value]) => (
-            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12, boxSizing: "border-box", minWidth: 0 }}>
               <div style={{ color: "#64748b", fontSize: 12, fontWeight: 900 }}>{name}</div>
               <strong style={{ color: "#0f172a", fontSize: 24 }}>{value}</strong>
             </Card>
@@ -730,16 +730,36 @@ export default function OperationalCommandCenterPage() {
             </div>
             <div style={{ color: "#64748b", fontSize: 13 }}>Read-only coordination layer</div>
           </div>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 10, minWidth: 0 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "stretch", gap: 12, minWidth: 0 }}>
             {categorySummary.map(({ category, config, total, critical, warning, info }) => {
               const Icon = config.icon;
               return (
                 <Link
                   key={category}
                   to={config.destination}
-                  style={{ color: "inherit", textDecoration: "none", minWidth: 0 }}
+                  style={{
+                    color: "inherit",
+                    textDecoration: "none",
+                    minWidth: 260,
+                    flex: "1 1 280px",
+                    display: "flex",
+                    boxSizing: "border-box",
+                  }}
                 >
-                  <Card style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8, height: "100%", minWidth: 0, overflowWrap: "anywhere" }}>
+                  <Card
+                    style={{
+                      borderRadius: 8,
+                      padding: 14,
+                      display: "grid",
+                      alignContent: "start",
+                      gap: 8,
+                      width: "100%",
+                      minHeight: 150,
+                      minWidth: 0,
+                      boxSizing: "border-box",
+                      overflowWrap: "anywhere",
+                    }}
+                  >
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                       <Icon size={18} />
                       <strong style={{ color: "#0f172a" }}>{config.label}</strong>
@@ -815,7 +835,7 @@ export default function OperationalCommandCenterPage() {
             <Card style={{ color: "#64748b" }}>No high-signal operational issues are currently visible.</Card>
           ) : null}
           {!loading && !error && signals.length > 0 && visibleSignals.length === 0 ? (
-            <Card style={{ color: "#64748b" }}>No operational items match the current search or filter.</Card>
+            <Card style={{ color: "#64748b", boxSizing: "border-box" }}>No operational items match the current search or filter.</Card>
           ) : null}
           {!loading && !error && visibleSignals.length ? (
             <div style={{ display: "grid", gap: 14 }}>
@@ -833,7 +853,18 @@ export default function OperationalCommandCenterPage() {
                   {group.signals.length ? (
                     <div style={{ display: "grid", gap: 10 }}>
                       {group.signals.map((signal) => (
-                        <Card key={signal.id} style={{ borderRadius: 8, padding: 14, display: "grid", gap: 8, minWidth: 0, overflowWrap: "anywhere" }}>
+                        <Card
+                          key={signal.id}
+                          style={{
+                            borderRadius: 8,
+                            padding: 14,
+                            display: "grid",
+                            gap: 8,
+                            minWidth: 0,
+                            boxSizing: "border-box",
+                            overflowWrap: "anywhere",
+                          }}
+                        >
                           <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
                             <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
                               <Badge severity={signal.severity}>{signal.severity}</Badge>
@@ -863,7 +894,9 @@ export default function OperationalCommandCenterPage() {
                       ))}
                     </div>
                   ) : (
-                    <Card style={{ color: "#64748b", borderRadius: 8 }}>No {group.label.toLowerCase()} items currently visible.</Card>
+                    <Card style={{ color: "#64748b", borderRadius: 8, boxSizing: "border-box" }}>
+                      No {group.label.toLowerCase()} items currently visible.
+                    </Card>
                   )}
                 </div>
               ))}


### PR DESCRIPTION
## Summary

Extends the Operational Command Center from a flat visibility queue into a prioritized coordination surface.

## Audit Summary

Inspected the current `/operations` implementation and reused its existing read-model inputs:

- decision inbox items and workflow metadata
- active lease operational readiness fields
- lease state/coherence and jurisdiction policy metadata
- property occupancy summaries
- dashboard summary counts

No backend routes, persistence, write paths, or workflow action behavior were changed.

## Prioritization Rules Added

Operational signals now carry deterministic priority metadata and are grouped as:

- `Critical`: delinquency/payment reviews, blocked workflows, escalated decisions, occupancy conflicts, blocked payment/lease execution readiness
- `Needs review`: signature/document readiness, waiting-context workflow items, warning-level reviews, non-critical policy/readiness items
- `Upcoming`: lease ending soon and renewal-style forward workflow guidance
- `Informational`: vacant-unit visibility and lower-risk operational context

Sorting is deterministic by priority group, severity, workflow category, title, and ID.

## UI Sections / Groups Added

- Priority routing queue
- Critical
- Needs review
- Upcoming
- Informational
- Counts for the priority groups
- Per-item workflow status, review status, optional financial status, and next action label

Existing coordination lanes and source workflow links are preserved.

## Guardrails

- No autonomous execution
- No auto-escalation or external routing
- No payment, ledger, lease, occupancy, decision, screening, or legal workflow behavior changed
- No backend mutation or schema changes
- Human-readable operational labels preserved

## Tests Run

- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/OperationalCommandCenterPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`

## Known Follow-ups

- `feat/operator-review-session-workspaces-v1`
- `feat/governed-operational-agent-routing-v1`
- `feat/operational-sla-and-escalation-policies-v1`
- Optional filters by priority/category/workflow status once operator workflow metadata is broader and stable