### PR TITLE
fix: verify Cloud Run preview revision public signal

### DIFF
--- a/docs/execution/CLOUD_RUN_DEPLOYMENT_CHECKLIST.md
+++ b/docs/execution/CLOUD_RUN_DEPLOYMENT_CHECKLIST.md
@@ -45,6 +45,17 @@ EXPECTED_COMMIT="$EXPECTED_COMMIT" \
 tools/qa/verify-cloud-run-preview-revision.sh
 ```
 
+When only the public Cloud Run signal is needed, and exact build identifiers are intentionally redacted from public responses, use public signal mode:
+
+```bash
+PREVIEW_URL=https://example-preview.vercel.app \
+BACKEND_BASE_URL=https://backend-preview.example.run.app \
+VERIFY_PUBLIC_SIGNAL_ONLY=true \
+tools/qa/verify-cloud-run-preview-revision.sh
+```
+
+This confirms that `/health` is reachable and reports revision metadata presence. It does not replace read-only Cloud Run metadata checks for exact revision name, image tag/digest, expected commit, or 100 percent traffic allocation.
+
 The verifier checks safe endpoints such as `/health`, `/health/ready`, `/health/db`, `/api/_build`, `/api/__probe/version`, and `/api/__probe/revision`. It fails when the expected commit, revision, or image token cannot be confirmed from endpoint output. Current public probes may expose only presence flags for build metadata; a verifier failure does not mutate Cloud Run and means manual revision/image/traffic confirmation is still required.
 
 Inspect the service:

--- a/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
+++ b/docs/execution/QA_PLAYWRIGHT_PROTOCOL.md
@@ -175,6 +175,7 @@ Optional:
 
 - `BACKEND_BASE_URL`: backend origin when the frontend preview and backend probe origin differ
 - `VERIFY_TIMEOUT_SECONDS`: per-endpoint curl timeout, default `10`
+- `VERIFY_PUBLIC_SIGNAL_ONLY=true`: confirm only that the public health signal is reachable and reports revision metadata presence
 
 Examples:
 
@@ -187,9 +188,16 @@ PREVIEW_URL=https://example-preview.vercel.app \
 BACKEND_BASE_URL=https://backend-preview.example.run.app \
 EXPECTED_IMAGE_TAG=<image-tag-or-short-sha> \
 tools/qa/verify-cloud-run-preview-revision.sh
+
+PREVIEW_URL=https://example-preview.vercel.app \
+BACKEND_BASE_URL=https://backend-preview.example.run.app \
+VERIFY_PUBLIC_SIGNAL_ONLY=true \
+tools/qa/verify-cloud-run-preview-revision.sh
 ```
 
 The verifier checks known safe probes, including `/health`, `/health/db`, `/health/ready`, `/api/_build`, `/api/__probe/version`, and `/api/__probe/revision`. It also reports gated diagnostics such as `/api/__debug/build` and `/api/_echo` when present, but gated `404` responses are not treated as proof of backend freshness.
+
+Public signal mode confirms only that `/health` is reachable and reports `revisionPresent: true`. It does not prove the exact commit, revision name, image tag, or traffic allocation. Use it when public endpoints intentionally redact exact build identifiers and Cloud Run metadata access is unavailable.
 
 If none of the safe endpoint responses contain an expected commit, revision, or image token, the script fails clearly. Current public probes may expose only route/build presence flags rather than the raw commit or revision value; in that case, use `docs/execution/CLOUD_RUN_DEPLOYMENT_CHECKLIST.md` to confirm the active Cloud Run revision, image tag/digest, and 100 percent traffic allocation before continuing preview QA.
 

--- a/tools/qa/verify-cloud-run-preview-revision.sh
+++ b/tools/qa/verify-cloud-run-preview-revision.sh
@@ -8,6 +8,7 @@ EXPECTED_REVISION="${EXPECTED_REVISION:-}"
 EXPECTED_IMAGE_TAG="${EXPECTED_IMAGE_TAG:-}"
 ALLOW_PRODUCTION_QA="${ALLOW_PRODUCTION_QA:-false}"
 VERIFY_TIMEOUT_SECONDS="${VERIFY_TIMEOUT_SECONDS:-10}"
+VERIFY_PUBLIC_SIGNAL_ONLY="${VERIFY_PUBLIC_SIGNAL_ONLY:-false}"
 
 if [ -z "$PREVIEW_URL" ]; then
   echo "PREVIEW_URL is required." >&2
@@ -15,8 +16,9 @@ if [ -z "$PREVIEW_URL" ]; then
   exit 2
 fi
 
