### PR TITLE
fix: harden frontend security headers and CSP

### DIFF
--- a/docs/reports/frontend-security-headers-and-csp-v1.md
+++ b/docs/reports/frontend-security-headers-and-csp-v1.md
@@ -1,0 +1,97 @@
+# Frontend Security Headers and CSP v1
+
+## Executive Summary
+
+This mission adds a conservative browser-security baseline for the RentChain Vercel frontend. The change is limited to frontend response headers and config-level regression tests. It does not change authentication, Firebase logic, backend routes, Firestore rules, payment flows, screening flows, exports, or review workflows.
+
+The baseline is designed to improve protection against script injection, clickjacking, MIME sniffing, referrer leakage, unsafe browser capabilities, and accidental third-party loading while preserving Vercel preview deployments, Cloud Run API rewrites, Firebase/Auth, Stripe/provider redirects, app assets, and PDF preview behavior.
+
+## Headers Added
+
+The following headers are applied to static assets and non-asset SPA routes in `rentchain-frontend/vercel.json`:
+
+- `Content-Security-Policy`
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy`
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+- `Cross-Origin-Opener-Policy: same-origin-allow-popups`
+- `Cross-Origin-Resource-Policy: same-origin`
+
+The existing cache policies are preserved:
+
+- immutable long-lived cache for `/assets/(.*)`
+- `no-store` for non-asset SPA routes
+
+The Cloud Run rewrites remain unchanged, including `/api/:path*`.
+
+## CSP Posture
+
+The CSP is intentionally conservative rather than maximally strict. It blocks object embeds, blocks framing of RentChain pages, limits scripts to same-origin built assets, permits inline styles for the existing React style usage, and permits required app connectivity for RentChain, Firebase/Google APIs, Stripe, and the Cloud Run API.
+
+Key directives:
+
+- `default-src 'self'`
+- `base-uri 'self'`
+- `object-src 'none'`
+- `frame-ancestors 'none'`
+- `script-src 'self'`
+- `style-src 'self' 'unsafe-inline'`
+- `connect-src 'self' ...`
+- `frame-src 'self' blob: data: https:`
+- `worker-src 'self' blob:`
+- `form-action 'self'`
+- `upgrade-insecure-requests`
+
+## Allowed External Sources
+
+The CSP allows the following external source families where currently needed or safely anticipated by existing flows:
+
+- RentChain domains: `https://*.rentchain.ai`
+- Cloud Run API: `https://rentchain-landlord-api-915921057662.us-central1.run.app`
+- Firebase and Google APIs: `https://*.googleapis.com`, `https://*.firebaseio.com`, `https://*.firebaseapp.com`, `https://*.gstatic.com`, `wss://*.firebaseio.com`
+- Stripe: `https://*.stripe.com`
+- Images and frames: `https:` in addition to `self`, `blob:`, and `data:` for compatibility with existing document/PDF/provider preview behavior
+
+## Known Limitations
+
+- `style-src` includes `'unsafe-inline'` because the frontend uses React inline styles and component-level dynamic styling. Removing it should be a later staged mission after style usage is inventoried.
+- `frame-src` remains broad enough to avoid breaking document/PDF/provider preview behavior. Future tightening should be based on deployed CSP violation data and a full iframe/embed inventory.
+- CSP reporting is not enabled because there is no governed CSP report ingestion endpoint yet.
+- This mission does not introduce runtime header middleware. Vercel remains the frontend header authority.
+- This mission does not harden backend Cloud Run responses.
+
+## Verification
+
+Config regression tests assert:
+
+- security headers are present on both asset and SPA route header rules
+- header names do not conflict within each route rule
+- cache policies remain unchanged
+- CSP includes required RentChain, Firebase/Google, Stripe, Cloud Run, worker, and frame directives
+- `/api/:path*` continues to rewrite to the Cloud Run API before the SPA fallback
+
+## Post-Deploy QA
+
+After Vercel preview deployment:
+
+1. Load `/`
+2. Load `/login`
+3. Load `/dashboard`
+4. Load `/operations`
+5. Verify normal `/api` calls still work through the preview
+6. Verify login/auth screens load
+7. Verify there are no CSP console errors blocking required app resources
+8. Verify Stripe/provider redirect entry points still render
+9. Verify document/PDF preview surfaces still render where available
+
+## Future Hardening
+
+Recommended follow-up work:
+
+1. Add a governed CSP report endpoint or third-party report collector with redaction.
+2. Inventory iframe, image, worker, and external navigation dependencies from preview CSP reports.
+3. Tighten `frame-src` from broad `https:` to explicit provider/domain allowlists.
+4. Remove `'unsafe-inline'` from `style-src` after replacing required inline style usage or adopting a nonce/hash strategy.
+5. Evaluate backend Cloud Run security headers separately.

