### PR TITLE
fix: add document upload and malware governance foundation

### DIFF
--- a/docs/reports/document-upload-and-malware-governance-v1.md
+++ b/docs/reports/document-upload-and-malware-governance-v1.md
@@ -1,0 +1,135 @@
+# Document Upload and Malware Governance v1
+
+## Executive Summary
+
+This audit establishes RentChain's first document/file governance baseline. The implementation adds a deterministic document security helper and tests for conservative MIME, extension, size, sensitivity, signed URL, malware-readiness, and safe-reference metadata rules.
+
+No document routes, authentication behavior, Firestore rules, storage bucket permissions, generated document contents, or document visibility rules were changed.
+
+## Current Document Surfaces Audited
+
+| Surface | Current pattern | Governance notes |
+| --- | --- | --- |
+| Lease PDFs and generated PDFs | `pdfStore` writes `application/pdf` objects through `uploadBufferToGcs` and creates signed download URLs. | Generated PDFs are storage-backed and should remain served through authorized signed URL flows. |
+| Schedule A / lease package flows | Generated document routes rely on backend PDF generation and GCS references. | Treat as operational or sensitive depending on included tenant/lease data. |
+| Unit lease document uploads | Multer memory upload, 10 MB limit, route-local MIME/extension allowlist for PDF, Word, JPEG, PNG. | Existing behavior is preserved; future work should move route-local policy to shared validation. |
+| Maintenance/work-order evidence | Multer memory upload, 10 MB limits, route-local image/PDF allowlists depending on attachment type. | Evidence metadata should remain reference-based and avoid raw payload duplication. |
+| Expense source documents | Multer memory upload, 10 MB limit, route-local allowlist includes CSV/XLS/XLSX/DOC/DOCX/PDF/images and route-specific `application/octet-stream`. | `application/octet-stream` should stay route-specific until reviewed; it is not part of the shared default allowlist. |
+| Ledger attachments | Metadata records store external HTTPS URLs, not uploaded file bytes. | Risk is ungoverned external document references; future validation should classify external attachment trust. |
+| Registry and CSV imports | CSV import flows store import source material as `text/csv` in GCS or parse memory uploads. | Raw CSV values are sensitive import material and must not become routine evidence/export payloads. |
+| Screening report exports | Screening report export PDFs are stored in GCS with export-token metadata. | Restricted; raw provider reports and payloads must not become routine document exports. |
+| Evidence packs and institutional exports | Projection-profile governed metadata references. | Must remain allowlist-based and exclude raw provider, raw CSV, payment credential, private message, and debug data. |
+
+## Storage Model Summary
+
+RentChain currently uses Google Cloud Storage through `GCS_UPLOAD_BUCKET` and helper functions in:
+
+- `rentchain-api/src/lib/gcs.ts`
+- `rentchain-api/src/lib/gcsSignedUrl.ts`
+- `rentchain-api/src/lib/gcsRead.ts`
+- `rentchain-api/src/storage/pdfStore.ts`
+
+The shared storage helper writes buffers with caller-provided content type and metadata. Existing validation is performed by individual routes rather than a central policy layer.
+
+## Signed URL Governance
+
+Current signed download URLs are time-limited. The helper defaults to 15 minutes, while some route flows request longer windows such as 30 minutes.
+
+Governance expectations:
+
+- signed URLs for sensitive documents should remain time-limited;
+- expired signed URLs should be refreshable by authorized users;
+- UI should not treat an expired signed URL as a missing document;
+- sensitive documents should not use permanent public URLs;
+- generated URLs should flow through authorized backend routes or services.
+
+Known follow-up:
+
+- `fix/lease-document-signed-url-refresh-v1`: address the preview QA issue where an expired signed Google Storage URL appeared in lease document viewing.
+
+## File Type and MIME Risk Analysis
+
+The shared document security helper defines a conservative default:
+
+- Default allowed MIME: `application/pdf`
+- Route-opt-in MIME groups:
+  - images: `image/jpeg`, `image/png`, `image/webp`
+  - CSV imports: `text/csv`, `application/vnd.ms-excel`
+  - Office documents: `application/msword`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+
+Disallowed by default:
+
+- `application/x-msdownload`
+- `application/javascript`
+- `text/html`
+- `application/zip`
+- `application/x-sh`
+- `application/octet-stream`
+
+`application/octet-stream` remains a route-specific legacy compatibility risk where currently used. It should not be accepted as a shared default document type.
+
+## Attachment Metadata Governance
+
+Document references should use human-readable labels as primary display text and keep bucket names, storage paths, and source IDs under internal metadata/reference fields.
+
+The new helper returns safe references with:
+
+- `profileVersion`
+- `label`
+- `documentKind`
+- `contentType`
+- `sensitivityClass`
+- `scanStatus`
+- `redactionSummary`
+- `internalReferences`
+
+This is metadata-only and does not change current route payloads.
+
+## Malware Scanning Current State
+
+No repository-managed malware scanning integration was found.
+
+The helper defines scan status terminology only:
+
+- `not_scanned`
+- `pending`
+- `clean`
+- `rejected`
+- `failed`
+
+This does not claim scanning exists. It establishes language for future scanner integration.
+
+## Production-Grade Scanning Path
+
+Recommended future hardening sequence:
+
+1. Centralize upload validation by route category.
+2. Add immutable document metadata records with scan status, uploader, source route, sensitivity, and storage reference.
+3. Add asynchronous malware scanning for upload buckets.
+4. Quarantine or block download of unscanned/rejected files where product flows can tolerate it.
+5. Add hash/integrity metadata for generated and uploaded files.
+6. Add scanner telemetry through structured logging redaction helpers.
+7. Preserve authorized signed URL refresh rather than permanent public URLs.
+
+Potential implementation options include Cloud Storage event triggers, Cloud Run scanner workers, managed malware scanning services, or provider-specific scanner integration after cost/security review.
+
+## Known Limitations
+
+- Route-level upload validation is still duplicated.
+- Existing upload routes are not migrated to the new helper in this mission.
+- Ledger attachment URLs are external references and are not scanner-governed.
+- Signed URL helpers return URL strings but no first-class expiry metadata.
+- No malware scanner is active.
+- Storage path conventions are documented by usage, not enforced centrally.
+
+## Acceptance Review
+
+This mission is safe because it:
+
+- does not widen document access;
+- does not change auth or Firestore rules;
+- does not change bucket permissions or storage paths;
+- does not alter signed document contents;
+- does not change existing document viewing behavior;
+- adds deterministic tests for document safety semantics;
+- documents future hardening before broader evidence, export, tenant trust, and review workflows expand.

