### PR TITLE
Add support escalation runbook governance

### DIFF
--- a/docs/reports/support-escalation-runbooks-v1.md
+++ b/docs/reports/support-escalation-runbooks-v1.md
@@ -1,0 +1,190 @@
+# Support Escalation Runbooks v1
+
+## Summary
+
+This mission establishes RentChain's first governed support escalation runbook foundation. It defines metadata-only escalation categories, manual review states, severity handling, approval expectations, safe references, and runbook templates for future support/security operations.
+
+No escalation persistence, routes, UI, support powers, impersonation powers, autonomous remediation, enforcement actions, Firestore rule changes, or tenant/landlord-facing support internals are introduced.
+
+## Audit Findings
+
+Existing foundations reviewed:
+
+- `supportSessionAudit` defines support-session lifecycle metadata and scoped append-compatible audit refs.
+- `impersonationGovernance` records support/admin impersonation lifecycle metadata and actor-chain attribution without adding persistence or revocation.
+- `adminSupportProjectionSafety` strips support/admin internals from landlord, tenant, public export, user-safe export, dashboard, timeline, and analytics projections.
+- `adminSecurityIncidents` provides an admin-only metadata review surface for security-relevant signals.
+- `security-audit-and-incident-response-foundations-v1` defines incident categories, manual response states, and affected-resource linkage expectations.
+
+No existing support escalation runbook helper, persistence model, or route family was found.
+
+## Runbook Philosophy
+
+Support escalation runbooks should provide deterministic manual-review guidance. They should answer:
+
+- what kind of escalation is being reviewed
+- how severe the escalation is
+- which manual state it is in
+- which scoped resources are relevant
+- what approval level is expected before manual action
+- what actions are explicitly prohibited
+
+Runbooks are governance metadata. They are not permission grants, workflow engines, or action executors.
+
+## Escalation Categories
+
+Implemented categories:
+
+- `security_incident`
+- `impersonation_review`
+- `policy_failure`
+- `projection_safety`
+- `document_access`
+- `export_governance`
+- `credential_secret`
+- `api_abuse`
+- `tenant_data_exposure`
+- `screening_provider`
+- `billing_support`
+- `technical_diagnostics`
+- `compliance_review`
+- `other`
+
+Unknown categories normalize to `other`.
+
+## Severity Model
+
+Implemented severities:
+
+- `informational`
+- `low`
+- `medium`
+- `high`
+- `critical`
+
+Unknown severities normalize to `low`.
+
+## Manual States
+
+Implemented states:
+
+- `draft`
+- `queued`
+- `triage_required`
+- `reviewing`
+- `awaiting_approval`
+- `approved_for_manual_action`
+- `resolved`
+- `dismissed`
+
+Unsupported states normalize to `triage_required`. This avoids interpreting unknown or autonomous-looking states as valid workflow progress.
+
+## Approval Expectations
+
+Approval requirements are deterministic:
+
+- Credential/secret and tenant data exposure escalations require `security_review`.
+- Critical escalations require `security_review`.
+- High severity escalations require `admin_review`.
+- Impersonation, policy failure, and projection safety escalations require `admin_review`.
+- Security incident, API abuse, and export governance escalations require `support_lead_review`.
+- Low-risk metadata-only review defaults to `none_for_metadata_review`.
+
+These requirements are descriptive metadata only. They do not grant access, mutate state, or execute actions.
+
+## Safe References
+
+Runbooks may include scoped internal references for:
+
+- incidents
+- support sessions
+- impersonation sessions
+- evidence packs
+- export packages
+- review workspaces
+- API routes
+- documents
+- screening orders
+- landlord, tenant, lease, property, and unit refs
+- support diagnostics
+
+References are filtered by landlord and tenant scope where provided. They are marked `internalReference: true` and `metadataOnly: true`.
+
+Runbook references must not include raw documents, provider payloads, raw reports, request/response bodies, storage paths, tokens, secrets, credentials, stack traces, debug payloads, or unrestricted policy internals.
+
+## Safety Contract
+
+Every generated runbook ref includes:
+
+- `visibilityClass: admin_support_internal`
+- `tenantVisible: false`
+- `landlordVisible: false`
+- `metadataOnly: true`
+- `appendCompatible: true`
+- `supportPowersGranted: false`
+- `impersonationEnabled: false`
+- `autonomousRemediationEnabled: false`
+- `autonomousEscalationEnabled: false`
+- `financialMutationEnabled: false`
+- `routeVisibilityChanged: false`
+
+Payload safety is explicit:
+
+- raw payloads are excluded
+- provider, evidence, export, and document data are reference-only
+- credential data is excluded
+- diagnostic data is metadata-only
+- internal policy data is summary-only
+
+## Current Implementation
+
+Added helper:
+
+- `normalizeSupportEscalationCategory()`
+- `normalizeSupportEscalationSeverity()`
+- `normalizeSupportEscalationState()`
+- `approvalRequirementForEscalation()`
+- `buildSupportEscalationRunbookTemplate()`
+- `normalizeSupportEscalationRefs()`
+- `buildSupportEscalationRunbookRef()`
+
+Added deterministic tests confirming:
+
+- category, severity, and state normalization
+- approval requirement derivation
+- metadata-only template generation
+- scoped safe reference filtering
+- raw/restricted fields are not carried into refs
+- runbook refs do not imply support powers, impersonation, autonomous remediation, autonomous escalation, route visibility change, or financial mutation
+- unsupported inputs fail into safe defaults
+
+## Known Limitations
+
+This mission does not add:
+
+- escalation persistence
+- Firestore collections
+- routes
+- frontend UI
+- status mutation
+- automated escalation
+- external alerting or SIEM integration
+- support/admin permission changes
+- tenant or landlord visible escalation surfaces
+- incident status writes
+
+Runbook refs are deterministic helper outputs only. A future mission must explicitly review persistence, retention, route authorization, and audit append semantics before storing or mutating escalation records.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Add append-only support escalation history after persistence and retention requirements are approved.
+2. Link admin security incident review records to runbook template suggestions without enabling automated remediation.
+3. Add admin-only escalation review UI once projection and route authorization are reviewed.
+4. Define manual escalation status transitions with audit lineage.
+5. Add incident/export/evidence-specific runbook detail pages that remain metadata-only.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, expose support internals to landlords or tenants, create routes, create public endpoints, mutate financial records, alter screening/provider/payment/lease flows, add dependencies, or introduce autonomous remediation.

