### PR TITLE
Add governed review workspace route UI contracts

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -78,6 +78,18 @@ vi.mock("./pages/admin/AdminNotificationsPage", () => ({
   default: () => <h1>Admin Notifications</h1>,
 }));
 
+vi.mock("./pages/admin/AdminSecurityIncidentsPage", () => ({
+  default: () => <h1>Security incidents</h1>,
+}));
+
+vi.mock("./pages/admin/AdminSupportEscalationsPage", () => ({
+  default: () => <h1>Support escalations</h1>,
+}));
+
+vi.mock("./pages/admin/AdminReviewWorkspacesPage", () => ({
+  default: () => <h1>Governed review workspaces</h1>,
+}));
+
 vi.mock("./pages/ReleaseGovernancePage", () => ({
   default: () => <h1>Release Governance Page</h1>,
 }));
@@ -609,6 +621,44 @@ describe("Routes: /admin/lease-lifecycle-review", () => {
     );
 
     expect(await screen.findByText(/Lease Lifecycle Review/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: governed review workspace surfaces", () => {
+  it("keeps the security incident review surface available behind the admin shell", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/security/incidents"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Security incidents/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the support escalation review surface available behind the admin shell", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/support/escalations"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Support escalations/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the governed review workspace surface available behind the admin shell", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/review-workspaces"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Governed review workspaces/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx
@@ -69,6 +69,10 @@ describe("AdminReviewWorkspacesPage", () => {
     expect(JSON.stringify(document.body.textContent)).not.toContain("tenant-raw-id");
     expect(JSON.stringify(document.body.textContent)).not.toContain("gs://");
     expect(JSON.stringify(document.body.textContent)).not.toContain("secret-token");
+    expect(document.body.textContent).not.toContain("fixture_workspace_");
+    expect(document.body.textContent).not.toContain("_fixture_ref");
+    expect(document.body.textContent).not.toContain("_fixture_link");
+    expect(document.body.textContent).not.toContain("_fixture_append_event");
   });
 
   it("sends filters to the workspace API", async () => {


### PR DESCRIPTION
## Summary
- Add route availability contracts for governed review workspace admin/support surfaces:
  - /admin/security/incidents
  - /admin/support/escalations
  - /admin/review-workspaces
- Tighten governed review workspace UI projection assertions so fixture workspace IDs, evidence reference IDs, link IDs, and append event IDs are not rendered as user-facing text.

## Scope
Testing/QA only. No production runtime, auth, pricing, entitlement, backend, deployment, package, or CI behavior changes.

## Validation
- cd rentchain-frontend && npm run test -- src/App.routes.test.tsx src/pages/admin/AdminReviewWorkspacesPage.test.tsx src/pages/admin/AdminSecurityIncidentsPage.test.tsx src/pages/admin/AdminSupportEscalationsPage.test.tsx: passed, 54/54
- cd rentchain-frontend && npm run test: passed, 284 files / 1114 tests
- git diff --check: passed
- git diff --cached --check: passed

## Notes
No Playwright files changed, so npm run test:e2e -- --list was not required for this mission.