### PR TITLE
Fix admin tenant lease workspace projection consistency

### DIFF
--- a/rentchain-api/src/routes/__tests__/adminRouteAuth.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminRouteAuth.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { routeSource } from "../../middleware/routeSource";
 
 const mocks = vi.hoisted(() => ({
   verifyAuthTokenMock: vi.fn(),
@@ -258,5 +261,88 @@ describe("admin route auth", () => {
       )).statusCode
     ).toBe(200);
     expect((await runRoute(adminPropertiesRoutes.default, "get", "/properties/export.csv", authReq)).statusCode).toBe(200);
+  });
+
+  it("returns normalized admin lease and tenant projection fields through the mounted API routes", async () => {
+    mocks.verifyAuthTokenMock.mockReturnValue({ sub: "admin-1" });
+    mocks.buildCanonicalSessionUserFromClaimsMock.mockResolvedValue({
+      id: "admin-1",
+      role: "admin",
+      permissions: ["system.admin"],
+      revokedPermissions: [],
+    });
+    mocks.listAdminLeasesMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: "ZD2VvH7cCZ7Q8YfVGR55",
+          propertyName: "Coburg Rd",
+          unitId: "a1O2tQcdEZ7t6y3GHT5G",
+          unitNumber: "6",
+          tenantName: "Chip Milo",
+          leaseDisplayLabel: "Coburg Rd · Unit 6 · Chip Milo",
+          startDate: "2026-05-01",
+          endDate: "2027-04-30",
+        },
+      ],
+      page: 1,
+      pageSize: 25,
+      total: 1,
+      hasMore: false,
+    });
+    mocks.listAdminTenantsMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: "tenant-chip-milo",
+          name: "Chip Milo",
+          propertyName: "Coburg Rd",
+          unitId: "a1O2tQcdEZ7t6y3GHT5G",
+          unitNumber: "6",
+          leaseStatus: "active",
+          currentLeaseStartDate: "2026-05-01",
+          currentLeaseEndDate: "2027-04-30",
+        },
+      ],
+      page: 1,
+      pageSize: 25,
+      total: 1,
+      hasMore: false,
+    });
+
+    const [adminTenantsRoutes, adminLeasesRoutes] = await Promise.all([
+      import("../adminTenantsRoutes"),
+      import("../adminLeasesRoutes"),
+    ]);
+
+    const app = express();
+    app.use("/api/admin", routeSource("adminTenantsRoutes.ts"), adminTenantsRoutes.default);
+    app.use("/api/admin", routeSource("adminLeasesRoutes.ts"), adminLeasesRoutes.default);
+
+    const leasesRes = await request(app)
+      .get("/api/admin/leases?q=milo&page=1&pageSize=25")
+      .set("Authorization", "Bearer admin-token");
+    expect(leasesRes.status).toBe(200);
+    expect(leasesRes.headers["x-route-source"]).toBe("adminLeasesRoutes.ts");
+    expect(leasesRes.body.items[0]).toMatchObject({
+      unitNumber: "6",
+      leaseDisplayLabel: "Coburg Rd · Unit 6 · Chip Milo",
+    });
+
+    const tenantsRes = await request(app)
+      .get("/api/admin/tenants?q=milo&page=1&pageSize=25")
+      .set("Authorization", "Bearer admin-token");
+    expect(tenantsRes.status).toBe(200);
+    expect(tenantsRes.headers["x-route-source"]).toBe("adminTenantsRoutes.ts");
+    expect(tenantsRes.body.items[0]).toMatchObject({
+      unitNumber: "6",
+      currentLeaseStartDate: "2026-05-01",
+      currentLeaseEndDate: "2027-04-30",
+    });
+
+    expect(mocks.listAdminLeasesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "milo", page: 1, pageSize: 25 })
+    );
+    expect(mocks.listAdminTenantsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "milo", page: 1, pageSize: 25 })
+    );
   });
 });

--- a/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
@@ -131,6 +131,20 @@ describe("adminLeaseView", () => {
       updatedAt: "2026-03-09T00:00:00.000Z",
       createdAt: "2026-03-06T00:00:00.000Z",
     });
+    seedDoc("leases", "ZD2VvH7cCZ7Q8YfVGR55", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "a1O2tQcdEZ7t6y3GHT5G",
+      unitNumber: "a1O2tQcdEZ7t6y3GHT5G",
+      tenantIds: ["tenant-5"],
+      status: "active",
+      monthlyRent: 2000,
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+      riskGrade: "A",
+      updatedAt: "2026-03-10T00:00:00.000Z",
+      createdAt: "2026-03-10T00:00:00.000Z",
+    });
 
     seedDoc("properties", "prop-1", { name: "Coburg Rd" });
     seedDoc("properties", "prop-2", { name: "Summit" });
@@ -146,6 +160,7 @@ describe("adminLeaseView", () => {
     seedDoc("units", "unit-doc-coburg-6", { propertyId: "prop-1", unitId: "unit-coburg-6", unitNumber: "6" });
     seedDoc("units", "unit-direct-6", { unitNumber: "6" });
     seedDoc("units", "unit-field-doc-6", { unitId: "unit-field-6", unitNumber: "6" });
+    seedDoc("units", "a1O2tQcdEZ7t6y3GHT5G", { propertyId: "prop-1", unitNumber: "6" });
   });
 
   it("returns safe shaped lease rows with tenant names", async () => {
@@ -161,14 +176,21 @@ describe("adminLeaseView", () => {
     expect(result.items[0]).not.toHaveProperty("auditBlob");
     expect(result.items.find((item) => item.id === "lease-1")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 101 · Jane Tenant");
     expect(result.items.find((item) => item.id === "lease-1")?.landlordDisplayName).toBe("Harbour Homes");
-    expect(result.items.find((item) => item.id === "lease-3")?.unitNumber).toBeNull();
-    expect(result.items.find((item) => item.id === "lease-3")?.leaseDisplayLabel).toBe("Coburg Rd · Unit not assigned · Old Lease");
+    expect(result.items.find((item) => item.id === "lease-3")?.unitNumber).toBe("6");
+    expect(result.items.find((item) => item.id === "lease-3")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 6 · Old Lease");
     expect(result.items.find((item) => item.id === "lease-4")?.unitNumber).toBe("6");
     expect(result.items.find((item) => item.id === "lease-4")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 6 · Chip Milo");
     expect(result.items.find((item) => item.id === "lease-5")?.unitNumber).toBe("6");
     expect(result.items.find((item) => item.id === "lease-5")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 6 · Chip Milo");
     expect(result.items.find((item) => item.id === "lease-6")?.unitNumber).toBe("6");
     expect(result.items.find((item) => item.id === "lease-6")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 6 · Chip Milo");
+    expect(result.items.find((item) => item.id === "ZD2VvH7cCZ7Q8YfVGR55")).toMatchObject({
+      unitId: "a1O2tQcdEZ7t6y3GHT5G",
+      unitNumber: "6",
+      leaseDisplayLabel: "Coburg Rd · Unit 6 · Chip Milo",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+    });
   });
 
   it("supports search across property, unit, tenant, and lease id", async () => {
@@ -200,8 +222,8 @@ describe("adminLeaseView", () => {
       pageSize: 25,
     });
 
-    expect(statusFiltered.items.map((item) => item.id)).toEqual(["lease-6", "lease-5", "lease-4", "lease-1"]);
-    expect(riskFiltered.items.map((item) => item.id)).toEqual(["lease-6", "lease-5", "lease-4", "lease-2"]);
+    expect(statusFiltered.items.map((item) => item.id)).toEqual(["ZD2VvH7cCZ7Q8YfVGR55", "lease-6", "lease-5", "lease-4", "lease-1"]);
+    expect(riskFiltered.items.map((item) => item.id)).toEqual(["ZD2VvH7cCZ7Q8YfVGR55", "lease-6", "lease-5", "lease-4", "lease-2"]);
     expect(integrityFiltered.items.map((item) => item.id)).toEqual(["lease-2"]);
     expect(dateFiltered.items.map((item) => item.id)).toEqual(["lease-2"]);
   });
@@ -218,10 +240,10 @@ describe("adminLeaseView", () => {
       pageSize: 1,
     });
 
-    expect(scoped.total).toBe(5);
+    expect(scoped.total).toBe(6);
     expect(scoped.page).toBe(3);
     expect(scoped.pageSize).toBe(1);
     expect(scoped.hasMore).toBe(true);
-    expect(scoped.items[0]?.id).toBe("lease-6");
+    expect(scoped.items[0]?.id).toBe("ZD2VvH7cCZ7Q8YfVGR55");
   });
 });

--- a/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
@@ -89,6 +89,48 @@ describe("adminLeaseView", () => {
       updatedAt: "2026-03-03T00:00:00.000Z",
       createdAt: "2026-03-01T00:00:00.000Z",
     });
+    seedDoc("leases", "lease-4", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-coburg-6",
+      unitNumber: "unit-coburg-6",
+      tenantId: "tenant-5",
+      status: "active",
+      monthlyRent: 2100,
+      leaseStartDate: "2026-04-01",
+      leaseEndDate: "2027-03-31",
+      riskGrade: "A",
+      updatedAt: "2026-03-07T00:00:00.000Z",
+      createdAt: "2026-03-04T00:00:00.000Z",
+    });
+    seedDoc("leases", "lease-5", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-direct-6",
+      unitNumber: "unit-direct-6",
+      tenantId: "tenant-5",
+      status: "active",
+      monthlyRent: 2000,
+      leaseStartDate: "2026-05-01",
+      leaseEndDate: "2027-04-30",
+      riskGrade: "A",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+      createdAt: "2026-03-05T00:00:00.000Z",
+    });
+    seedDoc("leases", "lease-6", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-field-6",
+      unitNumber: "unit-field-6",
+      tenantId: "tenant-5",
+      status: "active",
+      monthlyRent: 1900,
+      leaseStartDate: "2026-06-01",
+      leaseEndDate: "2027-05-31",
+      riskGrade: "A",
+      updatedAt: "2026-03-09T00:00:00.000Z",
+      createdAt: "2026-03-06T00:00:00.000Z",
+    });
 
     seedDoc("properties", "prop-1", { name: "Coburg Rd" });
     seedDoc("properties", "prop-2", { name: "Summit" });
