### PR TITLE
feat: add review workspace foundations

### DIFF
--- a/docs/reports/review-workspace-foundations-v1.md
+++ b/docs/reports/review-workspace-foundations-v1.md
@@ -1,0 +1,167 @@
+# Review Workspace Foundations v1
+
+## Executive Summary
+
+Review Workspace Foundations v1 introduces the first governed operational review workspace contract for RentChain. It is intentionally narrow: it defines deterministic review workspace metadata, scoped evidence linkage, related resource references, assignment state, review state, and future audit/event compatibility without adding autonomous workflows, broad route changes, cross-tenant visibility, institutional sharing, or external collaboration.
+
+This mission extends the existing `operatorReviewSessions` direction rather than replacing it. Operator review sessions remain the current manual review envelope. Review workspaces provide a higher-level operational coordination contract that can bridge into existing operator review session requests.
+
+## Scope
+
+Allowed v1 workspace types:
+
+- evidence review
+- payment/ledger review
+- screening review
+- operational anomaly review
+- document review
+- delinquency review
+
+Not in scope:
+
+- autonomous AI action
+- auto-decisioning
+- cross-landlord or cross-tenant review
+- public sharing
+- tenant-visible review internals
+- institutional review sharing
+- export expansion
+- Firestore rule changes
+- route visibility changes
+
+## Contract Summary
+
+The v1 workspace contract includes:
+
+- `workspaceId`
+- `workspaceContractVersion`
+- `workspaceType`
+- `workspaceScope`
+- `workspaceScopeId`
+- `landlordId`
+- `assignedReviewer`
+- `reviewStatus`
+- `reviewPriority`
+- `evidenceRefs`
+- `relatedResourceRefs`
+- `createdFromEvent`
+- `createdBy`
+- `createdAt`
+- `updatedAt`
+- `reviewSummary`
+- `reviewNotes`
+- `reviewTags`
+- `auditRefs`
+- `sensitivityClass`
+- `visibilityClass`
+- manual and safety flags
+
+Version:
+
+- `review_workspace_foundation_v1`
+
+## Safety Flags
+
+Every v1 review workspace is explicit about non-automation:
+
+- `manualOnly: true`
+- `autonomousActionsEnabled: false`
+- `externalSharingEnabled: false`
+- `institutionalSharingEnabled: false`
+- `financialMutationEnabled: false`
+
+These flags are not permission enforcement by themselves. They are contract metadata for review, tests, and future routing compatibility.
+
+## Evidence Linkage
+
+Workspace evidence references are metadata-only references to evidence packs/items and source collection IDs where practical. They do not duplicate raw evidence payloads.
+
+Evidence refs may include:
+
+- evidence pack ID
+- evidence item ID
+- safe label
+- source collection
+- source ID
+- sensitivity class
+
+Evidence refs must not include:
+
+- raw provider payloads
+- raw CSV values
+- payment credentials
+- raw screening reports
+- debug payloads
+- private message bodies
+
+## Relationship Linkage
+
+Related resource references are scoped by landlord and, when provided, tenant. References outside the workspace landlord/tenant scope are excluded during normalization.
+
+Supported resource types:
+
+- lease
+- tenant
+- property
+- unit
+- payment
+- ledger entry
+- screening order
+- document
+- decision
+- canonical event
+- evidence pack
+
+Resource references are for relationship continuity and routing. They are not a license to expose raw source records.
+
+## Audit and Event Compatibility
+
+Review workspaces are compatible with the canonical event taxonomy direction. The v1 contract includes:
+
+- `createdFromEvent`
+- `auditRefs`
+- `reviewStatus`
+- `reviewPriority`
+- `sensitivityClass`
+- `visibilityClass`
+
+This PR does not implement a runtime canonical event adapter or event bus. Future adapters should treat review workspace creation and state transitions as append-oriented operational workflow events.
+
+## Operator Review Session Compatibility
+
+Review workspaces can be converted into the existing `OperatorReviewOpenRequest` shape for compatibility with current manual review session infrastructure.
+
+Mapping is intentionally conservative:
+
+- `delinquency_review` -> `delinquency`
+- `evidence_review` and `document_review` -> `audit_compliance`
+- other workspace types -> `workflow`
+
+## Governance Risks Found
+
+Current review infrastructure already has useful manual-only operator review session helpers, but review concepts are distributed across decisions, evidence packs, readiness profiles, institutional docs, and operational routes.
+
+Risks before this foundation:
+
+- no shared higher-level workspace contract
+- review routing metadata spread across multiple domains
+- evidence/review linkage represented inconsistently
+- future review workspaces could accidentally duplicate sensitive payloads without an explicit contract
+
+## Remaining Follow-Ups
+
+Recommended next missions:
+
+1. `feat/review-workspace-route-preview-v1`
+2. `test/review-workspace-route-scoping-v1`
+3. `feat/operator-review-session-workspaces-v1`
+4. `fix/review-workspace-evidence-pack-linking-v1`
+5. `docs/review-workspace-event-adapter-plan-v1`
+
+## DO NOT IGNORE
+
+- Review workspaces must remain landlord/admin scoped.
+- Review workspace metadata must not mutate financial truth, ledger entries, decision derivation, or evidence source records.
+- Evidence refs and resource refs are lineage metadata, not raw payload copies.
+- Future institutional sharing requires separate export/profile governance.
+- Future agent or automation routing must remain supervised and policy-gated; this foundation does not authorize autonomous actions.

