### PR TITLE
Add governed review workspace read routes

### DIFF
--- a/docs/reports/governed-review-workspace-read-routes-v1.md
+++ b/docs/reports/governed-review-workspace-read-routes-v1.md
@@ -1,0 +1,153 @@
+# Governed Review Workspace Read Routes v1
+
+## Summary
+
+This mission adds tightly scoped admin-only GET routes for governed review workspace records.
+
+It does not add public routes, tenant/landlord visibility, create/update/delete routes, approve/resolve/dismiss actions, mutation controls, automation, impersonation enablement, or raw payload access.
+
+## Audit Findings
+
+Reviewed foundations:
+
+- `governedReviewWorkspaces` provides metadata-only workspace summaries.
+- `governedReviewWorkspacePersistence` provides persistence-readiness validation and sanitization.
+- `governedReviewWorkspaceAppendAdapter` provides an append-only adapter envelope over an injected append sink.
+- `adminSecurityIncidentRoutes` and `adminSupportEscalationRoutes` provide the existing admin-only route pattern and `system.admin` authorization convention.
+- `app.build.ts` mounts privileged admin review routes before broad admin/screening fallback routes.
+
+No frontend mutation controls or public read surfaces exist for governed review workspaces.
+
+## Routes Added
+
+Added:
+
+- `GET /api/admin/review-workspaces`
+- `GET /api/admin/review-workspaces/:workspaceId`
+
+Expected route source:
+
+- `x-route-source: governedReviewWorkspaceRoutes.ts`
+
+Both routes require:
+
+- authenticated request
+- `system.admin` permission
+
+No POST, PATCH, PUT, or DELETE routes were added.
+
+## Projection Behavior
+
+The read service loads from the narrow append-log collection name:
+
+- `governedReviewWorkspaceAppendLog`
+
+Every loaded candidate is re-sanitized through the PR #990 persistence validator before response projection.
+
+List responses include only metadata summaries:
+
+- workspace id and type
+- safe title and summary
+- workflow family
+- severity, review state, and approval expectation summaries
+- related counts
+- append event count
+- retention metadata
+- metadata-only/internal visibility flags
+
+Detail responses add only safe metadata:
+
+- safe evidence refs
+- related workspace links
+- append event summaries
+- payload safety summary
+- redaction summary
+- persistence decision
+
+## Empty-State Behavior
+
+If no append records exist, the list route returns:
+
+- `ok: true`
+- empty `workspaces`
+- metadata-only schema
+- safe empty-state message
+
+No fake workspace data is generated.
+
+## Redaction and Safety
+
+The routes never expose:
+
+- raw notes
+- raw documents
+- provider payloads
+- screening reports
+- storage paths
+- tokens
+- secrets
+- credentials
+- request bodies
+- response bodies
+- stack traces
+- debug payloads
+- raw actor IDs as labels
+- raw tenant/landlord IDs as labels
+- unrestricted policy internals
+- impersonation session IDs as labels
+
+All responses preserve:
+
+- `metadataOnly: true`
+- `visibilityClass: admin_support_internal`
+- `tenantVisible: false`
+- `landlordVisible: false`
+- `appendOnly: true`
+- `mutationControlsEnabled: false`
+- `rawPayloadAccessEnabled: false`
+
+## Persistence / Read Decision
+
+This mission adds read-only access to metadata records if the approved append log is populated.
+
+It does not add:
+
+- Firestore write adapters
+- route-based creation
+- status mutation
+- update/delete behavior
+- frontend mutation controls
+- tenant/landlord projections
+
+## Tests Added
+
+Added route tests covering:
+
+- admin access succeeds
+- non-admin access is denied
+- route-source attribution is correct
+- empty state is safe
+- unsafe stored inputs are re-sanitized before response
+- POST route remains unavailable
+
+Updated route ownership regression coverage to pin the governed review workspace routes before broad admin/screening fallback routes.
+
+## Known Limitations
+
+- No persisted workspace records exist unless the append log is populated by an approved future writer.
+- No frontend page was added in this mission.
+- No create/update/delete/approve/resolve/dismiss route exists.
+- Retention policy and collection ownership remain governance concerns for a future storage mission.
+
+## Future Roadmap
+
+Recommended follow-ups:
+
+1. Add a read-only admin frontend page for governed review workspaces.
+2. Add Firestore-backed append store after collection ownership and retention policy are approved.
+3. Add immutable audit event emission for append operations.
+4. Add export/audit readiness summaries for admin/support audiences only.
+
+## Guardrail Confirmation
+
+This mission does not widen permissions, change auth, change Firestore rules, add public routes, add tenant/landlord visibility, expose raw payloads, add mutation controls, enable impersonation, or introduce autonomous remediation/escalation.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -132,6 +132,7 @@ import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
 import adminObservabilityIncidentReadinessRoutes from "./routes/adminObservabilityIncidentReadinessRoutes";
 import adminSecurityIncidentRoutes from "./routes/adminSecurityIncidentRoutes";
 import adminSupportEscalationRoutes from "./routes/adminSupportEscalationRoutes";
