### PR TITLE
feat: add review assignment and status controls

### DIFF
--- a/docs/reports/review-assignment-and-status-controls-v1.md
+++ b/docs/reports/review-assignment-and-status-controls-v1.md
@@ -1,0 +1,76 @@
+# Review Assignment and Status Controls v1
+
+## Executive Summary
+
+This mission introduces the first manual assignment and review-status control surface for governed review workspaces and the operational review queue.
+
+The implementation is intentionally UI-foundational and manual-only. It does not create review workspaces, persist assignment changes, auto-route work, mutate source records, or alter financial state. It provides deterministic operator-facing metadata controls that prepare the interface for future audited review-session writes.
+
+## Scope
+
+Covered surfaces:
+
+- Operational review queue cards on `/operations`
+- Review workspace readiness panels on `/operations`
+
+Out of scope:
+
+- Autonomous assignment
+- Autonomous routing
+- Auto-resolution
+- Financial mutation
+- Tenant-visible review internals
+- Institutional sharing
+- Firestore schema changes
+- Auth or route behavior changes
+
+## Manual Assignment Metadata
+
+The UI exposes deterministic assignment choices:
+
+- Unassigned
+- Operations owned
+- Property manager
+- Finance reviewer
+- Document reviewer
+- Screening reviewer
+
+These values are display metadata only in this phase. They are not written to `operatorReviewSessions`, decision records, financial records, or source workflow records.
+
+## Review Status Semantics
+
+The UI exposes deterministic review lifecycle states:
+
+- Open
+- Needs review
+- In review
+- Awaiting information
+- Blocked
+- Resolved
+- Closed
+
+These statuses describe manual review handling only. They do not change financial status, workflow truth, tenant-facing state, or source records.
+
+## Governance Guarantees
+
+The control surface preserves:
+
+- Landlord/admin operational context only
+- Manual-only handling
+- Operational vs financial status separation
+- Scoped evidence/resource link display
+- No tenant-visible review internals
+- No autonomous action controls
+- No broad visibility changes
+
+## Future Work
+
+Future missions can safely add:
+
+- Persisted assignment metadata on governed review sessions
+- Append-only assignment/status audit events
+- Server-side status transition validation
+- Review workspace ownership views
+- Controlled escalation handoff metadata
+
+Those missions should continue to preserve manual-only behavior until an explicit governed automation design is approved.

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { OperationalReviewQueue, type OperationalReviewQueueItem } from "./OperationalReviewQueue";
 
