### PR TITLE
Link escalation review workspace metadata

### DIFF
--- a/docs/reports/escalation-review-workspace-linking-v1.md
+++ b/docs/reports/escalation-review-workspace-linking-v1.md
@@ -1,0 +1,120 @@
+# Escalation Review Workspace Linking v1
+
+## Summary
+
+This mission adds metadata-only cross-workflow linkage between the admin security incident review surface and the admin support escalation review surface.
+
+It does not add workflow mutation, approval, resolution, dismissal, remediation, escalation execution, tenant/landlord visibility, new permissions, new public routes, or raw payload access.
+
+## Audit Findings
+
+Reviewed foundations:
+
+- `adminSecurityIncidents` provides metadata-only security incident summaries and details.
+- `supportEscalationRunbooks` provides deterministic runbook templates, approval expectations, and prohibited action language.
+- `supportEscalationHistory` provides append-only history and review note contracts.
+- `adminSupportEscalations` provides metadata-only support escalation list/detail projections.
+- Existing admin pages already expose safe detail panels for incidents and escalations.
+- No approved persistent cross-workflow link store exists.
+
+The safest first step is a derived read-model helper that can build links from already-safe incident, escalation, runbook, history, note, and evidence references.
+
+## Relationship Types Added
+
+Supported relationship types:
+
+- `incident_to_escalation`
+- `escalation_to_runbook`
+- `escalation_to_history`
+- `escalation_to_note`
+- `escalation_to_evidence`
+- `incident_to_evidence`
+- `incident_to_review_workspace`
+
+Unsupported relationship types fail closed and do not produce links.
+
+## Link Metadata Contract
+
+Each link includes:
+
+- `linkId`
+- `linkType`
+- `sourceSummary`
+- `targetSummary`
+- `workflowFamily`
+- `createdAt`
+- `derivedAt`
+- `metadataOnly: true`
+- `visibilityClass: admin_support_internal`
+- `tenantVisible: false`
+- `landlordVisible: false`
+- `appendCompatible: true`
+
+Safety flags also explicitly state that support powers, impersonation, autonomous remediation, autonomous escalation, financial mutation, route visibility changes, and mutation controls are disabled.
+
+## Surfaces Updated
+
+Backend detail projections now include `relatedWorkspaceLinks`:
+
+- admin security incident detail
+- admin support escalation detail
+
+Frontend detail panels now render these safe links in:
+
+- `/admin/security/incidents`
+- `/admin/support/escalations`
+
+No new routes were added.
+No mutation controls were added.
+
+## Redaction and Projection Safety
+
+Workspace links are built from safe summaries only.
+
+They do not expose:
+
+- raw notes
+- raw tenant/landlord/user IDs as labels
+- raw documents
+- raw provider payloads
+- screening reports
+- storage paths
+- tokens
+- secrets
+- credentials
+- authorization headers
+- cookies
+- request/response bodies
+- stack traces
+- debug payloads
+- unrestricted policy internals
+- impersonation session IDs as visible labels
+
+Labels that look like raw IDs, storage paths, credentials, or tokens are replaced with safe fallback labels.
+
+## Persistence Decision
+
+Persistence is not added in this mission.
+
+Links are derived from existing metadata-only incident and escalation projections. A persistent append-only workspace link store should be a future mission after collection ownership, retention, and write authorization rules are explicitly approved.
+
+## Known Limitations
+
+- Cross-workflow links are derived from available safe references only.
+- Incident-to-escalation links require an explicit safe incident reference on the escalation side.
+- No workflow state transition, assignment, approval, dismissal, or remediation is implemented.
+- No tenant/landlord-facing visibility is introduced.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Add append-only persisted workspace link records after storage governance is approved.
+2. Add admin-only filtered views by linked workflow family.
+3. Link security incident review suggestions to runbook templates without automated execution.
+4. Add exportable admin-only workspace audit summaries with projection-safety tests.
+5. Add manual note creation only after append-only write governance and sanitization rules are approved.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, add public routes, expose tenant/landlord escalation visibility, add raw payload exploration, create workflow mutation controls, enable impersonation, or introduce autonomous remediation/escalation.

--- a/rentchain-api/src/lib/adminSecurityIncidents/adminSecurityIncidentReview.ts
+++ b/rentchain-api/src/lib/adminSecurityIncidents/adminSecurityIncidentReview.ts
@@ -1,5 +1,9 @@
 import crypto from "crypto";
 import { projectAdminSupportMetadataForAudience } from "../adminSupportProjectionSafety/adminSupportProjectionSafety";
+import {
+  buildIncidentWorkspaceLinks,
+  type EscalationReviewWorkspaceLink,
+} from "../escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks";
 
 export const ADMIN_SECURITY_INCIDENT_REVIEW_VERSION = "admin_security_incident_review_v1";
 