--- a/rentchain-api/src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import {
+  buildReviewWorkspace,
+  normalizeReviewWorkspace,
+  reviewWorkspaceToOperatorReviewOpenRequest,
+} from "../buildReviewWorkspace";
+
+const createdBy = { userId: "landlord-user-1", role: "landlord" as const, email: "ops@example.test" };
+
+describe("buildReviewWorkspace", () => {
+  it("builds deterministic manual-only review workspaces with scoped evidence linkage", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "delinquency_review",
+      workspaceScopeId: "lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      createdBy,
+      createdAt: "2026-05-20T10:00:00.000Z",
+      assignedReviewer: { userId: "operator-1", role: "operator" },
+      reviewPriority: "critical",
+      evidenceRefs: [
+        {
+          evidencePackId: "evidence-1",
+          evidenceItemId: "item-1",
+          label: "Missing payment evidence",
+          sourceCollection: "ledgerEntries",
+          sourceId: "ledger-1",
+          sensitivityClass: "sensitive",
+        },
+        {
+          evidencePackId: "evidence-1",
+          evidenceItemId: "item-1",
+          label: "Duplicate should collapse",
+          sourceCollection: "ledgerEntries",
+          sourceId: "ledger-1",
+        },
+      ],
+      relatedResourceRefs: [
+        {
+          resourceType: "lease",
+          resourceId: "lease-1",
+          label: "North Towers · Unit 104 lease context",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          unitId: "unit-104",
+          leaseId: "lease-1",
+        },
+      ],
+      createdFromEvent: {
+        eventId: "event-1",
+        eventType: "decision.workflow.review_required",
+        sourceSystem: "decision_workflow",
+      },
+      auditRefs: [{ auditId: "audit-1", eventType: "operator_review_session_opened", sourceCollection: "canonicalEvents" }],
+      reviewSummary: "Review missing payment evidence",
+      reviewTags: ["delinquency", "payment evidence", "delinquency"],
+    });
+    const duplicate = buildReviewWorkspace({
+      workspaceType: "delinquency_review",
+      workspaceScopeId: "lease-1",
+      landlordId: "landlord-1",
+      createdBy,
+      createdAt: "2026-05-20T10:00:00.000Z",
+    });
+
+    expect(workspace.workspaceId).toBe(duplicate.workspaceId);
+    expect(workspace).toEqual(
+      expect.objectContaining({
+        workspaceContractVersion: "review_workspace_foundation_v1",
+        workspaceType: "delinquency_review",
+        workspaceScope: "delinquency_review",
+        workspaceScopeId: "lease-1",
+        landlordId: "landlord-1",
+        reviewStatus: "open",
+        reviewPriority: "critical",
+        sensitivityClass: "sensitive",
+        visibilityClass: "landlord_operational",
+        manualOnly: true,
+        autonomousActionsEnabled: false,
+        externalSharingEnabled: false,
+        institutionalSharingEnabled: false,
+        financialMutationEnabled: false,
+      })
+    );
+    expect(workspace.evidenceRefs).toEqual([
+      {
+        evidencePackId: "evidence-1",
+        evidenceItemId: "item-1",
+        label: "Missing payment evidence",
+        sourceCollection: "ledgerEntries",
+        sourceId: "ledger-1",
+        sensitivityClass: "sensitive",
+      },
+    ]);
+    expect(workspace.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "lease",
+        resourceId: "lease-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+      }),
+    ]);
+    expect(workspace.reviewTags).toEqual(["delinquency", "payment_evidence"]);
+  });
+
+  it("excludes unrelated landlord and tenant resources from workspace linkage", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "payment_ledger_review",
+      workspaceScopeId: "payment-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      createdBy,
+      relatedResourceRefs: [
+        { resourceType: "payment", resourceId: "payment-1", label: "Scoped payment", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { resourceType: "payment", resourceId: "payment-2", label: "Wrong landlord", landlordId: "landlord-2", tenantId: "tenant-1" },
+        { resourceType: "payment", resourceId: "payment-3", label: "Wrong tenant", landlordId: "landlord-1", tenantId: "tenant-2" },
+      ],
+    });
+
+    expect(workspace.relatedResourceRefs).toEqual([
+      expect.objectContaining({ resourceId: "payment-1", label: "Scoped payment" }),
+    ]);
+    expect(JSON.stringify(workspace)).not.toContain("payment-2");
+    expect(JSON.stringify(workspace)).not.toContain("payment-3");
+  });
+
+  it("does not duplicate restricted raw payloads into review workspace metadata", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "screening_review",
+      workspaceScopeId: "screening-1",
+      landlordId: "landlord-1",
+      createdBy,
+      evidenceRefs: [
+        {
+          evidencePackId: "evidence-1",
+          label: "Screening status evidence",
+          rawPayload: { providerPayload: "raw provider dump" },
+          rawCsv: "raw csv data",
+          bankAccountNumber: "111122223333",
+          routeSource: "debug route",
+          stack: "private stack trace",
+        },
+      ],
+      relatedResourceRefs: [
+        {
+          resourceType: "screening_order",
+          resourceId: "screening-1",
+          label: "Screening review",
+          landlordId: "landlord-1",
+          providerPayload: "raw provider dump",
+          rawReport: "raw bureau report",
+          token: "secret-token",
+        },
+      ],
+      reviewNotes: ["<b>Manual review only</b>"],
+    });
+
+    expect(workspace.reviewNotes).toEqual(["bManual review only/b"]);
+    expectNoRestrictedProjectionFields(workspace);
+    expectPayloadDoesNotContainValues(workspace, [
+      "raw provider dump",
+      "raw csv data",
+      "111122223333",
+      "debug route",
+      "private stack trace",
+      "raw bureau report",
+      "secret-token",
+    ]);
+  });
+
+  it("bridges workspaces to existing operator review open requests without autonomous actions", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "evidence_review",
+      workspaceScopeId: "evidence-1",
+      landlordId: "landlord-1",
+      createdBy,
+      reviewSummary: "Review evidence package lineage",
+      evidenceRefs: [{ evidencePackId: "evidence-1", label: "Evidence pack", sensitivityClass: "restricted" }],
+    });
+
+    expect(reviewWorkspaceToOperatorReviewOpenRequest(workspace)).toEqual({
+      scope: "audit_compliance",
+      scopeId: "evidence-1",
+      linkedEvidence: [{ evidenceId: "evidence-1", label: "Evidence pack", kind: "workflow", destination: null }],
+      note: "Review evidence package lineage",
+    });
+  });
+
+  it("normalizes stored workspace records defensively", () => {
+    const normalized = normalizeReviewWorkspace({
+      workspaceId: "workspace-1",
+      workspaceType: "document_review",
+      workspaceScopeId: "lease-doc-1",
+      landlordId: "landlord-1",
+      createdBy,
+      createdAt: "2026-05-20T10:00:00.000Z",
+      updatedAt: "2026-05-20T10:05:00.000Z",
+      reviewStatus: "under_review",
+    });
+
+    expect(normalized).toEqual(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        workspaceType: "document_review",
+        reviewStatus: "under_review",
+        updatedAt: "2026-05-20T10:05:00.000Z",
+      })
+    );
+    expect(normalizeReviewWorkspace({ workspaceType: "document_review" })).toBeNull();
+  });
+});

