### PR TITLE
Consolidate governance reference vocabulary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,8 @@ RentChain is governed rental operations and property intelligence infrastructure
 
 For implementation workflow, repository discovery, and mission execution rules, follow `AGENTS.md`, `PROCESS.md`, `codex.md`, and `docs/execution/AI_COWORK_PROTOCOL.md`.
 
+For shared governance terminology, use `docs/ai/claude-context/GOVERNANCE_REFERENCE.md`.
+
 ## Architecture Diagram Maturity Legend
 
 The architecture map is an operational evolution map, not a guaranteed live production state map. It intentionally shows implemented foundations, in-development hardening, and planned roadmap layers together so engineering, QA, Claude, and strategic reviewers can reason about sequence.

--- a/CODEX_RULES.md
+++ b/CODEX_RULES.md
@@ -48,6 +48,7 @@ Defines strict guardrails Codex must never violate.
 
 ## Projection and Privacy Safety
 
+- Use `docs/ai/claude-context/GOVERNANCE_REFERENCE.md` for canonical definitions of projection-safe, append-safe, metadata-first, supervised AI, controlled operational routing, institutional readiness, and evidence/export governance.
 - Never widen tenant visibility into landlord, admin, support, or internal metadata.
 - Never expose raw Firestore IDs, unit IDs, lease IDs, landlord IDs, tenant IDs, storage paths, tokens, secrets, credentials, provider payloads, or raw documents as user-facing labels.
 - Preserve tenant-safe whitelist projections.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ RentChain engineering follows these rules:
 - exports are metadata-first, consent-aware, and redaction-aware
 - workflow mutation requires explicit mission scope and review
 
+For Claude/Codex terminology, `docs/ai/claude-context/GOVERNANCE_REFERENCE.md` defines the canonical meanings of projection-safe, append-safe, metadata-first, supervised AI, controlled operational routing, institutional readiness, evidence/export governance, and implementation status labels.
+
 ## Operational Architecture Direction
 
 The architecture is organized around layered operational infrastructure:

--- a/codex.md
+++ b/codex.md
@@ -24,6 +24,7 @@ Do not describe or implement RentChain as generic landlord SaaS. Do not infer au
 - `rentchain-api/` = backend API.
 - `docs/` = product, architecture, governance, strategy, execution, and Claude context docs.
 - `docs/ai/claude-context/` = Claude.ai upload/reference snapshots, not runtime source of truth.
+- `docs/ai/claude-context/GOVERNANCE_REFERENCE.md` = canonical governance vocabulary for Claude/Codex discussion.
 - `.codex/docs/` = technical deep-dives.
 - `.github/` = GitHub Actions and PR automation.
 - `.devcontainer/` = local cowork/sandbox foundation.

--- a/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
+++ b/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
@@ -2,6 +2,8 @@
 
 This file replaces stale `CURRENT_MISSION.md` context for Claude.ai sharing. It is strategic, chronological, and phase-oriented. It is not an implementation branch plan by itself; each item still requires an explicit operator mission before Codex or Claude acts on it.
 
+Use `GOVERNANCE_REFERENCE.md` for shared governance definitions and status labels before converting any mission theme into implementation scope.
+
 ## Current Platform Phase
 
 RentChain has completed the first governed operational infrastructure layer around:
@@ -152,9 +154,11 @@ Purpose: plan interoperability and integrity layers without bypassing governance
 
 ## Recommended Next Documentation Missions
 
-1. `docs/readme-modernization-v1` — completed by this modernization work; keep README aligned with governance-first platform framing.
-2. `docs/architecture-modernization-v1` — completed by this modernization work; keep architecture layers current as review/export/institutional foundations evolve.
-3. `docs/governance-reference-consolidation-v1` — recommended next docs mission to consolidate scattered governance reports into a stable Claude/operator reference index.
+1. `docs/readme-modernization-v1` — completed; keep README aligned with governance-first platform framing.
+2. `docs/architecture-modernization-v1` — completed; keep architecture layers current as review/export/institutional foundations evolve.
+3. `docs/platform-state-runtime-alignment-audit-v1` — completed; keep runtime surface claims separated from complete workflow and live integration claims.
+4. `docs/governance-reference-consolidation-v1` — current consolidation mission; use `GOVERNANCE_REFERENCE.md` as the canonical vocabulary layer.
+5. `docs/diagram-to-mission-phase-mapping-v1` — recommended next mission to map architecture diagram layers to mission phases without turning roadmap concepts into implemented claims.
 
 ## Best Immediate Claude Cleanup
 

