### PR TITLE
feat: add security audit and incident response foundations

### DIFF
--- a/docs/reports/security-audit-and-incident-response-foundations-v1.md
+++ b/docs/reports/security-audit-and-incident-response-foundations-v1.md
@@ -1,0 +1,211 @@
+# Security Audit and Incident Response Foundations v1
+
+## Executive Summary
+
+This mission establishes RentChain's first security incident-response governance language and metadata foundation. It defines incident categories, severity levels, manual response states, affected-resource linkage expectations, and evidence/audit linkage guidance.
+
+The implementation adds a metadata-only helper and deterministic tests. It does not write incidents to Firestore, create alerts, rotate credentials, revoke tokens, disable users, lock accounts, expose tenant-visible incident internals, or integrate external SIEM/alerting vendors.
+
+## Incident Taxonomy
+
+| Category | Meaning | Example signals | First response posture |
+| --- | --- | --- | --- |
+| `auth_session` | Login/session/token behavior requiring review. | unusual login failures, suspected session issue, logout/token handling concern | manual auth/session review |
+| `credential_secret` | Credential, API key, token, signing secret, or service account risk. | leaked key, suspicious secret access, webhook secret exposure | manual containment and rotation runbook review |
+| `api_abuse` | Request-rate, probing, scraping, or abuse signal. | rate-limit triggers, public token probing, diagnostics scraping | manual abuse triage |
+| `document_upload` | Unsafe or suspicious file/document handling. | unsupported MIME, oversized file, misleading extension, expired signed URL issue | manual document governance review |
+| `malware_suspected` | Potential malware or unsafe attachment signal. | future scanner finding, suspicious upload metadata | manual containment; no scanner automation exists yet |
+| `export_projection` | Evidence/export/projection safety concern. | restricted field discovered in export candidate, unrelated resource linkage | manual projection review |
+| `evidence_access` | Evidence pack or source-lineage access issue. | wrong scope ref, evidence link mismatch, unauthorized evidence request signal | manual evidence access review |
+| `tenant_data_exposure` | Possible tenant data visibility or projection leak. | cross-tenant record inclusion, tenant-safe projection failure | critical manual investigation |
+| `admin_support_access` | Admin/support access governance concern. | support console review, impersonation/delegation concern | admin-only manual review |
+| `webhook_provider` | Provider callback/signature/idempotency concern. | webhook signature mismatch, provider retry anomaly | manual provider-webhook review |
+| `dependency_supply_chain` | Dependency, build, package, or supply-chain concern. | advisory, lockfile concern, unexpected package behavior | manual dependency review |
+| `infrastructure_deployment` | Deployment, env, Vercel/Cloud Run, or Terraform drift concern. | preview/prod env mismatch, deployment security header issue | manual platform review |
+| `suspicious_activity` | General suspicious activity not yet categorized. | incomplete signal, unknown operational anomaly | manual triage |
+
+## Severity Definitions
+
+| Severity | Meaning | Example |
+| --- | --- | --- |
+| `informational` | Useful security context, no active risk known. | closed false-positive review note |
+| `low` | Limited or unconfirmed concern requiring tracking. | suspicious but low-impact deployment metadata mismatch |
+| `medium` | Operationally meaningful security concern without confirmed exposure. | API abuse signal, webhook anomaly, document validation concern |
+| `high` | Significant risk, production impact, or sensitive data involvement. | malware suspected, tenant evidence access concern, admin/support access concern |
+| `critical` | Confirmed credential/tenant-data exposure or severe active risk. | confirmed secret exposure, confirmed tenant data leak |
+
+Severity is a review classification. It does not trigger automatic locking, revocation, rotation, or remediation.
+
+## Manual Response States
+
+| State | Meaning |
+| --- | --- |
+| `observed` | Signal recorded or metadata prepared for review. |
+| `triaged` | Reviewed enough to classify category/severity. |
+| `investigating` | Manual investigation is active. |
+| `contained` | Manual containment has occurred, but remediation is incomplete. |
+| `remediated` | Manual remediation completed. |
+| `closed` | Incident review closed. |
+| `false_positive` | Signal reviewed and found non-incident. |
+
+These are manual states only. They do not imply an automated workflow engine.
+
+## Incident Metadata Contract
+
+The first-pass helper defines metadata concepts:
+
+- `incidentGovernanceVersion`
+- `incidentId`
+- `category`
+- `severity`
+- `responseState`
+- `title`
+- `summary`
+- `detectedAt`
+- `updatedAt`
+- `affectedResources`
+- `evidenceLinks`
+- `auditExpectation`
+- `visibilityClass`
+- `sensitivityClass`
+- manual-only safety flags
+- `redactionSummary`
+
+This is not a Firestore schema. It is a governance contract for future incident records, review workspaces, and audit/event adapters.
+
+## Affected-Resource Linkage
+
+Affected resources should remain reference-based and scoped:
+
+- resource type
+- resource ID as internal reference
+- safe label
+- landlord ID if applicable
+- tenant ID only when scoped and necessary
+- `internalReference: true`
+
+Allowed first-pass resource types:
+
+- landlord
+- tenant
+- lease
+- property
+- unit
+- payment
+- ledger entry
+- evidence pack
+- document
+- export package
+- webhook
+- API route
+- credential
+- deployment
+- dependency
+- review workspace
+
+Affected-resource refs must not include raw documents, raw provider payloads, unrestricted message bodies, tokens, stack traces, or debug payloads.
+
+## Evidence and Export Linkage
+
+Incident metadata may reference evidence packs and source lineage, but it must not duplicate restricted payloads. Evidence links should carry:
+
+- evidence ID
+- safe label
+- source collection
+- source ID
+- sensitivity class
+- `internalReference: true`
+
+Evidence and export incidents should align with:
+
+- evidence projection profiles
+- institutional export allowlist profiles
+- tenant-safe projection contracts
+- canonical event taxonomy
+- structured logging redaction
+
+## Credential, Document, and Access Incident Handling Notes
+
+Credential incidents:
+
+- Never store exposed secret values in incident metadata.
+- Record credential family and affected system as labels/references only.
+- Use a separate approved manual rotation runbook for live rotation.
+
+Document incidents:
+
+- Do not duplicate uploaded file bytes or extracted raw document text.
+- Record document metadata and storage reference lineage only.
+- Malware status should be reviewed manually until scanner infrastructure exists.
+
+Access incidents:
+
+- Do not expose incident internals to tenants.
+- Keep admin/support concerns in internal security or admin-support visibility.
+- Preserve server-side authority and landlord/tenant scoping.
+
+## Relationship to Existing Foundations
+
+This incident-response foundation builds on:
+
+- `frontend-security-headers-and-csp-v1`
+- `session-and-token-governance-hardening-v1`
+- `api-rate-limit-and-abuse-protection-v1`
+- `document-upload-and-malware-governance-v1`
+- `secret-rotation-and-env-governance-v1`
+- structured logging redaction
+- projection safety tests
+- evidence projection profiles
+- institutional export allowlists
+- review workspace governance
+- canonical event taxonomy
+
+## Known Limitations
+
+- No live incident response automation exists.
+- No external alerting integration exists.
+- No token revocation automation exists.
+- No credential rotation automation exists.
+- No account locking automation exists.
+- No malware scanner integration exists.
+- No SIEM integration exists.
+- No Firestore incident collection is introduced in this mission.
+- No tenant-visible incident projection is introduced.
+
+## Future Incident-Response Roadmap
+
+Recommended future missions:
+
+1. `docs/security-incident-runbooks-v1`
+2. `fix/security-incident-event-adapter-v1`
+3. `feat/admin-security-incident-review-surface-v1`
+4. `fix/webhook-verification-and-idempotency-hardening-v1`
+5. `fix/secret-rotation-runbook-execution-controls-v1`
+6. `fix/document-malware-scanning-integration-v1`
+7. `feat/security-abuse-telemetry-dashboard-v1`
+8. `fix/admin-support-access-governance-v1`
+9. `fix/dependency-supply-chain-governance-v1`
+
+## Do Not Ignore
+
+- Confirmed credential or tenant-data exposure must be treated as `critical`.
+- Raw secrets, provider payloads, raw documents, raw CSV, unrestricted message bodies, stack traces, and debug payloads must never be copied into incident metadata.
+- Future incident records must remain permission-scoped and internal/admin-only unless a later tenant-safe incident notification model is explicitly designed.
+- Incident classification must not become autonomous remediation.
+- Any actual credential rotation must happen through a controlled manual runbook, not a metadata helper.
+
+## Confirmation
+
+This mission does not:
+
+- add autonomous remediation;
+- auto-disable users;
+- auto-revoke tokens;
+- rotate credentials;
+- change auth behavior;
+- change Firestore rules;
+- broaden route visibility;
+- expose incident details to tenants;
+- create external alerting integrations;
+- add SIEM/vendor dependencies;
+- mutate financial records.