--- a/rentchain-api/src/lib/documents/__tests__/documentSecurity.test.ts
+++ b/rentchain-api/src/lib/documents/__tests__/documentSecurity.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DOCUMENT_MAX_BYTES,
+  DOCUMENT_SECURITY_PROFILE_VERSION,
+  buildSafeDocumentReference,
+  classifyDocumentSensitivity,
+  deriveSignedUrlGovernance,
+  isRoutineExportDocumentKind,
+  normalizeDocumentExtension,
+  validateAllowedDocumentExtension,
+  validateAllowedDocumentMimeType,
+  validateDocumentSizeLimit,
+  validateSafeDocumentFile,
+} from "../documentSecurity";
+
+describe("documentSecurity", () => {
+  it("allows only conservative MIME types by default", () => {
+    expect(validateAllowedDocumentMimeType("application/pdf")).toEqual({ ok: true });
+
+    expect(validateAllowedDocumentMimeType("image/png")).toMatchObject({
+      ok: false,
+      code: "document_mime_unsupported",
+    });
+    expect(validateAllowedDocumentMimeType("application/octet-stream")).toMatchObject({
+      ok: false,
+      code: "document_mime_disallowed",
+    });
+    expect(validateAllowedDocumentMimeType("text/html")).toMatchObject({
+      ok: false,
+      code: "document_mime_disallowed",
+    });
+  });
+
+  it("requires route-specific opt-in for images, CSVs, and Office documents", () => {
+    expect(validateAllowedDocumentMimeType("image/webp", { allowImages: true })).toEqual({ ok: true });
+    expect(validateAllowedDocumentMimeType("text/csv", { allowCsv: true })).toEqual({ ok: true });
+    expect(
+      validateAllowedDocumentMimeType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", {
+        allowOfficeDocuments: true,
+      })
+    ).toEqual({ ok: true });
+  });
+
+  it("normalizes extensions and rejects dangerous trailing extensions", () => {
+    expect(normalizeDocumentExtension("Lease.PDF")).toBe(".pdf");
+    expect(normalizeDocumentExtension("C:\\fakepath\\photo.PNG")).toBe(".png");
+
+    expect(validateAllowedDocumentExtension("lease.pdf")).toEqual({ ok: true });
+    expect(validateAllowedDocumentExtension("lease.pdf.exe")).toMatchObject({
+      ok: false,
+      code: "document_extension_dangerous",
+    });
+    expect(validateAllowedDocumentExtension("report.html")).toMatchObject({
+      ok: false,
+      code: "document_extension_dangerous",
+    });
+  });
+
+  it("validates whole file metadata deterministically", () => {
+    expect(
+      validateSafeDocumentFile({
+        fileName: "cost-receipt.png",
+        mimeType: "image/png",
+        sizeBytes: 1024,
+        options: { allowImages: true },
+      })
+    ).toEqual({ ok: true });
+
+    expect(
+      validateSafeDocumentFile({
+        fileName: "cost-receipt.png",
+        mimeType: "image/png",
+        sizeBytes: DEFAULT_DOCUMENT_MAX_BYTES + 1,
+        options: { allowImages: true },
+      })
+    ).toMatchObject({
+      ok: false,
+      code: "document_size_too_large",
+    });
+  });
+
+  it("classifies document sensitivity and routine export eligibility", () => {
+    expect(classifyDocumentSensitivity("lease_document")).toBe("operational");
+    expect(classifyDocumentSensitivity("tenant_document")).toBe("sensitive");
+    expect(classifyDocumentSensitivity("screening_report_export")).toBe("restricted");
+    expect(classifyDocumentSensitivity("institutional_export")).toBe("restricted");
+
+    expect(isRoutineExportDocumentKind("lease_document")).toBe(true);
+    expect(isRoutineExportDocumentKind("screening_report_export")).toBe(false);
+  });
+
+  it("recognizes signed URL expiry without treating the document as missing", () => {
+    expect(
+      deriveSignedUrlGovernance({
+        expiresAt: "2026-05-20T12:00:00.000Z",
+        now: "2026-05-20T12:01:00.000Z",
+      })
+    ).toEqual({ status: "expired", refreshRequired: true });
+
+    expect(
+      deriveSignedUrlGovernance({
+        expiresAt: "2026-05-20T12:10:00.000Z",
+        now: "2026-05-20T12:01:00.000Z",
+      })
+    ).toEqual({ status: "fresh", refreshRequired: false });
+  });
+
+  it("keeps storage paths and source IDs as internal references rather than primary labels", () => {
+    const reference = buildSafeDocumentReference({
+      fileName: "signed-lease.pdf",
+      documentKind: "lease_document",
+      contentType: "application/pdf; charset=binary",
+      sizeBytes: 2048,
+      bucket: "rentchain-private-documents",
+      storagePath: "leases/landlord-1/lease-1/signed-lease.pdf",
+      sourceCollection: "leases",
+      sourceId: "lease-1",
+    });
+
+    expect(reference).toMatchObject({
+      profileVersion: DOCUMENT_SECURITY_PROFILE_VERSION,
+      label: "signed-lease.pdf",
+      documentKind: "lease_document",
+      contentType: "application/pdf",
+      sensitivityClass: "operational",
+      scanStatus: "not_scanned",
+      internalReferences: {
+        bucket: "rentchain-private-documents",
+        storagePath: "leases/landlord-1/lease-1/signed-lease.pdf",
+        sourceCollection: "leases",
+        sourceId: "lease-1",
+      },
+    });
+    expect(reference.label).not.toContain("leases/landlord-1");
+    expect(reference.redactionSummary).toContain("internal references");
+  });
+
+  it("rejects invalid document sizes", () => {
+    expect(validateDocumentSizeLimit(-1)).toMatchObject({
+      ok: false,
+      code: "document_size_invalid",
+    });
+    expect(validateDocumentSizeLimit(Number.NaN)).toMatchObject({
+      ok: false,
+      code: "document_size_invalid",
+    });
+  });
+});

