### PR TITLE
Add admin support escalation review surface

### DIFF
--- a/docs/reports/admin-support-escalation-review-surface-v1.md
+++ b/docs/reports/admin-support-escalation-review-surface-v1.md
@@ -1,0 +1,168 @@
+# Admin Support Escalation Review Surface v1
+
+## Summary
+
+This mission adds a governed admin-only, metadata-only support escalation review surface. It exposes safe read-only summaries for support escalation history and manual review notes using the helper contracts introduced in PR #985 and PR #986.
+
+It does not add escalation creation, approval, resolution, dismissal, note writing, persistence writes, automation, remediation, impersonation, tenant/landlord visibility, or enforcement controls.
+
+## Audit Findings
+
+Reviewed foundations:
+
+- `supportEscalationRunbooks` provides categories, severities, manual states, approval expectations, safe refs, and prohibited action language.
+- `supportEscalationHistory` provides append-only history and manual review note helper contracts.
+- `adminSecurityIncidents` provides the closest backend route/service/frontend pattern for a metadata-only admin review page.
+- `adminSupportProjectionSafety` provides user-safe projection boundaries for support/admin metadata.
+- Existing admin route convention uses `requireAuth` plus `requirePermission("system.admin")` and route-source headers.
+- No approved escalation persistence writer exists.
+
+## Routes Added
+
+Added admin-only routes:
+
+- `GET /api/admin/support/escalations`
+- `GET /api/admin/support/escalations/:escalationId`
+
+Both routes require `system.admin` authority and set:
+
+- `x-route-source: adminSupportEscalationRoutes.ts`
+
+No mutation routes are added.
+
+## Frontend Page Added
+
+Added admin-only page:
+
+- `/admin/support/escalations`
+
+The page includes:
+
+- summary counts
+- category, severity, state, approval expectation, and search filters
+- escalation list
+- safe detail panel
+- safe empty state
+- explicit metadata-only messaging
+
+No buttons or controls exist for approve, resolve, dismiss, impersonate, remediate, contact tenant/landlord, or mutate records.
+
+## Read Model Behavior
+
+The backend read model projects escalation data into safe records with:
+
+- escalation ID
+- category
+- severity
+- state
+- approval expectation
+- title
+- summary
+- created and last-updated timestamps
+- safe actor summary
+- safe evidence refs
+- history count
+- note count
+- metadata-only/internal visibility flags
+
+Detail responses include:
+
+- safe escalation summary
+- sanitized history entries
+- sanitized manual review notes
+- redaction summary
+- approval expectation
+- prohibited actions
+- safe evidence references
+
+Raw event JSON and raw note payloads are not returned.
+
+## Persistence Decision
+
+Persistence remains read-only-if-present.
+
+The service reads from future append-only collection names if they exist:
+
+- `supportEscalationHistory`
+- `supportEscalationReviewNotes`
+
+It does not create, update, delete, or seed those collections. If no records exist, the list endpoint returns an honest empty state and schema/readiness metadata.
+
+This preserves the PR #986 decision that persistence writes require a separate scoped mission for collection ownership, retention, append-only write semantics, and route authorization.
+
+## Redaction and Projection Safety
+
+The review surface relies on helper outputs from `supportEscalationHistory` and `supportEscalationRunbooks`, which:
+
+- normalize unsupported action/note types to safe defaults
+- filter unrelated landlord/tenant refs
+- avoid raw actor IDs in summaries
+- sanitize note summaries
+- redact token, secret, credential, authorization, cookie, storage-path, stack/debug, and request/response-like content
+- carry provider, document, evidence, export, and policy data as reference/summary-only
+
+The API and UI must not expose:
+
+- tokens
+- secrets
+- credentials
+- raw actor IDs as labels
+- raw tenant or landlord IDs as labels
+- raw note payloads
+- raw provider payloads
+- screening reports
+- raw documents
+- storage paths
+- stack traces
+- debug payloads
+- unrestricted policy internals
+- impersonation session IDs as visible labels
+
+## Tests Added
+
+Backend tests confirm:
+
+- non-admin users are denied
+- admin users can access list and detail
+- route-source attribution is correct
+- empty state is safe
+- sensitive fields are stripped
+- responses are metadata-only
+- no mutation route exists
+
+Frontend tests confirm:
+
+- admin page renders
+- filters render and call the API
+- empty state renders
+- sensitive fields are not rendered
+- mutation controls are absent
+
+## Known Limitations
+
+This mission does not add:
+
+- escalation persistence writes
+- note creation
+- approval/resolution/dismissal mutation
+- escalation assignment
+- alerting or notifications
+- tenant/landlord visibility
+- raw event or note exploration
+- automation or remediation
+
+The review surface will show an empty state until an approved append-only writer exists or safe records are otherwise present.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Add an append-only support escalation writer after collection ownership and retention are approved.
+2. Add audited manual note creation with strict server-side sanitization.
+3. Link security incident records to suggested escalation runbooks without automated remediation.
+4. Add escalation status transitions only as append-only history, not mutable source-of-truth replacement.
+5. Add exportable admin-only escalation audit summaries with projection safety tests.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, add tenant/landlord routes, expose support internals publicly, enable impersonation, mutate financial records, alter screening/payment/pricing/lease/export workflows, add dependencies, or introduce autonomous escalation/remediation.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -131,6 +131,7 @@ import adminSupportOperationsRoutes from "./routes/adminSupportOperationsRoutes"
 import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
 import adminObservabilityIncidentReadinessRoutes from "./routes/adminObservabilityIncidentReadinessRoutes";
 import adminSecurityIncidentRoutes from "./routes/adminSecurityIncidentRoutes";
+import adminSupportEscalationRoutes from "./routes/adminSupportEscalationRoutes";
 import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
 import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHardeningRoutes";
 import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRoutes";
