### PR TITLE
Audit platform state against runtime surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,6 +53,19 @@ Projection-safety notation for this map:
 
 Frontend API calls must use the configured Cloud Run base URL through existing API helpers. A Vercel preview proves frontend freshness only; backend QA requires Cloud Run revision/image/traffic verification.
 
+## Runtime Alignment Boundary
+
+Current route inventory shows implemented surface area across public, landlord, tenant, contractor, admin, support, review-workspace, export/readiness, screening, billing/payment, maintenance, message, registry, audit, and observability workflows.
+
+Use this distinction when reading architecture docs:
+
+- **Mounted page or route**: the runtime surface exists.
+- **Helper or read model**: an implementation foundation exists, but may still be metadata-only, read-only, test-only, or persistence-readiness only.
+- **Readiness or observability page**: a governed review/readiness surface exists; it is not proof of live external integration.
+- **Preview behavior**: requires Vercel and Cloud Run alignment checks before being treated as current deployed truth.
+
+Do not upgrade a roadmap or readiness surface to a live production claim without checking source code, tests, authorization, representative payloads, and deployment revision.
+
 ## Layer 1 — Operational System of Record
 
 This layer contains the operational rental workflows:
@@ -75,7 +88,7 @@ This layer provides manual review and audit continuity:
 - governed review workspace summaries and read routes
 - impersonation actor-chain attribution and support/admin audit metadata
 
-Maturity: implemented and in development. Current surfaces are review and read-model foundations, not full workflow execution engines.
+Maturity: implemented and in development. Current surfaces are review and read-model foundations, not full workflow execution engines. Review workspace write/persistence behavior beyond helper/adapter foundations needs separate mission evidence before it is described as production workflow execution.
 
 Principle: review surfaces should be metadata-only, manual-review-first, and explicit about what they do not execute. No hidden approve, resolve, dismiss, remediate, impersonate, or enforcement behavior should be inferred.
 
@@ -90,7 +103,7 @@ This layer prepares evidence and export readiness:
 - identity, property, and account trust readiness models
 - redaction summaries and provenance metadata
 
-Maturity: in development. These foundations support controlled review and readiness, not live institutional submissions or certification.
+Maturity: in development. These foundations include implemented pages, routes, helpers, reports, and tests at varying depths. They support controlled review and readiness, not live institutional submissions or certification unless verified by a specific deployed route and payload.
 
 Principle: institutional trust is metadata-first and policy-gated. Raw provider payloads, documents, screening reports, private message bodies, storage paths, credentials, tokens, and unrestricted policy internals must not leak into user-safe or external-facing payloads.
 
@@ -135,7 +148,7 @@ This layer is planned / roadmap and should be treated carefully:
 - future payments, settlement coordination, and disbursement readiness concepts
 - inter-agency data-sharing readiness concepts
 
-Maturity: planned / roadmap, generally Phase 6+ or later. It does not imply live welfare support, housing program, government, payment, disbursement, or inter-agency integrations.
+Maturity: planned / roadmap, generally Phase 6+ or later. Some readiness pages may exist, but they do not imply live welfare support, housing program, government, payment, disbursement, or inter-agency integrations.
 
 Principle: institutional coordination requires consent, retention, authorization, redaction, and manual review. Do not claim live external integrations unless implementation and deployment prove them.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Current material foundations include:
 
 These foundations are implemented at different maturity levels. Do not infer full workflow execution, external institutional integrations, or autonomous remediation unless current code and mission scope explicitly confirm it.
 
+Runtime alignment note: RentChain contains many mounted pages, route families, helpers, and tests across landlord, tenant, admin, support, export/readiness, and review workspace areas. A page or route being present means the surface exists; it does not automatically prove complete workflow depth, live production data, external submission, compliance certification, or deployed-backend freshness.
+
 ## In-Progress Operational Systems
 
 Current operational direction includes:
@@ -108,6 +110,8 @@ Institutional readiness is a trajectory, not a blanket production claim. Current
 - metadata-first redaction and provenance
 
 Live institutional integrations, legal certification, external submissions, custody, settlement rails, and public trust profiles require future scoped missions.
