### PR TITLE
fix: harden production debug surfaces

### DIFF
--- a/docs/reports/production-debug-surface-hardening-v1.md
+++ b/docs/reports/production-debug-surface-hardening-v1.md
@@ -1,0 +1,76 @@
+# Production Debug Surface Hardening v1
+
+## Executive summary
+
+This audit reviewed RentChain production-exposed diagnostic, probe, echo, route-inspection, build, health, and status surfaces. The mission preserves deployment health observability while reducing public exposure of route structure, exact build identifiers, echo payloads, and low-value debug metadata.
+
+The implementation keeps public health/status checks minimal and introduces production gating for unsafe diagnostic surfaces using the existing internal job token pattern. Public build/revision probes now expose presence metadata instead of exact Cloud Run revision or commit identifiers.
+
+## Diagnostic surface inventory
+
+| Surface | Current purpose | Exposure classification | v1 posture |
+| --- | --- | --- | --- |
+| `/health` | Cloud Run/status health | public-safe health | Public, unchanged |
+| `/health/ready` | readiness check | public-safe health | Public, unchanged |
+| `/health/db` | DB readiness when configured | public-safe health | Public, unchanged |
+| `/health/version` | service version check | production-safe diagnostic | Public, unchanged |
+| `/api/status/public` | status app/public status payload | production-safe diagnostic | Public, unchanged |
+| `/api/__probe/version` | deployment probe | production-safe diagnostic | Public, redacted build presence metadata |
+| `/api/__probe/revision` | deployment revision probe | production-safe diagnostic | Public, redacted revision/commit presence metadata |
+| `/api/_build` | build stamp | production-safe diagnostic | Public, redacted revision/commit presence metadata |
+| `/api/__routes` | route mount summary | admin/internal diagnostic | Production gated |
+| `/api/__probe/routes` | Express route/mount dump | admin/internal diagnostic | Production gated |
+| `/api/__probe/routes-lite` | public route-lite probe | admin/internal diagnostic | Production gated |
+| `/api/__probe/tenants-mount` | route mount probe | admin/internal diagnostic | Production gated |
+| `/api/__probe/onboarding-route` | route mount probe | admin/internal diagnostic | Production gated |
+| `/api/_echo` | POST reachability echo | admin/internal diagnostic | Production gated and duplicate mount removed |
+| `/api/__debug/build` | Vercel/build route-check details | admin/internal diagnostic | Production gated and redacted |
+| `/api/__debug/ping-application-links` | low-value debug ping | admin/internal diagnostic | Production gated |
+
+## Production gating rules
+
+- Public health/status endpoints remain available because Cloud Run, Terraform, Vercel previews, and the status app depend on low-friction health verification.
+- Unsafe diagnostic endpoints are available in non-production for local/preview debugging and require `INTERNAL_JOB_TOKEN` via `x-internal-job-token` or `x-internal-token` in production.
+- Gated production diagnostics return a minimal 404 response instead of exposing whether the debug surface exists.
+- Public build/revision probes return only safe presence booleans, not exact revision IDs, commit SHAs, timestamps, env values, request bodies, tokens, stack traces, or route internals.
+
+## Health/status exception rationale
+
+`/health`, `/health/ready`, and `/health/db` are deliberately preserved as public minimal endpoints. They expose service availability and DB readiness only, and are required for deployment and status checks. This mission does not alter their route behavior.
+
+`/api/status/public` remains public because it is the status-app integration surface. It remains under the diagnostics rate-limit profile.
+
+## Preview/dev expectations
+
+Local and non-production environments continue to support diagnostic access for deployment troubleshooting. Production applies the internal-token gate to unsafe surfaces so diagnostics remain available to controlled internal checks without exposing internals to public traffic.
+
+## Tests added/updated
+
+- `diagnosticSurfaceGuard.test.ts` verifies production gating, internal-token access, and redacted build metadata.
+- `apiRouteOwnershipRegression.test.ts` now asserts:
+  - unsafe diagnostic surfaces are explicitly gated,
+  - `_echo` is mounted once,
+  - public revision probes are redacted,
+  - debug/echo payloads are not exposed without the internal diagnostic token,
+  - API catchall behavior remains deterministic.
+
+## Known limitations
+
+- The internal-token gate is a conservative first-pass control. It is not a complete admin diagnostics product or a full incident-response workflow.
+- Public health endpoints remain intentionally reachable. Future hardening can add environment-specific allowlists only if deployment/status checks are updated together.
+- Some route-source headers remain useful for protected route ownership regression and operational debugging. They should continue to avoid secrets, env values, stack traces, and raw payloads.
+
+## Future hardening roadmap
+
+1. Inventory any remaining route-specific probe endpoints as new route families are added.
+2. Add deployment-level policy checks for diagnostic routes after Cloud Run/Terraform/status dependencies are fully mapped.
+3. Consider a dedicated internal diagnostics router with admin/support authority once privileged-access governance matures.
+4. Add monitoring around 404/429 volume for gated diagnostic routes without logging tokens or request bodies.
+
+## Explicit confirmations
+
+- No auth behavior changed.
+- No Firestore rules changed.
+- No permissions were widened.
+- No product workflow behavior expanded.
+- `/health`, `/health/ready`, `/health/db`, and status app checks are preserved.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -3,6 +3,10 @@ import cors from "cors";
 import cookieParser from "cookie-parser";
 import { authenticateJwt } from "./middleware/authMiddleware";
 import { routeSource } from "./middleware/routeSource";