--- a/docs/reports/frontend-security-headers-and-csp-v1.md
+++ b/docs/reports/frontend-security-headers-and-csp-v1.md
@@ -62,6 +62,7 @@ The CSP allows the following external source families where currently needed or 
 - `frame-src` remains broad enough to avoid breaking document/PDF/provider preview behavior. Future tightening should be based on deployed CSP violation data and a full iframe/embed inventory.
 - `script-src` includes `https://vercel.live` so Vercel preview feedback can load without console-blocking errors during preview QA.
 - `connect-src` includes `https://*.a.run.app` because Cloud Run preview and alternate service URLs can differ from the explicit production Cloud Run host.
+- `Permissions-Policy` intentionally avoids unsupported experimental feature tokens such as `browsing-topics` to prevent browser console noise on preview and production deployments.
 - CSP reporting is not enabled because there is no governed CSP report ingestion endpoint yet.
 - This mission does not introduce runtime header middleware. Vercel remains the frontend header authority.
 - This mission does not harden backend Cloud Run responses.

--- a/docs/reports/frontend-security-headers-and-csp-v1.md
+++ b/docs/reports/frontend-security-headers-and-csp-v1.md
@@ -63,6 +63,7 @@ The CSP allows the following external source families where currently needed or 
 - `script-src` includes `https://vercel.live` so Vercel preview feedback can load without console-blocking errors during preview QA.
 - `connect-src` includes `https://*.a.run.app` because Cloud Run preview and alternate service URLs can differ from the explicit production Cloud Run host.
 - `Permissions-Policy` intentionally avoids unsupported experimental feature tokens such as `browsing-topics` to prevent browser console noise on preview and production deployments. The security headers are centralized in one broad Vercel rule to avoid route-specific duplicate policy blocks.
+- Vercel deployment protection can return a `401` shell for `/manifest.webmanifest` and static assets before repo-defined route/header behavior is applied. The manifest is present in `public/manifest.webmanifest` and generated into `dist/manifest.webmanifest`; a preview-only `401` from the protected deployment shell is not a missing manifest artifact.
 - CSP reporting is not enabled because there is no governed CSP report ingestion endpoint yet.
 - This mission does not introduce runtime header middleware. Vercel remains the frontend header authority.
 - This mission does not harden backend Cloud Run responses.
@@ -76,6 +77,7 @@ Config regression tests assert:
 - cache policies remain unchanged
 - CSP includes required RentChain, Firebase/Google, Stripe, Cloud Run, worker, and frame directives
 - `/api/:path*` continues to rewrite to the Cloud Run API before the SPA fallback
+- `/manifest.webmanifest` remains referenced by `index.html` and backed by a public manifest file
 
 ## Post-Deploy QA
 

--- a/docs/reports/frontend-security-headers-and-csp-v1.md
+++ b/docs/reports/frontend-security-headers-and-csp-v1.md
@@ -8,7 +8,7 @@ The baseline is designed to improve protection against script injection, clickja
 
 ## Headers Added
 
-The following headers are applied to static assets and non-asset SPA routes in `rentchain-frontend/vercel.json`:
+The following headers are applied through one broad frontend route rule in `rentchain-frontend/vercel.json` so static assets and SPA routes share the same browser-security baseline:
 
 - `Content-Security-Policy`
 - `X-Frame-Options: DENY`
