### PR TITLE
feat: add operational read model foundation

### DIFF
--- a/docs/reports/operational-read-model-foundation-v1.md
+++ b/docs/reports/operational-read-model-foundation-v1.md
@@ -1,0 +1,245 @@
+# Operational Read Model Foundation v1
+
+## Executive summary
+
+This mission establishes RentChain's first operational read-model foundation as a deterministic projection layer for operational coordination.
+
+It does not rewrite Firestore schemas, replace canonical source-of-truth collections, add routes, add writes, change authorization, broaden visibility, or introduce autonomous orchestration.
+
+The foundation is intentionally narrow:
+
+- define operational read-model terminology
+- define source-of-truth vs derived-read boundaries
+- add lightweight deterministic helper contracts
+- preserve source lineage through internal references
+- protect restricted/raw/provider data from projection payloads
+- prepare future operational command center, review queue, evidence linkage, and institutional workflow scaling
+
+## Read-model philosophy
+
+Operational read models are derived, rebuildable projections. They help operators scan and coordinate work, but they are not the legal, financial, operational, or workflow source of truth.
+
+A RentChain operational read model should answer:
+
+- what operational item needs attention
+- what source workflow produced it
+- which landlord/resource scope applies
+- whether it is reviewable
+- what evidence/resource references are linked
+- when the projection was generated
+- which source references would allow rebuild or audit
+
+Read models must not answer:
+
+- whether a financial record is valid
+- whether an action is legally enforceable
+- whether a workflow should auto-progress
+- whether a tenant, landlord, or admin gains new visibility
+- whether an autonomous agent may execute an action
+
+## Source of truth vs derived read
+
+Canonical source-of-truth collections remain authoritative:
+
+- `leases`
+- `tenants`
+- `properties`
+- `units`
+- `payments`
+- `ledgerEntries`
+- `workOrders`
+- `maintenanceRequests`
+- `operatorReviewSessions`
+- `landlordDecisionStates`
+- `decisionActions`
+- evidence/export source collections
+
+Operational read models are derived from these source records and related projection helpers. They may include:
+
+- source collection names
+- source IDs as internal references
+- operational labels
+- deterministic summary status
+- deterministic priority
+- counts
+- evidence linkage summaries
+- routing summaries
+
+They must not include:
+
+- raw provider payloads
+- raw CSV values
+- payment credentials
+- private message bodies
+- unrestricted document bodies
+- stack traces
+- debug payloads
+- route-source diagnostics
+- tokens or secrets
+- unrelated landlord/tenant/resource records
+
+## Operational coordination use cases
+
+The first read-model concepts are designed for:
+
+- operational command center summaries
+- operational review queue summaries
+- work-order operational summaries
+- review workspace summaries
+- evidence linkage summaries
+- future consent/routing readiness summaries
+- future institutional coordination dashboards
+
+V1 adds helper-level concepts only. It does not persist an operational read-model collection.
+
+## V1 helper contract
+
+The helper contract introduces:
+
+- `readModelVersion`
+- `readModelType`
+- `generatedAt`
+- `staleAt`
+- `sourceRefs`
+- `sourceCollections`
+- `operationalCounts`
+- `summaries`
+- `routingSummary`
+- `evidenceLinkageSummary`
+- `canonicalSourceOfTruth: false`
+- `projectionOnly: true`
+- `autonomousActionsEnabled: false`
+- `permissionWideningRequired: false`
+
+Source references are internal metadata and are not primary human-facing labels.
+
+## Summary concepts
+
+Supported summary types:
+
+| Summary type | Purpose |
+| --- | --- |
+| `operational_signal` | Generic operational command center signal projection. |
+| `review_queue` | Manual operational review queue summary. |
+| `review_workspace` | Governed review workspace summary. |
+| `work_order` | Work-order operational summary. |
+| `evidence_linkage` | Evidence/source reference summary. |
+| `consent_routing` | Future consent/routing readiness summary. |
+
+Supported read-model priorities:
+
+- `critical`
+- `warning`
+- `needs_review`
+- `upcoming`
+- `info`
+
+Supported read-model statuses:
+
+- `open`
+- `needs_review`
+- `in_review`
+- `blocked`
+- `resolved`
+- `closed`
+- `informational`
+
+## Projection and update expectations
+
+Operational read models should be:
+
+- deterministic
+- reproducible from source records
+- authority-scoped
+- projection-safe
+- explicitly versioned
+- clearly non-authoritative
+
+Future persisted read models should include:
+
+- `generatedAt`
+- `staleAt`
+- `sourceRefs`
+- `readModelVersion`
+- projection profile or sensitivity metadata where applicable
+- a documented rebuild path
+
+They should be refreshed from source changes or events, not hand-edited as workflow truth.
+
+## Consistency expectations
+
+V1 makes no distributed consistency guarantee. It establishes the terminology and helper contract that future persisted read-model jobs should follow.
+
+Expected consistency posture:
+
+- source-of-truth records remain canonical
+- read models may lag source records
+- stale read models must be marked stale or regenerated
+- workflow mutation must always write to canonical sources, not read-model outputs
+- financial truth must remain in payment/ledger source collections
+
+## Relationship to review and evidence systems
+
+Operational read models may summarize:
+
+- operational review routing decisions
+- review workspace metadata
+- evidence references
+- scoped related-resource references
+
+They must remain reference-based. Evidence payloads, raw provider material, unrestricted message bodies, and sensitive document contents must remain in their governed source/projection systems.
+
+## Relationship to operational command center
+
+The current `/operations` command center already derives visible signals and review queue items from existing source payloads. V1 does not replace that UI behavior.
+
+The helper contract provides a future backend-safe projection vocabulary for:
+
+- moving expensive joins out of UI-only aggregation
+- reusing routing/review/evidence summaries consistently
+- introducing rebuildable operational summaries
+- preparing for larger review queues
+
+## Known limitations
+
+- No persisted operational read-model collection exists yet.
+- No event adapter or distributed projection job exists yet.
+- No Firestore index strategy is implemented in this PR.
+- No operational command center route is migrated to read from the helper yet.
+- No distributed stale/read repair workflow exists yet.
+- No autonomous orchestration exists.
+- No canonical workflow source is replaced.
+
+## Future scaling roadmap
+
+Recommended sequencing:
+
+1. Inventory current `/operations` aggregation costs and query patterns.
+2. Define a persisted landlord-scoped operational read-model collection only after authority and projection rules are reviewed.
+3. Add rebuild jobs or event adapters that write projection summaries from canonical source records.
+4. Add stale/read freshness metadata and safe fallback behavior.
+5. Add operational read-model tests for command center, review queue, evidence linkage, and consent timelines.
+6. Introduce governance-safe pagination and query budgets for large landlords.
+7. Keep financial and operational read models separate.
+
+## Governance guardrails
+
+This mission preserves:
+
+- no schema rewrites
+- no auth changes
+- no Firestore rules changes
+- no visibility widening
+- no autonomous behavior
+- no financial mutation changes
+- no source-of-truth replacement
+- no hidden derived truth
+
+## DO NOT IGNORE
+
+- Operational read models must never become canonical workflow state.
+- Payment and ledger read models must not replace financial source-of-truth collections.
+- Evidence linkage must remain metadata/reference-based unless an explicit projection profile permits more.
+- Internal IDs are lineage metadata, not primary UI labels.
+- Tenant-safe projections must remain whitelist-based.
+- Future persisted read models need rebuild semantics before institutional workflows depend on them.

