### PR TITLE
Add authenticated admin Playwright smoke

### DIFF
--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -209,6 +209,10 @@ Precedence:
 
 The wrapper scripts print the active auth mode. When a storage-state variable is set, the referenced file must exist before Playwright starts; missing files fail fast with a clear message.
 
+Authenticated admin smoke is stricter than unauthenticated reachability smoke. When `QA_ADMIN_STORAGE_STATE` or `QA_STORAGE_STATE` is provided to `tools/qa/run-admin-smoke.sh`, the admin smoke suite applies the storage state and requires role-appropriate admin shell text on each checked route. If that shell text is missing, treat the result as an expired or wrong-role storage-state candidate unless screenshots/traces show a real admin route regression.
+
+The authenticated admin suite remains read-only. It checks admin dashboard, properties, tenants, leases, governed review workspaces, support escalations, security incidents, and support-operations continuity without approving, resolving, deleting, dismissing, or mutating records.
+
 Safe local locations:
 
 - outside the repository, such as `/tmp/rentchain-playwright/tenant.json`
@@ -230,6 +234,13 @@ PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
 4. Delete or rotate storage-state files after QA if the session should not persist.
 
 Codex should not request, generate, store, or commit credentials. If authenticated state is unavailable, run unauthenticated smoke and report auth-gated findings honestly.
+
+Admin example:
+
+```bash
+export QA_ADMIN_STORAGE_STATE=rentchain-frontend/test-results/storage-state/admin.json
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-admin-smoke.sh
+```
 
 ## Evidence Handling
 

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -516,7 +516,7 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText("Outstanding").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Underpaid").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
-    expect(screen.getByText("$4,250.00")).toBeInTheDocument();
+    expect(await screen.findByText("$4,250.00")).toBeInTheDocument();
     expect(screen.queryByText("425000")).not.toBeInTheDocument();
 
     expect(screen.getByText("Overdue — Rent past due date (obligation missing after due date)")).toBeInTheDocument();

