### PR TITLE
fix: add institutional export allowlist metadata

### DIFF
--- a/docs/reports/institutional-export-allowlist-v1.md
+++ b/docs/reports/institutional-export-allowlist-v1.md
@@ -1,0 +1,136 @@
+# Institutional Export Allowlist Profile v1
+
+## Executive Summary
+
+This report documents RentChain's first institutional export allowlist profile for generated institutional export previews.
+
+The implementation is a governance hardening step. It does not broaden export access, introduce external sharing, add public endpoints, change route visibility, modify auth, change Firestore schema, or change Firestore rules.
+
+## Allowlist Profile
+
+The V1 profile is `institutional_export_preview` with version `institution_export_allowlist_v1`.
+
+Profile metadata declares:
+
+- audience category
+- export scope
+- allowed collections
+- allowed field groups
+- excluded field groups
+- sensitivity class
+- authority basis
+- projection policy
+- retention policy
+- redaction policy
+- lineage policy
+- audit expectation
+
+## V1 Export Scope
+
+The V1 scope is `landlord_portfolio_preview`.
+
+This means the package is a landlord-scoped preview used for operational and institutional-readiness review. It is not an external submission, certification, public export, or automated institutional filing.
+
+## Authority Basis
+
+The V1 authority basis is `landlord_scoped_preview`.
+
+This means source inputs must already be scoped by the calling landlord route or service. The allowlist profile records the authority posture; it does not replace route authorization or broaden access.
+
+## Allowed Field Groups
+
+V1 institutional export previews allow:
+
+- aggregate counts
+- status summaries
+- occupancy summaries
+- delinquency summaries
+- audit event counts
+- portable trust metadata
+- redaction categories
+
+## Excluded Field Groups
+
+V1 institutional export previews exclude:
+
+- tenant contact details
+- identity documents
+- raw provider payloads
+- raw screening reports
+- raw CSV values
+- payment account details
+- private message contents
+- debug payloads
+- unrelated resource records
+
+## Metadata Added To Export Packages
+
+Export packages now include:
+
+- `exportProfile`
+- `exportVersion`
+- `exportScope`
+- `sensitivityClass`
+- `authorityBasis`
+- `sourceCollections`
+- `sourceRefs`
+- `projectionPolicy`
+- `redactionSummary`
+- `lineageSummary`
+- `exportGeneratedAt`
+
+These fields are deterministic metadata. They do not change source data, export visibility, or route authorization.
+
+## Lineage Expectations
+
+The V1 source lineage model records source collection and source ID references where practical.
+
+Source references are internal traceability metadata. They are not primary display labels and they are not a substitute for future canonical event lineage IDs.
+
+## Retention And Audit Expectations
+
+The V1 retention policy is preview metadata only. External sharing and longer retention policies require a future approved export workflow.
+
+The V1 audit expectation is manual review and audit event linkage before any institutional export release.
+
+## Relationship To Evidence Profiles
+
+This mission extends the same governance direction established by `evidence-pack-projection-profile-v1`:
+
+- explicit profile/version metadata
+- source lineage
+- redaction summary
+- sensitivity class
+- manual-review posture
+- no raw/provider/debug/private-message payload propagation
+
+## Not In Scope
+
+This V1 does not implement:
+
+- public export links
+- institutional submission flows
+- route authorization changes
+- Firestore migrations
+- export persistence changes
+- tenant trust export expansion
+- message-body export profiles
+- raw provider export profiles
+- runtime policy engine enforcement
+
+## Future Work
+
+Recommended follow-ups:
+
+1. Add route-level assertions for institutional export profile metadata.
+2. Add export checksum/hash metadata before external release workflows.
+3. Add canonical event lineage IDs when event adapters are implemented.
+4. Add consent-aware export profiles for tenant trust and government workflows.
+5. Add persistence rules only after export storage and retention policy are approved.
+
+## DO NOT IGNORE
+
+- Institutional exports must stay allowlist-based.
+- Export previews must not become broad landlord data dumps.
+- Raw provider, screening, banking, CSV, debug, and message-body data must stay excluded by default.
+- Export profile metadata does not certify compliance or authorize external sharing.