--- a/rentchain-api/src/lib/operationalReadModels/__tests__/buildOperationalReadModel.test.ts
+++ b/rentchain-api/src/lib/operationalReadModels/__tests__/buildOperationalReadModel.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import { deriveOperationalReviewRouting } from "../../operationalReviewRouting/deriveOperationalReviewRouting";
+import { buildReviewWorkspace } from "../../reviewWorkspaces/buildReviewWorkspace";
+import {
+  buildOperationalCounts,
+  buildOperationalReadModel,
+  buildOperationalReadModelSummary,
+  buildReviewQueueSummary,
+  buildReviewWorkspaceSummary,
+  normalizeOperationalReadModelResourceRefs,
+  normalizeOperationalReadModelSourceRefs,
+} from "../buildOperationalReadModel";
+
+const generatedAt = "2026-05-21T10:00:00.000Z";
+
+describe("operational read model foundations", () => {
+  it("builds deterministic projection-only summaries without becoming workflow truth", () => {
+    const summary = buildOperationalReadModelSummary({
+      summaryType: "work_order",
+      itemId: "work-order-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      generatedAt,
+      title: "Kitchen sink repair",
+      operationalSummary: "Work order is waiting on vendor scheduling.",
+      status: "waiting_on_vendor",
+      priority: "warning",
+      sourceRefs: [
+        { sourceCollection: "workOrders", sourceId: "work-order-1", resourceType: "work_order", landlordId: "landlord-1", tenantId: "tenant-1" },
+      ],
+      relatedResourceRefs: [
+        {
+          resourceType: "unit",
+          resourceId: "unit-103",
+          label: "North Towers · Unit 103",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          unitId: "unit-103",
+        },
+      ],
+    });
+    const duplicate = buildOperationalReadModelSummary({
+      summaryType: "work_order",
+      itemId: "work-order-1",
+      landlordId: "landlord-1",
+      generatedAt,
+    });
+
+    expect(summary.summaryId).toBe(duplicate.summaryId);
+    expect(summary).toEqual(
+      expect.objectContaining({
+        summaryId: "operational_read_model:landlord-1:work_order:work-order-1",
+        summaryType: "work_order",
+        status: "open",
+        priority: "warning",
+        canonicalSourceOfTruth: false,
+        projectionOnly: true,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(summary.sourceRefs).toEqual([
+      expect.objectContaining({
+        sourceCollection: "workOrders",
+        sourceId: "work-order-1",
+        internalReference: true,
+      }),
+    ]);
+    expect(summary.relatedResourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "unit",
+        resourceId: "unit-103",
+        internalReference: true,
+      }),
+    ]);
+  });
+
+  it("derives review queue summaries from routing metadata without auto-actions", () => {
+    const routing = deriveOperationalReviewRouting({
+      itemId: "decision-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      title: "Operational work order blocked",
+      category: "operations",
+      severity: "high",
+      status: "open",
+      relatedResourceRefs: [
+        {
+          resourceType: "work_order",
+          resourceId: "work-order-1",
+          label: "Operational work order",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+        },
+      ],
+    });
+    const summary = buildReviewQueueSummary({
+      routing,
+      title: "Operational work order blocked",
+      generatedAt,
+      tenantId: "tenant-1",
+    });
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        summaryType: "review_queue",
+        status: "needs_review",
+        priority: "critical",
+        canonicalSourceOfTruth: false,
+        projectionOnly: true,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(summary.routingSummary).toEqual(
+      expect.objectContaining({
+        reviewEligible: true,
+        reviewReasonLabel: "Operational work order review",
+        manualOnly: true,
+        autoCreateWorkspace: false,
+        autonomousActionsEnabled: false,
+      })
+    );
+    expect(summary.relatedResourceRefs).toEqual([
+      expect.objectContaining({ resourceType: "work_order", resourceId: "work-order-1", internalReference: true }),
+    ]);
+  });
+
+  it("derives review workspace summaries with reference-only evidence linkage", () => {
+    const workspace = buildReviewWorkspace({
+      workspaceType: "evidence_review",
+      workspaceScopeId: "evidence-pack-1",
+      landlordId: "landlord-1",
+      createdAt: generatedAt,
+      createdBy: { userId: "landlord-user-1", role: "landlord" },
+      reviewPriority: "needs_review",
+      reviewSummary: "Review evidence package lineage",
+      evidenceRefs: [
+        {
+          evidencePackId: "evidence-pack-1",
+          label: "Evidence pack",
+          sourceCollection: "canonicalEvents",
+          sourceId: "event-1",
+          sensitivityClass: "restricted",
+          projectionProfile: "landlord_evidence_review",
+        },
+      ],
+    });
+    const summary = buildReviewWorkspaceSummary({ workspace, generatedAt });
+
+    expect(summary.evidenceLinkageSummary).toEqual({
+      evidenceRefCount: 1,
+      sourceRefCount: 1,
+      sensitivityClasses: ["restricted"],
+      projectionProfiles: ["landlord_evidence_review"],
+      referenceOnly: true,
+    });
+    expect(summary.sourceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceCollection: "operatorReviewSessions", sourceId: workspace.workspaceId }),
+        expect.objectContaining({ sourceCollection: "canonicalEvents", sourceId: "event-1" }),
+      ])
+    );
+    expect(JSON.stringify(summary)).not.toContain("raw provider payload");
+  });
+
+  it("filters unrelated landlord and tenant refs from read-model projections", () => {
+    const sourceRefs = normalizeOperationalReadModelSourceRefs(
+      [
+        { sourceCollection: "leases", sourceId: "lease-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { sourceCollection: "leases", sourceId: "lease-2", landlordId: "landlord-2", tenantId: "tenant-1" },
+        { sourceCollection: "leases", sourceId: "lease-3", landlordId: "landlord-1", tenantId: "tenant-2" },
+      ],
+      { landlordId: "landlord-1", tenantId: "tenant-1" }
+    );
+    const resourceRefs = normalizeOperationalReadModelResourceRefs(
+      [
+        { resourceType: "lease", resourceId: "lease-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { resourceType: "lease", resourceId: "lease-2", landlordId: "landlord-2", tenantId: "tenant-1" },
+        { resourceType: "lease", resourceId: "lease-3", landlordId: "landlord-1", tenantId: "tenant-2" },
+      ],
+      { landlordId: "landlord-1", tenantId: "tenant-1" }
+    );
+
+    expect(sourceRefs.map((ref) => ref.sourceId)).toEqual(["lease-1"]);
+    expect(resourceRefs.map((ref) => ref.resourceId)).toEqual(["lease-1"]);
+  });
+
+  it("builds aggregate operational read models from scoped summaries", () => {
+    const summaries = [
+      buildOperationalReadModelSummary({
+        summaryType: "work_order",
+        itemId: "work-order-1",
+        landlordId: "landlord-1",
+        generatedAt,
+        priority: "warning",
+        sourceRefs: [{ sourceCollection: "workOrders", sourceId: "work-order-1", landlordId: "landlord-1" }],
+      }),
+      buildOperationalReadModelSummary({
+        summaryType: "review_workspace",
+        itemId: "workspace-1",
+        landlordId: "landlord-1",
+        generatedAt,
+        priority: "critical",
+        evidenceLinkageSummary: { evidenceRefCount: 1, sourceRefCount: 1, sensitivityClasses: ["sensitive"], projectionProfiles: [] },
+        sourceRefs: [{ sourceCollection: "operatorReviewSessions", sourceId: "workspace-1", landlordId: "landlord-1" }],
+      }),
+      buildOperationalReadModelSummary({
+        summaryType: "operational_signal",
+        itemId: "wrong-landlord",
+        landlordId: "landlord-2",
+        generatedAt,
+        priority: "critical",
+      }),
+    ];
+
+    const model = buildOperationalReadModel({
+      landlordId: "landlord-1",
+      generatedAt,
+      staleAt: "2026-05-21T10:05:00.000Z",
+      summaries,
+    });
+
+    expect(model).toEqual(
+      expect.objectContaining({
+        readModelVersion: "operational_read_model_foundation_v1",
+        readModelType: "operational_coordination",
+        landlordId: "landlord-1",
+        generatedAt,
+        staleAt: "2026-05-21T10:05:00.000Z",
+        consistencyExpectation: "projection_rebuildable_from_source",
+        canonicalSourceOfTruth: false,
+        projectionOnly: true,
+        autonomousActionsEnabled: false,
+        permissionWideningRequired: false,
+      })
+    );
+    expect(model.summaries.map((item) => item.landlordId)).toEqual(["landlord-1", "landlord-1"]);
+    expect(model.sourceCollections).toEqual(["operatorReviewSessions", "workOrders"]);
+    expect(model.operationalCounts).toEqual({
+      total: 2,
+      critical: 1,
+      warnings: 1,
+      needsReview: 0,
+      upcoming: 0,
+      informational: 0,
+      reviewEligible: 0,
+      workOrders: 1,
+      reviewWorkspaces: 1,
+      evidenceLinked: 1,
+    });
+  });
+
+  it("excludes restricted/raw/provider fields and values from summaries", () => {
+    const summary = buildOperationalReadModelSummary({
+      summaryType: "evidence_linkage",
+      itemId: "evidence-1",
+      landlordId: "landlord-1",
+      title: "<Evidence lineage>",
+      rawPayload: "ignored",
+      sourceRefs: [
+        {
+          sourceCollection: "evidencePacks",
+          sourceId: "evidence-1",
+          landlordId: "landlord-1",
+          rawPayload: "raw provider payload",
+          token: "secret-token",
+          routeSource: "debug-source",
+        },
+      ],
+      relatedResourceRefs: [
+        {
+          resourceType: "evidence_pack",
+          resourceId: "evidence-1",
+          label: "Evidence pack",
+          landlordId: "landlord-1",
+          providerPayload: "raw provider payload",
+          rawCsv: "raw csv values",
+          bankAccountNumber: "111122223333",
+          stack: "private stack trace",
+        },
+      ],
+    } as any);
+
+    expect(summary.title).toBe("Evidence lineage");
+    expectNoRestrictedProjectionFields(summary);
+    expectPayloadDoesNotContainValues(summary, [
+      "raw provider payload",
+      "secret-token",
+      "debug-source",
+      "raw csv values",
+      "111122223333",
+      "private stack trace",
+    ]);
+  });
+
+  it("counts read-model summaries deterministically", () => {
+    const counts = buildOperationalCounts([
+      buildOperationalReadModelSummary({ summaryType: "operational_signal", itemId: "a", landlordId: "landlord-1", priority: "critical" }),
+      buildOperationalReadModelSummary({ summaryType: "operational_signal", itemId: "b", landlordId: "landlord-1", priority: "upcoming" }),
+      buildOperationalReadModelSummary({ summaryType: "operational_signal", itemId: "c", landlordId: "landlord-1", priority: "info" }),
+    ]);
+
+    expect(counts).toEqual(
+      expect.objectContaining({
+        total: 3,
+        critical: 1,
+        upcoming: 1,
+        informational: 1,
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/operationalReadModels/buildOperationalReadModel.ts
+++ b/rentchain-api/src/lib/operationalReadModels/buildOperationalReadModel.ts
@@ -1,0 +1,375 @@
+import crypto from "crypto";
+import type {
+  BuildOperationalReadModelInput,
+  BuildOperationalReadModelSummaryInput,
+  OperationalReadModel,
+  OperationalReadModelCounts,
+  OperationalReadModelEvidenceLinkageSummary,
+  OperationalReadModelPriority,
+  OperationalReadModelResourceRef,
+  OperationalReadModelRoutingInput,
+  OperationalReadModelRoutingSummary,
+  OperationalReadModelSourceRef,
+  OperationalReadModelStatus,
+  OperationalReadModelSummary,
+  OperationalReadModelSummaryType,
+  OperationalReadModelWorkspaceInput,
+} from "./operationalReadModelTypes";
+import { OPERATIONAL_READ_MODEL_VERSION } from "./operationalReadModelTypes";
+import type {
+  ReviewWorkspacePriority,
+  ReviewWorkspaceSensitivityClass,
+  ReviewWorkspaceVisibilityClass,
+} from "../reviewWorkspaces/reviewWorkspaceTypes";
+
+const VALID_SUMMARY_TYPES = new Set<OperationalReadModelSummaryType>([
+  "operational_signal",
+  "review_queue",
+  "review_workspace",
+  "work_order",
+  "evidence_linkage",
+  "consent_routing",
+]);
+
+const VALID_PRIORITIES = new Set<OperationalReadModelPriority>(["critical", "warning", "needs_review", "upcoming", "info"]);
+const VALID_STATUSES = new Set<OperationalReadModelStatus>([
+  "open",
+  "needs_review",
+  "in_review",
+  "blocked",
+  "resolved",
+  "closed",
+  "informational",
+]);
+const VALID_SENSITIVITY = new Set<ReviewWorkspaceSensitivityClass>(["sensitive", "restricted"]);
+const VALID_VISIBILITY = new Set<ReviewWorkspaceVisibilityClass>(["landlord_operational", "admin_support"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function safeText(value: unknown, max = 500): string {
+  return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+function toIsoDate(value: unknown): string | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+function summaryId(input: { landlordId: string; summaryType: OperationalReadModelSummaryType; itemId: string }): string {
+  const clean = cleanIdPart(["operational_read_model", input.landlordId, input.summaryType, input.itemId].join(":"));
+  return clean || `operational_read_model:${crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex")}`;
+}
+
+function normalizePriority(value: unknown): OperationalReadModelPriority {
+  const normalized = cleanIdPart(value).replace(/-/g, "_");
+  if (normalized === "critical" || normalized === "high") return "critical";
+  if (normalized === "warning" || normalized === "medium") return "warning";
+  if (normalized === "upcoming") return "upcoming";
+  if (normalized === "informational" || normalized === "info" || normalized === "low") return "info";
+  return VALID_PRIORITIES.has(normalized as OperationalReadModelPriority)
+    ? (normalized as OperationalReadModelPriority)
+    : "needs_review";
+}
+
+function normalizeStatus(value: unknown): OperationalReadModelStatus {
+  const normalized = cleanIdPart(value).replace(/-/g, "_");
+  if (normalized === "under_review" || normalized === "in_progress") return "in_review";
+  if (normalized === "needs_review" || normalized === "review_needed" || normalized === "pending") return "needs_review";
+  if (normalized === "completed" || normalized === "resolved") return "resolved";
+  if (normalized === "dismissed" || normalized === "cancelled" || normalized === "canceled") return "closed";
+  if (normalized === "informational" || normalized === "info") return "informational";
+  return VALID_STATUSES.has(normalized as OperationalReadModelStatus) ? (normalized as OperationalReadModelStatus) : "open";
+}
+
+export function normalizeOperationalReadModelSourceRefs(
+  raw: unknown,
+  scope: { landlordId: string; tenantId?: string | null }
+): OperationalReadModelSourceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const sourceCollection = safeText(data.sourceCollection, 120);
+      const sourceId = asString(data.sourceId || data.resourceId || data.id, 240);
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
+      if (!sourceCollection || !sourceId) return null;
+      if (landlordId && landlordId !== scope.landlordId) return null;
+      if (scope.tenantId && tenantId && tenantId !== scope.tenantId) return null;
+      return {
+        sourceCollection,
+        sourceId,
+        resourceType: safeText(data.resourceType || data.type, 80) || null,
+        landlordId,
+        tenantId,
+        internalReference: true as const,
+      };
+    })
+    .filter(Boolean) as OperationalReadModelSourceRef[];
+  const byKey = new Map<string, OperationalReadModelSourceRef>();
+  for (const ref of refs) byKey.set(`${ref.sourceCollection}:${ref.sourceId}`, ref);
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}`.localeCompare(`${b.sourceCollection}:${b.sourceId}`)
+  );
+}
+
+export function normalizeOperationalReadModelResourceRefs(
+  raw: unknown,
+  scope: { landlordId: string; tenantId?: string | null }
+): OperationalReadModelResourceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const resourceType = safeText(data.resourceType || data.type, 80);
+      const resourceId = asString(data.resourceId || data.id, 240);
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
+      if (!resourceType || !resourceId) return null;
+      if (landlordId && landlordId !== scope.landlordId) return null;
+      if (scope.tenantId && tenantId && tenantId !== scope.tenantId) return null;
+      return {
+        resourceType,
+        resourceId,
+        label: safeText(data.label, 160) || `${resourceType.replace(/_/g, " ")} reference`,
+        landlordId,
+        tenantId,
+        propertyId: asString(data.propertyId, 240) || null,
+        unitId: asString(data.unitId, 240) || null,
+        leaseId: asString(data.leaseId, 240) || null,
+        internalReference: true as const,
+      };
+    })
+    .filter(Boolean) as OperationalReadModelResourceRef[];
+  const byKey = new Map<string, OperationalReadModelResourceRef>();
+  for (const ref of refs) byKey.set(`${ref.resourceType}:${ref.resourceId}`, ref);
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.resourceType}:${a.resourceId}`.localeCompare(`${b.resourceType}:${b.resourceId}`)
+  );
+}
+
+function normalizeEvidenceLinkageSummary(raw: unknown): OperationalReadModelEvidenceLinkageSummary {
+  const data = (raw || {}) as Partial<OperationalReadModelEvidenceLinkageSummary>;
+  const sensitivityClasses = uniqueSorted(
+    (Array.isArray(data.sensitivityClasses) ? data.sensitivityClasses : [])
+      .map((value) => asString(value, 40) as ReviewWorkspaceSensitivityClass)
+      .filter((value) => VALID_SENSITIVITY.has(value))
+  ) as ReviewWorkspaceSensitivityClass[];
+  return {
+    evidenceRefCount: Math.max(0, Number(data.evidenceRefCount || 0) || 0),
+    sourceRefCount: Math.max(0, Number(data.sourceRefCount || 0) || 0),
+    sensitivityClasses,
+    projectionProfiles: uniqueSorted(
+      (Array.isArray(data.projectionProfiles) ? data.projectionProfiles : []).map((value) => safeText(value, 120))
+    ),
+    referenceOnly: true,
+  };
+}
+
+function normalizeRoutingSummary(raw: unknown, fallbackPriority: OperationalReadModelPriority): OperationalReadModelRoutingSummary | null {
+  if (!raw || typeof raw !== "object") return null;
+  const data = raw as Partial<OperationalReadModelRoutingSummary>;
+  return {
+    reviewEligible: Boolean(data.reviewEligible),
+    reviewReasonLabel: safeText(data.reviewReasonLabel, 180) || null,
+    reviewPriority: normalizePriority(data.reviewPriority || fallbackPriority),
+    workspaceType: data.workspaceType || null,
+    manualOnly: true,
+    autoCreateWorkspace: false,
+    autonomousActionsEnabled: false,
+  };
+}
+
+export function buildOperationalReadModelSummary(input: BuildOperationalReadModelSummaryInput): OperationalReadModelSummary {
+  const landlordId = asString(input.landlordId, 240);
+  const itemId = asString(input.itemId, 240);
+  if (!landlordId || !itemId) throw new Error("operational_read_model_scope_required");
+  const summaryType = VALID_SUMMARY_TYPES.has(input.summaryType) ? input.summaryType : "operational_signal";
+  const generatedAt = toIsoDate(input.generatedAt) || new Date(0).toISOString();
+  const priority = normalizePriority(input.priority);
+  const tenantId = asString(input.tenantId, 240) || null;
+  const sourceRefs = normalizeOperationalReadModelSourceRefs(input.sourceRefs, { landlordId, tenantId });
+  const relatedResourceRefs = normalizeOperationalReadModelResourceRefs(input.relatedResourceRefs, { landlordId, tenantId });
+
+  return {
+    summaryId: summaryId({ landlordId, summaryType, itemId }),
+    summaryType,
+    title: safeText(input.title, 180) || "Operational summary",
+    operationalSummary: safeText(input.operationalSummary, 500) || "Projection summary derived from scoped operational source records.",
+    status: normalizeStatus(input.status),
+    priority,
+    landlordId,
+    tenantId,
+    generatedAt,
+    sourceRefs,
+    relatedResourceRefs,
+    routingSummary: normalizeRoutingSummary(input.routingSummary, priority),
+    evidenceLinkageSummary: normalizeEvidenceLinkageSummary(input.evidenceLinkageSummary),
+    sensitivityClass: VALID_SENSITIVITY.has(input.sensitivityClass as ReviewWorkspaceSensitivityClass)
+      ? (input.sensitivityClass as ReviewWorkspaceSensitivityClass)
+      : "sensitive",
+    visibilityClass: VALID_VISIBILITY.has(input.visibilityClass as ReviewWorkspaceVisibilityClass)
+      ? (input.visibilityClass as ReviewWorkspaceVisibilityClass)
+      : "landlord_operational",
+    canonicalSourceOfTruth: false,
+    projectionOnly: true,
+    autonomousActionsEnabled: false,
+  };
+}
+
+export function buildReviewQueueSummary(input: OperationalReadModelRoutingInput): OperationalReadModelSummary {
+  const routing = input.routing;
+  return buildOperationalReadModelSummary({
+    summaryType: "review_queue",
+    itemId: routing.itemId,
+    landlordId: routing.landlordId,
+    tenantId: input.tenantId,
+    generatedAt: input.generatedAt,
+    title: input.title || routing.reviewReasonLabel,
+    operationalSummary: input.operationalSummary || routing.priorityLabel,
+    status: input.status || (routing.reviewEligible ? "needs_review" : "informational"),
+    priority: routing.reviewPriority,
+    sourceRefs: [
+      {
+        sourceCollection: "operationalReviewRouting",
+        sourceId: routing.routingId,
+        resourceType: "review_routing",
+        landlordId: routing.landlordId,
+        tenantId: input.tenantId || null,
+      },
+    ],
+    relatedResourceRefs: routing.relatedResourceRefs,
+    routingSummary: {
+      reviewEligible: routing.reviewEligible,
+      reviewReasonLabel: routing.reviewReasonLabel,
+      reviewPriority: routing.reviewPriority,
+      workspaceType: routing.workspaceType,
+      manualOnly: true,
+      autoCreateWorkspace: false,
+      autonomousActionsEnabled: false,
+    },
+  });
+}
+
+export function buildReviewWorkspaceSummary(input: OperationalReadModelWorkspaceInput): OperationalReadModelSummary {
+  const workspace = input.workspace;
+  const evidenceSensitivity = uniqueSorted(workspace.evidenceRefs.map((ref) => ref.sensitivityClass)) as ReviewWorkspaceSensitivityClass[];
+  return buildOperationalReadModelSummary({
+    summaryType: "review_workspace",
+    itemId: workspace.workspaceId,
+    landlordId: workspace.landlordId,
+    generatedAt: input.generatedAt || workspace.updatedAt,
+    title: workspace.reviewSummary,
+    operationalSummary: `${workspace.workspaceType.replace(/_/g, " ")} is ${workspace.reviewStatus.replace(/_/g, " ")}.`,
+    status: workspace.reviewStatus === "under_review" ? "in_review" : workspace.reviewStatus === "completed" ? "resolved" : workspace.reviewStatus,
+    priority: workspace.reviewPriority,
+    sourceRefs: [
+      {
+        sourceCollection: "operatorReviewSessions",
+        sourceId: workspace.workspaceId,
+        resourceType: "review_workspace",
+        landlordId: workspace.landlordId,
+      },
+      ...workspace.evidenceRefs
+        .filter((ref) => ref.sourceCollection && ref.sourceId)
+        .map((ref) => ({
+          sourceCollection: ref.sourceCollection as string,
+          sourceId: ref.sourceId as string,
+          resourceType: ref.evidenceType,
+          landlordId: workspace.landlordId,
+          tenantId: ref.tenantId,
+        })),
+    ],
+    relatedResourceRefs: workspace.relatedResourceRefs,
+    evidenceLinkageSummary: {
+      evidenceRefCount: workspace.evidenceRefs.length,
+      sourceRefCount: workspace.evidenceRefs.filter((ref) => ref.sourceCollection && ref.sourceId).length,
+      sensitivityClasses: evidenceSensitivity,
+      projectionProfiles: uniqueSorted(workspace.evidenceRefs.map((ref) => ref.projectionProfile || "").filter(Boolean)),
+      referenceOnly: true,
+    },
+    routingSummary: {
+      reviewEligible: true,
+      reviewReasonLabel: workspace.reviewSummary,
+      reviewPriority: workspace.reviewPriority,
+      workspaceType: workspace.workspaceType,
+      manualOnly: true,
+      autoCreateWorkspace: false,
+      autonomousActionsEnabled: false,
+    },
+    sensitivityClass: workspace.sensitivityClass,
+    visibilityClass: workspace.visibilityClass,
+  });
+}
+
+function isSummary(value: unknown): value is OperationalReadModelSummary {
+  const data = value as OperationalReadModelSummary;
+  return Boolean(data?.summaryId && data?.readModelVersion === undefined && data?.projectionOnly === true);
+}
+
+export function buildOperationalCounts(summaries: OperationalReadModelSummary[]): OperationalReadModelCounts {
+  return {
+    total: summaries.length,
+    critical: summaries.filter((item) => item.priority === "critical").length,
+    warnings: summaries.filter((item) => item.priority === "warning").length,
+    needsReview: summaries.filter((item) => item.priority === "needs_review" || item.status === "needs_review").length,
+    upcoming: summaries.filter((item) => item.priority === "upcoming").length,
+    informational: summaries.filter((item) => item.priority === "info" || item.status === "informational").length,
+    reviewEligible: summaries.filter((item) => item.routingSummary?.reviewEligible).length,
+    workOrders: summaries.filter((item) => item.summaryType === "work_order").length,
+    reviewWorkspaces: summaries.filter((item) => item.summaryType === "review_workspace").length,
+    evidenceLinked: summaries.filter((item) => item.evidenceLinkageSummary.evidenceRefCount > 0).length,
+  };
+}
+
+export function buildOperationalReadModel(input: BuildOperationalReadModelInput): OperationalReadModel {
+  const landlordId = asString(input.landlordId, 240);
+  if (!landlordId) throw new Error("operational_read_model_landlord_required");
+  const generatedAt = toIsoDate(input.generatedAt) || new Date(0).toISOString();
+  const tenantlessScope = { landlordId };
+  const summaries = (input.summaries || [])
+    .filter(Boolean)
+    .map((item) => (isSummary(item) ? item : buildOperationalReadModelSummary(item as BuildOperationalReadModelSummaryInput)))
+    .filter((item) => item.landlordId === landlordId)
+    .sort((a, b) => a.summaryId.localeCompare(b.summaryId));
+  const sourceRefs = normalizeOperationalReadModelSourceRefs(
+    summaries.flatMap((summary) => summary.sourceRefs),
+    tenantlessScope
+  );
+  const sourceCollections = uniqueSorted(sourceRefs.map((ref) => ref.sourceCollection));
+
+  return {
+    readModelVersion: OPERATIONAL_READ_MODEL_VERSION,
+    readModelType: "operational_coordination",
+    landlordId,
+    generatedAt,
+    staleAt: toIsoDate(input.staleAt),
+    sourceCollections,
+    sourceRefs,
+    operationalCounts: buildOperationalCounts(summaries),
+    summaries,
+    consistencyExpectation: "projection_rebuildable_from_source",
+    canonicalSourceOfTruth: false,
+    projectionOnly: true,
+    autonomousActionsEnabled: false,
+    permissionWideningRequired: false,
+  };
+}

--- a/rentchain-api/src/lib/operationalReadModels/operationalReadModelTypes.ts
+++ b/rentchain-api/src/lib/operationalReadModels/operationalReadModelTypes.ts
@@ -1,0 +1,148 @@
+import type { OperationalReviewRoutingDecision } from "../operationalReviewRouting/operationalReviewRoutingTypes";
+import type {
+  ReviewWorkspace,
+  ReviewWorkspacePriority,
+  ReviewWorkspaceResourceRef,
+  ReviewWorkspaceSensitivityClass,
+  ReviewWorkspaceType,
+} from "../reviewWorkspaces/reviewWorkspaceTypes";
+
+export const OPERATIONAL_READ_MODEL_VERSION = "operational_read_model_foundation_v1";
+
+export type OperationalReadModelType = "operational_coordination";
+
+export type OperationalReadModelSummaryType =
+  | "operational_signal"
+  | "review_queue"
+  | "review_workspace"
+  | "work_order"
+  | "evidence_linkage"
+  | "consent_routing";
+
+export type OperationalReadModelPriority = ReviewWorkspacePriority;
+
+export type OperationalReadModelStatus = "open" | "needs_review" | "in_review" | "blocked" | "resolved" | "closed" | "informational";
+
+export type OperationalReadModelSourceRef = {
+  sourceCollection: string;
+  sourceId: string;
+  resourceType: string | null;
+  landlordId: string | null;
+  tenantId: string | null;
+  internalReference: true;
+};
+
+export type OperationalReadModelResourceRef = Pick<
+  ReviewWorkspaceResourceRef,
+  "resourceType" | "resourceId" | "label" | "landlordId" | "tenantId" | "propertyId" | "unitId" | "leaseId"
+> & {
+  internalReference: true;
+};
+
+export type OperationalReadModelEvidenceLinkageSummary = {
+  evidenceRefCount: number;
+  sourceRefCount: number;
+  sensitivityClasses: ReviewWorkspaceSensitivityClass[];
+  projectionProfiles: string[];
+  referenceOnly: true;
+};
+
+export type OperationalReadModelRoutingSummary = {
+  reviewEligible: boolean;
+  reviewReasonLabel: string | null;
+  reviewPriority: OperationalReadModelPriority;
+  workspaceType: ReviewWorkspaceType | null;
+  manualOnly: true;
+  autoCreateWorkspace: false;
+  autonomousActionsEnabled: false;
+};
+
+export type OperationalReadModelSummary = {
+  summaryId: string;
+  summaryType: OperationalReadModelSummaryType;
+  title: string;
+  operationalSummary: string;
+  status: OperationalReadModelStatus;
+  priority: OperationalReadModelPriority;
+  landlordId: string;
+  tenantId: string | null;
+  generatedAt: string;
+  sourceRefs: OperationalReadModelSourceRef[];
+  relatedResourceRefs: OperationalReadModelResourceRef[];
+  routingSummary: OperationalReadModelRoutingSummary | null;
+  evidenceLinkageSummary: OperationalReadModelEvidenceLinkageSummary;
+  sensitivityClass: ReviewWorkspaceSensitivityClass;
+  visibilityClass: "landlord_operational" | "admin_support";
+  canonicalSourceOfTruth: false;
+  projectionOnly: true;
+  autonomousActionsEnabled: false;
+};
+
+export type OperationalReadModelCounts = {
+  total: number;
+  critical: number;
+  warnings: number;
+  needsReview: number;
+  upcoming: number;
+  informational: number;
+  reviewEligible: number;
+  workOrders: number;
+  reviewWorkspaces: number;
+  evidenceLinked: number;
+};
+
+export type OperationalReadModel = {
+  readModelVersion: typeof OPERATIONAL_READ_MODEL_VERSION;
+  readModelType: OperationalReadModelType;
+  landlordId: string;
+  generatedAt: string;
+  staleAt: string | null;
+  sourceCollections: string[];
+  sourceRefs: OperationalReadModelSourceRef[];
+  operationalCounts: OperationalReadModelCounts;
+  summaries: OperationalReadModelSummary[];
+  consistencyExpectation: "projection_rebuildable_from_source";
+  canonicalSourceOfTruth: false;
+  projectionOnly: true;
+  autonomousActionsEnabled: false;
+  permissionWideningRequired: false;
+};
+
+export type BuildOperationalReadModelInput = {
+  landlordId: string;
+  generatedAt?: string | Date | null;
+  staleAt?: string | Date | null;
+  summaries?: Array<BuildOperationalReadModelSummaryInput | OperationalReadModelSummary | null | undefined> | null;
+};
+
+export type BuildOperationalReadModelSummaryInput = {
+  summaryType: OperationalReadModelSummaryType;
+  itemId: string;
+  title?: string | null;
+  operationalSummary?: string | null;
+  status?: string | null;
+  priority?: string | null;
+  landlordId: string;
+  tenantId?: string | null;
+  generatedAt?: string | Date | null;
+  sourceRefs?: Array<Record<string, unknown>> | null;
+  relatedResourceRefs?: Array<Record<string, unknown>> | null;
+  routingSummary?: Partial<OperationalReadModelRoutingSummary> | null;
+  evidenceLinkageSummary?: Partial<OperationalReadModelEvidenceLinkageSummary> | null;
+  sensitivityClass?: string | null;
+  visibilityClass?: string | null;
+};
+
+export type OperationalReadModelRoutingInput = {
+  routing: OperationalReviewRoutingDecision;
+  title?: string | null;
+  operationalSummary?: string | null;
+  status?: string | null;
+  tenantId?: string | null;
+  generatedAt?: string | Date | null;
+};
+
+export type OperationalReadModelWorkspaceInput = {
+  workspace: ReviewWorkspace;
+  generatedAt?: string | Date | null;
+};

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -157,7 +157,6 @@ describe("landlord maintenance workspace", () => {
 
     expect((await screen.findAllByText("In progress")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Urgent").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("General Repair").length).toBeGreaterThan(0);
     expect(screen.queryByText("in_progress")).not.toBeInTheDocument();
     expect(screen.queryByText("general_repair")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Added a backend-only operational read-model foundation helper and type contract.
- Added deterministic summaries for review queue routing metadata and review workspace metadata.
- Added source/reference normalization that filters unrelated landlord and tenant refs.
- Added the governance report documenting read-model philosophy, source-of-truth boundaries, consistency expectations, and future scaling roadmap.

## Audit findings
- Current /operations and review queue behavior is derived from visible operational signals and frontend aggregation.
- Review workspace and operational routing helpers already provide deterministic metadata and manual-only flags.
- Firestore collection ownership docs identify operational read models as a future scaling need, but no persisted read-model collection exists yet.
- The safest first step is a pure projection helper, not route writes or schema changes.

## Read-model philosophy
- Read models are projection/read layers only.
- Canonical workflow state remains in source-of-truth collections.
- Operational summaries are rebuildable from scoped source references.
- Source refs are internal lineage metadata, not primary display labels.
- Read models must not become hidden derived truth.

## Helper/tests added
- buildOperationalReadModel()
- buildOperationalReadModelSummary()
- buildReviewQueueSummary()
- buildReviewWorkspaceSummary()
- source/resource ref normalization helpers
- focused backend tests for determinism, scoping, evidence linkage, restricted-field exclusion, counts, and no autonomous flags

## Operational surfaces covered
- operational signal summaries
- operational review queue summaries
- review workspace summaries
- work-order summary type
- evidence linkage summaries
- future consent/routing summary type

## Known limitations
- No persisted operational read-model collection exists yet.
- No event adapter or projection job exists yet.
- No command center route is migrated to read from this helper yet.
- No distributed freshness/staleness repair workflow exists yet.

## CI repair note
- Included a test-only correction to `MaintenanceRequestsPage.test.tsx` after the full frontend suite exposed a brittle assertion from the prior work-order terminology mission. This does not change product behavior.

## Validation
- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- buildOperationalReadModel.test.ts
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- MaintenanceRequestsPage.test.tsx
- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build
- git diff --check

## Guardrail confirmations
- No permissions widened.
- No autonomous behavior introduced.
- No auth, schema, Firestore rules, route visibility, or frontend behavior changed.
- No canonical workflow source-of-truth replacement introduced.
- No financial mutation behavior changed.
