### PR TITLE
Add authenticated tenant Playwright smoke

### DIFF
--- a/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
+++ b/docs/ai/claude-context/CURRENT_ACTIVE_MISSIONS.md
@@ -67,6 +67,12 @@ Purpose: make Codex, Claude, Playwright, GitHub, Vercel, and Cloud Run collabora
 - `feat/playwright-admin-tenant-landlord-smoke-suite-v1` — add small role-aware smoke coverage for admin, tenant, and landlord surfaces.
 - `fix/cloud-run-preview-revision-verification-script-v1` — add safe helper script for Cloud Run revision/image/traffic verification.
 - `feat/qa-report-artifact-generation-v1` — generate safe QA summaries without committing secrets, screenshots with sensitive data, or raw payloads.
+- `feat/playwright-authenticated-storage-state-foundations-v1` — completed optional local storage-state support without committing cookies, tokens, or credentials.
+- `feat/qa-report-artifact-claude-review-pack-v1` — completed Claude-ready QA review pack generation.
+- `feat/playwright-authenticated-admin-smoke-v1` — completed authenticated admin smoke coverage with read-only operational checks.
+- `feat/playwright-authenticated-landlord-smoke-v1` — completed authenticated landlord smoke coverage with read-only operational checks.
+- `feat/playwright-authenticated-tenant-smoke-v1` — current authenticated tenant smoke coverage with read-only tenant portal checks.
+- `feat/playwright-storage-state-capture-workflow-v1` — future operator-supervised storage-state capture workflow. Expected commands: `npm run qa:capture-tenant-state`, `npm run qa:capture-landlord-state`, and `npm run qa:capture-admin-state`. The operator signs in manually, Playwright saves local state under `~/rentchain-auth/`, and no credentials or auth JSON are committed or uploaded.
 
 ### Phase 2 — Tenant & Operational Continuity Foundations
 

--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -224,9 +224,22 @@ The authenticated tenant suite remains read-only. It checks tenant workspace, le
 Safe local locations:
 
 - outside the repository, such as `/tmp/rentchain-playwright/tenant.json`
+- recommended local auth-state folder: `~/rentchain-auth`
 - ignored artifact paths, such as `rentchain-frontend/test-results/storage-state/tenant.json`
 
-Storage-state files can contain cookies, local storage, Firebase session material, and other secrets. Do not commit them, paste them into PRs, attach them to public issues, or include them in Claude uploads. `test-results/` and `playwright-report/` are ignored local artifact paths.
+Create the recommended local folder before using storage-state paths:
+
+```bash
+mkdir -p ~/rentchain-auth
+```
+
+Expected local filenames:
+
+- `~/rentchain-auth/tenant-storage-state.json`
+- `~/rentchain-auth/landlord-storage-state.json`
+- `~/rentchain-auth/admin-storage-state.json`
+
+Storage-state files can contain cookies, local storage, Firebase session material, and other secrets. They must remain local only. Do not commit them, paste them into PRs, attach them to public issues, include them in Claude/ChatGPT/Codex uploads, or upload them as QA artifacts. `test-results/` and `playwright-report/` are ignored local artifact paths.
 
 Manual operator workflow:
 
@@ -235,7 +248,7 @@ Manual operator workflow:
 3. Export only the local path, not credentials:
 
 ```bash
-export QA_TENANT_STORAGE_STATE=rentchain-frontend/test-results/storage-state/tenant.json
+export QA_TENANT_STORAGE_STATE=~/rentchain-auth/tenant-storage-state.json
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
 ```
 
@@ -246,23 +259,35 @@ Codex should not request, generate, store, or commit credentials. If authenticat
 Admin example:
 
 ```bash
-export QA_ADMIN_STORAGE_STATE=rentchain-frontend/test-results/storage-state/admin.json
+export QA_ADMIN_STORAGE_STATE=~/rentchain-auth/admin-storage-state.json
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-admin-smoke.sh
 ```
 
 Landlord example:
 
 ```bash
-export QA_LANDLORD_STORAGE_STATE=rentchain-frontend/test-results/storage-state/landlord.json
+export QA_LANDLORD_STORAGE_STATE=~/rentchain-auth/landlord-storage-state.json
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-landlord-smoke.sh
 ```
 
 Tenant example:
 
 ```bash
-export QA_TENANT_STORAGE_STATE=rentchain-frontend/test-results/storage-state/tenant.json
+export QA_TENANT_STORAGE_STATE=~/rentchain-auth/tenant-storage-state.json
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
 ```
+
+Planned capture workflow:
+
+- Future mission: `feat/playwright-storage-state-capture-workflow-v1`
+- Purpose: safely support operator-supervised storage-state capture commands:
+  - `npm run qa:capture-tenant-state`
+  - `npm run qa:capture-landlord-state`
+  - `npm run qa:capture-admin-state`
+- Expected flow: the operator runs a capture command, Playwright opens the preview login, the operator signs in manually, Playwright saves storage state under `~/rentchain-auth/`, and future authenticated smoke reuses the local file.
+- Guardrail: no credentials, cookies, tokens, or storage-state JSON are committed, pasted into AI tools, or uploaded as artifacts.
+
+Until that capture workflow exists, preserve current fail-closed behavior: when a `QA_*_STORAGE_STATE` path is provided but the file does not exist, smoke must fail clearly before Playwright starts.
 
 ## Evidence Handling
 

