### PR TITLE
Add mobile preview QA harness

### DIFF
--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -43,7 +43,10 @@ The smoke scripts:
 - verify `rentchain-frontend` exists
 - verify Playwright is available through the existing frontend install
 - print the target URL and role
-- run the existing Playwright test command when available
+- run the mobile preview smoke harness by default
+- pass `PREVIEW_URL` through Playwright `baseURL`
+- create role-labeled Playwright artifact and HTML report folders
+- refuse production URLs unless `ALLOW_PRODUCTION_QA=true` is explicitly set
 - fail clearly if dependencies are missing
 
 They do not:
@@ -60,7 +63,25 @@ They do not:
 - `tools/qa/run-admin-smoke.sh`: admin/governance smoke entrypoint
 - `tools/qa/run-tenant-smoke.sh`: tenant portal smoke entrypoint
 
-These scripts are intentionally thin wrappers around the existing frontend Playwright setup. Dedicated role-specific specs can be added in future missions.
+These scripts run `mobile-preview-smoke` unless `QA_SPEC` is overridden. The current harness is unauthenticated and non-mutating: protected routes may render login/access-denied states, but the run still verifies preview reachability, mobile viewport containment, console/page-error behavior, and artifact capture.
+
+Examples:
+
+```bash
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-mobile-smoke.sh
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-admin-smoke.sh
+```
+
+Optional inputs:
+
+- `QA_SPEC`: Playwright spec filter, default `mobile-preview-smoke`
+- `QA_GREP`: Playwright grep filter
+- `QA_BROWSER`: Playwright project name when projects are added
+- `QA_ARTIFACT_DIR`: output directory under `rentchain-frontend`, default `test-results/<role>-mobile-smoke`
+- `QA_HTML_REPORT_DIR`: HTML report directory under `rentchain-frontend`, default `playwright-report/<role>-mobile-smoke`
+- `QA_TRACE=on`: collect traces for all tests instead of failures only
+- `QA_VIDEO=on`: collect videos for all tests instead of failures only
 
 ## Evidence Handling
 
@@ -69,6 +90,7 @@ When Playwright produces artifacts:
 - keep `playwright-report/` and `test-results/` uncommitted
 - summarize key failures in the PR or QA report
 - include screenshots only when they do not expose secrets, raw IDs, private documents, tokens, or sensitive user data
+- failures should include the route/page label, viewport, target URL, and artifact/report path from the smoke script output
 
 ## Pass / Fail Interpretation
 
@@ -87,7 +109,7 @@ If Playwright disagrees with local tests, treat it as a QA finding and inspect t
 
 Future missions may add:
 
-- role-specific Playwright specs that use `PREVIEW_URL`
+- authenticated role-specific Playwright specs that use `PREVIEW_URL`
 - authenticated storage-state fixtures stored outside the repo
 - deterministic screenshot comparison for mobile layouts
 - route-source header checks for backend preview routes

--- a/rentchain-frontend/playwright.config.ts
+++ b/rentchain-frontend/playwright.config.ts
@@ -2,10 +2,17 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/playwright",
+  outputDir: process.env.QA_ARTIFACT_DIR || "test-results",
   timeout: 60_000,
   use: {
     headless: true,
     baseURL: process.env.BASE_URL || "http://localhost:5173",
+    screenshot: "only-on-failure",
+    trace: process.env.QA_TRACE === "on" ? "on" : "retain-on-failure",
+    video: process.env.QA_VIDEO === "on" ? "on" : "retain-on-failure",
   },
-  reporter: [["list"], ["html", { outputFolder: "playwright-report" }]],
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: process.env.QA_HTML_REPORT_DIR || "playwright-report" }],
+  ],
 });

--- a/rentchain-frontend/tests/playwright/mobile-preview-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/mobile-preview-smoke.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+type SmokeRoute = {
+  label: string;
+  path: string;
+  roles: Array<"mobile" | "landlord" | "tenant" | "admin">;
+};
+
+const viewports = [
+  { name: "iphone", size: { width: 390, height: 844 } },
+  { name: "android", size: { width: 412, height: 915 } },
+];
+
+const routes: SmokeRoute[] = [
+  { label: "landlord dashboard", path: "/dashboard", roles: ["mobile", "landlord"] },
+  { label: "landlord decision inbox", path: "/decision-inbox", roles: ["mobile", "landlord"] },
+  { label: "landlord operations", path: "/operations", roles: ["mobile", "landlord"] },
+  { label: "tenant workspace", path: "/tenant", roles: ["mobile", "tenant"] },
+  { label: "tenant documents", path: "/tenant/documents", roles: ["mobile", "tenant"] },
+  { label: "admin dashboard", path: "/admin", roles: ["mobile", "admin"] },
+  { label: "admin review workspaces", path: "/admin/review-workspaces", roles: ["mobile", "admin"] },
+];
+
+function selectedRole() {
+  const role = String(process.env.QA_ROLE || "mobile").trim().toLowerCase();
+  if (role === "landlord" || role === "tenant" || role === "admin") return role;
+  return "mobile";
+}
+
+for (const viewport of viewports) {
+  test.describe(`mobile preview smoke: ${viewport.name}`, () => {
+    test.use({ viewport: viewport.size });
+
+    for (const route of routes.filter((candidate) => candidate.roles.includes(selectedRole()))) {
+      test(`${route.label} renders without mobile overflow`, async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        const pageErrors: string[] = [];
+
+        page.on("console", (message) => {
+          if (message.type() === "error") {
+            consoleErrors.push(message.text());
+          }
+        });
+        page.on("pageerror", (error) => {
+          pageErrors.push(error.message);
+        });
+
+        const response = await page.goto(route.path, { waitUntil: "domcontentloaded" });
+        if (response) {
+          expect(response.status(), `${route.label} response status`).toBeLessThan(500);
+        }
+
+        await expect(page.locator("body")).toBeVisible();
+        await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
+
+        const overflow = await page.evaluate(() => {
+          const doc = document.documentElement;
+          return Math.max(0, doc.scrollWidth - doc.clientWidth);
+        });
+        expect(overflow, `${route.label} horizontal overflow`).toBeLessThanOrEqual(2);
+
+        await page.screenshot({
+          path: testInfo.outputPath(`${viewport.name}-${route.label.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}.png`),
+          fullPage: true,
+        });
+
+        expect(pageErrors, `${route.label} page errors`).toEqual([]);
+        expect(consoleErrors, `${route.label} console errors`).toEqual([]);
+      });
+    }
+  });
+}

