### PR TITLE
Add support session audit foundation

### DIFF
--- a/docs/reports/support-session-audit-log-v1.md
+++ b/docs/reports/support-session-audit-log-v1.md
@@ -1,0 +1,176 @@
+# Support Session Audit Log Foundation v1
+
+## Summary
+
+This report establishes RentChain's first support-session audit continuity model. It defines deterministic metadata for future privileged support sessions without adding support powers, impersonation powers, routes, persistence, tenant-visible surfaces, or autonomous escalation.
+
+The implementation is metadata-only. The helper in `rentchain-api/src/lib/supportSessionAudit/supportSessionAudit.ts` prepares append-compatible audit references that can later be written by an explicitly reviewed audit/event adapter.
+
+## Philosophy
+
+Support-session audit records should answer who accessed privileged operational context, why the access was needed, what scoped resources were referenced, and which manual review expectations apply. They must not become permission grants.
+
+The audit model is:
+
+- scoped to landlord and tenant context where present
+- internal to admin/support governance
+- append-compatible for future immutable audit/event logs
+- metadata/reference-based only
+- safe for incident, evidence, export, review, and diagnostics linkage
+- explicit that no impersonation or autonomous support behavior is enabled
+
+## Lifecycle States
+
+| State | Meaning |
+| --- | --- |
+| `requested` | A support session or privileged review request has been proposed but is not active. |
+| `active` | A manually authorized support context is active. This state is descriptive only in this foundation. |
+| `paused` | A support context is temporarily paused. |
+| `ended` | A support context completed normally. |
+| `expired` | A support context is no longer valid because its time window elapsed. |
+| `revoked` | A support context was manually revoked. |
+| `denied` | A support request was rejected. |
+
+Unknown or unsupported states normalize to `requested` so future callers fail into a non-granting default.
+
+## Reason Categories
+
+| Reason | Expected Use |
+| --- | --- |
+| `customer_support` | Customer-requested operational help. |
+| `incident_review` | Security or operational incident investigation. |
+| `evidence_review` | Evidence pack or evidence-linkage review. |
+| `export_review` | Tenant trust or institutional export review. |
+| `screening_review` | Screening workflow investigation without raw provider payload exposure. |
+| `billing_support` | Billing or account support context. |
+| `technical_diagnostics` | Deployment, route, or diagnostic investigation. |
+| `security_investigation` | Credential, abuse, access, or suspicious activity investigation. |
+| `compliance_review` | Governance or compliance review context. |
+| `other` | Explicit fallback for unsupported reasons. |
+
+Unsupported reasons normalize to `other` instead of broadening semantics.
+
+## Scoped Resource References
+
+Support-session resource references are internal lineage metadata. They are not user-facing labels and do not authorize access.
+
+Allowed reference metadata is intentionally narrow:
+
+- `resourceType`
+- `resourceId`
+- `label`
+- `landlordId`
+- `tenantId`
+- `internalReference: true`
+
+Supported resource types include landlord, tenant, lease, property, unit, payment, ledger entry, evidence pack, export package, review workspace, incident, API route, document, screening order, and support diagnostic references.
+
+References are filtered to the provided landlord scope. When a tenant scope is provided, references with a conflicting tenant are excluded. The helper does not include raw storage paths, provider payloads, report bodies, export contents, evidence payloads, debug payloads, tokens, secrets, or route-source internals.
+
+## Audit Metadata Contract
+
+`SupportSessionAuditRef` includes:
+
+- `supportSessionAuditVersion`
+- deterministic `supportSessionAuditId`
+- `sessionId`
+- normalized lifecycle state
+- normalized access reason
+- actor and approver references
+- landlord and optional tenant scope
+- start/end/occurrence timestamps
+- scoped resource/evidence/export/incident/review references
+- concise summary
+- `auditExpectation: manual_append_only`
+- `visibilityClass: admin_support_internal`
+- explicit non-granting flags
+
+The non-granting flags are required:
+
+- `tenantVisible: false`
+- `metadataOnly: true`
+- `appendCompatible: true`
+- `supportPowersGranted: false`
+- `impersonationEnabled: false`
+- `autonomousEscalationEnabled: false`
+- `financialMutationEnabled: false`
+
+The payload safety summary is required to remain exclusion/reference-only metadata:
+
+- `sensitiveData: excluded`
+- `restrictedData: excluded`
+- `providerData: reference_only`
+- `evidenceData: reference_only`
+- `exportData: reference_only`
+- `credentialData: excluded`
+- `diagnosticData: metadata_only`
+
+## Tenant Visibility Rules
+
+No tenant-visible support-session audit surface is introduced in this phase.
+
+Support-session metadata remains admin/support internal. Future tenant-facing transparency features would require a separate projection contract and review to avoid exposing privileged operational internals, incident details, or support diagnostics.
+
+## Incident, Evidence, Export, and Review Linkage
+
+Support-session audit metadata may reference incident, evidence, export, and review resources only by scoped metadata references. It must not duplicate:
+
+- raw evidence payloads
+- raw provider or screening reports
+- export package contents
+- unrestricted message bodies
+- payment credentials
+- tokens or secrets
+- stack traces or debug payloads
+
+Future incident or review surfaces should treat support-session references as lineage context, not as access grants.
+
+## Current Implementation
+
+Added helper:
+
+- `normalizeSupportSessionState()`
+- `normalizeSupportAccessReason()`
+- `normalizeSupportSessionResourceRefs()`
+- `buildSupportSessionAuditRef()`
+
+Added tests confirming:
+
+- lifecycle states normalize deterministically
+- reason categories normalize deterministically
+- unrelated landlord and tenant references are excluded
+- restricted/raw/provider/token/debug fields are not carried into audit metadata
+- tenant visibility remains false by default
+- metadata does not imply support powers, impersonation, autonomous escalation, or financial mutation
+- invalid actor roles normalize to `unknown`
+- audit refs remain append-compatible
+
+## Known Limitations
+
+This phase does not implement:
+
+- live support-session persistence
+- a Firestore support session collection
+- support-session start/end routes
+- an impersonation framework
+- support access powers
+- tenant-visible support audit views
+- autonomous escalation
+- external alerting or SIEM integration
+
+The helper is a contract foundation only. Runtime writes and operational controls must be introduced in later scoped missions with explicit authority checks and append-only audit semantics.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Define an append-only support-session audit writer after persistence and retention requirements are reviewed.
+2. Add impersonation governance and audit semantics without adding implicit impersonation powers.
+3. Add admin/support projection safety regression tests for future privileged surfaces.
+4. Link support-session refs to security incident review surfaces.
+5. Add support escalation runbooks with manual approval expectations.
+6. Define retention, exportability, and incident response expectations for support-session audit records.
+
+## Guardrail Confirmation
+
+This mission does not change auth behavior, JWT format, Firestore rules, route visibility, Firestore schema, document visibility, export visibility, or tenant projections. It does not introduce new support/admin powers, impersonation, autonomous escalation, financial mutation, or tenant-visible support internals.

