### PR TITLE
feat: add shared Playwright setup for legacy frontend smoke specs

### DIFF
--- a/docs/development/SMOKE_TEST.md
+++ b/docs/development/SMOKE_TEST.md
@@ -222,6 +222,135 @@ Each Playwright test attaches a `classified-smoke-findings` JSON payload with:
 
 The finding payload classifies expected 401/403 responses separately from hard failures and avoids storing raw credentials or provider payloads.
 
+## Legacy Frontend Smoke Setup
+
+For tests that need to bypass the dev preview gate but don't require full role-based authentication, use the **legacy smoke setup** pattern.
+
+### When to Use Legacy Smoke Setup
+
+Use `installLegacySmokeHarness()` for tests that:
+
+- Test frontend-only features without role context
+- Need to bypass DevAuthGate in development mode
+- Don't require authenticated API mocking or storage state
+- Focus on UI rendering, responsive design, or client-side functionality
+
+Examples: `ai-drawer.spec.ts`, `payments.responsive.spec.ts`
+
+### Legacy Setup API
+
+```typescript
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
+
+test("AI drawer loads", async ({ page }, testInfo) => {
+  // Unlock dev preview gate for this test
+  await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+
+  testInfo.annotations.push({
+    type: "smoke-mode",
+    description: "legacy smoke test with dev preview unlock",
+  });
+
+  await page.goto("/dashboard");
+  // Test assertions...
+});
+```
+
+### Legacy vs Authenticated Smoke
+
+| Feature | Legacy Smoke | Authenticated Smoke |
+|---------|-------------|-------------------|
+| **Setup** | `installLegacySmokeHarness()` | `installRoleSmokeHarness()` |
+| **Auth Mode** | Dev preview unlock only | Full role-based auth context |
+| **Storage State** | Not required | Requires `QA_*_STORAGE_STATE` |
+| **API Mocking** | No mocking | Full mocked API responses |
+| **Use Cases** | UI tests, responsive tests | Role workflow validation |
+
+### Running Legacy Smoke Tests
+
+Legacy smoke tests don't require storage state environment variables:
+
+```bash
+cd rentchain-frontend
+
+# Run specific legacy tests
+npm run test:e2e -- ai-drawer.spec.ts
+npm run test:e2e -- payments.responsive.spec.ts
+
+# Run with debug mode
+npm run test:e2e -- --debug ai-drawer.spec.ts
+```
+
+### Dev Preview Gate Details
+
+The legacy setup unlocks the dev preview gate by setting:
+
+```javascript
+localStorage.setItem("dev_auth_unlocked", "1");
+```
+
+This bypasses the `DevAuthGate` component that wraps the entire App in development mode.
+
+**Important**: Dev preview unlock is:
+- Idempotent (safe to call multiple times)
+- Scoped to the test page context only
+- Automatically cleared between test runs
+- Only active in development mode (`import.meta.env.DEV`)
+
+### Legacy Smoke Test Structure
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
+
+test.describe("My Legacy Feature", () => {
+  test("feature works correctly", async ({ page }, testInfo) => {
+    // 1. Set up dev preview unlock
+    await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+
+    // 2. Add test annotation
+    testInfo.annotations.push({
+      type: "smoke-mode",
+      description: "legacy smoke test with dev preview unlock"
+    });
+
+    // 3. Navigate and test as normal
+    await page.goto("/your-route");
+    await expect(page.getByText("Your Content")).toBeVisible();
+  });
+});
+```
+
+### Troubleshooting Legacy Smoke Tests
+
+#### Test still fails with dev preview gate
+
+**Symptom**: Test shows dev password screen even with `devPreviewUnlock: true`
+
+**Solutions**:
+1. Verify `installLegacySmokeHarness()` is called before `page.goto()`
+2. Check that `devPreviewUnlock: true` is passed in options
+3. Ensure you're running in dev mode (not production build)
+
+#### TypeError on import
+
+**Error**: `Cannot resolve module './legacy-smoke-setup'`
+
+**Solution**: Verify the import path is correct relative to your test file:
+```typescript
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
+```
+
+#### Legacy test passes but authenticated tests fail
+
+**Cause**: Environment variable conflict or missing storage state.
+
+**Solution**: Legacy and authenticated tests are independent. Set up storage state for authenticated tests separately:
+```bash
+cd rentchain-api && npm run storage-state:export
+export QA_ADMIN_STORAGE_STATE="../rentchain-api/.smoke-storage-state/admin-storage-state.json"
+```
+
 ## Troubleshooting
 
 ### Storage state file not found

--- a/rentchain-frontend/playwright.config.ts
+++ b/rentchain-frontend/playwright.config.ts
@@ -1,5 +1,27 @@
 import { defineConfig } from "@playwright/test";
 
+/**
+ * RentChain Frontend Playwright Configuration
+ *
+ * This configuration supports two distinct test modes that can coexist:
+ *
+ * 1. **Authenticated Role Smoke Tests** (admin-smoke.spec.ts, landlord-smoke.spec.ts, tenant-smoke.spec.ts)
+ *    - Uses storage state fixtures from environment variables (QA_ADMIN_STORAGE_STATE, etc.)
+ *    - Tests role-based access control and authenticated workflows
+ *    - Requires `npm run storage-state:export` in rentchain-api before running
+ *    - Uses installRoleSmokeHarness() from role-smoke-helpers.ts
+ *
+ * 2. **Legacy Smoke Tests** (ai-drawer.spec.ts, payments.responsive.spec.ts)
+ *    - Uses dev preview unlock to bypass DevAuthGate in development mode
+ *    - Tests frontend-only features without role context or authentication
+ *    - Does not require storage state environment variables
+ *    - Uses installLegacySmokeHarness() from legacy-smoke-setup.ts
+ *
+ * Both modes are idempotent and safe for unattended test runs. The storage state
+ * environment variables are optional - legacy tests run without them, while authenticated
+ * role tests require them and will throw descriptive errors if missing.
+ */
+
 export default defineConfig({
   testDir: "./tests/playwright",
   outputDir: process.env.QA_ARTIFACT_DIR || "test-results",

--- a/rentchain-frontend/tests/playwright/ai-drawer.spec.ts
+++ b/rentchain-frontend/tests/playwright/ai-drawer.spec.ts
@@ -1,6 +1,15 @@
 import { test, expect } from "@playwright/test";
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
 
-test("AI drawer loads summary", async ({ page }) => {
+test("AI drawer loads summary", async ({ page }, testInfo) => {
+  // Use legacy smoke setup to unlock dev preview gate for this test
+  await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+
+  testInfo.annotations.push({
+    type: "smoke-mode",
+    description: "legacy smoke test with dev preview unlock",
+  });
+
   await page.goto("/dashboard");
   await expect(page.getByText(/AI Portfolio Intelligence/i)).toBeVisible();
   await page.getByText(/AI Portfolio Intelligence/i).click();

--- a/rentchain-frontend/tests/playwright/legacy-smoke-setup.ts
+++ b/rentchain-frontend/tests/playwright/legacy-smoke-setup.ts
@@ -1,0 +1,53 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Options for configuring legacy smoke test setup.
+ */
+export type LegacySmokeSetupOptions = {
+  /**
+   * Whether to unlock the dev preview gate.
+   * When true, sets localStorage["dev_auth_unlocked"] = "1" to bypass the DevAuthGate component.
+   * This allows legacy tests to run in dev mode without authentication.
+   * @default false
+   */
+  devPreviewUnlock?: boolean;
+};
+
+/**
+ * Installs shared setup for legacy frontend smoke tests that need dev preview unlock
+ * but don't require full role-based authentication context.
+ *
+ * This is a simplified alternative to installRoleSmokeHarness for tests that:
+ * - Run against frontend-only features without role context
+ * - Need to bypass the dev preview gate in development mode
+ * - Don't require authenticated API mocking or storage state
+ *
+ * @example
+ * ```ts
+ * import { installLegacySmokeHarness } from "./legacy-smoke-setup";
+ *
+ * test("AI drawer loads", async ({ page }) => {
+ *   await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+ *   await page.goto("/dashboard");
+ *   // Test assertions...
+ * });
+ * ```
+ *
+ * @param page - Playwright page instance
+ * @param options - Setup configuration options
+ */
+export async function installLegacySmokeHarness(
+  page: Page,
+  options: LegacySmokeSetupOptions = {}
+): Promise<void> {
+  const { devPreviewUnlock = false } = options;
+
+  // Only set up the dev preview unlock if explicitly requested
+  if (devPreviewUnlock) {
+    await page.addInitScript(() => {
+      // Set the localStorage key that DevAuthGate checks to bypass the gate
+      // This matches the same key used in role-smoke-helpers.ts for consistency
+      window.localStorage.setItem("dev_auth_unlocked", "1");
+    });
+  }
+}

--- a/rentchain-frontend/tests/playwright/payments.responsive.spec.ts
+++ b/rentchain-frontend/tests/playwright/payments.responsive.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
 
 test.describe("Payments page responsive", () => {
   const viewports = [
@@ -9,6 +10,14 @@ test.describe("Payments page responsive", () => {
 
   for (const { name, size } of viewports) {
     test(`renders payments on ${name}`, async ({ page }, testInfo) => {
+      // Use legacy smoke setup to unlock dev preview gate for this test
+      await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+
+      testInfo.annotations.push({
+        type: "smoke-mode",
+        description: "legacy responsive smoke test with dev preview unlock",
+      });
+
       await page.setViewportSize(size);
       await page.goto("/payments");
       await expect(page.getByRole("heading", { name: /payments/i })).toBeVisible();


### PR DESCRIPTION
## Summary
Adds shared legacy smoke setup infrastructure to fix dev preview gate blocking issue affecting legacy frontend specs.

## Changes
- legacy-smoke-setup.ts — shared module with installLegacySmokeHarness() function
- ai-drawer.spec.ts — refactored to use legacy setup with dev preview unlock
- payments.responsive.spec.ts — refactored to use legacy setup for all viewport tests
- playwright.config.ts — dual-mode architecture documentation added
- SMOKE_TEST.md — comprehensive legacy smoke setup section added

## Validation
- TypeScript compilation: pass
- git diff --check: pass
- Scope: test infrastructure only, no source code changes

## Scope
QA infrastructure only. No source routes, services, auth rules, or production data changed.