### PR TITLE
feat: add operational review routing foundations

### DIFF
--- a/docs/reports/operational-review-routing-foundations-v1.md
+++ b/docs/reports/operational-review-routing-foundations-v1.md
@@ -1,0 +1,114 @@
+# Operational Review Routing Foundations v1
+
+## Executive Summary
+
+Operational Review Routing Foundations v1 introduces deterministic, manual-only routing metadata that connects operational command center style signals to governed review workspace concepts.
+
+This mission does not create review workspaces automatically, mutate source workflows, change permissions, alter Firestore rules, broaden visibility, or introduce autonomous workflow behavior.
+
+## Purpose
+
+The routing foundation answers:
+
+- Is this operational item reviewable?
+- Why is it reviewable?
+- Which review workspace type would be appropriate if an operator manually starts review?
+- What priority should the review carry?
+- Which source workflow link and scoped resource references should travel with the handoff?
+
+## Contract
+
+Routing metadata includes:
+
+- `routingId`
+- `routingVersion`
+- `itemId`
+- `landlordId`
+- `reviewEligible`
+- `reviewReasonKey`
+- `reviewReasonLabel`
+- `reviewPriority`
+- `priorityLabel`
+- `workspaceType`
+- `workspaceScopeId`
+- `sourceDestination`
+- `relatedResourceRefs`
+
+Safety flags:
+
+- `manualOnly: true`
+- `autoCreateWorkspace: false`
+- `autonomousActionsEnabled: false`
+- `permissionWideningRequired: false`
+
+Version:
+
+- `operational_review_routing_v1`
+
+## Review Reason Taxonomy
+
+V1 reason keys:
+
+- `delinquency_review`
+- `payment_evidence_review`
+- `screening_review`
+- `lease_execution_review`
+- `document_review`
+- `occupancy_review`
+- `evidence_review`
+- `operational_anomaly_review`
+- `informational_not_reviewable`
+
+## Workspace Compatibility
+
+Routing decisions map to the review workspace foundation contract:
+
+- delinquency review -> delinquency review workspace
+- payment evidence review -> payment/ledger review workspace
+- screening review -> screening review workspace
+- document or lease execution review -> document review workspace
+- evidence review -> evidence review workspace
+- occupancy and general operational anomalies -> operational anomaly review workspace
+
+The helper can produce `BuildReviewWorkspaceInput` for a later manual action. It returns `null` for non-reviewable items.
+
+## Scope Safety
+
+Related resource refs are filtered by:
+
+- landlord scope
+- tenant scope when provided
+
+Cross-landlord and unrelated-tenant resource refs are excluded before handoff metadata is returned.
+
+## Non-Goals
+
+This mission does not:
+
+- create routes
+- persist routing decisions
+- create review workspaces automatically
+- auto-assign reviewers
+- resolve decisions
+- mutate payments, leases, ledger entries, or screening records
+- expose tenant review internals
+- expand institutional exports
+- introduce AI or agent behavior
+
+## Future Follow-Ups
+
+Recommended next missions:
+
+1. `feat/operations-review-handoff-ui-v1`
+2. `test/operational-review-routing-route-scoping-v1`
+3. `feat/manual-review-workspace-creation-v1`
+4. `fix/operations-review-routing-label-normalization-v1`
+5. `docs/review-routing-event-taxonomy-v1`
+
+## DO NOT IGNORE
+
+- Routing metadata is not authorization.
+- Review eligibility is not auto-execution.
+- Manual-only handoff must remain explicit.
+- Tenant-visible projections must not include review internals.
+- Cross-landlord and unrelated-tenant resource refs must remain excluded.

