### PR TITLE
Add Playwright mobile layout regression matrix

### DIFF
--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -77,6 +77,8 @@ The role-specific scripts default to their matching Playwright spec:
 
 `run-mobile-smoke.sh` still defaults to `mobile-preview-smoke` unless `QA_SPEC` is overridden. The harness is non-mutating: protected routes may render login/access-denied states when authenticated storage state is not supplied, but the run still verifies preview reachability, desktop/mobile viewport containment, console/page-error behavior, and artifact capture.
 
+Use `QA_SPEC=mobile-layout-matrix` when the goal is responsive layout regression coverage across the tenant, landlord, and admin route matrix. The matrix runs iPhone, Android, and narrow mobile viewports and checks horizontal overflow, oversized panels/cards, fixed navigation overflow, clipped interactive controls, and role shell visibility. It remains non-mutating and uses the same artifact, finding classification, storage-state, QA summary, and Claude review-pack outputs as the other smoke suites.
+
 Role-specific wrapper scripts write to role-scoped artifact folders by default, such as `test-results/admin-smoke`, `test-results/tenant-smoke`, and `test-results/landlord-smoke`.
 
 Examples:
@@ -86,6 +88,7 @@ PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-mobile-smoke.sh
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-tenant-smoke.sh
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-admin-smoke.sh
 PREVIEW_URL=https://example-preview.vercel.app tools/qa/run-landlord-smoke.sh
