### PR TITLE
fix: refresh lease document signed urls

### DIFF
--- a/docs/reports/lease-document-signed-url-refresh-v1.md
+++ b/docs/reports/lease-document-signed-url-refresh-v1.md
@@ -14,6 +14,7 @@ No storage migration, Firestore rule change, public bucket access, auth rewrite,
 | Landlord active lease list | Shows `documentUrl` directly when available. | Storage-backed responses refresh the URL on load; the UI also calls a scoped refresh endpoint before opening a document. |
 | Tenant lease workspace | Shows tenant-safe `leaseDocumentContext.documentUrl`. | Storage-backed lease/attachment context refreshes the URL server-side; tenant UI calls a scoped refresh endpoint before opening. |
 | Legacy URL-only records | May only have an already-signed URL and no explicit storage reference. | Legacy GCS signed URLs are parsed into internal bucket/path refs and refreshed; non-GCS legacy URLs remain a compatibility fallback when no storage metadata can be derived. |
+| Email-linked tenant lease records | Some legacy leases can be linked by tenant email before canonical tenant ID fields are complete. | Tenant workspace resolution can derive a tenant-safe lease document context from an exact authenticated tenant email match without broadening access. |
 | Unit reconciliation documents | Existing unit `leaseDocument` signed URL hydration remains unchanged. | Future follow-up can apply the same explicit click-refresh pattern if needed. |
 
 ## Signed URL Governance
@@ -22,6 +23,7 @@ No storage migration, Firestore rule change, public bucket access, auth rewrite,
 - Permanent public URLs are not introduced.
 - Raw storage paths are internal metadata only, not primary UI labels.
 - Stale persisted signed URLs are not reused when explicit storage metadata or a parseable GCS signed URL is available.
+- App-domain `/leases/...pdf` paths are not used as document fallbacks.
 - Authorized viewers refresh through backend mediation:
   - landlord: `GET /api/leases/:leaseId/document-url`
   - tenant workspace: `GET /api/tenant/lease/document-url`
@@ -51,8 +53,10 @@ These fields are governance references for refresh and lineage. They are not dis
 - Landlord explicit document refresh endpoint returns a fresh signed URL and marks storage refs as internal references.
 - Tenant lease document refresh endpoint returns a tenant-scoped refreshed URL and does not leak the stale persisted URL.
 - Legacy persisted GCS signed URLs refresh through parsed internal storage refs instead of reopening expired URLs.
+- Email-linked active tenant leases can produce tenant-safe document context when the authenticated tenant email exactly matches the lease email.
 - Frontend landlord lease document action calls the refresh endpoint before opening.
 - Frontend tenant lease document action calls the refresh endpoint before opening.
+- Frontend document actions do not open stale GCS or app-domain PDF fallbacks when refresh fails; they surface a regeneration-needed message instead.
 - Lease summary export action is labelled `Print / Save PDF`.
 - Property unit occupancy links tenant names to tenant profiles while keeping lease links as explicit `View lease` actions.
 

--- a/docs/reports/lease-document-signed-url-refresh-v1.md
+++ b/docs/reports/lease-document-signed-url-refresh-v1.md
@@ -13,7 +13,7 @@ No storage migration, Firestore rule change, public bucket access, auth rewrite,
 | Lease/Schedule A generation | Generates a PDF, uploads to GCS when configured, and stores a signed URL in lease/workspace records. | Newly linked generated PDFs also retain internal `bucket`/`path` metadata for future refresh. |
 | Landlord active lease list | Shows `documentUrl` directly when available. | Storage-backed responses refresh the URL on load; the UI also calls a scoped refresh endpoint before opening a document. |
 | Tenant lease workspace | Shows tenant-safe `leaseDocumentContext.documentUrl`. | Storage-backed lease/attachment context refreshes the URL server-side; tenant UI calls a scoped refresh endpoint before opening. |
-| Legacy URL-only records | May only have an already-signed URL and no storage reference. | Preserved as legacy fallback; not made public or rewritten. |
+| Legacy URL-only records | May only have an already-signed URL and no explicit storage reference. | Legacy GCS signed URLs are parsed into internal bucket/path refs and refreshed; non-GCS legacy URLs remain a compatibility fallback when no storage metadata can be derived. |
 | Unit reconciliation documents | Existing unit `leaseDocument` signed URL hydration remains unchanged. | Future follow-up can apply the same explicit click-refresh pattern if needed. |
 
 ## Signed URL Governance
@@ -21,6 +21,7 @@ No storage migration, Firestore rule change, public bucket access, auth rewrite,
 - Signed URLs remain time-limited.
 - Permanent public URLs are not introduced.
 - Raw storage paths are internal metadata only, not primary UI labels.
+- Stale persisted signed URLs are not reused when explicit storage metadata or a parseable GCS signed URL is available.
 - Authorized viewers refresh through backend mediation:
   - landlord: `GET /api/leases/:leaseId/document-url`
   - tenant workspace: `GET /api/tenant/lease/document-url`
@@ -49,12 +50,15 @@ These fields are governance references for refresh and lineage. They are not dis
 - Landlord active lease route refreshes storage-backed document URLs instead of returning stale signed URLs.
 - Landlord explicit document refresh endpoint returns a fresh signed URL and marks storage refs as internal references.
 - Tenant lease document refresh endpoint returns a tenant-scoped refreshed URL and does not leak the stale persisted URL.
+- Legacy persisted GCS signed URLs refresh through parsed internal storage refs instead of reopening expired URLs.
 - Frontend landlord lease document action calls the refresh endpoint before opening.
 - Frontend tenant lease document action calls the refresh endpoint before opening.
+- Lease summary export action is labelled `Print / Save PDF`.
+- Property unit occupancy links tenant names to tenant profiles while keeping lease links as explicit `View lease` actions.
 
 ## Known Limitations
 
-- Legacy records with only a persisted signed URL and no storage metadata can only fall back to that URL. A future metadata backfill is needed if those records must become refreshable without regeneration.
+- Legacy records with a parseable GCS signed URL can refresh without a metadata backfill. Legacy non-GCS URLs with no storage metadata still use compatibility fallback behavior.
 - Unit reconciliation document links still rely on response-time signed URL hydration and do not yet have a dedicated click-refresh endpoint.
 - Evidence/export document refresh can reuse the same pattern in future missions, but this PR keeps scope to lease document continuity.
 

--- a/docs/reports/lease-document-signed-url-refresh-v1.md
+++ b/docs/reports/lease-document-signed-url-refresh-v1.md
@@ -1,0 +1,66 @@
+# Lease Document Signed URL Refresh v1
+
+## Executive Summary
+
+This stabilization pass keeps lease documents private while making signed URL access refresh-safe for authorized landlord and tenant flows. Generated lease PDFs remain stored in Google Cloud Storage with time-limited signed URLs; RentChain now preserves internal storage references as metadata and can mint a fresh signed URL through scoped backend routes instead of relying only on stale persisted URLs.
+
+No storage migration, Firestore rule change, public bucket access, auth rewrite, or document visibility expansion is introduced.
+
+## Current Model Audited
+
+| Surface | Current behavior | Stabilization outcome |
+| --- | --- | --- |
+| Lease/Schedule A generation | Generates a PDF, uploads to GCS when configured, and stores a signed URL in lease/workspace records. | Newly linked generated PDFs also retain internal `bucket`/`path` metadata for future refresh. |
+| Landlord active lease list | Shows `documentUrl` directly when available. | Storage-backed responses refresh the URL on load; the UI also calls a scoped refresh endpoint before opening a document. |
+| Tenant lease workspace | Shows tenant-safe `leaseDocumentContext.documentUrl`. | Storage-backed lease/attachment context refreshes the URL server-side; tenant UI calls a scoped refresh endpoint before opening. |
+| Legacy URL-only records | May only have an already-signed URL and no storage reference. | Preserved as legacy fallback; not made public or rewritten. |
+| Unit reconciliation documents | Existing unit `leaseDocument` signed URL hydration remains unchanged. | Future follow-up can apply the same explicit click-refresh pattern if needed. |
+
+## Signed URL Governance
+
+- Signed URLs remain time-limited.
+- Permanent public URLs are not introduced.
+- Raw storage paths are internal metadata only, not primary UI labels.
+- Authorized viewers refresh through backend mediation:
+  - landlord: `GET /api/leases/:leaseId/document-url`
+  - tenant workspace: `GET /api/tenant/lease/document-url`
+- Refresh routes preserve existing authority boundaries:
+  - landlord route requires `requireLandlord`, lease capability, and landlord-scoped lease lookup.
+  - tenant route requires tenant workspace identity and verifies the lease belongs to the tenant.
+
+## Metadata Added
+
+Generated lease PDFs now retain internal metadata where available:
+
+- `leaseDocument.bucket`
+- `leaseDocument.path`
+- `leaseDocument.fileName`
+- `leaseDocument.contentType`
+- `leaseDocument.source`
+- `leaseDocument.signedUrlExpiresAt`
+- tenant ledger attachment `storageBucket`
+- tenant ledger attachment `storagePath`
+- tenant ledger attachment `signedUrlExpiresAt`
+
+These fields are governance references for refresh and lineage. They are not display labels and are not public URLs.
+
+## Tests Added
+
+- Landlord active lease route refreshes storage-backed document URLs instead of returning stale signed URLs.
+- Landlord explicit document refresh endpoint returns a fresh signed URL and marks storage refs as internal references.
+- Tenant lease document refresh endpoint returns a tenant-scoped refreshed URL and does not leak the stale persisted URL.
+- Frontend landlord lease document action calls the refresh endpoint before opening.
+- Frontend tenant lease document action calls the refresh endpoint before opening.
+
+## Known Limitations
+
+- Legacy records with only a persisted signed URL and no storage metadata can only fall back to that URL. A future metadata backfill is needed if those records must become refreshable without regeneration.
+- Unit reconciliation document links still rely on response-time signed URL hydration and do not yet have a dedicated click-refresh endpoint.
+- Evidence/export document refresh can reuse the same pattern in future missions, but this PR keeps scope to lease document continuity.
+
+## Future Follow-Ups
+
+1. Backfill storage metadata for legacy lease records where the GCS object path can be derived safely.
+2. Add equivalent refresh endpoints for evidence and export documents after their access flows are reviewed.
+3. Add optional UI messaging for legacy URL-only documents when refresh metadata is unavailable.
+4. Review unit reconciliation document links for the same click-time refresh pattern.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import { authenticateJwt } from "./middleware/authMiddleware";
+import { requireLandlord } from "./middleware/requireLandlord";
 import { routeSource } from "./middleware/routeSource";
 import {
   requireDiagnosticAccess,
@@ -25,7 +26,7 @@ import authRoutes from "./routes/authRoutes";
 import paymentsRoutes, { handlePaymentEdit, paymentsEditRouter } from "./routes/paymentsRoutes";
 import applicationsRoutes from "./routes/applicationsRoutes";
 import applicationsConversionRoutes from "./routes/applicationsConversionRoutes";
-import leaseRoutes from "./routes/leaseRoutes";
+import leaseRoutes, { handleLeaseDocumentUrl } from "./routes/leaseRoutes";
 import tenantOnboardRoutes from "./routes/tenantOnboardRoutes";
 import eventsRoutes from "./routes/eventsRoutes";
 import dashboardRoutes from "./routes/dashboardRoutes";
@@ -442,6 +443,7 @@ app.get("/api/me", async (req: any, res: any, next: any) => {
 // Core prefixed APIs must mount before broad /api routers.
 app.use("/api/compliance", routeSource("complianceRoutes.ts"), complianceRoutes);
 app.use("/api/decisions", routeSource("decisionRoutes.ts"), decisionRoutes);
+app.get("/api/leases/:leaseId/document-url", routeSource("leaseRoutes.ts"), requireLandlord, handleLeaseDocumentUrl);
 app.use("/api/leases", routeSource("leaseRoutes.ts"), leaseRoutes);
 app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes);
 app.use("/api", routeSource("tenanciesRoutes.ts"), tenanciesRoutes);

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -211,15 +211,19 @@ async function invokeApp(
 }
 
 async function buildRuntimeOwnershipApp() {
+  const { requireLandlord } = await import("../../middleware/requireLandlord");
+  const { handleLeaseDocumentUrl } = await import("../leaseRoutes");
   const messagesRoutes = (await import("../messagesRoutes")).default;
   const landlordEvidencePackRoutes = (await import("../landlordEvidencePackRoutes")).default;
   const internalReportsRoutes = (await import("../internalReportsRoutes")).default;
+  const screeningJobsAdminRoutes = (await import("../screeningJobsAdminRoutes")).default;
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
 
   const app = express();
   app.post("/api/webhooks/stripe", routeSource("stripeScreeningOrdersWebhookRoutes.ts"), stripeWebhookHandler);
   app.post("/api/webhooks/transunion", routeSource("transunionWebhookRoutes.ts"), transunionWebhookHandler);
+  app.get("/api/leases/:leaseId/document-url", routeSource("leaseRoutes.ts"), requireLandlord, handleLeaseDocumentUrl);
   app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
   app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
   app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
@@ -239,6 +243,7 @@ async function buildRuntimeOwnershipApp() {
   app.post("/api/_echo", requireDiagnosticAccess("app.build.ts:/api/_echo"), (req, res) =>
     res.json({ ok: true, method: "POST", body: req.body ?? null })
   );
+  app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes);
   app.use("/api", (_req, res) => {
     res.setHeader("x-route-source", "not-found");
     return res.status(404).json({ ok: false, code: "NOT_FOUND", error: "Not Found" });
@@ -263,6 +268,9 @@ describe("API route ownership regression", () => {
     const source = appBuildSource();
     const ledgerMount = source.indexOf('app.use("/api/ledger", routeSource("ledgerRoutes.ts"), ledgerRoutes)');
     const decisionsMount = source.indexOf('app.use("/api/decisions", routeSource("decisionRoutes.ts"), decisionRoutes)');
+    const leaseDocumentUrlRoute = source.indexOf(
+      'app.get("/api/leases/:leaseId/document-url", routeSource("leaseRoutes.ts"), requireLandlord, handleLeaseDocumentUrl)'
+    );
     const leasesMount = source.indexOf('app.use("/api/leases", routeSource("leaseRoutes.ts"), leaseRoutes)');
     const tenantsMount = source.indexOf('app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes)');
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
@@ -270,12 +278,14 @@ describe("API route ownership regression", () => {
 
     expect(ledgerMount).toBeGreaterThan(-1);
     expect(decisionsMount).toBeGreaterThan(-1);
+    expect(leaseDocumentUrlRoute).toBeGreaterThan(-1);
     expect(leasesMount).toBeGreaterThan(-1);
     expect(tenantsMount).toBeGreaterThan(-1);
     expect(screeningJobsMount).toBeGreaterThan(-1);
     expect(apiCatchall).toBeGreaterThan(-1);
     expect(ledgerMount).toBeLessThan(screeningJobsMount);
     expect(decisionsMount).toBeLessThan(screeningJobsMount);
+    expect(leaseDocumentUrlRoute).toBeLessThan(screeningJobsMount);
     expect(leasesMount).toBeLessThan(screeningJobsMount);
     expect(tenantsMount).toBeLessThan(screeningJobsMount);
     expect(screeningJobsMount).toBeLessThan(apiCatchall);
@@ -325,6 +335,22 @@ describe("API route ownership regression", () => {
     });
     expect(internalRes.status).toBe(401);
     expect(internalRes.headers["x-route-source"]).toBe("internalReportsRoutes.ts");
+  });
+
+  it("keeps lease document URL refresh owned by lease routes before screening job fallback", async () => {
+    authState.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    const app = await buildRuntimeOwnershipApp();
+
+    const res = await invokeApp(app, {
+      method: "GET",
+      url: "/api/leases/lease-missing/document-url",
+      headers: { authorization: "Bearer landlord-token" },
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.headers["x-route-source"]).toBe("leaseRoutes.ts");
+    expect(res.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
+    expect(res.body?.error).not.toBe("Not Found");
   });
 
   it("keeps webhook requests public and owned by webhook routers", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -368,8 +368,8 @@ describe("leaseRoutes GET /active", () => {
       documentUrl: "https://storage.googleapis.com/signed-expired.pdf",
       leaseDocument: {
         bucket: "lease-documents",
-        path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
-        fileName: "schedule-a-v1.pdf",
+        path: "leases/landlord-1/lease-1/lease-v1.pdf",
+        fileName: "lease-v1.pdf",
       },
     });
 
@@ -393,13 +393,13 @@ describe("leaseRoutes GET /active", () => {
       expect.objectContaining({
         source: "leaseDocument",
         bucket: "lease-documents",
-        path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        path: "leases/landlord-1/lease-1/lease-v1.pdf",
         internalReferenceOnly: true,
       })
     );
     expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
       bucket: "lease-documents",
-      path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+      path: "leases/landlord-1/lease-1/lease-v1.pdf",
       expiresMinutes: 30,
     });
     expect(JSON.stringify(refreshRes.body)).not.toContain("signed-expired.pdf");
@@ -409,7 +409,7 @@ describe("leaseRoutes GET /active", () => {
     getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-legacy-list.pdf");
     getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-legacy-click.pdf");
     const staleUrl =
-      "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-legacy/schedule-a-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
+      "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-legacy/lease-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Centre Suites" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Bailey Blinkers", email: "hello+central1@rentchain.ai" });
     seedDoc("leases", "lease-legacy", {
@@ -446,11 +446,72 @@ describe("leaseRoutes GET /active", () => {
       expect.objectContaining({
         source: "lease.documentUrl",
         bucket: "lease-documents",
-        path: "leases/landlord-1/lease-legacy/schedule-a-v1.pdf",
+        path: "leases/landlord-1/lease-legacy/lease-v1.pdf",
         internalReferenceOnly: true,
       })
     );
     expect(JSON.stringify(refreshRes.body)).not.toContain(staleUrl);
+  });
+
+  it("keeps Schedule A separate from the primary lease document action", async () => {
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/schedule-a-list.pdf");
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/schedule-a-click.pdf");
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Coburg Rd" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Chip Milo", email: "hello+cob6tenant@rentchain.ai" });
+    seedDoc("leases", "lease-schedule-only", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      primaryTenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-6",
+      unitNumber: "6",
+      monthlyRent: 1800,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      sourceDraftId: "draft-1",
+    });
+    seedDoc("leaseDrafts", "draft-1", { landlordId: "landlord-1", lastGeneratedSnapshotId: "snapshot-1" });
+    seedDoc("leaseSnapshots", "snapshot-1", {
+      landlordId: "landlord-1",
+      generatedFiles: [
+        {
+          kind: "schedule-a-pdf",
+          bucket: "lease-documents",
+          path: "leases/landlord-1/draft-1/schedule-a-v1.pdf",
+          url: "https://storage.googleapis.com/lease-documents/leases/landlord-1/draft-1/schedule-a-v1.pdf?X-Goog-Expires=1",
+        },
+      ],
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const listRes = await invokeRouter(router, { method: "GET", url: "/active" });
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.leases?.[0]?.documentUrl).toBeNull();
+    expect(listRes.body?.leases?.[0]?.scheduleAUrl).toBe("https://signed.example.com/schedule-a-list.pdf");
+
+    const primaryRes = await invokeRouter(router, { method: "GET", url: "/lease-schedule-only/document-url" });
+    expect(primaryRes.status).toBe(404);
+    expect(primaryRes.body?.error).toBe("lease_document_not_found");
+
+    const scheduleRes = await invokeRouter(router, { method: "GET", url: "/lease-schedule-only/document-url?document=schedule-a" });
+    expect(scheduleRes.status).toBe(200);
+    expect(scheduleRes.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        documentUrl: "https://signed.example.com/schedule-a-click.pdf",
+        documentKind: "schedule-a",
+      })
+    );
+    expect(scheduleRes.body?.documentRef).toEqual(
+      expect.objectContaining({
+        source: "leaseSnapshots/snapshot-1",
+        bucket: "lease-documents",
+        path: "leases/landlord-1/draft-1/schedule-a-v1.pdf",
+        internalReferenceOnly: true,
+      })
+    );
   });
 
   it("does not use app-domain lease PDF paths as document URL fallback", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -348,6 +348,61 @@ describe("leaseRoutes GET /active", () => {
     );
   });
 
+  it("refreshes storage-backed lease document URLs for landlord lease responses and explicit refresh requests", async () => {
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-list.pdf");
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-click.pdf");
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      primaryTenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      documentUrl: "https://storage.googleapis.com/signed-expired.pdf",
+      leaseDocument: {
+        bucket: "lease-documents",
+        path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        fileName: "schedule-a-v1.pdf",
+      },
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const listRes = await invokeRouter(router, { method: "GET", url: "/active" });
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.leases?.[0]?.documentUrl).toBe("https://signed.example.com/fresh-list.pdf");
+
+    const refreshRes = await invokeRouter(router, { method: "GET", url: "/lease-1/document-url" });
+    expect(refreshRes.status).toBe(200);
+    expect(refreshRes.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        documentUrl: "https://signed.example.com/fresh-click.pdf",
+        refreshMode: "signed_url",
+        expiresInSeconds: 1800,
+      })
+    );
+    expect(refreshRes.body?.documentRef).toEqual(
+      expect.objectContaining({
+        source: "leaseDocument",
+        bucket: "lease-documents",
+        path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        internalReferenceOnly: true,
+      })
+    );
+    expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
+      bucket: "lease-documents",
+      path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+      expiresMinutes: 30,
+    });
+  });
+
   it("surfaces ledger payment activity separately from provider payment setup", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", status: "active" });

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -453,6 +453,34 @@ describe("leaseRoutes GET /active", () => {
     expect(JSON.stringify(refreshRes.body)).not.toContain(staleUrl);
   });
 
+  it("does not use app-domain lease PDF paths as document URL fallback", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Coburg Rd" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Chip Milo", email: "hello+cob6tenant@rentchain.ai" });
+    seedDoc("leases", "lease-app-domain", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      primaryTenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-6",
+      unitNumber: "6",
+      monthlyRent: 1800,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      documentUrl: "https://preview.rentchain.ai/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const listRes = await invokeRouter(router, { method: "GET", url: "/active" });
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.leases?.[0]?.documentUrl).toBeNull();
+
+    const refreshRes = await invokeRouter(router, { method: "GET", url: "/lease-app-domain/document-url" });
+    expect(refreshRes.status).toBe(404);
+    expect(JSON.stringify(refreshRes.body)).not.toContain("/leases/PXbRIbJdZpV2eBjzNmLaISgDa852");
+  });
+
   it("surfaces ledger payment activity separately from provider payment setup", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", status: "active" });

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -377,6 +377,7 @@ describe("leaseRoutes GET /active", () => {
     const listRes = await invokeRouter(router, { method: "GET", url: "/active" });
     expect(listRes.status).toBe(200);
     expect(listRes.body?.leases?.[0]?.documentUrl).toBe("https://signed.example.com/fresh-list.pdf");
+    expect(JSON.stringify(listRes.body)).not.toContain("signed-expired.pdf");
 
     const refreshRes = await invokeRouter(router, { method: "GET", url: "/lease-1/document-url" });
     expect(refreshRes.status).toBe(200);
@@ -401,6 +402,55 @@ describe("leaseRoutes GET /active", () => {
       path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
       expiresMinutes: 30,
     });
+    expect(JSON.stringify(refreshRes.body)).not.toContain("signed-expired.pdf");
+  });
+
+  it("refreshes legacy persisted GCS signed URLs instead of returning stale URLs", async () => {
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-legacy-list.pdf");
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-legacy-click.pdf");
+    const staleUrl =
+      "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-legacy/schedule-a-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Centre Suites" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Bailey Blinkers", email: "hello+central1@rentchain.ai" });
+    seedDoc("leases", "lease-legacy", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      primaryTenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      documentUrl: staleUrl,
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const listRes = await invokeRouter(router, { method: "GET", url: "/active" });
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.leases?.[0]?.documentUrl).toBe("https://signed.example.com/fresh-legacy-list.pdf");
+    expect(JSON.stringify(listRes.body)).not.toContain(staleUrl);
+
+    const refreshRes = await invokeRouter(router, { method: "GET", url: "/lease-legacy/document-url" });
+    expect(refreshRes.status).toBe(200);
+    expect(refreshRes.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        documentUrl: "https://signed.example.com/fresh-legacy-click.pdf",
+        refreshMode: "signed_url",
+      })
+    );
+    expect(refreshRes.body?.documentRef).toEqual(
+      expect.objectContaining({
+        source: "lease.documentUrl",
+        bucket: "lease-documents",
+        path: "leases/landlord-1/lease-legacy/schedule-a-v1.pdf",
+        internalReferenceOnly: true,
+      })
+    );
+    expect(JSON.stringify(refreshRes.body)).not.toContain(staleUrl);
   });
 
   it("surfaces ledger payment activity separately from provider payment setup", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -514,6 +514,103 @@ describe("leaseRoutes GET /active", () => {
     );
   });
 