+import {
+  requireDiagnosticAccess,
+  safeDiagnosticBuildMetadata,
+} from "./middleware/diagnosticSurfaceGuard";
 import { notFoundHandler, errorHandler } from "./middleware/errorHandler";
 import {
   rateLimitDiagnostics,
@@ -243,14 +247,18 @@ app.use("/api/api", (req, res) => {
 
 // Health
 app.use("/health", healthRoutes);
-app.get("/api/__routes", rateLimitDiagnostics, (_req, res) => {
-  res.setHeader("x-route-source", "app.build.ts:/api/__routes");
-  return res.json({
-    ok: true,
-    runtime: "app.build.ts",
-    mounted: ["/api/auth", "/api/access", "/api/invites"],
-  });
-});
+app.get(
+  "/api/__routes",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/__routes"),
+  (_req, res) => {
+    return res.json({
+      ok: true,
+      runtime: "app.build.ts",
+      mounted: ["/api/auth", "/api/access", "/api/invites"],
+    });
+  }
+);
 
 // Billing routes
 app.use("/api/billing", routeSource("billingRoutes.ts"), billingRoutes);
@@ -514,20 +522,21 @@ app.use("/api", routeSource("screeningReportRoutes.ts"), screeningReportRoutes);
 app.use("/api", tenantOnboardRoutes);
 app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/landlord", landlordMicroLiveRoutes);
-app.get("/api/__probe/tenants-mount", rateLimitDiagnostics, (_req, res) =>
-  res.json({ ok: true, probe: "tenants-mount", ts: Date.now() })
+app.get(
+  "/api/__probe/tenants-mount",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/__probe/tenants-mount"),
+  (_req, res) => res.json({ ok: true, probe: "tenants-mount" })
 );
-app.get("/api/__probe/version", rateLimitDiagnostics, (_req, res) =>
-  res.json({ ok: true, ts: Date.now(), marker: "probe-v1" })
-);
+app.get("/api/__probe/version", rateLimitDiagnostics, (_req, res) => {
+  res.setHeader("x-route-source", "app.build.ts:/api/__probe/version");
+  return res.json({ ok: true, marker: "probe-v1", ...safeDiagnosticBuildMetadata() });
+});
 app.get("/api/__probe/revision", rateLimitDiagnostics, (_req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/__probe/revision");
   return res.json({
     ok: true,
-    service: "rentchain-landlord-api",
-    revision: process.env.K_REVISION || null,
-    commit: process.env.GIT_SHA || process.env.COMMIT_SHA || null,
-    ts: Date.now(),
+    ...safeDiagnosticBuildMetadata(),
   });
 });
 app.use("/api/account", accountRoutes);
@@ -538,76 +547,83 @@ app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
 console.log(
   "[routes] /api/properties, /api/properties/:propertyId/units, /api/action-requests, /api/applications"
 );
-app.post("/api/_echo", rateLimitDiagnostics, (req, res) => {
-  res.setHeader("x-route-source", "app.build.ts:/api/_echo");
-  return res.json({ ok: true, method: "POST", body: req.body ?? null });
-});
+app.get(
+  "/api/__probe/routes",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/__probe/routes"),
+  (_req, res) => {
+    const appAny: any = app;
+    const stack = appAny?._router?.stack || [];
+    const mounts = stack
+      .filter((l: any) => l && l.name === "router" && l.regexp)
+      .map((l: any) => String(l.regexp));
+    const routes = stack
+      .filter((l: any) => l && l.route && l.route.path)
+      .map((l: any) => ({
+        path: l.route.path,
+        methods: l.route.methods,
+      }));
 
-app.get("/api/__probe/routes", rateLimitDiagnostics, (_req, res) => {
-  const appAny: any = app;
-  const stack = appAny?._router?.stack || [];
-  const mounts = stack
-    .filter((l: any) => l && l.name === "router" && l.regexp)
-    .map((l: any) => String(l.regexp));
-  const routes = stack
-    .filter((l: any) => l && l.route && l.route.path)
-    .map((l: any) => ({
-      path: l.route.path,
-      methods: l.route.methods,
-    }));
-
-  res.json({
-    ok: true,
-    mountsCount: mounts.length,
-    mounts,
-    routesCount: routes.length,
-    routes,
-    hasTenantsMount: mounts.some((s: string) => s.includes("tenants")),
-  });
-});
+    res.json({
+      ok: true,
+      mountsCount: mounts.length,
+      mounts,
+      routesCount: routes.length,
+      routes,
+      hasTenantsMount: mounts.some((s: string) => s.includes("tenants")),
+    });
+  }
+);
 
 // Build stamp
 app.get("/api/_build", rateLimitDiagnostics, (_req, res) => {
   res.setHeader("x-route-source", "app.build.ts:/api/_build");
   return res.json({
     ok: true,
-    service: process.env.K_SERVICE || null,
-    revision: process.env.K_REVISION || null,
-    time: new Date().toISOString(),
+    ...safeDiagnosticBuildMetadata(),
   });
 });
 
 // Echo for POST reachability
-app.post("/api/_echo", rateLimitDiagnostics, (req, res) => {
-  res.setHeader("x-route-source", "app.build.ts:/api/_echo");
-  return res.json({
-    ok: true,
-    method: req.method,
-    path: req.path,
-    body: req.body ?? null,
-  });
-});
+app.post(
+  "/api/_echo",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/_echo"),
+  (req, res) => {
+    return res.json({
+      ok: true,
+      method: req.method,
+      path: req.path,
+      body: req.body ?? null,
+    });
+  }
+);
 
-app.get("/api/__debug/build", rateLimitDiagnostics, (_req, res) => {
-  res.setHeader("x-route-source", "app.build.ts:/api/__debug/build");
-  return res.json({
-    ok: true,
-    vercel: {
-      gitCommitSha: process.env.VERCEL_GIT_COMMIT_SHA || null,
-      deploymentId: process.env.VERCEL_DEPLOYMENT_ID || null,
-      env: process.env.VERCEL_ENV || null,
-    },
-    routeCheck: {
-      landlordApplicationLinksMounted: true,
-      mountPath: "/api/landlord/application-links",
-    },
-  });
-});
+app.get(
+  "/api/__debug/build",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/__debug/build"),
+  (_req, res) => {
+    return res.json({
+      ok: true,
+      build: safeDiagnosticBuildMetadata(),
+      vercel: { env: process.env.VERCEL_ENV || null },
+      routeCheck: {
+        landlordApplicationLinksMounted: true,
+        mountPath: "/api/landlord/application-links",
+      },
+    });
+  }
+);
 
-app.get("/api/__debug/ping-application-links", rateLimitDiagnostics, (_req, res) => {
-  res.setHeader("x-route-source", "debugPingApplicationLinks");
-  return res.json({ ok: true });
-});
+app.get(
+  "/api/__debug/ping-application-links",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("debugPingApplicationLinks"),
+  (_req, res) => {
+    return res.json({ ok: true });
+  }
+);
 
 // API 404 handler
 app.use("/api", (_req, res) => {

--- a/rentchain-api/src/middleware/__tests__/diagnosticSurfaceGuard.test.ts
+++ b/rentchain-api/src/middleware/__tests__/diagnosticSurfaceGuard.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasInternalDiagnosticAccess,
+  isProductionDiagnosticRuntime,
+  requireDiagnosticAccess,
+  safeDiagnosticBuildMetadata,
+} from "../diagnosticSurfaceGuard";
+
+describe("diagnosticSurfaceGuard", () => {
+  it("detects production runtime deterministically", () => {
+    expect(isProductionDiagnosticRuntime({ NODE_ENV: "production" } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isProductionDiagnosticRuntime({ NODE_ENV: "test" } as NodeJS.ProcessEnv)).toBe(false);
+    expect(isProductionDiagnosticRuntime({ NODE_ENV: "" } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("requires the internal diagnostic token when one is configured", () => {
+    const req: any = { headers: { "x-internal-job-token": "secret-token" } };
+
+    expect(hasInternalDiagnosticAccess(req, { INTERNAL_JOB_TOKEN: "secret-token" } as NodeJS.ProcessEnv)).toBe(true);
+    expect(hasInternalDiagnosticAccess(req, { INTERNAL_JOB_TOKEN: "other-token" } as NodeJS.ProcessEnv)).toBe(false);
+    expect(hasInternalDiagnosticAccess(req, {} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("gates unsafe diagnostics in production without exposing internals", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalInternalToken = process.env.INTERNAL_JOB_TOKEN;
+    process.env.NODE_ENV = "production";
+    process.env.INTERNAL_JOB_TOKEN = "secret-token";
+
+    try {
+      const denied = invokeGuard({});
+      expect(denied.nextCalled).toBe(false);
+      expect(denied.statusCode).toBe(404);
+      expect(denied.headers["x-route-source"]).toBe("app.build.ts:/api/__debug/build");
+      expect(denied.body).toEqual({ ok: false, code: "NOT_FOUND", error: "Not Found" });
+      expect(JSON.stringify(denied.body)).not.toContain("visible");
+
+      const allowed = invokeGuard({ "x-internal-job-token": "secret-token" });
+      expect(allowed.nextCalled).toBe(true);
+      expect(allowed.statusCode).toBe(200);
+      expect(allowed.body).toBeUndefined();
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      if (originalInternalToken == null) delete process.env.INTERNAL_JOB_TOKEN;
+      else process.env.INTERNAL_JOB_TOKEN = originalInternalToken;
+    }
+  });
+
+  it("redacts exact build identifiers into safe presence metadata", () => {
+    const metadata = safeDiagnosticBuildMetadata({
+      K_SERVICE: "rentchain-landlord-api",
+      K_REVISION: "rentchain-landlord-api-00042-abc",
+      GIT_SHA: "abc123secret",
+    } as NodeJS.ProcessEnv);
+
+    expect(metadata).toEqual({
+      service: "rentchain-landlord-api",
+      revisionPresent: true,
+      commitPresent: true,
+    });
+    expect(JSON.stringify(metadata)).not.toContain("00042");
+    expect(JSON.stringify(metadata)).not.toContain("abc123secret");
+  });
+});
+
+function invokeGuard(headers: Record<string, string>) {
+  const req: any = { headers };
+  const result: {
+    statusCode: number;
+    headers: Record<string, unknown>;
+    body?: unknown;
+    nextCalled: boolean;
+  } = {
+    statusCode: 200,
+    headers: {},
+    nextCalled: false,
+  };
+  const res: any = {
+    setHeader(name: string, value: unknown) {
+      result.headers[String(name).toLowerCase()] = value;
+    },
+    status(code: number) {
+      result.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      result.body = payload;
+      return this;
+    },
+  };
+
+  requireDiagnosticAccess("app.build.ts:/api/__debug/build")(req, res, () => {
+    result.nextCalled = true;
+  });
+  return result;
+}

--- a/rentchain-api/src/middleware/diagnosticSurfaceGuard.ts
+++ b/rentchain-api/src/middleware/diagnosticSurfaceGuard.ts
@@ -1,0 +1,40 @@
+import type { NextFunction, Request, Response } from "express";
+
+function asString(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+export function isProductionDiagnosticRuntime(env: NodeJS.ProcessEnv = process.env): boolean {
+  return asString(env.NODE_ENV).toLowerCase() === "production";
+}
+
+export function hasInternalDiagnosticAccess(req: Request, env: NodeJS.ProcessEnv = process.env): boolean {
+  const expected = asString(env.INTERNAL_JOB_TOKEN);
+  if (!expected) return false;
+  const received =
+    asString(req.headers["x-internal-job-token"]) ||
+    asString(req.headers["x-internal-token"]);
+  return received === expected;
+}
+
+export function requireDiagnosticAccess(routeSourceLabel: string) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    res.setHeader("x-route-source", routeSourceLabel);
+    if (!isProductionDiagnosticRuntime() || hasInternalDiagnosticAccess(req)) return next();
+    return res.status(404).json({
+      ok: false,
+      code: "NOT_FOUND",
+      error: "Not Found",
+    });
+  };
+}
+
+export function safeDiagnosticBuildMetadata(env: NodeJS.ProcessEnv = process.env) {
+  const commit = asString(env.GIT_SHA) || asString(env.COMMIT_SHA) || asString(env.VERCEL_GIT_COMMIT_SHA);
+
+  return {
+    service: asString(env.K_SERVICE) || "rentchain-api",
+    revisionPresent: Boolean(asString(env.K_REVISION)),
+    commitPresent: Boolean(commit),
+  };
+}

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -3,6 +3,10 @@ import path from "path";
 import express from "express";
 import { describe, expect, it, vi } from "vitest";
 import { routeSource } from "../../middleware/routeSource";
+import {
+  requireDiagnosticAccess,
+  safeDiagnosticBuildMetadata,
+} from "../../middleware/diagnosticSurfaceGuard";
 
 const authState = vi.hoisted(() => ({
   user: null as any,
@@ -130,6 +134,10 @@ function appBuildSource() {
   return fs.readFileSync(path.resolve(__dirname, "../../app.build.ts"), "utf8");
 }
 
+function publicRoutesSource() {
+  return fs.readFileSync(path.resolve(__dirname, "../publicRoutes.ts"), "utf8");
+}
+
 async function invokeApp(
   app: any,
   options: {
@@ -216,12 +224,19 @@ async function buildRuntimeOwnershipApp() {
   app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
   app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
   app.get("/api/__probe/revision", routeSource("app.build.ts:/api/__probe/revision"), (_req, res) =>
-    res.json({ ok: true, revision: "test" })
+    res.json({
+      ok: true,
+      ...safeDiagnosticBuildMetadata({
+        K_SERVICE: "rentchain-api",
+        K_REVISION: "rev-1",
+        GIT_SHA: "sha-1",
+      } as NodeJS.ProcessEnv),
+    })
   );
-  app.get("/api/__debug/build", routeSource("app.build.ts:/api/__debug/build"), (_req, res) =>
+  app.get("/api/__debug/build", requireDiagnosticAccess("app.build.ts:/api/__debug/build"), (_req, res) =>
     res.json({ ok: true, routeCheck: { landlordApplicationLinksMounted: true } })
   );
-  app.post("/api/_echo", routeSource("app.build.ts:/api/_echo"), (req, res) =>
+  app.post("/api/_echo", requireDiagnosticAccess("app.build.ts:/api/_echo"), (req, res) =>
     res.json({ ok: true, method: "POST", body: req.body ?? null })
   );
   app.use("/api", (_req, res) => {
@@ -266,15 +281,25 @@ describe("API route ownership regression", () => {
     expect(screeningJobsMount).toBeLessThan(apiCatchall);
   });
 
-  it("documents intentionally reachable probe, debug, echo, and catchall route sources", () => {
+  it("documents public-safe probes, gated diagnostics, and catchall route sources", () => {
     const source = appBuildSource();
-    const echoRoutes = source.match(/app\.post\("\/api\/_echo"/g) || [];
+    const publicSource = publicRoutesSource();
+    const echoRoutes = source.match(/app\.post\(\s*"\/api\/_echo"/g) || [];
 
-    expect(source).toContain('app.get("/api/__probe/revision"');
-    expect(source).toContain('app.get("/api/__probe/routes"');
-    expect(source).toContain('app.get("/api/__debug/build"');
-    expect(source).toContain('app.get("/api/__debug/ping-application-links"');
-    expect(echoRoutes).toHaveLength(2);
+    expect(source).toMatch(/app\.get\(\s*"\/api\/__probe\/revision"/);
+    expect(source).toMatch(/app\.get\(\s*"\/api\/__probe\/routes"/);
+    expect(source).toMatch(/app\.get\(\s*"\/api\/__debug\/build"/);
+    expect(source).toMatch(/app\.get\(\s*"\/api\/__debug\/ping-application-links"/);
+    expect(source).toContain('safeDiagnosticBuildMetadata()');
+    expect(source).toContain('requireDiagnosticAccess("app.build.ts:/api/__routes")');
+    expect(source).toContain('requireDiagnosticAccess("app.build.ts:/api/__probe/routes")');
+    expect(source).toContain('requireDiagnosticAccess("app.build.ts:/api/_echo")');
+    expect(source).toContain('requireDiagnosticAccess("app.build.ts:/api/__debug/build")');
+    expect(source).toContain('requireDiagnosticAccess("debugPingApplicationLinks")');
+    expect(publicSource).toContain('requireDiagnosticAccess("publicRoutes.ts:/__probe/onboarding-route")');
+    expect(publicSource).toContain('requireDiagnosticAccess("publicRoutes.ts:/__probe/routes-lite")');
+    expect(publicSource).toContain("safeDiagnosticBuildMetadata()");
+    expect(echoRoutes).toHaveLength(1);
     expect(source).toContain('res.setHeader("x-route-source", "not-found")');
   });
 
@@ -340,25 +365,62 @@ describe("API route ownership regression", () => {
     expect(transunionRes.headers["x-route-source"]).toBe("transunionWebhookRoutes.ts");
   });
 
-  it("keeps probe/debug/echo exposure and API catchall deterministic", async () => {
-    const app = await buildRuntimeOwnershipApp();
+  it("keeps public-safe probes, gated diagnostics, and API catchall deterministic", async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalInternalToken = process.env.INTERNAL_JOB_TOKEN;
+    process.env.NODE_ENV = "production";
+    process.env.INTERNAL_JOB_TOKEN = "secret-token";
 
-    const revision = await invokeApp(app, { method: "GET", url: "/api/__probe/revision" });
-    expect(revision.status).toBe(200);
-    expect(revision.headers["x-route-source"]).toBe("app.build.ts:/api/__probe/revision");
+    try {
+      const app = await buildRuntimeOwnershipApp();
 
-    const debug = await invokeApp(app, { method: "GET", url: "/api/__debug/build" });
-    expect(debug.status).toBe(200);
-    expect(debug.headers["x-route-source"]).toBe("app.build.ts:/api/__debug/build");
+      const revision = await invokeApp(app, { method: "GET", url: "/api/__probe/revision" });
+      expect(revision.status).toBe(200);
+      expect(revision.headers["x-route-source"]).toBe("app.build.ts:/api/__probe/revision");
+      expect(revision.body).toMatchObject({
+        ok: true,
+        service: "rentchain-api",
+        revisionPresent: true,
+        commitPresent: true,
+      });
+      expect(JSON.stringify(revision.body)).not.toContain("rev-1");
+      expect(JSON.stringify(revision.body)).not.toContain("sha-1");
 
-    const echo = await invokeApp(app, { method: "POST", url: "/api/_echo", body: { ok: true } });
-    expect(echo.status).toBe(200);
-    expect(echo.headers["x-route-source"]).toBe("app.build.ts:/api/_echo");
-    expect(echo.body).toMatchObject({ ok: true, method: "POST", body: { ok: true } });
+      const debugDenied = await invokeApp(app, { method: "GET", url: "/api/__debug/build" });
+      expect(debugDenied.status).toBe(404);
+      expect(debugDenied.headers["x-route-source"]).toBe("app.build.ts:/api/__debug/build");
+      expect(debugDenied.body).toEqual({ ok: false, code: "NOT_FOUND", error: "Not Found" });
 
-    const missing = await invokeApp(app, { method: "GET", url: "/api/unknown-route" });
-    expect(missing.status).toBe(404);
-    expect(missing.headers["x-route-source"]).toBe("not-found");
-    expect(missing.body).toEqual({ ok: false, code: "NOT_FOUND", error: "Not Found" });
+      const echoDenied = await invokeApp(app, { method: "POST", url: "/api/_echo", body: { token: "secret" } });
+      expect(echoDenied.status).toBe(404);
+      expect(echoDenied.headers["x-route-source"]).toBe("app.build.ts:/api/_echo");
+      expect(JSON.stringify(echoDenied.body)).not.toContain("secret");
+
+      const debugAllowed = await invokeApp(app, {
+        method: "GET",
+        url: "/api/__debug/build",
+        headers: { "x-internal-job-token": "secret-token" },
+      });
+      expect(debugAllowed.status).toBe(200);
+      expect(debugAllowed.body).toMatchObject({ ok: true, routeCheck: { landlordApplicationLinksMounted: true } });
+
+      const echoAllowed = await invokeApp(app, {
+        method: "POST",
+        url: "/api/_echo",
+        body: { ok: true },
+        headers: { "x-internal-job-token": "secret-token" },
+      });
+      expect(echoAllowed.status).toBe(200);
+      expect(echoAllowed.body).toMatchObject({ ok: true, method: "POST", body: { ok: true } });
+
+      const missing = await invokeApp(app, { method: "GET", url: "/api/unknown-route" });
+      expect(missing.status).toBe(404);
+      expect(missing.headers["x-route-source"]).toBe("not-found");
+      expect(missing.body).toEqual({ ok: false, code: "NOT_FOUND", error: "Not Found" });
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      if (originalInternalToken == null) delete process.env.INTERNAL_JOB_TOKEN;
+      else process.env.INTERNAL_JOB_TOKEN = originalInternalToken;
+    }
   });
 });

--- a/rentchain-api/src/routes/publicRoutes.ts
+++ b/rentchain-api/src/routes/publicRoutes.ts
@@ -17,6 +17,10 @@ import { getBureauProvider } from "../services/screening/providers/bureauProvide
 import { getPricingHealth } from "../config/planMatrix";
 import { getEnvFlags } from "../config/requiredEnv";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
+import {
+  requireDiagnosticAccess,
+  safeDiagnosticBuildMetadata,
+} from "../middleware/diagnosticSurfaceGuard";
 
 const router = Router();
 
@@ -320,8 +324,7 @@ router.get("/__probe/version", (_req, res) => {
   res.json({
     ok: true,
     marker: "probe-v1",
-    commit: process.env.COMMIT_SHA || null,
-    ts: Date.now(),
+    ...safeDiagnosticBuildMetadata(),
   });
 });
 
@@ -329,17 +332,17 @@ router.get("/__probe/revision", (_req, res) => {
   res.setHeader("x-route-source", "publicRoutes.ts");
   res.json({
     ok: true,
-    service: "rentchain-landlord-api",
-    revision: process.env.K_REVISION || null,
-    commit: process.env.COMMIT_SHA || null,
-    ts: Date.now(),
+    ...safeDiagnosticBuildMetadata(),
   });
 });
 
-router.get("/__probe/onboarding-route", (_req, res) => {
-  res.setHeader("x-route-source", "publicRoutes.ts");
-  res.json({ ok: true, mounted: true });
-});
+router.get(
+  "/__probe/onboarding-route",
+  requireDiagnosticAccess("publicRoutes.ts:/__probe/onboarding-route"),
+  (_req, res) => {
+    res.json({ ok: true, mounted: true });
+  }
+);
 
 router.use("/onboarding", onboardingRoutes);
 
@@ -415,13 +418,16 @@ router.post("/notify-plan-interest", async (req: any, res) => {
   }
 });
 
-router.get("/__probe/routes-lite", (_req, res) => {
-  res.setHeader("x-route-source", "publicRoutes.ts");
-  return res.json({
-    ok: true,
-    routes: ["/__probe/version", "/tenants", "/tenants/:tenantId"],
-  });
-});
+router.get(
+  "/__probe/routes-lite",
+  requireDiagnosticAccess("publicRoutes.ts:/__probe/routes-lite"),
+  (_req, res) => {
+    return res.json({
+      ok: true,
+      routes: ["/__probe/version", "/tenants", "/tenants/:tenantId"],
+    });
+  }
+);
 
 router.get("/ready", (_req, res) => {
   res.setHeader("x-route-source", "publicRoutes.ts");


### PR DESCRIPTION
## Summary

- Adds a production diagnostic surface guard using the existing internal-token pattern for unsafe debug/probe/echo/route-inspection endpoints.
- Redacts public build/revision probes to safe presence metadata while preserving health/status observability.
- Removes the duplicate public _echo mount and updates route ownership regression coverage.
- Adds docs/reports/production-debug-surface-hardening-v1.md with surface inventory, gating rules, health/status rationale, and future hardening notes.

## Gated/redacted surfaces

Gated in production behind INTERNAL_JOB_TOKEN via x-internal-job-token or x-internal-token:
- /api/__routes
- /api/__probe/routes
- /api/__probe/tenants-mount
- /api/__debug/build
- /api/__debug/ping-application-links
- /api/_echo
- public route-lite/onboarding probes under publicRoutes.ts

Kept public and minimal/redacted:
- /health, /health/ready, /health/db, /health/version
- /api/status/public
- /api/__probe/version, /api/__probe/revision, /api/_build

## Validation

- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- apiRouteOwnershipRegression.test.ts diagnosticSurfaceGuard.test.ts
- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build
- git diff --check

## Guardrails

- No auth behavior changes.
- No Firestore rule/schema changes.
- No permission widening.
- No autonomous behavior.
- Deployment health/status checks are preserved.