### PR TITLE
fix: add api rate limit and abuse protection foundation

### DIFF
--- a/docs/reports/api-rate-limit-and-abuse-protection-v1.md
+++ b/docs/reports/api-rate-limit-and-abuse-protection-v1.md
@@ -1,0 +1,172 @@
+# API Rate Limit and Abuse Protection v1
+
+## Executive Summary
+
+This mission audits RentChain API abuse surfaces and adds a conservative first-pass rate-limit foundation without rewriting authentication, changing permissions, changing route visibility, or introducing new infrastructure.
+
+The implementation reuses the existing `express-rate-limit` dependency and the existing `rentchain-api/src/middleware/rateLimit.ts` pattern. It adds named, documented route-category profiles and mounts them only where the risk/retry tradeoff is clear.
+
+This is not the final distributed production abuse-control architecture. In-memory rate limiting provides process-local protection only; horizontally scaled Cloud Run instances require a future shared or edge-enforced strategy.
+
+## Files Inspected
+
+- `rentchain-api/src/app.build.ts`
+- `rentchain-api/src/middleware/rateLimit.ts`
+- `rentchain-api/src/middleware/authMiddleware.ts`
+- `rentchain-api/src/middleware/requireAuth.ts`
+- `rentchain-api/src/routes/authRoutes.ts`
+- `rentchain-api/src/routes/publicApplicationLinksRoutes.ts`
+- `rentchain-api/src/routes/invitesRoutes.ts`
+- `rentchain-api/src/routes/accessRoutes.ts`
+- `rentchain-api/src/routes/tenantPortalRoutes.ts`
+- `rentchain-api/src/routes/tenantInvitesRoutes.ts`
+- `rentchain-api/src/routes/landlordEvidencePackRoutes.ts`
+- `rentchain-api/src/routes/landlordInstitutionExportsRoutes.ts`
+- `rentchain-api/src/routes/landlordOperatorReviewRoutes.ts`
+- `rentchain-api/src/routes/internalReportsRoutes.ts`
+- `rentchain-api/src/routes/identityOracleInternalRoutes.ts`
+- `rentchain-api/src/routes/applicationReminderInternalRoutes.ts`
+- `rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts`
+- `rentchain-api/src/routes/transunionWebhookRoutes.ts`
+- `docs/reports/api-route-ownership-and-exposure-inventory-v1.md`
+- `docs/reports/session-and-token-governance-hardening-v1.md`
+
+## Route Categories Audited
+
+| Category | Example routes | Risk | First-pass treatment |
+| --- | --- | --- | --- |
+| Auth-sensitive | `/api/auth/login`, `/api/auth/signup`, `/api/auth/login/demo`, password reset confirmation | brute-force login/signup/password attempts | existing auth limiter retained and formalized as `auth-sensitive` |
+| Public token-scoped | `/api/public/application-links/*`, `/api/public/landlord-invites/*`, `/api/invites/*`, `/api/access/*` | invite/token probing and public intake abuse | conservative IP-based profile added |
+| Tenant workspace entry | `/api/tenant-invites/*`, `/api/tenant/invite/*` | tenant invite redemption/session-entry probing | actor-or-IP profile added on entry prefixes |
+| Evidence/export/review | `/api/landlord/evidence-packs/*`, `/api/landlord/institution-exports/*`, `/api/landlord/operator-reviews/*`, `/api/landlord/review-timeline/*` | expensive reads, evidence/export preview abuse, review-surface scraping | actor-or-IP profile added after auth decode and before route handlers |
+| Internal job-token | `/api/internal/*` | public network surface protected by internal job token | lenient IP-based profile added to avoid breaking legitimate retries |
+| Diagnostics/status | `/api/status/*`, `/api/__routes`, `/api/__probe/*`, `/api/__debug/*`, `/api/_build`, `/api/_echo` | public diagnostic metadata abuse | conservative IP-based profile added |
+| Webhooks | `/api/webhooks/stripe`, `/api/stripe/webhook`, `/api/webhooks/transunion` | provider callback retry safety | intentionally not rate-limited in this pass; signature/token validation remains route responsibility |
+
+## Applied Limits
+
+| Profile | Window | Max | Key strategy | Notes |
+| --- | --- | --- | --- | --- |
+| `auth-sensitive` | 15 minutes | 20 | IP | Existing auth behavior preserved; profile made explicit. |
+| `public-token` | 15 minutes | 60 | IP | Protects public invite/access/application-link surfaces without blocking normal user flow. |
+| `tenant-workspace-entry` | 15 minutes | 90 | actor-or-IP | Applies to tenant invite/session entry prefixes only, not broad tenant workspace browsing. |
+| `evidence-export-review` | 15 minutes | 120 | actor-or-IP | Applies after auth decode, so authenticated landlord/admin actors do not collide on IP alone. |
+| `internal-job` | 15 minutes | 300 | IP | Deliberately lenient to preserve internal job retries. |
+| `diagnostics` | 5 minutes | 120 | IP | Protects public diagnostics without changing visibility. |
+
+Existing route-specific limiters remain:
+
+- `public-apply` for public rental application submission
+- `leads` for landlord inquiry lead submission
+- `screening-user` and `screening-ip` for screening checkout/status surfaces
+- `tenant-invites-user` for landlord-created tenant invites
+- `referrals-user` for referrals
+- local 2FA rate limiting inside `authRoutes.ts`
+
+## Exemptions and Deferred Routes
+
+### Provider Webhooks
+
+Stripe and TransUnion webhook routes remain unmounted from category rate limiting. They are mounted before the JSON parser and must continue to support legitimate provider retry behavior. Abuse controls for these routes should focus on provider signature/token verification, idempotency, and provider-specific monitoring before rate limiting is introduced.
+
+### General Authenticated App Browsing
+
+Broad authenticated routes such as `/api/dashboard`, `/api/leases`, `/api/tenants`, `/api/properties`, and `/api/payments` are not globally rate-limited in this pass. Overly broad limits could block normal landlord workflows. Future production-grade controls should use shared counters, route-specific cost budgets, and observability-informed thresholds.
+
+### Broad Tenant Workspace Browsing
+
+Only tenant invite/session entry prefixes are limited. General tenant workspace routes are not broadly limited in this pass to avoid breaking normal tenant document/message/lease viewing behavior.
+
+## Response Semantics
+
+Rate-limited requests return:
+
+- HTTP `429`
+- `ok: false`
+- `code: "RATE_LIMITED"`
+- `error: "rate_limited"`
+- safe generic detail text
+- standard rate-limit headers and `Retry-After` where provided by the middleware
+
+The response intentionally does not expose internal counter state, actor identifiers, tokens, or route internals.
+
+## Logging and Redaction
+
+Rate-limit logs use `safeOperationalLog()` and include only:
+
+- profile name
+- route
+- method
+- retry-after seconds
+- whether an auth header was present
+
+Authorization header values, tokens, cookies, provider payloads, secrets, and raw request bodies are not logged. Regression tests assert that token material is absent from rate-limit log output.
+
+## Cloud Run and Proxy Considerations
+
+The Express app already sets `trust proxy` to `1`. This allows `req.ip` and `X-Forwarded-For` handling behind Cloud Run/Vercel proxying. Rate-limit key generation uses a safe IP helper and actor-or-IP fallback where authenticated user context is available.
+
+Because the limiter is in-memory, counters are local to each Cloud Run container instance. Under horizontal scaling, a single client can distribute requests across instances. This is acceptable only as a foundation and should be supplemented with a distributed or edge-level control.
+
+## Known Limitations
+
+- In-memory counters are not globally consistent across Cloud Run instances.
+- Limits reset on instance restart.
+- Existing route-local limiters remain split across route modules.
+- General authenticated app browsing is not globally limited yet.
+- Webhook abuse protection remains verification/idempotency based, not rate-limit based.
+- Public diagnostics are still reachable; this mission limits request rate but does not change exposure.
+- No abuse telemetry dashboard exists yet.
+
+## Future Production-Grade Path
+
+Recommended follow-up options:
+
+1. `fix/cloud-armor-api-abuse-policy-v1`
+2. `fix/shared-rate-limit-counter-store-v1`
+3. `fix/webhook-verification-and-idempotency-hardening-v1`
+4. `fix/debug-probe-production-gating-v1`
+5. `feat/api-abuse-telemetry-dashboard-v1`
+6. `fix/document-upload-governance-v1`
+7. `fix/admin-support-access-governance-v1`
+
+Production-grade controls may use:
+
+- Google Cloud Armor
+- API Gateway or Load Balancer policies
+- Redis or a managed shared counter store
+- Firebase/App Check where appropriate
+- provider-specific webhook verification hardening
+- abuse telemetry and incident-response dashboards
+
+## Behavior Preservation
+
+This mission does not change:
+
+- Firebase Auth behavior
+- JWT format
+- Firestore rules
+- user roles
+- landlord/tenant/admin permissions
+- route visibility
+- payment, screening, review, export, or tenant workspace business logic
+
+The goal is conservative request-rate governance, not a product behavior change.
+
+## Verification Expectations
+
+Required local verification:
+
+- rate-limit middleware tests
+- route ownership regression tests where mount/order behavior is relevant
+- backend build
+- `git diff --check`
+
+Preview QA:
+
+1. Log in normally once.
+2. Open `/dashboard`.
+3. Open `/operations`.
+4. Confirm normal authenticated app flow is not blocked.
+5. Confirm no new console/security errors.
+6. Confirm no token or Authorization values appear in logs or console output.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -4,6 +4,13 @@ import cookieParser from "cookie-parser";
 import { authenticateJwt } from "./middleware/authMiddleware";
 import { routeSource } from "./middleware/routeSource";
 import { notFoundHandler, errorHandler } from "./middleware/errorHandler";
