### PR TITLE
test: add API route ownership regression coverage

### DIFF
--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -1,0 +1,364 @@
+import fs from "fs";
+import path from "path";
+import express from "express";
+import { describe, expect, it, vi } from "vitest";
+import { routeSource } from "../../middleware/routeSource";
+
+const authState = vi.hoisted(() => ({
+  user: null as any,
+}));
+
+const stripeMocks = vi.hoisted(() => ({
+  constructEvent: vi.fn(),
+}));
+
+function buildEmptyQuery() {
+  return {
+    where: () => buildEmptyQuery(),
+    orderBy: () => buildEmptyQuery(),
+    limit: () => buildEmptyQuery(),
+    get: async () => ({ docs: [], empty: true, size: 0 }),
+  };
+}
+
+vi.mock("../../config/firebase", () => ({
+  FieldValue: {
+    serverTimestamp: () => "server-timestamp",
+  },
+  db: {
+    collection: () => ({
+      doc: (id = "doc-1") => ({
+        id,
+        get: async () => ({ id, exists: false, data: () => null }),
+        set: async () => undefined,
+      }),
+      where: () => buildEmptyQuery(),
+      orderBy: () => buildEmptyQuery(),
+      limit: () => buildEmptyQuery(),
+      get: async () => ({ docs: [], empty: true, size: 0 }),
+    }),
+  },
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    if (authState.user) req.user = authState.user;
+    next();
+  },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    const auth = String(req.headers?.authorization || "");
+    if (!auth.startsWith("Bearer ") || !authState.user) {
+      return res.status(401).json({ ok: false, error: "unauthenticated" });
+    }
+    req.user = authState.user;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const auth = String(req.headers?.authorization || "");
+    if (!auth.startsWith("Bearer ")) {
+      return res.status(401).json({ ok: false, error: "Unauthorized" });
+    }
+    req.user = authState.user || {
+      id: "landlord-1",
+      landlordId: "landlord-1",
+      role: "landlord",
+    };
+    return next();
+  },
+}));
+
+vi.mock("../../services/capabilityGuard", () => ({
+  requireCapability: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../config/screeningConfig", () => ({
+  STRIPE_WEBHOOK_SECRET: "whsec_test",
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  getStripeClient: () => ({
+    webhooks: {
+      constructEvent: stripeMocks.constructEvent,
+    },
+  }),
+  isStripeConfigured: () => true,
+}));
+
+vi.mock("../../lib/stripeNotConfigured", () => ({
+  stripeNotConfiguredResponse: () => ({ ok: false, error: "stripe_not_configured" }),
+  isStripeNotConfiguredError: () => false,
+}));
+
+vi.mock("../../services/stripeFinalize", () => ({
+  finalizeStripePayment: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/stripeScreeningProcessor", () => ({
+  applyScreeningResultsFromOrder: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/screening/screeningOrchestrator", () => ({
+  beginScreening: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/screening/providers/bureauProvider", () => ({
+  getBureauProvider: () => ({
+    name: "transunion",
+    isConfigured: () => true,
+  }),
+}));
+
+vi.mock("../../storage/pdfStore", () => ({
+  putPdfObject: vi.fn(async () => ({ url: "https://example.test/report.pdf" })),
+}));
+
+vi.mock("../../services/screening/screeningEvents", () => ({
+  writeScreeningEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../services/emailService", () => ({
+  sendEmail: vi.fn(async () => undefined),
+}));
+
+function appBuildSource() {
+  return fs.readFileSync(path.resolve(__dirname, "../../app.build.ts"), "utf8");
+}
+
+async function invokeApp(
+  app: any,
+  options: {
+    method: string;
+    url: string;
+    body?: any;
+    headers?: Record<string, string>;
+  }
+) {
+  return await new Promise<{ status: number; body: any; text?: string; headers: Record<string, any> }>(
+    (resolve, reject) => {
+      const [pathOnly, rawQuery] = options.url.split("?");
+      const req: any = {
+        method: options.method,
+        url: options.url,
+        originalUrl: options.url,
+        path: pathOnly,
+        query: rawQuery ? Object.fromEntries(new URLSearchParams(rawQuery).entries()) : {},
+        body: options.body ?? {},
+        headers: Object.fromEntries(
+          Object.entries(options.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+        ),
+        cookies: {},
+        get(name: string) {
+          return this.headers[String(name || "").toLowerCase()];
+        },
+        header(name: string) {
+          return this.headers[String(name || "").toLowerCase()];
+        },
+      };
+      const res: any = {
+        statusCode: 200,
+        headers: {} as Record<string, any>,
+        setHeader(name: string, value: any) {
+          this.headers[String(name).toLowerCase()] = value;
+        },
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload, headers: this.headers });
+          return this;
+        },
+        send(payload: any) {
+          resolve({
+            status: this.statusCode,
+            body: payload,
+            text: Buffer.isBuffer(payload) ? payload.toString("utf8") : String(payload ?? ""),
+            headers: this.headers,
+          });
+          return this;
+        },
+        end(payload?: any) {
+          resolve({
+            status: this.statusCode,
+            body: payload,
+            text: Buffer.isBuffer(payload) ? payload.toString("utf8") : String(payload ?? ""),
+            headers: this.headers,
+          });
+          return this;
+        },
+      };
+
+      app.handle(req, res, (error: any) => {
+        if (error) reject(error);
+        else reject(new Error(`Unhandled request: ${options.method} ${options.url}`));
+      });
+    }
+  );
+}
+
+async function buildRuntimeOwnershipApp() {
+  const messagesRoutes = (await import("../messagesRoutes")).default;
+  const landlordEvidencePackRoutes = (await import("../landlordEvidencePackRoutes")).default;
+  const internalReportsRoutes = (await import("../internalReportsRoutes")).default;
+  const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
+  const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
+
+  const app = express();
+  app.post("/api/webhooks/stripe", routeSource("stripeScreeningOrdersWebhookRoutes.ts"), stripeWebhookHandler);
+  app.post("/api/webhooks/transunion", routeSource("transunionWebhookRoutes.ts"), transunionWebhookHandler);
+  app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
+  app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
+  app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
+  app.get("/api/__probe/revision", routeSource("app.build.ts:/api/__probe/revision"), (_req, res) =>
+    res.json({ ok: true, revision: "test" })
+  );
+  app.get("/api/__debug/build", routeSource("app.build.ts:/api/__debug/build"), (_req, res) =>
+    res.json({ ok: true, routeCheck: { landlordApplicationLinksMounted: true } })
+  );
+  app.post("/api/_echo", routeSource("app.build.ts:/api/_echo"), (req, res) =>
+    res.json({ ok: true, method: "POST", body: req.body ?? null })
+  );
+  app.use("/api", (_req, res) => {
+    res.setHeader("x-route-source", "not-found");
+    return res.status(404).json({ ok: false, code: "NOT_FOUND", error: "Not Found" });
+  });
+  return app;
+}
+
+describe("API route ownership regression", () => {
+  it("keeps provider webhooks mounted before the JSON parser", () => {
+    const source = appBuildSource();
+    const jsonParserIndex = source.indexOf("const jsonParser = express.json");
+
+    expect(source.indexOf('"/api/webhooks/stripe"')).toBeGreaterThan(-1);
+    expect(source.indexOf('"/api/stripe/webhook"')).toBeGreaterThan(-1);
+    expect(source.indexOf('"/api/webhooks/transunion"')).toBeGreaterThan(-1);
+    expect(source.indexOf('"/api/webhooks/stripe"')).toBeLessThan(jsonParserIndex);
+    expect(source.indexOf('"/api/stripe/webhook"')).toBeLessThan(jsonParserIndex);
+    expect(source.indexOf('"/api/webhooks/transunion"')).toBeLessThan(jsonParserIndex);
+  });
+
+  it("keeps high-risk prefixed mounts ahead of broad fallback and screening job routes", () => {
+    const source = appBuildSource();
+    const ledgerMount = source.indexOf('app.use("/api/ledger", routeSource("ledgerRoutes.ts"), ledgerRoutes)');
+    const decisionsMount = source.indexOf('app.use("/api/decisions", routeSource("decisionRoutes.ts"), decisionRoutes)');
+    const leasesMount = source.indexOf('app.use("/api/leases", routeSource("leaseRoutes.ts"), leaseRoutes)');
+    const tenantsMount = source.indexOf('app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes)');
+    const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
+    const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
+
+    expect(ledgerMount).toBeGreaterThan(-1);
+    expect(decisionsMount).toBeGreaterThan(-1);
+    expect(leasesMount).toBeGreaterThan(-1);
+    expect(tenantsMount).toBeGreaterThan(-1);
+    expect(screeningJobsMount).toBeGreaterThan(-1);
+    expect(apiCatchall).toBeGreaterThan(-1);
+    expect(ledgerMount).toBeLessThan(screeningJobsMount);
+    expect(decisionsMount).toBeLessThan(screeningJobsMount);
+    expect(leasesMount).toBeLessThan(screeningJobsMount);
+    expect(tenantsMount).toBeLessThan(screeningJobsMount);
+    expect(screeningJobsMount).toBeLessThan(apiCatchall);
+  });
+
+  it("documents intentionally reachable probe, debug, echo, and catchall route sources", () => {
+    const source = appBuildSource();
+    const echoRoutes = source.match(/app\.post\("\/api\/_echo"/g) || [];
+
+    expect(source).toContain('app.get("/api/__probe/revision"');
+    expect(source).toContain('app.get("/api/__probe/routes"');
+    expect(source).toContain('app.get("/api/__debug/build"');
+    expect(source).toContain('app.get("/api/__debug/ping-application-links"');
+    expect(echoRoutes).toHaveLength(2);
+    expect(source).toContain('res.setHeader("x-route-source", "not-found")');
+  });
+
+  it("routes protected tenant, evidence, and internal endpoints to their owners before rejecting missing credentials", async () => {
+    authState.user = null;
+    const app = await buildRuntimeOwnershipApp();
+
+    const tenantRes = await invokeApp(app, { method: "GET", url: "/api/tenant/messages/conversation" });
+    expect(tenantRes.status).toBe(401);
+    expect(tenantRes.headers["x-route-source"]).toBe("messagesRoutes.ts");
+
+    const evidenceRes = await invokeApp(app, {
+      method: "GET",
+      url: "/api/landlord/evidence-packs/preview?scope=lease&scopeId=lease-1",
+    });
+    expect(evidenceRes.status).toBe(401);
+    expect(evidenceRes.headers["x-route-source"]).toBe("landlordEvidencePackRoutes.ts");
+
+    const internalRes = await invokeApp(app, {
+      method: "POST",
+      url: "/api/internal/reports/tu-referrals",
+      body: {},
+    });
+    expect(internalRes.status).toBe(401);
+    expect(internalRes.headers["x-route-source"]).toBe("internalReportsRoutes.ts");
+  });
+
+  it("keeps webhook requests public and owned by webhook routers", async () => {
+    stripeMocks.constructEvent.mockReset();
+    stripeMocks.constructEvent.mockReturnValueOnce({
+      type: "noop.event",
+      data: { object: {} },
+    });
+    const app = await buildRuntimeOwnershipApp();
+
+    const stripeRes = await invokeApp(app, {
+      method: "POST",
+      url: "/api/webhooks/stripe",
+      headers: {
+        "stripe-signature": "t=1,v1=test",
+        "content-type": "application/json",
+      },
+      body: Buffer.from('{"id":"evt_1","type":"noop.event"}'),
+    });
+    expect(stripeRes.status).toBe(200);
+    expect(stripeRes.headers["x-route-source"]).toBe("stripeScreeningOrdersWebhookRoutes.ts");
+    expect(stripeMocks.constructEvent).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "t=1,v1=test",
+      "whsec_test"
+    );
+
+    const transunionRes = await invokeApp(app, {
+      method: "POST",
+      url: "/api/webhooks/transunion",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: Buffer.from("{}"),
+    });
+    expect(transunionRes.status).toBe(400);
+    expect(transunionRes.body).toMatchObject({ ok: false, error: "missing_request_id" });
+    expect(transunionRes.headers["x-route-source"]).toBe("transunionWebhookRoutes.ts");
+  });
+
+  it("keeps probe/debug/echo exposure and API catchall deterministic", async () => {
+    const app = await buildRuntimeOwnershipApp();
+
+    const revision = await invokeApp(app, { method: "GET", url: "/api/__probe/revision" });
+    expect(revision.status).toBe(200);
+    expect(revision.headers["x-route-source"]).toBe("app.build.ts:/api/__probe/revision");
+
+    const debug = await invokeApp(app, { method: "GET", url: "/api/__debug/build" });
+    expect(debug.status).toBe(200);
+    expect(debug.headers["x-route-source"]).toBe("app.build.ts:/api/__debug/build");
+
+    const echo = await invokeApp(app, { method: "POST", url: "/api/_echo", body: { ok: true } });
+    expect(echo.status).toBe(200);
+    expect(echo.headers["x-route-source"]).toBe("app.build.ts:/api/_echo");
+    expect(echo.body).toMatchObject({ ok: true, method: "POST", body: { ok: true } });
+
+    const missing = await invokeApp(app, { method: "GET", url: "/api/unknown-route" });
+    expect(missing.status).toBe(404);
+    expect(missing.headers["x-route-source"]).toBe("not-found");
+    expect(missing.body).toEqual({ ok: false, code: "NOT_FOUND", error: "Not Found" });
+  });
+});