--- a/rentchain-api/src/lib/operationalReviewRouting/__tests__/deriveOperationalReviewRouting.test.ts
+++ b/rentchain-api/src/lib/operationalReviewRouting/__tests__/deriveOperationalReviewRouting.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { buildReviewWorkspace } from "../../reviewWorkspaces/buildReviewWorkspace";
+import {
+  buildReviewWorkspaceInputFromRouting,
+  deriveOperationalReviewRouting,
+  deriveOperationalReviewRoutingFromDecision,
+} from "../deriveOperationalReviewRouting";
+import type { DecisionInboxItem } from "../../decisions/decisionInboxTypes";
+
+function decision(overrides: Partial<DecisionInboxItem> = {}): DecisionInboxItem {
+  return {
+    id: "decision:review_missing_payment:lease-1",
+    title: "Missing payment review",
+    description: "Expected rent payment requires manual review.",
+    severity: "critical",
+    status: "open",
+    type: "billing",
+    source: "lease_ledger",
+    relatedEntity: { kind: "lease", id: "lease-1", label: "North Towers · Unit 104" },
+    destination: "/leases/lease-1/ledger",
+    automationEligible: false,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "escalated",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+    },
+    createdAt: "2026-05-20T00:00:00.000Z",
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("deriveOperationalReviewRouting", () => {
+  it("routes delinquency decisions to manual-only review workspace handoff metadata", () => {
+    const routing = deriveOperationalReviewRoutingFromDecision(decision(), {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+    });
+
+    expect(routing).toEqual(
+      expect.objectContaining({
+        routingVersion: "operational_review_routing_v1",
+        itemId: "decision:review_missing_payment:lease-1",
+        landlordId: "landlord-1",
+        reviewEligible: true,
+        reviewReasonKey: "delinquency_review",
+        reviewReasonLabel: "Delinquency review",
+        reviewPriority: "critical",
+        priorityLabel: "Critical review",
+        workspaceType: "delinquency_review",
+        workspaceScopeId: "decision:review_missing_payment:lease-1",
+        manualOnly: true,
+        autoCreateWorkspace: false,
+        autonomousActionsEnabled: false,
+        permissionWideningRequired: false,
+        sourceDestination: "/leases/lease-1/ledger",
+      })
+    );
+    expect(routing.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "lease",
+        resourceId: "lease-1",
+        label: "North Towers · Unit 104",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+      }),
+    ]);
+  });
+
+  it("keeps resolved or informational operational items out of review workspace eligibility", () => {
+    const routing = deriveOperationalReviewRoutingFromDecision(
+      decision({ status: "resolved", severity: "low", workflow: { ...decision().workflow, workflowState: "resolved" } }),
+      { landlordId: "landlord-1" }
+    );
+
+    expect(routing.reviewEligible).toBe(false);
+    expect(buildReviewWorkspaceInputFromRouting({ routing, createdBy: { userId: "user-1", role: "landlord" } })).toBeNull();
+  });
+
+  it("filters cross-landlord and unrelated tenant resource refs before handoff", () => {
+    const routing = deriveOperationalReviewRouting({
+      itemId: "payment-review-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      title: "Payment evidence review",
+      category: "payments",
+      severity: "medium",
+      status: "open",
+      relatedResourceRefs: [
+        { resourceType: "payment", resourceId: "payment-1", label: "Scoped payment", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { resourceType: "payment", resourceId: "payment-2", label: "Wrong landlord", landlordId: "landlord-2", tenantId: "tenant-1" },
+        { resourceType: "payment", resourceId: "payment-3", label: "Wrong tenant", landlordId: "landlord-1", tenantId: "tenant-2" },
+      ],
+    });
+
+    expect(routing.relatedResourceRefs).toEqual([
+      expect.objectContaining({ resourceId: "payment-1", label: "Scoped payment" }),
+    ]);
+    expect(JSON.stringify(routing)).not.toContain("payment-2");
+    expect(JSON.stringify(routing)).not.toContain("payment-3");
+  });
+
+  it("builds compatible review workspace input without creating a workspace automatically", () => {
+    const routing = deriveOperationalReviewRouting({
+      itemId: "screening-review-1",
+      landlordId: "landlord-1",
+      title: "Screening workflow requires review",
+      category: "screening",
+      severity: "high",
+      status: "open",
+      destination: "/applications/app-1",
+    });
+
+    const workspaceInput = buildReviewWorkspaceInputFromRouting({
+      routing,
+      createdBy: { userId: "landlord-user-1", role: "landlord" },
+      createdAt: "2026-05-20T12:00:00.000Z",
+    });
+
+    expect(workspaceInput).toEqual(
+      expect.objectContaining({
+        workspaceType: "screening_review",
+        workspaceScopeId: "screening-review-1",
+        landlordId: "landlord-1",
+        reviewPriority: "critical",
+        reviewStatus: "open",
+        reviewSummary: "Screening review",
+      })
+    );
+    const workspace = buildReviewWorkspace(workspaceInput!);
+    expect(workspace).toEqual(
+      expect.objectContaining({
+        workspaceType: "screening_review",
+        manualOnly: true,
+        autonomousActionsEnabled: false,
+        externalSharingEnabled: false,
+        institutionalSharingEnabled: false,
+        financialMutationEnabled: false,
+      })
+    );
+  });
+
+  it("maps operational categories into deterministic review reason taxonomy", () => {
+    expect(deriveOperationalReviewRouting({ itemId: "doc-1", landlordId: "landlord-1", category: "documents", status: "open" })).toEqual(
+      expect.objectContaining({ reviewReasonKey: "document_review", workspaceType: "document_review" })
+    );
+    expect(deriveOperationalReviewRouting({ itemId: "occ-1", landlordId: "landlord-1", category: "occupancy", status: "open" })).toEqual(
+      expect.objectContaining({ reviewReasonKey: "occupancy_review", workspaceType: "operational_anomaly_review" })
+    );
+    expect(deriveOperationalReviewRouting({ itemId: "evidence-1", landlordId: "landlord-1", category: "evidence", status: "open" })).toEqual(
+      expect.objectContaining({ reviewReasonKey: "evidence_review", workspaceType: "evidence_review" })
+    );
+  });
+});

