### PR TITLE
feat: Playwright authenticated storage state foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 .tmp/
 .temp/
 .cache/
+.smoke-storage-state/
 
 # Firebase / local emulation
 .firebase/

--- a/docs/development/SMOKE_TEST.md
+++ b/docs/development/SMOKE_TEST.md
@@ -1,0 +1,197 @@
+# Smoke Testing with Authenticated Storage State
+
+This document explains how to set up and run authenticated smoke tests using Playwright storage state fixtures.
+
+## Overview
+
+Smoke tests validate critical user workflows without deploying code to production. For authenticated smoke tests, we use **storage state presets** that simulate logged-in users with specific roles and permissions.
+
+The storage state system has three layers:
+1. **Fixtures** (backend): Define test data and user contexts
+2. **Presets** (backend): Generate Playwright storage state from fixtures
+3. **Export** (CLI): Serialize storage state to JSON files for tests to consume
+
+## Setup
+
+### Prerequisites
+
+- Node 20.11.1 (pinned)
+- Playwright 1.58.2+
+
+### Generate Storage State Files
+
+First, export the storage state presets to JSON files:
+
+```bash
+# From the project root
+cd rentchain-api
+npm run storage-state:export
+```
+
+This command:
+- Reads the fixture definitions from `tests/fixtures/admin-storage-state.ts`
+- Generates storage state for each role (admin, landlord, tenant)
+- Writes JSON files to `.smoke-storage-state/` by default
+- Outputs environment variable assignments
+
+### Configure Environment
+
+Source the exported environment variables:
+
+```bash
+# Option 1: Source the exports (one-time per shell)
+export QA_ADMIN_STORAGE_STATE="./.smoke-storage-state/admin-storage-state.json"
+export QA_LANDLORD_STORAGE_STATE="./.smoke-storage-state/landlord-storage-state.json"
+export QA_TENANT_STORAGE_STATE="./.smoke-storage-state/tenant-storage-state.json"
+
+# Option 2: Or set via command line
+QA_ADMIN_STORAGE_STATE="./.smoke-storage-state/admin-storage-state.json" npm run test:smoke
+```
+
+## Running Smoke Tests
+
+### Backend API Smoke Tests
+
+```bash
+cd rentchain-api
+npm run test:smoke        # Run all backend smoke tests
+npm run test:smoke -- --reporter=verbose
+```
+
+### Frontend Playwright Smoke Tests
+
+```bash
+cd rentchain-frontend
+npm run test:e2e          # Run all Playwright tests
+npm run test:e2e -- admin-smoke.spec.ts  # Run specific role tests
+npm run test:e2e -- --project=chromium   # Run specific browser
+```
+
+#### With UI Mode
+
+```bash
+cd rentchain-frontend
+npm run test:e2e -- --ui  # Interactive test runner
+```
+
+#### Debugging
+
+```bash
+cd rentchain-frontend
+npm run test:e2e -- --debug  # Step through tests
+npm run test:e2e -- --headed # See browser while tests run
+```
+
+## Storage State Structure
+
+Storage state is generated for three roles:
+
+### Admin Storage State
+
+- **User**: `smoke-admin` (admin@rentchain.ai)
+- **Access**: All admin routes and data
+- **Usage**: Admin workflow validation
+
+### Landlord Storage State
+
+- **User**: `smoke-landlord-a-user` (landlord.a@example.test)
+- **Access**: Landlord's properties, tenants, and maintenance requests
+- **Usage**: Landlord workflow validation, role-based access control
+
+### Tenant Storage State
+
+- **User**: `smoke-tenant-a-user` (tenant.a@example.test)
+- **Access**: Own lease, maintenance requests, and communications
+- **Usage**: Tenant workflow validation, isolated data access
+
+## Understanding the Fixture Format
+
+The base fixture (`admin-storage-state.ts`) contains:
+
+```typescript
+{
+  fixtureVersion: "authenticated-smoke-v1",
+  generatedAt: "ISO 8601 timestamp",
+  users: [ /* User definitions with roles */ ],
+  properties: [ /* Property data */ ],
+  units: [ /* Unit/suite data */ ],
+  tenants: [ /* Tenant records */ ],
+  leases: [ /* Lease agreements */ ],
+  maintenanceRequests: [ /* Maintenance tickets */ ],
+  auditEvents: [ /* System audit log */ ]
+}
+```
+
+## Architecture
+
+### Backend (`rentchain-api/tests/storage-state/`)
+
+- **storage-state-generator.ts**: Core logic to convert fixtures to Playwright format
+- **storage-state-presets.ts**: Pre-built storage state for each role
+- **export-storage-state.ts**: CLI to export presets to JSON files
+
+### Frontend (`rentchain-frontend/tests/playwright/`)
+
+- **role-smoke-helpers.ts**: Utilities to read storage state from environment variables
+- **admin-smoke.spec.ts**: Admin role workflow tests
+- **landlord-smoke.spec.ts**: Landlord role workflow tests
+- **tenant-smoke.spec.ts**: Tenant role workflow tests
+
+## Key Points
+
+### Storage State is Deterministic
+
+Storage state generation is deterministic—same fixture always produces identical storage state. This ensures test reliability.
+
+### Tokens are Mocked
+
+Auth tokens in smoke tests are deterministic mocks (e.g., `smoke-admin-smoke-admin-token`). The backend's test utilities verify role and permissions without checking token validity.
+
+### No Production Secrets
+
+Storage state files contain no real secrets, credentials, or API keys. They are safe to commit to version control (stored in `.smoke-storage-state/` which is gitignored by default).
+
+### Role Isolation
+
+Each role has isolated data access:
+- **Admin**: Sees all data across all landlords and tenants
+- **Landlord**: Sees only their own properties and associated tenants
+- **Tenant**: Sees only their own leases and communications
+
+This is enforced both in fixtures and in test assertions.
+
+## Troubleshooting
+
+### Storage state file not found
+
+**Error**: `Error: ENOENT: no such file or directory`
+
+**Solution**: Run `npm run storage-state:export` first to generate the JSON files.
+
+### Tests pass locally but fail in CI
+
+**Cause**: Environment variables not set in CI runner.
+
+**Solution**: Export storage state as part of CI setup:
+```bash
+npm run storage-state:export
+export QA_ADMIN_STORAGE_STATE="./.smoke-storage-state/admin-storage-state.json"
+# ... etc
+```
+
+### Storage state not being used by tests
+
+**Symptom**: Tests run as unauthenticated even though env vars are set.
+
+**Debugging**: Check that `storageStateDetailsForRole()` can read the env vars:
+```bash
+echo $QA_ADMIN_STORAGE_STATE
+# Should print the file path
+```
+
+## Next Steps
+
+- Run `npm run storage-state:export` to generate storage state files
+- Run backend smoke tests: `npm run test:smoke`
+- Run frontend Playwright tests: `npm run test:e2e`
+- Commit `.smoke-storage-state/` to version control (it's gitignored)

--- a/rentchain-api/tests/storage-state/export-storage-state.ts
+++ b/rentchain-api/tests/storage-state/export-storage-state.ts
@@ -1,0 +1,52 @@
+import { writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { getAllStorageStatePresets } from "./storage-state-presets";
+
+/**
+ * Export storage state presets to JSON files for use in Playwright tests.
+ * Usage: npx tsx rentchain-api/tests/storage-state/export-storage-state.ts [outputDir]
+ */
+async function exportStorageStates() {
+  const outputDir = process.argv[2] || "./.smoke-storage-state";
+
+  try {
+    mkdirSync(outputDir, { recursive: true });
+
+    const presets = getAllStorageStatePresets();
+    const filePathsWritten: string[] = [];
+
+    for (const preset of presets) {
+      const fileName = `${preset.role}-storage-state.json`;
+      const filePath = join(outputDir, fileName);
+
+      const content = JSON.stringify(preset.storageState, null, 2);
+      writeFileSync(filePath, content, "utf-8");
+      filePathsWritten.push(filePath);
+
+      console.log(`✓ Exported ${preset.role} storage state to ${filePath}`);
+    }
+
+    // Also write a summary that maps roles to file paths
+    const summaryPath = join(outputDir, "storage-state-manifest.json");
+    const manifest = Object.fromEntries(
+      presets.map((p) => [p.role, `./${p.role}-storage-state.json`])
+    );
+    writeFileSync(summaryPath, JSON.stringify(manifest, null, 2), "utf-8");
+    console.log(`✓ Wrote manifest to ${summaryPath}`);
+
+    // Output environment variable assignments for convenient sourcing
+    console.log("\n# Add these to your shell profile or .env.test:");
+    for (const preset of presets) {
+      const filePath = join(outputDir, `${preset.role}-storage-state.json`);
+      const envVar = `QA_${preset.role.toUpperCase()}_STORAGE_STATE`;
+      console.log(`export ${envVar}="${filePath}"`);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    console.error("Failed to export storage state:", error);
+    process.exit(1);
+  }
+}
+
+exportStorageStates();

--- a/rentchain-api/tests/storage-state/storage-state-generator.test.ts
+++ b/rentchain-api/tests/storage-state/storage-state-generator.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { buildAdminStorageStateFixture } from "../fixtures/admin-storage-state";
+import { generateStorageState } from "./storage-state-generator";
+
+describe("storage state generator", () => {
+  const fixture = buildAdminStorageStateFixture();
+
+  describe("generateStorageState", () => {
+    it("generates admin storage state with auth token", () => {
+      const storageState = generateStorageState({
+        fixture,
+        role: "admin",
+        baseUrl: "http://localhost:5173",
+      });
+
+      expect(storageState).toBeDefined();
+      expect(storageState?.cookies).toHaveLength(1);
+      expect(storageState?.cookies?.[0]).toMatchObject({
+        name: "auth-token",
+        value: expect.stringContaining("smoke-admin"),
+      });
+    });
+
+    it("includes user context in localStorage", () => {
+      const storageState = generateStorageState({
+        fixture,
+        role: "admin",
+      });
+
+      const localStorage = storageState?.origins?.[0]?.localStorage ?? [];
+      const userIdEntry = localStorage.find((e) => e.name === "smoke:user:id");
+      const roleEntry = localStorage.find((e) => e.name === "smoke:user:role");
+
+      expect(userIdEntry?.value).toBe("smoke-admin");
+      expect(roleEntry?.value).toBe("admin");
+    });
+
+    it("includes landlord context for landlord role", () => {
+      const storageState = generateStorageState({
+        fixture,
+        role: "landlord",
+      });
+
+      const localStorage = storageState?.origins?.[0]?.localStorage ?? [];
+      const landlordEntry = localStorage.find((e) => e.name === "smoke:landlord:id");
+
+      expect(landlordEntry?.value).toBe("smoke-landlord-a");
+    });
+
+    it("includes tenant context for tenant role", () => {
+      const storageState = generateStorageState({
+        fixture,
+        role: "tenant",
+      });
+
+      const localStorage = storageState?.origins?.[0]?.localStorage ?? [];
+      const tenantEntry = localStorage.find((e) => e.name === "smoke:tenant:id");
+
+      expect(tenantEntry?.value).toBe("smoke-tenant-a");
+    });
+
+    it("throws error for unknown role", () => {
+      expect(() => {
+        generateStorageState({
+          fixture,
+          role: "unknown" as any,
+        });
+      }).toThrow();
+    });
+
+    it("respects baseUrl parameter", () => {
+      const storageState = generateStorageState({
+        fixture,
+        role: "admin",
+        baseUrl: "https://example.com",
+      });
+
+      expect(storageState?.origins?.[0]?.origin).toBe("https://example.com");
+      expect(storageState?.cookies?.[0]?.domain).toBe("example.com");
+      expect(storageState?.cookies?.[0]?.secure).toBe(true);
+    });
+
+    it("includes fixture version and generation timestamp", () => {
+      const storageState = generateStorageState({
+        fixture,
+        role: "admin",
+      });
+
+      const localStorage = storageState?.origins?.[0]?.localStorage ?? [];
+      const versionEntry = localStorage.find((e) => e.name === "smoke:fixture:version");
+      const generatedEntry = localStorage.find((e) => e.name === "smoke:generated:at");
+
+      expect(versionEntry?.value).toBe("authenticated-smoke-v1");
+      expect(generatedEntry?.value).toBe(fixture.generatedAt);
+    });
+  });
+});

--- a/rentchain-api/tests/storage-state/storage-state-generator.ts
+++ b/rentchain-api/tests/storage-state/storage-state-generator.ts
@@ -1,0 +1,90 @@
+import type { BrowserContextOptions } from "@playwright/test";
+import type { AdminStorageStateFixture, SmokeRole, SmokeUser } from "../fixtures/admin-storage-state";
+
+export type PlaywrightStorageState = BrowserContextOptions["storageState"];
+
+export interface StorageStateGeneratorOptions {
+  baseUrl?: string;
+  fixture: AdminStorageStateFixture;
+  role: SmokeRole;
+}
+
+function findUserByRole(fixture: AdminStorageStateFixture, role: SmokeRole): SmokeUser | undefined {
+  return fixture.users.find((u) => u.role === role);
+}
+
+function generateAuthToken(userId: string, role: SmokeRole): string {
+  // Generate a deterministic test token (in smoke tests, tokens are mocked server-side)
+  return `smoke-${role}-${userId}-token`;
+}
+
+export function generateStorageState(options: StorageStateGeneratorOptions): PlaywrightStorageState {
+  const { fixture, role, baseUrl = "http://localhost:5173" } = options;
+  const user = findUserByRole(fixture, role);
+
+  if (!user) {
+    throw new Error(`No user found for role: ${role}`);
+  }
+
+  const authToken = generateAuthToken(user.id, role);
+  const originUrl = new URL(baseUrl);
+  const origin = originUrl.origin;
+
+  return {
+    cookies: [
+      {
+        name: "auth-token",
+        value: authToken,
+        domain: originUrl.hostname,
+        path: "/",
+        httpOnly: true,
+        secure: originUrl.protocol === "https:",
+        sameSite: "Lax" as const,
+      },
+    ],
+    origins: [
+      {
+        origin,
+        localStorage: [
+          {
+            name: "smoke:user:id",
+            value: user.id,
+          },
+          {
+            name: "smoke:user:role",
+            value: role,
+          },
+          {
+            name: "smoke:user:email",
+            value: user.email,
+          },
+          {
+            name: "smoke:fixture:version",
+            value: fixture.fixtureVersion,
+          },
+          {
+            name: "smoke:generated:at",
+            value: fixture.generatedAt,
+          },
+          // Store role-specific context
+          ...(user.landlordId
+            ? [
+                {
+                  name: "smoke:landlord:id",
+                  value: user.landlordId,
+                },
+              ]
+            : []),
+          ...(user.tenantId
+            ? [
+                {
+                  name: "smoke:tenant:id",
+                  value: user.tenantId,
+                },
+              ]
+            : []),
+        ],
+      },
+    ],
+  };
+}

--- a/rentchain-api/tests/storage-state/storage-state-presets.ts
+++ b/rentchain-api/tests/storage-state/storage-state-presets.ts
@@ -1,0 +1,43 @@
+import type { BrowserContextOptions } from "@playwright/test";
+import { buildAdminStorageStateFixture, type SmokeRole } from "../fixtures/admin-storage-state";
+import { generateStorageState } from "./storage-state-generator";
+
+export interface StorageStatePreset {
+  role: SmokeRole;
+  storageState: BrowserContextOptions["storageState"];
+}
+
+const baseUrl = process.env.VITE_API_BASE_URL || "http://localhost:5173";
+const fixture = buildAdminStorageStateFixture();
+
+function createPreset(role: SmokeRole): StorageStatePreset {
+  return {
+    role,
+    storageState: generateStorageState({
+      fixture,
+      role,
+      baseUrl,
+    }),
+  };
+}
+
+export const ADMIN_STORAGE_STATE: StorageStatePreset = createPreset("admin");
+export const LANDLORD_STORAGE_STATE: StorageStatePreset = createPreset("landlord");
+export const TENANT_STORAGE_STATE: StorageStatePreset = createPreset("tenant");
+
+export function getStorageStateForRole(role: SmokeRole): BrowserContextOptions["storageState"] {
+  switch (role) {
+    case "admin":
+      return ADMIN_STORAGE_STATE.storageState;
+    case "landlord":
+      return LANDLORD_STORAGE_STATE.storageState;
+    case "tenant":
+      return TENANT_STORAGE_STATE.storageState;
+    default:
+      throw new Error(`Unknown role: ${role}`);
+  }
+}
+
+export function getAllStorageStatePresets(): StorageStatePreset[] {
+  return [ADMIN_STORAGE_STATE, LANDLORD_STORAGE_STATE, TENANT_STORAGE_STATE];
+}


### PR DESCRIPTION
## Summary

Establish authenticated storage state fixtures for Playwright smoke tests. This mission extends the authenticated smoke readiness work from PRs #1028 and #1034.

**Core deliverables:**
- Storage state generator: Converts backend fixtures to Playwright browser context format
- Role-based presets: Admin, landlord, tenant storage state with deterministic mock tokens
- CLI exporter: `npx tsx export-storage-state.ts` generates JSON files for tests
- Documentation: Complete SMOKE_TEST.md guide for setup and execution
- Comprehensive tests: 7/7 storage state generation tests pass

**Design principles:**
- Deterministic: Same fixture always produces identical storage state
- No secrets: Mock tokens safe for version control
- Role isolation: Enforced through fixture and assertion helpers  
- Extends conventions: Reuses existing fixture types and auth helpers from prior missions

## Test plan

- [x] Backend smoke tests pass: `npm run test:smoke`
- [x] Storage state generator tests: 7/7 passing
- [x] Export script works: Generates valid Playwright storage state JSON
- [x] CI checks green: All backend tests pass
- [x] Build validation: TypeScript compilation passes