### PR TITLE
fix: harden session and token governance

### DIFF
--- a/docs/reports/session-and-token-governance-hardening-v1.md
+++ b/docs/reports/session-and-token-governance-hardening-v1.md
@@ -1,0 +1,187 @@
+# Session and Token Governance Hardening v1
+
+## Executive Summary
+
+This mission audits and hardens RentChain session/token handling without rewriting authentication. The current system uses Firebase Auth token fallback for landlord/admin API calls, legacy RentChain bearer tokens for existing landlord flows, tenant bearer tokens for tenant workspace routes, server-side JWT validation for protected backend routes, and explicit webhook/internal-token flows for provider/server operations.
+
+The implementation remains conservative:
+
+- no Firebase Auth architecture changes
+- no JWT format changes
+- no Firestore rule changes
+- no route visibility changes
+- no role or permission changes
+- no token lifetime changes
+- no login/logout UX rewrite
+
+The runtime changes are limited to safer log redaction and debug-token display suppression.
+
+## Current Auth Model Summary
+
+Frontend landlord/admin requests use a layered token model:
+
+- Firebase ID tokens are obtained through `getFirebaseIdToken()` when a Firebase user is available.
+- Stored RentChain bearer tokens are read through `getAuthToken()` for legacy/auth-route compatibility.
+- API clients set `Authorization: Bearer <token>` and `x-rc-auth` metadata when a token is present.
+- Missing-token diagnostics log only route/path/auth-source metadata, not token values.
+
+Tenant workspace requests use tenant bearer tokens:
+
+- tenant tokens are stored under `rentchain_tenant_token`
+- tenant API clients prefer tenant tokens for `/api/tenant/*`
+- tenant logout clears tenant token storage and invite/session markers
+
+Backend validation uses two current patterns:
+
+- `authenticateJwt` optionally hydrates `req.user` when a bearer token is present and leaves auth enforcement to route-level middleware for most routes.
+- `requireAuth` is strict and rejects missing/invalid bearer tokens before hydrating canonical session users.
+
+The shared request authority resolver remains the server-side source for effective landlord/tenant/admin authority semantics after auth has populated `req.user`.
+
+## Frontend Session Storage Observations
+
+Observed client-side session state:
+
+- `rentchain_token` can exist in `sessionStorage`, `localStorage`, and memory for landlord/admin compatibility.
+- legacy keys `rc_auth_token`, `authToken`, and `token` are migrated into `rentchain_token` and removed.
+- `rentchain_tenant_token` can exist in tenant session/local storage for tenant workspace compatibility.
+- `authJustLoggedInAt` is a non-secret timing marker used for short login grace handling.
+- `debugAuthEnabled` enables debug diagnostics.
+
+Minimal hardening added:
+
+- debug auth overlays now show only token presence and length with `[redacted]`.
+- token prefixes/suffixes are not displayed in debug UI.
+
+## Backend Token Validation Flow
+
+Observed backend validation:
+
+- `requireAuth` rejects missing tokens with `401 unauthenticated`.
+- `requireAuth` verifies JWT claims through `verifyAuthToken()`.
+- `requireAuth` hydrates a canonical session user through `buildCanonicalSessionUserFromClaims()`.
+- `authenticateJwt` allows public auth routes, health, CORS preflight, existing dev bypass paths, and optional event tracking.
+- `authenticateJwt` rejects malformed/invalid bearer tokens outside optional-auth paths.
+- Optional auth for `/api/events/track` remains intentionally permissive.
+
+Minimal hardening added:
+
+- invalid-token logging in `authenticateJwt` now uses `safeErrorLog()` instead of direct `console.error`.
+- the log preserves route, method, and auth-header presence while suppressing token/error secret content.
+
+## Optional Auth vs Required Auth
+
+Optional-auth routes:
+
+- may accept missing or invalid tokens without failing the request
+- must not infer privileged access from client-provided identity
+- should log only safe route/status metadata
+
+Required-auth routes:
+
+- must fail closed on missing or invalid bearer tokens
+- must hydrate server-side authority context from verified claims
+- must not rely on frontend role assumptions
+
+The existing optional-auth route explicitly identified during this audit is `/api/events/track`.
+
+## Logout and Session Invalidation Expectations
+
+Landlord/admin logout:
+
+- clears local, session, and in-memory `rentchain_token`
+- removes legacy token keys
+- removes login grace markers
+- notifies `/api/auth/logout` when a token was present
+
+Tenant logout:
+
+- clears tenant token storage
+- clears tenant invite/session markers
+- redirects to tenant login
+
+Known limitation:
+
+- backend logout is currently acknowledgement-style. It does not revoke already-issued JWTs server-side. Future revocation/session registry work should be handled as a separate auth architecture mission.
+
+## Internal Token Handling Expectations
+
+Internal/webhook/provider tokens must remain server-only:
+
+- `JWT_SECRET`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `INTERNAL_JOB_TOKEN`
+- provider API keys
+- webhook signatures/secrets
+
+Frontend `VITE_*` variables are client-exposed by design. They must not contain server-only secrets. This audit found an existing local development env file containing development-only frontend values; no production env or infrastructure settings were changed in this mission.
+
+## Impersonation and Support Access Notes
+
+Current authority semantics include awareness of:
+
+- `actorRole`
+- `actorLandlordId`
+- admin role checks
+- support/admin route families
+
+This mission does not add impersonation or support access behavior. Future admin/support governance should build on the request authority resolver and require explicit audit/event semantics.
+
+## Token Redaction Hardening
+
+The shared logger now treats these additional key families as restricted:
+
+- `authorization` / `Authorization`
+- `bearer`
+- `idToken`
+- `refreshToken`
+- `accessToken`
+- `firebaseToken`
+- `sessionToken`
+- `customToken`
+- `internalJobToken`
+- `cookie`
+- `set-cookie`
+
+Existing inline secret redaction continues to suppress bearer strings, JWT-looking strings, Stripe secrets, webhook secrets, and token/query-secret patterns.
+
+## Known Limitations
+
+- Multiple frontend API clients still exist and should be consolidated in a future mission.
+- Legacy bearer-token storage remains for compatibility.
+- Firebase Auth token refresh and persistence behavior are owned by Firebase SDK configuration.
+- Backend logout does not implement server-side token revocation.
+- Optional-auth route semantics are documented but not centralized in a route registry yet.
+- Debug auth remains available behind explicit debug flags, but now avoids displaying token material.
+
+## Future Hardening
+
+Recommended follow-up missions:
+
+1. `fix/api-auth-client-consolidation-v1`
+2. `fix/server-side-token-revocation-and-session-registry-v1`
+3. `fix/admin-support-access-governance-v1`
+4. `test/optional-auth-route-governance-regression-v1`
+5. `fix/frontend-env-secret-exposure-audit-v1`
+
+## Verification Expectations
+
+Required local verification for this mission:
+
+- safe logger tests
+- auth middleware tests
+- auth debug overlay tests
+- backend build
+- frontend build
+
+Preview QA after deployment:
+
+1. Load `/login`
+2. Log in successfully
+3. Open `/dashboard`
+4. Open `/operations`
+5. Log out
+6. Confirm unauthenticated/login state
+7. Confirm no token or `Authorization` values appear in console logs
+8. Confirm no CSP/security header regressions