--- a/rentchain-api/src/lib/securityIncidents/__tests__/securityIncidentGovernance.test.ts
+++ b/rentchain-api/src/lib/securityIncidents/__tests__/securityIncidentGovernance.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import {
+  SECURITY_INCIDENT_GOVERNANCE_VERSION,
+  buildSecurityIncidentReference,
+  classifySecurityIncidentSeverity,
+  normalizeSecurityIncidentAffectedResources,
+  normalizeSecurityIncidentCategory,
+  normalizeSecurityIncidentEvidenceLinks,
+  normalizeSecurityIncidentResponseState,
+  normalizeSecurityIncidentSeverity,
+} from "../securityIncidentGovernance";
+
+describe("securityIncidentGovernance", () => {
+  it("normalizes categories, severities, and manual response states deterministically", () => {
+    expect(normalizeSecurityIncidentCategory("Credential Secret")).toBe("credential_secret");
+    expect(normalizeSecurityIncidentCategory("unknown-new-category")).toBe("suspicious_activity");
+    expect(normalizeSecurityIncidentSeverity("Critical")).toBe("critical");
+    expect(normalizeSecurityIncidentSeverity("unknown")).toBe("medium");
+    expect(normalizeSecurityIncidentResponseState("Investigating")).toBe("investigating");
+    expect(normalizeSecurityIncidentResponseState("auto_remediated")).toBe("observed");
+  });
+
+  it("classifies severity without enabling automated remediation", () => {
+    expect(classifySecurityIncidentSeverity({ category: "credential_secret", confirmedExposure: true })).toBe(
+      "critical"
+    );
+    expect(classifySecurityIncidentSeverity({ category: "api_abuse", productionImpact: true })).toBe("high");
+    expect(classifySecurityIncidentSeverity({ category: "document_upload" })).toBe("medium");
+    expect(classifySecurityIncidentSeverity({ category: "infrastructure_deployment" })).toBe("low");
+  });
+
+  it("filters affected resources to the requested landlord and tenant scope", () => {
+    const refs = normalizeSecurityIncidentAffectedResources(
+      [
+        { resourceType: "lease", resourceId: "lease-1", label: "North Towers lease", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { resourceType: "lease", resourceId: "lease-2", label: "Wrong landlord", landlordId: "landlord-2", tenantId: "tenant-1" },
+        { resourceType: "lease", resourceId: "lease-3", label: "Wrong tenant", landlordId: "landlord-1", tenantId: "tenant-2" },
+        { resourceType: "unknown", resourceId: "unknown-1", label: "Unsupported resource", landlordId: "landlord-1" },
+      ],
+      { landlordId: "landlord-1", tenantId: "tenant-1" }
+    );
+
+    expect(refs).toEqual([
+      {
+        resourceType: "lease",
+        resourceId: "lease-1",
+        label: "North Towers lease",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        internalReference: true,
+      },
+    ]);
+  });
+
+  it("keeps evidence links as lineage references without raw payload duplication", () => {
+    const refs = normalizeSecurityIncidentEvidenceLinks([
+      {
+        evidencePackId: "evidence-1",
+        label: "Credential exposure review evidence",
+        sourceCollection: "canonicalEvents",
+        sourceId: "event-1",
+        sensitivityClass: "restricted",
+        providerPayload: "raw provider dump",
+        rawCsv: "raw csv data",
+        token: "secret-token",
+      },
+    ]);
+
+    expect(refs).toEqual([
+      {
+        evidenceId: "evidence-1",
+        label: "Credential exposure review evidence",
+        sourceCollection: "canonicalEvents",
+        sourceId: "event-1",
+        sensitivityClass: "restricted",
+        internalReference: true,
+      },
+    ]);
+    expectNoRestrictedProjectionFields(refs);
+    expectPayloadDoesNotContainValues(refs, ["raw provider dump", "raw csv data", "secret-token"]);
+  });
+
+  it("builds metadata-only manual security incident references", () => {
+    const incident = buildSecurityIncidentReference({
+      category: "credential_secret",
+      confirmedExposure: true,
+      responseState: "investigating",
+      title: "API key exposure review",
+      summary: "Potential exposed provider key requires manual investigation.",
+      detectedAt: "2026-05-21T10:00:00.000Z",
+      updatedAt: "2026-05-21T10:05:00.000Z",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      affectedResources: [
+        {
+          resourceType: "credential",
+          resourceId: "stripe-webhook-secret",
+          label: "Stripe webhook secret rotation review",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          webhookSecret: "whsec_sensitive",
+          stack: "private stack trace",
+        },
+      ],
+      evidenceLinks: [
+        {
+          evidenceId: "evidence-1",
+          label: "Secret exposure evidence",
+          sourceCollection: "securityTelemetry",
+          sourceId: "telemetry-1",
+          sensitivityClass: "critical",
+          apiKey: "sk_live_sensitive",
+        },
+      ],
+    });
+
+    expect(incident).toEqual(
+      expect.objectContaining({
+        incidentGovernanceVersion: SECURITY_INCIDENT_GOVERNANCE_VERSION,
+        incidentId: "security_incident:credential_secret:2026-05-21t10:00:00.000z",
+        category: "credential_secret",
+        severity: "critical",
+        responseState: "investigating",
+        visibilityClass: "admin_support",
+        sensitivityClass: "critical",
+        manualOnly: true,
+        autonomousRemediationEnabled: false,
+        tokenRevocationAutomated: false,
+        credentialRotationAutomated: false,
+        accountLockAutomated: false,
+        tenantVisible: false,
+        externalAlertingEnabled: false,
+      })
+    );
+    expect(incident.affectedResources).toEqual([
+      expect.objectContaining({
+        resourceType: "credential",
+        resourceId: "stripe-webhook-secret",
+        internalReference: true,
+      }),
+    ]);
+    expect(incident.evidenceLinks).toEqual([
+      expect.objectContaining({
+        evidenceId: "evidence-1",
+        sourceCollection: "securityTelemetry",
+        sourceId: "telemetry-1",
+        internalReference: true,
+      }),
+    ]);
+    expectNoRestrictedProjectionFields(incident);
+    expectPayloadDoesNotContainValues(incident, [
+      "whsec_sensitive",
+      "private stack trace",
+      "sk_live_sensitive",
+    ]);
+  });
+
+  it("does not imply tenant-visible incident internals or autonomous response controls", () => {
+    const incident = buildSecurityIncidentReference({
+      category: "tenant_data_exposure",
+      tenantDataInvolved: true,
+      affectedResources: [{ resourceType: "tenant", resourceId: "tenant-1", label: "Tenant data review" }],
+    });
+
+    expect(incident.tenantVisible).toBe(false);
+    expect(incident.manualOnly).toBe(true);
+    expect(incident.autonomousRemediationEnabled).toBe(false);
+    expect(incident.accountLockAutomated).toBe(false);
+    expect(incident.tokenRevocationAutomated).toBe(false);
+    expect(incident.credentialRotationAutomated).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/securityIncidents/securityIncidentGovernance.ts
+++ b/rentchain-api/src/lib/securityIncidents/securityIncidentGovernance.ts
@@ -1,0 +1,342 @@
+export const SECURITY_INCIDENT_GOVERNANCE_VERSION = "security_incident_governance_v1";
+
+export type SecurityIncidentCategory =
+  | "auth_session"
+  | "credential_secret"
+  | "api_abuse"
+  | "document_upload"
+  | "malware_suspected"
+  | "export_projection"
+  | "evidence_access"
+  | "tenant_data_exposure"
+  | "admin_support_access"
+  | "webhook_provider"
+  | "dependency_supply_chain"
+  | "infrastructure_deployment"
+  | "suspicious_activity";
+
+export type SecurityIncidentSeverity = "informational" | "low" | "medium" | "high" | "critical";
+
+export type SecurityIncidentResponseState =
+  | "observed"
+  | "triaged"
+  | "investigating"
+  | "contained"
+  | "remediated"
+  | "closed"
+  | "false_positive";
+
+export type SecurityIncidentResourceType =
+  | "landlord"
+  | "tenant"
+  | "lease"
+  | "property"
+  | "unit"
+  | "payment"
+  | "ledger_entry"
+  | "evidence_pack"
+  | "document"
+  | "export_package"
+  | "webhook"
+  | "api_route"
+  | "credential"
+  | "deployment"
+  | "dependency"
+  | "review_workspace";
+
+export type SecurityIncidentAffectedResourceRef = {
+  resourceType: SecurityIncidentResourceType;
+  resourceId: string;
+  label: string;
+  landlordId: string | null;
+  tenantId: string | null;
+  internalReference: true;
+};
+
+export type SecurityIncidentEvidenceLink = {
+  evidenceId: string;
+  label: string;
+  sourceCollection: string | null;
+  sourceId: string | null;
+  sensitivityClass: "sensitive" | "restricted" | "critical";
+  internalReference: true;
+};
+
+export type SecurityIncidentReference = {
+  incidentGovernanceVersion: typeof SECURITY_INCIDENT_GOVERNANCE_VERSION;
+  incidentId: string;
+  category: SecurityIncidentCategory;
+  severity: SecurityIncidentSeverity;
+  responseState: SecurityIncidentResponseState;
+  title: string;
+  summary: string;
+  detectedAt: string;
+  updatedAt: string;
+  affectedResources: SecurityIncidentAffectedResourceRef[];
+  evidenceLinks: SecurityIncidentEvidenceLink[];
+  auditExpectation: "manual_append_only";
+  visibilityClass: "internal_security" | "admin_support";
+  sensitivityClass: "sensitive" | "restricted" | "critical";
+  manualOnly: true;
+  autonomousRemediationEnabled: false;
+  tokenRevocationAutomated: false;
+  credentialRotationAutomated: false;
+  accountLockAutomated: false;
+  tenantVisible: false;
+  externalAlertingEnabled: false;
+  redactionSummary: string;
+};
+
+const VALID_CATEGORIES = new Set<SecurityIncidentCategory>([
+  "auth_session",
+  "credential_secret",
+  "api_abuse",
+  "document_upload",
+  "malware_suspected",
+  "export_projection",
+  "evidence_access",
+  "tenant_data_exposure",
+  "admin_support_access",
+  "webhook_provider",
+  "dependency_supply_chain",
+  "infrastructure_deployment",
+  "suspicious_activity",
+]);
+
+const VALID_SEVERITIES = new Set<SecurityIncidentSeverity>(["informational", "low", "medium", "high", "critical"]);
+const VALID_STATES = new Set<SecurityIncidentResponseState>([
+  "observed",
+  "triaged",
+  "investigating",
+  "contained",
+  "remediated",
+  "closed",
+  "false_positive",
+]);
+const VALID_RESOURCE_TYPES = new Set<SecurityIncidentResourceType>([
+  "landlord",
+  "tenant",
+  "lease",
+  "property",
+  "unit",
+  "payment",
+  "ledger_entry",
+  "evidence_pack",
+  "document",
+  "export_package",
+  "webhook",
+  "api_route",
+  "credential",
+  "deployment",
+  "dependency",
+  "review_workspace",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function safeText(value: unknown, max = 500): string {
+  return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function toIsoDate(value: unknown, fallback: Date): string {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const raw = asString(value, 120);
+  if (!raw) return fallback.toISOString();
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback.toISOString();
+}
+
+function safeIdPart(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function uniqueSorted<T>(values: T[], key: (value: T) => string): T[] {
+  const byKey = new Map<string, T>();
+  for (const value of values) {
+    const nextKey = key(value);
+    if (nextKey && !byKey.has(nextKey)) byKey.set(nextKey, value);
+  }
+  return Array.from(byKey.values()).sort((a, b) => key(a).localeCompare(key(b)));
+}
+
+export function normalizeSecurityIncidentCategory(value: unknown): SecurityIncidentCategory {
+  const normalized = normalizeKey(value);
+  return VALID_CATEGORIES.has(normalized as SecurityIncidentCategory)
+    ? (normalized as SecurityIncidentCategory)
+    : "suspicious_activity";
+}
+
+export function normalizeSecurityIncidentSeverity(value: unknown): SecurityIncidentSeverity {
+  const normalized = normalizeKey(value);
+  return VALID_SEVERITIES.has(normalized as SecurityIncidentSeverity)
+    ? (normalized as SecurityIncidentSeverity)
+    : "medium";
+}
+
+export function normalizeSecurityIncidentResponseState(value: unknown): SecurityIncidentResponseState {
+  const normalized = normalizeKey(value);
+  return VALID_STATES.has(normalized as SecurityIncidentResponseState)
+    ? (normalized as SecurityIncidentResponseState)
+    : "observed";
+}
+
+export function classifySecurityIncidentSeverity(input: {
+  category: SecurityIncidentCategory | string;
+  confirmedExposure?: boolean | null;
+  productionImpact?: boolean | null;
+  tenantDataInvolved?: boolean | null;
+}): SecurityIncidentSeverity {
+  const category = normalizeSecurityIncidentCategory(input.category);
+  if (input.confirmedExposure && (category === "credential_secret" || category === "tenant_data_exposure")) {
+    return "critical";
+  }
+  if (input.productionImpact && (category === "infrastructure_deployment" || category === "api_abuse")) {
+    return "high";
+  }
+  if (input.tenantDataInvolved && (category === "export_projection" || category === "evidence_access")) {
+    return "high";
+  }
+
+  if (category === "credential_secret" || category === "malware_suspected" || category === "tenant_data_exposure") {
+    return "high";
+  }
+  if (category === "api_abuse" || category === "webhook_provider" || category === "admin_support_access") {
+    return "medium";
+  }
+  if (category === "document_upload" || category === "dependency_supply_chain") {
+    return "medium";
+  }
+  if (category === "infrastructure_deployment" || category === "suspicious_activity") {
+    return "low";
+  }
+  return "low";
+}
+
+export function normalizeSecurityIncidentAffectedResources(
+  raw: unknown,
+  scope: { landlordId?: string | null; tenantId?: string | null } = {}
+): SecurityIncidentAffectedResourceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const resourceType = normalizeKey(data.resourceType || data.type) as SecurityIncidentResourceType;
+      const resourceId = asString(data.resourceId || data.id, 240);
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
+      if (!VALID_RESOURCE_TYPES.has(resourceType) || !resourceId) return null;
+      if (scope.landlordId && landlordId && landlordId !== scope.landlordId) return null;
+      if (scope.tenantId && tenantId && tenantId !== scope.tenantId) return null;
+      return {
+        resourceType,
+        resourceId,
+        label: safeText(data.label, 160) || `${resourceType.replace(/_/g, " ")} reference`,
+        landlordId,
+        tenantId,
+        internalReference: true,
+      };
+    })
+    .filter(Boolean) as SecurityIncidentAffectedResourceRef[];
+  return uniqueSorted(refs, (ref) => `${ref.resourceType}:${ref.resourceId}`).slice(0, 32);
+}
+
+export function normalizeSecurityIncidentEvidenceLinks(raw: unknown): SecurityIncidentEvidenceLink[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const evidenceId = asString(data.evidenceId || data.evidencePackId || data.id, 240);
+      if (!evidenceId) return null;
+      const sensitivityClass = normalizeKey(data.sensitivityClass) as SecurityIncidentEvidenceLink["sensitivityClass"];
+      return {
+        evidenceId,
+        label: safeText(data.label, 160) || "Evidence reference",
+        sourceCollection: asString(data.sourceCollection, 120) || null,
+        sourceId: asString(data.sourceId, 240) || null,
+        sensitivityClass:
+          sensitivityClass === "critical" || sensitivityClass === "restricted" || sensitivityClass === "sensitive"
+            ? sensitivityClass
+            : "sensitive",
+        internalReference: true,
+      };
+    })
+    .filter(Boolean) as SecurityIncidentEvidenceLink[];
+  return uniqueSorted(refs, (ref) => `${ref.evidenceId}:${ref.sourceCollection || ""}:${ref.sourceId || ""}`).slice(0, 24);
+}
+
+export function buildSecurityIncidentReference(input: {
+  incidentId?: string | null;
+  category: SecurityIncidentCategory | string;
+  severity?: SecurityIncidentSeverity | string | null;
+  responseState?: SecurityIncidentResponseState | string | null;
+  title?: string | null;
+  summary?: string | null;
+  detectedAt?: string | Date | null;
+  updatedAt?: string | Date | null;
+  affectedResources?: Array<Record<string, unknown>> | null;
+  evidenceLinks?: Array<Record<string, unknown>> | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  confirmedExposure?: boolean | null;
+  productionImpact?: boolean | null;
+  tenantDataInvolved?: boolean | null;
+}): SecurityIncidentReference {
+  const now = new Date();
+  const category = normalizeSecurityIncidentCategory(input.category);
+  const detectedAt = toIsoDate(input.detectedAt, now);
+  const incidentId =
+    asString(input.incidentId, 240) ||
+    safeIdPart(["security_incident", category, detectedAt].join(":")) ||
+    "security_incident:unknown";
+  const affectedResources = normalizeSecurityIncidentAffectedResources(input.affectedResources, {
+    landlordId: asString(input.landlordId, 240) || null,
+    tenantId: asString(input.tenantId, 240) || null,
+  });
+  const evidenceLinks = normalizeSecurityIncidentEvidenceLinks(input.evidenceLinks);
+  const severity = input.severity
+    ? normalizeSecurityIncidentSeverity(input.severity)
+    : classifySecurityIncidentSeverity({
+        category,
+        confirmedExposure: input.confirmedExposure,
+        productionImpact: input.productionImpact,
+        tenantDataInvolved: input.tenantDataInvolved,
+      });
+  const sensitivityClass =
+    severity === "critical" ? "critical" : severity === "high" || evidenceLinks.some((link) => link.sensitivityClass === "restricted") ? "restricted" : "sensitive";
+
+  return {
+    incidentGovernanceVersion: SECURITY_INCIDENT_GOVERNANCE_VERSION,
+    incidentId,
+    category,
+    severity,
+    responseState: normalizeSecurityIncidentResponseState(input.responseState),
+    title: safeText(input.title, 160) || `${category.replace(/_/g, " ")} review`,
+    summary: safeText(input.summary, 500) || "Security incident metadata prepared for manual review.",
+    detectedAt,
+    updatedAt: toIsoDate(input.updatedAt, new Date(detectedAt)),
+    affectedResources,
+    evidenceLinks,
+    auditExpectation: "manual_append_only",
+    visibilityClass: severity === "critical" ? "admin_support" : "internal_security",
+    sensitivityClass,
+    manualOnly: true,
+    autonomousRemediationEnabled: false,
+    tokenRevocationAutomated: false,
+    credentialRotationAutomated: false,
+    accountLockAutomated: false,
+    tenantVisible: false,
+    externalAlertingEnabled: false,
+    redactionSummary:
+      "Incident metadata excludes raw credentials, provider payloads, documents, exports, message bodies, stack traces, and debug payloads.",
+  };
+}


### PR DESCRIPTION
## Summary

- adds a security audit and incident-response governance report with incident taxonomy, severity definitions, manual response states, resource/evidence linkage guidance, and future runbook roadmap
- adds a metadata-only security incident governance helper for category/state/severity normalization, affected-resource refs, evidence refs, and incident references
- adds deterministic tests proving incident metadata remains manual-only, scoped, reference-based, and excludes restricted/raw/secret/debug values

## Guardrails

- no autonomous remediation, token revocation, credential rotation, account locking, external alerting, SIEM integration, or tenant-visible incident internals
- no Firestore writes or new incident collection
- no auth, Firestore rules, route visibility, schema, payment, export, document, or review workflow behavior changes
- no permission widening

## Incident model summary

Categories include auth/session, credential/secret, API abuse, document upload, malware suspected, export projection, evidence access, tenant data exposure, admin/support access, webhook/provider, dependency supply chain, infrastructure/deployment, and suspicious activity.

Severity levels are `informational`, `low`, `medium`, `high`, and `critical`.

Manual response states are `observed`, `triaged`, `investigating`, `contained`, `remediated`, `closed`, and `false_positive`.

## Validation

- `npm run test:single -- securityIncidentGovernance.test.ts` in `rentchain-api`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Known limitations / follow-ups

- no live incident response automation exists yet
- no external alerting or SIEM integration exists yet
- no token revocation or credential rotation automation exists yet
- no malware scanner integration exists yet
- future work should add incident runbooks, event adapters, admin review surfaces, and webhook/idempotency hardening