### PR TITLE
Add support escalation history governance

### DIFF
--- a/docs/reports/support-escalation-history-and-review-notes-v1.md
+++ b/docs/reports/support-escalation-history-and-review-notes-v1.md
@@ -1,0 +1,203 @@
+# Support Escalation History and Review Notes v1
+
+## Summary
+
+This mission adds a governed, append-only metadata foundation for support escalation history entries and manual review notes. It builds on `supportEscalationRunbooks` from PR #985 and keeps escalation history admin/support internal, projection-safe, and non-autonomous.
+
+No routes, frontend UI, Firestore collections, persistence writes, status mutation, support powers, impersonation powers, autonomous remediation, automated enforcement, or tenant/landlord-facing escalation visibility are introduced.
+
+## Audit Findings
+
+Reviewed foundations:
+
+- `supportEscalationRunbooks` provides deterministic categories, severity, manual states, approval requirements, and scoped safe refs.
+- `supportSessionAudit` provides append-compatible support-session audit metadata but no persistence writer.
+- `adminSecurityIncidents` provides admin-only incident review summaries and safe detail projections.
+- `adminSupportProjectionSafety` strips support/admin internals from user-safe surfaces.
+- `events/buildEvent` provides canonical event construction and Firestore writes, but this mission does not write events because support escalation persistence and retention are not yet approved.
+- Existing note/history patterns exist for lease lifecycle reviews, resolution notes, and review timelines, but they are domain-specific and not a reviewed support escalation persistence model.
+
+No existing support escalation history or support review note system was found.
+
+## Implemented Helpers
+
+Added helper:
+
+- `normalizeSupportEscalationActionType()`
+- `normalizeSupportEscalationNoteType()`
+- `buildSupportEscalationHistoryEntry()`
+- `buildSupportEscalationReviewNote()`
+
+The helper reuses runbook governance from `supportEscalationRunbooks` for:
+
+- category normalization
+- severity normalization
+- manual state normalization
+- approval requirement derivation
+- scoped safe evidence/resource refs
+
+## Supported Action Types
+
+Implemented action types:
+
+- `escalation_created`
+- `triage_started`
+- `review_note_added`
+- `approval_requested`
+- `manual_action_approved`
+- `manual_action_declined`
+- `escalation_resolved`
+- `escalation_dismissed`
+- `evidence_ref_added`
+- `runbook_template_applied`
+
+Unsupported action types normalize to `review_note_added`, a safe non-mutating default.
+
+## Supported Note Types
+
+Implemented note types:
+
+- `triage_note`
+- `security_review_note`
+- `support_lead_note`
+- `admin_review_note`
+- `evidence_note`
+- `resolution_note`
+- `dismissal_note`
+
+Unsupported note types normalize to `triage_note`.
+
+## History Entry Contract
+
+History entries include:
+
+- `historyEntryId`
+- `escalationRefId`
+- category, severity, state
+- action type
+- actor summary
+- occurrence timestamp
+- note summary
+- approval expectation
+- safe evidence refs
+- safe resource refs
+- metadata-only visibility and append-only flags
+
+History entries are intended as append-only metadata records. They are not status mutations, approval execution, remediation, or permission grants.
+
+## Manual Review Note Contract
+
+Manual review notes include:
+
+- `noteId`
+- `escalationRefId`
+- note type
+- normalized note summary
+- author summary
+- creation timestamp
+- safe evidence refs
+- safe resource refs
+- redaction summary
+- metadata-only visibility and append-only flags
+
+Freeform note text is normalized into a bounded metadata-only summary. It is not treated as a raw payload store.
+
+## Redaction and Projection Safety
+
+The helper avoids or redacts:
+
+- tokens
+- credentials
+- secrets
+- authorization headers
+- cookies
+- raw provider payloads
+- raw screening reports
+- raw documents
+- raw storage paths
+- raw request bodies
+- raw response bodies
+- stack traces
+- debug payloads
+- unrestricted policy internals
+
+Actor summaries intentionally exclude raw actor IDs. Safe refs reuse the runbook helper, which filters unrelated landlord/tenant scope and avoids raw storage/token-like labels.
+
+Every history entry and note includes:
+
+- `metadataOnly: true`
+- `visibilityClass: admin_support_internal`
+- `tenantVisible: false`
+- `landlordVisible: false`
+- `appendOnly: true`
+- `supportPowersGranted: false`
+- `impersonationEnabled: false`
+- `autonomousRemediationEnabled: false`
+- `autonomousEscalationEnabled: false`
+- `financialMutationEnabled: false`
+- `routeVisibilityChanged: false`
+
+## Persistence Decision
+
+Persistence is intentionally deferred.
+
+No existing reviewed support escalation collection or append-only support/admin note writer exists. Introducing storage would require separate review of:
+
+- collection ownership
+- retention policy
+- admin/support route authorization
+- route-source attribution
+- append-only write semantics
+- read projection rules
+- incident/runbook linkage
+- tenant/landlord exclusion guarantees
+
+This mission therefore adds helper/model foundations only.
+
+## Tests Added
+
+Tests confirm:
+
+- action type normalization
+- note type normalization
+- history entry creation
+- manual review note creation
+- category/severity/state reuse from runbook helper
+- approval expectation derivation
+- scoped safe refs
+- restricted field exclusion
+- tenant and landlord visibility remain false
+- append-only flag remains true
+- no support powers, impersonation, autonomous remediation, autonomous escalation, financial mutation, or route visibility change is implied
+- unsupported inputs fail safe
+
+## Known Limitations
+
+This phase does not add:
+
+- Firestore persistence
+- API routes
+- admin UI
+- note editing
+- status mutation
+- incident status linkage
+- escalation assignment
+- notification/alerting
+- external SIEM integration
+- automated remediation
+
+The helper is a deterministic contract foundation only.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Add an append-only admin/support escalation history writer after collection ownership and retention are approved.
+2. Add admin-only read routes for escalation history after route authorization and route-source ownership are reviewed.
+3. Link admin security incident records to suggested runbook templates and history entries without enabling automated actions.
+4. Add admin UI for manual escalation notes and history once projection safety tests exist for the route.
+5. Define immutable retention/export rules for admin/support escalation audit records.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, add routes, add UI, add persistence, expose support internals to landlords or tenants, enable impersonation, mutate financial records, alter screening/payment/pricing/lease/export workflows, add dependencies, or introduce autonomous remediation.

