### PR TITLE
fix: normalize work order operational labels

### DIFF
--- a/docs/reports/work-orders-operational-label-normalization-v1.md
+++ b/docs/reports/work-orders-operational-label-normalization-v1.md
@@ -1,0 +1,103 @@
+# Work Orders Operational Label Normalization v1
+
+## Executive summary
+
+This report documents RentChain's work-order and maintenance terminology normalization pass. The implementation is display and metadata focused:
+
+- tenant-facing surfaces use `Maintenance request`,
+- landlord/operator surfaces use `Work order`,
+- review/routing metadata uses `Operational work order`,
+- vendor/contractor language remains `Service task` where a vendor-specific label is needed,
+- machine-style status keys are normalized before primary display.
+
+No Firestore schema, auth, Firestore rules, permissions, route visibility, financial records, or workflow mutation behavior changed.
+
+## Canonical terminology
+
+| Audience | Canonical term | Notes |
+| --- | --- | --- |
+| Tenant | Maintenance request | Tenant-facing request intake and status language. |
+| Landlord/operator | Work order | Operator-facing coordination, cost, assignment, and closure language. |
+| Review/routing | Operational work order | Governance-safe review queue and routing metadata language. |
+| Vendor/contractor | Service task | Use only where a contractor-facing label is needed. |
+
+Avoid using `repair`, `issue`, `task`, or raw datastore identifiers as primary labels. These may remain as user-entered descriptions, expense categories, or internal resource metadata where already scoped.
+
+## Status mapping
+
+| Internal/source status | Tenant label | Operator/review label |
+| --- | --- | --- |
+| `submitted` | Submitted | Needs review |
+| `reviewed` | Acknowledged | Open |
+| `assigned` | Assigned | Assigned |
+| `scheduled` | Scheduled | Assigned |
+| `in_progress` | In progress | In progress |
+| `waiting_on_tenant`, `tenant_pending_signoff` | Waiting on tenant | Waiting on tenant |
+| `waiting_on_vendor`, `contractor_pending` | Waiting on vendor | Waiting on vendor |
+| `completed`, `resolved` | Completed | Completed |
+| `closed` | Closed | Closed |
+| `cancelled`, `canceled` | Cancelled | Cancelled |
+| `blocked` | Needs review | Needs review |
+
+The mapping is intentionally display-only. Internal statuses are preserved for workflow logic and route behavior.
+
+## Surfaces audited
+
+Backend:
+
+- `rentchain-api/src/routes/workOrdersRoutes.ts`
+- `rentchain-api/src/routes/maintenanceRequestsRoutes.ts`
+- `rentchain-api/src/lib/operationalReviewRouting/deriveOperationalReviewRouting.ts`
+- work-order, maintenance, marketplace, analytics, and review-routing tests.
+
+Frontend:
+
+- `rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx`
+- `rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx`
+- `rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx`
+- `rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx`
+- work-order, maintenance workspace, tenant maintenance, and operational label tests.
+
+## Labels normalized
+
+Implemented:
+
+- Added shared frontend label helper for canonical work-order terminology and status/category/priority formatting.
+- Normalized landlord work-order table, mobile cards, print summaries, and selected details so primary status/category/priority labels do not display raw keys such as `in_progress`.
+- Normalized landlord maintenance workspace primary status/category/priority labels.
+- Normalized tenant maintenance request list and detail metadata while preserving tenant-facing `Maintenance request` language.
+- Normalized operational review routing metadata for maintenance decisions to `Operational work order review`.
+- Normalized maintenance decision related refs from `maintenance_request`/`document` drift to a `work_order` metadata ref with `Operational work order` fallback label.
+
+## Tenant vs operator language boundaries
+
+Tenant-visible surfaces should not expose internal review terms such as `Operational work order review`, `review workspace`, or internal routing metadata. Tenants see maintenance request lifecycle language.
+
+Landlord/operator surfaces can use work-order language for assignment, completion, costs, evidence, and closure.
+
+Review/routing metadata can use operational work-order language but remains manual-only and internal to landlord/admin operational coordination.
+
+## Remaining inconsistencies and safe deferrals
+
+- Some analytics and pricing copy still use broader `maintenance` language. This is acceptable because those are product/domain summaries, not primary work-order labels.
+- Expense categories may still include `Repairs`. This is financial categorization language and was left unchanged to avoid accounting/reporting drift.
+- Contractor route paths and API concepts still use `jobs`. This is route/API compatibility language and was left unchanged.
+- Email subjects and backend event messages include both maintenance request and work-order language depending on audience. These should be reviewed in a later notification-copy mission if needed.
+
+## Future read-model and routing considerations
+
+Future operational read models should carry both:
+
+- canonical internal type/status fields for logic, and
+- audience-specific display labels for tenant, operator, review, and vendor surfaces.
+
+Review queue and evidence linkage surfaces should prefer:
+
+- `Operational work order review`,
+- human labels such as property/unit/title,
+- scoped internal refs only as metadata,
+- no autonomous routing or auto-resolution language.
+
+## Runtime behavior confirmation
+
+This mission does not change work-order persistence, maintenance request persistence, Firestore schema, Firestore rules, auth, permissions, route visibility, financial mutation behavior, contractor assignment behavior, or autonomous routing behavior. The code changes are display-label and metadata-label normalization only.