--- a/rentchain-api/src/lib/supportEscalationRunbooks/__tests__/supportEscalationRunbooks.test.ts
+++ b/rentchain-api/src/lib/supportEscalationRunbooks/__tests__/supportEscalationRunbooks.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  approvalRequirementForEscalation,
+  buildSupportEscalationRunbookRef,
+  buildSupportEscalationRunbookTemplate,
+  normalizeSupportEscalationCategory,
+  normalizeSupportEscalationRefs,
+  normalizeSupportEscalationSeverity,
+  normalizeSupportEscalationState,
+} from "../supportEscalationRunbooks";
+
+describe("supportEscalationRunbooks", () => {
+  it("normalizes categories, severities, and manual states deterministically", () => {
+    expect(normalizeSupportEscalationCategory("Projection Safety")).toBe("projection_safety");
+    expect(normalizeSupportEscalationCategory("unknown-new-signal")).toBe("other");
+    expect(normalizeSupportEscalationSeverity("CRITICAL")).toBe("critical");
+    expect(normalizeSupportEscalationSeverity("unexpected")).toBe("low");
+    expect(normalizeSupportEscalationState("Awaiting Approval")).toBe("awaiting_approval");
+    expect(normalizeSupportEscalationState("auto_resolved")).toBe("triage_required");
+  });
+
+  it("derives approval requirements without granting action authority", () => {
+    expect(approvalRequirementForEscalation({ category: "credential_secret", severity: "low" })).toBe("security_review");
+    expect(approvalRequirementForEscalation({ category: "projection_safety", severity: "medium" })).toBe("admin_review");
+    expect(approvalRequirementForEscalation({ category: "api_abuse", severity: "critical" })).toBe("security_review");
+    expect(approvalRequirementForEscalation({ category: "technical_diagnostics", severity: "low" })).toBe(
+      "none_for_metadata_review"
+    );
+  });
+
+  it("builds metadata-only runbook templates with prohibited autonomous actions", () => {
+    const template = buildSupportEscalationRunbookTemplate({
+      category: "tenant_data_exposure",
+      severity: "high",
+    });
+
+    expect(template).toEqual(
+      expect.objectContaining({
+        category: "tenant_data_exposure",
+        severity: "high",
+        approvalRequirement: "security_review",
+        metadataOnly: true,
+        autonomousActionEnabled: false,
+      })
+    );
+    expect(template.manualSteps.join(" ")).toContain("projection boundary");
+    expect(template.prohibitedActions.join(" ")).toContain("Do not perform autonomous remediation");
+  });
+
+  it("filters refs by scoped landlord and tenant and avoids raw labels", () => {
+    const refs = normalizeSupportEscalationRefs(
+      [
+        {
+          referenceType: "incident",
+          referenceId: "incident-1",
+          label: "<Incident> metadata",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          rawPayload: { secret: "do-not-copy" },
+        },
+        {
+          referenceType: "document",
+          referenceId: "document-1",
+          label: "Document ref",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+          storagePath: "gs://bucket/private.pdf",
+        },
+        {
+          referenceType: "tenant",
+          referenceId: "tenant-2",
+          landlordId: "landlord-1",
+          tenantId: "tenant-2",
+        },
+        {
+          referenceType: "document",
+          referenceId: "document-2",
+          label: "gs://bucket/private.pdf?token=do-not-copy",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          requestBody: { authorization: "Bearer secret" },
+          responseBody: { rawReport: "restricted" },
+          stackTrace: "debug trace",
+        },
+      ],
+      { landlordId: "landlord-1", tenantId: "tenant-1" }
+    );
+
+    expect(refs).toHaveLength(2);
+    expect(refs[0]).toEqual({
+      referenceType: "document",
+      referenceId: "document-2",
+      label: "document reference",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      internalReference: true,
+      metadataOnly: true,
+    });
+    expect(refs[1]).toEqual({
+      referenceType: "incident",
+      referenceId: "incident-1",
+      label: "Incident metadata",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      internalReference: true,
+      metadataOnly: true,
+    });
+    expect(JSON.stringify(refs)).not.toContain("secret");
+    expect(JSON.stringify(refs)).not.toContain("storagePath");
+    expect(JSON.stringify(refs)).not.toContain("gs://");
+    expect(JSON.stringify(refs)).not.toContain("requestBody");
+    expect(JSON.stringify(refs)).not.toContain("responseBody");
+    expect(JSON.stringify(refs)).not.toContain("stackTrace");
+  });
+
+  it("builds non-granting support escalation runbook refs", () => {
+    const runbook = buildSupportEscalationRunbookRef({
+      escalationId: "Escalation 1",
+      category: "impersonation_review",
+      severity: "medium",
+      state: "reviewing",
+      requestedBy: "admin-user-1",
+      assignedTo: "support-lead-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      occurredAt: "2026-05-23T12:00:00.000Z",
+      incidentRefs: [
+        {
+          referenceType: "incident",
+          referenceId: "incident-1",
+          label: "Impersonation lifecycle incident",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+        },
+      ],
+      evidenceRefs: [
+        {
+          referenceType: "evidence_pack",
+          referenceId: "evidence-1",
+          label: "Evidence lineage",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          providerPayload: { report: "restricted" },
+        },
+      ],
+    });
+
+    expect(runbook).toEqual(
+      expect.objectContaining({
+        escalationId: "escalation_1",
+        category: "impersonation_review",
+        severity: "medium",
+        state: "reviewing",
+        approvalRequirement: "admin_review",
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        metadataOnly: true,
+        appendCompatible: true,
+        supportPowersGranted: false,
+        impersonationEnabled: false,
+        autonomousRemediationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+        routeVisibilityChanged: false,
+      })
+    );
+    expect(runbook.incidentRefs).toHaveLength(1);
+    expect(runbook.evidenceRefs).toHaveLength(1);
+    expect(JSON.stringify(runbook)).not.toContain("restricted");
+  });
+
+  it("falls back safely for unsupported inputs", () => {
+    const runbook = buildSupportEscalationRunbookRef({
+      category: "auto-fix-account",
+      severity: "urgent-now",
+      state: "autonomous_remediation",
+      occurredAt: "not-a-date",
+    });
+
+    expect(runbook.category).toBe("other");
+    expect(runbook.severity).toBe("low");
+    expect(runbook.state).toBe("triage_required");
+    expect(runbook.occurredAt).toBe("1970-01-01T00:00:00.000Z");
+    expect(runbook.approvalRequirement).toBe("none_for_metadata_review");
+    expect(runbook.autonomousRemediationEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/supportEscalationRunbooks/supportEscalationRunbooks.ts
+++ b/rentchain-api/src/lib/supportEscalationRunbooks/supportEscalationRunbooks.ts
@@ -1,0 +1,431 @@
+export const SUPPORT_ESCALATION_RUNBOOK_VERSION = "support_escalation_runbooks_v1";
+
+export type SupportEscalationCategory =
+  | "security_incident"
+  | "impersonation_review"
+  | "policy_failure"
+  | "projection_safety"
+  | "document_access"
+  | "export_governance"
+  | "credential_secret"
+  | "api_abuse"
+  | "tenant_data_exposure"
+  | "screening_provider"
+  | "billing_support"
+  | "technical_diagnostics"
+  | "compliance_review"
+  | "other";
+
+export type SupportEscalationSeverity = "informational" | "low" | "medium" | "high" | "critical";
+
+export type SupportEscalationState =
+  | "draft"
+  | "queued"
+  | "triage_required"
+  | "reviewing"
+  | "awaiting_approval"
+  | "approved_for_manual_action"
+  | "resolved"
+  | "dismissed";
+
+export type SupportEscalationApprovalRequirement =
+  | "none_for_metadata_review"
+  | "support_lead_review"
+  | "admin_review"
+  | "security_review"
+  | "executive_review"
+  | "prohibited";
+
+export type SupportEscalationReferenceType =
+  | "incident"
+  | "support_session"
+  | "impersonation_session"
+  | "evidence_pack"
+  | "export_package"
+  | "review_workspace"
+  | "api_route"
+  | "document"
+  | "screening_order"
+  | "landlord"
+  | "tenant"
+  | "lease"
+  | "property"
+  | "unit"
+  | "support_diagnostic";
+
+export type SupportEscalationSafeRef = {
+  referenceType: SupportEscalationReferenceType;
+  referenceId: string;
+  label: string;
+  landlordId: string | null;
+  tenantId: string | null;
+  internalReference: true;
+  metadataOnly: true;
+};
+
+export type SupportEscalationRunbookTemplate = {
+  runbookTemplateId: string;
+  category: SupportEscalationCategory;
+  title: string;
+  severity: SupportEscalationSeverity;
+  manualSteps: string[];
+  approvalRequirement: SupportEscalationApprovalRequirement;
+  prohibitedActions: string[];
+  metadataOnly: true;
+  autonomousActionEnabled: false;
+};
+
+export type SupportEscalationRunbookRef = {
+  supportEscalationRunbookVersion: typeof SUPPORT_ESCALATION_RUNBOOK_VERSION;
+  escalationId: string;
+  category: SupportEscalationCategory;
+  severity: SupportEscalationSeverity;
+  state: SupportEscalationState;
+  title: string;
+  summary: string;
+  runbookTemplate: SupportEscalationRunbookTemplate;
+  approvalRequirement: SupportEscalationApprovalRequirement;
+  requestedBy: string | null;
+  assignedTo: string | null;
+  landlordId: string | null;
+  tenantId: string | null;
+  occurredAt: string;
+  resourceRefs: SupportEscalationSafeRef[];
+  evidenceRefs: SupportEscalationSafeRef[];
+  incidentRefs: SupportEscalationSafeRef[];
+  exportRefs: SupportEscalationSafeRef[];
+  reviewRefs: SupportEscalationSafeRef[];
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  metadataOnly: true;
+  appendCompatible: true;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousRemediationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  routeVisibilityChanged: false;
+  payloadSafety: {
+    rawPayloads: "excluded";
+    providerData: "reference_only";
+    evidenceData: "reference_only";
+    exportData: "reference_only";
+    documentData: "reference_only";
+    credentialData: "excluded";
+    diagnosticData: "metadata_only";
+    internalPolicyData: "summary_only";
+  };
+};
+
+const CATEGORIES = new Set<SupportEscalationCategory>([
+  "security_incident",
+  "impersonation_review",
+  "policy_failure",
+  "projection_safety",
+  "document_access",
+  "export_governance",
+  "credential_secret",
+  "api_abuse",
+  "tenant_data_exposure",
+  "screening_provider",
+  "billing_support",
+  "technical_diagnostics",
+  "compliance_review",
+  "other",
+]);
+
+const SEVERITIES = new Set<SupportEscalationSeverity>([
+  "informational",
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+const STATES = new Set<SupportEscalationState>([
+  "draft",
+  "queued",
+  "triage_required",
+  "reviewing",
+  "awaiting_approval",
+  "approved_for_manual_action",
+  "resolved",
+  "dismissed",
+]);
+
+const REF_TYPES = new Set<SupportEscalationReferenceType>([
+  "incident",
+  "support_session",
+  "impersonation_session",
+  "evidence_pack",
+  "export_package",
+  "review_workspace",
+  "api_route",
+  "document",
+  "screening_order",
+  "landlord",
+  "tenant",
+  "lease",
+  "property",
+  "unit",
+  "support_diagnostic",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 140).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function safeText(value: unknown, max = 500): string {
+  return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+function safeReferenceLabel(value: unknown, fallback: string): string {
+  const label = safeText(value, 160);
+  if (!label) return fallback;
+  if (/gs:\/\//i.test(label) || /storage\.googleapis\.com/i.test(label)) return fallback;
+  if (/token|secret|credential|authorization|cookie|password/i.test(label)) return fallback;
+  return label;
+}
+
+function idPart(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function toIso(value: unknown): string {
+  if (value && typeof (value as any).toDate === "function") {
+    return (value as any).toDate().toISOString();
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = asString(value, 120);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function uniqueSorted<T>(values: T[], key: (value: T) => string): T[] {
+  const byKey = new Map<string, T>();
+  for (const value of values) {
+    const nextKey = key(value);
+    if (nextKey && !byKey.has(nextKey)) byKey.set(nextKey, value);
+  }
+  return Array.from(byKey.values()).sort((a, b) => key(a).localeCompare(key(b)));
+}
+
+export function normalizeSupportEscalationCategory(value: unknown): SupportEscalationCategory {
+  const normalized = normalizeKey(value);
+  return CATEGORIES.has(normalized as SupportEscalationCategory)
+    ? (normalized as SupportEscalationCategory)
+    : "other";
+}
+
+export function normalizeSupportEscalationSeverity(value: unknown): SupportEscalationSeverity {
+  const normalized = normalizeKey(value);
+  return SEVERITIES.has(normalized as SupportEscalationSeverity)
+    ? (normalized as SupportEscalationSeverity)
+    : "low";
+}
+
+export function normalizeSupportEscalationState(value: unknown): SupportEscalationState {
+  const normalized = normalizeKey(value);
+  return STATES.has(normalized as SupportEscalationState)
+    ? (normalized as SupportEscalationState)
+    : "triage_required";
+}
+
+export function approvalRequirementForEscalation(input: {
+  category?: unknown;
+  severity?: unknown;
+}): SupportEscalationApprovalRequirement {
+  const category = normalizeSupportEscalationCategory(input.category);
+  const severity = normalizeSupportEscalationSeverity(input.severity);
+  if (category === "tenant_data_exposure" || category === "credential_secret") return "security_review";
+  if (severity === "critical") return "security_review";
+  if (severity === "high") return "admin_review";
+  if (category === "impersonation_review" || category === "policy_failure" || category === "projection_safety") {
+    return "admin_review";
+  }
+  if (category === "security_incident" || category === "api_abuse" || category === "export_governance") {
+    return "support_lead_review";
+  }
+  return "none_for_metadata_review";
+}
+
+function templateTitle(category: SupportEscalationCategory): string {
+  return category
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function defaultSteps(category: SupportEscalationCategory): string[] {
+  const baseline = [
+    "Confirm the scoped context and authority boundary before review.",
+    "Review metadata-only incident, support-session, evidence, or export references.",
+    "Record manual review outcome in the approved audit path when available.",
+  ];
+  if (category === "credential_secret") {
+    return [
+      "Confirm no secret value is copied into the runbook or audit notes.",
+      "Identify affected credential family and owner from metadata-only references.",
+      "Use the approved manual credential rotation runbook if live rotation is required.",
+    ];
+  }
+  if (category === "tenant_data_exposure" || category === "projection_safety") {
+    return [
+      "Confirm affected audience and projection boundary from metadata-only references.",
+      "Review whether any user-safe surface received internal support/admin metadata.",
+      "Escalate to security review before any tenant, landlord, or institution communication.",
+    ];
+  }
+  if (category === "impersonation_review") {
+    return [
+      "Confirm support/admin actor attribution and effective target role summary.",
+      "Review impersonation lifecycle metadata and reason category.",
+      "Confirm no write action or permission grant is implied by the escalation record.",
+    ];
+  }
+  return baseline;
+}
+
+export function buildSupportEscalationRunbookTemplate(input: {
+  category?: unknown;
+  severity?: unknown;
+}): SupportEscalationRunbookTemplate {
+  const category = normalizeSupportEscalationCategory(input.category);
+  const severity = normalizeSupportEscalationSeverity(input.severity);
+  return {
+    runbookTemplateId: idPart(["support_escalation_runbook", category, severity].join(":")),
+    category,
+    title: `${templateTitle(category)} runbook`,
+    severity,
+    manualSteps: defaultSteps(category),
+    approvalRequirement: approvalRequirementForEscalation({ category, severity }),
+    prohibitedActions: [
+      "Do not perform autonomous remediation.",
+      "Do not change permissions, auth, Firestore rules, or route visibility from this runbook.",
+      "Do not copy raw documents, provider payloads, tokens, secrets, credentials, or debug payloads.",
+      "Do not mutate financial records.",
+    ],
+    metadataOnly: true,
+    autonomousActionEnabled: false,
+  };
+}
+
+export function normalizeSupportEscalationRefs(
+  raw: unknown,
+  scope: { landlordId?: string | null; tenantId?: string | null } = {}
+): SupportEscalationSafeRef[] {
+  if (!Array.isArray(raw)) return [];
+  const landlordScope = asString(scope.landlordId, 240) || null;
+  const tenantScope = asString(scope.tenantId, 240) || null;
+
+  const refs = raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const referenceType = normalizeKey(data.referenceType || data.resourceType || data.type) as SupportEscalationReferenceType;
+      const referenceId = asString(data.referenceId || data.resourceId || data.id || data.sourceId, 240);
+      const landlordId = asString(data.landlordId, 240) || null;
+      const tenantId = asString(data.tenantId, 240) || null;
+      if (!REF_TYPES.has(referenceType) || !referenceId) return null;
+      if (landlordScope && landlordId && landlordId !== landlordScope) return null;
+      if (tenantScope && tenantId && tenantId !== tenantScope) return null;
+      return {
+        referenceType,
+        referenceId,
+        label: safeReferenceLabel(data.label, `${referenceType.replace(/_/g, " ")} reference`),
+        landlordId: landlordId || landlordScope,
+        tenantId,
+        internalReference: true,
+        metadataOnly: true,
+      };
+    })
+    .filter(Boolean) as SupportEscalationSafeRef[];
+
+  return uniqueSorted(refs, (ref) => `${ref.referenceType}:${ref.referenceId}`).slice(0, 32);
+}
+
+export function buildSupportEscalationRunbookRef(input: {
+  escalationId?: string | null;
+  category?: unknown;
+  severity?: unknown;
+  state?: unknown;
+  title?: string | null;
+  summary?: string | null;
+  requestedBy?: string | null;
+  assignedTo?: string | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  occurredAt?: unknown;
+  resourceRefs?: Array<Record<string, unknown>> | null;
+  evidenceRefs?: Array<Record<string, unknown>> | null;
+  incidentRefs?: Array<Record<string, unknown>> | null;
+  exportRefs?: Array<Record<string, unknown>> | null;
+  reviewRefs?: Array<Record<string, unknown>> | null;
+}): SupportEscalationRunbookRef {
+  const category = normalizeSupportEscalationCategory(input.category);
+  const severity = normalizeSupportEscalationSeverity(input.severity);
+  const state = normalizeSupportEscalationState(input.state);
+  const occurredAt = toIso(input.occurredAt);
+  const landlordId = asString(input.landlordId, 240) || null;
+  const tenantId = asString(input.tenantId, 240) || null;
+  const escalationId =
+    idPart(input.escalationId) ||
+    idPart(["support_escalation", category, severity, state, occurredAt].join(":")) ||
+    "support_escalation_unknown";
+  const scope = { landlordId, tenantId };
+  const template = buildSupportEscalationRunbookTemplate({ category, severity });
+
+  return {
+    supportEscalationRunbookVersion: SUPPORT_ESCALATION_RUNBOOK_VERSION,
+    escalationId,
+    category,
+    severity,
+    state,
+    title: safeText(input.title, 180) || template.title,
+    summary:
+      safeText(input.summary, 360) ||
+      "Support escalation runbook metadata prepared for manual review.",
+    runbookTemplate: template,
+    approvalRequirement: template.approvalRequirement,
+    requestedBy: asString(input.requestedBy, 240) || null,
+    assignedTo: asString(input.assignedTo, 240) || null,
+    landlordId,
+    tenantId,
+    occurredAt,
+    resourceRefs: normalizeSupportEscalationRefs(input.resourceRefs, scope),
+    evidenceRefs: normalizeSupportEscalationRefs(input.evidenceRefs, scope),
+    incidentRefs: normalizeSupportEscalationRefs(input.incidentRefs, scope),
+    exportRefs: normalizeSupportEscalationRefs(input.exportRefs, scope),
+    reviewRefs: normalizeSupportEscalationRefs(input.reviewRefs, scope),
+    visibilityClass: "admin_support_internal",
+    tenantVisible: false,
+    landlordVisible: false,
+    metadataOnly: true,
+    appendCompatible: true,
+    supportPowersGranted: false,
+    impersonationEnabled: false,
+    autonomousRemediationEnabled: false,
+    autonomousEscalationEnabled: false,
+    financialMutationEnabled: false,
+    routeVisibilityChanged: false,
+    payloadSafety: {
+      rawPayloads: "excluded",
+      providerData: "reference_only",
+      evidenceData: "reference_only",
+      exportData: "reference_only",
+      documentData: "reference_only",
+      credentialData: "excluded",
+      diagnosticData: "metadata_only",
+      internalPolicyData: "summary_only",
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add metadata-only support escalation runbook governance helper
- define escalation categories, severities, manual states, approval expectations, and safe scoped references
- add governance report for support escalation runbooks

## Safety
- no routes, frontend UI, persistence, status mutation, or runtime behavior added
- no support/admin powers granted
- no impersonation, autonomous remediation, autonomous escalation, financial mutation, or route visibility changes enabled
- raw documents, provider payloads, reports, request/response bodies, storage paths, tokens, secrets, credentials, stack traces, debug payloads, and unrestricted policy internals are excluded or reference/summary-only

## Validation
- npm run test:single -- src/lib/supportEscalationRunbooks/__tests__/supportEscalationRunbooks.test.ts
- npm run build (rentchain-api)
- git diff --check