### PR TITLE
Add governed review workspace preview fixtures

### DIFF
--- a/docs/reports/governed-review-workspace-preview-data-fixtures-v1.md
+++ b/docs/reports/governed-review-workspace-preview-data-fixtures-v1.md
@@ -1,0 +1,64 @@
+# Governed Review Workspace Preview Data Fixtures v1
+
+## Scope
+
+This mission adds deterministic non-production fixtures for governed review workspace admin-page validation.
+
+The fixtures are frontend test-only data under `rentchain-frontend/src/test/fixtures/`. They are not imported by runtime app code and do not create production data, persistence writes, public routes, or mutation behavior.
+
+## Fixture Coverage
+
+The fixture set includes metadata-only examples for:
+
+- Security review workspace
+- Support escalation review workspace
+- Export governance review workspace
+- Evidence review workspace
+
+Each fixture is designed to exercise the read-only admin workspace page with realistic counts, safe evidence references, append event summaries, related workspace links, retention metadata, and redaction summaries.
+
+## Safety Model
+
+Fixture records are explicitly:
+
+- `metadataOnly: true`
+- `visibilityClass: admin_support_internal`
+- `tenantVisible: false`
+- `landlordVisible: false`
+- `appendOnly: true`
+- `mutationControlsEnabled: false`
+- `rawPayloadAccessEnabled: false`
+
+The fixtures do not include raw notes, raw documents, provider payloads, screening reports, storage paths, tokens, secrets, credentials, debug payloads, request bodies, response bodies, stack traces, or raw IDs as primary labels.
+
+## Runtime And Persistence Decision
+
+No runtime fixture loading was added.
+
+No Firestore write path was added.
+
+No API route, backend helper, frontend mutation control, or public surface was added.
+
+The fixtures are limited to tests and future story/dev validation paths. Production data remains sourced only from the existing governed review workspace read routes and approved append-only persistence contracts.
+
+## Tests Added
+
+The fixture tests verify:
+
+- Required workspace categories are present.
+- Fixtures remain internal, metadata-only, append-only, and read-only.
+- Safe refs and links do not imply mutation controls.
+- Unsafe raw payload markers and raw ID labels are absent.
+- Deterministic list/detail response helpers support admin page tests.
+
+The admin page test now uses the fixture set instead of a single ad hoc workspace object.
+
+## Known Limitations
+
+- These fixtures do not populate the live admin page in production.
+- No storybook or preview-only fixture switch exists in this mission.
+- The fixtures do not validate authenticated API route behavior; route behavior is covered by the existing backend read-route tests.
+
+## Future Roadmap
+
+Future work may add a dedicated non-production story/dev harness for governed review workspaces, provided it remains disabled in production, metadata-only, admin-scoped, and free of mutation or persistence side effects.

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminReviewWorkspacesPage from "./AdminReviewWorkspacesPage";
+import {
+  getGovernedReviewWorkspaceFixtureDetail,
+  getGovernedReviewWorkspaceFixtureResponse,
+} from "../../test/fixtures/governedReviewWorkspaceFixtures";
 
 const showToast = vi.fn();
 const fetchAdminReviewWorkspaces = vi.fn();
@@ -27,116 +31,14 @@ vi.mock("../../components/ui/Ui", () => ({
   Section: ({ children }: any) => <section>{children}</section>,
 }));
 
