### PR TITLE
Add Claude context snapshot docs

### DIFF
--- a/docs/ai/claude-context/AI_COWORK_PROTOCOL.md
+++ b/docs/ai/claude-context/AI_COWORK_PROTOCOL.md
@@ -1,0 +1,83 @@
+# AI Cowork Protocol Summary
+
+## Source
+
+This is a Claude-ready summary of `docs/execution/AI_COWORK_PROTOCOL.md`.
+
+## ChatGPT / Orion Role
+
+ChatGPT/Orion acts as mission commander and product/QA interpreter.
+
+Responsibilities:
+
+- define mission scope and branch
+- interpret QA findings
+- separate blockers from follow-ups
+- authorize merge or deployment decisions
+- protect strategy sequencing
+
+## Codex Role
+
+Codex is the implementation agent in the local workspace.
+
+Responsibilities:
+
+- inspect repository source of truth
+- implement scoped changes
+- run tests/builds/checks
+- commit, push, and open PRs
+- report changed files, validation, risks, and limitations
+
+Codex should not merge or deploy without explicit operator authorization.
+
+## Claude Role
+
+Claude is an independent reviewer and QA/root-cause assessor.
+
+Responsibilities:
+
+- review architecture and governance
+- inspect likely code paths
+- critique projection/privacy risks
+- identify root causes for QA failures
+- recommend targeted fixes or future missions
+
+Claude should not override repo source of truth or treat future strategy as implemented behavior.
+
+## Playwright Role
+
+Playwright is the deterministic browser QA runner.
+
+It should capture repeatable evidence such as screenshots, console errors, traces, route behavior, and responsive layout state. It should not mutate production data unless explicitly authorized through a safe QA flow.
+
+## Local / Dev Container Sandbox Role
+
+The local sandbox or Dev Container is the controlled cowork environment.
+
+Rules:
+
+- no secrets committed
+- no production writes without explicit approval
+- no uncontrolled agent-to-agent loops
+- no autonomous merge or deploy
+- no bypassing auth, Firestore rules, or policy gates
+
+## QA Handoff Expectations
+
+Normal handoff:
+
+1. Codex builds or fixes.
+2. Claude reviews or audits independently when requested.
+3. Playwright captures deterministic browser evidence where applicable.
+4. Orion/operator decides pass/fail and authorizes merge/deploy.
+
+## Deployment Truth
+
+- GitHub PRs are code review and required check source of truth.
+- Vercel proves frontend preview deployment.
+- Cloud Run proves backend revision, image, and traffic.
+- A green Vercel preview does not prove backend code is current.
+
+## Implementation Path
+
+Codex remains the implementation path. Claude may recommend changes, but changes should flow through scoped mission branches, tests, PRs, preview QA, and explicit operator approval.

--- a/docs/ai/claude-context/CLAUDE_ROLE.md
+++ b/docs/ai/claude-context/CLAUDE_ROLE.md
@@ -1,0 +1,48 @@
+# Claude Role
+
+## Claude Should Help With
+
+Claude is an independent reviewer, strategist, and QA assessor in the RentChain workflow.
+
+Claude should help with:
+
+- architecture review
+- governance review
+- projection safety review
+- QA review and preview evidence interpretation
+- mission drafting
+- root-cause analysis
+- risk analysis
+- UX clarity
+- institutional-readiness critique
+- identifying stale docs or deployment drift
+
+## Claude Should Not
+
+Claude should not:
+
+- expand scope without labeling it
+- override repo source of truth
+- recommend production behavior based on stale docs
+- treat future vision as implemented
+- propose broad rewrites without audit-first justification
+- advise bypassing auth, entitlements, projection safety, or audit continuity
+- recommend autonomous remediation unless a mission explicitly establishes supervised controls
+- merge, deploy, or mutate production data without explicit operator authorization
+
+## Recommendation Labels
+
+Claude recommendations should be labeled as one of:
+
+- `required fix`: necessary to satisfy the active mission or unblock safe merge.
+- `recommended improvement`: useful but not necessarily blocking.
+- `future mission`: valid work that should be split from current scope.
+- `strategic note`: positioning or long-term direction, not an implementation instruction.
+
+## Source-of-Truth Rule
+
+When code and docs disagree, Claude should ask Codex/operator to audit the current code path, route, projection, test, deployment revision, and PR diff before recommending implementation.
+
+## Workflow Relationship
+
+Codex remains the implementation path. Claude can inspect, critique, and propose targeted fixes, but Codex or an operator should apply changes through the normal branch, test, PR, QA, and merge process.