+
+Readiness pages for production integrations, enterprise/municipal coordination, platform credentialing, controlled integrations, settlement, tokenization, and interoperability should be treated as review/readiness surfaces unless runtime payloads and deployed route behavior prove a specific implemented capability.
 
 ## Halifax Registry and Compliance Direction
 

--- a/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
+++ b/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
@@ -18,6 +18,8 @@ RentChain has completed the first governed operational infrastructure layer arou
 
 These are governance and review foundations. They should not be treated as autonomous remediation, workflow execution, or external institutional integration.
 
+Runtime alignment note: route/page/API inventory shows many implemented surfaces across landlord, tenant, admin, support, export/readiness, and review-workspace areas. A mounted route or visible page should be treated as implemented surface area, not automatically as complete production workflow, live integration, or deployed-current behavior.
+
 ## Current Strategic Direction
 
 RentChain is moving toward governed operational housing infrastructure:
@@ -34,6 +36,8 @@ RentChain is moving toward governed operational housing infrastructure:
 The next missions should continue hardening review, QA, projection safety, tenant continuity, and institutional evidence readiness before adding broad automation or external integrations.
 
 Architecture diagrams should be interpreted as evolution maps with maturity labels: implemented, in development, and planned / roadmap. Planned institutional, government, payment, identity, settlement, and interoperability layers must not be described as live production systems.
+
+Before a future mission upgrades any roadmap item to implemented status, require source-code audit, route/payload verification, test evidence, and Cloud Run/Vercel deployment alignment where applicable.
 
 ## Active Next Sequence
 

--- a/docs/ai/claude-context/CURRENT_ARCHITECTURE.md
+++ b/docs/ai/claude-context/CURRENT_ARCHITECTURE.md
@@ -40,6 +40,19 @@ Core API routes live in `rentchain-api`. Route ownership and route-source header
 
 Vercel preview freshness does not prove Cloud Run backend freshness. Backend changes require Cloud Run revision/image/traffic verification.
 
+## Runtime Alignment Boundary
+
+The current application includes mounted frontend pages and backend route families across public, landlord, tenant, admin, support, review workspace, export/readiness, screening, billing/payment, maintenance, message, registry, audit, and observability surfaces.
+
+For Claude review, distinguish these states:
+
+- a route/page exists: implemented surface, but not proof of full workflow depth
+- a helper/read model exists: implemented foundation, but not proof of live persistence or mutation controls
+- a readiness/export page exists: implemented review/readiness surface, but not proof of external submission, legal certification, or institution integration
+- a route is mounted: implemented API surface, but deployed behavior still requires Cloud Run revision and payload verification
+
+Do not convert route inventory into production capability claims without checking current code path, tests, authorization, deployment revision, and representative payloads.
+
 ## Event, Ledger, and Review Principles
 
 RentChain architecture favors:

--- a/docs/ai/claude-context/CURRENT_GOVERNANCE_MODEL.md
+++ b/docs/ai/claude-context/CURRENT_GOVERNANCE_MODEL.md
@@ -34,6 +34,8 @@ Institutional export and trust export docs favor:
 - provenance and audit references
 - no external submission by default
 
+Existing export/readiness pages and APIs should be read as review, readiness, or controlled-summary surfaces unless route-level payloads and deployment evidence prove a narrower implemented export capability. Do not infer signed packages, legal artifacts, external filings, or institution handoffs from page names alone.
+
 ## Support Escalation Governance
 
 Support escalation foundations include categories, severity, manual states, approval expectations, safe refs, append-only history, and review notes. These are governance metadata, not support powers or automated remediation.
@@ -41,6 +43,8 @@ Support escalation foundations include categories, severity, manual states, appr
 ## Institutional Export Readiness
 
 Institutional readiness is a controlled direction. Current docs support preview packages and trust-export frameworks, but Claude should not infer live institutional integrations or legal certification unless current implementation confirms them.
+
+Areas such as subsidy/program coordination, settlement/disbursement, government workflows, identity assurance, and inter-agency sharing remain planned or readiness-oriented unless current code, tests, authorization, payloads, and deployment verification demonstrate a specific implemented slice.
 
 ## Deny-by-Default Posture
 

