### PR TITLE
Harden impersonation governance and audit

### DIFF
--- a/docs/reports/impersonation-governance-and-audit-v1.md
+++ b/docs/reports/impersonation-governance-and-audit-v1.md
@@ -1,0 +1,184 @@
+# Impersonation Governance And Audit v1
+
+## Summary
+
+This report documents the impersonation governance hardening for RentChain support/admin operations. The mission tightens the existing tenant impersonation route so impersonation becomes an attributable, auditable, metadata-only support/admin capability rather than an ambiguous landlord convenience flow.
+
+No new broad support read access, auth rewrite, Firestore rule change, pricing change, payment change, screening provider change, or public workflow expansion is introduced.
+
+## Current Flow Discovered
+
+Existing implementation before this mission:
+
+- Active backend route: `POST /api/impersonation/landlord/tenants/:tenantId/impersonate`
+- Route owner: `impersonationRoutes.ts`
+- Previous authorization: landlord/admin via `requireLandlord`
+- Previous token: tenant JWT-like token issued directly with `jsonwebtoken`
+- Previous token expiry: 30 days
+- Previous audit: sparse `tenant_impersonation_issued` telemetry in an alternate unmounted route file
+- Previous actor chain: not preserved through `requireAuth`
+- Existing write guard: `blockImpersonationWrites`, only detecting `role=tenant` plus `actorRole=landlord`
+- Frontend: one unused `impersonateTenant()` API helper; no active UI banner or support impersonation mode found
+
+The alternate `landlordImpersonationRoutes.ts` route is not mounted in `app.build.ts`.
+
+## Governance Changes
+
+The mounted impersonation route now:
+
+- requires authenticated `system.admin` permission
+- requires an allowed reason category
+- fails closed when target tenant scope is missing
+- issues a short-lived 15 minute token through the existing `signAuthToken()` helper
+- records safe `impersonation.started` telemetry metadata
+- exposes only safe response summary metadata outside the token
+- preserves route ownership under `impersonationRoutes.ts`
+
+An explicit end route was added:
+
+- `POST /api/impersonation/landlord/tenants/:tenantId/impersonate/end`
+
+It records `impersonation.ended` metadata only. It does not revoke live tokens, persist session state, or add a support session store.
+
+## Lifecycle Semantics
+
+Supported lifecycle states:
+
+- `requested`
+- `started`
+- `active`
+- `ended`
+- `expired`
+- `revoked`
+- `denied`
+
+Unsupported states normalize to `denied` in governance helpers.
+
+## Reason Categories
+
+Allowed reason categories:
+
+- `customer_support`
+- `incident_review`
+- `evidence_review`
+- `export_review`
+- `screening_review`
+- `billing_support`
+- `technical_diagnostics`
+- `security_investigation`
+- `compliance_review`
+
+Unsupported reasons are rejected. The route does not allow arbitrary reason strings.
+
+## Actor Chain
+
+Impersonation tokens now carry actor-chain metadata through the existing JWT/session user pipeline:
+
+- `realActorId`
+- `realActorRole`
+- `effectiveActorId`
+- `effectiveActorRole`
+- `impersonationSessionId`
+- `impersonationReason`
+- `impersonationStartedAt`
+- `impersonationActive`
+
+This distinguishes:
+
+- the real admin/support operator
+- the effective tenant account
+- the target landlord scope
+- the support session lineage
+
+The helper rejects actor chains where the real actor role is not `admin` or `support`.
+
+## Audit/Event Metadata
+
+Added metadata helper:
+
+- `buildImpersonationAuditEvent()`
+- `buildImpersonationActorChain()`
+- `buildImpersonationTelemetryMeta()`
+- lifecycle/reason normalization helpers
+
+Telemetry metadata is intentionally narrow:
+
+- session id
+- lifecycle state
+- reason category
+- real/effective actor ids and roles
+- target account type/id
+- target landlord id
+- source action family
+- policy decision
+- internal visibility flags
+
+Telemetry does not include:
+
+- token values
+- credentials or secrets
+- tenant email
+- raw tenant documents
+- provider payloads
+- raw screening/report payloads
+- debug payloads
+- route-source metadata
+
+## Projection Safety
+
+Impersonation metadata is marked:
+
+- `visibilityClass: admin_support_internal`
+- `metadataOnly: true`
+- `tenantVisible: false`
+- `supportProjectionSafe: true`
+
+No landlord/tenant projection surfaces were added. Tenant-facing views do not receive impersonation internals.
+
+## Fail-Closed Behavior
+
+The route fails closed when:
+
+- authentication is missing
+- `system.admin` permission is missing
+- target tenant id is missing
+- reason category is missing or unsupported
+- target tenant does not exist
+- target tenant has no landlord scope
+- actor chain cannot be established safely
+
+Write blocking now recognizes both legacy and governed impersonation markers:
+
+- `impersonationActive`
+- `impersonationSessionId`
+- legacy tenant token with `actorRole=landlord` or `actorRole=admin`
+
+## Known Limitations
+
+This mission does not add:
+
+- a persisted impersonation session collection
+- token revocation lists
+- live session expiration checks beyond JWT expiry
+- frontend impersonation banner
+- support-session persistence
+- tenant-visible support audit views
+- SIEM or external alerting
+- broad support read access
+
+The end route records metadata only. It does not revoke previously issued JWTs. A future persisted session/revocation layer is required for server-side revocation and session replay protection.
+
+## Future Follow-Ups
+
+Recommended next steps:
+
+1. Add persisted append-only support/impersonation session records.
+2. Add server-side session revocation checks for impersonated tokens.
+3. Add admin/support projection safety regression tests for any future impersonation surfaces.
+4. Add admin security incident review surface linkage.
+5. Add support escalation runbooks with manual approval expectations.
+6. Add frontend support/admin impersonation banner only if a reviewed support flow is introduced.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, create impersonation access for non-admin actors, change Firestore rules, rewrite auth, expose tenant-visible support internals, add autonomous escalation, mutate financial records, or alter public landlord/tenant workflows.