-if [ -z "$EXPECTED_COMMIT" ] && [ -z "$EXPECTED_REVISION" ] && [ -z "$EXPECTED_IMAGE_TAG" ]; then
+if [ "$VERIFY_PUBLIC_SIGNAL_ONLY" != "true" ] && [ -z "$EXPECTED_COMMIT" ] && [ -z "$EXPECTED_REVISION" ] && [ -z "$EXPECTED_IMAGE_TAG" ]; then
   echo "Set at least one expected backend identifier: EXPECTED_COMMIT, EXPECTED_REVISION, or EXPECTED_IMAGE_TAG." >&2
+  echo "For public reachability only, set VERIFY_PUBLIC_SIGNAL_ONLY=true." >&2
   exit 2
 fi
 
@@ -112,16 +114,21 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
 confirmed="false"
+public_signal_confirmed="false"
 reachable="false"
 server_error="false"
 
 echo "RentChain Cloud Run preview revision verification"
 echo "Frontend preview: $frontend_origin"
 echo "Backend probe origin: $backend_origin"
-echo "Expected tokens:"
-for token in "${expected_tokens[@]}"; do
-  echo "  - $token"
-done
+if [ "$VERIFY_PUBLIC_SIGNAL_ONLY" = "true" ]; then
+  echo "Mode: public signal only"
+else
+  echo "Expected tokens:"
+  for token in "${expected_tokens[@]}"; do
+    echo "  - $token"
+  done
+fi
 echo
 
 for endpoint in "${endpoints[@]}"; do
@@ -176,19 +183,46 @@ for endpoint in "${endpoints[@]}"; do
   fi
 
   cat "$headers_file" "$body_file" > "$combined_file" 2>/dev/null || true
-  for token in "${expected_tokens[@]}"; do
-    if grep -Fq "$token" "$combined_file"; then
-      echo "  matched expected token: $token"
-      confirmed="true"
-    fi
-  done
+  if [ "$VERIFY_PUBLIC_SIGNAL_ONLY" != "true" ]; then
+    for token in "${expected_tokens[@]}"; do
+      if grep -Fq "$token" "$combined_file"; then
+        echo "  matched expected token: $token"
+        confirmed="true"
+      fi
+    done
+  fi
 
   if [ -s "$body_file" ]; then
     body_preview="$(head -c 600 "$body_file" | tr '\n' ' ' | sed 's/[[:space:]][[:space:]]*/ /g')"
     echo "  body preview: $body_preview"
   fi
+
+  if [ "$VERIFY_PUBLIC_SIGNAL_ONLY" = "true" ] && [ "$endpoint" = "/health" ]; then
+    if grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' "$body_file" \
+      && grep -Eq '"revisionPresent"[[:space:]]*:[[:space:]]*true' "$body_file"; then
+      echo "  public signal: ok with revision metadata present"
+      public_signal_confirmed="true"
+    fi
+  fi
   echo
 done
+
+if [ "$VERIFY_PUBLIC_SIGNAL_ONLY" = "true" ]; then
+  if [ "$public_signal_confirmed" = "true" ]; then
+    echo "Verified: public health signal is reachable and reports revision metadata presence."
+    echo "Exact commit/revision/image identity was not verified in public signal mode."
+    exit 0
+  fi
+
+  echo "Could not confirm the public Cloud Run revision signal from /health." >&2
+  if [ "$reachable" != "true" ]; then
+    echo "No safe endpoint returned a reachable non-5xx response." >&2
+  fi
+  if [ "$server_error" = "true" ]; then
+    echo "One or more endpoints returned 5xx and should be reviewed separately." >&2
+  fi
+  exit 1
+fi
 
 if [ "$confirmed" = "true" ]; then
   echo "Verified: backend response data contains at least one expected revision/commit/image token."


### PR DESCRIPTION
## Summary
Adds an explicit public-signal mode to the Cloud Run preview revision verifier so preview QA can confirm the public health signal without requiring public exposure of exact commit, revision, or image identifiers.

## Changes
- verify-cloud-run-preview-revision.sh — adds VERIFY_PUBLIC_SIGNAL_ONLY=true mode for public /health reachability and revision metadata presence
- QA_PLAYWRIGHT_PROTOCOL.md — documents public-signal verification mode and its limitations
- CLOUD_RUN_DEPLOYMENT_CHECKLIST.md — documents when public signal mode is appropriate versus exact Cloud Run metadata checks

## Validation
- Public verifier mode: pass against Cloud Run /health signal
- bash -n tools/qa/verify-cloud-run-preview-revision.sh: pass
- git diff --check: pass
- Protected diagnostic probes stayed fail-closed during public verification (/api/__debug/build and /api/_echo returned 404)

## Known Limitations
- Public signal mode confirms reachability and revision metadata presence only.
- It does not prove the exact commit, revision name, image tag, image digest, or traffic allocation.
- Read-only gcloud Cloud Run metadata checks could not complete locally because the active credentials require reauthentication in non-interactive mode.

## Scope
QA verification tooling and documentation only. No source routes, services, auth rules, deployment configuration, Terraform, or production data changed.