### PR TITLE
feat: add controlled agent routing readiness

### DIFF
--- a/docs/reports/controlled-agent-routing-readiness-v1.md
+++ b/docs/reports/controlled-agent-routing-readiness-v1.md
@@ -1,0 +1,161 @@
+# Controlled Agent Routing Readiness v1
+
+## Executive summary
+
+This report establishes RentChain's first controlled agent routing readiness foundation. It defines metadata and review semantics for future supervised operational assistance without enabling autonomous execution, AI provider calls, workflow mutation, auto-routing, auto-approval, or external agent runtimes.
+
+The implementation adds a deterministic metadata helper and tests. It does not change routes, auth, Firestore schema, Firestore rules, permissions, UI visibility, financial records, exports, evidence packs, reviews, consent records, or operational workflows.
+
+## Controlled routing philosophy
+
+Controlled agent routing must start as governance metadata, not automation.
+
+Future agent-assisted workflows may help operators summarize context, suggest manual routes, or prepare drafts for human review. They must not execute actions, approve decisions, mutate records, share data, or bypass server-side authority.
+
+Core principles:
+
+- human operators remain accountable for actions
+- landlord/admin scope must be server-authority resolved
+- source refs remain internal metadata
+- tenant-visible agent internals remain disabled
+- financial, legal, evidence/export, consent, credential, and admin/support actions require human review
+- autonomous execution remains explicitly disabled
+- future AI calls require separate approval, logging, redaction, and incident-response posture
+
+## Agent-readiness classes
+
+| Class | Meaning | Execution posture |
+| --- | --- | --- |
+| `not_agent_eligible` | Context is not metadata-only or lacks required governance shape. | No agent use. |
+| `summarize_only` | Safe internal metadata can be summarized for operators. | No execution. |
+| `suggest_route` | A manual routing suggestion may be surfaced when scoped refs exist. | Manual review only. |
+| `prepare_draft` | A draft may be prepared for later explicit approval. | Human approval required before any action. |
+| `requires_human_approval` | Human review is mandatory before even draft-like use expands. | Manual review only. |
+| `blocked` | Requested behavior is unsafe or autonomous. | Prohibited. |
+
+## Action risk classes
+
+| Risk class | Meaning | Baseline handling |
+| --- | --- | --- |
+| `informational` | Internal summary or status context. | Metadata-only summary allowed. |
+| `operational_metadata` | Routing/status/review metadata without mutation. | Manual routing suggestion may be allowed. |
+| `tenant_visible` | Any action or draft that may affect tenant-visible surfaces. | Explicit human approval required. |
+| `financial` | Payment, ledger, delinquency, billing, reconciliation, or obligation context. | Explicit human approval; no mutation. |
+| `legal_notice` | Lease notice, legal document, or regulated communication context. | Explicit human approval; no auto-send. |
+| `evidence_export` | Evidence pack, export, trust package, or institutional package context. | Explicit human approval and projection profile required. |
+| `consent_sensitive` | Consent, revocation, sharing, or coordination context. | Explicit human approval; no auto-consent. |
+| `credential_security` | Secrets, tokens, webhooks, incident security, or credential handling. | Admin approval required; no automated rotation. |
+| `admin_support` | Privileged admin/support context. | Admin/support review only. |
+| `prohibited_autonomous` | Any requested autonomous execution, approval, or resolution. | Blocked. |
+
+## Human approval model
+
+| Approval requirement | Meaning |
+| --- | --- |
+| `none_for_metadata_only` | Only safe informational summaries are permitted. |
+| `review_required` | Operator must review before acting. |
+| `explicit_approval_required` | Human must explicitly approve any draft, message, export, notice, or workflow action. |
+| `admin_approval_required` | Admin/support authority is required for privileged or credential/security contexts. |
+| `prohibited` | The action class is not allowed. |
+
+## Blocked action categories
+
+Always blocked in this foundation:
+
+- autonomous execution requests
+- auto-created reviews
+- auto-routed work
+- auto-approved decisions
+- auto-resolved decisions
+- financial mutation
+- lease/document/legal notice mutation
+- consent grant/revocation automation
+- public/institutional sharing automation
+- credential rotation or secret handling automation
+- tenant-visible agent internals
+- unrestricted raw/provider/debug/token payload handling
+
+## Routing metadata contract
+
+The V1 helper defines:
+
+- `controlledRoutingVersion`
+- `routingContextId`
+- `landlordId`
+- `tenantId`
+- `requestedAction`
+- `actionRiskClass`
+- `readinessClass`
+- `humanApprovalRequirement`
+- `reviewWorkspaceCompatible`
+- `manualHandoffOnly`
+- `sourceRefs`
+- `blockedReasons`
+- safety flags disabling execution, auto-routing, auto-approval, external AI providers, tenant-visible internals, and financial mutation
+
+This is not a Firestore schema and is not wired to runtime routes.
+
+## Review workspace handoff guidance
+
+Controlled routing readiness metadata may support future manual review handoff when:
+
+- source refs are scoped to the same landlord and tenant where applicable
+- action class is not prohibited
+- review workspace compatibility is true
+- explicit human approval is available for sensitive classes
+- evidence/export/consent references remain metadata-only
+
+Readiness metadata must not auto-create review workspaces. Existing review workspace foundations remain the manual coordination layer.
+
+## Consent, evidence, export, and incident linkage expectations
+
+Future agent-assisted routing must respect:
+
+- evidence projection profiles
+- institutional export allowlists
+- tenant-safe projection contracts
+- consent governance timeline semantics
+- security incident metadata boundaries
+- admin/support privileged access governance
+- structured logging redaction rules
+
+Agent readiness metadata may reference these artifacts by scoped internal refs only. It must not copy raw evidence payloads, raw exports, raw provider reports, consent payloads, incident internals, message bodies, tokens, secrets, debug payloads, or stack traces.
+
+## Helper implemented
+
+`rentchain-api/src/lib/controlledAgentRouting/controlledAgentRouting.ts` adds metadata-only helpers:
+
+- `classifyActionRisk`
+- `determineHumanApprovalRequirement`
+- `classifyAgentReadiness`
+- `normalizeControlledRoutingSourceRefs`
+- `buildControlledRoutingReadinessRef`
+- `normalizeControlledRoutingContext`
+
+## Known limitations
+
+- No agent runtime exists.
+- No AI provider calls exist.
+- No workflow mutation exists.
+- No production agent orchestration exists.
+- No route or UI is introduced.
+- No persistence model is introduced.
+- No automated approvals, routing, review creation, or resolutions exist.
+- No tenant-visible agent surface exists.
+
+## Future roadmap
+
+1. Add route-level assertions only if future supervised agent metadata is surfaced through an API.
+2. Add review-workspace handoff tests before any UI handoff controls are introduced.
+3. Add consent-aware and evidence-aware policy adapters before draft/export assistance expands.
+4. Add structured logging and incident telemetry only for reviewed, redacted agent metadata.
+5. Add AI-provider integration only after redaction, prompt governance, audit, and human approval controls are approved.
+6. Add tenant-facing explanations only through tenant-safe projection contracts and after explicit review.
+
+## DO NOT IGNORE
+
+- Controlled routing readiness is not agent execution.
+- Metadata-only summaries must not become autonomous routing.
+- Tenant-visible, financial, legal, evidence/export, consent-sensitive, credential/security, and admin/support actions require human review or admin review.
+- Source refs are internal references, not primary labels or permissions.
+- Future agent systems must remain authority-scoped, reviewable, auditable, and manually approved.

