### PR TITLE
Fix tenant message realtime refresh and read-state sync

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
@@ -346,6 +346,50 @@ describe("tenant communications routes", () => {
     expect(loadRes.body?.data?.thread?.unreadCount).toBe(2);
   });
 
+  it("marks communications thread messages read for tenant notification summary sync", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+      }),
+    };
+
+    const summaryBefore = await invokeRouter(router, {
+      method: "GET",
+      url: "/communication/summary",
+      headers,
+    });
+    expect(summaryBefore.status).toBe(200);
+    expect(summaryBefore.body?.unreadMessages).toBe(2);
+
+    const readRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/communications/read",
+      headers,
+    });
+    expect(readRes.status).toBe(200);
+    expect(ensureCollection("tenantMessageReads").get("tenant-1_msg-1")).toMatchObject({
+      tenantId: "tenant-1",
+      messageId: "msg-1",
+    });
+    expect(ensureCollection("tenantMessageReads").get("tenant-1_msg-2")).toMatchObject({
+      tenantId: "tenant-1",
+      messageId: "msg-2",
+    });
+
+    const summaryAfter = await invokeRouter(router, {
+      method: "GET",
+      url: "/communication/summary",
+      headers,
+    });
+    expect(summaryAfter.status).toBe(200);
+    expect(summaryAfter.body?.unreadMessages).toBe(0);
+  });
+
   it("send path respects authority context and records a scoped message", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
@@ -454,5 +454,31 @@ export async function markTenantCommunicationsRead(params: {
     },
     { merge: true }
   );
+  const tenantReadId = asString(params.context.tenantId) || asString(params.userId);
+  const resolvedConversationId = existingConversation.id || conversationId;
+  if (tenantReadId && resolvedConversationId) {
+    const snap = await db
+      .collection("messages")
+      .where("conversationId", "==", resolvedConversationId)
+      .limit(200)
+      .get();
+    const now = Date.now();
+    await Promise.all(
+      snap.docs.map((doc) =>
+        db
+          .collection("tenantMessageReads")
+          .doc(`${tenantReadId}_${doc.id}`)
+          .set(
+            {
+              tenantId: tenantReadId,
+              messageId: doc.id,
+              readAtMs: now,
+              createdAt: FieldValue.serverTimestamp(),
+            },
+            { merge: true }
+          )
+      )
+    );
+  }
   return { ok: true as const };
 }