--- a/tools/qa/run-mobile-smoke.sh
+++ b/tools/qa/run-mobile-smoke.sh
@@ -5,6 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FRONTEND_DIR="$ROOT_DIR/rentchain-frontend"
 PREVIEW_URL="${PREVIEW_URL:-http://localhost:5173}"
 QA_ROLE="${QA_ROLE:-mobile}"
+QA_SPEC="${QA_SPEC:-mobile-preview-smoke}"
+QA_ARTIFACT_DIR="${QA_ARTIFACT_DIR:-test-results/${QA_ROLE}-mobile-smoke}"
+QA_HTML_REPORT_DIR="${QA_HTML_REPORT_DIR:-playwright-report/${QA_ROLE}-mobile-smoke}"
+ALLOW_PRODUCTION_QA="${ALLOW_PRODUCTION_QA:-false}"
 
 if [ ! -d "$FRONTEND_DIR" ]; then
   echo "Missing rentchain-frontend directory." >&2
@@ -16,14 +20,33 @@ if [ ! -x "$FRONTEND_DIR/node_modules/.bin/playwright" ]; then
   exit 1
 fi
 
+case "$PREVIEW_URL" in
+  https://www.rentchain.ai*|https://rentchain.ai*)
+    if [ "$ALLOW_PRODUCTION_QA" != "true" ]; then
+      echo "Refusing to run mobile smoke against production URL without ALLOW_PRODUCTION_QA=true." >&2
+      exit 1
+    fi
+    ;;
+esac
+
 echo "Running RentChain Playwright smoke."
 echo "Role: $QA_ROLE"
 echo "Target: $PREVIEW_URL"
+echo "Spec filter: $QA_SPEC"
+echo "Artifacts: $FRONTEND_DIR/$QA_ARTIFACT_DIR"
+echo "HTML report: $FRONTEND_DIR/$QA_HTML_REPORT_DIR"
 
 cd "$FRONTEND_DIR"
 playwright_args=()
 if [ -n "${QA_BROWSER:-}" ]; then
   playwright_args+=(--project="$QA_BROWSER")
 fi
+if [ -n "${QA_GREP:-}" ]; then
+  playwright_args+=(--grep="$QA_GREP")
+fi
 
-BASE_URL="$PREVIEW_URL" npm run test:e2e -- "${playwright_args[@]}"
+BASE_URL="$PREVIEW_URL" \
+QA_ROLE="$QA_ROLE" \
+QA_ARTIFACT_DIR="$QA_ARTIFACT_DIR" \
+QA_HTML_REPORT_DIR="$QA_HTML_REPORT_DIR" \
+npm run test:e2e -- "$QA_SPEC" "${playwright_args[@]}"


### PR DESCRIPTION
## Summary
- add a governance-safe mobile preview Playwright smoke spec for iPhone and Android viewports
- cover landlord, tenant, admin, operations, review workspace, and dashboard route families without authenticated mutation
- update the QA wrapper to pass PREVIEW_URL as Playwright baseURL, label role/spec/artifact output, support QA_GREP, and block accidental production targets unless explicitly allowed
- configure Playwright traces/videos/screenshots and role-labeled artifact/report directories
- document preview QA usage, artifacts, safety rules, and limitations

## Validation
- bash -n tools/qa/run-mobile-smoke.sh tools/qa/run-admin-smoke.sh tools/qa/run-tenant-smoke.sh
- git diff --check
- git diff --cached --check
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && BASE_URL=http://localhost:5173 QA_ROLE=mobile QA_ARTIFACT_DIR=test-results/mobile-preview-smoke-list QA_HTML_REPORT_DIR=playwright-report/mobile-preview-smoke-list npm run test:e2e -- mobile-preview-smoke --list
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && BASE_URL=http://localhost:5173 QA_ROLE=tenant QA_ARTIFACT_DIR=test-results/tenant-mobile-smoke-list QA_HTML_REPORT_DIR=playwright-report/tenant-mobile-smoke-list npm run test:e2e -- mobile-preview-smoke --list
- PREVIEW_URL=https://www.rentchain.ai tools/qa/run-mobile-smoke.sh fails closed without ALLOW_PRODUCTION_QA=true

## Scope
QA infrastructure only. No production runtime behavior, pricing, entitlement, auth, routes, Firestore rules, deployment, package, or infrastructure changes.