### PR TITLE
Harden debug probe production gating

### DIFF
--- a/docs/reports/debug-probe-production-gating-v1.md
+++ b/docs/reports/debug-probe-production-gating-v1.md
@@ -1,0 +1,91 @@
+# Debug Probe Production Gating v1
+
+## Executive summary
+
+This mission finalizes RentChain's production debug/probe posture after the earlier production debug-surface hardening pass. The goal is to keep deployment health checks and status observability available while preventing public production traffic from receiving route internals, exact build/revision identifiers, echo payloads, env hints, tokens, secrets, stack traces, or raw debug metadata.
+
+The implementation remains conservative:
+
+- public health and status checks stay reachable;
+- unsafe debug/probe/echo/routes surfaces remain gated by the existing internal diagnostic token pattern;
+- the leftover billing probe is now production-gated;
+- public health-adjacent responses no longer expose exact revision or commit identifiers;
+- no auth behavior, Firestore rules, schemas, route visibility, product workflows, or permissions were changed.
+
+## Diagnostic surface inventory
+
+| Surface | Classification | Final posture |
+| --- | --- | --- |
+| `/health` | public-safe health | Public, minimal service/readiness metadata; exact release/revision/commit values redacted to presence booleans. |
+| `/health/ready` | public-safe readiness | Public, minimal route/db readiness checks preserved. |
+| `/health/db` | public-safe db health | Public, minimal ok/skipped/fail result preserved for deployment verification. |
+| `/health/version` | production-safe health diagnostic | Public; environment hint removed. |
+| `/api/status/public` | production-safe status | Public status-app integration preserved without route-source/debug headers. |
+| `/api/health` | production-safe app health | Public capability booleans only. |
+| `/api/health/stripe` | production-safe app health | Public Stripe/pricing readiness retained; exact Cloud Run revision redacted to safe build presence metadata. |
+| `/api/health/pricing` | production-safe app health | Public pricing configuration health retained. |
+| `/api/health/screening-provider` | production-safe provider readiness | Public provider readiness retained; exact commit/revision redacted to safe build presence metadata. |
+| `/api/__probe/version` | production-safe deployment probe | Public, redacted build presence metadata. |
+| `/api/__probe/revision` | production-safe deployment probe | Public, redacted revision/commit presence metadata. |
+| `/api/_build` | production-safe deployment probe | Public, redacted revision/commit presence metadata. |
+| `/api/_probe/billing` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
+| `/api/__routes` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
+| `/api/__probe/routes` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
+| `/api/__probe/routes-lite` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
+| `/api/__probe/tenants-mount` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
+| `/api/__probe/onboarding-route` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
+| `/api/_echo` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`; denied responses do not echo request payloads. |
+| `/api/__debug/build` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`; allowed response uses redacted build metadata. |
+| `/api/__debug/ping-application-links` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
+
+## Production gating rules
+
+Unsafe diagnostics use `requireDiagnosticAccess(...)`. In production, access requires the configured internal token in `x-internal-job-token` or `x-internal-token`. Without that token, diagnostics fail closed with the same minimal 404 shape used by the API catchall.
+
+Allowed diagnostic responses must not include:
+
+- env values or secret names as data;
+- raw request bodies;
+- tokens, cookies, API keys, or webhook secrets;
+- stack traces;
+- raw route tables or route internals;
+- exact Cloud Run revision IDs;
+- exact commit SHAs.
+
+## Health and status rationale
+
+`/health`, `/health/ready`, `/health/db`, and `/api/status/public` remain public because Cloud Run, Terraform, Vercel preview checks, smoke tests, and the status app rely on low-friction availability checks. These surfaces now remain minimal and avoid exact build identifiers.
+
+Provider and pricing health endpoints remain public because they support operational verification and existing QA workflows. They report readiness and configuration booleans, not secret values, raw provider payloads, or tenant data.
+
+## Preview and development expectations
+
+Non-production environments keep diagnostic access usable for deployment troubleshooting. Production applies the internal-token gate to unsafe diagnostics. Public deployment probes remain intentionally low detail so QA can confirm the service is alive without exposing exact revision data.
+
+## Tests added or updated
+
+- `healthRoutes.test.ts` verifies `/health`, `/health/version`, `/health/ready`, and `/health/db` remain reachable and do not expose exact release, revision, commit, or environment values.
+- `apiRouteOwnershipRegression.test.ts` verifies the billing probe is gated, public route probes use redacted build metadata, exact `apiRevision` fields are not reintroduced in `publicRoutes.ts`, and existing debug/echo route ownership remains deterministic.
+
+## Known limitations
+
+- Internal diagnostic access still depends on the existing shared `INTERNAL_JOB_TOKEN` pattern. This is appropriate for this phase but is not a full admin diagnostics product.
+- Public health endpoints intentionally remain reachable. Any future IP allowlisting or deployment-gateway restriction must be coordinated with Cloud Run, Terraform, Vercel, and the status app.
+- Route-source headers remain useful for ownership debugging. They should continue to identify route owners without exposing secrets, raw payloads, or stack traces.
+
+## Future hardening roadmap
+
+1. Replace broad `/api` route mounting with narrower route prefixes where practical.
+2. Add a generated route registry that can replace manual route-inspection probes.
+3. Move internal diagnostics toward privileged admin/support governance once that tooling exists.
+4. Add deployment-level policy checks for diagnostic surfaces after health/status dependencies are fully mapped.
+5. Continue regression-testing newly introduced probes before production exposure.
+
+## Explicit confirmations
+
+- No permissions were widened.
+- No auth behavior changed.
+- No Firestore rules or schemas changed.
+- No product workflow behavior expanded.
+- No autonomous behavior was introduced.
+- Deployment health and status checks remain preserved.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -262,6 +262,17 @@ app.get(
   }
 );
 