--- a/rentchain-api/src/lib/operationalReviewRouting/__tests__/deriveOperationalReviewRouting.test.ts
+++ b/rentchain-api/src/lib/operationalReviewRouting/__tests__/deriveOperationalReviewRouting.test.ts
@@ -155,4 +155,46 @@ describe("deriveOperationalReviewRouting", () => {
       expect.objectContaining({ reviewReasonKey: "evidence_review", workspaceType: "evidence_review" })
     );
   });
+
+  it("normalizes maintenance decisions as operational work order review metadata", () => {
+    const routing = deriveOperationalReviewRoutingFromDecision(
+      decision({
+        id: "decision:maintenance_review:maint-1",
+        title: "Work order needs review",
+        description: "Maintenance request requires operational follow-up.",
+        type: "maintenance",
+        relatedEntity: { kind: "maintenance_request", id: "maint-1", label: "" },
+        workflow: {
+          queue: "maintenance_review",
+          workflowState: "open",
+          ownershipType: "landlord",
+          reviewPriority: "needs_review",
+          escalationLevel: "attention",
+          manualOnly: true,
+        },
+      }),
+      { landlordId: "landlord-1", tenantId: "tenant-1" }
+    );
+
+    expect(routing).toEqual(
+      expect.objectContaining({
+        reviewReasonKey: "operational_work_order_review",
+        reviewReasonLabel: "Operational work order review",
+        workspaceType: "operational_anomaly_review",
+        manualOnly: true,
+        autoCreateWorkspace: false,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(routing.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "work_order",
+        resourceId: "maint-1",
+        label: "Operational work order",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+      }),
+    ]);
+    expect(JSON.stringify(routing)).not.toContain("maintenance_request");
+  });
 });

--- a/rentchain-api/src/lib/operationalReviewRouting/deriveOperationalReviewRouting.ts
+++ b/rentchain-api/src/lib/operationalReviewRouting/deriveOperationalReviewRouting.ts
@@ -44,6 +44,7 @@ function reviewReasonLabel(reason: OperationalReviewReasonKey): string {
   if (reason === "document_review") return "Document review";
   if (reason === "occupancy_review") return "Occupancy review";
   if (reason === "evidence_review") return "Evidence review";
+  if (reason === "operational_work_order_review") return "Operational work order review";
   if (reason === "informational_not_reviewable") return "Informational only";
   return "Operational anomaly review";
 }
@@ -97,6 +98,12 @@ function reasonFromInput(input: OperationalReviewRoutingInput): OperationalRevie
     return "payment_evidence_review";
   }
   if (input.category === "lease_lifecycle" || haystack.includes("lease")) return "lease_execution_review";
+  if (
+    input.category === "operations" &&
+    (haystack.includes("maintenance") || haystack.includes("work_order") || haystack.includes("work order"))
+  ) {
+    return "operational_work_order_review";
+  }
   return "operational_anomaly_review";
 }
 
@@ -140,6 +147,23 @@ function normalizeRelatedResourceRefs(input: OperationalReviewRoutingInput): Ope
   );
 }
 