--- a/rentchain-frontend/src/components/layout/TenantNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { TenantNav } from "./TenantNav";
+import { TENANT_COMMUNICATIONS_UPDATED_EVENT, TenantNav } from "./TenantNav";
 
 const tenantPortalApi = vi.hoisted(() => ({
   getTenantWorkspace: vi.fn(),
@@ -44,6 +44,7 @@ function renderTenantNav(initialPath = "/tenant/dashboard") {
 
 describe("TenantNav mobile bottom navigation", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     cleanup();
     vi.clearAllMocks();
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
@@ -112,6 +113,30 @@ describe("TenantNav mobile bottom navigation", () => {
     expect(within(menu).getByRole("button", { name: "Maintenance" })).toBeInTheDocument();
     expect(within(menu).queryByRole("button", { name: "Properties" })).not.toBeInTheDocument();
     expect(within(menu).queryByRole("button", { name: "Admin" })).not.toBeInTheDocument();
+  });
+
+  it("refreshes unread message badges when tenant communications update", async () => {
+    tenantCommunicationsApi.getTenantCommunicationSummary
+      .mockResolvedValueOnce({
+        unreadMessages: 1,
+        unreadNotices: 0,
+        unreadScreeningUpdates: 0,
+      })
+      .mockResolvedValue({
+        unreadMessages: 0,
+        unreadNotices: 0,
+        unreadScreeningUpdates: 0,
+      });
+
+    renderTenantNav();
+
+    const tabbar = screen.getByRole("navigation", { name: "Tenant bottom navigation" });
+    expect(await within(tabbar).findByText("Messages")).toBeInTheDocument();
+    await waitFor(() => expect(document.querySelector(".rc-tenant-mobile-tabbar-dot")).toBeInTheDocument());
+
+    window.dispatchEvent(new CustomEvent(TENANT_COMMUNICATIONS_UPDATED_EVENT));
+
+    await waitFor(() => expect(document.querySelector(".rc-tenant-mobile-tabbar-dot")).not.toBeInTheDocument());
   });
 
   it("does not render the mobile bottom nav or menu sheet on desktop", () => {

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -51,6 +51,8 @@ const mobileTabs = [
   },
 ];
 
+export const TENANT_COMMUNICATIONS_UPDATED_EVENT = "rentchain:tenant-communications-updated";
+
 function buildTenantContextLabel(property?: { name?: string | null; street1?: string | null } | null, unit?: { label?: string | null } | null) {
   const propertyLabel = String(property?.name || property?.street1 || "").trim();
   const unitLabel = String(unit?.label || "").trim();
@@ -135,29 +137,39 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [moreOpen]);
 
+  const loadCommunicationSummary = React.useCallback(async () => {
+    try {
+      const summary = await getTenantCommunicationSummary();
+      setUnreadMessages(Number(summary?.unreadMessages || 0));
+      setUnreadNotices(Number(summary?.unreadNotices || 0));
+      setUnreadScreening(Number(summary?.unreadScreeningUpdates || 0));
+    } catch {
+      setUnreadMessages(0);
+      setUnreadNotices(0);
+      setUnreadScreening(0);
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    const loadSummary = async () => {
-      try {
-        const summary = await getTenantCommunicationSummary();
-        if (!cancelled) {
-          setUnreadMessages(Number(summary?.unreadMessages || 0));
-          setUnreadNotices(Number(summary?.unreadNotices || 0));
-          setUnreadScreening(Number(summary?.unreadScreeningUpdates || 0));
-        }
-      } catch {
-        if (!cancelled) {
-          setUnreadMessages(0);
-          setUnreadNotices(0);
-          setUnreadScreening(0);
-        }
-      }
+    const loadIfMounted = async () => {
+      if (cancelled) return;
+      await loadCommunicationSummary();
     };
-    void loadSummary();
+    const onCommunicationsUpdated = () => {
+      void loadIfMounted();
+    };
+    void loadIfMounted();
+    const interval = window.setInterval(() => void loadIfMounted(), 30000);
+    window.addEventListener(TENANT_COMMUNICATIONS_UPDATED_EVENT, onCommunicationsUpdated);
+    window.addEventListener("focus", onCommunicationsUpdated);
     return () => {
       cancelled = true;
+      window.clearInterval(interval);
+      window.removeEventListener(TENANT_COMMUNICATIONS_UPDATED_EVENT, onCommunicationsUpdated);
+      window.removeEventListener("focus", onCommunicationsUpdated);
     };
-  }, []);
+  }, [loadCommunicationSummary]);
 
   const linkStyle = useMemo(
     () =>

--- a/rentchain-frontend/src/pages/tenant/TenantMessagesCenterPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMessagesCenterPage.tsx
@@ -14,6 +14,27 @@ import {
 } from "./TenantWorkspaceShared";
 import { spacing, text as textTokens } from "../../styles/tokens";
 import { buildTenantCommunicationsWorkspaceState } from "./tenantCommunicationsWorkspaceState";
+import { TENANT_COMMUNICATIONS_UPDATED_EVENT } from "../../components/layout/TenantNav";
+
+const POLL_COMMUNICATIONS_MS = 12000;
+
+function dispatchTenantCommunicationsUpdated() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(TENANT_COMMUNICATIONS_UPDATED_EVENT));
+}
+
+function markWorkspaceReadLocally(
+  workspace: Awaited<ReturnType<typeof getTenantCommunicationsWorkspace>>
+): Awaited<ReturnType<typeof getTenantCommunicationsWorkspace>> {
+  if (!workspace.thread) return workspace;
+  return {
+    ...workspace,
+    thread: {
+      ...workspace.thread,
+      unreadCount: 0,
+    },
+  };
+}
 
 export default function TenantMessagesCenterPage() {
   const [workspace, setWorkspace] = useState<Awaited<ReturnType<typeof getTenantCommunicationsWorkspace>> | null>(null);
@@ -22,23 +43,37 @@ export default function TenantMessagesCenterPage() {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const load = React.useCallback(async () => {
-    setLoading(true);
+  const load = React.useCallback(async (options?: { background?: boolean }) => {
+    const background = options?.background === true;
+    if (!background) setLoading(true);
     setError(null);
     try {
       const res = await getTenantCommunicationsWorkspace();
-      setWorkspace(res);
       await markTenantCommunicationsRead().catch(() => undefined);
+      setWorkspace(markWorkspaceReadLocally(res));
+      dispatchTenantCommunicationsUpdated();
     } catch (err: any) {
       setError(err?.message || "Unable to load messages.");
-      setWorkspace(null);
+      if (!background) setWorkspace(null);
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
     void load();
+  }, [load]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      void load({ background: true });
+    }, POLL_COMMUNICATIONS_MS);
+    const onFocus = () => void load({ background: true });
+    window.addEventListener("focus", onFocus);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
   }, [load]);
 
   const thread = workspace?.thread;
@@ -57,6 +92,7 @@ export default function TenantMessagesCenterPage() {
       await sendTenantCommunicationMessage(body);
       setComposer("");
       await load();
+      dispatchTenantCommunicationsUpdated();
     } catch (err: any) {
       setError(err?.message || "Unable to send your message.");
     } finally {

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TenantProfilePage from "./TenantProfilePage";
 import TenantMessagesCenterPage from "./TenantMessagesCenterPage";
@@ -40,6 +40,7 @@ vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 
 describe("tenant profile and communications pages", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     cleanup();
     vi.clearAllMocks();
     Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
@@ -863,14 +864,81 @@ describe("tenant profile and communications pages", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/A tenancy message is waiting for your reply/i)).toBeInTheDocument();
-    expect(screen.getByText(/Reply needed/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Your tenancy inbox is active/i)).toBeInTheDocument();
+    expect(screen.getByText(/Up to date/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unread messages:/i).parentElement).toHaveTextContent("0");
     expect(screen.getAllByText(/Can you confirm the move-in time\?/i).length).toBeGreaterThan(0);
     fireEvent.change(screen.getByRole("textbox", { name: /Compose message/i }), {
       target: { value: "Hello there" },
     });
     fireEvent.click(screen.getByRole("button", { name: /Send message/i }));
     expect(await screen.findByText(/Send failed/i)).toBeInTheDocument();
+  });
+
+  it("communications page refreshes thread data while open", async () => {
+    tenantCommunicationsApi.getTenantCommunicationsWorkspace
+      .mockResolvedValueOnce({
+        canSend: true,
+        canSendReason: null,
+        thread: {
+          id: "thread-1",
+          landlordLabel: "Landlord",
+          unreadCount: 0,
+          lastMessageAt: "2026-01-06T00:00:00.000Z",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          messages: [
+            {
+              id: "msg-1",
+              senderRole: "tenant",
+              body: "Initial message",
+              createdAt: "2026-01-06T00:00:00.000Z",
+              createdAtMs: 1234,
+            },
+          ],
+        },
+      })
+      .mockResolvedValue({
+        canSend: true,
+        canSendReason: null,
+        thread: {
+          id: "thread-1",
+          landlordLabel: "Landlord",
+          unreadCount: 1,
+          lastMessageAt: "2026-01-06T00:01:00.000Z",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          messages: [
+            {
+              id: "msg-1",
+              senderRole: "tenant",
+              body: "Initial message",
+              createdAt: "2026-01-06T00:00:00.000Z",
+              createdAtMs: 1234,
+            },
+            {
+              id: "msg-2",
+              senderRole: "landlord",
+              body: "New landlord reply",
+              createdAt: "2026-01-06T00:01:00.000Z",
+              createdAtMs: 5678,
+            },
+          ],
+        },
+      });
+    tenantCommunicationsApi.markTenantCommunicationsRead.mockResolvedValue(undefined);
+
+    render(
+      <MemoryRouter>
+        <TenantMessagesCenterPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Initial message/i)).length).toBeGreaterThan(0);
+    window.dispatchEvent(new Event("focus"));
+    expect((await screen.findAllByText(/New landlord reply/i)).length).toBeGreaterThan(0);
+    await waitFor(() => expect(tenantCommunicationsApi.markTenantCommunicationsRead).toHaveBeenCalledTimes(2));
+    expect(screen.getByText(/Unread messages:/i).parentElement).toHaveTextContent("0");
   });
 
   it("notifications page renders safe feed items", async () => {


### PR DESCRIPTION
## Summary
- mark tenant communication thread messages read in the same read-state store used by tenant unread badge summaries
- refresh tenant communication badges on focus, polling, and explicit tenant communication update events
- refresh the tenant messages center in the background so new messages appear without a full browser reload

## Root cause
Tenant /tenant/communications/read updated the conversation-level read marker, while the tenant unread badge summary is computed from message-level tenantMessageReads. The tenant nav also loaded the communication summary only once, so read-state changes and new messages were stale until a full refresh.

## Safety
- tenant-scoped communication routes and projections remain unchanged
- no landlord/admin data exposure added
- no auth, Firestore rules, payment, pricing, screening, lease, or profile behavior changes
- no dependency or lockfile changes

## Validation
- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- src/routes/__tests__/tenantCommunicationsRoutes.test.ts
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test -- TenantProfileCommunicationsPages TenantNav
- cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build
- git diff --check