--- a/rentchain-frontend/tests/playwright/admin-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/admin-smoke.spec.ts
@@ -2,22 +2,25 @@ import { test } from "@playwright/test";
 import {
   roleSmokeViewports,
   runRoleRouteSmoke,
-  storageStateForRole,
+  storageStateDetailsForRole,
   type RoleSmokeRoute,
 } from "./role-smoke-helpers";
 
 const adminRoutes: RoleSmokeRoute[] = [
   { label: "admin dashboard", path: "/admin", shellText: [/admin/i, /workspace/i] },
   { label: "admin properties", path: "/admin/properties", shellText: [/properties/i, /workspace/i] },
+  { label: "admin tenants", path: "/admin/tenants", shellText: [/tenants/i, /workspace/i] },
+  { label: "admin leases", path: "/admin/leases", shellText: [/leases/i, /workspace/i] },
   { label: "admin review workspaces", path: "/admin/review-workspaces", shellText: [/review workspaces/i, /workspace/i] },
   { label: "admin support escalations", path: "/admin/support/escalations", shellText: [/support/i, /escalation/i] },
   { label: "admin security incidents", path: "/admin/security/incidents", shellText: [/security/i, /incident/i] },
+  { label: "support operations", path: "/support-operations", shellText: [/support/i, /operations/i] },
 ];
 
 test.describe("admin role smoke", () => {
-  const storageState = storageStateForRole("admin");
-  if (storageState) {
-    test.use({ storageState });
+  const authDetails = storageStateDetailsForRole("admin");
+  if (authDetails.storageState) {
+    test.use({ storageState: authDetails.storageState });
   }
 
   for (const viewport of roleSmokeViewports) {
@@ -26,7 +29,10 @@ test.describe("admin role smoke", () => {
 
       for (const route of adminRoutes) {
         test(`${route.label} renders safely`, async ({ page }, testInfo) => {
-          await runRoleRouteSmoke(page, testInfo, route, viewport.name);
+          await runRoleRouteSmoke(page, testInfo, route, viewport.name, {
+            authDetails,
+            requireShellText: authDetails.mode === "authenticated",
+          });
         });
       }
     });

--- a/rentchain-frontend/tests/playwright/role-smoke-helpers.ts
+++ b/rentchain-frontend/tests/playwright/role-smoke-helpers.ts
@@ -9,14 +9,46 @@ export type RoleSmokeRoute = {
   shellText?: RegExp[];
 };
 
+export type RoleSmokeAuthDetails = {
+  mode: "authenticated" | "unauthenticated";
+  source?: string;
+  storageState?: string;
+};
+
+export type RoleRouteSmokeOptions = {
+  authDetails?: RoleSmokeAuthDetails;
+  requireShellText?: boolean;
+};
+
 export const roleSmokeViewports = [
   { name: "desktop", size: { width: 1280, height: 800 } },
   { name: "mobile", size: { width: 390, height: 844 } },
 ];
 
-export function storageStateForRole(role: RoleSmokeRole) {
+export function storageStateDetailsForRole(role: RoleSmokeRole): RoleSmokeAuthDetails {
   const roleKey = `QA_${role.toUpperCase()}_STORAGE_STATE`;
-  return process.env[roleKey] || process.env.QA_STORAGE_STATE || undefined;
+  const roleStorageState = process.env[roleKey];
+  if (roleStorageState) {
+    return {
+      mode: "authenticated",
+      source: roleKey,
+      storageState: roleStorageState,
+    };
+  }
+
+  if (process.env.QA_STORAGE_STATE) {
+    return {
+      mode: "authenticated",
+      source: "QA_STORAGE_STATE",
+      storageState: process.env.QA_STORAGE_STATE,
+    };
+  }
+
+  return { mode: "unauthenticated" };
+}
+
+export function storageStateForRole(role: RoleSmokeRole) {
+  return storageStateDetailsForRole(role).storageState;
 }
 
 export async function runRoleRouteSmoke(
@@ -24,9 +56,19 @@ export async function runRoleRouteSmoke(
   testInfo: TestInfo,
   route: RoleSmokeRoute,
   viewportName: string,
+  options: RoleRouteSmokeOptions = {},
 ) {
   const consoleErrors: string[] = [];
   const pageErrors: string[] = [];
+  const authMode = options.authDetails?.mode || "unauthenticated";
+
+  testInfo.annotations.push({
+    type: "auth-mode",
+    description:
+      authMode === "authenticated"
+        ? `authenticated via ${options.authDetails?.source || "storage state"}`
+        : "unauthenticated smoke",
+  });
 
   page.on("console", (message) => {
     if (message.type() === "error") {
@@ -68,6 +110,13 @@ export async function runRoleRouteSmoke(
         ? "matched role-appropriate shell text"
         : "role shell text not visible; route may be unauthenticated or access-gated",
     });
+
+    if (options.requireShellText) {
+      expect(
+        foundShellText.some(Boolean),
+        `${route.label} authenticated shell text; storage state may be expired, wrong role, or route regressed`,
+      ).toBe(true);
+    }
   }
 
   await page.screenshot({


### PR DESCRIPTION
## Summary
- add authenticated admin smoke mode that requires admin shell continuity when QA_ADMIN_STORAGE_STATE or QA_STORAGE_STATE is supplied
- expand read-only admin smoke coverage to tenants, leases, review workspaces, security incidents, support escalations, and support operations
- document safe authenticated admin storage-state workflow and non-mutating boundaries

## Validation
- bash -n tools/qa/*.sh
- cd rentchain-frontend && npm run test:e2e -- --list
- QA_ADMIN_STORAGE_STATE=/tmp/rentchain-missing-admin-storage.json PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-admin-smoke.sh (expected fail-fast for missing local storage state)
- PREVIEW_URL=https://rentchain-k9z8wj74v-rent-chain.vercel.app QA_GREP="admin dashboard" tools/qa/run-admin-smoke.sh
- git diff --check