### PR TITLE
Add governed review workspace persistence readiness

### DIFF
--- a/docs/reports/governed-review-workspace-persistence-readiness-v1.md
+++ b/docs/reports/governed-review-workspace-persistence-readiness-v1.md
@@ -1,0 +1,172 @@
+# Governed Review Workspace Persistence Readiness v1
+
+## Summary
+
+This mission adds append-only persistence-readiness contracts for governed review workspaces.
+
+It does not add Firestore writes, routes, frontend UI, mutation controls, automation, tenant/landlord visibility, public access, or raw payload access.
+
+## Audit Findings
+
+Reviewed foundations:
+
+- `governedReviewWorkspaces` now provides metadata-only workspace summaries for admin security incident and support escalation detail views.
+- `escalationReviewWorkspaceLinks` provides append-compatible metadata-only relationship links between incidents, escalations, runbooks, history, notes, evidence, and review workspaces.
+- `supportEscalationRunbooks` provides deterministic category, severity, state, approval, and safe reference contracts.
+- `supportEscalationHistory` provides append-only history and review note helper contracts.
+- Admin security incident and support escalation review routes already expose safe read-only metadata surfaces.
+
+No approved governed review workspace persistence store exists yet. Persistence remains deferred until collection ownership, retention, write authorization, and append-only audit semantics are explicitly approved.
+
+## Helper / Contract Added
+
+Added:
+
+- `rentchain-api/src/lib/governedReviewWorkspacePersistence/governedReviewWorkspacePersistence.ts`
+
+The helper defines:
+
+- governed review workspace persistence versioning
+- retention class normalization
+- append event type normalization
+- contract-only persistence records
+- append-compatible event references
+- candidate validation with warnings for unsafe inputs
+- safe metadata-only visibility flags
+- explicit disabled flags for Firestore writes, routes, status mutation, automation, and tenant/landlord projections
+
+## Persistence Contract
+
+Each persistence-readiness record includes:
+
+- `persistenceContractId`
+- `workspaceId`
+- `workspaceType`
+- `title`
+- `summary`
+- `workflowFamily`
+- `retentionClass`
+- `retentionReason`
+- `retentionReviewAt`
+- `createdAt`
+- `lastAppendedAt`
+- `workspaceSummary`
+- `appendEventRefs`
+- `safeEvidenceRefs`
+- `relatedWorkspaceLinks`
+- `payloadSafety`
+- `redactionSummary`
+- `persistenceDecision`
+
+All records are:
+
+- metadata-only
+- admin/support-internal
+- append-compatible
+- append-only
+- tenant-invisible
+- landlord-invisible
+- non-mutating
+- non-automated
+
+## Retention Classes
+
+Supported retention classes:
+
+- `standard_review`
+- `security_review`
+- `export_governance`
+- `legal_hold_candidate`
+- `short_lived_diagnostic`
+- `other`
+
+Unknown values normalize to `other`.
+
+## Append Event Types
+
+Supported append event reference types:
+
+- `workspace_candidate_created`
+- `workspace_link_added`
+- `workspace_evidence_ref_added`
+- `workspace_note_ref_added`
+- `workspace_export_readiness_assessed`
+- `workspace_retention_reviewed`
+
+Unknown values normalize to `workspace_candidate_created`.
+
+## Redaction and Projection Safety
+
+Persistence-readiness records exclude or sanitize:
+
+- raw notes
+- raw documents
+- provider payloads
+- screening reports
+- storage paths
+- tokens
+- secrets
+- credentials
+- authorization headers
+- cookies
+- request bodies
+- response bodies
+- stack traces
+- debug payloads
+- raw IDs as labels
+- unrestricted policy internals
+
+Unsafe labels are replaced with safe fallback text. Safe evidence references remain internal metadata references and strip tenant/landlord scoped identifiers at the workspace persistence layer.
+
+## Visibility and Mutation Flags
+
+Every record and append event reference includes:
+
+- `metadataOnly: true`
+- `visibilityClass: admin_support_internal`
+- `tenantVisible: false`
+- `landlordVisible: false`
+- `appendCompatible: true`
+- `appendOnly: true`
+- `supportPowersGranted: false`
+- `impersonationEnabled: false`
+- `autonomousRemediationEnabled: false`
+- `autonomousEscalationEnabled: false`
+- `financialMutationEnabled: false`
+- `routeVisibilityChanged: false`
+- `mutationControlsEnabled: false`
+- `rawPayloadAccessEnabled: false`
+- `firestoreWriteEnabled: false`
+- `createRouteEnabled: false`
+- `updateRouteEnabled: false`
+- `deleteRouteEnabled: false`
+- `statusMutationEnabled: false`
+- `tenantLandlordProjectionEnabled: false`
+
+## Persistence Decision
+
+Persistence is still deferred.
+
+This mission only defines storage-readiness contracts, validators, and sanitizers. It does not create collections, write paths, read routes, admin UI mutation controls, or workflow execution.
+
+## Known Limitations
+
+- No live persisted workspace records exist yet.
+- No collection ownership or retention schedule has been approved.
+- No admin route exists to create, update, resolve, dismiss, approve, or delete workspaces.
+- Validation is contract-oriented and sanitizing; future Firestore writes will need server-side authorization, append-only enforcement, and collection-specific tests.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Define Firestore collection ownership and retention policy for governed review workspace records.
+2. Add append-only write adapter behind admin/support-only authorization.
+3. Add immutable audit event emission for workspace append events.
+4. Add admin-only read routes for persisted workspace records.
+5. Add export/audit readiness summaries without raw payload access.
+6. Add manual review note append flows only after note sanitization and projection rules are reviewed.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, add public routes, add tenant/landlord visibility, expose raw payloads, add mutation controls, enable impersonation, create workflow execution, or introduce autonomous remediation/escalation.