@@ -75,6 +79,7 @@ export type AdminSecurityIncidentReviewDetail = AdminSecurityIncidentReviewRecor
   }>;
   redactionNotes: string[];
   suggestedNextReviewStep: string;
+  relatedWorkspaceLinks: EscalationReviewWorkspaceLink[];
 };
 
 const SUPPORTED_CATEGORIES = new Set<AdminSecurityIncidentCategory>([
@@ -339,6 +344,7 @@ export function buildAdminSecurityIncidentReviewDetail(
       "Raw actor ids, target ids, tokens, provider payloads, documents, storage paths, stack traces, and policy internals are not included.",
     ],
     suggestedNextReviewStep: record.recommendedReviewAction,
+    relatedWorkspaceLinks: buildIncidentWorkspaceLinks({ incident: record }),
   };
 }
 
@@ -369,4 +375,3 @@ export function filterAdminSecurityIncidentRecords(
     return true;
   });
 }
-

--- a/rentchain-api/src/lib/adminSupportEscalations/adminSupportEscalationReview.ts
+++ b/rentchain-api/src/lib/adminSupportEscalations/adminSupportEscalationReview.ts
@@ -12,6 +12,10 @@ import {
   type SupportEscalationHistoryEntry,
   type SupportEscalationReviewNote,
 } from "../supportEscalationHistory/supportEscalationHistory";
+import {
+  buildEscalationWorkspaceLinks,
+  type EscalationReviewWorkspaceLink,
+} from "../escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks";
 
 export const ADMIN_SUPPORT_ESCALATION_REVIEW_VERSION = "admin_support_escalation_review_v1";
 
@@ -41,6 +45,7 @@ export type AdminSupportEscalationReviewDetail = AdminSupportEscalationReviewRec
   reviewNotes: SupportEscalationReviewNote[];
   redactionSummary: string;
   prohibitedActions: string[];
+  relatedWorkspaceLinks: EscalationReviewWorkspaceLink[];
   emptyState: boolean;
 };
 
@@ -179,6 +184,17 @@ export function buildAdminSupportEscalationReviewDetail(
     redactionSummary:
       "Escalation details are metadata-only; raw notes, payloads, provider data, documents, storage paths, credentials, debug data, request/response bodies, and policy internals are excluded.",
     prohibitedActions: template.prohibitedActions,
+    relatedWorkspaceLinks: buildEscalationWorkspaceLinks({
+      escalation: {
+        ...record,
+        historyEntries,
+        reviewNotes,
+        redactionSummary: "",
+        prohibitedActions: template.prohibitedActions,
+        relatedWorkspaceLinks: [],
+        emptyState: false,
+      },
+    }),
     emptyState: false,
   };
 }

