### PR TITLE
Add governed review workspace append adapter

### DIFF
--- a/docs/reports/governed-review-workspace-append-only-adapter-v1.md
+++ b/docs/reports/governed-review-workspace-append-only-adapter-v1.md
@@ -1,0 +1,129 @@
+# Governed Review Workspace Append-Only Adapter v1
+
+## Summary
+
+This mission adds a narrowly scoped append-only adapter foundation for governed review workspace records.
+
+It does not add API routes, frontend UI, Firestore collection writes, mutation controls, approve/resolve/dismiss actions, automation, tenant/landlord visibility, or raw payload access.
+
+## Audit Findings
+
+Reviewed foundations:
+
+- `governedReviewWorkspacePersistence` provides contract-only workspace persistence records, append event references, redaction warnings, and metadata-only visibility flags.
+- `governedReviewWorkspaces` provides safe workspace summaries for admin incident and support escalation detail surfaces.
+- `escalationReviewWorkspaceLinks` provides metadata-only cross-workflow links.
+- `supportEscalationRunbooks` and `supportEscalationHistory` provide append-compatible runbook, history, and review note contracts.
+- Existing admin review surfaces remain read-only and do not expose mutation controls.
+
+No approved Firestore collection ownership or route contract exists yet for live governed review workspace writes.
+
+## Adapter Added
+
+Added:
+
+- `rentchain-api/src/lib/governedReviewWorkspaceAppendAdapter/governedReviewWorkspaceAppendAdapter.ts`
+
+The adapter provides:
+
+- `buildGovernedReviewWorkspaceAppendEnvelope`
+- `createGovernedReviewWorkspaceAppendAdapter`
+- an injected `GovernedReviewWorkspaceAppendStore` interface with a single `append` method
+- admin/support actor validation
+- metadata-only append envelopes
+- reuse of PR #990 validation and sanitization
+- explicit append-only flags
+
+## Storage / Write Decision
+
+Live Firestore writes remain deferred.
+
+The adapter is a port over an injected append sink, not a production Firestore writer. This preserves a testable append-only service boundary without introducing collections, routes, frontend controls, or runtime workflow mutation.
+
+Future Firestore implementation should add:
+
+- explicit collection ownership
+- admin/support-only authorization at the route/service boundary
+- append-only write enforcement
+- immutable audit event emission
+- retention policy tests
+- no update/delete/status mutation paths
+
+## Append Envelope
+
+Each append envelope includes:
+
+- `appendEnvelopeId`
+- `appendOperation: append_workspace_record`
+- `storageTarget: governed_review_workspace_append_log`
+- `storageWriteDecision: adapter_port_only_firestore_deferred`
+- safe actor summary
+- sanitized persistence record
+- validation warnings
+- metadata-only/internal visibility flags
+- disabled mutation, route, raw payload, and automation flags
+
+## Redaction and Projection Safety
+
+The adapter reuses the PR #990 persistence validator and enforces safe actor summaries.
+
+Append envelopes exclude or sanitize:
+
+- raw notes
+- raw documents
+- provider payloads
+- screening reports
+- storage paths
+- tokens
+- secrets
+- credentials
+- authorization headers
+- cookies
+- request bodies
+- response bodies
+- stack traces
+- debug payloads
+- raw actor IDs
+- raw tenant/landlord IDs as labels
+- unrestricted policy internals
+
+## Authority Boundary
+
+The adapter denies append attempts when the actor context is not admin/support-authorized.
+
+Denied attempts return a metadata-only failure result and do not call the append store.
+
+## Tests Added
+
+Added:
+
+- `rentchain-api/src/lib/governedReviewWorkspaceAppendAdapter/__tests__/governedReviewWorkspaceAppendAdapter.test.ts`
+
+Coverage includes:
+
+- admin/support-internal append envelopes
+- non-admin/non-support denial without writes
+- unsafe candidate sanitization before store append
+- append-only store contract with no update/delete operations
+
+## Known Limitations
+
+- No live persisted governed review workspace records are written.
+- No read routes or write routes exist for persisted workspace records.
+- No admin UI mutation controls exist.
+- No collection retention policy has been approved yet.
+- The adapter is ready for a future storage implementation but intentionally remains dependency-injected in this mission.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Define Firestore collection ownership and retention policy for `governed_review_workspace_append_log`.
+2. Add a Firestore-backed append store with immutable create-only semantics.
+3. Add admin/support-only route adapter after authorization and route-source review.
+4. Add read-only admin list/detail views for persisted workspace records.
+5. Add audit export readiness summaries without raw payload access.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, add public routes, add tenant/landlord visibility, expose raw payloads, add frontend mutation controls, enable impersonation, create workflow status mutation, or introduce autonomous remediation/escalation.

