### PR TITLE
Add tenant mobile bottom navigation

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -1681,6 +1681,10 @@ function App() {
           element={renderTenantShell(suspensePage(<TenantAttachmentsPage />))}
         />
         <Route
+          path="/tenant/documents"
+          element={renderTenantShell(suspensePage(<TenantAttachmentsPage />))}
+        />
+        <Route
           path="/tenant/notices"
           element={renderTenantShell(suspensePage(<TenantNoticesCenterPage />))}
         />

--- a/rentchain-frontend/src/components/layout/TenantNav.css
+++ b/rentchain-frontend/src/components/layout/TenantNav.css
@@ -1,0 +1,210 @@
+:root {
+  --rc-tenant-mobile-bottom-nav-height: 88px;
+  --rc-tenant-mobile-drawer-bottom-offset: calc(
+    var(--rc-tenant-mobile-bottom-nav-height) + env(safe-area-inset-bottom, 0px)
+  );
+}
+
+.rc-tenant-shell,
+.rc-tenant-shell *,
+.rc-tenant-shell *::before,
+.rc-tenant-shell *::after {
+  box-sizing: border-box;
+}
+
+.rc-tenant-shell {
+  min-height: 100vh;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  background: #f8fafc;
+}
+
+.rc-tenant-main {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+.rc-tenant-main > *,
+.rc-tenant-main main,
+.rc-tenant-main section,
+.rc-tenant-main article,
+.rc-tenant-main form,
+.rc-tenant-main table,
+.rc-tenant-main [role="table"],
+.rc-tenant-main [class*="grid"],
+.rc-tenant-main [class*="Grid"],
+.rc-tenant-main [class*="row"],
+.rc-tenant-main [class*="Row"],
+.rc-tenant-main [class*="card"],
+.rc-tenant-main [class*="Card"] {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.rc-tenant-mobile-tabbar {
+  display: none;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px));
+  z-index: 100;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  box-shadow: 0 -10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.rc-tenant-mobile-tabbar button {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  min-width: 0;
+  min-height: 52px;
+  padding: 6px 2px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.rc-tenant-mobile-tabbar button.active {
+  color: #0f172a;
+  background: rgba(29, 78, 216, 0.08);
+}
+
+.rc-tenant-mobile-tabbar-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  line-height: 1.1;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.rc-tenant-mobile-tabbar-dot {
+  width: 8px;
+  height: 8px;
+  margin-left: 4px;
+  border-radius: 999px;
+  background: #ef4444;
+}
+
+.rc-tenant-mobile-backdrop {
+  position: fixed;
+  inset: 0 0 var(--rc-tenant-mobile-drawer-bottom-offset) 0;
+  z-index: 60;
+  background: rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.rc-tenant-mobile-backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.rc-tenant-mobile-menu {
+  position: fixed;
+  right: max(12px, env(safe-area-inset-right, 0px));
+  bottom: var(--rc-tenant-mobile-drawer-bottom-offset);
+  left: max(12px, env(safe-area-inset-left, 0px));
+  z-index: 70;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-height: min(calc(100vh - var(--rc-tenant-mobile-drawer-bottom-offset) - 16px), 560px);
+  max-height: min(calc(100dvh - var(--rc-tenant-mobile-drawer-bottom-offset) - 16px), 560px);
+  padding: 16px 14px;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 -18px 40px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+  transform: translateY(calc(100% + 24px));
+  transition: transform 0.2s ease;
+  pointer-events: none;
+}
+
+.rc-tenant-mobile-menu.is-open {
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.rc-tenant-mobile-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 800;
+}
+
+.rc-tenant-mobile-menu-header button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 0;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.rc-tenant-mobile-menu-links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rc-tenant-mobile-menu-links button {
+  min-height: 48px;
+  padding: 10px 8px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 700;
+  text-align: center;
+}
+
+.rc-tenant-mobile-menu-links button.active {
+  border-color: rgba(29, 78, 216, 0.35);
+  background: rgba(29, 78, 216, 0.08);
+}
+
+.rc-tenant-mobile-menu-signout {
+  align-self: flex-start;
+  padding: 8px 4px;
+  border: 0;
+  background: transparent;
+  color: #dc2626;
+  font-weight: 700;
+}
+
+@media (max-width: 820px) {
+  .rc-tenant-header {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  .rc-tenant-main {
+    padding-bottom: calc(var(--rc-tenant-mobile-bottom-nav-height) + 24px + env(safe-area-inset-bottom, 0px)) !important;
+  }
+
+  .rc-tenant-mobile-tabbar {
+    display: grid;
+  }
+}

--- a/rentchain-frontend/src/components/layout/TenantNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.test.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { TenantNav } from "./TenantNav";
+
+const tenantPortalApi = vi.hoisted(() => ({
+  getTenantWorkspace: vi.fn(),
+}));
+
+const tenantCommunicationsApi = vi.hoisted(() => ({
+  getTenantCommunicationSummary: vi.fn(),
+}));
+
+const logoutTenant = vi.hoisted(() => ({
+  logoutTenant: vi.fn(),
+}));
+
+vi.mock("../../api/tenantPortal", () => tenantPortalApi);
+vi.mock("../../api/tenantCommunicationsApi", () => tenantCommunicationsApi);
+vi.mock("../../lib/logoutTenant", () => logoutTenant);
+
+function CurrentPath() {
+  const location = useLocation();
+  return <div data-testid="current-path">{location.pathname}</div>;
+}
+
+function renderTenantNav(initialPath = "/tenant/dashboard") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <TenantNav>
+              <div>Tenant content</div>
+              <CurrentPath />
+            </TenantNav>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("TenantNav mobile bottom navigation", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    tenantPortalApi.getTenantWorkspace.mockResolvedValue({
+      context: {
+        invitedEmail: "tenant@example.com",
+      },
+      unit: {
+        label: "6",
+      },
+    });
+    tenantCommunicationsApi.getTenantCommunicationSummary.mockResolvedValue({
+      unreadMessages: 2,
+      unreadNotices: 0,
+      unreadScreeningUpdates: 0,
+    });
+  });
+
+  it("renders tenant-safe bottom navigation tabs only", () => {
+    renderTenantNav();
+
+    const tabbar = screen.getByRole("navigation", { name: "Tenant bottom navigation" });
+    expect(within(tabbar).getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
+    expect(within(tabbar).getByRole("button", { name: "Lease" })).toBeInTheDocument();
+    expect(within(tabbar).getByRole("button", { name: "Documents" })).toBeInTheDocument();
+    expect(within(tabbar).getByRole("button", { name: "Messages" })).toBeInTheDocument();
+    expect(within(tabbar).getByRole("button", { name: "More" })).toBeInTheDocument();
+    expect(within(tabbar).queryByText("Properties")).not.toBeInTheDocument();
+    expect(within(tabbar).queryByText("Leases")).not.toBeInTheDocument();
+    expect(within(tabbar).queryByText("Admin")).not.toBeInTheDocument();
+  });
+
+  it("navigates tenant tabs to tenant-safe canonical routes", () => {
+    renderTenantNav();
+
+    const tabbar = screen.getByRole("navigation", { name: "Tenant bottom navigation" });
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Documents" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/tenant/documents");
+
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Lease" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/tenant/lease");
+
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Messages" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/tenant/messages");
+
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Dashboard" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/tenant");
+  });
+
+  it("keeps document tab active for the legacy tenant attachments route", () => {
+    renderTenantNav("/tenant/attachments");
+
+    const tabbar = screen.getByRole("navigation", { name: "Tenant bottom navigation" });
+    expect(within(tabbar).getByRole("button", { name: "Documents" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("opens a tenant-only More menu without landlord or admin routes", () => {
+    renderTenantNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    const menu = screen.getByRole("dialog", { name: "Tenant menu" });
+    expect(menu).toHaveClass("is-open");
+    expect(within(menu).getByRole("button", { name: "Profile" })).toBeInTheDocument();
+    expect(within(menu).getByRole("button", { name: "Maintenance" })).toBeInTheDocument();
+    expect(within(menu).queryByRole("button", { name: "Properties" })).not.toBeInTheDocument();
+    expect(within(menu).queryByRole("button", { name: "Admin" })).not.toBeInTheDocument();
+  });
+
+  it("adds mobile bottom spacing to tenant content", () => {
+    renderTenantNav();
+
+    expect(document.querySelector(".rc-tenant-main")).toBeInTheDocument();
+    expect(document.querySelector(".rc-tenant-mobile-tabbar")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { NavLink } from "react-router-dom";
+import { FileText, Home, Menu, MessageSquare, ScrollText, X } from "lucide-react";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { getTenantWorkspace } from "../../api/tenantPortal";
 import { getTenantCommunicationSummary } from "../../api/tenantCommunicationsApi";
 import { logoutTenant } from "../../lib/logoutTenant";
+import "./TenantNav.css";
 
 type Props = {
   children: React.ReactNode;
@@ -15,14 +17,43 @@ const navItems = [
   { label: "Onboarding", to: "/tenant/onboarding-hardening" },
   { label: "Access", to: "/tenant/access" },
   { label: "Application", to: "/tenant/application" },
-  { label: "Documents", to: "/tenant/attachments" },
+  { label: "Documents", to: "/tenant/documents" },
   { label: "History", to: "/tenant/activity" },
   { label: "Lease", to: "/tenant/lease" },
   { label: "Maintenance", to: "/tenant/maintenance" },
   { label: "Messages", to: "/tenant/messages" },
 ];
 
+const mobileTabs = [
+  {
+    label: "Dashboard",
+    to: "/tenant",
+    icon: Home,
+    isActive: (pathname: string) => pathname === "/tenant" || pathname.startsWith("/tenant/dashboard"),
+  },
+  {
+    label: "Lease",
+    to: "/tenant/lease",
+    icon: ScrollText,
+    isActive: (pathname: string) => pathname.startsWith("/tenant/lease"),
+  },
+  {
+    label: "Documents",
+    to: "/tenant/documents",
+    icon: FileText,
+    isActive: (pathname: string) => pathname.startsWith("/tenant/documents") || pathname.startsWith("/tenant/attachments"),
+  },
+  {
+    label: "Messages",
+    to: "/tenant/messages",
+    icon: MessageSquare,
+    isActive: (pathname: string) => pathname.startsWith("/tenant/messages"),
+  },
+];
+
 export const TenantNav: React.FC<Props> = ({ children }) => {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [tenantName, setTenantName] = useState<string | null>(null);
   const [tenantEmail, setTenantEmail] = useState<string | null>(null);
   const [tenantUnit, setTenantUnit] = useState<string | null>(null);
@@ -33,6 +64,8 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
   const [unreadMessages, setUnreadMessages] = useState(0);
   const [unreadNotices, setUnreadNotices] = useState(0);
   const [unreadScreening, setUnreadScreening] = useState(0);
+  const [moreOpen, setMoreOpen] = useState(false);
+
   useEffect(() => {
     let cancelled = false;
     const loadIdentity = async () => {
@@ -73,6 +106,19 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
   }, []);
 
   useEffect(() => {
+    setMoreOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!moreOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMoreOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [moreOpen]);
+
+  useEffect(() => {
     let cancelled = false;
     const loadSummary = async () => {
       try {
@@ -110,9 +156,15 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
     []
   );
 
+  const goTo = (path: string) => {
+    navigate(path);
+    setMoreOpen(false);
+  };
+
   return (
-    <div style={{ minHeight: "100vh", background: "#f8fafc" }}>
+    <div className="rc-tenant-shell">
       <header
+        className="rc-tenant-header"
         style={{
           position: "sticky",
           top: 0,
@@ -243,9 +295,83 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
           </nav>
         </div>
       </header>
-      <main style={{ maxWidth: 1120, margin: "0 auto", padding: isMobile ? 12 : 16 }}>
+      <main className="rc-tenant-main" style={{ maxWidth: 1120, margin: "0 auto", padding: isMobile ? 12 : 16 }}>
         {children}
       </main>
+      <div
+        className={`rc-tenant-mobile-backdrop${moreOpen ? " is-open" : ""}`}
+        aria-hidden="true"
+        onClick={() => setMoreOpen(false)}
+      />
+      <aside
+        id="rc-tenant-mobile-menu"
+        className={`rc-tenant-mobile-menu${moreOpen ? " is-open" : ""}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Tenant menu"
+      >
+        <div className="rc-tenant-mobile-menu-header">
+          <span>Tenant menu</span>
+          <button type="button" onClick={() => setMoreOpen(false)} aria-label="Close tenant menu">
+            <X size={18} />
+          </button>
+        </div>
+        <div className="rc-tenant-mobile-menu-links">
+          {navItems.map((item) => {
+            const active =
+              location.pathname === item.to ||
+              (item.to === "/tenant/documents" && location.pathname.startsWith("/tenant/attachments")) ||
+              (item.to !== "/tenant/dashboard" && location.pathname.startsWith(`${item.to}/`));
+            return (
+              <button
+                key={item.to}
+                type="button"
+                className={active ? "active" : undefined}
+                onClick={() => goTo(item.to)}
+              >
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+        <button type="button" className="rc-tenant-mobile-menu-signout" onClick={() => logoutTenant("/tenant/login")}>
+          Logout
+        </button>
+      </aside>
+      <nav className="rc-tenant-mobile-tabbar" aria-label="Tenant bottom navigation">
+        {mobileTabs.map((item) => {
+          const Icon = item.icon;
+          const active = item.isActive(location.pathname);
+          const hasUnread = item.to === "/tenant/messages" && unreadMessages > 0;
+          return (
+            <button
+              key={item.label}
+              type="button"
+              className={active ? "active" : undefined}
+              onClick={() => goTo(item.to)}
+              aria-current={active ? "page" : undefined}
+              aria-label={item.label}
+            >
+              <Icon size={20} strokeWidth={2.2} />
+              <span className="rc-tenant-mobile-tabbar-label">
+                {item.label}
+                {hasUnread ? <span className="rc-tenant-mobile-tabbar-dot" aria-hidden="true" /> : null}
+              </span>
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          className={moreOpen ? "active" : undefined}
+          onClick={() => setMoreOpen((open) => !open)}
+          aria-expanded={moreOpen}
+          aria-controls="rc-tenant-mobile-menu"
+          aria-label="More"
+        >
+          <Menu size={20} strokeWidth={2.2} />
+          <span className="rc-tenant-mobile-tabbar-label">More</span>
+        </button>
+      </nav>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a tenant-only mobile bottom navigation bar with Dashboard, Lease, Documents, Messages, and More
- add a tenant menu sheet for secondary tenant routes and preserve existing logout behavior
- add /tenant/documents as an alias to the existing tenant document vault route
- add targeted tenant nav regression tests

## Validation
- npm run test -- TenantNav
- npm run test -- App.routes
- npm run test -- TenantProfileCommunicationsPages TenantWorkspacePage
- source ~/.nvm/nvm.sh && nvm use 20 && npm run build
- git diff --check

## Manual QA Required
- Mobile preview: /tenant, /tenant/lease, /tenant/documents, /tenant/messages
- Confirm landlord/admin navigation remains unchanged