--- a/rentchain-api/src/lib/supportSessionAudit/__tests__/supportSessionAudit.test.ts
+++ b/rentchain-api/src/lib/supportSessionAudit/__tests__/supportSessionAudit.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+import {
+  SUPPORT_SESSION_AUDIT_VERSION,
+  buildSupportSessionAuditRef,
+  normalizeSupportAccessReason,
+  normalizeSupportSessionResourceRefs,
+  normalizeSupportSessionState,
+} from "../supportSessionAudit";
+
+describe("supportSessionAudit", () => {
+  it("normalizes support session lifecycle states deterministically", () => {
+    expect(normalizeSupportSessionState("Active")).toBe("active");
+    expect(normalizeSupportSessionState("ended")).toBe("ended");
+    expect(normalizeSupportSessionState("revoked")).toBe("revoked");
+    expect(normalizeSupportSessionState("unknown-state")).toBe("requested");
+  });
+
+  it("normalizes support access reasons deterministically", () => {
+    expect(normalizeSupportAccessReason("Customer Support")).toBe("customer_support");
+    expect(normalizeSupportAccessReason("security-investigation")).toBe("security_investigation");
+    expect(normalizeSupportAccessReason("evidence.review")).toBe("evidence_review");
+    expect(normalizeSupportAccessReason("unsafe reason")).toBe("other");
+  });
+
+  it("keeps support session resource refs scoped and metadata-only", () => {
+    const refs = normalizeSupportSessionResourceRefs(
+      [
+        {
+          resourceType: "tenant",
+          resourceId: "tenant-1",
+          label: "Scoped tenant",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          rawProviderPayload: "raw-provider-data",
+          token: "secret-token",
+        },
+        {
+          resourceType: "lease",
+          resourceId: "wrong-landlord-lease",
+          label: "Wrong landlord lease",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+        },
+        {
+          resourceType: "evidence_pack",
+          resourceId: "wrong-tenant-evidence",
+          label: "Wrong tenant evidence",
+          landlordId: "landlord-1",
+          tenantId: "tenant-2",
+        },
+      ],
+      { landlordId: "landlord-1", tenantId: "tenant-1" }
+    );
+
+    expect(refs).toEqual([
+      {
+        resourceType: "tenant",
+        resourceId: "tenant-1",
+        label: "Scoped tenant",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        internalReference: true,
+      },
+    ]);
+    expectNoRestrictedProjectionFields(refs);
+    expectPayloadDoesNotContainValues(refs, [
+      "raw-provider-data",
+      "secret-token",
+      "wrong-landlord-lease",
+      "wrong-tenant-evidence",
+    ]);
+  });
+
+  it("builds append-compatible support session audit refs without granting powers", () => {
+    const auditRef = buildSupportSessionAuditRef({
+      sessionId: "support session 1",
+      sessionState: "active",
+      accessReason: "incident review",
+      actorId: "support-1",
+      actorRole: "support",
+      requestedBy: "admin-1",
+      approvedBy: "admin-2",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      startedAt: "2026-05-22T10:00:00.000Z",
+      occurredAt: "2026-05-22T10:05:00.000Z",
+      resourceRefs: [
+        {
+          resourceType: "api_route",
+          resourceId: "/api/admin/support-console/resource",
+          label: "Support console resource route",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          routeSource: "supportConsoleRoutes.ts",
+          debugPayload: { token: "secret-token" },
+        },
+      ],
+      evidenceRefs: [
+        {
+          resourceType: "evidence_pack",
+          resourceId: "evidence-1",
+          label: "Scoped evidence pack",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          rawEvidencePayload: "raw-evidence-data",
+        },
+      ],
+      exportRefs: [
+        {
+          resourceType: "export_package",
+          resourceId: "wrong-tenant-export",
+          label: "Wrong tenant export",
+          landlordId: "landlord-1",
+          tenantId: "tenant-2",
+          rawExportPayload: "raw-export-data",
+        },
+      ],
+      incidentRefs: [
+        {
+          resourceType: "incident",
+          resourceId: "incident-1",
+          label: "Security incident",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+        },
+      ],
+      reviewRefs: [
+        {
+          resourceType: "review_workspace",
+          resourceId: "wrong-landlord-review",
+          label: "Wrong landlord review",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+        },
+      ],
+      summary: "Support reviewed scoped incident metadata.",
+    });
+
+    expect(auditRef).toEqual(
+      expect.objectContaining({
+        supportSessionAuditVersion: SUPPORT_SESSION_AUDIT_VERSION,
+        sessionId: "support_session_1",
+        sessionState: "active",
+        accessReason: "incident_review",
+        actorId: "support-1",
+        actorRole: "support",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        auditExpectation: "manual_append_only",
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        metadataOnly: true,
+        appendCompatible: true,
+        supportPowersGranted: false,
+        impersonationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+        payloadSafety: {
+          sensitiveData: "excluded",
+          restrictedData: "excluded",
+          providerData: "reference_only",
+          evidenceData: "reference_only",
+          exportData: "reference_only",
+          credentialData: "excluded",
+          diagnosticData: "metadata_only",
+        },
+      })
+    );
+    expect(auditRef.resourceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "api_route",
+        resourceId: "/api/admin/support-console/resource",
+        internalReference: true,
+      }),
+    ]);
+    expect(auditRef.evidenceRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "evidence_pack",
+        resourceId: "evidence-1",
+        internalReference: true,
+      }),
+    ]);
+    expect(auditRef.exportRefs).toEqual([]);
+    expect(auditRef.incidentRefs).toEqual([
+      expect.objectContaining({
+        resourceType: "incident",
+        resourceId: "incident-1",
+        internalReference: true,
+      }),
+    ]);
+    expect(auditRef.reviewRefs).toEqual([]);
+    expectNoRestrictedProjectionFields(auditRef);
+    expectPayloadDoesNotContainValues(auditRef, [
+      "secret-token",
+      "raw-evidence-data",
+      "raw-export-data",
+      "wrong-tenant-export",
+      "wrong-landlord-review",
+      "routeSource",
+      "debugPayload",
+    ]);
+  });
+
+  it("does not imply tenant visibility, impersonation, support powers, or autonomous escalation", () => {
+    const auditRef = buildSupportSessionAuditRef({
+      sessionId: "support-session-2",
+      sessionState: "requested",
+      accessReason: "technical_diagnostics",
+      actorId: "admin-1",
+      actorRole: "admin",
+      landlordId: "landlord-1",
+      occurredAt: "2026-05-22T11:00:00.000Z",
+      resourceRefs: [{ resourceType: "support_diagnostic", resourceId: "diag-1", landlordId: "landlord-1" }],
+    });
+
+    expect(auditRef).toEqual(
+      expect.objectContaining({
+        tenantVisible: false,
+        metadataOnly: true,
+        supportPowersGranted: false,
+        impersonationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+      })
+    );
+  });
+
+  it("normalizes invalid actor roles to unknown", () => {
+    const auditRef = buildSupportSessionAuditRef({
+      sessionId: "support-session-3",
+      sessionState: "active",
+      accessReason: "customer_support",
+      actorId: "support-1",
+      actorRole: "super-admin",
+      landlordId: "landlord-1",
+      occurredAt: "2026-05-22T12:00:00.000Z",
+    });
+
+    expect(auditRef.actorRole).toBe("unknown");
+  });
+});

