### PR TITLE
feat: add consent governance timeline foundation

### DIFF
--- a/docs/reports/consent-governance-timeline-v1.md
+++ b/docs/reports/consent-governance-timeline-v1.md
@@ -1,0 +1,174 @@
+# Consent Governance Timeline v1
+
+## Executive summary
+
+This report establishes RentChain's first governed consent timeline foundation for screening/reporting consent, evidence-sharing consent, tenant trust export consent, institutional export consent, and future coordination workflows.
+
+The implementation is metadata-only. It introduces deterministic consent lifecycle semantics and a small helper for audit-safe consent timeline metadata. It does not change legal agreements, authentication, Firestore schema, Firestore rules, route visibility, export visibility, tenant visibility, or sharing behavior.
+
+## Consent philosophy
+
+Consent is a lifecycle-bound governance record, not a one-time boolean.
+
+Future consent-aware workflows should be able to answer:
+
+- what consent type was requested or granted
+- who requested it and who granted it
+- what landlord, tenant, lease, application, export, evidence, review, or institution scope applied
+- when it was requested, granted, revoked, expired, superseded, or denied
+- what evidence/export/review artifacts reference that consent
+- whether the consent state is tenant-visible or internal audit-only
+- whether the workflow is metadata-only and projection-safe
+
+Consent timelines must remain server-authority scoped and append/audit compatible. They should never copy raw provider payloads, export payloads, evidence payloads, privileged review internals, debug metadata, tokens, or private message content.
+
+## Lifecycle state definitions
+
+| State | Meaning | Notes |
+| --- | --- | --- |
+| `requested` | Consent has been requested but not granted or denied. | Default state when only request metadata exists. |
+| `granted` | Consent was affirmatively granted. | Useful as an event/action label; timeline helpers normalize active granted consent to `active`. |
+| `active` | Consent is currently effective for the recorded scope. | Requires granted metadata and no expiry/revocation/supersession/denial. |
+| `expiring` | Consent is active but close to expiry. | V1 helper treats consent expiring within 14 days as expiring. |
+| `expired` | Consent is no longer effective because its expiry timestamp has passed. | Should block future sharing/export unless renewed or superseded by new consent. |
+| `revoked` | Consent was withdrawn. | Revocation should preserve audit history and reason metadata where available. |
+| `superseded` | Consent was replaced by a newer consent record. | New consent should carry its own scope and lineage. |
+| `denied` | Requested consent was declined. | Do not treat as permission for sharing/export. |
+
+## Consent type definitions
+
+| Type | Current/future use |
+| --- | --- |
+| `screening_consent` | Tenant/applicant consent for screening/reporting workflows. |
+| `reporting_consent` | Consent linked to credit/reporting submission or status workflows. |
+| `evidence_sharing_consent` | Future consent basis for scoped evidence package sharing. |
+| `tenant_trust_export_consent` | Consent for tenant-controlled trust/export package portability. |
+| `institutional_export_consent` | Future consent basis for government, lender, insurer, subsidy, or institutional export workflows. |
+| `future_subsidy_coordination_consent` | Reserved governance language for subsidy/program coordination. |
+| `future_caseworker_coordination_consent` | Reserved governance language for caseworker or support-agency coordination. |
+
+## Metadata expectations
+
+V1 timeline metadata concepts:
+
+- `consentTimelineVersion`
+- `consentId`
+- `consentType`
+- `consentState`
+- `requestedAt`
+- `grantedAt`
+- `expiresAt`
+- `revokedAt`
+- `supersededAt`
+- `deniedAt`
+- `requestedBy`
+- `grantedBy`
+- `authorityScope`
+- `evidenceRefs`
+- `exportRefs`
+- `reviewRefs`
+- `sourceRefs`
+- `revocationReason`
+- `timelineSummary`
+- `tenantVisible`
+- `metadataOnly`
+
+Internal references are lineage metadata only. They are not primary display labels and do not authorize broader access.
+
+## Export, evidence, and review linkage guidance
+
+Consent linkage should remain reference-based:
+
+- evidence packages should reference consent lineage without copying consent payloads
+- institutional exports should record consent basis and consent reference IDs only through explicit export profiles
+- tenant trust exports should require active, scope-compatible consent before portability
+- review workspaces may reference consent timelines internally for operational context
+- tenant-visible projections must not expose privileged review internals
+
+Consent references should include source collection and source ID where practical. They should not include raw provider reports, raw screening/reporting payloads, raw CSV content, payment credentials, document bodies, message bodies, debug payloads, stack traces, route-source diagnostics, tokens, or secrets.
+
+## Expiration and revocation semantics
+
+Expiration and revocation are not destructive actions. They are lifecycle states that should preserve prior consent history while preventing future sharing/export that depends on now-invalid consent.
+
+Future runtime systems should:
+
+- treat revoked consent as higher priority than active/granted metadata
+- treat superseded consent as non-current unless the newer consent is active
+- treat expired consent as non-effective until renewed
+- preserve revocation reasons as metadata, not raw legal or support notes
+- avoid automatic revocation or renewal until a reviewed consent workflow exists
+
+## Tenant-safe visibility expectations
+
+Tenant-visible consent timeline projections may show:
+
+- consent type
+- lifecycle state
+- requested/granted/expiry/revocation timestamps where appropriate
+- safe status labels
+- export/evidence consent purpose summaries
+
+Tenant-visible projections must exclude:
+
+- privileged review internals
+- support/admin notes
+- raw provider/reporting/screening payloads
+- raw export or evidence payloads
+- unrelated landlord/tenant/resource references
+- internal IDs as primary display labels
+- route-source/debug/stack metadata
+
+## Future institutional coordination direction
+
+Institutional, subsidy, and caseworker coordination must not be built by broadening existing exports. Future workflows need:
+
+- explicit consent type and purpose
+- explicit recipient/audience class
+- authority-scoped source resources
+- tenant-safe projection rules
+- evidence/export profile alignment
+- audit event linkage
+- expiration and revocation handling
+- review workspace compatibility
+
+## Helper implemented
+
+`rentchain-api/src/lib/consentGovernance/consentTimeline.ts` adds metadata-only helpers:
+
+- `normalizeConsentType`
+- `classifyConsentState`
+- `normalizeConsentRefs`
+- `buildConsentAuditRef`
+- `normalizeConsentTimeline`
+
+The helper is intentionally not wired to routes or persistence. It normalizes consent semantics and scoped internal references for future consent-aware surfaces.
+
+## Known limitations
+
+- No legal-signature engine is introduced.
+- No external identity verification is introduced.
+- No automatic consent revocation exists.
+- No automatic renewal or expiration job exists.
+- No institution-facing sharing portal exists.
+- No public trust-sharing infrastructure exists.
+- No Firestore collection migration or persistence model is introduced.
+- Existing screening/reporting consent workflows remain unchanged.
+
+## Future roadmap
+
+1. Add consent-aware projection profiles for tenant trust exports.
+2. Add route-level assertions for consent metadata on screening/reporting status surfaces where safe.
+3. Add consent event adapters after canonical event runtime adapters are approved.
+4. Add revocation/expiry handling only through explicit manual workflows.
+5. Add institutional recipient/audience policy only after consent, export, and authority scopes are reviewed together.
+6. Add tenant-facing consent timeline UI only after tenant-safe projection rules are approved.
+
+## DO NOT IGNORE
+
+- Consent must not be treated as a global permission flag.
+- Tenant-visible consent status must not expose privileged review internals.
+- Institutional exports must remain consent-aware and allowlist-based before expansion.
+- Revoked, expired, superseded, or denied consent must not authorize sharing/export.
+- Consent metadata must not copy raw provider, export, evidence, payment, message, debug, token, or secret payloads.
+- This V1 foundation does not create legal guarantees or automated consent orchestration.

