### PR TITLE
fix: harden review workspace evidence links

### DIFF
--- a/rentchain-api/src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts
@@ -89,14 +89,17 @@ describe("buildReviewWorkspace", () => {
       })
     );
     expect(workspace.evidenceRefs).toEqual([
-      {
+      expect.objectContaining({
+        evidenceRefId: "review_evidence_ref:evidence-1:item-1:ledgerentries:ledger-1",
         evidencePackId: "evidence-1",
         evidenceItemId: "item-1",
+        evidenceType: "evidence_pack",
         label: "Missing payment evidence",
         sourceCollection: "ledgerEntries",
         sourceId: "ledger-1",
+        sourceRef: { sourceCollection: "ledgerEntries", sourceId: "ledger-1" },
         sensitivityClass: "sensitive",
-      },
+      }),
     ]);
     expect(workspace.relatedResourceRefs).toEqual([
       expect.objectContaining({

--- a/rentchain-api/src/lib/reviewWorkspaces/__tests__/reviewWorkspaceScopeRegression.test.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/__tests__/reviewWorkspaceScopeRegression.test.ts
@@ -117,14 +117,17 @@ describe("review workspace scope and permission regression", () => {
     });
 
     expect(workspace.evidenceRefs).toEqual([
-      {
+      expect.objectContaining({
+        evidenceRefId: "review_evidence_ref:evidence-pack-1:item-1:ledgerentries:ledger-entry-1",
         evidencePackId: "evidence-pack-1",
         evidenceItemId: "item-1",
+        evidenceType: "evidence_pack",
         label: "Scoped evidence pack",
         sourceCollection: "ledgerEntries",
         sourceId: "ledger-entry-1",
+        sourceRef: { sourceCollection: "ledgerEntries", sourceId: "ledger-entry-1" },
         sensitivityClass: "restricted",
-      },
+      }),
     ]);
     expectNoRestrictedProjectionFields(workspace);
     expectPayloadDoesNotContainValues(workspace, [
@@ -137,6 +140,87 @@ describe("review workspace scope and permission regression", () => {
       "private message body",
     ]);
     expectManualOnlyReviewMetadata(workspace);
+  });
+
+  it("normalizes deterministic evidence-link governance metadata and excludes unrelated evidence refs", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "evidence_review",
+      workspaceScopeId: "evidence-pack-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      createdBy,
+      evidenceRefs: [
+        {
+          evidencePackId: "evidence-pack-1",
+          evidenceItemId: "decision-1",
+          evidenceType: "evidence_item",
+          label: "Missing payment review evidence",
+          sourceCollection: "decisionItems",
+          sourceId: "decision-1",
+          scopeType: "decision",
+          scopeId: "decision-1",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          sensitivityClass: "restricted",
+          projectionProfile: "landlord_evidence_review",
+          projectionVersion: "evidence_projection_profile_v1",
+          redactionSummary: "Restricted fields excluded; redaction categories retained.",
+          lineageSummary: "Derived from decisionItems:decision-1.",
+        },
+        {
+          evidencePackId: "evidence-pack-2",
+          evidenceItemId: "decision-2",
+          evidenceType: "evidence_item",
+          label: "Wrong landlord evidence",
+          sourceCollection: "decisionItems",
+          sourceId: "decision-2",
+          scopeType: "decision",
+          scopeId: "decision-2",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+          sensitivityClass: "restricted",
+        },
+        {
+          evidencePackId: "evidence-pack-3",
+          evidenceItemId: "decision-3",
+          evidenceType: "evidence_item",
+          label: "Wrong tenant evidence",
+          sourceCollection: "decisionItems",
+          sourceId: "decision-3",
+          scopeType: "decision",
+          scopeId: "decision-3",
+          landlordId: "landlord-1",
+          tenantId: "tenant-3",
+          sensitivityClass: "restricted",
+        },
+      ],
+    });
+
+    expect(workspace.evidenceRefs).toEqual([
+      {
+        evidenceRefId: "review_evidence_ref:evidence-pack-1:decision-1:decisionitems:decision-1",
+        evidencePackId: "evidence-pack-1",
+        evidenceItemId: "decision-1",
+        evidenceType: "evidence_item",
+        label: "Missing payment review evidence",
+        sourceCollection: "decisionItems",
+        sourceId: "decision-1",
+        sourceRef: { sourceCollection: "decisionItems", sourceId: "decision-1" },
+        scopeType: "decision",
+        scopeId: "decision-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        sensitivityClass: "restricted",
+        projectionProfile: "landlord_evidence_review",
+        projectionVersion: "evidence_projection_profile_v1",
+        redactionSummary: "Restricted fields excluded; redaction categories retained.",
+        lineageSummary: "Derived from decisionItems:decision-1.",
+      },
+    ]);
+    expect(JSON.stringify(workspace)).not.toContain("evidence-pack-2");
+    expect(JSON.stringify(workspace)).not.toContain("evidence-pack-3");
+    expect(JSON.stringify(workspace)).not.toContain("landlord-2");
+    expect(JSON.stringify(workspace)).not.toContain("tenant-3");
   });
 
   it("keeps operational routing handoff manual-only and filters unrelated resources before workspace input", () => {

--- a/rentchain-api/src/lib/reviewWorkspaces/buildReviewWorkspace.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/buildReviewWorkspace.ts
@@ -30,6 +30,7 @@ const VALID_STATUSES = new Set<ReviewWorkspaceStatus>(["open", "under_review", "
 const VALID_PRIORITIES = new Set<ReviewWorkspacePriority>(["critical", "warning", "needs_review", "upcoming", "info"]);
 const VALID_SENSITIVITY = new Set<ReviewWorkspaceSensitivityClass>(["sensitive", "restricted"]);
 const VALID_VISIBILITY = new Set<ReviewWorkspaceVisibilityClass>(["landlord_operational", "admin_support"]);
+const VALID_EVIDENCE_TYPES = new Set(["evidence_pack", "evidence_item", "source_reference"]);
 const VALID_RESOURCE_TYPES = new Set<ReviewWorkspaceResourceType>([
   "lease",
   "tenant",
@@ -70,6 +71,24 @@ function safeText(value: unknown, max = 1000): string {
   return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
 }
 
+function evidenceRefId(input: {
+  evidencePackId: string;
+  evidenceItemId?: string | null;
+  sourceCollection?: string | null;
+  sourceId?: string | null;
+}): string {
+  const clean = cleanIdPart(
+    [
+      "review_evidence_ref",
+      input.evidencePackId,
+      input.evidenceItemId || "pack",
+      input.sourceCollection || "source",
+      input.sourceId || "unknown",
+    ].join(":")
+  );
+  return clean || `review_evidence_ref:${crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex")}`;
+}
+
 function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
 }
@@ -102,7 +121,10 @@ export function normalizeReviewWorkspaceReviewer(raw: unknown): ReviewWorkspaceR
   };
 }
 
-export function normalizeReviewWorkspaceEvidenceRefs(raw: unknown): ReviewWorkspaceEvidenceRef[] {
+export function normalizeReviewWorkspaceEvidenceRefs(
+  raw: unknown,
+  scope: { landlordId: string; tenantId?: string | null }
+): ReviewWorkspaceEvidenceRef[] {
   if (!Array.isArray(raw)) return [];
   const refs = raw
     .map((item) => {
@@ -110,14 +132,39 @@ export function normalizeReviewWorkspaceEvidenceRefs(raw: unknown): ReviewWorksp
       const evidencePackId = asString(data.evidencePackId || data.evidenceId || data.id, 240);
       const label = safeText(data.label, 160);
       const sensitivityClass = asString(data.sensitivityClass, 40) as ReviewWorkspaceSensitivityClass;
+      const evidenceType = asString(data.evidenceType || data.type, 80);
+      const sourceCollection = asString(data.sourceCollection, 120) || null;
+      const sourceId = asString(data.sourceId, 240) || null;
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
       if (!evidencePackId || !label) return null;
+      if (landlordId && landlordId !== scope.landlordId) return null;
+      if (scope.tenantId && tenantId && tenantId !== scope.tenantId) return null;
       return {
+        evidenceRefId:
+          asString(data.evidenceRefId, 240) ||
+          evidenceRefId({
+            evidencePackId,
+            evidenceItemId: asString(data.evidenceItemId, 240) || null,
+            sourceCollection,
+            sourceId,
+          }),
         evidencePackId,
         evidenceItemId: asString(data.evidenceItemId, 240) || null,
+        evidenceType: VALID_EVIDENCE_TYPES.has(evidenceType) ? (evidenceType as ReviewWorkspaceEvidenceRef["evidenceType"]) : "evidence_pack",
         label,
-        sourceCollection: asString(data.sourceCollection, 120) || null,
-        sourceId: asString(data.sourceId, 240) || null,
+        sourceCollection,
+        sourceId,
+        sourceRef: sourceCollection && sourceId ? { sourceCollection, sourceId } : null,
+        scopeType: asString(data.scopeType || data.scope, 120) || null,
+        scopeId: asString(data.scopeId, 240) || null,
+        landlordId,
+        tenantId,
         sensitivityClass: VALID_SENSITIVITY.has(sensitivityClass) ? sensitivityClass : "sensitive",
+        projectionProfile: asString(data.projectionProfile || data.profileName, 120) || null,
+        projectionVersion: asString(data.projectionVersion || data.profileVersion, 120) || null,
+        redactionSummary: safeText(data.redactionSummary, 500) || null,
+        lineageSummary: safeText(data.lineageSummary, 500) || null,
       };
     })
     .filter(Boolean) as ReviewWorkspaceEvidenceRef[];
@@ -212,7 +259,10 @@ export function buildReviewWorkspace(input: BuildReviewWorkspaceInput): ReviewWo
   const reviewPriority = asString(input.reviewPriority, 40) as ReviewWorkspacePriority;
   const sensitivityClass = asString(input.sensitivityClass, 40) as ReviewWorkspaceSensitivityClass;
   const visibilityClass = asString(input.visibilityClass, 40) as ReviewWorkspaceVisibilityClass;
-  const evidenceRefs = normalizeReviewWorkspaceEvidenceRefs(input.evidenceRefs);
+  const evidenceRefs = normalizeReviewWorkspaceEvidenceRefs(input.evidenceRefs, {
+    landlordId,
+    tenantId: input.tenantId,
+  });
   const relatedResourceRefs = normalizeReviewWorkspaceResourceRefs(input.relatedResourceRefs, {
     landlordId,
     tenantId: input.tenantId,

--- a/rentchain-api/src/lib/reviewWorkspaces/reviewWorkspaceTypes.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/reviewWorkspaceTypes.ts
@@ -23,12 +23,26 @@ export type ReviewWorkspaceReviewer = {
 };
 
 export type ReviewWorkspaceEvidenceRef = {
+  evidenceRefId: string;
   evidencePackId: string;
   evidenceItemId: string | null;
+  evidenceType: "evidence_pack" | "evidence_item" | "source_reference";
   label: string;
   sourceCollection: string | null;
   sourceId: string | null;
+  sourceRef: {
+    sourceCollection: string;
+    sourceId: string;
+  } | null;
+  scopeType: string | null;
+  scopeId: string | null;
+  landlordId: string | null;
+  tenantId: string | null;
   sensitivityClass: ReviewWorkspaceSensitivityClass;
+  projectionProfile: string | null;
+  projectionVersion: string | null;
+  redactionSummary: string | null;
+  lineageSummary: string | null;
 };
 
 export type ReviewWorkspaceResourceType =


### PR DESCRIPTION
## Summary
- Refines review workspace evidence refs into deterministic metadata/reference records with evidence ref ID, evidence type, source ref, scope, landlord/tenant scope, sensitivity, projection profile/version, redaction summary, and lineage summary.
- Filters evidence refs by landlord and tenant scope where those fields are present.
- Extends regression coverage to prove unrelated evidence refs are excluded and restricted/raw payloads remain out of review workspace metadata.

## Evidence-link contract summary
Review workspace evidence refs now include:
- `evidenceRefId`
- `evidenceType`
- `sourceRef`
- `scopeType` / `scopeId`
- `landlordId` / `tenantId`
- `sensitivityClass`
- `projectionProfile` / `projectionVersion`
- `redactionSummary`
- `lineageSummary`

Existing `evidencePackId`, `evidenceItemId`, `label`, `sourceCollection`, and `sourceId` fields remain preserved for compatibility.

## Guardrails
- No review access was broadened.
- No tenant-visible review internals were introduced.
- No raw provider/screening/reporting/CSV/payment/debug/stack/token/secret payloads are duplicated into workspaces.
- No financial mutations, auto-creation, autonomous behavior, auth changes, Firestore rule changes, schema changes, or route visibility changes were introduced.

## Tests
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/reviewWorkspaces/__tests__/buildReviewWorkspace.test.ts src/lib/reviewWorkspaces/__tests__/reviewWorkspaceScopeRegression.test.ts src/lib/operationalReviewRouting/__tests__/deriveOperationalReviewRouting.test.ts src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Leaks / fixes
- No evidence scope or raw payload leaks were discovered.
- No UI or route behavior changed.

## Remaining follow-ups
- Link persisted evidence pack records into review workspaces when manual review workspace creation is introduced.
- Add route-level evidence-link permission tests when persisted review workspace APIs exist.
- Add UI display for projection profile/version metadata only after persisted workspace details are available.