### PR TITLE
Add admin security incident review surface

### DIFF
--- a/docs/reports/admin-security-incident-review-surface-v1.md
+++ b/docs/reports/admin-security-incident-review-surface-v1.md
@@ -1,0 +1,105 @@
+# Admin Security Incident Review Surface v1
+
+## Philosophy
+
+This mission adds a governed, metadata-only admin review surface for security-relevant operational signals. It is not a SIEM, raw event explorer, public endpoint, autonomous remediation engine, or unrestricted admin data browser.
+
+The review surface is intended to help RentChain operators manually inspect security signals while preserving tenant, landlord, provider, document, export, support, and impersonation projection boundaries.
+
+## Event Sources Audited
+
+- `telemetry_events`: operational telemetry, including impersonation lifecycle events emitted by impersonation governance.
+- `events`: legacy audit/canonical event metadata used by audit and readiness surfaces.
+- `impersonationRoutes.ts`: governed impersonation start/end telemetry source.
+- `adminSupportProjectionSafety`: audience-based filtering for support/admin metadata introduced before this mission.
+- `adminObservabilityIncidentReadinessRoutes.ts`: existing readiness-oriented incident governance surface, not a raw incident review workspace.
+- Admin audit/integrity/observability pages: existing admin UI patterns for safe summary views.
+
+Unsupported event types are intentionally excluded rather than displayed as raw records.
+
+## Implemented Categories
+
+- `impersonation_started`
+- `impersonation_ended`
+- `impersonation_denied`
+- `policy_denied`
+- `projection_safety_redaction`
+- `export_blocked`
+- `export_prepared`
+- `support_metadata_redacted`
+- `route_source_anomaly`
+- `auth_required_failure`
+- `admin_access_denied`
+- `automation_blocked`
+- `webhook_failure`
+- `screening_provider_callback_anomaly`
+
+These categories are derived only from existing metadata event names and route/source metadata. The implementation does not invent production incidents when no supported metadata exists.
+
+## Protected Routes
+
+- `GET /api/admin/security/incidents`
+- `GET /api/admin/security/incidents/:incidentId`
+
+Both routes require authenticated admin authority through the existing `system.admin` permission convention. Route source attribution is `adminSecurityIncidentRoutes.ts`.
+
+## Metadata Contract
+
+Incident summaries include:
+
+- category, severity, status
+- title and safe summary
+- occurred/last seen timestamps
+- safe actor and target summaries
+- workflow family
+- policy outcome summary
+- source route and route owner where already available
+- redaction summary
+- recommended manual review action
+- safe internal evidence references
+
+Detail responses add only safe timeline entries, related event summaries, redaction notes, and a suggested next review step.
+
+## Redacted Fields
+
+The review model excludes raw or sensitive fields including:
+
+- raw actor and target ids
+- impersonation session ids
+- tokens, credentials, cookies, authorization headers, and secrets
+- raw provider payloads and raw screening reports
+- raw request/response bodies
+- unrestricted event payloads
+- stack traces and debug payloads
+- raw tenant documents and storage paths
+
+Admin/support metadata is projected through the existing support projection safety helper before review summaries are built.
+
+## UI Surface
+
+The frontend adds `/admin/security/incidents` as an admin-only route. It provides:
+
+- summary counts
+- category, severity, status, and search filters
+- incident list
+- safe detail panel
+- explicit metadata-only and redaction messaging
+
+No mutation controls, enforcement actions, alerting integrations, raw JSON drawers, or public links are included.
+
+## Known Limitations
+
+- No incident persistence or status mutation is introduced.
+- No automatic alerting, account locking, token revocation, credential rotation, or remediation exists.
+- The read model is built from current metadata sources only; unsupported/raw-only events are excluded.
+- Incident ids are derived projection ids, not permanent workflow records.
+- Severity is deterministic and conservative, not a substitute for manual security triage.
+
+## Future Follow-Ups
+
+- Add append-oriented incident review notes once support-session audit persistence exists.
+- Add explicit admin incident status transitions with audit lineage.
+- Add support-session and impersonation review linking once persistence contracts are finalized.
+- Add incident runbook integration without autonomous remediation.
+- Add exportable admin-only incident summaries with projection-safe governance.
+

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -424,6 +424,8 @@ app.use("/api/admin", routeSource("adminObservabilityRoutes.ts"), adminObservabi
 console.log("[route-mount] adminObservabilityRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminObservabilityIncidentReadinessRoutes.ts"), adminObservabilityIncidentReadinessRoutes);
 console.log("[route-mount] adminObservabilityIncidentReadinessRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
+console.log("[route-mount] adminSecurityIncidentRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminReleaseGovernanceRoutes.ts"), adminReleaseGovernanceRoutes);
 console.log("[route-mount] adminReleaseGovernanceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes);
@@ -606,7 +608,6 @@ app.use("/api/admin", routeSource("adminOverviewRoutes.ts"), adminOverviewRoutes
 app.use("/api/admin", routeSource("adminIntegrityRoutes.ts"), adminIntegrityRoutes);
 app.use("/api/admin", routeSource("adminSavedFiltersRoutes.ts"), adminSavedFiltersRoutes);
 app.use("/api/admin", routeSource("adminAuditRoutes.ts"), adminAuditRoutes);
-app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
 app.use("/api/admin", routeSource("adminScreeningResultsRoutes.ts"), adminScreeningResultsRoutes);
 app.use("/api/admin", routeSource("adminScreeningUsageRoutes.ts"), adminScreeningUsageRoutes);
 app.use("/api/admin/demo", routeSource("adminDemoRoutes.ts"), adminDemoRoutes);

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -130,6 +130,7 @@ import adminNotificationRoutes from "./routes/adminNotificationRoutes";
 import adminSupportOperationsRoutes from "./routes/adminSupportOperationsRoutes";
 import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
 import adminObservabilityIncidentReadinessRoutes from "./routes/adminObservabilityIncidentReadinessRoutes";
+import adminSecurityIncidentRoutes from "./routes/adminSecurityIncidentRoutes";
 import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
 import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHardeningRoutes";
 import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRoutes";
@@ -605,6 +606,7 @@ app.use("/api/admin", routeSource("adminOverviewRoutes.ts"), adminOverviewRoutes
 app.use("/api/admin", routeSource("adminIntegrityRoutes.ts"), adminIntegrityRoutes);
 app.use("/api/admin", routeSource("adminSavedFiltersRoutes.ts"), adminSavedFiltersRoutes);
 app.use("/api/admin", routeSource("adminAuditRoutes.ts"), adminAuditRoutes);
+app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
 app.use("/api/admin", routeSource("adminScreeningResultsRoutes.ts"), adminScreeningResultsRoutes);
 app.use("/api/admin", routeSource("adminScreeningUsageRoutes.ts"), adminScreeningUsageRoutes);
 app.use("/api/admin/demo", routeSource("adminDemoRoutes.ts"), adminDemoRoutes);

--- a/rentchain-api/src/lib/adminSecurityIncidents/__tests__/adminSecurityIncidentReview.test.ts
+++ b/rentchain-api/src/lib/adminSecurityIncidents/__tests__/adminSecurityIncidentReview.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAdminSecurityIncidentReviewDetail,
+  buildAdminSecurityIncidentReviewRecord,
+  filterAdminSecurityIncidentRecords,
+} from "../adminSecurityIncidentReview";
+
+describe("adminSecurityIncidentReview", () => {
+  it("classifies impersonation telemetry without exposing actor-chain internals", () => {
+    const incident = buildAdminSecurityIncidentReviewRecord({
+      sourceCollection: "telemetry_events",
+      documentId: "telemetry-1",
+      data: {
+        type: "impersonation.started",
+        actor: "admin-raw-id",
+        landlordId: "landlord-raw-id",
+        ts: 1779540000000,
+        meta: {
+          realActorId: "admin-raw-id",
+          realActorRole: "admin",
+          effectiveActorId: "tenant-raw-id",
+          effectiveActorRole: "tenant",
+          impersonationSessionId: "session-raw-id",
+          reasonCategory: "security_investigation",
+          sourceActionFamily: "admin_support_impersonation",
+          policyDecision: "allowed",
+          token: "secret-token",
+        },
+      },
+    });
+
+    expect(incident).toEqual(
+      expect.objectContaining({
+        category: "impersonation_started",
+        metadataOnly: true,
+        actorSummary: expect.objectContaining({
+          role: "admin",
+          supportAttribution: true,
+          rawActorIdsIncluded: false,
+        }),
+        targetSummary: expect.objectContaining({
+          accountType: "tenant",
+          landlordScoped: true,
+          rawTargetIdsIncluded: false,
+        }),
+      })
+    );
+    const payload = JSON.stringify(incident);
+    expect(payload).not.toContain("admin-raw-id");
+    expect(payload).not.toContain("tenant-raw-id");
+    expect(payload).not.toContain("session-raw-id");
+    expect(payload).not.toContain("secret-token");
+  });
+
+  it("classifies route-source and projection safety events as metadata-only review records", () => {
+    const route = buildAdminSecurityIncidentReviewRecord({
+      sourceCollection: "events",
+      documentId: "event-1",
+      data: {
+        eventType: "route_source_anomaly",
+        occurredAt: "2026-05-23T12:00:00.000Z",
+        routeSource: "not-found",
+        sourceRoute: "/api/tenant/trust-exports",
+        requestBody: { authorization: "Bearer secret" },
+      },
+    });
+    const projection = buildAdminSecurityIncidentReviewRecord({
+      sourceCollection: "events",
+      documentId: "event-2",
+      data: {
+        eventType: "projection_safety_redaction",
+        occurredAt: "2026-05-23T12:05:00.000Z",
+        rawProviderPayload: "sensitive",
+      },
+    });
+
+    expect(route?.category).toBe("route_source_anomaly");
+    expect(route?.severity).toBe("high");
+    expect(projection?.category).toBe("projection_safety_redaction");
+    expect(projection?.status).toBe("reviewing");
+    expect(JSON.stringify([route, projection])).not.toContain("Bearer secret");
+    expect(JSON.stringify([route, projection])).not.toContain("sensitive");
+  });
+
+  it("fails safe for unsupported events and filters supported records deterministically", () => {
+    const unsupported = buildAdminSecurityIncidentReviewRecord({
+      sourceCollection: "events",
+      documentId: "event-unrelated",
+      data: { eventType: "lease_updated", occurredAt: "2026-05-23T12:00:00.000Z" },
+    });
+    expect(unsupported).toBeNull();
+
+    const first = buildAdminSecurityIncidentReviewRecord({
+      sourceCollection: "events",
+      documentId: "event-1",
+      data: { eventType: "admin_access_denied", occurredAt: "2026-05-23T12:00:00.000Z" },
+    })!;
+    const second = buildAdminSecurityIncidentReviewRecord({
+      sourceCollection: "events",
+      documentId: "event-2",
+      data: { eventType: "export_blocked", occurredAt: "2026-05-23T12:00:00.000Z" },
+    })!;
+
+    expect(filterAdminSecurityIncidentRecords([first, second], { category: "export_blocked" })).toEqual([second]);
+    expect(filterAdminSecurityIncidentRecords([first, second], { q: "admin access" })).toEqual([first]);
+  });
+
+  it("builds safe detail records without raw event JSON", () => {
+    const incident = buildAdminSecurityIncidentReviewRecord({
+      sourceCollection: "telemetry_events",
+      documentId: "telemetry-2",
+      data: { type: "policy.denied", ts: 1779540000000, meta: { policyDecision: "denied", stackTrace: "hidden" } },
+    })!;
+    const detail = buildAdminSecurityIncidentReviewDetail(incident);
+
+    expect(detail.timeline).toHaveLength(1);
+    expect(detail.relatedEventSummaries[0]).toEqual(expect.objectContaining({ metadataOnly: true }));
+    expect(JSON.stringify(detail)).not.toContain("hidden");
+    expect(JSON.stringify(detail)).not.toContain("stackTrace");
+  });
+});
+

--- a/rentchain-api/src/lib/adminSecurityIncidents/adminSecurityIncidentReview.ts
+++ b/rentchain-api/src/lib/adminSecurityIncidents/adminSecurityIncidentReview.ts
@@ -1,0 +1,372 @@
+import crypto from "crypto";
+import { projectAdminSupportMetadataForAudience } from "../adminSupportProjectionSafety/adminSupportProjectionSafety";
+
+export const ADMIN_SECURITY_INCIDENT_REVIEW_VERSION = "admin_security_incident_review_v1";
+
+export type AdminSecurityIncidentCategory =
+  | "impersonation_started"
+  | "impersonation_ended"
+  | "impersonation_denied"
+  | "policy_denied"
+  | "projection_safety_redaction"
+  | "export_blocked"
+  | "export_prepared"
+  | "support_metadata_redacted"
+  | "route_source_anomaly"
+  | "auth_required_failure"
+  | "admin_access_denied"
+  | "automation_blocked"
+  | "webhook_failure"
+  | "screening_provider_callback_anomaly";
+
+export type AdminSecurityIncidentSeverity = "info" | "low" | "medium" | "high" | "critical";
+export type AdminSecurityIncidentStatus = "open" | "reviewing" | "resolved" | "dismissed";
+
+export type AdminSecurityIncidentReviewRecord = {
+  incidentReviewVersion: typeof ADMIN_SECURITY_INCIDENT_REVIEW_VERSION;
+  incidentId: string;
+  category: AdminSecurityIncidentCategory;
+  severity: AdminSecurityIncidentSeverity;
+  status: AdminSecurityIncidentStatus;
+  title: string;
+  summary: string;
+  occurredAt: string;
+  lastSeenAt: string;
+  actorSummary: {
+    role: string | null;
+    supportAttribution: boolean;
+    rawActorIdsIncluded: false;
+  };
+  targetSummary: {
+    accountType: string | null;
+    resourceType: string | null;
+    landlordScoped: boolean;
+    tenantScoped: boolean;
+    rawTargetIdsIncluded: false;
+  };
+  workflowFamily: string | null;
+  policyOutcomeSummary: string | null;
+  sourceRoute: string | null;
+  routeSource: string | null;
+  metadataOnly: true;
+  redactionSummary: string;
+  recommendedReviewAction: string;
+  safeEvidenceReferences: Array<{
+    referenceType: "event" | "telemetry" | "audit" | "evidence" | "export";
+    referenceId: string;
+    label: string;
+    internalReference: true;
+  }>;
+};
+
+export type AdminSecurityIncidentReviewDetail = AdminSecurityIncidentReviewRecord & {
+  timeline: Array<{
+    occurredAt: string;
+    label: string;
+    category: AdminSecurityIncidentCategory;
+    metadataOnly: true;
+  }>;
+  relatedEventSummaries: Array<{
+    eventType: string;
+    sourceCollection: string;
+    occurredAt: string;
+    summary: string;
+    metadataOnly: true;
+  }>;
+  redactionNotes: string[];
+  suggestedNextReviewStep: string;
+};
+
+const SUPPORTED_CATEGORIES = new Set<AdminSecurityIncidentCategory>([
+  "impersonation_started",
+  "impersonation_ended",
+  "impersonation_denied",
+  "policy_denied",
+  "projection_safety_redaction",
+  "export_blocked",
+  "export_prepared",
+  "support_metadata_redacted",
+  "route_source_anomaly",
+  "auth_required_failure",
+  "admin_access_denied",
+  "automation_blocked",
+  "webhook_failure",
+  "screening_provider_callback_anomaly",
+]);
+
+const RESTRICTED_KEYS = new Set([
+  "realActorId",
+  "effectiveActorId",
+  "impersonationSessionId",
+  "targetAccountId",
+  "actor",
+  "actorUserId",
+  "userId",
+  "tenantId",
+  "landlordId",
+  "rawPayload",
+  "payload",
+  "rawReport",
+  "providerPayload",
+  "providerResponse",
+  "requestBody",
+  "responseBody",
+  "stack",
+  "stackTrace",
+  "token",
+  "authorization",
+  "cookie",
+  "secret",
+  "password",
+  "credential",
+  "storagePath",
+  "documentPath",
+]);
+
+function asString(value: unknown, max = 300): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function safeText(value: unknown, max = 500): string | null {
+  const next = asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  return next || null;
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function toIso(value: unknown): string {
+  if (value && typeof (value as any).toDate === "function") {
+    return (value as any).toDate().toISOString();
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = asString(value, 120);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function stableHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex").slice(0, 16);
+}
+
+function hasRestrictedMaterial(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some(hasRestrictedMaterial);
+  return Object.entries(value as Record<string, unknown>).some(([key, nested]) => {
+    if (RESTRICTED_KEYS.has(key) || /token|secret|password|credential|authorization|cookie|raw|payload|stack/i.test(key)) {
+      return true;
+    }
+    return hasRestrictedMaterial(nested);
+  });
+}
+
+function safeMeta(input: Record<string, unknown>): Record<string, unknown> {
+  const projected = projectAdminSupportMetadataForAudience(input, "admin_support") as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(projected || {})) {
+    if (RESTRICTED_KEYS.has(key) || /token|secret|password|credential|authorization|cookie|raw|payload|stack/i.test(key)) continue;
+    if (value == null || typeof value !== "object") {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+function eventTypeFor(record: Record<string, unknown>): string {
+  return asString(record.type || record.eventType || record.kind || record.action, 160);
+}
+
+function classifyCategory(record: Record<string, unknown>): AdminSecurityIncidentCategory | null {
+  const eventType = normalizeKey(eventTypeFor(record));
+  const meta = (record.meta && typeof record.meta === "object" ? record.meta : {}) as Record<string, unknown>;
+  const sourceRoute = normalizeKey(meta.sourceRoute || record.sourceRoute || record.route);
+  const routeSource = normalizeKey(meta.routeSource || record.routeSource);
+
+  if (eventType === "impersonation_started") return "impersonation_started";
+  if (eventType === "impersonation_ended") return "impersonation_ended";
+  if (eventType === "impersonation_denied" || eventType === "impersonation_expired" || eventType === "impersonation_revoked") {
+    return "impersonation_denied";
+  }
+  if (eventType.includes("policy") && (eventType.includes("denied") || eventType.includes("blocked"))) return "policy_denied";
+  if (eventType.includes("projection") && (eventType.includes("redaction") || eventType.includes("redacted"))) {
+    return "projection_safety_redaction";
+  }
+  if (eventType.includes("support") && eventType.includes("redacted")) return "support_metadata_redacted";
+  if (eventType.includes("export") && eventType.includes("blocked")) return "export_blocked";
+  if (eventType.includes("export") && (eventType.includes("prepared") || eventType.includes("ready"))) return "export_prepared";
+  if (eventType.includes("route_source") && eventType.includes("anomaly")) return "route_source_anomaly";
+  if ((sourceRoute || routeSource) && routeSource.includes("not_found")) return "route_source_anomaly";
+  if (eventType.includes("auth") && (eventType.includes("required") || eventType.includes("unauthorized"))) return "auth_required_failure";
+  if (eventType.includes("admin") && eventType.includes("denied")) return "admin_access_denied";
+  if (eventType.includes("automation") && eventType.includes("blocked")) return "automation_blocked";
+  if (eventType.includes("webhook") && (eventType.includes("failure") || eventType.includes("failed"))) return "webhook_failure";
+  if (eventType.includes("screening") && eventType.includes("callback") && eventType.includes("anomaly")) {
+    return "screening_provider_callback_anomaly";
+  }
+  return null;
+}
+
+function severityFor(category: AdminSecurityIncidentCategory): AdminSecurityIncidentSeverity {
+  if (category === "route_source_anomaly" || category === "projection_safety_redaction") return "high";
+  if (category === "admin_access_denied" || category === "impersonation_denied") return "medium";
+  if (category === "policy_denied" || category === "automation_blocked" || category === "webhook_failure") return "medium";
+  if (category === "screening_provider_callback_anomaly" || category === "support_metadata_redacted") return "medium";
+  if (category === "export_blocked") return "medium";
+  return "low";
+}
+
+function statusFor(category: AdminSecurityIncidentCategory): AdminSecurityIncidentStatus {
+  if (category === "impersonation_ended" || category === "export_prepared") return "resolved";
+  if (category === "projection_safety_redaction" || category === "support_metadata_redacted") return "reviewing";
+  return "open";
+}
+
+function titleFor(category: AdminSecurityIncidentCategory): string {
+  return category
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function reviewActionFor(category: AdminSecurityIncidentCategory): string {
+  if (category === "impersonation_started" || category === "impersonation_ended" || category === "impersonation_denied") {
+    return "Review support attribution and confirm the actor chain remains scoped.";
+  }
+  if (category === "route_source_anomaly") return "Confirm route ownership and deployed backend revision alignment.";
+  if (category === "projection_safety_redaction" || category === "support_metadata_redacted") {
+    return "Review projection boundary and confirm redaction happened before user-safe presentation.";
+  }
+  if (category === "policy_denied" || category === "admin_access_denied") return "Review policy outcome and confirm deny-by-default behavior.";
+  if (category === "export_blocked" || category === "export_prepared") return "Review export governance metadata and consent/projection scope.";
+  return "Review metadata-only incident context and determine whether manual follow-up is needed.";
+}
+
+function actorSummary(record: Record<string, unknown>) {
+  const meta = (record.meta && typeof record.meta === "object" ? record.meta : {}) as Record<string, unknown>;
+  const actorChain = (meta.actorChain && typeof meta.actorChain === "object" ? meta.actorChain : {}) as Record<string, unknown>;
+  return {
+    role: safeText(meta.realActorRole || actorChain.realActorRole || record.actorRole || record.role, 80),
+    supportAttribution: Boolean(meta.supportProjectionSafe || meta.sourceActionFamily === "admin_support_impersonation" || actorChain.supportAttribution),
+    rawActorIdsIncluded: false as const,
+  };
+}
+
+function targetSummary(record: Record<string, unknown>) {
+  const meta = (record.meta && typeof record.meta === "object" ? record.meta : {}) as Record<string, unknown>;
+  return {
+    accountType: safeText(meta.targetAccountType || meta.effectiveActorRole || record.targetAccountType, 80),
+    resourceType: safeText(meta.resourceType || record.resourceType, 80),
+    landlordScoped: Boolean(meta.targetLandlordId || record.landlordId),
+    tenantScoped: Boolean(meta.targetAccountType === "tenant" || meta.effectiveActorRole === "tenant"),
+    rawTargetIdsIncluded: false as const,
+  };
+}
+
+export function buildAdminSecurityIncidentReviewRecord(input: {
+  sourceCollection: "telemetry_events" | "events";
+  documentId: string;
+  data: Record<string, unknown>;
+}): AdminSecurityIncidentReviewRecord | null {
+  const category = classifyCategory(input.data);
+  if (!category || !SUPPORTED_CATEGORIES.has(category)) return null;
+  const occurredAt = toIso(input.data.occurredAt || input.data.createdAt || input.data.ts || input.data.timestamp);
+  const meta = (input.data.meta && typeof input.data.meta === "object" ? input.data.meta : {}) as Record<string, unknown>;
+  const safe = safeMeta(meta);
+  const incidentId = `security_incident:${stableHash([input.sourceCollection, input.documentId, eventTypeFor(input.data), occurredAt])}`;
+  const eventType = eventTypeFor(input.data) || category;
+  const redacted = hasRestrictedMaterial(input.data);
+
+  return {
+    incidentReviewVersion: ADMIN_SECURITY_INCIDENT_REVIEW_VERSION,
+    incidentId,
+    category,
+    severity: severityFor(category),
+    status: statusFor(category),
+    title: titleFor(category),
+    summary:
+      safeText(input.data.summary || input.data.title, 280) ||
+      `${titleFor(category)} signal derived from ${input.sourceCollection.replace(/_/g, " ")} metadata.`,
+    occurredAt,
+    lastSeenAt: toIso(input.data.updatedAt || input.data.createdAt || input.data.ts || input.data.occurredAt || occurredAt),
+    actorSummary: actorSummary(input.data),
+    targetSummary: targetSummary(input.data),
+    workflowFamily: safeText(safe.workflowFamily || safe.sourceActionFamily || input.data.workflow, 120),
+    policyOutcomeSummary: safeText(safe.policyOutcomeSummary || safe.policyDecision || input.data.policyOutcome, 120),
+    sourceRoute: safeText(safe.sourceRoute || input.data.sourceRoute || input.data.route, 180),
+    routeSource: safeText(safe.routeSource || input.data.routeSource, 180),
+    metadataOnly: true,
+    redactionSummary: redacted
+      ? "Restricted fields were detected in the source event and excluded from this review projection."
+      : "Incident review projection is metadata-only; raw event payloads and internal identifiers are excluded.",
+    recommendedReviewAction: reviewActionFor(category),
+    safeEvidenceReferences: [
+      {
+        referenceType: input.sourceCollection === "events" ? "event" : "telemetry",
+        referenceId: `${input.sourceCollection}:${stableHash(input.documentId)}`,
+        label: `${eventType} metadata reference`,
+        internalReference: true,
+      },
+    ],
+  };
+}
+
+export function buildAdminSecurityIncidentReviewDetail(
+  record: AdminSecurityIncidentReviewRecord
+): AdminSecurityIncidentReviewDetail {
+  return {
+    ...record,
+    timeline: [
+      {
+        occurredAt: record.occurredAt,
+        label: record.title,
+        category: record.category,
+        metadataOnly: true,
+      },
+    ],
+    relatedEventSummaries: [
+      {
+        eventType: record.category,
+        sourceCollection: record.safeEvidenceReferences[0]?.referenceType || "event",
+        occurredAt: record.occurredAt,
+        summary: record.summary,
+        metadataOnly: true,
+      },
+    ],
+    redactionNotes: [
+      record.redactionSummary,
+      "Raw actor ids, target ids, tokens, provider payloads, documents, storage paths, stack traces, and policy internals are not included.",
+    ],
+    suggestedNextReviewStep: record.recommendedReviewAction,
+  };
+}
+
+export function filterAdminSecurityIncidentRecords(
+  records: AdminSecurityIncidentReviewRecord[],
+  filters: {
+    category?: string | null;
+    severity?: string | null;
+    status?: string | null;
+    q?: string | null;
+  }
+) {
+  const category = normalizeKey(filters.category);
+  const severity = normalizeKey(filters.severity);
+  const status = normalizeKey(filters.status);
+  const q = asString(filters.q, 120).toLowerCase();
+  return records.filter((record) => {
+    if (category && record.category !== category) return false;
+    if (severity && record.severity !== severity) return false;
+    if (status && record.status !== status) return false;
+    if (q) {
+      const haystack = [record.title, record.summary, record.category, record.workflowFamily, record.routeSource]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    return true;
+  });
+}
+

--- a/rentchain-api/src/routes/__tests__/adminSecurityIncidentRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminSecurityIncidentRoutes.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({
+            id: doc.id,
+            exists: true,
+            data: () => doc.data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireAuthz", () => ({
+  requirePermission: () => (req: any, res: any, next: any) => {
+    const permissions = Array.isArray(req.user?.permissions) ? req.user.permissions : [];
+    if (req.user?.role !== "admin" && !permissions.includes("system.admin")) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const detailMatch = path.match(/^\/security\/incidents\/(.+)$/);
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: detailMatch ? { incidentId: decodeURIComponent(detailMatch[1]) } : {},
+      headers: {},
+      user: mockUser,
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      setHeader(name: string, value: string) {
+        this.headers[String(name).toLowerCase()] = value;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminSecurityIncidentRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedIncidentContext() {
+    seedDoc("telemetry_events", "telemetry-1", {
+      type: "impersonation.started",
+      actor: "admin-raw-id",
+      landlordId: "landlord-raw-id",
+      ts: 1779540000000,
+      meta: {
+        realActorId: "admin-raw-id",
+        realActorRole: "admin",
+        effectiveActorId: "tenant-raw-id",
+        effectiveActorRole: "tenant",
+        impersonationSessionId: "session-raw-id",
+        sourceActionFamily: "admin_support_impersonation",
+        policyDecision: "allowed",
+        token: "secret-token",
+      },
+    });
+    seedDoc("events", "event-1", {
+      eventType: "route_source_anomaly",
+      occurredAt: "2026-05-23T12:00:00.000Z",
+      routeSource: "not-found",
+      requestBody: { authorization: "Bearer secret" },
+    });
+    seedDoc("events", "event-2", {
+      eventType: "lease_updated",
+      occurredAt: "2026-05-23T12:05:00.000Z",
+      rawProviderPayload: "must-not-render",
+    });
+  }
+
+  it("denies non-admin access and returns admin-only metadata incident summaries", async () => {
+    seedIncidentContext();
+    const router = (await import("../adminSecurityIncidentRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/security/incidents",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/security/incidents",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("adminSecurityIncidentRoutes.ts");
+    expect(res.body.incidents).toHaveLength(2);
+    expect(res.body.summary.metadataOnly).toBe(true);
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("admin-raw-id");
+    expect(payload).not.toContain("tenant-raw-id");
+    expect(payload).not.toContain("session-raw-id");
+    expect(payload).not.toContain("secret-token");
+    expect(payload).not.toContain("Bearer secret");
+    expect(payload).not.toContain("must-not-render");
+  });
+
+  it("filters incidents and returns a safe detail payload", async () => {
+    seedIncidentContext();
+    const router = (await import("../adminSecurityIncidentRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/security/incidents?category=route_source_anomaly" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.incidents).toHaveLength(1);
+    expect(filtered.body.incidents[0].category).toBe("route_source_anomaly");
+
+    const incidentId = filtered.body.incidents[0].incidentId;
+    const detail = await invokeRouter(router, {
+      method: "GET",
+      url: `/security/incidents/${encodeURIComponent(incidentId)}`,
+    });
+
+    expect(detail.status).toBe(200);
+    expect(detail.body.incident).toEqual(
+      expect.objectContaining({
+        incidentId,
+        metadataOnly: true,
+        timeline: expect.any(Array),
+        redactionNotes: expect.any(Array),
+      })
+    );
+    expect(JSON.stringify(detail.body)).not.toContain("Bearer secret");
+  });
+
+  it("returns a useful empty state when no supported security events exist", async () => {
+    seedDoc("events", "event-unrelated", { eventType: "lease_updated", rawPayload: "hidden" });
+    const router = (await import("../adminSecurityIncidentRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/security/incidents" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.incidents).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+    expect(JSON.stringify(res.body)).not.toContain("hidden");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -218,6 +218,7 @@ async function buildRuntimeOwnershipApp() {
   const internalReportsRoutes = (await import("../internalReportsRoutes")).default;
   const telemetryRoutes = (await import("../telemetryRoutes")).default;
   const screeningRoutes = (await import("../screeningRoutes")).default;
+  const adminSecurityIncidentRoutes = (await import("../adminSecurityIncidentRoutes")).default;
   const screeningJobsAdminRoutes = (await import("../screeningJobsAdminRoutes")).default;
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
@@ -257,6 +258,7 @@ async function buildRuntimeOwnershipApp() {
   );
   app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
   app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes);
+  app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
   app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes);
   app.use("/api", (_req, res) => {
     res.setHeader("x-route-source", "not-found");
@@ -393,6 +395,9 @@ describe("API route ownership regression", () => {
     const incidentReadinessMount = source.indexOf(
       'app.use("/api/admin", routeSource("adminObservabilityIncidentReadinessRoutes.ts"), adminObservabilityIncidentReadinessRoutes)'
     );
+    const securityIncidentMount = source.indexOf(
+      'app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes)'
+    );
     const publicExposureMount = source.indexOf(
       'app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes)'
     );
@@ -401,22 +406,29 @@ describe("API route ownership regression", () => {
     );
     const impersonationMount = source.indexOf('app.use("/api/impersonation", routeSource("impersonationRoutes.ts"), impersonationRoutes)');
     const adminRoutesMount = source.indexOf('app.use("/api/admin", routeSource("adminRoutes.ts"), adminRoutes)');
+    const adminScreeningUsageMount = source.indexOf(
+      'app.use("/api/admin", routeSource("adminScreeningUsageRoutes.ts"), adminScreeningUsageRoutes)'
+    );
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
     const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
 
     expect(supportConsoleMount).toBeGreaterThan(-1);
     expect(supportOperationsMount).toBeGreaterThan(-1);
     expect(incidentReadinessMount).toBeGreaterThan(-1);
+    expect(securityIncidentMount).toBeGreaterThan(-1);
     expect(publicExposureMount).toBeGreaterThan(-1);
     expect(pdfObservabilityMount).toBeGreaterThan(-1);
     expect(impersonationMount).toBeGreaterThan(-1);
     expect(adminRoutesMount).toBeGreaterThan(-1);
+    expect(adminScreeningUsageMount).toBeGreaterThan(-1);
     expect(screeningJobsMount).toBeGreaterThan(-1);
     expect(apiCatchall).toBeGreaterThan(-1);
 
     expect(supportConsoleMount).toBeLessThan(adminRoutesMount);
     expect(supportOperationsMount).toBeLessThan(adminRoutesMount);
     expect(incidentReadinessMount).toBeLessThan(adminRoutesMount);
+    expect(securityIncidentMount).toBeLessThan(adminRoutesMount);
+    expect(securityIncidentMount).toBeLessThan(adminScreeningUsageMount);
     expect(publicExposureMount).toBeLessThan(adminRoutesMount);
     expect(pdfObservabilityMount).toBeLessThan(adminRoutesMount);
     expect(impersonationMount).toBeLessThan(screeningJobsMount);
@@ -485,6 +497,38 @@ describe("API route ownership regression", () => {
     expect(screeningHistoryRes.headers["x-route-source"]).toBe("screeningRoutes.ts");
     expect(screeningHistoryRes.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
     expect(JSON.stringify(screeningHistoryRes.body)).not.toContain("secret");
+  });
+
+  it("keeps admin security incidents owned by security incident routes before screening usage fallback", async () => {
+    authState.user = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+    const app = await buildRuntimeOwnershipApp();
+
+    const res = await invokeApp(app, {
+      method: "GET",
+      url: "/api/admin/security/incidents?limit=50",
+      headers: { authorization: "Bearer admin-token" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("adminSecurityIncidentRoutes.ts");
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        incidents: [],
+        summary: expect.objectContaining({ metadataOnly: true }),
+      })
+    );
+
+    authState.user = { id: "landlord-1", role: "landlord", permissions: [] };
+    const denied = await invokeApp(app, {
+      method: "GET",
+      url: "/api/admin/security/incidents?limit=50",
+      headers: { authorization: "Bearer landlord-token" },
+    });
+
+    expect(denied.status).toBe(403);
+    expect(denied.headers["x-route-source"]).toBe("adminSecurityIncidentRoutes.ts");
+    expect(denied.body?.error).not.toBe("Not Found");
   });
 
   it("keeps webhook requests public and owned by webhook routers", async () => {

--- a/rentchain-api/src/routes/adminSecurityIncidentRoutes.ts
+++ b/rentchain-api/src/routes/adminSecurityIncidentRoutes.ts
@@ -1,0 +1,43 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import {
+  loadAdminSecurityIncidentReviewDetail,
+  loadAdminSecurityIncidentReviews,
+} from "../services/admin/adminSecurityIncidentReview";
+
+const router = Router();
+
+router.get("/security/incidents", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  res.setHeader("x-route-source", "adminSecurityIncidentRoutes.ts");
+  try {
+    const result = await loadAdminSecurityIncidentReviews({
+      category: req.query?.category,
+      severity: req.query?.severity,
+      status: req.query?.status,
+      q: req.query?.q,
+      limit: Number(req.query?.limit || 50),
+    });
+    return res.json({ ok: true, ...result });
+  } catch (err: any) {
+    console.error("[admin-security-incidents] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_SECURITY_INCIDENTS_FAILED" });
+  }
+});
+
+router.get("/security/incidents/:incidentId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  res.setHeader("x-route-source", "adminSecurityIncidentRoutes.ts");
+  try {
+    const incidentId = String(req.params?.incidentId || "").trim();
+    if (!incidentId) return res.status(400).json({ ok: false, error: "INCIDENT_ID_REQUIRED" });
+    const incident = await loadAdminSecurityIncidentReviewDetail(incidentId);
+    if (!incident) return res.status(404).json({ ok: false, error: "INCIDENT_NOT_FOUND" });
+    return res.json({ ok: true, incident });
+  } catch (err: any) {
+    console.error("[admin-security-incidents] detail failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_SECURITY_INCIDENT_DETAIL_FAILED" });
+  }
+});
+
+export default router;
+

--- a/rentchain-api/src/services/admin/adminSecurityIncidentReview.ts
+++ b/rentchain-api/src/services/admin/adminSecurityIncidentReview.ts
@@ -1,0 +1,69 @@
+import { db } from "../../config/firebase";
+import {
+  buildAdminSecurityIncidentReviewDetail,
+  buildAdminSecurityIncidentReviewRecord,
+  filterAdminSecurityIncidentRecords,
+  type AdminSecurityIncidentReviewDetail,
+  type AdminSecurityIncidentReviewRecord,
+} from "../../lib/adminSecurityIncidents/adminSecurityIncidentReview";
+
+type LoadParams = {
+  category?: string | null;
+  severity?: string | null;
+  status?: string | null;
+  q?: string | null;
+  limit?: number | null;
+};
+
+async function loadCollection(collectionName: "telemetry_events" | "events", limit = 100) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc: any) => ({
+    sourceCollection: collectionName,
+    documentId: String(doc.id || ""),
+    data: { id: doc.id, ...((doc.data() as Record<string, unknown>) || {}) },
+  }));
+}
+
+export async function loadAdminSecurityIncidentReviews(
+  params: LoadParams = {}
+): Promise<{
+  incidents: AdminSecurityIncidentReviewRecord[];
+  summary: {
+    total: number;
+    open: number;
+    reviewing: number;
+    highOrCritical: number;
+    metadataOnly: true;
+  };
+}> {
+  const requestedLimit = Number(params.limit || 50);
+  const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 100) : 50;
+  const [telemetry, auditEvents] = await Promise.all([loadCollection("telemetry_events"), loadCollection("events")]);
+  const incidents = [...telemetry, ...auditEvents]
+    .map((item) => buildAdminSecurityIncidentReviewRecord(item))
+    .filter(Boolean) as AdminSecurityIncidentReviewRecord[];
+
+  const filtered = filterAdminSecurityIncidentRecords(incidents, params)
+    .sort((a, b) => Date.parse(b.lastSeenAt) - Date.parse(a.lastSeenAt) || a.incidentId.localeCompare(b.incidentId))
+    .slice(0, limit);
+
+  return {
+    incidents: filtered,
+    summary: {
+      total: filtered.length,
+      open: filtered.filter((incident) => incident.status === "open").length,
+      reviewing: filtered.filter((incident) => incident.status === "reviewing").length,
+      highOrCritical: filtered.filter((incident) => incident.severity === "high" || incident.severity === "critical").length,
+      metadataOnly: true,
+    },
+  };
+}
+
+export async function loadAdminSecurityIncidentReviewDetail(
+  incidentId: string
+): Promise<AdminSecurityIncidentReviewDetail | null> {
+  const { incidents } = await loadAdminSecurityIncidentReviews({ limit: 100 });
+  const incident = incidents.find((item) => item.incidentId === incidentId);
+  return incident ? buildAdminSecurityIncidentReviewDetail(incident) : null;
+}
+

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -111,6 +111,7 @@ const AdminLeaseLifecycleReviewPage = lazy(() => import("./pages/admin/AdminLeas
 const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabilityPage"));
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
+const AdminSecurityIncidentsPage = lazy(() => import("./pages/admin/AdminSecurityIncidentsPage"));
 const ObservabilityIncidentReadinessPage = lazy(() => import("./pages/ObservabilityIncidentReadinessPage"));
 const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
 const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
@@ -1044,6 +1045,18 @@ function App() {
               <RequireAdmin>
                 <Suspense fallback={null}>
                   <AdminAuditPage />
+                </Suspense>
+              </RequireAdmin>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/admin/security/incidents"
+          element={
+            <RequireAuth>
+              <RequireAdmin>
+                <Suspense fallback={null}>
+                  <AdminSecurityIncidentsPage />
                 </Suspense>
               </RequireAdmin>
             </RequireAuth>

--- a/rentchain-frontend/src/api/adminSecurityIncidentsApi.ts
+++ b/rentchain-frontend/src/api/adminSecurityIncidentsApi.ts
@@ -1,0 +1,94 @@
+import { apiFetch } from "./apiFetch";
+
+export type AdminSecurityIncidentSeverity = "info" | "low" | "medium" | "high" | "critical";
+export type AdminSecurityIncidentStatus = "open" | "reviewing" | "resolved" | "dismissed";
+
+export type AdminSecurityIncidentRecord = {
+  incidentReviewVersion: string;
+  incidentId: string;
+  category: string;
+  severity: AdminSecurityIncidentSeverity;
+  status: AdminSecurityIncidentStatus;
+  title: string;
+  summary: string;
+  occurredAt: string;
+  lastSeenAt: string;
+  actorSummary: {
+    role: string | null;
+    supportAttribution: boolean;
+    rawActorIdsIncluded: false;
+  };
+  targetSummary: {
+    accountType: string | null;
+    resourceType: string | null;
+    landlordScoped: boolean;
+    tenantScoped: boolean;
+    rawTargetIdsIncluded: false;
+  };
+  workflowFamily: string | null;
+  policyOutcomeSummary: string | null;
+  sourceRoute: string | null;
+  routeSource: string | null;
+  metadataOnly: true;
+  redactionSummary: string;
+  recommendedReviewAction: string;
+  safeEvidenceReferences: Array<{
+    referenceType: string;
+    referenceId: string;
+    label: string;
+    internalReference: true;
+  }>;
+};
+
+export type AdminSecurityIncidentDetail = AdminSecurityIncidentRecord & {
+  timeline: Array<{
+    occurredAt: string;
+    label: string;
+    category: string;
+    metadataOnly: true;
+  }>;
+  relatedEventSummaries: Array<{
+    eventType: string;
+    sourceCollection: string;
+    occurredAt: string;
+    summary: string;
+    metadataOnly: true;
+  }>;
+  redactionNotes: string[];
+  suggestedNextReviewStep: string;
+};
+
+export async function fetchAdminSecurityIncidents(params?: {
+  category?: string | null;
+  severity?: string | null;
+  status?: string | null;
+  q?: string | null;
+  limit?: number | null;
+}) {
+  const query = new URLSearchParams();
+  if (params?.category) query.set("category", params.category);
+  if (params?.severity) query.set("severity", params.severity);
+  if (params?.status) query.set("status", params.status);
+  if (params?.q) query.set("q", params.q);
+  if (params?.limit) query.set("limit", String(params.limit));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return apiFetch<{
+    ok: true;
+    incidents: AdminSecurityIncidentRecord[];
+    summary: {
+      total: number;
+      open: number;
+      reviewing: number;
+      highOrCritical: number;
+      metadataOnly: true;
+    };
+  }>(`/admin/security/incidents${suffix}`);
+}
+
+export async function fetchAdminSecurityIncidentDetail(incidentId: string) {
+  return apiFetch<{
+    ok: true;
+    incident: AdminSecurityIncidentDetail;
+  }>(`/admin/security/incidents/${encodeURIComponent(incidentId)}`);
+}
+

--- a/rentchain-frontend/src/pages/admin/AdminDashboardPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminDashboardPage.tsx
@@ -5,7 +5,17 @@ import { Button, Card, Pill, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
 import { fetchAdminOverview, type AdminOverview } from "../../api/adminApi";
 
-const QUICK_LINKS = [
+type AdminQuickLinkCountKey = keyof Pick<
+  AdminOverview["summary"],
+  "totalProperties" | "totalTenants" | "totalLeases" | "integrityWarnings"
+>;
+
+const QUICK_LINKS: Array<{
+  title: string;
+  to: string;
+  description: string;
+  countKey: AdminQuickLinkCountKey | null;
+}> = [
   {
     title: "Properties",
     to: "/admin/properties",
@@ -29,6 +39,12 @@ const QUICK_LINKS = [
     to: "/admin/integrity",
     description: "Integrity dashboard is the next phase for deeper issue review.",
     countKey: "integrityWarnings" as const,
+  },
+  {
+    title: "Security incidents",
+    to: "/admin/security/incidents",
+    description: "Review metadata-only security, impersonation, policy, and projection signals.",
+    countKey: null,
   },
 ];
 
@@ -133,7 +149,7 @@ export const AdminDashboardPage: React.FC = () => {
                 <Card key={link.to} style={{ display: "grid", gap: 10 }}>
                   <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
                     <div style={{ fontWeight: 700 }}>{link.title}</div>
-                    <Pill tone="accent">{overview.summary[link.countKey]}</Pill>
+                    {link.countKey ? <Pill tone="accent">{overview.summary[link.countKey]}</Pill> : <Pill tone="muted">Review</Pill>}
                   </div>
                   <div style={{ color: "#475569", minHeight: 40 }}>{link.description}</div>
                   <Link to={link.to} style={{ color: "#2563eb", fontWeight: 600, textDecoration: "none" }}>

--- a/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdminSecurityIncidentsPage from "./AdminSecurityIncidentsPage";
+
+const showToast = vi.fn();
+const fetchAdminSecurityIncidents = vi.fn();
+const fetchAdminSecurityIncidentDetail = vi.fn();
+
+vi.mock("../../api/adminSecurityIncidentsApi", () => ({
+  fetchAdminSecurityIncidents: (...args: any[]) => fetchAdminSecurityIncidents(...args),
+  fetchAdminSecurityIncidentDetail: (...args: any[]) => fetchAdminSecurityIncidentDetail(...args),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+const INCIDENT = {
+  incidentReviewVersion: "admin_security_incident_review_v1",
+  incidentId: "security_incident:safe",
+  category: "impersonation_started",
+  severity: "medium",
+  status: "open",
+  title: "Impersonation Started",
+  summary: "Impersonation started signal derived from telemetry metadata.",
+  occurredAt: "2026-05-23T12:00:00.000Z",
+  lastSeenAt: "2026-05-23T12:00:00.000Z",
+  actorSummary: { role: "admin", supportAttribution: true, rawActorIdsIncluded: false },
+  targetSummary: {
+    accountType: "tenant",
+    resourceType: null,
+    landlordScoped: true,
+    tenantScoped: true,
+    rawTargetIdsIncluded: false,
+  },
+  workflowFamily: "admin_support_impersonation",
+  policyOutcomeSummary: "allowed",
+  sourceRoute: null,
+  routeSource: "impersonationRoutes.ts",
+  metadataOnly: true,
+  redactionSummary: "Raw ids excluded.",
+  recommendedReviewAction: "Review support attribution.",
+  safeEvidenceReferences: [{ referenceType: "telemetry", referenceId: "telemetry:safe", label: "safe", internalReference: true }],
+};
+
+beforeEach(() => {
+  showToast.mockReset();
+  fetchAdminSecurityIncidents.mockReset();
+  fetchAdminSecurityIncidentDetail.mockReset();
+  fetchAdminSecurityIncidents.mockResolvedValue({
+    ok: true,
+    incidents: [INCIDENT],
+    summary: { total: 1, open: 1, reviewing: 0, highOrCritical: 0, metadataOnly: true },
+  });
+  fetchAdminSecurityIncidentDetail.mockResolvedValue({
+    ok: true,
+    incident: {
+      ...INCIDENT,
+      timeline: [{ occurredAt: INCIDENT.occurredAt, label: INCIDENT.title, category: INCIDENT.category, metadataOnly: true }],
+      relatedEventSummaries: [],
+      redactionNotes: ["Raw actor ids, target ids, tokens, provider payloads, documents, storage paths, stack traces, and policy internals are not included."],
+      suggestedNextReviewStep: "Review support attribution.",
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminSecurityIncidentsPage", () => {
+  it("renders metadata-only security incident summaries and details", async () => {
+    render(<AdminSecurityIncidentsPage />);
+
+    expect(await screen.findByRole("heading", { name: "Security incidents" })).toBeInTheDocument();
+    expect((await screen.findAllByText("Impersonation Started")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("impersonationRoutes.ts")).toBeInTheDocument();
+    expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);
+    expect(JSON.stringify(document.body.textContent)).not.toContain("realActorId");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("effectiveActorId");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("impersonationSessionId");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("tenant-raw-id");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("secret");
+  });
+
+  it("sends filter values to the incident API", async () => {
+    render(<AdminSecurityIncidentsPage />);
+    await screen.findByText("Impersonation Started");
+
+    fireEvent.change(screen.getByLabelText("Severity"), { target: { value: "medium" } });
+
+    await waitFor(() =>
+      expect(fetchAdminSecurityIncidents).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          severity: "medium",
+        })
+      )
+    );
+  });
+
+  it("renders the empty state without fake incidents", async () => {
+    fetchAdminSecurityIncidents.mockResolvedValueOnce({
+      ok: true,
+      incidents: [],
+      summary: { total: 0, open: 0, reviewing: 0, highOrCritical: 0, metadataOnly: true },
+    });
+
+    render(<AdminSecurityIncidentsPage />);
+
+    expect(await screen.findByText(/No reviewable security incident metadata is available/)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.tsx
@@ -1,0 +1,320 @@
+import React from "react";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import {
+  fetchAdminSecurityIncidentDetail,
+  fetchAdminSecurityIncidents,
+  type AdminSecurityIncidentDetail,
+  type AdminSecurityIncidentRecord,
+} from "../../api/adminSecurityIncidentsApi";
+
+const CATEGORIES = [
+  "impersonation_started",
+  "impersonation_ended",
+  "impersonation_denied",
+  "policy_denied",
+  "projection_safety_redaction",
+  "export_blocked",
+  "export_prepared",
+  "support_metadata_redacted",
+  "route_source_anomaly",
+  "auth_required_failure",
+  "admin_access_denied",
+  "automation_blocked",
+  "webhook_failure",
+  "screening_provider_callback_anomaly",
+];
+
+function label(value: string | null | undefined) {
+  const raw = String(value || "").trim();
+  if (!raw) return "Not specified";
+  return raw
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatTime(value: string) {
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return "Unknown time";
+  return new Date(ts).toLocaleString();
+}
+
+function toneForSeverity(severity: string) {
+  if (severity === "critical" || severity === "high") return "danger";
+  if (severity === "medium") return "accent";
+  return "muted";
+}
+
+function IncidentRow({
+  incident,
+  selected,
+  onSelect,
+}: {
+  incident: AdminSecurityIncidentRecord;
+  selected: boolean;
+  onSelect: (incident: AdminSecurityIncidentRecord) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(incident)}
+      style={{
+        textAlign: "left",
+        border: selected ? "1px solid #2563eb" : "1px solid rgba(15, 23, 42, 0.12)",
+        background: selected ? "#eff6ff" : "#fff",
+        borderRadius: 8,
+        padding: 12,
+        display: "grid",
+        gap: 8,
+        cursor: "pointer",
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <strong>{incident.title}</strong>
+        <Pill tone={toneForSeverity(incident.severity) as any}>{incident.severity}</Pill>
+        <Pill tone={incident.status === "open" ? "accent" : "muted"}>{label(incident.status)}</Pill>
+      </div>
+      <div style={{ color: "#475569" }}>{incident.summary}</div>
+      <div style={{ color: "#64748b", fontSize: 13 }}>
+        {label(incident.category)} · {formatTime(incident.lastSeenAt)}
+      </div>
+    </button>
+  );
+}
+
+function DetailPanel({ incident }: { incident: AdminSecurityIncidentDetail | null }) {
+  if (!incident) {
+    return (
+      <Card>
+        <div style={{ color: "#64748b" }}>Select an incident to review safe metadata details.</div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <h2 style={{ margin: 0, fontSize: "1.1rem" }}>{incident.title}</h2>
+          <Pill tone="muted">Metadata only</Pill>
+        </div>
+        <div style={{ color: "#475569" }}>{incident.summary}</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10 }}>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Actor</div>
+            <strong>{incident.actorSummary.role || "Support/admin actor"}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Target</div>
+            <strong>{incident.targetSummary.accountType || incident.targetSummary.resourceType || "Scoped resource"}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Route owner</div>
+            <strong>{incident.routeSource || "Not specified"}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Policy outcome</div>
+            <strong>{incident.policyOutcomeSummary || "Not specified"}</strong>
+          </div>
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Review action</div>
+          <div style={{ color: "#475569" }}>{incident.suggestedNextReviewStep}</div>
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Redaction notes</div>
+          <ul style={{ margin: "8px 0 0", paddingLeft: 18, color: "#475569" }}>
+            {incident.redactionNotes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Safe timeline</div>
+          <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+            {incident.timeline.map((item) => (
+              <div key={`${item.occurredAt}-${item.label}`} style={{ color: "#475569" }}>
+                {formatTime(item.occurredAt)} · {item.label}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default function AdminSecurityIncidentsPage() {
+  const { showToast } = useToast();
+  const [incidents, setIncidents] = React.useState<AdminSecurityIncidentRecord[]>([]);
+  const [summary, setSummary] = React.useState({ total: 0, open: 0, reviewing: 0, highOrCritical: 0, metadataOnly: true });
+  const [selected, setSelected] = React.useState<AdminSecurityIncidentRecord | null>(null);
+  const [detail, setDetail] = React.useState<AdminSecurityIncidentDetail | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [category, setCategory] = React.useState("");
+  const [severity, setSeverity] = React.useState("");
+  const [status, setStatus] = React.useState("");
+  const [q, setQ] = React.useState("");
+
+  const load = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetchAdminSecurityIncidents({
+        category: category || null,
+        severity: severity || null,
+        status: status || null,
+        q: q || null,
+        limit: 50,
+      });
+      setIncidents(response.incidents || []);
+      setSummary(response.summary);
+      setSelected((current) => {
+        if (!current) return response.incidents[0] || null;
+        return response.incidents.find((incident) => incident.incidentId === current.incidentId) || response.incidents[0] || null;
+      });
+    } catch (err: any) {
+      const message = err?.message || "Failed to load security incidents";
+      setError(message);
+      showToast({ message: "Failed to load security incidents", description: message, variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [category, q, severity, showToast, status]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  React.useEffect(() => {
+    if (!selected) {
+      setDetail(null);
+      return;
+    }
+    let active = true;
+    fetchAdminSecurityIncidentDetail(selected.incidentId)
+      .then((response) => {
+        if (active) setDetail(response.incident);
+      })
+      .catch(() => {
+        if (active) setDetail(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selected]);
+
+  return (
+    <MacShell title="Admin · Security incidents">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Security incidents</h1>
+                <Pill tone="accent">Admin</Pill>
+                <Pill tone="muted">Metadata only</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 860 }}>
+                Governed review of security-relevant operational signals. Raw event payloads, credentials, provider data, tenant documents, storage paths, and support internals are redacted.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void load()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        <Card>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 12 }}>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ fontSize: 12, color: "#64748b" }}>Search</span>
+              <input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search incidents" />
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ fontSize: 12, color: "#64748b" }}>Category</span>
+              <select value={category} onChange={(event) => setCategory(event.target.value)}>
+                <option value="">All categories</option>
+                {CATEGORIES.map((next) => (
+                  <option key={next} value={next}>
+                    {label(next)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ fontSize: 12, color: "#64748b" }}>Severity</span>
+              <select value={severity} onChange={(event) => setSeverity(event.target.value)}>
+                <option value="">All severities</option>
+                {["info", "low", "medium", "high", "critical"].map((next) => (
+                  <option key={next} value={next}>
+                    {label(next)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ fontSize: 12, color: "#64748b" }}>Status</span>
+              <select value={status} onChange={(event) => setStatus(event.target.value)}>
+                <option value="">All statuses</option>
+                {["open", "reviewing", "resolved", "dismissed"].map((next) => (
+                  <option key={next} value={next}>
+                    {label(next)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </Card>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 16 }}>
+          <Card>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Incidents</div>
+            <div style={{ fontSize: 24, fontWeight: 700 }}>{summary.total}</div>
+          </Card>
+          <Card>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Open</div>
+            <div style={{ fontSize: 24, fontWeight: 700 }}>{summary.open}</div>
+          </Card>
+          <Card>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Reviewing</div>
+            <div style={{ fontSize: 24, fontWeight: 700 }}>{summary.reviewing}</div>
+          </Card>
+          <Card>
+            <div style={{ fontSize: 12, color: "#64748b" }}>High or critical</div>
+            <div style={{ fontSize: 24, fontWeight: 700 }}>{summary.highOrCritical}</div>
+          </Card>
+        </div>
+
+        {loading ? <Card>Loading security incidents…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load security incidents: {error}</Card> : null}
+
+        {!loading && !error ? (
+          incidents.length ? (
+            <div style={{ display: "grid", gridTemplateColumns: "minmax(280px, 0.9fr) minmax(320px, 1.1fr)", gap: 16 }}>
+              <div style={{ display: "grid", gap: 10 }}>
+                {incidents.map((incident) => (
+                  <IncidentRow
+                    key={incident.incidentId}
+                    incident={incident}
+                    selected={selected?.incidentId === incident.incidentId}
+                    onSelect={setSelected}
+                  />
+                ))}
+              </div>
+              <DetailPanel incident={detail} />
+            </div>
+          ) : (
+            <Card>
+              No reviewable security incident metadata is available. Unsupported or raw-only events are excluded by default.
+            </Card>
+          )
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Adds admin-only metadata security incident review API routes under /api/admin/security/incidents.
- Adds deterministic incident classification/read-model over existing telemetry_events and events metadata.
- Adds /admin/security/incidents frontend page with filters, summary cards, incident list, and safe detail panel.
- Adds governance report documenting event sources, categories, redacted fields, protected routes, limitations, and follow-ups.

## Event sources discovered
- telemetry_events for operational telemetry, including impersonation lifecycle telemetry from impersonation governance.
- events for legacy audit/canonical event metadata.
- Existing admin observability/audit/readiness surfaces are summary views, not raw incident explorers.
- Admin/support projection safety helper from PR #983 is used before exposing review metadata.

## Incident categories implemented
- impersonation_started / impersonation_ended / impersonation_denied
- policy_denied / admin_access_denied / auth_required_failure
- projection_safety_redaction / support_metadata_redacted
- route_source_anomaly
- export_blocked / export_prepared
- automation_blocked / webhook_failure / screening_provider_callback_anomaly

## Safeguards
- Admin-only routes require system.admin.
- Unsupported events fail safe and are excluded.
- No raw event JSON, provider payloads, screening reports, credentials, tokens, secrets, storage paths, stack traces, or raw actor/target ids are returned.
- No mutation controls, autonomous remediation, alerting integrations, public routes, or new dependencies.

## Validation
- Backend targeted tests: npm run test:single -- src/lib/adminSecurityIncidents/__tests__/adminSecurityIncidentReview.test.ts src/routes/__tests__/adminSecurityIncidentRoutes.test.ts
- Frontend targeted tests: npm run test -- src/pages/admin/AdminSecurityIncidentsPage.test.tsx src/pages/admin/AdminDashboardPage.test.tsx
- Backend build: npm run build
- Frontend build: npm run build
- git diff --check

## Known limitations
- No persisted incident workflow/status mutation yet.
- Incident ids are derived projection ids, not permanent incident records.
- No SIEM/alerting integration and no autonomous remediation.
- Future follow-up should add append-oriented incident review notes and runbook links once support audit persistence is finalized.