--- a/rentchain-api/src/lib/escalationReviewWorkspaceLinks/__tests__/escalationReviewWorkspaceLinks.test.ts
+++ b/rentchain-api/src/lib/escalationReviewWorkspaceLinks/__tests__/escalationReviewWorkspaceLinks.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEscalationReviewWorkspaceLink,
+  buildEscalationWorkspaceLinks,
+  buildIncidentWorkspaceLinks,
+} from "../escalationReviewWorkspaceLinks";
+
+const incident = {
+  incidentReviewVersion: "admin_security_incident_review_v1" as const,
+  incidentId: "security_incident:abc123",
+  category: "projection_safety_redaction" as const,
+  severity: "high" as const,
+  status: "reviewing" as const,
+  title: "Projection Safety Redaction",
+  summary: "Projection safety metadata requires review.",
+  occurredAt: "2026-05-24T01:00:00.000Z",
+  lastSeenAt: "2026-05-24T01:05:00.000Z",
+  actorSummary: { role: "admin", supportAttribution: true, rawActorIdsIncluded: false as const },
+  targetSummary: {
+    accountType: "tenant",
+    resourceType: "review_workspace",
+    landlordScoped: true,
+    tenantScoped: true,
+    rawTargetIdsIncluded: false as const,
+  },
+  workflowFamily: "admin_security_incident_review",
+  policyOutcomeSummary: "redacted",
+  sourceRoute: "/api/admin/security/incidents",
+  routeSource: "adminSecurityIncidentRoutes.ts",
+  metadataOnly: true as const,
+  redactionSummary: "Restricted fields excluded.",
+  recommendedReviewAction: "Review projection boundary.",
+  safeEvidenceReferences: [
+    {
+      referenceType: "evidence" as const,
+      referenceId: "evidence:safe",
+      label: "Evidence metadata reference",
+      internalReference: true as const,
+    },
+  ],
+};
+
+const escalation = {
+  escalationReviewVersion: "admin_support_escalation_review_v1" as const,
+  escalationId: "escalation-safe",
+  category: "projection_safety" as const,
+  severity: "high" as const,
+  state: "awaiting_approval" as const,
+  approvalExpectation: "admin_review" as const,
+  title: "Projection Safety escalation",
+  summary: "Projection safety review escalation.",
+  createdAt: "2026-05-24T01:10:00.000Z",
+  lastUpdatedAt: "2026-05-24T01:20:00.000Z",
+  actorSummary: { role: "admin", displayName: "Security operator", supportAttribution: true, rawActorIdsIncluded: false as const },
+  safeEvidenceRefs: [
+    {
+      referenceType: "incident" as const,
+      referenceId: "abc123",
+      label: "Linked incident",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      internalReference: true as const,
+      metadataOnly: true as const,
+    },
+    {
+      referenceType: "evidence_pack" as const,
+      referenceId: "evidence-pack-safe",
+      label: "Evidence pack",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      internalReference: true as const,
+      metadataOnly: true as const,
+    },
+  ],
+  historyCount: 1,
+  noteCount: 1,
+  metadataOnly: true as const,
+  visibilityClass: "admin_support_internal" as const,
+  tenantVisible: false as const,
+  landlordVisible: false as const,
+};
+
+describe("escalation review workspace links", () => {
+  it("fails safe for unsupported relationship types", () => {
+    expect(
+      buildEscalationReviewWorkspaceLink({
+        linkType: "raw_debug_payload",
+        sourceSummary: { kind: "security_incident", label: "Incident" },
+        targetSummary: { kind: "support_escalation", label: "Escalation" },
+      })
+    ).toBeNull();
+  });
+
+  it("builds metadata-only incident to escalation and evidence links", () => {
+    const links = buildIncidentWorkspaceLinks({ incident, escalations: [escalation], derivedAt: "2026-05-24T02:00:00.000Z" });
+
+    expect(links.map((link) => link.linkType).sort()).toEqual(["incident_to_escalation", "incident_to_evidence"]);
+    for (const link of links) {
+      expect(link).toEqual(
+        expect.objectContaining({
+          metadataOnly: true,
+          visibilityClass: "admin_support_internal",
+          tenantVisible: false,
+          landlordVisible: false,
+          appendCompatible: true,
+          supportPowersGranted: false,
+          autonomousRemediationEnabled: false,
+          autonomousEscalationEnabled: false,
+          mutationControlsEnabled: false,
+        })
+      );
+      expect(link.sourceSummary.rawIdsIncluded).toBe(false);
+      expect(link.targetSummary.rawIdsIncluded).toBe(false);
+    }
+  });
+
+  it("builds escalation runbook, history, note, incident, and evidence links without raw payload labels", () => {
+    const links = buildEscalationWorkspaceLinks({
+      escalation: {
+        ...escalation,
+        historyEntries: [
+          {
+            supportEscalationHistoryVersion: "support_escalation_history_v1",
+            historyEntryId: "history-raw-id",
+            escalationRefId: "escalation-safe",
+            category: "projection_safety",
+            severity: "high",
+            state: "awaiting_approval",
+            actionType: "approval_requested",
+            actorSummary: { role: "admin", displayName: "Security operator", supportAttribution: true, rawActorIdsIncluded: false },
+            occurredAt: "2026-05-24T01:12:00.000Z",
+            noteSummary: "Bearer secret gs://bucket/raw.pdf",
+            approvalExpectation: "admin_review",
+            safeEvidenceRefs: [],
+            resourceRefs: [],
+            metadataOnly: true,
+            visibilityClass: "admin_support_internal",
+            tenantVisible: false,
+            landlordVisible: false,
+            appendOnly: true,
+            supportPowersGranted: false,
+            impersonationEnabled: false,
+            autonomousRemediationEnabled: false,
+            autonomousEscalationEnabled: false,
+            financialMutationEnabled: false,
+            routeVisibilityChanged: false,
+            payloadSafety: {
+              rawPayloads: "excluded",
+              providerData: "reference_only",
+              evidenceData: "reference_only",
+              exportData: "reference_only",
+              documentData: "reference_only",
+              credentialData: "excluded",
+              requestResponseData: "excluded",
+              diagnosticData: "metadata_only",
+              internalPolicyData: "summary_only",
+            },
+          },
+        ],
+        reviewNotes: [
+          {
+            supportEscalationHistoryVersion: "support_escalation_history_v1",
+            noteId: "note-raw-id",
+            escalationRefId: "escalation-safe",
+            noteType: "admin_review_note",
+            noteSummary: "authorization=Bearer-secret",
+            authorSummary: { role: "admin", displayName: "Security operator", supportAttribution: true, rawActorIdsIncluded: false },
+            createdAt: "2026-05-24T01:15:00.000Z",
+            safeEvidenceRefs: [],
+            resourceRefs: [],
+            redactionSummary: "Raw payloads excluded.",
+            metadataOnly: true,
+            visibilityClass: "admin_support_internal",
+            tenantVisible: false,
+            landlordVisible: false,
+            appendOnly: true,
+            supportPowersGranted: false,
+            impersonationEnabled: false,
+            autonomousRemediationEnabled: false,
+            autonomousEscalationEnabled: false,
+            financialMutationEnabled: false,
+            routeVisibilityChanged: false,
+            payloadSafety: {
+              rawPayloads: "excluded",
+              providerData: "reference_only",
+              evidenceData: "reference_only",
+              exportData: "reference_only",
+              documentData: "reference_only",
+              credentialData: "excluded",
+              requestResponseData: "excluded",
+              diagnosticData: "metadata_only",
+              internalPolicyData: "summary_only",
+            },
+          },
+        ],
+        redactionSummary: "Metadata-only.",
+        prohibitedActions: ["Do not perform autonomous remediation."],
+        relatedWorkspaceLinks: [],
+        emptyState: false,
+      },
+      incidents: [incident],
+    });
+
+    expect(links.map((link) => link.linkType).sort()).toEqual([
+      "escalation_to_evidence",
+      "escalation_to_history",
+      "escalation_to_note",
+      "escalation_to_runbook",
+      "incident_to_escalation",
+    ]);
+    const payload = JSON.stringify(links);
+    expect(payload).not.toContain("Bearer-secret");
+    expect(payload).not.toContain("gs://");
+    expect(payload).not.toContain("history-raw-id");
+    expect(payload).not.toContain("note-raw-id");
+  });
+});