+import governedReviewWorkspaceRoutes from "./routes/governedReviewWorkspaceRoutes";
 import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
 import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHardeningRoutes";
 import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRoutes";
@@ -429,6 +430,8 @@ app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecuri
 console.log("[route-mount] adminSecurityIncidentRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminSupportEscalationRoutes.ts"), adminSupportEscalationRoutes);
 console.log("[route-mount] adminSupportEscalationRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("governedReviewWorkspaceRoutes.ts"), governedReviewWorkspaceRoutes);
+console.log("[route-mount] governedReviewWorkspaceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminReleaseGovernanceRoutes.ts"), adminReleaseGovernanceRoutes);
 console.log("[route-mount] adminReleaseGovernanceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes);

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -220,6 +220,7 @@ async function buildRuntimeOwnershipApp() {
   const screeningRoutes = (await import("../screeningRoutes")).default;
   const adminSecurityIncidentRoutes = (await import("../adminSecurityIncidentRoutes")).default;
   const adminSupportEscalationRoutes = (await import("../adminSupportEscalationRoutes")).default;
+  const governedReviewWorkspaceRoutes = (await import("../governedReviewWorkspaceRoutes")).default;
   const screeningJobsAdminRoutes = (await import("../screeningJobsAdminRoutes")).default;
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
@@ -261,6 +262,7 @@ async function buildRuntimeOwnershipApp() {
   app.use("/api", routeSource("screeningRoutes.ts"), screeningRoutes);
   app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
   app.use("/api/admin", routeSource("adminSupportEscalationRoutes.ts"), adminSupportEscalationRoutes);
+  app.use("/api/admin", routeSource("governedReviewWorkspaceRoutes.ts"), governedReviewWorkspaceRoutes);
   app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes);
   app.use("/api", (_req, res) => {
     res.setHeader("x-route-source", "not-found");
@@ -403,6 +405,9 @@ describe("API route ownership regression", () => {
     const supportEscalationMount = source.indexOf(
       'app.use("/api/admin", routeSource("adminSupportEscalationRoutes.ts"), adminSupportEscalationRoutes)'
     );
+    const governedReviewWorkspaceMount = source.indexOf(
+      'app.use("/api/admin", routeSource("governedReviewWorkspaceRoutes.ts"), governedReviewWorkspaceRoutes)'
+    );
     const publicExposureMount = source.indexOf(
       'app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes)'
     );
@@ -422,6 +427,7 @@ describe("API route ownership regression", () => {
     expect(incidentReadinessMount).toBeGreaterThan(-1);
     expect(securityIncidentMount).toBeGreaterThan(-1);
     expect(supportEscalationMount).toBeGreaterThan(-1);
+    expect(governedReviewWorkspaceMount).toBeGreaterThan(-1);
     expect(publicExposureMount).toBeGreaterThan(-1);
     expect(pdfObservabilityMount).toBeGreaterThan(-1);
     expect(impersonationMount).toBeGreaterThan(-1);
@@ -437,6 +443,8 @@ describe("API route ownership regression", () => {
     expect(securityIncidentMount).toBeLessThan(adminScreeningUsageMount);
     expect(supportEscalationMount).toBeLessThan(adminRoutesMount);
     expect(supportEscalationMount).toBeLessThan(adminScreeningUsageMount);
+    expect(governedReviewWorkspaceMount).toBeLessThan(adminRoutesMount);
+    expect(governedReviewWorkspaceMount).toBeLessThan(adminScreeningUsageMount);
     expect(publicExposureMount).toBeLessThan(adminRoutesMount);
     expect(pdfObservabilityMount).toBeLessThan(adminRoutesMount);
     expect(impersonationMount).toBeLessThan(screeningJobsMount);
@@ -568,6 +576,38 @@ describe("API route ownership regression", () => {
 
     expect(denied.status).toBe(403);
     expect(denied.headers["x-route-source"]).toBe("adminSupportEscalationRoutes.ts");
+    expect(denied.body?.error).not.toBe("Not Found");
+  });
+
+  it("keeps governed review workspaces owned by governed workspace routes before screening usage fallback", async () => {
+    authState.user = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+    const app = await buildRuntimeOwnershipApp();
+
+    const res = await invokeApp(app, {
+      method: "GET",
+      url: "/api/admin/review-workspaces?limit=50",
+      headers: { authorization: "Bearer admin-token" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("governedReviewWorkspaceRoutes.ts");
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        workspaces: [],
+        summary: expect.objectContaining({ metadataOnly: true }),
+      })
+    );
+
+    authState.user = { id: "landlord-1", role: "landlord", permissions: [] };
+    const denied = await invokeApp(app, {
+      method: "GET",
+      url: "/api/admin/review-workspaces?limit=50",
+      headers: { authorization: "Bearer landlord-token" },
+    });
+
+    expect(denied.status).toBe(403);
+    expect(denied.headers["x-route-source"]).toBe("governedReviewWorkspaceRoutes.ts");
     expect(denied.body?.error).not.toBe("Not Found");
   });
 

--- a/rentchain-api/src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({
+            id: doc.id,
+            exists: true,
+            data: () => doc.data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireAuthz", () => ({
+  requirePermission: () => (req: any, res: any, next: any) => {
+    const permissions = Array.isArray(req.user?.permissions) ? req.user.permissions : [];
+    if (req.user?.role !== "admin" && !permissions.includes("system.admin")) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const detailMatch = path.match(/^\/review-workspaces\/(.+)$/);
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: detailMatch ? { workspaceId: decodeURIComponent(detailMatch[1]) } : {},
+      headers: {},
+      user: mockUser,
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      setHeader(name: string, value: string) {
+        this.headers[String(name).toLowerCase()] = value;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) return reject(error);
+      resolve({ status: 404, body: { ok: false, error: "NOT_FOUND" }, headers: res.headers });
+    });
+  });
+}
+
+describe("governedReviewWorkspaceRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedWorkspace() {
+    seedDoc("governedReviewWorkspaceAppendLog", "workspace-1", {
+      record: {
+        workspaceType: "security_review",
+        title: "Security review workspace",
+        summary: "Metadata-only workspace.",
+        workflowFamily: "admin_security_incident_review",
+        retentionClass: "security_review",
+        retentionReason: "token=secret gs://bucket/raw.pdf",
+        createdAt: "2026-05-24T01:00:00.000Z",
+        lastAppendedAt: "2026-05-24T01:05:00.000Z",
+        safeEvidenceRefs: [
+          {
+            referenceType: "document",
+            referenceId: "doc-safe",
+            label: "https://storage.googleapis.com/bucket/raw.pdf",
+            landlordId: "landlord-raw",
+            tenantId: "tenant-raw",
+          },
+        ],
+        appendEventRefs: [
+          {
+            eventType: "workspace_evidence_ref_added",
+            eventSummary: "authorization=Bearer-secret responseBody={raw}",
+            occurredAt: "2026-05-24T01:05:00.000Z",
+          },
+        ],
+      },
+    });
+  }
+
+  it("denies non-admin access and returns route-owned metadata-only workspace summaries", async () => {
+    seedWorkspace();
+    const router = (await import("../governedReviewWorkspaceRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/review-workspaces",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/review-workspaces",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("governedReviewWorkspaceRoutes.ts");
+    expect(res.body.workspaces).toHaveLength(1);
+    expect(res.body.workspaces[0]).toEqual(
+      expect.objectContaining({
+        workspaceType: "security_review",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+      })
+    );
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("landlord-raw");
+    expect(payload).not.toContain("tenant-raw");
+    expect(payload).not.toContain("storage.googleapis.com");
+    expect(payload).not.toContain("token=secret");
+  });
+
+  it("returns safe detail and no mutation route", async () => {
+    seedWorkspace();
+    const router = (await import("../governedReviewWorkspaceRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/review-workspaces" });
+    const workspaceId = list.body.workspaces[0].workspaceId;
+
+    const detail = await invokeRouter(router, {
+      method: "GET",
+      url: `/review-workspaces/${encodeURIComponent(workspaceId)}`,
+    });
+
+    expect(detail.status).toBe(200);
+    expect(detail.headers["x-route-source"]).toBe("governedReviewWorkspaceRoutes.ts");
+    expect(detail.body.workspace).toEqual(
+      expect.objectContaining({
+        workspaceId,
+        metadataOnly: true,
+        appendOnly: true,
+        appendEventSummaries: expect.any(Array),
+        persistenceDecision: "contract_only_firestore_deferred",
+      })
+    );
+    expect(JSON.stringify(detail.body)).not.toContain("Bearer-secret");
+    expect(JSON.stringify(detail.body)).not.toContain("responseBody");
+
+    const post = await invokeRouter(router, { method: "POST", url: "/review-workspaces" });
+    expect(post.status).toBe(404);
+  });
+
+  it("returns a safe empty state when no append records exist", async () => {
+    const router = (await import("../governedReviewWorkspaceRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/review-workspaces?limit=50" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("governedReviewWorkspaceRoutes.ts");
+    expect(res.body.workspaces).toEqual([]);
+    expect(res.body.summary).toEqual(
+      expect.objectContaining({
+        total: 0,
+        metadataOnly: true,
+        emptyState: expect.stringContaining("No governed review workspace append records"),
+      })
+    );
+    expect(res.body.schema).toEqual(
+      expect.objectContaining({
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+        mutationControlsEnabled: false,
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/governedReviewWorkspaceRoutes.ts
+++ b/rentchain-api/src/routes/governedReviewWorkspaceRoutes.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import {
+  loadGovernedReviewWorkspaceDetail,
+  loadGovernedReviewWorkspaces,
+} from "../services/admin/governedReviewWorkspaceRead";
+
+const router = Router();
+
+router.get("/review-workspaces", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  res.setHeader("x-route-source", "governedReviewWorkspaceRoutes.ts");
+  try {
+    const result = await loadGovernedReviewWorkspaces({
+      workspaceType: req.query?.workspaceType,
+      q: req.query?.q,
+      limit: Number(req.query?.limit || 50),
+    });
+    return res.json({ ok: true, ...result });
+  } catch (err: any) {
+    console.error("[governed-review-workspaces] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "GOVERNED_REVIEW_WORKSPACES_FAILED" });
+  }
+});
+
+router.get("/review-workspaces/:workspaceId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  res.setHeader("x-route-source", "governedReviewWorkspaceRoutes.ts");
+  try {
+    const workspaceId = String(req.params?.workspaceId || "").trim();
+    if (!workspaceId) return res.status(400).json({ ok: false, error: "WORKSPACE_ID_REQUIRED" });
+    const workspace = await loadGovernedReviewWorkspaceDetail(workspaceId);
+    if (!workspace) return res.status(404).json({ ok: false, error: "WORKSPACE_NOT_FOUND" });
+    return res.json({ ok: true, workspace });
+  } catch (err: any) {
+    console.error("[governed-review-workspaces] detail failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "GOVERNED_REVIEW_WORKSPACE_DETAIL_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/admin/governedReviewWorkspaceRead.ts
+++ b/rentchain-api/src/services/admin/governedReviewWorkspaceRead.ts
@@ -1,0 +1,206 @@
+import { db } from "../../config/firebase";
+import {
+  validateGovernedReviewWorkspacePersistenceCandidate,
+  type GovernedReviewWorkspaceAppendEventRef,
+  type GovernedReviewWorkspacePersistenceRecord,
+} from "../../lib/governedReviewWorkspacePersistence/governedReviewWorkspacePersistence";
+
+const COLLECTION = "governedReviewWorkspaceAppendLog";
+
+type LoadParams = {
+  workspaceType?: string | null;
+  q?: string | null;
+  limit?: number | null;
+};
+
+export type GovernedReviewWorkspaceReadSummary = {
+  workspaceId: string;
+  workspaceType: string;
+  title: string;
+  summary: string;
+  workflowFamily: string | null;
+  severitySummary: string;
+  reviewStateSummary: string;
+  approvalExpectationSummary: string;
+  relatedIncidentCount: number;
+  relatedEscalationCount: number;
+  relatedEvidenceCount: number;
+  relatedNoteCount: number;
+  appendEventCount: number;
+  retentionClass: string;
+  retentionReviewAt: string | null;
+  lastAppendedAt: string;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendOnly: true;
+  mutationControlsEnabled: false;
+  rawPayloadAccessEnabled: false;
+};
+
+export type GovernedReviewWorkspaceReadDetail = GovernedReviewWorkspaceReadSummary & {
+  safeEvidenceRefs: GovernedReviewWorkspacePersistenceRecord["safeEvidenceRefs"];
+  relatedWorkspaceLinks: GovernedReviewWorkspacePersistenceRecord["relatedWorkspaceLinks"];
+  appendEventSummaries: Array<{
+    eventRefId: string;
+    eventType: string;
+    eventSummary: string;
+    occurredAt: string;
+    metadataOnly: true;
+    visibilityClass: "admin_support_internal";
+    tenantVisible: false;
+    landlordVisible: false;
+    appendOnly: true;
+  }>;
+  redactionSummary: string;
+  payloadSafety: GovernedReviewWorkspacePersistenceRecord["payloadSafety"];
+  persistenceDecision: GovernedReviewWorkspacePersistenceRecord["persistenceDecision"];
+};
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function sourceRecord(raw: Record<string, unknown>): GovernedReviewWorkspacePersistenceRecord {
+  const record = (raw.record && typeof raw.record === "object" ? raw.record : raw) as Record<string, unknown>;
+  const validation = validateGovernedReviewWorkspacePersistenceCandidate({
+    workspaceSummary: (record.workspaceSummary as any) || null,
+    workspaceType: record.workspaceType,
+    title: record.title,
+    summary: record.summary,
+    workflowFamily: record.workflowFamily,
+    retentionClass: record.retentionClass,
+    retentionReason: record.retentionReason,
+    retentionReviewAt: record.retentionReviewAt,
+    createdAt: record.createdAt,
+    lastAppendedAt: record.lastAppendedAt,
+    safeEvidenceRefs: (record.safeEvidenceRefs as any) || [],
+    relatedWorkspaceLinks: (record.relatedWorkspaceLinks as any) || [],
+    appendEvents: Array.isArray(record.appendEventRefs)
+      ? (record.appendEventRefs as GovernedReviewWorkspaceAppendEventRef[]).map((event) => ({
+          eventType: event.eventType,
+          eventSummary: event.eventSummary,
+          occurredAt: event.occurredAt,
+          relatedEvidenceRefs: event.relatedEvidenceRefs,
+          relatedWorkspaceLinks: event.relatedWorkspaceLinks,
+        }))
+      : [],
+  });
+  return validation.record;
+}
+
+function toSummary(record: GovernedReviewWorkspacePersistenceRecord): GovernedReviewWorkspaceReadSummary {
+  return {
+    workspaceId: record.workspaceId,
+    workspaceType: record.workspaceType,
+    title: record.title,
+    summary: record.summary,
+    workflowFamily: record.workflowFamily,
+    severitySummary: record.workspaceSummary.severitySummary,
+    reviewStateSummary: record.workspaceSummary.reviewStateSummary,
+    approvalExpectationSummary: record.workspaceSummary.approvalExpectationSummary,
+    relatedIncidentCount: record.workspaceSummary.relatedIncidentCount,
+    relatedEscalationCount: record.workspaceSummary.relatedEscalationCount,
+    relatedEvidenceCount: record.workspaceSummary.relatedEvidenceCount,
+    relatedNoteCount: record.workspaceSummary.relatedNoteCount,
+    appendEventCount: record.appendEventRefs.length,
+    retentionClass: record.retentionClass,
+    retentionReviewAt: record.retentionReviewAt,
+    lastAppendedAt: record.lastAppendedAt,
+    metadataOnly: true,
+    visibilityClass: "admin_support_internal",
+    tenantVisible: false,
+    landlordVisible: false,
+    appendOnly: true,
+    mutationControlsEnabled: false,
+    rawPayloadAccessEnabled: false,
+  };
+}
+
+function toDetail(record: GovernedReviewWorkspacePersistenceRecord): GovernedReviewWorkspaceReadDetail {
+  return {
+    ...toSummary(record),
+    safeEvidenceRefs: record.safeEvidenceRefs,
+    relatedWorkspaceLinks: record.relatedWorkspaceLinks,
+    appendEventSummaries: record.appendEventRefs.map((event) => ({
+      eventRefId: event.eventRefId,
+      eventType: event.eventType,
+      eventSummary: event.eventSummary,
+      occurredAt: event.occurredAt,
+      metadataOnly: true,
+      visibilityClass: "admin_support_internal",
+      tenantVisible: false,
+      landlordVisible: false,
+      appendOnly: true,
+    })),
+    redactionSummary: record.redactionSummary,
+    payloadSafety: record.payloadSafety,
+    persistenceDecision: record.persistenceDecision,
+  };
+}
+
+async function loadRawRecords(limit = 100): Promise<GovernedReviewWorkspacePersistenceRecord[]> {
+  const snap = await db.collection(COLLECTION).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc: any) => sourceRecord({ id: String(doc.id || ""), ...(doc.data() || {}) }));
+}
+
+function filterRecords(records: GovernedReviewWorkspacePersistenceRecord[], params: LoadParams) {
+  const workspaceType = asString(params.workspaceType, 120);
+  const q = asString(params.q, 160).toLowerCase();
+  return records.filter((record) => {
+    if (workspaceType && record.workspaceType !== workspaceType) return false;
+    if (q) {
+      const haystack = [record.title, record.summary, record.workspaceType, record.workflowFamily]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+function schema() {
+  return {
+    metadataOnly: true as const,
+    visibilityClass: "admin_support_internal" as const,
+    tenantVisible: false as const,
+    landlordVisible: false as const,
+    appendOnly: true as const,
+    persistence: "read_only_if_present" as const,
+    mutationControlsEnabled: false as const,
+    rawPayloadAccessEnabled: false as const,
+    createRouteEnabled: false as const,
+    updateRouteEnabled: false as const,
+    deleteRouteEnabled: false as const,
+  };
+}
+
+export async function loadGovernedReviewWorkspaces(params: LoadParams = {}) {
+  const requestedLimit = Number(params.limit || 50);
+  const limit = Number.isFinite(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 100) : 50;
+  const records = filterRecords(await loadRawRecords(100), params)
+    .sort((a, b) => Date.parse(b.lastAppendedAt) - Date.parse(a.lastAppendedAt) || a.workspaceId.localeCompare(b.workspaceId))
+    .slice(0, limit);
+
+  return {
+    workspaces: records.map(toSummary),
+    summary: {
+      total: records.length,
+      metadataOnly: true as const,
+      emptyState: records.length
+        ? null
+        : "No governed review workspace append records are available yet. The read surface is ready and returns metadata-only records when the approved append store is populated.",
+    },
+    schema: schema(),
+  };
+}
+
+export async function loadGovernedReviewWorkspaceDetail(workspaceId: string): Promise<GovernedReviewWorkspaceReadDetail | null> {
+  const target = asString(workspaceId, 260);
+  if (!target) return null;
+  const records = await loadRawRecords(100);
+  const record = records.find((item) => item.workspaceId === target || item.persistenceContractId === target);
+  return record ? toDetail(record) : null;
+}


### PR DESCRIPTION
## Summary
- add admin-only GET routes for governed review workspace list/detail
- add read service that re-sanitizes append-log records through persistence readiness contracts
- preserve metadata-only, append-only, admin/support-internal projections
- add route ownership and route behavior tests

## Scope
- no public routes
- no tenant/landlord visibility
- no POST/PATCH/DELETE routes
- no mutation controls or workflow actions
- no frontend UI
- no dependency or lockfile changes

## Validation
- rentchain-api: npm run test:single -- src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts src/routes/__tests__/apiRouteOwnershipRegression.test.ts src/lib/governedReviewWorkspacePersistence/__tests__/governedReviewWorkspacePersistence.test.ts
- rentchain-api: npm run build
- git diff --check