### PR TITLE
chore: verify Vercel Pro transfer workflow

### DIFF
--- a/docs/runbooks/vercel-pro-transfer-verification-v1.md
+++ b/docs/runbooks/vercel-pro-transfer-verification-v1.md
@@ -1,0 +1,14 @@
+# Vercel Pro Transfer Verification v1
+
+Purpose: verify that the RentChain GitHub and Vercel deployment workflow remains healthy after the Vercel Pro migration.
+
+Scope:
+- Documentation-only verification change.
+- No application behavior changes.
+- No environment, infrastructure, auth, payment, screening, Firestore, or routing changes.
+
+Expected checks:
+- GitHub Actions checks run normally.
+- Vercel preview checks appear for `rentchain`.
+- Vercel preview checks appear for `rentchain-status`.
+- Production deployment updates from `main` after merge.


### PR DESCRIPTION
## Summary

Adds a documentation-only verification note to exercise the GitHub/Vercel deployment workflow after the Vercel Pro migration.

## Scope

- Docs-only change.
- No application behavior changes.
- No environment variable changes.
- No infrastructure changes.
- No auth, payment, screening, Firestore, or routing changes.

## Verification Objective

Confirm this PR triggers the normal checks and previews:

- GitHub Actions checks run normally.
- Vercel preview check appears for `rentchain`.
- Vercel preview check appears for `rentchain-status`.
- After merge, production deployment updates from `main`.

## Files Changed

- `docs/runbooks/vercel-pro-transfer-verification-v1.md`

## Preview QA

No product QA required. This PR exists only to verify deployment/check plumbing after the Vercel Pro transfer.