### PR TITLE
fix: add tenant-safe projection contracts

### DIFF
--- a/docs/reports/tenant-safe-projection-contract-v1.md
+++ b/docs/reports/tenant-safe-projection-contract-v1.md
@@ -1,0 +1,132 @@
+# Tenant-Safe Projection Contract v1
+
+## Executive Summary
+
+This report defines the first tenant-safe projection contract for RentChain tenant-facing workspace data. The contract makes tenant projections explicit, whitelist-oriented, scoped to the authenticated tenant relationship, and aligned with the sensitivity and projection governance registries.
+
+This mission does not change tenant access, route visibility, Firestore schema, Firestore rules, or tenant workspace behavior. It introduces a narrow projection contract and applies it to the current tenant lease projection surface.
+
+## Contract Scope
+
+Tenant-safe projection v1 applies first to the current lease projection used by tenant workspace and tenant portal lease surfaces.
+
+Contract identity:
+
+- Projection name: `tenant_safe_workspace_projection`
+- Projection version: `tenant_safe_projection_v1`
+- Audience: tenant workspace
+- Scope type: tenant current lease
+- Sensitivity class: sensitive
+- Authority basis: authenticated tenant scope
+- Relationship basis: authenticated tenant current lease relationship
+
+## Contract Fields
+
+The tenant-safe projection contract documents:
+
+- `projectionName`
+- `projectionVersion`
+- `audience`
+- `scopeType`
+- `allowedSourceCollections`
+- `allowedFieldGroups`
+- `excludedFieldGroups`
+- `sensitivityClass`
+- `authorityBasis`
+- `relationshipBasis`
+- `internalReferencePolicy`
+- `redactionPolicy`
+
+Tenant lease projections also expose deterministic metadata:
+
+- `projectionProfile`
+- `projectionVersion`
+- `sensitivityClass`
+- `sourceCollections`
+- `sourceRefs`
+- `redactionSummary`
+
+## Allowed Field Groups
+
+The v1 contract allows only tenant-facing lease workspace groups:
+
+- tenant visible lease summary
+- tenant visible document status
+- tenant signature status
+- payment readiness summary
+- scoped source references
+- operational labels
+
+## Excluded Field Groups
+
+The v1 contract explicitly excludes:
+
+- landlord-only notes
+- other-tenant records
+- raw provider payloads
+- raw screening reports
+- raw CSV values
+- payment account details
+- debug payloads
+- route-source metadata
+- stack traces
+- private message bodies
+
+## Source Lineage
+
+The tenant lease projection includes source lineage metadata for traceability:
+
+- `sourceCollections`
+- `sourceRefs`
+
+These fields are internal metadata references for diagnostics and lineage. They are not primary tenant-facing display labels and should not replace operational labels in UI copy.
+
+## What This Guarantees
+
+Tenant-safe projection contract v1 guarantees:
+
+- tenant current lease projections are explicitly versioned
+- projection metadata is deterministic
+- source collection lineage is visible to the server/client contract
+- restricted field groups are documented and tested
+- tenant lease shaping remains whitelist-based
+- raw/provider/payment/debug/private-message fields are excluded from the covered surface
+
+## What This Does Not Guarantee Yet
+
+This contract does not yet cover every tenant-facing route. Remaining tenant surfaces should be migrated incrementally.
+
+Not yet covered by a contract:
+
+- tenant message metadata projections
+- tenant notification/readiness projections
+- tenant maintenance workspace projections
+- tenant trust export package profiles
+- tenant document package projections beyond current lease metadata
+
+## Relationship To Evidence And Exports
+
+Tenant-safe projection contracts complement:
+
+- evidence pack projection profiles
+- institutional export allowlist profiles
+- Firestore sensitivity and projection registry
+- Firestore collection ownership registry
+
+Tenant projections should remain narrower than landlord operational, evidence, and institutional export projections. Tenant-safe payloads must be scoped by authenticated tenant authority and relationship lineage.
+
+## Future Follow-Ups
+
+Recommended follow-up missions:
+
+1. `fix/tenant-message-metadata-projection-contract-v1`
+2. `fix/tenant-maintenance-projection-contract-v1`
+3. `fix/tenant-trust-export-profile-v1`
+4. `test/tenant-projection-route-contracts-v1`
+
+## DO NOT IGNORE
+
+- Tenant-facing projections must remain whitelist-based.
+- Internal IDs may be retained as scoped metadata only, not primary labels.
+- Raw provider, screening, payment credential, CSV, debug, stack, and private message-body fields must not be exposed through tenant workspace projections.
+- Tenant projection expansion should be reviewed against authority context and relationship continuity tests before implementation.

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantProjectionService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantProjectionService.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import { projectTenantLease } from "../tenantProjectionService";
+
+describe("tenantProjectionService", () => {
+  it("adds deterministic tenant-safe projection contract metadata to current lease projections", () => {
+    const projected = projectTenantLease("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2026-06-01",
+      endDate: "2027-05-31",
+      monthlyRent: 1640,
+      dueDay: 1,
+      documentUrl: "https://example.test/tenant-safe-lease.pdf",
+      tenantSignedAt: "2026-05-01T12:00:00.000Z",
+    });
+
+    expect(projected.projectionVersion).toBe("tenant_safe_projection_v1");
+    expect(projected.sensitivityClass).toBe("sensitive");
+    expect(projected.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_workspace_projection",
+        projectionVersion: "tenant_safe_projection_v1",
+        audience: "tenant_workspace",
+        scopeType: "tenant_current_lease",
+        sensitivityClass: "sensitive",
+        authorityBasis: "authenticated_tenant_scope",
+        relationshipBasis: "Projection must be derived from the authenticated tenant's current lease relationship.",
+        internalReferencePolicy:
+          "Internal IDs are scoped references for navigation/traceability, not primary display labels.",
+      }),
+    );
+    expect(projected.projectionProfile.allowedFieldGroups).toEqual(
+      expect.arrayContaining([
+        "tenant_visible_lease_summary",
+        "tenant_visible_document_status",
+        "tenant_signature_status",
+        "payment_readiness_summary",
+        "scoped_source_references",
+      ]),
+    );
+    expect(projected.projectionProfile.excludedFieldGroups).toEqual(
+      expect.arrayContaining([
+        "landlord_only_notes",
+        "other_tenant_records",
+        "raw_provider_payloads",
+        "raw_screening_reports",
+        "raw_csv_values",
+        "payment_account_details",
+        "debug_payloads",
+        "private_message_bodies",
+      ]),
+    );
+    expect(projected.sourceCollections).toEqual(["leases", "properties", "tenants", "units"]);
+    expect(projected.sourceRefs).toEqual([
+      { sourceCollection: "leases", sourceId: "lease-1" },
+      { sourceCollection: "properties", sourceId: "prop-1" },
+      { sourceCollection: "tenants", sourceId: "tenant-1" },
+      { sourceCollection: "units", sourceId: "unit-1" },
+    ]);
+    expect(projected.redactionSummary).toEqual(
+      expect.objectContaining({
+        redactionPolicy:
+          "Exclude landlord-only notes, raw/provider/payment/debug/private-message fields, and unrelated tenant data.",
+        redactionCount: projected.projectionProfile.excludedFieldGroups.length,
+      }),
+    );
+  });
+
+  it("keeps tenant lease projections whitelist-based when source records contain restricted fields", () => {
+    const projected = projectTenantLease("lease-sensitive", {
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1", "other-tenant-1"],
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2026-06-01",
+      endDate: "2027-05-31",
+      monthlyRent: 1640,
+      dueDay: 1,
+      documentUrl: "https://example.test/tenant-safe-lease.pdf",
+      landlordOnlyNotes: "private landlord note",
+      internalNotes: "internal landlord note",
+      rawPayload: { providerPayload: "raw provider report" },
+      rawCsv: "raw tenant CSV data",
+      bankAccountNumber: "111122223333",
+      routingNumber: "000111222",
+      routeSource: "tenantPortalRoutes.ts",
+      stack: "private stack trace",
+      debugPayload: "debug details",
+      messageBody: "unrestricted private message body",
+      otherTenantRecords: [{ tenantId: "other-tenant-1", email: "other@example.test" }],
+      screening: { rawReport: "raw screening report" },
+    });
+
+    expect(projected.leaseId).toBe("lease-sensitive");
+    expect(projected.status).toBe("active");
+    expect(projected.documentUrl).toBe("https://example.test/tenant-safe-lease.pdf");
+    expect(projected.sourceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceCollection: "leases", sourceId: "lease-sensitive" }),
+        expect.objectContaining({ sourceCollection: "tenants", sourceId: "tenant-1" }),
+      ]),
+    );
+    expectNoRestrictedProjectionFields(projected);
+    expectPayloadDoesNotContainValues(projected, [
+      "private landlord note",
+      "internal landlord note",
+      "raw provider report",
+      "raw tenant CSV data",
+      "111122223333",
+      "000111222",
+      "tenantPortalRoutes.ts",
+      "private stack trace",
+      "debug details",
+      "unrestricted private message body",
+      "other-tenant-1",
+      "other@example.test",
+      "raw screening report",
+    ]);
+  });
+});

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -1,5 +1,11 @@
 import { deriveLeaseExecution, type LeaseExecution } from "../leaseExecution/deriveLeaseExecution";
 import { derivePaymentReadiness, type PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
+import {
+  deriveTenantSafeProjectionProfile,
+  deriveTenantSafeSourceRefs,
+  type TenantSafeProjectionProfile,
+  type TenantSafeProjectionSourceReference,
+} from "./tenantSafeProjectionContract";
 
 type TenantPropertyProjection = {
   propertyId: string;
@@ -14,6 +20,16 @@ type TenantPropertyProjection = {
 
 type TenantLeaseProjection = {
   leaseId: string;
+  projectionProfile: TenantSafeProjectionProfile;
+  projectionVersion: string;
+  sensitivityClass: TenantSafeProjectionProfile["sensitivityClass"];
+  sourceCollections: string[];
+  sourceRefs: TenantSafeProjectionSourceReference[];
+  redactionSummary: {
+    redactionPolicy: string;
+    redactedFieldGroups: string[];
+    redactionCount: number;
+  };
   startDate: string | null;
   endDate: string | null;
   monthlyRent: number | null;
@@ -398,9 +414,35 @@ export function projectTenantLease(recordId: string, data: any): TenantLeaseProj
   const dueDay = asNumber(data?.dueDay);
   const leaseReadiness = deriveTenantSafeLeaseReadinessMetadata(data, { documentUrl, leaseId: recordId });
   const leaseExecution = leaseReadiness.leaseExecution;
+  const tenantId = asString(data?.primaryTenantId) || asString(data?.tenantId) || asString(data?.tenantIds?.[0]);
+  const propertyId = asString(data?.propertyId);
+  const unitId = asString(data?.unitId) || asString(data?.unitNumber) || asString(data?.unit);
+  const sourceRefs = deriveTenantSafeSourceRefs({
+    leaseId: recordId,
+    propertyId,
+    unitId,
+    tenantId,
+  });
+  const sourceCollections = Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+  const projectionProfile = deriveTenantSafeProjectionProfile({
+    scopeType: "tenant_current_lease",
+    sourceCollections,
+  });
 
   return {
     leaseId: recordId,
+    projectionProfile,
+    projectionVersion: projectionProfile.projectionVersion,
+    sensitivityClass: projectionProfile.sensitivityClass,
+    sourceCollections,
+    sourceRefs,
+    redactionSummary: {
+      redactionPolicy: projectionProfile.redactionPolicy,
+      redactedFieldGroups: projectionProfile.excludedFieldGroups,
+      redactionCount: projectionProfile.excludedFieldGroups.length,
+    },
     startDate,
     endDate,
     monthlyRent,
@@ -414,9 +456,9 @@ export function projectTenantLease(recordId: string, data: any): TenantLeaseProj
       startDate,
       endDate,
       dueDay,
-      tenantId: asString(data?.primaryTenantId) || asString(data?.tenantId) || asString(data?.tenantIds?.[0]),
-      propertyId: asString(data?.propertyId),
-      unitId: asString(data?.unitId) || asString(data?.unitNumber) || asString(data?.unit),
+      tenantId,
+      propertyId,
+      unitId,
       leaseExecution,
     }),
   };

--- a/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
@@ -1,0 +1,92 @@
+export const TENANT_SAFE_PROJECTION_VERSION = "tenant_safe_projection_v1";
+
+export type TenantSafeProjectionAudience = "tenant_workspace";
+
+export type TenantSafeProjectionScopeType = "tenant_current_lease";
+
+export type TenantSafeProjectionSensitivityClass = "sensitive";
+
+export type TenantSafeProjectionSourceReference = {
+  sourceCollection: string;
+  sourceId: string;
+};
+
+export type TenantSafeProjectionProfile = {
+  projectionName: "tenant_safe_workspace_projection";
+  projectionVersion: typeof TENANT_SAFE_PROJECTION_VERSION;
+  audience: TenantSafeProjectionAudience;
+  scopeType: TenantSafeProjectionScopeType;
+  allowedSourceCollections: string[];
+  allowedFieldGroups: string[];
+  excludedFieldGroups: string[];
+  sensitivityClass: TenantSafeProjectionSensitivityClass;
+  authorityBasis: "authenticated_tenant_scope";
+  relationshipBasis: string;
+  internalReferencePolicy: string;
+  redactionPolicy: string;
+};
+
+const ALLOWED_FIELD_GROUPS = [
+  "tenant_visible_lease_summary",
+  "tenant_visible_document_status",
+  "tenant_signature_status",
+  "payment_readiness_summary",
+  "scoped_source_references",
+  "operational_labels",
+];
+
+const EXCLUDED_FIELD_GROUPS = [
+  "landlord_only_notes",
+  "other_tenant_records",
+  "raw_provider_payloads",
+  "raw_screening_reports",
+  "raw_csv_values",
+  "payment_account_details",
+  "debug_payloads",
+  "route_source_metadata",
+  "stack_traces",
+  "private_message_bodies",
+];
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+export function deriveTenantSafeProjectionProfile(input: {
+  scopeType: TenantSafeProjectionScopeType;
+  sourceCollections: string[];
+}): TenantSafeProjectionProfile {
+  return {
+    projectionName: "tenant_safe_workspace_projection",
+    projectionVersion: TENANT_SAFE_PROJECTION_VERSION,
+    audience: "tenant_workspace",
+    scopeType: input.scopeType,
+    allowedSourceCollections: uniqueSorted(input.sourceCollections),
+    allowedFieldGroups: ALLOWED_FIELD_GROUPS,
+    excludedFieldGroups: EXCLUDED_FIELD_GROUPS,
+    sensitivityClass: "sensitive",
+    authorityBasis: "authenticated_tenant_scope",
+    relationshipBasis: "Projection must be derived from the authenticated tenant's current lease relationship.",
+    internalReferencePolicy: "Internal IDs are scoped references for navigation/traceability, not primary display labels.",
+    redactionPolicy: "Exclude landlord-only notes, raw/provider/payment/debug/private-message fields, and unrelated tenant data.",
+  };
+}
+
+export function deriveTenantSafeSourceRefs(input: {
+  leaseId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+}): TenantSafeProjectionSourceReference[] {
+  const refs: TenantSafeProjectionSourceReference[] = [];
+  if (input.leaseId) refs.push({ sourceCollection: "leases", sourceId: input.leaseId });
+  if (input.propertyId) refs.push({ sourceCollection: "properties", sourceId: input.propertyId });
+  if (input.unitId) refs.push({ sourceCollection: "units", sourceId: input.unitId });
+  if (input.tenantId) refs.push({ sourceCollection: "tenants", sourceId: input.tenantId });
+
+  const byKey = new Map<string, TenantSafeProjectionSourceReference>();
+  for (const ref of refs) byKey.set(`${ref.sourceCollection}:${ref.sourceId}`, ref);
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}`.localeCompare(`${b.sourceCollection}:${b.sourceId}`)
+  );
+}


### PR DESCRIPTION
## Summary
- add a versioned tenant-safe projection contract for tenant workspace current-lease payloads
- attach deterministic projection metadata, source collections, source refs, sensitivity, and redaction summary to `projectTenantLease`
- add focused projection safety tests that prove restricted/raw/provider/payment/debug/private-message fields stay out of the tenant lease projection
- document tenant-safe projection contract v1 and remaining tenant projection follow-ups

## Tenant surface covered
- Tenant current lease projection via `projectTenantLease`, used by tenant portal/workspace lease-related payloads.

## Guardrails / behavior preservation
- No tenant access widening.
- No auth, route visibility, Firestore schema, or Firestore rules changes.
- No broad tenant workspace rewrite.
- Internal IDs remain scoped metadata/source refs, not primary display labels.
- No raw provider, screening, CSV, payment credential, debug, stack, route-source, landlord-only note, private message-body, or other-tenant values are exposed by the covered projection.

## Tests run
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/services/tenantPortal/__tests__/tenantProjectionService.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/services/tenantPortal/__tests__/tenantProjectionService.test.ts src/__tests__/tenantWorkspaceLeaseLinkageContinuity.test.ts src/routes/__tests__/tenantPortalRoutes.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Known follow-ups
- Add contracts for tenant message metadata projections.
- Add contracts for tenant maintenance workspace projections.
- Add tenant trust export profile coverage.
- Add route-level tenant projection contract tests after more tenant surfaces are migrated.