### PR TITLE
Add governed review workspace summaries

### DIFF
--- a/docs/reports/governed-review-workspace-foundations-v1.md
+++ b/docs/reports/governed-review-workspace-foundations-v1.md
@@ -1,0 +1,132 @@
+# Governed Review Workspace Foundations v1
+
+## Summary
+
+This mission adds a metadata-only governed review workspace summary model that can group security incidents, support escalations, runbooks, escalation history, review notes, evidence references, workspace links, and audit/export readiness context.
+
+It does not add persistence, new routes, public routes, mutation controls, automation, remediation, approval/resolution/dismissal actions, tenant/landlord visibility, or raw payload access.
+
+## Audit Findings
+
+Reviewed foundations:
+
+- `adminSecurityIncidents` provides admin-only, metadata-only incident list/detail projections.
+- `supportEscalationRunbooks` provides deterministic runbook templates, severity, approval expectations, and prohibited action language.
+- `supportEscalationHistory` provides append-compatible history entries and manual review note contracts.
+- `adminSupportEscalations` provides admin-only, metadata-only escalation list/detail projections.
+- `escalationReviewWorkspaceLinks` provides derived metadata-only links between incidents, escalations, runbooks, history, notes, and evidence references.
+
+No approved governed review workspace persistence store exists yet, so this mission keeps workspace summaries derived from existing safe metadata.
+
+## Helper / Read Model Added
+
+Added:
+
+- `rentchain-api/src/lib/governedReviewWorkspaces/governedReviewWorkspaces.ts`
+
+The helper defines:
+
+- workspace type normalization
+- safe workspace summary construction
+- incident-derived workspace summaries
+- escalation-derived workspace summaries
+- metadata-only flags
+- safe evidence reference normalization
+- safe workspace link inclusion
+
+## Workspace Types
+
+Supported workspace types:
+
+- `security_review`
+- `support_escalation_review`
+- `export_governance_review`
+- `evidence_review`
+- `policy_failure_review`
+- `projection_safety_review`
+- `operational_readiness_review`
+- `other`
+
+Unknown workspace types normalize to `other`.
+
+## Summary Fields
+
+Each governed workspace summary includes:
+
+- `workspaceId`
+- `workspaceType`
+- `title`
+- `summary`
+- `workflowFamily`
+- `severitySummary`
+- `reviewStateSummary`
+- `relatedIncidentCount`
+- `relatedEscalationCount`
+- `relatedEvidenceCount`
+- `relatedNoteCount`
+- `approvalExpectationSummary`
+- `safeEvidenceRefs`
+- `relatedWorkspaceLinks`
+- metadata-only/internal visibility flags
+
+## Surfaces Changed
+
+Existing admin detail projections now include a safe `governedReviewWorkspace` summary:
+
+- admin security incident detail
+- admin support escalation detail
+
+Existing admin pages render the safe summary in their detail panels:
+
+- `/admin/security/incidents`
+- `/admin/support/escalations`
+
+No new routes are added.
+No mutation controls are added.
+
+## Redaction and Projection Safety
+
+Workspace summaries never expose:
+
+- raw actor IDs as labels
+- raw tenant/landlord IDs as labels
+- raw documents
+- raw provider payloads
+- raw screening reports
+- raw storage paths
+- tokens
+- secrets
+- credentials
+- request/response bodies
+- stack traces
+- debug payloads
+- unrestricted policy internals
+- impersonation session IDs as labels
+
+Labels that look like raw IDs, storage paths, credentials, or tokens are replaced with safe fallback text. Evidence refs are internal, metadata-only, and stripped of landlord/tenant IDs in the workspace summary layer.
+
+## Persistence Decision
+
+Persistence is deferred.
+
+The workspace summary model is derived from already-projected admin/support metadata. A persistent workspace store should be introduced only after collection ownership, append-only write semantics, retention, and admin/support route authorization are explicitly approved.
+
+## Known Limitations
+
+- Workspace summaries are derived from currently available safe metadata only.
+- There is no workspace assignment, status mutation, note writing, approval, resolution, dismissal, or automation.
+- Cross-workflow grouping remains read-model-only until an approved append-only workspace store exists.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Add append-only governed workspace records after storage governance is approved.
+2. Add admin-only workspace list/detail routes after persistence is approved.
+3. Add manual workspace notes only with strict sanitization and append-only writes.
+4. Link governed workspaces to export/audit readiness summaries without exposing raw payloads.
+5. Add institutional audit export summaries scoped to admin/support audiences only.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, add public routes, add tenant/landlord visibility, expose raw payloads, add mutation controls, enable impersonation, or introduce autonomous remediation/escalation.

--- a/rentchain-api/src/lib/adminSecurityIncidents/adminSecurityIncidentReview.ts
+++ b/rentchain-api/src/lib/adminSecurityIncidents/adminSecurityIncidentReview.ts
@@ -4,6 +4,10 @@ import {
   buildIncidentWorkspaceLinks,
   type EscalationReviewWorkspaceLink,
 } from "../escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks";
+import {
+  buildIncidentGovernedReviewWorkspaceSummary,
+  type GovernedReviewWorkspaceSummary,
+} from "../governedReviewWorkspaces/governedReviewWorkspaces";
 
 export const ADMIN_SECURITY_INCIDENT_REVIEW_VERSION = "admin_security_incident_review_v1";
 
