### PR TITLE
Polish governed review workspace navigation

### DIFF
--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -60,6 +60,24 @@ describe("WorkspaceDrawer", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("shows governed review workspace navigation only for admins", () => {
+    const { rerender } = render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" userEmail="owner@example.com" />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole("button", { name: "Governed review workspaces" })).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer open onClose={vi.fn()} userRole="admin" userEmail="admin@example.com" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("button", { name: "Governed review workspaces" })).toBeInTheDocument();
+  });
+
   it("positions the mobile sheet above the bottom navigation", () => {
     render(
       <MemoryRouter initialEntries={["/dashboard"]}>

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -189,6 +189,13 @@ export const NAV_ITEMS: NavItem[] = [
     showInDrawer: true,
   },
   {
+    id: "governed-review-workspaces",
+    label: "Governed review workspaces",
+    to: "/admin/review-workspaces",
+    requiresAdmin: true,
+    showInDrawer: true,
+  },
+  {
     id: "pdf-export-observability",
     label: "PDF Observability",
     to: "/admin/pdf-export-observability",

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
@@ -159,6 +159,8 @@ describe("AdminReviewWorkspacesPage", () => {
     expect(screen.queryByRole("button", { name: /resolve/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remediate/i })).not.toBeInTheDocument();
     expect(JSON.stringify(document.body.textContent)).not.toContain("tenant-raw-id");
     expect(JSON.stringify(document.body.textContent)).not.toContain("gs://");
     expect(JSON.stringify(document.body.textContent)).not.toContain("secret-token");
@@ -206,6 +208,14 @@ describe("AdminReviewWorkspacesPage", () => {
     render(<AdminReviewWorkspacesPage />);
 
     expect(await screen.findByText(/No governed review workspace records are available yet/)).toBeInTheDocument();
+    expect(screen.getByText(/metadata-only surface is ready/)).toBeInTheDocument();
+    expect(screen.getByText(/append-only persistence and write governance are enabled/)).toBeInTheDocument();
+    expect(screen.getByText(/Unsupported or raw-only records are excluded by default/)).toBeInTheDocument();
     expect(screen.getByText(/No governed review workspace append records/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resolve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remediate/i })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
@@ -286,8 +286,11 @@ export default function AdminReviewWorkspacesPage() {
             {!loading && workspaces.length === 0 ? (
               <Card>
                 <div style={{ fontWeight: 700 }}>No governed review workspace records are available yet.</div>
-                <div style={{ color: "#64748b", marginTop: 6 }}>
-                  {summary.emptyState || "Append-only workspace records will appear here after an approved append store is populated."}
+                <div style={{ color: "#64748b", marginTop: 6, display: "grid", gap: 6 }}>
+                  <div>This metadata-only surface is ready, but no persisted governed review workspace records exist yet.</div>
+                  <div>Workspace records will appear after append-only persistence and write governance are enabled.</div>
+                  <div>Unsupported or raw-only records are excluded by default.</div>
+                  {summary.emptyState ? <div>{summary.emptyState}</div> : null}
                 </div>
               </Card>
             ) : null}


### PR DESCRIPTION
## Summary
- Adds a restrained admin drawer navigation entry for `/admin/review-workspaces`.
- Refines the governed review workspace empty state to clarify that no persisted append-only records exist yet.
- Extends frontend tests for admin-only navigation visibility, empty-state copy, and absence of mutation/remediation controls.

## Scope and safety
- Frontend-only change.
- No backend route changes, persistence, mutation controls, approve/resolve/dismiss actions, automation, remediation, tenant/landlord exposure, or dependency changes.
- The page remains metadata-only and read-only.

## Validation
- `npm run test -- src/pages/admin/AdminReviewWorkspacesPage.test.tsx src/components/layout/WorkspaceDrawer.test.tsx` passed: 7 tests.
- `npm run build` in `rentchain-frontend` passed.
- `git diff --check` and `git diff --cached --check` passed.
