### PR TITLE
fix: add admin support access governance

### DIFF
--- a/docs/reports/admin-support-access-governance-v1.md
+++ b/docs/reports/admin-support-access-governance-v1.md
@@ -1,0 +1,161 @@
+# Admin and Support Access Governance v1
+
+## Executive Summary
+
+This report documents RentChain's current privileged operational access posture and establishes a metadata-only governance contract for admin/support access review. It does not add admin powers, impersonation tooling, route visibility, Firestore rules, JWT claims, or cross-landlord visibility.
+
+The implementation adds deterministic helper/tests for privileged access context classification, scoped resource references, and audit-reference metadata. The helper is not wired into routes in this mission.
+
+## Current Access Model
+
+Current backend patterns:
+
+- `authenticateJwt` decodes JWTs and attaches `req.user` when an Authorization header is present.
+- `requireAuth` verifies RentChain auth tokens and hydrates canonical session users.
+- `requireAdmin` permits users with role `admin` or explicit admin email/sub allowlists.
+- `requirePermission("system.admin")` is used by many admin route families through RBAC.
+- `requireLandlord` and `requireLandlordOrAdmin` allow landlord/admin role access with effective landlord context.
+- `requestAuthority` centralizes actor role, actor ID, landlord/tenant scope, `actorLandlordId`, admin/support flags, and warnings/errors.
+- `blockImpersonationWrites` blocks writes for the existing tenant-role/landlord-actor impersonation shape.
+
+Current risk:
+
+- Admin and support concepts exist across route middleware, RBAC, request authority, support forensics, and review systems, but the privileged visibility/audit expectations are still implicit.
+
+## Privileged Route Families
+
+Privileged routes identified in `app.build.ts` include:
+
+- `/api/admin` support console and admin operational routes
+- `/api/admin` triage, resolution, SLA, alerting, assignment, notification, support operations
+- `/api/admin` observability and incident readiness routes
+- `/api/admin` release, public exposure, commercial readiness, controlled integrations, production integrations, municipal readiness, ecosystem coordination, platform credentialing, consumer reporting governance, PDF export observability
+- `/api/admin` properties, tenants, leases, overview, integrity, saved filters, audit, screening results, screening usage
+- `/api/impersonation` existing impersonation route family
+
+This mission does not change any route mount or route behavior.
+
+## Privileged Visibility Semantics
+
+Supported governance modes:
+
+| Mode | Meaning | Visibility |
+| --- | --- | --- |
+| `denied` | Actor/scope is not sufficient for privileged access metadata. | internal |
+| `landlord_operational` | Normal landlord-scoped operational access. | landlord operational |
+| `admin_scoped_review` | Admin review of a specific landlord/tenant/resource scope. | admin/support internal |
+| `admin_global_review` | Explicit system-admin review without a single landlord scope. | admin/support internal |
+| `support_scoped_diagnostic` | Support diagnostic review for an explicit landlord/tenant/resource scope. | admin/support internal |
+
+Support access should be scoped by default. Admin global review requires explicit system-admin context.
+
+## Impersonation and Delegation Expectations
+
+No live impersonation powers are introduced here.
+
+Governance expectations:
+
+- Impersonation/delegation must be explicit in server-side authority context.
+- Tenant-visible UI must not receive admin/support internals.
+- Write behavior during impersonation must remain blocked unless a future mission explicitly designs scoped write semantics.
+- Any future support session should record actor, effective scope, reason, started/ended timestamps, and audit refs.
+- `actorLandlordId` override warnings should remain visible to backend governance tooling.
+
+## Projection Expectations
+
+Admin/support projection surfaces may include scoped metadata and internal references, but must not include:
+
+- raw provider payloads
+- raw screening/reporting reports
+- raw evidence/export payloads
+- unrestricted message bodies
+- payment credentials
+- auth tokens/secrets
+- stack traces
+- route-source/debug payloads as product data
+- unrelated landlord/tenant records
+
+Tenant-safe projections must remain whitelist-based and must not include privileged review internals.
+
+## Audit/Event Expectations
+
+Privileged access should be audit-compatible and append-oriented:
+
+- actor ID and role
+- access mode
+- requested/effective landlord and tenant scope
+- route or workflow action
+- resource references as internal metadata
+- evidence/export/review refs as internal metadata
+- timestamp
+- reason or summary
+- no raw sensitive payloads
+
+The helper added in this mission builds metadata-only audit refs and sets:
+
+- `tenantVisible: false`
+- `metadataOnly: true`
+- `supportSafe: true`
+- `sensitivePayloadIncluded: false`
+- `restrictedPayloadIncluded: false`
+- `autonomousEscalationEnabled: false`
+
+## Cross-Tenant and Cross-Landlord Risk Areas
+
+Highest-risk areas to keep reviewing:
+
+- broad `/api/admin` route mounts
+- admin property/tenant/lease list views
+- support console diagnostics
+- evidence and institutional export previews
+- review workspace and operational review queue linkage
+- incident/security telemetry views
+- impersonation route family
+- debug/probe/internal diagnostic surfaces
+
+Existing tests already cover some admin projection safety and scoped review boundaries; future route-level tests should expand coverage where privileged reads are introduced.
+
+## Helper Contract
+
+New helper concepts:
+
+- `classifyAdminSupportScope()`
+- `normalizePrivilegedAccessResourceRefs()`
+- `buildPrivilegedAccessAuditRef()`
+
+The helper is deterministic and metadata-only. It does not enforce permissions, mutate auth state, write audit records, or grant access.
+
+## Known Limitations
+
+- No full support-session framework exists.
+- No new audit event writer is introduced.
+- No route-level privileged access middleware changes are made.
+- No institution-wide review access exists.
+- Live admin/support env allowlists are not verifiable from repository files alone.
+- Admin and support semantics are still split across RBAC, middleware, route-level checks, and request authority.
+
+## Future Governance Roadmap
+
+Recommended future missions:
+
+1. `fix/admin-support-route-scope-regression-v1`
+2. `feat/support-session-audit-log-v1`
+3. `fix/impersonation-governance-and-audit-v1`
+4. `fix/admin-support-projection-safety-regression-v1`
+5. `feat/admin-security-incident-review-surface-v1`
+6. `fix/debug-probe-production-gating-v1`
+7. `feat/support-escalation-runbooks-v1`
+
+## Confirmation
+
+This mission does not:
+
+- broaden admin/support visibility;
+- add impersonation powers;
+- change auth provider behavior;
+- change JWT format;
+- change Firestore rules;
+- expose tenant-visible admin/support internals;
+- add autonomous support escalation;
+- mutate financial records;
+- create cross-landlord review visibility.