--- a/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
+++ b/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
@@ -1,0 +1,48 @@
+# Current Active Missions
+
+## Source Audit
+
+`docs/execution/CURRENT_MISSION.md` currently appears to be a placeholder template. It should not be blindly copied into Claude.ai as the live mission.
+
+The current mission for this snapshot is operator-provided:
+
+- branch: `docs/ai-claude-context-snapshot-v1`
+- objective: create Claude.ai context snapshot files under `docs/ai/claude-context/`
+- scope: documentation only
+
+## Recently Completed Direction
+
+Recent merged work, based on current docs and branch history, has focused on:
+
+- AI cowork protocol and Dev Container/Playwright/Cloud Run QA foundations
+- tenant message read-state and refresh synchronization
+- tenant profile/document readiness consistency
+- tenant mobile bottom navigation
+- admin tenant/lease projection consistency
+- landlord/admin mobile layout and navigation polish
+- governed review workspace foundations, read routes, admin page, navigation, and fixtures
+- support escalation runbooks, history, review notes, and admin review surface
+- admin security incident review surface
+- impersonation governance and support/admin projection safety
+
+## Next Recommended Themes
+
+Potential next mission themes, subject to operator activation:
+
+- role-specific Playwright smoke specs using `PREVIEW_URL`
+- tenant profile card typography/responsive polish
+- tenant message realtime QA hardening if further preview issues appear
+- governed review workspace write governance only after append-only controls are explicitly approved
+- Cloud Run deployment verification automation that remains non-mutating by default
+- Claude context maintenance process to keep upload snapshots current
+
+## Known Follow-Up Areas
+
+- Avoid stale backend deployment drift by verifying Cloud Run revision/image/traffic for backend missions.
+- Keep tenant, landlord, and admin mobile navigation separate.
+- Keep institutional export/trust work consent-scoped and manual-review-first.
+- Preserve projection safety when connecting admin/support review surfaces.
+
+## Uncertainty Note
+
+This file summarizes current direction from available docs and recent branch context. If a new operator prompt or active PR contradicts this snapshot, that newer prompt/PR is the mission source of truth.

--- a/docs/ai/claude-context/CURRENT_ARCHITECTURE.md
+++ b/docs/ai/claude-context/CURRENT_ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# Current Architecture
+
+## Backend Stack
+
+- Node.js and Express.
+- TypeScript.
+- Firestore for persistence.
+- Firebase Auth and server-side authorization.
+- Google Cloud Storage where storage is required.
+- Cloud Run for the main API.
+
+Core API routes live in `rentchain-api`. Route ownership and route-source headers are important for preview QA and governance attribution.
+
+## Frontend Stack
+
+- React.
+- TypeScript.
+- Vite with SWC.
+- Vercel for frontend deployment.
+- Frontend API calls should use helpers that resolve to `VITE_API_BASE_URL` and Cloud Run for core API routes.
+
+## Deployment Model
+
+- Vercel deploys the frontend.
+- Cloud Run serves `rentchain-api`.
+- GitHub Actions run backend/frontend checks.
+- Terraform status is part of repo-level deployment context.
+
+Vercel preview freshness does not prove Cloud Run backend freshness. Backend changes require Cloud Run revision/image/traffic verification.
+
+## Event, Ledger, and Review Principles
+
+RentChain architecture favors:
+
+- audit continuity
+- append-safe records
+- metadata-only review envelopes
+- deterministic read models
+- manual review before operational mutation
+- projection-safe user-facing views
+
+Avoid hidden automation, unreviewed workflow mutation, or raw debug explorers.
+
+## Projection-Safe Read Models
+
+Tenant-facing data should use whitelist projections. Landlord/admin/support views should use explicit safe summaries. Internal support/admin metadata must not leak to tenant, landlord, public export, analytics, dashboard, or timeline surfaces.
+
+Raw Firestore IDs should not be user-facing labels.
+
+## AI-Assisted Workflow Posture
+
+AI can assist review, drafting, analysis, and triage, but workflows remain supervised. Current governance docs repeatedly prohibit autonomous remediation, hidden enforcement, and unsupervised status mutation unless an explicit mission defines safe controls.
+
+## CI/CD Notes
+
+Required check policy emphasizes actual frontend/backend delivery checks and Vercel contexts. `merge-gate` is supplemental, not a substitute for delivery checks.
+
+Cloud Run deployment verification is required for backend payload QA when stale deployment drift is plausible.