+function normalizeDecisionRelatedResource(decision: DecisionInboxItem): {
+  resourceType: string;
+  label: string;
+} | null {
+  if (!decision.relatedEntity) return null;
+  if (decision.relatedEntity.kind === "maintenance_request") {
+    return {
+      resourceType: "work_order",
+      label: safeLabel(decision.relatedEntity.label, "Operational work order"),
+    };
+  }
+  return {
+    resourceType: decision.relatedEntity.kind,
+    label: safeLabel(decision.relatedEntity.label, "Operational resource"),
+  };
+}
+
 export function deriveOperationalReviewRouting(input: OperationalReviewRoutingInput): OperationalReviewRoutingDecision {
   const itemId = asString(input.itemId, 500);
   const landlordId = asString(input.landlordId, 240);
@@ -173,12 +197,13 @@ export function deriveOperationalReviewRoutingFromDecision(
   decision: DecisionInboxItem,
   scope: { landlordId: string; tenantId?: string | null }
 ): OperationalReviewRoutingDecision {
-  const relatedResourceRefs: OperationalReviewResourceRefInput[] = decision.relatedEntity
+  const normalizedRelatedResource = normalizeDecisionRelatedResource(decision);
+  const relatedResourceRefs: OperationalReviewResourceRefInput[] = decision.relatedEntity && normalizedRelatedResource
     ? [
         {
-          resourceType: decision.relatedEntity.kind === "maintenance_request" ? "document" : decision.relatedEntity.kind,
+          resourceType: normalizedRelatedResource.resourceType,
           resourceId: decision.relatedEntity.id,
-          label: decision.relatedEntity.label,
+          label: normalizedRelatedResource.label,
           landlordId: scope.landlordId,
           tenantId: scope.tenantId || null,
         },

--- a/rentchain-api/src/lib/operationalReviewRouting/operationalReviewRoutingTypes.ts
+++ b/rentchain-api/src/lib/operationalReviewRouting/operationalReviewRoutingTypes.ts
@@ -10,6 +10,7 @@ export type OperationalReviewReasonKey =
   | "document_review"
   | "occupancy_review"
   | "evidence_review"
+  | "operational_work_order_review"
   | "operational_anomaly_review"
   | "informational_not_reviewable";
 

--- a/rentchain-frontend/src/lib/workOrderOperationalLabels.test.ts
+++ b/rentchain-frontend/src/lib/workOrderOperationalLabels.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isMachineStyleWorkOrderLabel,
+  workOrderCategoryLabel,
+  workOrderCollectionLabel,
+  workOrderEntityLabel,
+  workOrderPriorityLabel,
+  workOrderStatusLabel,
+} from "./workOrderOperationalLabels";
+
+describe("workOrderOperationalLabels", () => {
+  it("uses canonical terminology by audience", () => {
+    expect(workOrderEntityLabel("tenant")).toBe("Maintenance request");
+    expect(workOrderEntityLabel("operator")).toBe("Work order");
+    expect(workOrderEntityLabel("review")).toBe("Operational work order");
+    expect(workOrderEntityLabel("vendor")).toBe("Service task");
+
+    expect(workOrderCollectionLabel("tenant")).toBe("Maintenance requests");
+    expect(workOrderCollectionLabel("operator")).toBe("Work orders");
+    expect(workOrderCollectionLabel("review")).toBe("Operational work orders");
+    expect(workOrderCollectionLabel("vendor")).toBe("Service tasks");
+  });
+
+  it("normalizes workflow statuses without exposing machine-style labels", () => {
+    const labels = [
+      workOrderStatusLabel("submitted", "operator"),
+      workOrderStatusLabel("reviewed", "operator"),
+      workOrderStatusLabel("scheduled", "operator"),
+      workOrderStatusLabel("in_progress", "operator"),
+      workOrderStatusLabel("tenant_pending_signoff", "operator"),
+      workOrderStatusLabel("contractor_pending", "operator"),
+      workOrderStatusLabel("completed", "operator"),
+      workOrderStatusLabel("cancelled", "operator"),
+    ];
+
+    expect(labels).toEqual([
+      "Needs review",
+      "Open",
+      "Assigned",
+      "In progress",
+      "Waiting on tenant",
+      "Waiting on vendor",
+      "Completed",
+      "Cancelled",
+    ]);
+    expect(labels.some((label) => isMachineStyleWorkOrderLabel(label))).toBe(false);
+  });
+
+  it("keeps tenant-facing maintenance request status language safe", () => {
+    expect(workOrderStatusLabel("submitted", "tenant")).toBe("Submitted");
+    expect(workOrderStatusLabel("reviewed", "tenant")).toBe("Acknowledged");
+    expect(workOrderStatusLabel("scheduled", "tenant")).toBe("Scheduled");
+    expect(workOrderStatusLabel("tenant_pending_signoff", "tenant")).toBe("Waiting on tenant");
+  });
+
+  it("normalizes priority and category labels deterministically", () => {
+    expect(workOrderPriorityLabel("urgent")).toBe("Urgent");
+    expect(workOrderCategoryLabel("hvac")).toBe("HVAC");
+    expect(workOrderCategoryLabel("general_repair")).toBe("General Repair");
+  });
+});

--- a/rentchain-frontend/src/lib/workOrderOperationalLabels.ts
+++ b/rentchain-frontend/src/lib/workOrderOperationalLabels.ts
@@ -1,0 +1,77 @@
+export type WorkOrderAudience = "tenant" | "operator" | "review" | "vendor";
+
+function normalizeKey(value?: string | null) {
+  return String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function titleCase(value?: string | null) {
+  const normalized = normalizeKey(value);
+  if (!normalized) return "Unknown";
+  return normalized.replace(/_/g, " ").replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+export function workOrderEntityLabel(audience: WorkOrderAudience = "operator") {
+  if (audience === "tenant") return "Maintenance request";
+  if (audience === "review") return "Operational work order";
+  if (audience === "vendor") return "Service task";
+  return "Work order";
+}
+
+export function workOrderCollectionLabel(audience: WorkOrderAudience = "operator") {
+  if (audience === "tenant") return "Maintenance requests";
+  if (audience === "review") return "Operational work orders";
+  if (audience === "vendor") return "Service tasks";
+  return "Work orders";
+}
+
+export function workOrderStatusLabel(value?: string | null, audience: WorkOrderAudience = "operator") {
+  const status = normalizeKey(value);
+  switch (status) {
+    case "submitted":
+      return audience === "tenant" ? "Submitted" : "Needs review";
+    case "reviewed":
+      return audience === "tenant" ? "Acknowledged" : "Open";
+    case "assigned":
+      return "Assigned";
+    case "scheduled":
+      return audience === "tenant" ? "Scheduled" : "Assigned";
+    case "in_progress":
+    case "started":
+      return "In progress";
+    case "waiting_on_tenant":
+    case "tenant_pending_signoff":
+      return "Waiting on tenant";
+    case "waiting_on_vendor":
+    case "contractor_pending":
+      return "Waiting on vendor";
+    case "completed":
+    case "resolved":
+      return "Completed";
+    case "closed":
+      return "Closed";
+    case "cancelled":
+    case "canceled":
+      return "Cancelled";
+    case "blocked":
+      return "Needs review";
+    default:
+      return titleCase(status || "open");
+  }
+}
+
+export function workOrderPriorityLabel(value?: string | null) {
+  return titleCase(value || "normal");
+}
+
+export function workOrderCategoryLabel(value?: string | null) {
+  const category = normalizeKey(value);
+  if (!category) return "General";
+  if (category === "hvac") return "HVAC";
+  if (category === "pest") return "Pest";
+  return titleCase(category);
+}
+
+export function isMachineStyleWorkOrderLabel(value?: string | null) {
+  const raw = String(value || "");
+  return /[a-z]+_[a-z_]+/.test(raw) || /\b(?:workOrder|maintenanceRequest)Id\b/.test(raw);
+}

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -122,6 +122,46 @@ describe("landlord maintenance workspace", () => {
     expect(screen.getByText(/Mark reviewed/i)).toBeInTheDocument();
   });
 
+  it("normalizes landlord-facing maintenance request statuses without raw workflow keys", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "123 Main St",
+          unitLabel: "Unit 4",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "general_repair",
+          priority: "urgent",
+          status: "in_progress",
+          assignedContractorName: "North Shore HVAC",
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("In progress")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Urgent").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("General Repair").length).toBeGreaterThan(0);
+    expect(screen.queryByText("in_progress")).not.toBeInTheDocument();
+    expect(screen.queryByText("general_repair")).not.toBeInTheDocument();
+  });
+
   it("renders the PDF summary action and routes it through the shared print helper", async () => {
     render(
       <MemoryRouter initialEntries={["/maintenance/maint-1"]}>

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -32,6 +32,11 @@ import {
   buildMaintenanceSchedulingAccessView,
   buildMaintenanceSchedulingCalendarEvents,
 } from "./maintenanceSchedulingAccessState";
+import {
+  workOrderCategoryLabel,
+  workOrderPriorityLabel,
+  workOrderStatusLabel,
+} from "../lib/workOrderOperationalLabels";
 
 const FILTERS: Array<{ value: "all" | MaintenanceWorkflowStatus; label: string }> = [
   { value: "all", label: "All requests" },
@@ -681,8 +686,8 @@ export default function MaintenanceRequestsPage() {
                 <td>{item.tenantName || "Tenant"}</td>
                 <td>{displayPropertyLabel(item)}</td>
                 <td>{displayUnitLabel(item)}</td>
-                <td>{item.priority || "-"}</td>
-                <td>{item.status || "-"}</td>
+                <td>{workOrderPriorityLabel(item.priority)}</td>
+                <td>{workOrderStatusLabel(item.status, "operator")}</td>
                 <td>{item.assignedContractorName || "-"}</td>
                 <td>{fmtDate(item.createdAt)}</td>
                 <td>{fmtDate(item.updatedAt)}</td>
@@ -696,12 +701,12 @@ export default function MaintenanceRequestsPage() {
             <table className="printTable">
               <tbody>
                 <tr><th>Title</th><td>{selected.title}</td></tr>
-                <tr><th>Category</th><td>{selected.category || "-"}</td></tr>
+                <tr><th>Category</th><td>{workOrderCategoryLabel(selected.category)}</td></tr>
                 <tr><th>Tenant</th><td>{selected.tenantName || "Tenant"}</td></tr>
                 <tr><th>Property</th><td>{displayPropertyLabel(selected)}</td></tr>
                 <tr><th>Unit</th><td>{displayUnitLabel(selected)}</td></tr>
-                <tr><th>Priority</th><td>{selected.priority || "-"}</td></tr>
-                <tr><th>Status</th><td>{selected.status || "-"}</td></tr>
+                <tr><th>Priority</th><td>{workOrderPriorityLabel(selected.priority)}</td></tr>
+                <tr><th>Status</th><td>{workOrderStatusLabel(selected.status, "operator")}</td></tr>
                 <tr><th>Assigned contractor</th><td>{selected.assignedContractorName || "-"}</td></tr>
                 <tr><th>Service window start</th><td>{fmtDate(selected.serviceWindowStartAt)}</td></tr>
                 <tr><th>Service window end</th><td>{fmtDate(selected.serviceWindowEndAt)}</td></tr>
@@ -1182,7 +1187,7 @@ export default function MaintenanceRequestsPage() {
                               fontWeight: 700,
                             }}
                           >
-                            {item.status}
+                            {workOrderStatusLabel(item.status, "operator")}
                           </span>
                           <span
                             style={{
@@ -1193,7 +1198,7 @@ export default function MaintenanceRequestsPage() {
                           >
                             {assignment.assignmentLabel}
                           </span>
-                          <span style={{ color: text.muted, fontSize: 12 }}>{item.priority}</span>
+                          <span style={{ color: text.muted, fontSize: 12 }}>{workOrderPriorityLabel(item.priority)}</span>
                           <span style={{ color: text.muted, fontSize: 12 }}>{fmtDate(item.createdAt)}</span>
                         </div>
                         <div style={{ color: text.secondary, fontSize: 12 }}>{assignment.ownerSummary}</div>
@@ -1258,7 +1263,7 @@ export default function MaintenanceRequestsPage() {
                         fontWeight: 700,
                       }}
                     >
-                      {selected.status}
+                      {workOrderStatusLabel(selected.status, "operator")}
                     </div>
                   </div>
 

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -230,6 +230,29 @@ describe("WorkOrdersPage", () => {
     expect(mocks.listWorkOrders).toHaveBeenCalledWith();
   });
 
+  it("renders operator-facing work order labels without machine-style statuses", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.listWorkOrders.mockResolvedValue([
+      makeWorkOrder({
+        status: "in_progress",
+        priority: "urgent",
+        category: "general_repair",
+      }),
+    ]);
+
+    render(
+      <MemoryRouter>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("In progress")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Urgent").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("General Repair").length).toBeGreaterThan(0);
+    expect(screen.queryByText("in_progress")).not.toBeInTheDocument();
+    expect(screen.queryByText("general_repair")).not.toBeInTheDocument();
+  });
+
   it("hydrates maintenance-backlog query params into a property-scoped visible list", async () => {
     mocks.canUseWorkOrders = true;
     mocks.fetchProperties.mockResolvedValue({
@@ -614,7 +637,7 @@ describe("WorkOrdersPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole("button", { name: "Create Work Order" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Create work order" })).toBeInTheDocument();
     fireEvent.click(await screen.findByRole("button", { name: /timeline/i }));
     expect(await screen.findByText(/Unlock the contractor directory on Pro/i)).toBeInTheDocument();
     expect(mocks.fetchContractors).not.toHaveBeenCalled();

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -42,6 +42,12 @@ import {
 import { type ExpenseCategory } from "../../api/expensesApi";
 import { printSummaryDocument } from "../../utils/printSummary";
 import { triggerBlobDownload } from "../../utils/downloadBlob";
+import {
+  workOrderCategoryLabel,
+  workOrderCollectionLabel,
+  workOrderPriorityLabel,
+  workOrderStatusLabel,
+} from "../../lib/workOrderOperationalLabels";
 
 function formatDate(ms?: number | null) {
   if (!ms) return "-";
@@ -962,8 +968,8 @@ export default function WorkOrdersPage() {
     <div style={{ display: "grid", gap: 14 }}>
       <Card style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
         <div>
-          <div style={{ fontWeight: 700, fontSize: "1.06rem" }}>Work Orders</div>
-          <div style={{ color: "#64748b", marginTop: 4 }}>Create, assign, and track landlord maintenance jobs.</div>
+          <div style={{ fontWeight: 700, fontSize: "1.06rem" }}>{workOrderCollectionLabel("operator")}</div>
+          <div style={{ color: "#64748b", marginTop: 4 }}>Create, assign, and track landlord work orders.</div>
         </div>
         <div style={{ display: "flex", gap: 8 }}>
           <Button variant="secondary" onClick={() => void triggerExport("csv")} disabled={exporting !== null}>
@@ -979,7 +985,7 @@ export default function WorkOrdersPage() {
             Refresh
           </Button>
           <Link to="/work-orders/new">
-            <Button>Create Work Order</Button>
+            <Button>Create work order</Button>
           </Link>
         </div>
       </Card>
@@ -1036,9 +1042,9 @@ export default function WorkOrdersPage() {
               <tr key={item.id}>
                 <td>{item.title}</td>
                 <td>{getPropertyLabel(item)}</td>
-                <td>{item.category || "-"}</td>
-                <td>{item.priority || "-"}</td>
-                <td>{item.status || "-"}</td>
+                <td>{workOrderCategoryLabel(item.category)}</td>
+                <td>{workOrderPriorityLabel(item.priority)}</td>
+                <td>{workOrderStatusLabel(item.status, "operator")}</td>
                 <td>{getAssignedContractorLabel(item)}</td>
                 <td>{formatDate(item.scheduledFor)}</td>
                 <td>{formatDate(item.serviceStartedAt)}</td>
@@ -1055,9 +1061,9 @@ export default function WorkOrdersPage() {
               <tbody>
                 <tr><th>Title</th><td>{selected.title}</td></tr>
                 <tr><th>Property</th><td>{getPropertyLabel(selected)}</td></tr>
-                <tr><th>Category</th><td>{selected.category || "-"}</td></tr>
-                <tr><th>Priority</th><td>{selected.priority || "-"}</td></tr>
-                <tr><th>Status</th><td>{selected.status || "-"}</td></tr>
+                <tr><th>Category</th><td>{workOrderCategoryLabel(selected.category)}</td></tr>
+                <tr><th>Priority</th><td>{workOrderPriorityLabel(selected.priority)}</td></tr>
+                <tr><th>Status</th><td>{workOrderStatusLabel(selected.status, "operator")}</td></tr>
                 <tr><th>Assigned contractor</th><td>{getAssignedContractorLabel(selected)}</td></tr>
                 <tr><th>Scheduled for</th><td>{formatDate(selected.scheduledFor)}</td></tr>
                 <tr><th>Service started</th><td>{formatDate(selected.serviceStartedAt)}</td></tr>
@@ -1083,7 +1089,7 @@ export default function WorkOrdersPage() {
                     {updates.map((update) => (
                       <tr key={update.id}>
                         <td>{formatDate(update.createdAtMs)}</td>
-                        <td>{update.updateType}</td>
+                        <td>{workOrderStatusLabel(update.updateType, "operator")}</td>
                         <td>{String(update.message || "").trim() || "-"}</td>
                       </tr>
                     ))}
@@ -1098,9 +1104,9 @@ export default function WorkOrdersPage() {
       <div style={{ display: "grid", gap: 12, gridTemplateColumns: "minmax(0,1fr)", alignItems: "start" }}>
         <Card>
           {loading ? (
-            <div>Loading work orders...</div>
+            <div>Loading {workOrderCollectionLabel("operator").toLowerCase()}...</div>
           ) : visibleWorkOrders.length === 0 ? (
-            <div style={{ color: "#64748b" }}>No work orders yet.</div>
+            <div style={{ color: "#64748b" }}>No {workOrderCollectionLabel("operator").toLowerCase()} yet.</div>
           ) : isMobile ? (
             <div style={{ display: "grid", gap: 12 }}>
               {visibleWorkOrders.map((item) => (
@@ -1117,12 +1123,12 @@ export default function WorkOrdersPage() {
                   <div style={{ display: "grid", gap: 4 }}>
                     <div style={{ fontWeight: 700 }}>{item.title}</div>
                     <div style={{ color: "#64748b", fontSize: 13 }}>
-                      {item.category || "Uncategorized"} · {item.priority} priority
+                      {workOrderCategoryLabel(item.category)} · {workOrderPriorityLabel(item.priority)} priority
                     </div>
                   </div>
                   <div style={{ display: "grid", gap: 6, fontSize: 13 }}>
                     <div>
-                      <strong>Status:</strong> {item.status}
+                      <strong>Status:</strong> {workOrderStatusLabel(item.status, "operator")}
                     </div>
                     <div>
                       <strong>Assigned:</strong> {item.contractorAssignment?.displayName || item.assignedContractorId || "-"}
@@ -1199,9 +1205,9 @@ export default function WorkOrdersPage() {
                 {visibleWorkOrders.map((item) => (
                   <tr key={item.id} style={{ borderBottom: "1px solid #f1f5f9" }}>
                     <td style={{ padding: 8, fontWeight: 600 }}>{item.title}</td>
-                    <td style={{ padding: 8 }}>{item.category || "-"}</td>
-                    <td style={{ padding: 8 }}>{item.priority}</td>
-                    <td style={{ padding: 8 }}>{item.status}</td>
+                    <td style={{ padding: 8 }}>{workOrderCategoryLabel(item.category)}</td>
+                    <td style={{ padding: 8 }}>{workOrderPriorityLabel(item.priority)}</td>
+                    <td style={{ padding: 8 }}>{workOrderStatusLabel(item.status, "operator")}</td>
                     <td style={{ padding: 8 }}>{item.contractorAssignment?.displayName || item.assignedContractorId || "-"}</td>
                     <td style={{ padding: 8 }}>{formatDate(item.updatedAtMs)}</td>
                     <td style={{ padding: 8 }}>
@@ -1361,7 +1367,7 @@ export default function WorkOrdersPage() {
                 <div>
                   <div style={{ fontSize: 12, color: "#64748b" }}>Active rework cycle</div>
                   <div style={{ marginTop: 4 }}>
-                    Rework #{selected.reworkCycle.cycleNumber} • {selected.reworkCycle.status.replaceAll("_", " ")}
+                    Rework #{selected.reworkCycle.cycleNumber} • {workOrderStatusLabel(selected.reworkCycle.status, "operator")}
                   </div>
                   {selected.reworkCycle.completionSummary ? (
                     <div style={{ marginTop: 4, whiteSpace: "pre-wrap" }}>{selected.reworkCycle.completionSummary}</div>
@@ -1620,7 +1626,7 @@ export default function WorkOrdersPage() {
               <div style={{ fontWeight: 700 }}>Rework cycle</div>
               <div style={{ color: "#64748b" }}>
                 {selected.reworkCycle
-                  ? `Rework #${selected.reworkCycle.cycleNumber} is ${selected.reworkCycle.status.replaceAll("_", " ")}.`
+                  ? `Rework #${selected.reworkCycle.cycleNumber} is ${workOrderStatusLabel(selected.reworkCycle.status, "operator").toLowerCase()}.`
                   : selected.resolutionStatus === "follow_up_required"
                   ? "This work order is ready to move into a structured rework cycle."
                   : "No active rework cycle."}
@@ -1739,7 +1745,7 @@ export default function WorkOrdersPage() {
                       </div>
                       {selected.reworkReview.closureOutcome ? (
                         <div style={{ color: "#64748b", fontSize: 13 }}>
-                          Closure outcome: {selected.reworkReview.closureOutcome.replaceAll("_", " ")}
+                          Closure outcome: {workOrderStatusLabel(selected.reworkReview.closureOutcome, "operator")}
                         </div>
                       ) : null}
                       {selected.reworkReview.tenantDeclineReason ? (

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -12,7 +12,12 @@ import {
 import { Button, Card, Section } from "../../components/ui/Ui";
 import { clearTenantToken, getTenantToken } from "../../lib/tenantAuth";
 import { colors, radius, spacing, text as textTokens } from "../../styles/tokens";
-import { TenantSurfaceShell, prettyStatus } from "./TenantWorkspaceShared";
+import { TenantSurfaceShell } from "./TenantWorkspaceShared";
+import {
+  workOrderCategoryLabel,
+  workOrderPriorityLabel,
+  workOrderStatusLabel,
+} from "../../lib/workOrderOperationalLabels";
 import { buildMaintenanceLifecycleView } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
@@ -347,9 +352,9 @@ export default function TenantMaintenanceRequestDetailPage() {
             <div style={{ display: "grid", gap: spacing.sm }}>
               <div style={{ fontSize: "1.2rem", fontWeight: 800, color: textTokens.primary }}>{data.title}</div>
               <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", color: textTokens.muted, fontSize: "0.95rem" }}>
-                <span>Status: {prettyStatus(data.status)}</span>
-                <span>Priority: {prettyStatus(data.priority)}</span>
-                <span>Category: {prettyStatus(data.category)}</span>
+                <span>Status: {workOrderStatusLabel(data.status, "tenant")}</span>
+                <span>Priority: {workOrderPriorityLabel(data.priority)}</span>
+                <span>Category: {workOrderCategoryLabel(data.category)}</span>
                 {assignmentView ? <span>Handling: {assignmentView.tenantVisibleLabel}</span> : null}
               </div>
               <div style={{ color: textTokens.muted, fontSize: "0.95rem" }}>
@@ -581,7 +586,7 @@ export default function TenantMaintenanceRequestDetailPage() {
                   <div style={{ fontWeight: 800, color: textTokens.primary }}>Follow-up / rework</div>
                   <div style={{ color: textTokens.secondary }}>
                     {data.reworkCycle
-                      ? `Rework #${data.reworkCycle.cycleNumber} is ${data.reworkCycle.status.replaceAll("_", " ")}.`
+                      ? `Rework #${data.reworkCycle.cycleNumber} is ${workOrderStatusLabel(data.reworkCycle.status, "tenant").toLowerCase()}.`
                       : "A follow-up cycle has been recorded for this request."}
                   </div>
                   {data.reworkCycle?.completionSummary ? (
@@ -627,7 +632,7 @@ export default function TenantMaintenanceRequestDetailPage() {
                     <>
                       <div style={{ color: textTokens.primary, fontWeight: 700 }}>Return visit coordination</div>
                       <div style={{ color: textTokens.secondary }}>
-                        Status: {String(data.reworkCycle.schedule.status || "not_scheduled").replaceAll("_", " ")}
+                        Status: {workOrderStatusLabel(data.reworkCycle.schedule.status || "not_scheduled", "tenant")}
                       </div>
                       <div style={{ color: textTokens.secondary }}>
                         Visit time: {fmtDate(data.reworkCycle.schedule.scheduledFor || data.reworkCycle.schedule.timeWindowStart)}
@@ -637,7 +642,7 @@ export default function TenantMaintenanceRequestDetailPage() {
                       </div>
                       <div style={{ color: textTokens.secondary }}>
                         Access: {data.reworkCycle.schedule.requiresTenantAccess ? "required" : "not required"} • Your status:{" "}
-                        {String(data.reworkCycle.schedule.tenantAccessStatus || "pending").replaceAll("_", " ")}
+                        {workOrderStatusLabel(data.reworkCycle.schedule.tenantAccessStatus || "pending", "tenant")}
                       </div>
                       {data.reworkCycle.schedule.tenantAccessNote ? (
                         <div style={{ color: textTokens.secondary }}>{data.reworkCycle.schedule.tenantAccessNote}</div>

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
@@ -16,8 +16,12 @@ import {
   TenantInfoCard,
   TenantLoadingState,
   TenantSurfaceShell,
-  prettyStatus,
 } from "./TenantWorkspaceShared";
+import {
+  workOrderCategoryLabel,
+  workOrderPriorityLabel,
+  workOrderStatusLabel,
+} from "../../lib/workOrderOperationalLabels";
 
 function fmtDate(ts?: number | null) {
   if (!ts) return "—";
@@ -164,8 +168,8 @@ export default function TenantMaintenanceRequestsPage() {
                   accent={requestView?.needsAttention ? "#dc2626" : "#b45309"}
                 >
                                    <div style={{ color: textTokens.muted, fontSize: "0.92rem" }}>
-                    {requestView?.lifecycleLabel || prettyStatus(item.status)} • {prettyStatus(item.priority)} •{" "}
-                    {prettyStatus(item.category)}
+                    {requestView?.lifecycleLabel || workOrderStatusLabel(item.status, "tenant")} •{" "}
+                    {workOrderPriorityLabel(item.priority)} • {workOrderCategoryLabel(item.category)}
                   </div>
                   <div style={{ color: textTokens.secondary, lineHeight: 1.5 }}>
                     {requestView?.summary || "This request is visible in your tenant maintenance workspace."}


### PR DESCRIPTION
## Summary
- Added a shared work-order operational label helper for tenant, operator, review, and vendor-facing terminology.
- Normalized work-order and maintenance request status/category/priority copy across landlord and tenant UI surfaces.
- Updated operational review routing metadata so maintenance decisions are labeled as operational work-order review metadata instead of document-style refs.
- Added the governance report for canonical work-order terminology, status mappings, tenant/operator language boundaries, and deferred terminology risks.

## Terminology findings
- Tenant-facing surfaces should use `Maintenance request` language.
- Landlord/operator surfaces should use `Work order` language.
- Review/routing-facing metadata should use `Operational work order` language.
- Vendor/contractor-facing language remains `Service task` only where safely needed.
- Raw machine labels such as `in_progress`, `general_repair`, and `maintenance_request` were still visible in several display paths before this pass.

## Labels normalized
- Status labels: open, needs review, assigned, in progress, waiting on tenant, waiting on vendor, completed, closed, cancelled.
- Category/priority labels on work-order and maintenance request list/detail/print surfaces.
- Review routing reason now uses `Operational work order review` for maintenance/work-order operational items.
- Maintenance related refs normalize to `work_order` routing metadata with human-readable labels.

## Tests added/updated
- `workOrderOperationalLabels.test.ts`
- `WorkOrdersPage.test.tsx`
- `MaintenanceRequestsPage.test.tsx`
- `deriveOperationalReviewRouting.test.ts`

## Validation
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- workOrderOperationalLabels.test.ts WorkOrdersPage.test.tsx MaintenanceRequestsPage.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- deriveOperationalReviewRouting.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Deferred terminology risks
- Expense category wording such as `Repairs` remains unchanged because it is financial/accounting terminology, not operational work-order copy.
- Contractor route/API `jobs` language remains unchanged for compatibility and should only be revisited in a contractor-service-task mission.
- Email/backend event wording may still vary by recipient audience and can be handled in a later notification-copy pass.

## Guardrail confirmations
- No permissions widened.
- No auth, Firestore rules, schema, route visibility, or financial behavior changed.
- No autonomous routing or execution introduced.
- No work-order system rewrite included.