--- a/rentchain-api/src/lib/reviewWorkspaces/buildReviewWorkspace.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/buildReviewWorkspace.ts
@@ -1,0 +1,310 @@
+import crypto from "crypto";
+import type { OperatorReviewOpenRequest, OperatorReviewScope } from "../operatorReviews/operatorReviewTypes";
+import {
+  REVIEW_WORKSPACE_CONTRACT_VERSION,
+  type BuildReviewWorkspaceInput,
+  type ReviewWorkspace,
+  type ReviewWorkspaceAuditRef,
+  type ReviewWorkspaceEventRef,
+  type ReviewWorkspaceEvidenceRef,
+  type ReviewWorkspacePriority,
+  type ReviewWorkspaceResourceRef,
+  type ReviewWorkspaceResourceType,
+  type ReviewWorkspaceReviewer,
+  type ReviewWorkspaceSensitivityClass,
+  type ReviewWorkspaceStatus,
+  type ReviewWorkspaceType,
+  type ReviewWorkspaceVisibilityClass,
+} from "./reviewWorkspaceTypes";
+
+const VALID_WORKSPACE_TYPES = new Set<ReviewWorkspaceType>([
+  "evidence_review",
+  "payment_ledger_review",
+  "screening_review",
+  "operational_anomaly_review",
+  "document_review",
+  "delinquency_review",
+]);
+
+const VALID_STATUSES = new Set<ReviewWorkspaceStatus>(["open", "under_review", "blocked", "completed", "escalated"]);
+const VALID_PRIORITIES = new Set<ReviewWorkspacePriority>(["critical", "warning", "needs_review", "upcoming", "info"]);
+const VALID_SENSITIVITY = new Set<ReviewWorkspaceSensitivityClass>(["sensitive", "restricted"]);
+const VALID_VISIBILITY = new Set<ReviewWorkspaceVisibilityClass>(["landlord_operational", "admin_support"]);
+const VALID_RESOURCE_TYPES = new Set<ReviewWorkspaceResourceType>([
+  "lease",
+  "tenant",
+  "property",
+  "unit",
+  "payment",
+  "ledger_entry",
+  "screening_order",
+  "document",
+  "decision",
+  "canonical_event",
+  "evidence_pack",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function toIsoDate(value: unknown): string | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function safeText(value: unknown, max = 1000): string {
+  return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+function workspaceTypeLabel(value: ReviewWorkspaceType): string {
+  if (value === "evidence_review") return "Evidence review";
+  if (value === "payment_ledger_review") return "Payment ledger review";
+  if (value === "screening_review") return "Screening review";
+  if (value === "operational_anomaly_review") return "Operational anomaly review";
+  if (value === "document_review") return "Document review";
+  return "Delinquency review";
+}
+
+export function reviewWorkspaceId(input: {
+  landlordId: string;
+  workspaceType: ReviewWorkspaceType;
+  workspaceScopeId: string;
+}): string {
+  const clean = cleanIdPart(["review_workspace", input.landlordId, input.workspaceType, input.workspaceScopeId].join(":"));
+  return clean || `review_workspace:${crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex")}`;
+}
+
+export function normalizeReviewWorkspaceReviewer(raw: unknown): ReviewWorkspaceReviewer {
+  const data = (raw || {}) as Record<string, unknown>;
+  const role = asString(data.role, 40).toLowerCase();
+  return {
+    userId: asString(data.userId || data.actorId || data.id, 240) || null,
+    role: role === "admin" || role === "operator" ? role : "landlord",
+    email: asString(data.email, 320) || null,
+  };
+}
+
+export function normalizeReviewWorkspaceEvidenceRefs(raw: unknown): ReviewWorkspaceEvidenceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const evidencePackId = asString(data.evidencePackId || data.evidenceId || data.id, 240);
+      const label = safeText(data.label, 160);
+      const sensitivityClass = asString(data.sensitivityClass, 40) as ReviewWorkspaceSensitivityClass;
+      if (!evidencePackId || !label) return null;
+      return {
+        evidencePackId,
+        evidenceItemId: asString(data.evidenceItemId, 240) || null,
+        label,
+        sourceCollection: asString(data.sourceCollection, 120) || null,
+        sourceId: asString(data.sourceId, 240) || null,
+        sensitivityClass: VALID_SENSITIVITY.has(sensitivityClass) ? sensitivityClass : "sensitive",
+      };
+    })
+    .filter(Boolean) as ReviewWorkspaceEvidenceRef[];
+
+  const byKey = new Map<string, ReviewWorkspaceEvidenceRef>();
+  for (const ref of refs) {
+    const key = [ref.evidencePackId, ref.evidenceItemId || "", ref.sourceCollection || "", ref.sourceId || ""].join(":");
+    if (!byKey.has(key)) byKey.set(key, ref);
+  }
+  return Array.from(byKey.values())
+    .sort((a, b) => `${a.evidencePackId}:${a.evidenceItemId || ""}`.localeCompare(`${b.evidencePackId}:${b.evidenceItemId || ""}`))
+    .slice(0, 24);
+}
+
+export function normalizeReviewWorkspaceResourceRefs(
+  raw: unknown,
+  scope: { landlordId: string; tenantId?: string | null }
+): ReviewWorkspaceResourceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const resourceType = asString(data.resourceType || data.type, 80) as ReviewWorkspaceResourceType;
+      const resourceId = asString(data.resourceId || data.id, 240);
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
+      if (!VALID_RESOURCE_TYPES.has(resourceType) || !resourceId) return null;
+      if (landlordId && landlordId !== scope.landlordId) return null;
+      if (scope.tenantId && tenantId && tenantId !== scope.tenantId) return null;
+      return {
+        resourceType,
+        resourceId,
+        label: safeText(data.label, 160) || `${resourceType.replace(/_/g, " ")} reference`,
+        landlordId,
+        tenantId,
+        propertyId: asString(data.propertyId, 240) || null,
+        unitId: asString(data.unitId, 240) || null,
+        leaseId: asString(data.leaseId, 240) || null,
+      };
+    })
+    .filter(Boolean) as ReviewWorkspaceResourceRef[];
+
+  const byKey = new Map<string, ReviewWorkspaceResourceRef>();
+  for (const ref of refs) byKey.set(`${ref.resourceType}:${ref.resourceId}`, ref);
+  return Array.from(byKey.values())
+    .sort((a, b) => `${a.resourceType}:${a.resourceId}`.localeCompare(`${b.resourceType}:${b.resourceId}`))
+    .slice(0, 32);
+}
+
+export function normalizeReviewWorkspaceEventRef(raw: unknown): ReviewWorkspaceEventRef | null {
+  const data = (raw || {}) as Record<string, unknown>;
+  const eventId = asString(data.eventId || data.id, 240);
+  const eventType = asString(data.eventType || data.type, 160);
+  if (!eventId || !eventType) return null;
+  return {
+    eventId,
+    eventType,
+    sourceSystem: asString(data.sourceSystem, 120) || null,
+  };
+}
+
+export function normalizeReviewWorkspaceAuditRefs(raw: unknown): ReviewWorkspaceAuditRef[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const auditId = asString(data.auditId || data.eventId || data.id, 240);
+      const eventType = asString(data.eventType || data.type, 160);
+      if (!auditId || !eventType) return null;
+      return {
+        auditId,
+        eventType,
+        sourceCollection: asString(data.sourceCollection, 120) || null,
+      };
+    })
+    .filter(Boolean) as ReviewWorkspaceAuditRef[];
+  const byKey = new Map<string, ReviewWorkspaceAuditRef>();
+  for (const ref of refs) byKey.set(`${ref.sourceCollection || "audit"}:${ref.auditId}`, ref);
+  return Array.from(byKey.values()).sort((a, b) => a.auditId.localeCompare(b.auditId)).slice(0, 24);
+}
+
+export function buildReviewWorkspace(input: BuildReviewWorkspaceInput): ReviewWorkspace {
+  const workspaceType = VALID_WORKSPACE_TYPES.has(input.workspaceType) ? input.workspaceType : "operational_anomaly_review";
+  const workspaceScopeId = asString(input.workspaceScopeId, 500);
+  const landlordId = asString(input.landlordId, 240);
+  if (!workspaceScopeId || !landlordId) {
+    throw new Error("review_workspace_scope_required");
+  }
+
+  const createdAt = toIsoDate(input.createdAt) || new Date().toISOString();
+  const reviewStatus = asString(input.reviewStatus, 40) as ReviewWorkspaceStatus;
+  const reviewPriority = asString(input.reviewPriority, 40) as ReviewWorkspacePriority;
+  const sensitivityClass = asString(input.sensitivityClass, 40) as ReviewWorkspaceSensitivityClass;
+  const visibilityClass = asString(input.visibilityClass, 40) as ReviewWorkspaceVisibilityClass;
+  const evidenceRefs = normalizeReviewWorkspaceEvidenceRefs(input.evidenceRefs);
+  const relatedResourceRefs = normalizeReviewWorkspaceResourceRefs(input.relatedResourceRefs, {
+    landlordId,
+    tenantId: input.tenantId,
+  });
+  const reviewNotes = Array.isArray(input.reviewNotes)
+    ? input.reviewNotes.map((note) => safeText(note, 1000)).filter(Boolean).slice(0, 20)
+    : [];
+  const reviewTags = uniqueSorted(
+    (Array.isArray(input.reviewTags) ? input.reviewTags : [])
+      .map((tag) => cleanIdPart(tag).replace(/:/g, "_"))
+      .filter(Boolean)
+  ).slice(0, 20);
+
+  return {
+    workspaceId: reviewWorkspaceId({ landlordId, workspaceType, workspaceScopeId }),
+    workspaceContractVersion: REVIEW_WORKSPACE_CONTRACT_VERSION,
+    workspaceType,
+    workspaceScope: workspaceType,
+    workspaceScopeId,
+    landlordId,
+    assignedReviewer: input.assignedReviewer ? normalizeReviewWorkspaceReviewer(input.assignedReviewer) : null,
+    reviewStatus: VALID_STATUSES.has(reviewStatus) ? reviewStatus : "open",
+    reviewPriority: VALID_PRIORITIES.has(reviewPriority) ? reviewPriority : "needs_review",
+    evidenceRefs,
+    relatedResourceRefs,
+    createdFromEvent: normalizeReviewWorkspaceEventRef(input.createdFromEvent),
+    createdBy: normalizeReviewWorkspaceReviewer(input.createdBy),
+    createdAt,
+    updatedAt: createdAt,
+    reviewSummary: safeText(input.reviewSummary, 500) || `${workspaceTypeLabel(workspaceType)} workspace`,
+    reviewNotes,
+    reviewTags,
+    auditRefs: normalizeReviewWorkspaceAuditRefs(input.auditRefs),
+    sensitivityClass: VALID_SENSITIVITY.has(sensitivityClass) ? sensitivityClass : "sensitive",
+    visibilityClass: VALID_VISIBILITY.has(visibilityClass) ? visibilityClass : "landlord_operational",
+    manualOnly: true,
+    autonomousActionsEnabled: false,
+    externalSharingEnabled: false,
+    institutionalSharingEnabled: false,
+    financialMutationEnabled: false,
+  };
+}
+
+function operatorScopeForWorkspace(workspaceType: ReviewWorkspaceType): OperatorReviewScope {
+  if (workspaceType === "delinquency_review") return "delinquency";
+  if (workspaceType === "evidence_review" || workspaceType === "document_review") return "audit_compliance";
+  return "workflow";
+}
+
+export function reviewWorkspaceToOperatorReviewOpenRequest(workspace: ReviewWorkspace): OperatorReviewOpenRequest {
+  return {
+    scope: operatorScopeForWorkspace(workspace.workspaceType),
+    scopeId: workspace.workspaceScopeId,
+    linkedEvidence: workspace.evidenceRefs.map((ref) => ({
+      evidenceId: ref.evidencePackId,
+      label: ref.label,
+      kind: "workflow",
+      destination: null,
+    })),
+    note: workspace.reviewSummary,
+  };
+}
+
+export function normalizeReviewWorkspace(raw: unknown): ReviewWorkspace | null {
+  const data = (raw || {}) as Record<string, unknown>;
+  try {
+    const workspace = buildReviewWorkspace({
+      workspaceType: data.workspaceType as ReviewWorkspaceType,
+      workspaceScopeId: data.workspaceScopeId,
+      landlordId: data.landlordId,
+      createdBy: data.createdBy as ReviewWorkspaceReviewer,
+      createdAt: data.createdAt,
+      assignedReviewer: data.assignedReviewer as ReviewWorkspaceReviewer | null,
+      reviewStatus: data.reviewStatus as ReviewWorkspaceStatus,
+      reviewPriority: data.reviewPriority as ReviewWorkspacePriority,
+      evidenceRefs: data.evidenceRefs as Array<Record<string, unknown>>,
+      relatedResourceRefs: data.relatedResourceRefs as Array<Record<string, unknown>>,
+      createdFromEvent: data.createdFromEvent as Record<string, unknown>,
+      reviewSummary: data.reviewSummary as string,
+      reviewNotes: data.reviewNotes as unknown[],
+      reviewTags: data.reviewTags as unknown[],
+      auditRefs: data.auditRefs as Array<Record<string, unknown>>,
+      sensitivityClass: data.sensitivityClass as ReviewWorkspaceSensitivityClass,
+      visibilityClass: data.visibilityClass as ReviewWorkspaceVisibilityClass,
+      tenantId: data.tenantId as string | null,
+    });
+    return {
+      ...workspace,
+      workspaceId: asString(data.workspaceId, 240) || workspace.workspaceId,
+      updatedAt: toIsoDate(data.updatedAt) || workspace.updatedAt,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/rentchain-api/src/lib/reviewWorkspaces/reviewWorkspaceTypes.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/reviewWorkspaceTypes.ts
@@ -1,0 +1,118 @@
+export const REVIEW_WORKSPACE_CONTRACT_VERSION = "review_workspace_foundation_v1";
+
+export type ReviewWorkspaceType =
+  | "evidence_review"
+  | "payment_ledger_review"
+  | "screening_review"
+  | "operational_anomaly_review"
+  | "document_review"
+  | "delinquency_review";
+
+export type ReviewWorkspaceStatus = "open" | "under_review" | "blocked" | "completed" | "escalated";
+
+export type ReviewWorkspacePriority = "critical" | "warning" | "needs_review" | "upcoming" | "info";
+
+export type ReviewWorkspaceSensitivityClass = "sensitive" | "restricted";
+
+export type ReviewWorkspaceVisibilityClass = "landlord_operational" | "admin_support";
+
+export type ReviewWorkspaceReviewer = {
+  userId: string | null;
+  role: "landlord" | "admin" | "operator";
+  email?: string | null;
+};
+
+export type ReviewWorkspaceEvidenceRef = {
+  evidencePackId: string;
+  evidenceItemId: string | null;
+  label: string;
+  sourceCollection: string | null;
+  sourceId: string | null;
+  sensitivityClass: ReviewWorkspaceSensitivityClass;
+};
+
+export type ReviewWorkspaceResourceType =
+  | "lease"
+  | "tenant"
+  | "property"
+  | "unit"
+  | "payment"
+  | "ledger_entry"
+  | "screening_order"
+  | "document"
+  | "decision"
+  | "canonical_event"
+  | "evidence_pack";
+
+export type ReviewWorkspaceResourceRef = {
+  resourceType: ReviewWorkspaceResourceType;
+  resourceId: string;
+  label: string;
+  landlordId: string | null;
+  tenantId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  leaseId: string | null;
+};
+
+export type ReviewWorkspaceEventRef = {
+  eventId: string;
+  eventType: string;
+  sourceSystem: string | null;
+};
+
+export type ReviewWorkspaceAuditRef = {
+  auditId: string;
+  eventType: string;
+  sourceCollection: string | null;
+};
+
+export type ReviewWorkspace = {
+  workspaceId: string;
+  workspaceContractVersion: typeof REVIEW_WORKSPACE_CONTRACT_VERSION;
+  workspaceType: ReviewWorkspaceType;
+  workspaceScope: ReviewWorkspaceType;
+  workspaceScopeId: string;
+  landlordId: string;
+  assignedReviewer: ReviewWorkspaceReviewer | null;
+  reviewStatus: ReviewWorkspaceStatus;
+  reviewPriority: ReviewWorkspacePriority;
+  evidenceRefs: ReviewWorkspaceEvidenceRef[];
+  relatedResourceRefs: ReviewWorkspaceResourceRef[];
+  createdFromEvent: ReviewWorkspaceEventRef | null;
+  createdBy: ReviewWorkspaceReviewer;
+  createdAt: string;
+  updatedAt: string;
+  reviewSummary: string;
+  reviewNotes: string[];
+  reviewTags: string[];
+  auditRefs: ReviewWorkspaceAuditRef[];
+  sensitivityClass: ReviewWorkspaceSensitivityClass;
+  visibilityClass: ReviewWorkspaceVisibilityClass;
+  manualOnly: true;
+  autonomousActionsEnabled: false;
+  externalSharingEnabled: false;
+  institutionalSharingEnabled: false;
+  financialMutationEnabled: false;
+};
+
+export type BuildReviewWorkspaceInput = {
+  workspaceType: ReviewWorkspaceType;
+  workspaceScopeId: string;
+  landlordId: string;
+  createdBy: ReviewWorkspaceReviewer;
+  createdAt?: string | Date | null;
+  assignedReviewer?: ReviewWorkspaceReviewer | null;
+  reviewStatus?: ReviewWorkspaceStatus | null;
+  reviewPriority?: ReviewWorkspacePriority | null;
+  evidenceRefs?: Array<Record<string, unknown>> | null;
+  relatedResourceRefs?: Array<Record<string, unknown>> | null;
+  createdFromEvent?: Record<string, unknown> | null;
+  reviewSummary?: string | null;
+  reviewNotes?: unknown[] | null;
+  reviewTags?: unknown[] | null;
+  auditRefs?: Array<Record<string, unknown>> | null;
+  sensitivityClass?: ReviewWorkspaceSensitivityClass | null;
+  visibilityClass?: ReviewWorkspaceVisibilityClass | null;
+  tenantId?: string | null;
+};


### PR DESCRIPTION
## Summary
- add a versioned review workspace foundation contract for landlord/admin-scoped operational review coordination
- add deterministic helper functions for workspace creation, normalization, scoped evidence refs, related resource refs, audit refs, and operator-review compatibility
- add targeted tests covering scoping, deterministic metadata, evidence linkage, restricted field exclusion, and non-autonomous safety flags
- document Review Workspace Foundations v1, including non-goals and follow-up work

## Audit findings
- Existing `operatorReviewSessions` already provide a manual-only review envelope and should remain the current persistence/review-session pattern.
- Evidence packs already include projection metadata and operator review session linkage.
- Decision actions and canonical event taxonomy already define append-oriented audit direction.
- Missing foundation: a broader workspace contract that can coordinate review scope, priority, assignment, evidence/resource linkage, and future routing without implementing automation or sharing.

## Review workspace contract summary
New contract/version: `review_workspace_foundation_v1`.

Supported v1 workspace types:
- `evidence_review`
- `payment_ledger_review`
- `screening_review`
- `operational_anomaly_review`
- `document_review`
- `delinquency_review`

Safety flags are explicit:
- `manualOnly: true`
- `autonomousActionsEnabled: false`
- `externalSharingEnabled: false`
- `institutionalSharingEnabled: false`
- `financialMutationEnabled: false`

## Evidence linkage summary
- Evidence refs carry evidence pack/item IDs, safe labels, source collection/source ID metadata, and sensitivity class.
- Related resource refs are landlord-scoped and can be tenant-scoped when a tenant scope is provided.
- Restricted/raw/provider/payment/debug fields are not copied into workspace metadata.
- Workspaces can bridge to existing `OperatorReviewOpenRequest` without changing operator review session behavior.

## Behavior preservation
- No auth changes.
- No Firestore schema/rules changes.
- No route visibility changes.
- No cross-tenant/cross-landlord visibility expansion.
- No institutional export expansion.
- No autonomous action, auto-decisioning, or workflow execution.
- No financial/ledger/payment mutation behavior changed.

## Tests run
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts src/lib/operatorReviews/__tests__/buildOperatorReviewSession.test.ts src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Known follow-ups
- Add route-level review workspace previews after scoping is reviewed.
- Add review workspace route scoping tests when routes exist.
- Integrate operator review session UI/workspace surfaces.
- Add deeper evidence pack linking helpers.
- Plan canonical event adapter semantics for workspace lifecycle events.