--- a/docs/ai/claude-context/CURRENT_GOVERNANCE_MODEL.md
+++ b/docs/ai/claude-context/CURRENT_GOVERNANCE_MODEL.md
@@ -1,0 +1,47 @@
+# Current Governance Model
+
+## Audit-Safe Operational History
+
+RentChain emphasizes audit-safe operational history through canonical events, metadata-only review records, route-source attribution, and append-compatible references.
+
+Operational history should explain what happened without exposing raw private data or creating hidden workflow execution.
+
+## Append-Safe Workflows
+
+Recent support escalation and governed review workspace foundations are append-safe by design. Helper contracts and read routes avoid status mutation, approval execution, deletion, remediation, and tenant/landlord exposure unless separately authorized.
+
+## Projection Safety
+
+Projection safety is a core rule:
+
+- tenant-facing views must not receive support/admin internals
+- landlord-facing views must not receive tenant-private or admin-only data
+- public/user-safe exports must strip support metadata, actor chains, debug payloads, tokens, secrets, raw provider payloads, and raw documents
+- unknown audiences should fail safe
+
+## Privacy-Aware Tenant Data Handling
+
+Tenant data must be minimized and consent-aware. Trust exports and document vault surfaces should avoid overstating availability, leaking raw storage paths, or exposing internal lease/property/unit identifiers.
+
+## Metadata-First Trust and Export Posture
+
+Institutional export and trust export docs favor:
+
+- manual-only previews
+- policy-gated summaries
+- consent-scoped packages
+- redaction metadata
+- provenance and audit references
+- no external submission by default
+
+## Support Escalation Governance
+
+Support escalation foundations include categories, severity, manual states, approval expectations, safe refs, append-only history, and review notes. These are governance metadata, not support powers or automated remediation.
+
+## Institutional Export Readiness
+
+Institutional readiness is a controlled direction. Current docs support preview packages and trust-export frameworks, but Claude should not infer live institutional integrations or legal certification unless current implementation confirms them.
+
+## Deny-by-Default Posture
+
+Ambiguous permissions, unknown audiences, unsupported workflow states, and unsafe payloads should fail closed or normalize to safe review states.

--- a/docs/ai/claude-context/CURRENT_MOBILE_DIRECTION.md
+++ b/docs/ai/claude-context/CURRENT_MOBILE_DIRECTION.md
@@ -1,0 +1,53 @@
+# Current Mobile Direction
+
+## Landlord Mobile Operations
+
+Landlord mobile work is focused on operational usability:
+
+- bottom navigation for core landlord routes
+- responsive decision inbox and operational pages
+- mobile-safe admin/landlord layout containment
+- readable cards instead of squeezed desktop tables
+- no raw IDs in mobile admin/landlord presentation
+
+Landlord mobile should feel like an operational app, not a scaled-down desktop dashboard.
+
+## Tenant Mobile Companion Direction
+
+Tenant mobile work is focused on companion workflows:
+
+- tenant dashboard
+- lease context
+- document vault
+- messages
+- profile/readiness clarity
+- maintenance and trust/export flows where tenant-safe
+
+Tenant mobile navigation must remain tenant-safe and must not expose landlord/admin routes.
+
+## Field Coordination
+
+Mobile recommendations should account for field use:
+
+- quick triage
+- message and maintenance visibility
+- lease/document reference
+- readiness status
+- evidence access where tenant/landlord-safe
+
+Avoid dense desktop-only workflows when mobile is the target.
+
+## Mobile-First Triage
+
+For decision inbox, maintenance, messages, escalations, and admin review, mobile surfaces should favor:
+
+- stacked cards
+- clear status labels
+- accessible touch targets
+- safe bottom padding
+- no horizontal overflow
+- no broken drawers or nonfunctional nav controls
+
+## App-Store Readiness Guardrail
+
+Do not claim native app-store readiness. Current code is a web platform with mobile-responsive direction unless a future mission confirms native app packaging.