+  it("prefers primary lease PDFs when both lease PDF and Schedule A are present", async () => {
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/lease-list.pdf");
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/schedule-a-list.pdf");
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/lease-click.pdf");
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/schedule-a-click.pdf");
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Coburg Rd" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Chip Milo", email: "hello+cob6tenant@rentchain.ai" });
+    seedDoc("leases", "lease-both", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      primaryTenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-6",
+      unitNumber: "6",
+      monthlyRent: 1800,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      sourceDraftId: "draft-both",
+    });
+    seedDoc("leaseDrafts", "draft-both", { landlordId: "landlord-1", lastGeneratedSnapshotId: "snapshot-both" });
+    seedDoc("leaseSnapshots", "snapshot-both", {
+      landlordId: "landlord-1",
+      generatedFiles: [
+        {
+          kind: "lease-pdf",
+          bucket: "lease-documents",
+          path: "leases/landlord-1/draft-both/lease-v1.pdf",
+          url: "https://storage.googleapis.com/lease-documents/leases/landlord-1/draft-both/lease-v1.pdf?X-Goog-Expires=1",
+        },
+        {
+          kind: "schedule-a-pdf",
+          bucket: "lease-documents",
+          path: "leases/landlord-1/draft-both/schedule-a-v1.pdf",
+          url: "https://storage.googleapis.com/lease-documents/leases/landlord-1/draft-both/schedule-a-v1.pdf?X-Goog-Expires=1",
+        },
+      ],
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const listRes = await invokeRouter(router, { method: "GET", url: "/active" });
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.leases?.[0]?.documentUrl).toBe("https://signed.example.com/lease-list.pdf");
+    expect(listRes.body?.leases?.[0]?.scheduleAUrl).toBe("https://signed.example.com/schedule-a-list.pdf");
+
+    const primaryRes = await invokeRouter(router, { method: "GET", url: "/lease-both/document-url" });
+    expect(primaryRes.status).toBe(200);
+    expect(primaryRes.body).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://signed.example.com/lease-click.pdf",
+        documentKind: "lease",
+      })
+    );
+
+    const scheduleRes = await invokeRouter(router, { method: "GET", url: "/lease-both/document-url?document=schedule-a" });
+    expect(scheduleRes.status).toBe(200);
+    expect(scheduleRes.body).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://signed.example.com/schedule-a-click.pdf",
+        documentKind: "schedule-a",
+      })
+    );
+  });
+
+  it("keeps primary and Schedule A unavailable when no document metadata exists", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Coburg Rd" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Chip Milo", email: "hello+cob6tenant@rentchain.ai" });
+    seedDoc("leases", "lease-no-doc", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      primaryTenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-6",
+      unitNumber: "6",
+      monthlyRent: 1800,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const listRes = await invokeRouter(router, { method: "GET", url: "/active" });
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.leases?.[0]?.documentUrl).toBeNull();
+    expect(listRes.body?.leases?.[0]?.scheduleAUrl).toBeNull();
+
+    const primaryRes = await invokeRouter(router, { method: "GET", url: "/lease-no-doc/document-url" });
+    expect(primaryRes.status).toBe(404);
+    expect(primaryRes.body?.error).toBe("lease_document_not_found");
+
+    const scheduleRes = await invokeRouter(router, { method: "GET", url: "/lease-no-doc/document-url?document=schedule-a" });
+    expect(scheduleRes.status).toBe(404);
+    expect(scheduleRes.body?.error).toBe("schedule_a_document_not_found");
+  });
+
   it("does not use app-domain lease PDF paths as document URL fallback", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Coburg Rd" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Chip Milo", email: "hello+cob6tenant@rentchain.ai" });

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -961,6 +961,52 @@ describe("tenantPortalRoutes foundation", () => {
     });
   });
 