--- a/rentchain-api/src/lib/adminSupportAccess/__tests__/adminSupportAccessGovernance.test.ts
+++ b/rentchain-api/src/lib/adminSupportAccess/__tests__/adminSupportAccessGovernance.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import {
+  ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION,
+  buildPrivilegedAccessAuditRef,
+  classifyAdminSupportScope,
+  normalizePrivilegedAccessResourceRefs,
+} from "../adminSupportAccessGovernance";
+
+describe("adminSupportAccessGovernance", () => {
+  it("keeps landlord access scoped to the landlord context", () => {
+    const context = classifyAdminSupportScope({
+      authority: {
+        actorId: "landlord-user-1",
+        actorRole: "landlord",
+        effectiveLandlordId: "landlord-1",
+        effectiveTenantId: null,
+        isAdmin: false,
+        isSupport: false,
+        isLandlord: true,
+        isTenant: false,
+        warnings: [],
+        errors: [],
+      },
+      requestedLandlordId: "landlord-1",
+    });
+
+    expect(context).toEqual(
+      expect.objectContaining({
+        governanceVersion: ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION,
+        accessMode: "landlord_operational",
+        visibilityClass: "landlord_operational",
+        tenantVisible: false,
+        crossLandlordVisibilityEnabled: false,
+        impersonationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+        errors: [],
+      })
+    );
+  });
+
+  it("does not infer admin global access without explicit system-admin context", () => {
+    const context = classifyAdminSupportScope({
+      authority: {
+        actorId: "admin-1",
+        actorRole: "admin",
+        effectiveLandlordId: "admin-1",
+        effectiveTenantId: null,
+        isAdmin: true,
+        isSupport: false,
+        isLandlord: false,
+        isTenant: false,
+        warnings: [],
+        errors: [],
+      },
+    });
+
+    expect(context.accessMode).toBe("denied");
+    expect(context.errors).toContain("admin_scope_required");
+
+    const scoped = classifyAdminSupportScope({
+      authority: {
+        ...context,
+        errors: [],
+        warnings: [],
+        actorRole: "admin",
+        effectiveLandlordId: "admin-1",
+        isAdmin: true,
+        isSupport: false,
+        isLandlord: false,
+        isTenant: false,
+      },
+      requestedLandlordId: "landlord-1",
+    });
+    expect(scoped.accessMode).toBe("admin_scoped_review");
+  });
+
+  it("requires support access to be scoped and remains internal-only", () => {
+    const unscoped = classifyAdminSupportScope({
+      authority: {
+        actorId: "support-1",
+        actorRole: "support",
+        effectiveLandlordId: "support-1",
+        effectiveTenantId: null,
+        isAdmin: false,
+        isSupport: true,
+        isLandlord: false,
+        isTenant: false,
+        warnings: [],
+        errors: [],
+      },
+    });
+
+    expect(unscoped.accessMode).toBe("denied");
+    expect(unscoped.errors).toContain("support_scope_required");
+
+    const scoped = classifyAdminSupportScope({
+      authority: {
+        ...unscoped,
+        actorRole: "support",
+        isAdmin: false,
+        isSupport: true,
+        isLandlord: false,
+        isTenant: false,
+        errors: [],
+        warnings: [],
+      },
+      requestedLandlordId: "landlord-1",
+      requestedTenantId: "tenant-1",
+    });
+
+    expect(scoped).toEqual(
+      expect.objectContaining({
+        accessMode: "support_scoped_diagnostic",
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        impersonationEnabled: false,
+      })
+    );
+  });
+
+  it("denies tenant use of privileged access context", () => {
+    const context = classifyAdminSupportScope({
+      authority: {
+        actorId: "tenant-1",
+        actorRole: "tenant",
+        effectiveLandlordId: "landlord-1",
+        effectiveTenantId: "tenant-1",
+        isAdmin: false,
+        isSupport: false,
+        isLandlord: false,
+        isTenant: true,
+        warnings: [],
+        errors: [],
+      },
+      requestedLandlordId: "landlord-1",
+      requestedTenantId: "tenant-1",
+    });
+
+    expect(context.accessMode).toBe("denied");
+    expect(context.errors).toContain("tenant_cannot_use_privileged_access");
+    expect(context.tenantVisible).toBe(false);
+  });
+
+  it("filters privileged resource refs to the requested scope and omits raw payload fields", () => {
+    const refs = normalizePrivilegedAccessResourceRefs(
+      [
+        {
+          resourceType: "evidence_pack",
+          resourceId: "evidence-1",
+          label: "Scoped evidence",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          rawPayload: "raw provider dump",
+          token: "secret-token",
+        },
+        {
+          resourceType: "evidence_pack",
+          resourceId: "evidence-2",
+          label: "Wrong landlord",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+        },
+        {
+          resourceType: "evidence_pack",
+          resourceId: "evidence-3",
+          label: "Wrong tenant",
+          landlordId: "landlord-1",
+          tenantId: "tenant-2",
+        },
+      ],
+      { landlordId: "landlord-1", tenantId: "tenant-1" }
+    );
+
+    expect(refs).toEqual([
+      {
+        resourceType: "evidence_pack",
+        resourceId: "evidence-1",
+        label: "Scoped evidence",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        internalReference: true,
+      },
+    ]);
+    expectNoRestrictedProjectionFields(refs);
+    expectPayloadDoesNotContainValues(refs, ["raw provider dump", "secret-token", "evidence-2", "evidence-3"]);
+  });
+
+  it("builds metadata-only audit refs without autonomous escalation or tenant-visible internals", () => {
+    const context = classifyAdminSupportScope({
+      authority: {
+        actorId: "admin-1",
+        actorRole: "admin",
+        effectiveLandlordId: "admin-1",
+        effectiveTenantId: null,
+        isAdmin: true,
+        isSupport: false,
+        isLandlord: false,
+        isTenant: false,
+        warnings: [],
+        errors: [],
+      },
+      requestedLandlordId: "landlord-1",
+      requestedTenantId: "tenant-1",
+    });
+
+    const auditRef = buildPrivilegedAccessAuditRef({
+      context,
+      action: "Evidence Access Review",
+      occurredAt: "2026-05-21T12:00:00.000Z",
+      summary: "Admin reviewed scoped evidence metadata.",
+      resourceRefs: [
+        {
+          resourceType: "review_workspace",
+          resourceId: "workspace-1",
+          label: "Review workspace",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          providerPayload: "raw provider dump",
+          stack: "private stack trace",
+        },
+      ],
+      evidenceRefs: [
+        {
+          resourceType: "evidence_pack",
+          resourceId: "evidence-1",
+          label: "Evidence pack reference",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          webhookSecret: "whsec_sensitive",
+        },
+      ],
+    });
+
+    expect(auditRef).toEqual(
+      expect.objectContaining({
+        governanceVersion: ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION,
+        auditRefId: "privileged_access:admin-1:evidence_access_review:2026-05-21t12:00:00.000z",
+        accessMode: "admin_scoped_review",
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        metadataOnly: true,
+        supportSafe: true,
+        sensitivePayloadIncluded: false,
+        restrictedPayloadIncluded: false,
+        autonomousEscalationEnabled: false,
+      })
+    );
+    expectNoRestrictedProjectionFields(auditRef);
+    expectPayloadDoesNotContainValues(auditRef, ["raw provider dump", "private stack trace", "whsec_sensitive"]);
+  });
+});