--- a/docs/ai/claude-context/CURRENT_PLATFORM_STATE.md
+++ b/docs/ai/claude-context/CURRENT_PLATFORM_STATE.md
@@ -1,0 +1,47 @@
+# Current Platform State
+
+## Current
+
+RentChain currently has material foundations for:
+
+- landlord property, unit, tenant, application, lease, maintenance, message, document, and portfolio workflows
+- tenant portal profile, lease, document, message, maintenance, and trust/export-facing surfaces
+- Free, Starter, Pro, and Elite plan/capability tiers
+- backend-first entitlement/capability resolution
+- admin/support projection-safety helpers and tests
+- governed impersonation attribution and metadata-only audit continuity
+- admin security incident review surface
+- support escalation runbook helpers
+- support escalation history and manual review note helper contracts
+- admin support escalation review surface
+- governed review workspace models, append-readiness, append adapter, read routes, admin page, navigation, and test-only fixtures
+- mobile landlord and tenant bottom navigation work
+- Cloud Run deployment verification docs and AI cowork protocol docs
+
+Current admin/support governance surfaces are intentionally metadata-only, manual-review-oriented, and projection-safe.
+
+## In Progress
+
+Active direction includes:
+
+- improving tenant and landlord mobile workflows
+- tightening projection consistency between admin, landlord, and tenant views
+- building safe review workspace continuity across incidents, escalations, runbooks, notes, and evidence references
+- improving QA discipline for Vercel frontend previews and Cloud Run backend revision alignment
+- preparing Claude/Codex/Playwright cowork context and sandbox workflows
+
+`docs/execution/CURRENT_MISSION.md` appears to be a template placeholder rather than a live active mission source. Use explicit operator prompts and current PR/branch context as the current mission source of truth.
+
+## Future / Strategic
+
+Future-facing areas in docs include:
+
+- institution export and institutional trust export expansion
+- identity assurance and property/operator authority readiness
+- support escalation workflow execution after append-only governance is approved
+- governed review workspace persistence and supervised coordination
+- tenant trust portability and controlled sharing
+- institutional partner and legal/compliance readiness
+- physical mobile/PDF QA confidence improvements
+
+Do not represent future-facing strategy as implemented production capability unless source code, routes, tests, and current PR context confirm it.

--- a/docs/ai/claude-context/CURRENT_PRICING_AND_CAPABILITIES.md
+++ b/docs/ai/claude-context/CURRENT_PRICING_AND_CAPABILITIES.md
@@ -1,0 +1,72 @@
+# Current Pricing and Capabilities
+
+## Canonical Sources Audited
+
+Backend:
+
+- `rentchain-api/src/services/entitlements/planCapabilities.ts`
+- `rentchain-api/src/config/capabilities.ts`
+- `rentchain-api/src/config/planMatrix.ts`
+
+Frontend:
+
+- `rentchain-frontend/src/constants/pricingPlans.ts`
+- `rentchain-frontend/src/lib/entitlements.ts`
+
+No duplicate historical versions of these exact source files were found. `rentchain-api/src/middleware/entitlements.ts` is a middleware file, not a duplicate of the canonical frontend entitlement library.
+
+## Plans and Prices
+
+Confirmed from current code:
+
+- Free: `$0`
+- Starter: `$29/month`, `$290/year`
+- Pro: `$49/month`, `$490/year`
+- Elite: `$79/month`, `$790/year`
+
+Backend billing amounts are represented in cents:
+
+- Starter: `2900` monthly, `29000` yearly
+- Pro: `4900` monthly, `49000` yearly
+- Elite: `7900` monthly, `79000` yearly
+
+## Legacy Plan Mapping
+
+Confirmed in backend plan normalization:
+
+- `business` maps to `elite`
+- `enterprise` maps to `elite`
+- `core` maps to `starter`
+- `screening` maps to `free`
+
+Do not introduce a separate Business tier unless the backend canonical mapping changes.
+
+## Capability Model
+
+Backend source of truth is `planCapabilities.ts`.
+
+Current cumulative plan order:
+
+1. `free`
+2. `starter`
+3. `pro`
+4. `elite`
+
+Each higher tier includes lower-tier capabilities. Unknown plans resolve to `free`.
+
+Examples by tier:
+
+- Free: properties, units, manual tenants/applications, screening/pay-per-use screening history, portfolio health summary.
+- Starter: tenant invites, applications, messaging, ledger, leases, maintenance, notices, tenant portal, move-in readiness, work orders.
+- Pro: verified ledger, basic exports, PDF export, review summaries, compliance reports, marketplace directory, portfolio dashboard/score, team invites, registry filing/history.
+- Elite: AI summaries, advanced exports, audit logs, marketplace contractor assignment, portfolio analytics, portfolio action recommendations.
+
+## Frontend Consumption Pattern
+
+The frontend consumes capabilities from `/capabilities` and caches them through `rentchain-frontend/src/lib/entitlements.ts`. UI pricing copy uses `pricingPlans.ts`, which comments that it mirrors backend billing prices and entitlement gating.
+
+Frontend should not hardcode inconsistent pricing or capability logic. New capability gates should be added backend-first and consumed through the frontend entitlement path.
+
+## Guardrail
+
+When Claude recommends pricing, capability, or entitlement changes, it must first ask for an audit of the backend canonical files and relevant frontend consumers. Do not infer commercial truth from stale docs or marketing copy.