--- a/rentchain-api/src/lib/operationalReviewRouting/deriveOperationalReviewRouting.ts
+++ b/rentchain-api/src/lib/operationalReviewRouting/deriveOperationalReviewRouting.ts
@@ -1,0 +1,232 @@
+import crypto from "crypto";
+import type { DecisionInboxItem } from "../decisions/decisionInboxTypes";
+import type { BuildReviewWorkspaceInput, ReviewWorkspacePriority, ReviewWorkspaceType } from "../reviewWorkspaces/reviewWorkspaceTypes";
+import type {
+  OperationalReviewReasonKey,
+  OperationalReviewResourceRefInput,
+  OperationalReviewRoutingCategory,
+  OperationalReviewRoutingDecision,
+  OperationalReviewRoutingInput,
+  OperationalReviewRoutingSeverity,
+  OperationalReviewRoutingStatus,
+} from "./operationalReviewRoutingTypes";
+import { OPERATIONAL_REVIEW_ROUTING_VERSION } from "./operationalReviewRoutingTypes";
+
+const INACTIVE_STATUSES = new Set(["resolved", "dismissed", "informational"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function lower(value: unknown): string {
+  return asString(value, 500).toLowerCase();
+}
+
+function safeLabel(value: unknown, fallback: string): string {
+  const raw = asString(value, 180).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  return raw || fallback;
+}
+
+function reviewReasonLabel(reason: OperationalReviewReasonKey): string {
+  if (reason === "delinquency_review") return "Delinquency review";
+  if (reason === "payment_evidence_review") return "Payment evidence review";
+  if (reason === "screening_review") return "Screening review";
+  if (reason === "lease_execution_review") return "Lease execution review";
+  if (reason === "document_review") return "Document review";
+  if (reason === "occupancy_review") return "Occupancy review";
+  if (reason === "evidence_review") return "Evidence review";
+  if (reason === "informational_not_reviewable") return "Informational only";
+  return "Operational anomaly review";
+}
+
+function priorityLabel(priority: ReviewWorkspacePriority): string {
+  if (priority === "critical") return "Critical review";
+  if (priority === "warning") return "Warning review";
+  if (priority === "needs_review") return "Needs review";
+  if (priority === "upcoming") return "Upcoming review";
+  return "Informational";
+}
+
+function priorityFromInput(input: OperationalReviewRoutingInput): ReviewWorkspacePriority {
+  const severity = lower(input.severity);
+  const escalation = lower(input.escalationLevel);
+  const status = lower(input.status);
+  if (severity === "critical" || severity === "high" || escalation === "critical" || escalation === "urgent") {
+    return "critical";
+  }
+  if (status === "blocked" || severity === "medium" || escalation === "attention") return "warning";
+  if (input.category === "lease_lifecycle" || input.category === "occupancy") return "upcoming";
+  if (severity === "info" || status === "informational") return "info";
+  return "needs_review";
+}
+
+function reasonFromInput(input: OperationalReviewRoutingInput): OperationalReviewReasonKey {
+  const haystack = [
+    input.itemId,
+    input.title,
+    input.description,
+    input.category,
+    input.workflowQueue,
+    input.workflowState,
+    input.reviewStatus,
+    input.financialStatus,
+  ]
+    .map(lower)
+    .join(" ");
+
+  if (INACTIVE_STATUSES.has(lower(input.status)) || input.category === "operations" && lower(input.severity) === "info") {
+    return "informational_not_reviewable";
+  }
+  if (input.category === "evidence" || haystack.includes("evidence_pack")) return "evidence_review";
+  if (input.category === "screening" || haystack.includes("screening")) return "screening_review";
+  if (input.category === "documents" || haystack.includes("document") || haystack.includes("signature")) return "document_review";
+  if (input.category === "occupancy" || haystack.includes("occupancy") || haystack.includes("vacancy")) return "occupancy_review";
+  if (haystack.includes("delinquen") || haystack.includes("overdue") || haystack.includes("missing_payment")) {
+    return "delinquency_review";
+  }
+  if (input.category === "payments" || haystack.includes("payment") || haystack.includes("ledger")) {
+    return "payment_evidence_review";
+  }
+  if (input.category === "lease_lifecycle" || haystack.includes("lease")) return "lease_execution_review";
+  return "operational_anomaly_review";
+}
+
+function workspaceTypeFromReason(reason: OperationalReviewReasonKey): ReviewWorkspaceType {
+  if (reason === "delinquency_review") return "delinquency_review";
+  if (reason === "payment_evidence_review") return "payment_ledger_review";
+  if (reason === "screening_review") return "screening_review";
+  if (reason === "document_review" || reason === "lease_execution_review") return "document_review";
+  if (reason === "evidence_review") return "evidence_review";
+  return "operational_anomaly_review";
+}
+
+function routingId(input: { landlordId: string; itemId: string; reason: OperationalReviewReasonKey }) {
+  const clean = cleanIdPart(["review_routing", input.landlordId, input.reason, input.itemId].join(":"));
+  return clean || `review_routing:${crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex")}`;
+}
+
+function normalizeRelatedResourceRefs(input: OperationalReviewRoutingInput): OperationalReviewResourceRefInput[] {
+  const refs = Array.isArray(input.relatedResourceRefs) ? input.relatedResourceRefs : [];
+  const scoped = refs
+    .map((ref) => ({
+      resourceType: asString(ref.resourceType, 80),
+      resourceId: asString(ref.resourceId, 240),
+      label: safeLabel(ref.label, "Operational resource"),
+      landlordId: asString(ref.landlordId, 240) || null,
+      tenantId: asString(ref.tenantId, 240) || null,
+      propertyId: asString(ref.propertyId, 240) || null,
+      unitId: asString(ref.unitId, 240) || null,
+      leaseId: asString(ref.leaseId, 240) || null,
+    }))
+    .filter((ref) => ref.resourceType && ref.resourceId)
+    .filter((ref) => !ref.landlordId || ref.landlordId === input.landlordId)
+    .filter((ref) => !input.tenantId || !ref.tenantId || ref.tenantId === input.tenantId);
+  const byKey = new Map<string, OperationalReviewResourceRefInput>();
+  for (const ref of scoped) {
+    const key = `${ref.resourceType}:${ref.resourceId}`;
+    if (!byKey.has(key)) byKey.set(key, ref);
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.resourceType}:${a.resourceId}`.localeCompare(`${b.resourceType}:${b.resourceId}`)
+  );
+}
+
+export function deriveOperationalReviewRouting(input: OperationalReviewRoutingInput): OperationalReviewRoutingDecision {
+  const itemId = asString(input.itemId, 500);
+  const landlordId = asString(input.landlordId, 240);
+  if (!itemId || !landlordId) throw new Error("operational_review_routing_scope_required");
+
+  const reason = reasonFromInput(input);
+  const reviewPriority = priorityFromInput(input);
+  const reviewEligible = reason !== "informational_not_reviewable" && !INACTIVE_STATUSES.has(lower(input.status));
+  return {
+    routingId: routingId({ landlordId, itemId, reason }),
+    routingVersion: OPERATIONAL_REVIEW_ROUTING_VERSION,
+    itemId,
+    landlordId,
+    reviewEligible,
+    reviewReasonKey: reason,
+    reviewReasonLabel: reviewReasonLabel(reason),
+    reviewPriority,
+    priorityLabel: priorityLabel(reviewPriority),
+    workspaceType: workspaceTypeFromReason(reason),
+    workspaceScopeId: itemId,
+    manualOnly: true,
+    autoCreateWorkspace: false,
+    autonomousActionsEnabled: false,
+    permissionWideningRequired: false,
+    sourceDestination: asString(input.destination, 500) || null,
+    relatedResourceRefs: normalizeRelatedResourceRefs(input),
+  };
+}
+
+export function deriveOperationalReviewRoutingFromDecision(
+  decision: DecisionInboxItem,
+  scope: { landlordId: string; tenantId?: string | null }
+): OperationalReviewRoutingDecision {
+  const relatedResourceRefs: OperationalReviewResourceRefInput[] = decision.relatedEntity
+    ? [
+        {
+          resourceType: decision.relatedEntity.kind === "maintenance_request" ? "document" : decision.relatedEntity.kind,
+          resourceId: decision.relatedEntity.id,
+          label: decision.relatedEntity.label,
+          landlordId: scope.landlordId,
+          tenantId: scope.tenantId || null,
+        },
+      ]
+    : [];
+  return deriveOperationalReviewRouting({
+    itemId: decision.id,
+    landlordId: scope.landlordId,
+    tenantId: scope.tenantId || null,
+    title: decision.title,
+    description: decision.description,
+    category: categoryFromDecision(decision),
+    severity: decision.severity as OperationalReviewRoutingSeverity,
+    status: decision.status as OperationalReviewRoutingStatus,
+    workflowQueue: decision.workflow?.queue,
+    workflowState: decision.workflow?.workflowState,
+    escalationLevel: decision.workflow?.escalationLevel,
+    reviewStatus: decision.workflow?.reviewPriority,
+    destination: decision.destination,
+    relatedResourceRefs,
+  });
+}
+
+function categoryFromDecision(decision: DecisionInboxItem): OperationalReviewRoutingCategory {
+  if (decision.workflow?.queue === "delinquency_review" || decision.type === "billing") return "payments";
+  if (decision.workflow?.queue === "screening_review" || decision.type === "screening") return "screening";
+  if (decision.workflow?.queue === "lease_review" || decision.type === "lease") return "lease_lifecycle";
+  if (decision.workflow?.queue === "maintenance_review" || decision.type === "maintenance") return "operations";
+  if (decision.workflow?.queue === "admin_review" || decision.type === "admin") return "review_workflow";
+  return "review_workflow";
+}
+
+export function buildReviewWorkspaceInputFromRouting(input: {
+  routing: OperationalReviewRoutingDecision;
+  createdBy: BuildReviewWorkspaceInput["createdBy"];
+  createdAt?: string | Date | null;
+}): BuildReviewWorkspaceInput | null {
+  if (!input.routing.reviewEligible) return null;
+  return {
+    workspaceType: input.routing.workspaceType,
+    workspaceScopeId: input.routing.workspaceScopeId,
+    landlordId: input.routing.landlordId,
+    createdBy: input.createdBy,
+    createdAt: input.createdAt,
+    reviewPriority: input.routing.reviewPriority,
+    reviewStatus: "open",
+    relatedResourceRefs: input.routing.relatedResourceRefs,
+    reviewSummary: input.routing.reviewReasonLabel,
+    reviewTags: [input.routing.reviewReasonKey, input.routing.reviewPriority],
+  };
+}

--- a/rentchain-api/src/lib/operationalReviewRouting/operationalReviewRoutingTypes.ts
+++ b/rentchain-api/src/lib/operationalReviewRouting/operationalReviewRoutingTypes.ts
@@ -1,0 +1,84 @@
+import type { ReviewWorkspacePriority, ReviewWorkspaceType } from "../reviewWorkspaces/reviewWorkspaceTypes";
+
+export const OPERATIONAL_REVIEW_ROUTING_VERSION = "operational_review_routing_v1";
+
+export type OperationalReviewReasonKey =
+  | "delinquency_review"
+  | "payment_evidence_review"
+  | "screening_review"
+  | "lease_execution_review"
+  | "document_review"
+  | "occupancy_review"
+  | "evidence_review"
+  | "operational_anomaly_review"
+  | "informational_not_reviewable";
+
+export type OperationalReviewRoutingCategory =
+  | "payments"
+  | "screening"
+  | "lease_lifecycle"
+  | "documents"
+  | "occupancy"
+  | "evidence"
+  | "review_workflow"
+  | "operations";
+
+export type OperationalReviewRoutingSeverity = "critical" | "high" | "medium" | "low" | "info" | "unknown";
+
+export type OperationalReviewRoutingStatus =
+  | "open"
+  | "pending"
+  | "blocked"
+  | "resolved"
+  | "dismissed"
+  | "informational"
+  | "unknown";
+
+export type OperationalReviewResourceRefInput = {
+  resourceType: string;
+  resourceId: string;
+  label?: string | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  leaseId?: string | null;
+};
+
+export type OperationalReviewRoutingInput = {
+  itemId: string;
+  landlordId: string;
+  tenantId?: string | null;
+  title?: string | null;
+  description?: string | null;
+  category?: OperationalReviewRoutingCategory | null;
+  severity?: OperationalReviewRoutingSeverity | null;
+  status?: OperationalReviewRoutingStatus | null;
+  workflowQueue?: string | null;
+  workflowState?: string | null;
+  escalationLevel?: string | null;
+  reviewStatus?: string | null;
+  financialStatus?: string | null;
+  destination?: string | null;
+  relatedResourceRefs?: OperationalReviewResourceRefInput[] | null;
+};
+
+export type OperationalReviewRoutingDecision = {
+  routingId: string;
+  routingVersion: typeof OPERATIONAL_REVIEW_ROUTING_VERSION;
+  itemId: string;
+  landlordId: string;
+  reviewEligible: boolean;
+  reviewReasonKey: OperationalReviewReasonKey;
+  reviewReasonLabel: string;
+  reviewPriority: ReviewWorkspacePriority;
+  priorityLabel: string;
+  workspaceType: ReviewWorkspaceType;
+  workspaceScopeId: string;
+  manualOnly: true;
+  autoCreateWorkspace: false;
+  autonomousActionsEnabled: false;
+  permissionWideningRequired: false;
+  sourceDestination: string | null;
+  relatedResourceRefs: OperationalReviewResourceRefInput[];
+};


### PR DESCRIPTION
## Summary
- add deterministic operational review routing metadata helpers for operational items and decision inbox items
- map review reasons to manual-only review workspace handoff metadata without creating workspaces automatically
- filter related resource refs by landlord and tenant scope before handoff metadata is produced
- document Operational Review Routing Foundations v1 and future follow-ups

## Audit findings
- Existing decision workflow routing already derives manual-only queue/priority/escalation metadata.
- The Operational Command Center is currently frontend-derived, so this PR avoids changing UI behavior or backend contracts.
- PR #953 added review workspace contracts; this PR adds a backend routing bridge that can prepare future manual handoff metadata without writes.

## Routing foundation summary
New version: `operational_review_routing_v1`.

Reason taxonomy:
- `delinquency_review`
- `payment_evidence_review`
- `screening_review`
- `lease_execution_review`
- `document_review`
- `occupancy_review`
- `evidence_review`
- `operational_anomaly_review`
- `informational_not_reviewable`

Safety flags:
- `manualOnly: true`
- `autoCreateWorkspace: false`
- `autonomousActionsEnabled: false`
- `permissionWideningRequired: false`

## Behavior preservation
- No routes added or changed.
- No Firestore schema/rules changes.
- No auth behavior changes.
- No visibility widening.
- No tenant-visible review internals.
- No autonomous agent behavior.
- No review workspace auto-creation.
- No financial/payment/ledger mutation.
- No institutional export expansion.

## Tests run
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/operationalReviewRouting/__tests__/deriveOperationalReviewRouting.test.ts src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts src/lib/decisions/__tests__/deriveDecisionWorkflowRouting.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Known follow-ups
- Add /operations manual review handoff UI after routing metadata is reviewed.
- Add route-level scoping tests when review routing routes exist.
- Add manual review workspace creation flow with explicit operator action.
- Add routing event taxonomy documentation for future canonical event adapters.