### PR TITLE
Finalize debug probe production gating

### DIFF
--- a/docs/reports/debug-probe-production-gating-v1.md
+++ b/docs/reports/debug-probe-production-gating-v1.md
@@ -10,6 +10,8 @@ The implementation remains conservative:
 - unsafe debug/probe/echo/routes surfaces remain gated by the existing internal diagnostic token pattern;
 - the leftover billing probe is now production-gated;
 - public health-adjacent responses no longer expose exact revision or commit identifiers;
+- public health-adjacent responses avoid server-only env names and exact environment hints;
+- internal echo diagnostics no longer return raw request bodies;
 - no auth behavior, Firestore rules, schemas, route visibility, product workflows, or permissions were changed.
 
 ## Diagnostic surface inventory
@@ -21,9 +23,9 @@ The implementation remains conservative:
 | `/health/db` | public-safe db health | Public, minimal ok/skipped/fail result preserved for deployment verification. |
 | `/health/version` | production-safe health diagnostic | Public; environment hint removed. |
 | `/api/status/public` | production-safe status | Public status-app integration preserved without route-source/debug headers. |
-| `/api/health` | production-safe app health | Public capability booleans only. |
-| `/api/health/stripe` | production-safe app health | Public Stripe/pricing readiness retained; exact Cloud Run revision redacted to safe build presence metadata. |
-| `/api/health/pricing` | production-safe app health | Public pricing configuration health retained. |
+| `/api/health` | production-safe app health | Public capability booleans only; server-only env/provider details are not returned. |
+| `/api/health/stripe` | production-safe app health | Public Stripe/pricing readiness retained; exact Cloud Run revision and server-only Stripe env names are redacted. |
+| `/api/health/pricing` | production-safe app health | Public pricing configuration health retained as counts/booleans rather than specific env names. |
 | `/api/health/screening-provider` | production-safe provider readiness | Public provider readiness retained; exact commit/revision redacted to safe build presence metadata. |
 | `/api/__probe/version` | production-safe deployment probe | Public, redacted build presence metadata. |
 | `/api/__probe/revision` | production-safe deployment probe | Public, redacted revision/commit presence metadata. |
@@ -34,8 +36,8 @@ The implementation remains conservative:
 | `/api/__probe/routes-lite` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
 | `/api/__probe/tenants-mount` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
 | `/api/__probe/onboarding-route` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
-| `/api/_echo` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`; denied responses do not echo request payloads. |
-| `/api/__debug/build` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`; allowed response uses redacted build metadata. |
+| `/api/_echo` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`; allowed and denied responses do not echo request payloads. |
+| `/api/__debug/build` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`; allowed response uses redacted build metadata and does not return Vercel env values. |
 | `/api/__debug/ping-application-links` | internal diagnostic | Production-gated by `INTERNAL_JOB_TOKEN`. |
 
 ## Production gating rules
@@ -51,6 +53,7 @@ Allowed diagnostic responses must not include:
 - raw route tables or route internals;
 - exact Cloud Run revision IDs;
 - exact commit SHAs.
+- exact deployment environment labels from platform env vars.
 
 ## Health and status rationale
 
@@ -65,7 +68,7 @@ Non-production environments keep diagnostic access usable for deployment trouble
 ## Tests added or updated
 
 - `healthRoutes.test.ts` verifies `/health`, `/health/version`, `/health/ready`, and `/health/db` remain reachable and do not expose exact release, revision, commit, or environment values.
-- `apiRouteOwnershipRegression.test.ts` verifies the billing probe is gated, public route probes use redacted build metadata, exact `apiRevision` fields are not reintroduced in `publicRoutes.ts`, and existing debug/echo route ownership remains deterministic.
+- `apiRouteOwnershipRegression.test.ts` verifies the billing probe is gated, public route probes use redacted build metadata, exact `apiRevision` fields are not reintroduced in `publicRoutes.ts`, public health-adjacent responses avoid raw env/config fields, `_echo` does not return raw request bodies, and existing debug/echo route ownership remains deterministic.
 
 ## Known limitations
 

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -270,6 +270,85 @@ app.get("/api/_build", rateLimitDiagnostics, (_req, res) => {
     ...safeDiagnosticBuildMetadata(),
   });
 });