--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -217,6 +217,10 @@ Authenticated landlord smoke follows the same storage-state safety model. When `
 
 The authenticated landlord suite remains read-only. It checks dashboard, properties, applications, decision inbox, operations, leases, payments, work orders, and messages continuity without approving applications, sending notices, recording payments, assigning work orders, or mutating records.
 
+Authenticated tenant smoke follows the same storage-state safety model. When `QA_TENANT_STORAGE_STATE` or `QA_STORAGE_STATE` is provided to `tools/qa/run-tenant-smoke.sh`, the tenant suite applies the storage state and requires role-appropriate tenant shell text on each checked route. If that shell text is missing, treat the result as an expired or wrong-role storage-state candidate unless screenshots/traces show a real tenant portal regression.
+
+The authenticated tenant suite remains read-only. It checks tenant workspace, lease, ledger, documents, messages, profile, and maintenance continuity without sending messages, signing documents, initiating payments, editing profile data, submitting applications, or creating maintenance requests.
+
 Safe local locations:
 
 - outside the repository, such as `/tmp/rentchain-playwright/tenant.json`
@@ -251,6 +255,13 @@ Landlord example:
 ```bash
 export QA_LANDLORD_STORAGE_STATE=rentchain-frontend/test-results/storage-state/landlord.json
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-landlord-smoke.sh
+```
+
+Tenant example:
+
+```bash
+export QA_TENANT_STORAGE_STATE=rentchain-frontend/test-results/storage-state/tenant.json
+PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
 ```
 
 ## Evidence Handling

--- a/rentchain-frontend/tests/playwright/tenant-smoke.spec.ts
+++ b/rentchain-frontend/tests/playwright/tenant-smoke.spec.ts
@@ -2,22 +2,24 @@ import { test } from "@playwright/test";
 import {
   roleSmokeViewports,
   runRoleRouteSmoke,
-  storageStateForRole,
+  storageStateDetailsForRole,
   type RoleSmokeRoute,
 } from "./role-smoke-helpers";
 
 const tenantRoutes: RoleSmokeRoute[] = [
   { label: "tenant workspace", path: "/tenant", shellText: [/tenant/i, /rentchain tenant/i] },
   { label: "tenant lease", path: "/tenant/lease", shellText: [/lease/i, /tenant/i] },
+  { label: "tenant ledger", path: "/tenant/ledger", shellText: [/ledger/i, /tenant/i] },
   { label: "tenant documents", path: "/tenant/documents", shellText: [/documents/i, /schedule/i] },
   { label: "tenant messages", path: "/tenant/messages", shellText: [/messages/i, /tenant/i] },
   { label: "tenant profile", path: "/tenant/profile", shellText: [/profile/i, /tenant/i] },
+  { label: "tenant maintenance", path: "/tenant/maintenance", shellText: [/maintenance/i, /tenant/i] },
 ];
 
 test.describe("tenant role smoke", () => {
-  const storageState = storageStateForRole("tenant");
-  if (storageState) {
-    test.use({ storageState });
+  const authDetails = storageStateDetailsForRole("tenant");
+  if (authDetails.storageState) {
+    test.use({ storageState: authDetails.storageState });
   }
 
   for (const viewport of roleSmokeViewports) {
@@ -26,7 +28,10 @@ test.describe("tenant role smoke", () => {
 
       for (const route of tenantRoutes) {
         test(`${route.label} renders safely`, async ({ page }, testInfo) => {
-          await runRoleRouteSmoke(page, testInfo, route, viewport.name);
+          await runRoleRouteSmoke(page, testInfo, route, viewport.name, {
+            authDetails,
+            requireShellText: authDetails.mode === "authenticated",
+          });
         });
       }
     });


### PR DESCRIPTION
## Summary
- add authenticated tenant smoke mode that requires tenant shell continuity when QA_TENANT_STORAGE_STATE or QA_STORAGE_STATE is supplied
- expand read-only tenant smoke coverage to ledger and maintenance alongside workspace, lease, documents, messages, and profile
- document safe authenticated tenant storage-state workflow and non-mutating boundaries

## Validation
- bash -n tools/qa/*.sh
- cd rentchain-frontend && npm run test:e2e -- --list
- QA_TENANT_STORAGE_STATE=/tmp/rentchain-missing-tenant-storage.json PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh (expected fail-fast for missing local storage state)
- PREVIEW_URL=https://rentchain-k9z8wj74v-rent-chain.vercel.app QA_GREP="tenant workspace" tools/qa/run-tenant-smoke.sh
- git diff --check

## Notes
- Authenticated tenant smoke was not run because no operator-provided tenant storage-state file was available locally.
- Generated test-results and playwright-report artifacts are ignored and not committed.