@@ -62,7 +62,7 @@ The CSP allows the following external source families where currently needed or 
 - `frame-src` remains broad enough to avoid breaking document/PDF/provider preview behavior. Future tightening should be based on deployed CSP violation data and a full iframe/embed inventory.
 - `script-src` includes `https://vercel.live` so Vercel preview feedback can load without console-blocking errors during preview QA.
 - `connect-src` includes `https://*.a.run.app` because Cloud Run preview and alternate service URLs can differ from the explicit production Cloud Run host.
-- `Permissions-Policy` intentionally avoids unsupported experimental feature tokens such as `browsing-topics` to prevent browser console noise on preview and production deployments.
+- `Permissions-Policy` intentionally avoids unsupported experimental feature tokens such as `browsing-topics` to prevent browser console noise on preview and production deployments. The security headers are centralized in one broad Vercel rule to avoid route-specific duplicate policy blocks.
 - CSP reporting is not enabled because there is no governed CSP report ingestion endpoint yet.
 - This mission does not introduce runtime header middleware. Vercel remains the frontend header authority.
 - This mission does not harden backend Cloud Run responses.
@@ -71,7 +71,7 @@ The CSP allows the following external source families where currently needed or 
 
 Config regression tests assert:
 
-- security headers are present on both asset and SPA route header rules
+- security headers are present on the broad frontend route rule that covers asset and SPA responses
 - header names do not conflict within each route rule
 - cache policies remain unchanged
 - CSP includes required RentChain, Firebase/Google, Stripe, Cloud Run, worker, and frame directives

--- a/docs/reports/frontend-security-headers-and-csp-v1.md
+++ b/docs/reports/frontend-security-headers-and-csp-v1.md
@@ -36,7 +36,7 @@ Key directives:
 - `base-uri 'self'`
 - `object-src 'none'`
 - `frame-ancestors 'none'`
-- `script-src 'self'`
+- `script-src 'self' https://vercel.live`
 - `style-src 'self' 'unsafe-inline'`
 - `connect-src 'self' ...`
 - `frame-src 'self' blob: data: https:`
@@ -50,6 +50,8 @@ The CSP allows the following external source families where currently needed or 
 
 - RentChain domains: `https://*.rentchain.ai`
 - Cloud Run API: `https://rentchain-landlord-api-915921057662.us-central1.run.app`
+- Cloud Run preview/alternate services: `https://*.a.run.app`
+- Vercel preview feedback: `https://vercel.live`
 - Firebase and Google APIs: `https://*.googleapis.com`, `https://*.firebaseio.com`, `https://*.firebaseapp.com`, `https://*.gstatic.com`, `wss://*.firebaseio.com`
 - Stripe: `https://*.stripe.com`
 - Images and frames: `https:` in addition to `self`, `blob:`, and `data:` for compatibility with existing document/PDF/provider preview behavior
@@ -58,6 +60,8 @@ The CSP allows the following external source families where currently needed or 
 
 - `style-src` includes `'unsafe-inline'` because the frontend uses React inline styles and component-level dynamic styling. Removing it should be a later staged mission after style usage is inventoried.
 - `frame-src` remains broad enough to avoid breaking document/PDF/provider preview behavior. Future tightening should be based on deployed CSP violation data and a full iframe/embed inventory.
+- `script-src` includes `https://vercel.live` so Vercel preview feedback can load without console-blocking errors during preview QA.
+- `connect-src` includes `https://*.a.run.app` because Cloud Run preview and alternate service URLs can differ from the explicit production Cloud Run host.
 - CSP reporting is not enabled because there is no governed CSP report ingestion endpoint yet.
 - This mission does not introduce runtime header middleware. Vercel remains the frontend header authority.
 - This mission does not harden backend Cloud Run responses.
@@ -81,8 +85,8 @@ After Vercel preview deployment:
 3. Load `/dashboard`
 4. Load `/operations`
 5. Verify normal `/api` calls still work through the preview
-6. Verify login/auth screens load
-7. Verify there are no CSP console errors blocking required app resources
+6. Verify login/auth screens load and login requests are not blocked by CSP
+7. Verify there are no CSP console errors blocking required app or Vercel preview feedback resources
 8. Verify Stripe/provider redirect entry points still render
 9. Verify document/PDF preview surfaces still render where available
 

