### PR TITLE
chore: update workflow rules reset mission context

### DIFF
--- a/.claude/agents/qa-reviewer.md
+++ b/.claude/agents/qa-reviewer.md
@@ -66,6 +66,7 @@ Proceed with:
 4. Delete remote branch: [BRANCH_NAME]
 5. Confirm clean working tree on main
 6. Write full merge summary to .handoff/merge-log.md
+7. Write: echo "# Ready for next mission" > .handoff/mission-current.md
 
 POST-MERGE OUTPUT REQUIRED:
 1. Merge confirmation


### PR DESCRIPTION
## Summary
Updates merge execution step to reset mission context after each merge completes.

## Changes
- qa-reviewer.md — adds step 7 to write ready state to mission-current.md after merge

## Scope
Workflow configuration only. No source code, routes, services, or tests changed.