@@ -46,8 +46,13 @@ describe("OperationalReviewQueue", () => {
     expect(screen.getAllByText("North Towers · Unit 104 · James Smith").length).toBeGreaterThan(0);
     expect(screen.getByText("Payment Ledger Review")).toBeInTheDocument();
     expect(screen.getByText("Delinquency or payment evidence review")).toBeInTheDocument();
-    expect(screen.getByText("Operations owned")).toBeInTheDocument();
+    expect(screen.getAllByText("Operations owned").length).toBeGreaterThan(0);
     expect(screen.getByText("Review required")).toBeInTheDocument();
+    expect(screen.getByLabelText("Review status for Review missing payment")).toHaveValue("open");
+    expect(screen.getByLabelText("Assigned reviewer for Review missing payment")).toHaveValue("operations");
+    expect(screen.getByText("Manual status: Open")).toBeInTheDocument();
+    expect(screen.getByText("Manual assignment: Operations owned")).toBeInTheDocument();
+    expect(screen.getByText(/They do not route work automatically, change source records, or alter financial status/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Payments / obligations source workflow" })).toHaveAttribute(
       "href",
       "/leases/lease-1/ledger"
@@ -58,6 +63,30 @@ describe("OperationalReviewQueue", () => {
     expect(screen.queryByText(/mutate ledger/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/institutional sharing/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
+  });
+
+  it("updates manual assignment and status metadata without adding mutation actions", () => {
+    render(
+      <MemoryRouter>
+        <OperationalReviewQueue items={[queueItem()]} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Review status for Review missing payment"), {
+      target: { value: "in_review" },
+    });
+    fireEvent.change(screen.getByLabelText("Assigned reviewer for Review missing payment"), {
+      target: { value: "finance_reviewer" },
+    });
+
+    expect(screen.getByText("Manual status: In review")).toBeInTheDocument();
+    expect(screen.getByText("Manual assignment: Finance reviewer")).toBeInTheDocument();
+    expect(screen.getByText("Assignment reason: Finance reviewer owns the next manual review step.")).toBeInTheDocument();
+    expect(screen.getByText("Review status note: Operator review is actively underway.")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?assign/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?resolution/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/mutate ledger/i)).not.toBeInTheDocument();
   });
 
   it("uses safe fallback labels for raw internal identifiers", () => {

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
+import { ReviewAssignmentStatusControls } from "./ReviewAssignmentStatusControls";
 
 export type OperationalReviewQueueItem = {
   queueItemId: string;
@@ -127,6 +128,13 @@ export function OperationalReviewQueue({ items }: { items: OperationalReviewQueu
                 {metadata("Sensitivity", label(item.sensitivityClass))}
                 {metadata("Visibility", label(item.visibilityClass))}
               </div>
+
+              <ReviewAssignmentStatusControls
+                itemId={item.queueItemId}
+                title={safeDisplayLabel(item.title, "Operational review item")}
+                initialStatus={item.reviewStatus}
+                initialAssignment={item.assignmentLabel}
+              />
 
               <div style={{ display: "grid", gap: 5 }}>
                 <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Scoped evidence/resource links</span>

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewAssignmentStatusControls.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewAssignmentStatusControls.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+
+export type ReviewLifecycleStatus =
+  | "open"
+  | "needs_review"
+  | "in_review"
+  | "awaiting_information"
+  | "blocked"
+  | "resolved"
+  | "closed";
+
+export type ReviewAssignmentTarget =
+  | "unassigned"
+  | "operations"
+  | "property_manager"
+  | "finance_reviewer"
+  | "document_reviewer"
+  | "screening_reviewer";
+
+type ReviewStatusOption = {
+  value: ReviewLifecycleStatus;
+  label: string;
+  description: string;
+};
+
+type AssignmentOption = {
+  value: ReviewAssignmentTarget;
+  label: string;
+  reason: string;
+};
+
+export const REVIEW_STATUS_OPTIONS: ReviewStatusOption[] = [
+  { value: "open", label: "Open", description: "Ready for manual review intake." },
+  { value: "needs_review", label: "Needs review", description: "Requires operator attention before routing decisions." },
+  { value: "in_review", label: "In review", description: "Operator review is actively underway." },
+  { value: "awaiting_information", label: "Awaiting information", description: "Waiting for supporting context or evidence." },
+  { value: "blocked", label: "Blocked", description: "Cannot progress until a manual blocker is cleared." },
+  { value: "resolved", label: "Resolved", description: "Operational review item is resolved by staff." },
+  { value: "closed", label: "Closed", description: "Manual review handling is closed." },
+];
+
+export const REVIEW_ASSIGNMENT_OPTIONS: AssignmentOption[] = [
+  { value: "unassigned", label: "Unassigned", reason: "No manual owner selected." },
+  { value: "operations", label: "Operations owned", reason: "Operations team owns the next manual review step." },
+  { value: "property_manager", label: "Property manager", reason: "Property manager owns the next manual review step." },
+  { value: "finance_reviewer", label: "Finance reviewer", reason: "Finance reviewer owns the next manual review step." },
+  { value: "document_reviewer", label: "Document reviewer", reason: "Document reviewer owns the next manual review step." },
+  { value: "screening_reviewer", label: "Screening reviewer", reason: "Screening reviewer owns the next manual review step." },
+];
+
+function normalizeToken(value: string) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
+}
+
+export function normalizeReviewLifecycleStatus(value: string | null | undefined): ReviewLifecycleStatus {
+  const token = normalizeToken(value || "");
+  if (token === "needs_review" || token === "review_needed" || token === "manual_review") return "needs_review";
+  if (token === "in_review" || token === "under_review") return "in_review";
+  if (token === "awaiting_information" || token === "waiting_context" || token === "waiting_information") {
+    return "awaiting_information";
+  }
+  if (token === "blocked") return "blocked";
+  if (token === "resolved" || token === "completed") return "resolved";
+  if (token === "closed" || token === "abandoned") return "closed";
+  return "open";
+}
+
+export function normalizeReviewAssignmentTarget(value: string | null | undefined): ReviewAssignmentTarget {
+  const token = normalizeToken(value || "");
+  if (!token || token === "unassigned") return "unassigned";
+  if (token.includes("finance")) return "finance_reviewer";
+  if (token.includes("document")) return "document_reviewer";
+  if (token.includes("screening")) return "screening_reviewer";
+  if (token.includes("property")) return "property_manager";
+  if (token.includes("operation")) return "operations";
+  return "operations";
+}
+
+export function reviewStatusLabel(value: ReviewLifecycleStatus) {
+  return REVIEW_STATUS_OPTIONS.find((option) => option.value === value)?.label || "Open";
+}
+
+export function reviewAssignmentLabel(value: ReviewAssignmentTarget) {
+  return REVIEW_ASSIGNMENT_OPTIONS.find((option) => option.value === value)?.label || "Unassigned";
+}
+
+function selectedStatusDescription(value: ReviewLifecycleStatus) {
+  return REVIEW_STATUS_OPTIONS.find((option) => option.value === value)?.description || REVIEW_STATUS_OPTIONS[0].description;
+}
+
+function selectedAssignmentReason(value: ReviewAssignmentTarget) {
+  return REVIEW_ASSIGNMENT_OPTIONS.find((option) => option.value === value)?.reason || REVIEW_ASSIGNMENT_OPTIONS[0].reason;
+}
+
+export function ReviewAssignmentStatusControls({
+  itemId,
+  title,
+  initialStatus,
+  initialAssignment,
+  onChange,
+}: {
+  itemId: string;
+  title: string;
+  initialStatus: string;
+  initialAssignment: string;
+  onChange?: (next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }) => void;
+}) {
+  const [status, setStatus] = React.useState<ReviewLifecycleStatus>(() => normalizeReviewLifecycleStatus(initialStatus));
+  const [assignment, setAssignment] = React.useState<ReviewAssignmentTarget>(() =>
+    normalizeReviewAssignmentTarget(initialAssignment)
+  );
+
+  React.useEffect(() => {
+    setStatus(normalizeReviewLifecycleStatus(initialStatus));
+  }, [initialStatus]);
+
+  React.useEffect(() => {
+    setAssignment(normalizeReviewAssignmentTarget(initialAssignment));
+  }, [initialAssignment]);
+
+  function updateStatus(nextStatus: ReviewLifecycleStatus) {
+    setStatus(nextStatus);
+    onChange?.({ status: nextStatus, assignment });
+  }
+
+  function updateAssignment(nextAssignment: ReviewAssignmentTarget) {
+    setAssignment(nextAssignment);
+    onChange?.({ status, assignment: nextAssignment });
+  }
+
+  return (
+    <section
+      aria-label={`Manual review lifecycle controls for ${title}`}
+      style={{
+        border: "1px solid #dbe3ef",
+        borderRadius: 8,
+        background: "#f8fafc",
+        padding: 10,
+        display: "grid",
+        gap: 8,
+        minWidth: 0,
+      }}
+    >
+      <div style={{ display: "grid", gap: 3 }}>
+        <strong style={{ color: "#0f172a", fontSize: 13 }}>Manual review controls</strong>
+        <span style={{ color: "#475569", fontSize: 12, lineHeight: 1.45 }}>
+          Assignment and status selections are manual review metadata only. They do not route work automatically, change source
+          records, or alter financial status.
+        </span>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 160px), 1fr))", gap: 8 }}>
+        <label style={controlLabelStyle}>
+          Manual review status
+          <select
+            aria-label={`Review status for ${title}`}
+            value={status}
+            onChange={(event) => updateStatus(event.target.value as ReviewLifecycleStatus)}
+            style={selectStyle}
+          >
+            {REVIEW_STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={controlLabelStyle}>
+          Assigned reviewer
+          <select
+            aria-label={`Assigned reviewer for ${title}`}
+            value={assignment}
+            onChange={(event) => updateAssignment(event.target.value as ReviewAssignmentTarget)}
+            style={selectStyle}
+          >
+            {REVIEW_ASSIGNMENT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div id={`${itemId}-manual-review-summary`} style={{ display: "grid", gap: 3, color: "#334155", fontSize: 12 }}>
+        <span>Manual status: {reviewStatusLabel(status)}</span>
+        <span>Manual assignment: {reviewAssignmentLabel(assignment)}</span>
+        <span>Assignment reason: {selectedAssignmentReason(assignment)}</span>
+        <span>Review status note: {selectedStatusDescription(status)}</span>
+      </div>
+    </section>
+  );
+}
+
+const controlLabelStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 5,
+  color: "#334155",
+  fontSize: 12,
+  fontWeight: 900,
+};
+
+const selectStyle: React.CSSProperties = {
+  border: "1px solid #cbd5e1",
+  borderRadius: 8,
+  padding: "8px 10px",
+  color: "#0f172a",
+  background: "#fff",
+  minWidth: 0,
+  width: "100%",
+};

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { ReviewWorkspacePanel, type ReviewWorkspaceUiModel } from "./ReviewWorkspacePanel";
 
@@ -39,10 +39,37 @@ describe("ReviewWorkspacePanel", () => {
     expect(screen.getByText("Payment Ledger Review")).toBeInTheDocument();
     expect(screen.getByText("Delinquency or payment evidence review")).toBeInTheDocument();
     expect(screen.getByText("Landlord Operational")).toBeInTheDocument();
+    expect(screen.getByLabelText("Review status for Payment Ledger Review")).toHaveValue("open");
+    expect(screen.getByLabelText("Assigned reviewer for Payment Ledger Review")).toHaveValue("operations");
+    expect(screen.getByText(/They do not route work automatically, change source records, or alter financial status/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Payments / obligations source workflow" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByText("North Towers · Unit 104 · James Smith")).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
     expect(screen.queryByText(/auto-create/i)).not.toBeInTheDocument();
+  });
+
+  it("allows local manual assignment and status selections without persistence or autonomous controls", () => {
+    render(
+      <MemoryRouter>
+        <ReviewWorkspacePanel workspace={workspace()} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Review status for Payment Ledger Review"), {
+      target: { value: "blocked" },
+    });
+    fireEvent.change(screen.getByLabelText("Assigned reviewer for Payment Ledger Review"), {
+      target: { value: "property_manager" },
+    });
+
+    expect(screen.getByText("Manual status: Blocked")).toBeInTheDocument();
+    expect(screen.getByText("Manual assignment: Property manager")).toBeInTheDocument();
+    expect(screen.getByText("Assignment reason: Property manager owns the next manual review step.")).toBeInTheDocument();
+    expect(screen.getByText("Review status note: Cannot progress until a manual blocker is cleared.")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?assign/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?route/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/financial mutation/i)).not.toBeInTheDocument();
   });
 
   it("does not render raw resource identifiers as primary labels", () => {

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
+import { ReviewAssignmentStatusControls } from "./ReviewAssignmentStatusControls";
 
 export type ReviewWorkspaceUiLink = {
   label: string;
@@ -100,6 +101,13 @@ export function ReviewWorkspacePanel({ workspace }: { workspace: ReviewWorkspace
         {metadataCell("Sensitivity", label(workspace.sensitivityClass))}
         {metadataCell("Visibility", label(workspace.visibilityClass))}
       </div>
+
+      <ReviewAssignmentStatusControls
+        itemId={workspace.workspaceReference}
+        title={label(workspace.workspaceType)}
+        initialStatus={workspace.reviewStatus}
+        initialAssignment={workspace.assignmentLabel}
+      />
 
       <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
         <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Scoped evidence linkage</span>


### PR DESCRIPTION
## Summary
- add reusable manual review assignment/status controls for review workspace readiness panels and the operational review queue
- keep controls local/manual-only: no review workspaces are auto-created, no backend writes are added, no source records or financial state are changed
- document the v1 manual assignment/status governance expectations

## Audit findings
- existing `operatorReviewSessions` routes support open, note, and close flows only; there is no scoped assignment/status update contract to reuse safely in this mission
- operational review queue and review workspace readiness panels were read-only and already carried deterministic assignment/status metadata
- safest first foundation is UI-level manual metadata controls without persistence or workflow mutation

## Tests run
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- OperationalReviewQueue.test.tsx ReviewWorkspacePanel.test.tsx OperationalCommandCenterPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Guardrails confirmed
- no backend/auth/schema/Firestore/routing changes
- no autonomous assignment, routing, resolution, or financial mutation behavior
- no tenant-visible review internals introduced
- no create/auto-route/mutate/share buttons added

## Follow-ups
- persisted assignment/status updates should be added only after an audited review-session write contract and append-only event semantics are approved