### PR TITLE
feat: add review workspace UI foundations

### DIFF
--- a/docs/reports/review-workspace-ui-foundations-v1.md
+++ b/docs/reports/review-workspace-ui-foundations-v1.md
@@ -1,0 +1,91 @@
+# Review Workspace UI Foundations v1
+
+## Executive Summary
+
+Review Workspace UI Foundations v1 introduces the first read-only operator-facing presentation layer for governed review workspaces.
+
+This phase is deliberately narrow. It surfaces deterministic review workspace readiness metadata inside the operational command center without creating workspaces, mutating workflows, broadening visibility, or introducing autonomous review behavior.
+
+## UI Philosophy
+
+Review workspace UI should help an operator understand:
+
+- what review context would be used
+- why the item is reviewable
+- which source workflow and related resource are in scope
+- whether evidence can be linked during manual review
+- which status, priority, sensitivity, and visibility classes apply
+
+The UI must not imply that financial truth, ledger records, tenant visibility, or source workflow state changes when review metadata is displayed.
+
+## V1 Surface
+
+V1 adds a read-only review workspace readiness panel to operational command center items.
+
+The panel presents:
+
+- workspace type
+- review status
+- review priority
+- routing reason
+- assignment label
+- sensitivity class
+- visibility class
+- scoped evidence/source workflow link
+- related operational resource label
+- internal workspace reference label
+
+The panel is a manual handoff preview only. It does not call review APIs, create review sessions, create review workspaces, route work automatically, or perform source workflow actions.
+
+## Manual-Only Expectations
+
+The UI explicitly communicates:
+
+- manual-only review context
+- no workspace creation from the panel
+- no automatic routing
+- no source record mutation
+
+This preserves the existing operational vs financial separation and keeps review workspace foundations compatible with the manual handoff model.
+
+## Evidence Linkage Direction
+
+V1 links to the scoped source workflow as evidence context. It does not duplicate evidence payloads, raw provider data, message bodies, raw CSV values, payment credentials, or restricted exports into the UI model.
+
+Future work can attach persisted evidence pack references after review workspace creation becomes a manual, reviewed action.
+
+## Routing Compatibility
+
+The UI model aligns with the operational review routing foundation:
+
+- payment and delinquency signals map to payment ledger review
+- screening signals map to screening review
+- lease lifecycle and document signals map to document review
+- occupancy signals map to operational anomaly review
+- non-specialized operational signals map to evidence or operational review context
+
+This is presentation compatibility only. V1 does not trigger routing execution.
+
+## Non-Goals
+
+This phase does not introduce:
+
+- autonomous review actions
+- automatic workspace creation
+- tenant-visible review internals
+- institutional collaboration
+- cross-landlord review visibility
+- financial mutations
+- Firestore rule changes
+- auth changes
+- route changes
+
+## Future Follow-Ups
+
+Recommended next steps after review:
+
+1. Add a manual, audited review workspace creation action when governance approves write behavior.
+2. Add persisted review workspace list/detail routes with landlord/admin scoping.
+3. Link persisted evidence pack references after workspace creation.
+4. Add review workspace timeline integration using canonical event taxonomy.
+5. Add assignment controls only after ownership and escalation semantics are reviewed.

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReviewWorkspacePanel, type ReviewWorkspaceUiModel } from "./ReviewWorkspacePanel";
+
+function workspace(overrides: Partial<ReviewWorkspaceUiModel> = {}): ReviewWorkspaceUiModel {
+  return {
+    workspaceReference: "manual-review-preview:payments:critical",
+    workspaceType: "payment_ledger_review",
+    reviewStatus: "Open",
+    reviewPriority: "Critical",
+    routingReason: "Delinquency or payment evidence review",
+    assignmentLabel: "Operations owned",
+    sensitivityClass: "sensitive",
+    visibilityClass: "landlord_operational",
+    manualOnly: true,
+    autonomousActionsEnabled: false,
+    evidenceLinks: [{ label: "Payments / obligations source workflow", destination: "/leases/lease-1/ledger" }],
+    relatedResources: [{ label: "North Towers · Unit 104 · James Smith", resourceType: "lease" }],
+    ...overrides,
+  };
+}
+
+describe("ReviewWorkspacePanel", () => {
+  it("renders deterministic manual-only review metadata without actions", () => {
+    render(
+      <MemoryRouter>
+        <ReviewWorkspacePanel workspace={workspace()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Review workspace readiness")).toBeInTheDocument();
+    expect(screen.getByText(/does not create a workspace, route work automatically, or change source records/i)).toBeInTheDocument();
+    expect(screen.getByText("Payment Ledger Review")).toBeInTheDocument();
+    expect(screen.getByText("Delinquency or payment evidence review")).toBeInTheDocument();
+    expect(screen.getByText("Landlord Operational")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Payments / obligations source workflow" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByText("North Towers · Unit 104 · James Smith")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto-create/i)).not.toBeInTheDocument();
+  });
+
+  it("does not render raw resource identifiers as primary labels", () => {
+    render(
+      <MemoryRouter>
+        <ReviewWorkspacePanel
+          workspace={workspace({
+            evidenceLinks: [{ label: "Decision decision:review_missing_payment:lease_lifecycle:jjua9wfkdv19d5y5sdv7" }],
+            relatedResources: [{ label: "Lease JK6S7JQ2HsMj8m8RFI76", resourceType: "lease" }],
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Source workflow evidence")).toBeInTheDocument();
+    expect(screen.getByText("Lease context")).toBeInTheDocument();
+    expect(screen.queryByText(/Decision decision:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lease JK6S7JQ2HsMj8m8RFI76/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Card } from "@/components/ui/Ui";
+
+export type ReviewWorkspaceUiLink = {
+  label: string;
+  destination?: string | null;
+  sensitivityClass?: "sensitive" | "restricted" | string | null;
+};
+
+export type ReviewWorkspaceUiResource = {
+  label: string;
+  resourceType: string;
+};
+
+export type ReviewWorkspaceUiModel = {
+  workspaceReference: string;
+  workspaceType: string;
+  reviewStatus: string;
+  reviewPriority: string;
+  routingReason: string;
+  assignmentLabel: string;
+  sensitivityClass: "sensitive" | "restricted" | string;
+  visibilityClass: "landlord_operational" | "admin_support" | string;
+  manualOnly: true;
+  autonomousActionsEnabled: false;
+  evidenceLinks: ReviewWorkspaceUiLink[];
+  relatedResources: ReviewWorkspaceUiResource[];
+};
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function safeLabel(value: string, fallback: string) {
+  const raw = String(value || "").replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  if (!raw) return fallback;
+  if (/^(Lease|Property|Tenant|Unit|Decision)\s+[A-Za-z0-9:_-]{12,}$/i.test(raw)) return fallback;
+  return raw;
+}
+
+function metadataCell(labelText: string, value: string) {
+  return (
+    <div style={{ display: "grid", gap: 2, minWidth: 0 }}>
+      <span style={{ color: "#64748b", fontSize: 11, fontWeight: 900, textTransform: "uppercase" }}>{labelText}</span>
+      <span style={{ color: "#0f172a", fontSize: 13, fontWeight: 900, overflowWrap: "anywhere" }}>{value}</span>
+    </div>
+  );
+}
+
+export function ReviewWorkspacePanel({ workspace }: { workspace: ReviewWorkspaceUiModel }) {
+  return (
+    <Card
+      style={{
+        borderRadius: 8,
+        padding: 12,
+        background: "#f8fafc",
+        border: "1px solid #dbe3ef",
+        display: "grid",
+        gap: 10,
+        minWidth: 0,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "start" }}>
+        <div style={{ display: "grid", gap: 3, minWidth: 0 }}>
+          <strong style={{ color: "#0f172a", fontSize: 14 }}>Review workspace readiness</strong>
+          <span style={{ color: "#475569", fontSize: 13, lineHeight: 1.45 }}>
+            Manual-only review context. This panel does not create a workspace, route work automatically, or change source records.
+          </span>
+        </div>
+        <span
+          style={{
+            border: "1px solid #bfdbfe",
+            background: "#dbeafe",
+            color: "#1d4ed8",
+            borderRadius: 999,
+            padding: "3px 9px",
+            fontSize: 12,
+            fontWeight: 900,
+            whiteSpace: "nowrap",
+          }}
+        >
+          Manual only
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 150px), 1fr))",
+          gap: 8,
+          minWidth: 0,
+        }}
+      >
+        {metadataCell("Workspace type", label(workspace.workspaceType))}
+        {metadataCell("Review status", workspace.reviewStatus)}
+        {metadataCell("Priority", workspace.reviewPriority)}
+        {metadataCell("Routing reason", workspace.routingReason)}
+        {metadataCell("Assignment", workspace.assignmentLabel)}
+        {metadataCell("Sensitivity", label(workspace.sensitivityClass))}
+        {metadataCell("Visibility", label(workspace.visibilityClass))}
+      </div>
+
+      <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+        <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Scoped evidence linkage</span>
+        {workspace.evidenceLinks.length ? (
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {workspace.evidenceLinks.map((link) =>
+              link.destination ? (
+                <Link key={`${link.label}:${link.destination}`} to={link.destination} style={{ color: "#2563eb", fontSize: 13, fontWeight: 900 }}>
+                  {safeLabel(link.label, "Source workflow evidence")}
+                </Link>
+              ) : (
+                <span key={link.label} style={{ color: "#475569", fontSize: 13, fontWeight: 800 }}>
+                  {safeLabel(link.label, "Source workflow evidence")}
+                </span>
+              )
+            )}
+          </div>
+        ) : (
+          <span style={{ color: "#64748b", fontSize: 13 }}>Evidence can be attached during a manual review handoff.</span>
+        )}
+      </div>
+
+      <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+        <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Related resources</span>
+        {workspace.relatedResources.length ? (
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {workspace.relatedResources.map((resource) => (
+              <span
+                key={`${resource.resourceType}:${resource.label}`}
+                style={{
+                  border: "1px solid #e2e8f0",
+                  borderRadius: 999,
+                  padding: "3px 8px",
+                  color: "#475569",
+                  fontSize: 12,
+                  fontWeight: 800,
+                  background: "#fff",
+                }}
+              >
+                {safeLabel(resource.label, `${label(resource.resourceType)} context`)}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span style={{ color: "#64748b", fontSize: 13 }}>No related resources are displayed outside the scoped source workflow.</span>
+        )}
+      </div>
+
+      <div style={{ color: "#64748b", fontSize: 12 }}>
+        Internal workspace reference: {safeLabel(workspace.workspaceReference, "Manual review handoff preview")}
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import OperationalCommandCenterPage, { deriveCommandCenterSignals, prioritizeOperationalItems } from "./OperationalCommandCenterPage";
+import OperationalCommandCenterPage, {
+  deriveCommandCenterSignals,
+  prioritizeOperationalItems,
+  reviewWorkspacePreviewForSignal,
+} from "./OperationalCommandCenterPage";
 
 const mocks = vi.hoisted(() => ({
   fetchDecisionInbox: vi.fn(),
@@ -272,6 +276,35 @@ describe("deriveCommandCenterSignals", () => {
     expect(signals).toEqual([]);
   });
 
+  it("derives manual-only review workspace preview metadata from operational signals", () => {
+    const signal = deriveCommandCenterSignals({
+      decisions: [decision()],
+      leases: [lease()],
+      properties: [],
+    }).find((item) => item.id === "decision:decision-1");
+
+    expect(signal).toBeTruthy();
+    const preview = reviewWorkspacePreviewForSignal(signal!);
+    expect(preview).toEqual(
+      expect.objectContaining({
+        workspaceType: "payment_ledger_review",
+        reviewStatus: "Open",
+        reviewPriority: "Critical",
+        routingReason: "Delinquency or payment evidence review",
+        visibilityClass: "landlord_operational",
+        manualOnly: true,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(preview.evidenceLinks).toEqual([
+      expect.objectContaining({
+        label: "Payments / obligations source workflow",
+        destination: "/leases/lease-1/ledger",
+      }),
+    ]);
+    expect(preview.relatedResources).toEqual([expect.objectContaining({ label: "North Towers · 101 · John Smith" })]);
+  });
+
   it("normalizes raw decision context labels with operational lease and property references", () => {
     const signals = deriveCommandCenterSignals({
       decisions: [
@@ -400,6 +433,11 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Assignment: Operations owned").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Escalation: Critical").length).toBeGreaterThan(0);
     expect(screen.getByText("Next action: Review payment evidence")).toBeInTheDocument();
+    expect(screen.getAllByText("Review workspace readiness").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/does not create a workspace, route work automatically, or change source records/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Payment Ledger Review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Delinquency or payment evidence review").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /create review workspace/i })).not.toBeInTheDocument();
     expect(screen.getByText("Saved operational views")).toBeInTheDocument();
     expect(screen.getByTestId("operations-filter-panel")).toHaveStyle({
       display: "grid",

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -10,6 +10,7 @@ import {
 import { getActiveLeasesForLandlord, type LandlordActiveLease } from "@/api/leasesApi";
 import { fetchProperties, type Property } from "@/api/propertiesApi";
 import { MacShell } from "@/components/layout/MacShell";
+import { ReviewWorkspacePanel, type ReviewWorkspaceUiModel } from "@/components/reviewWorkspaces/ReviewWorkspacePanel";
 import { Card, Section } from "@/components/ui/Ui";
 
 type CommandCenterCategory =
@@ -265,6 +266,51 @@ function priorityRank(group: CommandCenterPriorityGroup) {
 
 function severityRank(severity: CommandCenterSeverity) {
   return { critical: 0, warning: 1, info: 2 }[severity];
+}
+
+function workspaceTypeForSignal(signal: CommandCenterSignal) {
+  if (signal.category === "payments") return "payment_ledger_review";
+  if (signal.category === "screening") return "screening_review";
+  if (signal.category === "documents" || signal.category === "lease_lifecycle") return "document_review";
+  if (signal.category === "occupancy") return "operational_anomaly_review";
+  return "evidence_review";
+}
+
+function routingReasonForSignal(signal: CommandCenterSignal) {
+  if (signal.category === "payments" || signal.riskState === "delinquent") return "Delinquency or payment evidence review";
+  if (signal.category === "screening") return "Screening workflow review";
+  if (signal.category === "documents") return "Document review";
+  if (signal.category === "lease_lifecycle") return "Lease execution review";
+  if (signal.category === "occupancy") return "Occupancy review";
+  return "Operational review";
+}
+
+export function reviewWorkspacePreviewForSignal(signal: CommandCenterSignal): ReviewWorkspaceUiModel {
+  return {
+    workspaceReference: `manual-review-preview:${signal.category}:${signal.priorityGroup}`,
+    workspaceType: workspaceTypeForSignal(signal),
+    reviewStatus: signal.reviewStatus,
+    reviewPriority: label(signal.priorityGroup),
+    routingReason: routingReasonForSignal(signal),
+    assignmentLabel: signal.assignmentLabel || "Unassigned",
+    sensitivityClass: signal.category === "screening" || signal.category === "documents" ? "restricted" : "sensitive",
+    visibilityClass: "landlord_operational",
+    manualOnly: true,
+    autonomousActionsEnabled: false,
+    evidenceLinks: [
+      {
+        label: `${CATEGORY_CONFIG[signal.category].label} source workflow`,
+        destination: signal.destination,
+        sensitivityClass: signal.category === "screening" || signal.category === "documents" ? "restricted" : "sensitive",
+      },
+    ],
+    relatedResources: [
+      {
+        label: signal.contextLabel,
+        resourceType: signal.category === "occupancy" ? "property" : signal.category === "payments" ? "lease" : "workflow",
+      },
+    ],
+  };
 }
 
 function priorityFromDecision(item: DecisionInboxItem, category: CommandCenterCategory): CommandCenterPriorityGroup {
@@ -1317,6 +1363,7 @@ export default function OperationalCommandCenterPage() {
                             <span>Assignment: {signal.assignmentLabel || "Unassigned"}</span>
                             <span>Escalation: {signal.escalationLabel || "Not escalated"}</span>
                           </div>
+                          <ReviewWorkspacePanel workspace={reviewWorkspacePreviewForSignal(signal)} />
                         </Card>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary
- Adds a read-only Review Workspace readiness panel for operational command center items.
- Surfaces deterministic manual-only review metadata, scoped evidence/source links, related operational resource labels, sensitivity, visibility, priority, and routing reason.
- Adds governance documentation for review workspace UI v1 and focused frontend coverage.

## Audit findings
- Existing review workspace foundations are backend helper/contracts only and remain manual-only.
- Operational review routing produces metadata-only handoff context and does not create workspaces.
- `/operations` is the lowest-risk initial UI surface because it already displays operational source workflow items without write behavior.

## Guardrails / behavior preservation
- No review workspaces are auto-created.
- No autonomous actions, routing execution, financial mutations, auth changes, schema changes, Firestore rule changes, route changes, or tenant-visible review internals were introduced.
- The UI uses human-readable labels and labels internal workspace references as internal metadata.

## Tests
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- OperationalCommandCenterPage.test.tsx ReviewWorkspacePanel.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Preview QA
- Open `/operations`.
- Confirm operational cards still render and filters/search still work.
- Confirm each visible operational item includes a read-only Review Workspace readiness panel.
- Confirm there are no create/auto-route/resolve actions in the review workspace panel.
- Confirm source workflow links still route correctly and no raw IDs are primary labels.