--- a/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
+++ b/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
@@ -91,8 +91,84 @@ describe("deriveInstitutionExportPackage", () => {
     expect(pkg.packageId).toBe("institution_export:lender_due_diligence:landlord-1");
     expect(pkg.audience).toBe("lender");
     expect(pkg.status).toBe("preview_ready");
+    expect(pkg.exportGeneratedAt).toBe("2026-05-05T12:00:00.000Z");
+    expect(pkg.exportVersion).toBe("institution_export_allowlist_v1");
+    expect(pkg.exportScope).toBe("landlord_portfolio_preview");
+    expect(pkg.sensitivityClass).toBe("restricted");
+    expect(pkg.authorityBasis).toBe("landlord_scoped_preview");
     expect(pkg.manualOnly).toBe(true);
     expect(pkg.externalSubmissionEnabled).toBe(false);
+    expect(pkg.exportProfile).toEqual(
+      expect.objectContaining({
+        exportProfile: "institutional_export_preview",
+        exportVersion: "institution_export_allowlist_v1",
+        audienceCategory: "lender",
+        exportScope: "landlord_portfolio_preview",
+        sensitivityClass: "restricted",
+        authorityBasis: "landlord_scoped_preview",
+        projectionPolicy: "Allowlisted aggregate preview only; do not include raw source records.",
+        retentionPolicy: "Preview metadata only; retention policy must be approved before external sharing.",
+        auditExpectation: "Manual review and audit event linkage required before institutional export release.",
+      }),
+    );
+    expect(pkg.exportProfile.allowedFieldGroups).toEqual(
+      expect.arrayContaining([
+        "aggregate_counts",
+        "status_summaries",
+        "occupancy_summaries",
+        "delinquency_summaries",
+        "redaction_categories",
+      ]),
+    );
+    expect(pkg.exportProfile.excludedFieldGroups).toEqual(
+      expect.arrayContaining([
+        "raw_provider_payloads",
+        "raw_screening_reports",
+        "raw_csv_values",
+        "payment_account_details",
+        "private_message_contents",
+        "debug_payloads",
+      ]),
+    );
+    expect(pkg.sourceCollections).toEqual(
+      expect.arrayContaining(["auditEvents", "decisionItems", "leases", "maintenanceRequests", "properties"]),
+    );
+    expect(pkg.sourceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceCollection: "properties", sourceId: "prop-1" }),
+        expect.objectContaining({ sourceCollection: "leases", sourceId: "lease-1" }),
+        expect.objectContaining({ sourceCollection: "maintenanceRequests", sourceId: "maint-1" }),
+        expect.objectContaining({ sourceCollection: "decisionItems", sourceId: "decision-1" }),
+        expect.objectContaining({ sourceCollection: "auditEvents", sourceId: "event-1" }),
+      ]),
+    );
+    expect(pkg.redactionSummary).toEqual(
+      expect.objectContaining({
+        redactionPolicy:
+          "Exclude raw/provider/payment credential/debug/private-message fields; include redaction categories only.",
+        redactionCount: 5,
+        redactedFieldGroups: [
+          "identity_documents",
+          "payment_account_details",
+          "private_message_contents",
+          "screening_payloads",
+          "tenant_contact_details",
+        ],
+      }),
+    );
+    expect(pkg.lineageSummary).toEqual(
+      expect.objectContaining({
+        sourceReferenceCount: 5,
+        sourceCollections: expect.arrayContaining([
+          "auditEvents",
+          "decisionItems",
+          "leases",
+          "maintenanceRequests",
+          "properties",
+        ]),
+        lineagePolicy: "Each represented source collection declares deterministic source IDs or count-only lineage.",
+      }),
+    );
     expect(pkg.sections).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ sectionKey: "property_summary", status: "included", recordsCount: 1 }),
@@ -106,6 +182,29 @@ describe("deriveInstitutionExportPackage", () => {
         delinquencySummary: expect.objectContaining({ decisionsCount: 1, criticalCount: 1 }),
       })
     );