+// Build stamp: mounted before broad /api routers so deployment probes do not fall through.
+app.get("/api/_build", rateLimitDiagnostics, (_req, res) => {
+  res.setHeader("x-route-source", "app.build.ts:/api/_build");
+  return res.json({
+    ok: true,
+    ...safeDiagnosticBuildMetadata(),
+  });
+});
+app.use("/api/status", rateLimitDiagnostics);
+app.use("/api/status", statusRoutes);
+
 // Billing routes
 app.use("/api/billing", routeSource("billingRoutes.ts"), billingRoutes);
 console.log("[boot] mounted billingRoutes at /api/billing");
@@ -295,8 +306,6 @@ app.use("/api/internal", rateLimitInternalJob);
 app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
 app.use("/api/internal", routeSource("identityOracleInternalRoutes.ts"), identityOracleInternalRoutes);
 app.use("/api/internal", routeSource("applicationReminderInternalRoutes.ts"), applicationReminderInternalRoutes);
-app.use("/api/status", rateLimitDiagnostics);
-app.use("/api/status", routeSource("statusRoutes.ts"), statusRoutes);
 
 // Auth decode (non-blocking if header missing)
 app.use(authenticateJwt);
@@ -578,15 +587,6 @@ app.get(
     });
   }
 );
-
-// Build stamp
-app.get("/api/_build", rateLimitDiagnostics, (_req, res) => {
-  res.setHeader("x-route-source", "app.build.ts:/api/_build");
-  return res.json({
-    ok: true,
-    ...safeDiagnosticBuildMetadata(),
-  });
-});
 
 // Echo for POST reachability
 app.post(

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -239,6 +239,16 @@ async function buildRuntimeOwnershipApp() {
       } as NodeJS.ProcessEnv),
     })
   );
+  app.get("/api/_build", routeSource("app.build.ts:/api/_build"), (_req, res) =>
+    res.json({
+      ok: true,
+      ...safeDiagnosticBuildMetadata({
+        K_SERVICE: "rentchain-api",
+        K_REVISION: "rev-1",
+        GIT_SHA: "sha-1",
+      } as NodeJS.ProcessEnv),
+    })
+  );
   app.get("/api/__debug/build", requireDiagnosticAccess("app.build.ts:/api/__debug/build"), (_req, res) =>
     res.json({ ok: true, routeCheck: { landlordApplicationLinksMounted: true } })
   );
