### PR TITLE
fix: add structured logging redaction

### DIFF
--- a/docs/reports/structured-logging-redaction-v1.md
+++ b/docs/reports/structured-logging-redaction-v1.md
@@ -1,0 +1,100 @@
+# Structured Logging Redaction v1
+
+## Executive Summary
+
+Structured logging redaction v1 introduces a small runtime foundation for privacy-aware diagnostics in RentChain. Logs are treated as projection surfaces: operationally useful metadata may be retained, but restricted, raw, provider, credential, debug, stack, and private payload fields must not be logged.
+
+This mission does not replace all logging globally and does not introduce a large logging framework. It adds a reusable helper and migrates a small set of higher-risk telemetry and webhook logging paths.
+
+## Logging Philosophy
+
+RentChain logs should be:
+
+- structured where practical
+- deterministic
+- metadata-oriented
+- sensitivity-aware
+- useful for operational support
+- safe for future evidence, audit, and governance workflows
+
+Logs should not become a secondary data export channel.
+
+## Redaction Rules
+
+The v1 helper suppresses restricted field groups such as:
+
+- SIN/SSN/government identity fields
+- bank, account, routing, transit, institution, IBAN, SWIFT, card, and CVV fields
+- tokens, API keys, webhook secrets, passwords, and credentials
+- raw/provider/report payloads
+- raw CSV and ignored CSV column values
+- stack traces
+- route-source and debug payload metadata
+
+Inline token-like values in strings are redacted where practical, including common bearer token, Stripe key, webhook secret, and query-style token patterns.
+
+## Safe Operational Metadata
+
+The helper preserves safe operational metadata such as:
+
+- route
+- requestId
+- correlationId
+- eventType
+- landlordId and tenantId where operationally necessary as internal references
+- status codes
+- projection profile names
+- export/evidence profile versions
+
+## Migrated Surfaces
+
+Targeted migrations in v1:
+
+- telemetry route write-failure logging
+- system observability fail-soft logging
+- Stripe screening webhook diagnostics
+- TransUnion webhook identity fallback diagnostics
+- telemetry sanitization now shares the restricted logging key detection baseline
+
+## What This Guarantees
+
+Structured logging redaction v1 guarantees:
+
+- a shared `sanitizeLogPayload` helper exists
+- a shared `safeOperationalLog` helper exists
+- a shared `safeErrorLog` helper exists
+- restricted key detection is reusable and tested
+- migrated log paths no longer write raw restricted payload keys
+- Error stacks are not logged by the helper
+
+## What This Does Not Guarantee Yet
+
+This is not a repo-wide logging rewrite. Many legacy `console.*` calls remain and should be migrated incrementally by risk.
+
+Not yet covered:
+
+- all lease/payment route diagnostics
+- all screening provider adapter diagnostics
+- all billing/subscription diagnostics
+- all admin/support diagnostics
+- boot-time logs
+- future external log drain policy
+
+## Future Follow-Ups
+
+Recommended follow-up missions:
+
+1. `fix/high-risk-route-safe-logging-v1`
+2. `test/console-log-redaction-regression-v1`
+3. `fix/screening-provider-adapter-log-safety-v1`
+4. `fix/payment-and-billing-log-safety-v1`
+5. `docs/logging-retention-and-access-policy-v1`
+
+## DO NOT IGNORE
+
+- Do not log raw provider payloads.
+- Do not log raw CSV values or ignored banking columns.
+- Do not log payment credentials or processor secrets.
+- Do not log stack traces into operational/evidence-facing diagnostics.
+- Do not rely on frontend projection filtering for log safety.
+- Future governance and agent-routing systems must consume redacted metadata, not raw diagnostic payloads.

--- a/rentchain-api/src/lib/governance/platformGovernance.ts
+++ b/rentchain-api/src/lib/governance/platformGovernance.ts
@@ -1,3 +1,5 @@
+import { isRestrictedLogKey } from "../logging/safeLogger";
+
 export type GovernanceSensitivity = "public" | "internal" | "confidential" | "restricted";
 export type GovernanceRetentionCategory =
   | "operational_short"