+  });
+
+  it("derives deterministic allowlist metadata and lineage ordering", () => {
+    const input = {
+      packageType: "auditor_review" as const,
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1", status: "active", unitsCount: 1 }],
+      leases: [{ id: "lease-1", status: "active", unitId: "unit-1" }],
+      units: [{ id: "unit-1", status: "occupied", leaseId: "lease-1" }],
+      decisionItems: [{ id: "decision-1", severity: "warning", workflow: { queue: "review" } }],
+      auditEvents: [{ id: "event-1" }],
+    };
+    const first = deriveInstitutionExportPackage(input);
+    const second = deriveInstitutionExportPackage(input);
+
+    expect(first.sourceRefs).toEqual(second.sourceRefs);
+    expect(first.sourceRefs.map((ref) => `${ref.sourceCollection}:${ref.sourceId}`)).toEqual(
+      [...first.sourceRefs.map((ref) => `${ref.sourceCollection}:${ref.sourceId}`)].sort(),
+    );
+    expect(first.exportProfile.allowedCollections).toEqual(first.sourceCollections);
+    expect(first.projectionPolicy).toBe("Allowlisted aggregate preview only; do not include raw source records.");
+    expect(first.payloadPreview).toEqual(second.payloadPreview);
   });
 
   it("blocks previews when landlord or property context is missing", () => {
@@ -180,6 +279,9 @@ describe("deriveInstitutionExportPackage", () => {
       ])
     );
     expectNoRestrictedProjectionFields(pkg.payloadPreview);
+    expectNoRestrictedProjectionFields(pkg.exportProfile);
+    expectNoRestrictedProjectionFields(pkg.redactionSummary);
+    expectNoRestrictedProjectionFields(pkg.lineageSummary);
     expectPayloadDoesNotContainValues(pkg.payloadPreview, [
       "123-45-6789",
       "creditReport",
@@ -192,6 +294,26 @@ describe("deriveInstitutionExportPackage", () => {
       "whsec_secret",
       "internal-router",
     ]);
+    expectPayloadDoesNotContainValues(
+      {
+        exportProfile: pkg.exportProfile,
+        sourceRefs: pkg.sourceRefs,
+        redactionSummary: pkg.redactionSummary,
+        lineageSummary: pkg.lineageSummary,
+      },
+      [
+        "123-45-6789",
+        "creditReport",
+        "000123",
+        "tenant-1",
+        "raw tenant export csv",
+        "raw provider payload",
+        "debug payload",
+        "private stack trace",
+        "whsec_secret",
+        "internal-router",
+      ],
+    );
   });
 
   it("optionally attaches policy-gated portable trust exports without changing route adoption", () => {
@@ -227,5 +349,14 @@ describe("deriveInstitutionExportPackage", () => {
     );
     expect(JSON.stringify(pkg.trustExport)).not.toContain("provider-reference");
     expect(JSON.stringify(pkg.trustExport)).not.toContain("internal-reference");
+    expect(pkg.sourceCollections).toEqual(expect.arrayContaining(["portableAttestations", "properties"]));
+    expect(pkg.sourceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceCollection: "portableAttestations",
+          sourceId: "institution-package-attestation-1",
+        }),
+      ]),
+    );
   });
 });

--- a/rentchain-api/src/lib/institutionExports/deriveInstitutionExportPackage.ts
+++ b/rentchain-api/src/lib/institutionExports/deriveInstitutionExportPackage.ts
@@ -12,6 +12,10 @@ import {
   deriveInstitutionalTrustExportPackage,
   institutionalTrustExportMappingForPackageType,
 } from "../institutionTrustExports/deriveInstitutionalTrustExportPackage";
+import {
+  deriveInstitutionExportProfile,
+  deriveInstitutionExportSourceRefs,
+} from "./institutionExportProfile";
 
 const PACKAGE_AUDIENCE: Record<InstitutionExportPackageType, InstitutionExportAudience> = {
   lender_due_diligence: "lender",
@@ -171,6 +175,14 @@ function summarizeMaintenance(records: Array<Record<string, unknown>>) {
   };
 }
 
