### PR TITLE
Stabilize telemetry and screening route governance

### DIFF
--- a/docs/reports/telemetry-and-screening-route-governance-v1.md
+++ b/docs/reports/telemetry-and-screening-route-governance-v1.md
@@ -1,0 +1,104 @@
+# Telemetry and Screening Route Governance v1
+
+## Executive Summary
+
+This report documents the route-governance stabilization for the frontend telemetry endpoint and landlord screening-history endpoints.
+
+The mission keeps the implementation narrow:
+
+- `/api/telemetry` remains an authenticated, non-blocking product telemetry write surface.
+- `/api/screenings/history` remains landlord/admin scoped and projection-safe.
+- Screening-history routes are now mounted explicitly in the production app build path.
+- Telemetry and screening-history ownership is pinned immediately after auth decode and ahead of broad `/api` routers such as risk-agent and screening job/admin fallback routes.
+- No auth behavior, Firestore rules, schemas, screening workflow semantics, or telemetry architecture were changed.
+
+## Route Inventory
+
+| Route | Owner | Intended Visibility | Behavior |
+| --- | --- | --- | --- |
+| `POST /api/telemetry` | `telemetryRoutes.ts` | Authenticated app users only | Accepts allowlisted `nudge_*` and `pdf_*` event names; stores sanitized metadata in `telemetry_events`. |
+| `GET /api/screenings/history` | `screeningRoutes.ts` | Landlord/admin only | Returns scoped screening history summaries for an application or tenant. |
+| `GET /api/screenings/history/:id` | `screeningRoutes.ts` | Landlord/admin only | Returns a scoped screening detail projection. |
+| `GET /api/screenings/history/:id/report` | `screeningRoutes.ts` | Landlord/admin only | Streams a stored report only when `screeningAccessService` authorizes access. |
+| `POST /api/admin/screening-jobs/run` | `screeningJobsAdminRoutes.ts` | Internal/admin only | Processes screening jobs through internal-token/admin controls. |
+| `POST /api/admin/screening-jobs/enqueue/:orderId` | `screeningJobsAdminRoutes.ts` | Internal/admin only | Enqueues a screening job for an existing order. |
+
+## Route Ownership Findings
+
+Preview QA showed unexplained `404` responses for:
+
+- `POST /api/telemetry`
+- `GET /api/screenings/history?...`
+
+Audit findings:
+
+- `telemetryRoutes.ts` existed and was mounted, but it was mounted after broad `/api` routers. That made route ownership harder to reason about when debugging preview responses.
+- `screeningRoutes.ts` contained the authoritative `/screenings/history` handlers, but it was not mounted in `app.build.ts`.
+- `riskAgentRoutes.ts` and `screeningJobsAdminRoutes.ts` are broad-mounted at `/api`, so sensitive route families must be mounted before them or otherwise pinned with explicit ownership tests.
+
+## Intended Visibility Model
+
+Telemetry:
+
+- Authenticated only.
+- Non-blocking from the frontend caller.
+- Event-name allowlisted to `nudge_*` and `pdf_*`.
+- Payloads pass through the shared governance sanitization path.
+- No public telemetry read surface is introduced.
+
+Screening history:
+
+- Landlord/admin only.
+- Requires `applicationId` or `tenantId` for list access.
+- Uses service-layer landlord scoping before returning records.
+- Returns screening summaries and report availability metadata, not raw provider payloads.
+- Full report streaming remains gated by `resolveScreeningReportAccess`.
+
+## Projection Safety
+
+These routes must not expose:
+
+- raw provider payloads
+- raw screening reports outside authorized report streaming
+- tokens, secrets, stack traces, or debug payloads
+- unrelated landlord or tenant records
+- unrestricted message bodies
+
+This mission does not add new telemetry event categories or raw diagnostic persistence.
+
+## Environment Expectations
+
+The same app-owned route behavior should apply in local, preview, and production:
+
+- `/api/telemetry` should be owned by `telemetryRoutes.ts`.
+- `/api/screenings/history` should be owned by `screeningRoutes.ts`.
+- Neither route should fall through to broad `/api` routers such as `riskAgentRoutes.ts` or `screeningJobsAdminRoutes.ts`.
+- Missing auth should produce an owner-specific authorization failure rather than an unrelated 404.
+
+## Tests Added
+
+Route ownership regression coverage now confirms:
+
+- telemetry and screening-history mounts appear before broad `/api` routers including `riskAgentRoutes.ts` and `screeningJobsAdminRoutes.ts`
+- `POST /api/telemetry` is owned by `telemetryRoutes.ts`
+- `GET /api/screenings/history` is owned by `screeningRoutes.ts`
+- neither route falls through to unrelated broad routers
+- unknown API paths still reach the explicit API catchall
+
+## Known Limitations
+
+- This does not build a full telemetry platform.
+- This does not add telemetry dashboards.
+- This does not add external observability vendors.
+- This does not change screening-history projection semantics beyond making the existing route reachable through the production app build.
+- This does not expose raw screening provider payloads.
+
+## Future Roadmap
+
+Recommended future missions:
+
+1. Add a support/admin observability view for sanitized telemetry counters.
+2. Add explicit telemetry retention summaries for high-volume events.
+3. Add screening-history UI empty/error states that distinguish no data from unavailable route ownership.
+4. Continue reducing broad `/api` fallback mounts in favor of narrower route prefixes.
+5. Add provider-specific report-access audit summaries without exposing raw provider payloads.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -105,6 +105,7 @@ import adminRegistryRoutes from "./routes/adminRegistryRoutes";
 import adminScreeningResultsRoutes from "./routes/adminScreeningResultsRoutes";
 import adminScreeningUsageRoutes from "./routes/adminScreeningUsageRoutes";
 import screeningReportRoutes from "./routes/screeningReportRoutes";
