### PR TITLE
Classify Playwright preview smoke findings

### DIFF
--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -117,6 +117,16 @@ When Playwright produces artifacts:
 
 Passing Playwright smoke is not merge approval by itself.
 
+Smoke findings are classified so preview QA can separate expected protected-route noise from real failures:
+
+- `expected-auth-gated-response`: expected `401` or `403` resource responses when a protected route is checked without authenticated storage state.
+- `expected-third-party-browser-noise`: known browser/provider noise, including CSP-blocked preview fonts, Google provider account-list messages, and FedCM token retrieval noise.
+- `environment-browser-permission-issue`: browser-launch or local environment restrictions, such as macOS Chromium Mach port permission failures in a sandbox.
+- `possible-app-regression`: unexpected console errors or throttling-like `429` responses that need operator review. Unknown console errors fail the smoke run; known `429` noise is reported as a warning.
+- `hard-failure`: fatal page errors, app crashes, and route-level failures such as unexpected `5xx` responses.
+
+Each smoke test attaches `classified-smoke-findings` JSON to its Playwright result. Claude/Codex review should cite the category and route before treating a finding as a product blocker.
+
 Merge readiness still requires:
 
 - relevant local validation

--- a/rentchain-frontend/tests/playwright/mobile-preview-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/mobile-preview-smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { reportSmokeFindings } from "./smoke-findings";
 
 type SmokeRoute = {
   label: string;
@@ -64,8 +65,7 @@ for (const viewport of viewports) {
           fullPage: true,
         });
 
-        expect(pageErrors, `${route.label} page errors`).toEqual([]);
-        expect(consoleErrors, `${route.label} console errors`).toEqual([]);
+        await reportSmokeFindings(testInfo, route.label, consoleErrors, pageErrors);
       });
     }
   });

--- a/rentchain-frontend/tests/playwright/role-smoke-helpers.ts
+++ b/rentchain-frontend/tests/playwright/role-smoke-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, type TestInfo } from "@playwright/test";
+import { reportSmokeFindings } from "./smoke-findings";
 
 export type RoleSmokeRole = "admin" | "tenant" | "landlord";
 
@@ -74,6 +75,5 @@ export async function runRoleRouteSmoke(
     fullPage: true,
   });
 
-  expect(pageErrors, `${route.label} page errors`).toEqual([]);
-  expect(consoleErrors, `${route.label} console errors`).toEqual([]);
+  await reportSmokeFindings(testInfo, route.label, consoleErrors, pageErrors);
 }

--- a/rentchain-frontend/tests/playwright/smoke-findings.ts
+++ b/rentchain-frontend/tests/playwright/smoke-findings.ts
@@ -1,0 +1,120 @@
+import { expect, type TestInfo } from "@playwright/test";
+
+export type SmokeFindingCategory =
+  | "expected-auth-gated-response"
+  | "expected-third-party-browser-noise"
+  | "environment-browser-permission-issue"
+  | "possible-app-regression"
+  | "hard-failure";
+
+export type SmokeFindingSeverity = "info" | "warning" | "failure";
+
+export type ClassifiedSmokeFinding = {
+  category: SmokeFindingCategory;
+  severity: SmokeFindingSeverity;
+  message: string;
+};
+
+const resourceStatusPattern = /Failed to load resource: the server responded with a status of (\d+)/i;
+
+export function classifyConsoleFinding(message: string): ClassifiedSmokeFinding {
+  const resourceStatus = message.match(resourceStatusPattern)?.[1];
+  if (resourceStatus === "401" || resourceStatus === "403") {
+    return {
+      category: "expected-auth-gated-response",
+      severity: "info",
+      message,
+    };
+  }
+
+  if (resourceStatus === "429") {
+    return {
+      category: "possible-app-regression",
+      severity: "warning",
+      message,
+    };
+  }
+
+  if (
+    /Content Security Policy directive: "font-src/i.test(message) ||
+    /space-mono.*\.woff2/i.test(message) ||
+    /Provider's accounts list is empty/i.test(message) ||
+    /\[GSI_LOGGER\]/i.test(message) ||
+    /FedCM .*NetworkError/i.test(message)
+  ) {
+    return {
+      category: "expected-third-party-browser-noise",
+      severity: "info",
+      message,
+    };
+  }
+
+  if (
+    /MachPortRendezvousServer/i.test(message) ||
+    /bootstrap_check_in/i.test(message) ||
+    /Permission denied \(1100\)/i.test(message) ||
+    /browserType\.launch/i.test(message)
+  ) {
+    return {
+      category: "environment-browser-permission-issue",
+      severity: "warning",
+      message,
+    };
+  }
+
+  return {
+    category: "possible-app-regression",
+    severity: "failure",
+    message,
+  };
+}
+
+export function summarizeSmokeFindings(findings: ClassifiedSmokeFinding[]) {
+  return findings.reduce<Record<SmokeFindingCategory, number>>(
+    (summary, finding) => {
+      summary[finding.category] += 1;
+      return summary;
+    },
+    {
+      "expected-auth-gated-response": 0,
+      "expected-third-party-browser-noise": 0,
+      "environment-browser-permission-issue": 0,
+      "possible-app-regression": 0,
+      "hard-failure": 0,
+    },
+  );
+}
+
+export async function reportSmokeFindings(
+  testInfo: TestInfo,
+  label: string,
+  consoleErrors: string[],
+  pageErrors: string[],
+) {
+  const findings: ClassifiedSmokeFinding[] = [
+    ...consoleErrors.map(classifyConsoleFinding),
+    ...pageErrors.map((message) => ({
+      category: "hard-failure" as const,
+      severity: "failure" as const,
+      message,
+    })),
+  ];
+
+  const summary = summarizeSmokeFindings(findings);
+  await testInfo.attach("classified-smoke-findings", {
+    contentType: "application/json",
+    body: Buffer.from(JSON.stringify({ label, summary, findings }, null, 2)),
+  });
+
+  for (const [category, count] of Object.entries(summary)) {
+    if (count > 0) {
+      testInfo.annotations.push({
+        type: `smoke-${category}`,
+        description: `${count} finding${count === 1 ? "" : "s"}`,
+      });
+    }
+  }
+
+  const failures = findings.filter((finding) => finding.severity === "failure");
+  expect(failures, `${label} hard smoke failures`).toEqual([]);
+}


### PR DESCRIPTION
## Summary
- Add shared Playwright smoke finding classification for expected auth-gated responses, third-party/browser provider noise, local browser permission issues, possible app regressions, and hard failures.
- Wire classification into both role smoke and mobile preview smoke specs.
- Document how Claude/Codex/operator review should interpret classified smoke artifacts.

## Validation
- bash -n tools/qa/*.sh
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:e2e -- --list
- PREVIEW_URL=https://rentchain-fl32xpsuc-rent-chain.vercel.app tools/qa/run-tenant-smoke.sh — 10 passed
- PREVIEW_URL=https://rentchain-fl32xpsuc-rent-chain.vercel.app tools/qa/run-landlord-smoke.sh — 10 passed
- PREVIEW_URL=https://rentchain-fl32xpsuc-rent-chain.vercel.app tools/qa/run-admin-smoke.sh — 10 passed
- git diff --check
- git diff --cached --check

## Notes
- Full preview smoke execution required escalated local browser permissions because the sandbox blocks Chromium Mach port registration on macOS.
- Unknown console errors and page errors still fail; known auth/provider/browser noise is attached as classified smoke findings.