### PR TITLE
test: add review workspace audit continuity coverage

### DIFF
--- a/rentchain-api/src/lib/reviewWorkspaces/__tests__/reviewWorkspaceAuditContinuity.test.ts
+++ b/rentchain-api/src/lib/reviewWorkspaces/__tests__/reviewWorkspaceAuditContinuity.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import {
+  buildReviewWorkspaceInputFromRouting,
+  deriveOperationalReviewRouting,
+} from "../../operationalReviewRouting/deriveOperationalReviewRouting";
+import {
+  buildReviewWorkspace,
+  reviewWorkspaceToOperatorReviewOpenRequest,
+} from "../buildReviewWorkspace";
+
+const createdBy = { userId: "landlord-user-1", role: "landlord" as const, email: "ops@example.test" };
+
+function expectManualOnlyContinuity(payload: unknown) {
+  expect(payload).toEqual(
+    expect.objectContaining({
+      manualOnly: true,
+      autonomousActionsEnabled: false,
+    })
+  );
+  expect(JSON.stringify(payload)).not.toContain("autoCreateWorkspace\":true");
+  expect(JSON.stringify(payload)).not.toContain("autoAssign");
+  expect(JSON.stringify(payload)).not.toContain("autoResolve");
+  expect(JSON.stringify(payload)).not.toContain("financialMutationEnabled\":true");
+  expect(JSON.stringify(payload)).not.toContain("institutionalSharingEnabled\":true");
+  expect(JSON.stringify(payload)).not.toContain("tenantVisible");
+}
+
+describe("review workspace audit continuity", () => {
+  it("preserves routing origin, scoped source linkage, evidence lineage, and manual-only handoff metadata", () => {
+    const routing = deriveOperationalReviewRouting({
+      itemId: "decision:review_missing_payment:lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      title: "Missing payment review",
+      description: "Rent evidence needs manual review.",
+      category: "payments",
+      severity: "critical",
+      status: "open",
+      workflowQueue: "delinquency_review",
+      workflowState: "new",
+      reviewStatus: "critical",
+      destination: "/leases/lease-1/ledger",
+      relatedResourceRefs: [
+        {
+          resourceType: "lease",
+          resourceId: "lease-1",
+          label: "North Towers · Unit 104 lease context",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          unitId: "unit-104",
+          leaseId: "lease-1",
+        },
+        {
+          resourceType: "payment",
+          resourceId: "payment-wrong-landlord",
+          label: "Wrong landlord payment",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+        },
+      ],
+    });
+
+    expect(routing).toEqual(
+      expect.objectContaining({
+        reviewEligible: true,
+        reviewReasonKey: "delinquency_review",
+        reviewReasonLabel: "Delinquency review",
+        sourceDestination: "/leases/lease-1/ledger",
+        manualOnly: true,
+        autoCreateWorkspace: false,
+        autonomousActionsEnabled: false,
+        permissionWideningRequired: false,
+      })
+    );
+    expect(routing.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "lease",
+        resourceId: "lease-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        propertyId: "property-1",
+        unitId: "unit-104",
+        leaseId: "lease-1",
+      }),
+    ]);
+
+    const workspaceInput = buildReviewWorkspaceInputFromRouting({
+      routing,
+      createdBy,
+      createdAt: "2026-05-20T12:00:00.000Z",
+    });
+    const workspace = buildReviewWorkspace({
+      ...workspaceInput!,
+      tenantId: "tenant-1",
+      evidenceRefs: [
+        {
+          evidencePackId: "evidence-pack-1",
+          evidenceItemId: "decision-1",
+          evidenceType: "evidence_item",
+          label: "Missing payment evidence",
+          sourceCollection: "decisionItems",
+          sourceId: "decision-1",
+          scopeType: "decision",
+          scopeId: "decision:review_missing_payment:lease-1",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          sensitivityClass: "restricted",
+          projectionProfile: "landlord_evidence_review",
+          projectionVersion: "evidence_projection_profile_v1",
+          redactionSummary: "Restricted fields excluded.",
+          lineageSummary: "Derived from decisionItems:decision-1.",
+          rawPayload: { providerPayload: "raw provider dump" },
+          rawCsv: "raw csv data",
+          accountNumber: "123456789",
+          routeSource: "debug route",
+          stack: "private stack trace",
+          token: "secret-token",
+          messageBody: "private message body",
+        },
+      ],
+      createdFromEvent: {
+        eventId: "event-1",
+        eventType: "decision.workflow.review_required",
+        sourceSystem: "decision_workflow",
+      },
+      auditRefs: [
+        {
+          auditId: "audit-1",
+          eventType: "operator_review_session_opened",
+          sourceCollection: "canonicalEvents",
+        },
+      ],
+    });
+
+    expect(workspace).toEqual(
+      expect.objectContaining({
+        workspaceType: "delinquency_review",
+        workspaceScopeId: "decision:review_missing_payment:lease-1",
+        reviewSummary: "Delinquency review",
+        reviewPriority: "critical",
+        reviewStatus: "open",
+        landlordId: "landlord-1",
+        createdAt: "2026-05-20T12:00:00.000Z",
+        updatedAt: "2026-05-20T12:00:00.000Z",
+      })
+    );
+    expect(workspace.reviewTags).toEqual(["critical", "delinquency_review"]);
+    expect(workspace.createdFromEvent).toEqual({
+      eventId: "event-1",
+      eventType: "decision.workflow.review_required",
+      sourceSystem: "decision_workflow",
+    });
+    expect(workspace.auditRefs).toEqual([
+      { auditId: "audit-1", eventType: "operator_review_session_opened", sourceCollection: "canonicalEvents" },
+    ]);
+    expect(workspace.evidenceRefs).toEqual([
+      expect.objectContaining({
+        evidenceRefId: "review_evidence_ref:evidence-pack-1:decision-1:decisionitems:decision-1",
+        evidencePackId: "evidence-pack-1",
+        evidenceItemId: "decision-1",
+        evidenceType: "evidence_item",
+        label: "Missing payment evidence",
+        sourceCollection: "decisionItems",
+        sourceId: "decision-1",
+        sourceRef: { sourceCollection: "decisionItems", sourceId: "decision-1" },
+        scopeType: "decision",
+        scopeId: "decision:review_missing_payment:lease-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        sensitivityClass: "restricted",
+        projectionProfile: "landlord_evidence_review",
+        projectionVersion: "evidence_projection_profile_v1",
+        redactionSummary: "Restricted fields excluded.",
+        lineageSummary: "Derived from decisionItems:decision-1.",
+      }),
+    ]);
+    expect(workspace.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "lease",
+        resourceId: "lease-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+      }),
+    ]);
+    expectManualOnlyContinuity(workspace);
+    expectNoRestrictedProjectionFields(workspace);
+    expectPayloadDoesNotContainValues(workspace, [
+      "payment-wrong-landlord",
+      "landlord-2",
+      "raw provider dump",
+      "raw csv data",
+      "123456789",
+      "debug route",
+      "private stack trace",
+      "secret-token",
+      "private message body",
+    ]);
+
+    const operatorReviewRequest = reviewWorkspaceToOperatorReviewOpenRequest(workspace);
+    expect(operatorReviewRequest).toEqual({
+      scope: "delinquency",
+      scopeId: "decision:review_missing_payment:lease-1",
+      linkedEvidence: [{ evidenceId: "evidence-pack-1", label: "Missing payment evidence", kind: "workflow", destination: null }],
+      note: "Delinquency review",
+    });
+    expect(JSON.stringify(operatorReviewRequest)).not.toContain("raw provider dump");
+    expect(JSON.stringify(operatorReviewRequest)).not.toContain("tenantVisible");
+    expect(JSON.stringify(operatorReviewRequest)).not.toContain("financialMutation");
+  });
+
+  it("keeps assignment and status metadata deterministic without auto-transition flags", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "payment_ledger_review",
+      workspaceScopeId: "payment-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      createdBy,
+      createdAt: "2026-05-20T12:05:00.000Z",
+      assignedReviewer: { userId: "finance-reviewer-1", role: "operator", email: "finance@example.test" },
+      reviewStatus: "under_review",
+      reviewPriority: "warning",
+      reviewSummary: "Payment evidence review",
+      relatedResourceRefs: [
+        {
+          resourceType: "payment",
+          resourceId: "payment-1",
+          label: "North Towers payment",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        },
+      ],
+    });
+
+    expect(workspace.assignedReviewer).toEqual({
+      userId: "finance-reviewer-1",
+      role: "operator",
+      email: "finance@example.test",
+    });
+    expect(workspace.reviewStatus).toBe("under_review");
+    expect(workspace.reviewPriority).toBe("warning");
+    expect(workspace.updatedAt).toBe("2026-05-20T12:05:00.000Z");
+    expect(workspace.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "payment",
+        resourceId: "payment-1",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+      }),
+    ]);
+    expectManualOnlyContinuity(workspace);
+    expect(JSON.stringify(workspace)).not.toContain("autoTransition");
+    expect(JSON.stringify(workspace)).not.toContain("autoResolved");
+    expect(JSON.stringify(workspace)).not.toContain("sourceRecordMutation");
+  });
+});

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewAssignmentStatusControls.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewAssignmentStatusControls.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizeReviewAssignmentTarget,
+  normalizeReviewLifecycleStatus,
+  ReviewAssignmentStatusControls,
+} from "./ReviewAssignmentStatusControls";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ReviewAssignmentStatusControls", () => {
+  it("normalizes status and assignment metadata deterministically", () => {
+    expect(normalizeReviewLifecycleStatus("under review")).toBe("in_review");
+    expect(normalizeReviewLifecycleStatus("waiting_context")).toBe("awaiting_information");
+    expect(normalizeReviewLifecycleStatus("completed")).toBe("resolved");
+    expect(normalizeReviewLifecycleStatus("unknown-state")).toBe("open");
+
+    expect(normalizeReviewAssignmentTarget("Finance review")).toBe("finance_reviewer");
+    expect(normalizeReviewAssignmentTarget("Document reviewer")).toBe("document_reviewer");
+    expect(normalizeReviewAssignmentTarget("")).toBe("unassigned");
+    expect(normalizeReviewAssignmentTarget("Operations owned")).toBe("operations");
+  });
+
+  it("updates manual metadata only and does not render autonomous or mutation controls", () => {
+    const onChange = vi.fn();
+    render(
+      <ReviewAssignmentStatusControls
+        itemId="queue-item-1"
+        title="Missing payment review"
+        initialStatus="Open"
+        initialAssignment="Unassigned"
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Review status for Missing payment review"), {
+      target: { value: "awaiting_information" },
+    });
+    fireEvent.change(screen.getByLabelText("Assigned reviewer for Missing payment review"), {
+      target: { value: "finance_reviewer" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ status: "awaiting_information", assignment: "unassigned" });
+    expect(onChange).toHaveBeenCalledWith({ status: "awaiting_information", assignment: "finance_reviewer" });
+    expect(screen.getByText("Manual status: Awaiting information")).toBeInTheDocument();
+    expect(screen.getByText("Manual assignment: Finance reviewer")).toBeInTheDocument();
+    expect(screen.getByText("Assignment reason: Finance reviewer owns the next manual review step.")).toBeInTheDocument();
+    expect(screen.getByText("Review status note: Waiting for supporting context or evidence.")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?assign/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?route/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/auto.?resolve/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/mutate ledger/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/institutional sharing/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -347,6 +347,79 @@ describe("deriveCommandCenterSignals", () => {
     expect(JSON.stringify(queueItems)).not.toContain("institutionalSharing");
   });
 
+  it("preserves review audit continuity from source signal into workspace preview and queue item metadata", () => {
+    const signals = deriveCommandCenterSignals({
+      decisions: [decision()],
+      leases: [lease()],
+      properties: [],
+    });
+    const sourceSignal = signals.find((signal) => signal.id === "decision:decision-1");
+
+    expect(sourceSignal).toEqual(
+      expect.objectContaining({
+        id: "decision:decision-1",
+        source: "Decision inbox · Delinquency Review",
+        destination: "/leases/lease-1/ledger",
+        contextLabel: "North Towers · 101 · John Smith",
+        reviewStatus: "Open",
+        assignmentLabel: "Operations owned",
+        financialStatus: "Review required",
+      })
+    );
+
+    const preview = reviewWorkspacePreviewForSignal(sourceSignal!);
+    expect(preview).toEqual(
+      expect.objectContaining({
+        workspaceReference: "manual-review-preview:payments:critical",
+        workspaceType: "payment_ledger_review",
+        reviewStatus: "Open",
+        reviewPriority: "Critical",
+        routingReason: "Delinquency or payment evidence review",
+        assignmentLabel: "Operations owned",
+        manualOnly: true,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(preview.evidenceLinks).toEqual([
+      expect.objectContaining({
+        label: "Payments / obligations source workflow",
+        destination: "/leases/lease-1/ledger",
+        sensitivityClass: "sensitive",
+      }),
+    ]);
+    expect(preview.relatedResources).toEqual([
+      expect.objectContaining({
+        label: "North Towers · 101 · John Smith",
+        resourceType: "lease",
+      }),
+    ]);
+
+    const queueItem = deriveOperationalReviewQueueItems(signals).find(
+      (item) => item.queueItemId === "manual-review-queue:decision:decision-1"
+    );
+    expect(queueItem).toEqual(
+      expect.objectContaining({
+        title: "Review missing payment",
+        sourceLabel: "Decision inbox · Delinquency Review",
+        destination: "/leases/lease-1/ledger",
+        routingReason: "Delinquency or payment evidence review",
+        evidenceLabel: "Payments / obligations source workflow",
+        relatedResourceLabel: "North Towers · 101 · John Smith",
+        reviewStatus: "Open",
+        assignmentLabel: "Operations owned",
+        manualOnly: true,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(JSON.stringify({ preview, queueItem })).not.toContain("autoCreate");
+    expect(JSON.stringify({ preview, queueItem })).not.toContain("autoAssign");
+    expect(JSON.stringify({ preview, queueItem })).not.toContain("autoResolve");
+    expect(JSON.stringify({ preview, queueItem })).not.toContain("tenantVisible");
+    expect(JSON.stringify({ preview, queueItem })).not.toContain("financialMutation");
+    expect(JSON.stringify({ preview, queueItem })).not.toContain("institutionalSharing");
+    expect(JSON.stringify({ preview, queueItem })).not.toContain("rawPayload");
+  });
+
   it("uses scoped lease summary links for lease review queue items when a landlord-scoped lease id is available", () => {
     const signals = deriveCommandCenterSignals({
       decisions: [],


### PR DESCRIPTION
## Summary
- add backend audit-continuity regression coverage for operational routing -> review workspace -> operator review handoff
- add frontend coverage for source signal -> review workspace preview -> operational review queue continuity
- add focused tests for deterministic manual assignment/status control metadata and no autonomous/mutation controls

## Audit continuity surfaces covered
- review origin and routing reason preservation
- scoped source workflow links and source labels
- evidence/source refs as lineage metadata only
- assignment and status metadata determinism
- manual-only flags and absence of autonomous behavior
- restricted/raw/provider/payment/debug/message fields excluded from review workspace payloads

## Tests run
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- reviewWorkspaceAuditContinuity.test.ts reviewWorkspaceScopeRegression.test.ts buildReviewWorkspace.test.ts deriveOperationalReviewRouting.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- ReviewAssignmentStatusControls.test.tsx OperationalReviewQueue.test.tsx ReviewWorkspacePanel.test.tsx OperationalCommandCenterPage.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Guardrails confirmed
- tests only; no product behavior changes
- no auth/schema/Firestore/routing changes
- no permission widening
- no tenant-visible review internals
- no autonomous assignment/routing/resolution
- no financial mutation paths

## Continuity gaps found
- none in the covered paths

## Follow-ups
- when persisted assignment/status writes are introduced, add append-only audit-event continuity tests for those write routes