--- a/docs/ai/claude-context/CURRENT_PLATFORM_STATE.md
+++ b/docs/ai/claude-context/CURRENT_PLATFORM_STATE.md
@@ -14,13 +14,36 @@ RentChain currently has material foundations for:
 - support escalation runbook helpers
 - support escalation history and manual review note helper contracts
 - admin support escalation review surface
-- governed review workspace models, append-readiness, append adapter, read routes, admin page, navigation, and test-only fixtures
+- governed review workspace models, append-readiness contracts, append adapter/helper foundations, read routes, admin page, navigation, and test-only fixtures
 - mobile landlord and tenant bottom navigation work
 - Cloud Run deployment verification docs and AI cowork protocol docs
 
 Current admin/support governance surfaces are intentionally metadata-only, manual-review-oriented, and projection-safe.
 
 Architecture diagrams and maps should be read as operational evolution maps. They combine current foundations, in-development hardening, and future roadmap layers. Do not treat every diagram node as live production behavior.
+
+## Runtime Surface Audit Notes
+
+Recent route and page inspection confirms these implemented runtime surface categories are materially present:
+
+- public/marketing, authentication, invite, application, help, legal, trust, security, status, and contact pages
+- landlord dashboard, billing, properties, tenants, applications, analytics, operations, decision inbox, agent supervision, institution exports, audit/compliance, evidence packs, review timeline, identity readiness, sharing-room, rental history, rental debt, settlement-readiness, regulatory, tokenization-readiness, network participant, cross-organization trust, portfolio, action recommendation, lease, ledger, payment, expense, work order, contractor, message, maintenance, account, and screening surfaces
+- tenant dashboard/workspace, application, lease, ledger, activity, participation, attachments/documents, notices, profile, screening, access, account, messages, maintenance, feedback, invite, and public sharing surfaces
+- admin dashboard, control tower, properties, tenants, leases, integrity, audit, security incidents, support escalations, review workspaces, screening usage, registry, observability, alerting, notification, release governance, public exposure, commercial readiness, controlled/production integration readiness, enterprise/municipal readiness, ecosystem coordination, platform credentialing, consumer reporting governance, portfolio score, support console, triage, and lease lifecycle review surfaces
+- Cloud Run API mounts for core public, authenticated, landlord, tenant, admin, support, review workspace, export/readiness, screening, billing/payment, maintenance, message, registry, audit, and observability route families
+
+This audit establishes that a route, page, helper, or test exists. It does not by itself prove production data availability, live external integrations, full workflow execution, regulated compliance status, or every page's deployed freshness.
+
+## Unclear / Needs Verification
+
+Treat the following as needing route-level, payload-level, or deployment verification before making production claims:
+
+- whether a specific preview or production environment is serving the latest Cloud Run backend revision
+- whether tenant portal behavior is enabled in a target environment through `VITE_TENANT_PORTAL_ENABLED`
+- whether a readiness page is backed by live operational data, static readiness summaries, test fixtures, or empty-state projections
+- whether any export/trust surface creates an external submission, signed package, legal artifact, or institution-facing handoff
+- whether identity, settlement, payment/disbursement, subsidy/program, government, insurer, lender, auditor, or inter-agency workflows have live integrations
+- whether admin/support review surfaces remain read-only, metadata-only, and free of mutation controls after future missions
 
 ## In Progress
 
@@ -41,7 +64,7 @@ Future-facing areas in docs include:
 - institution export and institutional trust export expansion
 - tenant identity readiness foundations and property/operator authority readiness
 - support escalation workflow execution after append-only governance is approved
-- governed review workspace persistence and supervised coordination
+- governed review workspace production persistence, write governance, and supervised coordination beyond current read/helper foundations
 - tenant trust portability and controlled sharing
 - institutional partner and legal/compliance readiness
 - physical mobile/PDF QA confidence improvements


### PR DESCRIPTION
## Summary
- inventory current frontend/backend runtime surface categories in Claude-facing platform state docs
- clarify that route/page/helper presence is not proof of full workflow execution, live integrations, or deployed backend freshness
- mark readiness, export, institutional, identity, settlement, and review-workspace areas that need route/payload/deployment verification before production claims

## Validation
- git diff --check

## Scope
Documentation-only. No runtime, config, package, CI, deployment, route, auth, pricing, entitlement, Firestore, or infrastructure changes.