--- a/rentchain-api/src/lib/escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks.ts
+++ b/rentchain-api/src/lib/escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks.ts
@@ -1,0 +1,332 @@
+import crypto from "crypto";
+import type {
+  AdminSecurityIncidentReviewDetail,
+  AdminSecurityIncidentReviewRecord,
+} from "../adminSecurityIncidents/adminSecurityIncidentReview";
+import type {
+  AdminSupportEscalationReviewDetail,
+  AdminSupportEscalationReviewRecord,
+} from "../adminSupportEscalations/adminSupportEscalationReview";
+import {
+  buildSupportEscalationRunbookTemplate,
+  type SupportEscalationApprovalRequirement,
+} from "../supportEscalationRunbooks/supportEscalationRunbooks";
+
+export const ESCALATION_REVIEW_WORKSPACE_LINK_VERSION = "escalation_review_workspace_linking_v1";
+
+export type EscalationReviewWorkspaceLinkType =
+  | "incident_to_escalation"
+  | "escalation_to_runbook"
+  | "escalation_to_history"
+  | "escalation_to_note"
+  | "escalation_to_evidence"
+  | "incident_to_evidence"
+  | "incident_to_review_workspace";
+
+export type EscalationReviewWorkspaceLinkSummary = {
+  kind: "security_incident" | "support_escalation" | "runbook" | "history_entry" | "review_note" | "evidence_reference" | "review_workspace";
+  label: string;
+  category: string | null;
+  severity: string | null;
+  state: string | null;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+};
+
+export type EscalationReviewWorkspaceLink = {
+  escalationReviewWorkspaceLinkVersion: typeof ESCALATION_REVIEW_WORKSPACE_LINK_VERSION;
+  linkId: string;
+  linkType: EscalationReviewWorkspaceLinkType;
+  sourceSummary: EscalationReviewWorkspaceLinkSummary;
+  targetSummary: EscalationReviewWorkspaceLinkSummary;
+  workflowFamily: string | null;
+  createdAt: string;
+  derivedAt: string;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendCompatible: true;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousRemediationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  routeVisibilityChanged: false;
+  mutationControlsEnabled: false;
+  redactionSummary: string;
+};
+
+const LINK_TYPES = new Set<EscalationReviewWorkspaceLinkType>([
+  "incident_to_escalation",
+  "escalation_to_runbook",
+  "escalation_to_history",
+  "escalation_to_note",
+  "escalation_to_evidence",
+  "incident_to_evidence",
+  "incident_to_review_workspace",
+]);
+
+type LinkInput = {
+  linkType?: unknown;
+  sourceSummary?: Partial<EscalationReviewWorkspaceLinkSummary> | null;
+  targetSummary?: Partial<EscalationReviewWorkspaceLinkSummary> | null;
+  workflowFamily?: unknown;
+  createdAt?: unknown;
+  derivedAt?: unknown;
+};
+
+function asString(value: unknown, max = 300): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function toIso(value: unknown): string {
+  if (value && typeof (value as any).toDate === "function") return (value as any).toDate().toISOString();
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = asString(value, 120);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function stableHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex").slice(0, 16);
+}
+
+function safeLabel(value: unknown, fallback: string): string {
+  const label = asString(value, 160).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  if (!label) return fallback;
+  if (/gs:\/\//i.test(label) || /storage\.googleapis\.com/i.test(label)) return fallback;
+  if (/token|secret|credential|authorization|cookie|password|bearer/i.test(label)) return fallback;
+  if (/^[a-zA-Z0-9_-]{16,}$/.test(label)) return fallback;
+  return label;
+}
+
+function normalizeLinkType(value: unknown): EscalationReviewWorkspaceLinkType | null {
+  const normalized = normalizeKey(value);
+  return LINK_TYPES.has(normalized as EscalationReviewWorkspaceLinkType)
+    ? (normalized as EscalationReviewWorkspaceLinkType)
+    : null;
+}
+
+function safeFlags() {
+  return {
+    metadataOnly: true as const,
+    visibilityClass: "admin_support_internal" as const,
+    tenantVisible: false as const,
+    landlordVisible: false as const,
+    appendCompatible: true as const,
+    supportPowersGranted: false as const,
+    impersonationEnabled: false as const,
+    autonomousRemediationEnabled: false as const,
+    autonomousEscalationEnabled: false as const,
+    financialMutationEnabled: false as const,
+    routeVisibilityChanged: false as const,
+    mutationControlsEnabled: false as const,
+  };
+}
+
+function summary(input: Partial<EscalationReviewWorkspaceLinkSummary> | null | undefined): EscalationReviewWorkspaceLinkSummary {
+  const kind = input?.kind || "evidence_reference";
+  return {
+    kind,
+    label: safeLabel(input?.label, `${kind.split("_").join(" ")} reference`),
+    category: asString(input?.category, 120) || null,
+    severity: asString(input?.severity, 80) || null,
+    state: asString(input?.state, 80) || null,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+  };
+}
+
+export function buildEscalationReviewWorkspaceLink(input: LinkInput): EscalationReviewWorkspaceLink | null {
+  const linkType = normalizeLinkType(input.linkType);
+  if (!linkType) return null;
+  const sourceSummary = summary(input.sourceSummary);
+  const targetSummary = summary(input.targetSummary);
+  const createdAt = toIso(input.createdAt);
+  const derivedAt = toIso(input.derivedAt || input.createdAt);
+  return {
+    escalationReviewWorkspaceLinkVersion: ESCALATION_REVIEW_WORKSPACE_LINK_VERSION,
+    linkId: `workspace_link:${stableHash([linkType, sourceSummary, targetSummary, createdAt])}`,
+    linkType,
+    sourceSummary,
+    targetSummary,
+    workflowFamily: asString(input.workflowFamily, 120) || null,
+    createdAt,
+    derivedAt,
+    redactionSummary:
+      "Workspace link is metadata-only; raw notes, documents, provider payloads, reports, storage paths, tokens, secrets, request/response bodies, debug payloads, and policy internals are excluded.",
+    ...safeFlags(),
+  };
+}
+
+function uniqueLinks(links: Array<EscalationReviewWorkspaceLink | null>): EscalationReviewWorkspaceLink[] {
+  const byKey = new Map<string, EscalationReviewWorkspaceLink>();
+  for (const link of links) {
+    if (link && !byKey.has(link.linkId)) byKey.set(link.linkId, link);
+  }
+  return Array.from(byKey.values()).sort((a, b) => a.linkId.localeCompare(b.linkId));
+}
+
+function incidentSummary(incident: AdminSecurityIncidentReviewRecord): EscalationReviewWorkspaceLinkSummary {
+  return summary({
+    kind: "security_incident",
+    label: incident.title,
+    category: incident.category,
+    severity: incident.severity,
+    state: incident.status,
+  });
+}
+
+function escalationSummary(escalation: AdminSupportEscalationReviewRecord): EscalationReviewWorkspaceLinkSummary {
+  return summary({
+    kind: "support_escalation",
+    label: escalation.title,
+    category: escalation.category,
+    severity: escalation.severity,
+    state: escalation.state,
+  });
+}
+
+function refSummary(ref: { referenceType?: string; label?: string }): EscalationReviewWorkspaceLinkSummary {
+  return summary({
+    kind: ref.referenceType === "review_workspace" ? "review_workspace" : "evidence_reference",
+    label: ref.label || `${ref.referenceType || "evidence"} reference`,
+    category: ref.referenceType || null,
+  });
+}
+
+function refMatchesIncident(ref: { referenceId?: string; referenceType?: string }, incident: AdminSecurityIncidentReviewRecord): boolean {
+  const refId = asString(ref.referenceId, 260).toLowerCase();
+  if (!refId || ref.referenceType !== "incident") return false;
+  return refId === incident.incidentId.toLowerCase() || incident.incidentId.toLowerCase().endsWith(refId);
+}
+
+export function buildIncidentWorkspaceLinks(input: {
+  incident: AdminSecurityIncidentReviewDetail | AdminSecurityIncidentReviewRecord;
+  escalations?: AdminSupportEscalationReviewRecord[];
+  derivedAt?: unknown;
+}): EscalationReviewWorkspaceLink[] {
+  const incident = input.incident;
+  const source = incidentSummary(incident);
+  const evidenceLinks = (incident.safeEvidenceReferences || []).map((ref) =>
+    buildEscalationReviewWorkspaceLink({
+      linkType: ref.referenceType === "evidence" || ref.referenceType === "export" ? "incident_to_evidence" : "incident_to_review_workspace",
+      sourceSummary: source,
+      targetSummary: refSummary(ref),
+      workflowFamily: incident.workflowFamily || "admin_security_incident_review",
+      createdAt: incident.occurredAt,
+      derivedAt: input.derivedAt,
+    })
+  );
+  const escalationLinks = (input.escalations || [])
+    .filter((escalation) => escalation.safeEvidenceRefs.some((ref) => refMatchesIncident(ref, incident)))
+    .map((escalation) =>
+      buildEscalationReviewWorkspaceLink({
+        linkType: "incident_to_escalation",
+        sourceSummary: source,
+        targetSummary: escalationSummary(escalation),
+        workflowFamily: incident.workflowFamily || "admin_security_incident_review",
+        createdAt: escalation.createdAt || incident.occurredAt,
+        derivedAt: input.derivedAt,
+      })
+    );
+  return uniqueLinks([...evidenceLinks, ...escalationLinks]);
+}
+
+export function buildEscalationWorkspaceLinks(input: {
+  escalation: AdminSupportEscalationReviewDetail | AdminSupportEscalationReviewRecord;
+  incidents?: AdminSecurityIncidentReviewRecord[];
+  derivedAt?: unknown;
+}): EscalationReviewWorkspaceLink[] {
+  const escalation = input.escalation;
+  const incidents = input.incidents || [];
+  const source = escalationSummary(escalation);
+  const template = buildSupportEscalationRunbookTemplate({ category: escalation.category, severity: escalation.severity });
+  const links: Array<EscalationReviewWorkspaceLink | null> = [
+    buildEscalationReviewWorkspaceLink({
+      linkType: "escalation_to_runbook",
+      sourceSummary: source,
+      targetSummary: summary({
+        kind: "runbook",
+        label: template.title,
+        category: escalation.category,
+        severity: template.severity,
+        state: template.approvalRequirement as SupportEscalationApprovalRequirement,
+      }),
+      workflowFamily: "admin_support_escalation_review",
+      createdAt: escalation.createdAt,
+      derivedAt: input.derivedAt,
+    }),
+    ...(escalation.safeEvidenceRefs || []).map((ref) =>
+      ref.referenceType === "incident" && incidents.some((incident) => refMatchesIncident(ref, incident))
+        ? null
+        : buildEscalationReviewWorkspaceLink({
+            linkType: ref.referenceType === "incident" ? "incident_to_escalation" : "escalation_to_evidence",
+            sourceSummary: ref.referenceType === "incident"
+              ? summary({ kind: "security_incident", label: ref.label, category: "incident" })
+              : source,
+            targetSummary: ref.referenceType === "incident" ? source : refSummary(ref),
+            workflowFamily: "admin_support_escalation_review",
+            createdAt: escalation.createdAt,
+            derivedAt: input.derivedAt,
+          })
+    ),
+  ];
+
+  if ("historyEntries" in escalation) {
+    links.push(
+      ...escalation.historyEntries.map((entry) =>
+        buildEscalationReviewWorkspaceLink({
+          linkType: "escalation_to_history",
+          sourceSummary: source,
+          targetSummary: summary({
+            kind: "history_entry",
+            label: `${entry.actionType.split("_").join(" ")} history`,
+            category: entry.category,
+            severity: entry.severity,
+            state: entry.state,
+          }),
+          workflowFamily: "admin_support_escalation_review",
+          createdAt: entry.occurredAt,
+          derivedAt: input.derivedAt,
+        })
+      ),
+      ...escalation.reviewNotes.map((note) =>
+        buildEscalationReviewWorkspaceLink({
+          linkType: "escalation_to_note",
+          sourceSummary: source,
+          targetSummary: summary({
+            kind: "review_note",
+            label: `${note.noteType.split("_").join(" ")} metadata`,
+          }),
+          workflowFamily: "admin_support_escalation_review",
+          createdAt: note.createdAt,
+          derivedAt: input.derivedAt,
+        })
+      )
+    );
+  }
+
+  for (const incident of incidents) {
+    if (escalation.safeEvidenceRefs.some((ref) => refMatchesIncident(ref, incident))) {
+      links.push(
+        buildEscalationReviewWorkspaceLink({
+          linkType: "incident_to_escalation",
+          sourceSummary: incidentSummary(incident),
+          targetSummary: source,
+          workflowFamily: incident.workflowFamily || "admin_support_escalation_review",
+          createdAt: escalation.createdAt,
+          derivedAt: input.derivedAt,
+        })
+      );
+    }
+  }
+
+  return uniqueLinks(links);
+}

--- a/rentchain-frontend/src/api/adminSecurityIncidentsApi.ts
+++ b/rentchain-frontend/src/api/adminSecurityIncidentsApi.ts
@@ -56,6 +56,37 @@ export type AdminSecurityIncidentDetail = AdminSecurityIncidentRecord & {
   }>;
   redactionNotes: string[];
   suggestedNextReviewStep: string;
+  relatedWorkspaceLinks: AdminReviewWorkspaceLink[];
+};
+
+export type AdminReviewWorkspaceLink = {
+  linkId: string;
+  linkType: string;
+  sourceSummary: {
+    kind: string;
+    label: string;
+    category: string | null;
+    severity: string | null;
+    state: string | null;
+    metadataOnly: true;
+    rawIdsIncluded: false;
+  };
+  targetSummary: {
+    kind: string;
+    label: string;
+    category: string | null;
+    severity: string | null;
+    state: string | null;
+    metadataOnly: true;
+    rawIdsIncluded: false;
+  };
+  workflowFamily: string | null;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendCompatible: true;
+  mutationControlsEnabled: false;
 };
 
 export async function fetchAdminSecurityIncidents(params?: {
@@ -91,4 +122,3 @@ export async function fetchAdminSecurityIncidentDetail(incidentId: string) {
     incident: AdminSecurityIncidentDetail;
   }>(`/admin/security/incidents/${encodeURIComponent(incidentId)}`);
 }
-

--- a/rentchain-frontend/src/api/adminSupportEscalationsApi.ts
+++ b/rentchain-frontend/src/api/adminSupportEscalationsApi.ts
@@ -37,7 +37,38 @@ export type AdminSupportEscalationDetail = AdminSupportEscalationRecord & {
   reviewNotes: Array<Record<string, unknown>>;
   redactionSummary: string;
   prohibitedActions: string[];
+  relatedWorkspaceLinks: AdminReviewWorkspaceLink[];
   emptyState: boolean;
+};
+
+export type AdminReviewWorkspaceLink = {
+  linkId: string;
+  linkType: string;
+  sourceSummary: {
+    kind: string;
+    label: string;
+    category: string | null;
+    severity: string | null;
+    state: string | null;
+    metadataOnly: true;
+    rawIdsIncluded: false;
+  };
+  targetSummary: {
+    kind: string;
+    label: string;
+    category: string | null;
+    severity: string | null;
+    state: string | null;
+    metadataOnly: true;
+    rawIdsIncluded: false;
+  };
+  workflowFamily: string | null;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendCompatible: true;
+  mutationControlsEnabled: false;
 };
 
 export type AdminSupportEscalationSummary = {

--- a/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.test.tsx
@@ -72,6 +72,37 @@ beforeEach(() => {
       relatedEventSummaries: [],
       redactionNotes: ["Raw actor ids, target ids, tokens, provider payloads, documents, storage paths, stack traces, and policy internals are not included."],
       suggestedNextReviewStep: "Review support attribution.",
+      relatedWorkspaceLinks: [
+        {
+          linkId: "workspace_link:safe",
+          linkType: "incident_to_evidence",
+          sourceSummary: {
+            kind: "security_incident",
+            label: "Impersonation Started",
+            category: "impersonation_started",
+            severity: "medium",
+            state: "open",
+            metadataOnly: true,
+            rawIdsIncluded: false,
+          },
+          targetSummary: {
+            kind: "evidence_reference",
+            label: "Telemetry metadata reference",
+            category: "telemetry",
+            severity: null,
+            state: null,
+            metadataOnly: true,
+            rawIdsIncluded: false,
+          },
+          workflowFamily: "admin_security_incident_review",
+          metadataOnly: true,
+          visibilityClass: "admin_support_internal",
+          tenantVisible: false,
+          landlordVisible: false,
+          appendCompatible: true,
+          mutationControlsEnabled: false,
+        },
+      ],
     },
   });
 });