--- a/docs/ai/claude-context/CURRENT_ARCHITECTURE.md
+++ b/docs/ai/claude-context/CURRENT_ARCHITECTURE.md
@@ -4,6 +4,8 @@
 
 Architecture diagrams and maps should be read as operational evolution maps, not guaranteed live production state maps.
 
+Use `GOVERNANCE_REFERENCE.md` for shared definitions of implementation status, projection safety, append safety, metadata-first evidence/export posture, supervised AI, and controlled operational routing.
+
 Use these labels:
 
 - Implemented: materially present in current code, routes, docs, tests, or UI surfaces.

--- a/docs/ai/claude-context/CURRENT_GOVERNANCE_MODEL.md
+++ b/docs/ai/claude-context/CURRENT_GOVERNANCE_MODEL.md
@@ -1,5 +1,7 @@
 # Current Governance Model
 
+Use `GOVERNANCE_REFERENCE.md` as the canonical vocabulary layer for projection-safe, append-safe, metadata-first, supervised AI, controlled operational routing, institutional readiness, evidence/export governance, and implementation status labels.
+
 ## Audit-Safe Operational History
 
 RentChain emphasizes audit-safe operational history through canonical events, metadata-only review records, route-source attribution, and append-compatible references.

--- a/docs/ai/claude-context/GOVERNANCE_REFERENCE.md
+++ b/docs/ai/claude-context/GOVERNANCE_REFERENCE.md
@@ -1,0 +1,119 @@
+# Governance Reference
+
+This file defines the shared governance vocabulary Claude, Codex, and reviewers should use when discussing RentChain. It is reference documentation only; it does not change runtime behavior.
+
+## Implementation Status Labels
+
+- **Implemented**: materially present in current code, routes, docs, tests, or UI surfaces. Implementation depth may vary by feature.
+- **In Development**: partial foundations, helpers, read models, tests, docs, or preview surfaces exist, but complete workflow execution is not proven.
+- **Planned / Roadmap**: strategic direction only. Requires future scoped missions, governance review, tests, QA, and deployment verification before it can be described as live.
+- **Needs Verification**: a claim requires source-code, route, payload, deployment, or QA confirmation before being upgraded.
+
+Route or page existence means a surface exists. It does not prove full production workflow depth, external integration, legal certification, or deployed-backend freshness.
+
+## Projection-Safe
+
+Projection-safe means every audience receives an explicit, minimal, role-appropriate view of data.
+
+Required posture:
+
+- tenant-facing views use whitelist projections
+- landlord, admin/support, export, dashboard, timeline, analytics, debug, and public-safe contexts remain separate
+- raw Firestore IDs, storage paths, provider payloads, raw documents, tokens, secrets, debug payloads, and unrestricted policy internals are excluded from user-facing labels and exports
+- ambiguous audience, ownership, role, or policy context fails closed
+
+Projection safety is not broad field stripping after loading everything. It is intentional audience-specific shaping.
+
+## Append-Safe
+
+Append-safe means operational history is preserved through additive records, events, references, or summaries rather than silent overwrite, deletion, or hidden mutation.
+
+Required posture:
+
+- preserve audit continuity
+- prefer immutable or append-compatible review history
+- do not erase actor, route-source, evidence, consent, or decision lineage
+- do not add approve, resolve, dismiss, enforcement, financial mutation, or remediation behavior unless explicitly scoped
+
+Append-safe does not mean every helper currently writes to persistence. Some foundations are contracts, read models, or readiness layers only.
+
+## Metadata-First
+
+Metadata-first means review, trust, evidence, and export workflows should expose safe summaries, status, provenance, redaction, counts, references, and readiness context before exposing any underlying sensitive payload.
+
+Required posture:
+
+- use safe summaries instead of raw notes, raw documents, screening reports, provider payloads, or request/response bodies
+- include consent, redaction, retention, route-source, or evidence-reference context where relevant
+- avoid claiming external submission, signed packages, legal artifacts, or institution handoffs unless current deployed routes prove them
+
+## Supervised AI
+
+Supervised AI means AI can assist review, triage, drafting, analysis, and QA, but it does not autonomously execute operational outcomes.
+
+Required posture:
+
+- keep Codex implementation scoped to operator-approved missions
+- keep Claude recommendations labeled as required fix, recommended improvement, future mission, or strategic note
+- keep Playwright deterministic and evidence-oriented
+- require explicit operator authorization for merge, deploy, production mutation, scope expansion, or workflow execution
+
+Avoid language that implies autonomous remediation, hidden enforcement, agent-driven escalation, or unsupervised status mutation.
+
+## Controlled Operational Routing
+
+Controlled operational routing means incidents, escalations, support notes, evidence references, and review workspaces can be grouped or surfaced for human review without automatically mutating business records.
+
+Required posture:
+
+- route-source attribution remains visible where present
+- recommendations and review summaries are not workflow execution
+- support/admin metadata stays internal unless an approved projection exposes a safe summary
+- tenant and landlord visibility must not be widened by review routing
+
+## Institutional Readiness
+
+Institutional readiness means RentChain is preparing governed infrastructure for future lender, insurer, auditor, government, subsidy/program, legal, and institutional workflows.
+
+Required posture:
+
+- distinguish readiness from live external integration
+- treat subsidy, welfare support, housing program, settlement, disbursement, inter-agency sharing, compliance certification, and KYC/identity assurance as planned or verification-gated unless source code and deployed payloads prove a specific implemented slice
+- preserve consent, redaction, retention, authorization, projection safety, and manual review
+
+## Evidence and Export Governance
+
+Evidence/export governance means evidence lineage, trust packages, export previews, and institutional summaries remain consent-aware and redaction-aware.
+
+Required posture:
+
+- expose metadata-safe evidence references before raw payloads
+- avoid raw tenant documents, private messages, screening reports, provider payloads, storage paths, or debug payloads
+- separate preview/readiness surfaces from live submission, legal certification, or partner handoff
+- verify Cloud Run backend revision and representative payloads before treating export behavior as current deployed truth
+
+## Tenant Visibility Limits
+
+Tenant visibility must not expand by accident.
+
+Required posture:
+
+- tenant views should not receive landlord-only, admin-only, support-only, or internal review metadata
+- landlord views should not receive tenant-private data beyond approved landlord operational projections
+- public/share/export views should be narrower than authenticated internal views
+- no raw internal IDs should be used as primary labels
+
+## Governance Review Checklist
+
+Before upgrading a claim or implementing a mission, verify:
+
+- Which audience sees the data?
+- Is the output projection-safe?
+- Is history append-safe?
+- Is the workflow metadata-first?
+- Is AI supervised?
+- Does routing mutate anything?
+- Is institutional language readiness-only or implemented?
+- Are tenant consent and visibility boundaries preserved?
+- Is Cloud Run/Vercel deployment alignment relevant?
+- Are implemented, in-development, planned, and needs-verification states clearly labeled?