--- a/rentchain-frontend/src/platform/securityHeaders.test.ts
+++ b/rentchain-frontend/src/platform/securityHeaders.test.ts
@@ -62,8 +62,10 @@ describe("frontend Vercel security headers", () => {
     for (const source of ["/assets/(.*)", "/((?!assets/).*)"]) {
       const rule = getHeaderRule(source);
       const normalizedHeaderNames = rule.headers.map((header) => header.key.toLowerCase());
+      const permissionsPolicy = getHeaderMap(rule).get("Permissions-Policy");
 
       expect(new Set(normalizedHeaderNames).size).toBe(normalizedHeaderNames.length);
+      expect(permissionsPolicy).not.toContain("browsing-topics");
     }
 
     expect(getHeaderMap(getHeaderRule("/assets/(.*)")).get("Cache-Control")).toBe(

--- a/rentchain-frontend/src/platform/securityHeaders.test.ts
+++ b/rentchain-frontend/src/platform/securityHeaders.test.ts
@@ -48,24 +48,22 @@ const getHeaderMap = (rule: VercelHeaderRule) =>
   new Map(rule.headers.map((header) => [header.key, header.value]));
 
 describe("frontend Vercel security headers", () => {
-  it("applies the security baseline to static assets and SPA routes", () => {
-    for (const source of ["/assets/(.*)", "/((?!assets/).*)"]) {
-      const headerMap = getHeaderMap(getHeaderRule(source));
+  it("applies one broad security baseline to all frontend routes", () => {
+    const headerMap = getHeaderMap(getHeaderRule("/(.*)"));
 
-      for (const headerName of requiredSecurityHeaders) {
-        expect(headerMap.get(headerName), `${source} missing ${headerName}`).toBeTruthy();
-      }
+    for (const headerName of requiredSecurityHeaders) {
+      expect(headerMap.get(headerName), `Missing ${headerName}`).toBeTruthy();
     }
   });
 
-  it("keeps cache policy and security headers non-conflicting per route", () => {
-    for (const source of ["/assets/(.*)", "/((?!assets/).*)"]) {
+  it("keeps cache policy and security headers non-conflicting per rule", () => {
+    for (const source of ["/assets/(.*)", "/((?!assets/).*)", "/(.*)"]) {
       const rule = getHeaderRule(source);
       const normalizedHeaderNames = rule.headers.map((header) => header.key.toLowerCase());
       const permissionsPolicy = getHeaderMap(rule).get("Permissions-Policy");
 
       expect(new Set(normalizedHeaderNames).size).toBe(normalizedHeaderNames.length);
-      expect(permissionsPolicy).not.toContain("browsing-topics");
+      expect(permissionsPolicy ?? "").not.toContain("browsing-topics");
     }
 
     expect(getHeaderMap(getHeaderRule("/assets/(.*)")).get("Cache-Control")).toBe(
@@ -77,7 +75,7 @@ describe("frontend Vercel security headers", () => {
   });
 
   it("uses a conservative CSP that preserves required app integrations", () => {
-    const csp = getHeaderMap(getHeaderRule("/((?!assets/).*)")).get(
+    const csp = getHeaderMap(getHeaderRule("/(.*)")).get(
       "Content-Security-Policy",
     );
 

--- a/rentchain-frontend/src/platform/securityHeaders.test.ts
+++ b/rentchain-frontend/src/platform/securityHeaders.test.ts
@@ -83,10 +83,11 @@ describe("frontend Vercel security headers", () => {
     expect(csp).toContain("base-uri 'self'");
     expect(csp).toContain("object-src 'none'");
     expect(csp).toContain("frame-ancestors 'none'");
-    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("script-src 'self' https://vercel.live");
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
     expect(csp).toContain("connect-src 'self'");
     expect(csp).toContain("https://rentchain-landlord-api-915921057662.us-central1.run.app");
+    expect(csp).toContain("https://*.a.run.app");
     expect(csp).toContain("https://*.rentchain.ai");
     expect(csp).toContain("https://*.googleapis.com");
     expect(csp).toContain("https://*.firebaseio.com");

--- a/rentchain-frontend/src/platform/securityHeaders.test.ts
+++ b/rentchain-frontend/src/platform/securityHeaders.test.ts
@@ -26,6 +26,7 @@ type VercelConfig = {
 const vercelConfig = JSON.parse(
   readFileSync(join(process.cwd(), "vercel.json"), "utf8"),
 ) as VercelConfig;
+const indexHtml = readFileSync(join(process.cwd(), "index.html"), "utf8");
 
 const requiredSecurityHeaders = [
   "Content-Security-Policy",
@@ -109,5 +110,12 @@ describe("frontend Vercel security headers", () => {
     });
     expect(rewriteSources.indexOf("/api/:path*")).toBeGreaterThan(-1);
     expect(rewriteSources.indexOf("/:path*")).toBeGreaterThan(rewriteSources.indexOf("/api/:path*"));
+  });
+
+  it("keeps the PWA manifest reference backed by a public manifest file", () => {
+    expect(indexHtml).toContain('<link rel="manifest" href="/manifest.webmanifest" />');
+    expect(() =>
+      readFileSync(join(process.cwd(), "public", "manifest.webmanifest"), "utf8"),
+    ).not.toThrow();
   });
 });

--- a/rentchain-frontend/src/platform/securityHeaders.test.ts
+++ b/rentchain-frontend/src/platform/securityHeaders.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+type VercelHeader = {
+  key: string;
+  value: string;
+};
+
+type VercelHeaderRule = {
+  source: string;
+  headers: VercelHeader[];
+};
+
+type VercelRewrite = {
+  source: string;
+  destination: string;
+};
+
+type VercelConfig = {
+  headers: VercelHeaderRule[];
+  rewrites: VercelRewrite[];
+};
+
+const vercelConfig = JSON.parse(
+  readFileSync(join(process.cwd(), "vercel.json"), "utf8"),
+) as VercelConfig;
+
+const requiredSecurityHeaders = [
+  "Content-Security-Policy",
+  "X-Frame-Options",
+  "X-Content-Type-Options",
+  "Referrer-Policy",
+  "Permissions-Policy",
+  "Strict-Transport-Security",
+  "Cross-Origin-Opener-Policy",
+  "Cross-Origin-Resource-Policy",
+];
+
+const getHeaderRule = (source: string) => {
+  const rule = vercelConfig.headers.find((entry) => entry.source === source);
+  expect(rule, `Missing Vercel header rule for ${source}`).toBeDefined();
+  return rule as VercelHeaderRule;
+};
+
+const getHeaderMap = (rule: VercelHeaderRule) =>
+  new Map(rule.headers.map((header) => [header.key, header.value]));
+
+describe("frontend Vercel security headers", () => {
+  it("applies the security baseline to static assets and SPA routes", () => {
+    for (const source of ["/assets/(.*)", "/((?!assets/).*)"]) {
+      const headerMap = getHeaderMap(getHeaderRule(source));
+
+      for (const headerName of requiredSecurityHeaders) {
+        expect(headerMap.get(headerName), `${source} missing ${headerName}`).toBeTruthy();
+      }
+    }
+  });
+
+  it("keeps cache policy and security headers non-conflicting per route", () => {
+    for (const source of ["/assets/(.*)", "/((?!assets/).*)"]) {
+      const rule = getHeaderRule(source);
+      const normalizedHeaderNames = rule.headers.map((header) => header.key.toLowerCase());
+
+      expect(new Set(normalizedHeaderNames).size).toBe(normalizedHeaderNames.length);
+    }
+
+    expect(getHeaderMap(getHeaderRule("/assets/(.*)")).get("Cache-Control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    expect(getHeaderMap(getHeaderRule("/((?!assets/).*)")).get("Cache-Control")).toBe(
+      "no-store",
+    );
+  });
+
+  it("uses a conservative CSP that preserves required app integrations", () => {
+    const csp = getHeaderMap(getHeaderRule("/((?!assets/).*)")).get(
+      "Content-Security-Policy",
+    );
+
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("https://rentchain-landlord-api-915921057662.us-central1.run.app");
+    expect(csp).toContain("https://*.rentchain.ai");
+    expect(csp).toContain("https://*.googleapis.com");
+    expect(csp).toContain("https://*.firebaseio.com");
+    expect(csp).toContain("https://*.firebaseapp.com");
+    expect(csp).toContain("https://*.stripe.com");
+    expect(csp).toContain("frame-src 'self' blob: data: https:");
+    expect(csp).toContain("worker-src 'self' blob:");
+    expect(csp).toContain("upgrade-insecure-requests");
+  });
+
+  it("preserves Cloud Run API rewrites before the SPA fallback", () => {
+    const rewriteSources = vercelConfig.rewrites.map((rewrite) => rewrite.source);
+    const apiRewrite = vercelConfig.rewrites.find((rewrite) => rewrite.source === "/api/:path*");
+
+    expect(apiRewrite).toEqual({
+      source: "/api/:path*",
+      destination:
+        "https://rentchain-landlord-api-915921057662.us-central1.run.app/api/:path*",
+    });
+    expect(rewriteSources.indexOf("/api/:path*")).toBeGreaterThan(-1);
+    expect(rewriteSources.indexOf("/:path*")).toBeGreaterThan(rewriteSources.indexOf("/api/:path*"));
+  });
+});

--- a/rentchain-frontend/vercel.json
+++ b/rentchain-frontend/vercel.json
@@ -10,7 +10,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.a.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "X-Frame-Options",
@@ -51,7 +51,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.a.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "X-Frame-Options",

--- a/rentchain-frontend/vercel.json
+++ b/rentchain-frontend/vercel.json
@@ -7,38 +7,6 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
-        },
-        {
-          "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.a.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "DENY"
-        },
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        },
-        {
-          "key": "Referrer-Policy",
-          "value": "strict-origin-when-cross-origin"
-        },
-        {
-          "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), serial=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=(), fullscreen=(self), clipboard-write=(self)"
-        },
-        {
-          "key": "Strict-Transport-Security",
-          "value": "max-age=31536000; includeSubDomains"
-        },
-        {
-          "key": "Cross-Origin-Opener-Policy",
-          "value": "same-origin-allow-popups"
-        },
-        {
-          "key": "Cross-Origin-Resource-Policy",
-          "value": "same-origin"
         }
       ]
     },
@@ -48,7 +16,12 @@
         {
           "key": "Cache-Control",
           "value": "no-store"
-        },
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.a.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"

--- a/rentchain-frontend/vercel.json
+++ b/rentchain-frontend/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "headers": [
     {
       "source": "/assets/(.*)",
@@ -6,6 +7,38 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), serial=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=(), fullscreen=(self), clipboard-write=(self)"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin-allow-popups"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
         }
       ]
     },
@@ -15,6 +48,38 @@
         {
           "key": "Cache-Control",
           "value": "no-store"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), serial=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=(), fullscreen=(self), clipboard-write=(self)"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin-allow-popups"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add a conservative Vercel frontend security header baseline, including CSP, frame protection, MIME sniffing protection, referrer policy, permissions policy, HSTS, COOP, and CORP
- preserve existing cache behavior and Cloud Run `/api/:path*` rewrite ordering
- add config-level regression tests for required headers, CSP integration allowlists, duplicate header conflicts, and API rewrite preservation
- document CSP posture, allowed external sources, known limitations, and preview QA steps

## Guardrails
- no auth, Firebase, Firestore, backend route, payment, screening, export, or review workflow behavior changed
- no Vercel rewrite behavior changed
- CSP is intentionally conservative to avoid breaking Firebase/Auth, Stripe/provider redirects, app assets, and PDF/document preview behavior

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- securityHeaders.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Preview QA
After Vercel preview deploys, verify:
- `/`, `/login`, `/dashboard`, and `/operations` load
- normal `/api` calls still work through the preview
- login/auth screens load without CSP-blocking console errors
- Stripe/provider redirect entry points still render
- document/PDF preview surfaces still render where available