### PR TITLE
test: add review workspace scope regression coverage

### DIFF
--- a/rentchain-api/src/lib/reviewWorkspaces/__tests__/reviewWorkspaceScopeRegression.test.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/__tests__/reviewWorkspaceScopeRegression.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import { deriveOperationalReviewRouting, buildReviewWorkspaceInputFromRouting } from "../../operationalReviewRouting/deriveOperationalReviewRouting";
+import { buildReviewWorkspace, reviewWorkspaceToOperatorReviewOpenRequest } from "../buildReviewWorkspace";
+
+const createdBy = { userId: "landlord-user-1", role: "landlord" as const, email: "ops@example.test" };
+
+function expectManualOnlyReviewMetadata(payload: unknown) {
+  expect(payload).toEqual(
+    expect.objectContaining({
+      manualOnly: true,
+      autonomousActionsEnabled: false,
+    })
+  );
+  expect(JSON.stringify(payload)).not.toContain("autoCreateWorkspace\":true");
+  expect(JSON.stringify(payload)).not.toContain("financialMutationEnabled\":true");
+  expect(JSON.stringify(payload)).not.toContain("institutionalSharingEnabled\":true");
+}
+
+describe("review workspace scope and permission regression", () => {
+  it("keeps workspace related resources scoped to the requested landlord and tenant", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "payment_ledger_review",
+      workspaceScopeId: "payment-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      createdBy,
+      relatedResourceRefs: [
+        {
+          resourceType: "payment",
+          resourceId: "payment-1",
+          label: "North Towers payment evidence",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          unitId: "unit-101",
+          leaseId: "lease-1",
+        },
+        {
+          resourceType: "lease",
+          resourceId: "lease-wrong-landlord",
+          label: "Wrong landlord lease",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+          propertyId: "property-2",
+          unitId: "unit-201",
+          leaseId: "lease-2",
+        },
+        {
+          resourceType: "tenant",
+          resourceId: "tenant-2",
+          label: "Wrong tenant",
+          landlordId: "landlord-1",
+          tenantId: "tenant-2",
+          propertyId: "property-1",
+          unitId: "unit-102",
+          leaseId: "lease-3",
+        },
+      ],
+    });
+
+    expect(workspace.landlordId).toBe("landlord-1");
+    expect(workspace.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "payment",
+        resourceId: "payment-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        propertyId: "property-1",
+        unitId: "unit-101",
+        leaseId: "lease-1",
+      }),
+    ]);
+    expect(JSON.stringify(workspace)).not.toContain("landlord-2");
+    expect(JSON.stringify(workspace)).not.toContain("tenant-2");
+    expect(JSON.stringify(workspace)).not.toContain("lease-wrong-landlord");
+    expectManualOnlyReviewMetadata(workspace);
+  });
+
+  it("keeps evidence linkage metadata-only and excludes restricted/raw payload fields", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "evidence_review",
+      workspaceScopeId: "evidence-pack-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      createdBy,
+      evidenceRefs: [
+        {
+          evidencePackId: "evidence-pack-1",
+          evidenceItemId: "item-1",
+          label: "Scoped evidence pack",
+          sourceCollection: "ledgerEntries",
+          sourceId: "ledger-entry-1",
+          sensitivityClass: "restricted",
+          rawPayload: { providerPayload: "raw provider dump" },
+          rawCsv: "raw csv data",
+          accountNumber: "123456789",
+          routeSource: "debug route",
+          stack: "stack trace",
+          token: "secret-token",
+          messageBody: "private message body",
+        },
+      ],
+      relatedResourceRefs: [
+        {
+          resourceType: "evidence_pack",
+          resourceId: "evidence-pack-1",
+          label: "Evidence pack",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+        },
+      ],
+    });
+
+    expect(workspace.evidenceRefs).toEqual([
+      {
+        evidencePackId: "evidence-pack-1",
+        evidenceItemId: "item-1",
+        label: "Scoped evidence pack",
+        sourceCollection: "ledgerEntries",
+        sourceId: "ledger-entry-1",
+        sensitivityClass: "restricted",
+      },
+    ]);
+    expectNoRestrictedProjectionFields(workspace);
+    expectPayloadDoesNotContainValues(workspace, [
+      "raw provider dump",
+      "raw csv data",
+      "123456789",
+      "debug route",
+      "stack trace",
+      "secret-token",
+      "private message body",
+    ]);
+    expectManualOnlyReviewMetadata(workspace);
+  });
+
+  it("keeps operational routing handoff manual-only and filters unrelated resources before workspace input", () => {
+    const routing = deriveOperationalReviewRouting({
+      itemId: "decision:review_missing_payment:lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      title: "Missing payment review",
+      category: "payments",
+      severity: "critical",
+      status: "open",
+      destination: "/leases/lease-1/ledger",
+      relatedResourceRefs: [
+        { resourceType: "lease", resourceId: "lease-1", label: "North Towers lease", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { resourceType: "payment", resourceId: "payment-2", label: "Wrong landlord payment", landlordId: "landlord-2", tenantId: "tenant-1" },
+        { resourceType: "payment", resourceId: "payment-3", label: "Wrong tenant payment", landlordId: "landlord-1", tenantId: "tenant-3" },
+      ],
+    });
+
+    expect(routing).toEqual(
+      expect.objectContaining({
+        reviewEligible: true,
+        manualOnly: true,
+        autoCreateWorkspace: false,
+        autonomousActionsEnabled: false,
+        permissionWideningRequired: false,
+      })
+    );
+    expect(routing.relatedResourceRefs).toEqual([
+      expect.objectContaining({ resourceType: "lease", resourceId: "lease-1", landlordId: "landlord-1", tenantId: "tenant-1" }),
+    ]);
+
+    const workspaceInput = buildReviewWorkspaceInputFromRouting({ routing, createdBy });
+    const workspace = buildReviewWorkspace(workspaceInput!);
+
+    expect(workspace.relatedResourceRefs).toEqual([
+      expect.objectContaining({ resourceType: "lease", resourceId: "lease-1", landlordId: "landlord-1", tenantId: "tenant-1" }),
+    ]);
+    expect(JSON.stringify(workspace)).not.toContain("payment-2");
+    expect(JSON.stringify(workspace)).not.toContain("payment-3");
+    expectManualOnlyReviewMetadata(workspace);
+  });
+
+  it("bridges to existing operator review sessions without exposing financial mutation or sharing controls", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "delinquency_review",
+      workspaceScopeId: "lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      createdBy,
+      evidenceRefs: [{ evidencePackId: "evidence-1", label: "Lease ledger evidence", sensitivityClass: "sensitive" }],
+      reviewSummary: "Review lease ledger evidence",
+    });
+    const request = reviewWorkspaceToOperatorReviewOpenRequest(workspace);
+
+    expect(request).toEqual({
+      scope: "delinquency",
+      scopeId: "lease-1",
+      linkedEvidence: [{ evidenceId: "evidence-1", label: "Lease ledger evidence", kind: "workflow", destination: null }],
+      note: "Review lease ledger evidence",
+    });
+    expect(JSON.stringify(request)).not.toContain("financialMutation");
+    expect(JSON.stringify(request)).not.toContain("institutionalSharing");
+    expect(JSON.stringify(request)).not.toContain("tenantVisible");
+    expectManualOnlyReviewMetadata(workspace);
+  });
+});

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import { ReviewWorkspacePanel, type ReviewWorkspaceUiModel } from "./ReviewWorkspacePanel";
+
+afterEach(() => {
+  cleanup();
+});
 
 function workspace(overrides: Partial<ReviewWorkspaceUiModel> = {}): ReviewWorkspaceUiModel {
   return {
@@ -57,5 +61,39 @@ describe("ReviewWorkspacePanel", () => {
     expect(screen.getByText("Lease context")).toBeInTheDocument();
     expect(screen.queryByText(/Decision decision:/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Lease JK6S7JQ2HsMj8m8RFI76/i)).not.toBeInTheDocument();
+  });
+
+  it("does not render autonomous, mutation, sharing, tenant-internal, or raw payload controls", () => {
+    render(
+      <MemoryRouter>
+        <ReviewWorkspacePanel
+          workspace={workspace({
+            workspaceReference: "internal-scope-reference:workspace-1",
+            evidenceLinks: [
+              {
+                label: "Screening source workflow",
+                destination: "/applications/app-1",
+                sensitivityClass: "restricted",
+              },
+            ],
+            relatedResources: [{ label: "Screening workflow review", resourceType: "screening_order" }],
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Internal workspace reference:/)).toBeInTheDocument();
+    expect(screen.getByText("Screening source workflow")).toBeInTheDocument();
+    expect(screen.getByText("Screening workflow review")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText(/create review workspace/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?route/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/resolve review/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/mutate ledger/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/institutional sharing/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/raw provider/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/raw csv/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/secret-token/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -303,6 +303,10 @@ describe("deriveCommandCenterSignals", () => {
       }),
     ]);
     expect(preview.relatedResources).toEqual([expect.objectContaining({ label: "North Towers · 101 · John Smith" })]);
+    expect(JSON.stringify(preview)).not.toContain("tenantVisible");
+    expect(JSON.stringify(preview)).not.toContain("financialMutation");
+    expect(JSON.stringify(preview)).not.toContain("institutionalSharing");
+    expect(JSON.stringify(preview)).not.toContain("rawPayload");
   });
 
   it("normalizes raw decision context labels with operational lease and property references", () => {
@@ -438,6 +442,10 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Payment Ledger Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Delinquency or payment evidence review").length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /create review workspace/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/institutional sharing/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/financial mutation/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/raw provider/i)).not.toBeInTheDocument();
     expect(screen.getByText("Saved operational views")).toBeInTheDocument();
     expect(screen.getByTestId("operations-filter-panel")).toHaveStyle({
       display: "grid",


### PR DESCRIPTION
## Summary
- Adds backend review workspace scope regression tests for landlord/tenant scoped resource refs, evidence metadata-only linkage, restricted field exclusion, and manual-only operator review compatibility.
- Extends review workspace UI tests to assert no create/auto-route/mutation/sharing/tenant-internal controls or raw payload labels appear.
- Extends `/operations` tests to assert review workspace preview metadata remains manual-only and excludes tenant-visible, financial mutation, institutional sharing, and raw payload markers.

## Scope surfaces covered
- Review workspace construction scope
- Evidence linkage scope
- Operational review routing handoff scope
- ReviewWorkspacePanel safety rendering
- OperationalCommandCenterPage review workspace preview safety

## Guardrails confirmed by tests
- No permissions widened.
- No autonomous behavior introduced.
- No tenant-visible review internals introduced.
- No payment/ledger mutations introduced.
- No institutional export/share controls introduced.
- No auth, schema, Firestore rule, route, or UI behavior changes beyond regression assertions.

## Leaks / fixes
- No scope or projection leaks were discovered.
- Minimal test-only cleanup was added to the ReviewWorkspacePanel test file to avoid DOM carryover between renders.

## Tests
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts src/lib/reviewWorkspaces/__tests__/reviewWorkspaceScopeRegression.test.ts src/lib/operationalReviewRouting/__tests__/deriveOperationalReviewRouting.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- OperationalCommandCenterPage.test.tsx ReviewWorkspacePanel.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Remaining follow-ups
- Add route-level tests when persisted review workspace list/detail APIs are introduced.
- Add manual workspace creation permission tests if a future manual creation action is approved.
- Add tenant-facing negative tests if any tenant route ever references review workspace metadata.