--- a/rentchain-api/src/lib/supportSessionAudit/supportSessionAudit.ts
+++ b/rentchain-api/src/lib/supportSessionAudit/supportSessionAudit.ts
@@ -1,0 +1,308 @@
+import type { RequestAuthorityRole } from "../../auth/requestAuthority";
+
+export const SUPPORT_SESSION_AUDIT_VERSION = "support_session_audit_v1";
+
+export type SupportSessionState =
+  | "requested"
+  | "active"
+  | "paused"
+  | "ended"
+  | "expired"
+  | "revoked"
+  | "denied";
+
+export type SupportAccessReason =
+  | "customer_support"
+  | "incident_review"
+  | "evidence_review"
+  | "export_review"
+  | "screening_review"
+  | "billing_support"
+  | "technical_diagnostics"
+  | "security_investigation"
+  | "compliance_review"
+  | "other";
+
+export type SupportSessionResourceType =
+  | "landlord"
+  | "tenant"
+  | "lease"
+  | "property"
+  | "unit"
+  | "payment"
+  | "ledger_entry"
+  | "evidence_pack"
+  | "export_package"
+  | "review_workspace"
+  | "incident"
+  | "api_route"
+  | "document"
+  | "screening_order"
+  | "support_diagnostic";
+
+export type SupportSessionResourceRef = {
+  resourceType: SupportSessionResourceType;
+  resourceId: string;
+  label: string;
+  landlordId: string | null;
+  tenantId: string | null;
+  internalReference: true;
+};
+
+export type SupportSessionAuditRef = {
+  supportSessionAuditVersion: typeof SUPPORT_SESSION_AUDIT_VERSION;
+  supportSessionAuditId: string;
+  sessionId: string;
+  sessionState: SupportSessionState;
+  accessReason: SupportAccessReason;
+  actorId: string | null;
+  actorRole: RequestAuthorityRole;
+  requestedBy: string | null;
+  approvedBy: string | null;
+  landlordId: string;
+  tenantId: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  occurredAt: string;
+  resourceRefs: SupportSessionResourceRef[];
+  evidenceRefs: SupportSessionResourceRef[];
+  exportRefs: SupportSessionResourceRef[];
+  incidentRefs: SupportSessionResourceRef[];
+  reviewRefs: SupportSessionResourceRef[];
+  summary: string;
+  auditExpectation: "manual_append_only";
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  metadataOnly: true;
+  appendCompatible: true;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  payloadSafety: {
+    sensitiveData: "excluded";
+    restrictedData: "excluded";
+    providerData: "reference_only";
+    evidenceData: "reference_only";
+    exportData: "reference_only";
+    credentialData: "excluded";
+    diagnosticData: "metadata_only";
+  };
+};
+
+const VALID_STATES = new Set<SupportSessionState>([
+  "requested",
+  "active",
+  "paused",
+  "ended",
+  "expired",
+  "revoked",
+  "denied",
+]);
+
+const VALID_REASONS = new Set<SupportAccessReason>([
+  "customer_support",
+  "incident_review",
+  "evidence_review",
+  "export_review",
+  "screening_review",
+  "billing_support",
+  "technical_diagnostics",
+  "security_investigation",
+  "compliance_review",
+  "other",
+]);
+
+const VALID_RESOURCE_TYPES = new Set<SupportSessionResourceType>([
+  "landlord",
+  "tenant",
+  "lease",
+  "property",
+  "unit",
+  "payment",
+  "ledger_entry",
+  "evidence_pack",
+  "export_package",
+  "review_workspace",
+  "incident",
+  "api_route",
+  "document",
+  "screening_order",
+  "support_diagnostic",
+]);
+
+const VALID_ACTOR_ROLES = new Set<RequestAuthorityRole>([
+  "admin",
+  "landlord",
+  "tenant",
+  "operator",
+  "contractor",
+  "support",
+  "unknown",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function safeText(value: unknown, max = 500): string {
+  return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function normalizeActorRole(value: unknown): RequestAuthorityRole {
+  const normalized = normalizeKey(value) as RequestAuthorityRole;
+  return VALID_ACTOR_ROLES.has(normalized) ? normalized : "unknown";
+}
+
+function toIsoOrNull(value: unknown): string | null {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function toIso(value: unknown): string {
+  return toIsoOrNull(value) || new Date(0).toISOString();
+}
+
+function idPart(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function uniqueSorted<T>(values: T[], key: (value: T) => string): T[] {
+  const byKey = new Map<string, T>();
+  for (const value of values) {
+    const nextKey = key(value);
+    if (nextKey && !byKey.has(nextKey)) byKey.set(nextKey, value);
+  }
+  return Array.from(byKey.values()).sort((a, b) => key(a).localeCompare(key(b)));
+}
+
+export function normalizeSupportSessionState(value: unknown): SupportSessionState {
+  const normalized = normalizeKey(value);
+  return VALID_STATES.has(normalized as SupportSessionState)
+    ? (normalized as SupportSessionState)
+    : "requested";
+}
+
+export function normalizeSupportAccessReason(value: unknown): SupportAccessReason {
+  const normalized = normalizeKey(value);
+  return VALID_REASONS.has(normalized as SupportAccessReason)
+    ? (normalized as SupportAccessReason)
+    : "other";
+}
+
+export function normalizeSupportSessionResourceRefs(
+  raw: unknown,
+  scope: { landlordId: string; tenantId?: string | null }
+): SupportSessionResourceRef[] {
+  if (!Array.isArray(raw)) return [];
+  const landlordScope = asString(scope.landlordId, 240);
+  const tenantScope = asString(scope.tenantId, 240) || null;
+  if (!landlordScope) return [];
+
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const resourceType = normalizeKey(data.resourceType || data.type) as SupportSessionResourceType;
+      const resourceId = asString(data.resourceId || data.id || data.sourceId, 240);
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
+      if (!VALID_RESOURCE_TYPES.has(resourceType) || !resourceId) return null;
+      if (landlordId && landlordId !== landlordScope) return null;
+      if (tenantScope && tenantId && tenantId !== tenantScope) return null;
+      return {
+        resourceType,
+        resourceId,
+        label: safeText(data.label, 160) || `${resourceType.replace(/_/g, " ")} reference`,
+        landlordId: landlordId || landlordScope,
+        tenantId,
+        internalReference: true,
+      };
+    })
+    .filter(Boolean) as SupportSessionResourceRef[];
+  return uniqueSorted(refs, (ref) => `${ref.resourceType}:${ref.resourceId}`).slice(0, 32);
+}
+
+export function buildSupportSessionAuditRef(input: {
+  sessionId: string;
+  sessionState?: unknown;
+  accessReason?: unknown;
+  actorId?: string | null;
+  actorRole?: RequestAuthorityRole | string | null;
+  requestedBy?: string | null;
+  approvedBy?: string | null;
+  landlordId: string;
+  tenantId?: string | null;
+  startedAt?: unknown;
+  endedAt?: unknown;
+  occurredAt?: unknown;
+  resourceRefs?: Array<Record<string, unknown>> | null;
+  evidenceRefs?: Array<Record<string, unknown>> | null;
+  exportRefs?: Array<Record<string, unknown>> | null;
+  incidentRefs?: Array<Record<string, unknown>> | null;
+  reviewRefs?: Array<Record<string, unknown>> | null;
+  summary?: string | null;
+}): SupportSessionAuditRef {
+  const landlordId = asString(input.landlordId, 240);
+  const tenantId = asString(input.tenantId, 240) || null;
+  const sessionId = idPart(input.sessionId) || "support_session_unknown";
+  const sessionState = normalizeSupportSessionState(input.sessionState);
+  const accessReason = normalizeSupportAccessReason(input.accessReason);
+  const occurredAt = toIso(input.occurredAt);
+  const scope = { landlordId, tenantId };
+
+  return {
+    supportSessionAuditVersion: SUPPORT_SESSION_AUDIT_VERSION,
+    supportSessionAuditId:
+      idPart(["support_session_audit", sessionId, sessionState, accessReason, occurredAt].join(":")) ||
+      "support_session_audit:unknown",
+    sessionId,
+    sessionState,
+    accessReason,
+    actorId: asString(input.actorId, 240) || null,
+    actorRole: normalizeActorRole(input.actorRole),
+    requestedBy: asString(input.requestedBy, 240) || null,
+    approvedBy: asString(input.approvedBy, 240) || null,
+    landlordId,
+    tenantId,
+    startedAt: toIsoOrNull(input.startedAt),
+    endedAt: toIsoOrNull(input.endedAt),
+    occurredAt,
+    resourceRefs: normalizeSupportSessionResourceRefs(input.resourceRefs, scope),
+    evidenceRefs: normalizeSupportSessionResourceRefs(input.evidenceRefs, scope),
+    exportRefs: normalizeSupportSessionResourceRefs(input.exportRefs, scope),
+    incidentRefs: normalizeSupportSessionResourceRefs(input.incidentRefs, scope),
+    reviewRefs: normalizeSupportSessionResourceRefs(input.reviewRefs, scope),
+    summary:
+      safeText(input.summary, 300) ||
+      "Support session audit metadata prepared for manual append-only review.",
+    auditExpectation: "manual_append_only",
+    visibilityClass: "admin_support_internal",
+    tenantVisible: false,
+    metadataOnly: true,
+    appendCompatible: true,
+    supportPowersGranted: false,
+    impersonationEnabled: false,
+    autonomousEscalationEnabled: false,
+    financialMutationEnabled: false,
+    payloadSafety: {
+      sensitiveData: "excluded",
+      restrictedData: "excluded",
+      providerData: "reference_only",
+      evidenceData: "reference_only",
+      exportData: "reference_only",
+      credentialData: "excluded",
+      diagnosticData: "metadata_only",
+    },
+  };
+}

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -479,17 +479,19 @@ describe("landlord maintenance workspace", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /Record cost/i }));
 
-    expect(workOrdersApi.submitLandlordWorkOrderCost).toHaveBeenCalledWith("maintenance_maint-1", {
-      actualCostCents: 24500,
-      currency: "CAD",
-      lineItems: [
-        { label: "Labor cost", amountCents: 15000, category: "labor" },
-        { label: "Material cost", amountCents: 5000, category: "materials" },
-        { label: "Vendor cost", amountCents: 4500, category: "other" },
-      ],
-      reviewNote: "Recorded after the final closure update.",
+    await waitFor(() => {
+      expect(workOrdersApi.submitLandlordWorkOrderCost).toHaveBeenCalledWith("maintenance_maint-1", {
+        actualCostCents: 24500,
+        currency: "CAD",
+        lineItems: [
+          { label: "Labor cost", amountCents: 15000, category: "labor" },
+          { label: "Material cost", amountCents: 5000, category: "materials" },
+          { label: "Vendor cost", amountCents: 4500, category: "other" },
+        ],
+        reviewNote: "Recorded after the final closure update.",
+      });
     });
-  });
+  }, 10000);
 
   it("links a recorded maintenance cost to an expense when eligible", async () => {
     maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({


### PR DESCRIPTION
## Summary
- add metadata-only support-session audit helper for lifecycle state, access reason, scoped resource refs, and append-compatible audit refs
- add deterministic tests proving scoped refs exclude unrelated landlord/tenant resources and restricted payload values
- add governance report documenting lifecycle states, reason categories, tenant visibility rules, limitations, and future roadmap

## Guardrails
- no auth, JWT, Firestore rule, schema, route, or visibility changes
- no support powers or impersonation powers added
- no tenant-visible support internals introduced
- no autonomous escalation or financial mutation behavior introduced

## Validation
- npm run test:single -- src/lib/supportSessionAudit/__tests__/supportSessionAudit.test.ts src/lib/adminSupportAccess/__tests__/adminSupportAccessGovernance.test.ts src/lib/securityIncidents/__tests__/securityIncidentGovernance.test.ts
- npm run build
- git diff --check

## Known limitations
- no live support-session persistence yet
- no support-session start/end routes yet
- no impersonation framework or tenant-visible support audit surface yet
- future persistence must remain append-oriented, authority-scoped, and projection-safe