### PR TITLE
Add governed review workspace admin page

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -113,6 +113,7 @@ const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabili
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
 const AdminSecurityIncidentsPage = lazy(() => import("./pages/admin/AdminSecurityIncidentsPage"));
 const AdminSupportEscalationsPage = lazy(() => import("./pages/admin/AdminSupportEscalationsPage"));
+const AdminReviewWorkspacesPage = lazy(() => import("./pages/admin/AdminReviewWorkspacesPage"));
 const ObservabilityIncidentReadinessPage = lazy(() => import("./pages/ObservabilityIncidentReadinessPage"));
 const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
 const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
@@ -1070,6 +1071,18 @@ function App() {
               <RequireAdmin>
                 <Suspense fallback={null}>
                   <AdminSupportEscalationsPage />
+                </Suspense>
+              </RequireAdmin>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/admin/review-workspaces"
+          element={
+            <RequireAuth>
+              <RequireAdmin>
+                <Suspense fallback={null}>
+                  <AdminReviewWorkspacesPage />
                 </Suspense>
               </RequireAdmin>
             </RequireAuth>

--- a/rentchain-frontend/src/api/adminReviewWorkspacesApi.ts
+++ b/rentchain-frontend/src/api/adminReviewWorkspacesApi.ts
@@ -1,0 +1,96 @@
+import { apiFetch } from "./apiFetch";
+import type { AdminReviewWorkspaceLink } from "./adminSecurityIncidentsApi";
+
+export type GovernedReviewWorkspaceRecord = {
+  workspaceId: string;
+  workspaceType: string;
+  title: string;
+  summary: string;
+  workflowFamily: string | null;
+  severitySummary: string;
+  reviewStateSummary: string;
+  approvalExpectationSummary: string;
+  relatedIncidentCount: number;
+  relatedEscalationCount: number;
+  relatedEvidenceCount: number;
+  relatedNoteCount: number;
+  appendEventCount: number;
+  retentionClass: string;
+  retentionReviewAt: string | null;
+  lastAppendedAt: string;
+  metadataOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  appendOnly: true;
+  mutationControlsEnabled: false;
+  rawPayloadAccessEnabled: false;
+};
+
+export type GovernedReviewWorkspaceDetail = GovernedReviewWorkspaceRecord & {
+  safeEvidenceRefs: Array<{
+    referenceType: string;
+    referenceId: string;
+    label: string;
+    internalReference: true;
+    metadataOnly: true;
+  }>;
+  relatedWorkspaceLinks: AdminReviewWorkspaceLink[];
+  appendEventSummaries: Array<{
+    eventRefId: string;
+    eventType: string;
+    eventSummary: string;
+    occurredAt: string;
+    metadataOnly: true;
+    visibilityClass: "admin_support_internal";
+    tenantVisible: false;
+    landlordVisible: false;
+    appendOnly: true;
+  }>;
+  redactionSummary: string;
+  payloadSafety: Record<string, string>;
+  persistenceDecision: string;
+};
+
+export type GovernedReviewWorkspaceSummary = {
+  total: number;
+  metadataOnly: true;
+  emptyState: string | null;
+};
+
+export async function fetchAdminReviewWorkspaces(params?: {
+  workspaceType?: string | null;
+  q?: string | null;
+  limit?: number | null;
+}) {
+  const query = new URLSearchParams();
+  if (params?.workspaceType) query.set("workspaceType", params.workspaceType);
+  if (params?.q) query.set("q", params.q);
+  if (params?.limit) query.set("limit", String(params.limit));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return apiFetch<{
+    ok: true;
+    workspaces: GovernedReviewWorkspaceRecord[];
+    summary: GovernedReviewWorkspaceSummary;
+    schema: {
+      metadataOnly: true;
+      visibilityClass: "admin_support_internal";
+      tenantVisible: false;
+      landlordVisible: false;
+      appendOnly: true;
+      persistence: "read_only_if_present";
+      mutationControlsEnabled: false;
+      rawPayloadAccessEnabled: false;
+      createRouteEnabled: false;
+      updateRouteEnabled: false;
+      deleteRouteEnabled: false;
+    };
+  }>(`/admin/review-workspaces${suffix}`);
+}
+
+export async function fetchAdminReviewWorkspaceDetail(workspaceId: string) {
+  return apiFetch<{
+    ok: true;
+    workspace: GovernedReviewWorkspaceDetail;
+  }>(`/admin/review-workspaces/${encodeURIComponent(workspaceId)}`);
+}

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
@@ -1,0 +1,211 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdminReviewWorkspacesPage from "./AdminReviewWorkspacesPage";
+
+const showToast = vi.fn();
+const fetchAdminReviewWorkspaces = vi.fn();
+const fetchAdminReviewWorkspaceDetail = vi.fn();
+
+vi.mock("../../api/adminReviewWorkspacesApi", () => ({
+  fetchAdminReviewWorkspaces: (...args: any[]) => fetchAdminReviewWorkspaces(...args),
+  fetchAdminReviewWorkspaceDetail: (...args: any[]) => fetchAdminReviewWorkspaceDetail(...args),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+const WORKSPACE = {
+  workspaceId: "governed_workspace:safe",
+  workspaceType: "security_review",
+  title: "Security review workspace",
+  summary: "Metadata-only workspace summary.",
+  workflowFamily: "admin_security_incident_review",
+  severitySummary: "medium",
+  reviewStateSummary: "metadata_review_ready",
+  approvalExpectationSummary: "admin_review",
+  relatedIncidentCount: 1,
+  relatedEscalationCount: 0,
+  relatedEvidenceCount: 1,
+  relatedNoteCount: 1,
+  appendEventCount: 1,
+  retentionClass: "security_review",
+  retentionReviewAt: "2026-06-01T00:00:00.000Z",
+  lastAppendedAt: "2026-05-24T01:00:00.000Z",
+  metadataOnly: true,
+  visibilityClass: "admin_support_internal",
+  tenantVisible: false,
+  landlordVisible: false,
+  appendOnly: true,
+  mutationControlsEnabled: false,
+  rawPayloadAccessEnabled: false,
+};
+
+beforeEach(() => {
+  showToast.mockReset();
+  fetchAdminReviewWorkspaces.mockReset();
+  fetchAdminReviewWorkspaceDetail.mockReset();
+  fetchAdminReviewWorkspaces.mockResolvedValue({
+    ok: true,
+    workspaces: [WORKSPACE],
+    summary: { total: 1, metadataOnly: true, emptyState: null },
+    schema: {
+      metadataOnly: true,
+      visibilityClass: "admin_support_internal",
+      tenantVisible: false,
+      landlordVisible: false,
+      appendOnly: true,
+      persistence: "read_only_if_present",
+      mutationControlsEnabled: false,
+      rawPayloadAccessEnabled: false,
+      createRouteEnabled: false,
+      updateRouteEnabled: false,
+      deleteRouteEnabled: false,
+    },
+  });
+  fetchAdminReviewWorkspaceDetail.mockResolvedValue({
+    ok: true,
+    workspace: {
+      ...WORKSPACE,
+      safeEvidenceRefs: [
+        {
+          referenceType: "evidence_pack",
+          referenceId: "evidence-safe",
+          label: "Evidence metadata reference",
+          internalReference: true,
+          metadataOnly: true,
+        },
+      ],
+      relatedWorkspaceLinks: [
+        {
+          linkId: "workspace_link:safe",
+          linkType: "incident_to_review_workspace",
+          sourceSummary: {
+            kind: "security_incident",
+            label: "Security incident",
+            category: "policy_denied",
+            severity: "medium",
+            state: "open",
+            metadataOnly: true,
+            rawIdsIncluded: false,
+          },
+          targetSummary: {
+            kind: "review_workspace",
+            label: "Governed workspace",
+            category: "security_review",
+            severity: "medium",
+            state: "metadata_review_ready",
+            metadataOnly: true,
+            rawIdsIncluded: false,
+          },
+          workflowFamily: "admin_security_incident_review",
+          metadataOnly: true,
+          visibilityClass: "admin_support_internal",
+          tenantVisible: false,
+          landlordVisible: false,
+          appendCompatible: true,
+          mutationControlsEnabled: false,
+        },
+      ],
+      appendEventSummaries: [
+        {
+          eventRefId: "event-safe",
+          eventType: "workspace_candidate_created",
+          eventSummary: "Workspace candidate created.",
+          occurredAt: "2026-05-24T01:00:00.000Z",
+          metadataOnly: true,
+          visibilityClass: "admin_support_internal",
+          tenantVisible: false,
+          landlordVisible: false,
+          appendOnly: true,
+        },
+      ],
+      redactionSummary: "Raw notes, documents, storage paths, tokens, secrets, and debug payloads are excluded.",
+      payloadSafety: { rawPayloads: "excluded" },
+      persistenceDecision: "contract_only_firestore_deferred",
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminReviewWorkspacesPage", () => {
+  it("renders metadata-only workspace list and detail", async () => {
+    render(<AdminReviewWorkspacesPage />);
+
+    expect(await screen.findByRole("heading", { name: "Governed review workspaces" })).toBeInTheDocument();
+    expect((await screen.findAllByText("Security review workspace")).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/Workspace Candidate Created/)).toBeInTheDocument();
+    expect(await screen.findByText(/Evidence metadata reference/)).toBeInTheDocument();
+    expect(await screen.findByText(/Incident To Review Workspace/)).toBeInTheDocument();
+    expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Read only").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resolve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+    expect(JSON.stringify(document.body.textContent)).not.toContain("tenant-raw-id");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("gs://");
+    expect(JSON.stringify(document.body.textContent)).not.toContain("secret-token");
+  });
+
+  it("sends filters to the workspace API", async () => {
+    render(<AdminReviewWorkspacesPage />);
+    await screen.findByText("Security review workspace");
+
+    fireEvent.change(screen.getByLabelText("Workspace type"), { target: { value: "security_review" } });
+
+    await waitFor(() =>
+      expect(fetchAdminReviewWorkspaces).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          workspaceType: "security_review",
+        })
+      )
+    );
+  });
+
+  it("renders safe empty state without fake workspaces", async () => {
+    fetchAdminReviewWorkspaces.mockResolvedValueOnce({
+      ok: true,
+      workspaces: [],
+      summary: {
+        total: 0,
+        metadataOnly: true,
+        emptyState: "No governed review workspace append records are available yet.",
+      },
+      schema: {
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+        persistence: "read_only_if_present",
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+        createRouteEnabled: false,
+        updateRouteEnabled: false,
+        deleteRouteEnabled: false,
+      },
+    });
+
+    render(<AdminReviewWorkspacesPage />);
+
+    expect(await screen.findByText(/No governed review workspace records are available yet/)).toBeInTheDocument();
+    expect(screen.getByText(/No governed review workspace append records/)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
@@ -1,0 +1,308 @@
+import React from "react";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import {
+  fetchAdminReviewWorkspaceDetail,
+  fetchAdminReviewWorkspaces,
+  type GovernedReviewWorkspaceDetail,
+  type GovernedReviewWorkspaceRecord,
+  type GovernedReviewWorkspaceSummary,
+} from "../../api/adminReviewWorkspacesApi";
+
+const WORKSPACE_TYPES = [
+  "security_review",
+  "support_escalation_review",
+  "export_governance_review",
+  "evidence_review",
+  "policy_failure_review",
+  "projection_safety_review",
+  "operational_readiness_review",
+  "other",
+];
+
+const EMPTY_SUMMARY: GovernedReviewWorkspaceSummary = {
+  total: 0,
+  metadataOnly: true,
+  emptyState: null,
+};
+
+function label(value: string | null | undefined) {
+  const raw = String(value || "").trim();
+  if (!raw) return "Not specified";
+  return raw
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatTime(value: string | null | undefined) {
+  const ts = Date.parse(String(value || ""));
+  if (!Number.isFinite(ts)) return "Not scheduled";
+  return new Date(ts).toLocaleString();
+}
+
+function WorkspaceRow({
+  workspace,
+  selected,
+  onSelect,
+}: {
+  workspace: GovernedReviewWorkspaceRecord;
+  selected: boolean;
+  onSelect: (workspace: GovernedReviewWorkspaceRecord) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(workspace)}
+      style={{
+        textAlign: "left",
+        border: selected ? "1px solid #2563eb" : "1px solid rgba(15, 23, 42, 0.12)",
+        background: selected ? "#eff6ff" : "#fff",
+        borderRadius: 8,
+        padding: 12,
+        display: "grid",
+        gap: 8,
+        cursor: "pointer",
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <strong>{workspace.title}</strong>
+        <Pill tone="muted">{label(workspace.workspaceType)}</Pill>
+        <Pill tone="muted">Append only</Pill>
+      </div>
+      <div style={{ color: "#475569" }}>{workspace.summary}</div>
+      <div style={{ color: "#64748b", fontSize: 13 }}>
+        {label(workspace.reviewStateSummary)} · {workspace.appendEventCount} append events · {formatTime(workspace.lastAppendedAt)}
+      </div>
+    </button>
+  );
+}
+
+function DetailPanel({ workspace }: { workspace: GovernedReviewWorkspaceDetail | null }) {
+  if (!workspace) {
+    return (
+      <Card>
+        <div style={{ color: "#64748b" }}>Select a workspace to review metadata-only details.</div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <h2 style={{ margin: 0, fontSize: "1.1rem" }}>{workspace.title}</h2>
+          <Pill tone="muted">Metadata only</Pill>
+          <Pill tone="muted">Read only</Pill>
+        </div>
+        <div style={{ color: "#475569" }}>{workspace.summary}</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 10 }}>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Workspace type</div>
+            <strong>{label(workspace.workspaceType)}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Approval expectation</div>
+            <strong>{label(workspace.approvalExpectationSummary)}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Retention class</div>
+            <strong>{label(workspace.retentionClass)}</strong>
+          </div>
+          <div>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Retention review</div>
+            <strong>{formatTime(workspace.retentionReviewAt)}</strong>
+          </div>
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Related metadata</div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}>
+            <Pill tone="muted">{workspace.relatedIncidentCount} incidents</Pill>
+            <Pill tone="muted">{workspace.relatedEscalationCount} escalations</Pill>
+            <Pill tone="muted">{workspace.relatedEvidenceCount} evidence refs</Pill>
+            <Pill tone="muted">{workspace.relatedNoteCount} notes</Pill>
+          </div>
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Append event summaries</div>
+          {workspace.appendEventSummaries.length ? (
+            <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+              {workspace.appendEventSummaries.map((event) => (
+                <div key={event.eventRefId} style={{ color: "#475569" }}>
+                  {formatTime(event.occurredAt)} · {label(event.eventType)} · {event.eventSummary}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div style={{ color: "#64748b", marginTop: 8 }}>No append event summaries are available.</div>
+          )}
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Safe evidence references</div>
+          {workspace.safeEvidenceRefs.length ? (
+            <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+              {workspace.safeEvidenceRefs.map((ref) => (
+                <div key={`${ref.referenceType}:${ref.referenceId}`} style={{ color: "#475569" }}>
+                  {label(ref.referenceType)} · {ref.label}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div style={{ color: "#64748b", marginTop: 8 }}>No safe evidence references are available.</div>
+          )}
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Related workspace links</div>
+          {workspace.relatedWorkspaceLinks.length ? (
+            <div style={{ display: "grid", gap: 8, marginTop: 8 }}>
+              {workspace.relatedWorkspaceLinks.map((link) => (
+                <div key={link.linkId} style={{ color: "#475569" }}>
+                  {label(link.linkType)} · {link.sourceSummary.label} → {link.targetSummary.label}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div style={{ color: "#64748b", marginTop: 8 }}>No metadata-only workspace links are available.</div>
+          )}
+        </div>
+        <div>
+          <div style={{ fontWeight: 700 }}>Redaction summary</div>
+          <div style={{ color: "#475569" }}>{workspace.redactionSummary}</div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default function AdminReviewWorkspacesPage() {
+  const { showToast } = useToast();
+  const [workspaces, setWorkspaces] = React.useState<GovernedReviewWorkspaceRecord[]>([]);
+  const [summary, setSummary] = React.useState<GovernedReviewWorkspaceSummary>(EMPTY_SUMMARY);
+  const [selected, setSelected] = React.useState<GovernedReviewWorkspaceRecord | null>(null);
+  const [detail, setDetail] = React.useState<GovernedReviewWorkspaceDetail | null>(null);
+  const [workspaceType, setWorkspaceType] = React.useState("");
+  const [q, setQ] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetchAdminReviewWorkspaces({
+        workspaceType: workspaceType || null,
+        q: q || null,
+        limit: 50,
+      });
+      setWorkspaces(response.workspaces || []);
+      setSummary(response.summary || EMPTY_SUMMARY);
+      setSelected((current) => {
+        if (!current) return response.workspaces[0] || null;
+        return response.workspaces.find((item) => item.workspaceId === current.workspaceId) || response.workspaces[0] || null;
+      });
+    } catch (err: any) {
+      const message = err?.message || "Failed to load governed review workspaces";
+      setError(message);
+      showToast({ message: "Failed to load governed review workspaces", description: message, variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [q, showToast, workspaceType]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  React.useEffect(() => {
+    if (!selected) {
+      setDetail(null);
+      return;
+    }
+    let active = true;
+    fetchAdminReviewWorkspaceDetail(selected.workspaceId)
+      .then((response) => {
+        if (active) setDetail(response.workspace);
+      })
+      .catch(() => {
+        if (active) setDetail(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selected]);
+
+  return (
+    <MacShell title="Admin · Governed review workspaces">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Governed review workspaces</h1>
+                <Pill tone="accent">Admin</Pill>
+                <Pill tone="muted">Metadata only</Pill>
+                <Pill tone="muted">Read only</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 860 }}>
+                Admin-only review surface for append-only governed workspace metadata. Raw notes, documents, provider payloads,
+                storage paths, tokens, secrets, debug payloads, and mutation controls are excluded.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void load()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12 }}>
+          <Card><strong>{summary.total}</strong><div style={{ color: "#64748b" }}>Workspaces</div></Card>
+          <Card><strong>{workspaces.reduce((sum, item) => sum + item.appendEventCount, 0)}</strong><div style={{ color: "#64748b" }}>Append events</div></Card>
+          <Card><strong>{workspaces.reduce((sum, item) => sum + item.relatedEvidenceCount, 0)}</strong><div style={{ color: "#64748b" }}>Evidence refs</div></Card>
+          <Card><strong>{workspaces.reduce((sum, item) => sum + item.relatedNoteCount, 0)}</strong><div style={{ color: "#64748b" }}>Review notes</div></Card>
+        </div>
+
+        <Card>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+            <label>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Workspace type</div>
+              <select aria-label="Workspace type" value={workspaceType} onChange={(event) => setWorkspaceType(event.target.value)}>
+                <option value="">All workspace types</option>
+                {WORKSPACE_TYPES.map((item) => <option key={item} value={item}>{label(item)}</option>)}
+              </select>
+            </label>
+            <label>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Search</div>
+              <input aria-label="Search" value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search metadata" />
+            </label>
+          </div>
+        </Card>
+
+        {error ? <Card><div style={{ color: "#b91c1c" }}>{error}</div></Card> : null}
+
+        <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) minmax(300px, 440px)", gap: 16 }}>
+          <div style={{ display: "grid", gap: 10 }}>
+            {loading ? <Card><div>Loading governed review workspace metadata...</div></Card> : null}
+            {!loading && workspaces.length === 0 ? (
+              <Card>
+                <div style={{ fontWeight: 700 }}>No governed review workspace records are available yet.</div>
+                <div style={{ color: "#64748b", marginTop: 6 }}>
+                  {summary.emptyState || "Append-only workspace records will appear here after an approved append store is populated."}
+                </div>
+              </Card>
+            ) : null}
+            {workspaces.map((workspace) => (
+              <WorkspaceRow
+                key={workspace.workspaceId}
+                workspace={workspace}
+                selected={selected?.workspaceId === workspace.workspaceId}
+                onSelect={setSelected}
+              />
+            ))}
+          </div>
+          <DetailPanel workspace={detail} />
+        </div>
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds the read-only admin page at `/admin/review-workspaces`.
- Adds a frontend API client for the metadata-only governed review workspace list/detail routes from PR #992.
- Adds targeted tests for rendering, empty state, filters, and absence of mutation controls or sensitive labels.

## Scope and safety
- Frontend-only change.
- No backend routes, persistence, mutation controls, approve/resolve/dismiss actions, automation, or tenant/landlord navigation added.
- The page renders metadata-only summaries and avoids displaying raw workspace IDs, raw payloads, storage paths, tokens, or debug payloads as user-facing labels.

## Validation
- `npm run test -- src/pages/admin/AdminReviewWorkspacesPage.test.tsx` in `rentchain-frontend` passed: 3 tests.
- `npm run build` in `rentchain-frontend` passed.
- `git diff --check` and `git diff --cached --check` passed.