@@ -279,9 +289,14 @@ describe("API route ownership regression", () => {
     const tenantsMount = source.indexOf('app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes)');
     const telemetryMount = source.indexOf('app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes)');
     const screeningRoutesMount = source.indexOf('app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes)');
+    const statusMount = source.indexOf('app.use("/api/status", statusRoutes)');
+    const paymentsBroadMount = source.indexOf('app.use("/api", routeSource("paymentsRoutes.ts"), paymentsRoutes)');
+    const publicPortfolioMount = source.indexOf('app.use("/api", routeSource("publicPortfolioScoreRoutes.ts"), publicPortfolioScoreRoutes)');
+    const viewingMount = source.indexOf('app.use("/api", routeSource("viewingRoutes.ts"), viewingRoutes)');
     const expensesMount = source.indexOf('app.use("/api", routeSource("expensesRoutes.ts"), expensesRoutes)');
     const riskAgentMount = source.indexOf('app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes)');
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
+    const buildProbeRoute = source.indexOf('app.get("/api/_build", rateLimitDiagnostics');
     const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
 
     expect(ledgerMount).toBeGreaterThan(-1);
@@ -291,19 +306,28 @@ describe("API route ownership regression", () => {
     expect(tenantsMount).toBeGreaterThan(-1);
     expect(telemetryMount).toBeGreaterThan(-1);
     expect(screeningRoutesMount).toBeGreaterThan(-1);
+    expect(statusMount).toBeGreaterThan(-1);
+    expect(paymentsBroadMount).toBeGreaterThan(-1);
+    expect(publicPortfolioMount).toBeGreaterThan(-1);
+    expect(viewingMount).toBeGreaterThan(-1);
     expect(expensesMount).toBeGreaterThan(-1);
     expect(riskAgentMount).toBeGreaterThan(-1);
     expect(screeningJobsMount).toBeGreaterThan(-1);
+    expect(buildProbeRoute).toBeGreaterThan(-1);
     expect(apiCatchall).toBeGreaterThan(-1);
     expect(ledgerMount).toBeLessThan(screeningJobsMount);
     expect(decisionsMount).toBeLessThan(screeningJobsMount);
     expect(leaseDocumentUrlRoute).toBeLessThan(screeningJobsMount);
     expect(leasesMount).toBeLessThan(screeningJobsMount);
     expect(tenantsMount).toBeLessThan(screeningJobsMount);
+    expect(statusMount).toBeLessThan(paymentsBroadMount);
+    expect(statusMount).toBeLessThan(publicPortfolioMount);
+    expect(statusMount).toBeLessThan(viewingMount);
     expect(telemetryMount).toBeLessThan(expensesMount);
     expect(screeningRoutesMount).toBeLessThan(expensesMount);
     expect(telemetryMount).toBeLessThan(riskAgentMount);
     expect(screeningRoutesMount).toBeLessThan(riskAgentMount);
+    expect(buildProbeRoute).toBeLessThan(riskAgentMount);
     expect(telemetryMount).toBeLessThan(screeningJobsMount);
     expect(screeningRoutesMount).toBeLessThan(screeningJobsMount);
     expect(screeningJobsMount).toBeLessThan(apiCatchall);
@@ -313,6 +337,7 @@ describe("API route ownership regression", () => {
     const source = appBuildSource();
     const publicSource = publicRoutesSource();
     const echoRoutes = source.match(/app\.post\(\s*"\/api\/_echo"/g) || [];
+    const buildRoutes = source.match(/app\.get\(\s*"\/api\/_build"/g) || [];
 
     expect(source).toMatch(/app\.get\(\s*"\/api\/__probe\/revision"/);
     expect(source).toMatch(/app\.get\(\s*"\/api\/__probe\/routes"/);
@@ -326,8 +351,13 @@ describe("API route ownership regression", () => {
     expect(source).toContain('requireDiagnosticAccess("debugPingApplicationLinks")');
     expect(publicSource).toContain('requireDiagnosticAccess("publicRoutes.ts:/__probe/onboarding-route")');
     expect(publicSource).toContain('requireDiagnosticAccess("publicRoutes.ts:/__probe/routes-lite")');
+    expect(publicSource).toContain('requireDiagnosticAccess("publicRoutes.ts:/_probe/billing")');
     expect(publicSource).toContain("safeDiagnosticBuildMetadata()");
+    expect(publicSource).not.toContain("apiRevision");
     expect(echoRoutes).toHaveLength(1);
+    expect(buildRoutes).toHaveLength(1);
+    expect(source).toContain('app.use("/api/status", statusRoutes)');
+    expect(source).not.toContain('routeSource("statusRoutes.ts"), statusRoutes');
     expect(source).toContain('res.setHeader("x-route-source", "not-found")');
   });
 
@@ -452,6 +482,18 @@ describe("API route ownership regression", () => {
       });
       expect(JSON.stringify(revision.body)).not.toContain("rev-1");
       expect(JSON.stringify(revision.body)).not.toContain("sha-1");
+
+      const build = await invokeApp(app, { method: "GET", url: "/api/_build" });
+      expect(build.status).toBe(200);
+      expect(build.headers["x-route-source"]).toBe("app.build.ts:/api/_build");
+      expect(build.body).toMatchObject({
+        ok: true,
+        service: "rentchain-api",
+        revisionPresent: true,
+        commitPresent: true,
+      });
+      expect(JSON.stringify(build.body)).not.toContain("rev-1");
+      expect(JSON.stringify(build.body)).not.toContain("sha-1");
 
       const debugDenied = await invokeApp(app, { method: "GET", url: "/api/__debug/build" });
       expect(debugDenied.status).toBe(404);

--- a/rentchain-api/src/routes/__tests__/healthRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/healthRoutes.test.ts
@@ -1,0 +1,126 @@
+import express from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import healthRoutes from "../healthRoutes";
+
+const firebaseMock = vi.hoisted(() => ({
+  listCollections: vi.fn(async () => []),
+}));
+const originalNodeEnv = process.env.NODE_ENV;
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    listCollections: firebaseMock.listCollections,
+  },
+}));
+
+function buildApp() {
+  const app = express();
+  app.use("/health", healthRoutes);
+  return app;
+}
+
+async function invokeApp(app: any, method: string, url: string) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, any> }>((resolve, reject) => {
+    const req: any = {
+      method,
+      url,
+      originalUrl: url,
+      path: url,
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name || "").toLowerCase()];
+      },
+      header(name: string) {
+        return this.headers[String(name || "").toLowerCase()];
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, any>,
+      setHeader(name: string, value: any) {
+        this.headers[String(name).toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+    };
+
+    app.handle(req, res, (error: any) => {
+      if (error) reject(error);
+      else reject(new Error(`Unhandled request: ${method} ${url}`));
+    });
+  });
+}
+
+describe("healthRoutes", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = originalNodeEnv;
+    delete process.env.RELEASE_SHA;
+    delete process.env.K_REVISION;
+    delete process.env.GIT_SHA;
+    delete process.env.COMMIT_SHA;
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    delete process.env.FIREBASE_CONFIG;
+  });
+
+  it("keeps /health reachable while redacting exact revision and commit values", async () => {
+    process.env.RELEASE_SHA = "release-secret-sha";
+    process.env.K_REVISION = "rentchain-landlord-api-00042-secret";
+    process.env.GIT_SHA = "abc123secret";
+
+    const res = await invokeApp(buildApp(), "GET", "/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      service: "rentchain-api",
+      revisionPresent: true,
+      commitPresent: true,
+      releaseShaPresent: true,
+    });
+    expect(JSON.stringify(res.body)).not.toContain("release-secret-sha");
+    expect(JSON.stringify(res.body)).not.toContain("00042-secret");
+    expect(JSON.stringify(res.body)).not.toContain("abc123secret");
+  });
+
+  it("keeps /health/version reachable without exposing environment hints", async () => {
+    process.env.NODE_ENV = "production";
+
+    const res = await invokeApp(buildApp(), "GET", "/health/version");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: "ok",
+      service: "rentchain-api",
+    });
+    expect(res.body.version).toBeDefined();
+    expect(res.body.env).toBeUndefined();
+  });
+
+  it("keeps readiness and db health safe for deployment verification", async () => {
+    const app = buildApp();
+
+    const ready = await invokeApp(app, "GET", "/health/ready");
+    expect(ready.status).toBe(200);
+    expect(ready.body).toMatchObject({
+      status: "ok",
+      service: "rentchain-api",
+      checks: { routes: "ok", db: "skipped" },
+    });
+
+    const db = await invokeApp(app, "GET", "/health/db");
+    expect(db.status).toBe(200);
+    expect(db.body).toEqual({ status: "skipped", message: "No DB credentials configured" });
+  });
+});

