### PR TITLE
Add role-based Playwright smoke suites

### DIFF
--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -62,8 +62,17 @@ They do not:
 - `tools/qa/run-mobile-smoke.sh`: general mobile-oriented smoke entrypoint
 - `tools/qa/run-admin-smoke.sh`: admin/governance smoke entrypoint
 - `tools/qa/run-tenant-smoke.sh`: tenant portal smoke entrypoint
+- `tools/qa/run-landlord-smoke.sh`: landlord operations smoke entrypoint
 
-These scripts run `mobile-preview-smoke` unless `QA_SPEC` is overridden. The current harness is unauthenticated and non-mutating: protected routes may render login/access-denied states, but the run still verifies preview reachability, mobile viewport containment, console/page-error behavior, and artifact capture.
+The role-specific scripts default to their matching Playwright spec:
+
+- `admin-smoke`
+- `tenant-smoke`
+- `landlord-smoke`
+
+`run-mobile-smoke.sh` still defaults to `mobile-preview-smoke` unless `QA_SPEC` is overridden. The harness is non-mutating: protected routes may render login/access-denied states when authenticated storage state is not supplied, but the run still verifies preview reachability, desktop/mobile viewport containment, console/page-error behavior, and artifact capture.
+
+Role-specific wrapper scripts write to role-scoped artifact folders by default, such as `test-results/admin-smoke`, `test-results/tenant-smoke`, and `test-results/landlord-smoke`.
 
 Examples:
 