+  it("refreshes tenant-scoped legacy GCS signed lease URLs instead of returning stale persisted URLs", async () => {
+    const staleUrl =
+      "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-1/schedule-a-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "active",
+      leaseDocument: undefined,
+      referenceDocument: undefined,
+      documentStorage: undefined,
+      signedDocument: undefined,
+      documentUrl: staleUrl,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease/document-url",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://signed.example/leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        displayLabel: "Signed lease document",
+        documentStatus: "signed",
+        source: "lease.documentUrl",
+        expiresInSeconds: 1800,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain(staleUrl);
+    expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
+      bucket: "lease-documents",
+      path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+      expiresMinutes: 30,
+    });
+  });
+
   it("prefers the current active lease document over an archived tenant lease reference", async () => {
     ensureCollection("tenants").set("tenant-1", {
       ...(ensureCollection("tenants").get("tenant-1") || {}),

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -923,8 +923,8 @@ describe("tenantPortalRoutes foundation", () => {
       documentUrl: "https://storage.googleapis.com/expired-tenant-lease.pdf",
       leaseDocument: {
         bucket: "lease-documents",
-        path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
-        fileName: "schedule-a-v1.pdf",
+        path: "leases/landlord-1/lease-1/lease-v1.pdf",
+        fileName: "lease-v1.pdf",
       },
     });
 
@@ -946,7 +946,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data).toEqual(
       expect.objectContaining({
-        documentUrl: "https://signed.example/leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        documentUrl: "https://signed.example/leases/landlord-1/lease-1/lease-v1.pdf",
         displayLabel: "Signed lease document",
         documentStatus: "signed",
         source: "leaseDocument",
@@ -956,14 +956,14 @@ describe("tenantPortalRoutes foundation", () => {
     expect(JSON.stringify(res.body)).not.toContain("expired-tenant-lease.pdf");
     expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
       bucket: "lease-documents",
-      path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+      path: "leases/landlord-1/lease-1/lease-v1.pdf",
       expiresMinutes: 30,
     });
   });
 
   it("refreshes tenant-scoped legacy GCS signed lease URLs instead of returning stale persisted URLs", async () => {
     const staleUrl =
-      "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-1/schedule-a-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
+      "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-1/lease-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
     ensureCollection("leases").set("lease-1", {
       ...(ensureCollection("leases").get("lease-1") || {}),
       status: "active",
@@ -992,7 +992,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data).toEqual(
       expect.objectContaining({
-        documentUrl: "https://signed.example/leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        documentUrl: "https://signed.example/leases/landlord-1/lease-1/lease-v1.pdf",
         displayLabel: "Signed lease document",
         documentStatus: "signed",
         source: "lease.documentUrl",
@@ -1002,14 +1002,98 @@ describe("tenantPortalRoutes foundation", () => {
     expect(JSON.stringify(res.body)).not.toContain(staleUrl);
     expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
       bucket: "lease-documents",
-      path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+      path: "leases/landlord-1/lease-1/lease-v1.pdf",
       expiresMinutes: 30,
     });
   });
 
+  it("does not treat Schedule A as the tenant primary lease document", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "active",
+      documentUrl: undefined,
+      approvedDocumentUrl: undefined,
+      sourceDraftId: "draft-1",
+    });
+    ensureCollection("leaseDrafts").set("draft-1", {
+      lastGeneratedSnapshotId: "snapshot-1",
+    });
+    ensureCollection("leaseSnapshots").set("snapshot-1", {
+      generatedFiles: [
+        {
+          kind: "schedule-a-pdf",
+          bucket: "lease-documents",
+          path: "leases/landlord-1/draft-1/schedule-a-v1.pdf",
+          url: "https://storage.googleapis.com/lease-documents/leases/landlord-1/draft-1/schedule-a-v1.pdf?X-Goog-Expires=1",
+        },
+      ],
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const primaryRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease/document-url",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+    expect(primaryRes.status).toBe(404);
+    expect(primaryRes.body?.error).toBe("lease_document_not_found");
+
+    const scheduleRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease/document-url?document=schedule-a",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+    expect(scheduleRes.status).toBe(200);
+    expect(scheduleRes.body?.data).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://signed.example/leases/landlord-1/draft-1/schedule-a-v1.pdf",
+        displayLabel: "Schedule A",
+        documentStatus: "generated",
+        source: "leaseSnapshots/snapshot-1",
+      })
+    );
+
+    const leaseRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+    expect(leaseRes.status).toBe(200);
+    expect(leaseRes.body?.data?.leaseDocumentContext?.documentStatus).toBe("missing");
+    expect(leaseRes.body?.data?.scheduleADocumentContext).toEqual(
+      expect.objectContaining({
+        displayLabel: "Schedule A",
+        documentUrl: "https://signed.example/leases/landlord-1/draft-1/schedule-a-v1.pdf",
+      })
+    );
+  });
+
   it("derives tenant-safe lease document context from an email-linked active lease with a refreshable legacy URL", async () => {
     const staleUrl =
-      "https://storage.googleapis.com/lease-documents/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
+      "https://storage.googleapis.com/lease-documents/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/lease-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
     ensureCollection("leases").set("lease-1", {
       ...(ensureCollection("leases").get("lease-1") || {}),
       status: "archived",
@@ -1050,7 +1134,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data?.leaseId).toBe("lease-email-linked");
     expect(res.body?.data?.documentUrl).toBe(
-      "https://signed.example/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf"
+      "https://signed.example/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/lease-v1.pdf"
     );
     expect(res.body?.data?.leaseDocumentContext).toEqual(
       expect.objectContaining({

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -916,6 +916,51 @@ describe("tenantPortalRoutes foundation", () => {
     );
   });
 
+  it("refreshes tenant-scoped storage-backed lease document URLs without exposing other tenant documents", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "active",
+      documentUrl: "https://storage.googleapis.com/expired-tenant-lease.pdf",
+      leaseDocument: {
+        bucket: "lease-documents",
+        path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        fileName: "schedule-a-v1.pdf",
+      },
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease/document-url",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://signed.example/leases/landlord-1/lease-1/schedule-a-v1.pdf",
+        displayLabel: "Signed lease document",
+        documentStatus: "signed",
+        source: "leaseDocument",
+        expiresInSeconds: 1800,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("expired-tenant-lease.pdf");
+    expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
+      bucket: "lease-documents",
+      path: "leases/landlord-1/lease-1/schedule-a-v1.pdf",
+      expiresMinutes: 30,
+    });
+  });
+
   it("prefers the current active lease document over an archived tenant lease reference", async () => {
     ensureCollection("tenants").set("tenant-1", {
       ...(ensureCollection("tenants").get("tenant-1") || {}),

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1007,6 +1007,60 @@ describe("tenantPortalRoutes foundation", () => {
     });
   });
 
+  it("derives tenant-safe lease document context from an email-linked active lease with a refreshable legacy URL", async () => {
+    const staleUrl =
+      "https://storage.googleapis.com/lease-documents/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf?X-Goog-Expires=1&X-Goog-Signature=expired";
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "archived",
+    });
+    ensureCollection("leases").set("lease-email-linked", {
+      propertyId: "prop-1",
+      unitId: "unit-6",
+      unitNumber: "6",
+      status: "active",
+      tenantEmail: "tenant@example.com",
+      tenantName: "Chip Milo",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+      documentUrl: staleUrl,
+      tenantSignature: {
+        signedAt: "2026-02-01T10:00:00.000Z",
+      },
+      landlordSignature: {
+        signedAt: "2026-02-01T11:00:00.000Z",
+      },
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.leaseId).toBe("lease-email-linked");
+    expect(res.body?.data?.documentUrl).toBe(
+      "https://signed.example/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf"
+    );
+    expect(res.body?.data?.leaseDocumentContext).toEqual(
+      expect.objectContaining({
+        documentStatus: "signed",
+        source: "lease.documentUrl",
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain(staleUrl);
+  });
+
   it("prefers the current active lease document over an archived tenant lease reference", async () => {
     ensureCollection("tenants").set("tenant-1", {
       ...(ensureCollection("tenants").get("tenant-1") || {}),

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -625,11 +625,11 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
 
   const directUrl =
     String(raw?.documentUrl || raw?.approvedDocumentUrl || raw?.documentRef || "").trim() || null;
-  if (directUrl && !isAppDomainLeasePdfUrl(directUrl)) return directUrl;
+  if (directUrl && !isAppDomainLeasePdfUrl(directUrl) && !isScheduleADocumentValue(directUrl)) return directUrl;
 
   const referenceBucket = String(raw?.referenceDocument?.bucket || raw?.leaseDocument?.bucket || "").trim();
   const referencePath = String(raw?.referenceDocument?.path || raw?.leaseDocument?.path || "").trim();
-  if (referenceBucket && referencePath) {
+  if (referenceBucket && referencePath && !isScheduleADocumentValue(referencePath)) {
     try {
       return await getSignedDownloadUrl({ bucket: referenceBucket, path: referencePath, expiresMinutes: 30 });
     } catch {
@@ -650,7 +650,45 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
     if (!snapshotSnap.exists) return null;
     const snapshot = snapshotSnap.data() as any;
     const generatedFiles = Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : [];
-    const firstFile = generatedFiles.find((item: any) => String(item?.url || "").trim());
+    const firstFile = firstGeneratedLeasePdfFile(generatedFiles);
+    return String(firstFile?.url || "").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadScheduleAUrlForLease(raw: any): Promise<string | null> {
+  const storageRef = await loadScheduleAStorageRefForLease(raw);
+  if (storageRef) {
+    try {
+      return await getSignedDownloadUrl({ bucket: storageRef.bucket, path: storageRef.path, expiresMinutes: 30 });
+    } catch {
+      return null;
+    }
+  }
+
+  const directUrl =
+    String(raw?.scheduleAUrl || raw?.scheduleADocumentUrl || raw?.scheduleADocument?.url || raw?.scheduleA?.url || "").trim() || null;
+  if (directUrl && !isAppDomainLeasePdfUrl(directUrl)) return directUrl;
+
+  const legacyUrl =
+    String(raw?.documentUrl || raw?.approvedDocumentUrl || raw?.documentRef || "").trim() || null;
+  if (legacyUrl && !isAppDomainLeasePdfUrl(legacyUrl) && isScheduleADocumentValue(legacyUrl)) return legacyUrl;
+
+  const draftId = String(raw?.sourceDraftId || "").trim();
+  if (!draftId) return null;
+
+  try {
+    const draftSnap = await db.collection("leaseDrafts").doc(draftId).get();
+    if (!draftSnap.exists) return null;
+    const draft = draftSnap.data() as any;
+    const snapshotId = String(draft?.lastGeneratedSnapshotId || "").trim();
+    if (!snapshotId) return null;
+    const snapshotSnap = await db.collection("leaseSnapshots").doc(snapshotId).get();
+    if (!snapshotSnap.exists) return null;
+    const snapshot = snapshotSnap.data() as any;
+    const generatedFiles = Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : [];
+    const firstFile = firstGeneratedScheduleAFile(generatedFiles);
     return String(firstFile?.url || "").trim() || null;
   } catch {
     return null;
@@ -662,6 +700,29 @@ type LeaseDocumentStorageRef = {
   path: string;
   source: string;
 };
+
+function isScheduleADocumentValue(value: unknown): boolean {
+  const normalized = String(value || "").trim().toLowerCase();
+  return Boolean(normalized) && (normalized.includes("schedule-a") || normalized.includes("schedule_a"));
+}
+
+function isScheduleADocumentRecord(record: any): boolean {
+  if (!record || typeof record !== "object") return false;
+  return [
+    record.kind,
+    record.fileName,
+    record.name,
+    record.title,
+    record.path,
+    record.objectKey,
+    record.storagePath,
+    record.url,
+  ].some(isScheduleADocumentValue);
+}
+
+function isScheduleAStorageRef(ref: LeaseDocumentStorageRef | null): boolean {
+  return Boolean(ref && (isScheduleADocumentValue(ref.path) || isScheduleADocumentValue(ref.source)));
+}
 
 function normalizeStoragePath(value: unknown): string {
   return String(value || "").trim().replace(/^\/+/, "");
@@ -728,23 +789,43 @@ function storageRefFromSignedUrlFields(record: any, source: string): LeaseDocume
   return null;
 }
 
-function storageRefFromGeneratedFile(file: any, source: string): LeaseDocumentStorageRef | null {
+function storageRefFromGeneratedFile(
+  file: any,
+  source: string,
+  options?: { scheduleAOnly?: boolean; includeScheduleA?: boolean }
+): LeaseDocumentStorageRef | null {
   const kind = String(file?.kind || "").trim().toLowerCase();
   const url = String(file?.url || "").trim();
-  const looksLikeLeasePdf = !kind || kind.includes("pdf") || kind.includes("schedule");
+  const isScheduleA = isScheduleADocumentRecord(file);
+  if (options?.scheduleAOnly && !isScheduleA) return null;
+  if (!options?.includeScheduleA && !options?.scheduleAOnly && isScheduleA) return null;
+  const looksLikeLeasePdf = !kind || kind.includes("pdf") || kind.includes("lease") || kind.includes("document") || kind.includes("schedule");
   if (!looksLikeLeasePdf && !url) return null;
   return storageRefFromDocumentRecord(file, source) || storageRefFromSignedUrlFields(file, source);
 }
 
 function directLeaseDocumentStorageRef(raw: any): LeaseDocumentStorageRef | null {
-  return (
-    storageRefFromDocumentRecord(raw?.leaseDocument, "leaseDocument") ||
-    storageRefFromDocumentRecord(raw?.referenceDocument, "referenceDocument") ||
-    storageRefFromDocumentRecord(raw?.documentStorage, "documentStorage") ||
-    storageRefFromDocumentRecord(raw?.signedDocument, "signedDocument") ||
-    storageRefFromSignedUrlFields(raw, "lease") ||
-    null
-  );
+  const refs = [
+    storageRefFromDocumentRecord(raw?.leaseDocument, "leaseDocument"),
+    storageRefFromDocumentRecord(raw?.referenceDocument, "referenceDocument"),
+    storageRefFromDocumentRecord(raw?.documentStorage, "documentStorage"),
+    storageRefFromDocumentRecord(raw?.signedDocument, "signedDocument"),
+    storageRefFromSignedUrlFields(raw, "lease"),
+  ];
+  return refs.find((ref) => ref && !isScheduleAStorageRef(ref)) || null;
+}
+
+function directScheduleAStorageRef(raw: any): LeaseDocumentStorageRef | null {
+  const refs = [
+    storageRefFromDocumentRecord(raw?.scheduleADocument, "scheduleADocument"),
+    storageRefFromDocumentRecord(raw?.scheduleA, "scheduleA"),
+    storageRefFromDocumentRecord(raw?.leaseDocument, "leaseDocument"),
+    storageRefFromDocumentRecord(raw?.referenceDocument, "referenceDocument"),
+    storageRefFromDocumentRecord(raw?.documentStorage, "documentStorage"),
+    storageRefFromDocumentRecord(raw?.signedDocument, "signedDocument"),
+    storageRefFromSignedUrlFields(raw, "lease"),
+  ];
+  return refs.find((ref) => ref && isScheduleAStorageRef(ref)) || null;
 }
 
 async function loadLeaseDocumentStorageRefForLease(raw: any): Promise<LeaseDocumentStorageRef | null> {
@@ -793,12 +874,67 @@ async function loadLeaseDocumentStorageRefForLease(raw: any): Promise<LeaseDocum
   return null;
 }
 
+async function loadScheduleAStorageRefForLease(raw: any): Promise<LeaseDocumentStorageRef | null> {
+  const directRef = directScheduleAStorageRef(raw);
+  if (directRef) return directRef;
+
+  const snapshotIds = [
+    raw?.latestLeaseSnapshotId,
+    raw?.lastGeneratedSnapshotId,
+    raw?.leaseSnapshotId,
+  ]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+
+  const draftId = String(raw?.sourceDraftId || raw?.draftId || "").trim();
+  if (draftId) {
+    try {
+      const draftSnap = await db.collection("leaseDrafts").doc(draftId).get();
+      if (draftSnap.exists) {
+        const draft = draftSnap.data() as any;
+        [draft?.lastGeneratedSnapshotId, draft?.latestLeaseSnapshotId]
+          .map((value) => String(value || "").trim())
+          .filter(Boolean)
+          .forEach((snapshotId) => snapshotIds.push(snapshotId));
+      }
+    } catch {
+      // Missing draft metadata should not make an otherwise valid lease fail.
+    }
+  }
+
+  for (const snapshotId of Array.from(new Set(snapshotIds))) {
+    try {
+      const snapshotSnap = await db.collection("leaseSnapshots").doc(snapshotId).get();
+      if (!snapshotSnap.exists) continue;
+      const snapshot = snapshotSnap.data() as any;
+      const generatedFiles = Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : [];
+      for (const file of generatedFiles) {
+        const ref = storageRefFromGeneratedFile(file, `leaseSnapshots/${snapshotId}`, { scheduleAOnly: true });
+        if (ref) return ref;
+      }
+    } catch {
+      // Continue through remaining metadata sources.
+    }
+  }
+
+  return null;
+}
+
 function firstGeneratedLeasePdfFile(generatedFiles: any[]): any | null {
   return (
     (Array.isArray(generatedFiles) ? generatedFiles : []).find((item: any) => {
       const url = String(item?.url || "").trim();
       const kind = String(item?.kind || "").trim().toLowerCase();
-      return url.startsWith("https://") && (!kind || kind.includes("pdf") || kind.includes("schedule"));
+      return url.startsWith("https://") && !isScheduleADocumentRecord(item) && (!kind || kind.includes("pdf") || kind.includes("lease") || kind.includes("document"));
+    }) || null
+  );
+}
+
+function firstGeneratedScheduleAFile(generatedFiles: any[]): any | null {
+  return (
+    (Array.isArray(generatedFiles) ? generatedFiles : []).find((item: any) => {
+      const url = String(item?.url || "").trim();
+      return url.startsWith("https://") && isScheduleADocumentRecord(item);
     }) || null
   );
 }
@@ -1176,10 +1312,11 @@ async function enrichLeaseRow(raw: any) {
   const tenantId =
     String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim() || null;
 
-  const [propertySnap, tenantSnap, documentUrl] = await Promise.all([
+  const [propertySnap, tenantSnap, documentUrl, scheduleAUrl] = await Promise.all([
     propertyId ? db.collection("properties").doc(propertyId).get().catch(() => null) : Promise.resolve(null),
     tenantId ? db.collection("tenants").doc(tenantId).get().catch(() => null) : Promise.resolve(null),
     loadLeaseDocumentUrlForLease(raw),
+    loadScheduleAUrlForLease(raw),
   ]);
 
   const propertyData = propertySnap?.exists ? propertySnap.data() : null;
@@ -1255,6 +1392,7 @@ async function enrichLeaseRow(raw: any) {
     tenantName,
     tenantEmail,
     documentUrl,
+    scheduleAUrl,
     ...leaseReadiness,
     paymentReadiness,
     rentPaymentSummary,
@@ -2846,21 +2984,33 @@ export async function handleLeaseDocumentUrl(req: any, res: Response) {
     if (!(await enforceLeaseCapability(req, res))) return;
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
     const leaseId = String(req.params?.leaseId || "").trim();
+    const requestQuery = new URLSearchParams(String(req.originalUrl || req.url || "").split("?")[1] || "");
+    const requestedDocument = String(
+      req.query?.document || req.query?.kind || requestQuery.get("document") || requestQuery.get("kind") || "lease"
+    )
+      .trim()
+      .toLowerCase();
+    const wantsScheduleA = requestedDocument === "schedule-a" || requestedDocument === "schedule_a" || requestedDocument === "schedule";
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
     if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
 
     const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
 
-    const storageRef = await loadLeaseDocumentStorageRefForLease(leaseCheck.lease as any);
+    const storageRef = wantsScheduleA
+      ? await loadScheduleAStorageRefForLease(leaseCheck.lease as any)
+      : await loadLeaseDocumentStorageRefForLease(leaseCheck.lease as any);
     if (!storageRef) {
-      const fallbackUrl = await loadLeaseDocumentUrlForLease(leaseCheck.lease as any);
-      if (!fallbackUrl) return res.status(404).json({ ok: false, error: "lease_document_not_found" });
+      const fallbackUrl = wantsScheduleA
+        ? await loadScheduleAUrlForLease(leaseCheck.lease as any)
+        : await loadLeaseDocumentUrlForLease(leaseCheck.lease as any);
+      if (!fallbackUrl) return res.status(404).json({ ok: false, error: wantsScheduleA ? "schedule_a_document_not_found" : "lease_document_not_found" });
       return res.status(200).json({
         ok: true,
         documentUrl: fallbackUrl,
         refreshMode: "legacy_url",
         expiresInSeconds: null,
+        documentKind: wantsScheduleA ? "schedule-a" : "lease",
       });
     }
 
@@ -2875,6 +3025,7 @@ export async function handleLeaseDocumentUrl(req: any, res: Response) {
       documentUrl,
       refreshMode: "signed_url",
       expiresInSeconds: expiresMinutes * 60,
+      documentKind: wantsScheduleA ? "schedule-a" : "lease",
       documentRef: {
         source: storageRef.source,
         bucket: storageRef.bucket,

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -619,8 +619,7 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
     try {
       return await getSignedDownloadUrl({ bucket: storageRef.bucket, path: storageRef.path, expiresMinutes: 30 });
     } catch {
-      // Fall back to the legacy persisted URL below; callers still get continuity
-      // for older records while storage-backed records refresh on each load.
+      return null;
     }
   }
 
@@ -676,12 +675,54 @@ function storageRefFromDocumentRecord(record: any, source: string): LeaseDocumen
   return { bucket, path, source };
 }
 
+function parseGcsSignedUrlStorageRef(value: unknown, source: string): LeaseDocumentStorageRef | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:") return null;
+    if (url.hostname === "storage.googleapis.com" || url.hostname === "storage.cloud.google.com") {
+      const segments = url.pathname.split("/").filter(Boolean);
+      const bucket = segments.shift() || "";
+      const path = normalizeStoragePath(segments.join("/"));
+      return bucket && path ? { bucket, path, source } : null;
+    }
+    if (url.hostname.endsWith(".storage.googleapis.com")) {
+      const bucket = url.hostname.slice(0, -".storage.googleapis.com".length);
+      const path = normalizeStoragePath(decodeURIComponent(url.pathname).replace(/^\/+/, ""));
+      return bucket && path ? { bucket, path, source } : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function storageRefFromSignedUrlFields(record: any, source: string): LeaseDocumentStorageRef | null {
+  const fields = [
+    "signedDocumentUrl",
+    "signedLeaseDocumentUrl",
+    "executedDocumentUrl",
+    "finalDocumentUrl",
+    "fullyExecutedDocumentUrl",
+    "documentUrl",
+    "approvedDocumentUrl",
+    "documentRef",
+    "url",
+  ];
+  for (const field of fields) {
+    const ref = parseGcsSignedUrlStorageRef(record?.[field], `${source}.${field}`);
+    if (ref) return ref;
+  }
+  return null;
+}
+
 function storageRefFromGeneratedFile(file: any, source: string): LeaseDocumentStorageRef | null {
   const kind = String(file?.kind || "").trim().toLowerCase();
   const url = String(file?.url || "").trim();
   const looksLikeLeasePdf = !kind || kind.includes("pdf") || kind.includes("schedule");
   if (!looksLikeLeasePdf && !url) return null;
-  return storageRefFromDocumentRecord(file, source);
+  return storageRefFromDocumentRecord(file, source) || storageRefFromSignedUrlFields(file, source);
 }
 
 function directLeaseDocumentStorageRef(raw: any): LeaseDocumentStorageRef | null {
@@ -690,6 +731,7 @@ function directLeaseDocumentStorageRef(raw: any): LeaseDocumentStorageRef | null
     storageRefFromDocumentRecord(raw?.referenceDocument, "referenceDocument") ||
     storageRefFromDocumentRecord(raw?.documentStorage, "documentStorage") ||
     storageRefFromDocumentRecord(raw?.signedDocument, "signedDocument") ||
+    storageRefFromSignedUrlFields(raw, "lease") ||
     null
   );
 }

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -2841,7 +2841,7 @@ router.get("/:leaseId/payments", requireLandlord, async (req: any, res: Response
   }
 });
 
-router.get("/:leaseId/document-url", requireLandlord, async (req: any, res: Response) => {
+export async function handleLeaseDocumentUrl(req: any, res: Response) {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
@@ -2886,7 +2886,9 @@ router.get("/:leaseId/document-url", requireLandlord, async (req: any, res: Resp
     console.error("[GET /api/leases/:leaseId/document-url] error", err);
     return res.status(500).json({ ok: false, error: "Failed to refresh lease document URL" });
   }
-});
+}
+
+router.get("/:leaseId/document-url", requireLandlord, handleLeaseDocumentUrl);
 
 router.post("/:leaseId/restore", requireLandlord, async (req: any, res: Response) => {
   try {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -614,6 +614,16 @@ async function resolveRestoreUnitTargetsForLease(lease: any, errorPrefix: string
 }
 
 async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
+  const storageRef = await loadLeaseDocumentStorageRefForLease(raw);
+  if (storageRef) {
+    try {
+      return await getSignedDownloadUrl({ bucket: storageRef.bucket, path: storageRef.path, expiresMinutes: 30 });
+    } catch {
+      // Fall back to the legacy persisted URL below; callers still get continuity
+      // for older records while storage-backed records refresh on each load.
+    }
+  }
+
   const directUrl =
     String(raw?.documentUrl || raw?.approvedDocumentUrl || raw?.documentRef || "").trim() || null;
   if (directUrl) return directUrl;
@@ -646,6 +656,88 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+type LeaseDocumentStorageRef = {
+  bucket: string;
+  path: string;
+  source: string;
+};
+
+function normalizeStoragePath(value: unknown): string {
+  return String(value || "").trim().replace(/^\/+/, "");
+}
+
+function storageRefFromDocumentRecord(record: any, source: string): LeaseDocumentStorageRef | null {
+  if (!record || typeof record !== "object") return null;
+  const bucket = String(record?.bucket || record?.storageBucket || "").trim();
+  const path = normalizeStoragePath(record?.path || record?.objectKey || record?.storagePath);
+  if (!bucket || !path) return null;
+  return { bucket, path, source };
+}
+
+function storageRefFromGeneratedFile(file: any, source: string): LeaseDocumentStorageRef | null {
+  const kind = String(file?.kind || "").trim().toLowerCase();
+  const url = String(file?.url || "").trim();
+  const looksLikeLeasePdf = !kind || kind.includes("pdf") || kind.includes("schedule");
+  if (!looksLikeLeasePdf && !url) return null;
+  return storageRefFromDocumentRecord(file, source);
+}
+
+function directLeaseDocumentStorageRef(raw: any): LeaseDocumentStorageRef | null {
+  return (
+    storageRefFromDocumentRecord(raw?.leaseDocument, "leaseDocument") ||
+    storageRefFromDocumentRecord(raw?.referenceDocument, "referenceDocument") ||
+    storageRefFromDocumentRecord(raw?.documentStorage, "documentStorage") ||
+    storageRefFromDocumentRecord(raw?.signedDocument, "signedDocument") ||
+    null
+  );
+}
+
+async function loadLeaseDocumentStorageRefForLease(raw: any): Promise<LeaseDocumentStorageRef | null> {
+  const directRef = directLeaseDocumentStorageRef(raw);
+  if (directRef) return directRef;
+
+  const snapshotIds = [
+    raw?.latestLeaseSnapshotId,
+    raw?.lastGeneratedSnapshotId,
+    raw?.leaseSnapshotId,
+  ]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+
+  const draftId = String(raw?.sourceDraftId || raw?.draftId || "").trim();
+  if (draftId) {
+    try {
+      const draftSnap = await db.collection("leaseDrafts").doc(draftId).get();
+      if (draftSnap.exists) {
+        const draft = draftSnap.data() as any;
+        [draft?.lastGeneratedSnapshotId, draft?.latestLeaseSnapshotId]
+          .map((value) => String(value || "").trim())
+          .filter(Boolean)
+          .forEach((snapshotId) => snapshotIds.push(snapshotId));
+      }
+    } catch {
+      // Missing draft metadata should not make an otherwise valid lease fail.
+    }
+  }
+
+  for (const snapshotId of Array.from(new Set(snapshotIds))) {
+    try {
+      const snapshotSnap = await db.collection("leaseSnapshots").doc(snapshotId).get();
+      if (!snapshotSnap.exists) continue;
+      const snapshot = snapshotSnap.data() as any;
+      const generatedFiles = Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : [];
+      for (const file of generatedFiles) {
+        const ref = storageRefFromGeneratedFile(file, `leaseSnapshots/${snapshotId}`);
+        if (ref) return ref;
+      }
+    } catch {
+      // Continue through remaining metadata sources.
+    }
+  }
+
+  return null;
 }
 
 function firstGeneratedLeasePdfFile(generatedFiles: any[]): any | null {
@@ -823,6 +915,19 @@ async function linkGeneratedLeasePdfToTenantWorkspace(params: {
     : [];
   const now = Date.now();
   const fileName = "schedule-a-v1.pdf";
+  const storageBucket = String(params.file?.bucket || params.file?.storageBucket || "").trim() || null;
+  const storagePath = normalizeStoragePath(params.file?.path || params.file?.objectKey || params.file?.storagePath) || null;
+  const leaseDocument =
+    storageBucket && storagePath
+      ? {
+          bucket: storageBucket,
+          path: storagePath,
+          fileName,
+          contentType: "application/pdf",
+          source: "lease_pdf_generation",
+          signedUrlExpiresAt: now + 30 * 60 * 1000,
+        }
+      : null;
 
   if (leaseId) {
     await db
@@ -833,6 +938,7 @@ async function linkGeneratedLeasePdfToTenantWorkspace(params: {
           documentUrl: url,
           approvedDocumentUrl: url,
           documentRef: url,
+          ...(leaseDocument ? { leaseDocument, referenceDocument: leaseDocument } : {}),
           documentGeneratedAt: now,
           leaseDocumentGeneratedAt: now,
           latestLeaseSnapshotId: params.snapshotId,
@@ -861,6 +967,9 @@ async function linkGeneratedLeasePdfToTenantWorkspace(params: {
           unitId,
           ledgerItemId: leaseId || `leaseDraft:${params.draftId}`,
           url,
+          ...(storageBucket ? { storageBucket } : {}),
+          ...(storagePath ? { storagePath } : {}),
+          signedUrlExpiresAt: now + 30 * 60 * 1000,
           title: "Lease document",
           fileName,
           category: "Lease",
@@ -2676,6 +2785,53 @@ router.get("/:leaseId/payments", requireLandlord, async (req: any, res: Response
   } catch (err) {
     console.error("[GET /api/leases/:leaseId/payments] error", err);
     return res.status(500).json({ ok: false, error: "LEASE_PAYMENT_STATUS_FAILED" });
+  }
+});
+
+router.get("/:leaseId/document-url", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.params?.leaseId || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
+
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
+
+    const storageRef = await loadLeaseDocumentStorageRefForLease(leaseCheck.lease as any);
+    if (!storageRef) {
+      const fallbackUrl = await loadLeaseDocumentUrlForLease(leaseCheck.lease as any);
+      if (!fallbackUrl) return res.status(404).json({ ok: false, error: "lease_document_not_found" });
+      return res.status(200).json({
+        ok: true,
+        documentUrl: fallbackUrl,
+        refreshMode: "legacy_url",
+        expiresInSeconds: null,
+      });
+    }
+
+    const expiresMinutes = 30;
+    const documentUrl = await getSignedDownloadUrl({
+      bucket: storageRef.bucket,
+      path: storageRef.path,
+      expiresMinutes,
+    });
+    return res.status(200).json({
+      ok: true,
+      documentUrl,
+      refreshMode: "signed_url",
+      expiresInSeconds: expiresMinutes * 60,
+      documentRef: {
+        source: storageRef.source,
+        bucket: storageRef.bucket,
+        path: storageRef.path,
+        internalReferenceOnly: true,
+      },
+    });
+  } catch (err) {
+    console.error("[GET /api/leases/:leaseId/document-url] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to refresh lease document URL" });
   }
 });
 

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -625,7 +625,7 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
 
   const directUrl =
     String(raw?.documentUrl || raw?.approvedDocumentUrl || raw?.documentRef || "").trim() || null;
-  if (directUrl) return directUrl;
+  if (directUrl && !isAppDomainLeasePdfUrl(directUrl)) return directUrl;
 
   const referenceBucket = String(raw?.referenceDocument?.bucket || raw?.leaseDocument?.bucket || "").trim();
   const referencePath = String(raw?.referenceDocument?.path || raw?.leaseDocument?.path || "").trim();
@@ -665,6 +665,17 @@ type LeaseDocumentStorageRef = {
 
 function normalizeStoragePath(value: unknown): string {
   return String(value || "").trim().replace(/^\/+/, "");
+}
+
+function isAppDomainLeasePdfUrl(value: unknown): boolean {
+  const raw = String(value || "").trim();
+  if (!raw) return false;
+  try {
+    const url = new URL(raw, "https://app.rentchain.invalid");
+    return /^\/leases\/.+\.pdf$/i.test(url.pathname);
+  } catch {
+    return /^\/leases\/.+\.pdf(?:$|\?)/i.test(raw);
+  }
 }
 
 function storageRefFromDocumentRecord(record: any, source: string): LeaseDocumentStorageRef | null {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -78,6 +78,7 @@ import {
 } from "../services/tenantPortal/tenantInstitutionAccessService";
 import { recordSystemObservabilityEvent } from "../services/observability/recordSystemObservabilityEvent";
 import { buildLeasePaymentProjection } from "../services/projections/buildLeasePaymentProjection";
+import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -3002,6 +3003,47 @@ function bestTenantLeaseAttachment(params: {
   return candidates[0]?.item || null;
 }
 
+type TenantLeaseDocumentStorageRef = {
+  bucket: string;
+  path: string;
+  source: string;
+};
+
+function normalizeLeaseDocumentStoragePath(value: unknown): string {
+  return String(value || "").trim().replace(/^\/+/, "");
+}
+
+function tenantLeaseStorageRefFromRecord(record: any, source: string): TenantLeaseDocumentStorageRef | null {
+  if (!record || typeof record !== "object") return null;
+  const bucket = String(record?.bucket || record?.storageBucket || "").trim();
+  const path = normalizeLeaseDocumentStoragePath(record?.path || record?.objectKey || record?.storagePath);
+  if (!bucket || !path) return null;
+  return { bucket, path, source };
+}
+
+function tenantLeaseDocumentStorageRef(params: {
+  leaseData?: any;
+  attachment?: any;
+}): TenantLeaseDocumentStorageRef | null {
+  return (
+    tenantLeaseStorageRefFromRecord(params.leaseData?.leaseDocument, "leaseDocument") ||
+    tenantLeaseStorageRefFromRecord(params.leaseData?.referenceDocument, "referenceDocument") ||
+    tenantLeaseStorageRefFromRecord(params.leaseData?.documentStorage, "documentStorage") ||
+    tenantLeaseStorageRefFromRecord(params.leaseData?.signedDocument, "signedDocument") ||
+    tenantLeaseStorageRefFromRecord(params.attachment, "ledgerAttachments") ||
+    null
+  );
+}
+
+async function refreshTenantLeaseSignedUrl(storageRef: TenantLeaseDocumentStorageRef | null): Promise<string | null> {
+  if (!storageRef) return null;
+  try {
+    return await getSignedDownloadUrl({ bucket: storageRef.bucket, path: storageRef.path, expiresMinutes: 30 });
+  } catch {
+    return null;
+  }
+}
+
 async function loadTenantLeaseAttachments(tenantId: string): Promise<any[]> {
   const normalizedTenantId = String(tenantId || "").trim();
   if (!normalizedTenantId) return [];
@@ -3054,6 +3096,8 @@ async function getTenantLeaseDocumentContext(params: {
   }
 
   const signed = isLeaseSigned(params.leaseData);
+  const directStorageRef = tenantLeaseDocumentStorageRef({ leaseData: params.leaseData });
+  const refreshedDirectUrl = await refreshTenantLeaseSignedUrl(directStorageRef);
   const signedUrl = firstLeaseDocumentUrl(params.leaseData, [
     "signedDocumentUrl",
     "signedLeaseDocumentUrl",
@@ -3064,7 +3108,7 @@ async function getTenantLeaseDocumentContext(params: {
     "approvedDocumentUrl",
     "documentRef",
   ]);
-  if (signed && signedUrl) {
+  if (signed && (refreshedDirectUrl || signedUrl)) {
     return {
       leaseId,
       tenantId: tenantId || undefined,
@@ -3074,16 +3118,16 @@ async function getTenantLeaseDocumentContext(params: {
       signingStatus: "signed",
       documentStatus: "signed",
       documentId: String(params.leaseData?.signedDocumentId || params.leaseData?.documentId || params.leaseData?.latestLeaseSnapshotId || "").trim() || undefined,
-      documentUrl: signedUrl,
+      documentUrl: refreshedDirectUrl || signedUrl || undefined,
       displayLabel: "Signed lease document",
-      source: "lease_signed_document",
+      source: refreshedDirectUrl ? directStorageRef?.source || "lease_signed_document" : "lease_signed_document",
       confidence: "high",
       warnings,
     };
   }
 
   const generatedUrl = firstLeaseDocumentUrl(params.leaseData, ["documentUrl", "approvedDocumentUrl", "documentRef"]);
-  if (generatedUrl) {
+  if (refreshedDirectUrl || generatedUrl) {
     return {
       leaseId,
       tenantId: tenantId || undefined,
@@ -3093,9 +3137,9 @@ async function getTenantLeaseDocumentContext(params: {
       signingStatus: signed ? "signed" : "unsigned",
       documentStatus: signed ? "signed" : "generated",
       documentId: String(params.leaseData?.documentId || params.leaseData?.latestLeaseSnapshotId || "").trim() || undefined,
-      documentUrl: generatedUrl,
+      documentUrl: refreshedDirectUrl || generatedUrl || undefined,
       displayLabel: signed ? "Signed lease document" : "Generated lease package",
-      source: "lease_document_fields",
+      source: refreshedDirectUrl ? directStorageRef?.source || "lease_document_fields" : "lease_document_fields",
       confidence: "high",
       warnings,
     };
@@ -3104,6 +3148,9 @@ async function getTenantLeaseDocumentContext(params: {
   const attachments = params.attachments || (tenantId ? await loadTenantLeaseAttachments(tenantId) : []);
   const attachment = bestTenantLeaseAttachment({ attachments, leaseId, propertyId, unitId });
   if (attachment) {
+    const refreshedAttachmentUrl = await refreshTenantLeaseSignedUrl(
+      tenantLeaseDocumentStorageRef({ attachment })
+    );
     return {
       leaseId,
       tenantId: tenantId || undefined,
@@ -3113,7 +3160,7 @@ async function getTenantLeaseDocumentContext(params: {
       signingStatus: signed ? "signed" : "unsigned",
       documentStatus: signed ? "signed" : "generated",
       documentId: String(attachment?.id || "").trim() || undefined,
-      documentUrl: String(attachment.url || "").trim(),
+      documentUrl: refreshedAttachmentUrl || String(attachment.url || "").trim(),
       displayLabel: signed ? "Signed lease document" : "Generated lease package",
       source: "ledgerAttachments",
       confidence: "high",
@@ -4856,6 +4903,49 @@ router.get("/lease", requireTenantWorkspaceIdentity, async (req: any, res) => {
   if (!context) return;
   const workspace = await loadTenantWorkspaceData(context);
   return res.json({ ok: true, data: workspace.lease });
+});
+
+router.get("/lease/document-url", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+  if (context.authority !== "active_tenant" || !context.tenantId || !context.leaseId) {
+    return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+  }
+
+  try {
+    const leaseSnap = await db.collection("leases").doc(context.leaseId).get();
+    if (!leaseSnap.exists) return res.status(404).json({ ok: false, error: "lease_document_not_found" });
+    const leaseData = leaseSnap.data() as any;
+    if (!leaseHasTenant(leaseData, context.tenantId)) {
+      return res.status(403).json({ ok: false, error: "lease_not_owned_by_tenant" });
+    }
+    const documentContext = await getTenantLeaseDocumentContext({
+      leaseId: context.leaseId,
+      tenantId: context.tenantId,
+      propertyId: context.propertyId,
+      unitId: context.unitId,
+      leaseData,
+    });
+    if (!documentContext.documentUrl || documentContext.documentStatus === "missing") {
+      return res.status(404).json({ ok: false, error: "lease_document_not_found" });
+    }
+    return res.json({
+      ok: true,
+      data: {
+        documentUrl: documentContext.documentUrl,
+        displayLabel: documentContext.displayLabel,
+        documentStatus: documentContext.documentStatus,
+        source: documentContext.source,
+        expiresInSeconds: 30 * 60,
+      },
+    });
+  } catch (err: any) {
+    console.error("[tenant/lease/document-url] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_LEASE_DOCUMENT_URL_FAILED" });
+  }
 });
 
 router.post("/leases/:leaseId/payments/checkout", requireTenantWorkspaceIdentity, async (req: any, res: any) => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2323,9 +2323,11 @@ async function findBestTenantLease(params: {
   current: { id: string; data: any } | null;
   tenantId: string | null;
   propertyId: string | null;
+  tenantEmail?: string | null;
 }) {
   const tenantId = String(params.tenantId || "").trim();
   const propertyId = String(params.propertyId || "").trim();
+  const tenantEmail = String(params.tenantEmail || "").trim().toLowerCase();
   const candidates = new Map<string, { id: string; data: any }>();
   if (params.current?.id) candidates.set(params.current.id, params.current);
   if (tenantId) {
@@ -2341,10 +2343,23 @@ async function findBestTenantLease(params: {
       }
     }
   }
+  if (tenantEmail) {
+    for (const query of [
+      () => db.collection("leases").where("tenantEmail", "==", tenantEmail).limit(20).get(),
+      () => db.collection("leases").where("email", "==", tenantEmail).limit(20).get(),
+    ]) {
+      try {
+        const snap = await query();
+        snap.docs.forEach((doc) => candidates.set(doc.id, { id: doc.id, data: doc.data() as any }));
+      } catch {
+        // Email-linked leases are a compatibility path only.
+      }
+    }
+  }
 
   const ranked = Array.from(candidates.values())
     .filter((candidate) => !propertyId || String(candidate.data?.propertyId || "").trim() === propertyId)
-    .filter((candidate) => !tenantId || leaseHasTenant(candidate.data, tenantId))
+    .filter((candidate) => leaseMatchesTenantIdentity(candidate.data, tenantId, tenantEmail))
     .sort((left, right) => {
       const rankDelta = leaseSelectionRank(right) - leaseSelectionRank(left);
       if (rankDelta !== 0) return rankDelta;
@@ -2375,7 +2390,12 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
   }
 
   let leaseDoc = await loadDocument("leases", context.leaseId);
-  leaseDoc = await findBestTenantLease({ current: leaseDoc, tenantId: context.tenantId, propertyId: context.propertyId });
+  leaseDoc = await findBestTenantLease({
+    current: leaseDoc,
+    tenantId: context.tenantId,
+    tenantEmail: context.invitedEmail,
+    propertyId: context.propertyId,
+  });
 
   const maintenanceItems: Array<{ id: string; data: any }> = [];
   if (context.tenantId) {
@@ -2395,6 +2415,7 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
     ? await getTenantLeaseDocumentContext({
         leaseId: leaseDoc.id,
         tenantId: context.tenantId,
+        tenantEmail: context.invitedEmail,
         propertyId: String(leaseDoc.data?.propertyId || context.propertyId || "").trim() || null,
         unitId: String(leaseDoc.data?.unitId || context.unitId || "").trim() || null,
         leaseData: leaseDoc.data,
@@ -2778,6 +2799,7 @@ async function withTenantLeaseDocumentContext(profile: Awaited<ReturnType<typeof
   const leaseDocumentContext = await getTenantLeaseDocumentContext({
     leaseId,
     tenantId,
+    tenantEmail: String(profile?.context?.invitedEmail || "").trim() || null,
     propertyId: String(profile?.context?.propertyId || leaseData?.propertyId || "").trim() || null,
     unitId: String(profile?.context?.unitId || leaseData?.unitId || "").trim() || null,
     leaseData,
@@ -2929,9 +2951,20 @@ type TenantLeaseDocumentContext = {
 function firstLeaseDocumentUrl(raw: any, fields: string[]): string | null {
   for (const field of fields) {
     const value = String(raw?.[field] || "").trim();
-    if (value.startsWith("https://")) return value;
+    if (value.startsWith("https://") && !isAppDomainLeasePdfUrl(value)) return value;
   }
   return null;
+}
+
+function isAppDomainLeasePdfUrl(value: unknown): boolean {
+  const raw = String(value || "").trim();
+  if (!raw) return false;
+  try {
+    const url = new URL(raw, "https://app.rentchain.invalid");
+    return /^\/leases\/.+\.pdf$/i.test(url.pathname);
+  } catch {
+    return /^\/leases\/.+\.pdf(?:$|\?)/i.test(raw);
+  }
 }
 
 function leaseHasTenant(raw: any, tenantId: string): boolean {
@@ -2940,6 +2973,23 @@ function leaseHasTenant(raw: any, tenantId: string): boolean {
   if (String(raw?.tenantId || "").trim() === normalizedTenantId) return true;
   if (String(raw?.primaryTenantId || "").trim() === normalizedTenantId) return true;
   return Array.isArray(raw?.tenantIds) && raw.tenantIds.map((value: any) => String(value || "").trim()).includes(normalizedTenantId);
+}
+
+function leaseMatchesTenantIdentity(raw: any, tenantId?: string | null, tenantEmail?: string | null): boolean {
+  const normalizedTenantId = String(tenantId || "").trim();
+  if (normalizedTenantId && leaseHasTenant(raw, normalizedTenantId)) return true;
+  const normalizedEmail = String(tenantEmail || "").trim().toLowerCase();
+  if (!normalizedEmail) return false;
+  const emails = [
+    raw?.tenantEmail,
+    raw?.email,
+    raw?.primaryTenantEmail,
+    raw?.tenant?.email,
+    raw?.applicantEmail,
+  ]
+    .map((value) => String(value || "").trim().toLowerCase())
+    .filter(Boolean);
+  return emails.includes(normalizedEmail);
 }
 
 function isLeaseSigned(raw: any): boolean {
@@ -3098,6 +3148,7 @@ async function loadTenantLeaseAttachments(tenantId: string): Promise<any[]> {
 async function getTenantLeaseDocumentContext(params: {
   leaseId: string | null;
   tenantId: string | null;
+  tenantEmail?: string | null;
   propertyId: string | null;
   unitId: string | null;
   leaseData: any;
@@ -3105,6 +3156,7 @@ async function getTenantLeaseDocumentContext(params: {
 }): Promise<TenantLeaseDocumentContext> {
   const leaseId = String(params.leaseId || "").trim();
   const tenantId = String(params.tenantId || "").trim();
+  const tenantEmail = String(params.tenantEmail || "").trim().toLowerCase();
   const propertyId = String(params.propertyId || params.leaseData?.propertyId || "").trim();
   const unitId = String(params.unitId || params.leaseData?.unitId || params.leaseData?.unit || "").trim();
   const leaseStatus = String(params.leaseData?.status || "").trim() || undefined;
@@ -3124,10 +3176,10 @@ async function getTenantLeaseDocumentContext(params: {
     };
   }
 
-  if (tenantId && !leaseHasTenant(params.leaseData, tenantId)) {
+  if ((tenantId || tenantEmail) && !leaseMatchesTenantIdentity(params.leaseData, tenantId, tenantEmail)) {
     return {
       leaseId,
-      tenantId,
+      tenantId: tenantId || undefined,
       propertyId: propertyId || undefined,
       unitId: unitId || undefined,
       leaseStatus,
@@ -4962,12 +5014,13 @@ router.get("/lease/document-url", requireTenantWorkspaceIdentity, async (req: an
     const leaseSnap = await db.collection("leases").doc(context.leaseId).get();
     if (!leaseSnap.exists) return res.status(404).json({ ok: false, error: "lease_document_not_found" });
     const leaseData = leaseSnap.data() as any;
-    if (!leaseHasTenant(leaseData, context.tenantId)) {
+    if (!leaseMatchesTenantIdentity(leaseData, context.tenantId, context.invitedEmail || req.user?.email)) {
       return res.status(403).json({ ok: false, error: "lease_not_owned_by_tenant" });
     }
     const documentContext = await getTenantLeaseDocumentContext({
       leaseId: context.leaseId,
       tenantId: context.tenantId,
+      tenantEmail: String(context.invitedEmail || req.user?.email || "").trim() || null,
       propertyId: context.propertyId,
       unitId: context.unitId,
       leaseData,
@@ -6911,6 +6964,7 @@ router.get("/lease", requireTenant, async (req: any, res) => {
     const bestLease = await findBestTenantLease({
       current: leaseRecord && leaseId ? { id: leaseId, data: leaseRecord } : null,
       tenantId,
+      tenantEmail: String(tenantData?.email || req.user?.email || "").trim() || null,
       propertyId,
     });
     if (bestLease) {
@@ -6950,6 +7004,7 @@ router.get("/lease", requireTenant, async (req: any, res) => {
         ? await getTenantLeaseDocumentContext({
             leaseId,
             tenantId,
+            tenantEmail: String(tenantData?.email || req.user?.email || "").trim() || null,
             propertyId,
             unitId,
             leaseData: leaseRecord,

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2421,6 +2421,17 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
         leaseData: leaseDoc.data,
       })
     : null;
+  const scheduleADocumentContext = leaseDoc
+    ? await getTenantLeaseDocumentContext({
+        leaseId: leaseDoc.id,
+        tenantId: context.tenantId,
+        tenantEmail: context.invitedEmail,
+        propertyId: String(leaseDoc.data?.propertyId || context.propertyId || "").trim() || null,
+        unitId: String(leaseDoc.data?.unitId || context.unitId || "").trim() || null,
+        leaseData: leaseDoc.data,
+        documentKind: "schedule-a",
+      })
+    : null;
   const leaseProjectionData =
     leaseDoc && leaseDocumentContext?.documentUrl
       ? {
@@ -2457,7 +2468,7 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
   return {
     property: propertyDoc ? projectTenantProperty(propertyDoc.id, propertyDoc.data) : null,
     application: applicationDoc ? projectTenantApplication(applicationDoc.id, applicationDoc.data) : null,
-    lease: lease ? { ...lease, leaseDocumentContext, rentPaymentSummary } : null,
+    lease: lease ? { ...lease, leaseDocumentContext, scheduleADocumentContext, rentPaymentSummary } : null,
     maintenance: maintenanceItems
       .map((item) => projectTenantMaintenance(item.id, item.data))
       .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0)),
@@ -2804,6 +2815,15 @@ async function withTenantLeaseDocumentContext(profile: Awaited<ReturnType<typeof
     unitId: String(profile?.context?.unitId || leaseData?.unitId || "").trim() || null,
     leaseData,
   });
+  const scheduleADocumentContext = await getTenantLeaseDocumentContext({
+    leaseId,
+    tenantId,
+    tenantEmail: String(profile?.context?.invitedEmail || "").trim() || null,
+    propertyId: String(profile?.context?.propertyId || leaseData?.propertyId || "").trim() || null,
+    unitId: String(profile?.context?.unitId || leaseData?.unitId || "").trim() || null,
+    leaseData,
+    documentKind: "schedule-a",
+  });
   const nextLease = leaseDocumentContext.documentUrl
     ? projectTenantLease(leaseId, {
         ...leaseData,
@@ -2815,7 +2835,7 @@ async function withTenantLeaseDocumentContext(profile: Awaited<ReturnType<typeof
     ...profile,
     profile: {
       ...profile.profile,
-      lease: nextLease ? { ...nextLease, leaseDocumentContext } : lease,
+      lease: nextLease ? { ...nextLease, leaseDocumentContext, scheduleADocumentContext } : lease,
     },
   };
 }
@@ -2948,10 +2968,33 @@ type TenantLeaseDocumentContext = {
   warnings: string[];
 };
 
-function firstLeaseDocumentUrl(raw: any, fields: string[]): string | null {
+function isScheduleADocumentValue(value: unknown): boolean {
+  const normalized = String(value || "").trim().toLowerCase();
+  return Boolean(normalized) && (normalized.includes("schedule-a") || normalized.includes("schedule_a"));
+}
+
+function isScheduleADocumentRecord(record: any): boolean {
+  if (!record || typeof record !== "object") return false;
+  return [
+    record.kind,
+    record.fileName,
+    record.name,
+    record.title,
+    record.path,
+    record.objectKey,
+    record.storagePath,
+    record.url,
+  ].some(isScheduleADocumentValue);
+}
+
+function firstLeaseDocumentUrl(raw: any, fields: string[], options?: { scheduleAOnly?: boolean; includeScheduleA?: boolean }): string | null {
   for (const field of fields) {
     const value = String(raw?.[field] || "").trim();
-    if (value.startsWith("https://") && !isAppDomainLeasePdfUrl(value)) return value;
+    if (!value.startsWith("https://") || isAppDomainLeasePdfUrl(value)) continue;
+    const isScheduleA = isScheduleADocumentValue(value);
+    if (options?.scheduleAOnly && !isScheduleA) continue;
+    if (!options?.includeScheduleA && !options?.scheduleAOnly && isScheduleA) continue;
+    return value;
   }
   return null;
 }
@@ -3059,6 +3102,10 @@ type TenantLeaseDocumentStorageRef = {
   source: string;
 };
 
+function isTenantScheduleAStorageRef(ref: TenantLeaseDocumentStorageRef | null): boolean {
+  return Boolean(ref && (isScheduleADocumentValue(ref.path) || isScheduleADocumentValue(ref.source)));
+}
+
 function normalizeLeaseDocumentStoragePath(value: unknown): string {
   return String(value || "").trim().replace(/^\/+/, "");
 }
@@ -3117,16 +3164,95 @@ function tenantLeaseDocumentStorageRef(params: {
   leaseData?: any;
   attachment?: any;
 }): TenantLeaseDocumentStorageRef | null {
-  return (
-    tenantLeaseStorageRefFromRecord(params.leaseData?.leaseDocument, "leaseDocument") ||
-    tenantLeaseStorageRefFromRecord(params.leaseData?.referenceDocument, "referenceDocument") ||
-    tenantLeaseStorageRefFromRecord(params.leaseData?.documentStorage, "documentStorage") ||
-    tenantLeaseStorageRefFromRecord(params.leaseData?.signedDocument, "signedDocument") ||
-    tenantLeaseStorageRefFromRecord(params.attachment, "ledgerAttachments") ||
-    tenantLeaseStorageRefFromSignedUrlFields(params.leaseData, "lease") ||
-    tenantLeaseStorageRefFromSignedUrlFields(params.attachment, "ledgerAttachments") ||
-    null
-  );
+  const refs = [
+    tenantLeaseStorageRefFromRecord(params.leaseData?.leaseDocument, "leaseDocument"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.referenceDocument, "referenceDocument"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.documentStorage, "documentStorage"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.signedDocument, "signedDocument"),
+    tenantLeaseStorageRefFromRecord(params.attachment, "ledgerAttachments"),
+    tenantLeaseStorageRefFromSignedUrlFields(params.leaseData, "lease"),
+    tenantLeaseStorageRefFromSignedUrlFields(params.attachment, "ledgerAttachments"),
+  ];
+  return refs.find((ref) => ref && !isTenantScheduleAStorageRef(ref)) || null;
+}
+
+function tenantScheduleAStorageRef(params: {
+  leaseData?: any;
+  attachment?: any;
+}): TenantLeaseDocumentStorageRef | null {
+  const refs = [
+    tenantLeaseStorageRefFromRecord(params.leaseData?.scheduleADocument, "scheduleADocument"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.scheduleA, "scheduleA"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.leaseDocument, "leaseDocument"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.referenceDocument, "referenceDocument"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.documentStorage, "documentStorage"),
+    tenantLeaseStorageRefFromRecord(params.leaseData?.signedDocument, "signedDocument"),
+    tenantLeaseStorageRefFromRecord(params.attachment, "ledgerAttachments"),
+    tenantLeaseStorageRefFromSignedUrlFields(params.leaseData, "lease"),
+    tenantLeaseStorageRefFromSignedUrlFields(params.attachment, "ledgerAttachments"),
+  ];
+  return refs.find((ref) => ref && isTenantScheduleAStorageRef(ref)) || null;
+}
+
+function tenantStorageRefFromGeneratedFile(
+  file: any,
+  source: string,
+  options?: { scheduleAOnly?: boolean; includeScheduleA?: boolean }
+): TenantLeaseDocumentStorageRef | null {
+  const kind = String(file?.kind || "").trim().toLowerCase();
+  const url = String(file?.url || "").trim();
+  const isScheduleA = isScheduleADocumentRecord(file);
+  if (options?.scheduleAOnly && !isScheduleA) return null;
+  if (!options?.includeScheduleA && !options?.scheduleAOnly && isScheduleA) return null;
+  const looksLikePdf = !kind || kind.includes("pdf") || kind.includes("lease") || kind.includes("document") || kind.includes("schedule");
+  if (!looksLikePdf && !url) return null;
+  return tenantLeaseStorageRefFromRecord(file, source) || tenantLeaseStorageRefFromSignedUrlFields(file, source);
+}
+
+async function loadTenantGeneratedDocumentStorageRef(
+  leaseData: any,
+  options?: { scheduleAOnly?: boolean; includeScheduleA?: boolean }
+): Promise<TenantLeaseDocumentStorageRef | null> {
+  const snapshotIds = [
+    leaseData?.latestLeaseSnapshotId,
+    leaseData?.lastGeneratedSnapshotId,
+    leaseData?.leaseSnapshotId,
+  ]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+
+  const draftId = String(leaseData?.sourceDraftId || leaseData?.draftId || "").trim();
+  if (draftId) {
+    try {
+      const draftSnap = await db.collection("leaseDrafts").doc(draftId).get();
+      if (draftSnap.exists) {
+        const draft = draftSnap.data() as any;
+        [draft?.lastGeneratedSnapshotId, draft?.latestLeaseSnapshotId]
+          .map((value) => String(value || "").trim())
+          .filter(Boolean)
+          .forEach((snapshotId) => snapshotIds.push(snapshotId));
+      }
+    } catch {
+      // Missing draft metadata should not expose or hide unrelated tenant documents.
+    }
+  }
+
+  for (const snapshotId of Array.from(new Set(snapshotIds))) {
+    try {
+      const snapshotSnap = await db.collection("leaseSnapshots").doc(snapshotId).get();
+      if (!snapshotSnap.exists) continue;
+      const snapshot = snapshotSnap.data() as any;
+      const generatedFiles = Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : [];
+      for (const file of generatedFiles) {
+        const ref = tenantStorageRefFromGeneratedFile(file, `leaseSnapshots/${snapshotId}`, options);
+        if (ref) return ref;
+      }
+    } catch {
+      // Continue through remaining snapshot candidates.
+    }
+  }
+
+  return null;
 }
 
 async function refreshTenantLeaseSignedUrl(storageRef: TenantLeaseDocumentStorageRef | null): Promise<string | null> {
@@ -3153,6 +3279,7 @@ async function getTenantLeaseDocumentContext(params: {
   unitId: string | null;
   leaseData: any;
   attachments?: any[];
+  documentKind?: "lease" | "schedule-a";
 }): Promise<TenantLeaseDocumentContext> {
   const leaseId = String(params.leaseId || "").trim();
   const tenantId = String(params.tenantId || "").trim();
@@ -3192,7 +3319,53 @@ async function getTenantLeaseDocumentContext(params: {
   }
 
   const signed = isLeaseSigned(params.leaseData);
-  const directStorageRef = tenantLeaseDocumentStorageRef({ leaseData: params.leaseData });
+
+  if (params.documentKind === "schedule-a") {
+    const directScheduleRef = tenantScheduleAStorageRef({ leaseData: params.leaseData });
+    const generatedScheduleRef = directScheduleRef
+      ? null
+      : await loadTenantGeneratedDocumentStorageRef(params.leaseData, { scheduleAOnly: true });
+    const storageRef = directScheduleRef || generatedScheduleRef;
+    const refreshedUrl = await refreshTenantLeaseSignedUrl(storageRef);
+    const scheduleUrl =
+      firstLeaseDocumentUrl(params.leaseData, ["scheduleAUrl", "scheduleADocumentUrl"], { includeScheduleA: true }) ||
+      firstLeaseDocumentUrl(params.leaseData?.scheduleADocument, ["url"], { includeScheduleA: true }) ||
+      firstLeaseDocumentUrl(params.leaseData?.scheduleA, ["url"], { includeScheduleA: true }) ||
+      firstLeaseDocumentUrl(params.leaseData, ["documentUrl", "approvedDocumentUrl", "documentRef"], { scheduleAOnly: true });
+    if (refreshedUrl || (!storageRef && scheduleUrl)) {
+      return {
+        leaseId,
+        tenantId: tenantId || undefined,
+        propertyId: propertyId || undefined,
+        unitId: unitId || undefined,
+        leaseStatus,
+        signingStatus: signed ? "signed" : "unsigned",
+        documentStatus: "generated",
+        documentId: String(params.leaseData?.scheduleADocumentId || params.leaseData?.latestLeaseSnapshotId || "").trim() || undefined,
+        documentUrl: refreshedUrl || scheduleUrl || undefined,
+        displayLabel: "Schedule A",
+        source: refreshedUrl ? storageRef?.source || "schedule_a_document" : "schedule_a_document",
+        confidence: "medium",
+        warnings,
+      };
+    }
+    return {
+      leaseId,
+      tenantId: tenantId || undefined,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      documentStatus: "missing",
+      displayLabel: "No Schedule A available yet",
+      source: "schedule_a_missing",
+      confidence: "low",
+      warnings: ["No tenant-safe Schedule A link is available yet."],
+    };
+  }
+
+  const directStorageRef =
+    tenantLeaseDocumentStorageRef({ leaseData: params.leaseData }) ||
+    (await loadTenantGeneratedDocumentStorageRef(params.leaseData));
   const refreshedDirectUrl = await refreshTenantLeaseSignedUrl(directStorageRef);
   const signedUrl = firstLeaseDocumentUrl(params.leaseData, [
     "signedDocumentUrl",
@@ -5017,6 +5190,12 @@ router.get("/lease/document-url", requireTenantWorkspaceIdentity, async (req: an
     if (!leaseMatchesTenantIdentity(leaseData, context.tenantId, context.invitedEmail || req.user?.email)) {
       return res.status(403).json({ ok: false, error: "lease_not_owned_by_tenant" });
     }
+    const requestQuery = new URLSearchParams(String(req.originalUrl || req.url || "").split("?")[1] || "");
+    const requestedDocument = String(
+      req.query?.document || req.query?.kind || requestQuery.get("document") || requestQuery.get("kind") || "lease"
+    )
+      .trim()
+      .toLowerCase();
     const documentContext = await getTenantLeaseDocumentContext({
       leaseId: context.leaseId,
       tenantId: context.tenantId,
@@ -5024,6 +5203,10 @@ router.get("/lease/document-url", requireTenantWorkspaceIdentity, async (req: an
       propertyId: context.propertyId,
       unitId: context.unitId,
       leaseData,
+      documentKind:
+        requestedDocument === "schedule-a" || requestedDocument === "schedule_a" || requestedDocument === "schedule"
+          ? "schedule-a"
+          : "lease",
     });
     if (!documentContext.documentUrl || documentContext.documentStatus === "missing") {
       return res.status(404).json({ ok: false, error: "lease_document_not_found" });
@@ -7010,6 +7193,18 @@ router.get("/lease", requireTenant, async (req: any, res) => {
             leaseData: leaseRecord,
           })
         : null;
+    const scheduleADocumentContext =
+      leaseId && leaseRecord
+        ? await getTenantLeaseDocumentContext({
+            leaseId,
+            tenantId,
+            tenantEmail: String(tenantData?.email || req.user?.email || "").trim() || null,
+            propertyId,
+            unitId,
+            leaseData: leaseRecord,
+            documentKind: "schedule-a",
+          })
+        : null;
     const projectedLease = leaseId
       ? projectTenantLease(leaseId, {
           ...(leaseRecord || {}),
@@ -7078,6 +7273,7 @@ router.get("/lease", requireTenant, async (req: any, res) => {
       leaseStart: projectedLease?.startDate ?? null,
       leaseEnd: projectedLease?.endDate ?? null,
       leaseDocumentContext,
+      scheduleADocumentContext,
     };
 
     return res.json({ ok: true, data: lease, lease, ...lease });

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -3021,6 +3021,48 @@ function tenantLeaseStorageRefFromRecord(record: any, source: string): TenantLea
   return { bucket, path, source };
 }
 
+function parseTenantLeaseGcsSignedUrlStorageRef(value: unknown, source: string): TenantLeaseDocumentStorageRef | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:") return null;
+    if (url.hostname === "storage.googleapis.com" || url.hostname === "storage.cloud.google.com") {
+      const segments = url.pathname.split("/").filter(Boolean);
+      const bucket = segments.shift() || "";
+      const path = normalizeLeaseDocumentStoragePath(segments.join("/"));
+      return bucket && path ? { bucket, path, source } : null;
+    }
+    if (url.hostname.endsWith(".storage.googleapis.com")) {
+      const bucket = url.hostname.slice(0, -".storage.googleapis.com".length);
+      const path = normalizeLeaseDocumentStoragePath(decodeURIComponent(url.pathname).replace(/^\/+/, ""));
+      return bucket && path ? { bucket, path, source } : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function tenantLeaseStorageRefFromSignedUrlFields(record: any, source: string): TenantLeaseDocumentStorageRef | null {
+  const fields = [
+    "signedDocumentUrl",
+    "signedLeaseDocumentUrl",
+    "executedDocumentUrl",
+    "finalDocumentUrl",
+    "fullyExecutedDocumentUrl",
+    "documentUrl",
+    "approvedDocumentUrl",
+    "documentRef",
+    "url",
+  ];
+  for (const field of fields) {
+    const ref = parseTenantLeaseGcsSignedUrlStorageRef(record?.[field], `${source}.${field}`);
+    if (ref) return ref;
+  }
+  return null;
+}
+
 function tenantLeaseDocumentStorageRef(params: {
   leaseData?: any;
   attachment?: any;
@@ -3031,6 +3073,8 @@ function tenantLeaseDocumentStorageRef(params: {
     tenantLeaseStorageRefFromRecord(params.leaseData?.documentStorage, "documentStorage") ||
     tenantLeaseStorageRefFromRecord(params.leaseData?.signedDocument, "signedDocument") ||
     tenantLeaseStorageRefFromRecord(params.attachment, "ledgerAttachments") ||
+    tenantLeaseStorageRefFromSignedUrlFields(params.leaseData, "lease") ||
+    tenantLeaseStorageRefFromSignedUrlFields(params.attachment, "ledgerAttachments") ||
     null
   );
 }
@@ -3108,7 +3152,7 @@ async function getTenantLeaseDocumentContext(params: {
     "approvedDocumentUrl",
     "documentRef",
   ]);
-  if (signed && (refreshedDirectUrl || signedUrl)) {
+  if (signed && (refreshedDirectUrl || (!directStorageRef && signedUrl))) {
     return {
       leaseId,
       tenantId: tenantId || undefined,
@@ -3127,7 +3171,7 @@ async function getTenantLeaseDocumentContext(params: {
   }
 
   const generatedUrl = firstLeaseDocumentUrl(params.leaseData, ["documentUrl", "approvedDocumentUrl", "documentRef"]);
-  if (refreshedDirectUrl || generatedUrl) {
+  if (refreshedDirectUrl || (!directStorageRef && generatedUrl)) {
     return {
       leaseId,
       tenantId: tenantId || undefined,
@@ -3148,24 +3192,26 @@ async function getTenantLeaseDocumentContext(params: {
   const attachments = params.attachments || (tenantId ? await loadTenantLeaseAttachments(tenantId) : []);
   const attachment = bestTenantLeaseAttachment({ attachments, leaseId, propertyId, unitId });
   if (attachment) {
-    const refreshedAttachmentUrl = await refreshTenantLeaseSignedUrl(
-      tenantLeaseDocumentStorageRef({ attachment })
-    );
-    return {
-      leaseId,
-      tenantId: tenantId || undefined,
-      propertyId: propertyId || undefined,
-      unitId: unitId || undefined,
-      leaseStatus,
-      signingStatus: signed ? "signed" : "unsigned",
-      documentStatus: signed ? "signed" : "generated",
-      documentId: String(attachment?.id || "").trim() || undefined,
-      documentUrl: refreshedAttachmentUrl || String(attachment.url || "").trim(),
-      displayLabel: signed ? "Signed lease document" : "Generated lease package",
-      source: "ledgerAttachments",
-      confidence: "high",
-      warnings,
-    };
+    const attachmentStorageRef = tenantLeaseDocumentStorageRef({ attachment });
+    const refreshedAttachmentUrl = await refreshTenantLeaseSignedUrl(attachmentStorageRef);
+    const attachmentUrl = refreshedAttachmentUrl || (!attachmentStorageRef ? String(attachment.url || "").trim() : "");
+    if (attachmentUrl) {
+      return {
+        leaseId,
+        tenantId: tenantId || undefined,
+        propertyId: propertyId || undefined,
+        unitId: unitId || undefined,
+        leaseStatus,
+        signingStatus: signed ? "signed" : "unsigned",
+        documentStatus: signed ? "signed" : "generated",
+        documentId: String(attachment?.id || "").trim() || undefined,
+        documentUrl: attachmentUrl,
+        displayLabel: signed ? "Signed lease document" : "Generated lease package",
+        source: refreshedAttachmentUrl ? attachmentStorageRef?.source || "ledgerAttachments" : "ledgerAttachments",
+        confidence: "high",
+        warnings,
+      };
+    }
   }
 
   if (isLeaseDocumentWorkflowPending(params.leaseData)) {

--- a/rentchain-api/src/services/__tests__/tenancyContextService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenancyContextService.test.ts
@@ -180,6 +180,33 @@ describe("resolveTenancyContext", () => {
     expect(result.leaseId).toBe("lease-email");
   });
 
+  it("resolves active tenant authority from an email-linked active lease when tenant id linkage is missing", async () => {
+    ensureCollection("tenants").set("tenant-by-email", {
+      tenantId: "tenant-by-email",
+      email: "tenant@example.com",
+    });
+    ensureCollection("leases").set("lease-email-only", {
+      tenantEmail: "tenant@example.com",
+      propertyId: "prop-email",
+      unitId: "unit-6",
+      status: "active",
+    });
+
+    const { resolveTenancyContext } = await import("../tenantPortal/tenancyContextService");
+    const result = await resolveTenancyContext({
+      uid: "auth-user-1",
+      email: "tenant@example.com",
+      tenantId: null,
+      leaseId: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.authority).toBe("active_tenant");
+    expect(result.tenantId).toBe("tenant-by-email");
+    expect(result.leaseId).toBe("lease-email-only");
+    expect(result.unitId).toBe("unit-6");
+  });
+
   it("does not grant tenant authority from an arbitrary mismatched email", async () => {
     ensureCollection("tenants").set("tenant-by-email", {
       tenantId: "tenant-by-email",

--- a/rentchain-api/src/services/tenantPortal/tenancyContextService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenancyContextService.ts
@@ -61,6 +61,27 @@ function isActiveLeaseStatus(status: unknown): boolean {
   return ACTIVE_LEASE_STATUSES.has(next);
 }
 
+function leaseMatchesTenantIdentity(data: any, tenantId: string | null, email: string | null): boolean {
+  const normalizedTenantId = asString(tenantId);
+  if (normalizedTenantId) {
+    if (asString(data?.tenantId) === normalizedTenantId) return true;
+    if (asString(data?.primaryTenantId) === normalizedTenantId) return true;
+    if (Array.isArray(data?.tenantIds) && data.tenantIds.map((value: any) => asString(value)).includes(normalizedTenantId)) return true;
+  }
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) return false;
+  return [
+    data?.tenantEmail,
+    data?.email,
+    data?.primaryTenantEmail,
+    data?.tenant?.email,
+    data?.applicantEmail,
+  ]
+    .map((value) => normalizeEmail(value))
+    .filter(Boolean)
+    .includes(normalizedEmail);
+}
+
 async function safeGetDocs(collectionName: string, field: string, value: string, operator: "==" | "array-contains" = "==") {
   if (!value) return [];
   try {
@@ -231,6 +252,8 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
   const leaseDocs = [
     ...(tenantRecordId ? await safeGetDocs("leases", "tenantId", tenantRecordId) : []),
     ...(tenantRecordId ? await safeGetDocs("leases", "tenantIds", tenantRecordId, "array-contains") : []),
+    ...(email ? await safeGetDocs("leases", "tenantEmail", email) : []),
+    ...(email ? await safeGetDocs("leases", "email", email) : []),
     ...(tenantRecordLeaseId ? [await db.collection("leases").doc(String(tenantRecordLeaseId)).get().catch(() => null as any)] : []),
   ].filter(Boolean);
 
@@ -238,6 +261,7 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
     if (!doc?.exists) continue;
     const data = (doc.data() || {}) as any;
     if (!isActiveLeaseStatus(data?.status)) continue;
+    if (!leaseMatchesTenantIdentity(data, tenantRecordId, email)) continue;
     const propertyId = asString(data?.propertyId);
     if (!propertyId) continue;
     pushCandidate({

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -173,6 +173,11 @@ function asString(value: unknown): string | null {
   return next || null;
 }
 
+function isScheduleADocumentUrl(value: unknown): boolean {
+  const normalized = String(value || "").trim().toLowerCase();
+  return Boolean(normalized) && (normalized.includes("schedule-a") || normalized.includes("schedule_a"));
+}
+
 function asNumber(value: unknown): number | null {
   const next = Number(value);
   return Number.isFinite(next) ? next : null;
@@ -403,8 +408,9 @@ export function projectTenantProperty(recordId: string, data: any): TenantProper
 }
 
 export function projectTenantLease(recordId: string, data: any): TenantLeaseProjection {
-  const documentUrl =
+  const rawDocumentUrl =
     asString(data?.documentUrl) || asString(data?.approvedDocumentUrl) || asString(data?.documentRef);
+  const documentUrl = isScheduleADocumentUrl(rawDocumentUrl) ? null : rawDocumentUrl;
   const startDate = asString(data?.startDate) || asString(data?.leaseStart);
   const endDate = asString(data?.endDate) || asString(data?.leaseEnd);
   const monthlyRent =

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -374,6 +374,19 @@ export async function getLeaseById(id: string): Promise<{ lease: LandlordActiveL
   return apiJson<{ lease: LandlordActiveLease }>(`/leases/${encodeURIComponent(id)}`);
 }
 
+export async function refreshLeaseDocumentUrl(id: string): Promise<{
+  documentUrl: string;
+  refreshMode: "signed_url" | "legacy_url";
+  expiresInSeconds: number | null;
+}> {
+  return apiJson<{
+    ok: true;
+    documentUrl: string;
+    refreshMode: "signed_url" | "legacy_url";
+    expiresInSeconds: number | null;
+  }>(`/leases/${encodeURIComponent(id)}/document-url`);
+}
+
 export async function getLeaseNotes(id: string): Promise<{ ok: true; notes: LeaseNote[] }> {
   return apiJson<{ ok: true; notes: LeaseNote[] }>(`/leases/${encodeURIComponent(id)}/notes`);
 }

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -124,6 +124,7 @@ export interface LandlordActiveLease extends Lease {
   tenantName?: string | null;
   tenantEmail?: string | null;
   documentUrl?: string | null;
+  scheduleAUrl?: string | null;
   signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
   signatureReadinessLabel?: string | null;
   signatureReadinessDescription?: string | null;
@@ -374,17 +375,20 @@ export async function getLeaseById(id: string): Promise<{ lease: LandlordActiveL
   return apiJson<{ lease: LandlordActiveLease }>(`/leases/${encodeURIComponent(id)}`);
 }
 
-export async function refreshLeaseDocumentUrl(id: string): Promise<{
+export async function refreshLeaseDocumentUrl(id: string, options?: { document?: "lease" | "schedule-a" }): Promise<{
   documentUrl: string;
   refreshMode: "signed_url" | "legacy_url";
   expiresInSeconds: number | null;
+  documentKind?: "lease" | "schedule-a";
 }> {
+  const documentKind = options?.document ? `?document=${encodeURIComponent(options.document)}` : "";
   return apiJson<{
     ok: true;
     documentUrl: string;
     refreshMode: "signed_url" | "legacy_url";
     expiresInSeconds: number | null;
-  }>(`/leases/${encodeURIComponent(id)}/document-url`);
+    documentKind?: "lease" | "schedule-a";
+  }>(`/leases/${encodeURIComponent(id)}/document-url${documentKind}`);
 }
 
 export async function getLeaseNotes(id: string): Promise<{ ok: true; notes: LeaseNote[] }> {

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -596,6 +596,26 @@ export async function getTenantLeaseWorkspace(): Promise<TenantWorkspaceLease | 
   return res?.data ?? null;
 }
 
+export async function refreshTenantLeaseDocumentUrl(): Promise<{
+  documentUrl: string;
+  displayLabel: string;
+  documentStatus: string;
+  source: string;
+  expiresInSeconds: number;
+}> {
+  const res = await tenantApiFetch<{
+    ok: boolean;
+    data: {
+      documentUrl: string;
+      displayLabel: string;
+      documentStatus: string;
+      source: string;
+      expiresInSeconds: number;
+    };
+  }>("/tenant/lease/document-url");
+  return res.data;
+}
+
 export async function createTenantLeasePaymentCheckout(
   leaseId: string
 ): Promise<{ rentPaymentId: string; status: "checkout_created"; redirectUrl: string }> {

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -46,6 +46,7 @@ export type TenantWorkspaceLease = {
   status: string | null;
   documentUrl: string | null;
   leaseDocumentContext?: TenantLeaseDocumentContext | null;
+  scheduleADocumentContext?: TenantLeaseDocumentContext | null;
   signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
   signatureReadinessLabel?: string | null;
   signatureReadinessDescription?: string | null;
@@ -596,13 +597,14 @@ export async function getTenantLeaseWorkspace(): Promise<TenantWorkspaceLease | 
   return res?.data ?? null;
 }
 
-export async function refreshTenantLeaseDocumentUrl(): Promise<{
+export async function refreshTenantLeaseDocumentUrl(options?: { document?: "lease" | "schedule-a" }): Promise<{
   documentUrl: string;
   displayLabel: string;
   documentStatus: string;
   source: string;
   expiresInSeconds: number;
 }> {
+  const query = options?.document ? `?document=${encodeURIComponent(options.document)}` : "";
   const res = await tenantApiFetch<{
     ok: boolean;
     data: {
@@ -612,7 +614,7 @@ export async function refreshTenantLeaseDocumentUrl(): Promise<{
       source: string;
       expiresInSeconds: number;
     };
-  }>("/tenant/lease/document-url");
+  }>(`/tenant/lease/document-url${query}`);
   return res.data;
 }
 

--- a/rentchain-frontend/src/api/tenantPortalApi.ts
+++ b/rentchain-frontend/src/api/tenantPortalApi.ts
@@ -23,6 +23,7 @@ export interface TenantLease {
   status: string | null;
   documentUrl?: string | null;
   leaseDocumentContext?: TenantLeaseDocumentContext | null;
+  scheduleADocumentContext?: TenantLeaseDocumentContext | null;
   signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
   signatureReadinessLabel?: string | null;
   signatureReadinessDescription?: string | null;

--- a/rentchain-frontend/src/components/dashboard/BoardSnapshotDrawer.tsx
+++ b/rentchain-frontend/src/components/dashboard/BoardSnapshotDrawer.tsx
@@ -41,7 +41,7 @@ export function BoardSnapshotDrawer({
       >
         Monthly Operations Snapshot
         <div style={{ display: "flex", gap: 8 }}>
-          <Button onClick={() => window.print()}>Export PDF</Button>
+          <Button onClick={() => window.print()}>Print / Save PDF</Button>
           <Button
             style={{ border: "1px solid #e5e7eb", background: "#fff", color: "#111827" }}
             onClick={onClose}

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -351,6 +351,7 @@ describe("PropertyDetailPanel", () => {
         {
           id: "lease-1",
           tenantId: "tenant-1",
+          tenantName: "Jane Tenant",
           propertyId: "prop-1",
           unitId: "unit-1",
           unitNumber: "101",
@@ -387,6 +388,13 @@ describe("PropertyDetailPanel", () => {
     );
 
     expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
+    const tenantLinks = screen.getAllByRole("link", { name: "Jane Tenant" });
+    expect(tenantLinks.length).toBeGreaterThan(0);
+    expect(tenantLinks[0]).toHaveAttribute("href", "/tenants?tenantId=tenant-1");
+    const leaseLinks = screen.getAllByRole("link", { name: "View lease" });
+    expect(leaseLinks.length).toBeGreaterThan(0);
+    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.queryByText("tenant-1")).not.toBeInTheDocument();
   });
 
   it("hydrates lease risk unit labels from property units instead of showing raw unit ids", async () => {
@@ -618,8 +626,10 @@ describe("PropertyDetailPanel", () => {
 
     expect((await screen.findAllByText("Upcoming")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Occupied").length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Future Tenant · Ends May 31, 2027/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Current Tenant · Ends Dec 31, 2026/).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Future Tenant" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Ends May 31, 2027/).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Current Tenant" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Ends Dec 31, 2026/).length).toBeGreaterThan(0);
     expect(screen.getByText("50%")).toBeInTheDocument();
   });
 
@@ -675,7 +685,8 @@ describe("PropertyDetailPanel", () => {
       </MemoryRouter>
     );
 
-    await waitFor(() => expect(screen.getAllByText(/John Smith · Ends May 29, 2027/).length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByRole("link", { name: "John Smith" }).length).toBeGreaterThan(0));
+    expect(screen.getAllByText(/Ends May 29, 2027/).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: "View related leases" })[0]).toHaveAttribute("href", "/leases?propertyId=prop-1");
     fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
 

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -72,6 +72,11 @@ function isRawUnitIdLabel(value: string, rawIds: string[]) {
   return RAW_ID_PATTERN.test(value) && /[A-Za-z]/.test(value) && /\d/.test(value);
 }
 
+function isScheduleADocumentUrl(value: unknown) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return Boolean(normalized) && (normalized.includes("schedule-a") || normalized.includes("schedule_a"));
+}
+
 function findLeaseRiskUnit(lease: Lease, unitsForDisplay: any[]): any | null {
   const rawIds = [cleanLabel(lease.unitId), cleanLabel((lease as any).id)].filter(Boolean);
   const unitReference = cleanLabel(lease.unitId || lease.unitNumber || lease.unitLabel);
@@ -1730,7 +1735,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                             <div style={{ fontSize: "0.78rem", color: "#2563eb" }}>
                               {(u as any).leaseDocument?.url ? (
                                 <a href={(u as any).leaseDocument.url} target="_blank" rel="noreferrer">
-                                  View lease document
+                                  {isScheduleADocumentUrl((u as any).leaseDocument.url) ? "View Schedule A" : "View lease document"}
                                 </a>
                               ) : (
                                 `Lease document: ${String((u as any).leaseDocument.fileName)}`
@@ -1879,7 +1884,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                       <div style={{ fontSize: "0.78rem", color: "#2563eb", marginTop: 4 }}>
                         {(u as any).leaseDocument?.url ? (
                           <a href={(u as any).leaseDocument.url} target="_blank" rel="noreferrer">
-                            View lease document
+                            {isScheduleADocumentUrl((u as any).leaseDocument.url) ? "View Schedule A" : "View lease document"}
                           </a>
                         ) : (
                           `Lease document: ${String((u as any).leaseDocument.fileName)}`

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -149,13 +149,26 @@ function buildUnitOccupancyView(unit: any, occupancy: UnitOccupancy) {
   const leaseEndDate = occupancy.status === "occupied" || occupancy.status === "upcoming"
     ? resolveOccupancyLeaseEndDate(unit, occupancy)
     : "";
+  const lease = occupancy.lease as any;
   const leaseId = String((occupancy.lease as any)?.id || (occupancy.lease as any)?.leaseId || "").trim();
+  const tenantId = String(
+    lease?.tenantId ||
+      lease?.primaryTenantId ||
+      (Array.isArray(lease?.tenantIds) ? lease.tenantIds[0] : "") ||
+      unit?.tenantId ||
+      unit?.currentTenantId ||
+      unit?.occupantTenantId ||
+      ""
+  ).trim();
   return {
     status: occupancy.status,
     label: occupancy.label,
     tenantName,
+    tenantId,
+    tenantHref: tenantName && tenantId ? `/tenants?tenantId=${encodeURIComponent(tenantId)}` : "",
     leaseEndDate,
     leaseId,
+    leaseHref: leaseId ? `/leases/${encodeURIComponent(leaseId)}/summary` : "",
     reviewReason: occupancy.status === "review_required" ? occupancy.reason || "Occupancy data needs review." : "",
     ledgerHref: leaseId ? `/leases/${encodeURIComponent(leaseId)}/ledger` : "",
   };
@@ -1688,8 +1701,18 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                           </span>
                           {occupantName ? (
                             <div style={{ fontSize: "0.8rem", color: "#475569" }}>
-                              {occupantName}
+                              {occupancyView.tenantHref ? (
+                                <a href={occupancyView.tenantHref}>{occupantName}</a>
+                              ) : (
+                                occupantName
+                              )}
                               {leaseEndDate ? ` · Ends ${formatDate(leaseEndDate)}` : ""}
+                              {occupancyView.leaseHref ? (
+                                <>
+                                  {" · "}
+                                  <a href={occupancyView.leaseHref}>View lease</a>
+                                </>
+                              ) : null}
                               {occupancyView.ledgerHref ? (
                                 <>
                                   {" · "}
@@ -1827,8 +1850,18 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                     <div className="rc-unit-value">{occupancy.label}</div>
                     {occupantName ? (
                       <div style={{ fontSize: "0.8rem", color: "#475569", marginTop: 4 }}>
-                        {occupantName}
+                        {occupancyView.tenantHref ? (
+                          <a href={occupancyView.tenantHref}>{occupantName}</a>
+                        ) : (
+                          occupantName
+                        )}
                         {leaseEndDate ? ` · Ends ${formatDate(leaseEndDate)}` : ""}
+                        {occupancyView.leaseHref ? (
+                          <>
+                            {" · "}
+                            <a href={occupancyView.leaseHref}>View lease</a>
+                          </>
+                        ) : null}
                         {occupancyView.ledgerHref ? (
                           <>
                             {" · "}

--- a/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
@@ -223,8 +223,10 @@ describe("PropertyDetailPanel occupancy regression coverage", () => {
     expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Upcoming").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Vacant").length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/John Smith · Ends May 31, 2099/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Bailey Blinkers · Ends Jun 30, 2100/).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "John Smith" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Ends May 31, 2099/).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Bailey Blinkers" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Ends Jun 30, 2100/).length).toBeGreaterThan(0);
     expect(screen.queryByText(/Casey Past · Ends May 31, 2026/)).not.toBeInTheDocument();
     expect(screen.queryByText(lifecycleContinuityIds.activeLeaseId)).not.toBeInTheDocument();
     expect(screen.queryByText(lifecycleContinuityIds.unit101Id)).not.toBeInTheDocument();
@@ -293,7 +295,8 @@ describe("PropertyDetailPanel occupancy regression coverage", () => {
 
     renderPropertyDetail();
 
-    await waitFor(() => expect(screen.getAllByText(/John Smith · Ends May 31, 2099/).length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByRole("link", { name: "John Smith" }).length).toBeGreaterThan(0));
+    expect(screen.getAllByText(/Ends May 31, 2099/).length).toBeGreaterThan(0);
     fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
 
     expect(screen.getByTestId("unit-edit-modal")).toBeInTheDocument();
@@ -344,7 +347,7 @@ describe("PropertyDetailPanel occupancy regression coverage", () => {
     expect(ledgerLinks.some((link) => link.getAttribute("href") === `/leases/${lifecycleContinuityIds.activeLeaseId}/ledger`)).toBe(true);
     expect(ledgerLinks.some((link) => link.getAttribute("href") === `/leases/${lifecycleContinuityIds.upcomingLeaseId}/ledger`)).toBe(true);
 
-    const activeRow = screen.getAllByText(/John Smith · Ends May 31, 2099/)[0].closest("td");
+    const activeRow = screen.getAllByRole("link", { name: "John Smith" })[0].closest("td");
     expect(activeRow).toBeTruthy();
     expect(within(activeRow as HTMLElement).getByRole("link", { name: "Ledger" })).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TenantDetailPanel } from "./TenantDetailPanel";
@@ -8,7 +8,9 @@ const mocks = vi.hoisted(() => ({
   fetchLedger: vi.fn(),
   fetchLeaseLedger: vi.fn(),
   fetchTenantFinancialActivity: vi.fn(),
+  downloadTenantReport: vi.fn(),
   getTenantSignals: vi.fn(),
+  printSummaryDocument: vi.fn(),
   showToast: vi.fn(),
 }));
 
@@ -29,8 +31,16 @@ vi.mock("@/api/tenantDetail", () => ({
   updateTenantMoveInReadiness: vi.fn(),
 }));
 
+vi.mock("@/api/tenantsApi", () => ({
+  downloadTenantReport: (...args: unknown[]) => mocks.downloadTenantReport(...args),
+}));
+
 vi.mock("@/api/tenantSignals", () => ({
   getTenantSignals: mocks.getTenantSignals,
+}));
+
+vi.mock("@/utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => mocks.printSummaryDocument(...args),
 }));
 
 vi.mock("../ui/ToastProvider", () => ({
@@ -96,6 +106,11 @@ describe("TenantDetailPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getTenantSignals.mockResolvedValue({ signals: null });
+    mocks.printSummaryDocument.mockResolvedValue(undefined);
+    mocks.downloadTenantReport.mockResolvedValue({
+      blob: new Blob(["tenant"], { type: "application/pdf" }),
+      filename: "tenant-summary.pdf",
+    });
     mocks.fetchTenantFinancialActivity.mockResolvedValue([
       {
         id: "row-1",
@@ -225,11 +240,17 @@ describe("TenantDetailPanel", () => {
     expect(screen.getByText(/Balance .*1,850\.00/i)).toBeInTheDocument();
     expect(await screen.findByText("Financial activity")).toBeInTheDocument();
     expect(screen.getByText("Recorded Payments")).toBeInTheDocument();
-    expect(screen.getByText("Recorded payment (e-transfer)")).toBeInTheDocument();
+    expect(screen.getAllByText("Recorded payment (e-transfer)").length).toBeGreaterThan(0);
     expect(screen.getByText("Tenant activity panel")).toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledWith("lease-1"));
     await waitFor(() => expect(mocks.fetchTenantFinancialActivity).toHaveBeenCalledWith("tenant-1"));
     expect(mocks.fetchLedger).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
+    await waitFor(() => expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary"));
+    expect(mocks.downloadTenantReport).not.toHaveBeenCalled();
+    expect(document.querySelector(".print-only-summary")?.textContent).toContain("Tenant summary");
+    expect(document.querySelector(".print-only-summary")?.textContent).toContain("Taylor Tenant");
   });
 
   it("falls back to the existing tenant-level ledger source when no current lease is linked", async () => {
@@ -310,8 +331,8 @@ describe("TenantDetailPanel", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("May 1, 2026")).toBeInTheDocument();
-    expect(screen.getByText("Apr 30, 2027")).toBeInTheDocument();
+    expect((await screen.findAllByText("May 1, 2026")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Apr 30, 2027").length).toBeGreaterThan(0);
     expect(screen.queryByText("Apr 30, 2026")).not.toBeInTheDocument();
     expect(screen.queryByText("Apr 29, 2027")).not.toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledWith("lease-1"));

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -29,6 +29,7 @@ import { TenantActivityPanel } from "./TenantActivityPanel";
 import { FinancialActivityPanel } from "./FinancialActivityPanel";
 import { FeatureGate } from "@/components/billing/FeatureGate";
 import { LockedFeature } from "@/components/billing/LockedFeature";
+import { printSummaryDocument } from "@/utils/printSummary";
 
 interface TenantDetailPanelProps {
   tenantId: string | null;
@@ -303,7 +304,19 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
     };
   }, [tenantId]);
 
-  const handleDownloadReport = async () => {
+  const downloadTenantReportFallback = async () => {
+    const report = await downloadTenantReport(tenantId);
+    const url = URL.createObjectURL(report.blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = report.filename || "tenant-summary.pdf";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handlePrintOrSaveReport = async () => {
     if (!canExportPdf) {
       openUpgrade({
         reason: "exports",
@@ -317,18 +330,14 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
       return;
     }
     try {
-      const report = await downloadTenantReport(tenantId);
-      const url = URL.createObjectURL(report.blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = report.filename || "tenant-summary.pdf";
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      if (typeof window !== "undefined" && typeof window.print === "function") {
+        await printSummaryDocument("summary");
+        return;
+      }
+      await downloadTenantReportFallback();
       showToast({
         message: "Tenant summary downloaded",
-        description: "The PDF summary has been saved.",
+        description: "Browser print was unavailable, so the PDF summary has been saved.",
         variant: "success",
       });
     } catch (err: any) {
@@ -459,7 +468,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
           <div style={{ display: "flex", gap: spacing.xs, flexWrap: "wrap", justifyContent: "flex-end" }}>
             <button
               type="button"
-              onClick={handleDownloadReport}
+              onClick={handlePrintOrSaveReport}
               style={{
                 borderRadius: radius.pill,
                 border: `1px solid ${colors.border}`,
@@ -474,10 +483,10 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
                 boxShadow: shadows.sm,
               }}
             >
-              <span role="img" aria-label="file">
+              <span aria-hidden="true">
                 📄
               </span>
-              <span>{canExportPdf ? "Download Tenant Summary (PDF)" : "Upgrade for Tenant PDF"}</span>
+              <span>{canExportPdf ? "Print / Save PDF" : "Upgrade for Tenant PDF"}</span>
             </button>
             {isLandlord ? (
               <>
@@ -593,6 +602,64 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
         {lifecycle?.flags?.hasStateConflict ? (
           <DetailField label="Lifecycle Review" value="Source status conflict detected" />
         ) : null}
+      </div>
+
+      <div className="print-only print-only-summary" aria-hidden="true">
+        <section
+          style={{
+            display: "grid",
+            gap: 12,
+            color: "#0f172a",
+            background: "#fff",
+            fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          }}
+        >
+          <header style={{ display: "grid", gap: 4 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, textTransform: "uppercase", color: "#475569" }}>
+              Tenant summary
+            </div>
+            <h1 style={{ margin: 0, fontSize: 24 }}>{tenant.fullName || tenant.name || "Unnamed Tenant"}</h1>
+            <div style={{ color: "#475569", fontSize: 14 }}>
+              {propertyLabel} · Unit {unitLabel}
+            </div>
+            {propertyAddress ? <div style={{ color: "#475569", fontSize: 13 }}>{propertyAddress}</div> : null}
+          </header>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 10 }}>
+            <DetailField label="Email" value={tenant.email ?? "--"} />
+            <DetailField label="Phone" value={tenant.phone ?? "--"} />
+            <DetailField label="Current lease status" value={formatLeaseStatus(lease?.status)} />
+            <DetailField
+              label="Monthly rent"
+              value={
+                monthlyRent || monthlyRent === 0
+                  ? `$${Number(monthlyRent).toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+                  : "--"
+              }
+            />
+            <DetailField label="Lease start" value={formatDateLabel(tenant.leaseStart ?? lease?.leaseStart)} />
+            <DetailField label="Lease end" value={formatDateLabel(tenant.leaseEnd ?? lease?.leaseEnd)} />
+            <DetailField label="Lifecycle" value={lifecycle?.lifecycleLabel ?? "--"} />
+            <DetailField label="Risk level" value={riskLevel} />
+          </div>
+          <section style={{ display: "grid", gap: 6 }}>
+            <h2 style={{ margin: 0, fontSize: 16 }}>Financial activity summary</h2>
+            {financialActivityRows.length ? (
+              financialActivityRows.slice(0, 6).map((row) => (
+                <div key={row.id} style={{ display: "flex", justifyContent: "space-between", gap: 12, fontSize: 13 }}>
+                  <span>{row.displayLabel || row.sourceBadge || "Financial activity"}</span>
+                  <span>
+                    {Number(row.amount || 0).toLocaleString(undefined, {
+                      style: "currency",
+                      currency: "CAD",
+                    })}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <div style={{ color: "#475569", fontSize: 13 }}>No financial activity rows loaded.</div>
+            )}
+          </section>
+        </section>
       </div>
 
       <CredibilityInsightsCard insights={credibilityInsights} />

--- a/rentchain-frontend/src/lib/documentRendering.test.ts
+++ b/rentchain-frontend/src/lib/documentRendering.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createPrintRoot,
+  PRINT_SAFE_CLASS,
   PRINT_ROOT_ATTRIBUTE,
   shouldStartNewPage,
   triggerDocumentDownload,
@@ -12,6 +13,7 @@ describe("documentRendering foundation", () => {
     const root = createPrintRoot(document);
 
     expect(root.getAttribute(PRINT_ROOT_ATTRIBUTE)).toBe("true");
+    expect(root.classList.contains(PRINT_SAFE_CLASS)).toBe(true);
   });
 
   it("keeps pagination decisions deterministic at the bottom guard", () => {

--- a/rentchain-frontend/src/lib/documentRendering.ts
+++ b/rentchain-frontend/src/lib/documentRendering.ts
@@ -32,6 +32,7 @@ export type PdfPreviewFallbackMetadata = {
 export function createPrintRoot(documentRef: Document = document): HTMLDivElement {
   const printableRoot = documentRef.createElement("div");
   printableRoot.setAttribute(PRINT_ROOT_ATTRIBUTE, "true");
+  printableRoot.classList.add(PRINT_SAFE_CLASS);
   return printableRoot;
 }
 

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   fetchLandlordApplicationFunnel: vi.fn(),
   getTransUnionIntegration: vi.fn(),
   trackTransUnionUsageEvent: vi.fn(),
+  printSummaryDocument: vi.fn(),
   showToast: vi.fn(),
   openUpgrade: vi.fn(),
   entitlementsMock: vi.fn(),
@@ -96,6 +97,10 @@ vi.mock("@/api/integrationsApi", () => ({
   requestTransUnionOnboarding: vi.fn(),
   trackTransUnionUsageEvent: mocks.trackTransUnionUsageEvent,
   updateTransUnionCredentials: vi.fn(),
+}));
+
+vi.mock("@/utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => mocks.printSummaryDocument(...args),
 }));
 
 vi.mock("@/api/viewingsApi", () => ({
@@ -355,6 +360,8 @@ describe("ApplicationsPage", () => {
       version: 1,
     });
     mocks.trackTransUnionUsageEvent.mockResolvedValue({ ok: true });
+    mocks.printSummaryDocument.mockReset();
+    mocks.printSummaryDocument.mockResolvedValue(undefined);
     mocks.showToast.mockReset();
     mocks.openUpgrade.mockReset();
   });
@@ -372,6 +379,26 @@ describe("ApplicationsPage", () => {
     expect(container.querySelector(".rc-viewing-requests-detail-pane")).toBeTruthy();
     expect(container.querySelector(".rc-applications-list-scroll")).toBeTruthy();
     expect(container.querySelector(".rc-applications-detail")).toBeTruthy();
+  });
+
+  it("provides a printable application summary action for the selected application", async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    const applicantName = await screen.findByText("Jamie Stone");
+    const applicantRow = applicantName.closest('[role="button"]');
+    expect(applicantRow).toBeTruthy();
+    fireEvent.click(applicantRow as HTMLElement);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Print / Save PDF" }));
+
+    expect(mocks.printSummaryDocument).toHaveBeenCalledWith("application");
+    const printSource = container.querySelector(".print-only-application");
+    expect(printSource?.textContent).toContain("Application summary");
+    expect(printSource?.textContent).toContain("Jamie Stone");
   });
 
   it("hides cancelled viewing requests by default and preserves active ordering", async () => {

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -66,6 +66,7 @@ import {
   screeningUnavailableMessage,
 } from "../config/screening";
 import { ApplicationDecisionSummaryCard } from "@/components/applications/ApplicationDecisionSummaryCard";
+import { PrintApplicationView } from "@/components/applications/PrintApplicationView";
 import {
   connectTransUnion,
   disconnectTransUnion,
@@ -77,6 +78,7 @@ import {
   type TransUnionIntegration,
 } from "@/api/integrationsApi";
 import { fetchLandlordApplicationFunnel, type LandlordApplicationFunnelAnalytics } from "@/api/landlordAnalyticsApi";
+import { printSummaryDocument } from "@/utils/printSummary";
 import { GetTransUnionAccessModal } from "@/components/integrations/GetTransUnionAccessModal";
 import { ConnectTransUnionModal } from "@/components/integrations/ConnectTransUnionModal";
 import { UpdateTransUnionCredentialsModal } from "@/components/integrations/UpdateTransUnionCredentialsModal";
@@ -694,6 +696,31 @@ const ApplicationsPage: React.FC = () => {
   const selectedLabel = detail
     ? `${detail.applicant.firstName} ${detail.applicant.lastName}`.trim()
     : "Application";
+  const printableApplication = useMemo(() => {
+    if (!detail) return null;
+    const applicantName = `${detail.applicant.firstName} ${detail.applicant.lastName}`.trim() || "Applicant";
+    const propertyName = properties.find((property) => property.id === detail.propertyId)?.name || "Property";
+    return {
+      ...detail,
+      fullName: applicantName,
+      applicantName,
+      email: detail.applicant.email,
+      phone: detail.applicant.phoneHome || detail.applicant.phoneWork || null,
+      applicantPhone: detail.applicant.phoneHome || detail.applicant.phoneWork || null,
+      dateOfBirth: detail.applicant.dob || null,
+      propertyName,
+      unitApplied: null,
+      monthlyIncome:
+        typeof detail.employment?.applicant?.monthlyIncomeCents === "number"
+          ? detail.employment.applicant.monthlyIncomeCents / 100
+          : null,
+      recentAddress: detail.residentialHistory?.[0]
+        ? {
+            streetName: detail.residentialHistory[0].address,
+          }
+        : null,
+    };
+  }, [detail, properties]);
   const screeningOrderId = detail?.screening?.orderId || null;
   const isTransUnionConnected = transUnionIntegration.status === "connected";
   const visibleViewingRequests = useMemo(
@@ -2816,20 +2843,30 @@ const ApplicationsPage: React.FC = () => {
               ) : !detail ? (
                 <div style={{ color: text.muted }}>Select an application to view details.</div>
               ) : (
-                <div style={{ display: "grid", gap: spacing.md }}>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <div style={{ display: "grid", gap: spacing.md }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: spacing.sm, flexWrap: "wrap" }}>
                 <div>
                   <div style={{ fontSize: "1.35rem", fontWeight: 700 }}>{detail.applicant.firstName} {detail.applicant.lastName}</div>
                   <div style={{ color: text.muted, fontSize: 13 }}>{detail.applicant.email}</div>
                 </div>
-                <div className="rc-applications-status-row">
-                  {statusOptions.map((s) => (
-                    <Button key={s} variant={detail.status === s ? "primary" : "secondary"} onClick={() => void setStatus(s)}>
-                      {s.replace("_", " ")}
-                    </Button>
-                  ))}
+                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", justifyContent: "flex-end" }}>
+                  <Button variant="secondary" onClick={() => void printSummaryDocument("application")}>
+                    Print / Save PDF
+                  </Button>
+                  <div className="rc-applications-status-row">
+                    {statusOptions.map((s) => (
+                      <Button key={s} variant={detail.status === s ? "primary" : "secondary"} onClick={() => void setStatus(s)}>
+                        {s.replace("_", " ")}
+                      </Button>
+                    ))}
+                  </div>
                 </div>
               </div>
+              {printableApplication ? (
+                <div className="print-only print-only-application" aria-hidden="true">
+                  <PrintApplicationView application={printableApplication as any} />
+                </div>
+              ) : null}
 
               <ApplicationDecisionSummaryCard
                 summary={decisionSummary}

--- a/rentchain-frontend/src/pages/ExpensesPage.test.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.test.tsx
@@ -80,7 +80,7 @@ describe("ExpensesPage", () => {
     expect(await screen.findByText("Upgrade to Pro to import receipts, PDFs, CSVs, and spreadsheets with AI-assisted review.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Export CSV" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Export Spreadsheet (.xls)" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Export PDF" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Print / Save PDF" })).not.toBeInTheDocument();
     expect(screen.getAllByText("Alpha Property").length).toBeGreaterThan(0);
   });
 
@@ -97,7 +97,7 @@ describe("ExpensesPage", () => {
       expect(screen.getByRole("button", { name: "Export CSV" })).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: "Export Spreadsheet (.xls)" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Export PDF" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
   });
 
   it("generates client-side CSV for CSV and spreadsheet downloads without HTML", async () => {
@@ -135,9 +135,12 @@ describe("ExpensesPage", () => {
     expect(spreadsheetText).not.toContain("unit-firestore-1");
     expect(mocks.exportExpensesMock).not.toHaveBeenCalledWith("xls", expect.any(Object));
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Export PDF" })[0]);
-    await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("pdf", expect.any(Object)));
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
+    fireEvent.click(screen.getAllByRole("button", { name: "Print / Save PDF" })[0]);
+    expect(printSpy).toHaveBeenCalled();
+    expect(mocks.exportExpensesMock).not.toHaveBeenCalledWith("pdf", expect.any(Object));
 
+    printSpy.mockRestore();
     click.mockRestore();
   });
 

--- a/rentchain-frontend/src/pages/ExpensesPage.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.tsx
@@ -214,6 +214,10 @@ const ExpensesPage: React.FC = () => {
   const triggerDownload = async (format: "csv" | "xls" | "pdf") => {
     try {
       setExporting(format);
+      if (format === "pdf" && typeof window !== "undefined" && typeof window.print === "function") {
+        window.print();
+        return;
+      }
       if (format === "csv" || format === "xls") {
         const blob = buildCsvBlob(
           ["date", "property", "unit", "category", "vendor", "description", "amount", "status", "source"],
@@ -345,7 +349,7 @@ const ExpensesPage: React.FC = () => {
                 {exporting === "xls" ? "Exporting..." : "Export Spreadsheet (.xls)"}
               </Button>
               <Button variant="secondary" onClick={() => void triggerDownload("pdf")} disabled={exporting !== null}>
-                {exporting === "pdf" ? "Exporting..." : "Export PDF"}
+                {exporting === "pdf" ? "Opening..." : "Print / Save PDF"}
               </Button>
             </>
           ) : null}

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   getArchivedLeasesForLandlord: vi.fn(),
   enableLeasePaymentRail: vi.fn(),
   getLeaseReconciliationCandidates: vi.fn(),
+  refreshLeaseDocumentUrl: vi.fn(),
   convertUnitReferenceToLease: vi.fn(),
   archiveLeaseRecord: vi.fn(),
   restoreLeaseRecord: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("@/api/leasesApi", () => ({
   getArchivedLeasesForLandlord: mocks.getArchivedLeasesForLandlord,
   enableLeasePaymentRail: mocks.enableLeasePaymentRail,
   getLeaseReconciliationCandidates: mocks.getLeaseReconciliationCandidates,
+  refreshLeaseDocumentUrl: mocks.refreshLeaseDocumentUrl,
   convertUnitReferenceToLease: mocks.convertUnitReferenceToLease,
   archiveLeaseRecord: mocks.archiveLeaseRecord,
   restoreLeaseRecord: mocks.restoreLeaseRecord,
@@ -161,6 +163,11 @@ describe("LandlordActiveLeasesPage", () => {
         },
       ],
     });
+    mocks.refreshLeaseDocumentUrl.mockResolvedValue({
+      documentUrl: "https://example.com/lease-refreshed.pdf",
+      refreshMode: "signed_url",
+      expiresInSeconds: 1800,
+    });
     mocks.convertUnitReferenceToLease.mockResolvedValue({
       ok: true,
       lease: { id: "lease-9" },
@@ -179,6 +186,7 @@ describe("LandlordActiveLeasesPage", () => {
     mocks.archiveLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-1" } });
     mocks.restoreLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-2" } });
     vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.spyOn(window, "open").mockReturnValue(null);
   });
 
   it("renders active leases with ledger, email, save, and archive actions", async () => {
@@ -199,13 +207,16 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getByText("Workflow guidance only — verify local legal requirements.")).toBeInTheDocument();
     expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View lease" })).toHaveAttribute("href", "https://example.com/lease.pdf");
+    expect(screen.getByRole("button", { name: "View lease" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",
       expect.stringContaining("mailto:jane%40example.com")
     );
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "View lease" }));
+    await waitFor(() => expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-1"));
+    expect(window.open).toHaveBeenCalledWith("https://example.com/lease-refreshed.pdf", "_blank", "noreferrer");
     fireEvent.click(screen.getByRole("button", { name: /Enable rent collection/i }));
     await waitFor(() => expect(mocks.enableLeasePaymentRail).toHaveBeenCalledWith("lease-1"));
     fireEvent.click(screen.getByRole("button", { name: "Archive lease" }));
@@ -682,7 +693,7 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect(await screen.findByTestId("lease-mobile-card")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View lease" })).toHaveAttribute("href", "https://example.com/lease.pdf");
+    expect(screen.getByRole("button", { name: "View lease" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Archive lease" })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -260,6 +260,49 @@ describe("LandlordActiveLeasesPage", () => {
     expect(await screen.findByText("refresh failed")).toBeInTheDocument();
   });
 
+  it("shows Schedule A as a separate action without replacing the lease summary action", async () => {
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-schedule",
+          propertyId: "prop-1",
+          propertyName: "Coburg Rd",
+          unitNumber: "6",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          tenantName: "Chip Milo",
+          tenantEmail: "hello+cob6tenant@rentchain.ai",
+          documentUrl: null,
+          scheduleAUrl: "https://example.com/schedule-a.pdf",
+        },
+      ],
+    });
+    mocks.refreshLeaseDocumentUrl.mockResolvedValueOnce({
+      documentUrl: "https://example.com/schedule-a-refreshed.pdf",
+      refreshMode: "signed_url",
+      expiresInSeconds: 1800,
+      documentKind: "schedule-a",
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("link", { name: "View lease" })).toHaveAttribute(
+      "href",
+      "/leases/lease-schedule/summary"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "View Schedule A" }));
+    await waitFor(() =>
+      expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-schedule", { document: "schedule-a" })
+    );
+    expect(window.open).toHaveBeenCalledWith("https://example.com/schedule-a-refreshed.pdf", "_blank", "noreferrer");
+  });
+
   it("renders date-only lease dates without shifting them backward across timezones", async () => {
     mocks.getActiveLeasesForLandlord.mockResolvedValue({
       leases: [

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -225,6 +225,41 @@ describe("LandlordActiveLeasesPage", () => {
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 
+  it("does not open stale GCS or app-domain lease document fallbacks when refresh fails", async () => {
+    mocks.refreshLeaseDocumentUrl.mockReset();
+    mocks.refreshLeaseDocumentUrl.mockRejectedValueOnce(new Error("refresh failed"));
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-stale",
+          propertyId: "prop-1",
+          propertyName: "Coburg Rd",
+          unitNumber: "6",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          tenantName: "Chip Milo",
+          tenantEmail: "hello+cob6tenant@rentchain.ai",
+          documentUrl:
+            "https://storage.googleapis.com/lease-documents/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf?X-Goog-Expires=1",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.open).mockClear();
+    fireEvent.click(await screen.findByRole("button", { name: "View lease" }));
+    await waitFor(() => expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-stale"));
+    expect(window.open).not.toHaveBeenCalled();
+    expect(await screen.findByText("refresh failed")).toBeInTheDocument();
+  });
+
   it("renders date-only lease dates without shifting them backward across timezones", async () => {
     mocks.getActiveLeasesForLandlord.mockResolvedValue({
       leases: [
@@ -488,6 +523,8 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect(await screen.findByText(/Occupied units missing lease records/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "View reference" })).not.toBeInTheDocument();
+    expect(screen.getByText("Lease document link expired and needs regeneration.")).toBeInTheDocument();
     fireEvent.click(screen.getAllByRole("button", { name: "Convert unit 9 to lease" })[0]);
     fireEvent.change(screen.getByLabelText("Tenant phone (optional)"), { target: { value: "(902) 555-1111 ext 9" } });
     fireEvent.change(screen.getByLabelText("Co-applicant email (optional)"), { target: { value: "coapplicant@example.com" } });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -254,8 +254,10 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     vi.mocked(window.open).mockClear();
-    fireEvent.click(await screen.findByRole("button", { name: "View lease" }));
-    await waitFor(() => expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-stale"));
+    expect(await screen.findByRole("button", { name: "Primary lease document unavailable" })).toBeDisabled();
+    expect(screen.getByRole("link", { name: "Lease summary" })).toHaveAttribute("href", "/leases/lease-stale/summary");
+    fireEvent.click(screen.getByRole("button", { name: "View Schedule A" }));
+    await waitFor(() => expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-stale", { document: "schedule-a" }));
     expect(window.open).not.toHaveBeenCalled();
     expect(await screen.findByText("refresh failed")).toBeInTheDocument();
   });
@@ -292,7 +294,8 @@ describe("LandlordActiveLeasesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole("link", { name: "View lease" })).toHaveAttribute(
+    expect(await screen.findByRole("button", { name: "Primary lease document unavailable" })).toBeDisabled();
+    expect(screen.getByRole("link", { name: "Lease summary" })).toHaveAttribute(
       "href",
       "/leases/lease-schedule/summary"
     );
@@ -301,6 +304,27 @@ describe("LandlordActiveLeasesPage", () => {
       expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-schedule", { document: "schedule-a" })
     );
     expect(window.open).toHaveBeenCalledWith("https://example.com/schedule-a-refreshed.pdf", "_blank", "noreferrer");
+  });
+
+  it("does not open a Schedule A URL returned by the primary lease refresh path", async () => {
+    mocks.refreshLeaseDocumentUrl.mockReset();
+    mocks.refreshLeaseDocumentUrl.mockResolvedValueOnce({
+      documentUrl: "https://storage.googleapis.com/lease-documents/leases/landlord/draft/schedule-a-v1.pdf",
+      refreshMode: "signed_url",
+      expiresInSeconds: 1800,
+      documentKind: "lease",
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.open).mockClear();
+    fireEvent.click(await screen.findByRole("button", { name: "View lease" }));
+    await waitFor(() => expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-1"));
+    expect(window.open).not.toHaveBeenCalled();
   });
 
   it("renders date-only lease dates without shifting them backward across timezones", async () => {
@@ -553,7 +577,8 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: "View lease" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByRole("button", { name: "Primary lease document unavailable" })).toBeDisabled();
+    expect(screen.getByRole("link", { name: "Lease summary" })).toHaveAttribute("href", "/leases/lease-1/summary");
     expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -419,11 +419,14 @@ export default function LandlordActiveLeasesPage() {
     }
   }
 
-  async function openLeaseDocument(lease: LandlordActiveLease) {
-    const fallbackUrl = String(lease.documentUrl || "").trim();
+  async function openLeaseDocument(lease: LandlordActiveLease, documentKind: "lease" | "schedule-a" = "lease") {
+    const fallbackUrl = String(documentKind === "schedule-a" ? lease.scheduleAUrl : lease.documentUrl || "").trim();
     setDocumentBusyLeaseId(lease.id);
     try {
-      const refreshed = await refreshLeaseDocumentUrl(lease.id);
+      const refreshed =
+        documentKind === "schedule-a"
+          ? await refreshLeaseDocumentUrl(lease.id, { document: "schedule-a" })
+          : await refreshLeaseDocumentUrl(lease.id);
       const nextUrl = String(refreshed?.documentUrl || "").trim() || fallbackUrl;
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
@@ -432,7 +435,7 @@ export default function LandlordActiveLeasesPage() {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
-      setError(errorMessage(err, "Lease document link expired and needs regeneration."));
+      setError(errorMessage(err, documentKind === "schedule-a" ? "Schedule A link expired and needs regeneration." : "Lease document link expired and needs regeneration."));
     } finally {
       setDocumentBusyLeaseId(null);
     }
@@ -519,6 +522,16 @@ export default function LandlordActiveLeasesPage() {
             View lease
           </Link>
         )}
+        {lease.scheduleAUrl ? (
+          <button
+            type="button"
+            onClick={() => void openLeaseDocument(lease, "schedule-a")}
+            disabled={documentBusyLeaseId === lease.id}
+            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+          >
+            {documentBusyLeaseId === lease.id ? "Opening..." : "View Schedule A"}
+          </button>
+        ) : null}
         <Link to={ledgerPath} style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}>
           Ledger
         </Link>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -7,6 +7,7 @@ import {
   getActiveLeasesForLandlord,
   getArchivedLeasesForLandlord,
   getLeaseReconciliationCandidates,
+  refreshLeaseDocumentUrl,
   restoreLeaseRecord,
   type LandlordActiveLease,
   type LeaseReconciliationCandidate,
@@ -300,6 +301,7 @@ export default function LandlordActiveLeasesPage() {
   const [selectedCandidate, setSelectedCandidate] = React.useState<LeaseReconciliationCandidate | null>(null);
   const [convertSaving, setConvertSaving] = React.useState(false);
   const [paymentRailBusyLeaseId, setPaymentRailBusyLeaseId] = React.useState<string | null>(null);
+  const [documentBusyLeaseId, setDocumentBusyLeaseId] = React.useState<string | null>(null);
   const [occupantName, setOccupantName] = React.useState("");
   const [tenantEmail, setTenantEmail] = React.useState("");
   const [tenantPhone, setTenantPhone] = React.useState("");
@@ -393,6 +395,25 @@ export default function LandlordActiveLeasesPage() {
     }
   }
 
+  async function openLeaseDocument(lease: LandlordActiveLease) {
+    const fallbackUrl = String(lease.documentUrl || "").trim();
+    setDocumentBusyLeaseId(lease.id);
+    try {
+      const refreshed = await refreshLeaseDocumentUrl(lease.id);
+      const nextUrl = String(refreshed?.documentUrl || "").trim() || fallbackUrl;
+      if (!nextUrl) throw new Error("Lease document is not available.");
+      window.open(nextUrl, "_blank", "noreferrer");
+    } catch (err: unknown) {
+      if (fallbackUrl) {
+        window.open(fallbackUrl, "_blank", "noreferrer");
+        return;
+      }
+      setError(errorMessage(err, "Lease document is not available."));
+    } finally {
+      setDocumentBusyLeaseId(null);
+    }
+  }
+
   async function handleConvert() {
     if (!selectedCandidate) return;
     setConvertSaving(true);
@@ -458,14 +479,14 @@ export default function LandlordActiveLeasesPage() {
     return (
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
         {lease.documentUrl ? (
-          <a
-            href={lease.documentUrl}
-            target="_blank"
-            rel="noreferrer"
+          <button
+            type="button"
+            onClick={() => void openLeaseDocument(lease)}
+            disabled={documentBusyLeaseId === lease.id}
             style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
           >
-            View lease
-          </a>
+            {documentBusyLeaseId === lease.id ? "Opening..." : "View lease"}
+          </button>
         ) : (
           <Link
             to={summaryPath}
@@ -497,18 +518,12 @@ export default function LandlordActiveLeasesPage() {
           type="button"
           onClick={() => {
             if (lease.documentUrl) {
-              const a = document.createElement("a");
-              a.href = lease.documentUrl;
-              a.target = "_blank";
-              a.rel = "noreferrer";
-              a.download = "";
-              document.body.appendChild(a);
-              a.click();
-              a.remove();
+              void openLeaseDocument(lease);
               return;
             }
             downloadLeaseSummaryPdf(lease);
           }}
+          disabled={documentBusyLeaseId === lease.id}
           style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
         >
           Save

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -66,6 +66,30 @@ function errorMessage(error: unknown, fallback: string) {
   return fallback;
 }
 
+function isGoogleStorageSignedUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.hostname === "storage.googleapis.com" || url.hostname === "storage.cloud.google.com" || url.hostname.endsWith(".storage.googleapis.com");
+  } catch {
+    return false;
+  }
+}
+
+function isAppDomainLeasePdfFallback(value: string) {
+  if (!value) return false;
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.origin === window.location.origin && /^\/leases\/.+\.pdf$/i.test(url.pathname);
+  } catch {
+    return /^\/leases\/.+\.pdf(?:$|\?)/i.test(value);
+  }
+}
+
+function canUseLegacyDocumentFallback(value: string) {
+  const next = String(value || "").trim();
+  return Boolean(next) && !isGoogleStorageSignedUrl(next) && !isAppDomainLeasePdfFallback(next);
+}
+
 function normalizePhoneInput(value: string) {
   return String(value || "").replace(/\D/g, "").slice(0, 15);
 }
@@ -404,11 +428,11 @@ export default function LandlordActiveLeasesPage() {
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
     } catch (err: unknown) {
-      if (fallbackUrl) {
+      if (canUseLegacyDocumentFallback(fallbackUrl)) {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
-      setError(errorMessage(err, "Lease document is not available."));
+      setError(errorMessage(err, "Lease document link expired and needs regeneration."));
     } finally {
       setDocumentBusyLeaseId(null);
     }
@@ -460,7 +484,7 @@ export default function LandlordActiveLeasesPage() {
         `Status: ${prettyLeaseStatus(lease.status)}`,
         `Term: ${formatDate(lease.startDate)} to ${formatDate(lease.endDate)}`,
         `View ledger: ${ledgerUrl}`,
-        lease.documentUrl ? `Lease document: ${lease.documentUrl}` : "",
+        `Lease summary: ${typeof window !== "undefined" ? `${window.location.origin}${summaryPath}` : summaryPath}`,
       ]
         .filter(Boolean)
         .join("\n")
@@ -693,9 +717,9 @@ export default function LandlordActiveLeasesPage() {
                 </div>
                 <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                   {candidate.leaseDocument?.url ? (
-                    <a href={candidate.leaseDocument.url} target="_blank" rel="noreferrer" style={{ color: "#2563eb" }}>
-                      View reference
-                    </a>
+                    <span style={{ color: "#64748b", fontSize: 13 }}>
+                      Lease document link expired and needs regeneration.
+                    </span>
                   ) : null}
                   {candidate.canConvert ? (
                     <button

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -90,6 +90,23 @@ function canUseLegacyDocumentFallback(value: string) {
   return Boolean(next) && !isGoogleStorageSignedUrl(next) && !isAppDomainLeasePdfFallback(next);
 }
 
+function isScheduleADocumentUrl(value: unknown) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return Boolean(normalized) && (normalized.includes("schedule-a") || normalized.includes("schedule_a"));
+}
+
+function primaryLeaseDocumentUrl(lease: LandlordActiveLease) {
+  const value = String(lease.documentUrl || "").trim();
+  return value && !isScheduleADocumentUrl(value) ? value : "";
+}
+
+function scheduleADocumentUrl(lease: LandlordActiveLease) {
+  const explicit = String(lease.scheduleAUrl || "").trim();
+  if (explicit) return explicit;
+  const legacy = String(lease.documentUrl || "").trim();
+  return isScheduleADocumentUrl(legacy) ? legacy : "";
+}
+
 function normalizePhoneInput(value: string) {
   return String(value || "").replace(/\D/g, "").slice(0, 15);
 }
@@ -420,7 +437,8 @@ export default function LandlordActiveLeasesPage() {
   }
 
   async function openLeaseDocument(lease: LandlordActiveLease, documentKind: "lease" | "schedule-a" = "lease") {
-    const fallbackUrl = String(documentKind === "schedule-a" ? lease.scheduleAUrl : lease.documentUrl || "").trim();
+    const fallbackUrl = documentKind === "schedule-a" ? scheduleADocumentUrl(lease) : primaryLeaseDocumentUrl(lease);
+    let primaryRefreshReturnedScheduleA = false;
     setDocumentBusyLeaseId(lease.id);
     try {
       const refreshed =
@@ -428,10 +446,14 @@ export default function LandlordActiveLeasesPage() {
           ? await refreshLeaseDocumentUrl(lease.id, { document: "schedule-a" })
           : await refreshLeaseDocumentUrl(lease.id);
       const nextUrl = String(refreshed?.documentUrl || "").trim() || fallbackUrl;
+      if (documentKind === "lease" && isScheduleADocumentUrl(nextUrl)) {
+        primaryRefreshReturnedScheduleA = true;
+        throw new Error("Primary lease document unavailable. Use View Schedule A for the supplemental form.");
+      }
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
     } catch (err: unknown) {
-      if (canUseLegacyDocumentFallback(fallbackUrl)) {
+      if (!primaryRefreshReturnedScheduleA && canUseLegacyDocumentFallback(fallbackUrl)) {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
@@ -503,9 +525,11 @@ export default function LandlordActiveLeasesPage() {
 
   function renderLeaseActions(lease: LandlordActiveLease) {
     const { ledgerPath, summaryPath, emailHref } = buildLeaseActionMeta(lease);
+    const primaryDocumentUrl = primaryLeaseDocumentUrl(lease);
+    const scheduleAUrl = scheduleADocumentUrl(lease);
     return (
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        {lease.documentUrl ? (
+        {primaryDocumentUrl ? (
           <button
             type="button"
             onClick={() => void openLeaseDocument(lease)}
@@ -515,14 +539,22 @@ export default function LandlordActiveLeasesPage() {
             {documentBusyLeaseId === lease.id ? "Opening..." : "View lease"}
           </button>
         ) : (
-          <Link
-            to={summaryPath}
-            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a", textDecoration: "none" }}
+          <button
+            type="button"
+            disabled
+            title={scheduleAUrl ? "Only Schedule A is available for this record." : "No primary lease PDF is attached to this record."}
+            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #e2e8f0", background: "#f8fafc", color: "#64748b" }}
           >
-            View lease
-          </Link>
+            Primary lease document unavailable
+          </button>
         )}
-        {lease.scheduleAUrl ? (
+        <Link
+          to={summaryPath}
+          style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a", textDecoration: "none" }}
+        >
+          Lease summary
+        </Link>
+        {scheduleAUrl ? (
           <button
             type="button"
             onClick={() => void openLeaseDocument(lease, "schedule-a")}
@@ -554,7 +586,7 @@ export default function LandlordActiveLeasesPage() {
         <button
           type="button"
           onClick={() => {
-            if (lease.documentUrl) {
+            if (primaryLeaseDocumentUrl(lease)) {
               void openLeaseDocument(lease);
               return;
             }

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -6,15 +6,22 @@ import { buildLeaseSummaryPdfSource } from "@/utils/leaseSummaryPdf";
 
 const mocks = vi.hoisted(() => ({
   getLeaseById: vi.fn(),
+  printSummaryDocument: vi.fn(),
 }));
 
 vi.mock("@/api/leasesApi", () => ({
   getLeaseById: mocks.getLeaseById,
 }));
 
+vi.mock("@/utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => mocks.printSummaryDocument(...args),
+}));
+
 describe("LandlordLeaseSummaryPage", () => {
   beforeEach(() => {
     mocks.getLeaseById.mockReset();
+    mocks.printSummaryDocument.mockReset();
+    mocks.printSummaryDocument.mockResolvedValue(undefined);
     mocks.getLeaseById.mockResolvedValue({
       lease: {
         id: "lease-1",
@@ -156,13 +163,36 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getByText("June 1, 2026")).toBeInTheDocument();
   });
 
-  it("saves missing-document lease summaries as PDFs instead of raw text", async () => {
+  it("opens the browser print flow before falling back to direct PDF download", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/summary"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Print / Save PDF" }));
+
+    await waitFor(() => {
+      expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
+    });
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+    expect(HTMLAnchorElement.prototype.click).not.toHaveBeenCalled();
+  });
+
+  it("falls back to direct PDF download only when browser printing is unavailable", async () => {
     const realCreateElement = document.createElement.bind(document);
     const createdAnchors: HTMLAnchorElement[] = [];
     vi.spyOn(document, "createElement").mockImplementation((tagName: string, options?: ElementCreationOptions) => {
       const element = realCreateElement(tagName, options);
       if (tagName.toLowerCase() === "a") createdAnchors.push(element as HTMLAnchorElement);
       return element;
+    });
+    const originalPrint = window.print;
+    Object.defineProperty(window, "print", {
+      configurable: true,
+      value: undefined,
     });
 
     render(
@@ -180,6 +210,7 @@ describe("LandlordLeaseSummaryPage", () => {
       expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
       expect(global.URL.revokeObjectURL).toHaveBeenCalledTimes(1);
     });
+    expect(mocks.printSummaryDocument).not.toHaveBeenCalled();
     const blob = vi.mocked(global.URL.createObjectURL).mock.calls[0][0] as Blob;
     expect(blob.type).toBe("application/pdf");
     const pdfText = buildLeaseSummaryPdfSource(mocks.getLeaseById.mock.calls.length ? (await mocks.getLeaseById.mock.results[0].value).lease : {});
@@ -193,6 +224,10 @@ describe("LandlordLeaseSummaryPage", () => {
     const downloadAnchor = createdAnchors[createdAnchors.length - 1];
     expect(downloadAnchor?.download).toBe("lease-3.pdf");
     expect(downloadAnchor?.download).not.toMatch(/\.txt$/);
+    Object.defineProperty(window, "print", {
+      configurable: true,
+      value: originalPrint,
+    });
   });
 
   it("paginates long lease summary content without adding empty trailing pages", () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -92,6 +92,7 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getByText("Tony Wenpeng")).toBeInTheDocument();
     expect(screen.queryByText(/gs:\/\//i)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
   });
 
@@ -172,7 +173,7 @@ describe("LandlordLeaseSummaryPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole("button", { name: "Save lease summary" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Print / Save PDF" }));
 
     await waitFor(() => {
       expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -84,23 +84,41 @@ describe("LandlordLeaseSummaryPage", () => {
     );
 
     expect(await screen.findByText("Lease summary")).toBeInTheDocument();
-    expect(screen.getByTestId("lease-document-view")).toBeInTheDocument();
-    expect(screen.getByRole("article", { name: "Residential Lease Pack" })).toBeInTheDocument();
-    expect(screen.getByRole("term", { name: "Property" })).toBeInTheDocument();
-    expect(screen.getByText("Residential Lease Pack")).toBeInTheDocument();
-    expect(screen.getByText("Property and Unit")).toBeInTheDocument();
-    expect(screen.getByText("Landlord and Tenant")).toBeInTheDocument();
-    expect(screen.getByText("Lease Term")).toBeInTheDocument();
-    expect(screen.getByText("Rent and Payment Terms")).toBeInTheDocument();
-    expect(screen.getByText("Clauses and Additional Terms")).toBeInTheDocument();
-    expect(screen.getByText("Audit and Events")).toBeInTheDocument();
+    expect(screen.getAllByTestId("lease-document-view").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("article", { name: "Residential Lease Pack" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("term", { name: "Property" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Residential Lease Pack").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Property and Unit").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Landlord and Tenant").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Lease Term").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Rent and Payment Terms").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Clauses and Additional Terms").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Audit and Events").length).toBeGreaterThan(0);
     expect(mocks.getLeaseById).toHaveBeenCalledWith("lease-1");
-    expect(screen.getByText("Coburg Rd")).toBeInTheDocument();
-    expect(screen.getByText("Tony Wenpeng")).toBeInTheDocument();
+    expect(screen.getAllByText("Coburg Rd").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Tony Wenpeng").length).toBeGreaterThan(0);
     expect(screen.queryByText(/gs:\/\//i)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
+  });
+
+  it("renders a non-empty printable lease summary source for browser print preview", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/leases/lease-1/summary"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Lease summary");
+    const printSource = container.querySelector(".print-only-summary");
+
+    expect(printSource).toBeTruthy();
+    expect(printSource?.textContent).toContain("Residential Lease Pack");
+    expect(printSource?.textContent).toContain("Coburg Rd");
+    expect(printSource?.textContent).toContain("Tony Wenpeng");
   });
 
   it("renders date-only lease summary dates without UTC timezone rollback", async () => {
@@ -128,8 +146,8 @@ describe("LandlordLeaseSummaryPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("May 1, 2026")).toBeInTheDocument();
-    expect(screen.getByText("June 1, 2026")).toBeInTheDocument();
+    expect((await screen.findAllByText("May 1, 2026")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("June 1, 2026").length).toBeGreaterThan(0);
     expect(screen.queryByText("April 30, 2026")).not.toBeInTheDocument();
     expect(screen.queryByText("May 31, 2026")).not.toBeInTheDocument();
   });
@@ -159,8 +177,8 @@ describe("LandlordLeaseSummaryPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("May 1, 2026")).toBeInTheDocument();
-    expect(screen.getByText("June 1, 2026")).toBeInTheDocument();
+    expect((await screen.findAllByText("May 1, 2026")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("June 1, 2026").length).toBeGreaterThan(0);
   });
 
   it("opens the browser print flow before falling back to direct PDF download", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -107,7 +107,14 @@ export default function LandlordLeaseSummaryPage() {
       {loading ? <div>Loading lease summary…</div> : null}
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
 
-      {lease ? <LeaseDocumentView lease={lease} /> : null}
+      {lease ? (
+        <>
+          <LeaseDocumentView lease={lease} />
+          <div className="print-only print-only-summary" aria-hidden="true">
+            <LeaseDocumentView lease={lease} />
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router-dom";
 import { getLeaseById, type LandlordActiveLease } from "@/api/leasesApi";
 import { LeaseDocumentView } from "@/components/leases/LeaseDocumentView";
 import { downloadLeaseSummaryPdf } from "@/utils/leaseSummaryPdf";
+import { printSummaryDocument } from "@/utils/printSummary";
 
 function errorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) return error.message;
@@ -62,6 +63,14 @@ export default function LandlordLeaseSummaryPage() {
   }, [leaseId]);
 
   const ledgerPath = lease ? `/leases/${encodeURIComponent(lease.id)}/ledger` : `/leases/${encodeURIComponent(leaseId)}/ledger`;
+  async function handlePrintOrSavePdf() {
+    if (!lease) return;
+    if (typeof window !== "undefined" && typeof window.print === "function") {
+      await printSummaryDocument("summary");
+      return;
+    }
+    downloadLeaseSummaryPdf(lease);
+  }
 
   return (
     <div style={{ display: "grid", gap: 16 }}>
@@ -81,9 +90,7 @@ export default function LandlordLeaseSummaryPage() {
         </Link>
           <button
             type="button"
-            onClick={() => {
-              if (lease) downloadLeaseSummaryPdf(lease);
-            }}
+            onClick={() => void handlePrintOrSavePdf()}
           disabled={!lease}
           style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
         >

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -87,7 +87,7 @@ export default function LandlordLeaseSummaryPage() {
           disabled={!lease}
           style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
         >
-          Save lease summary
+          Print / Save PDF
         </button>
         <Link
           to="/leases"

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -682,14 +682,8 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
   });
 
-  it("exports the lease ledger as a PDF download", async () => {
-    const realCreateElement = document.createElement.bind(document);
-    const createdAnchors: HTMLAnchorElement[] = [];
-    vi.spyOn(document, "createElement").mockImplementation((tagName: string, options?: ElementCreationOptions) => {
-      const element = realCreateElement(tagName, options);
-      if (tagName.toLowerCase() === "a") createdAnchors.push(element as HTMLAnchorElement);
-      return element;
-    });
+  it("opens browser print preview for lease ledger PDF output", async () => {
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
 
     render(
       <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
@@ -700,21 +694,14 @@ describe("LeaseLedgerPage", () => {
     );
 
     await screen.findAllByText("Harbour View · Unit 101");
-    fireEvent.click(screen.getByRole("button", { name: "Export PDF" }));
+    fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
 
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/leases/lease-1/ledger/export.pdf"),
-        expect.objectContaining({
-          method: "GET",
-          credentials: "include",
-        })
-      );
-      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
-    });
-    expect(createdAnchors[createdAnchors.length - 1]?.download).toBe("lease-ledger-harbour-view-unit-101.pdf");
-    expect(global.URL.createObjectURL).toHaveBeenCalled();
-    expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+    expect(printSpy).toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/leases/lease-1/ledger/export.pdf"),
+      expect.anything()
+    );
+    printSpy.mockRestore();
   });
 
   it("adds a lease note from the ledger detail surface", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -721,6 +721,14 @@ export default function LeaseLedgerPage() {
     }
   }
 
+  async function printOrExportLedgerPdf() {
+    if (typeof window !== "undefined" && typeof window.print === "function") {
+      window.print();
+      return;
+    }
+    await exportLedger("pdf");
+  }
+
   return (
     <div style={{ padding: 16, display: "grid", gap: 14 }}>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", justifyContent: "space-between" }}>
@@ -747,7 +755,7 @@ export default function LeaseLedgerPage() {
           <button onClick={() => setShowChargeModal(true)}>Add charge</button>
           <button onClick={() => setShowPaymentModal(true)}>Record payment</button>
           <button onClick={() => void exportLedger("csv")}>Export CSV</button>
-          <button onClick={() => void exportLedger("pdf")}>Export PDF</button>
+          <button onClick={() => void printOrExportLedgerPdf()}>Print / Save PDF</button>
           <button onClick={() => void toggleArchive()} disabled={saving || !lease}>
             {lease?.archivedAt ? "Restore lease" : "Archive lease"}
           </button>

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -170,7 +170,7 @@ describe("landlord maintenance workspace", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Export PDF Summary" }))[0]);
+    fireEvent.click((await screen.findAllByRole("button", { name: "Print / Save PDF" }))[0]);
     expect(printSummaryDocumentMock).toHaveBeenCalledWith("summary");
   });
 

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -605,7 +605,7 @@ export default function MaintenanceRequestsPage() {
           </div>
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
             <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>
-              Export PDF Summary
+              Print / Save PDF
             </Button>
             <Button variant="secondary" onClick={() => void load()} disabled={loading || saving}>
               Refresh

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -96,7 +96,7 @@ describe("PaymentsPage", () => {
     ).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Export CSV" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export Spreadsheet (.xls)" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Export PDF" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByText("AI-assisted payment CSV import")).toBeInTheDocument();
     expect((await screen.findAllByText("Taylor Tenant")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("123 Main St / Unit 3A").length).toBeGreaterThan(0);
@@ -106,7 +106,7 @@ describe("PaymentsPage", () => {
   it("routes PDF export through the shared print helper", async () => {
     render(<PaymentsPage />);
 
-    fireEvent.click((await screen.findAllByRole("button", { name: "Export PDF" }))[0]);
+    fireEvent.click((await screen.findAllByRole("button", { name: "Print / Save PDF" }))[0]);
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -223,7 +223,7 @@ const PaymentsPage: React.FC = () => {
             <Button variant="secondary" onClick={() => void triggerExport("xls")} disabled={exporting !== null}>
               {exporting === "xls" ? "Exporting..." : "Export Spreadsheet (.xls)"}
             </Button>
-            <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>Export PDF</Button>
+            <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>Print / Save PDF</Button>
           </div>
         </div>
       </Card>

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -498,7 +498,7 @@ describe("WorkOrdersPage", () => {
 
     expect(await screen.findByRole("button", { name: "Export CSV" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export Spreadsheet (.xls)" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Export PDF" }));
+    fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -979,7 +979,7 @@ export default function WorkOrdersPage() {
             {exporting === "xls" ? "Exporting..." : "Export Spreadsheet (.xls)"}
           </Button>
           <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>
-            Export PDF
+            Print / Save PDF
           </Button>
           <Button variant="secondary" onClick={() => void load()}>
             Refresh

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -109,12 +109,16 @@ export default function TenantLeasePage() {
     }
   }
 
-  async function handleOpenLeaseDocument() {
-    const fallbackUrl = String(data?.leaseDocumentContext?.documentUrl || data?.documentUrl || "").trim();
+  async function handleOpenLeaseDocument(documentKind: "lease" | "schedule-a" = "lease") {
+    const context = documentKind === "schedule-a" ? data?.scheduleADocumentContext : data?.leaseDocumentContext;
+    const fallbackUrl = String(context?.documentUrl || (documentKind === "lease" ? data?.documentUrl : "") || "").trim();
     setOpeningDocument(true);
     setError(null);
     try {
-      const refreshed = await refreshTenantLeaseDocumentUrl();
+      const refreshed =
+        documentKind === "schedule-a"
+          ? await refreshTenantLeaseDocumentUrl({ document: "schedule-a" })
+          : await refreshTenantLeaseDocumentUrl();
       const nextUrl = String(refreshed?.documentUrl || "").trim() || fallbackUrl;
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
@@ -123,7 +127,7 @@ export default function TenantLeasePage() {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
-      setError(err?.payload?.error || err?.message || "Lease document link expired and needs regeneration.");
+      setError(err?.payload?.error || err?.message || (documentKind === "schedule-a" ? "Schedule A link expired and needs regeneration." : "Lease document link expired and needs regeneration."));
     } finally {
       setOpeningDocument(false);
     }
@@ -149,7 +153,9 @@ export default function TenantLeasePage() {
 
   const execution = data?.leaseExecution || null;
   const leaseDocumentContext = data?.leaseDocumentContext || null;
+  const scheduleADocumentContext = data?.scheduleADocumentContext || null;
   const leaseDocumentUrl = leaseDocumentContext?.documentUrl || data?.documentUrl || null;
+  const scheduleAUrl = scheduleADocumentContext?.documentUrl || null;
   const leaseDocumentLabel = leaseDocumentContext?.displayLabel || data?.leasePdfLabel || null;
   const leaseDocumentWarnings = Array.isArray(leaseDocumentContext?.warnings) ? leaseDocumentContext.warnings : [];
   const paymentReadiness = data?.paymentReadiness || null;
@@ -385,6 +391,11 @@ export default function TenantLeasePage() {
                 No approved lease document link is available in this workspace yet.
               </div>
             )}
+            {scheduleAUrl ? (
+              <button type="button" onClick={() => void handleOpenLeaseDocument("schedule-a")} disabled={openingDocument}>
+                {openingDocument ? "Opening..." : "Open Schedule A"}
+              </button>
+            ) : null}
           </TenantInfoCard>
 
           <TenantInfoCard heading="Lease Signing" accent="#7c3aed">

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -24,6 +24,30 @@ import {
   prettyRentPaymentStatus,
 } from "../../lib/payments/paymentStatusGuidance";
 
+function isGoogleStorageSignedUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.hostname === "storage.googleapis.com" || url.hostname === "storage.cloud.google.com" || url.hostname.endsWith(".storage.googleapis.com");
+  } catch {
+    return false;
+  }
+}
+
+function isAppDomainLeasePdfFallback(value: string) {
+  if (!value) return false;
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.origin === window.location.origin && /^\/leases\/.+\.pdf$/i.test(url.pathname);
+  } catch {
+    return /^\/leases\/.+\.pdf(?:$|\?)/i.test(value);
+  }
+}
+
+function canUseLegacyDocumentFallback(value: string) {
+  const next = String(value || "").trim();
+  return Boolean(next) && !isGoogleStorageSignedUrl(next) && !isAppDomainLeasePdfFallback(next);
+}
+
 export default function TenantLeasePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantLeaseWorkspace>>>(null);
   const [rentPaymentDetails, setRentPaymentDetails] = React.useState<Awaited<
@@ -95,11 +119,11 @@ export default function TenantLeasePage() {
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
     } catch (err: any) {
-      if (fallbackUrl) {
+      if (canUseLegacyDocumentFallback(fallbackUrl)) {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
-      setError(err?.payload?.error || err?.message || "Lease document is not available.");
+      setError(err?.payload?.error || err?.message || "Lease document link expired and needs regeneration.");
     } finally {
       setOpeningDocument(false);
     }

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -48,6 +48,11 @@ function canUseLegacyDocumentFallback(value: string) {
   return Boolean(next) && !isGoogleStorageSignedUrl(next) && !isAppDomainLeasePdfFallback(next);
 }
 
+function isScheduleADocumentUrl(value: unknown) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return Boolean(normalized) && (normalized.includes("schedule-a") || normalized.includes("schedule_a"));
+}
+
 export default function TenantLeasePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantLeaseWorkspace>>>(null);
   const [rentPaymentDetails, setRentPaymentDetails] = React.useState<Awaited<
@@ -112,6 +117,7 @@ export default function TenantLeasePage() {
   async function handleOpenLeaseDocument(documentKind: "lease" | "schedule-a" = "lease") {
     const context = documentKind === "schedule-a" ? data?.scheduleADocumentContext : data?.leaseDocumentContext;
     const fallbackUrl = String(context?.documentUrl || (documentKind === "lease" ? data?.documentUrl : "") || "").trim();
+    let primaryRefreshReturnedScheduleA = false;
     setOpeningDocument(true);
     setError(null);
     try {
@@ -120,10 +126,18 @@ export default function TenantLeasePage() {
           ? await refreshTenantLeaseDocumentUrl({ document: "schedule-a" })
           : await refreshTenantLeaseDocumentUrl();
       const nextUrl = String(refreshed?.documentUrl || "").trim() || fallbackUrl;
+      if (documentKind === "lease" && isScheduleADocumentUrl(nextUrl)) {
+        primaryRefreshReturnedScheduleA = true;
+        throw new Error("Primary lease document unavailable. Use Open Schedule A for the supplemental form.");
+      }
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
     } catch (err: any) {
-      if (canUseLegacyDocumentFallback(fallbackUrl)) {
+      if (
+        !primaryRefreshReturnedScheduleA &&
+        canUseLegacyDocumentFallback(fallbackUrl) &&
+        (documentKind === "schedule-a" || !isScheduleADocumentUrl(fallbackUrl))
+      ) {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
@@ -154,9 +168,15 @@ export default function TenantLeasePage() {
   const execution = data?.leaseExecution || null;
   const leaseDocumentContext = data?.leaseDocumentContext || null;
   const scheduleADocumentContext = data?.scheduleADocumentContext || null;
-  const leaseDocumentUrl = leaseDocumentContext?.documentUrl || data?.documentUrl || null;
-  const scheduleAUrl = scheduleADocumentContext?.documentUrl || null;
-  const leaseDocumentLabel = leaseDocumentContext?.displayLabel || data?.leasePdfLabel || null;
+  const rawLeaseDocumentUrl = String(leaseDocumentContext?.documentUrl || data?.documentUrl || "").trim();
+  const rawScheduleAUrl = String(scheduleADocumentContext?.documentUrl || "").trim();
+  const leaseDocumentUrl = rawLeaseDocumentUrl && !isScheduleADocumentUrl(rawLeaseDocumentUrl) ? rawLeaseDocumentUrl : null;
+  const scheduleAUrl = rawScheduleAUrl || (isScheduleADocumentUrl(rawLeaseDocumentUrl) ? rawLeaseDocumentUrl : null);
+  const leaseDocumentLabel = leaseDocumentUrl
+    ? leaseDocumentContext?.displayLabel || data?.leasePdfLabel || null
+    : scheduleAUrl
+    ? "Primary lease document unavailable"
+    : leaseDocumentContext?.displayLabel || data?.leasePdfLabel || null;
   const leaseDocumentWarnings = Array.isArray(leaseDocumentContext?.warnings) ? leaseDocumentContext.warnings : [];
   const paymentReadiness = data?.paymentReadiness || null;
   const paymentSummary = rentPaymentDetails || data?.rentPaymentSummary || null;

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -3,6 +3,7 @@ import {
   createTenantLeasePaymentCheckout,
   getTenantLeasePaymentStatus,
   getTenantLeaseWorkspace,
+  refreshTenantLeaseDocumentUrl,
   signTenantLease,
 } from "../../api/tenantPortal";
 import {
@@ -31,6 +32,7 @@ export default function TenantLeasePage() {
   const [loading, setLoading] = React.useState(true);
   const [signing, setSigning] = React.useState(false);
   const [paying, setPaying] = React.useState(false);
+  const [openingDocument, setOpeningDocument] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
   const load = React.useCallback(async () => {
@@ -80,6 +82,26 @@ export default function TenantLeasePage() {
       setError(err?.payload?.error || err?.message || "Unable to record your lease signature.");
     } finally {
       setSigning(false);
+    }
+  }
+
+  async function handleOpenLeaseDocument() {
+    const fallbackUrl = String(data?.leaseDocumentContext?.documentUrl || data?.documentUrl || "").trim();
+    setOpeningDocument(true);
+    setError(null);
+    try {
+      const refreshed = await refreshTenantLeaseDocumentUrl();
+      const nextUrl = String(refreshed?.documentUrl || "").trim() || fallbackUrl;
+      if (!nextUrl) throw new Error("Lease document is not available.");
+      window.open(nextUrl, "_blank", "noreferrer");
+    } catch (err: any) {
+      if (fallbackUrl) {
+        window.open(fallbackUrl, "_blank", "noreferrer");
+        return;
+      }
+      setError(err?.payload?.error || err?.message || "Lease document is not available.");
+    } finally {
+      setOpeningDocument(false);
     }
   }
 
@@ -331,9 +353,9 @@ export default function TenantLeasePage() {
               </div>
             ) : null}
             {leaseDocumentUrl ? (
-              <a href={leaseDocumentUrl} target="_blank" rel="noreferrer">
-                Open lease document
-              </a>
+              <button type="button" onClick={() => void handleOpenLeaseDocument()} disabled={openingDocument}>
+                {openingDocument ? "Opening..." : "Open lease document"}
+              </button>
             ) : (
               <div style={{ color: "var(--text-muted, #64748b)" }}>
                 No approved lease document link is available in this workspace yet.

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2264,6 +2264,62 @@ describe("tenant workspace frontend shell", () => {
     expect(window.open).toHaveBeenCalledWith("https://example.com/refreshed-lease.pdf", "_blank", "noreferrer");
   });
 
+  it("does not open stale tenant GCS lease URLs when refresh fails", async () => {
+    tenantPortalApi.refreshTenantLeaseDocumentUrl.mockRejectedValueOnce(new Error("refresh failed"));
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-stale",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1800,
+      status: "active",
+      documentUrl:
+        "https://storage.googleapis.com/lease-documents/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf?X-Goog-Expires=1",
+      leaseDocumentContext: {
+        leaseId: "lease-stale",
+        documentUrl:
+          "https://storage.googleapis.com/lease-documents/leases/PXbRIbJdZpV2eBjzNmLaISgDa852/nkzRYxdZ49p0IGdXD3mS/schedule-a-v1.pdf?X-Goog-Expires=1",
+        displayLabel: "Signed lease document",
+        documentStatus: "signed",
+        source: "lease.documentUrl",
+        confidence: "high",
+        warnings: [],
+      },
+      signatureStatus: "signed",
+      signatureReadinessLabel: "Lease signing complete",
+      signatureReadinessDescription: "The visible lease record shows the current signing stage as complete.",
+      tenantSignature: {
+        signedAt: "2026-03-02T12:00:00.000Z",
+        signatureMethod: "typed",
+        signatureDisplayName: "Taylor Tenant",
+      },
+      leasePdfStatus: "available",
+      leasePdfLabel: "Lease document available",
+      leasePdfDescription: "A tenant-safe lease document is available in this workspace.",
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "The lease is fully executed.",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "generated",
+        completedAt: "2026-03-02T12:00:00.000Z",
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <TenantLeasePage />
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.open).mockClear();
+    fireEvent.click(await screen.findByRole("button", { name: /Open lease document/i }));
+    await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalled());
+    expect(window.open).not.toHaveBeenCalled();
+    expect(await screen.findByText("refresh failed")).toBeInTheDocument();
+  });
+
   it("shows the tenant lease sign action only when backend execution metadata requires it", async () => {
     tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
       leaseId: "lease-2",

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -12,6 +12,7 @@ import { TenantNav } from "../../components/layout/TenantNav";
 const tenantPortalApi = vi.hoisted(() => ({
   getTenantWorkspace: vi.fn(),
   getTenantLeaseWorkspace: vi.fn(),
+  refreshTenantLeaseDocumentUrl: vi.fn(),
   getTenantLeasePaymentStatus: vi.fn(),
   exportTenantIdentityPackage: vi.fn(),
   createInstitutionalHandoffDraft: vi.fn(),
@@ -458,6 +459,14 @@ describe("tenant workspace frontend shell", () => {
         },
       },
     });
+    tenantPortalApi.refreshTenantLeaseDocumentUrl.mockResolvedValue({
+      documentUrl: "https://example.com/refreshed-lease.pdf",
+      displayLabel: "Signed lease document",
+      documentStatus: "signed",
+      source: "leaseDocument",
+      expiresInSeconds: 1800,
+    });
+    vi.spyOn(window, "open").mockReturnValue(null);
     tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
       ok: true,
       data: [
@@ -2248,7 +2257,11 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByRole("button", { name: /Pay rent/i })).toBeInTheDocument();
     expect(screen.getByText(/^Drawn signature$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Taylor Tenant$/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Open lease document/i })).toBeInTheDocument();
+    const openLeaseButton = screen.getByRole("button", { name: /Open lease document/i });
+    expect(openLeaseButton).toBeInTheDocument();
+    fireEvent.click(openLeaseButton);
+    await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalled());
+    expect(window.open).toHaveBeenCalledWith("https://example.com/refreshed-lease.pdf", "_blank", "noreferrer");
   });
 
   it("shows the tenant lease sign action only when backend execution metadata requires it", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2189,6 +2189,21 @@ describe("tenant workspace frontend shell", () => {
         confidence: "high",
         warnings: [],
       },
+      scheduleADocumentContext: {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        leaseStatus: "active",
+        signingStatus: "signed",
+        documentStatus: "generated",
+        documentId: "snapshot-schedule-a",
+        documentUrl: "https://example.com/schedule-a.pdf",
+        displayLabel: "Schedule A",
+        source: "leaseSnapshots/snapshot-schedule-a",
+        confidence: "medium",
+        warnings: [],
+      },
       signatureStatus: "signed",
       signatureReadinessLabel: "Lease signing complete",
       signatureReadinessDescription: "The visible lease record shows the current signing stage as complete.",
@@ -2262,6 +2277,18 @@ describe("tenant workspace frontend shell", () => {
     fireEvent.click(openLeaseButton);
     await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalled());
     expect(window.open).toHaveBeenCalledWith("https://example.com/refreshed-lease.pdf", "_blank", "noreferrer");
+    tenantPortalApi.refreshTenantLeaseDocumentUrl.mockResolvedValueOnce({
+      documentUrl: "https://example.com/refreshed-schedule-a.pdf",
+      displayLabel: "Schedule A",
+      documentStatus: "generated",
+      source: "leaseSnapshots/snapshot-schedule-a",
+      expiresInSeconds: 1800,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Open Schedule A/i }));
+    await waitFor(() =>
+      expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith({ document: "schedule-a" })
+    );
+    expect(window.open).toHaveBeenCalledWith("https://example.com/refreshed-schedule-a.pdf", "_blank", "noreferrer");
   });
 
   it("does not open stale tenant GCS lease URLs when refresh fails", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2341,10 +2341,72 @@ describe("tenant workspace frontend shell", () => {
     );
 
     vi.mocked(window.open).mockClear();
-    fireEvent.click(await screen.findByRole("button", { name: /Open lease document/i }));
-    await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /Open lease document/i })).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: /Open Schedule A/i }));
+    await waitFor(() =>
+      expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith({ document: "schedule-a" })
+    );
     expect(window.open).not.toHaveBeenCalled();
     expect(await screen.findByText("refresh failed")).toBeInTheDocument();
+  });
+
+  it("does not open Schedule A when the tenant primary lease refresh path returns it", async () => {
+    tenantPortalApi.refreshTenantLeaseDocumentUrl.mockResolvedValueOnce({
+      documentUrl: "https://storage.googleapis.com/lease-documents/leases/landlord/draft/schedule-a-v1.pdf",
+      displayLabel: "Signed lease document",
+      documentStatus: "signed",
+      source: "leaseDocument",
+      expiresInSeconds: 1800,
+    });
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-tenant-primary",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1800,
+      status: "active",
+      documentUrl: "https://example.com/lease.pdf",
+      leaseDocumentContext: {
+        leaseId: "lease-tenant-primary",
+        documentUrl: "https://example.com/lease.pdf",
+        displayLabel: "Signed lease document",
+        documentStatus: "signed",
+        source: "lease.documentUrl",
+        confidence: "high",
+        warnings: [],
+      },
+      scheduleADocumentContext: {
+        leaseId: "lease-tenant-primary",
+        documentUrl: "https://example.com/schedule-a.pdf",
+        displayLabel: "Schedule A",
+        documentStatus: "generated",
+        source: "leaseSnapshots/snapshot-schedule-a",
+        confidence: "high",
+        warnings: [],
+      },
+      signatureStatus: "signed",
+      signatureReadinessLabel: "Lease signing complete",
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "The lease is fully executed.",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "generated",
+        completedAt: "2026-03-02T12:00:00.000Z",
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <TenantLeasePage />
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.open).mockClear();
+    fireEvent.click(await screen.findByRole("button", { name: /Open lease document/i }));
+    await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith());
+    expect(window.open).not.toHaveBeenCalled();
   });
 
   it("shows the tenant lease sign action only when backend execution metadata requires it", async () => {


### PR DESCRIPTION
## Summary
- Adds scoped landlord and tenant lease document URL refresh endpoints so authorized users can mint fresh time-limited GCS signed URLs.
- Preserves generated lease PDF storage refs as internal metadata for refresh-safe continuity while keeping existing legacy signed URL fallback behavior.
- Updates landlord and tenant lease document UI actions to refresh URLs before opening documents instead of relying only on stale page-load URLs.
- Adds governance report for lease document signed URL continuity.

## Tests
- rentchain-api: npm run test:single -- leaseRoutes.active.test.ts tenantPortalRoutes.test.ts
- rentchain-api: npm run build
- rentchain-frontend: npm run test -- LandlordActiveLeasesPage.test.tsx TenantWorkspacePage.test.tsx
- rentchain-frontend: npm run build
- git diff --check
- git diff --cached --check

## Guardrails
- No public document URLs introduced.
- No storage migration.
- No Firestore rules, auth, route visibility, or permission changes.
- No permanent signed URLs.
- Raw storage refs remain internal metadata only, not display labels.

## Follow-ups
- Legacy URL-only lease records still need a metadata backfill if they must become refreshable without regeneration.
- Unit reconciliation document links can adopt the same click-time refresh pattern in a later mission.
- Evidence/export document refresh should be handled in a dedicated follow-up after those access flows are reviewed.