+PREVIEW_URL=https://example-preview.vercel.app QA_SPEC=mobile-layout-matrix tools/qa/run-mobile-smoke.sh
 ```
 
 Optional inputs:

--- a/rentchain-frontend/tests/playwright/mobile-layout-matrix.spec.ts
+++ b/rentchain-frontend/tests/playwright/mobile-layout-matrix.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+import { reportSmokeFindings } from "./smoke-findings";
+import { storageStateDetailsForRole, type RoleSmokeRole } from "./role-smoke-helpers";
+
+type MatrixRole = RoleSmokeRole;
+
+type MatrixRoute = {
+  label: string;
+  path: string;
+  role: MatrixRole;
+  shellText?: RegExp[];
+};
+
+const matrixViewports = [
+  { name: "iphone", size: { width: 390, height: 844 } },
+  { name: "android", size: { width: 412, height: 915 } },
+  { name: "narrow", size: { width: 360, height: 780 } },
+];
+
+const matrixRoutes: MatrixRoute[] = [
+  { role: "tenant", label: "tenant workspace", path: "/tenant", shellText: [/tenant/i, /rentchain tenant/i] },
+  { role: "tenant", label: "tenant lease", path: "/tenant/lease", shellText: [/lease/i, /tenant/i] },
+  { role: "tenant", label: "tenant ledger", path: "/tenant/ledger", shellText: [/ledger/i, /tenant/i] },
+  { role: "tenant", label: "tenant documents", path: "/tenant/documents", shellText: [/documents/i, /schedule/i] },
+  { role: "tenant", label: "tenant messages", path: "/tenant/messages", shellText: [/messages/i, /tenant/i] },
+  { role: "tenant", label: "tenant profile", path: "/tenant/profile", shellText: [/profile/i, /tenant/i] },
+  { role: "tenant", label: "tenant maintenance", path: "/tenant/maintenance", shellText: [/maintenance/i, /tenant/i] },
+
+  { role: "landlord", label: "landlord dashboard", path: "/dashboard", shellText: [/dashboard/i, /portfolio/i] },
+  { role: "landlord", label: "landlord properties", path: "/properties", shellText: [/properties/i, /portfolio/i] },
+  { role: "landlord", label: "landlord applications", path: "/applications", shellText: [/applications/i, /screening/i] },
+  { role: "landlord", label: "landlord decision inbox", path: "/decision-inbox", shellText: [/decision/i, /inbox/i] },
+  { role: "landlord", label: "landlord operations", path: "/operations", shellText: [/operations/i, /command/i] },
+  { role: "landlord", label: "landlord leases", path: "/leases", shellText: [/leases/i, /active/i] },
+  { role: "landlord", label: "landlord payments", path: "/payments", shellText: [/payments/i, /rent/i] },
+  { role: "landlord", label: "landlord work orders", path: "/work-orders", shellText: [/work orders/i, /maintenance/i] },
+  { role: "landlord", label: "landlord messages", path: "/messages", shellText: [/messages/i, /inbox/i] },
+
+  { role: "admin", label: "admin dashboard", path: "/admin", shellText: [/admin/i, /workspace/i] },
+  { role: "admin", label: "admin properties", path: "/admin/properties", shellText: [/properties/i, /workspace/i] },
+  { role: "admin", label: "admin tenants", path: "/admin/tenants", shellText: [/tenants/i, /workspace/i] },
+  { role: "admin", label: "admin leases", path: "/admin/leases", shellText: [/leases/i, /workspace/i] },
+  { role: "admin", label: "admin review workspaces", path: "/admin/review-workspaces", shellText: [/review workspaces/i, /workspace/i] },
+  { role: "admin", label: "admin support escalations", path: "/admin/support/escalations", shellText: [/support/i, /escalation/i] },
+  { role: "admin", label: "admin security incidents", path: "/admin/security/incidents", shellText: [/security/i, /incident/i] },
+  { role: "admin", label: "support operations", path: "/support-operations", shellText: [/support/i, /operations/i] },
+];
+
+function selectedRole() {
+  const role = String(process.env.QA_ROLE || "mobile").trim().toLowerCase();
+  if (role === "landlord" || role === "tenant" || role === "admin") return role;
+  return "mobile";
+}
+
+function routeSlug(route: MatrixRoute) {
+  return `${route.role}-${route.label}`.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+}
+
+async function visibleShellText(page: Page, route: MatrixRoute) {
+  if (!route.shellText?.length) return false;
+  const matches = await Promise.all(
+    route.shellText.map(async (pattern) => {
+      try {
+        await expect(page.getByText(pattern).first()).toBeVisible({ timeout: 1_500 });
+        return true;
+      } catch {
+        return false;
+      }
+    }),
+  );
+  return matches.some(Boolean);
+}
+
+async function collectMobileLayoutMetrics(page: Page) {
+  return page.evaluate(() => {
+    const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const horizontalOverflow = Math.max(0, document.documentElement.scrollWidth - viewportWidth);
+    const visibleElements = Array.from(document.body.querySelectorAll<HTMLElement>("*")).filter((element) => {
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.display !== "none" &&
+        style.visibility !== "hidden" &&
+        rect.width > 0 &&
+        rect.height > 0 &&
+        element.getAttribute("aria-hidden") !== "true"
+      );
+    });
+
+    const describe = (element: HTMLElement) => {
+      const rect = element.getBoundingClientRect();
+      const label =
+        element.getAttribute("aria-label") ||
+        element.getAttribute("title") ||
+        element.textContent?.replace(/\s+/g, " ").trim().slice(0, 60) ||
+        element.tagName.toLowerCase();
+      return {
+        tag: element.tagName.toLowerCase(),
+        label,
+        width: Math.round(rect.width),
+        left: Math.round(rect.left),
+        right: Math.round(rect.right),
+      };
+    };
+
+    const oversizedElements = visibleElements
+      .filter((element) => {
+        const rect = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        return (
+          rect.width > viewportWidth + 2 &&
+          style.position !== "fixed" &&
+          !["HTML", "BODY", "SVG", "CANVAS"].includes(element.tagName)
+        );
+      })
+      .slice(0, 8)
+      .map(describe);
+
+    const fixedOverflowElements = visibleElements
+      .filter((element) => {
+        const rect = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        return style.position === "fixed" && (rect.left < -2 || rect.right > viewportWidth + 2 || rect.bottom > viewportHeight + 2);
+      })
+      .slice(0, 8)
+      .map(describe);
+
+    const clippedInteractiveElements = visibleElements
+      .filter((element) => element.matches("button, a, input, select, textarea, [role='button'], [tabindex]:not([tabindex='-1'])"))
+      .filter((element) => {
+        const rect = element.getBoundingClientRect();
+        return rect.left < -2 || rect.right > viewportWidth + 2;
+      })
+      .slice(0, 8)
+      .map(describe);
+
+    return {
+      viewportWidth,
+      viewportHeight,
+      horizontalOverflow,
+      oversizedElements,
+      fixedOverflowElements,
+      clippedInteractiveElements,
+    };
+  });
+}
+
+async function runMobileLayoutMatrix(page: Page, testInfo: TestInfo, route: MatrixRoute, viewportName: string) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  const activeRole = selectedRole();
+  const authDetails = activeRole === route.role ? storageStateDetailsForRole(route.role) : { mode: "unauthenticated" as const };
+
+  testInfo.annotations.push({
+    type: "matrix-role",
+    description: route.role,
+  });
+  testInfo.annotations.push({
+    type: "auth-mode",
+    description:
+      authDetails.mode === "authenticated"
+        ? `authenticated via ${authDetails.source || "storage state"}`
+        : "unauthenticated smoke",
+  });
+
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  const response = await page.goto(route.path, { waitUntil: "domcontentloaded" });
+  if (response) {
+    expect(response.status(), `${route.label} response status`).toBeLessThan(500);
+  }
+
+  await expect(page.locator("body"), `${route.label} body`).toBeVisible();
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
+
+  const shellVisible = await visibleShellText(page, route);
+  testInfo.annotations.push({
+    type: "matrix-shell",
+    description: shellVisible ? "matched role-appropriate shell text" : "shell text not visible; route may be unauthenticated or access-gated",
+  });
+  if (authDetails.mode === "authenticated") {
+    expect(shellVisible, `${route.label} authenticated shell text; storage state may be expired, wrong role, or route regressed`).toBe(true);
+  }
+
+  const metrics = await collectMobileLayoutMetrics(page);
+  await testInfo.attach("mobile-layout-metrics", {
+    contentType: "application/json",
+    body: Buffer.from(JSON.stringify({ route: route.label, viewport: viewportName, ...metrics }, null, 2)),
+  });
+
+  expect(metrics.horizontalOverflow, `${route.label} horizontal overflow`).toBeLessThanOrEqual(2);
+  expect(metrics.oversizedElements, `${route.label} elements exceeding viewport width`).toEqual([]);
+  expect(metrics.fixedOverflowElements, `${route.label} fixed/sticky navigation overflow`).toEqual([]);
+  expect(metrics.clippedInteractiveElements, `${route.label} clipped interactive controls`).toEqual([]);
+
+  await page.screenshot({
+    path: testInfo.outputPath(`${viewportName}-${routeSlug(route)}.png`),
+    fullPage: true,
+  });
+
+  await reportSmokeFindings(testInfo, route.label, consoleErrors, pageErrors);
+}
+
+const role = selectedRole();
+const routes = role === "mobile" ? matrixRoutes : matrixRoutes.filter((route) => route.role === role);
+const storageState = role === "mobile" ? undefined : storageStateDetailsForRole(role).storageState;
+if (storageState) {
+  test.use({ storageState });
+}
+
+for (const viewport of matrixViewports) {
+  test.describe(`mobile layout matrix: ${viewport.name}`, () => {
+    test.use({ viewport: viewport.size });
+
+    for (const route of routes) {
+      test(`${route.role}: ${route.label} has contained mobile layout`, async ({ page }, testInfo) => {
+        await runMobileLayoutMatrix(page, testInfo, route, viewport.name);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add a Playwright mobile layout regression matrix across tenant, landlord, and admin route surfaces.
- Cover iPhone, Android, and narrow mobile viewports.
- Assert horizontal containment, oversized element detection, fixed navigation overflow, clipped interactive controls, and authenticated shell visibility when role storage state is supplied.
- Document the QA_SPEC=mobile-layout-matrix workflow in the QA Playwright protocol.

## Changed files
- rentchain-frontend/tests/playwright/mobile-layout-matrix.spec.ts
- docs/execution/QA_PLAYWRIGHT_PROTOCOL.md

## Scope
QA infrastructure only. No production runtime, business logic, auth, pricing, entitlement, backend, deployment, package, or CI behavior changes.

## Validation
- bash -n tools/qa/*.sh: passed
- cd rentchain-frontend && npm run test:e2e -- --list: passed
- git diff --check: passed
- git diff --cached --check: passed
- Targeted preview sample: PREVIEW_URL=https://rentchain-k9z8wj74v-rent-chain.vercel.app QA_SPEC=mobile-layout-matrix QA_GREP="tenant workspace|landlord dashboard|admin dashboard" tools/qa/run-mobile-smoke.sh

Targeted preview sample result: 6 passed / 3 failed due existing Vercel preview auth/CORS noise from the preview gateway, not the new layout assertions. The matrix attached layout metrics and screenshots as expected.