### PR TITLE
feat: add export integrity and signature foundations

### DIFF
--- a/docs/reports/export-integrity-and-signature-foundations-v1.md
+++ b/docs/reports/export-integrity-and-signature-foundations-v1.md
@@ -1,0 +1,152 @@
+# Export Integrity and Signature Foundations v1
+
+## Executive summary
+
+This report establishes RentChain's first export-integrity and signature-readiness governance foundation for evidence packs, institutional exports, tenant trust exports, document exports, and governed review artifacts.
+
+This mission does not introduce production cryptographic signing, public verification APIs, blockchain anchoring, export visibility changes, or new export access paths. It defines deterministic metadata terminology and a small helper contract that future signed-export workflows can build on after separate security review.
+
+## Scope and non-goals
+
+In scope:
+
+- Export integrity terminology.
+- Signature-readiness metadata semantics.
+- Deterministic source lineage expectations.
+- Reproducibility expectations for governed exports.
+- Metadata-only helper and regression tests.
+
+Out of scope:
+
+- Production cryptographic signing.
+- Cryptographic verification.
+- Public verification endpoints.
+- Blockchain, tokenization, or on-chain anchoring.
+- Export payload expansion.
+- Tenant-visible internal verification metadata.
+- Auth, Firestore rules, schema, or route changes.
+
+## Export integrity philosophy
+
+RentChain exports should be reproducible from deterministic, authority-scoped projection inputs. Export integrity metadata should describe how an artifact was derived, which projection profile governed it, and which source references informed it without copying raw source payloads into secondary surfaces.
+
+Integrity metadata is not a substitute for access control. It must remain downstream of server-side authority checks, projection allowlists, sensitivity classification, and scoped source derivation.
+
+## Metadata concepts
+
+| Concept | Meaning |
+| --- | --- |
+| `exportIntegrityVersion` | Version of the integrity metadata contract. |
+| `exportProfile` | Export profile or package profile that produced the artifact. |
+| `exportVersion` | Export package/profile version. |
+| `exportGeneratedAt` | Deterministic timestamp field supplied by the caller or normalized to a safe default. |
+| `exportGeneratedBy` | Internal actor reference when already safely available. |
+| `integrityScope` | Artifact family, such as evidence pack, institutional export, tenant trust export, review artifact, or document export. |
+| `sourceCollections` | Sorted collection names represented by source references. |
+| `sourceRefs` | Internal source references containing collection/id only. |
+| `lineageSummary` | Metadata summary of source reference count and lineage policy. |
+| `projectionProfile` | Projection profile that shaped the export when known. |
+| `exportHashPlaceholder` | Explicit non-computed hash placeholder. |
+| `signatureStatus` | Metadata status such as `not_signed` or `signature_ready`; not a production signing guarantee. |
+| `verificationStatus` | Metadata readiness status; this phase does not claim cryptographic verification. |
+| `sensitivityClass` | Export sensitivity classification inherited from the governed projection surface. |
+| `reproducibilityExpectation` | Statement that deterministic projection inputs are required for repeatable exports. |
+
+## Source lineage and reproducibility
+
+Source lineage should remain reference-based. A source reference may include:
+
+- `sourceCollection`
+- `sourceId`
+- `internalReference: true`
+
+Source references must not include raw provider payloads, raw CSV rows, private message bodies, payment credentials, full document contents, debug payloads, stack traces, secrets, or route diagnostics.
+
+Reproducibility requires:
+
+- stable projection profiles,
+- stable source reference sets,
+- stable timestamp semantics,
+- server-side authority context,
+- deterministic sorting of source references,
+- whitelist projection over blacklist stripping.
+
+## Signature-readiness terminology
+
+`signature_ready` means an export has enough metadata structure to be evaluated by a future signing workflow. It does not mean:
+
+- an artifact was cryptographically signed,
+- a cryptographic digest was computed,
+- an external institution can verify the artifact,
+- a public verification endpoint exists,
+- a blockchain anchor exists.
+
+`exportHashPlaceholder` is intentionally `not_computed` in this phase. The placeholder exists to make future checksum semantics explicit without implying a production hash.
+
+## Verification metadata
+
+This phase recognizes metadata readiness only:
+
+- `metadata_only`: no sufficient source lineage/profile is present.
+- `ready_for_review`: source lineage and projection profile are present for future manual or implementation review.
+- `unavailable`: input status is unsupported or cannot be interpreted safely.
+
+This phase does not claim `verified` status for exports because no production cryptographic verification system exists yet.
+
+## Relationship to governed export surfaces
+
+Evidence packs:
+
+- should continue using evidence projection profiles and restricted-field exclusion.
+- may use integrity metadata later to describe evidence lineage without duplicating evidence payloads.
+
+Institutional exports:
+
+- should continue using institutional allowlist profiles.
+- should treat source refs as internal lineage metadata, not display labels.
+
+Tenant trust exports:
+
+- must only expose tenant-safe, authority-scoped projections.
+- should not expose internal verification metadata unless a tenant-safe projection explicitly allows it in a future mission.
+
+Review artifacts:
+
+- should reference evidence and related resources through scoped metadata refs.
+- must not duplicate raw provider, payment, message, or document payloads.
+
+## Governance risks
+
+Do not ignore:
+
+- Export signatures without projection allowlists can certify unsafe data exposure.
+- Hashes over unstable payloads are not reproducible.
+- Public verification endpoints can accidentally widen export visibility.
+- Internal source refs can become user-facing raw IDs if UI labels are not normalized.
+- Provider raw payloads must never be treated as routine export material.
+- Signature readiness is not the same as legal or institutional acceptance.
+
+## Known limitations
+
+- No production signing exists.
+- No cryptographic verification exists.
+- No public verification endpoint exists.
+- No blockchain or on-chain anchoring exists.
+- No distributed signing key management exists.
+- No export replay framework exists.
+- Integrity metadata is helper-level only and is not globally attached to all export routes yet.
+
+## Future roadmap
+
+Recommended future missions:
+
+1. Define export checksum canonicalization rules for selected export artifacts.
+2. Add signed-export dry-run tests against deterministic fixture payloads.
+3. Define signing key custody and rotation governance before any production signing.
+4. Add authority-scoped export replay metadata for review workspaces.
+5. Add tenant-safe verification summaries only after projection review.
+6. Add institutional verification workflows only after export allowlists and consent governance are complete.
+
+## Runtime behavior confirmation
+
+This mission does not change runtime export access, route visibility, auth behavior, Firestore rules, Firestore schema, export payload access scope, or tenant-visible export behavior. The helper and tests are metadata-only governance foundations.