--- a/rentchain-api/src/routes/healthRoutes.ts
+++ b/rentchain-api/src/routes/healthRoutes.ts
@@ -1,14 +1,15 @@
 import express from "express";
 import { getVersion } from "../version";
 import { db } from "../config/firebase";
+import { safeDiagnosticBuildMetadata } from "../middleware/diagnosticSurfaceGuard";
 
 const router = express.Router();
 
 router.get("/", (_req, res) => {
   res.json({
     ok: true,
-    service: "rentchain-api",
-    releaseSha: process.env.RELEASE_SHA || "unknown",
+    ...safeDiagnosticBuildMetadata(),
+    releaseShaPresent: Boolean(String(process.env.RELEASE_SHA || "").trim()),
     reportingEnabled: process.env.REPORTING_ENABLED === "true",
     reportingDryRun: process.env.REPORTING_DRY_RUN === "true",
   });
@@ -19,7 +20,6 @@ router.get("/version", (_req, res) => {
     status: "ok",
     service: "rentchain-api",
     version: getVersion(),
-    env: process.env.NODE_ENV || "development",
   });
 });
 

--- a/rentchain-api/src/routes/publicRoutes.ts
+++ b/rentchain-api/src/routes/publicRoutes.ts
@@ -63,14 +63,17 @@ router.get("/health", (_req, res) => {
   });
 });
 