--- a/rentchain-api/src/auth/jwt.ts
+++ b/rentchain-api/src/auth/jwt.ts
@@ -9,6 +9,13 @@ export type JwtClaimsV1 = {
   tenantId?: string;
   permissions?: Permission[];
   revokedPermissions?: Permission[];
+  realActorId?: string;
+  realActorRole?: string;
+  effectiveActorId?: string;
+  effectiveActorRole?: string;
+  impersonationSessionId?: string;
+  impersonationReason?: string;
+  impersonationStartedAt?: string;
   ver: 1;
 };
 

--- a/rentchain-api/src/lib/impersonationGovernance/__tests__/impersonationGovernance.test.ts
+++ b/rentchain-api/src/lib/impersonationGovernance/__tests__/impersonationGovernance.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  IMPERSONATION_GOVERNANCE_VERSION,
+  buildImpersonationActorChain,
+  buildImpersonationAuditEvent,
+  buildImpersonationTelemetryMeta,
+  normalizeImpersonationLifecycleState,
+  normalizeImpersonationReasonCategory,
+} from "../impersonationGovernance";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+
+describe("impersonationGovernance", () => {
+  it("normalizes lifecycle states and reason categories deterministically", () => {
+    expect(normalizeImpersonationLifecycleState("Started")).toBe("started");
+    expect(normalizeImpersonationLifecycleState("revoked")).toBe("revoked");
+    expect(normalizeImpersonationLifecycleState("unknown")).toBe("denied");
+    expect(normalizeImpersonationReasonCategory("Security Investigation")).toBe("security_investigation");
+    expect(normalizeImpersonationReasonCategory("technical-diagnostics")).toBe("technical_diagnostics");
+    expect(normalizeImpersonationReasonCategory("unsafe reason")).toBeNull();
+  });
+
+  it("requires a privileged real actor and preserves actor chain fields", () => {
+    expect(
+      buildImpersonationActorChain({
+        realActorId: "admin-1",
+        realActorRole: "admin",
+        effectiveActorId: "tenant-1",
+        effectiveActorRole: "tenant",
+        impersonationSessionId: "session-1",
+      })
+    ).toEqual({
+      realActorId: "admin-1",
+      realActorRole: "admin",
+      effectiveActorId: "tenant-1",
+      effectiveActorRole: "tenant",
+      impersonationSessionId: "session-1",
+      actingAsRole: "tenant",
+      supportAttribution: true,
+    });
+
+    expect(
+      buildImpersonationActorChain({
+        realActorId: "landlord-1",
+        realActorRole: "landlord",
+        effectiveActorId: "tenant-1",
+        effectiveActorRole: "tenant",
+        impersonationSessionId: "session-1",
+      })
+    ).toBeNull();
+  });
+
+  it("builds projection-safe started and ended audit events", () => {
+    const started = buildImpersonationAuditEvent({
+      eventType: "impersonation.started",
+      sessionId: "session-1",
+      lifecycleState: "started",
+      reasonCategory: "incident_review",
+      realActorId: "admin-1",
+      realActorRole: "admin",
+      effectiveActorId: "tenant-1",
+      effectiveActorRole: "tenant",
+      targetAccountId: "tenant-1",
+      targetAccountType: "tenant",
+      targetLandlordId: "landlord-1",
+      occurredAt: "2026-05-22T12:00:00.000Z",
+      startedAt: "2026-05-22T12:00:00.000Z",
+      policyDecision: "allowed",
+    });
+
+    expect(started).toEqual(
+      expect.objectContaining({
+        impersonationGovernanceVersion: IMPERSONATION_GOVERNANCE_VERSION,
+        eventType: "impersonation.started",
+        lifecycleState: "started",
+        reasonCategory: "incident_review",
+        visibilityClass: "admin_support_internal",
+        metadataOnly: true,
+        tenantVisible: false,
+        supportProjectionSafe: true,
+      })
+    );
+    expect(started.actorChain).toEqual(
+      expect.objectContaining({
+        realActorId: "admin-1",
+        effectiveActorId: "tenant-1",
+        impersonationSessionId: "session-1",
+      })
+    );
+
+    const ended = buildImpersonationAuditEvent({
+      eventType: "impersonation.ended",
+      sessionId: "session-1",
+      lifecycleState: "ended",
+      reasonCategory: "incident_review",
+      realActorId: "admin-1",
+      realActorRole: "admin",
+      effectiveActorId: "tenant-1",
+      effectiveActorRole: "tenant",
+      targetAccountId: "tenant-1",
+      targetAccountType: "tenant",
+      targetLandlordId: "landlord-1",
+      occurredAt: "2026-05-22T12:05:00.000Z",
+      endedAt: "2026-05-22T12:05:00.000Z",
+      policyDecision: "allowed",
+    });
+    expect(ended.lifecycleState).toBe("ended");
+    expect(ended.endedAt).toBe("2026-05-22T12:05:00.000Z");
+
+    expectNoRestrictedProjectionFields(started);
+    expectNoRestrictedProjectionFields(ended);
+    expectPayloadDoesNotContainValues(started, [
+      "rawProviderPayload",
+      "rawReport",
+      "secret-token",
+      "Authorization",
+      "routeSource",
+    ]);
+  });
+
+  it("keeps telemetry metadata support-safe and rejects missing reason or actor chains", () => {
+    const event = buildImpersonationAuditEvent({
+      eventType: "impersonation.started",
+      sessionId: "session-1",
+      lifecycleState: "started",
+      reasonCategory: "technical_diagnostics",
+      realActorId: "support-1",
+      realActorRole: "support",
+      effectiveActorId: "tenant-1",
+      effectiveActorRole: "tenant",
+      targetAccountId: "tenant-1",
+      targetAccountType: "tenant",
+      targetLandlordId: "landlord-1",
+      occurredAt: "2026-05-22T12:00:00.000Z",
+      policyDecision: "allowed",
+    });
+
+    const meta = buildImpersonationTelemetryMeta(event);
+    expect(meta).toEqual(
+      expect.objectContaining({
+        realActorId: "support-1",
+        effectiveActorId: "tenant-1",
+        tenantVisible: false,
+        metadataOnly: true,
+      })
+    );
+    expectNoRestrictedProjectionFields(meta);
+
+    expect(() =>
+      buildImpersonationAuditEvent({
+        ...event,
+        reasonCategory: "unsafe",
+      })
+    ).toThrow("impersonation_reason_required");
+    expect(() =>
+      buildImpersonationAuditEvent({
+        ...event,
+        realActorRole: "landlord",
+      })
+    ).toThrow("impersonation_actor_chain_invalid");
+  });
+});