--- a/rentchain-api/src/lib/supportEscalationHistory/__tests__/supportEscalationHistory.test.ts
+++ b/rentchain-api/src/lib/supportEscalationHistory/__tests__/supportEscalationHistory.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSupportEscalationHistoryEntry,
+  buildSupportEscalationReviewNote,
+  normalizeSupportEscalationActionType,
+  normalizeSupportEscalationNoteType,
+} from "../supportEscalationHistory";
+
+describe("supportEscalationHistory", () => {
+  it("normalizes unsupported action and note types to safe non-mutating defaults", () => {
+    expect(normalizeSupportEscalationActionType("auto_disable_account")).toBe("review_note_added");
+    expect(normalizeSupportEscalationActionType("Manual Action Approved")).toBe("manual_action_approved");
+    expect(normalizeSupportEscalationNoteType("raw_debug_note")).toBe("triage_note");
+    expect(normalizeSupportEscalationNoteType("Security Review Note")).toBe("security_review_note");
+  });
+
+  it("builds append-only metadata history entries using runbook normalization", () => {
+    const entry = buildSupportEscalationHistoryEntry({
+      escalationRefId: "Escalation 1",
+      category: "credential_secret",
+      severity: "critical",
+      state: "awaiting_approval",
+      actionType: "approval_requested",
+      actor: { id: "admin-raw-id", role: "admin", displayName: "Security operator" },
+      occurredAt: "2026-05-23T12:00:00.000Z",
+      noteSummary: "Credential family needs manual rotation review.",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      safeEvidenceRefs: [
+        {
+          referenceType: "incident",
+          referenceId: "incident-1",
+          label: "Credential incident",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+        },
+      ],
+    });
+
+    expect(entry).toEqual(
+      expect.objectContaining({
+        escalationRefId: "escalation_1",
+        category: "credential_secret",
+        severity: "critical",
+        state: "awaiting_approval",
+        actionType: "approval_requested",
+        approvalExpectation: "security_review",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+        supportPowersGranted: false,
+        impersonationEnabled: false,
+        autonomousRemediationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+        routeVisibilityChanged: false,
+      })
+    );
+    expect(entry.actorSummary).toEqual({
+      role: "admin",
+      displayName: "Security operator",
+      supportAttribution: true,
+      rawActorIdsIncluded: false,
+    });
+    expect(entry.safeEvidenceRefs).toHaveLength(1);
+    expect(JSON.stringify(entry)).not.toContain("admin-raw-id");
+  });
+
+  it("filters unsafe refs and strips restricted fields from history entries", () => {
+    const entry = buildSupportEscalationHistoryEntry({
+      escalationRefId: "escalation-2",
+      category: "projection_safety",
+      severity: "medium",
+      state: "reviewing",
+      actionType: "evidence_ref_added",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      noteSummary:
+        "Bearer abc123 token=secret gs://bucket/raw.pdf stackTrace=do-not-copy requestBody={raw}",
+      safeEvidenceRefs: [
+        {
+          referenceType: "evidence_pack",
+          referenceId: "evidence-1",
+          label: "gs://bucket/private.pdf?token=secret",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          rawPayload: { providerPayload: "restricted" },
+          requestBody: { authorization: "Bearer secret" },
+          responseBody: { rawReport: "restricted" },
+          stackTrace: "debug trace",
+        },
+        {
+          referenceType: "document",
+          referenceId: "document-2",
+          label: "Wrong landlord",
+          landlordId: "landlord-2",
+          tenantId: "tenant-1",
+        },
+        {
+          referenceType: "tenant",
+          referenceId: "tenant-2",
+          label: "Wrong tenant",
+          landlordId: "landlord-1",
+          tenantId: "tenant-2",
+        },
+      ],
+    });
+
+    expect(entry.safeEvidenceRefs).toEqual([
+      {
+        referenceType: "evidence_pack",
+        referenceId: "evidence-1",
+        label: "evidence pack reference",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        internalReference: true,
+        metadataOnly: true,
+      },
+    ]);
+    expect(entry.noteSummary).toContain("[redacted authorization]");
+    expect(entry.noteSummary).toContain("token=[redacted]");
+    expect(entry.noteSummary).toContain("[redacted storage reference]");
+    expect(JSON.stringify(entry)).not.toContain("providerPayload");
+    expect(JSON.stringify(entry)).not.toContain("requestBody");
+    expect(JSON.stringify(entry)).not.toContain("responseBody");
+    expect(JSON.stringify(entry)).not.toContain("stackTrace");
+    expect(JSON.stringify(entry)).not.toContain("gs://");
+  });
+
+  it("builds metadata-only manual review notes with redaction summary", () => {
+    const note = buildSupportEscalationReviewNote({
+      noteId: "Note 1",
+      escalationRefId: "Escalation 1",
+      noteType: "admin_review_note",
+      noteSummary:
+        "Reviewed policy outcome. authorization=Bearer-secret storage https://storage.googleapis.com/bucket/raw.pdf",
+      author: { id: "support-raw-id", role: "support", displayName: "Support lead" },
+      createdAt: "2026-05-23T13:00:00.000Z",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      resourceRefs: [
+        {
+          referenceType: "review_workspace",
+          referenceId: "review-1",
+          label: "Review workspace",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          debugPayload: "restricted",
+        },
+      ],
+    });
+
+    expect(note).toEqual(
+      expect.objectContaining({
+        noteId: "note_1",
+        escalationRefId: "escalation_1",
+        noteType: "admin_review_note",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+        supportPowersGranted: false,
+        impersonationEnabled: false,
+        autonomousRemediationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+        routeVisibilityChanged: false,
+      })
+    );
+    expect(note.authorSummary).toEqual({
+      role: "support",
+      displayName: "Support lead",
+      supportAttribution: true,
+      rawActorIdsIncluded: false,
+    });
+    expect(note.noteSummary).toContain("authorization=[redacted]");
+    expect(note.noteSummary).toContain("[redacted storage reference]");
+    expect(note.redactionSummary).toContain("metadata-only summary");
+    expect(JSON.stringify(note)).not.toContain("support-raw-id");
+    expect(JSON.stringify(note)).not.toContain("debugPayload");
+  });
+
+  it("fails unsupported inputs into safe defaults", () => {
+    const entry = buildSupportEscalationHistoryEntry({
+      escalationRefId: "",
+      category: "auto_remediation",
+      severity: "urgent",
+      state: "auto_resolved",
+      actionType: "disable_user",
+      occurredAt: "not-a-date",
+      noteSummary: "",
+    });
+    const note = buildSupportEscalationReviewNote({
+      noteType: "raw_payload_note",
+      createdAt: "not-a-date",
+      noteSummary: "",
+    });
+
+    expect(entry.escalationRefId).toBe("support_escalation_unknown");
+    expect(entry.category).toBe("other");
+    expect(entry.severity).toBe("low");
+    expect(entry.state).toBe("triage_required");
+    expect(entry.actionType).toBe("review_note_added");
+    expect(entry.occurredAt).toBe("1970-01-01T00:00:00.000Z");
+    expect(entry.noteSummary).toBe("Manual support escalation note recorded as metadata-only summary.");
+    expect(note.noteType).toBe("triage_note");
+    expect(note.createdAt).toBe("1970-01-01T00:00:00.000Z");
+    expect(note.autonomousRemediationEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/supportEscalationHistory/supportEscalationHistory.ts
+++ b/rentchain-api/src/lib/supportEscalationHistory/supportEscalationHistory.ts
@@ -1,0 +1,302 @@
+import {
+  approvalRequirementForEscalation,
+  normalizeSupportEscalationCategory,
+  normalizeSupportEscalationRefs,
+  normalizeSupportEscalationSeverity,
+  normalizeSupportEscalationState,
+  type SupportEscalationApprovalRequirement,
+  type SupportEscalationCategory,
+  type SupportEscalationSafeRef,
+  type SupportEscalationSeverity,
+  type SupportEscalationState,
+} from "../supportEscalationRunbooks/supportEscalationRunbooks";
+
+export const SUPPORT_ESCALATION_HISTORY_VERSION = "support_escalation_history_v1";
+
+export type SupportEscalationActionType =
+  | "escalation_created"
+  | "triage_started"
+  | "review_note_added"
+  | "approval_requested"
+  | "manual_action_approved"
+  | "manual_action_declined"
+  | "escalation_resolved"
+  | "escalation_dismissed"
+  | "evidence_ref_added"
+  | "runbook_template_applied";
+
+export type SupportEscalationNoteType =
+  | "triage_note"
+  | "security_review_note"
+  | "support_lead_note"
+  | "admin_review_note"
+  | "evidence_note"
+  | "resolution_note"
+  | "dismissal_note";
+
+export type SupportEscalationActorSummary = {
+  role: string | null;
+  displayName: string | null;
+  supportAttribution: boolean;
+  rawActorIdsIncluded: false;
+};
+
+export type SupportEscalationHistoryEntry = {
+  supportEscalationHistoryVersion: typeof SUPPORT_ESCALATION_HISTORY_VERSION;
+  historyEntryId: string;
+  escalationRefId: string;
+  category: SupportEscalationCategory;
+  severity: SupportEscalationSeverity;
+  state: SupportEscalationState;
+  actionType: SupportEscalationActionType;
+  actorSummary: SupportEscalationActorSummary;
+  occurredAt: string;
+  noteSummary: string;
+  approvalExpectation: SupportEscalationApprovalRequirement;
+  safeEvidenceRefs: SupportEscalationSafeRef[];
+  resourceRefs: SupportEscalationSafeRef[];
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendOnly: true;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousRemediationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  routeVisibilityChanged: false;
+  payloadSafety: SupportEscalationPayloadSafety;
+};
+
+export type SupportEscalationReviewNote = {
+  supportEscalationHistoryVersion: typeof SUPPORT_ESCALATION_HISTORY_VERSION;
+  noteId: string;
+  escalationRefId: string;
+  noteType: SupportEscalationNoteType;
+  noteSummary: string;
+  authorSummary: SupportEscalationActorSummary;
+  createdAt: string;
+  safeEvidenceRefs: SupportEscalationSafeRef[];
+  resourceRefs: SupportEscalationSafeRef[];
+  redactionSummary: string;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendOnly: true;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousRemediationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  routeVisibilityChanged: false;
+  payloadSafety: SupportEscalationPayloadSafety;
+};
+
+type SupportEscalationPayloadSafety = {
+  rawPayloads: "excluded";
+  providerData: "reference_only";
+  evidenceData: "reference_only";
+  exportData: "reference_only";
+  documentData: "reference_only";
+  credentialData: "excluded";
+  requestResponseData: "excluded";
+  diagnosticData: "metadata_only";
+  internalPolicyData: "summary_only";
+};
+
+const ACTION_TYPES = new Set<SupportEscalationActionType>([
+  "escalation_created",
+  "triage_started",
+  "review_note_added",
+  "approval_requested",
+  "manual_action_approved",
+  "manual_action_declined",
+  "escalation_resolved",
+  "escalation_dismissed",
+  "evidence_ref_added",
+  "runbook_template_applied",
+]);
+
+const NOTE_TYPES = new Set<SupportEscalationNoteType>([
+  "triage_note",
+  "security_review_note",
+  "support_lead_note",
+  "admin_review_note",
+  "evidence_note",
+  "resolution_note",
+  "dismissal_note",
+]);
+
+const PAYLOAD_SAFETY: SupportEscalationPayloadSafety = {
+  rawPayloads: "excluded",
+  providerData: "reference_only",
+  evidenceData: "reference_only",
+  exportData: "reference_only",
+  documentData: "reference_only",
+  credentialData: "excluded",
+  requestResponseData: "excluded",
+  diagnosticData: "metadata_only",
+  internalPolicyData: "summary_only",
+};
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 140).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function idPart(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function toIso(value: unknown): string {
+  if (value && typeof (value as any).toDate === "function") return (value as any).toDate().toISOString();
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = asString(value, 120);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function safeText(value: unknown, max = 500): string {
+  return asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+function redactNoteSummary(value: unknown): string {
+  let next = safeText(value, 700);
+  if (!next) return "Manual support escalation note recorded as metadata-only summary.";
+  next = next.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "[redacted authorization]");
+  next = next.replace(/(token|secret|credential|password|authorization|cookie)\s*[:=]\s*[^,\s;]+/gi, "$1=[redacted]");
+  next = next.replace(/gs:\/\/[^\s]+/gi, "[redacted storage reference]");
+  next = next.replace(/https:\/\/storage\.googleapis\.com\/[^\s]+/gi, "[redacted storage reference]");
+  next = next.replace(/stack(trace)?\s*[:=].*$/gi, "stack=[redacted diagnostic]");
+  return next.slice(0, 500).trim() || "Manual support escalation note recorded as metadata-only summary.";
+}
+
+function actorSummary(input: unknown): SupportEscalationActorSummary {
+  const data = (input && typeof input === "object" ? input : {}) as Record<string, unknown>;
+  return {
+    role: safeText(data.role || data.actorRole, 80) || null,
+    displayName: safeText(data.displayName || data.label || data.name, 120) || null,
+    supportAttribution: Boolean(data.supportAttribution || data.supportProjectionSafe || data.role === "admin" || data.role === "support"),
+    rawActorIdsIncluded: false,
+  };
+}
+
+export function normalizeSupportEscalationActionType(value: unknown): SupportEscalationActionType {
+  const normalized = normalizeKey(value);
+  return ACTION_TYPES.has(normalized as SupportEscalationActionType)
+    ? (normalized as SupportEscalationActionType)
+    : "review_note_added";
+}
+
+export function normalizeSupportEscalationNoteType(value: unknown): SupportEscalationNoteType {
+  const normalized = normalizeKey(value);
+  return NOTE_TYPES.has(normalized as SupportEscalationNoteType)
+    ? (normalized as SupportEscalationNoteType)
+    : "triage_note";
+}
+
+function escalationRefId(value: unknown): string {
+  return idPart(value) || "support_escalation_unknown";
+}
+
+function safeFlags() {
+  return {
+    metadataOnly: true as const,
+    visibilityClass: "admin_support_internal" as const,
+    tenantVisible: false as const,
+    landlordVisible: false as const,
+    appendOnly: true as const,
+    supportPowersGranted: false as const,
+    impersonationEnabled: false as const,
+    autonomousRemediationEnabled: false as const,
+    autonomousEscalationEnabled: false as const,
+    financialMutationEnabled: false as const,
+    routeVisibilityChanged: false as const,
+    payloadSafety: PAYLOAD_SAFETY,
+  };
+}
+
+export function buildSupportEscalationHistoryEntry(input: {
+  historyEntryId?: string | null;
+  escalationRefId?: string | null;
+  category?: unknown;
+  severity?: unknown;
+  state?: unknown;
+  actionType?: unknown;
+  actor?: Record<string, unknown> | null;
+  occurredAt?: unknown;
+  noteSummary?: string | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  safeEvidenceRefs?: Array<Record<string, unknown>> | null;
+  resourceRefs?: Array<Record<string, unknown>> | null;
+}): SupportEscalationHistoryEntry {
+  const category = normalizeSupportEscalationCategory(input.category);
+  const severity = normalizeSupportEscalationSeverity(input.severity);
+  const state = normalizeSupportEscalationState(input.state);
+  const actionType = normalizeSupportEscalationActionType(input.actionType);
+  const occurredAt = toIso(input.occurredAt);
+  const escalationId = escalationRefId(input.escalationRefId);
+  const scope = { landlordId: asString(input.landlordId, 240) || null, tenantId: asString(input.tenantId, 240) || null };
+  return {
+    supportEscalationHistoryVersion: SUPPORT_ESCALATION_HISTORY_VERSION,
+    historyEntryId:
+      idPart(input.historyEntryId) ||
+      idPart(["support_escalation_history", escalationId, actionType, occurredAt].join(":")),
+    escalationRefId: escalationId,
+    category,
+    severity,
+    state,
+    actionType,
+    actorSummary: actorSummary(input.actor),
+    occurredAt,
+    noteSummary: redactNoteSummary(input.noteSummary),
+    approvalExpectation: approvalRequirementForEscalation({ category, severity }),
+    safeEvidenceRefs: normalizeSupportEscalationRefs(input.safeEvidenceRefs, scope),
+    resourceRefs: normalizeSupportEscalationRefs(input.resourceRefs, scope),
+    ...safeFlags(),
+  };
+}
+
+export function buildSupportEscalationReviewNote(input: {
+  noteId?: string | null;
+  escalationRefId?: string | null;
+  noteType?: unknown;
+  noteSummary?: string | null;
+  author?: Record<string, unknown> | null;
+  createdAt?: unknown;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  safeEvidenceRefs?: Array<Record<string, unknown>> | null;
+  resourceRefs?: Array<Record<string, unknown>> | null;
+}): SupportEscalationReviewNote {
+  const noteType = normalizeSupportEscalationNoteType(input.noteType);
+  const createdAt = toIso(input.createdAt);
+  const escalationId = escalationRefId(input.escalationRefId);
+  const noteSummary = redactNoteSummary(input.noteSummary);
+  const scope = { landlordId: asString(input.landlordId, 240) || null, tenantId: asString(input.tenantId, 240) || null };
+  return {
+    supportEscalationHistoryVersion: SUPPORT_ESCALATION_HISTORY_VERSION,
+    noteId: idPart(input.noteId) || idPart(["support_escalation_note", escalationId, noteType, createdAt].join(":")),
+    escalationRefId: escalationId,
+    noteType,
+    noteSummary,
+    authorSummary: actorSummary(input.author),
+    createdAt,
+    safeEvidenceRefs: normalizeSupportEscalationRefs(input.safeEvidenceRefs, scope),
+    resourceRefs: normalizeSupportEscalationRefs(input.resourceRefs, scope),
+    redactionSummary:
+      "Manual note is stored as metadata-only summary; raw payloads, credentials, documents, storage paths, request/response bodies, stack traces, and debug payloads are excluded.",
+    ...safeFlags(),
+  };
+}


### PR DESCRIPTION
## Summary
- add append-only metadata helper for support escalation history entries
- add metadata-only manual review note helper with safe summaries and scoped refs
- add governance report documenting persistence deferral and projection safety

## Safety
- no routes, UI, persistence, status mutation, support powers, impersonation, or autonomous remediation added
- no tenant/landlord escalation visibility added
- no auth, Firestore rules, screening, payments, pricing, lease, export, or public workflow changes
- raw documents, provider payloads, screening reports, storage paths, tokens, credentials, secrets, request/response bodies, stack traces, debug payloads, and unrestricted policy internals are excluded or reference/summary-only

## Validation
- npm run test:single -- src/lib/supportEscalationHistory/__tests__/supportEscalationHistory.test.ts
- npm run build (rentchain-api)
- git diff --check