### PR TITLE
Add Playwright authenticated storage-state foundations

### DIFF
--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -43,6 +43,7 @@ The smoke scripts:
 - verify `rentchain-frontend` exists
 - verify Playwright is available through the existing frontend install
 - print the target URL and role
+- print whether the run is authenticated through local storage state or unauthenticated
 - run the mobile preview smoke harness by default
 - pass `PREVIEW_URL` through Playwright `baseURL`
 - create role-labeled Playwright artifact and HTML report folders
@@ -157,14 +158,44 @@ If none of the safe endpoint responses contain an expected commit, revision, or 
 
 ## Authenticated Role State
 
-Role smoke tests may use Playwright storage-state files when an operator provides them through environment variables:
+Role smoke tests may use Playwright storage-state files when an operator provides them through environment variables. Authenticated state is optional; if no storage-state path is provided, smoke tests keep running as unauthenticated reachability checks.
+
+Supported variables:
 
 - `QA_ADMIN_STORAGE_STATE`
 - `QA_TENANT_STORAGE_STATE`
 - `QA_LANDLORD_STORAGE_STATE`
 - `QA_STORAGE_STATE` as a generic fallback
 
-Storage-state files must be generated outside the repository or kept in ignored local artifact locations. Do not commit session cookies, bearer tokens, credentials, or storage-state JSON. If no storage state is provided, the role smoke tests run as unauthenticated reachability checks and annotate role-shell expectations as gated when protected pages redirect or block access.
+Precedence:
+
+1. role-specific storage state, such as `QA_TENANT_STORAGE_STATE`
+2. generic `QA_STORAGE_STATE`
+3. unauthenticated smoke mode
+
+The wrapper scripts print the active auth mode. When a storage-state variable is set, the referenced file must exist before Playwright starts; missing files fail fast with a clear message.
+
+Safe local locations:
+
+- outside the repository, such as `/tmp/rentchain-playwright/tenant.json`
+- ignored artifact paths, such as `rentchain-frontend/test-results/storage-state/tenant.json`
+
+Storage-state files can contain cookies, local storage, Firebase session material, and other secrets. Do not commit them, paste them into PRs, attach them to public issues, or include them in Claude uploads. `test-results/` and `playwright-report/` are ignored local artifact paths.
+
+Manual operator workflow:
+
+1. Open the target preview manually and sign in as the intended role.
+2. Use local Playwright tooling to save storage state to an ignored path.
+3. Export only the local path, not credentials:
+
+```bash
+export QA_TENANT_STORAGE_STATE=rentchain-frontend/test-results/storage-state/tenant.json
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
+```
+
+4. Delete or rotate storage-state files after QA if the session should not persist.
+
+Codex should not request, generate, store, or commit credentials. If authenticated state is unavailable, run unauthenticated smoke and report auth-gated findings honestly.
 
 ## Evidence Handling
 

--- a/tools/qa/run-mobile-smoke.sh
+++ b/tools/qa/run-mobile-smoke.sh
@@ -19,6 +19,29 @@ QA_JSON_REPORT_FILE="${QA_JSON_REPORT_FILE:-${QA_ARTIFACT_DIR}/qa-results.json}"
 QA_MARKDOWN_REPORT_FILE="${QA_MARKDOWN_REPORT_FILE:-${QA_ARTIFACT_DIR}/qa-summary.md}"
 ALLOW_PRODUCTION_QA="${ALLOW_PRODUCTION_QA:-false}"
 
+role_storage_key=""
+role_storage_state=""
+case "$QA_ROLE" in
+  admin|landlord|tenant)
+    role_storage_key="QA_$(printf "%s" "$QA_ROLE" | tr '[:lower:]' '[:upper:]')_STORAGE_STATE"
+    role_storage_state="${!role_storage_key:-}"
+    ;;
+esac
+fallback_storage_state="${QA_STORAGE_STATE:-}"
+
+auth_mode="unauthenticated"
+auth_source=""
+auth_storage_state=""
+if [ -n "$role_storage_state" ]; then
+  auth_mode="authenticated"
+  auth_source="$role_storage_key"
+  auth_storage_state="$role_storage_state"
+elif [ -n "$fallback_storage_state" ]; then
+  auth_mode="authenticated"
+  auth_source="QA_STORAGE_STATE"
+  auth_storage_state="$fallback_storage_state"
+fi
+
 if [ ! -d "$FRONTEND_DIR" ]; then
   echo "Missing rentchain-frontend directory." >&2
   exit 1
@@ -26,6 +49,12 @@ fi
 
 if [ ! -x "$FRONTEND_DIR/node_modules/.bin/playwright" ]; then
   echo "Playwright is unavailable. Run npm ci in rentchain-frontend first." >&2
+  exit 1
+fi
+
+if [ -n "$auth_storage_state" ] && [ ! -f "$auth_storage_state" ]; then
+  echo "Storage-state file from $auth_source was not found." >&2
+  echo "Keep storage-state JSON outside the repo or under ignored test-results paths." >&2
   exit 1
 fi
 
@@ -42,6 +71,11 @@ echo "Running RentChain Playwright smoke."
 echo "Role: $QA_ROLE"
 echo "Target: $PREVIEW_URL"
 echo "Spec filter: $QA_SPEC"
+if [ "$auth_mode" = "authenticated" ]; then
+  echo "Auth mode: authenticated storage state provided via $auth_source"
+else
+  echo "Auth mode: unauthenticated smoke; protected routes may be auth-gated"
+fi
 echo "Artifacts: $FRONTEND_DIR/$QA_ARTIFACT_DIR"
 echo "HTML report: $FRONTEND_DIR/$QA_HTML_REPORT_DIR"
 echo "JSON report: $FRONTEND_DIR/$QA_JSON_REPORT_FILE"


### PR DESCRIPTION
## Summary
- add smoke wrapper logging for authenticated versus unauthenticated QA mode
- fail fast when a provided storage-state env var points to a missing file
- document safe manual storage-state handling, precedence, ignored local paths, and no-credential rules

## Validation
- bash -n tools/qa/*.sh
- cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:e2e -- --list
- QA_TENANT_STORAGE_STATE=/tmp/rentchain-missing-storage-state.json PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
  - expected fail-fast result for missing local storage-state file
- PREVIEW_URL=https://rentchain-m8pw2yci8-rent-chain.vercel.app QA_GREP="tenant workspace" tools/qa/run-tenant-smoke.sh
  - 2 passed with unauthenticated mode logged
- git diff --check
- git diff --cached --check

## Notes
- Existing role smoke specs already consume QA_ADMIN_STORAGE_STATE, QA_LANDLORD_STORAGE_STATE, QA_TENANT_STORAGE_STATE, and QA_STORAGE_STATE.
- No credentials, cookies, tokens, storage-state JSON, runtime behavior, auth architecture, package, CI, or deployment changes are included.