+app.get(
+  "/api/__probe/tenants-mount",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/__probe/tenants-mount"),
+  (_req, res) => res.json({ ok: true, probe: "tenants-mount" })
+);
+app.get("/api/__probe/version", rateLimitDiagnostics, (_req, res) => {
+  res.setHeader("x-route-source", "app.build.ts:/api/__probe/version");
+  return res.json({ ok: true, marker: "probe-v1", ...safeDiagnosticBuildMetadata() });
+});
+app.get("/api/__probe/revision", rateLimitDiagnostics, (_req, res) => {
+  res.setHeader("x-route-source", "app.build.ts:/api/__probe/revision");
+  return res.json({
+    ok: true,
+    ...safeDiagnosticBuildMetadata(),
+  });
+});
+app.get(
+  "/api/__probe/routes",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/__probe/routes"),
+  (_req, res) => {
+    const appAny: any = app;
+    const stack = appAny?._router?.stack || [];
+    const mounts = stack
+      .filter((l: any) => l && l.name === "router" && l.regexp)
+      .map((l: any) => String(l.regexp));
+    const routes = stack
+      .filter((l: any) => l && l.route && l.route.path)
+      .map((l: any) => ({
+        path: l.route.path,
+        methods: l.route.methods,
+      }));
+
+    res.json({
+      ok: true,
+      mountsCount: mounts.length,
+      mounts,
+      routesCount: routes.length,
+      routes,
+      hasTenantsMount: mounts.some((s: string) => s.includes("tenants")),
+    });
+  }
+);
+app.post(
+  "/api/_echo",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/_echo"),
+  (req, res) => {
+    return res.json({
+      ok: true,
+      method: req.method,
+      path: req.path,
+      bodyPresent: req.body != null,
+    });
+  }
+);
+app.get(
+  "/api/__debug/build",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("app.build.ts:/api/__debug/build"),
+  (_req, res) => {
+    return res.json({
+      ok: true,
+      build: safeDiagnosticBuildMetadata(),
+      routeCheck: {
+        landlordApplicationLinksMounted: true,
+      },
+    });
+  }
+);
+app.get(
+  "/api/__debug/ping-application-links",
+  rateLimitDiagnostics,
+  requireDiagnosticAccess("debugPingApplicationLinks"),
+  (_req, res) => {
+    return res.json({ ok: true });
+  }
+);
 app.use("/api/status", rateLimitDiagnostics);
 app.use("/api/status", statusRoutes);
 
@@ -536,97 +615,12 @@ app.use("/api", routeSource("screeningReportRoutes.ts"), screeningReportRoutes);
 app.use("/api", tenantOnboardRoutes);
 app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/landlord", landlordMicroLiveRoutes);
