### PR TITLE
test: add projection safety regression coverage

### DIFF
--- a/rentchain-api/src/__tests__/helpers/projectionSafetyAssertions.ts
+++ b/rentchain-api/src/__tests__/helpers/projectionSafetyAssertions.ts
@@ -1,0 +1,70 @@
+import { expect } from "vitest";
+
+const RESTRICTED_PROJECTION_KEY_PATTERNS = [
+  /^(sin|ssn|cvv)$/i,
+  /social.*insurance/i,
+  /bank.*account/i,
+  /account.*number/i,
+  /routing.*number/i,
+  /transit.*number/i,
+  /institution.*number/i,
+  /^iban$/i,
+  /^swift$/i,
+  /card.*number/i,
+  /raw.*report/i,
+  /raw.*payload/i,
+  /provider.*payload/i,
+  /webhook.*secret/i,
+  /^api.*key$/i,
+  /^token$/i,
+  /password/i,
+  /secret/i,
+  /ignored.*csv.*columns/i,
+  /raw.*csv/i,
+  /internal.*debug/i,
+  /^stack$/i,
+  /route.*source/i,
+];
+
+const SAFE_NEGATIVE_CONTROL_KEYS = new Set([
+  "rawproviderpayloadincluded",
+  "rawsensitivepayloadstored",
+  "providerpayloadincluded",
+  "supportmetadataincluded",
+]);
+
+function normalizedKey(value: string) {
+  return value.replace(/[^a-z0-9]+/gi, "").toLowerCase();
+}
+
+function keyIsRestricted(value: string) {
+  const normalized = normalizedKey(value);
+  if (SAFE_NEGATIVE_CONTROL_KEYS.has(normalized)) return false;
+  return RESTRICTED_PROJECTION_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function collectRestrictedKeys(value: unknown, path = "$", findings: string[] = []) {
+  if (!value || typeof value !== "object") return findings;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectRestrictedKeys(item, `${path}[${index}]`, findings));
+    return findings;
+  }
+
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    const nextPath = `${path}.${key}`;
+    if (keyIsRestricted(key)) findings.push(nextPath);
+    collectRestrictedKeys(nested, nextPath, findings);
+  }
+  return findings;
+}
+
+export function expectNoRestrictedProjectionFields(payload: unknown) {
+  expect(collectRestrictedKeys(payload)).toEqual([]);
+}
+
+export function expectPayloadDoesNotContainValues(payload: unknown, values: string[]) {
+  const serialized = JSON.stringify(payload);
+  for (const value of values) {
+    expect(serialized).not.toContain(value);
+  }
+}

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { deriveEvidencePack } from "../deriveEvidencePack";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
 
 const decision: any = {
   id: "decision-1",
@@ -167,5 +171,76 @@ describe("deriveEvidencePack", () => {
     expect(pack.sections.flatMap((section) => section.items.map((item) => item.label))).not.toContain(
       "Decision reduce_vacancy_risk:ZaeL9oqpJCSZPguWa6wR"
     );
+  });
+
+  it("keeps raw provider, banking, debug, and private document fields out of evidence projections", () => {
+    const pack = deriveEvidencePack({
+      scope: "decision",
+      scopeId: "decision-sensitive",
+      landlordId: "landlord-1",
+      decisions: [
+        {
+          ...decision,
+          id: "decision-sensitive",
+          title: "Missing payment review",
+          description: "Payment evidence needs operational review.",
+          rawPayload: { accountNumber: "111122223333" },
+          providerPayload: { rawReport: "raw bureau report" },
+          internalDebug: "routeSource=debug-router",
+        },
+      ],
+      institutionExportPackage: exportPackage,
+      auditComplianceReadiness: readiness,
+      canonicalEvents: [
+        {
+          id: "event-sensitive",
+          type: "payment_review_created",
+          summary: "Payment review was created.",
+          resource: { id: "decision-sensitive" },
+          occurredAt: "2026-05-05T12:03:00.000Z",
+          rawCsv: "account 111122223333",
+          stack: "private stack trace",
+        },
+      ],
+      leases: [
+        {
+          id: "lease-sensitive",
+          leaseId: "lease-sensitive",
+          propertyName: "North Towers",
+          unitNumber: "104",
+          tenantName: "Taylor Tenant",
+          sin: "999-888-777",
+          bankAccountNumber: "111122223333",
+          privateDocument: "raw signed lease body",
+        },
+      ],
+      properties: [
+        {
+          id: "prop-sensitive",
+          name: "North Towers",
+          routeSource: "internal-router",
+        },
+      ],
+      maintenanceRequests: [
+        {
+          id: "maintenance-sensitive",
+          title: "Maintenance review",
+          rawReport: "private maintenance report",
+        },
+      ],
+    });
+
+    expectNoRestrictedProjectionFields(pack);
+    expectPayloadDoesNotContainValues(pack, [
+      "111122223333",
+      "raw bureau report",
+      "routeSource=debug-router",
+      "account 111122223333",
+      "private stack trace",
+      "999-888-777",
+      "raw signed lease body",
+      "internal-router",
+      "private maintenance report",
+    ]);
   });
 });

