### PR TITLE
fix: add evidence pack projection profile metadata

### DIFF
--- a/docs/reports/evidence-pack-projection-profile-v1.md
+++ b/docs/reports/evidence-pack-projection-profile-v1.md
@@ -1,0 +1,122 @@
+# Evidence Pack Projection Profile v1
+
+## Executive Summary
+
+This report documents the first explicit evidence pack projection profile used by RentChain evidence bundle derivation.
+
+The implementation is intentionally narrow. It does not change route access, Firestore schema, Firestore rules, authentication, institutional export behavior, or evidence pack collection storage. It adds metadata to derived evidence packs so downstream review, export, and governance systems can understand the projection boundary that produced the package.
+
+## Profile Contract
+
+The V1 profile is `landlord_evidence_review` with version `evidence_projection_profile_v1`.
+
+Profile metadata declares:
+
+- audience: landlord operational review
+- scope type: the requested evidence pack scope
+- allowed source collections represented by included evidence items
+- sensitivity class: sensitive or restricted
+- allowed field groups
+- excluded field groups
+- redaction policy
+- internal reference policy
+- source lineage policy
+
+## V1 Guarantees
+
+The profile guarantees that derived evidence packs are:
+
+- scoped to the requested evidence context
+- manual-review only
+- not externally shared
+- not certification artifacts
+- accompanied by redaction category metadata
+- accompanied by source collection/source ID lineage where practical
+- explicit about internal ID handling
+
+Internal IDs may appear as source references where needed for traceability. They are not intended to be primary display labels.
+
+## Allowed Field Groups
+
+V1 evidence packs allow:
+
+- operational labels
+- status summaries
+- timestamps
+- scoped source references
+- redaction categories
+- manual review metadata
+
+## Excluded Field Groups
+
+V1 evidence packs exclude:
+
+- raw provider payloads
+- raw CSV values
+- payment account details
+- private message bodies
+- identity documents
+- debug payloads
+- unrelated resource records
+
+## Source Lineage
+
+Evidence item lineage is derived from included evidence items. Each source reference includes:
+
+- source collection
+- source ID
+- evidence item type
+- evidence item label
+
+This provides deterministic lineage for review and future export governance without broadening evidence access.
+
+## Redaction Summary
+
+Evidence packs include a redaction summary with:
+
+- redaction policy
+- redacted field groups
+- redaction count
+
+The summary is metadata-only. It does not mutate canonical source records or append-only audit history.
+
+## Relationship To Governance Docs
+
+This profile implements the direction established by:
+
+- `firestore-sensitivity-and-projection-registry-v1`
+- `canonical-event-taxonomy-v1`
+- `firestore-collection-ownership-registry-v1`
+
+It is the first implementation bridge from projection governance into evidence infrastructure.
+
+## Not In Scope
+
+This V1 does not implement:
+
+- institutional exports
+- evidence sharing
+- route access changes
+- Firestore migrations
+- event bus/runtime event framework
+- message-body evidence profiles
+- provider/raw data profiles
+- tenant trust export expansion
+- review workspace orchestration
+
+## Future Work
+
+Recommended follow-ups:
+
+1. Add route-level evidence projection profile assertions.
+2. Add profile-specific evidence pack derivation for tenant-trust and institutional-review contexts.
+3. Add source event lineage IDs when canonical event runtime adapters are introduced.
+4. Add governed message-body evidence profiles only after consent and scope policy are approved.
+5. Persist profile metadata when evidence pack persistence is formalized.
+
+## DO NOT IGNORE
+
+- Evidence packs must remain whitelist projections, not raw object exports.
+- Raw provider data, raw CSV data, payment credentials, debug payloads, and message bodies must stay excluded by default.
+- Internal references are traceability metadata, not user-facing operational labels.
+- Projection metadata must not be treated as evidence certification or legal compliance.

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -89,10 +89,76 @@ describe("deriveEvidencePack", () => {
 
     expect(pack).toEqual(expect.objectContaining({
       evidencePackId: "evidence_pack:decision:landlord-1:decision-1",
+      projectionVersion: "evidence_projection_profile_v1",
+      sensitivityClass: "restricted",
       manualReviewRequired: true,
       externalSharingEnabled: false,
       certificationIssued: false,
     }));
+    expect(pack.projectionProfile).toEqual(
+      expect.objectContaining({
+        profileName: "landlord_evidence_review",
+        profileVersion: "evidence_projection_profile_v1",
+        audience: "landlord_operational_review",
+        scopeType: "decision",
+        sensitivityClass: "restricted",
+        internalReferencePolicy:
+          "Internal IDs may appear only as scoped source references, never as primary display labels.",
+        sourceLineagePolicy:
+          "Each included evidence item declares a source collection and source ID when available.",
+      }),
+    );
+    expect(pack.projectionProfile.allowedFieldGroups).toEqual(
+      expect.arrayContaining([
+        "operational_labels",
+        "status_summaries",
+        "scoped_source_references",
+        "redaction_categories",
+      ]),
+    );
+    expect(pack.projectionProfile.excludedFieldGroups).toEqual(
+      expect.arrayContaining([
+        "raw_provider_payloads",
+        "raw_csv_values",
+        "payment_account_details",
+        "private_message_bodies",
+        "debug_payloads",
+      ]),
+    );
+    expect(pack.sourceCollections).toEqual(
+      expect.arrayContaining([
+        "auditComplianceReadiness",
+        "canonicalEvents",
+        "decisionItems",
+        "institutionExportPackages",
+        "leases",
+        "operatorReviewSessions",
+        "properties",
+      ]),
+    );
+    expect(pack.sourceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceCollection: "decisionItems",
+          sourceId: "decision-1",
+          itemType: "decision",
+          itemLabel: "Review missing payment",
+        }),
+        expect.objectContaining({
+          sourceCollection: "canonicalEvents",
+          sourceId: "event-1",
+          itemType: "canonical_event",
+        }),
+      ]),
+    );
+    expect(pack.redactionSummary).toEqual(
+      expect.objectContaining({
+        redactionPolicy:
+          "Exclude raw/provider/payment credential/debug/private-message fields; include redaction categories only.",
+        redactionCount: 2,
+        redactedFieldGroups: ["payment_account_details", "screening_payloads"],
+      }),
+    );
     expect(pack.sections.map((section) => section.sectionKey)).toEqual(expect.arrayContaining([
       "decision_lineage",
       "workflow_routing",
@@ -106,6 +172,63 @@ describe("deriveEvidencePack", () => {
     ]));
     expect(pack.summary.redactedItems).toBeGreaterThan(0);
     expect(JSON.stringify(pack)).not.toMatch(/accountNumber|creditReport|bureauPayload|privateDocument/i);
+  });
+
+  it("derives deterministic source lineage without using internal IDs as primary labels", () => {
+    const first = deriveEvidencePack({
+      scope: "lease",
+      scopeId: "lease-1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      decisions: [decision],
+      canonicalEvents: [
+        {
+          id: "event-lease-1",
+          type: "lease_context_reviewed",
+          summary: "Lease context reviewed.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          occurredAt: "2026-05-05T12:03:00.000Z",
+        },
+      ],
+      leases: [{ id: "lease-1", propertyName: "North Towers", unitNumber: "101", tenantName: "John Smith" }],
+      properties: [{ id: "prop-1", name: "North Towers" }],
+      institutionExportPackage: exportPackage,
+      auditComplianceReadiness: readiness,
+    });
+    const second = deriveEvidencePack({
+      scope: "lease",
+      scopeId: "lease-1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      decisions: [decision],
+      canonicalEvents: [
+        {
+          id: "event-lease-1",
+          type: "lease_context_reviewed",
+          summary: "Lease context reviewed.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          occurredAt: "2026-05-05T12:03:00.000Z",
+        },
+      ],
+      leases: [{ id: "lease-1", propertyName: "North Towers", unitNumber: "101", tenantName: "John Smith" }],
+      properties: [{ id: "prop-1", name: "North Towers" }],
+      institutionExportPackage: exportPackage,
+      auditComplianceReadiness: readiness,
+    });
+
+    expect(first.sourceRefs).toEqual(second.sourceRefs);
+    expect(first.sourceRefs.map((ref) => `${ref.sourceCollection}:${ref.sourceId}:${ref.itemType}`)).toEqual(
+      [...first.sourceRefs.map((ref) => `${ref.sourceCollection}:${ref.sourceId}:${ref.itemType}`)].sort(),
+    );
+    expect(first.sections.find((section) => section.sectionKey === "lease_context")?.items[0]?.label).toBe(
+      "North Towers · Unit 101 · John Smith",
+    );
+    expect(first.sections.flatMap((section) => section.items.map((item) => item.label))).not.toContain(
+      "Lease lease-1",
+    );
+    expect(first.projectionProfile.allowedSourceCollections).toEqual(first.sourceCollections);
   });
 
   it("blocks readiness when redaction metadata is missing", () => {

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -11,6 +11,10 @@ import type {
   EvidencePackSectionKey,
   EvidenceSectionStatus,
 } from "./evidencePackTypes";
+import {
+  deriveEvidenceProjectionProfile,
+  deriveEvidenceSourceReferences,
+} from "./evidenceProjectionProfile";
 
 const DEFAULT_DISCLAIMERS = [
   "Preview only. Evidence is not shared externally.",
@@ -466,6 +470,14 @@ function derivePackStatus(sections: EvidencePackSection[], hasScope: boolean): E
   return "ready_for_review";
 }
 
+function hasRestrictedRedactions(redactions: EvidencePackRedaction[]): boolean {
+  return redactions.some((redaction) =>
+    /account|bank|card|credential|identity|message|payload|provider|raw|screening|token/i.test(
+      `${redaction.fieldCategory} ${redaction.reason}`,
+    ),
+  );
+}
+
 export function deriveEvidencePack(input: DeriveEvidencePackInput): EvidencePack {
   const scope = input.scope;
   const scopeId = asString(input.scopeId, 500);
@@ -483,6 +495,16 @@ export function deriveEvidencePack(input: DeriveEvidencePackInput): EvidencePack
     redactions.section,
   ];
   const allItems = sections.flatMap((item) => item.items);
+  const sourceRefs = deriveEvidenceSourceReferences(allItems);
+  const sourceCollections = Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+  const restricted = hasRestrictedRedactions(redactions.redactions);
+  const projectionProfile = deriveEvidenceProjectionProfile({
+    scope,
+    sourceCollections,
+    hasRestrictedRedactions: restricted,
+  });
   const blockedReasons = sections.flatMap((item) => item.blockedReasons);
   const missingItems = sections.reduce((sum, item) => sum + item.missingEvidence.length, 0);
   const hasScope = Boolean(scope && scopeId && input.landlordId);
@@ -494,6 +516,16 @@ export function deriveEvidencePack(input: DeriveEvidencePackInput): EvidencePack
     scope,
     scopeId,
     status: derivePackStatus(sections, hasScope),
+    projectionProfile,
+    projectionVersion: projectionProfile.profileVersion,
+    sensitivityClass: projectionProfile.sensitivityClass,
+    sourceCollections,
+    sourceRefs,
+    redactionSummary: {
+      redactionPolicy: projectionProfile.redactionPolicy,
+      redactedFieldGroups: redactions.redactions.map((item) => item.fieldCategory).sort((a, b) => a.localeCompare(b)),
+      redactionCount: redactions.redactions.length,
+    },
     manualReviewRequired: true,
     externalSharingEnabled: false,
     certificationIssued: false,

--- a/rentchain-api/src/lib/evidencePacks/evidencePackTypes.ts
+++ b/rentchain-api/src/lib/evidencePacks/evidencePackTypes.ts
@@ -89,11 +89,48 @@ export type EvidencePackRedaction = {
   reason: string;
 };
 
+export type EvidencePackSensitivityClass = "sensitive" | "restricted";
+
+export type EvidenceProjectionAudience = "landlord_operational_review";
+
+export type EvidenceProjectionProfile = {
+  profileName: "landlord_evidence_review";
+  profileVersion: string;
+  audience: EvidenceProjectionAudience;
+  scopeType: EvidencePackScope;
+  allowedSourceCollections: string[];
+  sensitivityClass: EvidencePackSensitivityClass;
+  allowedFieldGroups: string[];
+  excludedFieldGroups: string[];
+  redactionPolicy: string;
+  internalReferencePolicy: string;
+  sourceLineagePolicy: string;
+};
+
+export type EvidenceSourceReference = {
+  sourceCollection: string;
+  sourceId: string;
+  itemType: EvidenceItem["itemType"];
+  itemLabel: string;
+};
+
+export type EvidencePackRedactionSummary = {
+  redactionPolicy: string;
+  redactedFieldGroups: string[];
+  redactionCount: number;
+};
+
 export type EvidencePack = {
   evidencePackId: string;
   scope: EvidencePackScope;
   scopeId: string;
   status: EvidencePackStatus;
+  projectionProfile: EvidenceProjectionProfile;
+  projectionVersion: string;
+  sensitivityClass: EvidencePackSensitivityClass;
+  sourceCollections: string[];
+  sourceRefs: EvidenceSourceReference[];
+  redactionSummary: EvidencePackRedactionSummary;
   manualReviewRequired: true;
   externalSharingEnabled: false;
   certificationIssued: false;

--- a/rentchain-api/src/lib/evidencePacks/evidenceProjectionProfile.ts
+++ b/rentchain-api/src/lib/evidencePacks/evidenceProjectionProfile.ts
@@ -1,0 +1,87 @@
+import type {
+  EvidenceItem,
+  EvidenceItemSource,
+  EvidenceProjectionProfile,
+  EvidencePackScope,
+  EvidencePackSensitivityClass,
+  EvidenceSourceReference,
+} from "./evidencePackTypes";
+
+export const EVIDENCE_PROJECTION_PROFILE_VERSION = "evidence_projection_profile_v1";
+
+const SOURCE_COLLECTION_BY_ITEM_SOURCE: Record<EvidenceItemSource, string> = {
+  audit_compliance: "auditComplianceReadiness",
+  canonical_events: "canonicalEvents",
+  decision_inbox: "decisionItems",
+  institution_exports: "institutionExportPackages",
+  lease_ledger: "leases",
+  maintenance: "maintenanceRequests",
+  operator_review: "operatorReviewSessions",
+  registry: "properties",
+  workflow_routing: "decisionItems",
+  unknown: "unknown",
+};
+
+const ALLOWED_FIELD_GROUPS = [
+  "operational_labels",
+  "status_summaries",
+  "timestamps",
+  "scoped_source_references",
+  "redaction_categories",
+  "manual_review_metadata",
+];
+
+const EXCLUDED_FIELD_GROUPS = [
+  "raw_provider_payloads",
+  "raw_csv_values",
+  "payment_account_details",
+  "private_message_bodies",
+  "identity_documents",
+  "debug_payloads",
+  "unrelated_resource_records",
+];
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+export function deriveEvidenceProjectionProfile(input: {
+  scope: EvidencePackScope;
+  sourceCollections: string[];
+  hasRestrictedRedactions: boolean;
+}): EvidenceProjectionProfile {
+  return {
+    profileName: "landlord_evidence_review",
+    profileVersion: EVIDENCE_PROJECTION_PROFILE_VERSION,
+    audience: "landlord_operational_review",
+    scopeType: input.scope,
+    allowedSourceCollections: uniqueSorted(input.sourceCollections),
+    sensitivityClass: input.hasRestrictedRedactions ? "restricted" : "sensitive",
+    allowedFieldGroups: ALLOWED_FIELD_GROUPS,
+    excludedFieldGroups: EXCLUDED_FIELD_GROUPS,
+    redactionPolicy: "Exclude raw/provider/payment credential/debug/private-message fields; include redaction categories only.",
+    internalReferencePolicy: "Internal IDs may appear only as scoped source references, never as primary display labels.",
+    sourceLineagePolicy: "Each included evidence item declares a source collection and source ID when available.",
+  };
+}
+
+export function deriveEvidenceSourceReferences(items: EvidenceItem[]): EvidenceSourceReference[] {
+  const byKey = new Map<string, EvidenceSourceReference>();
+  for (const item of items) {
+    const sourceId = String(item.sourceId || "").trim();
+    if (!sourceId) continue;
+    const sourceCollection = SOURCE_COLLECTION_BY_ITEM_SOURCE[item.source] || "unknown";
+    const reference: EvidenceSourceReference = {
+      sourceCollection,
+      sourceId,
+      itemType: item.itemType,
+      itemLabel: item.label,
+    };
+    byKey.set(`${sourceCollection}:${sourceId}:${item.itemType}`, reference);
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}:${a.itemType}`.localeCompare(
+      `${b.sourceCollection}:${b.sourceId}:${b.itemType}`,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Add a narrow evidence projection profile contract for derived evidence packs.
- Include profile/version, sensitivity class, source collections, source refs, and redaction summary metadata in evidence pack derivation.
- Document Evidence Pack Projection Profile v1 and its guarantees/follow-ups.

## Audit findings
- Existing evidence derivation already constructs whitelist-style evidence items and avoids raw object projection.
- Projection governance metadata was implicit: no profile version, sensitivity class, source collection list, source refs, or redaction summary existed on the pack itself.
- Existing tests already guarded raw provider, banking, debug, and private document leakage; this PR extends those tests to cover profile metadata and deterministic source lineage.

## Profile contract summary
- `profileName`: `landlord_evidence_review`
- `profileVersion`: `evidence_projection_profile_v1`
- `audience`: `landlord_operational_review`
- `scopeType`: current evidence pack scope
- `allowedSourceCollections`: derived from included evidence item source refs
- `sensitivityClass`: `sensitive` or `restricted`
- `allowedFieldGroups` / `excludedFieldGroups`: explicit governance field groups
- `redactionPolicy`, `internalReferencePolicy`, `sourceLineagePolicy`: explicit text metadata

## Evidence metadata added
- `projectionProfile`
- `projectionVersion`
- `sensitivityClass`
- `sourceCollections`
- `sourceRefs`
- `redactionSummary`

## Restricted fields protected
Tests continue to assert evidence projections exclude raw provider payloads, raw CSV values, payment/banking credentials, private documents, debug fields, route-source payloads, and sensitive identity values.

## Leaks found/fixed
- No existing data leak was found.
- No auth, route, Firestore rules, schema, or visibility behavior changed.

## Remaining follow-ups
- Add route-level evidence projection profile assertions once evidence pack route contracts are formalized.
- Add profile-specific derivation for tenant trust and institutional review contexts.
- Add source event lineage IDs when canonical event runtime adapters are introduced.
- Persist profile metadata only when evidence pack persistence is formalized.

## Tests
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts src/__tests__/projectionSafetyRegression.test.ts src/__tests__/firestoreRelationshipContinuity.test.ts src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts`
  - Note: no standalone `projectionSafetyRegression.test.ts` exists in this branch; restricted-field assertions are exercised through evidence/export tests.
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`