-app.get(
-  "/api/__probe/tenants-mount",
-  rateLimitDiagnostics,
-  requireDiagnosticAccess("app.build.ts:/api/__probe/tenants-mount"),
-  (_req, res) => res.json({ ok: true, probe: "tenants-mount" })
-);
-app.get("/api/__probe/version", rateLimitDiagnostics, (_req, res) => {
-  res.setHeader("x-route-source", "app.build.ts:/api/__probe/version");
-  return res.json({ ok: true, marker: "probe-v1", ...safeDiagnosticBuildMetadata() });
-});
-app.get("/api/__probe/revision", rateLimitDiagnostics, (_req, res) => {
-  res.setHeader("x-route-source", "app.build.ts:/api/__probe/revision");
-  return res.json({
-    ok: true,
-    ...safeDiagnosticBuildMetadata(),
-  });
-});
 app.use("/api/account", accountRoutes);
 app.use("/api/onboarding", routeSource("onboardingRoutes.ts"), onboardingRoutes);
 app.use("/api", routeSource("onboardingRoutes.ts"), onboardingRoutes);
 app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
 console.log(
   "[routes] /api/properties, /api/properties/:propertyId/units, /api/action-requests, /api/applications"
-);
-app.get(
-  "/api/__probe/routes",
-  rateLimitDiagnostics,
-  requireDiagnosticAccess("app.build.ts:/api/__probe/routes"),
-  (_req, res) => {
-    const appAny: any = app;
-    const stack = appAny?._router?.stack || [];
-    const mounts = stack
-      .filter((l: any) => l && l.name === "router" && l.regexp)
-      .map((l: any) => String(l.regexp));
-    const routes = stack
-      .filter((l: any) => l && l.route && l.route.path)
-      .map((l: any) => ({
-        path: l.route.path,
-        methods: l.route.methods,
-      }));
-
-    res.json({
-      ok: true,
-      mountsCount: mounts.length,
-      mounts,
-      routesCount: routes.length,
-      routes,
-      hasTenantsMount: mounts.some((s: string) => s.includes("tenants")),
-    });
-  }
-);
-
-// Echo for POST reachability
-app.post(
-  "/api/_echo",
-  rateLimitDiagnostics,
-  requireDiagnosticAccess("app.build.ts:/api/_echo"),
-  (req, res) => {
-    return res.json({
-      ok: true,
-      method: req.method,
-      path: req.path,
-      body: req.body ?? null,
-    });
-  }
-);
-
-app.get(
-  "/api/__debug/build",
-  rateLimitDiagnostics,
-  requireDiagnosticAccess("app.build.ts:/api/__debug/build"),
-  (_req, res) => {
-    return res.json({
-      ok: true,
-      build: safeDiagnosticBuildMetadata(),
-      vercel: { env: process.env.VERCEL_ENV || null },
-      routeCheck: {
-        landlordApplicationLinksMounted: true,
-        mountPath: "/api/landlord/application-links",
-      },
-    });
-  }
-);
-
-app.get(
-  "/api/__debug/ping-application-links",
-  rateLimitDiagnostics,
-  requireDiagnosticAccess("debugPingApplicationLinks"),
-  (_req, res) => {
-    return res.json({ ok: true });
-  }
 );
 
 // API 404 handler

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -253,7 +253,7 @@ async function buildRuntimeOwnershipApp() {
     res.json({ ok: true, routeCheck: { landlordApplicationLinksMounted: true } })
   );
   app.post("/api/_echo", requireDiagnosticAccess("app.build.ts:/api/_echo"), (req, res) =>
-    res.json({ ok: true, method: "POST", body: req.body ?? null })
+    res.json({ ok: true, method: "POST", bodyPresent: req.body != null })
   );
   app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
   app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes);