-router.get("/_probe/billing", (_req, res) => {
-  res.setHeader("x-route-source", "publicRoutes.ts");
-  res.json({
-    ok: true,
-    billingExpectedPath: "/api/billing/checkout",
-    hint: "If POST /api/billing/checkout is 404, billingRoutes is not mounted in this build.",
-  });
-});
+router.get(
+  "/_probe/billing",
+  requireDiagnosticAccess("publicRoutes.ts:/_probe/billing"),
+  (_req, res) => {
+    res.json({
+      ok: true,
+      billingExpectedPath: "/api/billing/checkout",
+      hint: "If POST /api/billing/checkout is 404, billingRoutes is not mounted in this build.",
+    });
+  }
+);
 
 router.get("/health/stripe", async (_req, res) => {
   res.setHeader("x-route-source", "publicRoutes.ts");
@@ -136,7 +139,7 @@ router.get("/health/stripe", async (_req, res) => {
       STRIPE_PRICE_BUSINESS: has("STRIPE_PRICE_BUSINESS"),
     },
     deepChecked: deepCheckEnabled,
-    apiRevision: process.env.K_REVISION || null,
+    build: safeDiagnosticBuildMetadata(),
   });
 });
 
@@ -167,7 +170,7 @@ router.get("/health/screening-provider", async (_req, res) => {
     configured: health.configured,
     preflightOk: health.preflightOk,
     preflightDetail: health.preflightDetail || null,
-    apiRevision: process.env.COMMIT_SHA || process.env.GIT_SHA || null,
+    build: safeDiagnosticBuildMetadata(),
     ts: Date.now(),
   });
 });


### PR DESCRIPTION
## Summary
- Gate the remaining public billing probe behind the existing production diagnostic token guard.
- Redact exact revision/commit metadata from public health-adjacent diagnostic responses.
- Add the final debug/probe production gating governance report.
- Add regression coverage for health/status safety and diagnostic route ownership.

## Surfaces gated/redacted
- /api/_probe/billing is now production-gated via requireDiagnosticAccess.
- /api/health/stripe no longer returns exact Cloud Run revision metadata.
- /api/health/screening-provider no longer returns exact commit/revision metadata.
- /health now exposes build/release presence metadata instead of exact identifiers.
- /health/version remains reachable but no longer exposes the runtime environment string.

## Health/status preservation
- /health, /health/ready, /health/db, and /api/status/public remain public-safe deployment/status surfaces.
- Existing debug/echo/routes production gates remain intact.

## Validation
- npm run test:single -- src/routes/__tests__/healthRoutes.test.ts src/middleware/__tests__/diagnosticSurfaceGuard.test.ts src/routes/__tests__/apiRouteOwnershipRegression.test.ts
- npm run build
- git diff --check

## Guardrails
- No auth behavior changes.
- No Firestore rules or schema changes.
- No permission widening.
- No product workflow expansion.
- No autonomous behavior introduced.