### PR TITLE
feat: add operational review queue foundation

### DIFF
--- a/docs/reports/operational-review-queue-v1.md
+++ b/docs/reports/operational-review-queue-v1.md
@@ -1,0 +1,72 @@
+# Operational Review Queue v1
+
+## Executive Summary
+
+Operational Review Queue v1 adds the first manual, read-only queue layer for governed operational review coordination.
+
+The queue is derived from already-visible operational command center signals. It does not create review workspaces, route work automatically, mutate source workflows, change financial records, broaden permissions, or expose tenant-visible review internals.
+
+## Queue Philosophy
+
+The queue helps an operator answer:
+
+- what needs manual review
+- why it is routed for review
+- which review workspace type would apply during a future manual handoff
+- which source workflow and related resource are in scope
+- whether the item is assigned, critical, delinquency-related, upcoming, or informational
+
+The queue is operational coordination only. It is not a workflow execution engine.
+
+## V1 Surface
+
+V1 surfaces a compact review intake queue inside `/operations`.
+
+Each queue item presents:
+
+- review title
+- human-readable operational context
+- workspace type
+- review status
+- review priority
+- routing reason
+- assignment state
+- workflow status
+- financial status when present
+- sensitivity class
+- scoped source workflow evidence link
+- related resource label
+
+Internal references remain implementation metadata and are not used as primary labels.
+
+## Scope And Safety
+
+Queue items are generated from the same landlord-scoped command center payloads already used by `/operations`.
+
+V1 does not add:
+
+- new routes
+- new backend writes
+- automatic review creation
+- automatic routing
+- automatic resolution
+- financial mutations
+- institutional sharing
+- tenant-facing review internals
+- cross-landlord visibility
+
+Evidence and related-resource display remains reference-based. The queue does not duplicate evidence payloads, raw provider payloads, raw CSV data, payment credentials, unrestricted message bodies, debug payloads, tokens, secrets, or stack traces.
+
+## Operational Command Center Compatibility
+
+The queue derives from the filtered visible signal list. Existing `/operations` search, saved views, priority filters, and facet filters therefore continue to control queue visibility.
+
+The queue preserves existing priority sorting by using the same deterministic operational prioritization helper.
+
+## Future Follow-Ups
+
+1. Add persisted review workspace list/detail routes after manual creation semantics are approved.
+2. Add audited manual review workspace creation only after permission and event semantics are reviewed.
+3. Add assignment/status controls after ownership governance is finalized.
+4. Link persisted evidence pack references after workspace creation exists.
+5. Add review workspace timeline integration using the canonical event taxonomy.

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { OperationalReviewQueue, type OperationalReviewQueueItem } from "./OperationalReviewQueue";
+
+afterEach(() => {
+  cleanup();
+});
+
+function queueItem(overrides: Partial<OperationalReviewQueueItem> = {}): OperationalReviewQueueItem {
+  return {
+    queueItemId: "manual-review-queue:decision:decision-1",
+    title: "Review missing payment",
+    contextLabel: "North Towers · Unit 104 · James Smith",
+    sourceLabel: "Decision inbox · Delinquency review",
+    destination: "/leases/lease-1/ledger",
+    workspaceType: "payment_ledger_review",
+    reviewStatus: "Open",
+    reviewPriority: "Critical",
+    routingReason: "Delinquency or payment evidence review",
+    assignmentLabel: "Operations owned",
+    workflowStatus: "New",
+    financialStatus: "Review required",
+    sensitivityClass: "sensitive",
+    visibilityClass: "landlord_operational",
+    evidenceLabel: "Payments / obligations source workflow",
+    relatedResourceLabel: "North Towers · Unit 104 · James Smith",
+    manualOnly: true,
+    autonomousActionsEnabled: false,
+    ...overrides,
+  };
+}
+
+describe("OperationalReviewQueue", () => {
+  it("renders manual-only review queue metadata without action controls", () => {
+    render(
+      <MemoryRouter>
+        <OperationalReviewQueue items={[queueItem()]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Operational review queue")).toBeInTheDocument();
+    expect(screen.getByText(/does not create workspaces, route work automatically, or change source records/i)).toBeInTheDocument();
+    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getAllByText("North Towers · Unit 104 · James Smith").length).toBeGreaterThan(0);
+    expect(screen.getByText("Payment Ledger Review")).toBeInTheDocument();
+    expect(screen.getByText("Delinquency or payment evidence review")).toBeInTheDocument();
+    expect(screen.getByText("Operations owned")).toBeInTheDocument();
+    expect(screen.getByText("Review required")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Payments / obligations source workflow" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/ledger"
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText(/create review workspace/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?route/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/mutate ledger/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/institutional sharing/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
+  });
+
+  it("uses safe fallback labels for raw internal identifiers", () => {
+    render(
+      <MemoryRouter>
+        <OperationalReviewQueue
+          items={[
+            queueItem({
+              title: "Decision decision:review_missing_payment:lease_lifecycle:jjua9wfkdv19d5y5sdv7",
+              contextLabel: "Lease JK6S7JQ2HsMj8m8RFI76",
+              evidenceLabel: "Decision decision:review_missing_payment:lease_lifecycle:jjua9wfkdv19d5y5sdv7",
+              relatedResourceLabel: "Lease JK6S7JQ2HsMj8m8RFI76",
+            }),
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Operational review item")).toBeInTheDocument();
+    expect(screen.getByText("Operational review context")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open source workflow evidence" })).toBeInTheDocument();
+    expect(screen.getByText("Scoped resource context")).toBeInTheDocument();
+    expect(screen.queryByText(/Decision decision:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lease JK6S7JQ2HsMj8m8RFI76/i)).not.toBeInTheDocument();
+  });
+
+  it("renders a deterministic empty state when filters remove all queue items", () => {
+    render(
+      <MemoryRouter>
+        <OperationalReviewQueue items={[]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("0 reviewable")).toBeInTheDocument();
+    expect(screen.getByText(/No reviewable operational queue items match the current filters/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Card } from "@/components/ui/Ui";
+
+export type OperationalReviewQueueItem = {
+  queueItemId: string;
+  title: string;
+  contextLabel: string;
+  sourceLabel: string;
+  destination: string;
+  workspaceType: string;
+  reviewStatus: string;
+  reviewPriority: string;
+  routingReason: string;
+  assignmentLabel: string;
+  workflowStatus: string;
+  financialStatus?: string | null;
+  sensitivityClass: string;
+  visibilityClass: string;
+  evidenceLabel: string;
+  relatedResourceLabel: string;
+  manualOnly: true;
+  autonomousActionsEnabled: false;
+};
+
+function label(value: string) {
+  return String(value || "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function safeDisplayLabel(value: string, fallback: string) {
+  const raw = String(value || "").replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  if (!raw) return fallback;
+  if (/^(Lease|Property|Tenant|Unit|Decision)\s+[A-Za-z0-9:_-]{12,}$/i.test(raw)) return fallback;
+  return raw;
+}
+
+function metadata(labelText: string, value: string | null | undefined) {
+  if (!value) return null;
+  return (
+    <div style={{ display: "grid", gap: 2, minWidth: 0 }}>
+      <span style={{ color: "#64748b", fontSize: 11, fontWeight: 900, textTransform: "uppercase" }}>{labelText}</span>
+      <span style={{ color: "#0f172a", fontSize: 13, fontWeight: 900, overflowWrap: "anywhere" }}>{value}</span>
+    </div>
+  );
+}
+
+export function OperationalReviewQueue({ items }: { items: OperationalReviewQueueItem[] }) {
+  const assignedCount = items.filter((item) => !/^unassigned$/i.test(item.assignmentLabel)).length;
+
+  return (
+    <Card
+      data-testid="operational-review-queue"
+      style={{
+        borderRadius: 10,
+        padding: 14,
+        border: "1px solid #dbe3ef",
+        background: "#ffffff",
+        display: "grid",
+        gap: 12,
+        minWidth: 0,
+        boxSizing: "border-box",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+        <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+          <strong style={{ color: "#0f172a", fontSize: 16 }}>Operational review queue</strong>
+          <span style={{ color: "#475569", fontSize: 13, lineHeight: 1.5 }}>
+            Manual intake visibility for reviewable operational work. This queue does not create workspaces, route work automatically,
+            or change source records.
+          </span>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <span style={pillStyle("#dbeafe", "#1d4ed8", "#bfdbfe")}>{items.length} reviewable</span>
+          <span style={pillStyle("#f8fafc", "#475569", "#dbe3ef")}>{assignedCount} assigned</span>
+        </div>
+      </div>
+
+      {items.length ? (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 320px), 1fr))",
+            gap: 10,
+            minWidth: 0,
+          }}
+        >
+          {items.map((item) => (
+            <Card
+              key={item.queueItemId}
+              style={{
+                borderRadius: 8,
+                padding: 12,
+                border: "1px solid rgba(15, 23, 42, 0.08)",
+                display: "grid",
+                gap: 10,
+                minWidth: 0,
+                overflowWrap: "anywhere",
+              }}
+            >
+              <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                  <span style={pillStyle("#fef3c7", "#92400e", "#fde68a")}>{item.reviewPriority}</span>
+                  <span style={{ color: "#64748b", fontSize: 12, fontWeight: 900 }}>{label(item.workspaceType)}</span>
+                </div>
+                <strong style={{ color: "#0f172a", fontSize: 15 }}>{safeDisplayLabel(item.title, "Operational review item")}</strong>
+                <span style={{ color: "#475569", fontSize: 13 }}>
+                  {safeDisplayLabel(item.contextLabel, "Operational review context")}
+                </span>
+              </div>
+
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 150px), 1fr))",
+                  gap: 8,
+                  minWidth: 0,
+                }}
+              >
+                {metadata("Routing reason", item.routingReason)}
+                {metadata("Source", item.sourceLabel)}
+                {metadata("Review status", item.reviewStatus)}
+                {metadata("Assignment", item.assignmentLabel)}
+                {metadata("Workflow status", item.workflowStatus)}
+                {metadata("Financial status", item.financialStatus || null)}
+                {metadata("Sensitivity", label(item.sensitivityClass))}
+                {metadata("Visibility", label(item.visibilityClass))}
+              </div>
+
+              <div style={{ display: "grid", gap: 5 }}>
+                <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Scoped evidence/resource links</span>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                  <Link to={item.destination} style={{ color: "#2563eb", fontSize: 13, fontWeight: 900 }}>
+                    {safeDisplayLabel(item.evidenceLabel, "Open source workflow evidence")}
+                  </Link>
+                  <span
+                    style={{
+                      border: "1px solid #e2e8f0",
+                      borderRadius: 999,
+                      padding: "3px 8px",
+                      color: "#475569",
+                      fontSize: 12,
+                      fontWeight: 800,
+                      background: "#fff",
+                    }}
+                  >
+                    {safeDisplayLabel(item.relatedResourceLabel, "Scoped resource context")}
+                  </span>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <div style={{ color: "#64748b", fontSize: 13, lineHeight: 1.5 }}>
+          No reviewable operational queue items match the current filters. Adjust the triage view or reset filters to review the full
+          operational queue.
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function pillStyle(background: string, color: string, border: string): React.CSSProperties {
+  return {
+    border: `1px solid ${border}`,
+    background,
+    color,
+    borderRadius: 999,
+    padding: "3px 9px",
+    fontSize: 12,
+    fontWeight: 900,
+    whiteSpace: "nowrap",
+  };
+}

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OperationalCommandCenterPage, {
   deriveCommandCenterSignals,
+  deriveOperationalReviewQueueItems,
   prioritizeOperationalItems,
   reviewWorkspacePreviewForSignal,
 } from "./OperationalCommandCenterPage";
@@ -309,6 +310,42 @@ describe("deriveCommandCenterSignals", () => {
     expect(JSON.stringify(preview)).not.toContain("rawPayload");
   });
 
+  it("derives deterministic manual-only operational review queue items", () => {
+    const signals = deriveCommandCenterSignals({
+      decisions: [decision()],
+      leases: [lease()],
+      properties: [],
+    });
+
+    const queueItems = deriveOperationalReviewQueueItems(signals);
+    const paymentItem = queueItems.find((item) => item.queueItemId === "manual-review-queue:decision:decision-1");
+
+    expect(paymentItem).toEqual(
+      expect.objectContaining({
+        title: "Review missing payment",
+        contextLabel: "North Towers · 101 · John Smith",
+        workspaceType: "payment_ledger_review",
+        reviewStatus: "Open",
+        reviewPriority: "Critical",
+        routingReason: "Delinquency or payment evidence review",
+        assignmentLabel: "Operations owned",
+        financialStatus: "Review required",
+        sensitivityClass: "sensitive",
+        visibilityClass: "landlord_operational",
+        manualOnly: true,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(queueItems.map((item) => item.queueItemId)).toEqual(
+      prioritizeOperationalItems(signals).map((signal) => `manual-review-queue:${signal.id}`)
+    );
+    expect(JSON.stringify(queueItems)).not.toContain("tenantVisible");
+    expect(JSON.stringify(queueItems)).not.toContain("rawPayload");
+    expect(JSON.stringify(queueItems)).not.toContain("providerPayload");
+    expect(JSON.stringify(queueItems)).not.toContain("financialMutation");
+    expect(JSON.stringify(queueItems)).not.toContain("institutionalSharing");
+  });
+
   it("normalizes raw decision context labels with operational lease and property references", () => {
     const signals = deriveCommandCenterSignals({
       decisions: [
@@ -428,7 +465,7 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Needs review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Upcoming").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Informational").length).toBeGreaterThan(0);
-    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Context: North Towers · 101 · John Smith").length).toBeGreaterThan(0);
     expect(screen.getByText("Why: Lease is active but occupancy state conflicts.")).toBeInTheDocument();
     expect(screen.getByText("Workflow status: New")).toBeInTheDocument();
@@ -438,6 +475,11 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Escalation: Critical").length).toBeGreaterThan(0);
     expect(screen.getByText("Next action: Review payment evidence")).toBeInTheDocument();
     expect(screen.getAllByText("Review workspace readiness").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("operational-review-queue")).toBeInTheDocument();
+    expect(screen.getByText("Operational review queue")).toBeInTheDocument();
+    expect(screen.getByText(/does not create workspaces, route work automatically, or change source records/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Scoped evidence/resource links").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(1);
     expect(screen.getAllByText(/does not create a workspace, route work automatically, or change source records/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Payment Ledger Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Delinquency or payment evidence review").length).toBeGreaterThan(0);
@@ -471,16 +513,17 @@ describe("OperationalCommandCenterPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Review missing payment")).toBeInTheDocument();
-    expect(screen.getByText("Lease ending soon")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0));
+    expect(screen.getAllByText("Lease ending soon").length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: "Upcoming" }));
     expect(screen.queryByText("Review missing payment")).not.toBeInTheDocument();
-    expect(screen.getByText("Lease ending soon")).toBeInTheDocument();
+    expect(screen.getAllByText("Lease ending soon").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("operational-review-queue")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "All operational" }));
     fireEvent.change(screen.getByLabelText("Search operational items"), { target: { value: "North Towers 101" } });
-    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0);
     expect(screen.queryByText("Vacant units visible")).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Search operational items"), { target: { value: "no matching workflow" } });
@@ -495,10 +538,10 @@ describe("OperationalCommandCenterPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Review missing payment")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0));
 
     fireEvent.click(screen.getAllByRole("button", { name: "Delinquent" })[1]);
-    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0);
     expect(screen.queryByText("Vacant units visible")).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Review status"), { target: { value: "open" } });
@@ -507,8 +550,8 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getByText("No operational items match this triage view.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Reset filters" }));
-    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
-    expect(screen.getByText("Vacant units visible")).toBeInTheDocument();
+    expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Vacant units visible").length).toBeGreaterThan(0);
   });
 
   it("applies saved operational views without backend state changes", async () => {
@@ -518,16 +561,16 @@ describe("OperationalCommandCenterPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Review missing payment")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0));
     fireEvent.click(screen.getByRole("button", { name: "High Risk" }));
     expect(screen.getByRole("button", { name: "High Risk" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0);
     expect(screen.queryByText("Vacant units visible")).not.toBeInTheDocument();
     expect(screen.getByText(/Active view: Critical/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Upcoming Deadlines" }));
     expect(screen.queryByText("Review missing payment")).not.toBeInTheDocument();
-    expect(screen.getByText("Lease ending soon")).toBeInTheDocument();
+    expect(screen.getAllByText("Lease ending soon").length).toBeGreaterThan(0);
   });
 
   it("shows a safe empty state when no signals are visible", async () => {

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -10,6 +10,10 @@ import {
 import { getActiveLeasesForLandlord, type LandlordActiveLease } from "@/api/leasesApi";
 import { fetchProperties, type Property } from "@/api/propertiesApi";
 import { MacShell } from "@/components/layout/MacShell";
+import {
+  OperationalReviewQueue,
+  type OperationalReviewQueueItem,
+} from "@/components/reviewWorkspaces/OperationalReviewQueue";
 import { ReviewWorkspacePanel, type ReviewWorkspaceUiModel } from "@/components/reviewWorkspaces/ReviewWorkspacePanel";
 import { Card, Section } from "@/components/ui/Ui";
 
@@ -311,6 +315,34 @@ export function reviewWorkspacePreviewForSignal(signal: CommandCenterSignal): Re
       },
     ],
   };
+}
+
+export function deriveOperationalReviewQueueItems(signals: CommandCenterSignal[]): OperationalReviewQueueItem[] {
+  return prioritizeOperationalItems(signals).map((signal) => {
+    const preview = reviewWorkspacePreviewForSignal(signal);
+    const evidenceLink = preview.evidenceLinks[0];
+    const relatedResource = preview.relatedResources[0];
+    return {
+      queueItemId: `manual-review-queue:${signal.id}`,
+      title: signal.title,
+      contextLabel: signal.contextLabel,
+      sourceLabel: signal.source,
+      destination: signal.destination,
+      workspaceType: preview.workspaceType,
+      reviewStatus: preview.reviewStatus,
+      reviewPriority: preview.reviewPriority,
+      routingReason: preview.routingReason,
+      assignmentLabel: preview.assignmentLabel,
+      workflowStatus: signal.workflowStatus,
+      financialStatus: signal.financialStatus || null,
+      sensitivityClass: preview.sensitivityClass,
+      visibilityClass: preview.visibilityClass,
+      evidenceLabel: evidenceLink?.label || "Source workflow evidence",
+      relatedResourceLabel: relatedResource?.label || "Scoped operational context",
+      manualOnly: true,
+      autonomousActionsEnabled: false,
+    };
+  });
 }
 
 function priorityFromDecision(item: DecisionInboxItem, category: CommandCenterCategory): CommandCenterPriorityGroup {
@@ -931,6 +963,7 @@ export default function OperationalCommandCenterPage() {
     () => filterOperationalItems(signals, { search, filter: activeFilter, workflowType, reviewStatus, assignment, escalation, timingRisk }),
     [activeFilter, assignment, escalation, reviewStatus, search, signals, timingRisk, workflowType]
   );
+  const reviewQueueItems = React.useMemo(() => deriveOperationalReviewQueueItems(visibleSignals), [visibleSignals]);
   const categorySummary = React.useMemo(() => summarizeByCategory(visibleSignals), [visibleSignals]);
   const prioritySummary = React.useMemo(() => summarizeByPriority(visibleSignals), [visibleSignals]);
   const criticalCount = signals.filter((signal) => signal.severity === "critical").length;
@@ -1281,6 +1314,7 @@ export default function OperationalCommandCenterPage() {
               <span>Adjust the view or reset filters to return to the full operational queue.</span>
             </Card>
           ) : null}
+          {!loading && !error && visibleSignals.length ? <OperationalReviewQueue items={reviewQueueItems} /> : null}
           {!loading && !error && visibleSignals.length ? (
             <div style={{ display: "grid", gap: 16 }}>
               {prioritySummary.map((group) => (


### PR DESCRIPTION
## Summary
- Add a read-only Operational Review Queue surface to `/operations` derived from already-visible command center signals.
- Surface deterministic review metadata: workspace type, routing reason, review priority/status, assignment, workflow/financial status, sensitivity, visibility, source workflow link, and scoped resource label.
- Keep the queue manual-only with no workspace creation, auto-routing, mutation, sharing, or tenant-visible review internals.
- Add a governance report for the v1 queue philosophy, scope, and follow-ups.

## Audit findings
- `/operations` already derives landlord-scoped operational signals and renders review workspace readiness panels per item.
- Existing search, saved views, priority filters, and facet filters are frontend-derived from `visibleSignals`.
- The safest queue foundation is a presentation/read-model layer over `visibleSignals`, preserving existing filtering and priority sorting without backend changes.

## Files changed
- `rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx`
- `rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx`
- `rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx`
- `rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx`
- `docs/reports/operational-review-queue-v1.md`

## Tests
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- OperationalCommandCenterPage.test.tsx OperationalReviewQueue.test.tsx ReviewWorkspacePanel.test.tsx` - passed, 18/18
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build` - passed
- `git diff --check` - passed

## Behavior preservation
- No backend routes, auth, Firestore rules, schema, payment logic, evidence derivation, or review workspace writes changed.
- No autonomous behavior introduced.
- No permission or visibility widening.
- Existing `/operations` search/filter/saved view behavior remains the source of queue visibility.

## Preview QA notes
Verify `/operations` shows the new Operational review queue, existing search/saved views/facet filters still filter both the queue and priority sections, links open source workflows, and no create/auto-route/mutate/share controls appear.