### PR TITLE
Fix tenant profile readiness targeting

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
@@ -275,6 +275,8 @@ describe("tenant profile route", () => {
     expect(res.body?.data?.profile?.property?.street1).toBe("123 Main St");
     expect(res.body?.data?.profile?.property?.postalCode).toBe("B3H1A1");
     expect(res.body?.data?.profile?.unit).toEqual({ unitId: null, label: "6" });
+    expect(res.body?.data?.profile?.property?.unitNumber).toBe("6");
+    expect(res.body?.data?.profile?.property?.unitDisplayLabel).toBe("Unit 6");
     expect(res.body?.data?.profile?.property?.internalSecret).toBeUndefined();
     expect(res.body?.data?.profile?.unit?.internalUnitNotes).toBeUndefined();
     expect(res.body?.data?.profile?.application?.sin).toBeUndefined();

--- a/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
@@ -273,6 +273,7 @@ describe("tenant profile route", () => {
     expect(res.body?.data?.profile?.email).toBe("tenant@example.com");
     expect(res.body?.data?.profile?.phone).toBe("902-555-0100");
     expect(res.body?.data?.profile?.property?.street1).toBe("123 Main St");
+    expect(res.body?.data?.profile?.property?.postalCode).toBe("B3H1A1");
     expect(res.body?.data?.profile?.unit).toEqual({ unitId: "unit-1", label: "6" });
     expect(res.body?.data?.profile?.property?.internalSecret).toBeUndefined();
     expect(res.body?.data?.profile?.unit?.internalUnitNotes).toBeUndefined();

--- a/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
@@ -207,16 +207,23 @@ describe("tenant profile route", () => {
     ensureCollection("leases").set("lease-1", {
       tenantId: "tenant-1",
       propertyId: "prop-1",
+      unitId: "unit-1",
       status: "active",
       startDate: "2026-02-01",
       endDate: "2027-01-31",
       monthlyRent: 1800,
       confidentialNotes: "private",
     });
+    ensureCollection("units").set("unit-1", {
+      propertyId: "prop-1",
+      unitNumber: "6",
+      internalUnitNotes: "private",
+    });
     ensureCollection("tenants").set("tenant-1", {
       fullName: "Taylor Tenant",
       email: "tenant@example.com",
       phone: "902-555-0100",
+      unitId: "unit-1",
       internalRiskScore: 900,
     });
     ensureCollection("screening_requests").set("screen-1", {
@@ -266,7 +273,9 @@ describe("tenant profile route", () => {
     expect(res.body?.data?.profile?.email).toBe("tenant@example.com");
     expect(res.body?.data?.profile?.phone).toBe("902-555-0100");
     expect(res.body?.data?.profile?.property?.street1).toBe("123 Main St");
+    expect(res.body?.data?.profile?.unit).toEqual({ unitId: "unit-1", label: "6" });
     expect(res.body?.data?.profile?.property?.internalSecret).toBeUndefined();
+    expect(res.body?.data?.profile?.unit?.internalUnitNotes).toBeUndefined();
     expect(res.body?.data?.profile?.application?.sin).toBeUndefined();
     expect(res.body?.data?.profile?.lease?.confidentialNotes).toBeUndefined();
     expect(res.body?.data?.identity?.identityVerification?.status).toBe("verified");

--- a/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
@@ -385,4 +385,43 @@ describe("tenant profile route", () => {
       nextOfKin: null,
     });
   });
+
+  it("keeps safe unit display labels when the context unit value is already a unit number", async () => {
+    ensureCollection("leases").set("lease-display-unit", {
+      tenantId: "tenant-display-unit",
+      propertyId: "prop-1",
+      unitNumber: "6",
+      status: "active",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+    });
+    ensureCollection("tenants").set("tenant-display-unit", {
+      fullName: "Unit Number Tenant",
+      email: "display-unit@example.com",
+      phone: "902-555-0101",
+      propertyId: "prop-1",
+      leaseId: "lease-display-unit",
+      unit: "6",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-display-unit",
+          email: "display-unit@example.com",
+          role: "tenant",
+          tenantId: "tenant-display-unit",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.profile?.unit?.label).toBe("6");
+    expect(res.body?.data?.profile?.unit?.unitId).toBeNull();
+    expect(JSON.stringify(res.body)).not.toContain("internalUnitNotes");
+  });
 });

--- a/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
@@ -274,7 +274,7 @@ describe("tenant profile route", () => {
     expect(res.body?.data?.profile?.phone).toBe("902-555-0100");
     expect(res.body?.data?.profile?.property?.street1).toBe("123 Main St");
     expect(res.body?.data?.profile?.property?.postalCode).toBe("B3H1A1");
-    expect(res.body?.data?.profile?.unit).toEqual({ unitId: "unit-1", label: "6" });
+    expect(res.body?.data?.profile?.unit).toEqual({ unitId: null, label: "6" });
     expect(res.body?.data?.profile?.property?.internalSecret).toBeUndefined();
     expect(res.body?.data?.profile?.unit?.internalUnitNotes).toBeUndefined();
     expect(res.body?.data?.profile?.application?.sin).toBeUndefined();
@@ -423,6 +423,51 @@ describe("tenant profile route", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data?.profile?.unit?.label).toBe("6");
     expect(res.body?.data?.profile?.unit?.unitId).toBeNull();
+    expect(JSON.stringify(res.body)).not.toContain("internalUnitNotes");
+  });
+
+  it("resolves tenant profile unit labels from property-scoped unit records without exposing raw unit ids", async () => {
+    ensureCollection("leases").set("lease-property-scoped-unit", {
+      tenantId: "tenant-property-scoped-unit",
+      propertyId: "prop-1",
+      unitId: "raw-unit-doc-id-123456",
+      status: "active",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+    });
+    ensureCollection("tenants").set("tenant-property-scoped-unit", {
+      fullName: "Property Scoped Unit Tenant",
+      email: "property-scoped-unit@example.com",
+      phone: "902-555-0102",
+      propertyId: "prop-1",
+      leaseId: "lease-property-scoped-unit",
+      unitId: "raw-unit-doc-id-123456",
+    });
+    ensureCollection("units").set("different-unit-doc-id", {
+      propertyId: "prop-1",
+      unitId: "raw-unit-doc-id-123456",
+      unitNumber: "6",
+      internalUnitNotes: "private",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-property-scoped-unit",
+          email: "property-scoped-unit@example.com",
+          role: "tenant",
+          tenantId: "tenant-property-scoped-unit",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.profile?.unit?.label).toBe("6");
+    expect(res.body?.data?.profile?.unit?.label).not.toBe("raw-unit-doc-id-123456");
     expect(JSON.stringify(res.body)).not.toContain("internalUnitNotes");
   });
 });

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -19,6 +19,10 @@ export type TenantProfileProjection = {
     phone: string | null;
     authorityLabel: string;
     property: ReturnType<typeof projectTenantProperty> | null;
+    unit: {
+      unitId: string | null;
+      label: string | null;
+    } | null;
     application: ReturnType<typeof projectTenantApplication> | null;
     lease: ReturnType<typeof projectTenantLease> | null;
   };
@@ -283,6 +287,53 @@ async function loadWorkspaceDocuments(context: TenancyContext) {
   }
 
   return { property, application, lease, tenant };
+}
+
+function firstSafeDisplayString(values: unknown[], rawIds: unknown[]): string | null {
+  const blocked = new Set(
+    rawIds
+      .map((value) => asString(value))
+      .filter((value): value is string => Boolean(value))
+  );
+  for (const value of values) {
+    const candidate = asString(value);
+    if (!candidate || blocked.has(candidate)) continue;
+    return candidate;
+  }
+  return null;
+}
+
+async function loadTenantProfileUnitProjection(params: {
+  context: TenancyContext;
+  tenantData?: any;
+  leaseData?: any;
+}): Promise<TenantProfileProjection["profile"]["unit"]> {
+  const unitId =
+    asString(params.context.unitId) ||
+    asString(params.tenantData?.unitId) ||
+    asString(params.leaseData?.unitId) ||
+    null;
+  const unitDoc = await loadDocument("units", unitId);
+  const rawIds = [unitId, params.context.unitId, params.tenantData?.unitId, params.leaseData?.unitId];
+  const label = firstSafeDisplayString(
+    [
+      params.tenantData?.unitLabel,
+      params.tenantData?.unitNumber,
+      params.tenantData?.unit,
+      params.leaseData?.unitLabel,
+      params.leaseData?.unitNumber,
+      params.leaseData?.unit,
+      unitDoc?.data?.unitNumber,
+      unitDoc?.data?.label,
+      unitDoc?.data?.name,
+    ],
+    rawIds
+  );
+  if (!unitId && !label) return null;
+  return {
+    unitId,
+    label,
+  };
 }
 
 async function loadApplicationReuseSource(params: { context: TenancyContext; userEmail?: string | null }) {
@@ -813,6 +864,11 @@ export async function loadTenantProfileProjection(params: {
     screeningRequest: screeningRequest?.data || {},
     screeningResult: screeningResult?.data || {},
   });
+  const unit = await loadTenantProfileUnitProjection({
+    context,
+    tenantData: tenant?.data,
+    leaseData: lease?.data,
+  });
 
   return {
     context: {
@@ -839,6 +895,7 @@ export async function loadTenantProfileProjection(params: {
       phone: asString(tenant?.data?.phone) || asString(application?.data?.phone),
       authorityLabel: normalizeAuthorityLabel(context.authority),
       property: property ? projectTenantProperty(property.id, property.data) : null,
+      unit,
       application: application ? projectTenantApplication(application.id, application.data) : null,
       lease: lease ? projectTenantLease(lease.id, lease.data) : null,
     },

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -311,6 +311,7 @@ function firstSafeDisplayString(values: unknown[], rawIds: unknown[]): string | 
 
 async function loadTenantProfileUnitProjection(params: {
   context: TenancyContext;
+  propertyData?: any;
   tenantData?: any;
   leaseData?: any;
 }): Promise<TenantProfileProjection["profile"]["unit"]> {
@@ -330,7 +331,30 @@ async function loadTenantProfileUnitProjection(params: {
   const unitDocs = (await Promise.all(unitIdCandidates.map((candidate) => loadDocument("units", candidate)))).filter(
     (doc): doc is { id: string; data: any } => Boolean(doc?.data)
   );
-  const unitId = unitDocs[0]?.id || unitIdCandidates.find(isLikelyRawId) || null;
+  const propertyUnitDocs = params.context.propertyId
+    ? await queryMany("units", "propertyId", params.context.propertyId, "==", 250)
+    : [];
+  const propertyEmbeddedUnits = Array.isArray(params.propertyData?.units)
+    ? params.propertyData.units.map((unit: any, index: number) => ({ id: asString(unit?.id) || `property-unit-${index}`, data: unit }))
+    : [];
+  const scopedUnitDocs = [...unitDocs, ...propertyUnitDocs, ...propertyEmbeddedUnits];
+  const matchedUnitDocs = scopedUnitDocs.filter((doc) => {
+    const identifiers = [
+      doc.id,
+      doc.data?.id,
+      doc.data?.unitId,
+      doc.data?.unit_id,
+      doc.data?.unitNumber,
+      doc.data?.unitLabel,
+      doc.data?.label,
+      doc.data?.name,
+    ]
+      .map((value) => asString(value))
+      .filter(Boolean);
+    return identifiers.some((identifier) => unitIdCandidates.includes(identifier!));
+  });
+  const resolvedUnitDocs = matchedUnitDocs.length ? matchedUnitDocs : unitDocs;
+  const unitId = resolvedUnitDocs.find((doc) => isLikelyRawId(doc.id))?.id || unitIdCandidates.find(isLikelyRawId) || null;
   const rawIds = [unitId, params.context.unitId, params.tenantData?.unitId, params.leaseData?.unitId];
   const label = firstSafeDisplayString(
     [
@@ -340,7 +364,7 @@ async function loadTenantProfileUnitProjection(params: {
       params.leaseData?.unitLabel,
       params.leaseData?.unitNumber,
       params.leaseData?.unit,
-      ...unitDocs.flatMap((doc) => [doc.data?.unitNumber, doc.data?.label, doc.data?.name]),
+      ...resolvedUnitDocs.flatMap((doc) => [doc.data?.unitNumber, doc.data?.unitLabel, doc.data?.label, doc.data?.name]),
     ],
     rawIds
   );
@@ -881,6 +905,7 @@ export async function loadTenantProfileProjection(params: {
   });
   const unit = await loadTenantProfileUnitProjection({
     context,
+    propertyData: property?.data,
     tenantData: tenant?.data,
     leaseData: lease?.data,
   });

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -289,10 +289,16 @@ async function loadWorkspaceDocuments(context: TenancyContext) {
   return { property, application, lease, tenant };
 }
 
+function isLikelyRawId(value: string | null): boolean {
+  if (!value) return false;
+  return /^[A-Za-z0-9_-]{12,}$/.test(value);
+}
+
 function firstSafeDisplayString(values: unknown[], rawIds: unknown[]): string | null {
   const blocked = new Set(
     rawIds
       .map((value) => asString(value))
+      .filter(isLikelyRawId)
       .filter((value): value is string => Boolean(value))
   );
   for (const value of values) {
@@ -308,12 +314,23 @@ async function loadTenantProfileUnitProjection(params: {
   tenantData?: any;
   leaseData?: any;
 }): Promise<TenantProfileProjection["profile"]["unit"]> {
-  const unitId =
-    asString(params.context.unitId) ||
-    asString(params.tenantData?.unitId) ||
-    asString(params.leaseData?.unitId) ||
-    null;
-  const unitDoc = await loadDocument("units", unitId);
+  const unitIdCandidates = Array.from(
+    new Set(
+      [
+        params.context.unitId,
+        params.tenantData?.unitId,
+        params.leaseData?.unitId,
+        params.tenantData?.unit,
+        params.leaseData?.unit,
+      ]
+        .map((value) => asString(value))
+        .filter((value): value is string => Boolean(value))
+    )
+  );
+  const unitDocs = (await Promise.all(unitIdCandidates.map((candidate) => loadDocument("units", candidate)))).filter(
+    (doc): doc is { id: string; data: any } => Boolean(doc?.data)
+  );
+  const unitId = unitDocs[0]?.id || unitIdCandidates.find(isLikelyRawId) || null;
   const rawIds = [unitId, params.context.unitId, params.tenantData?.unitId, params.leaseData?.unitId];
   const label = firstSafeDisplayString(
     [
@@ -323,9 +340,7 @@ async function loadTenantProfileUnitProjection(params: {
       params.leaseData?.unitLabel,
       params.leaseData?.unitNumber,
       params.leaseData?.unit,
-      unitDoc?.data?.unitNumber,
-      unitDoc?.data?.label,
-      unitDoc?.data?.name,
+      ...unitDocs.flatMap((doc) => [doc.data?.unitNumber, doc.data?.label, doc.data?.name]),
     ],
     rawIds
   );

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -18,7 +18,10 @@ export type TenantProfileProjection = {
     email: string | null;
     phone: string | null;
     authorityLabel: string;
-    property: ReturnType<typeof projectTenantProperty> | null;
+    property: (ReturnType<typeof projectTenantProperty> & {
+      unitNumber?: string | null;
+      unitDisplayLabel?: string | null;
+    }) | null;
     unit: {
       unitId: string | null;
       label: string | null;
@@ -934,7 +937,13 @@ export async function loadTenantProfileProjection(params: {
         context.invitedEmail,
       phone: asString(tenant?.data?.phone) || asString(application?.data?.phone),
       authorityLabel: normalizeAuthorityLabel(context.authority),
-      property: property ? projectTenantProperty(property.id, property.data) : null,
+      property: property
+        ? {
+            ...projectTenantProperty(property.id, property.data),
+            unitNumber: unit?.label || null,
+            unitDisplayLabel: unit?.label ? `Unit ${unit.label}` : null,
+          }
+        : null,
       unit,
       application: application ? projectTenantApplication(application.id, application.data) : null,
       lease: lease ? projectTenantLease(lease.id, lease.data) : null,

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -525,6 +525,17 @@ export type InstitutionalHandoffSummary = {
 
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
+  tenant?: {
+    id?: string | null;
+    shortId?: string | null;
+    name?: string | null;
+    email?: string | null;
+    joinedAt?: number | null;
+    status?: string | null;
+  } | null;
+  landlord?: {
+    name?: string | null;
+  } | null;
   property: TenantWorkspaceProperty | null;
   unit: TenantWorkspaceUnit | null;
   application: TenantWorkspaceApplication | null;

--- a/rentchain-frontend/src/api/tenantProfile.ts
+++ b/rentchain-frontend/src/api/tenantProfile.ts
@@ -28,6 +28,10 @@ export type TenantProfileData = {
       postalCode: string | null;
       features: string[];
     } | null;
+    unit: {
+      unitId: string | null;
+      label: string | null;
+    } | null;
     application: {
       applicationId: string;
       status: string | null;

--- a/rentchain-frontend/src/api/tenantProfile.ts
+++ b/rentchain-frontend/src/api/tenantProfile.ts
@@ -26,6 +26,8 @@ export type TenantProfileData = {
       city: string | null;
       province: string | null;
       postalCode: string | null;
+      unitNumber?: string | null;
+      unitDisplayLabel?: string | null;
       features: string[];
     } | null;
     unit: {

--- a/rentchain-frontend/src/components/layout/TenantNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.test.tsx
@@ -46,6 +46,8 @@ describe("TenantNav mobile bottom navigation", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 844 });
     tenantPortalApi.getTenantWorkspace.mockResolvedValue({
       context: {
         invitedEmail: "tenant@example.com",
@@ -110,6 +112,18 @@ describe("TenantNav mobile bottom navigation", () => {
     expect(within(menu).getByRole("button", { name: "Maintenance" })).toBeInTheDocument();
     expect(within(menu).queryByRole("button", { name: "Properties" })).not.toBeInTheDocument();
     expect(within(menu).queryByRole("button", { name: "Admin" })).not.toBeInTheDocument();
+  });
+
+  it("suppresses the More sheet in compact landscape mobile view", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 820 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 390 });
+
+    renderTenantNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(screen.queryByRole("dialog", { name: "Tenant menu" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "More" })).toHaveAttribute("aria-disabled", "true");
   });
 
   it("adds mobile bottom spacing to tenant content", () => {

--- a/rentchain-frontend/src/components/layout/TenantNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.test.tsx
@@ -114,6 +114,16 @@ describe("TenantNav mobile bottom navigation", () => {
     expect(within(menu).queryByRole("button", { name: "Admin" })).not.toBeInTheDocument();
   });
 
+  it("does not render the mobile bottom nav or menu sheet on desktop", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1120 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+
+    renderTenantNav();
+
+    expect(screen.queryByRole("navigation", { name: "Tenant bottom navigation" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Tenant menu" })).not.toBeInTheDocument();
+  });
+
   it("suppresses the More sheet in compact landscape mobile view", () => {
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 820 });
     Object.defineProperty(window, "innerHeight", { configurable: true, value: 390 });

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -314,7 +314,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
       <main className="rc-tenant-main" style={{ maxWidth: 1120, margin: "0 auto", padding: isMobile ? 12 : 16 }}>
         {children}
       </main>
-      {!isCompactLandscape ? (
+      {isMobile && !isCompactLandscape ? (
         <>
           <div
             className={`rc-tenant-mobile-backdrop${moreOpen ? " is-open" : ""}`}
@@ -358,6 +358,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
           </aside>
         </>
       ) : null}
+      {isMobile ? (
       <nav className="rc-tenant-mobile-tabbar" aria-label="Tenant bottom navigation">
         {mobileTabs.map((item) => {
           const Icon = item.icon;
@@ -396,6 +397,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
           <span className="rc-tenant-mobile-tabbar-label">More</span>
         </button>
       </nav>
+      ) : null}
     </div>
   );
 };

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -51,6 +51,12 @@ const mobileTabs = [
   },
 ];
 
+function buildTenantContextLabel(property?: { name?: string | null; street1?: string | null } | null, unit?: { label?: string | null } | null) {
+  const propertyLabel = String(property?.name || property?.street1 || "").trim();
+  const unitLabel = String(unit?.label || "").trim();
+  return [propertyLabel, unitLabel ? `Unit ${unitLabel}` : null].filter(Boolean).join(" · ");
+}
+
 export const TenantNav: React.FC<Props> = ({ children }) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -74,13 +80,14 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
     const loadIdentity = async () => {
       try {
         const workspace = await getTenantWorkspace();
-        const name = String(workspace?.context?.invitedEmail || "").trim();
-        const email = String(workspace?.context?.invitedEmail || "").trim();
+        const tenantName = String(workspace?.tenant?.name || "").trim();
+        const email = String(workspace?.tenant?.email || workspace?.context?.invitedEmail || "").trim();
         const unit = String(workspace?.unit?.label || "").trim();
+        const contextLabel = buildTenantContextLabel(workspace?.property, workspace?.unit);
         if (!cancelled) {
-          setTenantName(name ? name.split("@")[0] : "Tenant workspace");
+          setTenantName(tenantName || email || "Tenant workspace");
           setTenantEmail(email || null);
-          setTenantUnit(unit || null);
+          setTenantUnit(contextLabel || (unit ? `Unit ${unit}` : null));
         }
       } catch {
         if (!cancelled) {
@@ -170,9 +177,10 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
     navigate(path);
     setMoreOpen(false);
   };
+  const headerDetailItems = [tenantName && tenantEmail === tenantName ? null : tenantEmail, tenantUnit].filter(Boolean);
 
   return (
-    <div className="rc-tenant-shell">
+    <div className={`rc-tenant-shell${isCompactLandscape ? " rc-tenant-shell--compact-landscape" : ""}`}>
       <header
         className="rc-tenant-header"
         style={{
@@ -202,9 +210,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
               {identityLoading ? "Loading your space..." : tenantName || "Your tenant space"}
             </div>
             <div style={{ fontSize: 12, color: "#94a3b8", minHeight: 16 }}>
-              {identityLoading
-                ? ""
-                : [tenantEmail, tenantUnit ? `Unit ${tenantUnit}` : null].filter(Boolean).join(" • ")}
+              {identityLoading ? "" : headerDetailItems.join(" • ")}
             </div>
           </div>
           <nav
@@ -308,47 +314,50 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
       <main className="rc-tenant-main" style={{ maxWidth: 1120, margin: "0 auto", padding: isMobile ? 12 : 16 }}>
         {children}
       </main>
-      <div
-        className={`rc-tenant-mobile-backdrop${moreOpen && !isCompactLandscape ? " is-open" : ""}`}
-        aria-hidden="true"
-        onClick={() => setMoreOpen(false)}
-      />
-      <aside
-        id="rc-tenant-mobile-menu"
-        className={`rc-tenant-mobile-menu${moreOpen && !isCompactLandscape ? " is-open" : ""}`}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Tenant menu"
-        aria-hidden={isCompactLandscape ? "true" : undefined}
-      >
-        <div className="rc-tenant-mobile-menu-header">
-          <span>Tenant menu</span>
-          <button type="button" onClick={() => setMoreOpen(false)} aria-label="Close tenant menu">
-            <X size={18} />
-          </button>
-        </div>
-        <div className="rc-tenant-mobile-menu-links">
-          {navItems.map((item) => {
-            const active =
-              location.pathname === item.to ||
-              (item.to === "/tenant/documents" && location.pathname.startsWith("/tenant/attachments")) ||
-              (item.to !== "/tenant/dashboard" && location.pathname.startsWith(`${item.to}/`));
-            return (
-              <button
-                key={item.to}
-                type="button"
-                className={active ? "active" : undefined}
-                onClick={() => goTo(item.to)}
-              >
-                {item.label}
+      {!isCompactLandscape ? (
+        <>
+          <div
+            className={`rc-tenant-mobile-backdrop${moreOpen ? " is-open" : ""}`}
+            aria-hidden="true"
+            onClick={() => setMoreOpen(false)}
+          />
+          <aside
+            id="rc-tenant-mobile-menu"
+            className={`rc-tenant-mobile-menu${moreOpen ? " is-open" : ""}`}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Tenant menu"
+          >
+            <div className="rc-tenant-mobile-menu-header">
+              <span>Tenant menu</span>
+              <button type="button" onClick={() => setMoreOpen(false)} aria-label="Close tenant menu">
+                <X size={18} />
               </button>
-            );
-          })}
-        </div>
-        <button type="button" className="rc-tenant-mobile-menu-signout" onClick={() => logoutTenant("/tenant/login")}>
-          Logout
-        </button>
-      </aside>
+            </div>
+            <div className="rc-tenant-mobile-menu-links">
+              {navItems.map((item) => {
+                const active =
+                  location.pathname === item.to ||
+                  (item.to === "/tenant/documents" && location.pathname.startsWith("/tenant/attachments")) ||
+                  (item.to !== "/tenant/dashboard" && location.pathname.startsWith(`${item.to}/`));
+                return (
+                  <button
+                    key={item.to}
+                    type="button"
+                    className={active ? "active" : undefined}
+                    onClick={() => goTo(item.to)}
+                  >
+                    {item.label}
+                  </button>
+                );
+              })}
+            </div>
+            <button type="button" className="rc-tenant-mobile-menu-signout" onClick={() => logoutTenant("/tenant/login")}>
+              Logout
+            </button>
+          </aside>
+        </>
+      ) : null}
       <nav className="rc-tenant-mobile-tabbar" aria-label="Tenant bottom navigation">
         {mobileTabs.map((item) => {
           const Icon = item.icon;

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -61,6 +61,9 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
   const [isMobile, setIsMobile] = useState<boolean>(() =>
     typeof window === "undefined" ? false : window.innerWidth < 900
   );
+  const [isCompactLandscape, setIsCompactLandscape] = useState<boolean>(() =>
+    typeof window === "undefined" ? false : window.innerWidth < 900 && window.innerWidth > window.innerHeight && window.innerHeight < 520
+  );
   const [unreadMessages, setUnreadMessages] = useState(0);
   const [unreadNotices, setUnreadNotices] = useState(0);
   const [unreadScreening, setUnreadScreening] = useState(0);
@@ -100,10 +103,17 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const onResize = () => setIsMobile(window.innerWidth < 900);
+    const onResize = () => {
+      setIsMobile(window.innerWidth < 900);
+      setIsCompactLandscape(window.innerWidth < 900 && window.innerWidth > window.innerHeight && window.innerHeight < 520);
+    };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
+
+  useEffect(() => {
+    if (isCompactLandscape) setMoreOpen(false);
+  }, [isCompactLandscape]);
 
   useEffect(() => {
     setMoreOpen(false);
@@ -299,16 +309,17 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
         {children}
       </main>
       <div
-        className={`rc-tenant-mobile-backdrop${moreOpen ? " is-open" : ""}`}
+        className={`rc-tenant-mobile-backdrop${moreOpen && !isCompactLandscape ? " is-open" : ""}`}
         aria-hidden="true"
         onClick={() => setMoreOpen(false)}
       />
       <aside
         id="rc-tenant-mobile-menu"
-        className={`rc-tenant-mobile-menu${moreOpen ? " is-open" : ""}`}
+        className={`rc-tenant-mobile-menu${moreOpen && !isCompactLandscape ? " is-open" : ""}`}
         role="dialog"
         aria-modal="true"
         aria-label="Tenant menu"
+        aria-hidden={isCompactLandscape ? "true" : undefined}
       >
         <div className="rc-tenant-mobile-menu-header">
           <span>Tenant menu</span>
@@ -362,11 +373,15 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
         })}
         <button
           type="button"
-          className={moreOpen ? "active" : undefined}
-          onClick={() => setMoreOpen((open) => !open)}
-          aria-expanded={moreOpen}
+          className={moreOpen && !isCompactLandscape ? "active" : undefined}
+          onClick={() => {
+            if (isCompactLandscape) return;
+            setMoreOpen((open) => !open);
+          }}
+          aria-expanded={moreOpen && !isCompactLandscape}
           aria-controls="rc-tenant-mobile-menu"
           aria-label="More"
+          aria-disabled={isCompactLandscape ? "true" : undefined}
         >
           <Menu size={20} strokeWidth={2.2} />
           <span className="rc-tenant-mobile-tabbar-label">More</span>

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -170,6 +170,7 @@ describe("tenant profile and communications pages", () => {
           street2: null,
           city: "Halifax",
           province: "NS",
+          postalCode: "B3H 1Z8",
         },
         unit: { unitId: "unit-4", label: "4" },
         application: { status: "submitted" },
@@ -210,7 +211,7 @@ describe("tenant profile and communications pages", () => {
     expect((await screen.findAllByText(/Verification is still in progress/i)).length).toBeGreaterThan(0);
     expect(screen.getByRole("textbox", { name: /Display name/i })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /Phone/i })).toBeInTheDocument();
-    expect(screen.getByText(/123 Main St · Unit 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/123 Main St · Unit 4 · Halifax, NS B3H 1Z8/i)).toBeInTheDocument();
     expect(screen.queryByText(/unit-4/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Rental record/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Employment and income/i).length).toBeGreaterThan(0);
@@ -220,6 +221,57 @@ describe("tenant profile and communications pages", () => {
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Review requested documents/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Open documents|Review documents/i }).length).toBeGreaterThan(0);
+  });
+
+  it("tenant profile property display falls back safely when unit or postal code is missing", async () => {
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Active tenant",
+        property: {
+          street1: "123 Main St",
+          street2: "Apartment 4",
+          city: "Halifax",
+          province: "NS",
+          postalCode: null,
+        },
+        unit: { unitId: "raw-unit-id-123456789", label: "raw-unit-id-123456789" },
+        application: { status: "submitted" },
+        lease: { status: "active", monthlyRent: 1800, startDate: "2026-02-01", endDate: "2027-01-31", documentUrl: null },
+      },
+      identity: {
+        overallStatus: "verified",
+        identityVerification: {
+          status: "verified",
+          label: "Verified",
+          note: "Verified.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: true,
+          path: "/tenant/attachments",
+          label: "Open documents",
+          note: null,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/123 Main St · Apartment 4 · Halifax, NS/i)).toBeInTheDocument();
+    expect(screen.queryByText(/raw-unit-id-123456789/i)).not.toBeInTheDocument();
   });
 
   it("formats tenant rental record date-only lease dates without shifting backward", () => {

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -125,7 +125,8 @@ describe("tenant profile and communications pages", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText((content) => content.includes("tenant@example.com") && content.includes("Unit 1"))).toBeInTheDocument();
+    expect(await screen.findByText("tenant@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Unit 1")).toBeInTheDocument();
     expect(screen.queryByText(/iXHTFgm8ay3iuUptfI4I/)).not.toBeInTheDocument();
   });
 
@@ -155,6 +156,81 @@ describe("tenant profile and communications pages", () => {
     expect(await screen.findByText("tenant@example.com")).toBeInTheDocument();
     expect(screen.queryByText(/raw-internal-unit-id/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Unit raw-internal-unit-id/)).not.toBeInTheDocument();
+  });
+
+  it("tenant profile property display uses the workspace unit fallback when profile unit is missing", async () => {
+    tenantPortalApi.getTenantWorkspace.mockResolvedValueOnce({
+      context: {
+        authority: "active_tenant",
+        propertyId: "prop-1",
+        rc_prop_id: "rc-prop-1",
+        applicationId: "app-1",
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        unitId: "raw-unit-id-123456789",
+        invitedEmail: "tenant@example.com",
+      },
+      property: {
+        propertyId: "prop-1",
+        rc_prop_id: "rc-prop-1",
+        street1: "6227 Coburg Road",
+        street2: null,
+        city: "Halifax",
+        province: "NS",
+        postalCode: "B3H 1Z8",
+        features: [],
+      },
+      unit: {
+        unitId: "raw-unit-id-123456789",
+        label: "6",
+      },
+    });
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Active tenant",
+        property: {
+          propertyId: "prop-1",
+          rc_prop_id: "rc-prop-1",
+          street1: "6227 Coburg Road",
+          street2: null,
+          city: "Halifax",
+          province: "NS",
+          postalCode: "B3H 1Z8",
+          features: [],
+        },
+        unit: null,
+        application: { status: "submitted" },
+        lease: { status: "active", monthlyRent: 1800, startDate: "2026-02-01", endDate: "2027-01-31", documentUrl: null },
+      },
+      identity: {
+        overallStatus: "verified",
+        identityVerification: {
+          status: "verified",
+          label: "Verified",
+          note: "Verified.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: { available: true, path: "/tenant/attachments", label: "Open documents", note: null },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/6227 Coburg Road · Unit 6 · Halifax, NS B3H 1Z8/i)).toBeInTheDocument();
+    expect(screen.queryByText(/raw-unit-id-123456789/i)).not.toBeInTheDocument();
   });
 
   it("tenant profile page renders safe projected profile data and identity states", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -233,6 +233,70 @@ describe("tenant profile and communications pages", () => {
     expect(screen.queryByText(/raw-unit-id-123456789/i)).not.toBeInTheDocument();
   });
 
+  it("tenant profile property display uses profile property unit fields when present", async () => {
+    tenantPortalApi.getTenantWorkspace.mockResolvedValueOnce({
+      context: {
+        authority: "active_tenant",
+        propertyId: "prop-1",
+        rc_prop_id: "rc-prop-1",
+        applicationId: "app-1",
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        unitId: "raw-unit-id-123456789",
+        invitedEmail: "tenant@example.com",
+      },
+      unit: null,
+    });
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Active tenant",
+        property: {
+          propertyId: "prop-1",
+          rc_prop_id: "rc-prop-1",
+          street1: "6227 Coburg Road",
+          street2: null,
+          city: "Halifax",
+          province: "NS",
+          postalCode: "B3H 1Z8",
+          unitNumber: "6",
+          unitDisplayLabel: "Unit 6",
+          features: [],
+        },
+        unit: null,
+        application: { status: "submitted" },
+        lease: { status: "active", monthlyRent: 1800, startDate: "2026-02-01", endDate: "2027-01-31", documentUrl: null },
+      },
+      identity: {
+        overallStatus: "verified",
+        identityVerification: {
+          status: "verified",
+          label: "Verified",
+          note: "Verified.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: { available: true, path: "/tenant/attachments", label: "Open documents", note: null },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/6227 Coburg Road · Unit 6 · Halifax, NS B3H 1Z8/i)).toBeInTheDocument();
+    expect(screen.queryByText(/raw-unit-id-123456789/i)).not.toBeInTheDocument();
+  });
+
   it("tenant profile page renders safe projected profile data and identity states", async () => {
     tenantProfileApi.getTenantProfile.mockResolvedValue({
       context: { authority: "active_tenant" },

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -167,10 +167,11 @@ describe("tenant profile and communications pages", () => {
         authorityLabel: "Active tenant",
         property: {
           street1: "123 Main St",
-          street2: "Unit 4",
+          street2: null,
           city: "Halifax",
           province: "NS",
         },
+        unit: { unitId: "unit-4", label: "4" },
         application: { status: "submitted" },
         lease: { status: "active", monthlyRent: 1800, startDate: "2026-02-01", endDate: "2027-01-31", documentUrl: null },
       },
@@ -209,6 +210,8 @@ describe("tenant profile and communications pages", () => {
     expect((await screen.findAllByText(/Verification is still in progress/i)).length).toBeGreaterThan(0);
     expect(screen.getByRole("textbox", { name: /Display name/i })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /Phone/i })).toBeInTheDocument();
+    expect(screen.getByText(/123 Main St · Unit 4/i)).toBeInTheDocument();
+    expect(screen.queryByText(/unit-4/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Rental record/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Employment and income/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
@@ -542,6 +545,60 @@ describe("tenant profile and communications pages", () => {
     fireEvent.click(screen.getByRole("button", { name: /Update missing details/i }));
 
     expect(document.activeElement).toBe(phoneInput);
+  });
+
+  it("tenant profile completion CTA targets the actual incomplete identity area", async () => {
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Active tenant",
+        property: {
+          street1: "Coburg Rd",
+          street2: null,
+          city: "Halifax",
+          province: "NS",
+        },
+        unit: { unitId: "unit-safe", label: "6" },
+        application: { status: "converted" },
+        lease: { status: "active", monthlyRent: 1800, startDate: "2026-05-01", endDate: "2027-04-30", documentUrl: null },
+      },
+      identity: {
+        overallStatus: "pending",
+        identityVerification: {
+          status: "pending",
+          label: "Pending",
+          note: "Verification is still in progress.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: false,
+          path: null,
+          label: "Open documents",
+          note: null,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    await screen.findByDisplayValue("Taylor Tenant");
+    expect(screen.getByText(/Identity verification: Verification is still in progress/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Update missing details/i }));
+
+    expect(document.activeElement).toHaveTextContent(/Identity status/i);
+    expect(document.activeElement).not.toBe(screen.getByRole("textbox", { name: /Phone/i }));
   });
 
   it("communications page handles empty state and compose/send success", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCompletionCard.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCompletionCard.tsx
@@ -100,7 +100,7 @@ export default function TenantProfileCompletionCard({
         {missingPreview.length ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ color: textTokens.primary, fontWeight: 700 }}>
-              Add missing details to keep your rental profile organized.
+              Review the remaining profile area to keep your rental profile organized.
             </div>
             {missingPreview.map((item) => (
               <div key={item} style={{ color: textTokens.secondary }}>

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -46,7 +46,10 @@ function cleanProfileDisplayValue(value: string | null | undefined): string | nu
 function buildProfilePropertyDisplay(property: Awaited<ReturnType<typeof getTenantProfile>>["profile"]["property"], unitLabel?: string | null) {
   if (!property) return "";
   const street = cleanProfileDisplayValue(property.street1);
-  const unit = cleanProfileDisplayValue(unitLabel);
+  const unit =
+    cleanProfileDisplayValue(unitLabel) ||
+    cleanProfileDisplayValue(property.unitNumber) ||
+    cleanProfileDisplayValue(String(property.unitDisplayLabel || "").replace(/^unit\s+/i, ""));
   const city = cleanProfileDisplayValue(property.city);
   const province = cleanProfileDisplayValue(property.province);
   const postalCode = cleanProfileDisplayValue(property.postalCode);

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -43,6 +43,9 @@ export default function TenantProfilePage() {
   const [attachments, setAttachments] = useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const displayNameRef = React.useRef<HTMLInputElement | null>(null);
   const phoneRef = React.useRef<HTMLInputElement | null>(null);
+  const rentalRecordRef = React.useRef<HTMLDivElement | null>(null);
+  const identityStatusRef = React.useRef<HTMLDivElement | null>(null);
+  const documentChecklistRef = React.useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -121,16 +124,37 @@ export default function TenantProfilePage() {
     }
   };
 
+  const completion = data ? buildTenantProfileCompletion(data) : null;
+  const firstIncompleteCompletionKey =
+    completion?.sections.flatMap((section) => section.items).find((item) => item.status !== "complete")?.key || null;
   const focusMissingEditableField = React.useCallback(() => {
-    const firstMissingEditableField = !data?.profile?.phone
-      ? phoneRef.current
-      : !data?.profile?.displayName
-      ? displayNameRef.current
-      : displayNameRef.current;
-    if (!firstMissingEditableField) return;
-    firstMissingEditableField.scrollIntoView({ behavior: "smooth", block: "center" });
-    firstMissingEditableField.focus();
-  }, [data?.profile?.displayName, data?.profile?.phone]);
+    const focusTarget = (target: HTMLElement | null) => {
+      if (!target) return;
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+      target.focus();
+    };
+
+    switch (firstIncompleteCompletionKey) {
+      case "phone":
+        focusTarget(phoneRef.current);
+        return;
+      case "display_name":
+        focusTarget(displayNameRef.current);
+        return;
+      case "property_summary":
+      case "application_or_lease":
+        focusTarget(rentalRecordRef.current);
+        return;
+      case "identity_verification":
+        focusTarget(identityStatusRef.current);
+        return;
+      case "document_checklist":
+        focusTarget(documentChecklistRef.current);
+        return;
+      default:
+        focusTarget(phoneRef.current || displayNameRef.current);
+    }
+  }, [firstIncompleteCompletionKey]);
 
   if (loading) {
     return (
@@ -158,7 +182,6 @@ export default function TenantProfilePage() {
   const identityTone = statusTone(data?.identity?.overallStatus || "missing");
   const verificationTone = statusTone(data?.identity?.identityVerification?.status || "missing");
   const documentEntry = data?.actions?.documentEntry;
-  const completion = data ? buildTenantProfileCompletion(data) : null;
   const propertyAddress = [
     data?.profile?.property?.street1,
     data?.profile?.property?.street2,
@@ -167,6 +190,13 @@ export default function TenantProfilePage() {
   ]
     .filter(Boolean)
     .join(", ");
+  const propertyLabel = data?.profile?.property?.street1 || propertyAddress;
+  const propertyDisplay = [
+    propertyLabel,
+    data?.profile?.unit?.label ? `Unit ${data.profile.unit.label}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
   const applicationSignals = [
     ...(data?.profile?.application?.missingSteps || []),
     ...(data?.profile?.application?.nextActions || []),
@@ -202,7 +232,7 @@ export default function TenantProfilePage() {
               { label: "Email", value: data?.profile?.email || "—" },
               { label: "Phone", value: data?.profile?.phone || "—" },
               { label: "Access", value: data?.profile?.authorityLabel || "Tenant" },
-              { label: "Property", value: propertyAddress || "No property linked yet" },
+              { label: "Property", value: propertyDisplay || "No property linked yet" },
               { label: "Lease status", value: prettyStatus(data?.profile?.lease?.status) },
             ]}
           />
@@ -313,6 +343,7 @@ export default function TenantProfilePage() {
           gap: spacing.md,
         }}
       >
+        <div ref={rentalRecordRef} tabIndex={-1} style={{ outline: "none" }}>
         <TenantInfoCard heading="Rental record" accent="#7c3aed">
           <TenantKeyValueGrid
             rows={[
@@ -333,7 +364,9 @@ export default function TenantProfilePage() {
             This section keeps your current rental record visible in one place. Longer history can be added over time as more tenant-safe records are linked.
           </div>
         </TenantInfoCard>
+        </div>
 
+        <div ref={identityStatusRef} tabIndex={-1} style={{ outline: "none" }}>
         <TenantInfoCard heading="Identity status" accent="#1d4ed8">
           <div style={{ display: "grid", gap: spacing.sm }}>
             <div
@@ -362,6 +395,7 @@ export default function TenantProfilePage() {
             </div>
           </div>
         </TenantInfoCard>
+        </div>
 
         <TenantInfoCard heading="Employment and income" accent="#0891b2">
           <div style={{ display: "grid", gap: spacing.sm }}>
@@ -421,6 +455,7 @@ export default function TenantProfilePage() {
         </div>
       </TenantInfoCard>
 
+      <div ref={documentChecklistRef} tabIndex={-1} style={{ outline: "none" }}>
       <TenantInfoCard heading="Document checklist" accent="#b45309">
         {documentEntry?.note ? <div style={{ color: textTokens.secondary }}>{documentEntry.note}</div> : null}
         {data?.identity?.documentChecklist?.length ? (
@@ -472,6 +507,7 @@ export default function TenantProfilePage() {
           />
         )}
       </TenantInfoCard>
+      </div>
 
       <TenantInfoCard heading="Next steps" accent="#0891b2">
         {data?.identity?.nextSteps?.length ? (

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -32,6 +32,29 @@ function statusTone(status: TenantProfileStatus): { label: string; color: string
   }
 }
 
+function isLikelyRawId(value: string | null): boolean {
+  return Boolean(value && /^[A-Za-z0-9_-]{12,}$/.test(value));
+}
+
+function cleanProfileDisplayValue(value: string | null | undefined): string | null {
+  const next = String(value || "").trim();
+  if (!next || isLikelyRawId(next)) return null;
+  return next;
+}
+
+function buildProfilePropertyDisplay(property: Awaited<ReturnType<typeof getTenantProfile>>["profile"]["property"], unitLabel?: string | null) {
+  if (!property) return "";
+  const street = cleanProfileDisplayValue(property.street1);
+  const unit = cleanProfileDisplayValue(unitLabel);
+  const city = cleanProfileDisplayValue(property.city);
+  const province = cleanProfileDisplayValue(property.province);
+  const postalCode = cleanProfileDisplayValue(property.postalCode);
+  const locality = [city, [province, postalCode].filter(Boolean).join(" ")].filter(Boolean).join(", ");
+  return [street, unit ? `Unit ${unit}` : cleanProfileDisplayValue(property.street2), locality]
+    .filter(Boolean)
+    .join(" · ");
+}
+
 export default function TenantProfilePage() {
   const [data, setData] = useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [loading, setLoading] = useState(true);
@@ -182,21 +205,7 @@ export default function TenantProfilePage() {
   const identityTone = statusTone(data?.identity?.overallStatus || "missing");
   const verificationTone = statusTone(data?.identity?.identityVerification?.status || "missing");
   const documentEntry = data?.actions?.documentEntry;
-  const propertyAddress = [
-    data?.profile?.property?.street1,
-    data?.profile?.property?.street2,
-    data?.profile?.property?.city,
-    data?.profile?.property?.province,
-  ]
-    .filter(Boolean)
-    .join(", ");
-  const propertyLabel = data?.profile?.property?.street1 || propertyAddress;
-  const propertyDisplay = [
-    propertyLabel,
-    data?.profile?.unit?.label ? `Unit ${data.profile.unit.label}` : null,
-  ]
-    .filter(Boolean)
-    .join(" · ");
+  const propertyDisplay = buildProfilePropertyDisplay(data?.profile?.property || null, data?.profile?.unit?.label);
   const applicationSignals = [
     ...(data?.profile?.application?.missingSteps || []),
     ...(data?.profile?.application?.nextActions || []),

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { getTenantProfile, updateTenantProfile, type TenantProfileStatus } from "../../api/tenantProfile";
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
+import { getTenantWorkspace } from "../../api/tenantPortal";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -64,6 +65,7 @@ export default function TenantProfilePage() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [attachments, setAttachments] = useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
+  const [workspace, setWorkspace] = useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
   const displayNameRef = React.useRef<HTMLInputElement | null>(null);
   const phoneRef = React.useRef<HTMLInputElement | null>(null);
   const rentalRecordRef = React.useRef<HTMLDivElement | null>(null);
@@ -107,6 +109,22 @@ export default function TenantProfilePage() {
       }
     };
     void loadAttachments();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadWorkspace = async () => {
+      try {
+        const next = await getTenantWorkspace();
+        if (!cancelled) setWorkspace(next);
+      } catch {
+        if (!cancelled) setWorkspace(null);
+      }
+    };
+    void loadWorkspace();
     return () => {
       cancelled = true;
     };
@@ -205,7 +223,10 @@ export default function TenantProfilePage() {
   const identityTone = statusTone(data?.identity?.overallStatus || "missing");
   const verificationTone = statusTone(data?.identity?.identityVerification?.status || "missing");
   const documentEntry = data?.actions?.documentEntry;
-  const propertyDisplay = buildProfilePropertyDisplay(data?.profile?.property || null, data?.profile?.unit?.label);
+  const propertyDisplay = buildProfilePropertyDisplay(
+    data?.profile?.property || workspace?.property || null,
+    data?.profile?.unit?.label || workspace?.unit?.label
+  );
   const applicationSignals = [
     ...(data?.profile?.application?.missingSteps || []),
     ...(data?.profile?.application?.nextActions || []),

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -1277,6 +1277,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
     expect(screen.getByText(/Rent terms ready for future setup/i)).toBeInTheDocument();
     expect(screen.getByText(/Confirm payment setup later/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Internal Lease ID/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.getByText(/^Application created$/i)).toBeInTheDocument();
     expect(screen.getByText(/A rental application record was started\./i)).toBeInTheDocument();
     expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -1282,7 +1282,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();
     expect(screen.getByText(/Income documents/i)).toBeInTheDocument();
     expect(screen.getByText(/Manage Shared Access/i)).toBeInTheDocument();
-    expect(screen.getByText(/Add missing details to keep your rental profile organized/i)).toBeInTheDocument();
+    expect(screen.getByText(/Review the remaining profile area to keep your rental profile organized/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /View your profile/i })).toBeInTheDocument();
     expect(screen.queryByText(/^Applicant$/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Active tenancy/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -1146,6 +1146,10 @@ describe("tenant workspace frontend shell", () => {
         postalCode: "B3H1A1",
         features: ["laundry"],
       },
+      unit: {
+        unitId: "unit-1",
+        label: "4",
+      },
       application: {
         applicationId: "app-1",
         status: "submitted",
@@ -1297,7 +1301,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByRole("link", { name: /Open communications inbox/i })).toBeInTheDocument();
     expect(screen.getByText(/Screening consent requested for 1 application/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Review request/i })).toBeInTheDocument();
-    expect(screen.getByText(/123 Main St, Unit 4, Halifax, NS/i)).toBeInTheDocument();
+    expect(screen.getByText(/123 Main St · Unit 4 · Halifax, NS/i)).toBeInTheDocument();
     expect(screen.getByText(/finish_profile/i)).toBeInTheDocument();
     expect(screen.getAllByText(/1 active access grant/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/1 document in your vault, 1 ready to share, and 0 still needing attention/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -258,6 +258,33 @@ function prettyAccessAuditReason(value: string | null | undefined) {
   return prettyPolicyReason(value);
 }
 
+function isLikelyRawTenantReference(value: string | null | undefined): boolean {
+  return Boolean(String(value || "").trim().match(/^[A-Za-z0-9_-]{12,}$/));
+}
+
+function safeTenantContextValue(value: string | null | undefined): string | null {
+  const next = String(value || "").trim();
+  if (!next || isLikelyRawTenantReference(next)) return null;
+  return next;
+}
+
+function buildTenantDashboardPropertyDisplay(
+  property: Awaited<ReturnType<typeof getTenantWorkspace>>["property"] | null | undefined,
+  unit: Awaited<ReturnType<typeof getTenantWorkspace>>["unit"] | null | undefined
+) {
+  const propertyLabel =
+    safeTenantContextValue((property as any)?.name) ||
+    safeTenantContextValue(property?.street1) ||
+    safeTenantContextValue(property?.street2);
+  const unitLabel = safeTenantContextValue(unit?.label);
+  const city = safeTenantContextValue(property?.city);
+  const province = safeTenantContextValue(property?.province);
+  const locality = [city, province].filter(Boolean).join(", ");
+  return [propertyLabel, unitLabel ? `Unit ${unitLabel}` : safeTenantContextValue(property?.street2), locality]
+    .filter(Boolean)
+    .join(" · ");
+}
+
 function prettyInstitutionType(
   value: "bank" | "lender" | "insurer" | "regulator" | "internal_review" | null | undefined
 ) {
@@ -919,9 +946,7 @@ export default function TenantWorkspacePage() {
     );
   }
 
-  const propertyAddress = [data?.property?.street1, data?.property?.street2, data?.property?.city, data?.property?.province]
-    .filter(Boolean)
-    .join(", ");
+  const propertyAddress = buildTenantDashboardPropertyDisplay(data?.property || null, data?.unit || null);
   const maintenanceCount = Array.isArray(data?.maintenance) ? data.maintenance.length : 0;
   const nextActions = data?.application?.nextActions || [];
   const profileCompletion = profileData ? buildTenantProfileCompletion(profileData) : null;

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -1013,7 +1013,6 @@ export default function TenantWorkspacePage() {
           <TenantKeyValueGrid
             rows={[
               { label: "Status", value: activeTenancy.label },
-              { label: "Internal Lease ID", value: data?.lease?.leaseId || "Not visible yet" },
               { label: "Lease status", value: prettyStatus(data?.lease?.status) },
               {
                 label: "Lease document",

--- a/rentchain-frontend/src/pages/tenant/tenantProfileCompletion.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantProfileCompletion.test.ts
@@ -57,8 +57,8 @@ describe("buildTenantProfileCompletion", () => {
     expect(summary.totalCount).toBe(7);
     expect(summary.progressPercent).toBeGreaterThan(0);
     expect(summary.overallStatus).toBe("missing");
-    expect(summary.missingItems.some((item) => /name/i.test(item))).toBe(true);
-    expect(summary.missingItems.some((item) => /phone/i.test(item))).toBe(true);
+    expect(summary.missingItems.some((item) => /Display name:.*name/i.test(item))).toBe(true);
+    expect(summary.missingItems.some((item) => /Phone number:.*phone/i.test(item))).toBe(true);
   });
 
   it("marks a complete tenant-safe profile as fully organized", () => {

--- a/rentchain-frontend/src/pages/tenant/tenantProfileCompletion.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantProfileCompletion.ts
@@ -209,7 +209,7 @@ export function buildTenantProfileCompletion(
   );
   const missingItems = allItems
     .filter((item) => item.status !== "complete")
-    .map((item) => item.detail);
+    .map((item) => `${item.label}: ${item.detail}`);
 
   return {
     progressPercent,


### PR DESCRIPTION
## Summary
- add a tenant-safe unit summary to the tenant profile projection so the profile Property row can show property + unit without raw IDs
- make profile completion missing guidance name the specific incomplete area
- update the profile completion CTA to focus the actual incomplete profile, rental, identity, or document section
- keep tenant document vault count logic unchanged so Schedule A remains a ready document without forcing unrelated profile gaps into missing counts

## Validation
- source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- src/routes/__tests__/tenantProfileRoutes.test.ts (rentchain-api)
- npm run test -- TenantProfileCommunicationsPages tenantProfileCompletion TenantAttachmentsPage TenantWorkspacePage (rentchain-frontend)
- source ~/.nvm/nvm.sh && nvm use 20 && npm run build (rentchain-api)
- source ~/.nvm/nvm.sh && nvm use 20 && npm run build (rentchain-frontend)
- git diff --check

## Manual QA Required
- /profile property row shows safe property + unit
- profile completion explains the missing item
- Update missing details targets the actual missing area
- /tenant/documents vault counts remain honest
- tenant bottom nav still works