--- a/rentchain-api/src/lib/adminSupportAccess/adminSupportAccessGovernance.ts
+++ b/rentchain-api/src/lib/adminSupportAccess/adminSupportAccessGovernance.ts
@@ -1,0 +1,274 @@
+import type { RequestAuthority, RequestAuthorityRole } from "../../auth/requestAuthority";
+
+export const ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION = "admin_support_access_governance_v1";
+
+export type PrivilegedAccessMode =
+  | "denied"
+  | "landlord_operational"
+  | "admin_global_review"
+  | "admin_scoped_review"
+  | "support_scoped_diagnostic";
+
+export type PrivilegedAccessVisibilityClass = "landlord_operational" | "admin_support_internal";
+
+export type PrivilegedAccessResourceType =
+  | "landlord"
+  | "tenant"
+  | "lease"
+  | "property"
+  | "unit"
+  | "payment"
+  | "ledger_entry"
+  | "evidence_pack"
+  | "export_package"
+  | "review_workspace"
+  | "incident"
+  | "admin_route"
+  | "support_diagnostic";
+
+export type PrivilegedAccessResourceRef = {
+  resourceType: PrivilegedAccessResourceType;
+  resourceId: string;
+  label: string;
+  landlordId: string | null;
+  tenantId: string | null;
+  internalReference: true;
+};
+
+export type PrivilegedAccessContext = {
+  governanceVersion: typeof ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION;
+  actorId: string | null;
+  actorRole: RequestAuthorityRole;
+  accessMode: PrivilegedAccessMode;
+  visibilityClass: PrivilegedAccessVisibilityClass;
+  effectiveLandlordId: string | null;
+  effectiveTenantId: string | null;
+  requestedLandlordId: string | null;
+  requestedTenantId: string | null;
+  tenantVisible: false;
+  crossLandlordVisibilityEnabled: false;
+  impersonationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  requiresAuditEvent: true;
+  warnings: string[];
+  errors: string[];
+};
+
+export type PrivilegedAccessAuditRef = {
+  governanceVersion: typeof ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION;
+  auditRefId: string;
+  action: string;
+  actorId: string | null;
+  actorRole: RequestAuthorityRole;
+  accessMode: PrivilegedAccessMode;
+  visibilityClass: PrivilegedAccessVisibilityClass;
+  resourceRefs: PrivilegedAccessResourceRef[];
+  evidenceRefs: PrivilegedAccessResourceRef[];
+  occurredAt: string;
+  summary: string;
+  tenantVisible: false;
+  metadataOnly: true;
+  supportSafe: true;
+  sensitivePayloadIncluded: false;
+  restrictedPayloadIncluded: false;
+  autonomousEscalationEnabled: false;
+};
+
+const VALID_RESOURCE_TYPES = new Set<PrivilegedAccessResourceType>([
+  "landlord",
+  "tenant",
+  "lease",
+  "property",
+  "unit",
+  "payment",
+  "ledger_entry",
+  "evidence_pack",
+  "export_package",
+  "review_workspace",
+  "incident",
+  "admin_route",
+  "support_diagnostic",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function safeText(value: unknown, max = 500): string {
+  return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+function cleanMode(value: unknown): PrivilegedAccessMode | null {
+  const normalized = asString(value, 80).toLowerCase().replace(/[\s.-]+/g, "_");
+  if (
+    normalized === "denied" ||
+    normalized === "landlord_operational" ||
+    normalized === "admin_global_review" ||
+    normalized === "admin_scoped_review" ||
+    normalized === "support_scoped_diagnostic"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function toIsoDate(value: unknown): string {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const parsed = Date.parse(asString(value, 120));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function idPart(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function uniqueSorted<T>(values: T[], key: (value: T) => string): T[] {
+  const byKey = new Map<string, T>();
+  for (const value of values) {
+    const nextKey = key(value);
+    if (nextKey && !byKey.has(nextKey)) byKey.set(nextKey, value);
+  }
+  return Array.from(byKey.values()).sort((a, b) => key(a).localeCompare(key(b)));
+}
+
+export function classifyAdminSupportScope(params: {
+  authority: Pick<
+    RequestAuthority,
+    "actorId" | "actorRole" | "effectiveLandlordId" | "effectiveTenantId" | "isAdmin" | "isSupport" | "isLandlord" | "isTenant" | "warnings" | "errors"
+  >;
+  requestedLandlordId?: string | null;
+  requestedTenantId?: string | null;
+  requestedMode?: PrivilegedAccessMode | string | null;
+  hasSystemAdminPermission?: boolean | null;
+}): PrivilegedAccessContext {
+  const authority = params.authority;
+  const requestedLandlordId = asString(params.requestedLandlordId, 240) || null;
+  const requestedTenantId = asString(params.requestedTenantId, 240) || null;
+  const warnings = [...(authority.warnings || [])];
+  const errors = [...(authority.errors || [])];
+  const requestedMode = cleanMode(params.requestedMode);
+  const effectiveLandlordId = authority.effectiveLandlordId || null;
+  const effectiveTenantId = authority.effectiveTenantId || null;
+
+  let accessMode: PrivilegedAccessMode = "denied";
+  let visibilityClass: PrivilegedAccessVisibilityClass = "admin_support_internal";
+
+  if (authority.isTenant) {
+    errors.push("tenant_cannot_use_privileged_access");
+  } else if (authority.isLandlord && effectiveLandlordId) {
+    accessMode = "landlord_operational";
+    visibilityClass = "landlord_operational";
+    if (requestedLandlordId && requestedLandlordId !== effectiveLandlordId) errors.push("landlord_scope_mismatch");
+  } else if (authority.isAdmin) {
+    if (requestedLandlordId) accessMode = "admin_scoped_review";
+    else if (params.hasSystemAdminPermission || requestedMode === "admin_global_review") accessMode = "admin_global_review";
+    else {
+      accessMode = "denied";
+      errors.push("admin_scope_required");
+    }
+  } else if (authority.isSupport) {
+    if (requestedLandlordId) accessMode = "support_scoped_diagnostic";
+    else {
+      accessMode = "denied";
+      errors.push("support_scope_required");
+    }
+  } else {
+    errors.push("privileged_role_required");
+  }
+
+  if (requestedTenantId && !requestedLandlordId && (authority.isAdmin || authority.isSupport)) {
+    warnings.push("tenant_scope_without_landlord_scope");
+  }
+
+  return {
+    governanceVersion: ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION,
+    actorId: authority.actorId || null,
+    actorRole: authority.actorRole,
+    accessMode: errors.length ? "denied" : accessMode,
+    visibilityClass,
+    effectiveLandlordId,
+    effectiveTenantId,
+    requestedLandlordId,
+    requestedTenantId,
+    tenantVisible: false,
+    crossLandlordVisibilityEnabled: false,
+    impersonationEnabled: false,
+    autonomousEscalationEnabled: false,
+    financialMutationEnabled: false,
+    requiresAuditEvent: true,
+    warnings: uniqueSorted(warnings, (value) => value),
+    errors: uniqueSorted(errors, (value) => value),
+  };
+}
+
+export function normalizePrivilegedAccessResourceRefs(
+  raw: unknown,
+  scope: { landlordId?: string | null; tenantId?: string | null } = {}
+): PrivilegedAccessResourceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const landlordScope = asString(scope.landlordId, 240) || null;
+  const tenantScope = asString(scope.tenantId, 240) || null;
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const resourceType = asString(data.resourceType || data.type, 80).toLowerCase() as PrivilegedAccessResourceType;
+      const resourceId = asString(data.resourceId || data.id, 240);
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
+      if (!VALID_RESOURCE_TYPES.has(resourceType) || !resourceId) return null;
+      if (landlordScope && landlordId && landlordId !== landlordScope) return null;
+      if (tenantScope && tenantId && tenantId !== tenantScope) return null;
+      return {
+        resourceType,
+        resourceId,
+        label: safeText(data.label, 160) || `${resourceType.replace(/_/g, " ")} reference`,
+        landlordId,
+        tenantId,
+        internalReference: true,
+      };
+    })
+    .filter(Boolean) as PrivilegedAccessResourceRef[];
+  return uniqueSorted(refs, (ref) => `${ref.resourceType}:${ref.resourceId}`).slice(0, 32);
+}
+
+export function buildPrivilegedAccessAuditRef(params: {
+  context: PrivilegedAccessContext;
+  action: string;
+  occurredAt?: string | Date | null;
+  resourceRefs?: Array<Record<string, unknown>> | null;
+  evidenceRefs?: Array<Record<string, unknown>> | null;
+  summary?: string | null;
+}): PrivilegedAccessAuditRef {
+  const occurredAt = toIsoDate(params.occurredAt);
+  const action = asString(params.action, 120).toLowerCase().replace(/[\s.-]+/g, "_") || "privileged_access_review";
+  const scope = {
+    landlordId: params.context.requestedLandlordId || params.context.effectiveLandlordId,
+    tenantId: params.context.requestedTenantId || params.context.effectiveTenantId,
+  };
+  return {
+    governanceVersion: ADMIN_SUPPORT_ACCESS_GOVERNANCE_VERSION,
+    auditRefId:
+      idPart(["privileged_access", params.context.actorId || "unknown", action, occurredAt].join(":")) ||
+      "privileged_access:unknown",
+    action,
+    actorId: params.context.actorId,
+    actorRole: params.context.actorRole,
+    accessMode: params.context.accessMode,
+    visibilityClass: params.context.visibilityClass,
+    resourceRefs: normalizePrivilegedAccessResourceRefs(params.resourceRefs, scope),
+    evidenceRefs: normalizePrivilegedAccessResourceRefs(params.evidenceRefs, scope),
+    occurredAt,
+    summary: safeText(params.summary, 300) || "Privileged access metadata prepared for manual audit review.",
+    tenantVisible: false,
+    metadataOnly: true,
+    supportSafe: true,
+    sensitivePayloadIncluded: false,
+    restrictedPayloadIncluded: false,
+    autonomousEscalationEnabled: false,
+  };
+}


### PR DESCRIPTION
## Summary

- adds an admin/support access governance report covering privileged route families, visibility semantics, impersonation/delegation expectations, audit expectations, and future governance work
- adds metadata-only admin/support access governance helpers for privileged context classification, scoped resource refs, and audit-ref metadata
- adds deterministic tests for landlord/admin/support/tenant boundary behavior, scoped resource filtering, restricted-field exclusion, and manual-only/no-autonomous metadata

## Guardrails

- no admin/support visibility widening
- no new impersonation powers or support tooling
- no auth provider, JWT, Firestore rule, route visibility, schema, payment, export, review, or tenant behavior changes
- no autonomous support escalation
- no financial mutations or cross-landlord review visibility

## Governance findings

- admin/support semantics are currently spread across `requestAuthority`, `requireAdmin`, `requirePermission("system.admin")`, landlord/admin middleware, support forensics, and review systems
- `/api/admin` contains many broad privileged route families and should get route-level scope regression coverage next
- support access should be explicit and scoped by default; admin global review should require explicit system-admin context
- existing impersonation/write-block behavior should remain until a dedicated governance/audit mission designs any future changes

## Validation

- `npm run test:single -- adminSupportAccessGovernance.test.ts requestAuthority.test.ts` in `rentchain-api`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Known follow-ups

- `fix/admin-support-route-scope-regression-v1`
- `feat/support-session-audit-log-v1`
- `fix/impersonation-governance-and-audit-v1`
- `fix/admin-support-projection-safety-regression-v1`
- `fix/debug-probe-production-gating-v1`