### PR TITLE
Add cowork devcontainer and QA foundation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-20-bookworm
+
+USER root
+
+# Keep browser dependencies available for existing Playwright workflows without
+# changing package manifests or lockfiles.
+RUN npx --yes playwright@1.50.1 install-deps chromium
+
+USER node
+
+WORKDIR /workspace/rentchain

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+{
+  "name": "RentChain AI Cowork",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace/rentchain",
+  "remoteUser": "node",
+  "containerEnv": {
+    "SHELL": "/bin/bash"
+  },
+  "postCreateCommand": "bash -lc 'node --version && npm --version && gh --version || true && gcloud --version || true'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "github.vscode-pull-request-github",
+        "ms-azuretools.vscode-docker",
+        "ms-playwright.playwright",
+        "googlecloudtools.cloudcode"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "editor.formatOnSave": false,
+        "eslint.workingDirectories": [
+          "rentchain-frontend",
+          "rentchain-api"
+        ]
+      }
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/google-cloud-cli:1": {}
+  },
+  "forwardPorts": [
+    5173,
+    8080
+  ],
+  "portsAttributes": {
+    "5173": {
+      "label": "Vite frontend"
+    },
+    "8080": {
+      "label": "API"
+    }
+  }
+}

--- a/docs/execution/CLOUD_RUN_DEPLOYMENT_CHECKLIST.md
+++ b/docs/execution/CLOUD_RUN_DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,88 @@
+# Cloud Run Deployment Checklist
+
+## Purpose
+
+This checklist prevents false QA failures caused by stale backend deployments. Vercel preview freshness does not prove Cloud Run is serving the expected backend commit.
+
+Use this checklist for any mission that changes `rentchain-api`, backend routes, backend projections, service logic, or API payloads used by a preview.
+
+## Required Evidence
+
+Before declaring backend preview QA valid, confirm:
+
+1. Cloud Run service name
+2. active revision name
+3. revision creation timestamp
+4. container image tag or digest
+5. expected PR or merge commit
+6. traffic allocation is 100 percent to the expected revision
+7. authenticated API payload reflects the expected code path
+
+## Suggested Commands
+
+Set these locally without committing them:
+
+```bash
+export CLOUD_RUN_SERVICE=rentchain-landlord-api
+export CLOUD_RUN_REGION=<region>
+export EXPECTED_COMMIT=<commit-sha>
+```
+
+Inspect the service:
+
+```bash
+gcloud run services describe "$CLOUD_RUN_SERVICE" \
+  --region "$CLOUD_RUN_REGION" \
+  --format "yaml(status.latestReadyRevisionName,status.traffic,spec.template.spec.containers[0].image)"
+```
+
+Inspect revisions:
+
+```bash
+gcloud run revisions list \
+  --service "$CLOUD_RUN_SERVICE" \
+  --region "$CLOUD_RUN_REGION" \
+  --sort-by "~metadata.creationTimestamp" \
+  --limit 5
+```
+
+Confirm traffic:
+
+```bash
+gcloud run services describe "$CLOUD_RUN_SERVICE" \
+  --region "$CLOUD_RUN_REGION" \
+  --format "table(status.traffic.revisionName,status.traffic.percent,status.traffic.tag)"
+```
+
+## Backend Freshness Rule
+
+If Cloud Run still points to an older image or revision:
+
+1. stop coding new backend fixes
+2. report deployment drift
+3. deploy or sync the expected backend revision only with operator authorization
+4. confirm traffic is 100 percent to the new revision
+5. retest authenticated API payloads after the revision is active
+
+## Payload Verification
+
+After revision alignment, verify the actual route payload relevant to the mission.
+
+Examples:
+
+- admin list/detail projections
+- tenant-safe profile or document projections
+- route-source headers
+- audit/governance metadata summaries
+
+Do not rely only on local service tests when the QA failure is in a deployed preview.
+
+## Non-Goals
+
+This checklist does not:
+
+- authorize deployment by itself
+- replace operator deployment approval
+- store credentials or project IDs in the repo
+- change Terraform or Cloud Run configuration
+- prove frontend freshness