@@ -97,9 +139,13 @@ describe("adminLeaseView", () => {
     seedDoc("tenants", "tenant-2", { firstName: "Co", lastName: "Tenant" });
     seedDoc("tenants", "tenant-3", { fullName: "Alex Summit" });
     seedDoc("tenants", "tenant-4", { fullName: "Old Lease" });
+    seedDoc("tenants", "tenant-5", { fullName: "Chip Milo" });
 
     seedDoc("landlords", "landlord-1", { businessName: "Harbour Homes" });
     seedDoc("landlords", "landlord-2", { displayName: "Summit Rentals" });
+    seedDoc("units", "unit-doc-coburg-6", { propertyId: "prop-1", unitId: "unit-coburg-6", unitNumber: "6" });
+    seedDoc("units", "unit-direct-6", { unitNumber: "6" });
+    seedDoc("units", "unit-field-doc-6", { unitId: "unit-field-6", unitNumber: "6" });
   });
 
   it("returns safe shaped lease rows with tenant names", async () => {
@@ -117,6 +163,12 @@ describe("adminLeaseView", () => {
     expect(result.items.find((item) => item.id === "lease-1")?.landlordDisplayName).toBe("Harbour Homes");
     expect(result.items.find((item) => item.id === "lease-3")?.unitNumber).toBeNull();
     expect(result.items.find((item) => item.id === "lease-3")?.leaseDisplayLabel).toBe("Coburg Rd · Unit not assigned · Old Lease");
+    expect(result.items.find((item) => item.id === "lease-4")?.unitNumber).toBe("6");
+    expect(result.items.find((item) => item.id === "lease-4")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 6 · Chip Milo");
+    expect(result.items.find((item) => item.id === "lease-5")?.unitNumber).toBe("6");
+    expect(result.items.find((item) => item.id === "lease-5")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 6 · Chip Milo");
+    expect(result.items.find((item) => item.id === "lease-6")?.unitNumber).toBe("6");
+    expect(result.items.find((item) => item.id === "lease-6")?.leaseDisplayLabel).toBe("Coburg Rd · Unit 6 · Chip Milo");
   });
 
   it("supports search across property, unit, tenant, and lease id", async () => {
@@ -148,8 +200,8 @@ describe("adminLeaseView", () => {
       pageSize: 25,
     });
 
-    expect(statusFiltered.items.map((item) => item.id)).toEqual(["lease-1"]);
-    expect(riskFiltered.items.map((item) => item.id)).toEqual(["lease-2"]);
+    expect(statusFiltered.items.map((item) => item.id)).toEqual(["lease-6", "lease-5", "lease-4", "lease-1"]);
+    expect(riskFiltered.items.map((item) => item.id)).toEqual(["lease-6", "lease-5", "lease-4", "lease-2"]);
     expect(integrityFiltered.items.map((item) => item.id)).toEqual(["lease-2"]);
     expect(dateFiltered.items.map((item) => item.id)).toEqual(["lease-2"]);
   });
@@ -162,14 +214,14 @@ describe("adminLeaseView", () => {
       propertyId: "prop-1",
       sortBy: "monthlyRent",
       sortDir: "desc",
-      page: 2,
+      page: 3,
       pageSize: 1,
     });
 
-    expect(scoped.total).toBe(2);
-    expect(scoped.page).toBe(2);
+    expect(scoped.total).toBe(5);
+    expect(scoped.page).toBe(3);
     expect(scoped.pageSize).toBe(1);
-    expect(scoped.hasMore).toBe(false);
-    expect(scoped.items[0]?.id).toBe("lease-3");
+    expect(scoped.hasMore).toBe(true);
+    expect(scoped.items[0]?.id).toBe("lease-6");
   });
 });

--- a/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminLeaseView.test.ts
@@ -204,6 +204,36 @@ describe("adminLeaseView", () => {
     expect(byLeaseId.items.map((item) => item.id)).toEqual(["lease-3"]);
   });
 
+  it("resolves lease unit document ids when lease unitNumber is missing", async () => {
+    seedDoc("leases", "lease-null-unit", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-null-6",
+      tenantId: "tenant-null",
+      status: "active",
+      monthlyRent: 2000,
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+      updatedAt: "2026-03-11T00:00:00.000Z",
+      createdAt: "2026-03-11T00:00:00.000Z",
+    });
+    seedDoc("tenants", "tenant-null", { fullName: "Null Unit" });
+    seedDoc("units", "unit-null-6", { propertyId: "prop-1", unitNumber: "6" });
+
+    const { listAdminLeases } = await import("../admin/adminLeaseView");
+    const result = await listAdminLeases({ firestore: fakeDb as any, q: "null unit", page: 1, pageSize: 25 });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "lease-null-unit",
+      unitId: "unit-null-6",
+      unitNumber: "6",
+      leaseDisplayLabel: "Coburg Rd · Unit 6 · Null Unit",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+    });
+  });
+
   it("filters by status, risk grade, integrity, and date range", async () => {
     const { listAdminLeases } = await import("../admin/adminLeaseView");
     const statusFiltered = await listAdminLeases({ firestore: fakeDb as any, status: "active", page: 1, pageSize: 25 });

--- a/rentchain-api/src/services/__tests__/adminTenantView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminTenantView.test.ts
@@ -90,6 +90,40 @@ describe("adminTenantView", () => {
       createdAt: "2026-03-03T00:00:00.000Z",
       updatedAt: "2026-03-04T00:00:00.000Z",
     });
+    seedDoc("tenants", "tenant-4", {
+      fullName: "Chip Milo",
+      email: "chip@example.com",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-coburg-6",
+      unitNumber: "unit-coburg-6",
+      currentLeaseId: "lease-4",
+      screeningStatus: "complete",
+      moveInStatus: "ready",
+      createdAt: "2026-03-04T00:00:00.000Z",
+      updatedAt: "2026-03-07T00:00:00.000Z",
+    });
+    seedDoc("tenants", "tenant-6", {
+      fullName: "Field Unit Tenant",
+      email: "field@example.com",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-field-6",
+      unitNumber: "unit-field-6",
+      currentLeaseId: "lease-6",
+      createdAt: "2026-03-04T00:00:00.000Z",
+      updatedAt: "2026-03-09T00:00:00.000Z",
+    });
+    seedDoc("tenants", "tenant-5", {
+      fullName: "Chip Milo",
+      email: "chip.applicant@example.com",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      applicantStatus: "submitted",
+      applicationId: "application-chip",
+      createdAt: "2026-03-04T00:00:00.000Z",
+      updatedAt: "2026-03-08T00:00:00.000Z",
+    });
 
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",
@@ -114,9 +148,29 @@ describe("adminTenantView", () => {
       unitId: "unit-9",
       status: "active",
     });
+    seedDoc("leases", "lease-4", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-coburg-6",
+      unitNumber: "unit-coburg-6",
+      status: "active",
+      leaseStartDate: "2026-04-01",
+      leaseEndDate: "2027-03-31",
+    });
+    seedDoc("leases", "lease-6", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-field-6",
+      unitNumber: "unit-field-6",
+      status: "active",
+      leaseStartDate: "2026-05-01",
+      leaseEndDate: "2027-04-30",
+    });
 
     seedDoc("properties", "prop-1", { name: "Coburg Rd" });
     seedDoc("properties", "prop-2", { name: "Summit" });
+    seedDoc("units", "unit-doc-coburg-6", { propertyId: "prop-1", unitId: "unit-coburg-6", unitNumber: "6" });
+    seedDoc("units", "unit-field-doc-6", { unitId: "unit-field-6", unitNumber: "6" });
   });
 
   it("returns only safe admin tenant view fields", async () => {
@@ -190,8 +244,8 @@ describe("adminTenantView", () => {
       pageSize: 25,
     });
 
-    expect(leaseFiltered.items.map((item) => item.id)).toEqual(["tenant-1"]);
-    expect(screeningFiltered.items.map((item) => item.id)).toEqual(["tenant-1"]);
+    expect(leaseFiltered.items.map((item) => item.id)).toEqual(["tenant-6", "tenant-4", "tenant-1"]);
+    expect(screeningFiltered.items.map((item) => item.id)).toEqual(["tenant-4", "tenant-1"]);
     expect(moveInFiltered.items.map((item) => item.id)).toEqual(["tenant-2"]);
   });
 
@@ -204,6 +258,46 @@ describe("adminTenantView", () => {
     expect(result.items[0]?.flags.missingLeaseLink).toBe(true);
   });
 
