### PR TITLE
fix: harden command center responsive layout

### DIFF
--- a/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
@@ -40,4 +40,38 @@ describe("KpiStrip", () => {
     expect(screen.getByText("Properties")).toBeInTheDocument();
     expect(screen.getByText("Units")).toBeInTheDocument();
   });
+
+  it("uses safe desktop grid tracks that cannot overflow the container width", () => {
+    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { container } = render(
+      <MemoryRouter>
+        <KpiStrip
+          kpis={{
+            propertiesCount: 2,
+            unitsCount: 4,
+            tenantsCount: 3,
+            openActionsCount: 1,
+            delinquentCount: 0,
+          }}
+        />
+      </MemoryRouter>
+    );
+
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid).toHaveStyle({
+      gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 160px), 1fr))",
+      width: "100%",
+      boxSizing: "border-box",
+    });
+  });
 });

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
@@ -42,7 +42,7 @@ export function KpiStrip({ kpis, loading, links }: Props) {
     <div
       style={{
         display: "grid",
-        gridTemplateColumns: isMobile ? "1fr" : "repeat(auto-fit, minmax(140px, 1fr))",
+        gridTemplateColumns: isMobile ? "1fr" : "repeat(auto-fit, minmax(min(100%, 160px), 1fr))",
         gap: isMobile ? 16 : spacing.sm,
         alignItems: "stretch",
         minWidth: 0,

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -327,6 +327,12 @@ describe("DashboardPage", () => {
     expect(screen.getAllByText("Partial payment received").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Payment mismatch detected").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("dashboard-kpi-decision-stack")).toHaveStyle({
+      display: "grid",
+      gap: "2rem",
+      width: "100%",
+      boxSizing: "border-box",
+    });
   });
 
   it("updates dashboard decision status from human actions", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -178,11 +178,29 @@ function DashboardDecisionSummaryPanel({
         </div>
       ) : (
         <>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: spacing.sm }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 130px), 1fr))",
+              gap: spacing.sm,
+              minWidth: 0,
+              boxSizing: "border-box",
+            }}
+          >
             {cells.map((cell) => {
               const tone = decisionSeverityStyle[cell.severity];
               return (
-                <div key={cell.label} style={{ border: `1px solid ${tone.border}`, background: tone.bg, borderRadius: 10, padding: 10 }}>
+                <div
+                  key={cell.label}
+                  style={{
+                    border: `1px solid ${tone.border}`,
+                    background: tone.bg,
+                    borderRadius: 10,
+                    padding: 10,
+                    minWidth: 0,
+                    boxSizing: "border-box",
+                  }}
+                >
                   <div style={{ color: tone.color, fontSize: 12, fontWeight: 700 }}>{cell.label}</div>
                   <strong style={{ color: tone.color, fontSize: 20 }}>{cell.value}</strong>
                 </div>
@@ -814,7 +832,18 @@ const DashboardPage: React.FC = () => {
         ) : null}
 
         {dataReady ? (
-          <div style={{ display: "grid", gap: spacing.lg, minWidth: 0, width: "100%", boxSizing: "border-box", clear: "both" }}>
+          <div
+            data-testid="dashboard-kpi-decision-stack"
+            style={{
+              display: "grid",
+              gap: spacing.xl,
+              minWidth: 0,
+              width: "100%",
+              boxSizing: "border-box",
+              clear: "both",
+              alignItems: "start",
+            }}
+          >
             <KpiStrip
               kpis={kpis}
               loading={loading}

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -378,6 +378,10 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Payments / obligations").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lease lifecycle").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Documents / workspace").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("operations-coordination-lanes")).toHaveStyle({
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
+    });
     expect(screen.getByText("Priority routing queue")).toBeInTheDocument();
     expect(screen.getByText(/Highest priority first by urgency, severity, and source workflow/i)).toBeInTheDocument();
     expect(screen.getAllByText("Critical").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -705,7 +705,15 @@ export default function OperationalCommandCenterPage() {
           </div>
         </Section>
 
-        <Section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10, minWidth: 0 }}>
+        <Section
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 160px), 1fr))",
+            gap: 10,
+            minWidth: 0,
+            boxSizing: "border-box",
+          }}
+        >
           {[
             ["Signals", signals.length],
             ["Critical", criticalCount],
@@ -730,7 +738,18 @@ export default function OperationalCommandCenterPage() {
             </div>
             <div style={{ color: "#64748b", fontSize: 13 }}>Read-only coordination layer</div>
           </div>
-          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "stretch", gap: 12, minWidth: 0 }}>
+          <div
+            data-testid="operations-coordination-lanes"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
+              alignItems: "stretch",
+              gap: 12,
+              minWidth: 0,
+              width: "100%",
+              boxSizing: "border-box",
+            }}
+          >
             {categorySummary.map(({ category, config, total, critical, warning, info }) => {
               const Icon = config.icon;
               return (
@@ -740,9 +759,8 @@ export default function OperationalCommandCenterPage() {
                   style={{
                     color: "inherit",
                     textDecoration: "none",
-                    minWidth: 260,
-                    flex: "1 1 280px",
                     display: "flex",
+                    minWidth: 0,
                     boxSizing: "border-box",
                   }}
                 >


### PR DESCRIPTION
## Summary

Hardened the `/operations` and `/dashboard` responsive layout after PR #935 preview QA found remaining overlap at standard desktop and laptop widths.

## Audit Findings

- `/operations` coordination lanes were still vulnerable to card overflow because track/card minimums could exceed available container width.
- `/dashboard` KPI cards and the Decision summary stack needed stricter full-width, border-box layout boundaries.
- Existing `/operations` search, priority filters, and normalized labels were already working and were preserved.

## Changes

- Updated `/operations` summary and coordination lane grids to use overflow-safe `minmax(min(100%, ...), 1fr)` tracks.
- Added local `minWidth`, `width`, and `boxSizing` constraints to the affected operational cards.
- Updated `/dashboard` KPI strip and Decision summary stack to use full-width border-box layout and safer grid tracks.
- Added layout smoke assertions for:
  - `/operations` coordination lanes
  - `/dashboard` KPI + Decision summary stack
  - desktop/mobile KPI strip grid behavior

## Guardrails

- No backend changes.
- No workflow logic changes.
- No routing changes.
- No financial/payment/ledger changes.
- Existing `/operations` search/filter behavior and label normalization remain intact.

## Verification

- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/OperationalCommandCenterPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/components/dashboard/KpiStrip.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/DashboardPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`

## Preview QA Required

Please confirm on desktop, tablet, and mobile widths:

- `/operations` coordination lanes no longer overlap.
- `/dashboard` KPI cards and Decision summary no longer overlap or crowd.
- `/operations` search and priority filters remain intact.
- Existing normalized labels remain readable.