### PR TITLE
Align Playwright smoke specs with preview base URL

### DIFF
--- a/rentchain-frontend/tests/playwright/ai-drawer.spec.ts
+++ b/rentchain-frontend/tests/playwright/ai-drawer.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 test("AI drawer loads summary", async ({ page }) => {
-  await page.goto("http://localhost:5173/dashboard");
+  await page.goto("/dashboard");
   await expect(page.getByText(/AI Portfolio Intelligence/i)).toBeVisible();
   await page.getByText(/AI Portfolio Intelligence/i).click();
   await expect(page.getByRole("button", { name: /Portfolio Health/i })).toBeVisible();

--- a/rentchain-frontend/tests/playwright/payments.responsive.spec.ts
+++ b/rentchain-frontend/tests/playwright/payments.responsive.spec.ts
@@ -8,13 +8,13 @@ test.describe("Payments page responsive", () => {
   ];
 
   for (const { name, size } of viewports) {
-    test(`renders payments on ${name}`, async ({ page }) => {
+    test(`renders payments on ${name}`, async ({ page }, testInfo) => {
       await page.setViewportSize(size);
-      await page.goto("http://localhost:5173/payments");
+      await page.goto("/payments");
       await expect(page.getByRole("heading", { name: /payments/i })).toBeVisible();
       await expect(page.getByRole("table")).toBeVisible();
       await page.screenshot({
-        path: `screenshots/payments-${name}.png`,
+        path: testInfo.outputPath(`payments-${name}.png`),
         fullPage: true,
       });
     });


### PR DESCRIPTION
## Summary
- audited existing devcontainer, AI cowork docs, Cloud Run checklist, Playwright protocol, and QA smoke scripts
- kept existing foundation intact because the devcontainer/docs/scripts already exist on main
- updated existing Playwright specs to use the configured Playwright baseURL instead of hardcoded localhost
- moved payments screenshots into Playwright-managed test output via testInfo.outputPath

## Validation
- bash -n tools/qa/run-mobile-smoke.sh tools/qa/run-admin-smoke.sh tools/qa/run-tenant-smoke.sh
- git diff --check
- git diff --cached --check
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:e2e -- --list

## Scope
QA/dev workflow only. No production runtime, source product behavior, config, package, CI, deployment, pricing, entitlement, auth, route, Firestore, or infrastructure changes.