@@ -338,6 +338,10 @@ describe("API route ownership regression", () => {
     const publicSource = publicRoutesSource();
     const echoRoutes = source.match(/app\.post\(\s*"\/api\/_echo"/g) || [];
     const buildRoutes = source.match(/app\.get\(\s*"\/api\/_build"/g) || [];
+    const routesProbeRoute = source.indexOf('app.get(\n  "/api/__probe/routes"');
+    const echoRoute = source.indexOf('app.post(\n  "/api/_echo"');
+    const debugBuildRoute = source.indexOf('app.get(\n  "/api/__debug/build"');
+    const riskAgentMount = source.indexOf('app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes)');
 
     expect(source).toMatch(/app\.get\(\s*"\/api\/__probe\/revision"/);
     expect(source).toMatch(/app\.get\(\s*"\/api\/__probe\/routes"/);
@@ -353,9 +357,21 @@ describe("API route ownership regression", () => {
     expect(publicSource).toContain('requireDiagnosticAccess("publicRoutes.ts:/__probe/routes-lite")');
     expect(publicSource).toContain('requireDiagnosticAccess("publicRoutes.ts:/_probe/billing")');
     expect(publicSource).toContain("safeDiagnosticBuildMetadata()");
+    expect(publicSource).toContain("publicCapabilitySummary()");
+    expect(publicSource).not.toContain("config: getEnvFlags()");
+    expect(publicSource).not.toContain("webhookSecretConfigured");
+    expect(publicSource).not.toContain("priceEnv");
+    expect(publicSource).not.toContain("env: health.env");
     expect(publicSource).not.toContain("apiRevision");
     expect(echoRoutes).toHaveLength(1);
     expect(buildRoutes).toHaveLength(1);
+    expect(routesProbeRoute).toBeGreaterThan(-1);
+    expect(echoRoute).toBeGreaterThan(-1);
+    expect(debugBuildRoute).toBeGreaterThan(-1);
+    expect(riskAgentMount).toBeGreaterThan(-1);
+    expect(routesProbeRoute).toBeLessThan(riskAgentMount);
+    expect(echoRoute).toBeLessThan(riskAgentMount);
+    expect(debugBuildRoute).toBeLessThan(riskAgentMount);
     expect(source).toContain('app.use("/api/status", statusRoutes)');
     expect(source).not.toContain('routeSource("statusRoutes.ts"), statusRoutes');
     expect(source).toContain('res.setHeader("x-route-source", "not-found")');
@@ -552,6 +568,8 @@ describe("API route ownership regression", () => {
       });
       expect(debugAllowed.status).toBe(200);
       expect(debugAllowed.body).toMatchObject({ ok: true, routeCheck: { landlordApplicationLinksMounted: true } });
+      expect(JSON.stringify(debugAllowed.body)).not.toContain("preview");
+      expect(JSON.stringify(debugAllowed.body)).not.toContain("VERCEL_ENV");
 
       const echoAllowed = await invokeApp(app, {
         method: "POST",
@@ -560,7 +578,9 @@ describe("API route ownership regression", () => {
         headers: { "x-internal-job-token": "secret-token" },
       });
       expect(echoAllowed.status).toBe(200);
-      expect(echoAllowed.body).toMatchObject({ ok: true, method: "POST", body: { ok: true } });
+      expect(echoAllowed.body).toMatchObject({ ok: true, method: "POST", bodyPresent: true });
+      expect(JSON.stringify(echoAllowed.body)).not.toContain("secret");
+      expect(JSON.stringify(echoAllowed.body)).not.toContain('"body"');
 
       const missing = await invokeApp(app, { method: "GET", url: "/api/unknown-route" });
       expect(missing.status).toBe(404);

--- a/rentchain-api/src/routes/publicRoutes.ts
+++ b/rentchain-api/src/routes/publicRoutes.ts
@@ -53,13 +53,21 @@ function resolveEmailFromAddress(): string {
   ).trim();
 }
 
+function publicCapabilitySummary() {
+  const flags = getEnvFlags();
+  return {
+    emailConfigured: Boolean(flags.emailConfigured),
+    stripeConfigured: Boolean(flags.stripeConfigured),
+    pricingConfigured: Boolean(flags.pricingConfigured),
+  };
+}
+
 router.get("/health", (_req, res) => {
   res.setHeader("x-route-source", "publicRoutes.ts");
   res.json({
     ok: true,
     service: "rentchain-api",
-    ts: Date.now(),
-    config: getEnvFlags(),
+    capabilities: publicCapabilitySummary(),
   });
 });
 
@@ -80,10 +88,6 @@ router.get("/health/stripe", async (_req, res) => {
   const has = (key: string) => {
     const raw = process.env[key];
     return Boolean(raw && String(raw).trim());
-  };
-  const getTrimmed = (key: string) => {
-    const raw = process.env[key];
-    return raw ? String(raw).trim() : "";
   };
   const priceKeys = [
     "STRIPE_PRICE_STARTER_MONTHLY",
@@ -106,37 +110,28 @@ router.get("/health/stripe", async (_req, res) => {
       const stripe = getStripeClient();
       for (const key of priceKeys) {
         if (!has(key)) continue;
-        const priceId = getTrimmed(key);
+        const priceId = String(process.env[key] || "").trim();
         if (!priceId.startsWith("price_")) {
-          return res.json({ ok: false, error: "price_invalid", key });
+          return res.json({ ok: false, error: "price_invalid" });
         }
         try {
           await stripe.prices.retrieve(priceId);
         } catch (err) {
-          return res.json({ ok: false, error: "price_invalid", key });
+          return res.json({ ok: false, error: "price_invalid" });
         }
       }
     } catch (err) {
       return res.json({ ok: false, error: "stripe_not_configured" });
     }
   }
+  const configuredPriceCount = priceKeys.filter((key) => has(key)).length;
   res.json({
     ok: true,
     stripeConfigured: isStripeConfigured(),
-    webhookSecretConfigured: Boolean(process.env.STRIPE_WEBHOOK_SECRET),
-    priceEnv: {
-      STRIPE_PRICE_STARTER_MONTHLY: has("STRIPE_PRICE_STARTER_MONTHLY"),
-      STRIPE_PRICE_STARTER_YEARLY: has("STRIPE_PRICE_STARTER_YEARLY"),
-      STRIPE_PRICE_PRO_MONTHLY: has("STRIPE_PRICE_PRO_MONTHLY"),
-      STRIPE_PRICE_PRO_YEARLY: has("STRIPE_PRICE_PRO_YEARLY"),
-      STRIPE_PRICE_ELITE_MONTHLY: has("STRIPE_PRICE_ELITE_MONTHLY"),
-      STRIPE_PRICE_ELITE_YEARLY: has("STRIPE_PRICE_ELITE_YEARLY"),
-      STRIPE_PRICE_BUSINESS_MONTHLY: has("STRIPE_PRICE_BUSINESS_MONTHLY"),
-      STRIPE_PRICE_BUSINESS_YEARLY: has("STRIPE_PRICE_BUSINESS_YEARLY"),
-      STRIPE_PRICE_STARTER: has("STRIPE_PRICE_STARTER"),
-      STRIPE_PRICE_PRO: has("STRIPE_PRICE_PRO"),
-      STRIPE_PRICE_ELITE: has("STRIPE_PRICE_ELITE"),
-      STRIPE_PRICE_BUSINESS: has("STRIPE_PRICE_BUSINESS"),
+    priceConfiguration: {
+      configured: configuredPriceCount > 0,
+      configuredCount: configuredPriceCount,
+      expectedCount: priceKeys.length,
     },
     deepChecked: deepCheckEnabled,
     build: safeDiagnosticBuildMetadata(),
@@ -151,13 +146,10 @@ router.get("/health/pricing", (_req, res) => {
     ok: health.ok,
     stripeConfigured: isStripeConfigured(),
     planPricesConfigured: health.ok,
-    missing: health.missing,
-    invalid: health.invalid,
-    amountInvalid: health.amountInvalid,
-    used: health.used,
+    missingCount: health.missing.length,
+    invalidCount: health.invalid.length,
+    amountInvalidCount: health.amountInvalid.length,
     fallbackUsed,
-    env: health.env,
-    ts: Date.now(),
   });
 });
 


### PR DESCRIPTION
## Summary
- Redact remaining public health-adjacent env/config details into capability counts and booleans.
- Stop `/api/_echo` from returning raw request bodies, even for internal diagnostic access.
- Remove Vercel environment metadata and route path details from `/api/__debug/build`.
- Update debug/probe production gating report and regression assertions.

## Surfaces inventoried and hardened
- `/api/health`, `/api/health/stripe`, `/api/health/pricing`
- `/api/_echo`
- `/api/__debug/build`
- Existing health/status/probe route ownership coverage remains intact.

## Tests
- `npm run test:single -- src/routes/__tests__/apiRouteOwnershipRegression.test.ts src/middleware/__tests__/diagnosticSurfaceGuard.test.ts src/routes/__tests__/healthRoutes.test.ts`
- `npm run build`
- `git diff --check`

## Guardrails
- No auth, schema, Firestore rule, or permission changes.
- No product behavior expansion.
- Health/status deployment checks preserved.
- No autonomous behavior introduced.