--- a/rentchain-api/src/lib/consentGovernance/__tests__/consentTimeline.test.ts
+++ b/rentchain-api/src/lib/consentGovernance/__tests__/consentTimeline.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildConsentAuditRef,
+  classifyConsentState,
+  CONSENT_TIMELINE_VERSION,
+  normalizeConsentTimeline,
+  normalizeConsentType,
+} from "../consentTimeline";
+
+describe("consent timeline governance", () => {
+  it("normalizes consent types and lifecycle states deterministically", () => {
+    expect(normalizeConsentType("Screening Consent")).toBe("screening_consent");
+    expect(normalizeConsentType("tenant-trust.export consent")).toBe("tenant_trust_export_consent");
+    expect(normalizeConsentType("unknown")).toBe("evidence_sharing_consent");
+
+    expect(classifyConsentState({ requestedAt: "2026-05-01T00:00:00.000Z" })).toBe("requested");
+    expect(classifyConsentState({ grantedAt: "2026-05-01T00:00:00.000Z" })).toBe("active");
+    expect(
+      classifyConsentState({
+        grantedAt: "2026-05-01T00:00:00.000Z",
+        expiresAt: "2026-05-10T00:00:00.000Z",
+        generatedAt: "2026-05-01T00:00:00.000Z",
+      }),
+    ).toBe("expiring");
+    expect(
+      classifyConsentState({
+        grantedAt: "2026-05-01T00:00:00.000Z",
+        expiresAt: "2026-05-01T00:00:00.000Z",
+        generatedAt: "2026-05-08T00:00:00.000Z",
+      }),
+    ).toBe("expired");
+    expect(classifyConsentState({ grantedAt: "2026-05-01T00:00:00.000Z", revokedAt: "2026-05-02T00:00:00.000Z" })).toBe("revoked");
+    expect(classifyConsentState({ grantedAt: "2026-05-01T00:00:00.000Z", supersededAt: "2026-05-02T00:00:00.000Z" })).toBe("superseded");
+    expect(classifyConsentState({ deniedAt: "2026-05-02T00:00:00.000Z" })).toBe("denied");
+  });
+
+  it("builds metadata-only consent timelines with scoped lineage references", () => {
+    const timeline = normalizeConsentTimeline({
+      consentId: "consent-1",
+      consentType: "institutional_export_consent",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      requestedAt: "2026-05-01T00:00:00.000Z",
+      grantedAt: "2026-05-02T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      grantedBy: "tenant-1",
+      requestedBy: "landlord-1",
+      authorityScope: {
+        scopeType: "export",
+        scopeId: "export-1",
+        authorityBasis: "server_resolved_tenant_export_scope",
+      },
+      evidenceRefs: [
+        { sourceCollection: "evidencePacks", sourceId: "evidence-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { sourceCollection: "evidencePacks", sourceId: "other-landlord", landlordId: "landlord-2", tenantId: "tenant-1" },
+      ],
+      exportRefs: [
+        { sourceCollection: "tenantTrustExports", sourceId: "export-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+      ],
+      reviewRefs: [
+        { sourceCollection: "operatorReviewSessions", sourceId: "review-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+      ],
+      sourceRefs: [
+        { sourceCollection: "reportingConsents", sourceId: "consent-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+      ],
+    });
+
+    expect(timeline).toMatchObject({
+      consentTimelineVersion: CONSENT_TIMELINE_VERSION,
+      consentId: "consent-1",
+      consentType: "institutional_export_consent",
+      consentState: "active",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      authorityScope: {
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        scopeType: "export",
+        scopeId: "export-1",
+        authorityBasis: "server_resolved_tenant_export_scope",
+      },
+      metadataOnly: true,
+      publicSharingEnabled: false,
+      externalSubmissionEnabled: false,
+      autonomousConsentActionsEnabled: false,
+      legalSignatureEngineEnabled: false,
+    });
+    expect(timeline.evidenceRefs).toHaveLength(1);
+    expect(timeline.exportRefs).toHaveLength(1);
+    expect(timeline.reviewRefs).toHaveLength(1);
+    expect(timeline.sourceRefs).toHaveLength(1);
+    expect(timeline.timelineSummary.refCounts).toEqual({ evidence: 1, export: 1, review: 1, source: 1 });
+    expect(timeline.evidenceRefs[0]).toEqual(
+      expect.objectContaining({
+        sourceCollection: "evidencePacks",
+        sourceId: "evidence-1",
+        internalReference: true,
+        tenantVisible: false,
+      }),
+    );
+    expect(JSON.stringify(timeline)).not.toContain("other-landlord");
+  });
+
+  it("keeps tenant-visible timelines free of privileged review internals", () => {
+    const timeline = normalizeConsentTimeline({
+      consentId: "consent-tenant-1",
+      consentType: "screening_consent",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      requestedAt: "2026-05-01T00:00:00.000Z",
+      tenantVisible: true,
+      reviewRefs: [
+        { sourceCollection: "operatorReviewSessions", sourceId: "review-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+      ],
+    });
+
+    expect(timeline.tenantVisible).toBe(true);
+    expect(timeline.reviewRefs).toEqual([]);
+    expect(timeline.privilegedReviewInternalsIncluded).toBe(false);
+    expect(JSON.stringify(timeline)).not.toContain("operatorReviewSessions");
+  });
+
+  it("does not copy restricted/raw payload fields into timeline metadata", () => {
+    const timeline = normalizeConsentTimeline({
+      consentId: "consent-raw-1",
+      consentType: "reporting_consent",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      grantedAt: "2026-05-02T00:00:00.000Z",
+      sourceRefs: [
+        {
+          sourceCollection: "reportingConsents",
+          sourceId: "consent-raw-1",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          rawProviderPayload: { token: "secret-token" },
+          rawExportPayload: "raw export",
+          stack: "stack trace",
+          routeSource: "debug",
+        },
+      ],
+    });
+
+    const serialized = JSON.stringify(timeline);
+    expect(timeline.rawProviderPayloadIncluded).toBe(false);
+    expect(timeline.rawExportPayloadIncluded).toBe(false);
+    expect(timeline.rawEvidencePayloadIncluded).toBe(false);
+    expect(serialized).not.toContain("secret-token");
+    expect(serialized).not.toContain("raw export");
+    expect(serialized).not.toContain("stack trace");
+    expect(serialized).not.toContain("routeSource");
+  });
+
+  it("builds consent audit refs as internal references only", () => {
+    expect(
+      buildConsentAuditRef({
+        sourceCollection: "reportingConsents",
+        sourceId: "consent-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+      }),
+    ).toEqual({
+      refType: "source",
+      sourceCollection: "reportingConsents",
+      sourceId: "consent-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      internalReference: true,
+      tenantVisible: false,
+    });
+  });
+});

--- a/rentchain-api/src/lib/consentGovernance/consentTimeline.ts
+++ b/rentchain-api/src/lib/consentGovernance/consentTimeline.ts
@@ -1,0 +1,329 @@
+export const CONSENT_TIMELINE_VERSION = "consent_governance_timeline_v1";
+
+export type ConsentTimelineType =
+  | "screening_consent"
+  | "reporting_consent"
+  | "evidence_sharing_consent"
+  | "tenant_trust_export_consent"
+  | "institutional_export_consent"
+  | "future_subsidy_coordination_consent"
+  | "future_caseworker_coordination_consent";
+
+export type ConsentTimelineState =
+  | "requested"
+  | "granted"
+  | "active"
+  | "expiring"
+  | "expired"
+  | "revoked"
+  | "superseded"
+  | "denied";
+
+export type ConsentTimelineSensitivityClass = "sensitive" | "restricted";
+
+export type ConsentTimelineAuthorityScope = {
+  landlordId: string | null;
+  tenantId: string | null;
+  scopeType: "tenant" | "lease" | "application" | "screening_order" | "export" | "evidence" | "review" | "future_institution";
+  scopeId: string | null;
+  authorityBasis: string;
+};
+
+export type ConsentTimelineRef = {
+  refType: "evidence" | "export" | "review" | "source";
+  sourceCollection: string;
+  sourceId: string;
+  landlordId: string | null;
+  tenantId: string | null;
+  internalReference: true;
+  tenantVisible: false;
+};
+
+export type ConsentTimeline = {
+  consentTimelineVersion: typeof CONSENT_TIMELINE_VERSION;
+  consentId: string;
+  consentType: ConsentTimelineType;
+  consentState: ConsentTimelineState;
+  landlordId: string;
+  tenantId: string | null;
+  grantedAt: string | null;
+  requestedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  supersededAt: string | null;
+  deniedAt: string | null;
+  grantedBy: string | null;
+  requestedBy: string | null;
+  authorityScope: ConsentTimelineAuthorityScope;
+  evidenceRefs: ConsentTimelineRef[];
+  exportRefs: ConsentTimelineRef[];
+  reviewRefs: ConsentTimelineRef[];
+  sourceRefs: ConsentTimelineRef[];
+  revocationReason: string | null;
+  timelineSummary: {
+    lifecycleLabel: string;
+    refCounts: {
+      evidence: number;
+      export: number;
+      review: number;
+      source: number;
+    };
+    expirationKnown: boolean;
+    revocationKnown: boolean;
+  };
+  tenantVisible: boolean;
+  metadataOnly: true;
+  sensitivityClass: ConsentTimelineSensitivityClass;
+  rawProviderPayloadIncluded: false;
+  rawExportPayloadIncluded: false;
+  rawEvidencePayloadIncluded: false;
+  privilegedReviewInternalsIncluded: false;
+  publicSharingEnabled: false;
+  externalSubmissionEnabled: false;
+  autonomousConsentActionsEnabled: false;
+  legalSignatureEngineEnabled: false;
+};
+
+type RefInput = Record<string, unknown>;
+
+const VALID_CONSENT_TYPES = new Set<ConsentTimelineType>([
+  "screening_consent",
+  "reporting_consent",
+  "evidence_sharing_consent",
+  "tenant_trust_export_consent",
+  "institutional_export_consent",
+  "future_subsidy_coordination_consent",
+  "future_caseworker_coordination_consent",
+]);
+
+const VALID_CONSENT_STATES = new Set<ConsentTimelineState>([
+  "requested",
+  "granted",
+  "active",
+  "expiring",
+  "expired",
+  "revoked",
+  "superseded",
+  "denied",
+]);
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function toIsoOrNull(value: unknown): string | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function toIso(value: unknown): string {
+  return toIsoOrNull(value) || new Date(0).toISOString();
+}
+
+function timestampAtOrBefore(value: string | null, generatedAt: string) {
+  if (!value) return false;
+  const candidate = Date.parse(value);
+  const now = Date.parse(generatedAt);
+  return Number.isFinite(candidate) && Number.isFinite(now) && candidate <= now;
+}
+
+function timestampWithinDays(value: string | null, generatedAt: string, days: number) {
+  if (!value) return false;
+  const candidate = Date.parse(value);
+  const now = Date.parse(generatedAt);
+  if (!Number.isFinite(candidate) || !Number.isFinite(now) || candidate <= now) return false;
+  return candidate - now <= days * 24 * 60 * 60 * 1000;
+}
+
+function uniqueSortedRefs(refs: ConsentTimelineRef[]): ConsentTimelineRef[] {
+  const byKey = new Map<string, ConsentTimelineRef>();
+  for (const ref of refs) {
+    byKey.set(`${ref.refType}:${ref.sourceCollection}:${ref.sourceId}`, ref);
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.refType}:${a.sourceCollection}:${a.sourceId}`.localeCompare(
+      `${b.refType}:${b.sourceCollection}:${b.sourceId}`,
+    ),
+  );
+}
+
+export function normalizeConsentType(value: unknown): ConsentTimelineType {
+  const normalized = normalizeKey(value);
+  return VALID_CONSENT_TYPES.has(normalized as ConsentTimelineType)
+    ? (normalized as ConsentTimelineType)
+    : "evidence_sharing_consent";
+}
+
+export function classifyConsentState(input: {
+  consentState?: unknown;
+  requestedAt?: unknown;
+  grantedAt?: unknown;
+  expiresAt?: unknown;
+  revokedAt?: unknown;
+  supersededAt?: unknown;
+  deniedAt?: unknown;
+  generatedAt?: unknown;
+}): ConsentTimelineState {
+  const generatedAt = toIso(input.generatedAt);
+  const requestedAt = toIsoOrNull(input.requestedAt);
+  const grantedAt = toIsoOrNull(input.grantedAt);
+  const expiresAt = toIsoOrNull(input.expiresAt);
+  const revokedAt = toIsoOrNull(input.revokedAt);
+  const supersededAt = toIsoOrNull(input.supersededAt);
+  const deniedAt = toIsoOrNull(input.deniedAt);
+  const explicitState = normalizeKey(input.consentState);
+
+  if (revokedAt || explicitState === "revoked") return "revoked";
+  if (supersededAt || explicitState === "superseded") return "superseded";
+  if (deniedAt || explicitState === "denied") return "denied";
+  if (timestampAtOrBefore(expiresAt, generatedAt) || explicitState === "expired") return "expired";
+  if (timestampWithinDays(expiresAt, generatedAt, 14) || explicitState === "expiring") return "expiring";
+  if (grantedAt && (explicitState === "granted" || explicitState === "active" || !explicitState)) return "active";
+  if (VALID_CONSENT_STATES.has(explicitState as ConsentTimelineState)) return explicitState as ConsentTimelineState;
+  if (requestedAt) return "requested";
+  return "requested";
+}
+
+export function normalizeConsentRefs(input: {
+  refs?: RefInput[] | null;
+  refType: ConsentTimelineRef["refType"];
+  landlordId: string;
+  tenantId?: string | null;
+}): ConsentTimelineRef[] {
+  const tenantScope = asString(input.tenantId) || null;
+  const refs = (input.refs || [])
+    .map((item) => {
+      const sourceCollection = asString(item.sourceCollection || item.collection, 120);
+      const sourceId = asString(item.sourceId || item.id || item.resourceId, 240);
+      const landlordId = asString(item.landlordId) || input.landlordId;
+      const tenantId = asString(item.tenantId) || null;
+      if (!sourceCollection || !sourceId || landlordId !== input.landlordId) return null;
+      if (tenantScope && tenantId && tenantId !== tenantScope) return null;
+      return {
+        refType: input.refType,
+        sourceCollection,
+        sourceId,
+        landlordId,
+        tenantId,
+        internalReference: true,
+        tenantVisible: false,
+      };
+    })
+    .filter(Boolean) as ConsentTimelineRef[];
+  return uniqueSortedRefs(refs);
+}
+
+export function buildConsentAuditRef(input: {
+  sourceCollection: string;
+  sourceId: string;
+  landlordId: string;
+  tenantId?: string | null;
+  refType?: ConsentTimelineRef["refType"] | null;
+}): ConsentTimelineRef {
+  return {
+    refType: input.refType || "source",
+    sourceCollection: asString(input.sourceCollection, 120) || "unknown",
+    sourceId: asString(input.sourceId, 240) || "unknown",
+    landlordId: asString(input.landlordId, 240) || "unknown",
+    tenantId: asString(input.tenantId, 240) || null,
+    internalReference: true,
+    tenantVisible: false,
+  };
+}
+
+export function normalizeConsentTimeline(input: {
+  consentId: string;
+  consentType?: unknown;
+  consentState?: unknown;
+  landlordId: string;
+  tenantId?: string | null;
+  requestedAt?: unknown;
+  grantedAt?: unknown;
+  expiresAt?: unknown;
+  revokedAt?: unknown;
+  supersededAt?: unknown;
+  deniedAt?: unknown;
+  grantedBy?: string | null;
+  requestedBy?: string | null;
+  authorityScope?: Partial<ConsentTimelineAuthorityScope> | null;
+  evidenceRefs?: RefInput[] | null;
+  exportRefs?: RefInput[] | null;
+  reviewRefs?: RefInput[] | null;
+  sourceRefs?: RefInput[] | null;
+  revocationReason?: string | null;
+  tenantVisible?: boolean | null;
+  sensitivityClass?: ConsentTimelineSensitivityClass | string | null;
+  generatedAt?: unknown;
+}): ConsentTimeline {
+  const landlordId = asString(input.landlordId, 240);
+  const tenantId = asString(input.tenantId, 240) || null;
+  const consentType = normalizeConsentType(input.consentType);
+  const consentState = classifyConsentState(input);
+  const tenantVisible = input.tenantVisible === true;
+  const evidenceRefs = normalizeConsentRefs({ refs: input.evidenceRefs, refType: "evidence", landlordId, tenantId });
+  const exportRefs = normalizeConsentRefs({ refs: input.exportRefs, refType: "export", landlordId, tenantId });
+  const reviewRefs = tenantVisible
+    ? []
+    : normalizeConsentRefs({ refs: input.reviewRefs, refType: "review", landlordId, tenantId });
+  const sourceRefs = normalizeConsentRefs({ refs: input.sourceRefs, refType: "source", landlordId, tenantId });
+  const authorityScope = input.authorityScope || {};
+  const sensitivityClass = input.sensitivityClass === "sensitive" ? "sensitive" : "restricted";
+
+  return {
+    consentTimelineVersion: CONSENT_TIMELINE_VERSION,
+    consentId: asString(input.consentId, 240) || "consent_unknown",
+    consentType,
+    consentState,
+    landlordId,
+    tenantId,
+    grantedAt: toIsoOrNull(input.grantedAt),
+    requestedAt: toIsoOrNull(input.requestedAt),
+    expiresAt: toIsoOrNull(input.expiresAt),
+    revokedAt: toIsoOrNull(input.revokedAt),
+    supersededAt: toIsoOrNull(input.supersededAt),
+    deniedAt: toIsoOrNull(input.deniedAt),
+    grantedBy: asString(input.grantedBy, 240) || null,
+    requestedBy: asString(input.requestedBy, 240) || null,
+    authorityScope: {
+      landlordId,
+      tenantId,
+      scopeType: authorityScope.scopeType || "tenant",
+      scopeId: asString(authorityScope.scopeId, 240) || tenantId,
+      authorityBasis: asString(authorityScope.authorityBasis, 240) || "server_resolved_scope",
+    },
+    evidenceRefs,
+    exportRefs,
+    reviewRefs,
+    sourceRefs,
+    revocationReason: asString(input.revocationReason, 500) || null,
+    timelineSummary: {
+      lifecycleLabel: consentState.replace(/_/g, " "),
+      refCounts: {
+        evidence: evidenceRefs.length,
+        export: exportRefs.length,
+        review: reviewRefs.length,
+        source: sourceRefs.length,
+      },
+      expirationKnown: Boolean(toIsoOrNull(input.expiresAt)),
+      revocationKnown: Boolean(toIsoOrNull(input.revokedAt)),
+    },
+    tenantVisible,
+    metadataOnly: true,
+    sensitivityClass,
+    rawProviderPayloadIncluded: false,
+    rawExportPayloadIncluded: false,
+    rawEvidencePayloadIncluded: false,
+    privilegedReviewInternalsIncluded: false,
+    publicSharingEnabled: false,
+    externalSubmissionEnabled: false,
+    autonomousConsentActionsEnabled: false,
+    legalSignatureEngineEnabled: false,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a metadata-only consent governance timeline helper for lifecycle classification, scoped consent refs, and audit-safe timeline metadata.
- Adds deterministic regression tests for consent state normalization, scoped refs, tenant-safe visibility, restricted-field exclusion, and internal audit refs.
- Adds docs/reports/consent-governance-timeline-v1.md with consent philosophy, lifecycle semantics, metadata expectations, export/evidence/review linkage guidance, known limitations, and future roadmap.

## Consent lifecycle summary

V1 documents and normalizes:
- requested
- granted
- active
- expiring
- expired
- revoked
- superseded
- denied

## Metadata concepts introduced

- consentTimelineVersion
- consentType / consentState
- requestedAt / grantedAt / expiresAt / revokedAt / supersededAt / deniedAt
- requestedBy / grantedBy
- authorityScope
- evidenceRefs / exportRefs / reviewRefs / sourceRefs
- tenantVisible
- metadataOnly
- autonomousConsentActionsEnabled: false
- publicSharingEnabled: false
- legalSignatureEngineEnabled: false

## Guardrails

- No routes changed.
- No Firestore schema/rule changes.
- No auth behavior changes.
- No visibility or permission widening.
- No autonomous consent behavior.
- No public sharing or institution-facing consent portal.
- No legal-signature automation.

## Validation

- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- consentTimeline.test.ts
- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build
- git diff --check