### PR TITLE
Add authenticated landlord Playwright smoke

### DIFF
--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -213,6 +213,10 @@ Authenticated admin smoke is stricter than unauthenticated reachability smoke. W
 
 The authenticated admin suite remains read-only. It checks admin dashboard, properties, tenants, leases, governed review workspaces, support escalations, security incidents, and support-operations continuity without approving, resolving, deleting, dismissing, or mutating records.
 
+Authenticated landlord smoke follows the same storage-state safety model. When `QA_LANDLORD_STORAGE_STATE` or `QA_STORAGE_STATE` is provided to `tools/qa/run-landlord-smoke.sh`, the landlord suite applies the storage state and requires role-appropriate landlord shell text on each checked route. If that shell text is missing, treat the result as an expired or wrong-role storage-state candidate unless screenshots/traces show a real landlord route regression.
+
+The authenticated landlord suite remains read-only. It checks dashboard, properties, applications, decision inbox, operations, leases, payments, work orders, and messages continuity without approving applications, sending notices, recording payments, assigning work orders, or mutating records.
+
 Safe local locations:
 
 - outside the repository, such as `/tmp/rentchain-playwright/tenant.json`
@@ -240,6 +244,13 @@ Admin example:
 ```bash
 export QA_ADMIN_STORAGE_STATE=rentchain-frontend/test-results/storage-state/admin.json
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-admin-smoke.sh
+```
+
+Landlord example:
+
+```bash
+export QA_LANDLORD_STORAGE_STATE=rentchain-frontend/test-results/storage-state/landlord.json
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-landlord-smoke.sh
 ```
 
 ## Evidence Handling

--- a/rentchain-frontend/tests/playwright/landlord-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/landlord-smoke.spec.ts
@@ -2,22 +2,26 @@ import { test } from "@playwright/test";
 import {
   roleSmokeViewports,
   runRoleRouteSmoke,
-  storageStateForRole,
+  storageStateDetailsForRole,
   type RoleSmokeRoute,
 } from "./role-smoke-helpers";
 
 const landlordRoutes: RoleSmokeRoute[] = [
   { label: "landlord dashboard", path: "/dashboard", shellText: [/dashboard/i, /portfolio/i] },
+  { label: "landlord properties", path: "/properties", shellText: [/properties/i, /portfolio/i] },
+  { label: "landlord applications", path: "/applications", shellText: [/applications/i, /screening/i] },
   { label: "landlord decision inbox", path: "/decision-inbox", shellText: [/decision/i, /inbox/i] },
   { label: "landlord operations", path: "/operations", shellText: [/operations/i, /command/i] },
   { label: "landlord leases", path: "/leases", shellText: [/leases/i, /active/i] },
+  { label: "landlord payments", path: "/payments", shellText: [/payments/i, /rent/i] },
+  { label: "landlord work orders", path: "/work-orders", shellText: [/work orders/i, /maintenance/i] },
   { label: "landlord messages", path: "/messages", shellText: [/messages/i, /inbox/i] },
 ];
 
 test.describe("landlord role smoke", () => {
-  const storageState = storageStateForRole("landlord");
-  if (storageState) {
-    test.use({ storageState });
+  const authDetails = storageStateDetailsForRole("landlord");
+  if (authDetails.storageState) {
+    test.use({ storageState: authDetails.storageState });
   }
 
   for (const viewport of roleSmokeViewports) {
@@ -26,7 +30,10 @@ test.describe("landlord role smoke", () => {
 
       for (const route of landlordRoutes) {
         test(`${route.label} renders safely`, async ({ page }, testInfo) => {
-          await runRoleRouteSmoke(page, testInfo, route, viewport.name);
+          await runRoleRouteSmoke(page, testInfo, route, viewport.name, {
+            authDetails,
+            requireShellText: authDetails.mode === "authenticated",
+          });
         });
       }
     });


### PR DESCRIPTION
## Summary
- add authenticated landlord smoke mode that requires landlord shell continuity when QA_LANDLORD_STORAGE_STATE or QA_STORAGE_STATE is supplied
- expand read-only landlord smoke coverage to properties, applications, payments, and work orders alongside existing dashboard, decision inbox, operations, leases, and messages checks
- document safe authenticated landlord storage-state workflow and non-mutating boundaries

## Validation
- bash -n tools/qa/*.sh
- cd rentchain-frontend && npm run test:e2e -- --list
- QA_LANDLORD_STORAGE_STATE=/tmp/rentchain-missing-landlord-storage.json PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-landlord-smoke.sh (expected fail-fast for missing local storage state)
- PREVIEW_URL=https://rentchain-k9z8wj74v-rent-chain.vercel.app QA_GREP="landlord dashboard" tools/qa/run-landlord-smoke.sh
- git diff --check

## Notes
- Authenticated landlord smoke was not run because no operator-provided landlord storage-state file was available locally.
- Generated test-results and playwright-report artifacts are ignored and not committed.