@@ -71,6 +80,7 @@ Examples:
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-mobile-smoke.sh
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-admin-smoke.sh
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-landlord-smoke.sh
 ```
 
 Optional inputs:
@@ -82,6 +92,17 @@ Optional inputs:
 - `QA_HTML_REPORT_DIR`: HTML report directory under `rentchain-frontend`, default `playwright-report/<role>-mobile-smoke`
 - `QA_TRACE=on`: collect traces for all tests instead of failures only
 - `QA_VIDEO=on`: collect videos for all tests instead of failures only
+
+## Authenticated Role State
+
+Role smoke tests may use Playwright storage-state files when an operator provides them through environment variables:
+
+- `QA_ADMIN_STORAGE_STATE`
+- `QA_TENANT_STORAGE_STATE`
+- `QA_LANDLORD_STORAGE_STATE`
+- `QA_STORAGE_STATE` as a generic fallback
+
+Storage-state files must be generated outside the repository or kept in ignored local artifact locations. Do not commit session cookies, bearer tokens, credentials, or storage-state JSON. If no storage state is provided, the role smoke tests run as unauthenticated reachability checks and annotate role-shell expectations as gated when protected pages redirect or block access.
 
 ## Evidence Handling
 

--- a/rentchain-frontend/tests/playwright/admin-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/admin-smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "@playwright/test";
+import {
+  roleSmokeViewports,
+  runRoleRouteSmoke,
+  storageStateForRole,
+  type RoleSmokeRoute,
+} from "./role-smoke-helpers";
+
+const adminRoutes: RoleSmokeRoute[] = [
+  { label: "admin dashboard", path: "/admin", shellText: [/admin/i, /workspace/i] },
+  { label: "admin properties", path: "/admin/properties", shellText: [/properties/i, /workspace/i] },
+  { label: "admin review workspaces", path: "/admin/review-workspaces", shellText: [/review workspaces/i, /workspace/i] },
+  { label: "admin support escalations", path: "/admin/support/escalations", shellText: [/support/i, /escalation/i] },
+  { label: "admin security incidents", path: "/admin/security/incidents", shellText: [/security/i, /incident/i] },
+];
+
+test.describe("admin role smoke", () => {
+  const storageState = storageStateForRole("admin");
+  if (storageState) {
+    test.use({ storageState });
+  }
+
+  for (const viewport of roleSmokeViewports) {
+    test.describe(viewport.name, () => {
+      test.use({ viewport: viewport.size });
+
+      for (const route of adminRoutes) {
+        test(`${route.label} renders safely`, async ({ page }, testInfo) => {
+          await runRoleRouteSmoke(page, testInfo, route, viewport.name);
+        });
+      }
+    });
+  }
+});

--- a/rentchain-frontend/tests/playwright/landlord-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/landlord-smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "@playwright/test";
+import {
+  roleSmokeViewports,
+  runRoleRouteSmoke,
+  storageStateForRole,
+  type RoleSmokeRoute,
+} from "./role-smoke-helpers";
+
+const landlordRoutes: RoleSmokeRoute[] = [
+  { label: "landlord dashboard", path: "/dashboard", shellText: [/dashboard/i, /portfolio/i] },
+  { label: "landlord decision inbox", path: "/decision-inbox", shellText: [/decision/i, /inbox/i] },
+  { label: "landlord operations", path: "/operations", shellText: [/operations/i, /command/i] },
+  { label: "landlord leases", path: "/leases", shellText: [/leases/i, /active/i] },
+  { label: "landlord messages", path: "/messages", shellText: [/messages/i, /inbox/i] },
+];
+
+test.describe("landlord role smoke", () => {
+  const storageState = storageStateForRole("landlord");
+  if (storageState) {
+    test.use({ storageState });
+  }
+
+  for (const viewport of roleSmokeViewports) {
+    test.describe(viewport.name, () => {
+      test.use({ viewport: viewport.size });
+
+      for (const route of landlordRoutes) {
+        test(`${route.label} renders safely`, async ({ page }, testInfo) => {
+          await runRoleRouteSmoke(page, testInfo, route, viewport.name);
+        });
+      }
+    });
+  }
+});

--- a/rentchain-frontend/tests/playwright/role-smoke-helpers.ts
+++ b/rentchain-frontend/tests/playwright/role-smoke-helpers.ts
@@ -1,0 +1,79 @@
+import { expect, type Page, type TestInfo } from "@playwright/test";
+
+export type RoleSmokeRole = "admin" | "tenant" | "landlord";
+
+export type RoleSmokeRoute = {
+  label: string;
+  path: string;
+  shellText?: RegExp[];
+};
+
+export const roleSmokeViewports = [
+  { name: "desktop", size: { width: 1280, height: 800 } },
+  { name: "mobile", size: { width: 390, height: 844 } },
+];
+
+export function storageStateForRole(role: RoleSmokeRole) {
+  const roleKey = `QA_${role.toUpperCase()}_STORAGE_STATE`;
+  return process.env[roleKey] || process.env.QA_STORAGE_STATE || undefined;
+}
+
+export async function runRoleRouteSmoke(
+  page: Page,
+  testInfo: TestInfo,
+  route: RoleSmokeRoute,
+  viewportName: string,
+) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  const response = await page.goto(route.path, { waitUntil: "domcontentloaded" });
+  if (response) {
+    expect(response.status(), `${route.label} response status`).toBeLessThan(500);
+  }
+
+  await expect(page.locator("body"), `${route.label} body`).toBeVisible();
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
+
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    return Math.max(0, doc.scrollWidth - doc.clientWidth);
+  });
+  expect(overflow, `${route.label} horizontal overflow`).toBeLessThanOrEqual(2);
+
+  if (route.shellText?.length) {
+    const foundShellText = await Promise.all(
+      route.shellText.map(async (pattern) => {
+        try {
+          await expect(page.getByText(pattern).first()).toBeVisible({ timeout: 1_500 });
+          return true;
+        } catch {
+          return false;
+        }
+      }),
+    );
+    testInfo.annotations.push({
+      type: "role-shell",
+      description: foundShellText.some(Boolean)
+        ? "matched role-appropriate shell text"
+        : "role shell text not visible; route may be unauthenticated or access-gated",
+    });
+  }
+
+  await page.screenshot({
+    path: testInfo.outputPath(`${viewportName}-${route.label.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}.png`),
+    fullPage: true,
+  });
+
+  expect(pageErrors, `${route.label} page errors`).toEqual([]);
+  expect(consoleErrors, `${route.label} console errors`).toEqual([]);
+}

--- a/rentchain-frontend/tests/playwright/tenant-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/tenant-smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "@playwright/test";
+import {
+  roleSmokeViewports,
+  runRoleRouteSmoke,
+  storageStateForRole,
+  type RoleSmokeRoute,
+} from "./role-smoke-helpers";
+
+const tenantRoutes: RoleSmokeRoute[] = [
+  { label: "tenant workspace", path: "/tenant", shellText: [/tenant/i, /rentchain tenant/i] },
+  { label: "tenant lease", path: "/tenant/lease", shellText: [/lease/i, /tenant/i] },
+  { label: "tenant documents", path: "/tenant/documents", shellText: [/documents/i, /schedule/i] },
+  { label: "tenant messages", path: "/tenant/messages", shellText: [/messages/i, /tenant/i] },
+  { label: "tenant profile", path: "/tenant/profile", shellText: [/profile/i, /tenant/i] },
+];
+
+test.describe("tenant role smoke", () => {
+  const storageState = storageStateForRole("tenant");
+  if (storageState) {
+    test.use({ storageState });
+  }
+
+  for (const viewport of roleSmokeViewports) {
+    test.describe(viewport.name, () => {
+      test.use({ viewport: viewport.size });
+
+      for (const route of tenantRoutes) {
+        test(`${route.label} renders safely`, async ({ page }, testInfo) => {
+          await runRoleRouteSmoke(page, testInfo, route, viewport.name);
+        });
+      }
+    });
+  }
+});

--- a/tools/qa/run-admin-smoke.sh
+++ b/tools/qa/run-admin-smoke.sh
@@ -2,4 +2,7 @@
 set -euo pipefail
 
 export QA_ROLE="${QA_ROLE:-admin}"
+export QA_SPEC="${QA_SPEC:-admin-smoke}"
+export QA_ARTIFACT_DIR="${QA_ARTIFACT_DIR:-test-results/admin-smoke}"
+export QA_HTML_REPORT_DIR="${QA_HTML_REPORT_DIR:-playwright-report/admin-smoke}"
 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run-mobile-smoke.sh"

--- a/tools/qa/run-landlord-smoke.sh
+++ b/tools/qa/run-landlord-smoke.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export QA_ROLE="${QA_ROLE:-landlord}"
+export QA_SPEC="${QA_SPEC:-landlord-smoke}"
+export QA_ARTIFACT_DIR="${QA_ARTIFACT_DIR:-test-results/landlord-smoke}"
+export QA_HTML_REPORT_DIR="${QA_HTML_REPORT_DIR:-playwright-report/landlord-smoke}"
+"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run-mobile-smoke.sh"

--- a/tools/qa/run-tenant-smoke.sh
+++ b/tools/qa/run-tenant-smoke.sh
@@ -2,4 +2,7 @@
 set -euo pipefail
 
 export QA_ROLE="${QA_ROLE:-tenant}"
+export QA_SPEC="${QA_SPEC:-tenant-smoke}"
+export QA_ARTIFACT_DIR="${QA_ARTIFACT_DIR:-test-results/tenant-smoke}"
+export QA_HTML_REPORT_DIR="${QA_HTML_REPORT_DIR:-playwright-report/tenant-smoke}"
 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run-mobile-smoke.sh"


### PR DESCRIPTION
## Summary
- Add admin, tenant, and landlord Playwright smoke specs for desktop/mobile route reachability and overflow checks.
- Add shared role smoke helper with page/console error capture, screenshot artifacts, and optional storage-state auth support.
- Add landlord smoke wrapper and update role smoke scripts/docs for role-scoped artifacts and preview-safe auth handling.

## Validation
- bash -n tools/qa/*.sh
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:e2e -- --list
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:e2e -- admin-smoke --list
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:e2e -- tenant-smoke --list
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:e2e -- landlord-smoke --list
- PREVIEW_URL=https://www.rentchain.ai tools/qa/run-landlord-smoke.sh failed closed as expected without ALLOW_PRODUCTION_QA=true
- git diff --check
- git diff --cached --check

## Notes
- Full browser execution was not run locally because this sandbox does not have a live local/preview app target with role auth state.
- Authenticated role assertions can use QA_ADMIN_STORAGE_STATE, QA_TENANT_STORAGE_STATE, QA_LANDLORD_STORAGE_STATE, or QA_STORAGE_STATE; no credentials or storage state files are committed.