--- a/rentchain-api/src/lib/impersonationGovernance/impersonationGovernance.ts
+++ b/rentchain-api/src/lib/impersonationGovernance/impersonationGovernance.ts
@@ -1,0 +1,246 @@
+import crypto from "crypto";
+
+export const IMPERSONATION_GOVERNANCE_VERSION = "impersonation_governance_v1";
+
+export type ImpersonationLifecycleState =
+  | "requested"
+  | "started"
+  | "active"
+  | "ended"
+  | "expired"
+  | "revoked"
+  | "denied";
+
+export type ImpersonationReasonCategory =
+  | "customer_support"
+  | "incident_review"
+  | "evidence_review"
+  | "export_review"
+  | "screening_review"
+  | "billing_support"
+  | "technical_diagnostics"
+  | "security_investigation"
+  | "compliance_review";
+
+export type ImpersonationTargetRole = "tenant" | "landlord";
+
+export type ImpersonationPolicyDecision = "allowed" | "denied" | "expired" | "revoked";
+
+export type ImpersonationActorChain = {
+  realActorId: string;
+  realActorRole: "admin" | "support";
+  effectiveActorId: string;
+  effectiveActorRole: ImpersonationTargetRole;
+  impersonationSessionId: string;
+  actingAsRole: ImpersonationTargetRole;
+  supportAttribution: true;
+};
+
+export type ImpersonationAuditEvent = {
+  impersonationGovernanceVersion: typeof IMPERSONATION_GOVERNANCE_VERSION;
+  eventType:
+    | "impersonation.started"
+    | "impersonation.ended"
+    | "impersonation.expired"
+    | "impersonation.revoked"
+    | "impersonation.denied";
+  sessionId: string;
+  lifecycleState: ImpersonationLifecycleState;
+  reasonCategory: ImpersonationReasonCategory;
+  actorChain: ImpersonationActorChain;
+  targetAccountType: ImpersonationTargetRole;
+  targetAccountId: string;
+  targetLandlordId: string | null;
+  occurredAt: string;
+  startedAt: string | null;
+  endedAt: string | null;
+  sourceActionFamily: "admin_support_impersonation";
+  policyDecision: ImpersonationPolicyDecision;
+  visibilityClass: "admin_support_internal";
+  metadataOnly: true;
+  tenantVisible: false;
+  supportProjectionSafe: true;
+  payloadSafety: {
+    sensitiveData: "excluded";
+    credentialData: "excluded";
+    providerData: "excluded";
+    debugData: "excluded";
+  };
+};
+
+const VALID_STATES = new Set<ImpersonationLifecycleState>([
+  "requested",
+  "started",
+  "active",
+  "ended",
+  "expired",
+  "revoked",
+  "denied",
+]);
+
+const VALID_REASONS = new Set<ImpersonationReasonCategory>([
+  "customer_support",
+  "incident_review",
+  "evidence_review",
+  "export_review",
+  "screening_review",
+  "billing_support",
+  "technical_diagnostics",
+  "security_investigation",
+  "compliance_review",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function toIso(value: unknown, fallback = new Date(0)): string {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const raw = asString(value, 120);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback.toISOString();
+}
+
+function stablePart(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function normalizeImpersonationLifecycleState(value: unknown): ImpersonationLifecycleState {
+  const normalized = normalizeKey(value);
+  return VALID_STATES.has(normalized as ImpersonationLifecycleState)
+    ? (normalized as ImpersonationLifecycleState)
+    : "denied";
+}
+
+export function normalizeImpersonationReasonCategory(value: unknown): ImpersonationReasonCategory | null {
+  const normalized = normalizeKey(value);
+  return VALID_REASONS.has(normalized as ImpersonationReasonCategory)
+    ? (normalized as ImpersonationReasonCategory)
+    : null;
+}
+
+export function buildImpersonationSessionId(input: {
+  realActorId: string;
+  effectiveActorId: string;
+  occurredAt: unknown;
+  nonce?: string | null;
+}): string {
+  const basis = [
+    "impersonation",
+    stablePart(input.realActorId),
+    stablePart(input.effectiveActorId),
+    toIso(input.occurredAt),
+    stablePart(input.nonce || crypto.randomUUID()),
+  ].join(":");
+  return basis || "impersonation:unknown";
+}
+
+export function buildImpersonationActorChain(input: {
+  realActorId: string;
+  realActorRole: unknown;
+  effectiveActorId: string;
+  effectiveActorRole: ImpersonationTargetRole;
+  impersonationSessionId: string;
+}): ImpersonationActorChain | null {
+  const realActorId = asString(input.realActorId, 240);
+  const effectiveActorId = asString(input.effectiveActorId, 240);
+  const sessionId = asString(input.impersonationSessionId, 300);
+  const role = normalizeKey(input.realActorRole);
+  if (!realActorId || !effectiveActorId || !sessionId) return null;
+  if (role !== "admin" && role !== "support") return null;
+  return {
+    realActorId,
+    realActorRole: role,
+    effectiveActorId,
+    effectiveActorRole: input.effectiveActorRole,
+    impersonationSessionId: sessionId,
+    actingAsRole: input.effectiveActorRole,
+    supportAttribution: true,
+  };
+}
+
+export function buildImpersonationAuditEvent(input: {
+  eventType: ImpersonationAuditEvent["eventType"];
+  sessionId: string;
+  lifecycleState: unknown;
+  reasonCategory: unknown;
+  realActorId: string;
+  realActorRole: unknown;
+  effectiveActorId: string;
+  effectiveActorRole: ImpersonationTargetRole;
+  targetAccountId: string;
+  targetAccountType: ImpersonationTargetRole;
+  targetLandlordId?: string | null;
+  occurredAt?: unknown;
+  startedAt?: unknown;
+  endedAt?: unknown;
+  policyDecision: ImpersonationPolicyDecision;
+}): ImpersonationAuditEvent {
+  const occurredAt = toIso(input.occurredAt, new Date());
+  const reasonCategory = normalizeImpersonationReasonCategory(input.reasonCategory);
+  if (!reasonCategory) throw new Error("impersonation_reason_required");
+  const actorChain = buildImpersonationActorChain({
+    realActorId: input.realActorId,
+    realActorRole: input.realActorRole,
+    effectiveActorId: input.effectiveActorId,
+    effectiveActorRole: input.effectiveActorRole,
+    impersonationSessionId: input.sessionId,
+  });
+  if (!actorChain) throw new Error("impersonation_actor_chain_invalid");
+
+  return {
+    impersonationGovernanceVersion: IMPERSONATION_GOVERNANCE_VERSION,
+    eventType: input.eventType,
+    sessionId: asString(input.sessionId, 300),
+    lifecycleState: normalizeImpersonationLifecycleState(input.lifecycleState),
+    reasonCategory,
+    actorChain,
+    targetAccountType: input.targetAccountType,
+    targetAccountId: asString(input.targetAccountId, 240),
+    targetLandlordId: asString(input.targetLandlordId, 240) || null,
+    occurredAt,
+    startedAt: input.startedAt == null ? null : toIso(input.startedAt),
+    endedAt: input.endedAt == null ? null : toIso(input.endedAt),
+    sourceActionFamily: "admin_support_impersonation",
+    policyDecision: input.policyDecision,
+    visibilityClass: "admin_support_internal",
+    metadataOnly: true,
+    tenantVisible: false,
+    supportProjectionSafe: true,
+    payloadSafety: {
+      sensitiveData: "excluded",
+      credentialData: "excluded",
+      providerData: "excluded",
+      debugData: "excluded",
+    },
+  };
+}
+
+export function buildImpersonationTelemetryMeta(event: ImpersonationAuditEvent) {
+  return {
+    sessionId: event.sessionId,
+    lifecycleState: event.lifecycleState,
+    reasonCategory: event.reasonCategory,
+    realActorId: event.actorChain.realActorId,
+    realActorRole: event.actorChain.realActorRole,
+    effectiveActorId: event.actorChain.effectiveActorId,
+    effectiveActorRole: event.actorChain.effectiveActorRole,
+    targetAccountType: event.targetAccountType,
+    targetAccountId: event.targetAccountId,
+    targetLandlordId: event.targetLandlordId,
+    sourceActionFamily: event.sourceActionFamily,
+    policyDecision: event.policyDecision,
+    visibilityClass: event.visibilityClass,
+    metadataOnly: event.metadataOnly,
+    tenantVisible: event.tenantVisible,
+    supportProjectionSafe: event.supportProjectionSafe,
+  };
+}

--- a/rentchain-api/src/middleware/__tests__/blockImpersonationWrites.test.ts
+++ b/rentchain-api/src/middleware/__tests__/blockImpersonationWrites.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { blockImpersonationWrites } from "../blockImpersonationWrites";
+
+function invoke(input: { method: string; user?: Record<string, unknown> }) {
+  const next = vi.fn();
+  const req = { method: input.method, user: input.user || {} } as any;
+  const res = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: undefined as any,
+    setHeader(name: string, value: string) {
+      this.headers[String(name).toLowerCase()] = value;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  } as any;
+  blockImpersonationWrites(req, res, next);
+  return { next, res };
+}
+
+describe("blockImpersonationWrites", () => {
+  it("blocks writes for governed impersonation sessions while allowing reads", () => {
+    const write = invoke({
+      method: "POST",
+      user: {
+        role: "tenant",
+        impersonationActive: true,
+        impersonationSessionId: "session-1",
+        realActorId: "admin-1",
+        effectiveActorId: "tenant-1",
+      },
+    });
+
+    expect(write.res.statusCode).toBe(403);
+    expect(write.res.body).toEqual({ error: "Writes blocked during impersonation" });
+    expect(write.res.headers["x-impersonation"]).toBe("true");
+    expect(write.next).not.toHaveBeenCalled();
+
+    const read = invoke({
+      method: "GET",
+      user: { role: "tenant", impersonationSessionId: "session-1" },
+    });
+    expect(read.next).toHaveBeenCalledTimes(1);
+    expect(read.res.headers["x-impersonation"]).toBe("true");
+  });
+
+  it("does not affect normal non-impersonated actions", () => {
+    const result = invoke({ method: "POST", user: { role: "tenant", tenantId: "tenant-1" } });
+    expect(result.next).toHaveBeenCalledTimes(1);
+    expect(result.res.headers["x-impersonation"]).toBeUndefined();
+  });
+});

--- a/rentchain-api/src/middleware/blockImpersonationWrites.ts
+++ b/rentchain-api/src/middleware/blockImpersonationWrites.ts
@@ -1,5 +1,8 @@
 export function blockImpersonationWrites(req: any, res: any, next: any) {
-  const isImpersonation = req.user?.role === "tenant" && req.user?.actorRole === "landlord";
+  const isImpersonation =
+    req.user?.impersonationActive === true ||
+    Boolean(req.user?.impersonationSessionId) ||
+    (req.user?.role === "tenant" && (req.user?.actorRole === "landlord" || req.user?.actorRole === "admin"));
   if (isImpersonation) {
     res.setHeader("x-impersonation", "true");
     const method = String(req.method || "").toUpperCase();

--- a/rentchain-api/src/routes/__tests__/impersonationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/impersonationRoutes.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAuthUser: null as any,
+  signAuthTokenMock: vi.fn(),
+  logEventMock: vi.fn(),
+  tenantDocs: new Map<string, any>(),
+}));
+
+vi.mock("../../firebase", () => ({
+  db: {
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        get: async () => {
+          if (name !== "tenants") return { exists: false, data: () => null };
+          const data = mocks.tenantDocs.get(id);
+          return { exists: Boolean(data), data: () => data };
+        },
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mocks.requireAuthUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mocks.requireAuthUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireAuthz", () => ({
+  requirePermission: () => (req: any, res: any, next: any) => {
+    const permissions = Array.isArray(req.user?.permissions) ? req.user.permissions : [];
+    if (req.user?.role !== "admin" && !permissions.includes("system.admin")) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    return next();
+  },
+}));
+
+vi.mock("../../auth/jwt", () => ({
+  signAuthToken: mocks.signAuthTokenMock,
+}));
+
+vi.mock("../../services/telemetryService", () => ({
+  logEvent: mocks.logEventMock,
+}));
+
+function createReq(options: {
+  method: string;
+  url: string;
+  body?: Record<string, unknown>;
+  user?: Record<string, unknown> | null;
+}) {
+  const [path] = options.url.split("?");
+  const startMatch = path.match(/^\/landlord\/tenants\/([^/]+)\/impersonate$/);
+  const endMatch = path.match(/^\/landlord\/tenants\/([^/]+)\/impersonate\/end$/);
+  mocks.requireAuthUser = options.user ?? mocks.requireAuthUser;
+  return {
+    method: options.method,
+    url: options.url,
+    originalUrl: options.url,
+    path,
+    params: { tenantId: decodeURIComponent((startMatch || endMatch)?.[1] || "") },
+    body: options.body || {},
+    headers: {},
+    user: mocks.requireAuthUser,
+  } as any;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: undefined as any,
+    setHeader(name: string, value: string) {
+      this.headers[String(name).toLowerCase()] = value;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  } as any;
+}
+
+async function invokeRouter(router: any, req: any) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const res = createRes();
+    router.handle(req, res, (error: unknown) => {
+      if (error) reject(error);
+      else resolve({ status: res.statusCode, body: res.body, headers: res.headers });
+    });
+    setTimeout(() => resolve({ status: res.statusCode, body: res.body, headers: res.headers }), 0);
+  });
+}
+
+describe("impersonationRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.tenantDocs.clear();
+    mocks.requireAuthUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+    mocks.signAuthTokenMock.mockReturnValue("signed-impersonation-token");
+    mocks.logEventMock.mockResolvedValue(undefined);
+    mocks.tenantDocs.set("tenant-1", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      email: "tenant@example.test",
+      rawProviderPayload: "must-not-leak",
+    });
+  });
+
+  it("requires admin/system permission and a governed reason before issuing impersonation", async () => {
+    const router = (await import("../impersonationRoutes")).default;
+
+    const landlordRes = await invokeRouter(
+      router,
+      createReq({
+        method: "POST",
+        url: "/landlord/tenants/tenant-1/impersonate",
+        body: { reasonCategory: "customer_support" },
+        user: { id: "landlord-1", role: "landlord", permissions: [] },
+      })
+    );
+    expect(landlordRes.status).toBe(403);
+
+    const missingReason = await invokeRouter(
+      router,
+      createReq({
+        method: "POST",
+        url: "/landlord/tenants/tenant-1/impersonate",
+        body: {},
+        user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+      })
+    );
+    expect(missingReason.status).toBe(400);
+    expect(missingReason.body.error).toBe("impersonation_reason_required");
+  });
+
+  it("issues short-lived impersonation tokens with actor-chain claims and safe audit telemetry", async () => {
+    const router = (await import("../impersonationRoutes")).default;
+    const res = await invokeRouter(
+      router,
+      createReq({
+        method: "POST",
+        url: "/landlord/tenants/tenant-1/impersonate",
+        body: { reasonCategory: "incident_review" },
+        user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("impersonationRoutes");
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        token: "signed-impersonation-token",
+        tenantId: "tenant-1",
+      })
+    );
+    expect(res.body.impersonation).toEqual(
+      expect.objectContaining({
+        state: "active",
+        reasonCategory: "incident_review",
+        targetAccountType: "tenant",
+        targetAccountId: "tenant-1",
+        metadataOnly: true,
+        tenantVisible: false,
+      })
+    );
+    expect(mocks.signAuthTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sub: "tenant-1",
+        role: "tenant",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        realActorId: "admin-1",
+        realActorRole: "admin",
+        effectiveActorId: "tenant-1",
+        effectiveActorRole: "tenant",
+        impersonationReason: "incident_review",
+      }),
+      { expiresIn: "15m" }
+    );
+    expect(mocks.logEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "impersonation.started",
+        landlordId: "landlord-1",
+        actor: "admin-1",
+        meta: expect.objectContaining({
+          realActorId: "admin-1",
+          effectiveActorId: "tenant-1",
+          targetAccountId: "tenant-1",
+          tenantVisible: false,
+          metadataOnly: true,
+        }),
+      })
+    );
+    const serialized = JSON.stringify(mocks.logEventMock.mock.calls[0][0]);
+    expect(serialized).not.toContain("tenant@example.test");
+    expect(serialized).not.toContain("rawProviderPayload");
+    expect(serialized).not.toContain("must-not-leak");
+    expect(serialized).not.toContain("signed-impersonation-token");
+  });
+
+  it("records safe impersonation end audit telemetry", async () => {
+    const router = (await import("../impersonationRoutes")).default;
+    const res = await invokeRouter(
+      router,
+      createReq({
+        method: "POST",
+        url: "/landlord/tenants/tenant-1/impersonate/end",
+        body: { sessionId: "session-1", reasonCategory: "incident_review" },
+        user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.impersonation).toEqual(
+      expect.objectContaining({
+        sessionId: "session-1",
+        state: "ended",
+        targetAccountId: "tenant-1",
+        tenantVisible: false,
+        metadataOnly: true,
+      })
+    );
+    expect(mocks.logEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "impersonation.ended",
+        actor: "admin-1",
+        meta: expect.objectContaining({
+          sessionId: "session-1",
+          lifecycleState: "ended",
+          realActorId: "admin-1",
+          effectiveActorId: "tenant-1",
+        }),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/impersonationRoutes.ts
+++ b/rentchain-api/src/routes/impersonationRoutes.ts
@@ -1,45 +1,169 @@
 import { Router } from "express";
-import jwt from "jsonwebtoken";
 import { db } from "../firebase";
 import { requireAuth } from "../middleware/requireAuth";
-import { requireLandlord } from "../middleware/requireLandlord";
-import { JWT_SECRET } from "../config/authConfig";
+import { requirePermission } from "../middleware/requireAuthz";
+import { signAuthToken } from "../auth/jwt";
+import { logEvent } from "../services/telemetryService";
+import {
+  buildImpersonationAuditEvent,
+  buildImpersonationSessionId,
+  buildImpersonationTelemetryMeta,
+  normalizeImpersonationReasonCategory,
+} from "../lib/impersonationGovernance/impersonationGovernance";
 
 const router = Router();
 
 router.post(
   "/landlord/tenants/:tenantId/impersonate",
   requireAuth,
-  requireLandlord,
+  requirePermission("system.admin"),
   async (req: any, res) => {
     res.setHeader("x-route-source", "impersonationRoutes");
-    const landlordId = req.user?.landlordId || req.user?.id;
+    const operatorId = String(req.user?.id || "").trim();
+    const operatorRole = String(req.user?.actorRole || req.user?.role || "").trim().toLowerCase();
     const tenantId = String(req.params.tenantId || "");
-    if (!landlordId) return res.status(401).json({ error: "Unauthorized" });
+    const reasonCategory = normalizeImpersonationReasonCategory(req.body?.reasonCategory || req.body?.reason);
+    if (!operatorId) return res.status(401).json({ ok: false, error: "Unauthorized" });
     if (!tenantId) return res.status(400).json({ error: "Missing tenantId" });
+    if (!reasonCategory) return res.status(400).json({ ok: false, error: "impersonation_reason_required" });
 
     const tenantSnap = await db.collection("tenants").doc(tenantId).get();
     if (!tenantSnap.exists) return res.status(404).json({ error: "Tenant not found" });
     const tenant = tenantSnap.data() as any;
-    if (tenant?.landlordId && tenant.landlordId !== landlordId) {
-      return res.status(403).json({ error: "Forbidden" });
+    const landlordId = String(tenant?.landlordId || "").trim();
+    if (!landlordId) {
+      return res.status(403).json({ ok: false, error: "impersonation_target_scope_missing" });
     }
+    const startedAt = new Date().toISOString();
+    const sessionId = buildImpersonationSessionId({
+      realActorId: operatorId,
+      effectiveActorId: tenantId,
+      occurredAt: startedAt,
+    });
+    const auditEvent = buildImpersonationAuditEvent({
+      eventType: "impersonation.started",
+      sessionId,
+      lifecycleState: "started",
+      reasonCategory,
+      realActorId: operatorId,
+      realActorRole: operatorRole,
+      effectiveActorId: tenantId,
+      effectiveActorRole: "tenant",
+      targetAccountId: tenantId,
+      targetAccountType: "tenant",
+      targetLandlordId: landlordId,
+      occurredAt: startedAt,
+      startedAt,
+      policyDecision: "allowed",
+    });
 
-    const payload = {
-      role: "tenant",
-      tenantId,
-      id: tenantId,
+    const token = signAuthToken(
+      {
+        sub: tenantId,
+        role: "tenant",
+        tenantId,
+        landlordId,
+        permissions: [],
+        revokedPermissions: [],
+        realActorId: operatorId,
+        realActorRole: auditEvent.actorChain.realActorRole,
+        effectiveActorId: tenantId,
+        effectiveActorRole: "tenant",
+        impersonationSessionId: sessionId,
+        impersonationReason: reasonCategory,
+        impersonationStartedAt: startedAt,
+      },
+      { expiresIn: "15m" }
+    );
+
+    await logEvent({
+      type: "impersonation.started",
       landlordId,
-      email: tenant?.email || undefined,
-      propertyId: tenant?.propertyId || null,
-      unitId: tenant?.unitId || null,
-    };
+      actor: operatorId,
+      meta: buildImpersonationTelemetryMeta(auditEvent),
+    });
 
-    if (!JWT_SECRET) {
-      return res.status(500).json({ error: "JWT_SECRET missing" });
+    return res.json({
+      ok: true,
+      token,
+      tenantId,
+      exp: Date.now() + 15 * 60 * 1000,
+      impersonation: {
+        sessionId,
+        state: "active",
+        reasonCategory,
+        targetAccountType: "tenant",
+        targetAccountId: tenantId,
+        startedAt,
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        metadataOnly: true,
+        tenantVisible: false,
+      },
+    });
+  }
+);
+
+router.post(
+  "/landlord/tenants/:tenantId/impersonate/end",
+  requireAuth,
+  requirePermission("system.admin"),
+  async (req: any, res) => {
+    res.setHeader("x-route-source", "impersonationRoutes");
+    const operatorId = String(req.user?.id || "").trim();
+    const operatorRole = String(req.user?.actorRole || req.user?.role || "").trim().toLowerCase();
+    const tenantId = String(req.params.tenantId || "");
+    const sessionId = String(req.body?.sessionId || "").trim();
+    const reasonCategory = normalizeImpersonationReasonCategory(req.body?.reasonCategory || req.body?.reason);
+    if (!operatorId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (!tenantId) return res.status(400).json({ ok: false, error: "Missing tenantId" });
+    if (!sessionId) return res.status(400).json({ ok: false, error: "impersonation_session_required" });
+    if (!reasonCategory) return res.status(400).json({ ok: false, error: "impersonation_reason_required" });
+
+    const tenantSnap = await db.collection("tenants").doc(tenantId).get();
+    if (!tenantSnap.exists) return res.status(404).json({ ok: false, error: "Tenant not found" });
+    const tenant = tenantSnap.data() as any;
+    const landlordId = String(tenant?.landlordId || "").trim();
+    if (!landlordId) {
+      return res.status(403).json({ ok: false, error: "impersonation_target_scope_missing" });
     }
-    const token = jwt.sign(payload, JWT_SECRET, { expiresIn: "30d" });
-    return res.json({ ok: true, token, tenantId });
+    const endedAt = new Date().toISOString();
+    const auditEvent = buildImpersonationAuditEvent({
+      eventType: "impersonation.ended",
+      sessionId,
+      lifecycleState: "ended",
+      reasonCategory,
+      realActorId: operatorId,
+      realActorRole: operatorRole,
+      effectiveActorId: tenantId,
+      effectiveActorRole: "tenant",
+      targetAccountId: tenantId,
+      targetAccountType: "tenant",
+      targetLandlordId: landlordId,
+      occurredAt: endedAt,
+      endedAt,
+      policyDecision: "allowed",
+    });
+
+    await logEvent({
+      type: "impersonation.ended",
+      landlordId,
+      actor: operatorId,
+      meta: buildImpersonationTelemetryMeta(auditEvent),
+    });
+
+    return res.json({
+      ok: true,
+      impersonation: {
+        sessionId,
+        state: "ended",
+        reasonCategory,
+        targetAccountType: "tenant",
+        targetAccountId: tenantId,
+        endedAt,
+        metadataOnly: true,
+        tenantVisible: false,
+      },
+    });
   }
 );
 

--- a/rentchain-api/src/services/__tests__/sessionUserImpersonation.test.ts
+++ b/rentchain-api/src/services/__tests__/sessionUserImpersonation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../entitlementsService", () => ({
+  getUserEntitlements: vi.fn(async (_userId: string, params: any) => ({
+    role: params.claimsRole,
+    landlordId: params.landlordIdHint,
+    plan: "test",
+    capabilities: [],
+  })),
+}));
+
+vi.mock("../../firebase", () => ({
+  db: {
+    collection: () => ({
+      where: () => ({ limit: () => ({ get: async () => ({ empty: true, docs: [] }) }) }),
+      doc: () => ({ get: async () => ({ exists: false, data: () => null }) }),
+    }),
+  },
+}));
+
+describe("buildCanonicalSessionUserFromClaims impersonation metadata", () => {
+  it("preserves real and effective actor chain for impersonated sessions", async () => {
+    const { buildCanonicalSessionUserFromClaims } = await import("../sessionUserService");
+
+    const user = await buildCanonicalSessionUserFromClaims({
+      ver: 1,
+      sub: "tenant-1",
+      role: "tenant",
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      permissions: [],
+      revokedPermissions: [],
+      realActorId: "admin-1",
+      realActorRole: "admin",
+      effectiveActorId: "tenant-1",
+      effectiveActorRole: "tenant",
+      impersonationSessionId: "session-1",
+      impersonationReason: "incident_review",
+      impersonationStartedAt: "2026-05-22T12:00:00.000Z",
+    });
+
+    expect(user).toEqual(
+      expect.objectContaining({
+        id: "tenant-1",
+        role: "tenant",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        realActorId: "admin-1",
+        realActorRole: "admin",
+        effectiveActorId: "tenant-1",
+        effectiveActorRole: "tenant",
+        impersonationSessionId: "session-1",
+        impersonationReason: "incident_review",
+        impersonationStartedAt: "2026-05-22T12:00:00.000Z",
+        impersonationActive: true,
+      })
+    );
+  });
+});

--- a/rentchain-api/src/services/sessionUserService.ts
+++ b/rentchain-api/src/services/sessionUserService.ts
@@ -15,6 +15,14 @@ export type HydratedSessionUser = {
   permissions?: Permission[];
   revokedPermissions?: Permission[];
   entitlements: UserEntitlements;
+  realActorId?: string;
+  realActorRole?: string;
+  effectiveActorId?: string;
+  effectiveActorRole?: string;
+  impersonationSessionId?: string;
+  impersonationReason?: string;
+  impersonationStartedAt?: string;
+  impersonationActive?: boolean;
 };
 
 type BuildSessionUserOptions = {
@@ -30,6 +38,14 @@ type BaseUser = {
   tenantId?: string;
   permissions?: Permission[];
   revokedPermissions?: Permission[];
+  realActorId?: string;
+  realActorRole?: string;
+  effectiveActorId?: string;
+  effectiveActorRole?: string;
+  impersonationSessionId?: string;
+  impersonationReason?: string;
+  impersonationStartedAt?: string;
+  impersonationActive?: boolean;
 };
 
 async function applyEntitlements(
@@ -92,6 +108,14 @@ export async function buildCanonicalSessionUserFromClaims(
     tenantId: claims.tenantId,
     permissions: claims.permissions ?? [],
     revokedPermissions: claims.revokedPermissions ?? [],
+    realActorId: claims.realActorId,
+    realActorRole: claims.realActorRole,
+    effectiveActorId: claims.effectiveActorId,
+    effectiveActorRole: claims.effectiveActorRole,
+    impersonationSessionId: claims.impersonationSessionId,
+    impersonationReason: claims.impersonationReason,
+    impersonationStartedAt: claims.impersonationStartedAt,
+    impersonationActive: Boolean(claims.impersonationSessionId),
   };
   const claimsPlan = (claims as any)?.plan ?? null;
   const requestCache = options.requestCache;
@@ -231,6 +255,14 @@ export async function buildCanonicalSessionUserFromClaims(
       revokedPermissions: Array.isArray(mergedDoc.revokedPermissions)
         ? mergedDoc.revokedPermissions
         : baseUser.revokedPermissions,
+      realActorId: baseUser.realActorId,
+      realActorRole: baseUser.realActorRole,
+      effectiveActorId: baseUser.effectiveActorId,
+      effectiveActorRole: baseUser.effectiveActorRole,
+      impersonationSessionId: baseUser.impersonationSessionId,
+      impersonationReason: baseUser.impersonationReason,
+      impersonationStartedAt: baseUser.impersonationStartedAt,
+      impersonationActive: baseUser.impersonationActive,
     },
     approved,
     claimsPlan,


### PR DESCRIPTION
## Summary
- Tightens the mounted impersonation route to require system.admin authority plus an allowed reason category before issuing a short-lived impersonation token.
- Adds metadata-only impersonation governance helpers for lifecycle state, reason category, actor-chain, and support-safe telemetry/audit metadata.
- Propagates optional actor-chain claims through canonical session users so impersonated requests preserve both the real operator and effective tenant actor.
- Updates impersonation write blocking to fail closed for governed impersonation session markers, while preserving the legacy marker path.
- Adds the governance report for current flow, limitations, and future persisted session/revocation follow-ups.

## Current Flow Discovered
- Active mounted route: POST /api/impersonation/landlord/tenants/:tenantId/impersonate in impersonationRoutes.ts.
- Previous mounted route used landlord-scoped access and a 30-day token without canonical actor-chain preservation.
- An alternate landlordImpersonationRoutes.ts path existed but was not mounted in app.build.ts.
- No active frontend impersonation banner/support mode was found; the existing frontend API helper appears unused.

## Governance Notes
- No new support powers, impersonation UI, persistence collection, token revocation list, auth provider behavior, Firestore rule, route visibility, pricing, payment, screening, or public workflow changes are introduced.
- Audit metadata remains internal, metadata-only, and excludes tokens, tenant email, raw tenant docs, provider payloads, reports, debug payloads, and route-source details.
- Server-side revocation remains a future follow-up because no persisted impersonation session store exists yet; issued tokens are now short-lived and carry explicit session metadata.

## Validation
- rentchain-api: npm run test:single -- src/lib/impersonationGovernance/__tests__/impersonationGovernance.test.ts src/routes/__tests__/impersonationRoutes.test.ts src/services/__tests__/sessionUserImpersonation.test.ts src/middleware/__tests__/blockImpersonationWrites.test.ts src/lib/supportSessionAudit/__tests__/supportSessionAudit.test.ts src/routes/__tests__/apiRouteOwnershipRegression.test.ts
- rentchain-api: npm run build
- rentchain-frontend: npm run build
- rentchain-frontend: npm run test
- repo root: git diff --check

## Known Validation Note
A full backend npm run test was also attempted. After rerunning outside the sandbox to avoid local socket EPERM errors, it still reported existing unrelated failures in lease draft route and decision execution mapping tests. The targeted backend tests for this mission and backend build passed.