--- a/docs/ai/claude-context/CURRENT_STRATEGIC_DIRECTION.md
+++ b/docs/ai/claude-context/CURRENT_STRATEGIC_DIRECTION.md
@@ -1,0 +1,57 @@
+# Current Strategic Direction
+
+## Governance-First Rental Operations
+
+RentChain's strategic direction is governance-first rental operations. The platform should strengthen audit lineage, consent, projection safety, and explainable workflow history before adding broad automation or external sharing.
+
+## Operational Command Center Direction
+
+Landlord and admin experiences are moving toward operational command surfaces:
+
+- decision inboxes
+- portfolio and lease context
+- maintenance/work-order coordination
+- review timelines
+- evidence and document readiness
+- operational risk and support review surfaces
+
+Recommendations should favor dense, readable operational UI over generic marketing SaaS patterns.
+
+## Support and Review Workspace Direction
+
+Recent architecture work emphasizes governed review spaces:
+
+- security incident review
+- support escalation review
+- escalation runbooks
+- manual review notes
+- evidence references
+- governed review workspace summaries
+
+These surfaces are read-only or append-safe unless a mission explicitly authorizes mutation controls.
+
+## Institutional Readiness
+
+Institutional readiness is strategic, not a blanket claim of live integration. Current docs support careful foundations for:
+
+- export previews
+- institutional trust packages
+- identity and property readiness
+- audit-safe evidence references
+- manual review and redaction
+
+Avoid claiming live lender, insurer, government, or auditor integrations unless confirmed by current code and deployment.
+
+## Tenant Trust and Controlled Sharing
+
+Tenant trust direction centers on controlled, consent-aware sharing:
+
+- tenant-safe projections
+- document vault clarity
+- trust export consent
+- no public trust profiles by default
+- no raw tenant document or provider payload leakage
+
+## Positioning Guardrail
+
+Do not position RentChain as commodity landlord SaaS. Position it as governed rental operations, property intelligence, tenant trust, and institution-ready operational infrastructure.

--- a/docs/ai/claude-context/PLATFORM_GUARDRAILS.md
+++ b/docs/ai/claude-context/PLATFORM_GUARDRAILS.md
@@ -1,0 +1,21 @@
+# Platform Guardrails
+
+Claude must not violate these rules when advising on RentChain.
+
+- Never widen tenant visibility into landlord/admin/support data.
+- Never expose raw Firestore IDs, unit IDs, lease IDs, landlord IDs, tenant IDs, storage paths, or internal references as user-facing labels.
+- Never bypass governance layers, route authorization, entitlement gates, or projection helpers.
+- Never remove audit continuity or append-safe operational history.
+- Never introduce hidden automation, autonomous remediation, or unreviewed enforcement.
+- Prefer append-safe history and metadata-only records for operational review.
+- Preserve projection safety for tenant, landlord, admin/support, export, dashboard, timeline, analytics, and public-safe contexts.
+- Keep AI workflows supervised and operator-approved.
+- Protect tenant consent, privacy, and document minimization.
+- Separate current implementation from future vision.
+- Recommend audit-first missions before implementation.
+- Do not treat stale docs as source of truth over active code paths.
+- Do not recommend production mutation from sandbox.
+- Do not add dependencies, CI changes, auth changes, Firestore rule changes, pricing changes, or payment/screening changes unless the active mission explicitly authorizes them.
+- Do not create broad raw admin explorers.
+- Do not treat Vercel frontend deployment as proof of backend Cloud Run freshness.
+- Do not merge or deploy without explicit operator authorization.