--- a/rentchain-api/src/lib/governedReviewWorkspacePersistence/__tests__/governedReviewWorkspacePersistence.test.ts
+++ b/rentchain-api/src/lib/governedReviewWorkspacePersistence/__tests__/governedReviewWorkspacePersistence.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGovernedReviewWorkspacePersistenceRecord,
+  normalizeGovernedReviewWorkspaceAppendEventType,
+  normalizeGovernedReviewWorkspaceRetentionClass,
+  validateGovernedReviewWorkspacePersistenceCandidate,
+} from "../governedReviewWorkspacePersistence";
+
+const safeWorkspaceLink = {
+  escalationReviewWorkspaceLinkVersion: "escalation_review_workspace_linking_v1" as const,
+  linkId: "workspace_link:safe",
+  linkType: "incident_to_review_workspace" as const,
+  sourceSummary: {
+    kind: "security_incident" as const,
+    label: "Security incident",
+    category: "policy_denied",
+    severity: "medium",
+    state: "open",
+    metadataOnly: true as const,
+    rawIdsIncluded: false as const,
+  },
+  targetSummary: {
+    kind: "review_workspace" as const,
+    label: "Governed workspace",
+    category: "security_review",
+    severity: "medium",
+    state: "metadata_review_ready",
+    metadataOnly: true as const,
+    rawIdsIncluded: false as const,
+  },
+  workflowFamily: "admin_security_incident_review",
+  createdAt: "2026-05-24T01:00:00.000Z",
+  derivedAt: "2026-05-24T01:00:00.000Z",
+  metadataOnly: true as const,
+  visibilityClass: "admin_support_internal" as const,
+  tenantVisible: false as const,
+  landlordVisible: false as const,
+  appendCompatible: true as const,
+  supportPowersGranted: false as const,
+  impersonationEnabled: false as const,
+  autonomousRemediationEnabled: false as const,
+  autonomousEscalationEnabled: false as const,
+  financialMutationEnabled: false as const,
+  routeVisibilityChanged: false as const,
+  mutationControlsEnabled: false as const,
+  redactionSummary: "Metadata-only.",
+};
+
+describe("governed review workspace persistence readiness", () => {
+  it("normalizes retention classes and append event types with fail-safe defaults", () => {
+    expect(normalizeGovernedReviewWorkspaceRetentionClass("security-review")).toBe("security_review");
+    expect(normalizeGovernedReviewWorkspaceRetentionClass("raw_forever_store")).toBe("other");
+    expect(normalizeGovernedReviewWorkspaceAppendEventType("workspace.link.added")).toBe("workspace_link_added");
+    expect(normalizeGovernedReviewWorkspaceAppendEventType("approve_and_resolve")).toBe("workspace_candidate_created");
+  });
+
+  it("builds contract-only append-compatible persistence records", () => {
+    const record = buildGovernedReviewWorkspacePersistenceRecord({
+      workspaceType: "security_review",
+      title: "Security review workspace",
+      summary: "Metadata-only persistence readiness.",
+      workflowFamily: "admin_security_incident_review",
+      severity: "medium",
+      reviewState: "metadata_review_ready",
+      approvalExpectation: "admin_review",
+      retentionClass: "security_review",
+      retentionReason: "Security review metadata retention readiness.",
+      createdAt: "2026-05-24T01:00:00.000Z",
+      safeEvidenceRefs: [
+        {
+          referenceType: "evidence_pack",
+          referenceId: "evidence-safe",
+          label: "Evidence metadata reference",
+          landlordId: "landlord-raw",
+          tenantId: "tenant-raw",
+        },
+      ],
+      relatedWorkspaceLinks: [safeWorkspaceLink],
+      appendEvents: [
+        {
+          eventType: "workspace_evidence_ref_added",
+          eventSummary: "Evidence reference added.",
+          actor: { role: "admin", displayName: "Security operator", actorId: "raw-actor-id" },
+          occurredAt: "2026-05-24T01:05:00.000Z",
+        },
+      ],
+    });
+
+    expect(record).toEqual(
+      expect.objectContaining({
+        workspaceType: "security_review",
+        retentionClass: "security_review",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendCompatible: true,
+        appendOnly: true,
+        firestoreWriteEnabled: false,
+        createRouteEnabled: false,
+        updateRouteEnabled: false,
+        deleteRouteEnabled: false,
+        statusMutationEnabled: false,
+        tenantLandlordProjectionEnabled: false,
+        persistenceDecision: "contract_only_firestore_deferred",
+      })
+    );
+    expect(record.appendEventRefs[0]).toEqual(
+      expect.objectContaining({
+        eventType: "workspace_evidence_ref_added",
+        metadataOnly: true,
+        appendOnly: true,
+        rawPayloadAccessEnabled: false,
+      })
+    );
+    expect(record.safeEvidenceRefs[0]).toEqual(
+      expect.objectContaining({
+        landlordId: null,
+        tenantId: null,
+        metadataOnly: true,
+      })
+    );
+    expect(JSON.stringify(record)).not.toContain("landlord-raw");
+    expect(JSON.stringify(record)).not.toContain("tenant-raw");
+    expect(JSON.stringify(record)).not.toContain("raw-actor-id");
+  });
+
+  it("sanitizes unsafe candidate inputs and reports warnings", () => {
+    const validation = validateGovernedReviewWorkspacePersistenceCandidate({
+      workspaceType: "projection_safety_review",
+      title: "abcdefghijklmnopqrstuvwxyz1234567890",
+      summary: "Bearer raw.token.value requestBody={raw} stackTrace=unsafe",
+      retentionReason: "secret=value gs://bucket/raw.pdf",
+      createdAt: "2026-05-24T01:00:00.000Z",
+      safeEvidenceRefs: [
+        {
+          referenceType: "document",
+          referenceId: "doc-safe",
+          label: "https://storage.googleapis.com/bucket/raw.pdf",
+        },
+      ],
+      appendEvents: [
+        {
+          eventType: "debug_payload_added",
+          eventSummary: "token=secret responseBody={raw}",
+          actor: { authorization: "Bearer raw", cookie: "session=raw", displayName: "Support" },
+        },
+      ],
+    });
+
+    expect(validation.ok).toBe(true);
+    expect(validation.warnings).toEqual(
+      expect.arrayContaining([
+        "restricted_credential_or_secret_like_input_sanitized",
+        "storage_path_or_signed_url_input_sanitized",
+        "raw_payload_input_excluded_from_contract",
+      ])
+    );
+    expect(validation.record.title).toBe("Governed review workspace");
+    expect(validation.record.retentionReason).toBe("Metadata-only governed review workspace retention candidate.");
+    expect(validation.record.safeEvidenceRefs[0].label).toBe("document reference");
+    expect(validation.record.appendEventRefs[0].eventType).toBe("workspace_candidate_created");
+    expect(validation.record.appendEventRefs[0].eventSummary).toBe("workspace candidate created metadata event");
+    expect(JSON.stringify(validation.record)).not.toContain("raw.token.value");
+    expect(JSON.stringify(validation.record)).not.toContain("gs://");
+    expect(JSON.stringify(validation.record)).not.toContain("storage.googleapis.com");
+    expect(JSON.stringify(validation.record)).not.toContain("responseBody");
+  });
+
+  it("forces unsafe workspace summary visibility to internal metadata-only contract", () => {
+    const validation = validateGovernedReviewWorkspacePersistenceCandidate({
+      workspaceSummary: {
+        metadataOnly: true,
+        tenantVisible: true as any,
+        landlordVisible: true as any,
+        workspaceType: "support_escalation_review",
+        title: "Support escalation workspace",
+        summary: "Support escalation metadata.",
+        workflowFamily: "admin_support_escalation_review",
+        severitySummary: "low",
+        reviewStateSummary: "metadata_review_ready",
+        approvalExpectationSummary: "none_for_metadata_review",
+        relatedIncidentCount: 0,
+        relatedEscalationCount: 1,
+        relatedEvidenceCount: 0,
+        relatedNoteCount: 0,
+        safeEvidenceRefs: [],
+        relatedWorkspaceLinks: [],
+      },
+    });
+
+    expect(validation.warnings).toContain("tenant_or_landlord_visibility_forced_false");
+    expect(validation.record.tenantVisible).toBe(false);
+    expect(validation.record.landlordVisible).toBe(false);
+    expect(validation.record.workspaceSummary.tenantVisible).toBe(false);
+    expect(validation.record.workspaceSummary.landlordVisible).toBe(false);
+    expect(validation.record.supportPowersGranted).toBe(false);
+    expect(validation.record.autonomousRemediationEnabled).toBe(false);
+    expect(validation.record.mutationControlsEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/governedReviewWorkspacePersistence/governedReviewWorkspacePersistence.ts
+++ b/rentchain-api/src/lib/governedReviewWorkspacePersistence/governedReviewWorkspacePersistence.ts
@@ -1,0 +1,400 @@
+import crypto from "crypto";
+import {
+  buildGovernedReviewWorkspaceSummary,
+  normalizeGovernedReviewWorkspaceType,
+  type GovernedReviewWorkspaceSummary,
+  type GovernedReviewWorkspaceType,
+} from "../governedReviewWorkspaces/governedReviewWorkspaces";
+import type { EscalationReviewWorkspaceLink } from "../escalationReviewWorkspaceLinks/escalationReviewWorkspaceLinks";
+import type { SupportEscalationSafeRef } from "../supportEscalationRunbooks/supportEscalationRunbooks";
+
+export const GOVERNED_REVIEW_WORKSPACE_PERSISTENCE_VERSION =
+  "governed_review_workspace_persistence_readiness_v1";
+
+export type GovernedReviewWorkspaceRetentionClass =
+  | "standard_review"
+  | "security_review"
+  | "export_governance"
+  | "legal_hold_candidate"
+  | "short_lived_diagnostic"
+  | "other";
+
+export type GovernedReviewWorkspaceAppendEventType =
+  | "workspace_candidate_created"
+  | "workspace_link_added"
+  | "workspace_evidence_ref_added"
+  | "workspace_note_ref_added"
+  | "workspace_export_readiness_assessed"
+  | "workspace_retention_reviewed";
+
+export type GovernedReviewWorkspacePersistenceVisibility = {
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendCompatible: true;
+  appendOnly: true;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousRemediationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  routeVisibilityChanged: false;
+  mutationControlsEnabled: false;
+  rawPayloadAccessEnabled: false;
+  firestoreWriteEnabled: false;
+  createRouteEnabled: false;
+  updateRouteEnabled: false;
+  deleteRouteEnabled: false;
+  statusMutationEnabled: false;
+  tenantLandlordProjectionEnabled: false;
+};
+
+export type GovernedReviewWorkspacePayloadSafety = {
+  rawPayloads: "excluded";
+  rawNotes: "summary_only";
+  providerData: "reference_only";
+  screeningReports: "reference_only";
+  storagePaths: "excluded";
+  credentialData: "excluded";
+  requestResponseData: "excluded";
+  diagnosticData: "metadata_only";
+  internalPolicyData: "summary_only";
+  rawIdsAsLabels: "excluded";
+};
+
+export type GovernedReviewWorkspaceAppendEventRef = GovernedReviewWorkspacePersistenceVisibility & {
+  governedReviewWorkspacePersistenceVersion: typeof GOVERNED_REVIEW_WORKSPACE_PERSISTENCE_VERSION;
+  eventRefId: string;
+  eventType: GovernedReviewWorkspaceAppendEventType;
+  workspaceId: string;
+  eventSummary: string;
+  actorSummary: {
+    role: string | null;
+    displayName: string | null;
+    rawActorIdsIncluded: false;
+  };
+  occurredAt: string;
+  relatedEvidenceRefs: SupportEscalationSafeRef[];
+  relatedWorkspaceLinks: EscalationReviewWorkspaceLink[];
+  payloadSafety: GovernedReviewWorkspacePayloadSafety;
+  redactionSummary: string;
+};
+
+export type GovernedReviewWorkspacePersistenceRecord = GovernedReviewWorkspacePersistenceVisibility & {
+  governedReviewWorkspacePersistenceVersion: typeof GOVERNED_REVIEW_WORKSPACE_PERSISTENCE_VERSION;
+  persistenceContractId: string;
+  workspaceId: string;
+  workspaceType: GovernedReviewWorkspaceType;
+  title: string;
+  summary: string;
+  workflowFamily: string | null;
+  retentionClass: GovernedReviewWorkspaceRetentionClass;
+  retentionReason: string;
+  retentionReviewAt: string | null;
+  createdAt: string;
+  lastAppendedAt: string;
+  workspaceSummary: GovernedReviewWorkspaceSummary;
+  appendEventRefs: GovernedReviewWorkspaceAppendEventRef[];
+  safeEvidenceRefs: SupportEscalationSafeRef[];
+  relatedWorkspaceLinks: EscalationReviewWorkspaceLink[];
+  payloadSafety: GovernedReviewWorkspacePayloadSafety;
+  redactionSummary: string;
+  persistenceDecision: "contract_only_firestore_deferred";
+};
+
+export type GovernedReviewWorkspacePersistenceValidation = {
+  ok: true;
+  record: GovernedReviewWorkspacePersistenceRecord;
+  warnings: string[];
+};
+
+const RETENTION_CLASSES = new Set<GovernedReviewWorkspaceRetentionClass>([
+  "standard_review",
+  "security_review",
+  "export_governance",
+  "legal_hold_candidate",
+  "short_lived_diagnostic",
+  "other",
+]);
+
+const APPEND_EVENT_TYPES = new Set<GovernedReviewWorkspaceAppendEventType>([
+  "workspace_candidate_created",
+  "workspace_link_added",
+  "workspace_evidence_ref_added",
+  "workspace_note_ref_added",
+  "workspace_export_readiness_assessed",
+  "workspace_retention_reviewed",
+]);
+
+const PAYLOAD_SAFETY: GovernedReviewWorkspacePayloadSafety = {
+  rawPayloads: "excluded",
+  rawNotes: "summary_only",
+  providerData: "reference_only",
+  screeningReports: "reference_only",
+  storagePaths: "excluded",
+  credentialData: "excluded",
+  requestResponseData: "excluded",
+  diagnosticData: "metadata_only",
+  internalPolicyData: "summary_only",
+  rawIdsAsLabels: "excluded",
+};
+
+type AppendEventInput = {
+  eventType?: unknown;
+  eventSummary?: unknown;
+  actor?: Record<string, unknown> | null;
+  occurredAt?: unknown;
+  relatedEvidenceRefs?: Array<Partial<SupportEscalationSafeRef> | Record<string, unknown>> | null;
+  relatedWorkspaceLinks?: EscalationReviewWorkspaceLink[] | null;
+};
+
+type PersistenceInput = {
+  workspaceSummary?: Partial<GovernedReviewWorkspaceSummary> | null;
+  workspaceType?: unknown;
+  title?: unknown;
+  summary?: unknown;
+  workflowFamily?: unknown;
+  severity?: unknown;
+  reviewState?: unknown;
+  approvalExpectation?: unknown;
+  retentionClass?: unknown;
+  retentionReason?: unknown;
+  retentionReviewAt?: unknown;
+  createdAt?: unknown;
+  lastAppendedAt?: unknown;
+  safeEvidenceRefs?: Array<Partial<SupportEscalationSafeRef> | Record<string, unknown>> | null;
+  relatedWorkspaceLinks?: EscalationReviewWorkspaceLink[] | null;
+  appendEvents?: AppendEventInput[] | null;
+};
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 140).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function stableHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex").slice(0, 16);
+}
+
+function toIso(value: unknown): string {
+  if (value && typeof (value as any).toDate === "function") return (value as any).toDate().toISOString();
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = asString(value, 120);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function safeLabel(value: unknown, fallback: string, max = 220): string {
+  const label = asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  if (!label) return fallback;
+  if (/gs:\/\//i.test(label) || /storage\.googleapis\.com/i.test(label)) return fallback;
+  if (/token|secret|credential|authorization|cookie|password|bearer/i.test(label)) return fallback;
+  if (/request\s*body|response\s*body|stack(trace)?|debug payload/i.test(label)) return fallback;
+  if (/^[a-zA-Z0-9_-]{16,}$/.test(label)) return fallback;
+  return label;
+}
+
+function visibilityFlags(): GovernedReviewWorkspacePersistenceVisibility {
+  return {
+    metadataOnly: true,
+    visibilityClass: "admin_support_internal",
+    tenantVisible: false,
+    landlordVisible: false,
+    appendCompatible: true,
+    appendOnly: true,
+    supportPowersGranted: false,
+    impersonationEnabled: false,
+    autonomousRemediationEnabled: false,
+    autonomousEscalationEnabled: false,
+    financialMutationEnabled: false,
+    routeVisibilityChanged: false,
+    mutationControlsEnabled: false,
+    rawPayloadAccessEnabled: false,
+    firestoreWriteEnabled: false,
+    createRouteEnabled: false,
+    updateRouteEnabled: false,
+    deleteRouteEnabled: false,
+    statusMutationEnabled: false,
+    tenantLandlordProjectionEnabled: false,
+  };
+}
+
+export function normalizeGovernedReviewWorkspaceRetentionClass(
+  value: unknown
+): GovernedReviewWorkspaceRetentionClass {
+  const normalized = normalizeKey(value);
+  return RETENTION_CLASSES.has(normalized as GovernedReviewWorkspaceRetentionClass)
+    ? (normalized as GovernedReviewWorkspaceRetentionClass)
+    : "other";
+}
+
+export function normalizeGovernedReviewWorkspaceAppendEventType(
+  value: unknown
+): GovernedReviewWorkspaceAppendEventType {
+  const normalized = normalizeKey(value);
+  return APPEND_EVENT_TYPES.has(normalized as GovernedReviewWorkspaceAppendEventType)
+    ? (normalized as GovernedReviewWorkspaceAppendEventType)
+    : "workspace_candidate_created";
+}
+
+function actorSummary(actor: AppendEventInput["actor"]): GovernedReviewWorkspaceAppendEventRef["actorSummary"] {
+  const data = (actor && typeof actor === "object" ? actor : {}) as Record<string, unknown>;
+  return {
+    role: safeLabel(data.role || data.actorRole, "", 80) || null,
+    displayName: safeLabel(data.displayName || data.label || data.name, "", 120) || null,
+    rawActorIdsIncluded: false,
+  };
+}
+
+function buildWorkspaceSummary(input: PersistenceInput): GovernedReviewWorkspaceSummary {
+  if (input.workspaceSummary?.metadataOnly === true) {
+    return buildGovernedReviewWorkspaceSummary({
+      workspaceType: input.workspaceSummary.workspaceType,
+      title: input.workspaceSummary.title,
+      summary: input.workspaceSummary.summary,
+      workflowFamily: input.workspaceSummary.workflowFamily,
+      severity: input.workspaceSummary.severitySummary,
+      reviewState: input.workspaceSummary.reviewStateSummary,
+      approvalExpectation: input.workspaceSummary.approvalExpectationSummary,
+      relatedIncidentCount: input.workspaceSummary.relatedIncidentCount,
+      relatedEscalationCount: input.workspaceSummary.relatedEscalationCount,
+      relatedEvidenceCount: input.workspaceSummary.relatedEvidenceCount,
+      relatedNoteCount: input.workspaceSummary.relatedNoteCount,
+      safeEvidenceRefs: input.workspaceSummary.safeEvidenceRefs,
+      relatedWorkspaceLinks: input.workspaceSummary.relatedWorkspaceLinks,
+    });
+  }
+  return buildGovernedReviewWorkspaceSummary({
+    workspaceType: input.workspaceType,
+    title: input.title,
+    summary: input.summary,
+    workflowFamily: input.workflowFamily,
+    severity: input.severity,
+    reviewState: input.reviewState,
+    approvalExpectation: input.approvalExpectation,
+    safeEvidenceRefs: input.safeEvidenceRefs,
+    relatedWorkspaceLinks: input.relatedWorkspaceLinks,
+  });
+}
+
+function buildAppendEventRef(input: {
+  event: AppendEventInput;
+  workspaceId: string;
+  fallbackOccurredAt: string;
+  workspaceEvidenceRefs: SupportEscalationSafeRef[];
+  workspaceLinks: EscalationReviewWorkspaceLink[];
+}): GovernedReviewWorkspaceAppendEventRef {
+  const eventType = normalizeGovernedReviewWorkspaceAppendEventType(input.event.eventType);
+  const occurredAt = toIso(input.event.occurredAt || input.fallbackOccurredAt);
+  const relatedEvidenceRefs = buildGovernedReviewWorkspaceSummary({
+    safeEvidenceRefs: input.event.relatedEvidenceRefs || input.workspaceEvidenceRefs,
+  }).safeEvidenceRefs;
+  const relatedWorkspaceLinks = (input.event.relatedWorkspaceLinks || input.workspaceLinks)
+    .filter((link) => link?.metadataOnly === true)
+    .slice(0, 20);
+  const eventSummary = safeLabel(
+    input.event.eventSummary,
+    `${eventType.split("_").join(" ")} metadata event`,
+    240
+  );
+  return {
+    governedReviewWorkspacePersistenceVersion: GOVERNED_REVIEW_WORKSPACE_PERSISTENCE_VERSION,
+    eventRefId: `governed_workspace_event:${stableHash([input.workspaceId, eventType, eventSummary, occurredAt])}`,
+    eventType,
+    workspaceId: input.workspaceId,
+    eventSummary,
+    actorSummary: actorSummary(input.event.actor),
+    occurredAt,
+    relatedEvidenceRefs,
+    relatedWorkspaceLinks,
+    payloadSafety: PAYLOAD_SAFETY,
+    redactionSummary:
+      "Append event refs are metadata-only; raw notes, documents, provider payloads, reports, storage paths, tokens, secrets, request/response bodies, debug payloads, raw IDs as labels, and policy internals are excluded.",
+    ...visibilityFlags(),
+  };
+}
+
+export function buildGovernedReviewWorkspacePersistenceRecord(
+  input: PersistenceInput = {}
+): GovernedReviewWorkspacePersistenceRecord {
+  const workspaceSummary = buildWorkspaceSummary(input);
+  const workspaceType = normalizeGovernedReviewWorkspaceType(workspaceSummary.workspaceType);
+  const createdAt = toIso(input.createdAt);
+  const lastAppendedAt = toIso(input.lastAppendedAt || input.createdAt);
+  const retentionClass = normalizeGovernedReviewWorkspaceRetentionClass(input.retentionClass);
+  const appendEventRefs = (input.appendEvents || [
+    {
+      eventType: "workspace_candidate_created",
+      eventSummary: "Governed review workspace persistence candidate created.",
+      occurredAt: createdAt,
+    },
+  ])
+    .map((event) =>
+      buildAppendEventRef({
+        event,
+        workspaceId: workspaceSummary.workspaceId,
+        fallbackOccurredAt: createdAt,
+        workspaceEvidenceRefs: workspaceSummary.safeEvidenceRefs,
+        workspaceLinks: workspaceSummary.relatedWorkspaceLinks,
+      })
+    )
+    .sort((a, b) => `${a.occurredAt}:${a.eventRefId}`.localeCompare(`${b.occurredAt}:${b.eventRefId}`))
+    .slice(0, 50);
+
+  return {
+    governedReviewWorkspacePersistenceVersion: GOVERNED_REVIEW_WORKSPACE_PERSISTENCE_VERSION,
+    persistenceContractId: `governed_workspace_persistence:${stableHash([
+      workspaceSummary.workspaceId,
+      workspaceType,
+      createdAt,
+    ])}`,
+    workspaceId: workspaceSummary.workspaceId,
+    workspaceType,
+    title: workspaceSummary.title,
+    summary: workspaceSummary.summary,
+    workflowFamily: workspaceSummary.workflowFamily,
+    retentionClass,
+    retentionReason: safeLabel(input.retentionReason, "Metadata-only governed review workspace retention candidate.", 240),
+    retentionReviewAt: input.retentionReviewAt ? toIso(input.retentionReviewAt) : null,
+    createdAt,
+    lastAppendedAt,
+    workspaceSummary,
+    appendEventRefs,
+    safeEvidenceRefs: workspaceSummary.safeEvidenceRefs,
+    relatedWorkspaceLinks: workspaceSummary.relatedWorkspaceLinks,
+    payloadSafety: PAYLOAD_SAFETY,
+    redactionSummary:
+      "Persistence readiness records are contract-only and metadata-only. Firestore writes, routes, status mutation, tenant/landlord projections, raw payload access, raw notes, documents, provider payloads, screening reports, storage paths, tokens, secrets, request/response bodies, debug payloads, raw IDs as labels, and policy internals are excluded.",
+    persistenceDecision: "contract_only_firestore_deferred",
+    ...visibilityFlags(),
+  };
+}
+
+export function validateGovernedReviewWorkspacePersistenceCandidate(
+  input: PersistenceInput = {}
+): GovernedReviewWorkspacePersistenceValidation {
+  const warnings: string[] = [];
+  const raw = JSON.stringify(input ?? {});
+  if (/token|secret|credential|authorization|cookie|password|bearer/i.test(raw)) {
+    warnings.push("restricted_credential_or_secret_like_input_sanitized");
+  }
+  if (/gs:\/\/|storage\.googleapis\.com/i.test(raw)) {
+    warnings.push("storage_path_or_signed_url_input_sanitized");
+  }
+  if (/requestBody|responseBody|stackTrace|debugPayload|rawProviderPayload|rawScreeningReport/i.test(raw)) {
+    warnings.push("raw_payload_input_excluded_from_contract");
+  }
+  if ((input.workspaceSummary as any)?.tenantVisible === true || (input.workspaceSummary as any)?.landlordVisible === true) {
+    warnings.push("tenant_or_landlord_visibility_forced_false");
+  }
+  return {
+    ok: true,
+    record: buildGovernedReviewWorkspacePersistenceRecord(input),
+    warnings,
+  };
+}


### PR DESCRIPTION
## Summary
- add contract-only governed review workspace persistence readiness helper
- define retention classes, append event refs, payload safety, and disabled mutation/storage flags
- add governance report and deterministic backend tests

## Scope
- no Firestore writes
- no routes or frontend UI
- no tenant/landlord visibility
- no mutation controls or automation
- no dependency or lockfile changes

## Validation
- rentchain-api: npm run test:single -- src/lib/governedReviewWorkspacePersistence/__tests__/governedReviewWorkspacePersistence.test.ts src/lib/governedReviewWorkspaces/__tests__/governedReviewWorkspaces.test.ts
- rentchain-api: npm run build
- git diff --cached --check