+function hasRestrictedRedactions(redactions: InstitutionExportRedaction[]): boolean {
+  return redactions.some((redaction) =>
+    /account|bank|card|credential|identity|message|payload|provider|raw|screening|token/i.test(
+      `${redaction.fieldCategory} ${redaction.reason}`,
+    ),
+  );
+}
+
 export function deriveInstitutionExportPackage(input: DeriveInstitutionExportPackageInput): InstitutionExportPackage {
   const packageType = input.packageType;
   const audience = PACKAGE_AUDIENCE[packageType];
@@ -269,12 +281,52 @@ export function deriveInstitutionExportPackage(input: DeriveInstitutionExportPac
     );
   }
 
+  const sourceRefs = deriveInstitutionExportSourceRefs({
+    properties,
+    leases,
+    units,
+    maintenanceRequests,
+    decisionItems,
+    auditEvents,
+    portableAttestations: portableAttestations as Array<Record<string, unknown>> | null,
+  });
+  const sourceCollections = Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+  const exportScope = "landlord_portfolio_preview";
+  const exportProfile = deriveInstitutionExportProfile({
+    packageType,
+    audience,
+    exportScope,
+    sourceCollections,
+    hasRestrictedRedactions: hasRestrictedRedactions(DEFAULT_REDACTIONS),
+  });
+
   return {
     packageId: cleanId(`institution_export:${packageType}:${landlordId || "missing_landlord"}`),
     packageType,
     audience,
     status: blockedReasons.length ? "blocked" : "preview_ready",
     generatedAt,
+    exportGeneratedAt: generatedAt,
+    exportProfile,
+    exportVersion: exportProfile.exportVersion,
+    exportScope,
+    sensitivityClass: exportProfile.sensitivityClass,
+    authorityBasis: exportProfile.authorityBasis,
+    sourceCollections,
+    sourceRefs,
+    projectionPolicy: exportProfile.projectionPolicy,
+    redactionSummary: {
+      redactionPolicy: exportProfile.redactionPolicy,
+      redactedFieldGroups: DEFAULT_REDACTIONS.map((item) => item.fieldCategory).sort((a, b) => a.localeCompare(b)),
+      redactionCount: DEFAULT_REDACTIONS.length,
+    },
+    lineageSummary: {
+      sourceReferenceCount: sourceRefs.length,
+      sourceCollections,
+      lineagePolicy: exportProfile.lineagePolicy,
+    },
     manualOnly: true,
     externalSubmissionEnabled: false,
     sections,

--- a/rentchain-api/src/lib/institutionExports/institutionExportProfile.ts
+++ b/rentchain-api/src/lib/institutionExports/institutionExportProfile.ts
@@ -1,0 +1,117 @@
+import type {
+  InstitutionExportAudience,
+  InstitutionExportPackageType,
+  InstitutionExportProfile,
+  InstitutionExportScope,
+  InstitutionExportSensitivityClass,
+  InstitutionExportSourceReference,
+} from "./institutionExportTypes";
+
+export const INSTITUTION_EXPORT_PROFILE_VERSION = "institution_export_allowlist_v1";
+
+const ALLOWED_COLLECTIONS = [
+  "auditEvents",
+  "decisionItems",
+  "leases",
+  "maintenanceRequests",
+  "portableAttestations",
+  "properties",
+  "units",
+];
+
+const ALLOWED_FIELD_GROUPS = [
+  "aggregate_counts",
+  "status_summaries",
+  "occupancy_summaries",
+  "delinquency_summaries",
+  "audit_event_counts",
+  "portable_trust_metadata",
+  "redaction_categories",
+];
+
+const EXCLUDED_FIELD_GROUPS = [
+  "tenant_contact_details",
+  "identity_documents",
+  "raw_provider_payloads",
+  "raw_screening_reports",
+  "raw_csv_values",
+  "payment_account_details",
+  "private_message_contents",
+  "debug_payloads",
+  "unrelated_resource_records",
+];
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+export function deriveInstitutionExportProfile(input: {
+  packageType: InstitutionExportPackageType;
+  audience: InstitutionExportAudience;
+  exportScope: InstitutionExportScope;
+  sourceCollections: string[];
+  hasRestrictedRedactions: boolean;
+}): InstitutionExportProfile {
+  const sensitivityClass: InstitutionExportSensitivityClass =
+    input.hasRestrictedRedactions || input.audience !== "internal" ? "restricted" : "sensitive";
+
+  return {
+    exportProfile: "institutional_export_preview",
+    exportVersion: INSTITUTION_EXPORT_PROFILE_VERSION,
+    audienceCategory: input.audience,
+    exportScope: input.exportScope,
+    allowedCollections: uniqueSorted(input.sourceCollections).filter((collection) =>
+      ALLOWED_COLLECTIONS.includes(collection)
+    ),
+    allowedFieldGroups: ALLOWED_FIELD_GROUPS,
+    excludedFieldGroups: EXCLUDED_FIELD_GROUPS,
+    sensitivityClass,
+    authorityBasis: "landlord_scoped_preview",
+    projectionPolicy: "Allowlisted aggregate preview only; do not include raw source records.",
+    retentionPolicy: "Preview metadata only; retention policy must be approved before external sharing.",
+    redactionPolicy: "Exclude raw/provider/payment credential/debug/private-message fields; include redaction categories only.",
+    lineagePolicy: "Each represented source collection declares deterministic source IDs or count-only lineage.",
+    auditExpectation: "Manual review and audit event linkage required before institutional export release.",
+  };
+}
+
+export function deriveInstitutionExportSourceRefs(input: {
+  properties: Array<Record<string, unknown>>;
+  leases: Array<Record<string, unknown>>;
+  units: Array<Record<string, unknown>>;
+  maintenanceRequests: Array<Record<string, unknown>>;
+  decisionItems: Array<Record<string, unknown>>;
+  auditEvents: unknown[];
+  portableAttestations: Array<Record<string, unknown>> | null;
+}): InstitutionExportSourceReference[] {
+  const refs: InstitutionExportSourceReference[] = [];
+
+  function pushRecords(sourceCollection: string, records: Array<Record<string, unknown>>, idKeys: string[]) {
+    for (const record of records) {
+      const sourceId = idKeys.map((key) => String(record[key] ?? "").trim()).find(Boolean);
+      if (!sourceId) continue;
+      refs.push({ sourceCollection, sourceId });
+    }
+  }
+
+  pushRecords("properties", input.properties, ["id", "propertyId"]);
+  pushRecords("leases", input.leases, ["id", "leaseId"]);
+  pushRecords("units", input.units, ["id", "unitId"]);
+  pushRecords("maintenanceRequests", input.maintenanceRequests, ["id", "maintenanceRequestId", "workOrderId"]);
+  pushRecords("decisionItems", input.decisionItems, ["id", "decisionId"]);
+  pushRecords("portableAttestations", input.portableAttestations || [], ["attestationId", "id"]);
+
+  input.auditEvents.forEach((event) => {
+    if (!event || typeof event !== "object") return;
+    const sourceId = String((event as Record<string, unknown>).id ?? (event as Record<string, unknown>).eventId ?? "").trim();
+    if (sourceId) refs.push({ sourceCollection: "auditEvents", sourceId });
+  });
+
+  const byKey = new Map<string, InstitutionExportSourceReference>();
+  for (const ref of refs) {
+    byKey.set(`${ref.sourceCollection}:${ref.sourceId}`, ref);
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}`.localeCompare(`${b.sourceCollection}:${b.sourceId}`)
+  );
+}

--- a/rentchain-api/src/lib/institutionExports/institutionExportTypes.ts
+++ b/rentchain-api/src/lib/institutionExports/institutionExportTypes.ts
@@ -37,12 +37,61 @@ export type InstitutionExportRedaction = {
   reason: string;
 };
 
+export type InstitutionExportSensitivityClass = "sensitive" | "restricted";
+
+export type InstitutionExportScope = "landlord_portfolio_preview";
+
+export type InstitutionExportProfile = {
+  exportProfile: "institutional_export_preview";
+  exportVersion: string;
+  audienceCategory: InstitutionExportAudience;
+  exportScope: InstitutionExportScope;
+  allowedCollections: string[];
+  allowedFieldGroups: string[];
+  excludedFieldGroups: string[];
+  sensitivityClass: InstitutionExportSensitivityClass;
+  authorityBasis: string;
+  projectionPolicy: string;
+  retentionPolicy: string;
+  redactionPolicy: string;
+  lineagePolicy: string;
+  auditExpectation: string;
+};
+
+export type InstitutionExportSourceReference = {
+  sourceCollection: string;
+  sourceId: string;
+};
+
+export type InstitutionExportRedactionSummary = {
+  redactionPolicy: string;
+  redactedFieldGroups: string[];
+  redactionCount: number;
+};
+
+export type InstitutionExportLineageSummary = {
+  sourceReferenceCount: number;
+  sourceCollections: string[];
+  lineagePolicy: string;
+};
+
 export type InstitutionExportPackage = {
   packageId: string;
   packageType: InstitutionExportPackageType;
   audience: InstitutionExportAudience;
   status: InstitutionExportStatus;
   generatedAt: string;
+  exportGeneratedAt: string;
+  exportProfile: InstitutionExportProfile;
+  exportVersion: string;
+  exportScope: InstitutionExportScope;
+  sensitivityClass: InstitutionExportSensitivityClass;
+  authorityBasis: string;
+  sourceCollections: string[];
+  sourceRefs: InstitutionExportSourceReference[];
+  projectionPolicy: string;
+  redactionSummary: InstitutionExportRedactionSummary;
+  lineageSummary: InstitutionExportLineageSummary;
   manualOnly: true;
   externalSubmissionEnabled: false;
   sections: InstitutionExportSection[];


### PR DESCRIPTION
## Summary
- Add an institutional export allowlist profile contract for derived institutional export previews.
- Include deterministic export governance metadata: profile/version, scope, sensitivity class, authority basis, source collections, source refs, projection policy, redaction summary, lineage summary, and export generated timestamp.
- Document Institutional Export Allowlist Profile v1 and its guarantees/follow-ups.

## Audit findings
- Existing institutional export derivation is aggregate-preview oriented and already avoids raw source records in `payloadPreview`.
- Export governance metadata was implicit: no export profile version, source lineage, redaction summary, authority basis, retention policy, or allowlist field groups were declared on the export package.
- Existing projection tests already guard sensitive raw payload categories; this PR extends those tests to cover export profile metadata and deterministic lineage.

## Export profile contract summary
- `exportProfile`: `institutional_export_preview`
- `exportVersion`: `institution_export_allowlist_v1`
- `audienceCategory`: current package audience
- `exportScope`: `landlord_portfolio_preview`
- `authorityBasis`: `landlord_scoped_preview`
- `allowedCollections`, `allowedFieldGroups`, `excludedFieldGroups`
- `sensitivityClass`, `projectionPolicy`, `retentionPolicy`, `redactionPolicy`, `lineagePolicy`, `auditExpectation`

## Governance metadata added
- `exportGeneratedAt`
- `exportProfile`
- `exportVersion`
- `exportScope`
- `sensitivityClass`
- `authorityBasis`
- `sourceCollections`
- `sourceRefs`
- `projectionPolicy`
- `redactionSummary`
- `lineageSummary`

## Restricted fields protected
Tests assert institutional export previews and metadata exclude raw screening reports, provider payloads, bank/account data, raw CSV values, webhook secrets/tokens, debug payloads, stack traces, and unrelated raw values.

## Leaks found/fixed
- No existing export leak was found.
- No auth, route, Firestore rules, schema, visibility, or export access behavior changed.

## Remaining follow-ups
- Add route-level assertions for institutional export profile metadata.
- Add export checksum/hash metadata before external release workflows.
- Add canonical event lineage IDs when event adapters are implemented.
- Add consent-aware export profiles for tenant trust and government workflows.
- Add persistence/retention rules only after export storage policy is approved.

## Tests
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts src/__tests__/firestoreRelationshipContinuity.test.ts src/routes/__tests__/landlordInstitutionExportsRoutes.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`