--- a/rentchain-api/src/lib/exportIntegrity/__tests__/exportIntegrityGovernance.test.ts
+++ b/rentchain-api/src/lib/exportIntegrity/__tests__/exportIntegrityGovernance.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import {
+  EXPORT_INTEGRITY_GOVERNANCE_VERSION,
+  buildExportIntegrityMetadata,
+  classifyVerificationReadiness,
+  normalizeExportIntegrityScope,
+  normalizeExportLineage,
+} from "../exportIntegrityGovernance";
+
+describe("exportIntegrityGovernance", () => {
+  it("normalizes integrity scope and source lineage deterministically", () => {
+    expect(normalizeExportIntegrityScope("Institutional Export")).toBe("institutional_export");
+    expect(normalizeExportIntegrityScope("unknown-scope")).toBe("review_artifact");
+
+    const lineage = normalizeExportLineage([
+      {
+        sourceCollection: "payments",
+        sourceId: "payment-2",
+        rawPayload: "raw provider dump",
+        token: "secret-token",
+      },
+      { sourceCollection: "leases", sourceId: "lease-1" },
+      { sourceCollection: "payments", sourceId: "payment-2", providerPayload: "duplicate raw dump" },
+      { sourceCollection: "", sourceId: "missing-collection" },
+      { sourceCollection: "tenants", sourceId: "" },
+    ]);
+
+    expect(lineage).toEqual([
+      { sourceCollection: "leases", sourceId: "lease-1", internalReference: true },
+      { sourceCollection: "payments", sourceId: "payment-2", internalReference: true },
+    ]);
+    expectNoRestrictedProjectionFields(lineage);
+    expectPayloadDoesNotContainValues(lineage, ["raw provider dump", "secret-token", "duplicate raw dump"]);
+  });
+
+  it("builds metadata-only export integrity records without live signing or public verification", () => {
+    const metadata = buildExportIntegrityMetadata({
+      exportProfile: "institutional_export_v1",
+      exportVersion: "2026-05-21",
+      exportGeneratedAt: "2026-05-21T12:30:00.000Z",
+      exportGeneratedBy: "admin-1",
+      integrityScope: "institutional_export",
+      projectionProfile: "institutional_export_projection_v1",
+      sourceRefs: [
+        { sourceCollection: "leases", sourceId: "lease-1" },
+        { sourceCollection: "payments", sourceId: "payment-1" },
+      ],
+      signatureStatus: "signature_ready",
+    });
+
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        exportIntegrityVersion: EXPORT_INTEGRITY_GOVERNANCE_VERSION,
+        exportProfile: "institutional_export_v1",
+        exportVersion: "2026-05-21",
+        exportGeneratedAt: "2026-05-21T12:30:00.000Z",
+        exportGeneratedBy: "admin-1",
+        integrityScope: "institutional_export",
+        sensitivityClass: "restricted",
+        projectionProfile: "institutional_export_projection_v1",
+        signatureStatus: "signature_ready",
+        verificationStatus: "ready_for_review",
+        reproducibilityExpectation: "deterministic_projection_inputs_required",
+        authorityScoped: true,
+        publicVerificationEnabled: false,
+        cryptographicSigningEnabled: false,
+        blockchainAnchoringEnabled: false,
+        tenantVisibleInternalMetadata: false,
+      })
+    );
+    expect(metadata.sourceCollections).toEqual(["leases", "payments"]);
+    expect(metadata.sourceRefs).toEqual([
+      { sourceCollection: "leases", sourceId: "lease-1", internalReference: true },
+      { sourceCollection: "payments", sourceId: "payment-1", internalReference: true },
+    ]);
+    expect(metadata.exportHashPlaceholder).toEqual({
+      status: "not_computed",
+      algorithm: "sha256",
+      value: null,
+      reason: "Hash computation is intentionally deferred until signed/exported artifact workflows are approved.",
+    });
+  });
+
+  it("keeps source refs internal and excludes restricted/raw/provider payload material", () => {
+    const metadata = buildExportIntegrityMetadata({
+      exportProfile: "evidence_pack_v1",
+      exportVersion: "v1",
+      integrityScope: "evidence_pack",
+      projectionProfile: "evidence_pack_projection_v1",
+      sourceRefs: [
+        {
+          sourceCollection: "evidencePacks",
+          sourceId: "evidence-1",
+          rawReport: "raw credit report",
+          providerPayload: "bureau payload",
+          rawCsv: "raw csv row",
+          bankAccount: "000123456",
+          token: "secret-token",
+          stack: "private stack trace",
+          routeSource: "debug route source",
+        },
+      ],
+    });
+
+    expect(metadata.sourceRefs).toEqual([
+      { sourceCollection: "evidencePacks", sourceId: "evidence-1", internalReference: true },
+    ]);
+    expectNoRestrictedProjectionFields(metadata.sourceRefs);
+    expectPayloadDoesNotContainValues(metadata, [
+      "raw credit report",
+      "bureau payload",
+      "raw csv row",
+      "000123456",
+      "secret-token",
+      "private stack trace",
+      "debug route source",
+    ]);
+  });
+
+  it("classifies verification readiness without implying production cryptographic verification", () => {
+    expect(
+      classifyVerificationReadiness({
+        sourceRefs: [{ sourceCollection: "leases", sourceId: "lease-1", internalReference: true }],
+        projectionProfile: "tenant_trust_export_projection_v1",
+        signatureStatus: "signed",
+      })
+    ).toBe("ready_for_review");
+    expect(classifyVerificationReadiness({ sourceRefs: [], projectionProfile: "profile", signatureStatus: "not_signed" })).toBe(
+      "metadata_only"
+    );
+    expect(classifyVerificationReadiness({ signatureStatus: "unexpected-status" })).toBe("unavailable");
+  });
+
+  it("defaults to safe metadata when optional inputs are missing", () => {
+    const metadata = buildExportIntegrityMetadata({
+      exportProfile: "",
+      exportVersion: "",
+      integrityScope: "unknown",
+      sourceRefs: null,
+    });
+
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        exportProfile: "export_profile_unknown",
+        exportVersion: "export_version_unknown",
+        exportGeneratedAt: "1970-01-01T00:00:00.000Z",
+        exportGeneratedBy: null,
+        integrityScope: "review_artifact",
+        sourceCollections: [],
+        sourceRefs: [],
+        signatureStatus: "not_signed",
+        verificationStatus: "metadata_only",
+        publicVerificationEnabled: false,
+        cryptographicSigningEnabled: false,
+        blockchainAnchoringEnabled: false,
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/exportIntegrity/exportIntegrityGovernance.ts
+++ b/rentchain-api/src/lib/exportIntegrity/exportIntegrityGovernance.ts
@@ -1,0 +1,177 @@
+export const EXPORT_INTEGRITY_GOVERNANCE_VERSION = "export_integrity_governance_v1";
+
+export type ExportIntegrityScope =
+  | "evidence_pack"
+  | "institutional_export"
+  | "tenant_trust_export"
+  | "review_artifact"
+  | "document_export";
+
+export type ExportSignatureStatus = "not_signed" | "signature_ready" | "signed" | "verification_unavailable";
+
+export type ExportVerificationStatus = "metadata_only" | "ready_for_review" | "verified" | "failed" | "unavailable";
+
+export type ExportIntegritySensitivityClass = "sensitive" | "restricted" | "critical";
+
+export type ExportIntegritySourceRef = {
+  sourceCollection: string;
+  sourceId: string;
+  internalReference: true;
+};
+
+export type ExportIntegrityMetadata = {
+  exportIntegrityVersion: typeof EXPORT_INTEGRITY_GOVERNANCE_VERSION;
+  exportProfile: string;
+  exportVersion: string;
+  exportGeneratedAt: string;
+  exportGeneratedBy: string | null;
+  integrityScope: ExportIntegrityScope;
+  sensitivityClass: ExportIntegritySensitivityClass;
+  sourceCollections: string[];
+  sourceRefs: ExportIntegritySourceRef[];
+  lineageSummary: {
+    sourceReferenceCount: number;
+    sourceCollections: string[];
+    lineagePolicy: string;
+  };
+  projectionProfile: string | null;
+  exportHashPlaceholder: {
+    status: "not_computed";
+    algorithm: "sha256";
+    value: null;
+    reason: string;
+  };
+  signatureStatus: ExportSignatureStatus;
+  verificationStatus: ExportVerificationStatus;
+  reproducibilityExpectation: "deterministic_projection_inputs_required";
+  authorityScoped: true;
+  publicVerificationEnabled: false;
+  cryptographicSigningEnabled: false;
+  blockchainAnchoringEnabled: false;
+  tenantVisibleInternalMetadata: false;
+  redactionSummary: string;
+};
+
+const VALID_SCOPES = new Set<ExportIntegrityScope>([
+  "evidence_pack",
+  "institutional_export",
+  "tenant_trust_export",
+  "review_artifact",
+  "document_export",
+]);
+
+const VALID_SIGNATURE_STATUSES = new Set<ExportSignatureStatus>([
+  "not_signed",
+  "signature_ready",
+  "signed",
+  "verification_unavailable",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function toIsoDate(value: unknown): string {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const parsed = Date.parse(asString(value, 120));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+export function normalizeExportIntegrityScope(value: unknown): ExportIntegrityScope {
+  const normalized = normalizeKey(value);
+  return VALID_SCOPES.has(normalized as ExportIntegrityScope) ? (normalized as ExportIntegrityScope) : "review_artifact";
+}
+
+export function normalizeExportLineage(raw: unknown): ExportIntegritySourceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const sourceCollection = asString(data.sourceCollection, 120);
+      const sourceId = asString(data.sourceId, 240);
+      if (!sourceCollection || !sourceId) return null;
+      return { sourceCollection, sourceId, internalReference: true };
+    })
+    .filter(Boolean) as ExportIntegritySourceRef[];
+  const byKey = new Map<string, ExportIntegritySourceRef>();
+  for (const ref of refs) byKey.set(`${ref.sourceCollection}:${ref.sourceId}`, ref);
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}`.localeCompare(`${b.sourceCollection}:${b.sourceId}`)
+  );
+}
+
+export function classifyVerificationReadiness(input: {
+  sourceRefs?: ExportIntegritySourceRef[] | null;
+  signatureStatus?: ExportSignatureStatus | string | null;
+  projectionProfile?: string | null;
+}): ExportVerificationStatus {
+  const signatureStatus = normalizeKey(input.signatureStatus);
+  if (signatureStatus && !VALID_SIGNATURE_STATUSES.has(signatureStatus as ExportSignatureStatus)) return "unavailable";
+  if ((input.sourceRefs || []).length > 0 && asString(input.projectionProfile, 120)) return "ready_for_review";
+  return "metadata_only";
+}
+
+export function buildExportIntegrityMetadata(input: {
+  exportProfile: string;
+  exportVersion: string;
+  exportGeneratedAt?: string | Date | null;
+  exportGeneratedBy?: string | null;
+  integrityScope: ExportIntegrityScope | string;
+  sensitivityClass?: ExportIntegritySensitivityClass | null;
+  sourceRefs?: Array<Record<string, unknown>> | null;
+  projectionProfile?: string | null;
+  signatureStatus?: ExportSignatureStatus | string | null;
+}): ExportIntegrityMetadata {
+  const sourceRefs = normalizeExportLineage(input.sourceRefs);
+  const sourceCollections = uniqueSorted(sourceRefs.map((ref) => ref.sourceCollection));
+  const signatureStatus = normalizeKey(input.signatureStatus) as ExportSignatureStatus;
+  const normalizedSignatureStatus = VALID_SIGNATURE_STATUSES.has(signatureStatus) ? signatureStatus : "not_signed";
+  const projectionProfile = asString(input.projectionProfile, 120) || null;
+  const sensitivityClass = input.sensitivityClass || "restricted";
+
+  return {
+    exportIntegrityVersion: EXPORT_INTEGRITY_GOVERNANCE_VERSION,
+    exportProfile: asString(input.exportProfile, 120) || "export_profile_unknown",
+    exportVersion: asString(input.exportVersion, 120) || "export_version_unknown",
+    exportGeneratedAt: toIsoDate(input.exportGeneratedAt),
+    exportGeneratedBy: asString(input.exportGeneratedBy, 240) || null,
+    integrityScope: normalizeExportIntegrityScope(input.integrityScope),
+    sensitivityClass,
+    sourceCollections,
+    sourceRefs,
+    lineageSummary: {
+      sourceReferenceCount: sourceRefs.length,
+      sourceCollections,
+      lineagePolicy: "Integrity metadata records deterministic source references without copying raw source payloads.",
+    },
+    projectionProfile,
+    exportHashPlaceholder: {
+      status: "not_computed",
+      algorithm: "sha256",
+      value: null,
+      reason: "Hash computation is intentionally deferred until signed/exported artifact workflows are approved.",
+    },
+    signatureStatus: normalizedSignatureStatus,
+    verificationStatus: classifyVerificationReadiness({
+      sourceRefs,
+      signatureStatus: normalizedSignatureStatus,
+      projectionProfile,
+    }),
+    reproducibilityExpectation: "deterministic_projection_inputs_required",
+    authorityScoped: true,
+    publicVerificationEnabled: false,
+    cryptographicSigningEnabled: false,
+    blockchainAnchoringEnabled: false,
+    tenantVisibleInternalMetadata: false,
+    redactionSummary:
+      "Integrity metadata excludes raw provider payloads, raw CSV values, credentials, private message bodies, document contents, and debug payloads.",
+  };
+}


### PR DESCRIPTION
## Summary
- Adds metadata-only export integrity/signature-readiness governance helper for governed export artifacts.
- Documents export integrity terminology, lineage/reproducibility expectations, known limitations, and future verification roadmap.
- Adds deterministic tests for source lineage normalization, restricted payload exclusion, signature-readiness metadata, and no live signing/public verification flags.

## Guardrails
- No production cryptographic signing rollout.
- No public verification endpoints.
- No blockchain/tokenization behavior.
- No auth, Firestore rules, schema, route, or export visibility changes.
- No export access widening or tenant-visible internal verification metadata.

## Validation
- `npm run test:single -- exportIntegrityGovernance.test.ts`
- `npm run build`
- `git diff --check`

## Known limitations / follow-ups
- Integrity metadata is helper-level only and not globally attached to all export routes yet.
- No production hash computation, signing key custody, cryptographic verification, public verification endpoint, or export replay framework exists yet.
- Future work should define checksum canonicalization and signing key governance before any production signing.