+import screeningRoutes from "./routes/screeningRoutes";
 import telemetryRoutes from "./routes/telemetryRoutes";
 import invitesRoutes from "./routes/invitesRoutes";
 import accessRoutes from "./routes/accessRoutes";
@@ -299,6 +300,8 @@ app.use("/api/status", routeSource("statusRoutes.ts"), statusRoutes);
 
 // Auth decode (non-blocking if header missing)
 app.use(authenticateJwt);
+app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
+app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes);
 app.use("/api/events", routeSource("eventsRoutes.ts"), eventsRoutes);
 app.use("/api", routeSource("expensesRoutes.ts"), expensesRoutes);
 console.log("[route-mount] expensesRoutes mounted at /api");
@@ -545,7 +548,6 @@ app.use("/api/account", accountRoutes);
 app.use("/api/onboarding", routeSource("onboardingRoutes.ts"), onboardingRoutes);
 app.use("/api", routeSource("onboardingRoutes.ts"), onboardingRoutes);
 app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
-app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
 console.log(
   "[routes] /api/properties, /api/properties/:propertyId/units, /api/action-requests, /api/applications"
 );

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -216,6 +216,8 @@ async function buildRuntimeOwnershipApp() {
   const messagesRoutes = (await import("../messagesRoutes")).default;
   const landlordEvidencePackRoutes = (await import("../landlordEvidencePackRoutes")).default;
   const internalReportsRoutes = (await import("../internalReportsRoutes")).default;
+  const telemetryRoutes = (await import("../telemetryRoutes")).default;
+  const screeningRoutes = (await import("../screeningRoutes")).default;
   const screeningJobsAdminRoutes = (await import("../screeningJobsAdminRoutes")).default;
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
@@ -243,6 +245,8 @@ async function buildRuntimeOwnershipApp() {
   app.post("/api/_echo", requireDiagnosticAccess("app.build.ts:/api/_echo"), (req, res) =>
     res.json({ ok: true, method: "POST", body: req.body ?? null })
   );
+  app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
+  app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes);
   app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes);
   app.use("/api", (_req, res) => {
     res.setHeader("x-route-source", "not-found");
@@ -273,6 +277,10 @@ describe("API route ownership regression", () => {
     );
     const leasesMount = source.indexOf('app.use("/api/leases", routeSource("leaseRoutes.ts"), leaseRoutes)');
     const tenantsMount = source.indexOf('app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes)');
+    const telemetryMount = source.indexOf('app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes)');
+    const screeningRoutesMount = source.indexOf('app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes)');
+    const expensesMount = source.indexOf('app.use("/api", routeSource("expensesRoutes.ts"), expensesRoutes)');
+    const riskAgentMount = source.indexOf('app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes)');
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
     const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
 
@@ -281,6 +289,10 @@ describe("API route ownership regression", () => {
     expect(leaseDocumentUrlRoute).toBeGreaterThan(-1);
     expect(leasesMount).toBeGreaterThan(-1);
     expect(tenantsMount).toBeGreaterThan(-1);
+    expect(telemetryMount).toBeGreaterThan(-1);
+    expect(screeningRoutesMount).toBeGreaterThan(-1);
+    expect(expensesMount).toBeGreaterThan(-1);
+    expect(riskAgentMount).toBeGreaterThan(-1);
     expect(screeningJobsMount).toBeGreaterThan(-1);
     expect(apiCatchall).toBeGreaterThan(-1);
     expect(ledgerMount).toBeLessThan(screeningJobsMount);
@@ -288,6 +300,12 @@ describe("API route ownership regression", () => {
     expect(leaseDocumentUrlRoute).toBeLessThan(screeningJobsMount);
     expect(leasesMount).toBeLessThan(screeningJobsMount);
     expect(tenantsMount).toBeLessThan(screeningJobsMount);
+    expect(telemetryMount).toBeLessThan(expensesMount);
+    expect(screeningRoutesMount).toBeLessThan(expensesMount);
+    expect(telemetryMount).toBeLessThan(riskAgentMount);
+    expect(screeningRoutesMount).toBeLessThan(riskAgentMount);
+    expect(telemetryMount).toBeLessThan(screeningJobsMount);
+    expect(screeningRoutesMount).toBeLessThan(screeningJobsMount);
     expect(screeningJobsMount).toBeLessThan(apiCatchall);
   });
 
@@ -351,6 +369,29 @@ describe("API route ownership regression", () => {
     expect(res.headers["x-route-source"]).toBe("leaseRoutes.ts");
     expect(res.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
     expect(res.body?.error).not.toBe("Not Found");
+  });
+
+  it("keeps telemetry and screening history owned by explicit routers before screening job fallback", async () => {
+    authState.user = null;
+    const app = await buildRuntimeOwnershipApp();
+
+    const telemetryRes = await invokeApp(app, {
+      method: "POST",
+      url: "/api/telemetry",
+      body: { eventName: "nudge_impression", eventProps: { token: "secret" } },
+    });
+    expect(telemetryRes.status).toBe(401);
+    expect(telemetryRes.headers["x-route-source"]).toBe("telemetryRoutes.ts");
+    expect(telemetryRes.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
+
+    const screeningHistoryRes = await invokeApp(app, {
+      method: "GET",
+      url: "/api/screenings/history?applicationId=application-1",
+    });
+    expect(screeningHistoryRes.status).toBe(401);
+    expect(screeningHistoryRes.headers["x-route-source"]).toBe("screeningRoutes.ts");
+    expect(screeningHistoryRes.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
+    expect(JSON.stringify(screeningHistoryRes.body)).not.toContain("secret");
   });
 
   it("keeps webhook requests public and owned by webhook routers", async () => {

--- a/rentchain-api/src/routes/__tests__/telemetryRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/telemetryRoutes.test.ts
@@ -101,6 +101,46 @@ describe("telemetryRoutes", () => {
     });
   });
 
+  it("accepts PDF print preview telemetry and keeps it sanitized", async () => {
+    const router = (await import("../telemetryRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/telemetry",
+      user: { id: "user-1", role: "landlord", landlordId: "landlord-1" },
+      body: {
+        eventName: "pdf_print_opened",
+        eventProps: {
+          exportType: "print_summary",
+          renderingPath: "window_print",
+          status: "print_opened",
+          token: "secret-token",
+          rawPayload: { html: "<private-document>" },
+          tenantName: "Private Tenant",
+        },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const stored = Array.from(collections.get("telemetry_events")?.values() || []);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      eventName: "pdf_print_opened",
+      eventProps: expect.objectContaining({
+        exportType: "print_summary",
+        renderingPath: "window_print",
+        status: "print_opened",
+      }),
+      governance: expect.objectContaining({
+        sensitivity: "confidential",
+        retentionCategory: "export_metadata",
+        metadataOnly: true,
+      }),
+    });
+    expect(stored[0].eventProps.token).toBeUndefined();
+    expect(stored[0].eventProps.rawPayload).toBeUndefined();
+    expect(stored[0].eventProps.tenantName).toBeUndefined();
+  });
+
   it("continues rejecting unrelated telemetry event families", async () => {
     const router = (await import("../telemetryRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/screeningRoutes.ts
+++ b/rentchain-api/src/routes/screeningRoutes.ts
@@ -68,7 +68,7 @@ function logMockProviderCheckout(seedKey: string) {
   });
 }
 
-router.use(authenticateJwt, attachAccount);
+router.use(["/screenings", "/screening/report"], authenticateJwt, attachAccount);
 
 router.get("/screenings/config", (_req, res: Response) => {
   res.status(200).json({

--- a/rentchain-frontend/src/api/telemetryApi.test.ts
+++ b/rentchain-frontend/src/api/telemetryApi.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  isTelemetryEnabled: vi.fn(() => true),
+}));
+
+vi.mock("./apiFetch", () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+vi.mock("@/lib/telemetry", () => ({
+  isTelemetryEnabled: mocks.isTelemetryEnabled,
+}));
+
+describe("logTelemetryEvent", () => {
+  beforeEach(() => {
+    mocks.apiFetch.mockReset();
+    mocks.apiFetch.mockResolvedValue({ ok: true });
+    mocks.isTelemetryEnabled.mockReset();
+    mocks.isTelemetryEnabled.mockReturnValue(true);
+  });
+
+  it("posts PDF print telemetry as a JSON object so apiFetch sets the JSON content type", async () => {
+    const { logTelemetryEvent } = await import("./telemetryApi");
+
+    await logTelemetryEvent("pdf_print_opened", {
+      exportType: "print_summary",
+      renderingPath: "window_print",
+      status: "print_opened",
+    });
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/telemetry", {
+      method: "POST",
+      body: {
+        eventName: "pdf_print_opened",
+        eventProps: {
+          exportType: "print_summary",
+          renderingPath: "window_print",
+          status: "print_opened",
+        },
+      },
+    });
+    expect(typeof mocks.apiFetch.mock.calls[0][1].body).toBe("object");
+  });
+
+  it("does not send unapproved event families", async () => {
+    const { logTelemetryEvent } = await import("./telemetryApi");
+
+    await logTelemetryEvent("print_opened", { exportType: "print_summary" });
+
+    expect(mocks.apiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/api/telemetryApi.ts
+++ b/rentchain-frontend/src/api/telemetryApi.ts
@@ -11,10 +11,10 @@ export async function logTelemetryEvent(
   try {
     await apiFetch("/telemetry", {
       method: "POST",
-      body: JSON.stringify({
+      body: {
         eventName: normalized,
         eventProps: eventProps || {},
-      }),
+      },
     });
   } catch {
     // non-blocking


### PR DESCRIPTION
## Summary

- Mount existing `screeningRoutes.ts` in the production app build so `/api/screenings/history` is owned deterministically.
- Move authenticated `/api/telemetry` ownership ahead of the broad screening jobs fallback route.
- Narrow screening route auth middleware to screening prefixes so mounting the router does not intercept unrelated `/api` paths.
- Add route ownership regression coverage and a governance report for telemetry/screening route behavior.

## Governance Notes

- No auth behavior changes.
- No Firestore rule or schema changes.
- No telemetry visibility widening.
- No raw screening/provider payload exposure.
- No autonomous observability behavior introduced.

## Validation

- `npm run test:single -- src/routes/__tests__/apiRouteOwnershipRegression.test.ts`
- `npm run test:single -- src/routes/__tests__/routeMountSmoke.test.ts src/routes/__tests__/screeningJobsAdminRoutes.mount.test.ts`
- `npm run build`
- `git diff --check`