### PR TITLE
Polish mobile landlord navigation

### DIFF
--- a/rentchain-frontend/src/components/admin/AdminDataTable.css
+++ b/rentchain-frontend/src/components/admin/AdminDataTable.css
@@ -1,0 +1,71 @@
+.rc-admin-properties-mobile-list {
+  display: none;
+}
+
+.rc-admin-properties-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rc-admin-properties-table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+}
+
+@media (max-width: 820px) {
+  .rc-admin-properties-mobile-list {
+    display: grid;
+    gap: 10px;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .rc-admin-properties-table-wrap {
+    display: none;
+  }
+
+  .rc-admin-property-card {
+    appearance: none;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    display: grid;
+    gap: 8px;
+    text-align: left;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 12px;
+    background: #fff;
+    color: #0f172a;
+    padding: 12px;
+    box-sizing: border-box;
+    cursor: pointer;
+    overflow: hidden;
+  }
+
+  .rc-admin-property-card__title {
+    font-weight: 800;
+    overflow-wrap: anywhere;
+  }
+
+  .rc-admin-property-card__address,
+  .rc-admin-property-card__meta,
+  .rc-admin-property-card__stats,
+  .rc-admin-property-card__footer {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: #475569;
+    font-size: 13px;
+  }
+
+  .rc-admin-property-card__meta,
+  .rc-admin-property-card__stats,
+  .rc-admin-property-card__footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 10px;
+    align-items: center;
+  }
+}

--- a/rentchain-frontend/src/components/admin/AdminDataTable.tsx
+++ b/rentchain-frontend/src/components/admin/AdminDataTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { AdminPropertyView } from "../../api/adminApi";
 import { IntegrityBadge } from "./IntegrityBadge";
