### PR TITLE
Fix QA smoke script empty args

### DIFF
--- a/tools/qa/run-mobile-smoke.sh
+++ b/tools/qa/run-mobile-smoke.sh
@@ -45,8 +45,12 @@ if [ -n "${QA_GREP:-}" ]; then
   playwright_args+=(--grep="$QA_GREP")
 fi
 
-BASE_URL="$PREVIEW_URL" \
-QA_ROLE="$QA_ROLE" \
-QA_ARTIFACT_DIR="$QA_ARTIFACT_DIR" \
-QA_HTML_REPORT_DIR="$QA_HTML_REPORT_DIR" \
-npm run test:e2e -- "$QA_SPEC" "${playwright_args[@]}"
+export BASE_URL="$PREVIEW_URL"
+export QA_ROLE
+export QA_ARTIFACT_DIR
+export QA_HTML_REPORT_DIR
+if [ "${#playwright_args[@]}" -gt 0 ]; then
+  npm run test:e2e -- "$QA_SPEC" "${playwright_args[@]}"
+else
+  npm run test:e2e -- "$QA_SPEC"
+fi


### PR DESCRIPTION
## Summary
- Fix the QA smoke wrapper when no optional Playwright args are provided under set -u.
- Export the preview/role/artifact environment once, then call Playwright with or without optional args depending on array length.

## Validation
- bash -n tools/qa/*.sh
- PREVIEW_URL=https://rentchain-fl32xpsuc-rent-chain.vercel.app tools/qa/run-tenant-smoke.sh started correctly; remaining failures were preview smoke assertions from unauthenticated console errors/CSP/provider logs, not the shell bug.
- PREVIEW_URL=https://rentchain-fl32xpsuc-rent-chain.vercel.app tools/qa/run-landlord-smoke.sh started correctly; remaining failures were preview smoke assertions from unauthenticated console errors/CSP/provider logs, not the shell bug.
- PREVIEW_URL=https://rentchain-fl32xpsuc-rent-chain.vercel.app tools/qa/run-admin-smoke.sh started correctly; remaining failures were preview smoke assertions from unauthenticated console errors/CSP/provider logs, not the shell bug.
- git diff --check
- git diff --cached --check

## Notes
- No Playwright specs, runtime app code, package files, config, CI, or deployment files changed.