--- a/rentchain-api/src/lib/governance/__tests__/platformGovernance.test.ts
+++ b/rentchain-api/src/lib/governance/__tests__/platformGovernance.test.ts
@@ -5,6 +5,10 @@ import {
   redactIdentifierMap,
   sanitizeTelemetryProps,
 } from "../platformGovernance";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
 
 describe("platformGovernance", () => {
   it("normalizes attributable actor context from requests", () => {
@@ -30,9 +34,15 @@ describe("platformGovernance", () => {
       nested: {
         documentText: "raw document body",
         accountNumber: "123456",
+        rawPayload: { providerPayload: "raw provider dump" },
+        routingNumber: "000111222",
+        webhookSecret: "whsec_secret",
         safeStatus: "completed",
       },
       tenantEmail: "tenant@example.com",
+      routeSource: "internal-debug-router",
+      stack: "private stack trace",
+      token: "secret-token",
     });
 
     expect(projected).toEqual({
@@ -42,8 +52,18 @@ describe("platformGovernance", () => {
         safeStatus: "completed",
       },
     });
-    expect(JSON.stringify(projected)).not.toContain("tenant@example.com");
-    expect(JSON.stringify(projected)).not.toContain("raw document body");
+    expectNoRestrictedProjectionFields(projected);
+    expectPayloadDoesNotContainValues(projected, [
+      "tenant@example.com",
+      "raw document body",
+      "123456",
+      "raw provider dump",
+      "000111222",
+      "whsec_secret",
+      "internal-debug-router",
+      "private stack trace",
+      "secret-token",
+    ]);
   });
 
   it("classifies high-risk document exports as restricted", () => {

--- a/rentchain-api/src/lib/governance/platformGovernance.ts
+++ b/rentchain-api/src/lib/governance/platformGovernance.ts
@@ -38,9 +38,11 @@ const SENSITIVE_KEY_FRAGMENTS = [
   "provider",
   "reporttext",
   "routing",
+  "routesource",
   "screeningpayload",
   "secret",
   "sin",
+  "stack",
   "ssn",
   "token",
 ];

--- a/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
+++ b/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { deriveInstitutionExportPackage } from "../deriveInstitutionExportPackage";
 import type { PortableAttestation } from "../../portableAttestations/portableAttestationTypes";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
 
 function attestation(): PortableAttestation {
   return {
@@ -133,7 +137,7 @@ describe("deriveInstitutionExportPackage", () => {
       packageType: "government_program_review",
       landlordId: "landlord-1",
       generatedAt: "2026-05-05T12:00:00.000Z",
-      properties: [{ id: "prop-1" }],
+      properties: [{ id: "prop-1", rawPayload: { routeSource: "internal-router" } } as any],
       leases: [
         {
           id: "lease-1",
@@ -141,6 +145,29 @@ describe("deriveInstitutionExportPackage", () => {
           ssn: "123-45-6789",
           creditReport: { score: 700 },
           bankAccountNumber: "000123",
+          rawCsv: "raw tenant export csv",
+        } as any,
+      ],
+      maintenanceRequests: [
+        {
+          id: "maint-1",
+          providerPayload: { rawReport: "raw provider payload" },
+        } as any,
+      ],
+      decisionItems: [
+        {
+          id: "decision-1",
+          severity: "critical",
+          type: "billing",
+          workflow: { queue: "delinquency_review" },
+          internalDebug: "debug payload",
+        } as any,
+      ],
+      auditEvents: [
+        {
+          id: "event-1",
+          stack: "private stack trace",
+          webhookSecret: "whsec_secret",
         } as any,
       ],
     });
@@ -152,7 +179,19 @@ describe("deriveInstitutionExportPackage", () => {
         expect.objectContaining({ fieldCategory: "payment_account_details" }),
       ])
     );
-    expect(JSON.stringify(pkg.payloadPreview)).not.toMatch(/123-45-6789|creditReport|000123|tenant-1/);
+    expectNoRestrictedProjectionFields(pkg.payloadPreview);
+    expectPayloadDoesNotContainValues(pkg.payloadPreview, [
+      "123-45-6789",
+      "creditReport",
+      "000123",
+      "tenant-1",
+      "raw tenant export csv",
+      "raw provider payload",
+      "debug payload",
+      "private stack trace",
+      "whsec_secret",
+      "internal-router",
+    ]);
   });
 
   it("optionally attaches policy-gated portable trust exports without changing route adoption", () => {

--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../__tests__/helpers/projectionSafetyAssertions";
 
 const { sendEmailMock } = vi.hoisted(() => ({
   sendEmailMock: vi.fn(),
@@ -152,6 +156,15 @@ describe("messagesRoutes notifications", () => {
       landlordId: "landlord-1",
       tenantId: "tenant-1",
       unitId: "unit-1",
+      rawPayload: { providerPayload: "raw conversation payload" },
+      internalDebug: "debug conversation route",
+      routeSource: "messagesRoutes.ts",
+    });
+    ensureCollection("messages").set("message-1", {
+      conversationId: "conv-1",
+      senderRole: "tenant",
+      body: "private tenant message body",
+      rawReport: "raw message report",
     });
     ensureCollection("tenants").set("tenant-1", {
       email: "tenant@example.com",
@@ -296,6 +309,14 @@ describe("messagesRoutes notifications", () => {
         unitDisplayLabel: "Unit 2A",
       })
     );
+    expectNoRestrictedProjectionFields(res.body);
+    expectPayloadDoesNotContainValues(res.body, [
+      "private tenant message body",
+      "raw message report",
+      "raw conversation payload",
+      "debug conversation route",
+      "messagesRoutes.ts",
+    ]);
   });
 
   it("preserves landlord message scope fallback from user id when landlordId is absent", async () => {

--- a/rentchain-api/src/services/__tests__/ledgerPaymentImportPreviewService.test.ts
+++ b/rentchain-api/src/services/__tests__/ledgerPaymentImportPreviewService.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { previewPaymentCsvImport } from "../ledgerPaymentImportPreviewService";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../__tests__/helpers/projectionSafetyAssertions";
 
 const tenants = [
   { id: "tenant-1", fullName: "Bailey Blinkers", email: "bailey@example.com", landlordId: "landlord-1" },
@@ -178,13 +182,18 @@ describe("ledgerPaymentImportPreviewService", () => {
       ],
     });
 
-    const serialized = JSON.stringify(result);
-    expect(serialized).not.toContain("123456789");
-    expect(serialized).not.toContain("00123");
-    expect(serialized).not.toContain("99999.99");
-    expect(serialized).not.toContain("account 123456789 transfer");
-    expect(serialized).not.toContain("Bank Account Number");
-    expect(serialized).not.toContain("Transit Number");
+    expectNoRestrictedProjectionFields(result);
+    expectPayloadDoesNotContainValues(result, [
+      "123456789",
+      "00123",
+      "99999.99",
+      "account 123456789 transfer",
+      "Bank Account Number",
+      "Transit Number",
+      "Institution Number",
+      "Running Balance",
+      "Memo",
+    ]);
   });
 
   it("reports generic ignored columns without returning ignored values", () => {

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
 
 const collections = new Map<string, Map<string, any>>();
 let generatedId = 0;
@@ -85,10 +89,19 @@ describe("tenantTrustExportService", () => {
     });
     loadTenantIdentityRecord.mockResolvedValue({
       identityStatus: "verified",
-      profile: { completionStatus: "complete" },
+      profile: {
+        completionStatus: "complete",
+        sin: "999-888-777",
+        bankAccountNumber: "111122223333",
+        rawPayload: "raw identity payload",
+      },
       application: { reusable: true, lastSubmittedAt: "2026-04-20T00:00:00.000Z" },
       documents: { completionStatus: "complete", missingCategories: [] },
-      screening: { status: "completed", lastCompletedAt: "2026-04-21T00:00:00.000Z" },
+      screening: {
+        status: "completed",
+        lastCompletedAt: "2026-04-21T00:00:00.000Z",
+        providerPayload: { rawReport: "raw screening report" },
+      },
       leases: { activeCount: 1, historicalCount: 1, lastSignedAt: "2026-04-22T00:00:00.000Z" },
       verification: { level: "strong" },
       readinessLabel: "Well established",
@@ -111,6 +124,14 @@ describe("tenantTrustExportService", () => {
     expect(preview?.excludedClaims.length).toBeGreaterThan(0);
     expect(JSON.stringify(preview)).not.toContain("documentUrl");
     expect(JSON.stringify(preview)).not.toContain("paymentMethod");
+    expectNoRestrictedProjectionFields(preview);
+    expectPayloadDoesNotContainValues(preview, [
+      "tenant@example.com",
+      "999-888-777",
+      "111122223333",
+      "raw identity payload",
+      "raw screening report",
+    ]);
     expect(preview?.publicAccessEnabled).toBe(false);
     expect(preview?.externalSubmissionEnabled).toBe(false);
   });
@@ -165,6 +186,14 @@ describe("tenantTrustExportService", () => {
     expect(payload).not.toContain("publicAccessEnabled\":true");
     expect(payload).not.toContain("externalSubmissionEnabled\":true");
     expect(payload).not.toContain("tenant-1");
+    expectNoRestrictedProjectionFields(prepared);
+    expectPayloadDoesNotContainValues(prepared, [
+      "tenant@example.com",
+      "999-888-777",
+      "111122223333",
+      "raw identity payload",
+      "raw screening report",
+    ]);
     expect(ensureCollection("tenantTrustExports").size).toBe(1);
     expect(Array.from(ensureCollection("tenantTrustExports").values())[0]?.tenantId).toBe("tenant-1");
   });


### PR DESCRIPTION
## Summary

Adds targeted projection safety regression coverage for high-risk RentChain payload surfaces following the Firestore sensitivity/projection registry.

Covered surfaces:
- evidence pack projection derivation
- institutional export preview derivation
- payment CSV import preview projection
- governance telemetry sanitization
- tenant trust export projection
- landlord messaging conversation metadata projection

## Restricted field categories protected

The new shared test helper asserts protected projection payloads do not expose keys or sentinel values for:
- raw/provider/report payloads
- raw CSV / ignored CSV data
- bank account, routing, transit, institution, card, IBAN/SWIFT fields
- SIN/SSN fields
- tokens/secrets/API keys/webhook secrets
- stack traces, route-source, and internal debug fields

## Minimal fix applied

The tests found that `sanitizeTelemetryProps` still allowed top-level `routeSource` and `stack` fields. This PR adds those two key fragments to the existing telemetry sanitizer deny list. No route, schema, auth, Firestore rules, export, or evidence behavior was broadened.

## Verification

Targeted backend tests:

```bash
source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts src/services/__tests__/ledgerPaymentImportPreviewService.test.ts src/lib/governance/__tests__/platformGovernance.test.ts src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts src/routes/__tests__/messagesRoutes.test.ts
```

Result: 6 files passed, 44 tests passed.

Backend build:

```bash
source ~/.nvm/nvm.sh && nvm use 20 && npm run build
```

Result: passed.

## Remaining projection-risk follow-ups

- Add route-level tenant workspace projection contract tests.
- Add evidence-pack projection profile/version tests once explicit profiles exist.
- Add institutional export allowlist tests before expanding external exports.
- Add broader structured logging redaction helper coverage when the logging framework is centralized.