--- a/rentchain-api/src/lib/documents/documentSecurity.ts
+++ b/rentchain-api/src/lib/documents/documentSecurity.ts
@@ -1,0 +1,276 @@
+export const DOCUMENT_SECURITY_PROFILE_VERSION = "document-security-v1";
+
+export const DEFAULT_DOCUMENT_MAX_BYTES = 10 * 1024 * 1024;
+
+export type DocumentSensitivityClass = "operational" | "sensitive" | "restricted";
+
+export type DocumentScanStatus = "not_scanned" | "pending" | "clean" | "rejected" | "failed";
+
+export type DocumentKind =
+  | "lease_document"
+  | "schedule_a"
+  | "evidence_attachment"
+  | "ledger_attachment"
+  | "tenant_document"
+  | "screening_report_export"
+  | "csv_import"
+  | "institutional_export"
+  | "generated_pdf"
+  | "unknown";
+
+export type DocumentValidationOptions = {
+  allowCsv?: boolean;
+  allowOfficeDocuments?: boolean;
+  allowImages?: boolean;
+  maxBytes?: number;
+};
+
+export type DocumentValidationResult = {
+  ok: boolean;
+  code?: string;
+  message?: string;
+};
+
+export type SafeDocumentReference = {
+  profileVersion: typeof DOCUMENT_SECURITY_PROFILE_VERSION;
+  label: string;
+  documentKind: DocumentKind;
+  contentType: string;
+  sizeBytes?: number;
+  sensitivityClass: DocumentSensitivityClass;
+  scanStatus: DocumentScanStatus;
+  redactionSummary: string;
+  internalReferences: {
+    bucket?: string;
+    storagePath?: string;
+    sourceCollection?: string;
+    sourceId?: string;
+  };
+};
+
+const CORE_ALLOWED_MIME_TYPES = new Set(["application/pdf"]);
+const IMAGE_ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+const CSV_ALLOWED_MIME_TYPES = new Set(["text/csv", "application/vnd.ms-excel"]);
+const OFFICE_ALLOWED_MIME_TYPES = new Set([
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]);
+
+const CORE_ALLOWED_EXTENSIONS = new Set([".pdf"]);
+const IMAGE_ALLOWED_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp"]);
+const CSV_ALLOWED_EXTENSIONS = new Set([".csv"]);
+const OFFICE_ALLOWED_EXTENSIONS = new Set([".doc", ".docx", ".xlsx"]);
+
+const DISALLOWED_MIME_TYPES = new Set([
+  "application/javascript",
+  "application/octet-stream",
+  "application/x-msdownload",
+  "application/x-sh",
+  "application/zip",
+  "text/html",
+]);
+
+const DANGEROUS_EXTENSIONS = new Set([
+  ".bat",
+  ".cmd",
+  ".com",
+  ".exe",
+  ".html",
+  ".js",
+  ".msi",
+  ".ps1",
+  ".scr",
+  ".sh",
+  ".vbs",
+  ".zip",
+]);
+
+const ROUTINE_DOCUMENT_KINDS = new Set<DocumentKind>([
+  "lease_document",
+  "schedule_a",
+  "evidence_attachment",
+  "ledger_attachment",
+  "tenant_document",
+  "generated_pdf",
+]);
+
+function normalizeMimeType(mimeType: string | undefined | null): string {
+  return String(mimeType ?? "")
+    .split(";")[0]
+    .trim()
+    .toLowerCase();
+}
+
+export function normalizeDocumentExtension(fileName: string | undefined | null): string | null {
+  const sanitized = String(fileName ?? "").trim().toLowerCase();
+  const lastSegment = sanitized.split(/[\\/]/).pop() ?? "";
+  const lastDot = lastSegment.lastIndexOf(".");
+  if (lastDot <= 0 || lastDot === lastSegment.length - 1) return null;
+  return lastSegment.slice(lastDot);
+}
+
+function allowedMimeTypes(options: DocumentValidationOptions): Set<string> {
+  return new Set([
+    ...CORE_ALLOWED_MIME_TYPES,
+    ...(options.allowImages ? IMAGE_ALLOWED_MIME_TYPES : []),
+    ...(options.allowCsv ? CSV_ALLOWED_MIME_TYPES : []),
+    ...(options.allowOfficeDocuments ? OFFICE_ALLOWED_MIME_TYPES : []),
+  ]);
+}
+
+function allowedExtensions(options: DocumentValidationOptions): Set<string> {
+  return new Set([
+    ...CORE_ALLOWED_EXTENSIONS,
+    ...(options.allowImages ? IMAGE_ALLOWED_EXTENSIONS : []),
+    ...(options.allowCsv ? CSV_ALLOWED_EXTENSIONS : []),
+    ...(options.allowOfficeDocuments ? OFFICE_ALLOWED_EXTENSIONS : []),
+  ]);
+}
+
+export function validateAllowedDocumentMimeType(
+  mimeType: string | undefined | null,
+  options: DocumentValidationOptions = {}
+): DocumentValidationResult {
+  const normalized = normalizeMimeType(mimeType);
+  if (!normalized) {
+    return { ok: false, code: "document_mime_missing", message: "Document MIME type is required." };
+  }
+
+  if (DISALLOWED_MIME_TYPES.has(normalized)) {
+    return { ok: false, code: "document_mime_disallowed", message: "Document MIME type is disallowed." };
+  }
+
+  if (!allowedMimeTypes(options).has(normalized)) {
+    return { ok: false, code: "document_mime_unsupported", message: "Document MIME type is unsupported." };
+  }
+
+  return { ok: true };
+}
+
+export function validateAllowedDocumentExtension(
+  fileName: string | undefined | null,
+  options: DocumentValidationOptions = {}
+): DocumentValidationResult {
+  const extension = normalizeDocumentExtension(fileName);
+  if (!extension) {
+    return { ok: false, code: "document_extension_missing", message: "Document extension is required." };
+  }
+
+  if (DANGEROUS_EXTENSIONS.has(extension)) {
+    return {
+      ok: false,
+      code: "document_extension_dangerous",
+      message: "Document extension is dangerous.",
+    };
+  }
+
+  if (!allowedExtensions(options).has(extension)) {
+    return {
+      ok: false,
+      code: "document_extension_unsupported",
+      message: "Document extension is unsupported.",
+    };
+  }
+
+  return { ok: true };
+}
+
+export function validateDocumentSizeLimit(
+  sizeBytes: number | undefined | null,
+  maxBytes = DEFAULT_DOCUMENT_MAX_BYTES
+): DocumentValidationResult {
+  if (!Number.isFinite(sizeBytes) || Number(sizeBytes) < 0) {
+    return { ok: false, code: "document_size_invalid", message: "Document size is invalid." };
+  }
+
+  if (Number(sizeBytes) > maxBytes) {
+    return { ok: false, code: "document_size_too_large", message: "Document exceeds the configured size limit." };
+  }
+
+  return { ok: true };
+}
+
+export function validateSafeDocumentFile(params: {
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  options?: DocumentValidationOptions;
+}): DocumentValidationResult {
+  const options = params.options ?? {};
+  const mimeValidation = validateAllowedDocumentMimeType(params.mimeType, options);
+  if (!mimeValidation.ok) return mimeValidation;
+
+  const extensionValidation = validateAllowedDocumentExtension(params.fileName, options);
+  if (!extensionValidation.ok) return extensionValidation;
+
+  return validateDocumentSizeLimit(params.sizeBytes, options.maxBytes ?? DEFAULT_DOCUMENT_MAX_BYTES);
+}
+
+export function classifyDocumentSensitivity(documentKind: DocumentKind): DocumentSensitivityClass {
+  if (documentKind === "screening_report_export" || documentKind === "institutional_export") {
+    return "restricted";
+  }
+
+  if (documentKind === "tenant_document" || documentKind === "evidence_attachment" || documentKind === "csv_import") {
+    return "sensitive";
+  }
+
+  return "operational";
+}
+
+export function isRoutineExportDocumentKind(documentKind: DocumentKind): boolean {
+  return ROUTINE_DOCUMENT_KINDS.has(documentKind);
+}
+
+export function deriveSignedUrlGovernance(params: {
+  expiresAt?: Date | string | number | null;
+  now?: Date | string | number;
+}): { status: "fresh" | "expired" | "unknown"; refreshRequired: boolean } {
+  if (!params.expiresAt) return { status: "unknown", refreshRequired: false };
+
+  const expiresAtMs = new Date(params.expiresAt).getTime();
+  const nowMs = new Date(params.now ?? Date.now()).getTime();
+
+  if (!Number.isFinite(expiresAtMs) || !Number.isFinite(nowMs)) {
+    return { status: "unknown", refreshRequired: false };
+  }
+
+  if (expiresAtMs <= nowMs) {
+    return { status: "expired", refreshRequired: true };
+  }
+
+  return { status: "fresh", refreshRequired: false };
+}
+
+export function buildSafeDocumentReference(params: {
+  label?: string;
+  fileName?: string;
+  documentKind: DocumentKind;
+  contentType: string;
+  sizeBytes?: number;
+  bucket?: string;
+  storagePath?: string;
+  sourceCollection?: string;
+  sourceId?: string;
+  scanStatus?: DocumentScanStatus;
+}): SafeDocumentReference {
+  const label = String(params.label || params.fileName || "Document reference").trim();
+
+  return {
+    profileVersion: DOCUMENT_SECURITY_PROFILE_VERSION,
+    label,
+    documentKind: params.documentKind,
+    contentType: normalizeMimeType(params.contentType),
+    sizeBytes: params.sizeBytes,
+    sensitivityClass: classifyDocumentSensitivity(params.documentKind),
+    scanStatus: params.scanStatus ?? "not_scanned",
+    redactionSummary: "Storage path and source identifiers are retained as internal references, not primary labels.",
+    internalReferences: {
+      bucket: params.bucket,
+      storagePath: params.storagePath,
+      sourceCollection: params.sourceCollection,
+      sourceId: params.sourceId,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- adds a lightweight document security helper for conservative MIME, extension, size, sensitivity, signed URL, scan-status, and safe-reference governance
- adds deterministic backend tests for allowed/disallowed document metadata, dangerous extensions, oversized files, signed URL expiry recognition, and internal-reference labeling
- adds the document upload and malware governance report covering current upload/storage surfaces, signed URL expectations, current malware-scanning limitations, and future scanner/integrity hardening

## Guardrails

- no document access widening
- no auth, Firestore rules, route visibility, bucket permission, storage path, or document content changes
- no malware-scanning service introduced or claimed
- existing document generation/view flows are not modified

## Document surfaces audited

- generated lease/Schedule A PDFs and `pdfStore`
- GCS upload/read/signed URL helpers
- unit lease document uploads
- maintenance/work-order evidence and cost attachments
- expense source-document uploads
- ledger attachment URL metadata
- CSV/registry import storage
- screening report exports
- evidence/institutional export projection governance

## Validation

- `npm run test:single -- documentSecurity.test.ts` in `rentchain-api`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Known follow-ups

- `fix/lease-document-signed-url-refresh-v1` for refreshing expired signed lease-document URLs
- centralize existing route-local upload validation behind the shared helper after each route’s compatibility constraints are reviewed
- introduce production malware scanning/quarantine/integrity metadata in a later scoped mission