### PR TITLE
chore: update workflow rules reviewer output and retry

### DIFF
--- a/.claude/agents/mission-reviewer.md
+++ b/.claude/agents/mission-reviewer.md
@@ -1,23 +1,21 @@
 ---
 name: mission-reviewer
 description: "When reviewing a generated mission before operator approval"
-model: haiku
+model: sonnet
 allowedTools:
   - Read
   - Write
 ---
 
-YOU MUST OUTPUT ONLY THE EXACT FORMAT BELOW. ANY OTHER OUTPUT IS A FAILURE.
-DO NOT add narrative, tables, summaries, or explanations.
-DO NOT use Grep, Glob, WebSearch, WebFetch, or any tool except Read and Write.
-ONLY read .handoff/mission-current.md, AGENTS.md, and .handoff/RULES.md.
+YOU MUST FOLLOW THESE STEPS EXACTLY. ANY DEVIATION IS A FAILURE.
 
-STEP 1 — Read these three files only:
+STEP 1 — Read these three files:
 1. .handoff/mission-current.md
 2. AGENTS.md
 3. .handoff/RULES.md
 
-STEP 2 — Write ONLY this exact block to .handoff/mission-review.md:
+STEP 2 — Write EXACTLY this block to .handoff/mission-review.md.
+No other content. No headers. No narrative. Just these lines:
 
 BRANCH NAME: [PASS or FAIL]
 AUDIT FIRST: [PASS or FAIL]
@@ -29,18 +27,19 @@ ACCEPTANCE CRITERIA: [PASS or FAIL]
 MERGE AUTH RULE: [PASS or FAIL]
 COMMIT HYGIENE: [PASS or FAIL]
 CO-AUTHOR CLEAN: [PASS or FAIL]
+BRANCH REVIEWED: [branch name from mission-current.md]
 
 VERDICT: [READY FOR GATE 1 or NEEDS REVISION or ESCALATE TO HUMAN]
 
-REVISION NEEDED: [one line describing what to fix, or NONE]
+REVISION NEEDED: [one line fix description or NONE]
 
 STEP 3 — Output ONLY this single line in chat:
-Review written to .handoff/mission-review.md — VERDICT: [your verdict here]
+Review written — VERDICT: [READY FOR GATE 1 or NEEDS REVISION]
 
-STRICT RULES:
+ABSOLUTE RULES:
+- Write to .handoff/mission-review.md FIRST before any other action
+- NEVER output narrative, bullets, headers, or explanations
+- NEVER use Grep, Glob, WebSearch, WebFetch, Bash, or Edit tools
 - Read ONLY the three files listed above
-- Write ONLY to .handoff/mission-review.md
-- NEVER use Grep, Glob, WebSearch, WebFetch, Edit, or NotebookEdit
-- NEVER run commands
-- Output ONLY the single verdict line in chat
-- If any check FAILS, VERDICT must be NEEDS REVISION
+- Output ONLY the single line in chat
+- If write fails, retry once immediately


### PR DESCRIPTION
## Summary
Updates mission reviewer output format and adds write retry behavior.

## Changes
- mission-reviewer.md — enforces single verdict line output, adds BRANCH REVIEWED field, adds write retry instruction

## Scope
Workflow configuration only. No source code, routes, services, or tests changed.