+  it("uses linked unit documents when lease and tenant unit fields contain raw unit ids", async () => {
+    const { listAdminTenants } = await import("../admin/adminTenantView");
+    const result = await listAdminTenants({ firestore: fakeDb as any, q: "chip@example.com", page: 1, pageSize: 25 });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      fullName: "Chip Milo",
+      propertyName: "Coburg Rd",
+      unitNumber: "6",
+      leaseId: "lease-4",
+      leaseStatus: "active",
+      currentLeaseStartDate: "2026-04-01",
+      currentLeaseEndDate: "2027-03-31",
+    });
+  });
+
+  it("uses unitId field lookup when raw unit id does not match the unit document id", async () => {
+    const { listAdminTenants } = await import("../admin/adminTenantView");
+    const result = await listAdminTenants({ firestore: fakeDb as any, q: "field@example.com", page: 1, pageSize: 25 });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      fullName: "Field Unit Tenant",
+      propertyName: "Coburg Rd",
+      unitNumber: "6",
+      leaseId: "lease-6",
+      leaseStatus: "active",
+    });
+  });
+
+  it("keeps legitimate applicant and active tenant workspaces distinct for the same person", async () => {
+    const { listAdminTenants } = await import("../admin/adminTenantView");
+    const result = await listAdminTenants({ firestore: fakeDb as any, q: "chip milo", sortBy: "createdAt", sortDir: "asc", page: 1, pageSize: 25 });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map((item) => item.id).sort()).toEqual(["tenant-4", "tenant-5"]);
+    expect(result.items.find((item) => item.id === "tenant-4")?.lifecycle.lifecycleState).toBe("active");
+    expect(result.items.find((item) => item.id === "tenant-5")?.lifecycle.lifecycleState).toBe("applicant");
+  });
+
   it("supports sort and pagination", async () => {
     const { listAdminTenants } = await import("../admin/adminTenantView");
     const result = await listAdminTenants({
@@ -214,7 +308,7 @@ describe("adminTenantView", () => {
       pageSize: 1,
     });
 
-    expect(result.total).toBe(3);
+    expect(result.total).toBe(6);
     expect(result.page).toBe(2);
     expect(result.pageSize).toBe(1);
     expect(result.hasMore).toBe(true);

--- a/rentchain-api/src/services/__tests__/adminTenantView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminTenantView.test.ts
@@ -128,6 +128,7 @@ describe("adminTenantView", () => {
     seedDoc("tenants", "tenant-live-chip", {
       fullName: "Chip Milo",
       email: "chip.live@example.com",
+      tenantId: "chip-user-1",
       landlordId: "landlord-1",
       propertyId: "prop-1",
       unitId: "a1O2tQcdEZ7t6y3GHT5G",
@@ -184,7 +185,7 @@ describe("adminTenantView", () => {
       propertyId: "prop-1",
       unitId: "a1O2tQcdEZ7t6y3GHT5G",
       unitNumber: "a1O2tQcdEZ7t6y3GHT5G",
-      tenantIds: ["tenant-live-chip"],
+      tenantIds: ["chip-user-1"],
       status: "active",
       startDate: "2026-05-01",
       endDate: "2027-04-30",
@@ -326,6 +327,34 @@ describe("adminTenantView", () => {
       leaseStatus: "active",
       currentLeaseStartDate: "2026-05-01",
       currentLeaseEndDate: "2027-04-30",
+    });
+  });
+
+  it("does not expose raw unit ids when converted tenant unit references cannot be resolved", async () => {
+    seedDoc("tenants", "tenant-alice", {
+      fullName: "Alice Wonderland",
+      email: "alice@example.com",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "LP1buUj0kSH6A668slqP",
+      unitNumber: "LP1buUj0kSH6A668slqP",
+      leaseStatus: "active",
+      status: "active",
+      createdAt: "2026-03-11T00:00:00.000Z",
+      updatedAt: "2026-03-11T00:00:00.000Z",
+    });
+
+    const { listAdminTenants } = await import("../admin/adminTenantView");
+    const result = await listAdminTenants({ firestore: fakeDb as any, q: "alice", page: 1, pageSize: 25 });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      fullName: "Alice Wonderland",
+      unitId: "LP1buUj0kSH6A668slqP",
+      unitNumber: null,
+      leaseStatus: "active",
+      currentLeaseStartDate: null,
+      currentLeaseEndDate: null,
     });
   });
 

--- a/rentchain-api/src/services/__tests__/adminTenantView.test.ts
+++ b/rentchain-api/src/services/__tests__/adminTenantView.test.ts
@@ -11,6 +11,7 @@ const { fakeDb, resetFakeDb, seedDoc } = (() => {
   function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
     return filters.every(({ field, op, value }) => {
       const actual = doc?.data?.[field];
+      if (op === "array-contains") return Array.isArray(actual) && actual.includes(value);
       if (op === "==") return actual === value;
       return false;
     });
@@ -124,6 +125,18 @@ describe("adminTenantView", () => {
       createdAt: "2026-03-04T00:00:00.000Z",
       updatedAt: "2026-03-08T00:00:00.000Z",
     });
+    seedDoc("tenants", "tenant-live-chip", {
+      fullName: "Chip Milo",
+      email: "chip.live@example.com",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "a1O2tQcdEZ7t6y3GHT5G",
+      unitNumber: "a1O2tQcdEZ7t6y3GHT5G",
+      leaseStatus: "active",
+      status: "active",
+      createdAt: "2026-03-10T00:00:00.000Z",
+      updatedAt: "2026-03-10T00:00:00.000Z",
+    });
 
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",
@@ -166,11 +179,22 @@ describe("adminTenantView", () => {
       leaseStartDate: "2026-05-01",
       leaseEndDate: "2027-04-30",
     });
+    seedDoc("leases", "ZD2VvH7cCZ7Q8YfVGR55", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "a1O2tQcdEZ7t6y3GHT5G",
+      unitNumber: "a1O2tQcdEZ7t6y3GHT5G",
+      tenantIds: ["tenant-live-chip"],
+      status: "active",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+    });
 
     seedDoc("properties", "prop-1", { name: "Coburg Rd" });
     seedDoc("properties", "prop-2", { name: "Summit" });
     seedDoc("units", "unit-doc-coburg-6", { propertyId: "prop-1", unitId: "unit-coburg-6", unitNumber: "6" });
     seedDoc("units", "unit-field-doc-6", { unitId: "unit-field-6", unitNumber: "6" });
+    seedDoc("units", "a1O2tQcdEZ7t6y3GHT5G", { propertyId: "prop-1", unitNumber: "6" });
   });
 
   it("returns only safe admin tenant view fields", async () => {
@@ -244,7 +268,7 @@ describe("adminTenantView", () => {
       pageSize: 25,
     });
 
-    expect(leaseFiltered.items.map((item) => item.id)).toEqual(["tenant-6", "tenant-4", "tenant-1"]);
+    expect(leaseFiltered.items.map((item) => item.id)).toEqual(["tenant-live-chip", "tenant-6", "tenant-4", "tenant-1"]);
     expect(screeningFiltered.items.map((item) => item.id)).toEqual(["tenant-4", "tenant-1"]);
     expect(moveInFiltered.items.map((item) => item.id)).toEqual(["tenant-2"]);
   });
@@ -288,14 +312,32 @@ describe("adminTenantView", () => {
     });
   });
 
+  it("reverse-links active leases and resolves raw unit ids when tenant lease pointers are missing", async () => {
+    const { listAdminTenants } = await import("../admin/adminTenantView");
+    const result = await listAdminTenants({ firestore: fakeDb as any, q: "chip.live@example.com", page: 1, pageSize: 25 });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      fullName: "Chip Milo",
+      propertyName: "Coburg Rd",
+      unitId: "a1O2tQcdEZ7t6y3GHT5G",
+      unitNumber: "6",
+      leaseId: "ZD2VvH7cCZ7Q8YfVGR55",
+      leaseStatus: "active",
+      currentLeaseStartDate: "2026-05-01",
+      currentLeaseEndDate: "2027-04-30",
+    });
+  });
+
   it("keeps legitimate applicant and active tenant workspaces distinct for the same person", async () => {
     const { listAdminTenants } = await import("../admin/adminTenantView");
     const result = await listAdminTenants({ firestore: fakeDb as any, q: "chip milo", sortBy: "createdAt", sortDir: "asc", page: 1, pageSize: 25 });
 
-    expect(result.items).toHaveLength(2);
-    expect(result.items.map((item) => item.id).sort()).toEqual(["tenant-4", "tenant-5"]);
+    expect(result.items).toHaveLength(3);
+    expect(result.items.map((item) => item.id).sort()).toEqual(["tenant-4", "tenant-5", "tenant-live-chip"]);
     expect(result.items.find((item) => item.id === "tenant-4")?.lifecycle.lifecycleState).toBe("active");
     expect(result.items.find((item) => item.id === "tenant-5")?.lifecycle.lifecycleState).toBe("applicant");
+    expect(result.items.find((item) => item.id === "tenant-live-chip")?.lifecycle.lifecycleState).toBe("active");
   });
 
   it("supports sort and pagination", async () => {
@@ -308,7 +350,7 @@ describe("adminTenantView", () => {
       pageSize: 1,
     });
 
-    expect(result.total).toBe(6);
+    expect(result.total).toBe(7);
     expect(result.page).toBe(2);
     expect(result.pageSize).toBe(1);
     expect(result.hasMore).toBe(true);

--- a/rentchain-api/src/services/admin/adminLeaseView.ts
+++ b/rentchain-api/src/services/admin/adminLeaseView.ts
@@ -1,4 +1,11 @@
 import { db } from "../../config/firebase";
+import {
+  loadUnitsForProperty,
+  resolveUnitReference,
+  toCanonicalLeaseRecord,
+  toCanonicalUnitRecord,
+  type CanonicalUnitRecord,
+} from "../leaseCanonicalizationService";
 
 type FirestoreLike = Pick<FirebaseFirestore.Firestore, "collection">;
 
@@ -172,6 +179,12 @@ function buildLeaseDisplayLabel(input: {
   return `${property} · ${unit} · ${tenant}`;
 }
 
+function normalizeUnitDisplayValue(value: unknown): string | null {
+  const next = asTrimmedString(value);
+  if (!next) return null;
+  return next.replace(/^unit\s+/i, "").trim() || null;
+}
+
 function isLikelyRawInternalId(value: string | null, knownId?: string | null): boolean {
   const normalized = asTrimmedString(value);
   if (!normalized) return false;
@@ -179,15 +192,59 @@ function isLikelyRawInternalId(value: string | null, knownId?: string | null): b
   return /^[A-Za-z0-9_-]{16,}$/.test(normalized) && !/\s/.test(normalized);
 }
 
-function safeUnitDisplayLabel(raw: Record<string, unknown>): string | null {
+function canonicalUnitLabel(unit?: CanonicalUnitRecord | null): string | null {
+  if (!unit) return null;
+  const candidates = [
+    unit.unitNumber,
+    unit.label,
+    unit.raw?.unitNumber,
+    unit.raw?.unitLabel,
+    unit.raw?.label,
+    unit.raw?.name,
+    unit.raw?.unit,
+  ]
+    .map((value) => normalizeUnitDisplayValue(value))
+    .filter(Boolean);
+  for (const candidate of candidates) {
+    if (!isLikelyRawInternalId(candidate, unit.id)) return candidate;
+  }
+  return null;
+}
+
+function resolveUnitDisplayFromPropertyUnits(
+  raw: Record<string, unknown>,
+  propertyUnits: CanonicalUnitRecord[]
+): string | null {
+  const references = [raw.unitId, raw.resolvedUnitId, raw.unitNumber, raw.unitLabel, raw.unit]
+    .map((value) => asTrimmedString(value))
+    .filter(Boolean);
+  for (const reference of references) {
+    const resolution = resolveUnitReference(propertyUnits, reference);
+    if (!resolution.ambiguous && resolution.unit) {
+      const label = canonicalUnitLabel(resolution.unit);
+      if (label) return label;
+    }
+    const exactUnit = propertyUnits.find((unit) =>
+      [unit.id, unit.raw?.unitId, unit.raw?.uid, unit.raw?.id]
+        .map((value) => asTrimmedString(value))
+        .filter(Boolean)
+        .includes(reference)
+    );
+    const exactLabel = canonicalUnitLabel(exactUnit);
+    if (exactLabel) return exactLabel;
+  }
+  return null;
+}
+
+function safeUnitDisplayLabel(raw: Record<string, unknown>, propertyUnits: CanonicalUnitRecord[]): string | null {
   const unitId = asTrimmedString(raw.unitId) || null;
   const candidates = [raw.unitNumber, raw.unitLabel, raw.unit]
-    .map((value) => asTrimmedString(value))
+    .map((value) => normalizeUnitDisplayValue(value))
     .filter(Boolean);
   for (const candidate of candidates) {
     if (!isLikelyRawInternalId(candidate, unitId)) return candidate;
   }
-  return null;
+  return resolveUnitDisplayFromPropertyUnits(raw, propertyUnits);
 }
 
 async function loadLinkedDocs(
@@ -207,9 +264,35 @@ async function loadLinkedDocs(
   return out;
 }
 
+async function loadUnitsByReferences(
+  firestore: FirestoreLike,
+  references: string[]
+): Promise<Map<string, CanonicalUnitRecord[]>> {
+  const out = new Map<string, CanonicalUnitRecord[]>();
+  const uniqueReferences = Array.from(new Set(references.map((value) => asTrimmedString(value)).filter(Boolean)));
+  await Promise.all(
+    uniqueReferences.map(async (reference) => {
+      const rows: CanonicalUnitRecord[] = [];
+      const docSnap = await (firestore.collection("units") as any).doc(reference).get().catch(() => null);
+      if (docSnap?.exists) {
+        rows.push(toCanonicalUnitRecord(docSnap.id || reference, (docSnap.data() || {}) as Record<string, unknown>));
+      }
+      const fieldSnap = await (firestore.collection("units") as any).where("unitId", "==", reference).get().catch(() => null);
+      for (const doc of fieldSnap?.docs || []) {
+        rows.push(toCanonicalUnitRecord(doc.id, (doc.data() || {}) as Record<string, unknown>));
+      }
+      if (rows.length) out.set(reference, rows);
+    })
+  );
+  return out;
+}
+
 function buildView(
   lease: LeaseDocRow,
   propertiesById: Map<string, Record<string, unknown>>,
+  unitsByPropertyId: Map<string, CanonicalUnitRecord[]>,
+  unitsById: Map<string, Record<string, unknown>>,
+  unitsByReference: Map<string, CanonicalUnitRecord[]>,
   tenantsById: Map<string, Record<string, unknown>>,
   landlordsById: Map<string, Record<string, unknown>>
 ): AdminLeaseView {
@@ -230,15 +313,50 @@ function buildView(
     asTrimmedString(property?.name) ||
     asTrimmedString(raw.propertyName || raw.propertyLabel) ||
     null;
-  const unitNumber = safeUnitDisplayLabel(raw);
-  const landlordDisplayName = safeLandlordDisplayName(landlord) || "Landlord account";
+  const unitId =
+    asTrimmedString(raw.unitId) ||
+    asTrimmedString(raw.resolvedUnitId) ||
+    asTrimmedString(raw.unitNumber) ||
+    null;
+  const propertyUnits = propertyId ? [...(unitsByPropertyId.get(propertyId) || [])] : [];
+  const unitReferences = [raw.unitId, raw.resolvedUnitId, raw.unitNumber, raw.unitLabel, raw.unit]
+    .map((value) => asTrimmedString(value))
+    .filter(Boolean);
+  for (const reference of unitReferences) {
+    for (const unit of unitsByReference.get(reference) || []) {
+      if (!propertyUnits.some((existing) => existing.id === unit.id)) propertyUnits.push(unit);
+    }
+  }
+  const directUnitRaw = unitId ? unitsById.get(unitId) : null;
+  if (directUnitRaw && !propertyUnits.some((unit) => unit.id === unitId)) {
+    propertyUnits.push({
+      id: unitId!,
+      landlordId: asTrimmedString(directUnitRaw.landlordId) || null,
+      propertyId: asTrimmedString(directUnitRaw.propertyId) || propertyId,
+      unitNumber: asTrimmedString(directUnitRaw.unitNumber ?? directUnitRaw.unit ?? directUnitRaw.name) || null,
+      label: asTrimmedString(directUnitRaw.label ?? directUnitRaw.displayLabel ?? directUnitRaw.unitLabel ?? directUnitRaw.unitNumber) || null,
+      rent: Number.isFinite(Number(directUnitRaw.rent ?? directUnitRaw.marketRent ?? directUnitRaw.monthlyRent))
+        ? Number(directUnitRaw.rent ?? directUnitRaw.marketRent ?? directUnitRaw.monthlyRent)
+        : null,
+      raw: directUnitRaw,
+    });
+  }
+  const canonicalLease = toCanonicalLeaseRecord(lease.id, raw, propertyUnits);
+  const unitNumber =
+    canonicalUnitLabel(propertyUnits.find((unit) => unit.id === canonicalLease.resolvedUnitId)) ||
+    normalizeUnitDisplayValue(canonicalLease.resolvedUnitLabel) ||
+    normalizeUnitDisplayValue(canonicalLease.resolvedUnitNumber) ||
+    safeUnitDisplayLabel(raw, propertyUnits);
+  const landlordDisplayName =
+    safeLandlordDisplayName(landlord) ||
+    (landlordId ? "Landlord linked / profile missing" : "Landlord profile unavailable");
 
   return {
     id: lease.id,
     leaseDisplayLabel: buildLeaseDisplayLabel({ propertyName, unitNumber, tenantNames }),
     propertyId,
     propertyName,
-    unitId: asTrimmedString(raw.unitId) || null,
+    unitId,
     unitNumber,
     landlordId,
     landlordDisplayName,
@@ -301,13 +419,31 @@ export async function listAdminLeases(
   const propertyIds = Array.from(new Set(leaseDocs.map((lease) => asTrimmedString(lease.raw.propertyId)).filter(Boolean)));
   const tenantIds = Array.from(new Set(leaseDocs.flatMap((lease) => tenantIdsFromLease(lease.raw))));
   const landlordIds = Array.from(new Set(leaseDocs.map((lease) => asTrimmedString(lease.raw.landlordId)).filter(Boolean)));
-  const [propertiesById, tenantsById, landlordsById] = await Promise.all([
+  const unitIds = Array.from(
+    new Set(
+      leaseDocs
+        .flatMap((lease) => [lease.raw.unitId, lease.raw.resolvedUnitId, lease.raw.unitNumber, lease.raw.unitLabel, lease.raw.unit])
+        .map((value) => asTrimmedString(value))
+        .filter(Boolean)
+    )
+  );
+  const [propertiesById, tenantsById, landlordsById, unitsById, unitsByReference] = await Promise.all([
     loadLinkedDocs(firestore, "properties", propertyIds),
     loadLinkedDocs(firestore, "tenants", tenantIds),
     loadLinkedDocs(firestore, "landlords", landlordIds),
+    loadLinkedDocs(firestore, "units", unitIds),
+    loadUnitsByReferences(firestore, unitIds),
   ]);
+  const unitsByPropertyId = new Map<string, CanonicalUnitRecord[]>();
+  await Promise.all(
+    propertyIds.map(async (propertyId) => {
+      unitsByPropertyId.set(propertyId, await loadUnitsForProperty(firestore as any, propertyId).catch(() => []));
+    })
+  );
 
-  const allViews = leaseDocs.map((lease) => buildView(lease, propertiesById, tenantsById, landlordsById));
+  const allViews = leaseDocs.map((lease) =>
+    buildView(lease, propertiesById, unitsByPropertyId, unitsById, unitsByReference, tenantsById, landlordsById)
+  );
 
   const filtered = allViews.filter((view) => {
     if (!matchesSearch(view, query.q)) return false;

--- a/rentchain-api/src/services/admin/adminLeaseView.ts
+++ b/rentchain-api/src/services/admin/adminLeaseView.ts
@@ -343,6 +343,7 @@ function buildView(
   }
   const canonicalLease = toCanonicalLeaseRecord(lease.id, raw, propertyUnits);
   const unitNumber =
+    canonicalUnitLabel(directUnitRaw ? toCanonicalUnitRecord(unitId!, directUnitRaw) : null) ||
     canonicalUnitLabel(propertyUnits.find((unit) => unit.id === canonicalLease.resolvedUnitId)) ||
     normalizeUnitDisplayValue(canonicalLease.resolvedUnitLabel) ||
     normalizeUnitDisplayValue(canonicalLease.resolvedUnitNumber) ||

--- a/rentchain-api/src/services/admin/adminLeaseView.ts
+++ b/rentchain-api/src/services/admin/adminLeaseView.ts
@@ -68,6 +68,16 @@ function unitScopeKey(propertyId: string | null | undefined, landlordId: string 
   return `${asTrimmedString(propertyId)}::${asTrimmedString(landlordId)}`;
 }
 
+function mergeUnits(...groups: CanonicalUnitRecord[][]): CanonicalUnitRecord[] {
+  const out = new Map<string, CanonicalUnitRecord>();
+  for (const group of groups) {
+    for (const unit of group) {
+      if (!out.has(unit.id)) out.set(unit.id, unit);
+    }
+  }
+  return Array.from(out.values());
+}
+
 function asTrimmedString(value: unknown): string {
   return String(value || "").trim();
 }
@@ -251,6 +261,11 @@ function safeUnitDisplayLabel(raw: Record<string, unknown>, propertyUnits: Canon
   return resolveUnitDisplayFromPropertyUnits(raw, propertyUnits);
 }
 
+function sanitizeUnitNumber(value: string | null, unitId: string | null): string | null {
+  const normalized = normalizeUnitDisplayValue(value);
+  return normalized && !isLikelyRawInternalId(normalized, unitId) ? normalized : null;
+}
+
 async function loadLinkedDocs(
   firestore: FirestoreLike,
   collectionName: string,
@@ -322,7 +337,12 @@ function buildView(
     asTrimmedString(raw.resolvedUnitId) ||
     asTrimmedString(raw.unitNumber) ||
     null;
-  const propertyUnits = propertyId ? [...(unitsByPropertyScope.get(unitScopeKey(propertyId, landlordId)) || [])] : [];
+  const propertyUnits = propertyId
+    ? mergeUnits(
+        unitsByPropertyScope.get(unitScopeKey(propertyId, landlordId)) || [],
+        unitsByPropertyScope.get(unitScopeKey(propertyId, null)) || []
+      )
+    : [];
   const unitReferences = [raw.unitId, raw.resolvedUnitId, raw.unitNumber, raw.unitLabel, raw.unit]
     .map((value) => asTrimmedString(value))
     .filter(Boolean);
@@ -346,12 +366,13 @@ function buildView(
     });
   }
   const canonicalLease = toCanonicalLeaseRecord(lease.id, raw, propertyUnits);
-  const unitNumber =
+  const resolvedUnitNumber =
     canonicalUnitLabel(directUnitRaw ? toCanonicalUnitRecord(unitId!, directUnitRaw) : null) ||
     canonicalUnitLabel(propertyUnits.find((unit) => unit.id === canonicalLease.resolvedUnitId)) ||
     normalizeUnitDisplayValue(canonicalLease.resolvedUnitLabel) ||
     normalizeUnitDisplayValue(canonicalLease.resolvedUnitNumber) ||
     safeUnitDisplayLabel(raw, propertyUnits);
+  const unitNumber = sanitizeUnitNumber(resolvedUnitNumber, unitId);
   const landlordDisplayName =
     safeLandlordDisplayName(landlord) ||
     (landlordId ? "Landlord linked / profile missing" : "Landlord profile unavailable");
@@ -439,16 +460,18 @@ export async function listAdminLeases(
     loadLinkedDocs(firestore, "units", unitIds),
     loadUnitsByReferences(firestore, unitIds),
   ]);
+  const scopedUnitEntries = leaseDocs
+    .map((lease) => {
+      const propertyId = asTrimmedString(lease.raw.propertyId);
+      if (!propertyId) return null;
+      const landlordId = asTrimmedString(lease.raw.landlordId);
+      return [unitScopeKey(propertyId, landlordId), { propertyId, landlordId }] as const;
+    })
+    .filter((value): value is readonly [string, { propertyId: string; landlordId: string }] => Boolean(value));
+  const unscopedUnitEntries = propertyIds.map((propertyId) => [unitScopeKey(propertyId, null), { propertyId, landlordId: "" }] as const);
   const unitScopes = Array.from(
     new Map(
-      leaseDocs
-        .map((lease) => {
-          const propertyId = asTrimmedString(lease.raw.propertyId);
-          if (!propertyId) return null;
-          const landlordId = asTrimmedString(lease.raw.landlordId);
-          return [unitScopeKey(propertyId, landlordId), { propertyId, landlordId }] as const;
-        })
-        .filter((value): value is readonly [string, { propertyId: string; landlordId: string }] => Boolean(value))
+      [...scopedUnitEntries, ...unscopedUnitEntries]
     ).values()
   );
   const unitsByPropertyScope = new Map<string, CanonicalUnitRecord[]>();

--- a/rentchain-api/src/services/admin/adminLeaseView.ts
+++ b/rentchain-api/src/services/admin/adminLeaseView.ts
@@ -64,6 +64,10 @@ type LeaseDocRow = {
   raw: Record<string, unknown>;
 };
 
+function unitScopeKey(propertyId: string | null | undefined, landlordId: string | null | undefined): string {
+  return `${asTrimmedString(propertyId)}::${asTrimmedString(landlordId)}`;
+}
+
 function asTrimmedString(value: unknown): string {
   return String(value || "").trim();
 }
@@ -290,7 +294,7 @@ async function loadUnitsByReferences(
 function buildView(
   lease: LeaseDocRow,
   propertiesById: Map<string, Record<string, unknown>>,
-  unitsByPropertyId: Map<string, CanonicalUnitRecord[]>,
+  unitsByPropertyScope: Map<string, CanonicalUnitRecord[]>,
   unitsById: Map<string, Record<string, unknown>>,
   unitsByReference: Map<string, CanonicalUnitRecord[]>,
   tenantsById: Map<string, Record<string, unknown>>,
@@ -318,7 +322,7 @@ function buildView(
     asTrimmedString(raw.resolvedUnitId) ||
     asTrimmedString(raw.unitNumber) ||
     null;
-  const propertyUnits = propertyId ? [...(unitsByPropertyId.get(propertyId) || [])] : [];
+  const propertyUnits = propertyId ? [...(unitsByPropertyScope.get(unitScopeKey(propertyId, landlordId)) || [])] : [];
   const unitReferences = [raw.unitId, raw.resolvedUnitId, raw.unitNumber, raw.unitLabel, raw.unit]
     .map((value) => asTrimmedString(value))
     .filter(Boolean);
@@ -435,15 +439,30 @@ export async function listAdminLeases(
     loadLinkedDocs(firestore, "units", unitIds),
     loadUnitsByReferences(firestore, unitIds),
   ]);
-  const unitsByPropertyId = new Map<string, CanonicalUnitRecord[]>();
+  const unitScopes = Array.from(
+    new Map(
+      leaseDocs
+        .map((lease) => {
+          const propertyId = asTrimmedString(lease.raw.propertyId);
+          if (!propertyId) return null;
+          const landlordId = asTrimmedString(lease.raw.landlordId);
+          return [unitScopeKey(propertyId, landlordId), { propertyId, landlordId }] as const;
+        })
+        .filter((value): value is readonly [string, { propertyId: string; landlordId: string }] => Boolean(value))
+    ).values()
+  );
+  const unitsByPropertyScope = new Map<string, CanonicalUnitRecord[]>();
   await Promise.all(
-    propertyIds.map(async (propertyId) => {
-      unitsByPropertyId.set(propertyId, await loadUnitsForProperty(firestore as any, propertyId).catch(() => []));
+    unitScopes.map(async ({ propertyId, landlordId }) => {
+      unitsByPropertyScope.set(
+        unitScopeKey(propertyId, landlordId),
+        await loadUnitsForProperty(firestore as any, propertyId, landlordId).catch(() => [])
+      );
     })
   );
 
   const allViews = leaseDocs.map((lease) =>
-    buildView(lease, propertiesById, unitsByPropertyId, unitsById, unitsByReference, tenantsById, landlordsById)
+    buildView(lease, propertiesById, unitsByPropertyScope, unitsById, unitsByReference, tenantsById, landlordsById)
   );
 
   const filtered = allViews.filter((view) => {

--- a/rentchain-api/src/services/admin/adminTenantView.ts
+++ b/rentchain-api/src/services/admin/adminTenantView.ts
@@ -77,6 +77,10 @@ type LeaseDocRow = {
   raw: Record<string, unknown>;
 };
 
+function unitScopeKey(propertyId: string | null | undefined, landlordId: string | null | undefined): string {
+  return `${asTrimmedString(propertyId)}::${asTrimmedString(landlordId)}`;
+}
+
 function asTrimmedString(value: unknown): string {
   return String(value || "").trim();
 }
@@ -353,7 +357,7 @@ function buildView(
   leasesById: Map<string, Record<string, unknown>>,
   reverseLeasesByTenantId: Map<string, LeaseDocRow[]>,
   propertiesById: Map<string, Record<string, unknown>>,
-  unitsByPropertyId: Map<string, CanonicalUnitRecord[]>,
+  unitsByPropertyScope: Map<string, CanonicalUnitRecord[]>,
   unitsById: Map<string, Record<string, unknown>>,
   unitsByReference: Map<string, CanonicalUnitRecord[]>
 ): AdminTenantView {
@@ -365,6 +369,7 @@ function buildView(
     asTrimmedString(linkedLease?.raw.propertyId) ||
     null;
   const property = propertyId ? propertiesById.get(propertyId) : null;
+  const landlordId = asTrimmedString(tenant.raw.landlordId) || asTrimmedString(linkedLease?.raw.landlordId) || null;
   const propertyName =
     asTrimmedString(property?.name) ||
     asTrimmedString(tenant.raw.propertyName || tenant.raw.property) ||
@@ -378,7 +383,7 @@ function buildView(
     asTrimmedString(tenant.raw.unitNumber) ||
     asTrimmedString(linkedLease?.raw.unitNumber) ||
     null;
-  const propertyUnits = propertyId ? unitsByPropertyId.get(propertyId) || [] : [];
+  const propertyUnits = propertyId ? unitsByPropertyScope.get(unitScopeKey(propertyId, landlordId)) || [] : [];
   const directUnitRaw = unitId ? unitsById.get(unitId) : null;
   const unitCandidates = [...propertyUnits];
   const unitReferences = [
@@ -450,7 +455,7 @@ function buildView(
     lastName: names.lastName,
     email: asTrimmedString(tenant.raw.email) || null,
     phone: asTrimmedString(tenant.raw.phone) || null,
-    landlordId: asTrimmedString(tenant.raw.landlordId) || asTrimmedString(linkedLease?.raw.landlordId) || null,
+    landlordId,
     propertyId,
     propertyName,
     unitId,
@@ -564,15 +569,31 @@ export async function listAdminTenants(
   );
   const unitsById = await loadLinkedDocs(firestore, "units", unitIds);
   const unitsByReference = await loadUnitsByReferences(firestore, unitIds);
-  const unitsByPropertyId = new Map<string, CanonicalUnitRecord[]>();
+  const unitScopes = Array.from(
+    new Map(
+      tenantDocs
+        .map((tenant) => {
+          const linkedLease = resolveLeaseLink(tenant, leasesById, reverseLeasesByTenantId);
+          const propertyId = asTrimmedString(tenant.raw.propertyId || linkedLease?.raw.propertyId);
+          if (!propertyId) return null;
+          const landlordId = asTrimmedString(tenant.raw.landlordId || linkedLease?.raw.landlordId);
+          return [unitScopeKey(propertyId, landlordId), { propertyId, landlordId }] as const;
+        })
+        .filter((value): value is readonly [string, { propertyId: string; landlordId: string }] => Boolean(value))
+    ).values()
+  );
+  const unitsByPropertyScope = new Map<string, CanonicalUnitRecord[]>();
   await Promise.all(
-    propertyIds.map(async (propertyId) => {
-      unitsByPropertyId.set(propertyId, await loadUnitsForProperty(firestore as any, propertyId).catch(() => []));
+    unitScopes.map(async ({ propertyId, landlordId }) => {
+      unitsByPropertyScope.set(
+        unitScopeKey(propertyId, landlordId),
+        await loadUnitsForProperty(firestore as any, propertyId, landlordId).catch(() => [])
+      );
     })
   );
 
   const allViews = tenantDocs.map((tenant) =>
-    buildView(tenant, leasesById, reverseLeasesByTenantId, propertiesById, unitsByPropertyId, unitsById, unitsByReference)
+    buildView(tenant, leasesById, reverseLeasesByTenantId, propertiesById, unitsByPropertyScope, unitsById, unitsByReference)
   );
 
   const filtered = allViews.filter((view) => {

--- a/rentchain-api/src/services/admin/adminTenantView.ts
+++ b/rentchain-api/src/services/admin/adminTenantView.ts
@@ -72,6 +72,11 @@ type LeaseLink = {
   raw: Record<string, unknown>;
 } | null;
 
+type LeaseDocRow = {
+  id: string;
+  raw: Record<string, unknown>;
+};
+
 function asTrimmedString(value: unknown): string {
   return String(value || "").trim();
 }
@@ -222,6 +227,19 @@ function leaseStatus(raw: Record<string, unknown>) {
   return asTrimmedString(raw.leaseStatus || raw.status) || null;
 }
 
+function isCurrentLeaseStatus(value: unknown) {
+  const normalized = asLower(value);
+  return ["active", "current", "notice_pending", "renewal_pending", "renewal_accepted", "move_out_pending"].includes(normalized);
+}
+
+function leaseStart(raw: Record<string, unknown>) {
+  return normalizeDate(raw.leaseStartDate) || normalizeDate(raw.startDate) || normalizeDate(raw.leaseStart);
+}
+
+function leaseEnd(raw: Record<string, unknown>) {
+  return normalizeDate(raw.leaseEndDate) || normalizeDate(raw.endDate) || normalizeDate(raw.leaseEnd);
+}
+
 function compareValues(a: string | number | null, b: string | number | null, dir: "asc" | "desc") {
   const aValue = a ?? "";
   const bValue = b ?? "";
@@ -272,40 +290,75 @@ async function loadUnitsByReferences(
   return out;
 }
 
+async function loadReverseLeaseLinks(
+  firestore: FirestoreLike,
+  tenantIds: string[]
+): Promise<Map<string, LeaseDocRow[]>> {
+  const out = new Map<string, LeaseDocRow[]>();
+  const uniqueTenantIds = Array.from(new Set(tenantIds.map((value) => asTrimmedString(value)).filter(Boolean)));
+  await Promise.all(
+    uniqueTenantIds.map(async (tenantId) => {
+      const rows = new Map<string, LeaseDocRow>();
+      const directSnap = await (firestore.collection("leases") as any).where("tenantId", "==", tenantId).get().catch(() => null);
+      for (const doc of directSnap?.docs || []) {
+        rows.set(doc.id, { id: doc.id, raw: (doc.data() || {}) as Record<string, unknown> });
+      }
+      const arraySnap = await (firestore.collection("leases") as any)
+        .where("tenantIds", "array-contains", tenantId)
+        .get()
+        .catch(() => null);
+      for (const doc of arraySnap?.docs || []) {
+        rows.set(doc.id, { id: doc.id, raw: (doc.data() || {}) as Record<string, unknown> });
+      }
+      if (rows.size) out.set(tenantId, Array.from(rows.values()));
+    })
+  );
+  return out;
+}
+
 function resolveLeaseLink(
   tenant: TenantDocRow,
-  leasesById: Map<string, Record<string, unknown>>
+  leasesById: Map<string, Record<string, unknown>>,
+  reverseLeasesByTenantId: Map<string, LeaseDocRow[]> = new Map()
 ): LeaseLink {
   const leaseId = asTrimmedString(tenant.raw.currentLeaseId || tenant.raw.leaseId);
-  if (!leaseId) return null;
-  const raw = leasesById.get(leaseId);
-  if (!raw) return null;
+  const explicitRaw = leaseId ? leasesById.get(leaseId) : null;
+  const candidates: LeaseDocRow[] = explicitRaw
+    ? [{ id: leaseId, raw: explicitRaw }]
+    : reverseLeasesByTenantId.get(tenant.id) || [];
+  const compatible = candidates.filter(({ raw }) => {
+    if (!explicitRaw && !isCurrentLeaseStatus(leaseStatus(raw))) return false;
 
-  const tenantLandlordId = asTrimmedString(tenant.raw.landlordId);
-  const leaseLandlordId = asTrimmedString(raw.landlordId);
-  if (tenantLandlordId && leaseLandlordId && tenantLandlordId !== leaseLandlordId) return null;
+    const tenantLandlordId = asTrimmedString(tenant.raw.landlordId);
+    const leaseLandlordId = asTrimmedString(raw.landlordId);
+    if (tenantLandlordId && leaseLandlordId && tenantLandlordId !== leaseLandlordId) return false;
 
-  const tenantPropertyId = asTrimmedString(tenant.raw.propertyId);
-  const leasePropertyId = asTrimmedString(raw.propertyId);
-  if (tenantPropertyId && leasePropertyId && tenantPropertyId !== leasePropertyId) return null;
+    const tenantPropertyId = asTrimmedString(tenant.raw.propertyId);
+    const leasePropertyId = asTrimmedString(raw.propertyId);
+    if (tenantPropertyId && leasePropertyId && tenantPropertyId !== leasePropertyId) return false;
 
-  const tenantUnitId = asTrimmedString(tenant.raw.unitId);
-  const leaseUnitId = asTrimmedString(raw.unitId);
-  if (tenantUnitId && leaseUnitId && tenantUnitId !== leaseUnitId) return null;
+    const tenantUnitId = asTrimmedString(tenant.raw.unitId);
+    const leaseUnitId = asTrimmedString(raw.unitId);
+    if (tenantUnitId && leaseUnitId && tenantUnitId !== leaseUnitId) return false;
 
-  return { id: leaseId, raw };
+    return true;
+  });
+  compatible.sort((a, b) => (leaseStart(b.raw) || "").localeCompare(leaseStart(a.raw) || ""));
+  const winner = compatible[0];
+  return winner ? { id: winner.id, raw: winner.raw } : null;
 }
 
 function buildView(
   tenant: TenantDocRow,
   leasesById: Map<string, Record<string, unknown>>,
+  reverseLeasesByTenantId: Map<string, LeaseDocRow[]>,
   propertiesById: Map<string, Record<string, unknown>>,
   unitsByPropertyId: Map<string, CanonicalUnitRecord[]>,
   unitsById: Map<string, Record<string, unknown>>,
   unitsByReference: Map<string, CanonicalUnitRecord[]>
 ): AdminTenantView {
   const names = nameParts(tenant.raw);
-  const linkedLease = resolveLeaseLink(tenant, leasesById);
+  const linkedLease = resolveLeaseLink(tenant, leasesById, reverseLeasesByTenantId);
 
   const propertyId =
     asTrimmedString(tenant.raw.propertyId) ||
@@ -402,6 +455,7 @@ function buildView(
     propertyName,
     unitId,
     unitNumber:
+      canonicalUnitLabel(directUnitRaw ? toCanonicalUnitRecord(unitId!, directUnitRaw) : null) ||
       safeUnitLabel(tenant.raw, unitCandidates) ||
       resolvedLeaseUnit ||
       safeUnitLabel((linkedLease?.raw || {}) as Record<string, unknown>, unitCandidates) ||
@@ -411,12 +465,10 @@ function buildView(
     screeningStatus: currentScreeningStatus,
     moveInStatus: currentMoveInStatus,
     currentLeaseStartDate:
-      normalizeDate(linkedLease?.raw.leaseStartDate) ||
-      normalizeDate(linkedLease?.raw.leaseStart) ||
+      leaseStart((linkedLease?.raw || {}) as Record<string, unknown>) ||
       normalizeDate(tenant.raw.leaseStart),
     currentLeaseEndDate:
-      normalizeDate(linkedLease?.raw.leaseEndDate) ||
-      normalizeDate(linkedLease?.raw.leaseEnd) ||
+      leaseEnd((linkedLease?.raw || {}) as Record<string, unknown>) ||
       normalizeDate(tenant.raw.leaseEnd),
     createdAt: safeValue(tenant.raw.createdAt ?? tenant.raw.created_at),
     updatedAt: safeValue(tenant.raw.updatedAt ?? tenant.raw.updated_at),
@@ -471,13 +523,17 @@ export async function listAdminTenants(
         .filter(Boolean)
     )
   );
-  const leasesById = await loadLinkedDocs(firestore, "leases", leaseIds);
+  const tenantIds = tenantDocs.map((tenant) => tenant.id);
+  const [leasesById, reverseLeasesByTenantId] = await Promise.all([
+    loadLinkedDocs(firestore, "leases", leaseIds),
+    loadReverseLeaseLinks(firestore, tenantIds),
+  ]);
 
   const propertyIds = Array.from(
     new Set(
       tenantDocs
         .map((tenant) => {
-          const linkedLease = resolveLeaseLink(tenant, leasesById);
+          const linkedLease = resolveLeaseLink(tenant, leasesById, reverseLeasesByTenantId);
           return asTrimmedString(tenant.raw.propertyId || linkedLease?.raw.propertyId);
         })
         .filter(Boolean)
@@ -488,7 +544,7 @@ export async function listAdminTenants(
     new Set(
       tenantDocs
         .flatMap((tenant) => {
-          const linkedLease = resolveLeaseLink(tenant, leasesById);
+          const linkedLease = resolveLeaseLink(tenant, leasesById, reverseLeasesByTenantId);
           return [
             tenant.raw.unitId,
             tenant.raw.resolvedUnitId,
@@ -515,7 +571,9 @@ export async function listAdminTenants(
     })
   );
 
-  const allViews = tenantDocs.map((tenant) => buildView(tenant, leasesById, propertiesById, unitsByPropertyId, unitsById, unitsByReference));
+  const allViews = tenantDocs.map((tenant) =>
+    buildView(tenant, leasesById, reverseLeasesByTenantId, propertiesById, unitsByPropertyId, unitsById, unitsByReference)
+  );
 
   const filtered = allViews.filter((view) => {
     if (!matchesSearch(view, query.q)) return false;

--- a/rentchain-api/src/services/admin/adminTenantView.ts
+++ b/rentchain-api/src/services/admin/adminTenantView.ts
@@ -81,6 +81,16 @@ function unitScopeKey(propertyId: string | null | undefined, landlordId: string 
   return `${asTrimmedString(propertyId)}::${asTrimmedString(landlordId)}`;
 }
 
+function mergeUnits(...groups: CanonicalUnitRecord[][]): CanonicalUnitRecord[] {
+  const out = new Map<string, CanonicalUnitRecord>();
+  for (const group of groups) {
+    for (const unit of group) {
+      if (!out.has(unit.id)) out.set(unit.id, unit);
+    }
+  }
+  return Array.from(out.values());
+}
+
 function asTrimmedString(value: unknown): string {
   return String(value || "").trim();
 }
@@ -211,6 +221,11 @@ function safeUnitLabel(raw: Record<string, unknown>, propertyUnits: CanonicalUni
   return resolveUnitDisplayFromPropertyUnits(raw, propertyUnits);
 }
 
+function sanitizeUnitNumber(value: string | null, unitId: string | null): string | null {
+  const normalized = normalizeUnitDisplayValue(value);
+  return normalized && !isLikelyRawInternalId(normalized, unitId) ? normalized : null;
+}
+
 function screeningStatus(raw: Record<string, unknown>) {
   return (
     asTrimmedString(raw.screeningStatus) ||
@@ -294,12 +309,39 @@ async function loadUnitsByReferences(
   return out;
 }
 
+function tenantRelationshipKeys(tenant: TenantDocRow): string[] {
+  return Array.from(
+    new Set(
+      [
+        tenant.id,
+        tenant.raw.id,
+        tenant.raw.tenantId,
+        tenant.raw.userId,
+        tenant.raw.uid,
+        tenant.raw.accountId,
+        tenant.raw.profileId,
+        tenant.raw.authUid,
+      ]
+        .map((value) => asTrimmedString(value))
+        .filter(Boolean)
+    )
+  );
+}
+
 async function loadReverseLeaseLinks(
   firestore: FirestoreLike,
-  tenantIds: string[]
+  tenants: TenantDocRow[]
 ): Promise<Map<string, LeaseDocRow[]>> {
   const out = new Map<string, LeaseDocRow[]>();
-  const uniqueTenantIds = Array.from(new Set(tenantIds.map((value) => asTrimmedString(value)).filter(Boolean)));
+  const keyToTenantIds = new Map<string, string[]>();
+  for (const tenant of tenants) {
+    for (const key of tenantRelationshipKeys(tenant)) {
+      const existing = keyToTenantIds.get(key) || [];
+      existing.push(tenant.id);
+      keyToTenantIds.set(key, existing);
+    }
+  }
+  const uniqueTenantIds = Array.from(keyToTenantIds.keys());
   await Promise.all(
     uniqueTenantIds.map(async (tenantId) => {
       const rows = new Map<string, LeaseDocRow>();
@@ -314,7 +356,13 @@ async function loadReverseLeaseLinks(
       for (const doc of arraySnap?.docs || []) {
         rows.set(doc.id, { id: doc.id, raw: (doc.data() || {}) as Record<string, unknown> });
       }
-      if (rows.size) out.set(tenantId, Array.from(rows.values()));
+      if (rows.size) {
+        for (const ownerTenantId of keyToTenantIds.get(tenantId) || []) {
+          const existing = new Map((out.get(ownerTenantId) || []).map((row) => [row.id, row]));
+          for (const row of rows.values()) existing.set(row.id, row);
+          out.set(ownerTenantId, Array.from(existing.values()));
+        }
+      }
     })
   );
   return out;
@@ -383,7 +431,12 @@ function buildView(
     asTrimmedString(tenant.raw.unitNumber) ||
     asTrimmedString(linkedLease?.raw.unitNumber) ||
     null;
-  const propertyUnits = propertyId ? unitsByPropertyScope.get(unitScopeKey(propertyId, landlordId)) || [] : [];
+  const propertyUnits = propertyId
+    ? mergeUnits(
+        unitsByPropertyScope.get(unitScopeKey(propertyId, landlordId)) || [],
+        unitsByPropertyScope.get(unitScopeKey(propertyId, null)) || []
+      )
+    : [];
   const directUnitRaw = unitId ? unitsById.get(unitId) : null;
   const unitCandidates = [...propertyUnits];
   const unitReferences = [
@@ -459,12 +512,14 @@ function buildView(
     propertyId,
     propertyName,
     unitId,
-    unitNumber:
+    unitNumber: sanitizeUnitNumber(
       canonicalUnitLabel(directUnitRaw ? toCanonicalUnitRecord(unitId!, directUnitRaw) : null) ||
-      safeUnitLabel(tenant.raw, unitCandidates) ||
-      resolvedLeaseUnit ||
-      safeUnitLabel((linkedLease?.raw || {}) as Record<string, unknown>, unitCandidates) ||
-      null,
+        safeUnitLabel(tenant.raw, unitCandidates) ||
+        resolvedLeaseUnit ||
+        safeUnitLabel((linkedLease?.raw || {}) as Record<string, unknown>, unitCandidates) ||
+        null,
+      unitId
+    ),
     leaseId,
     leaseStatus: currentLeaseStatus,
     screeningStatus: currentScreeningStatus,
@@ -528,10 +583,9 @@ export async function listAdminTenants(
         .filter(Boolean)
     )
   );
-  const tenantIds = tenantDocs.map((tenant) => tenant.id);
   const [leasesById, reverseLeasesByTenantId] = await Promise.all([
     loadLinkedDocs(firestore, "leases", leaseIds),
-    loadReverseLeaseLinks(firestore, tenantIds),
+    loadReverseLeaseLinks(firestore, tenantDocs),
   ]);
 
   const propertyIds = Array.from(
@@ -569,17 +623,19 @@ export async function listAdminTenants(
   );
   const unitsById = await loadLinkedDocs(firestore, "units", unitIds);
   const unitsByReference = await loadUnitsByReferences(firestore, unitIds);
+  const scopedUnitEntries = tenantDocs
+    .map((tenant) => {
+      const linkedLease = resolveLeaseLink(tenant, leasesById, reverseLeasesByTenantId);
+      const propertyId = asTrimmedString(tenant.raw.propertyId || linkedLease?.raw.propertyId);
+      if (!propertyId) return null;
+      const landlordId = asTrimmedString(tenant.raw.landlordId || linkedLease?.raw.landlordId);
+      return [unitScopeKey(propertyId, landlordId), { propertyId, landlordId }] as const;
+    })
+    .filter((value): value is readonly [string, { propertyId: string; landlordId: string }] => Boolean(value));
+  const unscopedUnitEntries = propertyIds.map((propertyId) => [unitScopeKey(propertyId, null), { propertyId, landlordId: "" }] as const);
   const unitScopes = Array.from(
     new Map(
-      tenantDocs
-        .map((tenant) => {
-          const linkedLease = resolveLeaseLink(tenant, leasesById, reverseLeasesByTenantId);
-          const propertyId = asTrimmedString(tenant.raw.propertyId || linkedLease?.raw.propertyId);
-          if (!propertyId) return null;
-          const landlordId = asTrimmedString(tenant.raw.landlordId || linkedLease?.raw.landlordId);
-          return [unitScopeKey(propertyId, landlordId), { propertyId, landlordId }] as const;
-        })
-        .filter((value): value is readonly [string, { propertyId: string; landlordId: string }] => Boolean(value))
+      [...scopedUnitEntries, ...unscopedUnitEntries]
     ).values()
   );
   const unitsByPropertyScope = new Map<string, CanonicalUnitRecord[]>();

--- a/rentchain-api/src/services/admin/adminTenantView.ts
+++ b/rentchain-api/src/services/admin/adminTenantView.ts
@@ -3,6 +3,13 @@ import {
   deriveTenantLifecycle,
   type TenantLifecycleResult,
 } from "../../lib/tenants/deriveTenantLifecycle";
+import {
+  loadUnitsForProperty,
+  resolveUnitReference,
+  toCanonicalLeaseRecord,
+  toCanonicalUnitRecord,
+  type CanonicalUnitRecord,
+} from "../leaseCanonicalizationService";
 
 type FirestoreLike = Pick<FirebaseFirestore.Firestore, "collection">;
 
@@ -124,11 +131,75 @@ function nameParts(raw: Record<string, unknown>) {
 
 function unitLabel(raw: Record<string, unknown>) {
   return (
-    asTrimmedString(raw.unitNumber) ||
-    asTrimmedString(raw.unitLabel) ||
-    asTrimmedString(raw.unit) ||
+    normalizeUnitDisplayValue(raw.unitNumber) ||
+    normalizeUnitDisplayValue(raw.unitLabel) ||
+    normalizeUnitDisplayValue(raw.unit) ||
     null
   );
+}
+
+function normalizeUnitDisplayValue(value: unknown): string | null {
+  const next = asTrimmedString(value);
+  if (!next) return null;
+  return next.replace(/^unit\s+/i, "").trim() || null;
+}
+
+function isLikelyRawInternalId(value: string | null, knownId?: string | null): boolean {
+  const normalized = asTrimmedString(value);
+  if (!normalized) return false;
+  if (knownId && normalized === asTrimmedString(knownId)) return true;
+  return /^[A-Za-z0-9_-]{16,}$/.test(normalized) && !/\s/.test(normalized);
+}
+
+function canonicalUnitLabel(unit?: CanonicalUnitRecord | null): string | null {
+  if (!unit) return null;
+  const candidates = [
+    unit.unitNumber,
+    unit.label,
+    unit.raw?.unitNumber,
+    unit.raw?.unitLabel,
+    unit.raw?.label,
+    unit.raw?.name,
+    unit.raw?.unit,
+  ]
+    .map((value) => normalizeUnitDisplayValue(value))
+    .filter(Boolean);
+  for (const candidate of candidates) {
+    if (!isLikelyRawInternalId(candidate, unit.id)) return candidate;
+  }
+  return null;
+}
+
+function resolveUnitDisplayFromPropertyUnits(
+  raw: Record<string, unknown>,
+  propertyUnits: CanonicalUnitRecord[]
+): string | null {
+  const references = [raw.unitId, raw.resolvedUnitId, raw.unitNumber, raw.unitLabel, raw.unit]
+    .map((value) => asTrimmedString(value))
+    .filter(Boolean);
+  for (const reference of references) {
+    const resolution = resolveUnitReference(propertyUnits, reference);
+    if (!resolution.ambiguous && resolution.unit) {
+      const label = canonicalUnitLabel(resolution.unit);
+      if (label) return label;
+    }
+    const exactUnit = propertyUnits.find((unit) =>
+      [unit.id, unit.raw?.unitId, unit.raw?.uid, unit.raw?.id]
+        .map((value) => asTrimmedString(value))
+        .filter(Boolean)
+        .includes(reference)
+    );
+    const exactLabel = canonicalUnitLabel(exactUnit);
+    if (exactLabel) return exactLabel;
+  }
+  return null;
+}
+
+function safeUnitLabel(raw: Record<string, unknown>, propertyUnits: CanonicalUnitRecord[]) {
+  const unitId = asTrimmedString(raw.unitId) || asTrimmedString(raw.resolvedUnitId) || null;
+  const rawLabel = unitLabel(raw);
+  if (rawLabel && !isLikelyRawInternalId(rawLabel, unitId)) return rawLabel;
+  return resolveUnitDisplayFromPropertyUnits(raw, propertyUnits);
 }
 
 function screeningStatus(raw: Record<string, unknown>) {
@@ -178,6 +249,29 @@ async function loadLinkedDocs(
   return out;
 }
 
+async function loadUnitsByReferences(
+  firestore: FirestoreLike,
+  references: string[]
+): Promise<Map<string, CanonicalUnitRecord[]>> {
+  const out = new Map<string, CanonicalUnitRecord[]>();
+  const uniqueReferences = Array.from(new Set(references.map((value) => asTrimmedString(value)).filter(Boolean)));
+  await Promise.all(
+    uniqueReferences.map(async (reference) => {
+      const rows: CanonicalUnitRecord[] = [];
+      const docSnap = await (firestore.collection("units") as any).doc(reference).get().catch(() => null);
+      if (docSnap?.exists) {
+        rows.push(toCanonicalUnitRecord(docSnap.id || reference, (docSnap.data() || {}) as Record<string, unknown>));
+      }
+      const fieldSnap = await (firestore.collection("units") as any).where("unitId", "==", reference).get().catch(() => null);
+      for (const doc of fieldSnap?.docs || []) {
+        rows.push(toCanonicalUnitRecord(doc.id, (doc.data() || {}) as Record<string, unknown>));
+      }
+      if (rows.length) out.set(reference, rows);
+    })
+  );
+  return out;
+}
+
 function resolveLeaseLink(
   tenant: TenantDocRow,
   leasesById: Map<string, Record<string, unknown>>
@@ -205,7 +299,10 @@ function resolveLeaseLink(
 function buildView(
   tenant: TenantDocRow,
   leasesById: Map<string, Record<string, unknown>>,
-  propertiesById: Map<string, Record<string, unknown>>
+  propertiesById: Map<string, Record<string, unknown>>,
+  unitsByPropertyId: Map<string, CanonicalUnitRecord[]>,
+  unitsById: Map<string, Record<string, unknown>>,
+  unitsByReference: Map<string, CanonicalUnitRecord[]>
 ): AdminTenantView {
   const names = nameParts(tenant.raw);
   const linkedLease = resolveLeaseLink(tenant, leasesById);
@@ -218,7 +315,56 @@ function buildView(
   const propertyName =
     asTrimmedString(property?.name) ||
     asTrimmedString(tenant.raw.propertyName || tenant.raw.property) ||
+    asTrimmedString(linkedLease?.raw.propertyName) ||
     asTrimmedString(linkedLease?.raw.propertyLabel) ||
+    null;
+  const unitId =
+    asTrimmedString(tenant.raw.unitId) ||
+    asTrimmedString(linkedLease?.raw.unitId) ||
+    asTrimmedString(linkedLease?.raw.resolvedUnitId) ||
+    asTrimmedString(tenant.raw.unitNumber) ||
+    asTrimmedString(linkedLease?.raw.unitNumber) ||
+    null;
+  const propertyUnits = propertyId ? unitsByPropertyId.get(propertyId) || [] : [];
+  const directUnitRaw = unitId ? unitsById.get(unitId) : null;
+  const unitCandidates = [...propertyUnits];
+  const unitReferences = [
+    tenant.raw.unitId,
+    tenant.raw.resolvedUnitId,
+    tenant.raw.unitNumber,
+    tenant.raw.unitLabel,
+    tenant.raw.unit,
+    linkedLease?.raw.unitId,
+    linkedLease?.raw.resolvedUnitId,
+    linkedLease?.raw.unitNumber,
+    linkedLease?.raw.unitLabel,
+    linkedLease?.raw.unit,
+  ]
+    .map((value) => asTrimmedString(value))
+    .filter(Boolean);
+  for (const reference of unitReferences) {
+    for (const unit of unitsByReference.get(reference) || []) {
+      if (!unitCandidates.some((existing) => existing.id === unit.id)) unitCandidates.push(unit);
+    }
+  }
+  if (directUnitRaw && !unitCandidates.some((unit) => unit.id === unitId)) {
+    unitCandidates.push({
+      id: unitId!,
+      landlordId: asTrimmedString(directUnitRaw.landlordId) || null,
+      propertyId: asTrimmedString(directUnitRaw.propertyId) || propertyId,
+      unitNumber: asTrimmedString(directUnitRaw.unitNumber ?? directUnitRaw.unit ?? directUnitRaw.name) || null,
+      label: asTrimmedString(directUnitRaw.label ?? directUnitRaw.displayLabel ?? directUnitRaw.unitLabel ?? directUnitRaw.unitNumber) || null,
+      rent: Number.isFinite(Number(directUnitRaw.rent ?? directUnitRaw.marketRent ?? directUnitRaw.monthlyRent))
+        ? Number(directUnitRaw.rent ?? directUnitRaw.marketRent ?? directUnitRaw.monthlyRent)
+        : null,
+      raw: directUnitRaw,
+    });
+  }
+  const canonicalLease = linkedLease ? toCanonicalLeaseRecord(linkedLease.id, linkedLease.raw, unitCandidates) : null;
+  const resolvedLeaseUnit =
+    canonicalUnitLabel(unitCandidates.find((unit) => unit.id === canonicalLease?.resolvedUnitId)) ||
+    normalizeUnitDisplayValue(canonicalLease?.resolvedUnitLabel) ||
+    normalizeUnitDisplayValue(canonicalLease?.resolvedUnitNumber) ||
     null;
 
   const leaseId = linkedLease?.id || null;
@@ -254,10 +400,11 @@ function buildView(
     landlordId: asTrimmedString(tenant.raw.landlordId) || asTrimmedString(linkedLease?.raw.landlordId) || null,
     propertyId,
     propertyName,
-    unitId: asTrimmedString(tenant.raw.unitId) || asTrimmedString(linkedLease?.raw.unitId) || null,
+    unitId,
     unitNumber:
-      unitLabel(tenant.raw) ||
-      unitLabel((linkedLease?.raw || {}) as Record<string, unknown>) ||
+      safeUnitLabel(tenant.raw, unitCandidates) ||
+      resolvedLeaseUnit ||
+      safeUnitLabel((linkedLease?.raw || {}) as Record<string, unknown>, unitCandidates) ||
       null,
     leaseId,
     leaseStatus: currentLeaseStatus,
@@ -337,8 +484,38 @@ export async function listAdminTenants(
     )
   );
   const propertiesById = await loadLinkedDocs(firestore, "properties", propertyIds);
+  const unitIds = Array.from(
+    new Set(
+      tenantDocs
+        .flatMap((tenant) => {
+          const linkedLease = resolveLeaseLink(tenant, leasesById);
+          return [
+            tenant.raw.unitId,
+            tenant.raw.resolvedUnitId,
+            tenant.raw.unitNumber,
+            tenant.raw.unitLabel,
+            tenant.raw.unit,
+            linkedLease?.raw.unitId,
+            linkedLease?.raw.resolvedUnitId,
+            linkedLease?.raw.unitNumber,
+            linkedLease?.raw.unitLabel,
+            linkedLease?.raw.unit,
+          ];
+        })
+        .map((value) => asTrimmedString(value))
+        .filter(Boolean)
+    )
+  );
+  const unitsById = await loadLinkedDocs(firestore, "units", unitIds);
+  const unitsByReference = await loadUnitsByReferences(firestore, unitIds);
+  const unitsByPropertyId = new Map<string, CanonicalUnitRecord[]>();
+  await Promise.all(
+    propertyIds.map(async (propertyId) => {
+      unitsByPropertyId.set(propertyId, await loadUnitsForProperty(firestore as any, propertyId).catch(() => []));
+    })
+  );
 
-  const allViews = tenantDocs.map((tenant) => buildView(tenant, leasesById, propertiesById));
+  const allViews = tenantDocs.map((tenant) => buildView(tenant, leasesById, propertiesById, unitsByPropertyId, unitsById, unitsByReference));
 
   const filtered = allViews.filter((view) => {
     if (!matchesSearch(view, query.q)) return false;

--- a/rentchain-frontend/src/pages/admin/AdminLeasesPage.css
+++ b/rentchain-frontend/src/pages/admin/AdminLeasesPage.css
@@ -10,8 +10,31 @@
 
 .rc-admin-leases-table {
   width: 100%;
-  min-width: 1080px;
+  min-width: 920px;
   border-collapse: collapse;
+  table-layout: auto;
+}
+
+.rc-admin-leases-table th,
+.rc-admin-leases-table td {
+  vertical-align: top;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.rc-admin-leases-table__primary {
+  min-width: 260px;
+  max-width: 380px;
+}
+
+.rc-admin-leases-table__placement {
+  min-width: 160px;
+  max-width: 240px;
+}
+
+.rc-admin-leases-table__name {
+  min-width: 160px;
+  max-width: 260px;
 }
 
 @media (max-width: 820px) {
@@ -66,5 +89,37 @@
     flex-wrap: wrap;
     gap: 6px 8px;
     align-items: center;
+  }
+}
+
+.rc-admin-lease-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(480px, 100%);
+  max-width: 100%;
+  min-width: 0;
+  height: 100dvh;
+  max-height: 100dvh;
+  background: #fff;
+  border-left: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: -8px 0 24px rgba(15, 23, 42, 0.12);
+  padding: max(20px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right)) max(20px, env(safe-area-inset-bottom)) 20px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  z-index: 3100;
+  display: grid;
+  gap: 16px;
+  box-sizing: border-box;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 520px) {
+  .rc-admin-lease-drawer {
+    left: 0;
+    width: 100%;
+    border-left: 0;
+    padding: max(16px, env(safe-area-inset-top)) 16px max(16px, env(safe-area-inset-bottom));
   }
 }

--- a/rentchain-frontend/src/pages/admin/AdminLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeasesPage.tsx
@@ -40,7 +40,7 @@ function leaseLabel(lease: AdminLeaseView) {
 }
 
 function landlordLabel(lease: AdminLeaseView) {
-  return lease.landlordDisplayName || "Landlord account";
+  return lease.landlordDisplayName || (lease.landlordId ? "Landlord linked / profile missing" : "Landlord profile unavailable");
 }
 
 function tenantLabel(lease: AdminLeaseView) {
@@ -332,7 +332,7 @@ export const AdminLeasesPage: React.FC = () => {
                 <table className="rc-admin-leases-table">
                   <thead>
                     <tr style={{ textAlign: "left", borderBottom: "1px solid rgba(15, 23, 42, 0.08)" }}>
-                      {["Lease", "Property / Unit", "Tenant(s)", "Landlord", "Status", "Rent", "Start", "End", "Risk", "Integrity", "Updated"].map((label) => (
+                      {["Lease", "Tenant(s)", "Landlord", "Status / Rent", "Dates", "Risk / Integrity", "Updated"].map((label) => (
                         <th key={label} style={{ padding: "10px 12px", fontSize: 13, color: "#475569" }}>
                           {label}
                         </th>
@@ -346,27 +346,29 @@ export const AdminLeasesPage: React.FC = () => {
                         onClick={() => setSelectedLease(item)}
                         style={{ cursor: "pointer", borderBottom: "1px solid rgba(15, 23, 42, 0.06)" }}
                       >
-                        <td style={{ padding: "12px" }}>
+                        <td className="rc-admin-leases-table__primary" style={{ padding: "12px" }}>
                           <div style={{ fontWeight: 600 }}>{leaseLabel(item)}</div>
                           <div style={{ color: "#64748b", fontSize: 13 }}>Admin lease record</div>
                         </td>
+                        <td className="rc-admin-leases-table__name" style={{ padding: "12px" }}>{tenantLabel(item)}</td>
+                        <td className="rc-admin-leases-table__name" style={{ padding: "12px" }}>{landlordLabel(item)}</td>
                         <td style={{ padding: "12px" }}>
-                          <div>{item.propertyName || "Property not linked"}</div>
-                          <div style={{ color: "#64748b", fontSize: 13 }}>{item.unitNumber ? `Unit ${item.unitNumber}` : "Unit not assigned"}</div>
-                        </td>
-                        <td style={{ padding: "12px" }}>{tenantLabel(item)}</td>
-                        <td style={{ padding: "12px" }}>{landlordLabel(item)}</td>
-                        <td style={{ padding: "12px" }}>
-                          <Pill tone="default">{formatValue(item.status)}</Pill>
-                        </td>
-                        <td style={{ padding: "12px" }}>{formatMoney(item.monthlyRent)}</td>
-                        <td style={{ padding: "12px" }}>{item.startDate || "—"}</td>
-                        <td style={{ padding: "12px" }}>{item.endDate || "—"}</td>
-                        <td style={{ padding: "12px" }}>
-                          <Pill tone="accent">{item.riskGrade || "—"}</Pill>
+                          <div style={{ display: "grid", gap: 6 }}>
+                            <Pill tone="default">{formatValue(item.status)}</Pill>
+                            <span>{formatMoney(item.monthlyRent)}</span>
+                          </div>
                         </td>
                         <td style={{ padding: "12px" }}>
-                          <IntegrityPill lease={item} />
+                          <div style={{ display: "grid", gap: 4 }}>
+                            <span>Start: {item.startDate || "—"}</span>
+                            <span>End: {item.endDate || "—"}</span>
+                          </div>
+                        </td>
+                        <td style={{ padding: "12px" }}>
+                          <div style={{ display: "grid", gap: 6 }}>
+                            <Pill tone="accent">{item.riskGrade || "—"}</Pill>
+                            <IntegrityPill lease={item} />
+                          </div>
                         </td>
                         <td style={{ padding: "12px" }}>{String(item.updatedAt || "—")}</td>
                       </tr>
@@ -404,28 +406,14 @@ export const AdminLeasesPage: React.FC = () => {
         <div
           role="dialog"
           aria-label="Lease detail drawer"
-          style={{
-            position: "fixed",
-            top: 0,
-            right: 0,
-            width: "min(420px, 100vw)",
-            height: "100vh",
-            background: "#fff",
-            borderLeft: "1px solid rgba(15, 23, 42, 0.08)",
-            boxShadow: "-8px 0 24px rgba(15, 23, 42, 0.12)",
-            padding: 20,
-            overflowY: "auto",
-            zIndex: 60,
-            display: "grid",
-            gap: 16,
-          }}
+          className="rc-admin-lease-drawer"
         >
           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
             <div>
               <div style={{ fontWeight: 700, fontSize: 18 }}>{leaseLabel(selectedLease)}</div>
               <div style={{ color: "#64748b", fontSize: 14 }}>{landlordLabel(selectedLease)}</div>
             </div>
-            <Button variant="secondary" onClick={() => setSelectedLease(null)}>
+            <Button variant="secondary" onClick={() => setSelectedLease(null)} style={{ minWidth: 76, whiteSpace: "nowrap" }}>
               Close
             </Button>
           </div>

--- a/rentchain-frontend/src/pages/admin/AdminTenantsPage.css
+++ b/rentchain-frontend/src/pages/admin/AdminTenantsPage.css
@@ -59,7 +59,8 @@
 
   .rc-admin-tenant-card__contact,
   .rc-admin-tenant-card__placement,
-  .rc-admin-tenant-card__meta {
+  .rc-admin-tenant-card__meta,
+  .rc-admin-tenant-card__explanation {
     min-width: 0;
     color: #475569;
     font-size: 13px;
@@ -72,5 +73,37 @@
     flex-wrap: wrap;
     gap: 8px 10px;
     align-items: center;
+  }
+}
+
+.rc-admin-tenant-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(420px, 100%);
+  max-width: 100%;
+  min-width: 0;
+  height: 100dvh;
+  max-height: 100dvh;
+  background: #fff;
+  border-left: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: -8px 0 24px rgba(15, 23, 42, 0.12);
+  padding: max(20px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right)) max(20px, env(safe-area-inset-bottom)) 20px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  z-index: 3100;
+  display: grid;
+  gap: 16px;
+  box-sizing: border-box;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 520px) {
+  .rc-admin-tenant-drawer {
+    left: 0;
+    width: 100%;
+    border-left: 0;
+    padding: max(16px, env(safe-area-inset-top)) 16px max(16px, env(safe-area-inset-bottom));
   }
 }

--- a/rentchain-frontend/src/pages/admin/AdminTenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTenantsPage.test.tsx
@@ -76,6 +76,47 @@ describe("AdminTenantsPage", () => {
             hasScreening: true,
           },
         },
+        {
+          id: "tenant-applicant-1",
+          fullName: "Jane Tenant",
+          firstName: "Jane",
+          lastName: "Tenant",
+          email: "jane.applicant@example.com",
+          phone: null,
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          propertyName: "Coburg Rd",
+          unitId: null,
+          unitNumber: null,
+          leaseId: null,
+          leaseStatus: null,
+          screeningStatus: null,
+          moveInStatus: null,
+          currentLeaseStartDate: null,
+          currentLeaseEndDate: null,
+          createdAt: "2026-03-02T00:00:00.000Z",
+          updatedAt: "2026-03-04T00:00:00.000Z",
+          lifecycle: {
+            lifecycleState: "applicant",
+            lifecycleLabel: "Applicant",
+            lifecycleReason: "application_signal",
+            confidence: "medium",
+            sourceFields: {},
+            flags: {
+              hasActiveLease: false,
+              hasPendingLease: false,
+              hasCompletedScreening: false,
+              isArchived: false,
+              isPastTenant: false,
+              hasStateConflict: false,
+            },
+          },
+          flags: {
+            missingLeaseLink: false,
+            missingPropertyLink: false,
+            hasScreening: false,
+          },
+        },
       ],
       page: 1,
       pageSize: 25,
@@ -110,6 +151,9 @@ describe("AdminTenantsPage", () => {
     expect(screen.getByLabelText("Admin tenants mobile list")).toBeInTheDocument();
     expect(screen.getAllByText("Landlord linked").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Active tenant workspace").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Lease-linked tenant record").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Applicant workspace").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Application-only record").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lifecycle: Active").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lease: Active").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Screening: Complete").length).toBeGreaterThan(0);
@@ -144,5 +188,6 @@ describe("AdminTenantsPage", () => {
     expect(within(drawer).queryByText("landlord-1")).not.toBeInTheDocument();
     expect(within(drawer).queryByText("lease-1")).not.toBeInTheDocument();
     expect(within(drawer).queryByText("tenant-1")).not.toBeInTheDocument();
+    expect(within(drawer).queryByRole("link", { name: /lease/i })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/admin/AdminTenantsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTenantsPage.tsx
@@ -73,6 +73,24 @@ function tenantWorkspaceContext(item: AdminTenantView) {
   return `${lifecycleLabel(item)} workspace`;
 }
 
+function tenantWorkspaceExplanation(item: AdminTenantView) {
+  const lifecycle = String(item.lifecycle?.lifecycleState || "").toLowerCase();
+  const leaseStatus = String(item.leaseStatus || "").toLowerCase();
+  if (item.leaseId || item.lifecycle?.flags?.hasActiveLease || leaseStatus === "active" || leaseStatus === "current") {
+    return "Lease-linked tenant record";
+  }
+  if (item.lifecycle?.flags?.hasPendingLease || lifecycle.includes("lease")) {
+    return "Lease workflow record";
+  }
+  if (lifecycle.includes("screening")) {
+    return "Screening workflow record";
+  }
+  if (lifecycle === "applicant" || (!item.unitNumber && !item.leaseStatus)) {
+    return "Application-only record";
+  }
+  return "Tenant workspace record";
+}
+
 export const AdminTenantsPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -329,6 +347,7 @@ export const AdminTenantsPage: React.FC = () => {
                   >
                     <span className="rc-admin-tenant-card__title">{item.fullName || "Unnamed tenant"}</span>
                     <span className="rc-admin-tenant-card__context">{tenantWorkspaceContext(item)}</span>
+                    <span className="rc-admin-tenant-card__explanation">{tenantWorkspaceExplanation(item)}</span>
                     <span className="rc-admin-tenant-card__contact">{item.email || item.phone || "Contact unavailable"}</span>
                     <span className="rc-admin-tenant-card__placement">
                       {item.propertyName || "Unknown property"} · {item.unitNumber ? `Unit ${item.unitNumber}` : "No unit"}
@@ -422,26 +441,13 @@ export const AdminTenantsPage: React.FC = () => {
         <div
           role="dialog"
           aria-label="Tenant detail drawer"
-          style={{
-            position: "fixed",
-            top: 0,
-            right: 0,
-            width: "min(420px, 100vw)",
-            height: "100vh",
-            background: "#fff",
-            borderLeft: "1px solid rgba(15, 23, 42, 0.08)",
-            boxShadow: "-8px 0 24px rgba(15, 23, 42, 0.12)",
-            padding: 20,
-            overflowY: "auto",
-            zIndex: 60,
-            display: "grid",
-            gap: 16,
-          }}
+          className="rc-admin-tenant-drawer"
         >
           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
             <div>
               <div style={{ fontWeight: 700, fontSize: 18 }}>{selectedTenant.fullName || "Unnamed tenant"}</div>
               <div style={{ color: "#64748b", fontSize: 14 }}>{tenantWorkspaceContext(selectedTenant)}</div>
+              <div style={{ color: "#64748b", fontSize: 13 }}>{tenantWorkspaceExplanation(selectedTenant)}</div>
             </div>
             <Button variant="secondary" onClick={() => setSelectedTenant(null)}>
               Close


### PR DESCRIPTION
## Summary
- Add linked unit document fallback to admin lease projections when lease unit fields contain raw unit ids.
- Apply the same safe unit fallback to admin tenant projections so admin tenant detail and admin leases agree with landlord lease context.
- Preserve legitimate separate tenant/application records while keeping lifecycle/workspace states explicit.

## Root Cause
Admin projections already rejected raw-looking unit values, but they did not hydrate the linked `units` document before falling back to `Unit not assigned`. Landlord lease views could still show the safe unit number from lease/unit context, creating mismatch for records like Coburg Rd / Chip Milo.

## Safety
- No schema, Firestore rules, auth, permissions, payments, pricing, screening, lease logic, or mutation behavior changed.
- No data deletion or record merging.
- Raw unit ids remain excluded from primary display labels.

## Validation
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/services/__tests__/adminLeaseView.test.ts src/services/__tests__/adminTenantView.test.ts`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/pages/admin/AdminTenantsPage.test.tsx src/pages/admin/AdminLeasesPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`