--- a/docs/ai/claude-context/PROJECT_OVERVIEW.md
+++ b/docs/ai/claude-context/PROJECT_OVERVIEW.md
@@ -1,0 +1,49 @@
+# RentChain Project Overview
+
+## Platform Purpose
+
+RentChain is governed rental operations and property intelligence infrastructure. It is not positioned as generic landlord SaaS. The platform organizes rental operations around auditable workflows, safe projections, tenant trust, evidence continuity, operational review, and institution-ready summaries.
+
+RentChain's current product surface supports landlord, tenant, admin, and support workflows while preserving clear boundaries between user-facing views and internal governance metadata.
+
+## Core Users
+
+- Landlords and operators managing properties, applications, leases, maintenance, messages, documents, and portfolio operations.
+- Tenants using a tenant portal for profile, lease, documents, messages, maintenance, and trust/export workflows.
+- Admin/support operators reviewing platform health, support escalations, security incidents, projection safety, and governed review workspaces.
+- Future institutional reviewers such as lenders, insurers, auditors, and program partners, through controlled export and trust-package concepts.
+
+## Current Focus
+
+The current engineering focus is operational governance:
+
+- projection-safe read models
+- admin/support metadata boundaries
+- tenant-safe document and profile projections
+- mobile landlord and tenant usability
+- support escalation and review workspace foundations
+- deployment verification discipline across Vercel and Cloud Run
+- AI cowork process safety for Codex, Claude, Playwright, and operator approval
+
+## Long-Term Institutional Direction
+
+The long-term direction is institutional rental infrastructure:
+
+- consent-scoped trust exports
+- evidence-backed landlord and tenant operational history
+- metadata-only review workspaces
+- governed escalation and incident review
+- identity, property, lease, and export readiness foundations
+- supervised AI-assisted workflows, not autonomous enforcement
+
+Future-facing docs describe readiness layers and strategy. Claude should not treat every strategic document as production behavior.
+
+## Stack Summary
+
+- Frontend: React, TypeScript, Vite, SWC, Vercel.
+- Backend: Node.js, Express, TypeScript, Cloud Run.
+- Auth: Firebase Auth and server-side authorization middleware.
+- Database: Firestore.
+- Storage: Google Cloud Storage where applicable.
+- CI/CD: GitHub Actions, Vercel previews, Google Cloud Build/Cloud Run, Terraform context checks.
+- QA: Vitest, Playwright readiness, manual preview QA, Cloud Run revision verification for backend changes.


### PR DESCRIPTION
## Summary
- adds Claude.ai upload-ready context snapshots under docs/ai/claude-context/
- summarizes current platform state, strategy, pricing/capabilities, architecture, governance, mobile direction, guardrails, Claude role, active mission context, and AI cowork protocol
- keeps files self-contained and documentation-only for reference/upload use

## Runtime confirmation
- docs/ai/claude-context/ is not referenced by frontend/backend code, workflows, devcontainer, or tools in repo search
- no production TypeScript files changed
- no package, config, CI, routing, deployment, Firestore, auth, pricing, or entitlement files changed
- platform behavior remains unchanged

## Audit
Inspected README.md, AGENTS.md, PROCESS.md, codex.md, CODEX_RULES.md, ARCHITECTURE.md, docs/execution/CURRENT_MISSION.md, docs/missions/_template.md, docs/execution/AI_COWORK_PROTOCOL.md, canonical pricing/entitlement files, and relevant governance/identity/export/support/review/mobile docs.

## Canonical pricing/capability sources
- rentchain-api/src/services/entitlements/planCapabilities.ts
- rentchain-api/src/config/capabilities.ts
- rentchain-api/src/config/planMatrix.ts
- rentchain-frontend/src/constants/pricingPlans.ts
- rentchain-frontend/src/lib/entitlements.ts

## Validation
- git diff --cached --check
- git diff --check

No product tests/builds were run because this is documentation-only.