@@ -70,7 +72,7 @@ function normalizedKey(value: string): string {
 
 function isSensitiveKey(key: string): boolean {
   const normalized = normalizedKey(key);
-  return SENSITIVE_KEY_FRAGMENTS.some((fragment) => normalized.includes(normalizedKey(fragment)));
+  return isRestrictedLogKey(key) || SENSITIVE_KEY_FRAGMENTS.some((fragment) => normalized.includes(normalizedKey(fragment)));
 }
 
 export function actorFromRequest(req: any): GovernanceActor {

--- a/rentchain-api/src/lib/logging/__tests__/safeLogger.test.ts
+++ b/rentchain-api/src/lib/logging/__tests__/safeLogger.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import {
+  isRestrictedLogKey,
+  redactLogString,
+  safeErrorLog,
+  safeOperationalLog,
+  sanitizeLogPayload,
+} from "../safeLogger";
+
+describe("safeLogger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("deterministically removes restricted field groups while preserving safe operational metadata", () => {
+    const sanitized = sanitizeLogPayload({
+      route: "/api/ledger/imports/payment-csv/confirm",
+      requestId: "req-1",
+      correlationId: "corr-1",
+      eventType: "payment_import_confirm_failed",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      statusCode: 500,
+      projectionProfile: "tenant_safe_workspace_projection",
+      exportVersion: "institutional_export_v1",
+      rawPayload: { providerPayload: "raw provider dump" },
+      rawCsv: "bank csv contents",
+      ignoredCsvColumns: ["Bank Account"],
+      bankAccount: "111122223333",
+      accountNumber: "444455556666",
+      routingNumber: "000111222",
+      token: "secret-token",
+      apiKey: "sk_live_sensitive",
+      webhookSecret: "whsec_sensitive",
+      stack: "private stack trace",
+      routeSource: "debug router",
+      debugPayload: { internalDebug: "debug details" },
+    });
+
+    expect(sanitized).toEqual({
+      route: "/api/ledger/imports/payment-csv/confirm",
+      requestId: "req-1",
+      correlationId: "corr-1",
+      eventType: "payment_import_confirm_failed",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      statusCode: 500,
+      projectionProfile: "tenant_safe_workspace_projection",
+      exportVersion: "institutional_export_v1",
+    });
+    expectNoRestrictedProjectionFields(sanitized);
+    expectPayloadDoesNotContainValues(sanitized, [
+      "raw provider dump",
+      "bank csv contents",
+      "111122223333",
+      "444455556666",
+      "000111222",
+      "secret-token",
+      "sk_live_sensitive",
+      "whsec_sensitive",
+      "private stack trace",
+      "debug router",
+      "debug details",
+    ]);
+  });
+
+  it("redacts inline secrets from string messages and Error objects without logging stacks", () => {
+    const error = new Error("provider failed with token=abc123 and whsec_secret");
+    error.stack = "private stack trace with sk_live_secret";
+
+    const sanitized = sanitizeLogPayload({
+      message: "Authorization: Bearer eyJsecret.jwt",
+      error,
+    });
+
+    expect(sanitized).toEqual({
+      message: "Authorization: [REDACTED]",
+      error: {
+        name: "Error",
+        message: "provider failed with token=[REDACTED] and [REDACTED]",
+      },
+    });
+    expectPayloadDoesNotContainValues(sanitized, ["abc123", "whsec_secret", "private stack trace", "sk_live_secret"]);
+  });
+
+  it("uses sanitized payloads for operational and error console helpers", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    safeOperationalLog("warn", "[test] raw webhook warning token=abc123", {
+      route: "/api/stripe/webhook",
+      providerPayload: "raw provider dump",
+      routeSource: "internal router",
+      safeStatus: "blocked",
+    });
+    safeErrorLog("[test] provider failure", new Error("failed with sk_test_secret"), {
+      screeningOrderId: "order-1",
+      stack: "private stack trace",
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith("[test] raw webhook warning token=[REDACTED]", {
+      route: "/api/stripe/webhook",
+      safeStatus: "blocked",
+    });
+    expect(errorSpy).toHaveBeenCalledWith("[test] provider failure", {
+      screeningOrderId: "order-1",
+      error: {
+        name: "Error",
+        message: "failed with [REDACTED]",
+      },
+    });
+  });
+
+  it("keeps restricted-key detection explicit for future logging migrations", () => {
+    expect(isRestrictedLogKey("providerPayload")).toBe(true);
+    expect(isRestrictedLogKey("rawCsv")).toBe(true);
+    expect(isRestrictedLogKey("routeSource")).toBe(true);
+    expect(isRestrictedLogKey("requestId")).toBe(false);
+  });
+
+  it("redacts common inline token formats deterministically", () => {
+    expect(redactLogString("token=abc123 api_key=key123 whsec_secret sk_test_secret")).toBe(
+      "token=[REDACTED] api_key=[REDACTED] [REDACTED] [REDACTED]",
+    );
+  });
+});