@@ -88,6 +119,8 @@ describe("AdminSecurityIncidentsPage", () => {
     expect(await screen.findByRole("heading", { name: "Security incidents" })).toBeInTheDocument();
     expect((await screen.findAllByText("Impersonation Started")).length).toBeGreaterThan(0);
     expect(await screen.findByText("impersonationRoutes.ts")).toBeInTheDocument();
+    expect(await screen.findByText(/Incident To Evidence/)).toBeInTheDocument();
+    expect(await screen.findByText(/Telemetry metadata reference/)).toBeInTheDocument();
     expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);
     expect(JSON.stringify(document.body.textContent)).not.toContain("realActorId");
     expect(JSON.stringify(document.body.textContent)).not.toContain("effectiveActorId");

--- a/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.tsx
@@ -141,6 +141,20 @@ function DetailPanel({ incident }: { incident: AdminSecurityIncidentDetail | nul
             ))}
           </div>
         </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Related review workspace links</div>
+          {incident.relatedWorkspaceLinks?.length ? (
+            <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+              {incident.relatedWorkspaceLinks.map((link) => (
+                <div key={link.linkId} style={{ color: "#475569" }}>
+                  {label(link.linkType)} · {link.sourceSummary.label} → {link.targetSummary.label}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div style={{ color: "#64748b", marginTop: 8 }}>No metadata-only workspace links are available yet.</div>
+          )}
+        </div>
       </div>
     </Card>
   );
@@ -317,4 +331,3 @@ export default function AdminSecurityIncidentsPage() {
     </MacShell>
   );
 }
-

--- a/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.test.tsx
@@ -72,6 +72,37 @@ beforeEach(() => {
       reviewNotes: [],
       redactionSummary: "Escalation details are metadata-only.",
       prohibitedActions: ["Do not perform autonomous remediation."],
+      relatedWorkspaceLinks: [
+        {
+          linkId: "workspace_link:safe",
+          linkType: "escalation_to_runbook",
+          sourceSummary: {
+            kind: "support_escalation",
+            label: "Credential Secret escalation",
+            category: "credential_secret",
+            severity: "critical",
+            state: "awaiting_approval",
+            metadataOnly: true,
+            rawIdsIncluded: false,
+          },
+          targetSummary: {
+            kind: "runbook",
+            label: "Credential or Secret Exposure Runbook",
+            category: "credential_secret",
+            severity: "critical",
+            state: "security_review",
+            metadataOnly: true,
+            rawIdsIncluded: false,
+          },
+          workflowFamily: "admin_support_escalation_review",
+          metadataOnly: true,
+          visibilityClass: "admin_support_internal",
+          tenantVisible: false,
+          landlordVisible: false,
+          appendCompatible: true,
+          mutationControlsEnabled: false,
+        },
+      ],
       emptyState: false,
     },
   });