--- a/rentchain-api/src/lib/logging/__tests__/safeLogger.test.ts
+++ b/rentchain-api/src/lib/logging/__tests__/safeLogger.test.ts
@@ -40,6 +40,18 @@ describe("safeLogger", () => {
       stack: "private stack trace",
       routeSource: "debug router",
       debugPayload: { internalDebug: "debug details" },
+      authorization: "Bearer eyJauthorization.jwt",
+      Authorization: "Bearer eyJuppercase.jwt",
+      bearer: "eyJbearer.jwt",
+      idToken: "id-token-secret",
+      refreshToken: "refresh-token-secret",
+      accessToken: "access-token-secret",
+      firebaseToken: "firebase-token-secret",
+      sessionToken: "session-token-secret",
+      customToken: "custom-token-secret",
+      internalJobToken: "internal-job-token-secret",
+      cookie: "session=secret",
+      "set-cookie": "session=secret; HttpOnly",
     });
 
     expect(sanitized).toEqual({
@@ -66,6 +78,17 @@ describe("safeLogger", () => {
       "private stack trace",
       "debug router",
       "debug details",
+      "eyJauthorization.jwt",
+      "eyJuppercase.jwt",
+      "eyJbearer.jwt",
+      "id-token-secret",
+      "refresh-token-secret",
+      "access-token-secret",
+      "firebase-token-secret",
+      "session-token-secret",
+      "custom-token-secret",
+      "internal-job-token-secret",
+      "session=secret",
     ]);
   });
 