--- a/rentchain-api/src/lib/logging/safeLogger.ts
+++ b/rentchain-api/src/lib/logging/safeLogger.ts
@@ -1,0 +1,115 @@
+export type SafeLogLevel = "info" | "warn" | "error" | "debug";
+
+export type SafeLogPayload = Record<string, unknown>;
+
+export const REDACTED_LOG_VALUE = "[REDACTED]";
+
+const MAX_DEPTH = 4;
+const MAX_ARRAY_LENGTH = 25;
+const MAX_STRING_LENGTH = 500;
+
+const RESTRICTED_KEY_PATTERNS = [
+  /^(sin|ssn|cvv)$/i,
+  /social.*insurance/i,
+  /bank.*account/i,
+  /account.*number/i,
+  /routing.*number/i,
+  /transit.*number/i,
+  /institution.*number/i,
+  /^iban$/i,
+  /^swift$/i,
+  /card.*number/i,
+  /credential/i,
+  /raw.*report/i,
+  /raw.*payload/i,
+  /provider.*payload/i,
+  /^payload$/i,
+  /webhook.*secret/i,
+  /^api.*key$/i,
+  /^token$/i,
+  /password/i,
+  /secret/i,
+  /ignored.*csv.*columns/i,
+  /raw.*csv/i,
+  /internal.*debug/i,
+  /^stack$/i,
+  /route.*source/i,
+  /debug.*payload/i,
+];
+
+const INLINE_SECRET_PATTERNS = [
+  /\bwhsec_[A-Za-z0-9_=-]+\b/g,
+  /\bsk_(?:live|test)_[A-Za-z0-9_=-]+\b/g,
+  /\bpk_(?:live|test)_[A-Za-z0-9_=-]+\b/g,
+  /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi,
+  /\beyJ[A-Za-z0-9._-]+\b/g,
+  /\b(token|secret|password|api[_-]?key)=([^&\s]+)/gi,
+];
+
+function normalizedKey(value: string): string {
+  return value.replace(/[^a-z0-9]+/gi, "").toLowerCase();
+}
+
+export function isRestrictedLogKey(key: string): boolean {
+  const normalized = normalizedKey(key);
+  return RESTRICTED_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function redactLogString(value: unknown, max = MAX_STRING_LENGTH): string {
+  let next = String(value ?? "").trim().replace(/\s+/g, " ").slice(0, max);
+  for (const pattern of INLINE_SECRET_PATTERNS) {
+    next = next.replace(pattern, (match, label) => {
+      if (typeof label === "string" && label) return `${label}=${REDACTED_LOG_VALUE}`;
+      return REDACTED_LOG_VALUE;
+    });
+  }
+  return next;
+}
+
+export function sanitizeLogPayload(value: unknown, depth = 0): unknown {
+  if (depth > MAX_DEPTH) return null;
+  if (value == null) return null;
+  if (typeof value === "string") return redactLogString(value);
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.toISOString() : null;
+  if (value instanceof Error) {
+    return {
+      name: redactLogString(value.name, 120) || "Error",
+      message: redactLogString(value.message, 300) || "error",
+    };
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_ARRAY_LENGTH).map((item) => sanitizeLogPayload(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    const out: SafeLogPayload = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (isRestrictedLogKey(key)) continue;
+      const sanitized = sanitizeLogPayload(nested, depth + 1);
+      if (sanitized !== undefined) out[key] = sanitized;
+    }
+    return out;
+  }
+  return null;
+}
+
+export function safeOperationalLog(level: SafeLogLevel, message: string, payload?: unknown) {
+  const sanitizedMessage = redactLogString(message, 240) || "operational_log";
+  const sanitizedPayload = sanitizeLogPayload(payload);
+  const logger = console[level] || console.log;
+  if (payload === undefined) {
+    logger(sanitizedMessage);
+    return;
+  }
+  logger(sanitizedMessage, sanitizedPayload);
+}
+
+export function safeErrorLog(message: string, error: unknown, payload?: unknown) {
+  const sanitizedPayload = sanitizeLogPayload(payload);
+  safeOperationalLog("error", message, {
+    ...(sanitizedPayload && typeof sanitizedPayload === "object" && !Array.isArray(sanitizedPayload)
+      ? (sanitizedPayload as SafeLogPayload)
+      : {}),
+    error: sanitizeLogPayload(error),
+  });
+}

--- a/rentchain-api/src/routes/stripeWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeWebhookRoutes.ts
@@ -23,6 +23,7 @@ import { setLastProviderError } from "../services/screeningRequestService";
 import { addRecord } from "../services/billingService";
 import { BillingRecord } from "../types/billing";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
+import { safeErrorLog, safeOperationalLog } from "../lib/logging/safeLogger";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -89,7 +90,7 @@ router.post(
         STRIPE_WEBHOOK_SECRET
       );
     } catch (err: any) {
-      console.error("[stripe-webhook] Signature verification failed", {
+      safeOperationalLog("error", "[stripe-webhook] Signature verification failed", {
         message: err && (err as any).message ? (err as any).message : String(err),
       });
       res.status(400).send("Signature verification failed");
@@ -119,7 +120,7 @@ router.post(
             (value) => typeof value === "string"
           ) &&
           metaKeys.every((key) => key.toLowerCase().includes("id"));
-        console.log("[webhook] checkout.session.completed", {
+        safeOperationalLog("info", "[webhook] checkout.session.completed", {
           eventType: event.type,
           sessionId: session.id,
           paymentStatus: session.payment_status,
@@ -129,9 +130,7 @@ router.post(
 
       if (!screeningRequestId) {
         if (isDev) {
-          console.warn(
-            "[webhook] checkout.session.completed missing screeningRequestId metadata"
-          );
+          safeOperationalLog("warn", "[webhook] checkout.session.completed missing screeningRequestId metadata");
         }
         res.sendStatus(200);
         return;
@@ -140,10 +139,9 @@ router.post(
       const screeningRequest = getScreeningRequestById(screeningRequestId);
       if (!screeningRequest) {
         if (isDev) {
-          console.warn(
-            "[webhook] checkout.session.completed could not find screeningRequest",
-            { screeningRequestId }
-          );
+          safeOperationalLog("warn", "[webhook] checkout.session.completed could not find screeningRequest", {
+            screeningRequestId,
+          });
         }
         res.sendStatus(200);
         return;
@@ -202,7 +200,7 @@ router.post(
             }
           } catch (err) {
             if (isDev) {
-              console.warn("[stripe-webhook] Unable to fetch receipt", {
+              safeOperationalLog("warn", "[stripe-webhook] Unable to fetch receipt", {
                 message:
                   err && (err as any).message ? (err as any).message : String(err),
               });
@@ -276,7 +274,7 @@ router.post(
             }),
           }).catch((err) => {
             if (isDev) {
-              console.warn("[stripe-webhook] Failed to send email", {
+              safeOperationalLog("warn", "[stripe-webhook] Failed to send email", {
                 message:
                   err && (err as any).message ? (err as any).message : String(err),
               });
@@ -324,16 +322,13 @@ router.post(
         );
         setLastProviderError(new Date().toISOString());
         if (isDev) {
-          console.error("[stripe-webhook] provider error", {
-            message:
-              err && (err as any).message ? (err as any).message : String(err),
-          });
+          safeErrorLog("[stripe-webhook] provider error", err, { screeningRequestId, applicationId });
         }
         return res.sendStatus(200);
       }
 
       if (isDev) {
-        console.log("[stripe] screening completed", {
+        safeOperationalLog("info", "[stripe] screening completed", {
           screeningRequestId,
           applicationId,
           paymentStatus: session.payment_status,

--- a/rentchain-api/src/routes/telemetryRoutes.ts
+++ b/rentchain-api/src/routes/telemetryRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { db } from "../config/firebase";
 import { actorFromRequest, governanceMetadata, sanitizeTelemetryProps } from "../lib/governance/platformGovernance";
+import { safeErrorLog } from "../lib/logging/safeLogger";
 import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
@@ -37,7 +38,7 @@ router.post("/telemetry", requireAuth, async (req: any, res) => {
     });
     return res.status(200).json({ ok: true });
   } catch (err: any) {
-    console.error("[telemetryRoutes] write failed", err?.message || err);
+    safeErrorLog("[telemetryRoutes] write failed", err, { eventName, userId, landlordId, role });
     return res.status(500).json({ ok: false, error: "telemetry_write_failed" });
   }
 });

--- a/rentchain-api/src/routes/transunionWebhookRoutes.ts
+++ b/rentchain-api/src/routes/transunionWebhookRoutes.ts
@@ -8,6 +8,7 @@ import { getStripeClient, isStripeConfigured } from "../services/stripeService";
 import { resolveFrontendBase } from "../services/screening/inviteTokens";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
+import { safeErrorLog } from "../lib/logging/safeLogger";
 
 interface WebhookRequest extends Request {
   rawBody?: Buffer;
@@ -159,7 +160,11 @@ export const transunionWebhookHandler = async (req: WebhookRequest, res: Respons
           }
         }
       } catch (err: any) {
-        console.error("[transunion-webhook] identity fallback failed", err?.message || err);
+        safeErrorLog("[transunion-webhook] identity fallback failed", err, {
+          orderId: orderDoc.id,
+          requestId,
+          eventType,
+        });
       }
     }
 

--- a/rentchain-api/src/services/observability/recordSystemObservabilityEvent.ts
+++ b/rentchain-api/src/services/observability/recordSystemObservabilityEvent.ts
@@ -1,5 +1,6 @@
 import crypto from "crypto";
 import { db } from "../../config/firebase";
+import { safeOperationalLog } from "../../lib/logging/safeLogger";
 import {
   SYSTEM_OBSERVABILITY_EVENTS_COLLECTION,
   type SystemObservabilityEventInput,
@@ -128,7 +129,7 @@ export async function recordSystemObservabilityEvent(
     return { ok: true, duplicate: Boolean(existing), record };
   } catch (err) {
     if (!failSoft) throw err;
-    console.warn("[systemObservability] record failed softly", {
+    safeOperationalLog("warn", "[systemObservability] record failed softly", {
       eventType: input?.eventType || null,
       workflow: input?.workflow || null,
       message: (err as any)?.message || err,


### PR DESCRIPTION
## Summary
- add a lightweight structured logging/redaction helper with deterministic restricted-key suppression and inline secret redaction
- migrate targeted high-risk logging paths in telemetry, system observability, Stripe screening webhook diagnostics, and TransUnion webhook fallback diagnostics
- align telemetry property sanitization with the shared restricted logging key baseline
- document structured logging redaction v1 and remaining migration follow-ups

## Audit findings
- Existing logging is mostly ad-hoc `console.*` calls across routes/services.
- `platformGovernance.sanitizeTelemetryProps` already provided a metadata-only sanitizer, but restricted key detection was local to that file.
- Higher-risk logging surfaces included telemetry write failures, fail-soft observability logging, Stripe webhook debug logs, and TransUnion webhook fallback logs.
- A repo-wide logging replacement would be too broad for this mission, so this PR adds a shared helper and migrates targeted paths only.

## Logging helper summary
New helper: `rentchain-api/src/lib/logging/safeLogger.ts`
- `sanitizeLogPayload()`
- `safeOperationalLog()`
- `safeErrorLog()`
- `isRestrictedLogKey()`
- `redactLogString()`

## Redaction rules added
Suppresses restricted key groups including SIN/SSN, bank/account/routing/card fields, credentials, tokens, webhook secrets, raw/provider/report payloads, raw CSV, ignored CSV columns, stacks, route-source, and debug payload fields. Inline token-like strings are redacted where practical.

## Migrated logging surfaces
- `telemetryRoutes` write-failure logging
- `recordSystemObservabilityEvent` fail-soft logging
- `stripeWebhookRoutes` screening webhook diagnostics
- `transunionWebhookRoutes` identity fallback diagnostics
- `sanitizeTelemetryProps` now reuses the shared restricted logging key detection baseline

## Behavior preservation
- No auth changes.
- No Firestore schema/rules changes.
- No route visibility changes.
- No external logging drains added.
- No broad repo-wide logging rewrite.
- Operational metadata such as route, requestId, eventType, landlordId/tenantId, status, and projection/export profile metadata remains available when passed through the helper.

## Tests run
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/logging/__tests__/safeLogger.test.ts src/lib/governance/__tests__/platformGovernance.test.ts src/services/observability/__tests__/recordSystemObservabilityEvent.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/routes/__tests__/stripeWebhookPublicRoute.test.ts src/routes/__tests__/transunionRoutes.test.ts src/routes/__tests__/telemetryRoutes.test.ts`
  - first sandbox run hit `listen EPERM` for `transunionRoutes.test.ts`; rerun with local listener access passed
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Known follow-ups
- Migrate remaining high-risk route/service console diagnostics incrementally.
- Add broader console redaction regression coverage.
- Add screening provider adapter log-safety coverage.
- Add payment/billing log-safety coverage.
- Define logging retention and access policy.