### PR TITLE
fix: scope review queue lease links

### DIFF
--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -7,6 +7,7 @@ import OperationalCommandCenterPage, {
   deriveOperationalReviewQueueItems,
   prioritizeOperationalItems,
   reviewWorkspacePreviewForSignal,
+  scopedSourceDestinationForSignal,
 } from "./OperationalCommandCenterPage";
 
 const mocks = vi.hoisted(() => ({
@@ -344,6 +345,65 @@ describe("deriveCommandCenterSignals", () => {
     expect(JSON.stringify(queueItems)).not.toContain("providerPayload");
     expect(JSON.stringify(queueItems)).not.toContain("financialMutation");
     expect(JSON.stringify(queueItems)).not.toContain("institutionalSharing");
+  });
+
+  it("uses scoped lease summary links for lease review queue items when a landlord-scoped lease id is available", () => {
+    const signals = deriveCommandCenterSignals({
+      decisions: [],
+      leases: [lease()],
+      properties: [],
+    });
+
+    const executionSignal = signals.find((signal) => signal.id === "lease-execution:lease-1");
+    expect(executionSignal).toEqual(
+      expect.objectContaining({
+        destination: "/leases",
+        scopedLeaseId: "lease-1",
+      })
+    );
+    expect(scopedSourceDestinationForSignal(executionSignal!)).toBe("/leases/lease-1/summary");
+
+    const queueItems = deriveOperationalReviewQueueItems(signals);
+    const executionQueueItem = queueItems.find((item) => item.queueItemId === "manual-review-queue:lease-execution:lease-1");
+    expect(executionQueueItem).toEqual(
+      expect.objectContaining({
+        title: "Lease execution blocked",
+        destination: "/leases/lease-1/summary",
+        contextLabel: "North Towers · 101 · John Smith",
+      })
+    );
+  });
+
+  it("keeps the generic lease fallback when no scoped lease id is available", () => {
+    const fallbackSignal = {
+      id: "lease-review:unscoped",
+      category: "lease_lifecycle",
+      severity: "warning",
+      priorityGroup: "needs_review",
+      title: "Lease review needed",
+      description: "Review the lease workflow.",
+      contextLabel: "Lease context review",
+      destination: "/leases",
+      source: "Lease operations",
+      workflowStatus: "Review needed",
+      reviewStatus: "Review needed",
+      financialStatus: null,
+      nextActionLabel: "Review lease execution",
+      assignmentState: "unassigned",
+      assignmentLabel: "Unassigned",
+      escalationState: "not_escalated",
+      escalationLabel: "Not escalated",
+      timingState: "current",
+      riskState: "review",
+    } as const;
+
+    expect(scopedSourceDestinationForSignal(fallbackSignal)).toBe("/leases");
+    expect(deriveOperationalReviewQueueItems([fallbackSignal])[0]).toEqual(
+      expect.objectContaining({
+        destination: "/leases",
+        contextLabel: "Lease context review",
+      })
+    );
   });
 
   it("normalizes raw decision context labels with operational lease and property references", () => {

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -73,6 +73,7 @@ export type CommandCenterSignal = {
   escalationLabel?: string;
   timingState?: "upcoming" | "current";
   riskState?: "delinquent" | "high_risk" | "review" | "informational";
+  scopedLeaseId?: string | null;
 };
 
 type CategoryConfig = {
@@ -289,6 +290,16 @@ function routingReasonForSignal(signal: CommandCenterSignal) {
   return "Operational review";
 }
 
+function leaseSummaryDestination(leaseId: string) {
+  return `/leases/${encodeURIComponent(leaseId)}/summary`;
+}
+
+export function scopedSourceDestinationForSignal(signal: CommandCenterSignal) {
+  const scopedLeaseId = String(signal.scopedLeaseId || "").trim();
+  if (scopedLeaseId && signal.destination === "/leases") return leaseSummaryDestination(scopedLeaseId);
+  return signal.destination;
+}
+
 export function reviewWorkspacePreviewForSignal(signal: CommandCenterSignal): ReviewWorkspaceUiModel {
   return {
     workspaceReference: `manual-review-preview:${signal.category}:${signal.priorityGroup}`,
@@ -304,7 +315,7 @@ export function reviewWorkspacePreviewForSignal(signal: CommandCenterSignal): Re
     evidenceLinks: [
       {
         label: `${CATEGORY_CONFIG[signal.category].label} source workflow`,
-        destination: signal.destination,
+        destination: scopedSourceDestinationForSignal(signal),
         sensitivityClass: signal.category === "screening" || signal.category === "documents" ? "restricted" : "sensitive",
       },
     ],
@@ -327,7 +338,7 @@ export function deriveOperationalReviewQueueItems(signals: CommandCenterSignal[]
       title: signal.title,
       contextLabel: signal.contextLabel,
       sourceLabel: signal.source,
-      destination: signal.destination,
+      destination: evidenceLink?.destination || scopedSourceDestinationForSignal(signal),
       workspaceType: preview.workspaceType,
       reviewStatus: preview.reviewStatus,
       reviewPriority: preview.reviewPriority,
@@ -520,6 +531,18 @@ function resolveDecisionContextLabel(
   return "Operational review";
 }
 
+function resolveDecisionLease(
+  item: DecisionInboxItem,
+  lookups: { leases: Map<string, LandlordActiveLease> }
+) {
+  const relatedId = String(item.relatedEntity?.id || "").trim();
+  const destinationLeaseId = leaseIdFromDestination(item.destination);
+  return [relatedId, destinationLeaseId]
+    .filter(Boolean)
+    .map((id) => lookups.leases.get(String(id)))
+    .find(Boolean);
+}
+
 export function prioritizeOperationalItems(signals: CommandCenterSignal[]): CommandCenterSignal[] {
   return [...signals].sort((a, b) => {
     return (
@@ -568,6 +591,7 @@ export function deriveCommandCenterSignals(input: {
     const category = decisionCategory(item);
     const priorityGroup = priorityFromDecision(item, category);
     const severity = severityFromDecision(item);
+    const scopedLease = resolveDecisionLease(item, lookups);
     signals.push({
       id: `decision:${item.id}`,
       category,
@@ -582,6 +606,7 @@ export function deriveCommandCenterSignals(input: {
       reviewStatus: label(item.status || "open"),
       financialStatus: category === "payments" ? "Review required" : null,
       nextActionLabel: nextActionForDecision(item, category),
+      scopedLeaseId: scopedLease?.id || null,
       ...assignmentForDecision(item),
       ...escalationForDecision(item),
     });
@@ -609,6 +634,7 @@ export function deriveCommandCenterSignals(input: {
         reviewStatus: "Review needed",
         financialStatus: null,
         nextActionLabel: "Review occupancy context",
+        scopedLeaseId: lease.id,
       });
     }
 
@@ -627,6 +653,7 @@ export function deriveCommandCenterSignals(input: {
         reviewStatus: "Review needed",
         financialStatus: null,
         nextActionLabel: "Review lease execution",
+        scopedLeaseId: lease.id,
       });
     }
 
@@ -645,6 +672,7 @@ export function deriveCommandCenterSignals(input: {
         reviewStatus: "Review needed",
         financialStatus: null,
         nextActionLabel: "Review lease package",
+        scopedLeaseId: lease.id,
       });
     }
 
@@ -663,6 +691,7 @@ export function deriveCommandCenterSignals(input: {
         reviewStatus: lease.leasePdfStatus === "not_available" ? "Review needed" : "Informational",
         financialStatus: null,
         nextActionLabel: "Review document context",
+        scopedLeaseId: lease.id,
       });
     }
 
@@ -681,6 +710,7 @@ export function deriveCommandCenterSignals(input: {
         reviewStatus: "Review needed",
         financialStatus: label(lease.paymentReadiness.readinessStatus),
         nextActionLabel: "Review payment setup",
+        scopedLeaseId: lease.id,
       });
     }
 
@@ -699,6 +729,7 @@ export function deriveCommandCenterSignals(input: {
         reviewStatus: endingIn <= 30 ? "Needs review" : "Upcoming",
         financialStatus: null,
         nextActionLabel: "Review renewal timing",
+        scopedLeaseId: lease.id,
       });
     }
 
@@ -719,6 +750,7 @@ export function deriveCommandCenterSignals(input: {
         reviewStatus: "Review needed",
         financialStatus: null,
         nextActionLabel: "Review jurisdiction guidance",
+        scopedLeaseId: lease.id,
       });
     }
   }


### PR DESCRIPTION
## Summary
- Add a deterministic scoped source-link helper for operational review queue/workspace links.
- Upgrade generic `/leases` source links to `/leases/:leaseId/summary` only when the signal was derived from an already-loaded landlord-scoped lease record.
- Preserve generic `/leases` fallback when no scoped lease ID is available.

## Audit findings
- `/leases/:leaseId/summary` is an existing canonical frontend route used by landlord lease summary navigation.
- Several lease-derived `/operations` signals currently use generic `/leases` even though the signal is built from a scoped `LandlordActiveLease` record.
- The safest first pass is lease deep-link support only, leaving existing ledger links and generic fallbacks unchanged.

## Files changed
- `rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx`
- `rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx`

## Scoped link helper summary
- Added `scopedSourceDestinationForSignal(signal)`.
- If `signal.scopedLeaseId` exists and `signal.destination === "/leases"`, it returns `/leases/:leaseId/summary`.
- Otherwise it returns the existing destination unchanged.
- Decision-derived scoped lease IDs are only populated when the ID resolves through the already-loaded landlord lease lookup.

## Routes supported
- Added scoped support for lease summary links: `/leases/:leaseId/summary`.
- Existing ledger links such as `/leases/:leaseId/ledger` remain unchanged.

## Fallback behavior
- Signals without a scoped lease ID keep the existing generic `/leases` fallback.
- Human-readable labels remain primary UI text; internal IDs are navigation metadata only.

## Tests
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- OperationalCommandCenterPage.test.tsx OperationalReviewQueue.test.tsx ReviewWorkspacePanel.test.tsx` - passed, 20/20
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build` - passed
- `git diff --check` - passed

## Guardrails
- No backend changes.
- No auth, Firestore rules, schema, or route visibility changes.
- No permission widening.
- No autonomous behavior.
- No financial mutations.
- No tenant-visible review internals introduced.