+import {
+  rateLimitDiagnostics,
+  rateLimitEvidenceExportReview,
+  rateLimitInternalJob,
+  rateLimitPublicToken,
+  rateLimitTenantWorkspaceEntry,
+} from "./middleware/rateLimit";
 import { corsOptions } from "./lib/cors";
 import { getPricingHealth } from "./config/planMatrix";
 import { resolveCanonicalPlan } from "./services/entitlements/planCapabilities";
@@ -236,7 +243,7 @@ app.use("/api/api", (req, res) => {
 
 // Health
 app.use("/health", healthRoutes);
-app.get("/api/__routes", (_req, res) => {
+app.get("/api/__routes", rateLimitDiagnostics, (_req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/__routes");
   return res.json({
     ok: true,
@@ -261,18 +268,24 @@ app.use("/api", routeSource("publicRoutes.ts"), publicRoutes);
 app.use("/api/public", routeSource("publicRoutes.ts"), publicRoutes);
 app.use("/api", routeSource("publicPortfolioScoreRoutes.ts"), publicPortfolioScoreRoutes);
 app.use("/api/public", routeSource("publicTenantShareRoutes.ts"), publicTenantShareRoutes);
+app.use("/api/public/landlord-invites", rateLimitPublicToken);
 app.use("/api/public", routeSource("landlordInvitesPublicRoutes.ts"), landlordInvitesPublicRoutes);
 app.use("/api/public", routeSource("landlordInquiryRoutes.ts"), landlordInquiryPublicRoutes);
 app.use("/api/public", tenantHistorySharePublicRouter);
+app.use("/api/public/application-links", rateLimitPublicToken);
 app.use("/api/public", routeSource("publicApplicationLinksRoutes.ts"), publicApplicationLinksRoutes);
 app.use("/api", routeSource("viewingRoutes.ts"), viewingRoutes);
 app.use("/api/auth", routeSource("authRoutes.ts"), authRoutes);
+app.use("/api/invites", rateLimitPublicToken);
 app.use("/api/invites", routeSource("invitesRoutes.ts"), invitesRoutes);
+app.use("/api/access", rateLimitPublicToken);
 app.use("/api/access", routeSource("accessRoutes.ts"), accessRoutes);
 app.use("/api/capabilities", routeSource("capabilitiesRoutes.ts"), capabilitiesRoutes);
+app.use("/api/internal", rateLimitInternalJob);
 app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
 app.use("/api/internal", routeSource("identityOracleInternalRoutes.ts"), identityOracleInternalRoutes);
 app.use("/api/internal", routeSource("applicationReminderInternalRoutes.ts"), applicationReminderInternalRoutes);
+app.use("/api/status", rateLimitDiagnostics);
 app.use("/api/status", routeSource("statusRoutes.ts"), statusRoutes);
 
 // Auth decode (non-blocking if header missing)
@@ -348,14 +361,18 @@ app.use("/api", routeSource("landlordPortfolioScoreSharingRoutes.ts"), landlordP
 console.log("[route-mount] landlordPortfolioScoreSharingRoutes mounted at /api");
 app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlordDecisionInboxRoutes);
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
+app.use("/api/landlord/institution-exports", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordInstitutionExportsRoutes.ts"), landlordInstitutionExportsRoutes);
 console.log("[route-mount] landlordInstitutionExportsRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordAuditComplianceRoutes.ts"), landlordAuditComplianceRoutes);
 console.log("[route-mount] landlordAuditComplianceRoutes mounted at /api/landlord");
+app.use("/api/landlord/operator-reviews", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordOperatorReviewRoutes.ts"), landlordOperatorReviewRoutes);
 console.log("[route-mount] landlordOperatorReviewRoutes mounted at /api/landlord");
+app.use("/api/landlord/evidence-packs", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
 console.log("[route-mount] landlordEvidencePackRoutes mounted at /api/landlord");
+app.use("/api/landlord/review-timeline", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordReviewTimelineRoutes.ts"), landlordReviewTimelineRoutes);
 console.log("[route-mount] landlordReviewTimelineRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordIdentityLayerRoutes.ts"), landlordIdentityLayerRoutes);
@@ -438,7 +455,9 @@ app.use(
   routeSource("landlordApplicationLinksRoutes.ts"),
   landlordApplicationLinksRoutes
 );
+app.use("/api/tenant-invites", rateLimitTenantWorkspaceEntry);
 app.use("/api/tenant-invites", tenantInvitesRoutes);
+app.use("/api/tenant/invite", rateLimitTenantWorkspaceEntry);
 app.use("/api/tenant", tenantPortalRoutes);
 app.use("/api/recipient", routeSource("recipientTrustReviewRoutes.ts"), recipientTrustReviewRoutes);
 app.use("/api/tenant", tenantParticipationRoutes);
@@ -495,13 +514,13 @@ app.use("/api", routeSource("screeningReportRoutes.ts"), screeningReportRoutes);
 app.use("/api", tenantOnboardRoutes);
 app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/landlord", landlordMicroLiveRoutes);
-app.get("/api/__probe/tenants-mount", (_req, res) =>
+app.get("/api/__probe/tenants-mount", rateLimitDiagnostics, (_req, res) =>
   res.json({ ok: true, probe: "tenants-mount", ts: Date.now() })
 );
-app.get("/api/__probe/version", (_req, res) =>
+app.get("/api/__probe/version", rateLimitDiagnostics, (_req, res) =>
   res.json({ ok: true, ts: Date.now(), marker: "probe-v1" })
 );
-app.get("/api/__probe/revision", (_req, res) => {
+app.get("/api/__probe/revision", rateLimitDiagnostics, (_req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/__probe/revision");
   return res.json({
     ok: true,
@@ -519,12 +538,12 @@ app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
 console.log(
   "[routes] /api/properties, /api/properties/:propertyId/units, /api/action-requests, /api/applications"
 );
-app.post("/api/_echo", (req, res) => {
+app.post("/api/_echo", rateLimitDiagnostics, (req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/_echo");
   return res.json({ ok: true, method: "POST", body: req.body ?? null });
 });
 
-app.get("/api/__probe/routes", (_req, res) => {
+app.get("/api/__probe/routes", rateLimitDiagnostics, (_req, res) => {
   const appAny: any = app;
   const stack = appAny?._router?.stack || [];
   const mounts = stack
@@ -548,7 +567,7 @@ app.get("/api/__probe/routes", (_req, res) => {
 });
 
 // Build stamp
-app.get("/api/_build", (_req, res) => {
+app.get("/api/_build", rateLimitDiagnostics, (_req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/_build");
   return res.json({
     ok: true,
@@ -559,7 +578,7 @@ app.get("/api/_build", (_req, res) => {
 });
 
 // Echo for POST reachability
-app.post("/api/_echo", (req, res) => {
+app.post("/api/_echo", rateLimitDiagnostics, (req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/_echo");
   return res.json({
     ok: true,
@@ -569,7 +588,7 @@ app.post("/api/_echo", (req, res) => {
   });
 });
 
-app.get("/api/__debug/build", (_req, res) => {
+app.get("/api/__debug/build", rateLimitDiagnostics, (_req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/__debug/build");
   return res.json({
     ok: true,
@@ -585,7 +604,7 @@ app.get("/api/__debug/build", (_req, res) => {
   });
 });
 
-app.get("/api/__debug/ping-application-links", (_req, res) => {
+app.get("/api/__debug/ping-application-links", rateLimitDiagnostics, (_req, res) => {
   res.setHeader("x-route-source", "debugPingApplicationLinks");
   return res.json({ ok: true });
 });

--- a/rentchain-api/src/middleware/__tests__/rateLimit.test.ts
+++ b/rentchain-api/src/middleware/__tests__/rateLimit.test.ts
@@ -1,0 +1,261 @@
+import fs from "fs";
+import path from "path";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createRateLimiter,
+  RATE_LIMIT_PROFILES,
+  rateLimitInternalJob,
+  type RateLimitProfile,
+} from "../rateLimit";
+
+function testLimiter(profile: Partial<RateLimitProfile> & Pick<RateLimitProfile, "profileName">) {
+  return createRateLimiter({
+    windowMs: 60_000,
+    max: 2,
+    keyStrategy: "ip",
+    description: "test profile",
+    ...profile,
+  });
+}
+
+function buildApp(limiter: ReturnType<typeof createRateLimiter>) {
+  const app = express();
+  app.set("trust proxy", 1);
+  app.use(limiter);
+  app.get("/ok", (_req, res) => res.json({ ok: true }));
+  app.post("/ok", (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+function appBuildSource() {
+  return fs.readFileSync(path.resolve(__dirname, "../../app.build.ts"), "utf8");
+}
+
+async function invokeApp(
+  app: any,
+  options: {
+    method: string;
+    url: string;
+    headers?: Record<string, string>;
+  }
+) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, any> }>((resolve, reject) => {
+    const [pathOnly, rawQuery] = options.url.split("?");
+    const headers = Object.fromEntries(
+      Object.entries(options.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+    );
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: pathOnly,
+      query: rawQuery ? Object.fromEntries(new URLSearchParams(rawQuery).entries()) : {},
+      headers,
+      ip: headers["x-forwarded-for"] || "127.0.0.1",
+      socket: { remoteAddress: headers["x-forwarded-for"] || "127.0.0.1" },
+      get(name: string) {
+        return this.headers[String(name || "").toLowerCase()];
+      },
+      header(name: string) {
+        return this.headers[String(name || "").toLowerCase()];
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, any>,
+      setHeader(name: string, value: any) {
+        this.headers[String(name).toLowerCase()] = value;
+      },
+      getHeader(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      removeHeader(name: string) {
+        delete this.headers[String(name).toLowerCase()];
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+      end(payload?: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+    };
+
+    app.handle(req, res, (error: any) => {
+      if (error) reject(error);
+      else reject(new Error(`Unhandled request: ${options.method} ${options.url}`));
+    });
+  });
+}
+
+describe("rate limit middleware", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns deterministic 429 responses after the configured threshold", async () => {
+    const app = buildApp(testLimiter({ profileName: "test-auth-sensitive", max: 2 }));
+
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/ok", headers: { "x-forwarded-for": "203.0.113.10" } }))
+        .status
+    ).toBe(200);
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/ok", headers: { "x-forwarded-for": "203.0.113.10" } }))
+        .status
+    ).toBe(200);
+    const limited = await invokeApp(app, { method: "GET", url: "/ok", headers: { "x-forwarded-for": "203.0.113.10" } });
+
+    expect(limited.status).toBe(429);
+    expect(limited.body).toEqual({
+      ok: false,
+      code: "RATE_LIMITED",
+      error: "rate_limited",
+      detail: "Too many requests. Please try again later.",
+    });
+    expect(limited.headers["retry-after"]).toBeDefined();
+  });
+
+  it("keeps separate route categories from sharing counters", async () => {
+    const app = express();
+    app.set("trust proxy", 1);
+    app.use("/auth", testLimiter({ profileName: "test-auth-category", max: 1 }));
+    app.use("/exports", testLimiter({ profileName: "test-export-category", max: 1 }));
+    app.get("/auth/ping", (_req, res) => res.json({ ok: true, category: "auth" }));
+    app.get("/exports/ping", (_req, res) => res.json({ ok: true, category: "exports" }));
+
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/auth/ping", headers: { "x-forwarded-for": "203.0.113.11" } }))
+        .status
+    ).toBe(200);
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/exports/ping", headers: { "x-forwarded-for": "203.0.113.11" } }))
+        .status
+    ).toBe(200);
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/auth/ping", headers: { "x-forwarded-for": "203.0.113.11" } }))
+        .status
+    ).toBe(429);
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/exports/ping", headers: { "x-forwarded-for": "203.0.113.11" } }))
+        .status
+    ).toBe(429);
+  });
+
+  it("uses actor identity when safely available so authenticated users do not collide on IP alone", async () => {
+    const app = express();
+    app.set("trust proxy", 1);
+    app.use((req: any, _res, next) => {
+      req.user = { id: String(req.header("x-test-actor") || "") };
+      next();
+    });
+    app.use(
+      createRateLimiter({
+        profileName: "test-actor-or-ip",
+        windowMs: 60_000,
+        max: 1,
+        keyStrategy: "actor-or-ip",
+        description: "actor key test",
+      })
+    );
+    app.get("/ok", (_req, res) => res.json({ ok: true }));
+
+    expect(
+      (
+        await invokeApp(app, {
+          method: "GET",
+          url: "/ok",
+          headers: { "x-forwarded-for": "203.0.113.12", "x-test-actor": "actor-a" },
+        })
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await invokeApp(app, {
+          method: "GET",
+          url: "/ok",
+          headers: { "x-forwarded-for": "203.0.113.12", "x-test-actor": "actor-a" },
+        })
+      ).status
+    ).toBe(429);
+    expect(
+      (
+        await invokeApp(app, {
+          method: "GET",
+          url: "/ok",
+          headers: { "x-forwarded-for": "203.0.113.12", "x-test-actor": "actor-b" },
+        })
+      ).status
+    ).toBe(200);
+  });
+
+  it("does not log Authorization header or token material when a request is limited", async () => {
+    const warnSpy = vi.mocked(console.warn);
+    const app = buildApp(testLimiter({ profileName: "test-log-redaction", max: 1 }));
+
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/ok", headers: { authorization: "Bearer leaked.jwt.value" } }))
+        .status
+    ).toBe(200);
+    expect(
+      (await invokeApp(app, { method: "GET", url: "/ok", headers: { authorization: "Bearer leaked.jwt.value" } }))
+        .status
+    ).toBe(429);
+
+    const serializedLogs = JSON.stringify(warnSpy.mock.calls);
+    expect(serializedLogs).toContain("[rate-limit] request limited");
+    expect(serializedLogs).toContain("authHeaderPresent");
+    expect(serializedLogs).not.toContain("Bearer leaked.jwt.value");
+    expect(serializedLogs).not.toContain("authorization");
+  });
+
+  it("keeps internal job limiting lenient for normal retries", async () => {
+    const app = buildApp(rateLimitInternalJob);
+
+    expect(
+      (await invokeApp(app, { method: "POST", url: "/ok", headers: { "x-forwarded-for": "203.0.113.13" } }))
+        .status
+    ).toBe(200);
+    expect(
+      (await invokeApp(app, { method: "POST", url: "/ok", headers: { "x-forwarded-for": "203.0.113.13" } }))
+        .status
+    ).toBe(200);
+  });
+
+  it("documents the first-pass route categories and conservative defaults", () => {
+    expect(RATE_LIMIT_PROFILES.authSensitive.max).toBe(20);
+    expect(RATE_LIMIT_PROFILES.publicToken.max).toBe(60);
+    expect(RATE_LIMIT_PROFILES.evidenceExportReview.keyStrategy).toBe("actor-or-ip");
+    expect(RATE_LIMIT_PROFILES.internalJob.max).toBeGreaterThan(RATE_LIMIT_PROFILES.authSensitive.max);
+  });
+
+  it("keeps webhook routes before parser and category rate-limit mounts", () => {
+    const source = appBuildSource();
+    const stripeWebhook = source.indexOf('"/api/webhooks/stripe"');
+    const transunionWebhook = source.indexOf('"/api/webhooks/transunion"');
+    const jsonParser = source.indexOf("const jsonParser = express.json");
+    const firstCategoryLimiterMount = source.indexOf('app.use("/api/public/landlord-invites", rateLimitPublicToken)');
+
+    expect(stripeWebhook).toBeGreaterThan(-1);
+    expect(transunionWebhook).toBeGreaterThan(-1);
+    expect(jsonParser).toBeGreaterThan(-1);
+    expect(firstCategoryLimiterMount).toBeGreaterThan(-1);
+    expect(stripeWebhook).toBeLessThan(jsonParser);
+    expect(transunionWebhook).toBeLessThan(jsonParser);
+    expect(jsonParser).toBeLessThan(firstCategoryLimiterMount);
+  });
+});

--- a/rentchain-api/src/middleware/rateLimit.ts
+++ b/rentchain-api/src/middleware/rateLimit.ts
@@ -1,9 +1,12 @@
 import expressRateLimit from "express-rate-limit";
+import type { Request } from "express";
+import { safeOperationalLog } from "../lib/logging/safeLogger";
 
 type RateLimitOptions = {
   windowMs: number;
   max: number;
-  keyGenerator: (req: any) => string;
+  keyGenerator: (req: Request) => string;
+  profileName?: string;
 };
 
 type SimpleRateLimitOptions = {
@@ -11,14 +14,110 @@ type SimpleRateLimitOptions = {
   max: number;
 };
 
+type RateLimitKeyStrategy = "ip" | "actor-or-ip";
+
+export type RateLimitProfile = {
+  profileName: string;
+  windowMs: number;
+  max: number;
+  keyStrategy: RateLimitKeyStrategy;
+  description: string;
+};
+
+export const RATE_LIMIT_PROFILES = {
+  authSensitive: {
+    profileName: "auth-sensitive",
+    windowMs: 15 * 60 * 1000,
+    max: 20,
+    keyStrategy: "ip",
+    description: "Login, signup, demo login, and password-reset confirmation routes.",
+  },
+  publicToken: {
+    profileName: "public-token",
+    windowMs: 15 * 60 * 1000,
+    max: 60,
+    keyStrategy: "ip",
+    description: "Public invite, access, landlord invite, tenant invite alias, and application-link token surfaces.",
+  },
+  tenantWorkspaceEntry: {
+    profileName: "tenant-workspace-entry",
+    windowMs: 15 * 60 * 1000,
+    max: 90,
+    keyStrategy: "actor-or-ip",
+    description: "Tenant workspace invite/session entry points.",
+  },
+  evidenceExportReview: {
+    profileName: "evidence-export-review",
+    windowMs: 15 * 60 * 1000,
+    max: 120,
+    keyStrategy: "actor-or-ip",
+    description: "Landlord evidence, export, review timeline, and operator review surfaces.",
+  },
+  internalJob: {
+    profileName: "internal-job",
+    windowMs: 15 * 60 * 1000,
+    max: 300,
+    keyStrategy: "ip",
+    description: "Internal job-token routes. Lenient to preserve legitimate retries.",
+  },
+  diagnostics: {
+    profileName: "diagnostics",
+    windowMs: 5 * 60 * 1000,
+    max: 120,
+    keyStrategy: "ip",
+    description: "Public debug, probe, echo, build, and status diagnostics.",
+  },
+} satisfies Record<string, RateLimitProfile>;
+
 const allowlist = String(process.env.RATE_LIMIT_ALLOWLIST || "")
   .split(",")
   .map((v) => v.trim())
   .filter(Boolean);
 
-const handler = (_req: any, res: any) => {
+function requestIp(req: Request) {
+  const forwarded = String(req.headers["x-forwarded-for"] || "").split(",")[0]?.trim();
+  return String(req.ip || forwarded || req.socket?.remoteAddress || "unknown");
+}
+
+function safeIpKey(req: Request) {
+  return requestIp(req);
+}
+
+function actorKey(req: Request) {
+  const user = (req as any).user || {};
+  return String(
+    user?.id ||
+      user?.uid ||
+      user?.sub ||
+      user?.tenantId ||
+      user?.landlordId ||
+      user?.actorLandlordId ||
+      ""
+  ).trim();
+}
+
+function keyForProfile(profile: Pick<RateLimitProfile, "profileName" | "keyStrategy">) {
+  return (req: Request) => {
+    if (profile.keyStrategy === "actor-or-ip") {
+      const actor = actorKey(req);
+      if (actor) return `${profile.profileName}:actor:${actor}`;
+    }
+    return `${profile.profileName}:ip:${safeIpKey(req)}`;
+  };
+}
+
+const handler = (req: Request, res: any, _next: any, options: any, profileName?: string) => {
+  const retryAfterSeconds = Math.ceil(Number(options?.windowMs || 0) / 1000) || undefined;
+  safeOperationalLog("warn", "[rate-limit] request limited", {
+    profileName: profileName || "rate-limit",
+    route: req.originalUrl || req.path,
+    method: req.method,
+    retryAfterSeconds,
+    authHeaderPresent: Boolean(req.get("authorization")),
+  });
   return res.status(429).json({
     ok: false,
+    code: "RATE_LIMITED",
     error: "rate_limited",
     detail: "Too many requests. Please try again later.",
   });
@@ -31,11 +130,20 @@ function createLimiter(opts: RateLimitOptions) {
     standardHeaders: true,
     legacyHeaders: false,
     keyGenerator: opts.keyGenerator,
-    handler,
+    handler: (req, res, next, options) => handler(req, res, next, options, opts.profileName),
     skip: (req) => {
-      const ip = req.ip || "";
+      const ip = requestIp(req);
       return allowlist.includes(ip);
     },
+  });
+}
+
+export function createRateLimiter(profile: RateLimitProfile) {
+  return createLimiter({
+    windowMs: profile.windowMs,
+    max: profile.max,
+    keyGenerator: keyForProfile(profile),
+    profileName: profile.profileName,
   });
 }
 
@@ -43,55 +151,63 @@ export function rateLimitSimple(opts: SimpleRateLimitOptions) {
   return createLimiter({
     windowMs: opts.windowMs,
     max: opts.max,
-    keyGenerator: keyByIp,
+    keyGenerator: keyForProfile({
+      profileName: `simple-${opts.windowMs}-${opts.max}`,
+      keyStrategy: "ip",
+    }),
+    profileName: `simple-${opts.windowMs}-${opts.max}`,
   });
 }
 
 // Backwards-compatible export used by older route modules.
 export const rateLimit = rateLimitSimple;
 
-const keyByIp = (req: any) => String(req.ip || "unknown");
-const keyByUser = (req: any) =>
-  String(req.user?.id || req.user?.uid || req.user?.landlordId || req.ip || "unknown");
-
 export const rateLimitPublicApply = createLimiter({
   windowMs: 15 * 60 * 1000,
   max: 10,
-  keyGenerator: keyByIp,
+  keyGenerator: keyForProfile({ profileName: "public-apply", keyStrategy: "ip" }),
+  profileName: "public-apply",
 });
 
 export const rateLimitLeads = createLimiter({
   windowMs: 60 * 60 * 1000,
   max: 10,
-  keyGenerator: keyByIp,
+  keyGenerator: keyForProfile({ profileName: "leads", keyStrategy: "ip" }),
+  profileName: "leads",
 });
 
-export const rateLimitAuth = createLimiter({
-  windowMs: 15 * 60 * 1000,
-  max: 20,
-  keyGenerator: keyByIp,
-});
+export const rateLimitAuth = createRateLimiter(RATE_LIMIT_PROFILES.authSensitive);
 
 export const rateLimitScreeningUser = createLimiter({
   windowMs: 60 * 60 * 1000,
   max: 30,
-  keyGenerator: keyByUser,
+  keyGenerator: keyForProfile({ profileName: "screening-user", keyStrategy: "actor-or-ip" }),
+  profileName: "screening-user",
 });
 
 export const rateLimitScreeningIp = createLimiter({
   windowMs: 60 * 60 * 1000,
   max: 60,
-  keyGenerator: keyByIp,
+  keyGenerator: keyForProfile({ profileName: "screening-ip", keyStrategy: "ip" }),
+  profileName: "screening-ip",
 });
 
 export const rateLimitTenantInvitesUser = createLimiter({
   windowMs: 60 * 60 * 1000,
   max: 30,
-  keyGenerator: keyByUser,
+  keyGenerator: keyForProfile({ profileName: "tenant-invites-user", keyStrategy: "actor-or-ip" }),
+  profileName: "tenant-invites-user",
 });
 
 export const rateLimitReferralsUser = createLimiter({
   windowMs: 24 * 60 * 60 * 1000,
   max: 10,
-  keyGenerator: keyByUser,
+  keyGenerator: keyForProfile({ profileName: "referrals-user", keyStrategy: "actor-or-ip" }),
+  profileName: "referrals-user",
 });
+
+export const rateLimitPublicToken = createRateLimiter(RATE_LIMIT_PROFILES.publicToken);
+export const rateLimitTenantWorkspaceEntry = createRateLimiter(RATE_LIMIT_PROFILES.tenantWorkspaceEntry);
+export const rateLimitEvidenceExportReview = createRateLimiter(RATE_LIMIT_PROFILES.evidenceExportReview);
+export const rateLimitInternalJob = createRateLimiter(RATE_LIMIT_PROFILES.internalJob);
+export const rateLimitDiagnostics = createRateLimiter(RATE_LIMIT_PROFILES.diagnostics);


### PR DESCRIPTION
## Summary
- formalize named API rate-limit profiles for auth-sensitive, public-token, tenant workspace entry, evidence/export/review, internal job, and diagnostics surfaces
- mount conservative first-pass limiters on high-risk public-token, tenant-entry, internal, diagnostic, and landlord evidence/export/review prefixes
- preserve webhook retry safety by leaving Stripe/TransUnion webhooks before JSON parsing and outside category rate limiting
- add the API abuse-protection governance report with applied limits, exemptions, in-memory limitations, and future production-grade options

## Route categories audited
- auth-sensitive routes (`/api/auth/login`, signup, demo login, password reset)
- public token-scoped routes (`/api/public/application-links`, landlord invites, `/api/invites`, `/api/access`)
- tenant workspace entry routes (`/api/tenant-invites`, `/api/tenant/invite`)
- landlord evidence/export/review routes (`/api/landlord/evidence-packs`, institution exports, operator reviews, review timeline)
- internal job-token routes (`/api/internal/*`)
- diagnostics/status routes (`/api/status`, probes, debug, echo, build)
- provider webhooks, documented as retry-safe exemptions

## Limits added
- `auth-sensitive`: 20 / 15 minutes by IP (existing auth limiter formalized)
- `public-token`: 60 / 15 minutes by IP
- `tenant-workspace-entry`: 90 / 15 minutes by actor-or-IP
- `evidence-export-review`: 120 / 15 minutes by actor-or-IP
- `internal-job`: 300 / 15 minutes by IP, intentionally lenient
- `diagnostics`: 120 / 5 minutes by IP

## Guardrails
- no auth rewrite
- no Firebase/JWT/Firestore rule/schema changes
- no role, permission, or route visibility changes
- no payment, screening, export, review, or tenant workspace business-logic changes
- no new infrastructure or paid dependencies
- no webhook rate limiting in this pass

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- rateLimit.test.ts apiRouteOwnershipRegression.test.ts` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build` from `rentchain-api`
- `git diff --check`

## Known limitations
- in-memory rate limiting is process-local and not sufficient as final distributed Cloud Run abuse protection
- general authenticated app browsing is not globally limited in this pass to avoid blocking normal workflows
- webhook protection remains verification/idempotency based, not rate-limit based

## Preview QA
- log in normally once
- open `/dashboard`
- open `/operations`
- confirm no normal app flow is blocked
- confirm no new console/security errors
- confirm no token or Authorization values appear in logs or console output