--- a/rentchain-api/src/routes/__tests__/ledgerPaymentImportRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/ledgerPaymentImportRoutes.test.ts
@@ -196,6 +196,29 @@ describe("ledger payment CSV import routes", () => {
     expect(writeTracker.ledgerEntryWrites).toBe(0);
   });
 
+  it("keeps payment CSV confirm route ahead of broad screening fallback routes", async () => {
+    const router = (await import("../ledgerRoutes")).default;
+    const app = buildAppWithBroadScreeningFallback(router);
+    const csv = "tenantName,property,unit,amount,paymentDate\nBailey Blinkers,Harbour View,1,150,2026-05-15";
+
+    const preview = await request(app)
+      .post("/api/ledger/imports/payment-csv/preview")
+      .attach("file", Buffer.from(csv), {
+        filename: "payments.csv",
+        contentType: "text/csv",
+      });
+
+    const res = await request(app).post("/api/ledger/imports/payment-csv/confirm").send({
+      importBatchId: preview.body.importBatchId,
+      selectedRowIds: [preview.body.rows[0].rowId],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("ledgerRoutes.ts");
+    expect(res.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
+    expect(res.body).toMatchObject({ ok: true, importedCount: 1 });
+  });
+
   it("does not match tenants outside the authenticated landlord scope", async () => {
     const router = (await import("../ledgerRoutes")).default;
     const app = buildApp(router);


### PR DESCRIPTION
## Summary
- Adds API route ownership regression coverage for high-risk route families from the route inventory audit.
- Verifies route-source ownership for tenant messages, landlord evidence packs, internal reports, webhook routes, probe/debug/echo routes, and API catchall behavior.
- Adds a ledger CSV confirm route fallthrough guard so `/api/ledger/imports/payment-csv/confirm` stays on `ledgerRoutes.ts`, not broad screening/admin routers.

## Routes tested
- `/api/ledger/imports/payment-csv/preview`
- `/api/ledger/imports/payment-csv/confirm`
- `/api/payments/:paymentId` via existing route resolution coverage
- `/api/tenant/messages/*`
- `/api/landlord/evidence-packs/*`
- `/api/internal/*`
- `/api/__probe/*`
- `/api/__debug/*`
- Stripe webhook route ordering/ownership
- TransUnion webhook route ordering/ownership
- `/api/_echo`
- catchall `/api/*` not-found behavior

## Ownership and fallthrough protections
- Asserts critical prefixed mounts remain ahead of broad screening/admin and not-found routes.
- Asserts protected routes resolve to the intended owner before rejecting unauthenticated requests.
- Asserts webhook routes are statically mounted before the JSON parser.
- Documents intentionally reachable probe/debug/echo route-source diagnostics.

## Remaining route-risk areas
- This PR does not rewrite routing, remove duplicate mounts, or change auth behavior.
- Shared route registry/authority enforcement and debug exposure hardening remain follow-up repair missions from the inventory.

## Verification
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/routes/__tests__/apiRouteOwnershipRegression.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/routes/__tests__/ledgerPaymentImportRoutes.test.ts src/routes/__tests__/paymentsRouteResolution.test.ts src/routes/__tests__/eventsRouteResolution.test.ts src/routes/__tests__/stripeWebhookPublicRoute.test.ts src/routes/__tests__/apiRouteOwnershipRegression.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build`

No product behavior changed; test-only route governance hardening.