--- a/docs/ai/claude-context/PLATFORM_GUARDRAILS.md
+++ b/docs/ai/claude-context/PLATFORM_GUARDRAILS.md
@@ -2,6 +2,8 @@
 
 Claude must not violate these rules when advising on RentChain.
 
+Use `GOVERNANCE_REFERENCE.md` for canonical definitions of projection-safe, append-safe, metadata-first, supervised AI, controlled operational routing, institutional readiness, evidence/export governance, and implementation status labels.
+
 - Never widen tenant visibility into landlord/admin/support data.
 - Never expose raw Firestore IDs, unit IDs, lease IDs, landlord IDs, tenant IDs, storage paths, or internal references as user-facing labels.
 - Never bypass governance layers, route authorization, entitlement gates, or projection helpers.


### PR DESCRIPTION
## Summary
- add GOVERNANCE_REFERENCE.md as the canonical Claude/Codex governance vocabulary layer
- define projection-safe, append-safe, metadata-first, supervised AI, controlled routing, institutional readiness, evidence/export governance, tenant visibility limits, and implementation status labels
- add short pointers from core docs and Claude context docs to keep terminology consistent
- update active documentation sequence to recommend docs/diagram-to-mission-phase-mapping-v1 next

## Validation
- git diff --check
- git diff --cached --check

## Scope
Documentation-only. No runtime, source, config, package, CI, deployment, pricing, entitlement, auth, route, Firestore, or infrastructure changes.