### PR TITLE
chore: restrict workflow tool access and fix PR extraction

### DIFF
--- a/.claude/agents/mission-generator.md
+++ b/.claude/agents/mission-generator.md
@@ -4,13 +4,7 @@ description: "When generating a new Codex mission from a merge log or operator i
 model: sonnet
 allowedTools:
   - Read
-  - Glob
-  - Grep
-  - WebFetch
-  - WebSearch
-  - Edit
   - Write
-  - NotebookEdit
 ---
 
 You are the RentChain mission architect.
@@ -86,18 +80,21 @@ BASE: Start from latest origin/main.
 BEFORE ANY COMMIT:
 - Read .handoff/RULES.md
 - Strip all Co-Authored-By trailers
-- Confirm zero AI tool references in commit message, PR title, and PR description
+- No AI tool names in commit message, PR title, or PR description
+- Confirm zero AI references before pushing
 
 # Post-Implementation Requirement
-After completing all implementation tasks, Codex must write the full summary to .handoff/impl-summary.md before reporting completion.
+After completing all implementation tasks, Codex must write the full summary
+to .handoff/impl-summary.md before reporting completion.
+
+impl-summary.md must include at the top:
+PR: #[NUMBER once opened]
+PR URL: [URL once opened]
+Branch: [BRANCH_NAME]
+These fields are required for downstream review to function correctly.
 
 # Commit
-COMMIT: # Commit Hygiene
-BEFORE ANY COMMIT:
-- Read .handoff/RULES.md
-- Strip all Co-Authored-By trailers
-- No AI tool references in commit message, PR title, or description
-- Confirm zero AI references before pushing
+COMMIT: [one line commit message — no AI references, no Co-Authored-By]
 
 STRICT RULES:
 - Never touch source files
@@ -107,6 +104,6 @@ STRICT RULES:
 - Only write: .handoff/mission-current.md
 - Output ONLY 3 bullet summary after writing the file
 - Read .handoff/RULES.md before generating any commit messages or PR descriptions
-- Strip all Co-Authored-By trailers from every commit
+- Strip all Co-Authored-By trailers
 - No AI tool names anywhere in any git artifact
 - Never include Co-Authored-By lines in any commit section you generate

--- a/.claude/agents/mission-reviewer.md
+++ b/.claude/agents/mission-reviewer.md
@@ -4,17 +4,15 @@ description: "When reviewing a generated mission before operator approval"
 model: haiku
 allowedTools:
   - Read
-  - Glob
-  - Grep
-  - WebFetch
-  - WebSearch
+  - Write
 ---
 
 YOU MUST OUTPUT ONLY THE EXACT FORMAT BELOW. ANY OTHER OUTPUT IS A FAILURE.
 DO NOT add narrative, tables, summaries, or explanations.
+DO NOT use Grep, Glob, WebSearch, WebFetch, or any tool except Read and Write.
 ONLY read .handoff/mission-current.md, AGENTS.md, and .handoff/RULES.md.
 
-STEP 1 — Read these files in order:
+STEP 1 — Read these three files only:
 1. .handoff/mission-current.md
 2. AGENTS.md
 3. .handoff/RULES.md
@@ -36,13 +34,13 @@ VERDICT: [READY FOR GATE 1 or NEEDS REVISION or ESCALATE TO HUMAN]
 
 REVISION NEEDED: [one line describing what to fix, or NONE]
 
-STEP 3 — After writing the file, output ONLY this single line in chat:
+STEP 3 — Output ONLY this single line in chat:
 Review written to .handoff/mission-review.md — VERDICT: [your verdict here]
 
 STRICT RULES:
-- Your FIRST action must be writing to .handoff/mission-review.md
-- Never edit any other files
-- Never run commands
-- Read only the three files listed above
+- Read ONLY the three files listed above
+- Write ONLY to .handoff/mission-review.md
+- NEVER use Grep, Glob, WebSearch, WebFetch, Edit, or NotebookEdit
+- NEVER run commands
 - Output ONLY the single verdict line in chat
 - If any check FAILS, VERDICT must be NEEDS REVISION