@@ -89,6 +120,8 @@ describe("AdminSupportEscalationsPage", () => {
     expect(await screen.findByRole("heading", { name: "Support escalations" })).toBeInTheDocument();
     expect((await screen.findAllByText("Credential Secret escalation")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Security operator")).toBeInTheDocument();
+    expect(await screen.findByText(/Escalation To Runbook/)).toBeInTheDocument();
+    expect(await screen.findByText(/Credential or Secret Exposure Runbook/)).toBeInTheDocument();
     expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /resolve/i })).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.tsx
@@ -136,6 +136,20 @@ function DetailPanel({ escalation }: { escalation: AdminSupportEscalationDetail 
             ))}
           </ul>
         </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Related review workspace links</div>
+          {escalation.relatedWorkspaceLinks?.length ? (
+            <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+              {escalation.relatedWorkspaceLinks.map((link) => (
+                <div key={link.linkId} style={{ color: "#475569" }}>
+                  {label(link.linkType)} · {link.sourceSummary.label} → {link.targetSummary.label}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div style={{ color: "#64748b", marginTop: 8 }}>No metadata-only workspace links are available yet.</div>
+          )}
+        </div>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add metadata-only escalation review workspace link helper/read model
- derive safe links between security incidents, support escalations, runbooks, history, review notes, and evidence references
- surface related workspace links in existing admin incident and support escalation detail panels
- add governance report for cross-workflow linking posture

## Safety
- no new routes or mutation controls
- no autonomous remediation, escalation, approval, resolve, dismiss, or enforcement behavior
- no tenant/landlord visibility and no permission widening
- no raw notes, documents, provider payloads, reports, storage paths, tokens, secrets, request/response bodies, debug payloads, or policy internals exposed
- labels are metadata-only and avoid raw IDs as display labels

## Validation
- rentchain-api: npm run test:single -- src/lib/escalationReviewWorkspaceLinks/__tests__/escalationReviewWorkspaceLinks.test.ts src/lib/adminSecurityIncidents/__tests__/adminSecurityIncidentReview.test.ts src/lib/adminSupportEscalations/__tests__/adminSupportEscalationReview.test.ts
- rentchain-frontend: npm run test -- src/pages/admin/AdminSecurityIncidentsPage.test.tsx src/pages/admin/AdminSupportEscalationsPage.test.tsx
- rentchain-api: npm run build
- rentchain-frontend: npm run build
- git diff --check