### PR TITLE
Harden admin support projection safety

### DIFF
--- a/docs/reports/admin-support-projection-safety-regression-v1.md
+++ b/docs/reports/admin-support-projection-safety-regression-v1.md
@@ -131,6 +131,7 @@ Dashboard and operations surfaces continue consuming their existing safe summari
 - Support console routes remain admin-gated and can show dedicated safe diagnostic resources; future support surfaces should use this helper or an equivalent audience-aware projection contract.
 - Future persisted impersonation sessions should use the same audience categories before any landlord, tenant, export, or timeline projection.
 - Server-side revocation/session persistence remains outside this mission.
+- Tenant trust exports remain JSON-first as the canonical audit package in this phase. A future mission should add a tenant-friendly PDF trust export summary while preserving JSON as the canonical, projection-safe audit package.
 
 ## Guardrail Confirmation
 

--- a/docs/reports/admin-support-projection-safety-regression-v1.md
+++ b/docs/reports/admin-support-projection-safety-regression-v1.md
@@ -1,0 +1,137 @@
+# Admin Support Projection Safety Regression v1
+
+## Summary
+
+This report documents the projection-safety hardening added after impersonation governance was introduced. The goal is to ensure richer support/admin and impersonation metadata remains restricted to safe internal contexts and cannot leak into landlord, tenant, export, timeline, dashboard, or public-safe projections.
+
+No auth behavior, Firestore rules, role permissions, route visibility, pricing, payments, screening provider logic, or public workflows were changed.
+
+## Surfaces Audited
+
+Backend surfaces inspected:
+
+- `rentchain-api/src/auth/jwt.ts`
+- `rentchain-api/src/services/sessionUserService.ts`
+- `rentchain-api/src/routes/impersonationRoutes.ts`
+- `rentchain-api/src/lib/impersonationGovernance/*`
+- `rentchain-api/src/lib/adminSupportAccess/*`
+- `rentchain-api/src/lib/supportConsole/*`
+- `rentchain-api/src/routes/supportConsoleRoutes.ts`
+- `rentchain-api/src/lib/timeline/timelineAdapter.ts`
+- `rentchain-api/src/routes/timelineRoutes.ts`
+- `rentchain-api/src/lib/institutionExports/*`
+- `rentchain-api/src/lib/institutionTrustExports/*`
+- `rentchain-api/src/services/tenantPortal/*`
+- existing projection/redaction regression tests
+
+Frontend surfaces inspected:
+
+- support console API/types
+- tenant workspace tests and tenant-safe visibility assertions
+- operational command center/review workspace tests
+- dashboard/timeline surfaces that render projected backend metadata
+
+## Findings
+
+PR #982 added explicit impersonation actor-chain fields to JWT/session user hydration and safe metadata-only impersonation telemetry. Those fields are intentionally useful for internal audit continuity, but they are unsafe for landlord, tenant, public export, user-safe export, analytics, dashboard, and timeline payloads unless explicitly projected.
+
+Existing high-risk surfaces mostly used safe summaries already:
+
+- `timelineAdapter` converts canonical events to display-only timeline items and does not project event metadata.
+- `deriveInstitutionExportPackage` uses aggregate/count previews and source refs rather than raw audit event payloads.
+- `supportConsole` routes are `system.admin` gated and already use redacted identifiers for diagnostics.
+- tenant projection services use explicit tenant-safe contracts.
+
+The gap was lack of a reusable audience-aware regression helper that knows about the new impersonation/support fields.
+
+## Projection Safety Helper
+
+Added backend helper:
+
+- `rentchain-api/src/lib/adminSupportProjectionSafety/adminSupportProjectionSafety.ts`
+
+Audience categories:
+
+- `tenant`
+- `landlord`
+- `admin_support`
+- `export_public`
+- `export_user_safe`
+- `internal_debug`
+
+Unknown audience values fail safe as `export_user_safe`.
+
+## Deny-By-Default Internal Fields
+
+For tenant, landlord, public export, user-safe export, and unknown audiences, the helper strips:
+
+- `realActorId`
+- `realActorRole`
+- `effectiveActorId`
+- `effectiveActorRole`
+- `impersonationSessionId`
+- `impersonationReason`
+- `impersonationStartedAt`
+- `impersonationActive`
+- `actorChain`
+- `supportProjectionSafe`
+- `visibilityClass`
+- `sourceActionFamily`
+- `policyDecision`
+- `internalOnly`
+- `tenantVisible`
+- `debug`
+- `debugPayload`
+- `internalDebug`
+- `routeSource`
+- token, secret, credential, authorization, cookie, stack, raw payload, provider payload, and raw report fields
+
+Objects marked `visibilityClass: admin_support_internal` project to an empty safe object for user-facing audiences.
+
+## Admin/Support Safe Summaries
+
+For `admin_support` and `internal_debug`, impersonation-like metadata projects to a metadata-only summary:
+
+- `sessionId`
+- lifecycle state
+- reason category
+- timestamps
+- actor role summary without raw actor ids
+- target summary without raw target ids
+- policy outcome summary
+- `metadataOnly: true`
+- `tenantVisible: false`
+- `supportSafe: true`
+
+This preserves operational review value without exposing raw actor-chain identifiers in generic support projections.
+
+## Export Protection
+
+Institution export previews were regression-tested with an impersonation audit event containing raw actor-chain metadata, provider payloads, token-like values, debug payloads, and internal visibility flags.
+
+The generated export preview keeps only count/source-reference lineage:
+
+- audit event count
+- deterministic audit event source id
+- no raw support/admin metadata
+- no actor-chain fields
+- no token/debug/provider values
+
+No new export categories were added.
+
+## Timeline / Dashboard Protection
+
+Timeline conversion was regression-tested with impersonation metadata embedded in a canonical event. The resulting timeline item contains only title, summary, timestamp, domain, status, and actor label fields. Raw metadata and actor-chain fields are not projected.
+
+Dashboard and operations surfaces continue consuming their existing safe summaries; no frontend projection behavior was changed.
+
+## Known Limitations
+
+- This mission does not retrofit every historical projection helper to call the new sanitizer at runtime.
+- Support console routes remain admin-gated and can show dedicated safe diagnostic resources; future support surfaces should use this helper or an equivalent audience-aware projection contract.
+- Future persisted impersonation sessions should use the same audience categories before any landlord, tenant, export, or timeline projection.
+- Server-side revocation/session persistence remains outside this mission.
+
+## Guardrail Confirmation
+
+This mission does not widen support/admin access, expose support internals to landlord/tenant views, change auth behavior, alter Firestore rules, add dependencies, change provider/payment/pricing logic, create routes, or add public workflows.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -559,7 +559,7 @@ app.use(
 app.use("/api/tenant-invites", rateLimitTenantWorkspaceEntry);
 app.use("/api/tenant-invites", tenantInvitesRoutes);
 app.use("/api/tenant/invite", rateLimitTenantWorkspaceEntry);
-app.use("/api/tenant", tenantPortalRoutes);
+app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes);
 app.use("/api/recipient", routeSource("recipientTrustReviewRoutes.ts"), recipientTrustReviewRoutes);
 app.use("/api/tenant", tenantParticipationRoutes);
 app.use("/api/tenant", tenantOnboardingHardeningRoutes);

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -550,16 +550,16 @@ app.use("/api/ledger", routeSource("ledgerRoutes.ts"), ledgerRoutes);
 app.use("/api/dashboard", routeSource("dashboardRoutes.ts"), dashboardRoutes);
 app.use("/api/landlord", routeSource("landlordActivationRoutes.ts"), landlordActivationRoutes);
 app.use("/api/application-links", routeSource("landlordApplicationLinksRoutes.ts"), landlordApplicationLinksRoutes);
+app.use("/api/tenant-invites", rateLimitTenantWorkspaceEntry);
+app.use("/api/tenant-invites", tenantInvitesRoutes);
+app.use("/api/tenant/invite", rateLimitTenantWorkspaceEntry);
+app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes);
 app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes);
 app.use(
   "/api/landlord/application-links",
   routeSource("landlordApplicationLinksRoutes.ts"),
   landlordApplicationLinksRoutes
 );
-app.use("/api/tenant-invites", rateLimitTenantWorkspaceEntry);
-app.use("/api/tenant-invites", tenantInvitesRoutes);
-app.use("/api/tenant/invite", rateLimitTenantWorkspaceEntry);
-app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes);
 app.use("/api/recipient", routeSource("recipientTrustReviewRoutes.ts"), recipientTrustReviewRoutes);
 app.use("/api/tenant", tenantParticipationRoutes);
 app.use("/api/tenant", tenantOnboardingHardeningRoutes);

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -554,7 +554,7 @@ app.use("/api/tenant-invites", rateLimitTenantWorkspaceEntry);
 app.use("/api/tenant-invites", tenantInvitesRoutes);
 app.use("/api/tenant/invite", rateLimitTenantWorkspaceEntry);
 app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes);
-app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes);
+app.use("/api", referralsRoutes);
 app.use(
   "/api/landlord/application-links",
   routeSource("landlordApplicationLinksRoutes.ts"),

--- a/rentchain-api/src/lib/adminSupportProjectionSafety/__tests__/adminSupportProjectionSafety.test.ts
+++ b/rentchain-api/src/lib/adminSupportProjectionSafety/__tests__/adminSupportProjectionSafety.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectAdminSupportMetadataForAudience,
+  stripAdminSupportInternalsForUser,
+} from "../adminSupportProjectionSafety";
+import {
+  expectNoRestrictedProjectionFields,
+  expectPayloadDoesNotContainValues,
+} from "../../../__tests__/helpers/projectionSafetyAssertions";
+
+const IMPERSONATION_PAYLOAD = {
+  eventType: "impersonation.started",
+  sessionId: "session-1",
+  lifecycleState: "started",
+  reasonCategory: "incident_review",
+  occurredAt: "2026-05-22T20:00:00.000Z",
+  startedAt: "2026-05-22T20:00:00.000Z",
+  targetAccountType: "tenant",
+  targetAccountId: "tenant-1",
+  targetLandlordId: "landlord-1",
+  realActorId: "admin-1",
+  realActorRole: "admin",
+  effectiveActorId: "tenant-1",
+  effectiveActorRole: "tenant",
+  impersonationSessionId: "session-1",
+  impersonationReason: "incident_review",
+  impersonationStartedAt: "2026-05-22T20:00:00.000Z",
+  impersonationActive: true,
+  supportProjectionSafe: true,
+  visibilityClass: "admin_support_internal",
+  sourceActionFamily: "admin_support_impersonation",
+  policyDecision: "allowed",
+  tenantVisible: false,
+  actorChain: {
+    realActorId: "admin-1",
+    realActorRole: "admin",
+    effectiveActorId: "tenant-1",
+    effectiveActorRole: "tenant",
+    impersonationSessionId: "session-1",
+  },
+  rawProviderPayload: { token: "secret-token" },
+  debugPayload: { stack: "private stack trace" },
+};
+
+function serialized(value: unknown) {
+  return JSON.stringify(value);
+}
+
+describe("adminSupportProjectionSafety", () => {
+  it("strips impersonation and support internals from landlord projections", () => {
+    const result = projectAdminSupportMetadataForAudience(
+      {
+        label: "Lease timeline",
+        supportEvent: IMPERSONATION_PAYLOAD,
+        publicCount: 2,
+      },
+      "landlord"
+    );
+
+    expect(result).toEqual({
+      label: "Lease timeline",
+      supportEvent: {},
+      publicCount: 2,
+    });
+    expect(serialized(result)).not.toContain("realActorId");
+    expect(serialized(result)).not.toContain("impersonationSessionId");
+    expect(serialized(result)).not.toContain("supportProjectionSafe");
+    expectPayloadDoesNotContainValues(result, ["admin-1", "tenant-1", "secret-token", "private stack trace"]);
+    expectNoRestrictedProjectionFields(result);
+  });
+
+  it("strips impersonation and support internals from tenant projections", () => {
+    const result = projectAdminSupportMetadataForAudience(
+      {
+        tenantWorkspace: { status: "active" },
+        event: IMPERSONATION_PAYLOAD,
+      },
+      "tenant"
+    );
+
+    expect(result).toEqual({
+      tenantWorkspace: { status: "active" },
+      event: {},
+    });
+    expect(serialized(result)).not.toContain("impersonationReason");
+    expect(serialized(result)).not.toContain("visibilityClass");
+    expectPayloadDoesNotContainValues(result, ["incident_review", "admin_support_internal", "admin-1"]);
+  });
+
+  it("fails safe for unknown and user-safe export audiences", () => {
+    const unknownAudience = projectAdminSupportMetadataForAudience(IMPERSONATION_PAYLOAD, "partner");
+    const exportAudience = stripAdminSupportInternalsForUser(IMPERSONATION_PAYLOAD);
+
+    expect(unknownAudience).toEqual({});
+    expect(exportAudience).toEqual({});
+    expectPayloadDoesNotContainValues({ unknownAudience, exportAudience }, [
+      "realActorId",
+      "effectiveActorId",
+      "impersonationSessionId",
+      "admin-1",
+      "tenant-1",
+    ]);
+  });
+
+  it("returns metadata-only admin/support summaries without raw actor chains", () => {
+    const result = projectAdminSupportMetadataForAudience(IMPERSONATION_PAYLOAD, "admin_support");
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        schemaVersion: "admin_support_projection_safety_v1",
+        sessionId: "session-1",
+        lifecycleState: "started",
+        reasonCategory: "incident_review",
+        targetSummary: expect.objectContaining({
+          accountType: "tenant",
+          landlordScoped: true,
+          rawTargetIdsIncluded: false,
+        }),
+        actorSummary: expect.objectContaining({
+          realActorRole: "admin",
+          effectiveActorRole: "tenant",
+          rawActorIdsIncluded: false,
+        }),
+        metadataOnly: true,
+        tenantVisible: false,
+        supportSafe: true,
+      })
+    );
+    expect(serialized(result)).not.toContain("realActorId");
+    expect(serialized(result)).not.toContain("effectiveActorId");
+    expect(serialized(result)).not.toContain("actorChain");
+    expectPayloadDoesNotContainValues(result, ["admin-1", "tenant-1", "secret-token", "private stack trace"]);
+    expectNoRestrictedProjectionFields(result);
+  });
+});