@@ -120,6 +143,11 @@ describe("safeLogger", () => {
     expect(isRestrictedLogKey("providerPayload")).toBe(true);
     expect(isRestrictedLogKey("rawCsv")).toBe(true);
     expect(isRestrictedLogKey("routeSource")).toBe(true);
+    expect(isRestrictedLogKey("Authorization")).toBe(true);
+    expect(isRestrictedLogKey("idToken")).toBe(true);
+    expect(isRestrictedLogKey("refreshToken")).toBe(true);
+    expect(isRestrictedLogKey("sessionToken")).toBe(true);
+    expect(isRestrictedLogKey("set-cookie")).toBe(true);
     expect(isRestrictedLogKey("requestId")).toBe(false);
   });
 

--- a/rentchain-api/src/lib/logging/safeLogger.ts
+++ b/rentchain-api/src/lib/logging/safeLogger.ts
@@ -35,6 +35,17 @@ const RESTRICTED_KEY_PATTERNS = [
   /^stack$/i,
   /route.*source/i,
   /debug.*payload/i,
+  /^authorization$/i,
+  /^bearer$/i,
+  /id.*token/i,
+  /refresh.*token/i,
+  /access.*token/i,
+  /firebase.*token/i,
+  /session.*token/i,
+  /custom.*token/i,
+  /internal.*job.*token/i,
+  /^cookie$/i,
+  /set.*cookie/i,
 ];
 
 const INLINE_SECRET_PATTERNS = [

--- a/rentchain-api/src/middleware/__tests__/authMiddleware.test.ts
+++ b/rentchain-api/src/middleware/__tests__/authMiddleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const jwtMocks = vi.hoisted(() => ({
   verify: vi.fn(),
@@ -31,6 +31,10 @@ function createRes() {
 }
 
 describe("authenticateJwt optional auth for events track", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("allows /api/events/track through without auth", async () => {
     const { authenticateJwt } = await import("../authMiddleware");
     const req: any = {
@@ -71,8 +75,9 @@ describe("authenticateJwt optional auth for events track", () => {
   });
 
   it("still rejects invalid bearer auth on unrelated routes", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     jwtMocks.verify.mockImplementationOnce(() => {
-      throw new Error("bad token");
+      throw new Error("bad token Authorization: Bearer leaked.jwt.value");
     });
     const { authenticateJwt } = await import("../authMiddleware");
     const req: any = {
@@ -97,5 +102,14 @@ describe("authenticateJwt optional auth for events track", () => {
         code: "UNAUTHORIZED",
       })
     );
+    expect(errorSpy).toHaveBeenCalledWith("[authenticateJwt] verification failed", {
+      route: "/api/account/limits",
+      method: "GET",
+      authHeaderPresent: true,
+      error: {
+        name: "Error",
+        message: "bad token Authorization: [REDACTED]",
+      },
+    });
   });
 });

--- a/rentchain-api/src/middleware/authMiddleware.ts
+++ b/rentchain-api/src/middleware/authMiddleware.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from "express";
 import jwt from "jsonwebtoken";
 import { JWT_SECRET } from "../config/authConfig";
 import { jsonError } from "../lib/httpResponse";
+import { safeErrorLog } from "../lib/logging/safeLogger";
 
 export interface AuthenticatedUser {
   id: string;
@@ -114,7 +115,11 @@ export const authenticateJwt: RequestHandler = (req, res, next): void => {
     if (isOptionalAuthPath(req)) {
       return next();
     }
-    console.error("[authenticateJwt] verification failed", err);
+    safeErrorLog("[authenticateJwt] verification failed", err, {
+      route: req.originalUrl || req.path,
+      method: req.method,
+      authHeaderPresent: true,
+    });
     jsonError(res, 401, "UNAUTHORIZED", "UNAUTHORIZED", undefined, (req as any).requestId);
   }
 };

--- a/rentchain-frontend/src/components/debug/AuthDebugOverlay.test.tsx
+++ b/rentchain-frontend/src/components/debug/AuthDebugOverlay.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { DEBUG_AUTH_KEY, TENANT_TOKEN_KEY } from "../../lib/authKeys";
+import { TOKEN_KEY } from "../../lib/authToken";
+import { AuthDebugOverlay } from "./AuthDebugOverlay";
+
+describe("AuthDebugOverlay", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("shows token presence without exposing token prefixes or suffixes", () => {
+    window.localStorage.setItem(DEBUG_AUTH_KEY, "1");
+    window.sessionStorage.setItem(TOKEN_KEY, "header.payload.signature");
+    window.localStorage.setItem(TENANT_TOKEN_KEY, "tenant.header.signature");
+
+    render(React.createElement(AuthDebugOverlay));
+
+    expect(screen.getByText("debugAuth")).toBeInTheDocument();
+    const renderedText = document.body.textContent || "";
+    expect(renderedText).toContain("session: yes len=24 [redacted]");
+    expect(renderedText).toContain("tenant local: yes [redacted]");
+    expect(renderedText).not.toContain("header.payload");
+    expect(renderedText).not.toContain("signature");
+    expect(renderedText).not.toContain("tenant.header");
+  });
+});

--- a/rentchain-frontend/src/components/debug/AuthDebugOverlay.tsx
+++ b/rentchain-frontend/src/components/debug/AuthDebugOverlay.tsx
@@ -20,8 +20,7 @@ function previewToken(tok: string | null) {
   const t = String(tok);
   const len = t.length;
   const whitespace = /\s/.test(t);
-  const preview =
-    len >= 25 ? `${t.slice(0, 10)}…${t.slice(-10)}` : `${t.slice(0, 10)}…`;
+  const preview = "[redacted]";
   return { present: true, len, preview, whitespace };
 }
 

--- a/rentchain-frontend/src/context/AuthContext.tsx
+++ b/rentchain-frontend/src/context/AuthContext.tsx
@@ -89,9 +89,7 @@ function tokenPreview(token: string | null | undefined) {
   const t = String(token);
   if (!t) return { has: false, len: 0, preview: "" };
   const len = t.length;
-  const first = t.slice(0, 10);
-  const last = t.slice(-10);
-  return { has: true, len, preview: `${first}...${last}` };
+  return { has: true, len, preview: "[redacted]" };
 }
 
 interface AuthProviderProps {


### PR DESCRIPTION
## Summary
- add the session/token governance hardening report covering the current auth model, storage/transmission paths, optional vs required auth, logout expectations, internal-token handling, and future hardening gaps
- expand safe logging redaction for Authorization headers, token families, bearer/cookie fields, and route invalid-token logging through `safeErrorLog`
- redact token previews in debug auth UI while preserving token presence/length diagnostics

## Guardrails
- no auth rewrite
- no JWT/Firebase/Auth/Firestore rule/schema changes
- no route visibility, role, or permission changes
- no token lifetime changes
- no login/logout UX rewrite

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- safeLogger.test.ts authMiddleware.test.ts` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- AuthDebugOverlay.test.tsx AuthContext.test.ts` from `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build` from `rentchain-frontend`
- `git diff --check`

## Preview QA
- load `/login`
- log in successfully
- open `/dashboard`
- open `/operations`
- log out and confirm unauthenticated/login state
- confirm no token or Authorization values appear in console logs
- confirm no CSP/security header regressions