@@ -426,6 +427,8 @@ app.use("/api/admin", routeSource("adminObservabilityIncidentReadinessRoutes.ts"
 console.log("[route-mount] adminObservabilityIncidentReadinessRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
 console.log("[route-mount] adminSecurityIncidentRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminSupportEscalationRoutes.ts"), adminSupportEscalationRoutes);
+console.log("[route-mount] adminSupportEscalationRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminReleaseGovernanceRoutes.ts"), adminReleaseGovernanceRoutes);
 console.log("[route-mount] adminReleaseGovernanceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes);

--- a/rentchain-api/src/lib/adminSupportEscalations/__tests__/adminSupportEscalationReview.test.ts
+++ b/rentchain-api/src/lib/adminSupportEscalations/__tests__/adminSupportEscalationReview.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAdminSupportEscalationReviewDetail,
+  buildAdminSupportEscalationReviewRecords,
+  emptyAdminSupportEscalationReviewSummary,
+  filterAdminSupportEscalationReviewRecords,
+} from "../adminSupportEscalationReview";
+
+const history = [
+  {
+    escalationRefId: "escalation-1",
+    category: "credential_secret",
+    severity: "critical",
+    state: "awaiting_approval",
+    actionType: "approval_requested",
+    actor: { id: "raw-admin-id", role: "admin", displayName: "Security operator" },
+    occurredAt: "2026-05-23T12:00:00.000Z",
+    noteSummary: "Bearer abc token=secret gs://bucket/raw.pdf",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    safeEvidenceRefs: [
+      {
+        referenceType: "incident",
+        referenceId: "incident-1",
+        label: "Credential incident",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        rawProviderPayload: "restricted",
+      },
+      {
+        referenceType: "document",
+        referenceId: "unrelated-document",
+        label: "Unrelated document",
+        landlordId: "other-landlord",
+        storagePath: "gs://bucket/raw.pdf",
+      },
+    ],
+  },
+];
+
+const notes = [
+  {
+    escalationRefId: "escalation-1",
+    noteType: "security_review_note",
+    noteSummary: "authorization=Bearer-secret https://storage.googleapis.com/bucket/raw.pdf",
+    author: { id: "raw-support-id", role: "support", displayName: "Support lead" },
+    createdAt: "2026-05-23T13:00:00.000Z",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    safeEvidenceRefs: [
+      {
+        referenceType: "review_workspace",
+        referenceId: "review-1",
+        label: "Review workspace",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        debugPayload: "restricted",
+      },
+    ],
+  },
+];
+
+describe("admin support escalation review read model", () => {
+  it("groups history and notes into metadata-only admin/support records", () => {
+    const [record] = buildAdminSupportEscalationReviewRecords({ history, notes });
+
+    expect(record).toEqual(
+      expect.objectContaining({
+        escalationId: "escalation-1",
+        category: "credential_secret",
+        severity: "critical",
+        state: "awaiting_approval",
+        approvalExpectation: "security_review",
+        historyCount: 1,
+        noteCount: 1,
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+      })
+    );
+    expect(record.safeEvidenceRefs.map((ref) => ref.referenceId).sort()).toEqual(["incident-1", "review-1"]);
+
+    const payload = JSON.stringify(record);
+    expect(payload).not.toContain("raw-admin-id");
+    expect(payload).not.toContain("raw-support-id");
+    expect(payload).not.toContain("Bearer-secret");
+    expect(payload).not.toContain("rawProviderPayload");
+    expect(payload).not.toContain("debugPayload");
+    expect(payload).not.toContain("gs://");
+    expect(payload).not.toContain("storage.googleapis.com");
+    expect(payload).not.toContain("unrelated-document");
+  });
+
+  it("builds safe details without exposing mutation controls or raw payloads", () => {
+    const detail = buildAdminSupportEscalationReviewDetail("escalation-1", { history, notes });
+
+    expect(detail).toEqual(
+      expect.objectContaining({
+        escalationId: "escalation-1",
+        metadataOnly: true,
+        emptyState: false,
+        historyEntries: expect.any(Array),
+        reviewNotes: expect.any(Array),
+        prohibitedActions: expect.arrayContaining(["Do not perform autonomous remediation."]),
+      })
+    );
+    expect(detail?.historyEntries[0]).toEqual(
+      expect.objectContaining({
+        supportPowersGranted: false,
+        impersonationEnabled: false,
+        autonomousRemediationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+        routeVisibilityChanged: false,
+      })
+    );
+    expect(JSON.stringify(detail)).not.toContain("Bearer-secret");
+    expect(JSON.stringify(detail)).not.toContain("storage.googleapis.com");
+  });
+
+  it("filters records deterministically and keeps empty state explicit", () => {
+    const records = buildAdminSupportEscalationReviewRecords({
+      history: [
+        ...history,
+        {
+          escalationRefId: "escalation-2",
+          category: "api_abuse",
+          severity: "low",
+          state: "triage_required",
+          occurredAt: "2026-05-23T14:00:00.000Z",
+        },
+      ],
+      notes,
+    });
+
+    expect(filterAdminSupportEscalationReviewRecords(records, { severity: "critical" })).toHaveLength(1);
+    expect(filterAdminSupportEscalationReviewRecords(records, { q: "api abuse" })).toHaveLength(1);
+    expect(emptyAdminSupportEscalationReviewSummary()).toEqual(
+      expect.objectContaining({
+        total: 0,
+        metadataOnly: true,
+        emptyState: expect.stringContaining("No persisted support escalation history"),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/adminSupportEscalations/adminSupportEscalationReview.ts
+++ b/rentchain-api/src/lib/adminSupportEscalations/adminSupportEscalationReview.ts
@@ -1,0 +1,216 @@
+import {
+  buildSupportEscalationRunbookTemplate,
+  type SupportEscalationApprovalRequirement,
+  type SupportEscalationCategory,
+  type SupportEscalationSafeRef,
+  type SupportEscalationSeverity,
+  type SupportEscalationState,
+} from "../supportEscalationRunbooks/supportEscalationRunbooks";
+import {
+  buildSupportEscalationHistoryEntry,
+  buildSupportEscalationReviewNote,
+  type SupportEscalationHistoryEntry,
+  type SupportEscalationReviewNote,
+} from "../supportEscalationHistory/supportEscalationHistory";
+
+export const ADMIN_SUPPORT_ESCALATION_REVIEW_VERSION = "admin_support_escalation_review_v1";
+
+export type AdminSupportEscalationReviewRecord = {
+  escalationReviewVersion: typeof ADMIN_SUPPORT_ESCALATION_REVIEW_VERSION;
+  escalationId: string;
+  category: SupportEscalationCategory;
+  severity: SupportEscalationSeverity;
+  state: SupportEscalationState;
+  approvalExpectation: SupportEscalationApprovalRequirement;
+  title: string;
+  summary: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+  actorSummary: SupportEscalationHistoryEntry["actorSummary"] | null;
+  safeEvidenceRefs: SupportEscalationSafeRef[];
+  historyCount: number;
+  noteCount: number;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+};
+
+export type AdminSupportEscalationReviewDetail = AdminSupportEscalationReviewRecord & {
+  historyEntries: SupportEscalationHistoryEntry[];
+  reviewNotes: SupportEscalationReviewNote[];
+  redactionSummary: string;
+  prohibitedActions: string[];
+  emptyState: boolean;
+};
+
+export type AdminSupportEscalationReviewInput = {
+  history?: Array<Record<string, unknown>>;
+  notes?: Array<Record<string, unknown>>;
+};
+
+type Filters = {
+  category?: string | null;
+  severity?: string | null;
+  state?: string | null;
+  approvalExpectation?: string | null;
+  q?: string | null;
+};
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function label(value: string): string {
+  return value
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function minIso(values: string[]): string {
+  const valid = values.filter((value) => Number.isFinite(Date.parse(value))).sort();
+  return valid[0] || new Date(0).toISOString();
+}
+
+function maxIso(values: string[]): string {
+  const valid = values.filter((value) => Number.isFinite(Date.parse(value))).sort();
+  return valid[valid.length - 1] || new Date(0).toISOString();
+}
+
+function safeFlags() {
+  return {
+    metadataOnly: true as const,
+    visibilityClass: "admin_support_internal" as const,
+    tenantVisible: false as const,
+    landlordVisible: false as const,
+  };
+}
+
+function uniqueRefs(refs: SupportEscalationSafeRef[]): SupportEscalationSafeRef[] {
+  const byKey = new Map<string, SupportEscalationSafeRef>();
+  for (const ref of refs) {
+    const key = `${ref.referenceType}:${ref.referenceId}`;
+    if (!byKey.has(key)) byKey.set(key, ref);
+  }
+  return Array.from(byKey.values()).sort((a, b) => `${a.referenceType}:${a.referenceId}`.localeCompare(`${b.referenceType}:${b.referenceId}`));
+}
+
+function buildGroupRecord(
+  escalationId: string,
+  historyEntries: SupportEscalationHistoryEntry[],
+  reviewNotes: SupportEscalationReviewNote[]
+): AdminSupportEscalationReviewRecord | null {
+  const latestHistory = [...historyEntries].sort((a, b) => b.occurredAt.localeCompare(a.occurredAt))[0] || null;
+  const latestNote = [...reviewNotes].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0] || null;
+  if (!latestHistory && !latestNote) return null;
+  const category = latestHistory?.category || "other";
+  const severity = latestHistory?.severity || "low";
+  const state = latestHistory?.state || "triage_required";
+  const template = buildSupportEscalationRunbookTemplate({ category, severity });
+  const times = [
+    ...historyEntries.map((entry) => entry.occurredAt),
+    ...reviewNotes.map((note) => note.createdAt),
+  ];
+  return {
+    escalationReviewVersion: ADMIN_SUPPORT_ESCALATION_REVIEW_VERSION,
+    escalationId,
+    category,
+    severity,
+    state,
+    approvalExpectation: latestHistory?.approvalExpectation || template.approvalRequirement,
+    title: `${label(category)} escalation`,
+    summary:
+      latestNote?.noteSummary ||
+      latestHistory?.noteSummary ||
+      "Support escalation metadata is available for admin/support review.",
+    createdAt: minIso(times),
+    lastUpdatedAt: maxIso(times),
+    actorSummary: latestHistory?.actorSummary || latestNote?.authorSummary || null,
+    safeEvidenceRefs: uniqueRefs([
+      ...historyEntries.flatMap((entry) => entry.safeEvidenceRefs),
+      ...reviewNotes.flatMap((note) => note.safeEvidenceRefs),
+    ]).slice(0, 20),
+    historyCount: historyEntries.length,
+    noteCount: reviewNotes.length,
+    ...safeFlags(),
+  };
+}
+
+export function buildAdminSupportEscalationReviewRecords(input: AdminSupportEscalationReviewInput = {}) {
+  const historyEntries = (input.history || []).map((item) => buildSupportEscalationHistoryEntry(item));
+  const reviewNotes = (input.notes || []).map((item) => buildSupportEscalationReviewNote(item));
+  const ids = new Set<string>([
+    ...historyEntries.map((entry) => entry.escalationRefId),
+    ...reviewNotes.map((note) => note.escalationRefId),
+  ]);
+
+  return Array.from(ids)
+    .sort()
+    .map((id) =>
+      buildGroupRecord(
+        id,
+        historyEntries.filter((entry) => entry.escalationRefId === id),
+        reviewNotes.filter((note) => note.escalationRefId === id)
+      )
+    )
+    .filter(Boolean) as AdminSupportEscalationReviewRecord[];
+}
+
+export function buildAdminSupportEscalationReviewDetail(
+  escalationId: string,
+  input: AdminSupportEscalationReviewInput = {}
+): AdminSupportEscalationReviewDetail | null {
+  const safeEscalationId = asString(escalationId, 240).toLowerCase().replace(/[^a-z0-9_.:-]+/g, "_");
+  if (!safeEscalationId) return null;
+  const historyEntries = (input.history || [])
+    .map((item) => buildSupportEscalationHistoryEntry(item))
+    .filter((entry) => entry.escalationRefId === safeEscalationId);
+  const reviewNotes = (input.notes || [])
+    .map((item) => buildSupportEscalationReviewNote(item))
+    .filter((note) => note.escalationRefId === safeEscalationId);
+  const record = buildGroupRecord(safeEscalationId, historyEntries, reviewNotes);
+  if (!record) return null;
+  const template = buildSupportEscalationRunbookTemplate({ category: record.category, severity: record.severity });
+  return {
+    ...record,
+    historyEntries: historyEntries.sort((a, b) => a.occurredAt.localeCompare(b.occurredAt)),
+    reviewNotes: reviewNotes.sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    redactionSummary:
+      "Escalation details are metadata-only; raw notes, payloads, provider data, documents, storage paths, credentials, debug data, request/response bodies, and policy internals are excluded.",
+    prohibitedActions: template.prohibitedActions,
+    emptyState: false,
+  };
+}
+
+export function filterAdminSupportEscalationReviewRecords(
+  records: AdminSupportEscalationReviewRecord[],
+  filters: Filters = {}
+) {
+  const q = asString(filters.q, 160).toLowerCase();
+  return records.filter((record) => {
+    if (filters.category && record.category !== filters.category) return false;
+    if (filters.severity && record.severity !== filters.severity) return false;
+    if (filters.state && record.state !== filters.state) return false;
+    if (filters.approvalExpectation && record.approvalExpectation !== filters.approvalExpectation) return false;
+    if (q) {
+      const haystack = [record.title, record.summary, record.category, record.severity, record.state, record.approvalExpectation]
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+export function emptyAdminSupportEscalationReviewSummary() {
+  return {
+    total: 0,
+    highOrCritical: 0,
+    awaitingApproval: 0,
+    notes: 0,
+    metadataOnly: true as const,
+    emptyState:
+      "No persisted support escalation history or review note metadata is available yet. This surface is ready for append-only metadata once an approved writer exists.",
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminSupportEscalationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminSupportEscalationRoutes.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({
+            id: doc.id,
+            exists: true,
+            data: () => doc.data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireAuthz", () => ({
+  requirePermission: () => (req: any, res: any, next: any) => {
+    const permissions = Array.isArray(req.user?.permissions) ? req.user.permissions : [];
+    if (req.user?.role !== "admin" && !permissions.includes("system.admin")) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const detailMatch = path.match(/^\/support\/escalations\/(.+)$/);
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: detailMatch ? { escalationId: decodeURIComponent(detailMatch[1]) } : {},
+      headers: {},
+      user: mockUser,
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      setHeader(name: string, value: string) {
+        this.headers[String(name).toLowerCase()] = value;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) return reject(error);
+      resolve({ status: 404, body: { ok: false, error: "NOT_FOUND" }, headers: res.headers });
+    });
+  });
+}
+
+describe("adminSupportEscalationRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedEscalationContext() {
+    seedDoc("supportEscalationHistory", "history-1", {
+      escalationRefId: "escalation-1",
+      category: "credential_secret",
+      severity: "critical",
+      state: "awaiting_approval",
+      actionType: "approval_requested",
+      actor: { id: "admin-raw-id", role: "admin", displayName: "Security operator" },
+      occurredAt: "2026-05-23T12:00:00.000Z",
+      noteSummary: "Bearer abc token=secret gs://bucket/raw.pdf",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      safeEvidenceRefs: [
+        {
+          referenceType: "incident",
+          referenceId: "incident-1",
+          label: "Credential incident",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          rawPayload: { providerPayload: "restricted" },
+        },
+      ],
+    });
+    seedDoc("supportEscalationReviewNotes", "note-1", {
+      escalationRefId: "escalation-1",
+      noteType: "security_review_note",
+      noteSummary: "authorization=Bearer-secret https://storage.googleapis.com/bucket/raw.pdf",
+      author: { id: "support-raw-id", role: "support", displayName: "Support lead" },
+      createdAt: "2026-05-23T13:00:00.000Z",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      resourceRefs: [
+        {
+          referenceType: "review_workspace",
+          referenceId: "review-1",
+          label: "Review workspace",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          debugPayload: "restricted",
+        },
+      ],
+    });
+  }
+
+  it("denies non-admin access and returns admin-only escalation summaries", async () => {
+    seedEscalationContext();
+    const router = (await import("../adminSupportEscalationRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/support/escalations",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/support/escalations",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("adminSupportEscalationRoutes.ts");
+    expect(res.body.escalations).toHaveLength(1);
+    expect(res.body.escalations[0]).toEqual(
+      expect.objectContaining({
+        escalationId: "escalation-1",
+        category: "credential_secret",
+        severity: "critical",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+      })
+    );
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("admin-raw-id");
+    expect(payload).not.toContain("support-raw-id");
+    expect(payload).not.toContain("Bearer-secret");
+    expect(payload).not.toContain("providerPayload");
+    expect(payload).not.toContain("debugPayload");
+    expect(payload).not.toContain("gs://");
+  });
+
+  it("returns safe details and no mutation route", async () => {
+    seedEscalationContext();
+    const router = (await import("../adminSupportEscalationRoutes")).default;
+
+    const detail = await invokeRouter(router, {
+      method: "GET",
+      url: "/support/escalations/escalation-1",
+    });
+
+    expect(detail.status).toBe(200);
+    expect(detail.body.escalation).toEqual(
+      expect.objectContaining({
+        escalationId: "escalation-1",
+        metadataOnly: true,
+        historyEntries: expect.any(Array),
+        reviewNotes: expect.any(Array),
+        prohibitedActions: expect.any(Array),
+      })
+    );
+    expect(JSON.stringify(detail.body)).not.toContain("storage.googleapis.com");
+
+    const post = await invokeRouter(router, {
+      method: "POST",
+      url: "/support/escalations",
+    });
+    expect(post.status).toBe(404);
+  });
+
+  it("returns a safe empty state when no escalation metadata exists", async () => {
+    const router = (await import("../adminSupportEscalationRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/support/escalations" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("adminSupportEscalationRoutes.ts");
+    expect(res.body.escalations).toEqual([]);
+    expect(res.body.summary).toEqual(
+      expect.objectContaining({
+        total: 0,
+        metadataOnly: true,
+        emptyState: expect.stringContaining("No persisted support escalation history"),
+      })
+    );
+    expect(res.body.schema).toEqual(
+      expect.objectContaining({
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        mutationControlsEnabled: false,
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -219,6 +219,7 @@ async function buildRuntimeOwnershipApp() {
   const telemetryRoutes = (await import("../telemetryRoutes")).default;
   const screeningRoutes = (await import("../screeningRoutes")).default;
   const adminSecurityIncidentRoutes = (await import("../adminSecurityIncidentRoutes")).default;
+  const adminSupportEscalationRoutes = (await import("../adminSupportEscalationRoutes")).default;
   const screeningJobsAdminRoutes = (await import("../screeningJobsAdminRoutes")).default;
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
@@ -259,6 +260,7 @@ async function buildRuntimeOwnershipApp() {
   app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes);
   app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes);
   app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
+  app.use("/api/admin", routeSource("adminSupportEscalationRoutes.ts"), adminSupportEscalationRoutes);
   app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes);
   app.use("/api", (_req, res) => {
     res.setHeader("x-route-source", "not-found");
@@ -398,6 +400,9 @@ describe("API route ownership regression", () => {
     const securityIncidentMount = source.indexOf(
       'app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes)'
     );
+    const supportEscalationMount = source.indexOf(
+      'app.use("/api/admin", routeSource("adminSupportEscalationRoutes.ts"), adminSupportEscalationRoutes)'
+    );
     const publicExposureMount = source.indexOf(
       'app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes)'
     );
@@ -416,6 +421,7 @@ describe("API route ownership regression", () => {
     expect(supportOperationsMount).toBeGreaterThan(-1);
     expect(incidentReadinessMount).toBeGreaterThan(-1);
     expect(securityIncidentMount).toBeGreaterThan(-1);
+    expect(supportEscalationMount).toBeGreaterThan(-1);
     expect(publicExposureMount).toBeGreaterThan(-1);
     expect(pdfObservabilityMount).toBeGreaterThan(-1);
     expect(impersonationMount).toBeGreaterThan(-1);
@@ -429,6 +435,8 @@ describe("API route ownership regression", () => {
     expect(incidentReadinessMount).toBeLessThan(adminRoutesMount);
     expect(securityIncidentMount).toBeLessThan(adminRoutesMount);
     expect(securityIncidentMount).toBeLessThan(adminScreeningUsageMount);
+    expect(supportEscalationMount).toBeLessThan(adminRoutesMount);
+    expect(supportEscalationMount).toBeLessThan(adminScreeningUsageMount);
     expect(publicExposureMount).toBeLessThan(adminRoutesMount);
     expect(pdfObservabilityMount).toBeLessThan(adminRoutesMount);
     expect(impersonationMount).toBeLessThan(screeningJobsMount);
@@ -528,6 +536,38 @@ describe("API route ownership regression", () => {
 
     expect(denied.status).toBe(403);
     expect(denied.headers["x-route-source"]).toBe("adminSecurityIncidentRoutes.ts");
+    expect(denied.body?.error).not.toBe("Not Found");
+  });
+
+  it("keeps admin support escalations owned by support escalation routes before screening usage fallback", async () => {
+    authState.user = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+    const app = await buildRuntimeOwnershipApp();
+
+    const res = await invokeApp(app, {
+      method: "GET",
+      url: "/api/admin/support/escalations?limit=50",
+      headers: { authorization: "Bearer admin-token" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("adminSupportEscalationRoutes.ts");
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        escalations: [],
+        summary: expect.objectContaining({ metadataOnly: true }),
+      })
+    );
+
+    authState.user = { id: "landlord-1", role: "landlord", permissions: [] };
+    const denied = await invokeApp(app, {
+      method: "GET",
+      url: "/api/admin/support/escalations?limit=50",
+      headers: { authorization: "Bearer landlord-token" },
+    });
+
+    expect(denied.status).toBe(403);
+    expect(denied.headers["x-route-source"]).toBe("adminSupportEscalationRoutes.ts");
     expect(denied.body?.error).not.toBe("Not Found");
   });
 

--- a/rentchain-api/src/routes/adminSupportEscalationRoutes.ts
+++ b/rentchain-api/src/routes/adminSupportEscalationRoutes.ts
@@ -1,0 +1,43 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import {
+  loadAdminSupportEscalationReviewDetail,
+  loadAdminSupportEscalationReviews,
+} from "../services/admin/adminSupportEscalationReview";
+
+const router = Router();
+
+router.get("/support/escalations", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  res.setHeader("x-route-source", "adminSupportEscalationRoutes.ts");
+  try {
+    const result = await loadAdminSupportEscalationReviews({
+      category: req.query?.category,
+      severity: req.query?.severity,
+      state: req.query?.state,
+      approvalExpectation: req.query?.approvalExpectation,
+      q: req.query?.q,
+      limit: Number(req.query?.limit || 50),
+    });
+    return res.json({ ok: true, ...result });
+  } catch (err: any) {
+    console.error("[admin-support-escalations] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_SUPPORT_ESCALATIONS_FAILED" });
+  }
+});
+
+router.get("/support/escalations/:escalationId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  res.setHeader("x-route-source", "adminSupportEscalationRoutes.ts");
+  try {
+    const escalationId = String(req.params?.escalationId || "").trim();
+    if (!escalationId) return res.status(400).json({ ok: false, error: "ESCALATION_ID_REQUIRED" });
+    const escalation = await loadAdminSupportEscalationReviewDetail(escalationId);
+    if (!escalation) return res.status(404).json({ ok: false, error: "ESCALATION_NOT_FOUND" });
+    return res.json({ ok: true, escalation });
+  } catch (err: any) {
+    console.error("[admin-support-escalations] detail failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_SUPPORT_ESCALATION_DETAIL_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/admin/adminSupportEscalationReview.ts
+++ b/rentchain-api/src/services/admin/adminSupportEscalationReview.ts
@@ -1,0 +1,92 @@
+import { db } from "../../config/firebase";
+import {
+  buildAdminSupportEscalationReviewDetail,
+  buildAdminSupportEscalationReviewRecords,
+  emptyAdminSupportEscalationReviewSummary,
+  filterAdminSupportEscalationReviewRecords,
+  type AdminSupportEscalationReviewDetail,
+  type AdminSupportEscalationReviewRecord,
+} from "../../lib/adminSupportEscalations/adminSupportEscalationReview";
+
+type LoadParams = {
+  category?: string | null;
+  severity?: string | null;
+  state?: string | null;
+  approvalExpectation?: string | null;
+  q?: string | null;
+  limit?: number | null;
+};
+
+const HISTORY_COLLECTION = "supportEscalationHistory";
+const NOTES_COLLECTION = "supportEscalationReviewNotes";
+
+async function loadCollection(collectionName: typeof HISTORY_COLLECTION | typeof NOTES_COLLECTION, limit = 100) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc: any) => ({
+    id: String(doc.id || ""),
+    ...((doc.data() as Record<string, unknown>) || {}),
+  }));
+}
+
+async function loadEscalationSources() {
+  const [history, notes] = await Promise.all([
+    loadCollection(HISTORY_COLLECTION),
+    loadCollection(NOTES_COLLECTION),
+  ]);
+  return { history, notes };
+}
+
+function summaryFor(records: AdminSupportEscalationReviewRecord[]) {
+  if (!records.length) return emptyAdminSupportEscalationReviewSummary();
+  return {
+    total: records.length,
+    highOrCritical: records.filter((record) => record.severity === "high" || record.severity === "critical").length,
+    awaitingApproval: records.filter((record) => record.state === "awaiting_approval").length,
+    notes: records.reduce((sum, record) => sum + record.noteCount, 0),
+    metadataOnly: true as const,
+    emptyState: null,
+  };
+}
+
+export async function loadAdminSupportEscalationReviews(
+  params: LoadParams = {}
+): Promise<{
+  escalations: AdminSupportEscalationReviewRecord[];
+  summary: ReturnType<typeof summaryFor>;
+  schema: {
+    metadataOnly: true;
+    visibilityClass: "admin_support_internal";
+    tenantVisible: false;
+    landlordVisible: false;
+    persistence: "read_only_if_present";
+    mutationControlsEnabled: false;
+  };
+}> {
+  const requestedLimit = Number(params.limit || 50);
+  const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 100) : 50;
+  const sources = await loadEscalationSources();
+  const records = buildAdminSupportEscalationReviewRecords(sources);
+  const filtered = filterAdminSupportEscalationReviewRecords(records, params)
+    .sort((a, b) => Date.parse(b.lastUpdatedAt) - Date.parse(a.lastUpdatedAt) || a.escalationId.localeCompare(b.escalationId))
+    .slice(0, limit);
+
+  return {
+    escalations: filtered,
+    summary: summaryFor(filtered),
+    schema: {
+      metadataOnly: true,
+      visibilityClass: "admin_support_internal",
+      tenantVisible: false,
+      landlordVisible: false,
+      persistence: "read_only_if_present",
+      mutationControlsEnabled: false,
+    },
+  };
+}
+
+export async function loadAdminSupportEscalationReviewDetail(
+  escalationId: string
+): Promise<AdminSupportEscalationReviewDetail | null> {
+  const sources = await loadEscalationSources();
+  return buildAdminSupportEscalationReviewDetail(escalationId, sources);
+}

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -112,6 +112,7 @@ const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabilityPage"));
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
 const AdminSecurityIncidentsPage = lazy(() => import("./pages/admin/AdminSecurityIncidentsPage"));
+const AdminSupportEscalationsPage = lazy(() => import("./pages/admin/AdminSupportEscalationsPage"));
 const ObservabilityIncidentReadinessPage = lazy(() => import("./pages/ObservabilityIncidentReadinessPage"));
 const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
 const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
@@ -1057,6 +1058,18 @@ function App() {
               <RequireAdmin>
                 <Suspense fallback={null}>
                   <AdminSecurityIncidentsPage />
+                </Suspense>
+              </RequireAdmin>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/admin/support/escalations"
+          element={
+            <RequireAuth>
+              <RequireAdmin>
+                <Suspense fallback={null}>
+                  <AdminSupportEscalationsPage />
                 </Suspense>
               </RequireAdmin>
             </RequireAuth>

--- a/rentchain-frontend/src/api/adminSupportEscalationsApi.ts
+++ b/rentchain-frontend/src/api/adminSupportEscalationsApi.ts
@@ -1,0 +1,88 @@
+import { apiFetch } from "./apiFetch";
+
+export type AdminSupportEscalationRecord = {
+  escalationReviewVersion: string;
+  escalationId: string;
+  category: string;
+  severity: string;
+  state: string;
+  approvalExpectation: string;
+  title: string;
+  summary: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+  actorSummary: {
+    role: string | null;
+    displayName: string | null;
+    supportAttribution: boolean;
+    rawActorIdsIncluded: false;
+  } | null;
+  safeEvidenceRefs: Array<{
+    referenceType: string;
+    referenceId: string;
+    label: string;
+    internalReference: true;
+    metadataOnly: true;
+  }>;
+  historyCount: number;
+  noteCount: number;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+};
+
+export type AdminSupportEscalationDetail = AdminSupportEscalationRecord & {
+  historyEntries: Array<Record<string, unknown>>;
+  reviewNotes: Array<Record<string, unknown>>;
+  redactionSummary: string;
+  prohibitedActions: string[];
+  emptyState: boolean;
+};
+
+export type AdminSupportEscalationSummary = {
+  total: number;
+  highOrCritical: number;
+  awaitingApproval: number;
+  notes: number;
+  metadataOnly: true;
+  emptyState: string | null;
+};
+
+export async function fetchAdminSupportEscalations(params?: {
+  category?: string | null;
+  severity?: string | null;
+  state?: string | null;
+  approvalExpectation?: string | null;
+  q?: string | null;
+  limit?: number | null;
+}) {
+  const query = new URLSearchParams();
+  if (params?.category) query.set("category", params.category);
+  if (params?.severity) query.set("severity", params.severity);
+  if (params?.state) query.set("state", params.state);
+  if (params?.approvalExpectation) query.set("approvalExpectation", params.approvalExpectation);
+  if (params?.q) query.set("q", params.q);
+  if (params?.limit) query.set("limit", String(params.limit));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return apiFetch<{
+    ok: true;
+    escalations: AdminSupportEscalationRecord[];
+    summary: AdminSupportEscalationSummary;
+    schema: {
+      metadataOnly: true;
+      visibilityClass: "admin_support_internal";
+      tenantVisible: false;
+      landlordVisible: false;
+      persistence: "read_only_if_present";
+      mutationControlsEnabled: false;
+    };
+  }>(`/admin/support/escalations${suffix}`);
+}
+
+export async function fetchAdminSupportEscalationDetail(escalationId: string) {
+  return apiFetch<{
+    ok: true;
+    escalation: AdminSupportEscalationDetail;
+  }>(`/admin/support/escalations/${encodeURIComponent(escalationId)}`);
+}

--- a/rentchain-frontend/src/pages/admin/AdminDashboardPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminDashboardPage.tsx
@@ -46,6 +46,12 @@ const QUICK_LINKS: Array<{
     description: "Review metadata-only security, impersonation, policy, and projection signals.",
     countKey: null,
   },
+  {
+    title: "Support escalations",
+    to: "/admin/support/escalations",
+    description: "Review metadata-only support escalation history and manual notes.",
+    countKey: null,
+  },
 ];
 
 const EMPTY_OVERVIEW: AdminOverview = {

--- a/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.test.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdminSupportEscalationsPage from "./AdminSupportEscalationsPage";
+
+const showToast = vi.fn();
+const fetchAdminSupportEscalations = vi.fn();
+const fetchAdminSupportEscalationDetail = vi.fn();
+
+vi.mock("../../api/adminSupportEscalationsApi", () => ({
+  fetchAdminSupportEscalations: (...args: any[]) => fetchAdminSupportEscalations(...args),
+  fetchAdminSupportEscalationDetail: (...args: any[]) => fetchAdminSupportEscalationDetail(...args),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+const ESCALATION = {
+  escalationReviewVersion: "admin_support_escalation_review_v1",
+  escalationId: "escalation-safe",
+  category: "credential_secret",
+  severity: "critical",
+  state: "awaiting_approval",
+  approvalExpectation: "security_review",
+  title: "Credential Secret escalation",
+  summary: "Credential family needs manual review.",
+  createdAt: "2026-05-23T12:00:00.000Z",
+  lastUpdatedAt: "2026-05-23T13:00:00.000Z",
+  actorSummary: { role: "admin", displayName: "Security operator", supportAttribution: true, rawActorIdsIncluded: false },
+  safeEvidenceRefs: [{ referenceType: "incident", referenceId: "incident-1", label: "Credential incident", internalReference: true, metadataOnly: true }],
+  historyCount: 1,
+  noteCount: 1,
+  metadataOnly: true,
+  visibilityClass: "admin_support_internal",
+  tenantVisible: false,
+  landlordVisible: false,
+};
+
+beforeEach(() => {
+  showToast.mockReset();
+  fetchAdminSupportEscalations.mockReset();
+  fetchAdminSupportEscalationDetail.mockReset();
+  fetchAdminSupportEscalations.mockResolvedValue({
+    ok: true,
+    escalations: [ESCALATION],
+    summary: { total: 1, highOrCritical: 1, awaitingApproval: 1, notes: 1, metadataOnly: true, emptyState: null },
+    schema: {
+      metadataOnly: true,
+      visibilityClass: "admin_support_internal",
+      tenantVisible: false,
+      landlordVisible: false,
+      persistence: "read_only_if_present",
+      mutationControlsEnabled: false,
+    },
+  });
+  fetchAdminSupportEscalationDetail.mockResolvedValue({
+    ok: true,
+    escalation: {
+      ...ESCALATION,
+      historyEntries: [],
+      reviewNotes: [],
+      redactionSummary: "Escalation details are metadata-only.",
+      prohibitedActions: ["Do not perform autonomous remediation."],
+      emptyState: false,
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminSupportEscalationsPage", () => {
+  it("renders metadata-only escalation summaries and safe details", async () => {
+    render(<AdminSupportEscalationsPage />);
+
+    expect(await screen.findByRole("heading", { name: "Support escalations" })).toBeInTheDocument();
+    expect((await screen.findAllByText("Credential Secret escalation")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Security operator")).toBeInTheDocument();
+    expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resolve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /impersonate/i })).not.toBeInTheDocument();
+    expect(JSON.stringify(document.body.textContent)).not.toContain("rawActorId");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("tenant-raw-id");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("secret-token");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("gs://");
+  });
+
+  it("sends filters to the escalation API", async () => {
+    render(<AdminSupportEscalationsPage />);
+    await screen.findByText("Credential Secret escalation");
+
+    fireEvent.change(screen.getByLabelText("Severity"), { target: { value: "critical" } });
+
+    await waitFor(() =>
+      expect(fetchAdminSupportEscalations).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          severity: "critical",
+        })
+      )
+    );
+  });
+
+  it("renders a safe empty state without fake escalations", async () => {
+    fetchAdminSupportEscalations.mockResolvedValueOnce({
+      ok: true,
+      escalations: [],
+      summary: {
+        total: 0,
+        highOrCritical: 0,
+        awaitingApproval: 0,
+        notes: 0,
+        metadataOnly: true,
+        emptyState: "No persisted support escalation history or review note metadata is available yet.",
+      },
+      schema: {
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        persistence: "read_only_if_present",
+        mutationControlsEnabled: false,
+      },
+    });
+
+    render(<AdminSupportEscalationsPage />);
+
+    expect(await screen.findByText(/No support escalation metadata is available yet/)).toBeInTheDocument();
+    expect(screen.getByText(/No persisted support escalation history/)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.tsx
@@ -1,0 +1,306 @@
+import React from "react";
+import { MacShell } from "../../components/layout/MacShell";
+import { Card, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import {
+  fetchAdminSupportEscalationDetail,
+  fetchAdminSupportEscalations,
+  type AdminSupportEscalationDetail,
+  type AdminSupportEscalationRecord,
+  type AdminSupportEscalationSummary,
+} from "../../api/adminSupportEscalationsApi";
+
+const CATEGORIES = [
+  "security_incident",
+  "impersonation_review",
+  "policy_failure",
+  "projection_safety",
+  "document_access",
+  "export_governance",
+  "credential_secret",
+  "api_abuse",
+  "tenant_data_exposure",
+  "screening_provider",
+  "billing_support",
+  "technical_diagnostics",
+  "compliance_review",
+  "other",
+];
+
+const SEVERITIES = ["informational", "low", "medium", "high", "critical"];
+const STATES = ["draft", "queued", "triage_required", "reviewing", "awaiting_approval", "approved_for_manual_action", "resolved", "dismissed"];
+const APPROVALS = ["none_for_metadata_review", "support_lead_review", "admin_review", "security_review", "executive_review", "prohibited"];
+
+function label(value: string | null | undefined) {
+  const raw = String(value || "").trim();
+  if (!raw) return "Not specified";
+  return raw
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatTime(value: string) {
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return "Unknown time";
+  return new Date(ts).toLocaleString();
+}
+
+function toneForSeverity(severity: string) {
+  if (severity === "critical" || severity === "high") return "danger";
+  if (severity === "medium") return "accent";
+  return "muted";
+}
+
+function EscalationRow({
+  escalation,
+  selected,
+  onSelect,
+}: {
+  escalation: AdminSupportEscalationRecord;
+  selected: boolean;
+  onSelect: (escalation: AdminSupportEscalationRecord) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(escalation)}
+      style={{
+        textAlign: "left",
+        border: selected ? "1px solid #2563eb" : "1px solid rgba(15, 23, 42, 0.12)",
+        background: selected ? "#eff6ff" : "#fff",
+        borderRadius: 8,
+        padding: 12,
+        display: "grid",
+        gap: 8,
+        cursor: "pointer",
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <strong>{escalation.title}</strong>
+        <Pill tone={toneForSeverity(escalation.severity) as any}>{label(escalation.severity)}</Pill>
+        <Pill tone={escalation.state === "awaiting_approval" ? "accent" : "muted"}>{label(escalation.state)}</Pill>
+      </div>
+      <div style={{ color: "#475569" }}>{escalation.summary}</div>
+      <div style={{ color: "#64748b", fontSize: 13 }}>
+        {label(escalation.category)} · {label(escalation.approvalExpectation)} · {formatTime(escalation.lastUpdatedAt)}
+      </div>
+    </button>
+  );
+}
+
+function DetailPanel({ escalation }: { escalation: AdminSupportEscalationDetail | null }) {
+  if (!escalation) {
+    return (
+      <Card>
+        <div style={{ color: "#64748b" }}>Select an escalation to review metadata-only details.</div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <h2 style={{ margin: 0, fontSize: "1.1rem" }}>{escalation.title}</h2>
+          <Pill tone="muted">Metadata only</Pill>
+        </div>
+        <div style={{ color: "#475569" }}>{escalation.summary}</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10 }}>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Approval expectation</div>
+            <strong>{label(escalation.approvalExpectation)}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Actor</div>
+            <strong>{escalation.actorSummary?.displayName || escalation.actorSummary?.role || "Support/admin actor"}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>History</div>
+            <strong>{escalation.historyCount} entries</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Notes</div>
+            <strong>{escalation.noteCount} notes</strong>
+          </div>
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Redaction summary</div>
+          <div style={{ color: "#475569" }}>{escalation.redactionSummary}</div>
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Prohibited actions</div>
+          <ul style={{ margin: "8px 0 0", paddingLeft: 18, color: "#475569" }}>
+            {escalation.prohibitedActions.map((action) => (
+              <li key={action}>{action}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+const EMPTY_SUMMARY: AdminSupportEscalationSummary = {
+  total: 0,
+  highOrCritical: 0,
+  awaitingApproval: 0,
+  notes: 0,
+  metadataOnly: true,
+  emptyState: null,
+};
+
+export default function AdminSupportEscalationsPage() {
+  const { showToast } = useToast();
+  const [escalations, setEscalations] = React.useState<AdminSupportEscalationRecord[]>([]);
+  const [summary, setSummary] = React.useState<AdminSupportEscalationSummary>(EMPTY_SUMMARY);
+  const [selected, setSelected] = React.useState<AdminSupportEscalationRecord | null>(null);
+  const [detail, setDetail] = React.useState<AdminSupportEscalationDetail | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [category, setCategory] = React.useState("");
+  const [severity, setSeverity] = React.useState("");
+  const [state, setState] = React.useState("");
+  const [approvalExpectation, setApprovalExpectation] = React.useState("");
+  const [q, setQ] = React.useState("");
+
+  const load = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetchAdminSupportEscalations({
+        category: category || null,
+        severity: severity || null,
+        state: state || null,
+        approvalExpectation: approvalExpectation || null,
+        q: q || null,
+        limit: 50,
+      });
+      setEscalations(response.escalations || []);
+      setSummary(response.summary);
+      setSelected((current) => {
+        if (!current) return response.escalations[0] || null;
+        return response.escalations.find((item) => item.escalationId === current.escalationId) || response.escalations[0] || null;
+      });
+    } catch (err: any) {
+      const message = err?.message || "Failed to load support escalations";
+      setError(message);
+      showToast({ message: "Failed to load support escalations", description: message, variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [approvalExpectation, category, q, severity, showToast, state]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  React.useEffect(() => {
+    if (!selected) {
+      setDetail(null);
+      return;
+    }
+    let active = true;
+    fetchAdminSupportEscalationDetail(selected.escalationId)
+      .then((response) => {
+        if (active) setDetail(response.escalation);
+      })
+      .catch(() => {
+        if (active) setDetail(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selected]);
+
+  return (
+    <MacShell title="Admin · Support escalations">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Support escalations</h1>
+                <Pill tone="accent">Admin</Pill>
+                <Pill tone="muted">Metadata only</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 780 }}>
+                Admin/support-only review surface for escalation history and manual notes. This page does not approve,
+                resolve, remediate, impersonate, or expose raw note payloads.
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12 }}>
+          <Card><strong>{summary.total}</strong><div style={{ color: "#64748b" }}>Escalations</div></Card>
+          <Card><strong>{summary.highOrCritical}</strong><div style={{ color: "#64748b" }}>High or critical</div></Card>
+          <Card><strong>{summary.awaitingApproval}</strong><div style={{ color: "#64748b" }}>Awaiting approval</div></Card>
+          <Card><strong>{summary.notes}</strong><div style={{ color: "#64748b" }}>Review notes</div></Card>
+        </div>
+
+        <Card>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12 }}>
+            <label>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Category</div>
+              <select aria-label="Category" value={category} onChange={(event) => setCategory(event.target.value)}>
+                <option value="">All categories</option>
+                {CATEGORIES.map((item) => <option key={item} value={item}>{label(item)}</option>)}
+              </select>
+            </label>
+            <label>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Severity</div>
+              <select aria-label="Severity" value={severity} onChange={(event) => setSeverity(event.target.value)}>
+                <option value="">All severities</option>
+                {SEVERITIES.map((item) => <option key={item} value={item}>{label(item)}</option>)}
+              </select>
+            </label>
+            <label>
+              <div style={{ fontSize: 12, color: "#64748b" }}>State</div>
+              <select aria-label="State" value={state} onChange={(event) => setState(event.target.value)}>
+                <option value="">All states</option>
+                {STATES.map((item) => <option key={item} value={item}>{label(item)}</option>)}
+              </select>
+            </label>
+            <label>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Approval expectation</div>
+              <select aria-label="Approval expectation" value={approvalExpectation} onChange={(event) => setApprovalExpectation(event.target.value)}>
+                <option value="">All approvals</option>
+                {APPROVALS.map((item) => <option key={item} value={item}>{label(item)}</option>)}
+              </select>
+            </label>
+            <label>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Search</div>
+              <input aria-label="Search" value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search metadata" />
+            </label>
+          </div>
+        </Card>
+
+        {error ? <Card><div style={{ color: "#b91c1c" }}>{error}</div></Card> : null}
+
+        <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) minmax(280px, 420px)", gap: 16 }}>
+          <div style={{ display: "grid", gap: 10 }}>
+            {loading ? <Card><div>Loading support escalation metadata...</div></Card> : null}
+            {!loading && escalations.length === 0 ? (
+              <Card>
+                <div style={{ fontWeight: 700 }}>No support escalation metadata is available yet.</div>
+                <div style={{ color: "#64748b", marginTop: 6 }}>
+                  {summary.emptyState || "Append-only escalation history and review note metadata will appear here after an approved writer exists."}
+                </div>
+              </Card>
+            ) : null}
+            {escalations.map((item) => (
+              <EscalationRow
+                key={item.escalationId}
+                escalation={item}
+                selected={selected?.escalationId === item.escalationId}
+                onSelect={setSelected}
+              />
+            ))}
+          </div>
+          <DetailPanel escalation={detail} />
+        </div>
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin-only support escalation review routes with metadata-only list/detail responses
- add safe read model over append-only support escalation history/review note contracts
- add admin Support escalations page, filters, detail panel, and dashboard link
- add governance report for the review surface and persistence decision

## Safety
- no mutation routes, persistence writes, automation, remediation, impersonation, or support powers added
- no tenant/landlord visibility added
- responses remain metadata-only and admin_support_internal
- no raw payloads, storage paths, tokens, secrets, provider data, raw notes, or unrestricted policy internals exposed

## Validation
- rentchain-api: npm run test:single -- src/routes/__tests__/adminSupportEscalationRoutes.test.ts src/lib/adminSupportEscalations/__tests__/adminSupportEscalationReview.test.ts
- rentchain-frontend: npm run test -- src/pages/admin/AdminSupportEscalationsPage.test.tsx src/pages/admin/AdminDashboardPage.test.tsx
- rentchain-api: npm run build
- rentchain-frontend: npm run build
- git diff --check