--- a/rentchain-api/src/lib/governedReviewWorkspaceAppendAdapter/__tests__/governedReviewWorkspaceAppendAdapter.test.ts
+++ b/rentchain-api/src/lib/governedReviewWorkspaceAppendAdapter/__tests__/governedReviewWorkspaceAppendAdapter.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGovernedReviewWorkspaceAppendEnvelope,
+  createGovernedReviewWorkspaceAppendAdapter,
+  type GovernedReviewWorkspaceAppendEnvelope,
+} from "../governedReviewWorkspaceAppendAdapter";
+
+const safeCandidate = {
+  workspaceType: "security_review",
+  title: "Security review workspace",
+  summary: "Metadata-only workspace record.",
+  workflowFamily: "admin_security_incident_review",
+  severity: "medium",
+  reviewState: "metadata_review_ready",
+  approvalExpectation: "admin_review",
+  retentionClass: "security_review",
+  createdAt: "2026-05-24T01:00:00.000Z",
+  appendEvents: [
+    {
+      eventType: "workspace_candidate_created",
+      eventSummary: "Workspace candidate prepared.",
+      occurredAt: "2026-05-24T01:00:00.000Z",
+    },
+  ],
+};
+
+describe("governed review workspace append adapter", () => {
+  it("builds admin/support-internal append-only envelopes", () => {
+    const result = buildGovernedReviewWorkspaceAppendEnvelope({
+      actor: {
+        actorRole: "admin",
+        displayName: "Security operator",
+        permission: "system.admin",
+      },
+      candidate: safeCandidate,
+      occurredAt: "2026-05-24T01:05:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected append envelope");
+
+    expect(result.envelope).toEqual(
+      expect.objectContaining({
+        appendOnly: true,
+        appendOperation: "append_workspace_record",
+        storageTarget: "governed_review_workspace_append_log",
+        storageWriteDecision: "adapter_port_only_firestore_deferred",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        createRouteEnabled: false,
+        updateRouteEnabled: false,
+        deleteRouteEnabled: false,
+        statusMutationEnabled: false,
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+      })
+    );
+    expect(result.envelope.actorSummary).toEqual(
+      expect.objectContaining({
+        role: "admin",
+        displayName: "Security operator",
+        systemAdminAuthorized: true,
+        rawActorIdsIncluded: false,
+      })
+    );
+    expect(result.envelope.record.metadataOnly).toBe(true);
+    expect(result.envelope.record.tenantVisible).toBe(false);
+    expect(result.envelope.record.landlordVisible).toBe(false);
+  });
+
+  it("denies non-admin and non-support actors without writing", async () => {
+    const writes: GovernedReviewWorkspaceAppendEnvelope[] = [];
+    const adapter = createGovernedReviewWorkspaceAppendAdapter({
+      async append(envelope) {
+        writes.push(envelope);
+      },
+    });
+
+    const result = await adapter.appendWorkspaceRecord({
+      actor: {
+        actorRole: "tenant",
+        displayName: "Tenant user",
+      },
+      candidate: safeCandidate,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "admin_support_authority_required",
+        metadataOnly: true,
+        tenantVisible: false,
+        landlordVisible: false,
+        supportPowersGranted: false,
+        rawPayloadAccessEnabled: false,
+      })
+    );
+    expect(writes).toHaveLength(0);
+  });
+
+  it("sanitizes unsafe payloads before append store receives the envelope", async () => {
+    const writes: GovernedReviewWorkspaceAppendEnvelope[] = [];
+    const adapter = createGovernedReviewWorkspaceAppendAdapter({
+      async append(envelope) {
+        writes.push(envelope);
+      },
+    });
+
+    const result = await adapter.appendWorkspaceRecord({
+      actor: {
+        actorRole: "support",
+        supportAuthorized: true,
+        displayName: "support-token-secret",
+      },
+      candidate: {
+        workspaceType: "projection_safety_review",
+        title: "abcdefghijklmnopqrstuvwxyz1234567890",
+        summary: "Bearer raw.token.value requestBody={raw} stackTrace=unsafe",
+        retentionReason: "secret=value gs://bucket/raw.pdf",
+        createdAt: "2026-05-24T01:00:00.000Z",
+        safeEvidenceRefs: [
+          {
+            referenceType: "document",
+            referenceId: "doc-safe",
+            label: "https://storage.googleapis.com/bucket/raw.pdf",
+          },
+        ],
+        appendEvents: [
+          {
+            eventType: "debug_payload_added",
+            eventSummary: "token=secret responseBody={raw}",
+            actor: { authorization: "Bearer raw", cookie: "session=raw", displayName: "Support" },
+          },
+        ],
+      },
+      occurredAt: "2026-05-24T01:10:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(writes).toHaveLength(1);
+    const serialized = JSON.stringify(writes[0]);
+    expect(writes[0].warnings).toEqual(
+      expect.arrayContaining([
+        "restricted_credential_or_secret_like_input_sanitized",
+        "storage_path_or_signed_url_input_sanitized",
+        "raw_payload_input_excluded_from_contract",
+      ])
+    );
+    expect(writes[0].actorSummary.displayName).toBeNull();
+    expect(writes[0].record.title).toBe("Governed review workspace");
+    expect(writes[0].record.safeEvidenceRefs[0].label).toBe("document reference");
+    expect(serialized).not.toContain("raw.token.value");
+    expect(serialized).not.toContain("gs://");
+    expect(serialized).not.toContain("storage.googleapis.com");
+    expect(serialized).not.toContain("responseBody");
+    expect(serialized).not.toContain("support-token-secret");
+  });
+
+  it("uses an append-only store contract without update or delete operations", async () => {
+    const writes: GovernedReviewWorkspaceAppendEnvelope[] = [];
+    const store = {
+      async append(envelope: GovernedReviewWorkspaceAppendEnvelope) {
+        writes.push(envelope);
+      },
+    };
+    const adapter = createGovernedReviewWorkspaceAppendAdapter(store);
+
+    const result = await adapter.appendWorkspaceRecord({
+      actor: { actorRole: "admin" },
+      candidate: safeCandidate,
+      occurredAt: "2026-05-24T01:15:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect("update" in store).toBe(false);
+    expect("delete" in store).toBe(false);
+    expect(writes[0].record.firestoreWriteEnabled).toBe(false);
+    expect(writes[0].record.updateRouteEnabled).toBe(false);
+    expect(writes[0].record.deleteRouteEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/governedReviewWorkspaceAppendAdapter/governedReviewWorkspaceAppendAdapter.ts
+++ b/rentchain-api/src/lib/governedReviewWorkspaceAppendAdapter/governedReviewWorkspaceAppendAdapter.ts
@@ -1,0 +1,204 @@
+import crypto from "crypto";
+import {
+  validateGovernedReviewWorkspacePersistenceCandidate,
+  type GovernedReviewWorkspacePersistenceRecord,
+} from "../governedReviewWorkspacePersistence/governedReviewWorkspacePersistence";
+
+export const GOVERNED_REVIEW_WORKSPACE_APPEND_ADAPTER_VERSION =
+  "governed_review_workspace_append_only_adapter_v1";
+
+export type GovernedReviewWorkspaceAppendActorRole = "admin" | "support" | "unknown";
+
+export type GovernedReviewWorkspaceAppendActorContext = {
+  actorRole?: unknown;
+  displayName?: unknown;
+  permission?: unknown;
+  supportAuthorized?: unknown;
+};
+
+export type GovernedReviewWorkspaceAppendEnvelope = {
+  governedReviewWorkspaceAppendAdapterVersion: typeof GOVERNED_REVIEW_WORKSPACE_APPEND_ADAPTER_VERSION;
+  appendEnvelopeId: string;
+  appendOnly: true;
+  appendOperation: "append_workspace_record";
+  storageTarget: "governed_review_workspace_append_log";
+  storageWriteDecision: "adapter_port_only_firestore_deferred";
+  actorSummary: {
+    role: GovernedReviewWorkspaceAppendActorRole;
+    displayName: string | null;
+    systemAdminAuthorized: boolean;
+    supportAuthorized: boolean;
+    rawActorIdsIncluded: false;
+  };
+  occurredAt: string;
+  warnings: string[];
+  record: GovernedReviewWorkspacePersistenceRecord;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  supportPowersGranted: false;
+  impersonationEnabled: false;
+  autonomousRemediationEnabled: false;
+  autonomousEscalationEnabled: false;
+  financialMutationEnabled: false;
+  routeVisibilityChanged: false;
+  mutationControlsEnabled: false;
+  rawPayloadAccessEnabled: false;
+  createRouteEnabled: false;
+  updateRouteEnabled: false;
+  deleteRouteEnabled: false;
+  statusMutationEnabled: false;
+  redactionSummary: string;
+};
+
+export type GovernedReviewWorkspaceAppendStore = {
+  append(envelope: GovernedReviewWorkspaceAppendEnvelope): Promise<void>;
+};
+
+export type GovernedReviewWorkspaceAppendResult =
+  | {
+      ok: true;
+      envelope: GovernedReviewWorkspaceAppendEnvelope;
+    }
+  | {
+      ok: false;
+      error: "admin_support_authority_required";
+      metadataOnly: true;
+      tenantVisible: false;
+      landlordVisible: false;
+      supportPowersGranted: false;
+      rawPayloadAccessEnabled: false;
+    };
+
+type AppendInput = {
+  actor: GovernedReviewWorkspaceAppendActorContext;
+  candidate: Parameters<typeof validateGovernedReviewWorkspacePersistenceCandidate>[0];
+  occurredAt?: unknown;
+};
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function stableHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex").slice(0, 16);
+}
+
+function toIso(value: unknown): string {
+  if (value && typeof (value as any).toDate === "function") return (value as any).toDate().toISOString();
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = asString(value, 120);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date(0).toISOString();
+}
+
+function safeLabel(value: unknown, max = 120): string | null {
+  const label = asString(value, max).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+  if (!label) return null;
+  if (/gs:\/\//i.test(label) || /storage\.googleapis\.com/i.test(label)) return null;
+  if (/token|secret|credential|authorization|cookie|password|bearer/i.test(label)) return null;
+  if (/^[a-zA-Z0-9_-]{16,}$/.test(label)) return null;
+  return label;
+}
+
+function normalizeActorRole(value: unknown): GovernedReviewWorkspaceAppendActorRole {
+  const normalized = normalizeKey(value);
+  if (normalized === "admin" || normalized === "system_admin") return "admin";
+  if (normalized === "support" || normalized === "operator_support") return "support";
+  return "unknown";
+}
+
+function actorSummary(actor: GovernedReviewWorkspaceAppendActorContext): GovernedReviewWorkspaceAppendEnvelope["actorSummary"] {
+  const role = normalizeActorRole(actor.actorRole);
+  const permission = normalizeKey(actor.permission);
+  return {
+    role,
+    displayName: safeLabel(actor.displayName),
+    systemAdminAuthorized: permission === "system_admin" || permission === "system.admin" || role === "admin",
+    supportAuthorized: Boolean(actor.supportAuthorized) || role === "support",
+    rawActorIdsIncluded: false,
+  };
+}
+
+function actorCanAppend(summary: GovernedReviewWorkspaceAppendEnvelope["actorSummary"]): boolean {
+  return summary.systemAdminAuthorized || summary.supportAuthorized;
+}
+
+function safeFlags() {
+  return {
+    metadataOnly: true as const,
+    visibilityClass: "admin_support_internal" as const,
+    tenantVisible: false as const,
+    landlordVisible: false as const,
+    supportPowersGranted: false as const,
+    impersonationEnabled: false as const,
+    autonomousRemediationEnabled: false as const,
+    autonomousEscalationEnabled: false as const,
+    financialMutationEnabled: false as const,
+    routeVisibilityChanged: false as const,
+    mutationControlsEnabled: false as const,
+    rawPayloadAccessEnabled: false as const,
+    createRouteEnabled: false as const,
+    updateRouteEnabled: false as const,
+    deleteRouteEnabled: false as const,
+    statusMutationEnabled: false as const,
+  };
+}
+
+export function buildGovernedReviewWorkspaceAppendEnvelope(input: AppendInput): GovernedReviewWorkspaceAppendResult {
+  const validation = validateGovernedReviewWorkspacePersistenceCandidate(input.candidate);
+  const actor = actorSummary(input.actor || {});
+  if (!actorCanAppend(actor)) {
+    return {
+      ok: false,
+      error: "admin_support_authority_required",
+      metadataOnly: true,
+      tenantVisible: false,
+      landlordVisible: false,
+      supportPowersGranted: false,
+      rawPayloadAccessEnabled: false,
+    };
+  }
+  const occurredAt = toIso(input.occurredAt);
+  const record = validation.record;
+  return {
+    ok: true,
+    envelope: {
+      governedReviewWorkspaceAppendAdapterVersion: GOVERNED_REVIEW_WORKSPACE_APPEND_ADAPTER_VERSION,
+      appendEnvelopeId: `governed_workspace_append:${stableHash([
+        record.persistenceContractId,
+        actor.role,
+        actor.displayName,
+        occurredAt,
+      ])}`,
+      appendOnly: true,
+      appendOperation: "append_workspace_record",
+      storageTarget: "governed_review_workspace_append_log",
+      storageWriteDecision: "adapter_port_only_firestore_deferred",
+      actorSummary: actor,
+      occurredAt,
+      warnings: validation.warnings,
+      record,
+      redactionSummary:
+        "Append adapter envelopes are metadata-only and append-only. Raw notes, documents, provider payloads, screening reports, storage paths, tokens, secrets, request/response bodies, stack traces, debug payloads, raw IDs as labels, and policy internals are excluded.",
+      ...safeFlags(),
+    },
+  };
+}
+
+export function createGovernedReviewWorkspaceAppendAdapter(store: GovernedReviewWorkspaceAppendStore) {
+  return {
+    async appendWorkspaceRecord(input: AppendInput): Promise<GovernedReviewWorkspaceAppendResult> {
+      const result = buildGovernedReviewWorkspaceAppendEnvelope(input);
+      if (!result.ok) return result;
+      await store.append(result.envelope);
+      return result;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add metadata-only append adapter envelope for governed review workspace records
- reuse PR #990 persistence validation/sanitization before append
- add admin/support actor gate and append-only injected store port
- document storage decision and guardrails

## Scope
- no routes or frontend UI
- no live Firestore collection writes
- no tenant/landlord visibility
- no mutation controls, workflow status changes, approval, resolve, or dismiss actions
- no automation or autonomous remediation
- no dependency or lockfile changes

## Validation
- rentchain-api: npm run test:single -- src/lib/governedReviewWorkspaceAppendAdapter/__tests__/governedReviewWorkspaceAppendAdapter.test.ts src/lib/governedReviewWorkspacePersistence/__tests__/governedReviewWorkspacePersistence.test.ts
- rentchain-api: npm run build
- git diff --check