--- a/rentchain-api/src/lib/adminSupportProjectionSafety/adminSupportProjectionSafety.ts
+++ b/rentchain-api/src/lib/adminSupportProjectionSafety/adminSupportProjectionSafety.ts
@@ -1,0 +1,158 @@
+export type AdminSupportProjectionAudience =
+  | "tenant"
+  | "landlord"
+  | "admin_support"
+  | "export_public"
+  | "export_user_safe"
+  | "internal_debug";
+
+export const ADMIN_SUPPORT_PROJECTION_SAFETY_VERSION = "admin_support_projection_safety_v1";
+
+const USER_SAFE_AUDIENCES = new Set<AdminSupportProjectionAudience>([
+  "tenant",
+  "landlord",
+  "export_public",
+  "export_user_safe",
+]);
+
+const INTERNAL_KEYS = new Set([
+  "realActorId",
+  "realActorRole",
+  "effectiveActorId",
+  "effectiveActorRole",
+  "impersonationSessionId",
+  "impersonationReason",
+  "impersonationStartedAt",
+  "impersonationActive",
+  "actorChain",
+  "supportProjectionSafe",
+  "visibilityClass",
+  "sourceActionFamily",
+  "policyDecision",
+  "internalOnly",
+  "tenantVisible",
+  "debug",
+  "debugPayload",
+  "internalDebug",
+  "routeSource",
+]);
+
+const ALWAYS_RESTRICTED_KEY_PATTERNS = [
+  /token/i,
+  /secret/i,
+  /password/i,
+  /credential/i,
+  /raw.*payload/i,
+  /provider.*payload/i,
+  /raw.*report/i,
+  /stack/i,
+  /authorization/i,
+  /cookie/i,
+];
+
+function normalizeAudience(value: unknown): AdminSupportProjectionAudience {
+  const normalized = String(value ?? "").trim().toLowerCase().replace(/[\s.-]+/g, "_");
+  if (
+    normalized === "tenant" ||
+    normalized === "landlord" ||
+    normalized === "admin_support" ||
+    normalized === "export_public" ||
+    normalized === "export_user_safe" ||
+    normalized === "internal_debug"
+  ) {
+    return normalized;
+  }
+  return "export_user_safe";
+}
+
+function keyIsAlwaysRestricted(key: string) {
+  return ALWAYS_RESTRICTED_KEY_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+function keyIsInternal(key: string) {
+  return INTERNAL_KEYS.has(key);
+}
+
+function safeString(value: unknown, max = 160): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function maybeImpersonationSummary(input: Record<string, unknown>) {
+  const sessionId = safeString(input.impersonationSessionId || input.sessionId, 240);
+  const lifecycleState = safeString(input.lifecycleState || input.state, 80);
+  const reasonCategory = safeString(input.reasonCategory || input.impersonationReason, 120);
+  const occurredAt = safeString(input.occurredAt, 120);
+  const startedAt = safeString(input.startedAt || input.impersonationStartedAt, 120);
+  const endedAt = safeString(input.endedAt, 120);
+  const targetAccountType = safeString(input.targetAccountType, 80);
+  const targetLandlordId = safeString(input.targetLandlordId, 240);
+  const actorChain = input.actorChain && typeof input.actorChain === "object" ? (input.actorChain as Record<string, unknown>) : null;
+  const realActorRole = safeString(input.realActorRole || actorChain?.realActorRole, 80);
+  const effectiveActorRole = safeString(input.effectiveActorRole || actorChain?.effectiveActorRole, 80);
+
+  if (
+    !sessionId &&
+    !lifecycleState &&
+    !reasonCategory &&
+    !realActorRole &&
+    !effectiveActorRole &&
+    !targetAccountType &&
+    !targetLandlordId
+  ) {
+    return null;
+  }
+
+  return {
+    schemaVersion: ADMIN_SUPPORT_PROJECTION_SAFETY_VERSION,
+    sessionId,
+    lifecycleState,
+    reasonCategory,
+    occurredAt,
+    startedAt,
+    endedAt,
+    actorSummary: {
+      realActorRole,
+      effectiveActorRole,
+      supportAttribution: true,
+      rawActorIdsIncluded: false,
+    },
+    targetSummary: {
+      accountType: targetAccountType,
+      landlordScoped: Boolean(targetLandlordId),
+      rawTargetIdsIncluded: false,
+    },
+    policyOutcomeSummary: safeString(input.policyDecision, 80),
+    metadataOnly: true,
+    tenantVisible: false,
+    supportSafe: true,
+  };
+}
+
+function cloneForAudience(value: unknown, audience: AdminSupportProjectionAudience): unknown {
+  if (value == null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((item) => cloneForAudience(item, audience));
+
+  const source = value as Record<string, unknown>;
+  if (audience === "admin_support" || audience === "internal_debug") {
+    const summary = maybeImpersonationSummary(source);
+    if (summary) return summary;
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(source)) {
+    if (keyIsAlwaysRestricted(key)) continue;
+    if (USER_SAFE_AUDIENCES.has(audience) && keyIsInternal(key)) continue;
+    if (USER_SAFE_AUDIENCES.has(audience) && source.visibilityClass === "admin_support_internal") continue;
+    output[key] = cloneForAudience(nested, audience);
+  }
+  return output;
+}
+
+export function projectAdminSupportMetadataForAudience<T = unknown>(payload: T, audience: unknown): T {
+  return cloneForAudience(payload, normalizeAudience(audience)) as T;
+}
+
+export function stripAdminSupportInternalsForUser<T = unknown>(payload: T): T {
+  return projectAdminSupportMetadataForAudience(payload, "export_user_safe");
+}

--- a/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
+++ b/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
@@ -316,6 +316,73 @@ describe("deriveInstitutionExportPackage", () => {
     );
   });
 
+  it("keeps impersonation/support metadata out of user-safe institution export previews", () => {
+    const pkg = deriveInstitutionExportPackage({
+      packageType: "lender_due_diligence",
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1", status: "active", unitsCount: 4 }],
+      auditEvents: [
+        {
+          id: "impersonation-event-1",
+          type: "impersonation.started",
+          realActorId: "admin-1",
+          realActorRole: "admin",
+          effectiveActorId: "tenant-1",
+          effectiveActorRole: "tenant",
+          impersonationSessionId: "session-1",
+          impersonationReason: "incident_review",
+          impersonationStartedAt: "2026-05-22T20:00:00.000Z",
+          supportProjectionSafe: true,
+          tenantVisible: false,
+          visibilityClass: "admin_support_internal",
+          policyDecision: "allowed",
+          sourceActionFamily: "admin_support_impersonation",
+          actorChain: {
+            realActorId: "admin-1",
+            effectiveActorId: "tenant-1",
+          },
+          debugPayload: { stack: "private stack trace" },
+          rawProviderPayload: { token: "secret-token" },
+        } as any,
+      ],
+    });
+
+    expect(pkg.sourceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceCollection: "auditEvents", sourceId: "impersonation-event-1" }),
+      ]),
+    );
+    expect(pkg.payloadPreview).toEqual(
+      expect.objectContaining({
+        auditEventSummary: { total: 1 },
+      }),
+    );
+    expectPayloadDoesNotContainValues(pkg, [
+      "realActorId",
+      "realActorRole",
+      "effectiveActorId",
+      "effectiveActorRole",
+      "impersonationSessionId",
+      "impersonationReason",
+      "impersonationStartedAt",
+      "impersonationActive",
+      "supportProjectionSafe",
+      "tenantVisible",
+      "visibilityClass",
+      "policyDecision",
+      "sourceActionFamily",
+      "actorChain",
+      "admin-1",
+      "tenant-1",
+      "session-1",
+      "incident_review",
+      "private stack trace",
+      "secret-token",
+    ]);
+    expectNoRestrictedProjectionFields(pkg.payloadPreview);
+  });
+
   it("optionally attaches policy-gated portable trust exports without changing route adoption", () => {
     const pkg = deriveInstitutionExportPackage({
       packageType: "lender_due_diligence",

--- a/rentchain-api/src/lib/timeline/timelineAdapter.test.ts
+++ b/rentchain-api/src/lib/timeline/timelineAdapter.test.ts
@@ -72,4 +72,40 @@ describe("timelineAdapter", () => {
 
     expect(result.details).toBeUndefined();
   });
+
+  it("does not project impersonation actor-chain metadata into timeline items", () => {
+    const result = canonicalEventToTimelineItem(
+      buildEvent({
+        id: "impersonation-event-1",
+        type: "impersonation.started",
+        domain: "system",
+        action: "impersonation_started",
+        visibility: "internal",
+        summary: "Support impersonation started.",
+        metadata: {
+          realActorId: "admin-1",
+          realActorRole: "admin",
+          effectiveActorId: "tenant-1",
+          effectiveActorRole: "tenant",
+          impersonationSessionId: "session-1",
+          impersonationReason: "incident_review",
+          supportProjectionSafe: true,
+          visibilityClass: "admin_support_internal",
+          actorChain: {
+            realActorId: "admin-1",
+            effectiveActorId: "tenant-1",
+          },
+        },
+      })
+    );
+
+    expect(result.title).toBe("System Impersonation Started");
+    const payload = JSON.stringify(result);
+    expect(payload).not.toContain("realActorId");
+    expect(payload).not.toContain("effectiveActorId");
+    expect(payload).not.toContain("impersonationSessionId");
+    expect(payload).not.toContain("supportProjectionSafe");
+    expect(payload).not.toContain("admin-1");
+    expect(payload).not.toContain("tenant-1");
+  });
 });

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -296,7 +296,7 @@ describe("API route ownership regression", () => {
     const expensesMount = source.indexOf('app.use("/api", routeSource("expensesRoutes.ts"), expensesRoutes)');
     const riskAgentMount = source.indexOf('app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes)');
     const tenantPortalMount = source.indexOf('app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes)');
-    const referralsMount = source.indexOf('app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes)');
+    const referralsMount = source.indexOf('app.use("/api", referralsRoutes)');
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
     const buildProbeRoute = source.indexOf('app.get("/api/_build", rateLimitDiagnostics');
     const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
@@ -337,6 +337,7 @@ describe("API route ownership regression", () => {
     expect(telemetryMount).toBeLessThan(screeningJobsMount);
     expect(screeningRoutesMount).toBeLessThan(screeningJobsMount);
     expect(screeningJobsMount).toBeLessThan(apiCatchall);
+    expect(source).not.toContain('app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes)');
   });
 
   it("documents public-safe probes, gated diagnostics, and catchall route sources", () => {

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -296,6 +296,7 @@ describe("API route ownership regression", () => {
     const expensesMount = source.indexOf('app.use("/api", routeSource("expensesRoutes.ts"), expensesRoutes)');
     const riskAgentMount = source.indexOf('app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes)');
     const tenantPortalMount = source.indexOf('app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes)');
+    const referralsMount = source.indexOf('app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes)');
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
     const buildProbeRoute = source.indexOf('app.get("/api/_build", rateLimitDiagnostics');
     const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
@@ -314,6 +315,7 @@ describe("API route ownership regression", () => {
     expect(expensesMount).toBeGreaterThan(-1);
     expect(riskAgentMount).toBeGreaterThan(-1);
     expect(tenantPortalMount).toBeGreaterThan(-1);
+    expect(referralsMount).toBeGreaterThan(-1);
     expect(screeningJobsMount).toBeGreaterThan(-1);
     expect(buildProbeRoute).toBeGreaterThan(-1);
     expect(apiCatchall).toBeGreaterThan(-1);
@@ -330,6 +332,7 @@ describe("API route ownership regression", () => {
     expect(telemetryMount).toBeLessThan(riskAgentMount);
     expect(screeningRoutesMount).toBeLessThan(riskAgentMount);
     expect(buildProbeRoute).toBeLessThan(riskAgentMount);
+    expect(tenantPortalMount).toBeLessThan(referralsMount);
     expect(tenantPortalMount).toBeLessThan(screeningJobsMount);
     expect(telemetryMount).toBeLessThan(screeningJobsMount);
     expect(screeningRoutesMount).toBeLessThan(screeningJobsMount);

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -295,6 +295,7 @@ describe("API route ownership regression", () => {
     const viewingMount = source.indexOf('app.use("/api", routeSource("viewingRoutes.ts"), viewingRoutes)');
     const expensesMount = source.indexOf('app.use("/api", routeSource("expensesRoutes.ts"), expensesRoutes)');
     const riskAgentMount = source.indexOf('app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes)');
+    const tenantPortalMount = source.indexOf('app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes)');
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
     const buildProbeRoute = source.indexOf('app.get("/api/_build", rateLimitDiagnostics');
     const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
@@ -312,6 +313,7 @@ describe("API route ownership regression", () => {
     expect(viewingMount).toBeGreaterThan(-1);
     expect(expensesMount).toBeGreaterThan(-1);
     expect(riskAgentMount).toBeGreaterThan(-1);
+    expect(tenantPortalMount).toBeGreaterThan(-1);
     expect(screeningJobsMount).toBeGreaterThan(-1);
     expect(buildProbeRoute).toBeGreaterThan(-1);
     expect(apiCatchall).toBeGreaterThan(-1);
@@ -328,6 +330,7 @@ describe("API route ownership regression", () => {
     expect(telemetryMount).toBeLessThan(riskAgentMount);
     expect(screeningRoutesMount).toBeLessThan(riskAgentMount);
     expect(buildProbeRoute).toBeLessThan(riskAgentMount);
+    expect(tenantPortalMount).toBeLessThan(screeningJobsMount);
     expect(telemetryMount).toBeLessThan(screeningJobsMount);
     expect(screeningRoutesMount).toBeLessThan(screeningJobsMount);
     expect(screeningJobsMount).toBeLessThan(apiCatchall);

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1828,6 +1828,7 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(missingConsent.status).toBe(400);
+    expect(missingConsent.headers["x-route-source"]).toBe("tenantPortalRoutes.ts");
     expect(missingConsent.body?.error).toBe("TENANT_TRUST_EXPORT_CONSENT_REQUIRED");
 
     const preview = await invokeRouter(router, {
@@ -1871,6 +1872,7 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(prepared.status).toBe(200);
+    expect(prepared.headers["x-route-source"]).toBe("tenantPortalRoutes.ts");
     expect(prepared.body?.data?.lifecycle).toBe("prepared");
     expect(prepared.body?.data?.consent?.granted).toBe(true);
     expect(prepared.body?.data?.package?.status).toBe("export_ready");
@@ -1926,6 +1928,7 @@ describe("tenantPortalRoutes foundation", () => {
       },
     });
     expect(listed.status).toBe(200);
+    expect(listed.headers["x-route-source"]).toBe("tenantPortalRoutes.ts");
     expect(listed.body?.data?.items?.[0]?.exportId).toBe(exportId);
 
     const revoked = await invokeRouter(router, {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -3368,6 +3368,59 @@ describe("tenantPortalRoutes foundation", () => {
     ).toBe(true);
   });
 
+  it("includes tenant-safe Schedule A attachments in the document vault without making them primary lease documents", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      status: "active",
+      documentUrl: null,
+      approvedDocumentUrl: null,
+      documentRef: null,
+      leaseDocument: null,
+      scheduleADocument: {
+        bucket: "test-bucket",
+        path: "leases/landlord-1/draft-1/schedule-a-v1.pdf",
+      },
+      internalOnly: "support-only",
+      realActorId: "support-operator",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/attachments",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.summary?.total).toBeGreaterThan(0);
+    expect(res.body?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "SCHEDULE_A — Schedule A",
+          category: "Attachments",
+          purpose: "SCHEDULE_A",
+          purposeLabel: "Schedule A",
+          fileName: "schedule-a.pdf",
+          url: "https://signed.example/leases/landlord-1/draft-1/schedule-a-v1.pdf",
+        }),
+      ])
+    );
+    const primaryLeaseItems = res.body?.data?.filter((item: any) => item.category === "Lease" && item.purpose === "LEASE");
+    expect(primaryLeaseItems).toEqual([]);
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("support-operator");
+    expect(payload).not.toContain("internalOnly");
+    expect(payload).not.toContain("storagePath");
+    expect(payload).not.toContain("test-bucket");
+  });
+
   it("dedupes duplicate visible Lease attachments in the tenant document vault", async () => {
     ensureCollection("leases").set("lease-1", {
       ...(ensureCollection("leases").get("lease-1") || {}),

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "crypto";
 import { Router } from "express";
 import { authenticateJwt } from "../middleware/authMiddleware";
+import { routeSource } from "../middleware/routeSource";
 import { db, FieldValue } from "../config/firebase";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
@@ -82,6 +83,7 @@ import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 
 const router = Router();
 router.use(authenticateJwt);
+const tenantPortalRouteSource = routeSource("tenantPortalRoutes.ts");
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -4120,7 +4122,7 @@ router.post("/identity/export", requireTenantWorkspaceIdentity, async (req: any,
   });
 });
 
-router.get("/trust-exports", requireTenantWorkspaceIdentity, async (req: any, res) => {
+router.get("/trust-exports", tenantPortalRouteSource, requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
 
@@ -4141,7 +4143,7 @@ router.get("/trust-exports", requireTenantWorkspaceIdentity, async (req: any, re
   }
 });
 
-router.post("/trust-exports/preview", requireTenantWorkspaceIdentity, async (req: any, res) => {
+router.post("/trust-exports/preview", tenantPortalRouteSource, requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
 
@@ -4171,7 +4173,7 @@ router.post("/trust-exports/preview", requireTenantWorkspaceIdentity, async (req
   }
 });
 
-router.post("/trust-exports", requireTenantWorkspaceIdentity, async (req: any, res) => {
+router.post("/trust-exports", tenantPortalRouteSource, requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
 
@@ -4204,7 +4206,7 @@ router.post("/trust-exports", requireTenantWorkspaceIdentity, async (req: any, r
   }
 });
 
-router.post("/trust-exports/:id/revoke", requireTenantWorkspaceIdentity, async (req: any, res) => {
+router.post("/trust-exports/:id/revoke", tenantPortalRouteSource, requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
 

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2855,6 +2855,7 @@ function documentCategoryForLabel(value: string): string {
   if (normalized.includes("identity") || normalized.includes("id") || normalized.includes("passport") || normalized.includes("license")) {
     return "Identity";
   }
+  if (normalized.includes("schedule a") || normalized.includes("schedulea")) return "Attachments";
   if (normalized.includes("lease")) return "Lease";
   if (normalized.includes("invite")) return "Invite";
   return "Documents";
@@ -3474,9 +3475,11 @@ function buildTenantDocumentWorkspace(params: {
   attachments: Array<any>;
   profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>;
   leaseDocumentContext?: TenantLeaseDocumentContext | null;
+  scheduleADocumentContext?: TenantLeaseDocumentContext | null;
 }) {
   const checklist = Array.isArray(params.profile?.identity?.documentChecklist) ? params.profile.identity.documentChecklist : [];
   const leaseDocumentContext = params.leaseDocumentContext || null;
+  const scheduleADocumentContext = params.scheduleADocumentContext || null;
   const contextAttachment =
     leaseDocumentContext?.documentUrl &&
     leaseDocumentContext.documentStatus !== "missing" &&
@@ -3498,8 +3501,29 @@ function buildTenantDocumentWorkspace(params: {
           source: leaseDocumentContext.source,
         }
       : null;
+  const scheduleAContextAttachment =
+    scheduleADocumentContext?.documentUrl &&
+    scheduleADocumentContext.documentStatus !== "missing"
+      ? {
+          id: scheduleADocumentContext.documentId || `schedule-a-context-${scheduleADocumentContext.leaseId || "current"}`,
+          tenantId: scheduleADocumentContext.tenantId || null,
+          leaseId: scheduleADocumentContext.leaseId || null,
+          propertyId: scheduleADocumentContext.propertyId || null,
+          unitId: scheduleADocumentContext.unitId || null,
+          ledgerItemId: scheduleADocumentContext.leaseId || null,
+          title: "Schedule A",
+          fileName: "schedule-a.pdf",
+          category: "Attachments",
+          purpose: "SCHEDULE_A",
+          purposeLabel: "Schedule A",
+          url: scheduleADocumentContext.documentUrl,
+          createdAt: 0,
+          source: scheduleADocumentContext.source,
+        }
+      : null;
   const attachments = dedupeTenantVisibleLeaseAttachments([
     ...(contextAttachment ? [contextAttachment] : []),
+    ...(scheduleAContextAttachment ? [scheduleAContextAttachment] : []),
     ...(Array.isArray(params.attachments) ? params.attachments : []),
   ]);
 
@@ -7077,6 +7101,7 @@ router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res)
       attachments: rawAttachments,
       profile,
       leaseDocumentContext: workspaceData.lease?.leaseDocumentContext || (profile.profile?.lease as any)?.leaseDocumentContext || null,
+      scheduleADocumentContext: workspaceData.lease?.scheduleADocumentContext || (profile.profile?.lease as any)?.scheduleADocumentContext || null,
     });
 
     return res.json({
@@ -7086,6 +7111,7 @@ router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res)
       guidance: documentWorkspace.guidance,
       updatedAt: documentWorkspace.updatedAt,
       leaseDocumentContext: workspaceData.lease?.leaseDocumentContext || (profile.profile?.lease as any)?.leaseDocumentContext || null,
+      scheduleADocumentContext: workspaceData.lease?.scheduleADocumentContext || (profile.profile?.lease as any)?.scheduleADocumentContext || null,
     });
   } catch (err) {
     console.error("[tenant/attachments] failed", {

--- a/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
@@ -96,6 +96,9 @@ describe("adminLeaseView", () => {
     seedDoc("tenants", "tenant-2", { firstName: "Co", lastName: "Tenant" });
     seedDoc("tenants", "tenant-3", { fullName: "Alex Summit" });
     seedDoc("tenants", "tenant-4", { fullName: "Old Lease" });
+
+    seedDoc("landlords", "landlord-1", { businessName: "Harbour Homes" });
+    seedDoc("landlords", "landlord-2", { displayName: "Summit Rentals" });
   });
 
   it("returns safe shaped lease rows with tenant names", async () => {
@@ -105,8 +108,12 @@ describe("adminLeaseView", () => {
     expect(result.items[0]).toHaveProperty("id");
     expect(result.items[0]).toHaveProperty("propertyName");
     expect(result.items[0]).toHaveProperty("tenantNames");
+    expect(result.items[0]).toHaveProperty("leaseDisplayLabel");
+    expect(result.items[0]).toHaveProperty("landlordDisplayName");
     expect(result.items[0]).toHaveProperty("integrity");
     expect(result.items[0]).not.toHaveProperty("auditBlob");
+    expect(result.items.find((item) => item.id === "lease-1")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 101 · Jane Tenant");
+    expect(result.items.find((item) => item.id === "lease-1")?.landlordDisplayName).toBe("Harbour Homes");
   });
 
   it("supports search across property, unit, tenant, and lease id", async () => {

--- a/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
@@ -77,7 +77,8 @@ describe("adminLeaseView", () => {
     seedDoc("leases", "lease-3", {
       landlordId: "landlord-1",
       propertyId: "prop-1",
-      unitNumber: "102",
+      unitId: "a1O2tQcdEZ7t6y3GHT5G",
+      unitNumber: "a1O2tQcdEZ7t6y3GHT5G",
       tenantId: "tenant-4",
       status: "inactive",
       monthlyRent: 1200,
@@ -114,6 +115,8 @@ describe("adminLeaseView", () => {
     expect(result.items[0]).not.toHaveProperty("auditBlob");
     expect(result.items.find((item) => item.id === "lease-1")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 101 · Jane Tenant");
     expect(result.items.find((item) => item.id === "lease-1")?.landlordDisplayName).toBe("Harbour Homes");
+    expect(result.items.find((item) => item.id === "lease-3")?.unitNumber).toBeNull();
+    expect(result.items.find((item) => item.id === "lease-3")?.leaseDisplayLabel).toBe("Coburg Rd · Unit not assigned · Old Lease");
   });
 
   it("supports search across property, unit, tenant, and lease id", async () => {

--- a/rentchain-api/src/services/__tests__/adminPropertyView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminPropertyView.test.ts
@@ -19,6 +19,12 @@ const { fakeDb, resetFakeDb, seedDoc } = (() => {
   function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
     return {
       where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      doc: (id: string) => ({
+        get: async () => {
+          const doc = ensureCollection(name).get(id);
+          return { id, exists: !!doc, data: () => doc?.data };
+        },
+      }),
       get: async () => {
         const docs = Array.from(ensureCollection(name).values())
           .filter((doc) => matches(doc, filters))
@@ -34,6 +40,7 @@ const { fakeDb, resetFakeDb, seedDoc } = (() => {
     fakeDb: {
       collection: (name: string) => ({
         where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        doc: (id: string) => makeQuery(name).doc(id),
         get: async () => makeQuery(name).get(),
       }),
     },
@@ -82,6 +89,9 @@ describe("adminPropertyView", () => {
     seedDoc("units", "unit-1", { propertyId: "prop-1", occupancyStatus: "occupied" });
     seedDoc("units", "unit-2", { propertyId: "prop-1", occupancyStatus: "vacant" });
     seedDoc("units", "unit-3", { propertyId: "prop-2", occupancyStatus: "occupied" });
+    seedDoc("landlords", "landlord-1", { businessName: "Harbour Homes" });
+    seedDoc("landlords", "landlord-2", { displayName: "Summit Rentals" });
+    seedDoc("users", "owner-1", { displayName: "Owner One" });
   });
 
   it("returns only safe admin property view fields with counts", async () => {
@@ -91,9 +101,12 @@ describe("adminPropertyView", () => {
     expect(result.items[0]).toEqual(
       expect.objectContaining({
         id: expect.any(String),
+        displayLabel: expect.any(String),
         name: expect.anything(),
         ownerUserId: expect.anything(),
         landlordId: expect.anything(),
+        ownerDisplayName: expect.anything(),
+        ownerStatusLabel: expect.any(String),
         managerUserIds: expect.any(Array),
         unitCount: expect.any(Number),
         occupiedUnitCount: expect.any(Number),
@@ -102,6 +115,9 @@ describe("adminPropertyView", () => {
       })
     );
     expect(result.items[0]).not.toHaveProperty("internalNotes");
+    expect(result.items.find((item) => item.id === "prop-1")?.ownerDisplayName).toBe("Owner One");
+    expect(result.items.find((item) => item.id === "prop-2")?.ownerDisplayName).toBe("Summit Rentals");
+    expect(result.items.find((item) => item.id === "prop-2")?.ownerStatusLabel).toBe("Landlord linked / owner profile missing");
   });
 
   it("filters by search and province", async () => {

--- a/rentchain-api/src/services/admin/adminLeaseView.ts
+++ b/rentchain-api/src/services/admin/adminLeaseView.ts
@@ -4,11 +4,13 @@ type FirestoreLike = Pick<FirebaseFirestore.Firestore, "collection">;
 
 export type AdminLeaseView = {
   id: string;
+  leaseDisplayLabel: string;
   propertyId: string | null;
   propertyName: string | null;
   unitId: string | null;
   unitNumber: string | null;
   landlordId: string | null;
+  landlordDisplayName: string | null;
   tenantIds: string[];
   tenantNames: string[];
   status: string | null;
@@ -149,6 +151,27 @@ function computeIntegrity(raw: Record<string, unknown>) {
   };
 }
 
+function safeLandlordDisplayName(record: Record<string, unknown> | null | undefined): string | null {
+  return (
+    asTrimmedString(record?.businessName) ||
+    asTrimmedString(record?.companyName) ||
+    asTrimmedString(record?.displayName) ||
+    asTrimmedString(record?.name) ||
+    null
+  );
+}
+
+function buildLeaseDisplayLabel(input: {
+  propertyName: string | null;
+  unitNumber: string | null;
+  tenantNames: string[];
+}): string {
+  const property = input.propertyName || "Property not linked";
+  const unit = input.unitNumber ? `Unit ${input.unitNumber}` : "Unit not assigned";
+  const tenant = input.tenantNames[0] || "Tenant not linked";
+  return `${property} · ${unit} · ${tenant}`;
+}
+
 async function loadLinkedDocs(
   firestore: FirestoreLike,
   collectionName: string,
@@ -169,11 +192,14 @@ async function loadLinkedDocs(
 function buildView(
   lease: LeaseDocRow,
   propertiesById: Map<string, Record<string, unknown>>,
-  tenantsById: Map<string, Record<string, unknown>>
+  tenantsById: Map<string, Record<string, unknown>>,
+  landlordsById: Map<string, Record<string, unknown>>
 ): AdminLeaseView {
   const raw = lease.raw;
   const propertyId = asTrimmedString(raw.propertyId) || null;
   const property = propertyId ? propertiesById.get(propertyId) : null;
+  const landlordId = asTrimmedString(raw.landlordId) || null;
+  const landlord = landlordId ? landlordsById.get(landlordId) : null;
   const tenantIds = tenantIdsFromLease(raw);
   const tenantNames = tenantIds
     .map((tenantId) => {
@@ -182,17 +208,22 @@ function buildView(
     })
     .filter(Boolean);
   const integrity = computeIntegrity(raw);
+  const propertyName =
+    asTrimmedString(property?.name) ||
+    asTrimmedString(raw.propertyName || raw.propertyLabel) ||
+    null;
+  const unitNumber = asTrimmedString(raw.unitNumber || raw.unitLabel || raw.unit) || null;
+  const landlordDisplayName = safeLandlordDisplayName(landlord) || "Landlord account";
 
   return {
     id: lease.id,
+    leaseDisplayLabel: buildLeaseDisplayLabel({ propertyName, unitNumber, tenantNames }),
     propertyId,
-    propertyName:
-      asTrimmedString(property?.name) ||
-      asTrimmedString(raw.propertyName || raw.propertyLabel) ||
-      null,
+    propertyName,
     unitId: asTrimmedString(raw.unitId) || null,
-    unitNumber: asTrimmedString(raw.unitNumber || raw.unitLabel || raw.unit) || null,
-    landlordId: asTrimmedString(raw.landlordId) || null,
+    unitNumber,
+    landlordId,
+    landlordDisplayName,
     tenantIds,
     tenantNames,
     status: asTrimmedString(raw.status) || null,
@@ -217,9 +248,10 @@ function matchesSearch(view: AdminLeaseView, q: string | null) {
   if (!q) return true;
   const haystack = [
     view.id,
+    view.leaseDisplayLabel,
     view.propertyName,
     view.unitNumber,
-    view.landlordId,
+    view.landlordDisplayName,
     ...view.tenantNames,
   ]
     .map((value) => asLower(value))
@@ -250,12 +282,14 @@ export async function listAdminLeases(
 
   const propertyIds = Array.from(new Set(leaseDocs.map((lease) => asTrimmedString(lease.raw.propertyId)).filter(Boolean)));
   const tenantIds = Array.from(new Set(leaseDocs.flatMap((lease) => tenantIdsFromLease(lease.raw))));
-  const [propertiesById, tenantsById] = await Promise.all([
+  const landlordIds = Array.from(new Set(leaseDocs.map((lease) => asTrimmedString(lease.raw.landlordId)).filter(Boolean)));
+  const [propertiesById, tenantsById, landlordsById] = await Promise.all([
     loadLinkedDocs(firestore, "properties", propertyIds),
     loadLinkedDocs(firestore, "tenants", tenantIds),
+    loadLinkedDocs(firestore, "landlords", landlordIds),
   ]);
 
-  const allViews = leaseDocs.map((lease) => buildView(lease, propertiesById, tenantsById));
+  const allViews = leaseDocs.map((lease) => buildView(lease, propertiesById, tenantsById, landlordsById));
 
   const filtered = allViews.filter((view) => {
     if (!matchesSearch(view, query.q)) return false;

--- a/rentchain-api/src/services/admin/adminLeaseView.ts
+++ b/rentchain-api/src/services/admin/adminLeaseView.ts
@@ -172,6 +172,24 @@ function buildLeaseDisplayLabel(input: {
   return `${property} · ${unit} · ${tenant}`;
 }
 
+function isLikelyRawInternalId(value: string | null, knownId?: string | null): boolean {
+  const normalized = asTrimmedString(value);
+  if (!normalized) return false;
+  if (knownId && normalized === asTrimmedString(knownId)) return true;
+  return /^[A-Za-z0-9_-]{16,}$/.test(normalized) && !/\s/.test(normalized);
+}
+
+function safeUnitDisplayLabel(raw: Record<string, unknown>): string | null {
+  const unitId = asTrimmedString(raw.unitId) || null;
+  const candidates = [raw.unitNumber, raw.unitLabel, raw.unit]
+    .map((value) => asTrimmedString(value))
+    .filter(Boolean);
+  for (const candidate of candidates) {
+    if (!isLikelyRawInternalId(candidate, unitId)) return candidate;
+  }
+  return null;
+}
+
 async function loadLinkedDocs(
   firestore: FirestoreLike,
   collectionName: string,
@@ -212,7 +230,7 @@ function buildView(
     asTrimmedString(property?.name) ||
     asTrimmedString(raw.propertyName || raw.propertyLabel) ||
     null;
-  const unitNumber = asTrimmedString(raw.unitNumber || raw.unitLabel || raw.unit) || null;
+  const unitNumber = safeUnitDisplayLabel(raw);
   const landlordDisplayName = safeLandlordDisplayName(landlord) || "Landlord account";
 
   return {

--- a/rentchain-api/src/services/admin/adminPropertyView.ts
+++ b/rentchain-api/src/services/admin/adminPropertyView.ts
@@ -4,6 +4,7 @@ type FirestoreLike = Pick<FirebaseFirestore.Firestore, "collection">;
 
 export type AdminPropertyView = {
   id: string;
+  displayLabel: string;
   name: string | null;
   address1: string | null;
   city: string | null;
@@ -12,6 +13,8 @@ export type AdminPropertyView = {
   pid: string | null;
   ownerUserId: string | null;
   landlordId: string | null;
+  ownerDisplayName: string | null;
+  ownerStatusLabel: string;
   managerUserIds: string[];
   unitCount: number;
   occupiedUnitCount: number;
@@ -86,7 +89,41 @@ function computeIntegrity(raw: Record<string, unknown>) {
   };
 }
 
-function matchesSearch(raw: Record<string, unknown>, propertyId: string, q: string | null) {
+function safeAccountDisplayName(record: Record<string, unknown> | null | undefined): string | null {
+  return (
+    asTrimmedString(record?.businessName) ||
+    asTrimmedString(record?.companyName) ||
+    asTrimmedString(record?.displayName) ||
+    asTrimmedString(record?.name) ||
+    null
+  );
+}
+
+function ownerStatusLabel(input: { ownerUserId: string | null; landlordId: string | null; managerUserIds: string[] }) {
+  if (input.ownerUserId) return "Owner profile linked";
+  if (input.landlordId) return "Landlord linked / owner profile missing";
+  if (input.managerUserIds.length) return "Manager linked / owner profile missing";
+  return "No owner or landlord link";
+}
+
+async function loadLinkedDocs(
+  firestore: FirestoreLike,
+  collectionName: string,
+  ids: string[]
+): Promise<Map<string, Record<string, unknown>>> {
+  const out = new Map<string, Record<string, unknown>>();
+  await Promise.all(
+    ids.map(async (id) => {
+      const trimmed = asTrimmedString(id);
+      if (!trimmed) return;
+      const snap = await (firestore.collection(collectionName) as any).doc(trimmed).get().catch(() => null);
+      if (snap?.exists) out.set(trimmed, (snap.data() || {}) as Record<string, unknown>);
+    })
+  );
+  return out;
+}
+
+function matchesSearch(raw: Record<string, unknown>, propertyId: string, q: string | null, ownerDisplayName?: string | null) {
   if (!q) return true;
   const haystack = [
     propertyId,
@@ -94,7 +131,7 @@ function matchesSearch(raw: Record<string, unknown>, propertyId: string, q: stri
     raw.addressLine1,
     raw.address1,
     raw.city,
-    raw.landlordId,
+    ownerDisplayName,
     raw.pid,
     raw.propertyPid,
     raw.parcelId,
@@ -159,6 +196,12 @@ export async function listAdminProperties(
 
   const snap = await collectionQuery.get();
   const allDocs = (snap.docs || []).map((doc: any) => ({ id: doc.id, raw: (doc.data() || {}) as Record<string, unknown> }));
+  const landlordIds = Array.from(new Set(allDocs.map(({ raw }) => asTrimmedString(raw.landlordId)).filter(Boolean)));
+  const ownerUserIds = Array.from(new Set(allDocs.map(({ raw }) => asTrimmedString(raw.ownerUserId)).filter(Boolean)));
+  const [landlordsById, usersById] = await Promise.all([
+    loadLinkedDocs(firestore, "landlords", landlordIds),
+    loadLinkedDocs(firestore, "users", ownerUserIds),
+  ]);
 
   const filtered = allDocs.filter(({ id, raw }) => {
     if (query.province && asTrimmedString(raw.province).toUpperCase() !== query.province) return false;
@@ -166,7 +209,12 @@ export async function listAdminProperties(
     if (query.integrity === "issues" && !integrity.hasIssues) return false;
     if (query.integrity === "orphaned" && !integrity.orphaned) return false;
     if (query.integrity === "missingOwner" && !integrity.missingOwner) return false;
-    return matchesSearch(raw, id, query.q);
+    const landlordId = asTrimmedString(raw.landlordId) || null;
+    const ownerUserId = asTrimmedString(raw.ownerUserId) || null;
+    const ownerDisplayName =
+      safeAccountDisplayName(ownerUserId ? usersById.get(ownerUserId) : null) ||
+      safeAccountDisplayName(landlordId ? landlordsById.get(landlordId) : null);
+    return matchesSearch(raw, id, query.q, ownerDisplayName);
   });
 
   filtered.sort((a, b) => {
@@ -193,9 +241,18 @@ export async function listAdminProperties(
     const counts = countsByProperty.get(id);
     const integrity = computeIntegrity(raw);
     const fallbackUnitCount = Number(raw.unitCount || raw.totalUnits || 0) || 0;
+    const ownerUserId = asTrimmedString(raw.ownerUserId) || null;
+    const landlordId = asTrimmedString(raw.landlordId) || null;
+    const managerUserIds = safeArray(raw.managerUserIds);
+    const ownerDisplayName =
+      safeAccountDisplayName(ownerUserId ? usersById.get(ownerUserId) : null) ||
+      safeAccountDisplayName(landlordId ? landlordsById.get(landlordId) : null) ||
+      null;
+    const name = asTrimmedString(raw.name) || null;
     return {
       id,
-      name: asTrimmedString(raw.name) || null,
+      displayLabel: name || "Property not labelled",
+      name,
       address1: asTrimmedString(raw.addressLine1 || raw.address1) || null,
       city: asTrimmedString(raw.city) || null,
       province: asTrimmedString(raw.province) || null,
@@ -210,9 +267,11 @@ export async function listAdminProperties(
         asTrimmedString((raw.metadata as any)?.propertyPid) ||
         asTrimmedString((raw.metadata as any)?.parcelId) ||
         null,
-      ownerUserId: asTrimmedString(raw.ownerUserId) || null,
-      landlordId: asTrimmedString(raw.landlordId) || null,
-      managerUserIds: safeArray(raw.managerUserIds),
+      ownerUserId,
+      landlordId,
+      ownerDisplayName,
+      ownerStatusLabel: ownerStatusLabel({ ownerUserId, landlordId, managerUserIds }),
+      managerUserIds,
       unitCount: counts?.unitCount ?? fallbackUnitCount,
       occupiedUnitCount: counts?.occupiedUnitCount ?? 0,
       vacantUnitCount: counts?.vacantUnitCount ?? 0,

--- a/rentchain-frontend/src/api/adminApi.ts
+++ b/rentchain-frontend/src/api/adminApi.ts
@@ -82,11 +82,13 @@ export type FetchAdminTenantsParams = {
 
 export type AdminLeaseView = {
   id: string;
+  leaseDisplayLabel: string;
   propertyId: string | null;
   propertyName: string | null;
   unitId: string | null;
   unitNumber: string | null;
   landlordId: string | null;
+  landlordDisplayName: string | null;
   tenantIds: string[];
   tenantNames: string[];
   status: string | null;

--- a/rentchain-frontend/src/api/adminApi.ts
+++ b/rentchain-frontend/src/api/adminApi.ts
@@ -7,6 +7,7 @@ import type { TenantLifecycle } from "./tenantsApi";
 
 export type AdminPropertyView = {
   id: string;
+  displayLabel: string;
   name: string | null;
   address1: string | null;
   city: string | null;
@@ -14,6 +15,8 @@ export type AdminPropertyView = {
   postalCode: string | null;
   ownerUserId: string | null;
   landlordId: string | null;
+  ownerDisplayName: string | null;
+  ownerStatusLabel: string;
   managerUserIds: string[];
   unitCount: number;
   occupiedUnitCount: number;

--- a/rentchain-frontend/src/api/tenantTrustExports.test.ts
+++ b/rentchain-frontend/src/api/tenantTrustExports.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { prepareTenantTrustExport, previewTenantTrustExport } from "./tenantTrustExports";
+
+const tenantApiFetchMock = vi.hoisted(() => ({
+  tenantApiFetch: vi.fn(),
+}));
+
+vi.mock("./tenantApiFetch", () => tenantApiFetchMock);
+
+describe("tenantTrustExports API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantApiFetchMock.tenantApiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        exportId: "export-1",
+        lifecycle: "prepared",
+      },
+    });
+  });
+
+  it("sends preview consent as a JSON object so the tenant API wrapper adds Content-Type", async () => {
+    await previewTenantTrustExport({
+      audience: "tenant_portability",
+      purpose: "tenant_controlled_portability",
+      expiresInDays: 14,
+      consentAccepted: true,
+    });
+
+    expect(tenantApiFetchMock.tenantApiFetch).toHaveBeenCalledWith(
+      "/tenant/trust-exports/preview",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.objectContaining({
+          consentAccepted: true,
+        }),
+      })
+    );
+    expect(typeof tenantApiFetchMock.tenantApiFetch.mock.calls[0][1].body).toBe("object");
+  });
+
+  it("sends prepare consent as a JSON object so checked consent reaches the backend", async () => {
+    await prepareTenantTrustExport({
+      audience: "tenant_portability",
+      purpose: "tenant_controlled_portability",
+      expiresInDays: 14,
+      consentAccepted: true,
+    });
+
+    expect(tenantApiFetchMock.tenantApiFetch).toHaveBeenCalledWith(
+      "/tenant/trust-exports",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.objectContaining({
+          consentAccepted: true,
+        }),
+      })
+    );
+    expect(JSON.stringify(tenantApiFetchMock.tenantApiFetch.mock.calls[0][1].body)).not.toContain("realActorId");
+  });
+});

--- a/rentchain-frontend/src/api/tenantTrustExports.ts
+++ b/rentchain-frontend/src/api/tenantTrustExports.ts
@@ -168,7 +168,7 @@ export async function previewTenantTrustExport(
 ): Promise<TenantTrustExportPreview> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantTrustExportPreview }>("/tenant/trust-exports/preview", {
     method: "POST",
-    body: JSON.stringify(request),
+    body: request,
   });
   return res.data;
 }
@@ -178,7 +178,7 @@ export async function prepareTenantTrustExport(
 ): Promise<TenantTrustExportRecord> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantTrustExportRecord }>("/tenant/trust-exports", {
     method: "POST",
-    body: JSON.stringify(request),
+    body: request,
   });
   return res.data;
 }

--- a/rentchain-frontend/src/components/admin/AdminDataTable.tsx
+++ b/rentchain-frontend/src/components/admin/AdminDataTable.tsx
@@ -8,6 +8,14 @@ function formatDate(value: string | number | null) {
   return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleDateString();
 }
 
+function propertyDisplayName(item: AdminPropertyView) {
+  return item.displayLabel || item.name || "Property not labelled";
+}
+
+function ownerDisplayName(item: AdminPropertyView) {
+  return item.ownerDisplayName || item.ownerStatusLabel || "Owner profile unavailable";
+}
+
 type Props = {
   items: AdminPropertyView[];
   sortBy: "createdAt" | "updatedAt" | "name";
@@ -52,14 +60,14 @@ export const AdminDataTable: React.FC<Props> = ({ items, sortBy, sortDir, onSort
               style={{ borderBottom: "1px solid rgba(148,163,184,0.14)", cursor: "pointer" }}
             >
               <td style={{ padding: "12px" }}>
-                <div style={{ fontWeight: 700 }}>{item.name || item.id}</div>
-                <div style={{ fontSize: 12, color: "#64748b" }}>{item.id}</div>
+                <div style={{ fontWeight: 700 }}>{propertyDisplayName(item)}</div>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Admin property record</div>
               </td>
               <td style={{ padding: "12px" }}>{[item.address1, item.city].filter(Boolean).join(", ") || "--"}</td>
               <td style={{ padding: "12px" }}>{item.province || "--"}</td>
               <td style={{ padding: "12px" }}>
-                <div>{item.ownerUserId || "--"}</div>
-                <div style={{ fontSize: 12, color: "#64748b" }}>{item.landlordId || "--"}</div>
+                <div>{ownerDisplayName(item)}</div>
+                <div style={{ fontSize: 12, color: "#64748b" }}>{item.ownerStatusLabel || "Ownership status unavailable"}</div>
               </td>
               <td style={{ padding: "12px" }}>{item.unitCount}</td>
               <td style={{ padding: "12px" }}>{item.occupiedUnitCount}</td>

--- a/rentchain-frontend/src/components/admin/AdminDetailDrawer.tsx
+++ b/rentchain-frontend/src/components/admin/AdminDetailDrawer.tsx
@@ -12,6 +12,14 @@ function metadataRow(label: string, value: React.ReactNode) {
   );
 }
 
+function propertyDisplayName(property: AdminPropertyView) {
+  return property.displayLabel || property.name || "Property not labelled";
+}
+
+function ownerDisplayName(property: AdminPropertyView) {
+  return property.ownerDisplayName || property.ownerStatusLabel || "Owner profile unavailable";
+}
+
 export const AdminDetailDrawer: React.FC<{
   property: AdminPropertyView | null;
   onClose: () => void;
@@ -47,8 +55,8 @@ export const AdminDetailDrawer: React.FC<{
       >
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
           <div style={{ display: "grid", gap: 6 }}>
-            <div style={{ fontSize: "1.2rem", fontWeight: 800 }}>{property.name || property.id}</div>
-            <div style={{ color: "#475569" }}>{[property.address1, property.city, property.province].filter(Boolean).join(", ") || property.id}</div>
+            <div style={{ fontSize: "1.2rem", fontWeight: 800 }}>{propertyDisplayName(property)}</div>
+            <div style={{ color: "#475569" }}>{[property.address1, property.city, property.province].filter(Boolean).join(", ") || "Address not available"}</div>
           </div>
           <Button variant="ghost" onClick={onClose}>Close</Button>
         </div>
@@ -58,9 +66,9 @@ export const AdminDetailDrawer: React.FC<{
             <IntegrityBadge integrity={property.integrity} />
             {property.managerUserIds.length ? <Pill>{property.managerUserIds.length} managers</Pill> : null}
           </div>
-          {metadataRow("Owner user", property.ownerUserId || "--")}
-          {metadataRow("Landlord id", property.landlordId || "--")}
-          {metadataRow("Managers", property.managerUserIds.length ? property.managerUserIds.join(", ") : "--")}
+          {metadataRow("Owner / landlord", ownerDisplayName(property))}
+          {metadataRow("Ownership status", property.ownerStatusLabel || "Ownership status unavailable")}
+          {metadataRow("Managers", property.managerUserIds.length ? `${property.managerUserIds.length} linked manager${property.managerUserIds.length === 1 ? "" : "s"}` : "--")}
         </Card>
 
         <Card style={{ display: "grid", gap: 12 }}>

--- a/rentchain-frontend/src/pages/admin/AdminLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeasesPage.test.tsx
@@ -37,11 +37,13 @@ describe("AdminLeasesPage", () => {
       items: [
         {
           id: "lease-1",
+          leaseDisplayLabel: "Coburg Rd · Unit 101 · Jane Tenant",
           propertyId: "prop-1",
           propertyName: "Coburg Rd",
           unitId: "unit-1",
           unitNumber: "101",
           landlordId: "landlord-1",
+          landlordDisplayName: "Harbour Homes",
           tenantIds: ["tenant-1"],
           tenantNames: ["Jane Tenant"],
           status: "active",
@@ -87,7 +89,9 @@ describe("AdminLeasesPage", () => {
       });
     });
 
-    expect(screen.getByText("lease-1")).toBeInTheDocument();
+    expect(screen.getByText("Coburg Rd · Unit 101 · Jane Tenant")).toBeInTheDocument();
+    expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("landlord-1")).not.toBeInTheDocument();
   });
 
   it("opens the lease detail drawer when a row is selected", async () => {
@@ -99,14 +103,19 @@ describe("AdminLeasesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("lease-1")).toBeInTheDocument();
-    fireEvent.click(screen.getAllByText("lease-1")[0]);
+    expect(await screen.findByText("Coburg Rd · Unit 101 · Jane Tenant")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByText("Coburg Rd · Unit 101 · Jane Tenant")[0]);
 
     const drawer = screen.getByRole("dialog", { name: "Lease detail drawer" });
     expect(drawer).toBeInTheDocument();
-    expect(within(drawer).getByText("prop-1")).toBeInTheDocument();
+    expect(within(drawer).getByText("Coburg Rd · Unit 101 · Jane Tenant")).toBeInTheDocument();
+    expect(within(drawer).queryByText("prop-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("unit-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("tenant-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("lease-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("landlord-1")).not.toBeInTheDocument();
     expect(within(drawer).getByText("Unit 101")).toBeInTheDocument();
     expect(within(drawer).getByText("Jane Tenant")).toBeInTheDocument();
-    expect(within(drawer).getByText("landlord-1")).toBeInTheDocument();
+    expect(within(drawer).getAllByText("Harbour Homes").length).toBeGreaterThan(0);
   });
 });

--- a/rentchain-frontend/src/pages/admin/AdminLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeasesPage.tsx
@@ -34,6 +34,14 @@ function IntegrityPill({ lease }: { lease: AdminLeaseView }) {
   return <Pill tone="default">Healthy</Pill>;
 }
 
+function leaseLabel(lease: AdminLeaseView) {
+  return lease.leaseDisplayLabel || `${lease.propertyName || "Property not linked"} · ${lease.unitNumber ? `Unit ${lease.unitNumber}` : "Unit not assigned"}`;
+}
+
+function landlordLabel(lease: AdminLeaseView) {
+  return lease.landlordDisplayName || "Landlord account";
+}
+
 export const AdminLeasesPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -303,14 +311,15 @@ export const AdminLeasesPage: React.FC = () => {
                         style={{ cursor: "pointer", borderBottom: "1px solid rgba(15, 23, 42, 0.06)" }}
                       >
                         <td style={{ padding: "12px" }}>
-                          <div style={{ fontWeight: 600 }}>{item.id}</div>
+                          <div style={{ fontWeight: 600 }}>{leaseLabel(item)}</div>
+                          <div style={{ color: "#64748b", fontSize: 13 }}>Admin lease record</div>
                         </td>
                         <td style={{ padding: "12px" }}>
-                          <div>{item.propertyName || "Unknown property"}</div>
-                          <div style={{ color: "#64748b", fontSize: 13 }}>{item.unitNumber ? `Unit ${item.unitNumber}` : "No unit"}</div>
+                          <div>{item.propertyName || "Property not linked"}</div>
+                          <div style={{ color: "#64748b", fontSize: 13 }}>{item.unitNumber ? `Unit ${item.unitNumber}` : "Unit not assigned"}</div>
                         </td>
                         <td style={{ padding: "12px" }}>{item.tenantNames.length ? item.tenantNames.join(", ") : "—"}</td>
-                        <td style={{ padding: "12px" }}>{item.landlordId || "—"}</td>
+                        <td style={{ padding: "12px" }}>{landlordLabel(item)}</td>
                         <td style={{ padding: "12px" }}>
                           <Pill tone="default">{formatValue(item.status)}</Pill>
                         </td>
@@ -377,8 +386,8 @@ export const AdminLeasesPage: React.FC = () => {
         >
           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
             <div>
-              <div style={{ fontWeight: 700, fontSize: 18 }}>{selectedLease.id}</div>
-              <div style={{ color: "#64748b", fontSize: 14 }}>{selectedLease.propertyName || "Unknown property"}</div>
+              <div style={{ fontWeight: 700, fontSize: 18 }}>{leaseLabel(selectedLease)}</div>
+              <div style={{ color: "#64748b", fontSize: 14 }}>{landlordLabel(selectedLease)}</div>
             </div>
             <Button variant="secondary" onClick={() => setSelectedLease(null)}>
               Close
@@ -394,17 +403,14 @@ export const AdminLeasesPage: React.FC = () => {
 
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 600 }}>Property / Unit</div>
-            <div>{selectedLease.propertyName || "Unknown property"}</div>
-            <div>{selectedLease.propertyId || "No property id"}</div>
-            <div>{selectedLease.unitNumber ? `Unit ${selectedLease.unitNumber}` : "No unit number"}</div>
-            <div>{selectedLease.unitId || "No unit id"}</div>
-            <div>{selectedLease.landlordId || "No landlord id"}</div>
+            <div>{selectedLease.propertyName || "Property not linked"}</div>
+            <div>{selectedLease.unitNumber ? `Unit ${selectedLease.unitNumber}` : "Unit not assigned"}</div>
+            <div>{landlordLabel(selectedLease)}</div>
           </Card>
 
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 600 }}>Tenant(s)</div>
             <div>{selectedLease.tenantNames.length ? selectedLease.tenantNames.join(", ") : "No linked tenants"}</div>
-            <div>{selectedLease.tenantIds.length ? selectedLease.tenantIds.join(", ") : "No tenant ids"}</div>
           </Card>
 
           <Card style={{ display: "grid", gap: 8 }}>

--- a/rentchain-frontend/src/pages/admin/AdminPropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminPropertiesPage.test.tsx
@@ -37,6 +37,7 @@ describe("AdminPropertiesPage", () => {
       items: [
         {
           id: "prop-1",
+          displayLabel: "Coburg Rd",
           name: "Coburg Rd",
           address1: "123 Coburg Rd",
           city: "Halifax",
@@ -44,6 +45,8 @@ describe("AdminPropertiesPage", () => {
           postalCode: "B3H 1Y5",
           ownerUserId: "owner-1",
           landlordId: "landlord-1",
+          ownerDisplayName: "Harbour Homes",
+          ownerStatusLabel: "Owner profile linked",
           managerUserIds: ["manager-1"],
           unitCount: 2,
           occupiedUnitCount: 1,
@@ -82,6 +85,8 @@ describe("AdminPropertiesPage", () => {
     });
 
     expect(screen.getByText("Coburg Rd")).toBeInTheDocument();
+    expect(screen.queryByText("prop-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("landlord-1")).not.toBeInTheDocument();
   });
 
   it("opens the property detail drawer when a row is selected", async () => {
@@ -99,7 +104,10 @@ describe("AdminPropertiesPage", () => {
 
     const drawer = screen.getByRole("dialog", { name: "Property detail drawer" });
     expect(drawer).toBeInTheDocument();
-    expect(within(drawer).getByText("owner-1")).toBeInTheDocument();
-    expect(within(drawer).getByText("landlord-1")).toBeInTheDocument();
+    expect(within(drawer).getByText("Harbour Homes")).toBeInTheDocument();
+    expect(within(drawer).getByText("Owner profile linked")).toBeInTheDocument();
+    expect(within(drawer).queryByText("owner-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("landlord-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("prop-1")).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
@@ -148,6 +148,59 @@ describe("tenant attachments page", () => {
     expect(screen.getByText(/Direct upload is not available from this page yet/i)).toBeInTheDocument();
   });
 
+  it("does not render a zero-document vault when tenant-safe lease attachments are available", async () => {
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: "schedule-a-context-lease-1",
+          label: "SCHEDULE_A — Schedule A",
+          category: "Attachments",
+          status: "uploaded",
+          title: "Schedule A",
+          fileName: "schedule-a.pdf",
+          url: "https://signed.example/schedule-a.pdf",
+          uploadedAt: 1710002000000,
+          nextAction: "This file has been added to your record.",
+          purpose: "SCHEDULE_A",
+          purposeLabel: "Schedule A",
+        },
+      ],
+      summary: {
+        total: 1,
+        missing: 0,
+        uploaded: 1,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "Your current tenant-safe document record is up to date.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: 1710002000000,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantAttachmentsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Document Vault Summary/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No documents in your vault yet/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Schedule A/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/schedule-a\.pdf/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Open file/i })).toHaveAttribute("href", "https://signed.example/schedule-a.pdf");
+    expect(screen.queryByText(/support-operator/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/realActorId/i)).not.toBeInTheDocument();
+  });
+
   it("renders unauthorized state safely", async () => {
     tenantAttachmentsApi.getTenantAttachments.mockRejectedValue({ message: "FORBIDDEN" });
 

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
@@ -12,8 +12,13 @@ const tenantAccessApi = vi.hoisted(() => ({
   getTenantAccess: vi.fn(),
 }));
 
+const tenantPortalApi = vi.hoisted(() => ({
+  getTenantLeaseWorkspace: vi.fn(),
+}));
+
 vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
+vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 
 describe("tenant attachments page", () => {
   beforeEach(() => {
@@ -45,6 +50,7 @@ describe("tenant attachments page", () => {
         body: "This view shows tenant-safe sharing records only.",
       },
     });
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue(null);
   });
 
   it("renders empty state correctly", async () => {
@@ -199,6 +205,69 @@ describe("tenant attachments page", () => {
     expect(screen.getByRole("link", { name: /Open file/i })).toHaveAttribute("href", "https://signed.example/schedule-a.pdf");
     expect(screen.queryByText(/support-operator/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/realActorId/i)).not.toBeInTheDocument();
+  });
+
+  it("uses tenant-safe lease workspace context when the attachments projection omits lease documents", async () => {
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [],
+      summary: {
+        total: 0,
+        missing: 0,
+        uploaded: 0,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "You have not added any tenant-visible documents yet.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: null,
+    });
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-1",
+      startDate: null,
+      endDate: null,
+      monthlyRent: null,
+      status: "active",
+      documentUrl: null,
+      leaseDocumentContext: null,
+      scheduleADocumentContext: {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        leaseStatus: "active",
+        signingStatus: null,
+        documentStatus: "generated",
+        documentId: "schedule-a-doc",
+        documentUrl: "https://signed.example/schedule-a.pdf",
+        displayLabel: "Schedule A",
+        source: "tenant-safe-lease-workspace",
+        confidence: "high",
+        warnings: [],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantAttachmentsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Document Vault Summary/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No documents in your vault yet/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Schedule A/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/schedule-a\.pdf/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Open file/i })).toHaveAttribute("href", "https://signed.example/schedule-a.pdf");
+    expect(screen.queryByText(/tenant-1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/schedule-a-doc/i)).not.toBeInTheDocument();
   });
 
   it("renders unauthorized state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
@@ -5,11 +5,7 @@ import {
   type TenantAttachment,
 } from "../../api/tenantAttachmentsApi";
 import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
-import {
-  getTenantLeaseWorkspace,
-  type TenantLeaseDocumentContext,
-  type TenantWorkspaceLease,
-} from "../../api/tenantPortal";
+import { getTenantLeaseWorkspace } from "../../api/tenantPortal";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -21,6 +17,7 @@ import {
 } from "./TenantWorkspaceShared";
 import { spacing, text as textTokens } from "../../styles/tokens";
 import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
+import { mergeTenantAttachments, tenantLeaseWorkspaceAttachments } from "./tenantLeaseDocumentAttachments";
 
 function statusTone(status?: TenantAttachment["status"]) {
   switch (status) {
@@ -54,75 +51,6 @@ function sortUrgent(items: TenantAttachment[]) {
     if (left !== right) return left - right;
     return Number(b.uploadedAt || b.createdAt || 0) - Number(a.uploadedAt || a.createdAt || 0);
   });
-}
-
-function documentContextToAttachment(
-  context: TenantLeaseDocumentContext | null | undefined,
-  kind: "lease" | "schedule-a"
-): TenantAttachment | null {
-  if (!context || !context.documentUrl || context.documentStatus === "missing") return null;
-  const leaseId = String(context.leaseId || "current").trim() || "current";
-  if (kind === "lease") {
-    return {
-      id: `lease-document-context-${leaseId}`,
-      tenantId: context.tenantId || null,
-      leaseId: context.leaseId || null,
-      title: "Lease document",
-      label: "Lease document",
-      category: "Lease documents",
-      status: context.documentStatus === "pending" ? "pending_review" : "uploaded",
-      purpose: "LEASE",
-      purposeLabel: "Lease",
-      fileName: "lease-document.pdf",
-      url: context.documentUrl,
-      uploadedAt: null,
-      createdAt: null,
-      nextAction: "This tenant-safe lease document is linked to your lease workspace.",
-    };
-  }
-  return {
-    id: `schedule-a-context-${leaseId}`,
-    tenantId: context.tenantId || null,
-    leaseId: context.leaseId || null,
-    title: "Schedule A",
-    label: "Schedule A",
-    category: "Lease documents / attachments",
-    status: context.documentStatus === "pending" ? "pending_review" : "uploaded",
-    purpose: "SCHEDULE_A",
-    purposeLabel: "Schedule A",
-    fileName: "schedule-a.pdf",
-    url: context.documentUrl,
-    uploadedAt: null,
-    createdAt: null,
-    nextAction: "This tenant-safe lease attachment is linked to your lease workspace.",
-  };
-}
-
-function tenantLeaseWorkspaceAttachments(lease: TenantWorkspaceLease | null | undefined): TenantAttachment[] {
-  if (!lease) return [];
-  return [
-    documentContextToAttachment(lease.leaseDocumentContext, "lease"),
-    documentContextToAttachment(lease.scheduleADocumentContext, "schedule-a"),
-  ].filter(Boolean) as TenantAttachment[];
-}
-
-function mergeTenantAttachments(items: TenantAttachment[], leaseWorkspaceItems: TenantAttachment[]): TenantAttachment[] {
-  const merged: TenantAttachment[] = [];
-  const seen = new Set<string>();
-  for (const item of [...leaseWorkspaceItems, ...items]) {
-    const key = [
-      String(item.purpose || "").trim().toUpperCase(),
-      String(item.leaseId || "").trim(),
-      String(item.fileName || item.title || item.label || "").trim().toLowerCase(),
-      String(item.url || "").trim(),
-    ].join("|");
-    const fallbackKey = String(item.id || key).trim();
-    const finalKey = key.replace(/\|/g, "") ? key : fallbackKey;
-    if (seen.has(finalKey)) continue;
-    seen.add(finalKey);
-    merged.push(item);
-  }
-  return merged;
 }
 
 export default function TenantAttachmentsPage() {

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
@@ -6,6 +6,11 @@ import {
 } from "../../api/tenantAttachmentsApi";
 import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
 import {
+  getTenantLeaseWorkspace,
+  type TenantLeaseDocumentContext,
+  type TenantWorkspaceLease,
+} from "../../api/tenantPortal";
+import {
   TenantEmptyState,
   TenantErrorState,
   TenantInfoCard,
@@ -51,6 +56,75 @@ function sortUrgent(items: TenantAttachment[]) {
   });
 }
 
+function documentContextToAttachment(
+  context: TenantLeaseDocumentContext | null | undefined,
+  kind: "lease" | "schedule-a"
+): TenantAttachment | null {
+  if (!context || !context.documentUrl || context.documentStatus === "missing") return null;
+  const leaseId = String(context.leaseId || "current").trim() || "current";
+  if (kind === "lease") {
+    return {
+      id: `lease-document-context-${leaseId}`,
+      tenantId: context.tenantId || null,
+      leaseId: context.leaseId || null,
+      title: "Lease document",
+      label: "Lease document",
+      category: "Lease documents",
+      status: context.documentStatus === "pending" ? "pending_review" : "uploaded",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      fileName: "lease-document.pdf",
+      url: context.documentUrl,
+      uploadedAt: null,
+      createdAt: null,
+      nextAction: "This tenant-safe lease document is linked to your lease workspace.",
+    };
+  }
+  return {
+    id: `schedule-a-context-${leaseId}`,
+    tenantId: context.tenantId || null,
+    leaseId: context.leaseId || null,
+    title: "Schedule A",
+    label: "Schedule A",
+    category: "Lease documents / attachments",
+    status: context.documentStatus === "pending" ? "pending_review" : "uploaded",
+    purpose: "SCHEDULE_A",
+    purposeLabel: "Schedule A",
+    fileName: "schedule-a.pdf",
+    url: context.documentUrl,
+    uploadedAt: null,
+    createdAt: null,
+    nextAction: "This tenant-safe lease attachment is linked to your lease workspace.",
+  };
+}
+
+function tenantLeaseWorkspaceAttachments(lease: TenantWorkspaceLease | null | undefined): TenantAttachment[] {
+  if (!lease) return [];
+  return [
+    documentContextToAttachment(lease.leaseDocumentContext, "lease"),
+    documentContextToAttachment(lease.scheduleADocumentContext, "schedule-a"),
+  ].filter(Boolean) as TenantAttachment[];
+}
+
+function mergeTenantAttachments(items: TenantAttachment[], leaseWorkspaceItems: TenantAttachment[]): TenantAttachment[] {
+  const merged: TenantAttachment[] = [];
+  const seen = new Set<string>();
+  for (const item of [...leaseWorkspaceItems, ...items]) {
+    const key = [
+      String(item.purpose || "").trim().toUpperCase(),
+      String(item.leaseId || "").trim(),
+      String(item.fileName || item.title || item.label || "").trim().toLowerCase(),
+      String(item.url || "").trim(),
+    ].join("|");
+    const fallbackKey = String(item.id || key).trim();
+    const finalKey = key.replace(/\|/g, "") ? key : fallbackKey;
+    if (seen.has(finalKey)) continue;
+    seen.add(finalKey);
+    merged.push(item);
+  }
+  return merged;
+}
+
 export default function TenantAttachmentsPage() {
   const [items, setItems] = useState<TenantAttachment[]>([]);
   const [summary, setSummary] = useState<Awaited<ReturnType<typeof getTenantAttachments>>["summary"]>(undefined);
@@ -66,16 +140,19 @@ export default function TenantAttachmentsPage() {
       setLoading(true);
       setError(null);
       try {
-        const [attachmentsResult, accessResult] = await Promise.allSettled([
+        const [attachmentsResult, accessResult, leaseWorkspaceResult] = await Promise.allSettled([
           getTenantAttachments(),
           getTenantAccess(),
+          getTenantLeaseWorkspace(),
         ]);
         if (attachmentsResult.status !== "fulfilled") {
           throw attachmentsResult.reason;
         }
         const res = attachmentsResult.value;
         if (!cancelled) {
-          setItems(Array.isArray(res?.data) ? sortUrgent(res.data) : []);
+          const leaseWorkspaceItems =
+            leaseWorkspaceResult.status === "fulfilled" ? tenantLeaseWorkspaceAttachments(leaseWorkspaceResult.value) : [];
+          setItems(sortUrgent(mergeTenantAttachments(Array.isArray(res?.data) ? res.data : [], leaseWorkspaceItems)));
           setSummary(res?.summary);
           setGuidance(res?.guidance);
           setUpdatedAt(typeof res?.updatedAt === "number" ? res.updatedAt : null);

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -404,19 +404,33 @@ export default function TenantLeasePage() {
             ) : null}
             {leaseDocumentUrl ? (
               <button type="button" onClick={() => void handleOpenLeaseDocument()} disabled={openingDocument}>
-                {openingDocument ? "Opening..." : "Open lease document"}
+                {openingDocument ? "Opening..." : "View lease"}
               </button>
             ) : (
               <div style={{ color: "var(--text-muted, #64748b)" }}>
                 No approved lease document link is available in this workspace yet.
               </div>
             )}
-            {scheduleAUrl ? (
+          </TenantInfoCard>
+
+          {scheduleAUrl ? (
+            <TenantInfoCard heading="Schedule A / attachment" accent="#0891b2">
+              <div style={{ display: "grid", gap: 6 }}>
+                <div style={{ fontWeight: 800 }}>Schedule A</div>
+                <div style={{ color: "var(--text-muted, #64748b)" }}>
+                  This supplemental form is separate from the primary lease document.
+                </div>
+                {scheduleADocumentContext?.documentStatus ? (
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>
+                    Document status: {prettyStatus(scheduleADocumentContext.documentStatus)}
+                  </div>
+                ) : null}
+              </div>
               <button type="button" onClick={() => void handleOpenLeaseDocument("schedule-a")} disabled={openingDocument}>
                 {openingDocument ? "Opening..." : "Open Schedule A"}
               </button>
-            ) : null}
-          </TenantInfoCard>
+            </TenantInfoCard>
+          ) : null}
 
           <TenantInfoCard heading="Lease Signing" accent="#7c3aed">
             <div style={{ display: "grid", gap: 12 }}>

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -1305,6 +1305,70 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
   });
 
+  it("includes tenant-safe lease attachment context in dashboard document summary", async () => {
+    const workspace = await tenantPortalApi.getTenantWorkspace();
+    tenantPortalApi.getTenantWorkspace.mockResolvedValue({
+      ...workspace,
+      lease: {
+        leaseId: "lease-1",
+        startDate: null,
+        endDate: null,
+        monthlyRent: null,
+        status: "active",
+        documentUrl: null,
+        leaseDocumentContext: null,
+        scheduleADocumentContext: {
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          leaseStatus: "active",
+          signingStatus: null,
+          documentStatus: "generated",
+          documentId: "schedule-a-doc",
+          documentUrl: "https://signed.example/schedule-a.pdf",
+          displayLabel: "Schedule A",
+          source: "tenant-safe-lease-workspace",
+          confidence: "high",
+          warnings: [],
+        },
+      },
+    });
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [],
+      summary: {
+        total: 0,
+        missing: 0,
+        uploaded: 0,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "You have not added any tenant-visible documents yet.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/^Tenant Dashboard$/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 document in your vault, 1 ready to share, and 0 still needing attention/i)).toBeInTheDocument();
+    expect(screen.queryByText(/schedule-a-doc/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tenant-1/i)).not.toBeInTheDocument();
+  });
+
   it("starts tenant checkout from the workspace when rent collection is enabled", async () => {
     tenantPortalApi.getTenantWorkspace.mockResolvedValue({
       context: {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2272,7 +2272,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByRole("button", { name: /Pay rent/i })).toBeInTheDocument();
     expect(screen.getByText(/^Drawn signature$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Taylor Tenant$/i)).toBeInTheDocument();
-    const openLeaseButton = screen.getByRole("button", { name: /Open lease document/i });
+    const openLeaseButton = screen.getByRole("button", { name: /View lease/i });
     expect(openLeaseButton).toBeInTheDocument();
     fireEvent.click(openLeaseButton);
     await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalled());
@@ -2342,6 +2342,7 @@ describe("tenant workspace frontend shell", () => {
 
     vi.mocked(window.open).mockClear();
     expect(screen.queryByRole("button", { name: /Open lease document/i })).not.toBeInTheDocument();
+    expect(await screen.findByText(/Schedule A \/ attachment/i)).toBeInTheDocument();
     fireEvent.click(await screen.findByRole("button", { name: /Open Schedule A/i }));
     await waitFor(() =>
       expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith({ document: "schedule-a" })
@@ -2404,7 +2405,7 @@ describe("tenant workspace frontend shell", () => {
     );
 
     vi.mocked(window.open).mockClear();
-    fireEvent.click(await screen.findByRole("button", { name: /Open lease document/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /View lease/i }));
     await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith());
     expect(window.open).not.toHaveBeenCalled();
   });

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -68,6 +68,7 @@ import {
 import TenantProfileCompletionCard from "./TenantProfileCompletionCard";
 import { buildTenantProfileCompletion } from "./tenantProfileCompletion";
 import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
+import { mergeTenantAttachments, tenantLeaseWorkspaceAttachments } from "./tenantLeaseDocumentAttachments";
 import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
 import { buildTenantWorkspaceModeView } from "./tenantWorkspaceMode";
 import { buildActiveTenancyWorkspaceState } from "./activeTenancyWorkspaceState";
@@ -925,7 +926,7 @@ export default function TenantWorkspacePage() {
   const nextActions = data?.application?.nextActions || [];
   const profileCompletion = profileData ? buildTenantProfileCompletion(profileData) : null;
   const documentVault = buildTenantDocumentVaultView({
-    items: attachments?.data || [],
+    items: mergeTenantAttachments(attachments?.data || [], tenantLeaseWorkspaceAttachments(data?.lease || null)),
     summary: attachments?.summary,
     guidance: attachments?.guidance,
     updatedAt: attachments?.updatedAt,

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -2437,7 +2437,9 @@ export default function TenantWorkspacePage() {
                 : "Open your document vault to review readiness and sharing visibility."}
             </div>
             <div style={{ color: textTokens.muted }}>
-              {attachments?.guidance?.headline || "Keep your profile organized by keeping documents ready in one place."}
+              {(documentVault.metrics[0]?.value || 0) > 0
+                ? "Your tenant-visible documents are available in the document vault."
+                : attachments?.guidance?.headline || "Keep your profile organized by keeping documents ready in one place."}
             </div>
             <Link to="/tenant/attachments">Open document vault</Link>
           </div>

--- a/rentchain-frontend/src/pages/tenant/tenantLeaseDocumentAttachments.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantLeaseDocumentAttachments.ts
@@ -1,0 +1,71 @@
+import type { TenantAttachment } from "../../api/tenantAttachmentsApi";
+import type { TenantLeaseDocumentContext, TenantWorkspaceLease } from "../../api/tenantPortal";
+
+function documentContextToAttachment(
+  context: TenantLeaseDocumentContext | null | undefined,
+  kind: "lease" | "schedule-a"
+): TenantAttachment | null {
+  if (!context || !context.documentUrl || context.documentStatus === "missing") return null;
+  const leaseId = String(context.leaseId || "current").trim() || "current";
+  if (kind === "lease") {
+    return {
+      id: `lease-document-context-${leaseId}`,
+      tenantId: context.tenantId || null,
+      leaseId: context.leaseId || null,
+      title: "Lease document",
+      label: "Lease document",
+      category: "Lease documents",
+      status: context.documentStatus === "pending" ? "pending_review" : "uploaded",
+      purpose: "LEASE",
+      purposeLabel: "Lease",
+      fileName: "lease-document.pdf",
+      url: context.documentUrl,
+      uploadedAt: null,
+      createdAt: null,
+      nextAction: "This tenant-safe lease document is linked to your lease workspace.",
+    };
+  }
+  return {
+    id: `schedule-a-context-${leaseId}`,
+    tenantId: context.tenantId || null,
+    leaseId: context.leaseId || null,
+    title: "Schedule A",
+    label: "Schedule A",
+    category: "Lease documents / attachments",
+    status: context.documentStatus === "pending" ? "pending_review" : "uploaded",
+    purpose: "SCHEDULE_A",
+    purposeLabel: "Schedule A",
+    fileName: "schedule-a.pdf",
+    url: context.documentUrl,
+    uploadedAt: null,
+    createdAt: null,
+    nextAction: "This tenant-safe lease attachment is linked to your lease workspace.",
+  };
+}
+
+export function tenantLeaseWorkspaceAttachments(lease: TenantWorkspaceLease | null | undefined): TenantAttachment[] {
+  if (!lease) return [];
+  return [
+    documentContextToAttachment(lease.leaseDocumentContext, "lease"),
+    documentContextToAttachment(lease.scheduleADocumentContext, "schedule-a"),
+  ].filter(Boolean) as TenantAttachment[];
+}
+
+export function mergeTenantAttachments(items: TenantAttachment[], leaseWorkspaceItems: TenantAttachment[]): TenantAttachment[] {
+  const merged: TenantAttachment[] = [];
+  const seen = new Set<string>();
+  for (const item of [...leaseWorkspaceItems, ...items]) {
+    const key = [
+      String(item.purpose || "").trim().toUpperCase(),
+      String(item.leaseId || "").trim(),
+      String(item.fileName || item.title || item.label || "").trim().toLowerCase(),
+      String(item.url || "").trim(),
+    ].join("|");
+    const fallbackKey = String(item.id || key).trim();
+    const finalKey = key.replace(/\|/g, "") ? key : fallbackKey;
+    if (seen.has(finalKey)) continue;
+    seen.add(finalKey);
+    merged.push(item);
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary
- Adds an audience-aware admin/support projection safety helper that strips impersonation and support internals from tenant, landlord, public export, user-safe export, and unknown audiences.
- Provides metadata-only admin/support summaries for impersonation-like payloads without raw actor-chain IDs.
- Adds regression coverage for institution export previews and timeline item conversion so impersonation/support internals are not projected into user-safe surfaces.
- Documents audited projection surfaces, known limitations, and follow-up guidance.

## Projection Surfaces Audited
- Impersonation governance/session fields from PR #982.
- Admin/support governance helpers and support console diagnostics.
- Canonical event timeline adapter and timeline routes.
- Institution export previews and trust export packages.
- Tenant-safe projection contracts and tenant portal projection services.
- Frontend support console, tenant workspace, operations, dashboard, and review projection consumers.

## Safety Model
- Unknown audiences fail safe as user-safe export.
- Landlord/tenant/user-safe export audiences strip actor-chain, impersonation session, internal visibility, policy decision, debug, route-source, token, secret, raw/provider payload, and stack fields.
- Admin/support receives only a safe summary: lifecycle, reason, timestamps, actor roles without raw IDs, target type/scope, policy outcome summary, and metadata-only flags.

## Validation
- rentchain-api: npm run test:single -- src/lib/adminSupportProjectionSafety/__tests__/adminSupportProjectionSafety.test.ts src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts src/lib/timeline/timelineAdapter.test.ts src/lib/impersonationGovernance/__tests__/impersonationGovernance.test.ts src/lib/adminSupportAccess/__tests__/adminSupportAccessGovernance.test.ts src/lib/supportConsole/__tests__/operatorAuditTimeline.test.ts src/lib/supportConsole/__tests__/buildSupportConsoleResource.test.ts
- rentchain-api: npm run build
- rentchain-frontend: npm run build
- repo root: git diff --check

## Known Validation Note
A full backend npm run test was also run outside the sandbox. It still reports the existing unrelated lease draft route and lease-renewal decision mapping failures observed before this mission; the targeted tests and builds for this mission pass.

## Guardrails
No permissions were widened. No auth, schema, Firestore rules, route visibility, pricing, payment, screening provider, or public workflow behavior changed.