-const WORKSPACE = {
-  workspaceId: "governed_workspace:safe",
-  workspaceType: "security_review",
-  title: "Security review workspace",
-  summary: "Metadata-only workspace summary.",
-  workflowFamily: "admin_security_incident_review",
-  severitySummary: "medium",
-  reviewStateSummary: "metadata_review_ready",
-  approvalExpectationSummary: "admin_review",
-  relatedIncidentCount: 1,
-  relatedEscalationCount: 0,
-  relatedEvidenceCount: 1,
-  relatedNoteCount: 1,
-  appendEventCount: 1,
-  retentionClass: "security_review",
-  retentionReviewAt: "2026-06-01T00:00:00.000Z",
-  lastAppendedAt: "2026-05-24T01:00:00.000Z",
-  metadataOnly: true,
-  visibilityClass: "admin_support_internal",
-  tenantVisible: false,
-  landlordVisible: false,
-  appendOnly: true,
-  mutationControlsEnabled: false,
-  rawPayloadAccessEnabled: false,
-};
-
 beforeEach(() => {
   showToast.mockReset();
   fetchAdminReviewWorkspaces.mockReset();
   fetchAdminReviewWorkspaceDetail.mockReset();
-  fetchAdminReviewWorkspaces.mockResolvedValue({
-    ok: true,
-    workspaces: [WORKSPACE],
-    summary: { total: 1, metadataOnly: true, emptyState: null },
-    schema: {
-      metadataOnly: true,
-      visibilityClass: "admin_support_internal",
-      tenantVisible: false,
-      landlordVisible: false,
-      appendOnly: true,
-      persistence: "read_only_if_present",
-      mutationControlsEnabled: false,
-      rawPayloadAccessEnabled: false,
-      createRouteEnabled: false,
-      updateRouteEnabled: false,
-      deleteRouteEnabled: false,
-    },
-  });
-  fetchAdminReviewWorkspaceDetail.mockResolvedValue({
-    ok: true,
-    workspace: {
-      ...WORKSPACE,
-      safeEvidenceRefs: [
-        {
-          referenceType: "evidence_pack",
-          referenceId: "evidence-safe",
-          label: "Evidence metadata reference",
-          internalReference: true,
-          metadataOnly: true,
-        },
-      ],
-      relatedWorkspaceLinks: [
-        {
-          linkId: "workspace_link:safe",
-          linkType: "incident_to_review_workspace",
-          sourceSummary: {
-            kind: "security_incident",
-            label: "Security incident",
-            category: "policy_denied",
-            severity: "medium",
-            state: "open",
-            metadataOnly: true,
-            rawIdsIncluded: false,
-          },
-          targetSummary: {
-            kind: "review_workspace",
-            label: "Governed workspace",
-            category: "security_review",
-            severity: "medium",
-            state: "metadata_review_ready",
-            metadataOnly: true,
-            rawIdsIncluded: false,
-          },
-          workflowFamily: "admin_security_incident_review",
-          metadataOnly: true,
-          visibilityClass: "admin_support_internal",
-          tenantVisible: false,
-          landlordVisible: false,
-          appendCompatible: true,
-          mutationControlsEnabled: false,
-        },
-      ],
-      appendEventSummaries: [
-        {
-          eventRefId: "event-safe",
-          eventType: "workspace_candidate_created",
-          eventSummary: "Workspace candidate created.",
-          occurredAt: "2026-05-24T01:00:00.000Z",
-          metadataOnly: true,
-          visibilityClass: "admin_support_internal",
-          tenantVisible: false,
-          landlordVisible: false,
-          appendOnly: true,
-        },
-      ],
-      redactionSummary: "Raw notes, documents, storage paths, tokens, secrets, and debug payloads are excluded.",
-      payloadSafety: { rawPayloads: "excluded" },
-      persistenceDecision: "contract_only_firestore_deferred",
-    },
-  });
+  fetchAdminReviewWorkspaces.mockResolvedValue(getGovernedReviewWorkspaceFixtureResponse());
+  fetchAdminReviewWorkspaceDetail.mockImplementation((workspaceId: string) =>
+    Promise.resolve(getGovernedReviewWorkspaceFixtureDetail(workspaceId))
+  );
 });
 
 afterEach(() => {
@@ -150,8 +52,11 @@ describe("AdminReviewWorkspacesPage", () => {
 
     expect(await screen.findByRole("heading", { name: "Governed review workspaces" })).toBeInTheDocument();
     expect((await screen.findAllByText("Security review workspace")).length).toBeGreaterThan(0);
+    expect(screen.getByText("Support escalation review workspace")).toBeInTheDocument();
+    expect(screen.getByText("Export governance review workspace")).toBeInTheDocument();
+    expect(screen.getByText("Evidence review workspace")).toBeInTheDocument();
     expect(await screen.findByText(/Workspace Candidate Created/)).toBeInTheDocument();
-    expect(await screen.findByText(/Evidence metadata reference/)).toBeInTheDocument();
+    expect(await screen.findByText(/Security review workspace evidence metadata/)).toBeInTheDocument();
     expect(await screen.findByText(/Incident To Review Workspace/)).toBeInTheDocument();
     expect(screen.getAllByText("Metadata only").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Read only").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/test/fixtures/governedReviewWorkspaceFixtures.test.ts
+++ b/rentchain-frontend/src/test/fixtures/governedReviewWorkspaceFixtures.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getGovernedReviewWorkspaceFixtureDetail,
+  getGovernedReviewWorkspaceFixtureResponse,
+  governedReviewWorkspaceFixtureDetails,
+  governedReviewWorkspaceFixtureRecords,
+  governedReviewWorkspaceFixtureScope,
+} from "./governedReviewWorkspaceFixtures";
+
+const UNSAFE_PATTERNS = [
+  "gs://",
+  "storage.googleapis.com",
+  "secret-token",
+  "Bearer ",
+  "credential-value",
+  "authorization:",
+  "cookie=",
+  "rawProviderPayload",
+  "rawDocument",
+  "rawNote",
+  "requestBody",
+  "responseBody",
+  "stackTrace",
+  "debugPayload",
+  "tenant-raw-id",
+  "landlord-raw-id",
+];
+
+function collectStrings(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (!value || typeof value !== "object") return [];
+  if (Array.isArray(value)) return value.flatMap(collectStrings);
+  return Object.values(value as Record<string, unknown>).flatMap(collectStrings);
+}
+
+describe("governed review workspace preview fixtures", () => {
+  it("covers required metadata-only workspace examples", () => {
+    expect(governedReviewWorkspaceFixtureRecords.map((item) => item.workspaceType)).toEqual([
+      "security_review",
+      "support_escalation_review",
+      "export_governance_review",
+      "evidence_review",
+    ]);
+    expect(governedReviewWorkspaceFixtureScope).toMatchObject({
+      fixtureOnly: true,
+      productionRuntime: false,
+      firestoreWrites: false,
+      mutationControlsEnabled: false,
+      tenantVisible: false,
+      landlordVisible: false,
+    });
+  });
+
+  it("keeps records and details internal, metadata-only, append-only, and read-only", () => {
+    for (const record of governedReviewWorkspaceFixtureRecords) {
+      expect(record).toMatchObject({
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+      });
+      expect(record.title).not.toContain(record.workspaceId);
+    }
+
+    for (const detail of Object.values(governedReviewWorkspaceFixtureDetails)) {
+      expect(detail.safeEvidenceRefs.every((ref) => ref.metadataOnly && ref.internalReference)).toBe(true);
+      expect(detail.relatedWorkspaceLinks.every((link) => link.metadataOnly && !link.mutationControlsEnabled)).toBe(true);
+      expect(detail.appendEventSummaries.every((event) => event.metadataOnly && event.appendOnly)).toBe(true);
+      expect(detail.payloadSafety).toMatchObject({
+        rawNotes: "excluded",
+        rawDocuments: "excluded",
+        providerPayloads: "excluded",
+        storagePaths: "excluded",
+        tokens: "excluded",
+        secrets: "excluded",
+        debugPayloads: "excluded",
+        requestResponseBodies: "excluded",
+      });
+    }
+  });
+
+  it("does not carry unsafe raw payload markers or raw IDs as labels", () => {
+    const strings = collectStrings({
+      records: governedReviewWorkspaceFixtureRecords,
+      details: governedReviewWorkspaceFixtureDetails,
+    });
+    const joined = strings.join("\n");
+
+    for (const pattern of UNSAFE_PATTERNS) {
+      expect(joined).not.toContain(pattern);
+    }
+    for (const detail of Object.values(governedReviewWorkspaceFixtureDetails)) {
+      for (const link of detail.relatedWorkspaceLinks) {
+        expect(link.sourceSummary.rawIdsIncluded).toBe(false);
+        expect(link.targetSummary.rawIdsIncluded).toBe(false);
+      }
+    }
+  });
+
+  it("returns deterministic list and detail responses for page tests", () => {
+    const response = getGovernedReviewWorkspaceFixtureResponse();
+    const detail = getGovernedReviewWorkspaceFixtureDetail("fixture_workspace_security_review");
+
+    expect(response.summary.total).toBe(4);
+    expect(response.schema).toMatchObject({
+      metadataOnly: true,
+      tenantVisible: false,
+      landlordVisible: false,
+      createRouteEnabled: false,
+      updateRouteEnabled: false,
+      deleteRouteEnabled: false,
+    });
+    expect(detail.workspace.title).toBe("Security review workspace");
+  });
+});

--- a/rentchain-frontend/src/test/fixtures/governedReviewWorkspaceFixtures.ts
+++ b/rentchain-frontend/src/test/fixtures/governedReviewWorkspaceFixtures.ts
@@ -1,0 +1,246 @@
+import type {
+  GovernedReviewWorkspaceDetail,
+  GovernedReviewWorkspaceRecord,
+  GovernedReviewWorkspaceSummary,
+} from "../../api/adminReviewWorkspacesApi";
+
+export const governedReviewWorkspaceFixtureScope = {
+  fixtureOnly: true,
+  productionRuntime: false,
+  firestoreWrites: false,
+  publicRoutes: false,
+  mutationControlsEnabled: false,
+  tenantVisible: false,
+  landlordVisible: false,
+} as const;
+
+export const governedReviewWorkspaceFixtureDates = {
+  now: "2026-05-24T12:00:00.000Z",
+  retentionReview: "2026-06-24T12:00:00.000Z",
+} as const;
+
+const payloadSafety = {
+  rawNotes: "excluded",
+  rawDocuments: "excluded",
+  providerPayloads: "excluded",
+  storagePaths: "excluded",
+  tokens: "excluded",
+  secrets: "excluded",
+  debugPayloads: "excluded",
+  requestResponseBodies: "excluded",
+} as const;
+
+function record(input: {
+  workspaceId: string;
+  workspaceType: string;
+  title: string;
+  summary: string;
+  workflowFamily: string;
+  severitySummary: string;
+  reviewStateSummary: string;
+  approvalExpectationSummary: string;
+  relatedIncidentCount?: number;
+  relatedEscalationCount?: number;
+  relatedEvidenceCount?: number;
+  relatedNoteCount?: number;
+  appendEventCount?: number;
+}): GovernedReviewWorkspaceRecord {
+  return {
+    workspaceId: input.workspaceId,
+    workspaceType: input.workspaceType,
+    title: input.title,
+    summary: input.summary,
+    workflowFamily: input.workflowFamily,
+    severitySummary: input.severitySummary,
+    reviewStateSummary: input.reviewStateSummary,
+    approvalExpectationSummary: input.approvalExpectationSummary,
+    relatedIncidentCount: input.relatedIncidentCount ?? 0,
+    relatedEscalationCount: input.relatedEscalationCount ?? 0,
+    relatedEvidenceCount: input.relatedEvidenceCount ?? 1,
+    relatedNoteCount: input.relatedNoteCount ?? 1,
+    appendEventCount: input.appendEventCount ?? 1,
+    retentionClass: input.workspaceType,
+    retentionReviewAt: governedReviewWorkspaceFixtureDates.retentionReview,
+    lastAppendedAt: governedReviewWorkspaceFixtureDates.now,
+    metadataOnly: true,
+    visibilityClass: "admin_support_internal",
+    tenantVisible: false,
+    landlordVisible: false,
+    appendOnly: true,
+    mutationControlsEnabled: false,
+    rawPayloadAccessEnabled: false,
+  };
+}
+
+function detail(base: GovernedReviewWorkspaceRecord, input: {
+  evidenceLabel: string;
+  linkType: string;
+  sourceLabel: string;
+  targetLabel: string;
+  eventSummary: string;
+}): GovernedReviewWorkspaceDetail {
+  return {
+    ...base,
+    safeEvidenceRefs: [
+      {
+        referenceType: "evidence_metadata",
+        referenceId: `${base.workspaceType}_fixture_ref`,
+        label: input.evidenceLabel,
+        internalReference: true,
+        metadataOnly: true,
+      },
+    ],
+    relatedWorkspaceLinks: [
+      {
+        linkId: `${base.workspaceType}_fixture_link`,
+        linkType: input.linkType,
+        sourceSummary: {
+          kind: "governed_review_source",
+          label: input.sourceLabel,
+          category: base.workspaceType,
+          severity: base.severitySummary,
+          state: base.reviewStateSummary,
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        },
+        targetSummary: {
+          kind: "governed_review_workspace",
+          label: input.targetLabel,
+          category: base.workspaceType,
+          severity: base.severitySummary,
+          state: base.reviewStateSummary,
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        },
+        workflowFamily: base.workflowFamily || "governed_review_workspace",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendCompatible: true,
+        mutationControlsEnabled: false,
+      },
+    ],
+    appendEventSummaries: [
+      {
+        eventRefId: `${base.workspaceType}_fixture_append_event`,
+        eventType: "workspace_candidate_created",
+        eventSummary: input.eventSummary,
+        occurredAt: governedReviewWorkspaceFixtureDates.now,
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+      },
+    ],
+    redactionSummary:
+      "Fixture excludes raw notes, documents, provider payloads, storage paths, tokens, secrets, debug payloads, and request or response bodies.",
+    payloadSafety,
+    persistenceDecision: "test_fixture_only_no_firestore_writes",
+  };
+}
+
+export const governedReviewWorkspaceFixtureRecords: GovernedReviewWorkspaceRecord[] = [
+  record({
+    workspaceId: "fixture_workspace_security_review",
+    workspaceType: "security_review",
+    title: "Security review workspace",
+    summary: "Metadata-only review of policy and route-source signals.",
+    workflowFamily: "admin_security_incident_review",
+    severitySummary: "medium",
+    reviewStateSummary: "metadata_review_ready",
+    approvalExpectationSummary: "admin_review",
+    relatedIncidentCount: 2,
+  }),
+  record({
+    workspaceId: "fixture_workspace_support_escalation_review",
+    workspaceType: "support_escalation_review",
+    title: "Support escalation review workspace",
+    summary: "Metadata-only review of manual support escalation context.",
+    workflowFamily: "admin_support_escalation_review",
+    severitySummary: "high",
+    reviewStateSummary: "manual_review_required",
+    approvalExpectationSummary: "support_lead_review",
+    relatedEscalationCount: 1,
+  }),
+  record({
+    workspaceId: "fixture_workspace_export_governance_review",
+    workspaceType: "export_governance_review",
+    title: "Export governance review workspace",
+    summary: "Metadata-only review of export readiness and redaction posture.",
+    workflowFamily: "export_governance_review",
+    severitySummary: "low",
+    reviewStateSummary: "metadata_review_ready",
+    approvalExpectationSummary: "metadata_review_only",
+    relatedEvidenceCount: 2,
+  }),
+  record({
+    workspaceId: "fixture_workspace_evidence_review",
+    workspaceType: "evidence_review",
+    title: "Evidence review workspace",
+    summary: "Metadata-only review of safe evidence references and linkage.",
+    workflowFamily: "evidence_review",
+    severitySummary: "medium",
+    reviewStateSummary: "metadata_review_ready",
+    approvalExpectationSummary: "admin_review",
+    relatedEvidenceCount: 3,
+    relatedNoteCount: 2,
+  }),
+];
+
+export const governedReviewWorkspaceFixtureDetails: Record<string, GovernedReviewWorkspaceDetail> = Object.fromEntries(
+  governedReviewWorkspaceFixtureRecords.map((item) => [
+    item.workspaceId,
+    detail(item, {
+      evidenceLabel: `${item.title} evidence metadata`,
+      linkType:
+        item.workspaceType === "security_review"
+          ? "incident_to_review_workspace"
+          : item.workspaceType === "support_escalation_review"
+            ? "escalation_to_runbook"
+            : item.workspaceType === "export_governance_review"
+              ? "escalation_to_evidence"
+              : "incident_to_evidence",
+      sourceLabel: item.workspaceType === "support_escalation_review" ? "Support escalation summary" : "Governed review source",
+      targetLabel: "Governed review workspace",
+      eventSummary: `${item.title} fixture candidate created.`,
+    }),
+  ]),
+) as Record<string, GovernedReviewWorkspaceDetail>;
+
+export const governedReviewWorkspaceFixtureSummary: GovernedReviewWorkspaceSummary = {
+  total: governedReviewWorkspaceFixtureRecords.length,
+  metadataOnly: true,
+  emptyState: null,
+};
+
+export function getGovernedReviewWorkspaceFixtureResponse() {
+  return {
+    ok: true as const,
+    workspaces: governedReviewWorkspaceFixtureRecords,
+    summary: governedReviewWorkspaceFixtureSummary,
+    schema: {
+      metadataOnly: true as const,
+      visibilityClass: "admin_support_internal" as const,
+      tenantVisible: false as const,
+      landlordVisible: false as const,
+      appendOnly: true as const,
+      persistence: "read_only_if_present" as const,
+      mutationControlsEnabled: false as const,
+      rawPayloadAccessEnabled: false as const,
+      createRouteEnabled: false as const,
+      updateRouteEnabled: false as const,
+      deleteRouteEnabled: false as const,
+    },
+  };
+}
+
+export function getGovernedReviewWorkspaceFixtureDetail(workspaceId: string) {
+  return {
+    ok: true as const,
+    workspace:
+      governedReviewWorkspaceFixtureDetails[workspaceId] ||
+      governedReviewWorkspaceFixtureDetails[governedReviewWorkspaceFixtureRecords[0].workspaceId],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds deterministic frontend test fixtures for governed review workspace records.
- Covers security review, support escalation review, export governance review, and evidence review workspace examples.
- Updates the admin review workspace page test to use the realistic metadata-only fixture set.
- Adds a governance report documenting fixture scope, safety model, and non-production limitations.

## Scope and safety
- Frontend test-only fixtures; no runtime fixture loading.
- No production data, Firestore writes, backend routes, persistence, public routes, mutation controls, tenant/landlord exposure, automation, or dependency changes.
- Fixture tests assert metadata-only, admin-support-internal, append-only, read-only behavior and absence of unsafe raw payload markers.

## Validation
- `npm run test -- src/test/fixtures/governedReviewWorkspaceFixtures.test.ts src/pages/admin/AdminReviewWorkspacesPage.test.tsx` passed: 7 tests.
- `npm run build` in `rentchain-frontend` passed.
- `git diff --check` and `git diff --cached --check` passed.