--- a/rentchain-api/src/lib/controlledAgentRouting/__tests__/controlledAgentRouting.test.ts
+++ b/rentchain-api/src/lib/controlledAgentRouting/__tests__/controlledAgentRouting.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildControlledRoutingReadinessRef,
+  classifyActionRisk,
+  classifyAgentReadiness,
+  CONTROLLED_AGENT_ROUTING_READINESS_VERSION,
+  determineHumanApprovalRequirement,
+  normalizeControlledRoutingContext,
+} from "../controlledAgentRouting";
+
+describe("controlled agent routing readiness", () => {
+  it("classifies action risk and human approval requirements deterministically", () => {
+    expect(classifyActionRisk("payment ledger adjustment")).toBe("financial");
+    expect(classifyActionRisk("legal notice draft")).toBe("legal_notice");
+    expect(classifyActionRisk("institutional export review")).toBe("evidence_export");
+    expect(classifyActionRisk("consent renewal")).toBe("consent_sensitive");
+    expect(classifyActionRisk("webhookSecret rotation")).toBe("credential_security");
+    expect(classifyActionRisk("admin support escalation")).toBe("admin_support");
+    expect(classifyActionRisk("route suggestion")).toBe("operational_metadata");
+    expect(classifyActionRisk("summary")).toBe("informational");
+
+    expect(determineHumanApprovalRequirement("informational")).toBe("none_for_metadata_only");
+    expect(determineHumanApprovalRequirement("operational_metadata")).toBe("review_required");
+    expect(determineHumanApprovalRequirement("tenant_visible")).toBe("explicit_approval_required");
+    expect(determineHumanApprovalRequirement("financial")).toBe("explicit_approval_required");
+    expect(determineHumanApprovalRequirement("credential_security")).toBe("admin_approval_required");
+    expect(determineHumanApprovalRequirement("prohibited_autonomous")).toBe("prohibited");
+  });
+
+  it("keeps metadata-only summaries non-executable", () => {
+    const context = normalizeControlledRoutingContext({
+      landlordId: "landlord-1",
+      requestedAction: "summarize operational context",
+      actionRiskClass: "informational",
+      metadataOnly: true,
+    });
+
+    expect(context).toMatchObject({
+      controlledRoutingVersion: CONTROLLED_AGENT_ROUTING_READINESS_VERSION,
+      readinessClass: "summarize_only",
+      humanApprovalRequirement: "none_for_metadata_only",
+      manualHandoffOnly: true,
+      noExecution: true,
+      autonomousExecutionEnabled: false,
+      externalAiProviderEnabled: false,
+    });
+  });
+
+  it("allows operational routing suggestions only as manual metadata with scoped refs", () => {
+    const context = normalizeControlledRoutingContext({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      requestedAction: "suggest_route",
+      actionRiskClass: "operational_metadata",
+      sourceRefs: [
+        { sourceCollection: "decisionActions", sourceId: "decision-1", landlordId: "landlord-1", tenantId: "tenant-1" },
+        { sourceCollection: "decisionActions", sourceId: "other-tenant", landlordId: "landlord-1", tenantId: "tenant-2" },
+        { sourceCollection: "decisionActions", sourceId: "other-landlord", landlordId: "landlord-2", tenantId: "tenant-1" },
+      ],
+    });
+
+    expect(context.readinessClass).toBe("suggest_route");
+    expect(context.humanApprovalRequirement).toBe("review_required");
+    expect(context.autoRouteEnabled).toBe(false);
+    expect(context.sourceRefs).toHaveLength(1);
+    expect(JSON.stringify(context)).not.toContain("other-tenant");
+    expect(JSON.stringify(context)).not.toContain("other-landlord");
+  });
+
+  it("requires human approval for financial, legal, evidence/export, and consent-sensitive drafts", () => {
+    for (const actionRiskClass of ["financial", "legal_notice", "evidence_export", "consent_sensitive"] as const) {
+      const context = normalizeControlledRoutingContext({
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        requestedAction: `${actionRiskClass}_draft`,
+        actionRiskClass,
+        explicitHumanApprovalAvailable: true,
+        sourceRefs: [{ sourceCollection: "operatorReviewSessions", sourceId: actionRiskClass, landlordId: "landlord-1", tenantId: "tenant-1" }],
+      });
+
+      expect(context.readinessClass).toBe("prepare_draft");
+      expect(context.humanApprovalRequirement).toBe("explicit_approval_required");
+      expect(context.autonomousExecutionEnabled).toBe(false);
+      expect(context.autoApprovalEnabled).toBe(false);
+      expect(context.financialMutationEnabled).toBe(false);
+    }
+  });
+
+  it("blocks autonomous execution requests and admin/security-sensitive internals", () => {
+    expect(
+      classifyAgentReadiness({
+        actionRiskClass: "operational_metadata",
+        metadataOnly: true,
+        requestedAutonomousExecution: true,
+      }),
+    ).toBe("blocked");
+
+    const credentialContext = normalizeControlledRoutingContext({
+      landlordId: "landlord-1",
+      requestedAction: "rotate token",
+      actionRiskClass: "credential_security",
+      sourceRefs: [
+        {
+          sourceCollection: "securityIncidents",
+          sourceId: "incident-1",
+          landlordId: "landlord-1",
+          rawProviderPayload: { token: "secret-token" },
+          debugPayload: "stack trace",
+        },
+      ],
+    });
+
+    expect(credentialContext.readinessClass).toBe("requires_human_approval");
+    expect(credentialContext.humanApprovalRequirement).toBe("admin_approval_required");
+    expect(credentialContext.blockedReasons).toContain("credential_security_requires_admin_review");
+    expect(credentialContext.tenantVisibleAgentInternals).toBe(false);
+    expect(JSON.stringify(credentialContext)).not.toContain("secret-token");
+    expect(JSON.stringify(credentialContext)).not.toContain("stack trace");
+  });
+
+  it("builds readiness source refs as internal references only", () => {
+    expect(
+      buildControlledRoutingReadinessRef({
+        sourceCollection: "operatorReviewSessions",
+        sourceId: "review-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+      }),
+    ).toEqual({
+      sourceCollection: "operatorReviewSessions",
+      sourceId: "review-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      internalReference: true,
+      tenantVisible: false,
+    });
+  });
+});

--- a/rentchain-api/src/lib/controlledAgentRouting/controlledAgentRouting.ts
+++ b/rentchain-api/src/lib/controlledAgentRouting/controlledAgentRouting.ts
@@ -1,0 +1,262 @@
+export const CONTROLLED_AGENT_ROUTING_READINESS_VERSION = "controlled_agent_routing_readiness_v1";
+
+export type AgentReadinessClass =
+  | "not_agent_eligible"
+  | "summarize_only"
+  | "suggest_route"
+  | "prepare_draft"
+  | "requires_human_approval"
+  | "blocked";
+
+export type AgentActionRiskClass =
+  | "informational"
+  | "operational_metadata"
+  | "tenant_visible"
+  | "financial"
+  | "legal_notice"
+  | "evidence_export"
+  | "consent_sensitive"
+  | "credential_security"
+  | "admin_support"
+  | "prohibited_autonomous";
+
+export type HumanApprovalRequirement =
+  | "none_for_metadata_only"
+  | "review_required"
+  | "explicit_approval_required"
+  | "admin_approval_required"
+  | "prohibited";
+
+export type ControlledRoutingSourceRef = {
+  sourceCollection: string;
+  sourceId: string;
+  landlordId: string | null;
+  tenantId: string | null;
+  internalReference: true;
+  tenantVisible: false;
+};
+
+export type ControlledRoutingContext = {
+  controlledRoutingVersion: typeof CONTROLLED_AGENT_ROUTING_READINESS_VERSION;
+  routingContextId: string;
+  landlordId: string;
+  tenantId: string | null;
+  requestedAction: string;
+  actionRiskClass: AgentActionRiskClass;
+  readinessClass: AgentReadinessClass;
+  humanApprovalRequirement: HumanApprovalRequirement;
+  reviewWorkspaceCompatible: boolean;
+  manualHandoffOnly: true;
+  sourceRefs: ControlledRoutingSourceRef[];
+  blockedReasons: string[];
+  governanceSummary: string;
+  metadataOnly: true;
+  noExecution: true;
+  autonomousExecutionEnabled: false;
+  autoRouteEnabled: false;
+  autoApprovalEnabled: false;
+  autoResolutionEnabled: false;
+  financialMutationEnabled: false;
+  tenantVisibleAgentInternals: false;
+  externalAiProviderEnabled: false;
+  restrictedPayloadIncluded: false;
+};
+
+const VALID_RISK_CLASSES = new Set<AgentActionRiskClass>([
+  "informational",
+  "operational_metadata",
+  "tenant_visible",
+  "financial",
+  "legal_notice",
+  "evidence_export",
+  "consent_sensitive",
+  "credential_security",
+  "admin_support",
+  "prohibited_autonomous",
+]);
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 160).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function uniqueSortedRefs(refs: ControlledRoutingSourceRef[]): ControlledRoutingSourceRef[] {
+  const byKey = new Map<string, ControlledRoutingSourceRef>();
+  for (const ref of refs) byKey.set(`${ref.sourceCollection}:${ref.sourceId}`, ref);
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}`.localeCompare(`${b.sourceCollection}:${b.sourceId}`),
+  );
+}
+
+export function classifyActionRisk(value: unknown): AgentActionRiskClass {
+  const normalized = normalizeKey(value);
+  if (VALID_RISK_CLASSES.has(normalized as AgentActionRiskClass)) return normalized as AgentActionRiskClass;
+  if (normalized.includes("payment") || normalized.includes("ledger") || normalized.includes("financial")) return "financial";
+  if (normalized.includes("lease_notice") || normalized.includes("legal")) return "legal_notice";
+  if (normalized.includes("evidence") || normalized.includes("export")) return "evidence_export";
+  if (normalized.includes("consent")) return "consent_sensitive";
+  if (normalized.includes("credential") || normalized.includes("secret") || normalized.includes("token")) return "credential_security";
+  if (normalized.includes("admin") || normalized.includes("support")) return "admin_support";
+  if (normalized.includes("tenant_visible") || normalized.includes("tenant")) return "tenant_visible";
+  if (normalized.includes("route") || normalized.includes("workflow") || normalized.includes("assignment")) {
+    return "operational_metadata";
+  }
+  return "informational";
+}
+
+export function determineHumanApprovalRequirement(riskClass: AgentActionRiskClass): HumanApprovalRequirement {
+  if (riskClass === "informational") return "none_for_metadata_only";
+  if (riskClass === "operational_metadata") return "review_required";
+  if (riskClass === "tenant_visible" || riskClass === "financial" || riskClass === "legal_notice") {
+    return "explicit_approval_required";
+  }
+  if (riskClass === "admin_support" || riskClass === "credential_security") return "admin_approval_required";
+  if (riskClass === "prohibited_autonomous") return "prohibited";
+  return "explicit_approval_required";
+}
+
+export function classifyAgentReadiness(input: {
+  actionRiskClass: AgentActionRiskClass;
+  metadataOnly?: boolean | null;
+  hasScopedSourceRefs?: boolean | null;
+  reviewWorkspaceCompatible?: boolean | null;
+  explicitHumanApprovalAvailable?: boolean | null;
+  requestedAutonomousExecution?: boolean | null;
+}): AgentReadinessClass {
+  if (input.requestedAutonomousExecution) return "blocked";
+  if (input.actionRiskClass === "prohibited_autonomous") return "blocked";
+  if (input.actionRiskClass === "credential_security" || input.actionRiskClass === "admin_support") {
+    return "requires_human_approval";
+  }
+  if (!input.metadataOnly) return "not_agent_eligible";
+  if (input.actionRiskClass === "informational") return "summarize_only";
+  if (input.actionRiskClass === "operational_metadata" && input.hasScopedSourceRefs) return "suggest_route";
+  if (
+    (input.actionRiskClass === "tenant_visible" ||
+      input.actionRiskClass === "financial" ||
+      input.actionRiskClass === "legal_notice" ||
+      input.actionRiskClass === "evidence_export" ||
+      input.actionRiskClass === "consent_sensitive") &&
+    input.reviewWorkspaceCompatible &&
+    input.explicitHumanApprovalAvailable
+  ) {
+    return "prepare_draft";
+  }
+  return "requires_human_approval";
+}
+
+export function normalizeControlledRoutingSourceRefs(input: {
+  refs?: Array<Record<string, unknown>> | null;
+  landlordId: string;
+  tenantId?: string | null;
+}): ControlledRoutingSourceRef[] {
+  const tenantScope = asString(input.tenantId) || null;
+  const refs = (input.refs || [])
+    .map((item) => {
+      const sourceCollection = asString(item.sourceCollection || item.collection, 120);
+      const sourceId = asString(item.sourceId || item.id || item.resourceId, 240);
+      const landlordId = asString(item.landlordId) || input.landlordId;
+      const tenantId = asString(item.tenantId) || null;
+      if (!sourceCollection || !sourceId || landlordId !== input.landlordId) return null;
+      if (tenantScope && tenantId && tenantId !== tenantScope) return null;
+      return {
+        sourceCollection,
+        sourceId,
+        landlordId,
+        tenantId,
+        internalReference: true,
+        tenantVisible: false,
+      };
+    })
+    .filter(Boolean) as ControlledRoutingSourceRef[];
+  return uniqueSortedRefs(refs);
+}
+
+export function buildControlledRoutingReadinessRef(input: {
+  sourceCollection: string;
+  sourceId: string;
+  landlordId: string;
+  tenantId?: string | null;
+}): ControlledRoutingSourceRef {
+  return {
+    sourceCollection: asString(input.sourceCollection, 120) || "unknown",
+    sourceId: asString(input.sourceId, 240) || "unknown",
+    landlordId: asString(input.landlordId, 240) || "unknown",
+    tenantId: asString(input.tenantId, 240) || null,
+    internalReference: true,
+    tenantVisible: false,
+  };
+}
+
+export function normalizeControlledRoutingContext(input: {
+  routingContextId?: string | null;
+  landlordId: string;
+  tenantId?: string | null;
+  requestedAction: string;
+  actionRiskClass?: unknown;
+  metadataOnly?: boolean | null;
+  reviewWorkspaceCompatible?: boolean | null;
+  explicitHumanApprovalAvailable?: boolean | null;
+  requestedAutonomousExecution?: boolean | null;
+  sourceRefs?: Array<Record<string, unknown>> | null;
+}): ControlledRoutingContext {
+  const landlordId = asString(input.landlordId, 240);
+  const tenantId = asString(input.tenantId, 240) || null;
+  const requestedAction = asString(input.requestedAction, 160) || "summarize_context";
+  const actionRiskClass = classifyActionRisk(input.actionRiskClass || requestedAction);
+  const sourceRefs = normalizeControlledRoutingSourceRefs({ refs: input.sourceRefs, landlordId, tenantId });
+  const approval = determineHumanApprovalRequirement(actionRiskClass);
+  const reviewWorkspaceCompatible = input.reviewWorkspaceCompatible !== false;
+  const metadataOnly = input.metadataOnly !== false;
+  const readinessClass = classifyAgentReadiness({
+    actionRiskClass,
+    metadataOnly,
+    hasScopedSourceRefs: sourceRefs.length > 0,
+    reviewWorkspaceCompatible,
+    explicitHumanApprovalAvailable: input.explicitHumanApprovalAvailable === true,
+    requestedAutonomousExecution: input.requestedAutonomousExecution === true,
+  });
+  const blockedReasons: string[] = [];
+  if (input.requestedAutonomousExecution) blockedReasons.push("autonomous_execution_requested");
+  if (!metadataOnly) blockedReasons.push("non_metadata_payload_requested");
+  if (approval === "prohibited") blockedReasons.push("prohibited_action_risk");
+  if (actionRiskClass === "credential_security") blockedReasons.push("credential_security_requires_admin_review");
+  if (actionRiskClass === "admin_support") blockedReasons.push("admin_support_requires_privileged_review");
+
+  return {
+    controlledRoutingVersion: CONTROLLED_AGENT_ROUTING_READINESS_VERSION,
+    routingContextId: cleanId(input.routingContextId || `controlled_agent_routing:${landlordId}:${requestedAction}`) || "controlled_agent_routing",
+    landlordId,
+    tenantId,
+    requestedAction,
+    actionRiskClass,
+    readinessClass,
+    humanApprovalRequirement: approval,
+    reviewWorkspaceCompatible,
+    manualHandoffOnly: true,
+    sourceRefs,
+    blockedReasons,
+    governanceSummary: `${requestedAction.replace(/_/g, " ")} is classified as ${readinessClass.replace(/_/g, " ")} with ${approval.replace(/_/g, " ")}.`,
+    metadataOnly: true,
+    noExecution: true,
+    autonomousExecutionEnabled: false,
+    autoRouteEnabled: false,
+    autoApprovalEnabled: false,
+    autoResolutionEnabled: false,
+    financialMutationEnabled: false,
+    tenantVisibleAgentInternals: false,
+    externalAiProviderEnabled: false,
+    restrictedPayloadIncluded: false,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a metadata-only controlled agent routing readiness helper for action risk classification, human approval requirements, readiness classes, and scoped internal source refs.
- Adds deterministic tests proving metadata-only summaries stay non-executable, tenant/financial/legal/evidence/export/consent-sensitive actions require human approval, and credential/admin-support contexts require privileged review.
- Adds docs/reports/controlled-agent-routing-readiness-v1.md documenting controlled routing philosophy, risk classes, approval model, blocked action categories, review workspace handoff guidance, and future roadmap.

## Readiness model

Readiness classes:
- not_agent_eligible
- summarize_only
- suggest_route
- prepare_draft
- requires_human_approval
- blocked

## Risk/approval model

Action risk classes:
- informational
- operational_metadata
- tenant_visible
- financial
- legal_notice
- evidence_export
- consent_sensitive
- credential_security
- admin_support
- prohibited_autonomous

Approval requirements:
- none_for_metadata_only
- review_required
- explicit_approval_required
- admin_approval_required
- prohibited

## Guardrails

- No routes changed.
- No auth/schema/Firestore rule changes.
- No permission or visibility widening.
- No AI provider calls.
- No agent runtime.
- No autonomous execution, auto-routing, auto-approval, auto-resolution, or financial mutation.

## Validation

- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- controlledAgentRouting.test.ts
- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build
- git diff --check