--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -1,0 +1,94 @@
+# QA Playwright Protocol
+
+## Purpose
+
+This protocol defines safe Playwright readiness for RentChain preview QA. It supports Codex implementation checks, Claude audit/testing, and operator review without creating production mutations or replacing manual approval.
+
+## Existing State
+
+- Playwright is already present in `rentchain-frontend` as a dev dependency.
+- The current config is `rentchain-frontend/playwright.config.ts`.
+- Existing Playwright tests live under `rentchain-frontend/tests/playwright`.
+- This mission adds wrapper scripts only. It does not add dependencies or change product runtime behavior.
+
+## Safety Rules
+
+- Use preview or local URLs only.
+- Do not run QA against production unless the operator explicitly authorizes it.
+- Do not commit credentials, session cookies, screenshots containing secrets, or downloaded sensitive payloads.
+- Do not mutate production records from browser QA.
+- Do not test landlord, tenant, or admin flows with another role's credentials.
+- Capture screenshots/traces only when they are safe to store locally and are not committed by default.
+
+## Environment Inputs
+
+QA scripts use:
+
+- `PREVIEW_URL`: target preview or local base URL
+- `QA_ROLE`: `tenant`, `landlord`, or `admin`
+- `QA_BROWSER`: optional Playwright browser name for future extension
+
+Example:
+
+```bash
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
+```
+
+If `PREVIEW_URL` is not set, scripts default to `http://localhost:5173`.
+
+## Script Behavior
+
+The smoke scripts:
+
+- verify `rentchain-frontend` exists
+- verify Playwright is available through the existing frontend install
+- print the target URL and role
+- run the existing Playwright test command when available
+- fail clearly if dependencies are missing
+
+They do not:
+
+- install dependencies
+- add test data
+- write to Firestore
+- deploy code
+- modify product runtime configuration
+
+## Role-Specific Smoke Scripts
+
+- `tools/qa/run-mobile-smoke.sh`: general mobile-oriented smoke entrypoint
+- `tools/qa/run-admin-smoke.sh`: admin/governance smoke entrypoint
+- `tools/qa/run-tenant-smoke.sh`: tenant portal smoke entrypoint
+
+These scripts are intentionally thin wrappers around the existing frontend Playwright setup. Dedicated role-specific specs can be added in future missions.
+
+## Evidence Handling
+
+When Playwright produces artifacts:
+
+- keep `playwright-report/` and `test-results/` uncommitted
+- summarize key failures in the PR or QA report
+- include screenshots only when they do not expose secrets, raw IDs, private documents, tokens, or sensitive user data
+
+## Pass / Fail Interpretation
+
+Passing Playwright smoke is not merge approval by itself.
+
+Merge readiness still requires:
+
+- relevant local validation
+- GitHub required checks
+- operator/Orion QA interpretation
+- explicit merge authorization
+
+If Playwright disagrees with local tests, treat it as a QA finding and inspect the runtime path before assuming either signal is wrong.
+
+## Future Roadmap
+
+Future missions may add:
+
+- role-specific Playwright specs that use `PREVIEW_URL`
+- authenticated storage-state fixtures stored outside the repo
+- deterministic screenshot comparison for mobile layouts
+- route-source header checks for backend preview routes
+- safe trace collection conventions

--- a/tools/qa/run-admin-smoke.sh
+++ b/tools/qa/run-admin-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export QA_ROLE="${QA_ROLE:-admin}"
+"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run-mobile-smoke.sh"

--- a/tools/qa/run-mobile-smoke.sh
+++ b/tools/qa/run-mobile-smoke.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/rentchain-frontend"
+PREVIEW_URL="${PREVIEW_URL:-http://localhost:5173}"
+QA_ROLE="${QA_ROLE:-mobile}"
+
+if [ ! -d "$FRONTEND_DIR" ]; then
+  echo "Missing rentchain-frontend directory." >&2
+  exit 1
+fi
+
+if [ ! -x "$FRONTEND_DIR/node_modules/.bin/playwright" ]; then
+  echo "Playwright is unavailable. Run npm ci in rentchain-frontend first." >&2
+  exit 1
+fi
+
+echo "Running RentChain Playwright smoke."
+echo "Role: $QA_ROLE"
+echo "Target: $PREVIEW_URL"
+
+cd "$FRONTEND_DIR"
+playwright_args=()
+if [ -n "${QA_BROWSER:-}" ]; then
+  playwright_args+=(--project="$QA_BROWSER")
+fi
+
+BASE_URL="$PREVIEW_URL" npm run test:e2e -- "${playwright_args[@]}"

--- a/tools/qa/run-tenant-smoke.sh
+++ b/tools/qa/run-tenant-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export QA_ROLE="${QA_ROLE:-tenant}"
+"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run-mobile-smoke.sh"


### PR DESCRIPTION
## Summary
- adds a VS Code Dev Container foundation for RentChain AI cowork workflows
- documents Playwright QA protocol and Cloud Run deployment verification checklist
- adds safe tenant/admin/mobile QA wrapper scripts that use the existing frontend Playwright setup

## Audit findings
- frontend and backend both require Node >=20 <21
- CI uses Node 20.20.0
- frontend already has @playwright/test and rentchain-frontend/playwright.config.ts
- no existing .devcontainer directory was present
- no existing tools/qa runner scripts were present
- Mission 1 AI_COWORK_PROTOCOL.md is present and referenced by this mission's scope

## Scope and safety
- chore/tooling/docs only
- no product runtime behavior changes
- no dependency or lockfile changes
- no CI workflow changes
- no auth, Firestore rules, payment, pricing, screening, lease, message, tenant, landlord, or admin UI behavior changes

## Validation
- bash -n tools/qa/run-mobile-smoke.sh tools/qa/run-admin-smoke.sh tools/qa/run-tenant-smoke.sh
- git diff --cached --check
- git diff --check

Frontend/backend builds were not run because no frontend/backend runtime or package config files were changed.