### PR TITLE
chore: update workflow rules

### DIFF
--- a/.claude/agents/mission-generator.md
+++ b/.claude/agents/mission-generator.md
@@ -88,6 +88,9 @@ BEFORE ANY COMMIT:
 - Strip all Co-Authored-By trailers
 - Confirm zero AI tool references in commit message, PR title, and PR description
 
+# Post-Implementation Requirement
+After completing all implementation tasks, Codex must write the full summary to .handoff/impl-summary.md before reporting completion.
+
 # Commit
 COMMIT: # Commit Hygiene
 BEFORE ANY COMMIT:

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ docs/reports/
 
 # AI handoff working files - never commit
 .handoff/
+
+# Mission documentation — local only
+docs/missions/


### PR DESCRIPTION
## Summary
Updates workflow configuration and gitignore rules.

## Changes
- .gitignore — adds docs/missions/ to prevent mission documentation from being committed
- workflow generator configuration — adds post-implementation requirement to write summary to .handoff/impl-summary.md automatically

## Scope
Workflow configuration only. No source code, routes, services, or tests changed.