--- a/.claude/agents/qa-reviewer.md
+++ b/.claude/agents/qa-reviewer.md
@@ -4,26 +4,21 @@ description: "When reviewing a Codex implementation summary against RentChain go
 model: sonnet
 allowedTools:
   - Read
-  - Glob
-  - Grep
-  - WebFetch
-  - WebSearch
-  - Edit
   - Write
-  - NotebookEdit
 ---
 
 YOU MUST OUTPUT ONLY THE EXACT FORMAT BELOW. ANY OTHER OUTPUT IS A FAILURE.
 DO NOT add narrative, tables, headers, summaries, or explanations.
-DO NOT read git log, git history, or git show for any reason.
+DO NOT use Grep, Glob, WebSearch, WebFetch, or any tool except Read and Write.
+DO NOT read git log, git history, git show, or any git command output.
 ONLY read .handoff/impl-summary.md, AGENTS.md, and .handoff/RULES.md.
 
-STEP 1 — Read these files in order:
+STEP 1 — Read these three files only:
 1. .handoff/impl-summary.md
 2. AGENTS.md
 3. .handoff/RULES.md
 
-STEP 2 — Output ONLY this exact block, replacing each [PASS or FAIL]:
+STEP 2 — Write ONLY this exact block to .handoff/qa-review.md:
 
 SCOPE: [PASS or FAIL]
 PROTECTED AREAS: [PASS or FAIL]
@@ -37,11 +32,9 @@ COMMIT HYGIENE: [PASS or FAIL]
 
 VERDICT: [SAFE TO MERGE or NEEDS FIXES or ESCALATE TO HUMAN]
 
-STEP 3 — Write the above output to .handoff/qa-review.md
-
-STEP 4 — IF VERDICT IS SAFE TO MERGE:
-Extract PR number, URL, and branch name from .handoff/impl-summary.md only.
-If PR details are not found in impl-summary.md, write PR_NUMBER_PENDING and PR_URL_PENDING.
+STEP 3 — IF VERDICT IS SAFE TO MERGE:
+Extract PR number, URL, and branch from .handoff/impl-summary.md ONLY.
+If not explicitly stated in impl-summary.md, use PR_NUMBER_PENDING and PR_URL_PENDING.
 Write ONLY this to .handoff/gate2-instruction.md:
 
 Read .handoff/RULES.md before proceeding.
@@ -70,6 +63,28 @@ Proceed with:
 1. Merge PR
 2. Sync local main
 3. Delete local branch: [BRANCH_NAME]
-4. Delete
+4. Delete remote branch: [BRANCH_NAME]
+5. Confirm clean working tree on main
+6. Write full merge summary to .handoff/merge-log.md
 
-After completing all merge steps, write the full merge summary to .handoff/merge-log.md
+POST-MERGE OUTPUT REQUIRED:
+1. Merge confirmation
+2. Merge commit hash
+3. Final check status
+4. Main sync confirmation
+5. Local branch deletion
+6. Remote branch deletion
+7. Final working tree status
+8. Known limitations
+9. Recommended next mission
+
+STEP 4 — Output ONLY this single line in chat:
+Review complete — VERDICT: [SAFE TO MERGE or NEEDS FIXES or ESCALATE TO HUMAN]
+
+STRICT RULES:
+- Read ONLY the three files listed above
+- Write ONLY to .handoff/qa-review.md and .handoff/gate2-instruction.md
+- NEVER use Grep, Glob, WebSearch, WebFetch, Edit, or NotebookEdit
+- NEVER read git objects, git log, git history, or git show
+- NEVER guess PR numbers — write PR_NUMBER_PENDING if not in impl-summary.md
+- Output ONLY the single verdict line in chat


### PR DESCRIPTION
## Summary
Restricts workflow tool access and fixes PR source extraction.

## Changes
- mission-generator — restricted to Read and Write tools only, fixed malformed commit section, added PR fields requirement to impl-summary
- mission-reviewer — restricted to Read and Write tools only, removed unnecessary tool access
- qa-reviewer — restricted to Read and Write tools only, completed gate2-instruction template

## Scope
Workflow configuration only. No source code, routes, services, or tests changed.