@@ -80,6 +84,7 @@ export type AdminSecurityIncidentReviewDetail = AdminSecurityIncidentReviewRecor
   redactionNotes: string[];
   suggestedNextReviewStep: string;
   relatedWorkspaceLinks: EscalationReviewWorkspaceLink[];
+  governedReviewWorkspace: GovernedReviewWorkspaceSummary;
 };
 
 const SUPPORTED_CATEGORIES = new Set<AdminSecurityIncidentCategory>([
@@ -320,14 +325,15 @@ export function buildAdminSecurityIncidentReviewRecord(input: {
 export function buildAdminSecurityIncidentReviewDetail(
   record: AdminSecurityIncidentReviewRecord
 ): AdminSecurityIncidentReviewDetail {
-  return {
+  const relatedWorkspaceLinks = buildIncidentWorkspaceLinks({ incident: record });
+  const detailWithoutWorkspace = {
     ...record,
     timeline: [
       {
         occurredAt: record.occurredAt,
         label: record.title,
         category: record.category,
-        metadataOnly: true,
+        metadataOnly: true as const,
       },
     ],
     relatedEventSummaries: [
@@ -336,7 +342,7 @@ export function buildAdminSecurityIncidentReviewDetail(
         sourceCollection: record.safeEvidenceReferences[0]?.referenceType || "event",
         occurredAt: record.occurredAt,
         summary: record.summary,
-        metadataOnly: true,
+        metadataOnly: true as const,
       },
     ],
     redactionNotes: [
@@ -344,7 +350,11 @@ export function buildAdminSecurityIncidentReviewDetail(
       "Raw actor ids, target ids, tokens, provider payloads, documents, storage paths, stack traces, and policy internals are not included.",
     ],
     suggestedNextReviewStep: record.recommendedReviewAction,
-    relatedWorkspaceLinks: buildIncidentWorkspaceLinks({ incident: record }),
+    relatedWorkspaceLinks,
+  };
+  return {
+    ...detailWithoutWorkspace,
+    governedReviewWorkspace: buildIncidentGovernedReviewWorkspaceSummary(detailWithoutWorkspace),
   };
 }
 

--- a/rentchain-api/src/lib/adminSupportEscalations/adminSupportEscalationReview.ts
+++ b/rentchain-api/src/lib/adminSupportEscalations/adminSupportEscalationReview.ts
@@ -16,6 +16,10 @@ import {
   buildEscalationWorkspaceLinks,
   type EscalationReviewWorkspaceLink,
 } from "../escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks";
+import {
+  buildEscalationGovernedReviewWorkspaceSummary,
+  type GovernedReviewWorkspaceSummary,
+} from "../governedReviewWorkspaces/governedReviewWorkspaces";
 
 export const ADMIN_SUPPORT_ESCALATION_REVIEW_VERSION = "admin_support_escalation_review_v1";
 
@@ -46,6 +50,7 @@ export type AdminSupportEscalationReviewDetail = AdminSupportEscalationReviewRec
   redactionSummary: string;
   prohibitedActions: string[];
   relatedWorkspaceLinks: EscalationReviewWorkspaceLink[];
+  governedReviewWorkspace: GovernedReviewWorkspaceSummary;
   emptyState: boolean;
 };
 
@@ -177,25 +182,27 @@ export function buildAdminSupportEscalationReviewDetail(
   const record = buildGroupRecord(safeEscalationId, historyEntries, reviewNotes);
   if (!record) return null;
   const template = buildSupportEscalationRunbookTemplate({ category: record.category, severity: record.severity });
-  return {
+  const sortedHistory = historyEntries.sort((a, b) => a.occurredAt.localeCompare(b.occurredAt));
+  const sortedNotes = reviewNotes.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  const detailWithoutWorkspace = {
     ...record,
-    historyEntries: historyEntries.sort((a, b) => a.occurredAt.localeCompare(b.occurredAt)),
-    reviewNotes: reviewNotes.sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    historyEntries: sortedHistory,
+    reviewNotes: sortedNotes,
     redactionSummary:
       "Escalation details are metadata-only; raw notes, payloads, provider data, documents, storage paths, credentials, debug data, request/response bodies, and policy internals are excluded.",
     prohibitedActions: template.prohibitedActions,
     relatedWorkspaceLinks: buildEscalationWorkspaceLinks({
       escalation: {
         ...record,
-        historyEntries,
-        reviewNotes,
-        redactionSummary: "",
-        prohibitedActions: template.prohibitedActions,
-        relatedWorkspaceLinks: [],
-        emptyState: false,
+        historyEntries: sortedHistory,
+        reviewNotes: sortedNotes,
       },
     }),
     emptyState: false,
+  };
+  return {
+    ...detailWithoutWorkspace,
+    governedReviewWorkspace: buildEscalationGovernedReviewWorkspaceSummary(detailWithoutWorkspace),
   };
 }
 

--- a/rentchain-api/src/lib/escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks.ts
+++ b/rentchain-api/src/lib/escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks.ts
@@ -1,16 +1,18 @@
 import crypto from "crypto";
 import type {
-  AdminSecurityIncidentReviewDetail,
   AdminSecurityIncidentReviewRecord,
 } from "../adminSecurityIncidents/adminSecurityIncidentReview";
 import type {
-  AdminSupportEscalationReviewDetail,
   AdminSupportEscalationReviewRecord,
 } from "../adminSupportEscalations/adminSupportEscalationReview";
 import {
   buildSupportEscalationRunbookTemplate,
   type SupportEscalationApprovalRequirement,
 } from "../supportEscalationRunbooks/supportEscalationRunbooks";
+import type {
+  SupportEscalationHistoryEntry,
+  SupportEscalationReviewNote,
+} from "../supportEscalationHistory/supportEscalationHistory";
 
 export const ESCALATION_REVIEW_WORKSPACE_LINK_VERSION = "escalation_review_workspace_linking_v1";
 
@@ -208,7 +210,7 @@ function refMatchesIncident(ref: { referenceId?: string; referenceType?: string 
 }
 
 export function buildIncidentWorkspaceLinks(input: {
-  incident: AdminSecurityIncidentReviewDetail | AdminSecurityIncidentReviewRecord;
+  incident: AdminSecurityIncidentReviewRecord;
   escalations?: AdminSupportEscalationReviewRecord[];
   derivedAt?: unknown;
 }): EscalationReviewWorkspaceLink[] {
@@ -240,7 +242,10 @@ export function buildIncidentWorkspaceLinks(input: {
 }
 
 export function buildEscalationWorkspaceLinks(input: {
-  escalation: AdminSupportEscalationReviewDetail | AdminSupportEscalationReviewRecord;
+  escalation: AdminSupportEscalationReviewRecord & {
+    historyEntries?: SupportEscalationHistoryEntry[];
+    reviewNotes?: SupportEscalationReviewNote[];
+  };
   incidents?: AdminSecurityIncidentReviewRecord[];
   derivedAt?: unknown;
 }): EscalationReviewWorkspaceLink[] {
@@ -279,7 +284,7 @@ export function buildEscalationWorkspaceLinks(input: {
     ),
   ];
 
-  if ("historyEntries" in escalation) {
+  if (escalation.historyEntries && escalation.reviewNotes) {
     links.push(
       ...escalation.historyEntries.map((entry) =>
         buildEscalationReviewWorkspaceLink({

--- a/rentchain-api/src/lib/governedReviewWorkspaces/__tests__/governedReviewWorkspaces.test.ts
+++ b/rentchain-api/src/lib/governedReviewWorkspaces/__tests__/governedReviewWorkspaces.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEscalationGovernedReviewWorkspaceSummary,
+  buildGovernedReviewWorkspaceSummary,
+  buildIncidentGovernedReviewWorkspaceSummary,
+  normalizeGovernedReviewWorkspaceType,
+} from "../governedReviewWorkspaces";
+
+const workspaceLink = {
+  escalationReviewWorkspaceLinkVersion: "escalation_review_workspace_linking_v1" as const,
+  linkId: "workspace_link:safe",
+  linkType: "incident_to_escalation" as const,
+  sourceSummary: {
+    kind: "security_incident" as const,
+    label: "Projection Safety Redaction",
+    category: "projection_safety_redaction",
+    severity: "high",
+    state: "reviewing",
+    metadataOnly: true as const,
+    rawIdsIncluded: false as const,
+  },
+  targetSummary: {
+    kind: "support_escalation" as const,
+    label: "Projection Safety escalation",
+    category: "projection_safety",
+    severity: "high",
+    state: "awaiting_approval",
+    metadataOnly: true as const,
+    rawIdsIncluded: false as const,
+  },
+  workflowFamily: "admin_security_incident_review",
+  createdAt: "2026-05-24T01:00:00.000Z",
+  derivedAt: "2026-05-24T01:00:00.000Z",
+  metadataOnly: true as const,
+  visibilityClass: "admin_support_internal" as const,
+  tenantVisible: false as const,
+  landlordVisible: false as const,
+  appendCompatible: true as const,
+  supportPowersGranted: false as const,
+  impersonationEnabled: false as const,
+  autonomousRemediationEnabled: false as const,
+  autonomousEscalationEnabled: false as const,
+  financialMutationEnabled: false as const,
+  routeVisibilityChanged: false as const,
+  mutationControlsEnabled: false as const,
+  redactionSummary: "Metadata-only.",
+};
+
+describe("governed review workspaces", () => {
+  it("normalizes workspace types and fails safe for unsupported values", () => {
+    expect(normalizeGovernedReviewWorkspaceType("projection-safety review")).toBe("projection_safety_review");
+    expect(normalizeGovernedReviewWorkspaceType("raw_admin_console")).toBe("other");
+  });
+
+  it("builds metadata-only workspace summaries with safe labels and flags", () => {
+    const workspace = buildGovernedReviewWorkspaceSummary({
+      workspaceType: "security_review",
+      title: "abcdefghijklmnopqrstuvwxyz1234567890",
+      summary: "token=secret gs://bucket/raw.pdf",
+      workflowFamily: "policy.failure",
+      severity: "critical",
+      reviewState: "reviewing",
+      approvalExpectation: "security_review",
+      relatedIncidentCount: 1,
+      relatedEscalationCount: 1,
+      relatedEvidenceCount: 1,
+      relatedNoteCount: 2,
+      safeEvidenceRefs: [
+        {
+          referenceType: "evidence_pack",
+          referenceId: "evidence-1",
+          label: "https://storage.googleapis.com/bucket/raw.pdf",
+          landlordId: "landlord-raw",
+          tenantId: "tenant-raw",
+        },
+        {
+          referenceType: "unsupported_debug" as any,
+          referenceId: "debug-1",
+          label: "Debug context",
+        },
+      ],
+      relatedWorkspaceLinks: [workspaceLink],
+    });
+
+    expect(workspace).toEqual(
+      expect.objectContaining({
+        workspaceType: "security_review",
+        title: "Governed review workspace",
+        summary: "Metadata-only review workspace summary. Raw payloads and tenant/landlord-facing details are excluded.",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendCompatible: true,
+        supportPowersGranted: false,
+        impersonationEnabled: false,
+        autonomousRemediationEnabled: false,
+        autonomousEscalationEnabled: false,
+        financialMutationEnabled: false,
+        routeVisibilityChanged: false,
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+      })
+    );
+    expect(workspace.safeEvidenceRefs[0]).toEqual(
+      expect.objectContaining({
+        label: "evidence pack reference",
+        landlordId: null,
+        tenantId: null,
+        metadataOnly: true,
+      })
+    );
+    expect(workspace.safeEvidenceRefs[1].referenceType).toBe("support_diagnostic");
+    expect(JSON.stringify(workspace)).not.toContain("landlord-raw");
+    expect(JSON.stringify(workspace)).not.toContain("tenant-raw");
+    expect(JSON.stringify(workspace)).not.toContain("token=secret");
+    expect(JSON.stringify(workspace)).not.toContain("gs://");
+  });
+
+  it("derives incident workspace summaries from safe incident metadata", () => {
+    const workspace = buildIncidentGovernedReviewWorkspaceSummary({
+      incidentReviewVersion: "admin_security_incident_review_v1",
+      incidentId: "security_incident:safe",
+      category: "projection_safety_redaction",
+      severity: "high",
+      status: "reviewing",
+      title: "Projection Safety Redaction",
+      summary: "Projection safety metadata requires review.",
+      occurredAt: "2026-05-24T01:00:00.000Z",
+      lastSeenAt: "2026-05-24T01:05:00.000Z",
+      actorSummary: { role: "admin", supportAttribution: true, rawActorIdsIncluded: false },
+      targetSummary: { accountType: "tenant", resourceType: "review_workspace", landlordScoped: true, tenantScoped: true, rawTargetIdsIncluded: false },
+      workflowFamily: "admin_security_incident_review",
+      policyOutcomeSummary: "redacted",
+      sourceRoute: "/api/admin/security/incidents",
+      routeSource: "adminSecurityIncidentRoutes.ts",
+      metadataOnly: true,
+      redactionSummary: "Restricted fields excluded.",
+      recommendedReviewAction: "Review projection boundary.",
+      safeEvidenceReferences: [{ referenceType: "evidence", referenceId: "evidence:safe", label: "Evidence metadata reference", internalReference: true }],
+      timeline: [],
+      relatedEventSummaries: [],
+      redactionNotes: [],
+      suggestedNextReviewStep: "Review projection boundary.",
+      relatedWorkspaceLinks: [workspaceLink],
+      governedReviewWorkspace: null as any,
+    });
+
+    expect(workspace.workspaceType).toBe("projection_safety_review");
+    expect(workspace.relatedIncidentCount).toBe(1);
+    expect(workspace.relatedEscalationCount).toBe(1);
+    expect(workspace.relatedWorkspaceLinks).toHaveLength(1);
+  });
+
+  it("derives support escalation workspace summaries from safe escalation metadata", () => {
+    const workspace = buildEscalationGovernedReviewWorkspaceSummary({
+      escalationReviewVersion: "admin_support_escalation_review_v1",
+      escalationId: "escalation-safe",
+      category: "projection_safety",
+      severity: "high",
+      state: "awaiting_approval",
+      approvalExpectation: "admin_review",
+      title: "Projection Safety escalation",
+      summary: "Projection safety escalation metadata.",
+      createdAt: "2026-05-24T01:10:00.000Z",
+      lastUpdatedAt: "2026-05-24T01:20:00.000Z",
+      actorSummary: { role: "admin", displayName: "Security operator", supportAttribution: true, rawActorIdsIncluded: false },
+      safeEvidenceRefs: [{ referenceType: "incident", referenceId: "incident-safe", label: "Linked incident", landlordId: null, tenantId: null, internalReference: true, metadataOnly: true }],
+      historyCount: 1,
+      noteCount: 2,
+      metadataOnly: true,
+      visibilityClass: "admin_support_internal",
+      tenantVisible: false,
+      landlordVisible: false,
+      relatedWorkspaceLinks: [workspaceLink],
+    });
+
+    expect(workspace.workspaceType).toBe("projection_safety_review");
+    expect(workspace.relatedEscalationCount).toBe(1);
+    expect(workspace.relatedNoteCount).toBe(2);
+    expect(workspace.approvalExpectationSummary).toBe("admin_review");
+  });
+});

--- a/rentchain-api/src/lib/governedReviewWorkspaces/governedReviewWorkspaces.ts
+++ b/rentchain-api/src/lib/governedReviewWorkspaces/governedReviewWorkspaces.ts
@@ -1,0 +1,260 @@
+import crypto from "crypto";
+import type {
+  AdminSecurityIncidentReviewDetail,
+  AdminSecurityIncidentReviewRecord,
+} from "../adminSecurityIncidents/adminSecurityIncidentReview";
+import type {
+  AdminSupportEscalationReviewDetail,
+  AdminSupportEscalationReviewRecord,
+} from "../adminSupportEscalations/adminSupportEscalationReview";
+import type { EscalationReviewWorkspaceLink } from "../escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks";
+import type { SupportEscalationSafeRef } from "../supportEscalationRunbooks/supportEscalationRunbooks";
+
+export const GOVERNED_REVIEW_WORKSPACE_VERSION = "governed_review_workspace_foundations_v1";
+
+export type GovernedReviewWorkspaceType =
+  | "security_review"
+  | "support_escalation_review"
+  | "export_governance_review"
+  | "evidence_review"
+  | "policy_failure_review"
+  | "projection_safety_review"
+  | "operational_readiness_review"
+  | "other";
+
+export type GovernedReviewWorkspaceSummary = {
+  governedReviewWorkspaceVersion: typeof GOVERNED_REVIEW_WORKSPACE_VERSION;
+  workspaceId: string;
+  workspaceType: GovernedReviewWorkspaceType;
+  title: string;
+  summary: string;
+  workflowFamily: string | null;
+  severitySummary: string;
+  reviewStateSummary: string;
+  relatedIncidentCount: number;
+  relatedEscalationCount: number;
+  relatedEvidenceCount: number;
+  relatedNoteCount: number;
+  approvalExpectationSummary: string;
+  safeEvidenceRefs: SupportEscalationSafeRef[];
+  relatedWorkspaceLinks: EscalationReviewWorkspaceLink[];
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendCompatible: true;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousRemediationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  routeVisibilityChanged: false;
+  mutationControlsEnabled: false;
+  rawPayloadAccessEnabled: false;
+  redactionSummary: string;
+};
+
+const WORKSPACE_TYPES = new Set<GovernedReviewWorkspaceType>([
+  "security_review",
+  "support_escalation_review",
+  "export_governance_review",
+  "evidence_review",
+  "policy_failure_review",
+  "projection_safety_review",
+  "operational_readiness_review",
+  "other",
+]);
+
+const SAFE_REF_TYPES = new Set<SupportEscalationSafeRef["referenceType"]>([
+  "incident",
+  "support_session",
+  "impersonation_session",
+  "evidence_pack",
+  "export_package",
+  "review_workspace",
+  "api_route",
+  "document",
+  "screening_order",
+  "landlord",
+  "tenant",
+  "lease",
+  "property",
+  "unit",
+  "support_diagnostic",
+]);
+
+type BuildInput = {
+  workspaceType?: unknown;
+  title?: unknown;
+  summary?: unknown;
+  workflowFamily?: unknown;
+  severity?: unknown;
+  reviewState?: unknown;
+  approvalExpectation?: unknown;
+  relatedIncidentCount?: unknown;
+  relatedEscalationCount?: unknown;
+  relatedEvidenceCount?: unknown;
+  relatedNoteCount?: unknown;
+  safeEvidenceRefs?: Array<Partial<SupportEscalationSafeRef> | Record<string, unknown>> | null;
+  relatedWorkspaceLinks?: EscalationReviewWorkspaceLink[] | null;
+};
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 140).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function stableHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex").slice(0, 16);
+}
+
+function safeLabel(value: unknown, fallback: string, max = 160): string {
+  const label = asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  if (!label) return fallback;
+  if (/gs:\/\//i.test(label) || /storage\.googleapis\.com/i.test(label)) return fallback;
+  if (/token|secret|credential|authorization|cookie|password|bearer/i.test(label)) return fallback;
+  if (/^[a-zA-Z0-9_-]{16,}$/.test(label)) return fallback;
+  return label;
+}
+
+function count(value: unknown): number {
+  const next = Number(value || 0);
+  return Number.isFinite(next) && next > 0 ? Math.floor(next) : 0;
+}
+
+function safeFlags() {
+  return {
+    metadataOnly: true as const,
+    visibilityClass: "admin_support_internal" as const,
+    tenantVisible: false as const,
+    landlordVisible: false as const,
+    appendCompatible: true as const,
+    supportPowersGranted: false as const,
+    impersonationEnabled: false as const,
+    autonomousRemediationEnabled: false as const,
+    autonomousEscalationEnabled: false as const,
+    financialMutationEnabled: false as const,
+    routeVisibilityChanged: false as const,
+    mutationControlsEnabled: false as const,
+    rawPayloadAccessEnabled: false as const,
+  };
+}
+
+export function normalizeGovernedReviewWorkspaceType(value: unknown): GovernedReviewWorkspaceType {
+  const normalized = normalizeKey(value);
+  return WORKSPACE_TYPES.has(normalized as GovernedReviewWorkspaceType)
+    ? (normalized as GovernedReviewWorkspaceType)
+    : "other";
+}
+
+function normalizeSafeRefs(refs: BuildInput["safeEvidenceRefs"]): SupportEscalationSafeRef[] {
+  const output: SupportEscalationSafeRef[] = [];
+  const seen = new Set<string>();
+  for (const ref of refs || []) {
+    const rawReferenceType = normalizeKey((ref as any).referenceType) as SupportEscalationSafeRef["referenceType"];
+    const referenceType = SAFE_REF_TYPES.has(rawReferenceType) ? rawReferenceType : "support_diagnostic";
+    const referenceId = asString((ref as any).referenceId, 220).toLowerCase().replace(/[^a-z0-9_.:-]+/g, "_");
+    if (!referenceId) continue;
+    const key = `${referenceType}:${referenceId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push({
+      referenceType,
+      referenceId,
+      label: safeLabel((ref as any).label, `${referenceType.split("_").join(" ")} reference`),
+      landlordId: null,
+      tenantId: null,
+      internalReference: true,
+      metadataOnly: true,
+    });
+  }
+  return output.sort((a, b) => `${a.referenceType}:${a.referenceId}`.localeCompare(`${b.referenceType}:${b.referenceId}`)).slice(0, 20);
+}
+
+export function buildGovernedReviewWorkspaceSummary(input: BuildInput = {}): GovernedReviewWorkspaceSummary {
+  const workspaceType = normalizeGovernedReviewWorkspaceType(input.workspaceType);
+  const title = safeLabel(input.title, "Governed review workspace");
+  const workflowFamily = safeLabel(input.workflowFamily, "", 120) || null;
+  const severitySummary = safeLabel(input.severity, "metadata_only_review", 80);
+  const reviewStateSummary = safeLabel(input.reviewState, "metadata_review_ready", 80);
+  const approvalExpectationSummary = safeLabel(input.approvalExpectation, "none_for_metadata_review", 120);
+  const safeEvidenceRefs = normalizeSafeRefs(input.safeEvidenceRefs);
+  const relatedWorkspaceLinks = (input.relatedWorkspaceLinks || []).filter((link) => link?.metadataOnly === true).slice(0, 30);
+  return {
+    governedReviewWorkspaceVersion: GOVERNED_REVIEW_WORKSPACE_VERSION,
+    workspaceId: `governed_workspace:${stableHash([workspaceType, title, workflowFamily, severitySummary, reviewStateSummary])}`,
+    workspaceType,
+    title,
+    summary:
+      safeLabel(input.summary, "Metadata-only review workspace summary. Raw payloads and tenant/landlord-facing details are excluded.", 320),
+    workflowFamily,
+    severitySummary,
+    reviewStateSummary,
+    relatedIncidentCount: count(input.relatedIncidentCount),
+    relatedEscalationCount: count(input.relatedEscalationCount),
+    relatedEvidenceCount: count(input.relatedEvidenceCount || safeEvidenceRefs.length),
+    relatedNoteCount: count(input.relatedNoteCount),
+    approvalExpectationSummary,
+    safeEvidenceRefs,
+    relatedWorkspaceLinks,
+    redactionSummary:
+      "Governed review workspace summaries are metadata-only; raw notes, documents, provider payloads, screening reports, storage paths, tokens, secrets, request/response bodies, debug payloads, raw actor IDs, and policy internals are excluded.",
+    ...safeFlags(),
+  };
+}
+
+function incidentWorkspaceType(category: string): GovernedReviewWorkspaceType {
+  if (category === "projection_safety_redaction" || category === "support_metadata_redacted") return "projection_safety_review";
+  if (category === "policy_denied" || category === "admin_access_denied" || category === "automation_blocked") return "policy_failure_review";
+  if (category === "export_blocked" || category === "export_prepared") return "export_governance_review";
+  return "security_review";
+}
+
+export function buildIncidentGovernedReviewWorkspaceSummary(
+  incident: AdminSecurityIncidentReviewDetail | AdminSecurityIncidentReviewRecord
+): GovernedReviewWorkspaceSummary {
+  const links = "relatedWorkspaceLinks" in incident ? incident.relatedWorkspaceLinks : [];
+  return buildGovernedReviewWorkspaceSummary({
+    workspaceType: incidentWorkspaceType(incident.category),
+    title: `${incident.title} workspace`,
+    summary: incident.summary,
+    workflowFamily: incident.workflowFamily || "admin_security_incident_review",
+    severity: incident.severity,
+    reviewState: incident.status,
+    approvalExpectation: incident.recommendedReviewAction,
+    relatedIncidentCount: 1,
+    relatedEscalationCount: links.filter((link) => link.linkType === "incident_to_escalation").length,
+    relatedEvidenceCount: incident.safeEvidenceReferences.length,
+    relatedNoteCount: "relatedEventSummaries" in incident ? incident.relatedEventSummaries.length : 0,
+    safeEvidenceRefs: incident.safeEvidenceReferences.map((ref) => ({
+      referenceType: ref.referenceType === "export" ? "export_package" : ref.referenceType === "evidence" ? "evidence_pack" : "support_diagnostic",
+      referenceId: ref.referenceId,
+      label: ref.label,
+    })),
+    relatedWorkspaceLinks: links,
+  });
+}
+
+export function buildEscalationGovernedReviewWorkspaceSummary(
+  escalation: AdminSupportEscalationReviewDetail | AdminSupportEscalationReviewRecord
+): GovernedReviewWorkspaceSummary {
+  const links = "relatedWorkspaceLinks" in escalation ? escalation.relatedWorkspaceLinks : [];
+  return buildGovernedReviewWorkspaceSummary({
+    workspaceType: escalation.category === "projection_safety" ? "projection_safety_review" : "support_escalation_review",
+    title: `${escalation.title} workspace`,
+    summary: escalation.summary,
+    workflowFamily: "admin_support_escalation_review",
+    severity: escalation.severity,
+    reviewState: escalation.state,
+    approvalExpectation: escalation.approvalExpectation,
+    relatedIncidentCount: links.filter((link) => link.linkType === "incident_to_escalation").length,
+    relatedEscalationCount: 1,
+    relatedEvidenceCount: escalation.safeEvidenceRefs.length,
+    relatedNoteCount: escalation.noteCount,
+    safeEvidenceRefs: escalation.safeEvidenceRefs,
+    relatedWorkspaceLinks: links,
+  });
+}

--- a/rentchain-frontend/src/api/adminSecurityIncidentsApi.ts
+++ b/rentchain-frontend/src/api/adminSecurityIncidentsApi.ts
@@ -57,6 +57,29 @@ export type AdminSecurityIncidentDetail = AdminSecurityIncidentRecord & {
   redactionNotes: string[];
   suggestedNextReviewStep: string;
   relatedWorkspaceLinks: AdminReviewWorkspaceLink[];
+  governedReviewWorkspace: GovernedReviewWorkspaceSummary;
+};
+
+export type GovernedReviewWorkspaceSummary = {
+  workspaceId: string;
+  workspaceType: string;
+  title: string;
+  summary: string;
+  workflowFamily: string | null;
+  severitySummary: string;
+  reviewStateSummary: string;
+  relatedIncidentCount: number;
+  relatedEscalationCount: number;
+  relatedEvidenceCount: number;
+  relatedNoteCount: number;
+  approvalExpectationSummary: string;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendCompatible: true;
+  mutationControlsEnabled: false;
+  rawPayloadAccessEnabled: false;
 };
 
 export type AdminReviewWorkspaceLink = {

--- a/rentchain-frontend/src/api/adminSupportEscalationsApi.ts
+++ b/rentchain-frontend/src/api/adminSupportEscalationsApi.ts
@@ -38,7 +38,30 @@ export type AdminSupportEscalationDetail = AdminSupportEscalationRecord & {
   redactionSummary: string;
   prohibitedActions: string[];
   relatedWorkspaceLinks: AdminReviewWorkspaceLink[];
+  governedReviewWorkspace: GovernedReviewWorkspaceSummary;
   emptyState: boolean;
+};
+
+export type GovernedReviewWorkspaceSummary = {
+  workspaceId: string;
+  workspaceType: string;
+  title: string;
+  summary: string;
+  workflowFamily: string | null;
+  severitySummary: string;
+  reviewStateSummary: string;
+  relatedIncidentCount: number;
+  relatedEscalationCount: number;
+  relatedEvidenceCount: number;
+  relatedNoteCount: number;
+  approvalExpectationSummary: string;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendCompatible: true;
+  mutationControlsEnabled: false;
+  rawPayloadAccessEnabled: false;
 };
 
 export type AdminReviewWorkspaceLink = {

--- a/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.test.tsx
@@ -103,6 +103,27 @@ beforeEach(() => {
           mutationControlsEnabled: false,
         },
       ],
+      governedReviewWorkspace: {
+        workspaceId: "governed_workspace:safe",
+        workspaceType: "security_review",
+        title: "Impersonation Started workspace",
+        summary: "Metadata-only review workspace summary.",
+        workflowFamily: "admin_security_incident_review",
+        severitySummary: "medium",
+        reviewStateSummary: "open",
+        relatedIncidentCount: 1,
+        relatedEscalationCount: 0,
+        relatedEvidenceCount: 1,
+        relatedNoteCount: 0,
+        approvalExpectationSummary: "Review support attribution.",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendCompatible: true,
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+      },
     },
   });
 });
@@ -119,6 +140,8 @@ describe("AdminSecurityIncidentsPage", () => {
     expect(await screen.findByRole("heading", { name: "Security incidents" })).toBeInTheDocument();
     expect((await screen.findAllByText("Impersonation Started")).length).toBeGreaterThan(0);
     expect(await screen.findByText("impersonationRoutes.ts")).toBeInTheDocument();
+    expect(await screen.findByText("Metadata-only review workspace summary.")).toBeInTheDocument();
+    expect(await screen.findByText("1 evidence refs")).toBeInTheDocument();
     expect(await screen.findByText(/Incident To Evidence/)).toBeInTheDocument();
     expect(await screen.findByText(/Telemetry metadata reference/)).toBeInTheDocument();
     expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSecurityIncidentsPage.tsx
@@ -123,6 +123,17 @@ function DetailPanel({ incident }: { incident: AdminSecurityIncidentDetail | nul
           <div style={{ fontWeight: 700 }}>Review action</div>
           <div style={{ color: "#475569" }}>{incident.suggestedNextReviewStep}</div>
         </div>
+        {incident.governedReviewWorkspace ? (
+          <div>
+            <div style={{ fontWeight: 700 }}>Governed review workspace</div>
+            <div style={{ color: "#475569", marginTop: 6 }}>{incident.governedReviewWorkspace.summary}</div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}>
+              <Pill tone="muted">{label(incident.governedReviewWorkspace.workspaceType)}</Pill>
+              <Pill tone="muted">{incident.governedReviewWorkspace.relatedEvidenceCount} evidence refs</Pill>
+              <Pill tone="muted">{incident.governedReviewWorkspace.relatedEscalationCount} escalation links</Pill>
+            </div>
+          </div>
+        ) : null}
         <div>
           <div style={{ fontWeight: 700 }}>Redaction notes</div>
           <ul style={{ margin: "8px 0 0", paddingLeft: 18, color: "#475569" }}>

--- a/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.test.tsx
@@ -103,6 +103,27 @@ beforeEach(() => {
           mutationControlsEnabled: false,
         },
       ],
+      governedReviewWorkspace: {
+        workspaceId: "governed_workspace:safe",
+        workspaceType: "support_escalation_review",
+        title: "Credential Secret escalation workspace",
+        summary: "Metadata-only support escalation workspace summary.",
+        workflowFamily: "admin_support_escalation_review",
+        severitySummary: "critical",
+        reviewStateSummary: "awaiting_approval",
+        relatedIncidentCount: 0,
+        relatedEscalationCount: 1,
+        relatedEvidenceCount: 1,
+        relatedNoteCount: 1,
+        approvalExpectationSummary: "security_review",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendCompatible: true,
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+      },
       emptyState: false,
     },
   });
@@ -120,6 +141,8 @@ describe("AdminSupportEscalationsPage", () => {
     expect(await screen.findByRole("heading", { name: "Support escalations" })).toBeInTheDocument();
     expect((await screen.findAllByText("Credential Secret escalation")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Security operator")).toBeInTheDocument();
+    expect(await screen.findByText("Metadata-only support escalation workspace summary.")).toBeInTheDocument();
+    expect(await screen.findByText("1 evidence refs")).toBeInTheDocument();
     expect(await screen.findByText(/Escalation To Runbook/)).toBeInTheDocument();
     expect(await screen.findByText(/Credential or Secret Exposure Runbook/)).toBeInTheDocument();
     expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.tsx
@@ -128,6 +128,17 @@ function DetailPanel({ escalation }: { escalation: AdminSupportEscalationDetail 
           <div style={{ fontWeight: 700 }}>Redaction summary</div>
           <div style={{ color: "#475569" }}>{escalation.redactionSummary}</div>
         </div>
+        {escalation.governedReviewWorkspace ? (
+          <div>
+            <div style={{ fontWeight: 700 }}>Governed review workspace</div>
+            <div style={{ color: "#475569", marginTop: 6 }}>{escalation.governedReviewWorkspace.summary}</div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}>
+              <Pill tone="muted">{label(escalation.governedReviewWorkspace.workspaceType)}</Pill>
+              <Pill tone="muted">{escalation.governedReviewWorkspace.relatedEvidenceCount} evidence refs</Pill>
+              <Pill tone="muted">{escalation.governedReviewWorkspace.relatedNoteCount} notes</Pill>
+            </div>
+          </div>
+        ) : null}
         <div>
           <div style={{ fontWeight: 700 }}>Prohibited actions</div>
           <ul style={{ margin: "8px 0 0", paddingLeft: 18, color: "#475569" }}>


### PR DESCRIPTION
## Summary
- add metadata-only governed review workspace helper/read model
- derive safe workspace summaries from admin security incident and support escalation details
- surface safe workspace summaries in existing admin incident/escalation detail panels
- add governance report for review workspace foundation and persistence decision

## Safety
- no new routes, persistence, mutation controls, approval/resolve/dismiss actions, automation, or remediation
- no tenant/landlord visibility and no permission widening
- no raw notes, documents, provider payloads, screening reports, storage paths, tokens, secrets, request/response bodies, debug payloads, raw IDs as labels, or unrestricted policy internals
- workspace summaries remain metadata-only, admin_support_internal, append-compatible, and read-only

## Validation
- rentchain-api: npm run test:single -- src/lib/governedReviewWorkspaces/__tests__/governedReviewWorkspaces.test.ts src/lib/escalationReviewWorkspaceLinks/__tests__/escalationReviewWorkspaceLinks.test.ts src/lib/adminSecurityIncidents/__tests__/adminSecurityIncidentReview.test.ts src/lib/adminSupportEscalations/__tests__/adminSupportEscalationReview.test.ts
- rentchain-frontend: npm run test -- src/pages/admin/AdminSecurityIncidentsPage.test.tsx src/pages/admin/AdminSupportEscalationsPage.test.tsx
- rentchain-api: npm run build
- rentchain-frontend: npm run build
- git diff --check