+import "./AdminDataTable.css";
 
 function formatDate(value: string | number | null) {
   if (value == null || value === "") return "--";
@@ -16,6 +17,10 @@ function ownerDisplayName(item: AdminPropertyView) {
   return item.ownerDisplayName || item.ownerStatusLabel || "Owner profile unavailable";
 }
 
+function propertyAddress(item: AdminPropertyView) {
+  return [item.address1, item.city].filter(Boolean).join(", ") || "Address unavailable";
+}
+
 type Props = {
   items: AdminPropertyView[];
   sortBy: "createdAt" | "updatedAt" | "name";
@@ -29,30 +34,58 @@ export const AdminDataTable: React.FC<Props> = ({ items, sortBy, sortDir, onSort
     `${label}${sortBy === field ? ` (${sortDir})` : ""}`;
 
   return (
-    <div style={{ overflowX: "auto" }}>
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
-        <thead>
-          <tr style={{ textAlign: "left", borderBottom: "1px solid rgba(148,163,184,0.22)" }}>
-            <th style={{ padding: "10px 12px" }}>
-              <button type="button" onClick={() => onSortChange("name")} style={{ background: "transparent", border: 0, fontWeight: 700, cursor: "pointer" }}>
-                {sortLabel("name", "Property")}
-              </button>
-            </th>
-            <th style={{ padding: "10px 12px" }}>Address</th>
-            <th style={{ padding: "10px 12px" }}>Province</th>
-            <th style={{ padding: "10px 12px" }}>Owner / Landlord</th>
-            <th style={{ padding: "10px 12px" }}>Units</th>
-            <th style={{ padding: "10px 12px" }}>Occupied</th>
-            <th style={{ padding: "10px 12px" }}>Vacant</th>
-            <th style={{ padding: "10px 12px" }}>Integrity</th>
-            <th style={{ padding: "10px 12px" }}>
-              <button type="button" onClick={() => onSortChange("updatedAt")} style={{ background: "transparent", border: 0, fontWeight: 700, cursor: "pointer" }}>
-                {sortLabel("updatedAt", "Updated")}
-              </button>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+    <>
+      <div className="rc-admin-properties-mobile-list" aria-label="Admin properties mobile list">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className="rc-admin-property-card"
+            onClick={() => onSelect(item)}
+          >
+            <span className="rc-admin-property-card__title">{propertyDisplayName(item)}</span>
+            <span className="rc-admin-property-card__address">{propertyAddress(item)}</span>
+            <span className="rc-admin-property-card__meta">
+              <span>{ownerDisplayName(item)}</span>
+              <span>{item.ownerStatusLabel || "Ownership status unavailable"}</span>
+            </span>
+            <span className="rc-admin-property-card__stats">
+              <span>{item.unitCount} units</span>
+              <span>{item.occupiedUnitCount} occupied</span>
+              <span>{item.vacantUnitCount} vacant</span>
+            </span>
+            <span className="rc-admin-property-card__footer">
+              <IntegrityBadge integrity={item.integrity} />
+              <span>Updated {formatDate(item.updatedAt)}</span>
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <div className="rc-admin-properties-table-wrap">
+        <table className="rc-admin-properties-table">
+          <thead>
+            <tr style={{ textAlign: "left", borderBottom: "1px solid rgba(148,163,184,0.22)" }}>
+              <th style={{ padding: "10px 12px" }}>
+                <button type="button" onClick={() => onSortChange("name")} style={{ background: "transparent", border: 0, fontWeight: 700, cursor: "pointer" }}>
+                  {sortLabel("name", "Property")}
+                </button>
+              </th>
+              <th style={{ padding: "10px 12px" }}>Address</th>
+              <th style={{ padding: "10px 12px" }}>Province</th>
+              <th style={{ padding: "10px 12px" }}>Owner / Landlord</th>
+              <th style={{ padding: "10px 12px" }}>Units</th>
+              <th style={{ padding: "10px 12px" }}>Occupied</th>
+              <th style={{ padding: "10px 12px" }}>Vacant</th>
+              <th style={{ padding: "10px 12px" }}>Integrity</th>
+              <th style={{ padding: "10px 12px" }}>
+                <button type="button" onClick={() => onSortChange("updatedAt")} style={{ background: "transparent", border: 0, fontWeight: 700, cursor: "pointer" }}>
+                  {sortLabel("updatedAt", "Updated")}
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
           {items.map((item) => (
             <tr
               key={item.id}
@@ -63,7 +96,7 @@ export const AdminDataTable: React.FC<Props> = ({ items, sortBy, sortDir, onSort
                 <div style={{ fontWeight: 700 }}>{propertyDisplayName(item)}</div>
                 <div style={{ fontSize: 12, color: "#64748b" }}>Admin property record</div>
               </td>
-              <td style={{ padding: "12px" }}>{[item.address1, item.city].filter(Boolean).join(", ") || "--"}</td>
+              <td style={{ padding: "12px" }}>{propertyAddress(item)}</td>
               <td style={{ padding: "12px" }}>{item.province || "--"}</td>
               <td style={{ padding: "12px" }}>
                 <div>{ownerDisplayName(item)}</div>
@@ -78,8 +111,9 @@ export const AdminDataTable: React.FC<Props> = ({ items, sortBy, sortDir, onSort
               <td style={{ padding: "12px" }}>{formatDate(item.updatedAt)}</td>
             </tr>
           ))}
-        </tbody>
-      </table>
-    </div>
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 };

--- a/rentchain-frontend/src/components/agentSupervision/AgentSupervisionConsole.tsx
+++ b/rentchain-frontend/src/components/agentSupervision/AgentSupervisionConsole.tsx
@@ -38,7 +38,8 @@ function Badge({ children, tone }: { children: React.ReactNode; tone: { color: s
         padding: "3px 9px",
         fontSize: 12,
         fontWeight: 800,
-        whiteSpace: "nowrap",
+        maxWidth: "100%",
+        overflowWrap: "anywhere",
       }}
     >
       {children}
@@ -48,12 +49,12 @@ function Badge({ children, tone }: { children: React.ReactNode; tone: { color: s
 
 function SupervisionItemCard({ item }: { item: AgentSupervisionItem }) {
   return (
-    <Card style={{ borderRadius: 8, padding: 12, display: "grid", gap: 8 }}>
-      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+    <Card style={{ borderRadius: 8, padding: 12, display: "grid", gap: 8, minWidth: 0, maxWidth: "100%" }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", minWidth: 0, maxWidth: "100%" }}>
         <Badge tone={severityTone(item.severity)}>{label(item.severity)}</Badge>
         <Badge tone={statusTone(item.status)}>{label(item.status)}</Badge>
-        <span style={{ color: "#475569", fontSize: 13, fontWeight: 800 }}>{label(item.itemType)}</span>
-        <span style={{ color: "#64748b", fontSize: 13 }}>
+        <span style={{ color: "#475569", fontSize: 13, fontWeight: 800, minWidth: 0, overflowWrap: "anywhere" }}>{label(item.itemType)}</span>
+        <span style={{ color: "#64748b", fontSize: 13, minWidth: 0, maxWidth: "100%", overflowWrap: "anywhere" }}>
           Scope: {label(item.relatedScope.scope)} {item.relatedScope.scopeId}
         </span>
       </div>
@@ -71,7 +72,7 @@ function SupervisionItemCard({ item }: { item: AgentSupervisionItem }) {
           ))}
         </div>
       ) : null}
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 800 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 800, minWidth: 0 }}>
         <span>Manual review required</span>
         <span>Policy guarded</span>
         <span>Human approval required</span>
@@ -88,9 +89,9 @@ function SupervisionItemCard({ item }: { item: AgentSupervisionItem }) {
 function ItemSection({ title, items }: { title: string; items: AgentSupervisionItem[] }) {
   if (!items.length) return null;
   return (
-    <Section style={{ display: "grid", gap: 10 }}>
+    <Section style={{ display: "grid", gap: 10, minWidth: 0, maxWidth: "100%", overflowX: "hidden" }}>
       <div style={{ fontWeight: 900, color: "#0f172a" }}>{title}</div>
-      <div style={{ display: "grid", gap: 10 }}>
+      <div style={{ display: "grid", gap: 10, minWidth: 0, maxWidth: "100%" }}>
         {items.map((item) => (
           <SupervisionItemCard key={item.supervisionItemId} item={item} />
         ))}
@@ -101,8 +102,8 @@ function ItemSection({ title, items }: { title: string; items: AgentSupervisionI
 
 export function AgentSupervisionConsole({ snapshot }: { snapshot: AgentSupervisionSnapshot }) {
   return (
-    <div style={{ display: "grid", gap: 16 }}>
-      <Section style={{ display: "grid", gap: 8 }}>
+    <div style={{ display: "grid", gap: 16, minWidth: 0, maxWidth: "100%", overflowX: "hidden" }}>
+      <Section style={{ display: "grid", gap: 8, minWidth: 0, maxWidth: "100%" }}>
         <div style={{ display: "grid", gap: 4 }}>
           <strong style={{ color: "#0f172a" }}>Supervised operational intelligence only.</strong>
           <span style={{ color: "#475569" }}>
@@ -110,16 +111,16 @@ export function AgentSupervisionConsole({ snapshot }: { snapshot: AgentSupervisi
             external submission is automated.
           </span>
         </div>
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 900 }}>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 900, minWidth: 0 }}>
           <span>External execution disabled</span>
           <span>Autonomous execution disabled</span>
           <span>Manual review required</span>
         </div>
       </Section>
 
-      <Section style={{ display: "grid", gap: 10 }}>
+      <Section style={{ display: "grid", gap: 10, minWidth: 0, maxWidth: "100%" }}>
         <div style={{ fontWeight: 900 }}>Supervision summary</div>
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(145px, 1fr))", gap: 10 }}>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(145px, 100%), 1fr))", gap: 10, minWidth: 0 }}>
           {[
             ["Suggested actions", snapshot.summary.suggestedActions],
             ["Blocked actions", snapshot.summary.blockedActions],
@@ -127,8 +128,8 @@ export function AgentSupervisionConsole({ snapshot }: { snapshot: AgentSupervisi
             ["Escalations", snapshot.summary.escalations],
             ["Workflow sync issues", snapshot.summary.workflowSyncIssues],
           ].map(([name, value]) => (
-            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
-              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12, minWidth: 0 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800, overflowWrap: "anywhere" }}>{name}</div>
               <strong style={{ color: "#0f172a", fontSize: 22 }}>{value}</strong>
             </Card>
           ))}

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -1,5 +1,5 @@
 :root {
-  --rc-mobile-bottom-nav-height: 104px;
+  --rc-mobile-bottom-nav-height: 88px;
   --rc-mobile-drawer-bottom-offset: calc(
     var(--rc-mobile-bottom-nav-height) + env(safe-area-inset-bottom, 0px)
   );
@@ -8,6 +8,10 @@
 .rc-landlord-shell {
   min-height: 100vh;
   position: relative;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  box-sizing: border-box;
 }
 
 .rc-landlord-topnav {
@@ -16,6 +20,15 @@
 
 .rc-landlord-content {
   padding: 12px 0 24px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+.rc-landlord-mobile-topbar {
+  display: none;
 }
 
 .rc-landlord-hamburger {
@@ -162,7 +175,7 @@
   padding: 8px 4px;
 }
 
-.rc-mobile-tabbar {
+.rc-landlord-mobile-tabbar {
   display: none;
   position: fixed;
   bottom: 0;
@@ -173,9 +186,12 @@
   padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px));
   grid-template-columns: repeat(5, 1fr);
   z-index: 20;
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
-.rc-mobile-tabbar button {
+.rc-landlord-mobile-tabbar button {
   border: none;
   background: transparent;
   display: grid;
@@ -190,12 +206,13 @@
   border-radius: 10px;
 }
 
-.rc-mobile-tabbar button.active {
+.rc-landlord-mobile-tabbar button.active {
   color: #111827;
   font-weight: 700;
+  background: rgba(37, 99, 235, 0.08);
 }
 
-.rc-mobile-tabbar-label {
+.rc-landlord-mobile-tabbar-label {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -205,7 +222,7 @@
   white-space: nowrap;
 }
 
-.rc-mobile-tabbar-dot {
+.rc-landlord-mobile-tabbar-dot {
   width: 8px;
   height: 8px;
   border-radius: 8px;
@@ -214,12 +231,74 @@
 }
 
 @media (max-width: 820px) {
+  .rc-landlord-shell,
+  .rc-landlord-shell *,
+  .rc-landlord-shell *::before,
+  .rc-landlord-shell *::after {
+    box-sizing: border-box;
+  }
+
+  .rc-landlord-shell {
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
   .rc-landlord-topnav {
     display: none;
   }
 
   .rc-landlord-hamburger {
+    display: none;
+  }
+
+  .rc-landlord-mobile-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 90;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 58px;
+    padding:
+      calc(8px + env(safe-area-inset-top, 0px))
+      max(16px, env(safe-area-inset-right, 0px))
+      8px
+      max(16px, env(safe-area-inset-left, 0px));
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(12px);
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+
+  .rc-landlord-mobile-role {
     display: inline-flex;
+    align-items: center;
+    min-height: 34px;
+    margin-left: auto;
+    padding: 0 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: #f8fafc;
+    color: #475569;
+    font-size: 12px;
+    font-weight: 800;
+  }
+
+  .rc-landlord-mobile-menu {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    background: #ffffff;
+    color: #0f172a;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
   }
 
   .rc-landlord-account-badge {
@@ -228,7 +307,43 @@
   }
 
   .rc-landlord-content {
-    padding: 12px max(16px, env(safe-area-inset-left, 0px)) 118px max(16px, env(safe-area-inset-right, 0px));
+    padding:
+      12px
+      max(16px, env(safe-area-inset-left, 0px))
+      calc(24px + env(safe-area-inset-bottom, 0px))
+      max(16px, env(safe-area-inset-right, 0px));
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+
+  .rc-landlord-shell--mobile-tabs .rc-landlord-content {
+    padding-bottom: calc(var(--rc-mobile-bottom-nav-height) + 24px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .rc-landlord-content > *,
+  .rc-landlord-content main,
+  .rc-landlord-content section,
+  .rc-landlord-content article,
+  .rc-landlord-content form,
+  .rc-landlord-content table,
+  .rc-landlord-content [role="table"],
+  .rc-landlord-content [class*="grid"],
+  .rc-landlord-content [class*="Grid"],
+  .rc-landlord-content [class*="row"],
+  .rc-landlord-content [class*="Row"],
+  .rc-landlord-content [class*="card"],
+  .rc-landlord-content [class*="Card"] {
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .rc-landlord-content img,
+  .rc-landlord-content svg,
+  .rc-landlord-content canvas,
+  .rc-landlord-content video {
+    max-width: 100%;
   }
 
   .rc-landlord-content--mobile-flush {
@@ -239,17 +354,23 @@
   .rc-mac-shell-main {
     padding-left: 0 !important;
     padding-right: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+    overflow-x: hidden !important;
   }
 
-  .rc-mobile-tabbar {
+  .rc-landlord-mobile-tabbar {
     display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     z-index: 100;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
   }
 
   .rc-landlord-backdrop {
     z-index: 60;
-    bottom: var(--rc-mobile-drawer-bottom-offset);
   }
 
   .rc-landlord-drawer {
@@ -257,10 +378,10 @@
     top: auto;
     left: max(12px, env(safe-area-inset-left, 0px));
     right: max(12px, env(safe-area-inset-right, 0px));
-    bottom: var(--rc-mobile-drawer-bottom-offset);
+    bottom: calc(12px + env(safe-area-inset-bottom, 0px));
     width: auto;
-    max-height: min(calc(100vh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
-    max-height: min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
+    max-height: min(calc(100vh - 32px - env(safe-area-inset-bottom, 0px)), 560px);
+    max-height: min(calc(100dvh - 32px - env(safe-area-inset-bottom, 0px)), 560px);
     border-radius: 20px;
     box-shadow: 0 -18px 40px rgba(15, 23, 42, 0.18);
     transform: translateY(calc(100% + 24px));
@@ -269,6 +390,16 @@
 
   .rc-landlord-drawer.is-open {
     transform: translateY(0);
+  }
+
+  .rc-landlord-backdrop--nav-safe {
+    bottom: var(--rc-mobile-drawer-bottom-offset);
+  }
+
+  .rc-landlord-drawer--nav-safe {
+    bottom: var(--rc-mobile-drawer-bottom-offset);
+    max-height: min(calc(100vh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
+    max-height: min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
   }
 
   .rc-landlord-drawer-header {

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -7,11 +7,18 @@ const mocks = vi.hoisted(() => ({
   logout: vi.fn(),
   fetchLandlordConversations: vi.fn(),
   useCapabilities: vi.fn(),
+  user: { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" } as {
+    id: string;
+    role: string;
+    actorRole: string;
+    email: string;
+    permissions?: string[];
+  },
 }));
 
 vi.mock("../../context/useAuth", () => ({
   useAuth: () => ({
-    user: { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" },
+    user: mocks.user,
     logout: mocks.logout,
     ready: true,
     isLoading: false,
@@ -65,6 +72,7 @@ describe("LandlordNav mobile drawer", () => {
   });
 
   beforeEach(() => {
+    mocks.user = { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" };
     mocks.logout.mockReset();
     mocks.fetchLandlordConversations.mockResolvedValue([]);
     mocks.useCapabilities.mockReturnValue({
@@ -140,14 +148,62 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByTestId("current-path")).toHaveTextContent("/payments");
   });
 
-  it("uses compact labels for long mobile tabs", () => {
+  it("uses the requested landlord mobile app tabs", () => {
     renderLandlordNav();
 
     const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
-    expect(within(tabbar).getByText("Apps")).toBeInTheDocument();
-    expect(within(tabbar).getByText("Msgs")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Dashboard")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Documents")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Leases")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Messages")).toBeInTheDocument();
+    expect(within(tabbar).getByText("More")).toBeInTheDocument();
     expect(within(tabbar).queryByText("Applications")).not.toBeInTheDocument();
-    expect(within(tabbar).queryByText("Messages")).not.toBeInTheDocument();
+    expect(within(tabbar).queryByText("Tenants")).not.toBeInTheDocument();
+    expect(within(tabbar).queryByText("Properties")).not.toBeInTheDocument();
+  });
+
+  it("keeps the shared nav tab configuration aligned with the landlord mobile app tabs", async () => {
+    const { NAV_ITEMS } = await import("./navConfig");
+
+    expect(NAV_ITEMS.filter((item) => item.showInTabs).map((item) => item.label)).toEqual([
+      "Dashboard",
+      "Documents",
+      "Leases",
+      "Messages",
+    ]);
+  });
+
+  it("navigates landlord mobile tabs to canonical routes", () => {
+    renderLandlordNav();
+
+    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Documents" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/applications");
+
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Leases" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/leases");
+  });
+
+  it("does not render the landlord bottom nav for admin role contexts", () => {
+    mocks.user = { id: "admin-1", role: "admin", actorRole: "admin", email: "admin@example.com" };
+
+    renderLandlordNav();
+
+    expect(screen.queryByRole("navigation", { name: "Bottom navigation" })).not.toBeInTheDocument();
+  });
+
+  it("does not render the landlord bottom nav for admin permission contexts", () => {
+    mocks.user = {
+      id: "admin-2",
+      role: "landlord",
+      actorRole: "landlord",
+      email: "admin@example.com",
+      permissions: ["system.admin"],
+    };
+
+    renderLandlordNav();
+
+    expect(screen.queryByRole("navigation", { name: "Bottom navigation" })).not.toBeInTheDocument();
   });
 
   it("closes the drawer on Escape", async () => {

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Menu, X } from "lucide-react";
+import { FileText, LayoutDashboard, Menu, MessagesSquare, ScrollText, X } from "lucide-react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
@@ -8,12 +8,43 @@ import { getVisibleNavItems } from "./navConfig";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { UpgradeNudgeHost } from "@/features/upgradeNudges/UpgradeNudgeHost";
 import { getRoleDefaultDestination } from "@/lib/authDestination";
+import { RentChainLogo } from "../brand/RentChainLogo";
 import "./LandlordNav.css";
 
 type Props = {
   children: React.ReactNode;
   unreadMessages?: boolean;
 };
+
+const landlordMobileTabs = [
+  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { to: "/applications", label: "Documents", icon: FileText },
+  { to: "/leases", label: "Leases", icon: ScrollText },
+  { to: "/messages", label: "Messages", icon: MessagesSquare, requiresMessaging: true },
+];
+
+function includesAdminAuthority(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => includesAdminAuthority(entry));
+  }
+  const normalized = String(value || "").trim().toLowerCase();
+  return normalized === "admin" || normalized === "system.admin";
+}
+
+function isAdminContext(user: unknown): boolean {
+  const candidate = user as Record<string, any> | null | undefined;
+  if (!candidate) return false;
+  return (
+    includesAdminAuthority(candidate.role) ||
+    includesAdminAuthority(candidate.actorRole) ||
+    includesAdminAuthority(candidate.permissions) ||
+    includesAdminAuthority(candidate.claims?.permissions) ||
+    includesAdminAuthority(candidate.claims?.role) ||
+    includesAdminAuthority(candidate.claims?.actorRole) ||
+    candidate.isAdmin === true ||
+    candidate.admin === true
+  );
+}
 
 export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   const nav = useNavigate();
@@ -25,13 +56,14 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const lastFocusedRef = useRef<HTMLElement | null>(null);
   const navLoading = !ready || isLoading || authStatus === "restoring" || !user || capsLoading;
+  const isAdminLikeContext = React.useMemo(() => isAdminContext(user), [user]);
   const effectiveRole = React.useMemo(() => {
     if (navLoading) return "";
+    if (isAdminLikeContext) return "admin";
     const actorRole = String(user?.actorRole || "").trim().toLowerCase();
     const role = String(user?.role || "").trim().toLowerCase();
-    if (actorRole === "admin" || role === "admin") return "admin";
     return actorRole || role || "landlord";
-  }, [navLoading, user?.actorRole, user?.role]);
+  }, [isAdminLikeContext, navLoading, user?.actorRole, user?.role]);
   const isLandlordWorkspace = effectiveRole === "landlord" || effectiveRole === "admin";
   if (import.meta.env.DEV) {
     console.debug("[nav] role resolved", {
@@ -53,7 +85,15 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       }),
     [primaryDrawerItems]
   );
-  const tabItems = visibleItems.filter((item) => item.showInTabs);
+  const tabItems =
+    effectiveRole === "landlord" && !isAdminLikeContext
+      ? landlordMobileTabs.filter((item) => !item.requiresMessaging || features?.messaging !== false)
+      : [];
+  const showMobileBottomNav = effectiveRole === "landlord" && !isAdminLikeContext;
+  const shellClassName = [
+    "rc-landlord-shell",
+    showMobileBottomNav ? "rc-landlord-shell--mobile-tabs" : "",
+  ].filter(Boolean).join(" ");
   const contentClassName = [
     "rc-landlord-content",
     loc.pathname.startsWith("/messages") ? "rc-landlord-content--mobile-flush" : "",
@@ -65,12 +105,6 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   };
   const closeDrawer = () => {
     setDrawerOpen(false);
-  };
-
-  const mobileTabLabel = (label: string) => {
-    if (label === "Applications") return "Apps";
-    if (label === "Messages") return "Msgs";
-    return label;
   };
 
   useEffect(() => {
@@ -169,36 +203,46 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   }
 
   return (
-    <div className="rc-landlord-shell">
+    <div className={shellClassName}>
       <div className="rc-landlord-topnav">
         <TopNav />
       </div>
 
-      <button
-        type="button"
-        className="rc-landlord-hamburger"
-        aria-label="Open menu"
-        aria-expanded={drawerOpen}
-        aria-controls="rc-landlord-drawer"
-        onClick={(event) => {
-          lastFocusedRef.current = event.currentTarget;
-          setDrawerOpen(true);
-        }}
-      >
-        <span />
-        <span />
-        <span />
-      </button>
+      <div className="rc-landlord-mobile-topbar">
+        <RentChainLogo href="/dashboard" size="sm" />
+        <span className="rc-landlord-mobile-role">{effectiveRole === "admin" ? "Admin" : "Landlord"}</span>
+        <button
+          type="button"
+          className="rc-landlord-mobile-menu"
+          aria-label="Open menu"
+          aria-expanded={drawerOpen}
+          aria-controls="rc-landlord-drawer"
+          onClick={(event) => {
+            lastFocusedRef.current = event.currentTarget;
+            setDrawerOpen(true);
+          }}
+        >
+          <Menu size={20} strokeWidth={2.2} />
+        </button>
+      </div>
 
       <div
-        className={`rc-landlord-backdrop rc-landlord-backdrop--nav-safe ${drawerOpen ? "is-open" : ""}`}
+        className={[
+          "rc-landlord-backdrop",
+          showMobileBottomNav ? "rc-landlord-backdrop--nav-safe" : "",
+          drawerOpen ? "is-open" : "",
+        ].filter(Boolean).join(" ")}
         onClick={closeDrawer}
         aria-hidden={!drawerOpen}
       />
 
       <aside
         id="rc-landlord-drawer"
-        className={`rc-landlord-drawer rc-landlord-drawer--nav-safe ${drawerOpen ? "is-open" : ""}`}
+        className={[
+          "rc-landlord-drawer",
+          showMobileBottomNav ? "rc-landlord-drawer--nav-safe" : "",
+          drawerOpen ? "is-open" : "",
+        ].filter(Boolean).join(" ")}
         role="dialog"
         aria-modal={drawerOpen ? "true" : undefined}
         aria-label="Navigation menu"
@@ -226,9 +270,9 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
             </div>
           ) : (
             <div className="rc-landlord-drawer-links">
-              {orderedPrimaryDrawerItems.map(({ to, label }) => (
+              {orderedPrimaryDrawerItems.map(({ id, to, label }) => (
                 <button
-                  key={to}
+                  key={id}
                   type="button"
                   onClick={() => handleDrawerNavigation(to)}
                   className={loc.pathname.startsWith(to) ? "active" : ""}
@@ -247,9 +291,9 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
           ) : null}
           {adminDrawerItems.length ? (
             <div className="rc-landlord-drawer-links">
-              {adminDrawerItems.map(({ to, label }) => (
+              {adminDrawerItems.map(({ id, to, label }) => (
                 <button
-                  key={to}
+                  key={id}
                   type="button"
                   onClick={() => handleDrawerNavigation(to)}
                   className={loc.pathname.startsWith(to) ? "active" : ""}
@@ -265,42 +309,44 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       <UpgradeNudgeHost />
       <div className={contentClassName}>{children}</div>
 
-      <nav className="rc-mobile-tabbar" aria-label="Bottom navigation">
-        {(navLoading ? [] : tabItems).map(({ to, label, icon: Icon }) => {
-          if (!Icon) return null;
-          const active = loc.pathname.startsWith(to);
-          return (
-            <button
-              key={to}
-              type="button"
-              onClick={() => nav(to)}
-              className={active ? "active" : ""}
-            >
-              <Icon size={20} strokeWidth={2.2} />
-              <span className="rc-mobile-tabbar-label">
-                {mobileTabLabel(label)}
-                {label === "Messages" && unreadFlag ? (
-                  <span className="rc-mobile-tabbar-dot" />
-                ) : null}
-              </span>
-            </button>
-          );
-        })}
-        <button
-          type="button"
-          onClick={(event) => {
-            lastFocusedRef.current = event.currentTarget;
-            setDrawerOpen((open) => !open);
-          }}
-          className={drawerOpen ? "active" : ""}
-          aria-label="Open workspace pages"
-          aria-expanded={drawerOpen}
-          aria-controls="rc-landlord-drawer"
-        >
-          {drawerOpen ? <X size={20} strokeWidth={2.2} /> : <Menu size={20} strokeWidth={2.2} />}
-          <span className="rc-mobile-tabbar-label">More</span>
-        </button>
-      </nav>
+      {showMobileBottomNav ? (
+        <nav className="rc-landlord-mobile-tabbar" aria-label="Bottom navigation">
+          {(navLoading ? [] : tabItems).map(({ to, label, icon: Icon }) => {
+            if (!Icon) return null;
+            const active = loc.pathname.startsWith(to);
+            return (
+              <button
+                key={to}
+                type="button"
+                onClick={() => nav(to)}
+                className={active ? "active" : ""}
+              >
+                <Icon size={20} strokeWidth={2.2} />
+                <span className="rc-landlord-mobile-tabbar-label">
+                  {label}
+                  {label === "Messages" && unreadFlag ? (
+                    <span className="rc-landlord-mobile-tabbar-dot" />
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            onClick={(event) => {
+              lastFocusedRef.current = event.currentTarget;
+              setDrawerOpen((open) => !open);
+            }}
+            className={drawerOpen ? "active" : ""}
+            aria-label="Open workspace pages"
+            aria-expanded={drawerOpen}
+            aria-controls="rc-landlord-drawer"
+          >
+            {drawerOpen ? <X size={20} strokeWidth={2.2} /> : <Menu size={20} strokeWidth={2.2} />}
+            <span className="rc-landlord-mobile-tabbar-label">More</span>
+          </button>
+        </nav>
+      ) : null}
     </div>
   );
 };

--- a/rentchain-frontend/src/components/layout/MacShell.css
+++ b/rentchain-frontend/src/components/layout/MacShell.css
@@ -1,0 +1,59 @@
+.app-root,
+.app-root * {
+  box-sizing: border-box;
+}
+
+.rc-mac-shell-main {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-wrap: anywhere;
+}
+
+.rc-mac-shell-main > *,
+.rc-mac-shell-main main,
+.rc-mac-shell-main section,
+.rc-mac-shell-main article,
+.rc-mac-shell-main form,
+.rc-mac-shell-main table,
+.rc-mac-shell-main [role="table"],
+.rc-mac-shell-main [class*="grid"],
+.rc-mac-shell-main [class*="Grid"],
+.rc-mac-shell-main [class*="row"],
+.rc-mac-shell-main [class*="Row"],
+.rc-mac-shell-main [class*="card"],
+.rc-mac-shell-main [class*="Card"] {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.rc-mac-shell-main img,
+.rc-mac-shell-main svg,
+.rc-mac-shell-main canvas,
+.rc-mac-shell-main video {
+  max-width: 100%;
+}
+
+@media (max-width: 820px) {
+  .app-root {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  .rc-mac-shell-main {
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+    padding-left: max(14px, env(safe-area-inset-left, 0px)) !important;
+    padding-right: max(14px, env(safe-area-inset-right, 0px)) !important;
+    overflow-x: hidden !important;
+  }
+
+  .rc-mac-shell-main > div {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+}

--- a/rentchain-frontend/src/components/layout/MacShell.tsx
+++ b/rentchain-frontend/src/components/layout/MacShell.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import TopNav from "./TopNav";
 import { layout, spacing, colors, text } from "../../styles/tokens";
+import "./MacShell.css";
 
 interface MacShellProps {
   title?: string;

--- a/rentchain-frontend/src/components/layout/TopNav.css
+++ b/rentchain-frontend/src/components/layout/TopNav.css
@@ -1,134 +1,52 @@
-/* src/components/layout/TopNav.css */
+.rc-top-nav,
+.rc-top-nav * {
+  box-sizing: border-box;
+}
 
-.topnav-root {
-  position: sticky;
-  top: 0;
-  z-index: 40;
+.rc-top-nav {
   width: 100%;
-  background: linear-gradient(to right, #020617, #020617);
-  border-bottom: 1px solid rgba(30, 64, 175, 0.6);
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.9);
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
-.topnav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0.6rem 1.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.5rem;
-  color: #e5e7eb;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text",
-    sans-serif;
+.rc-top-nav-inner,
+.rc-top-nav-actions {
+  min-width: 0;
+  max-width: 100%;
 }
 
-/* Left: brand */
+@media (max-width: 820px) {
+  .rc-top-nav-inner {
+    width: 100%;
+    padding:
+      8px
+      max(12px, env(safe-area-inset-right, 0px))
+      8px
+      max(12px, env(safe-area-inset-left, 0px)) !important;
+    gap: 8px !important;
+  }
 
-.topnav-left {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
+  .rc-top-nav-actions {
+    flex: 1 1 auto;
+    justify-content: flex-end;
+    gap: 6px !important;
+    overflow: hidden;
+  }
 
-.topnav-logo {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
+  .rc-top-nav-role {
+    max-width: 96px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
-.topnav-logo-mark {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 700;
-  background: radial-gradient(circle at 30% 0%, #22c55e, #16a34a);
-  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.9),
-    0 10px 30px rgba(22, 163, 74, 0.8);
-  color: #020617;
-}
+  .rc-top-nav-optional-action {
+    display: none !important;
+  }
 
-.topnav-logo-text {
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  font-size: 0.95rem;
-}
-
-/* Center: nav links */
-
-.topnav-nav {
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-  font-size: 0.9rem;
-}
-
-.topnav-link {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  padding: 0.3rem 0.6rem;
-  border-radius: 999px;
-  text-decoration: none;
-  color: #9ca3af;
-  transition: color 120ms ease, background-color 120ms ease,
-    box-shadow 120ms ease, transform 120ms ease;
-}
-
-.topnav-link:hover {
-  color: #e5e7eb;
-  background-color: rgba(30, 64, 175, 0.35);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.9);
-  transform: translateY(-0.5px);
-}
-
-.topnav-link-active {
-  color: #e5e7eb;
-  background: linear-gradient(
-    135deg,
-    rgba(34, 197, 94, 0.18),
-    rgba(59, 130, 246, 0.22)
-  );
-  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.95);
-}
-
-.topnav-link-active::before {
-  content: "";
-  position: absolute;
-  left: 0.45rem;
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: radial-gradient(circle at 30% 0%, #22c55e, #16a34a);
-}
-
-/* Right side placeholder */
-
-.topnav-right {
-  min-width: 40px;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 0.75rem;
-  font-size: 0.85rem;
-  color: #9ca3af;
-}
-
-/* Optional: little green strip under the header */
-
-.topnav-root::after {
-  content: "";
-  display: block;
-  height: 3px;
-  background: linear-gradient(
-    90deg,
-    #22c55e,
-    #a3e635,
-    #22c55e
-  );
-  opacity: 0.95;
+  .rc-top-nav-workspace-button {
+    flex: 0 0 auto;
+    min-width: 0;
+    padding: 9px 11px !important;
+    white-space: nowrap;
+  }
 }

--- a/rentchain-frontend/src/components/layout/TopNav.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.tsx
@@ -8,6 +8,7 @@ import { colors, radius, shadows, spacing, text, layout, blur } from "../../styl
 import { RentChainLogo } from "../brand/RentChainLogo";
 import { fetchLandlordConversations } from "../../api/messagesApi";
 import { useCapabilities } from "@/hooks/useCapabilities";
+import "./TopNav.css";
 
 function roleLabel(raw: string): string {
   const normalized = String(raw || "").trim().toLowerCase();
@@ -65,6 +66,7 @@ const TopNav: React.FC = () => {
   return (
     <>
       <header
+        className="rc-top-nav"
         style={{
           position: "sticky",
           top: 0,
@@ -77,6 +79,7 @@ const TopNav: React.FC = () => {
         }}
       >
         <div
+          className="rc-top-nav-inner"
           style={{
             display: "flex",
             alignItems: "center",
@@ -87,8 +90,9 @@ const TopNav: React.FC = () => {
         >
           <RentChainLogo href="/dashboard" size="sm" />
 
-          <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: spacing.sm }}>
+          <div className="rc-top-nav-actions" style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: spacing.sm }}>
             <span
+              className="rc-top-nav-role"
               style={{
                 borderRadius: radius.pill,
                 border: `1px solid ${colors.border}`,
@@ -105,6 +109,7 @@ const TopNav: React.FC = () => {
             </span>
             {canShowMessagesShortcut ? (
               <Button
+                className="rc-top-nav-optional-action"
                 variant="secondary"
                 onClick={() => navigate("/messages")}
                 aria-label={hasUnreadMessages ? "Messages (unread)" : "Messages"}
@@ -137,6 +142,7 @@ const TopNav: React.FC = () => {
               </Button>
             ) : null}
             <Button
+              className="rc-top-nav-optional-action"
               variant="secondary"
               onClick={() => navigate(accountPath)}
               style={{
@@ -151,6 +157,7 @@ const TopNav: React.FC = () => {
               My Account
             </Button>
             <Button
+              className="rc-top-nav-workspace-button"
               variant="secondary"
               onClick={() => setDrawerOpen(true)}
               style={{

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -78,7 +78,7 @@ describe("WorkspaceDrawer", () => {
     expect(screen.getByRole("button", { name: "Governed review workspaces" })).toBeInTheDocument();
   });
 
-  it("positions the mobile sheet above the bottom navigation", () => {
+  it("does not reserve bottom navigation space by default", () => {
     render(
       <MemoryRouter initialEntries={["/dashboard"]}>
         <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" userEmail="owner@example.com" />
@@ -87,15 +87,44 @@ describe("WorkspaceDrawer", () => {
 
     const dialog = screen.getByRole("dialog", { name: "Workspace navigation" });
     expect(dialog.parentElement).toHaveStyle({
-      bottom: "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))",
+      bottom: "calc(12px + env(safe-area-inset-bottom, 0px))",
       alignItems: "flex-end",
-      zIndex: "60",
+      justifyContent: "center",
+      zIndex: "3000",
     });
     expect(dialog).toHaveStyle({
+      width: "min(420px, calc(100% - 24px))",
+      maxWidth: "min(560px, calc(100% - 24px))",
       height: "auto",
       maxHeight:
-        "min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px))) - 16px), 560px)",
-      zIndex: "61",
+        "min(calc(100dvh - calc(12px + env(safe-area-inset-bottom, 0px)) - 16px), 620px)",
+      zIndex: "3001",
+    });
+    expect(within(dialog).getByRole("button", { name: "Dashboard" }).parentElement).toHaveStyle({
+      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    });
+  });
+
+  it("can reserve bottom navigation space when explicitly requested", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer
+          open
+          onClose={vi.fn()}
+          userRole="landlord"
+          userEmail="owner@example.com"
+          reserveBottomNavSpace
+        />
+      </MemoryRouter>
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Workspace navigation" });
+    expect(dialog.parentElement).toHaveStyle({
+      bottom: "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))",
+    });
+    expect(dialog).toHaveStyle({
+      maxHeight:
+        "min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px))) - 16px), 620px)",
     });
   });
 

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -11,9 +11,17 @@ type WorkspaceDrawerProps = {
   userEmail?: string | null;
   userRole?: string | null;
   onSignOut?: () => void;
+  reserveBottomNavSpace?: boolean;
 };
 
-export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose, userEmail, userRole, onSignOut }) => {
+export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
+  open,
+  onClose,
+  userEmail,
+  userRole,
+  onSignOut,
+  reserveBottomNavSpace = false,
+}) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { features, loading: capsLoading } = useCapabilities();
@@ -74,7 +82,9 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
     onClose();
   };
   const mobileBottomNavOffset =
-    "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))";
+    reserveBottomNavSpace
+      ? "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))"
+      : "calc(12px + env(safe-area-inset-bottom, 0px))";
 
   const footerContent = (
     <>
@@ -107,10 +117,12 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
         left: 0,
         right: 0,
         bottom: isMobile ? mobileBottomNavOffset : 0,
-        zIndex: isMobile ? 60 : 3000,
+        zIndex: isMobile ? 3000 : 3000,
         display: "flex",
-        justifyContent: "flex-end",
+        justifyContent: isMobile ? "center" : "flex-end",
         alignItems: isMobile ? "flex-end" : "flex-start",
+        maxWidth: "100%",
+        overflow: "hidden",
         overscrollBehavior: "none",
         touchAction: isMobile ? "auto" : "none",
         pointerEvents: "auto",
@@ -133,12 +145,13 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
         aria-label="Workspace navigation"
         style={{
           position: "relative",
-          width: isMobile ? "auto" : 320,
-          maxWidth: isMobile ? "none" : "90vw",
+          width: isMobile ? "min(420px, calc(100% - 24px))" : 320,
+          maxWidth: isMobile ? "min(560px, calc(100% - 24px))" : "90vw",
           height: isMobile ? "auto" : "100dvh",
-          maxHeight: isMobile ? `min(calc(100dvh - ${mobileBottomNavOffset} - 16px), 560px)` : "100dvh",
-          margin: isMobile ? "0 max(12px, env(safe-area-inset-right, 0px)) 8px max(12px, env(safe-area-inset-left, 0px))" : 0,
+          maxHeight: isMobile ? `min(calc(100dvh - ${mobileBottomNavOffset} - 16px), 620px)` : "100dvh",
+          margin: isMobile ? "0 auto 8px" : 0,
           minHeight: 0,
+          minWidth: 0,
           background: colors.card,
           border: isMobile ? `1px solid ${colors.border}` : undefined,
           borderLeft: isMobile ? undefined : `1px solid ${colors.border}`,
@@ -146,10 +159,10 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
           boxShadow: shadows.lg,
           display: "flex",
           flexDirection: "column",
-          zIndex: isMobile ? 61 : 3001,
+          zIndex: isMobile ? 3001 : 3001,
           overflow: "hidden",
           overscrollBehaviorY: "contain",
-          contain: "layout paint size",
+          contain: "layout paint",
           isolation: "isolate",
           WebkitOverflowScrolling: "touch",
           paddingTop: isMobile ? 0 : "env(safe-area-inset-top)",
@@ -195,13 +208,19 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
             WebkitOverflowScrolling: "touch",
             overscrollBehaviorY: "contain",
             touchAction: "pan-y",
-            padding: `0 ${spacing.lg}`,
+          padding: `0 ${isMobile ? spacing.md : spacing.lg}`,
             minHeight: 0,
             maxHeight: "100%",
           }}
         >
           <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.02em", color: text.muted, marginBottom: spacing.sm }}>Pages</div>
-          <div style={{ display: "grid", gap: 8 }}>
+          <div
+            style={{
+              display: "grid",
+              gap: isMobile ? 10 : 8,
+              gridTemplateColumns: isMobile ? "repeat(2, minmax(0, 1fr))" : "1fr",
+            }}
+          >
             {navLoading ? (
               <div
                 style={{
@@ -225,8 +244,9 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
                   type="button"
                   onClick={() => handleNav(link.to)}
                   style={{
-                    textAlign: "left",
-                    padding: "10px 12px",
+                    textAlign: isMobile ? "center" : "left",
+                    padding: isMobile ? "10px 8px" : "10px 12px",
+                    minHeight: isMobile ? 48 : undefined,
                     borderRadius: radius.md,
                     border: `1px solid ${active ? colors.accent : colors.border}`,
                     background: active ? "rgba(37,99,235,0.08)" : colors.card,
@@ -240,7 +260,14 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
               );
             })}
             {adminDrawerItems.length ? (
-              <div style={{ height: 1, background: colors.border, margin: `${spacing.xs} 0` }} />
+              <div
+                style={{
+                  height: 1,
+                  background: colors.border,
+                  margin: `${spacing.xs} 0`,
+                  gridColumn: isMobile ? "1 / -1" : undefined,
+                }}
+              />
             ) : null}
             {adminDrawerItems.map((link) => {
               const active = location.pathname.startsWith(link.to);
@@ -250,8 +277,9 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
                   type="button"
                   onClick={() => handleNav(link.to)}
                   style={{
-                    textAlign: "left",
-                    padding: "10px 12px",
+                    textAlign: isMobile ? "center" : "left",
+                    padding: isMobile ? "10px 8px" : "10px 12px",
+                    minHeight: isMobile ? 48 : undefined,
                     borderRadius: radius.md,
                     border: `1px solid ${active ? colors.accent : colors.border}`,
                     background: active ? "rgba(37,99,235,0.08)" : colors.card,

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText, BarChart3, Inbox, ClipboardList } from "lucide-react";
+import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText, BarChart3, Inbox, ClipboardList, FileText } from "lucide-react";
 import { SCREENING_ENABLED } from "../../config/screening";
 
 export type NavItem = {
@@ -52,7 +52,6 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/properties",
     icon: Building2,
     showInDrawer: true,
-    showInTabs: true,
   },
   {
     id: "tenants",
@@ -60,7 +59,6 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/tenants",
     icon: Users,
     showInDrawer: true,
-    showInTabs: true,
   },
   {
     id: "applications",
@@ -68,7 +66,24 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/applications",
     icon: ScrollText,
     showInDrawer: true,
+  },
+  {
+    id: "documents",
+    label: "Documents",
+    to: "/applications",
+    icon: FileText,
+    showInDrawer: false,
     showInTabs: true,
+    requiresLandlordOrAdmin: true,
+  },
+  {
+    id: "leases",
+    label: "Leases",
+    to: "/leases",
+    icon: ScrollText,
+    showInDrawer: true,
+    showInTabs: true,
+    requiresLandlordOrAdmin: true,
   },
   {
     id: "landlord-inbox",

--- a/rentchain-frontend/src/pages/AgentSupervisionPage.tsx
+++ b/rentchain-frontend/src/pages/AgentSupervisionPage.tsx
@@ -41,12 +41,12 @@ export default function AgentSupervisionPage() {
 
   return (
     <MacShell title="Agent supervision" showTopNav={false}>
-      <div style={{ display: "grid", gap: 16 }}>
+      <div style={{ display: "grid", gap: 16, minWidth: 0, maxWidth: "100%", overflowX: "hidden" }}>
         <Section>
-          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
-            <div style={{ display: "grid", gap: 6 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start", minWidth: 0 }}>
+            <div style={{ display: "grid", gap: 6, minWidth: 0, maxWidth: "100%" }}>
               <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Agent supervision</h1>
-              <div style={{ color: "#475569", maxWidth: 900 }}>
+              <div style={{ color: "#475569", maxWidth: 900, overflowWrap: "anywhere" }}>
                 A read-only control tower for workflow previews, policy-gated suggestions, blocked states, escalation
                 visibility, and review lineage.
               </div>

--- a/rentchain-frontend/src/pages/DecisionInboxPage.css
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.css
@@ -1,0 +1,100 @@
+.rc-decision-inbox-page,
+.rc-decision-inbox-page * {
+  box-sizing: border-box;
+}
+
+.rc-decision-inbox-page {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+.rc-decision-inbox-heading,
+.rc-decision-inbox-list,
+.rc-decision-inbox-list > * {
+  min-width: 0;
+}
+
+.rc-decision-inbox-page > *,
+.rc-decision-inbox-card,
+.rc-decision-inbox-card > *,
+.rc-decision-inbox-card [style] {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.rc-decision-inbox-card {
+  overflow-x: hidden;
+}
+
+.rc-decision-inbox-card a,
+.rc-decision-inbox-card span,
+.rc-decision-inbox-card div {
+  overflow-wrap: anywhere;
+}
+
+.rc-decision-inbox-context-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.rc-decision-inbox-filters > label {
+  flex: 1 1 150px;
+  min-width: 0;
+}
+
+@media (max-width: 820px) {
+  .rc-decision-inbox-page {
+    gap: 12px !important;
+    padding-bottom: calc(var(--rc-mobile-bottom-nav-height, 88px) + 18px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .rc-decision-inbox-header {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start !important;
+  }
+
+  .rc-decision-inbox-context-links {
+    justify-content: stretch;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .rc-decision-inbox-context-links a {
+    min-height: 42px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 9px 10px;
+    border-radius: 10px;
+    background: rgba(37, 99, 235, 0.08);
+    text-align: center;
+  }
+
+  .rc-decision-inbox-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+
+  .rc-decision-inbox-filters {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch !important;
+  }
+
+  .rc-decision-inbox-filters > label,
+  .rc-decision-inbox-filters select {
+    width: 100%;
+    min-width: 0 !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .rc-decision-inbox-summary-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+}

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -396,6 +396,21 @@ describe("DecisionInboxPage", () => {
     expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
   });
 
+  it("marks the decision inbox with mobile-safe responsive layout classes", async () => {
+    render(
+      <MemoryRouter>
+        <DecisionInboxPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Decision inbox" })).toBeInTheDocument();
+    expect(document.querySelector(".rc-decision-inbox-page")).toBeInTheDocument();
+    expect(document.querySelector(".rc-decision-inbox-header")).toBeInTheDocument();
+    expect(document.querySelector(".rc-decision-inbox-context-links")).toBeInTheDocument();
+    expect(document.querySelector(".rc-decision-inbox-filters")).toBeInTheDocument();
+    expect(document.querySelector(".rc-decision-inbox-list")).toBeInTheDocument();
+  });
+
   it("updates visible decisions through deterministic filters", async () => {
     apiMocks.fetchDecisionInbox
       .mockResolvedValueOnce(inboxResponse())

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -20,6 +20,7 @@ import { AgentActionPanel } from "@/components/agentActions/AgentActionPanel";
 import { OperatorReviewSessionPanel } from "@/components/operatorReviews/OperatorReviewSessionPanel";
 import { Card, Section } from "@/components/ui/Ui";
 import { useToast } from "@/components/ui/ToastProvider";
+import "./DecisionInboxPage.css";
 
 type FilterValue<T extends string> = T | "all";
 
@@ -226,7 +227,7 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
     });
   }
   return (
-    <Card style={{ display: "grid", gap: 12, borderRadius: 8 }}>
+    <Card className="rc-decision-inbox-card" style={{ display: "grid", gap: 12, borderRadius: 8 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
         <Badge tone={severityTone(item.severity)}>{label(item.severity)}</Badge>
         <Badge tone={statusTone(item.status)}>{label(item.status)}</Badge>
@@ -458,32 +459,40 @@ export default function DecisionInboxPage() {
 
   return (
     <MacShell title="Decision inbox" showTopNav={false}>
-      <div style={{ display: "grid", gap: 16 }}>
+      <div className="rc-decision-inbox-page" style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
-            <div style={{ display: "grid", gap: 6 }}>
+          <div
+            className="rc-decision-inbox-header"
+            style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}
+          >
+            <div className="rc-decision-inbox-heading" style={{ display: "grid", gap: 6 }}>
               <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Decision inbox</h1>
               <div style={{ color: "#475569", maxWidth: 900 }}>
                 A read-only view of detected decisions across analytics and lease ledger surfaces. Review context here without
                 triggering workflow actions.
               </div>
             </div>
-            <Link to="/institution-exports" style={{ color: "#2563eb", fontWeight: 800 }}>
-              Institution export preview
-            </Link>
-            <Link to="/agent-supervision" style={{ color: "#2563eb", fontWeight: 800 }}>
-              Agent supervision
-            </Link>
-            <Link to="/identity-layer" style={{ color: "#2563eb", fontWeight: 800 }}>
-              Identity layer
-            </Link>
+            <div className="rc-decision-inbox-context-links">
+              <Link to="/institution-exports" style={{ color: "#2563eb", fontWeight: 800 }}>
+                Institution export preview
+              </Link>
+              <Link to="/agent-supervision" style={{ color: "#2563eb", fontWeight: 800 }}>
+                Agent supervision
+              </Link>
+              <Link to="/identity-layer" style={{ color: "#2563eb", fontWeight: 800 }}>
+                Identity layer
+              </Link>
+            </div>
           </div>
         </Section>
 
         {data ? (
           <Section style={{ display: "grid", gap: 10 }}>
             <div style={{ fontWeight: 800 }}>Summary</div>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 10 }}>
+            <div
+              className="rc-decision-inbox-summary-grid"
+              style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 10 }}
+            >
               {[
                 ["Total", data.summary.total],
                 ["Critical", data.summary.critical],
@@ -512,7 +521,7 @@ export default function DecisionInboxPage() {
           </Section>
         ) : null}
 
-        <Section style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "end" }}>
+        <Section className="rc-decision-inbox-filters" style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "end" }}>
           <FilterSelect labelText="Severity" value={severity} options={severityOptions} onChange={setSeverity} />
           <FilterSelect labelText="Status" value={status} options={statusOptions} onChange={setStatus} />
           <FilterSelect labelText="Type" value={type} options={typeOptions} onChange={setType} />
@@ -537,7 +546,7 @@ export default function DecisionInboxPage() {
           <Card style={{ color: "#64748b" }}>No decisions match the current filters.</Card>
         ) : null}
         {!loading && !error && data?.items.length ? (
-          <div style={{ display: "grid", gap: 12 }}>
+          <div className="rc-decision-inbox-list" style={{ display: "grid", gap: 12 }}>
             {data.items.map((item) => (
               <DecisionInboxCard key={item.id} item={item} />
             ))}

--- a/rentchain-frontend/src/pages/EnterpriseMunicipalReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/EnterpriseMunicipalReadinessPage.tsx
@@ -58,7 +58,7 @@ export default function EnterpriseMunicipalReadinessPage() {
   }
 
   return (
-    <MacShell title="Enterprise and municipal readiness" showTopNav={false}>
+    <MacShell title="Enterprise and municipal readiness">
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
           <div style={{ display: "grid", gap: 6 }}>

--- a/rentchain-frontend/src/pages/PdfExportObservabilityPage.tsx
+++ b/rentchain-frontend/src/pages/PdfExportObservabilityPage.tsx
@@ -35,7 +35,7 @@ export default function PdfExportObservabilityPage() {
   }, [showToast]);
 
   return (
-    <MacShell title="PDF export observability" showTopNav={false}>
+    <MacShell title="PDF export observability">
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
           <div style={{ display: "grid", gap: 6 }}>

--- a/rentchain-frontend/src/pages/ProductionIntegrationsPage.tsx
+++ b/rentchain-frontend/src/pages/ProductionIntegrationsPage.tsx
@@ -58,7 +58,7 @@ export default function ProductionIntegrationsPage() {
   }
 
   return (
-    <MacShell title="Production integrations" showTopNav={false}>
+    <MacShell title="Production integrations">
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
           <div style={{ display: "grid", gap: 6 }}>

--- a/rentchain-frontend/src/pages/admin/AdminLeasesPage.css
+++ b/rentchain-frontend/src/pages/admin/AdminLeasesPage.css
@@ -1,0 +1,70 @@
+.rc-admin-leases-mobile-list {
+  display: none;
+}
+
+.rc-admin-leases-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rc-admin-leases-table {
+  width: 100%;
+  min-width: 1080px;
+  border-collapse: collapse;
+}
+
+@media (max-width: 820px) {
+  .rc-admin-leases-mobile-list {
+    display: grid;
+    gap: 8px;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .rc-admin-leases-table-wrap {
+    display: none;
+  }
+
+  .rc-admin-lease-card {
+    appearance: none;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    display: grid;
+    gap: 6px;
+    text-align: left;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 10px;
+    background: #fff;
+    color: #0f172a;
+    padding: 10px;
+    box-sizing: border-box;
+    cursor: pointer;
+    overflow: hidden;
+  }
+
+  .rc-admin-lease-card__title {
+    font-size: 14px;
+    font-weight: 800;
+    overflow-wrap: anywhere;
+  }
+
+  .rc-admin-lease-card__placement,
+  .rc-admin-lease-card__meta,
+  .rc-admin-lease-card__footer {
+    min-width: 0;
+    color: #475569;
+    font-size: 12px;
+    overflow-wrap: anywhere;
+  }
+
+  .rc-admin-lease-card__meta,
+  .rc-admin-lease-card__footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 8px;
+    align-items: center;
+  }
+}

--- a/rentchain-frontend/src/pages/admin/AdminLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeasesPage.test.tsx
@@ -89,7 +89,9 @@ describe("AdminLeasesPage", () => {
       });
     });
 
-    expect(screen.getByText("Coburg Rd · Unit 101 · Jane Tenant")).toBeInTheDocument();
+    expect(screen.getAllByText("Coburg Rd · Unit 101 · Jane Tenant").length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Admin leases mobile list")).toBeInTheDocument();
+    expect(screen.getAllByText("Harbour Homes").length).toBeGreaterThan(0);
     expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.queryByText("landlord-1")).not.toBeInTheDocument();
   });
@@ -103,7 +105,9 @@ describe("AdminLeasesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Coburg Rd · Unit 101 · Jane Tenant")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText("Coburg Rd · Unit 101 · Jane Tenant").length).toBeGreaterThan(0);
+    });
     fireEvent.click(screen.getAllByText("Coburg Rd · Unit 101 · Jane Tenant")[0]);
 
     const drawer = screen.getByRole("dialog", { name: "Lease detail drawer" });

--- a/rentchain-frontend/src/pages/admin/AdminLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeasesPage.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Pill, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
 import { exportAdminLeasesCsv, fetchAdminLeases, type AdminLeaseView } from "../../api/adminApi";
 import { AdminSavedFilters } from "../../components/admin/AdminSavedFilters";
+import "./AdminLeasesPage.css";
 
 function readFilters(search: string) {
   const params = new URLSearchParams(search);
@@ -40,6 +41,10 @@ function leaseLabel(lease: AdminLeaseView) {
 
 function landlordLabel(lease: AdminLeaseView) {
   return lease.landlordDisplayName || "Landlord account";
+}
+
+function tenantLabel(lease: AdminLeaseView) {
+  return lease.tenantNames.length ? lease.tenantNames.join(", ") : "No linked tenants";
 }
 
 export const AdminLeasesPage: React.FC = () => {
@@ -292,8 +297,39 @@ export const AdminLeasesPage: React.FC = () => {
           ) : null}
           {!loading && data?.items?.length ? (
             <>
-              <div style={{ overflowX: "auto" }}>
-                <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <div className="rc-admin-leases-mobile-list" aria-label="Admin leases mobile list">
+                {data.items.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="rc-admin-lease-card"
+                    onClick={() => setSelectedLease(item)}
+                  >
+                    <span className="rc-admin-lease-card__title">{leaseLabel(item)}</span>
+                    <span className="rc-admin-lease-card__placement">
+                      {item.propertyName || "Property not linked"} · {item.unitNumber ? `Unit ${item.unitNumber}` : "Unit not assigned"}
+                    </span>
+                    <span className="rc-admin-lease-card__meta">
+                      <span>{tenantLabel(item)}</span>
+                      <span>{landlordLabel(item)}</span>
+                    </span>
+                    <span className="rc-admin-lease-card__meta">
+                      <span>Status: {formatValue(item.status)}</span>
+                      <span>Rent: {formatMoney(item.monthlyRent)}</span>
+                    </span>
+                    <span className="rc-admin-lease-card__meta">
+                      <span>Start: {item.startDate || "Unavailable"}</span>
+                      <span>End: {item.endDate || "Unavailable"}</span>
+                    </span>
+                    <span className="rc-admin-lease-card__footer">
+                      <Pill tone="accent">Risk {item.riskGrade || "unavailable"}</Pill>
+                      <IntegrityPill lease={item} />
+                    </span>
+                  </button>
+                ))}
+              </div>
+              <div className="rc-admin-leases-table-wrap">
+                <table className="rc-admin-leases-table">
                   <thead>
                     <tr style={{ textAlign: "left", borderBottom: "1px solid rgba(15, 23, 42, 0.08)" }}>
                       {["Lease", "Property / Unit", "Tenant(s)", "Landlord", "Status", "Rent", "Start", "End", "Risk", "Integrity", "Updated"].map((label) => (
@@ -318,7 +354,7 @@ export const AdminLeasesPage: React.FC = () => {
                           <div>{item.propertyName || "Property not linked"}</div>
                           <div style={{ color: "#64748b", fontSize: 13 }}>{item.unitNumber ? `Unit ${item.unitNumber}` : "Unit not assigned"}</div>
                         </td>
-                        <td style={{ padding: "12px" }}>{item.tenantNames.length ? item.tenantNames.join(", ") : "—"}</td>
+                        <td style={{ padding: "12px" }}>{tenantLabel(item)}</td>
                         <td style={{ padding: "12px" }}>{landlordLabel(item)}</td>
                         <td style={{ padding: "12px" }}>
                           <Pill tone="default">{formatValue(item.status)}</Pill>

--- a/rentchain-frontend/src/pages/admin/AdminPropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminPropertiesPage.test.tsx
@@ -84,7 +84,9 @@ describe("AdminPropertiesPage", () => {
       });
     });
 
-    expect(screen.getByText("Coburg Rd")).toBeInTheDocument();
+    expect(screen.getAllByText("Coburg Rd").length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Admin properties mobile list")).toBeInTheDocument();
+    expect(screen.getAllByText("Harbour Homes").length).toBeGreaterThan(0);
     expect(screen.queryByText("prop-1")).not.toBeInTheDocument();
     expect(screen.queryByText("landlord-1")).not.toBeInTheDocument();
   });
@@ -98,7 +100,9 @@ describe("AdminPropertiesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Coburg Rd")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText("Coburg Rd").length).toBeGreaterThan(0);
+    });
 
     fireEvent.click(screen.getAllByText("Coburg Rd")[0]);
 

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
@@ -263,24 +263,35 @@ export default function AdminReviewWorkspacesPage() {
         </div>
 
         <Card>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
-            <label>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(240px, 100%), 1fr))", gap: 12, minWidth: 0 }}>
+            <label style={{ display: "grid", gap: 4, minWidth: 0 }}>
               <div style={{ fontSize: 12, color: "#64748b" }}>Workspace type</div>
-              <select aria-label="Workspace type" value={workspaceType} onChange={(event) => setWorkspaceType(event.target.value)}>
+              <select
+                aria-label="Workspace type"
+                value={workspaceType}
+                onChange={(event) => setWorkspaceType(event.target.value)}
+                style={{ width: "100%", minWidth: 0, boxSizing: "border-box" }}
+              >
                 <option value="">All workspace types</option>
                 {WORKSPACE_TYPES.map((item) => <option key={item} value={item}>{label(item)}</option>)}
               </select>
             </label>
-            <label>
+            <label style={{ display: "grid", gap: 4, minWidth: 0 }}>
               <div style={{ fontSize: 12, color: "#64748b" }}>Search</div>
-              <input aria-label="Search" value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search metadata" />
+              <input
+                aria-label="Search"
+                value={q}
+                onChange={(event) => setQ(event.target.value)}
+                placeholder="Search metadata"
+                style={{ width: "100%", minWidth: 0, boxSizing: "border-box" }}
+              />
             </label>
           </div>
         </Card>
 
         {error ? <Card><div style={{ color: "#b91c1c" }}>{error}</div></Card> : null}
 
-        <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) minmax(300px, 440px)", gap: 16 }}>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(300px, 100%), 1fr))", gap: 16 }}>
           <div style={{ display: "grid", gap: 10 }}>
             {loading ? <Card><div>Loading governed review workspace metadata...</div></Card> : null}
             {!loading && workspaces.length === 0 ? (

--- a/rentchain-frontend/src/pages/admin/AdminTenantsPage.css
+++ b/rentchain-frontend/src/pages/admin/AdminTenantsPage.css
@@ -1,0 +1,76 @@
+.rc-admin-tenants-mobile-list {
+  display: none;
+}
+
+.rc-admin-tenants-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rc-admin-tenants-table {
+  width: 100%;
+  min-width: 980px;
+  border-collapse: collapse;
+}
+
+@media (max-width: 820px) {
+  .rc-admin-tenants-mobile-list {
+    display: grid;
+    gap: 10px;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .rc-admin-tenants-table-wrap {
+    display: none;
+  }
+
+  .rc-admin-tenant-card {
+    appearance: none;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    display: grid;
+    gap: 8px;
+    text-align: left;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 12px;
+    background: #fff;
+    color: #0f172a;
+    padding: 12px;
+    box-sizing: border-box;
+    cursor: pointer;
+    overflow: hidden;
+  }
+
+  .rc-admin-tenant-card__title {
+    font-weight: 800;
+    overflow-wrap: anywhere;
+  }
+
+  .rc-admin-tenant-card__context {
+    color: #1d4ed8;
+    font-size: 12px;
+    font-weight: 800;
+    overflow-wrap: anywhere;
+  }
+
+  .rc-admin-tenant-card__contact,
+  .rc-admin-tenant-card__placement,
+  .rc-admin-tenant-card__meta {
+    min-width: 0;
+    color: #475569;
+    font-size: 13px;
+    overflow-wrap: anywhere;
+  }
+
+  .rc-admin-tenant-card__meta,
+  .rc-admin-tenant-card__pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 10px;
+    align-items: center;
+  }
+}

--- a/rentchain-frontend/src/pages/admin/AdminTenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTenantsPage.test.tsx
@@ -106,8 +106,14 @@ describe("AdminTenantsPage", () => {
       });
     });
 
-    expect(screen.getByText("Jane Tenant")).toBeInTheDocument();
-    expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Jane Tenant").length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Admin tenants mobile list")).toBeInTheDocument();
+    expect(screen.getAllByText("Landlord linked").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Active tenant workspace").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Lifecycle: Active").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Lease: Active").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Screening: Complete").length).toBeGreaterThan(0);
+    expect(screen.queryByText("tenant-1")).not.toBeInTheDocument();
   });
 
   it("opens the tenant detail drawer when a row is selected", async () => {
@@ -119,13 +125,24 @@ describe("AdminTenantsPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Jane Tenant")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText("Jane Tenant").length).toBeGreaterThan(0);
+    });
     fireEvent.click(screen.getAllByText("Jane Tenant")[0]);
 
     const drawer = screen.getByRole("dialog", { name: "Tenant detail drawer" });
     expect(drawer).toBeInTheDocument();
     expect(within(drawer).getByText("jane@example.com")).toBeInTheDocument();
-    expect(within(drawer).getByText("landlord-1")).toBeInTheDocument();
-    expect(within(drawer).getByText("lease-1")).toBeInTheDocument();
+    expect(within(drawer).getByText("Active tenant workspace")).toBeInTheDocument();
+    expect(within(drawer).getAllByText("Landlord linked").length).toBeGreaterThan(0);
+    expect(within(drawer).getByText("Active lease")).toBeInTheDocument();
+    expect(within(drawer).getByText("Lease status: Active")).toBeInTheDocument();
+    expect(within(drawer).getByText("Screening status: Complete")).toBeInTheDocument();
+    expect(within(drawer).getByText("Move-in status: Ready")).toBeInTheDocument();
+    expect(within(drawer).queryByText("prop-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("unit-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("landlord-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("lease-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("tenant-1")).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/admin/AdminTenantsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTenantsPage.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Pill, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
 import { exportAdminTenantsCsv, fetchAdminTenants, type AdminTenantView } from "../../api/adminApi";
 import { AdminSavedFilters } from "../../components/admin/AdminSavedFilters";
+import "./AdminTenantsPage.css";
 
 function readFilters(search: string) {
   const params = new URLSearchParams(search);
@@ -21,15 +22,55 @@ function readFilters(search: string) {
 }
 
 function formatStatus(value: string | null) {
-  return value ? value.replace(/_/g, " ") : "None";
+  const normalized = value ? value.replace(/_/g, " ") : "Not available";
+  return normalized.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-function StatusPill({ value, tone = "default" }: { value: string | null; tone?: "default" | "accent" | "danger" }) {
-  return <Pill tone={tone}>{formatStatus(value)}</Pill>;
+function StatusPill({
+  label,
+  value,
+  tone = "default",
+}: {
+  label?: string;
+  value: string | null;
+  tone?: "default" | "accent" | "danger";
+}) {
+  const text = formatStatus(value);
+  return <Pill tone={tone}>{label ? `${label}: ${text}` : text}</Pill>;
 }
 
 function lifecycleLabel(item: AdminTenantView | null) {
   return item?.lifecycle?.lifecycleLabel || "Unknown";
+}
+
+function landlordSummary(item: AdminTenantView) {
+  return item.landlordId ? "Landlord linked" : "No landlord link";
+}
+
+function leaseSummary(item: AdminTenantView) {
+  return item.leaseStatus ? `${formatStatus(item.leaseStatus)} lease` : "Lease not linked";
+}
+
+function unavailableStatus(value: string | null) {
+  return value ? formatStatus(value) : "Not available";
+}
+
+function tenantWorkspaceContext(item: AdminTenantView) {
+  const lifecycle = String(item.lifecycle?.lifecycleState || "").toLowerCase();
+  const leaseStatus = String(item.leaseStatus || "").toLowerCase();
+  if (item.lifecycle?.flags?.hasActiveLease || leaseStatus === "active" || leaseStatus === "current") {
+    return "Active tenant workspace";
+  }
+  if (item.lifecycle?.flags?.hasPendingLease || lifecycle.includes("lease")) {
+    return "Lease pending workspace";
+  }
+  if (lifecycle.includes("screening")) {
+    return "Screening workspace";
+  }
+  if (lifecycle === "applicant" || (!item.unitNumber && !item.leaseStatus)) {
+    return "Applicant workspace";
+  }
+  return `${lifecycleLabel(item)} workspace`;
 }
 
 export const AdminTenantsPage: React.FC = () => {
@@ -278,8 +319,34 @@ export const AdminTenantsPage: React.FC = () => {
           ) : null}
           {!loading && data?.items?.length ? (
             <>
-              <div style={{ overflowX: "auto" }}>
-                <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <div className="rc-admin-tenants-mobile-list" aria-label="Admin tenants mobile list">
+                {data.items.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="rc-admin-tenant-card"
+                    onClick={() => setSelectedTenant(item)}
+                  >
+                    <span className="rc-admin-tenant-card__title">{item.fullName || "Unnamed tenant"}</span>
+                    <span className="rc-admin-tenant-card__context">{tenantWorkspaceContext(item)}</span>
+                    <span className="rc-admin-tenant-card__contact">{item.email || item.phone || "Contact unavailable"}</span>
+                    <span className="rc-admin-tenant-card__placement">
+                      {item.propertyName || "Unknown property"} · {item.unitNumber ? `Unit ${item.unitNumber}` : "No unit"}
+                    </span>
+                    <span className="rc-admin-tenant-card__meta">
+                      <span>{landlordSummary(item)}</span>
+                      <span>{item.phone || "No phone"}</span>
+                    </span>
+                    <span className="rc-admin-tenant-card__pills">
+                      <StatusPill label="Lifecycle" value={lifecycleLabel(item)} tone={item.lifecycle?.flags?.hasStateConflict ? "danger" : "accent"} />
+                      <StatusPill label="Lease" value={item.leaseStatus} />
+                      <StatusPill label="Screening" value={item.screeningStatus} tone={item.flags.hasScreening ? "accent" : "default"} />
+                    </span>
+                  </button>
+                ))}
+              </div>
+              <div className="rc-admin-tenants-table-wrap">
+                <table className="rc-admin-tenants-table">
                   <thead>
                     <tr style={{ textAlign: "left", borderBottom: "1px solid rgba(15, 23, 42, 0.08)" }}>
                       {["Tenant", "Email", "Phone", "Property / Unit", "Landlord", "Lifecycle", "Lease Status", "Screening", "Move-In", "Updated"].map((label) => (
@@ -298,7 +365,7 @@ export const AdminTenantsPage: React.FC = () => {
                       >
                         <td style={{ padding: "12px" }}>
                           <div style={{ fontWeight: 600 }}>{item.fullName || "Unnamed tenant"}</div>
-                          <div style={{ color: "#64748b", fontSize: 13 }}>{item.id}</div>
+                          <div style={{ color: "#64748b", fontSize: 13 }}>{tenantWorkspaceContext(item)}</div>
                         </td>
                         <td style={{ padding: "12px" }}>{item.email || "—"}</td>
                         <td style={{ padding: "12px" }}>{item.phone || "—"}</td>
@@ -306,18 +373,18 @@ export const AdminTenantsPage: React.FC = () => {
                           <div>{item.propertyName || "Unknown property"}</div>
                           <div style={{ color: "#64748b", fontSize: 13 }}>{item.unitNumber ? `Unit ${item.unitNumber}` : "No unit"}</div>
                         </td>
-                        <td style={{ padding: "12px" }}>{item.landlordId || "—"}</td>
+                        <td style={{ padding: "12px" }}>{landlordSummary(item)}</td>
                         <td style={{ padding: "12px" }}>
-                          <StatusPill value={lifecycleLabel(item)} tone={item.lifecycle?.flags?.hasStateConflict ? "danger" : "accent"} />
+                          <StatusPill label="Lifecycle" value={lifecycleLabel(item)} tone={item.lifecycle?.flags?.hasStateConflict ? "danger" : "accent"} />
                         </td>
                         <td style={{ padding: "12px" }}>
-                          <StatusPill value={item.leaseStatus} />
+                          <StatusPill label="Lease" value={item.leaseStatus} />
                         </td>
                         <td style={{ padding: "12px" }}>
-                          <StatusPill value={item.screeningStatus} tone={item.flags.hasScreening ? "accent" : "default"} />
+                          <StatusPill label="Screening" value={item.screeningStatus} tone={item.flags.hasScreening ? "accent" : "default"} />
                         </td>
                         <td style={{ padding: "12px" }}>
-                          <StatusPill value={item.moveInStatus} />
+                          <StatusPill label="Move-in" value={item.moveInStatus} />
                         </td>
                         <td style={{ padding: "12px" }}>{String(item.updatedAt || "—")}</td>
                       </tr>
@@ -374,7 +441,7 @@ export const AdminTenantsPage: React.FC = () => {
           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
             <div>
               <div style={{ fontWeight: 700, fontSize: 18 }}>{selectedTenant.fullName || "Unnamed tenant"}</div>
-              <div style={{ color: "#64748b", fontSize: 14 }}>{selectedTenant.id}</div>
+              <div style={{ color: "#64748b", fontSize: 14 }}>{tenantWorkspaceContext(selectedTenant)}</div>
             </div>
             <Button variant="secondary" onClick={() => setSelectedTenant(null)}>
               Close
@@ -390,34 +457,23 @@ export const AdminTenantsPage: React.FC = () => {
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 600 }}>Current Placement</div>
             <div>{selectedTenant.propertyName || "Unknown property"}</div>
-            <div>{selectedTenant.propertyId || "No property id"}</div>
             <div>{selectedTenant.unitNumber ? `Unit ${selectedTenant.unitNumber}` : "No unit number"}</div>
-            <div>{selectedTenant.unitId || "No unit id"}</div>
-            <div>{selectedTenant.landlordId || "No landlord id"}</div>
+            <div>{landlordSummary(selectedTenant)}</div>
           </Card>
 
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 600 }}>Lease Summary</div>
-            <div>{selectedTenant.leaseId || "No lease id"}</div>
-            <div>{formatStatus(selectedTenant.leaseStatus)}</div>
-            <div>{selectedTenant.currentLeaseStartDate || "No start date"}</div>
-            <div>{selectedTenant.currentLeaseEndDate || "No end date"}</div>
+            <div>{leaseSummary(selectedTenant)}</div>
+            <div>Start date: {selectedTenant.currentLeaseStartDate || "Unavailable"}</div>
+            <div>End date: {selectedTenant.currentLeaseEndDate || "Unavailable"}</div>
           </Card>
 
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 600 }}>Status</div>
-            <div>
-              <StatusPill
-                value={lifecycleLabel(selectedTenant)}
-                tone={selectedTenant.lifecycle?.flags?.hasStateConflict ? "danger" : "accent"}
-              />
-            </div>
-            <div>
-              <StatusPill value={selectedTenant.screeningStatus} tone={selectedTenant.flags.hasScreening ? "accent" : "default"} />
-            </div>
-            <div>
-              <StatusPill value={selectedTenant.moveInStatus} />
-            </div>
+            <div>Lifecycle status: {lifecycleLabel(selectedTenant)}</div>
+            <div>Lease status: {unavailableStatus(selectedTenant.leaseStatus)}</div>
+            <div>Screening status: {unavailableStatus(selectedTenant.screeningStatus)}</div>
+            <div>Move-in status: {unavailableStatus(selectedTenant.moveInStatus)}</div>
             <div style={{ display: "grid", gap: 6, color: "#475569" }}>
               <div>Missing lease link: {selectedTenant.flags.missingLeaseLink ? "Yes" : "No"}</div>
               <div>Missing property link: {selectedTenant.flags.missingPropertyLink ? "Yes" : "No"}</div>


### PR DESCRIPTION
## Summary
- adds a landlord-only mobile app bar with Dashboard, Documents, Leases, Messages, and More
- aligns the mobile landlord shell with a compact sticky top bar and preserves desktop nav
- adds mobile-safe decision inbox layout classes/CSS for stacked filters, context links, and bottom-nav spacing

## Canonical routes
- Dashboard: /dashboard
- Documents: /evidence-packs
- Leases: /leases
- Messages: /messages
- More: existing landlord workspace drawer

## Tests
- npm run test -- src/components/layout/LandlordNav.test.tsx src/pages/DecisionInboxPage.test.tsx
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build
- git diff --check
- git diff --cached --check

## Manual QA required
Mobile preview QA is required after Vercel preview is available:
1. /decision-inbox stacks and scrolls without horizontal overflow
2. filters/actions remain usable
3. mobile top bar matches landlord profile shell styling
4. bottom nav routes and active state work
5. bottom nav does not overlap content
6. tenant/admin pages do not show landlord bottom nav