### PR TITLE
feat: harden tenant workspace projection contracts

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
@@ -261,6 +261,15 @@ describe("tenant communications routes", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.body?.data?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_communications_projection",
+        audience: "tenant_workspace",
+        authorityBasis: "authenticated_tenant_scope",
+      })
+    );
+    expect(res.body?.data?.projectionVersion).toBe("tenant_safe_projection_v1");
+    expect(res.body?.data?.redactionSummary?.redactedFieldGroups).toContain("private_message_bodies");
     expect(res.body?.data?.thread?.id).toBe("conv-linked-unit");
     expect(res.body?.data?.thread?.messages).toEqual(
       expect.arrayContaining([

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -290,6 +290,8 @@ describe("tenantPortalRoutes foundation", () => {
       tenantConfirmationStatus: null,
       tenantConfirmationUpdatedAt: null,
       accessAcknowledgedAt: null,
+      reopenedByActorId: "raw-landlord-user-id",
+      reopenedByActorRole: "landlord",
       statusHistory: [
         {
           status: "submitted",
@@ -527,9 +529,21 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.body?.data?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_workspace_context_projection",
+        audience: "tenant_workspace",
+        authorityBasis: "authenticated_tenant_scope",
+      })
+    );
+    expect(res.body?.data?.projectionVersion).toBe("tenant_safe_projection_v1");
+    expect(res.body?.data?.sensitivityClass).toBe("sensitive");
+    expect(res.body?.data?.redactionSummary?.redactedFieldGroups).toContain("landlord_only_notes");
     expect(res.body?.data?.property?.street1).toBe("123 Main St");
+    expect(res.body?.data?.property?.projectionProfile?.projectionName).toBe("tenant_safe_property_projection");
     expect(res.body?.data?.property?.internalSecret).toBeUndefined();
     expect(res.body?.data?.application?.status).toBe("submitted");
+    expect(res.body?.data?.application?.projectionProfile?.projectionName).toBe("tenant_safe_application_projection");
     expect(res.body?.data?.application?.sin).toBeUndefined();
     expect(res.body?.data?.lease?.monthlyRent).toBe(1800);
     expect(res.body?.data?.lease?.confidentialNotes).toBeUndefined();
@@ -566,6 +580,9 @@ describe("tenantPortalRoutes foundation", () => {
     );
     expect(Array.isArray(res.body?.data?.tenantIdentityRecord?.documents?.missingCategories)).toBe(true);
     expect(res.body?.data?.maintenance?.[0]?.title).toBe("Leaky tap");
+    expect(res.body?.data?.maintenance?.[0]?.projectionProfile?.projectionName).toBe("tenant_safe_maintenance_projection");
+    expect(res.body?.data?.maintenance?.[0]?.reopenedByActorRole).toBe("landlord");
+    expect(res.body?.data?.maintenance?.[0]?.reopenedByActorId).toBeUndefined();
     expect(res.body?.data?.maintenance?.[0]?.assignedContractorName).toBe("North Shore Plumbing");
     expect(res.body?.data?.maintenance?.[0]?.contractorStatus).toBe("assigned");
     expect(res.body?.data?.maintenance?.[0]?.serviceWindowStartAt).toBe(300);
@@ -624,6 +641,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.identityTimeline?.events?.[0]?.metadata).toBeUndefined();
     expect(JSON.stringify(res.body?.data?.portableIdentity || {})).not.toContain("token");
     expect(JSON.stringify(res.body?.data?.portableIdentity || {})).not.toContain("drawnDataUrl");
+    expect(JSON.stringify(res.body)).not.toContain("raw-landlord-user-id");
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_workspace_viewed")).toBe(true);
@@ -2852,6 +2870,8 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.resolutionStatus).toBe("follow_up_required");
     expect(res.body?.data?.reopenReason).toBe("The latch failed again after closure.");
     expect(typeof res.body?.data?.reopenedAt).toBe("number");
+    expect(res.body?.data?.reopenedByActorRole).toBe("tenant");
+    expect(res.body?.data?.reopenedByActorId).toBeUndefined();
 
     const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-2b");
     expect(savedWorkOrder?.followUpRequired).toBe(true);

--- a/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
@@ -269,6 +269,15 @@ describe("tenant profile route", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.body?.data?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_profile_projection",
+        audience: "tenant_workspace",
+        authorityBasis: "authenticated_tenant_scope",
+      })
+    );
+    expect(res.body?.data?.projectionVersion).toBe("tenant_safe_projection_v1");
+    expect(res.body?.data?.redactionSummary?.redactedFieldGroups).toContain("raw_screening_reports");
     expect(res.body?.data?.profile?.displayName).toBe("Taylor Tenant");
     expect(res.body?.data?.profile?.email).toBe("tenant@example.com");
     expect(res.body?.data?.profile?.phone).toBe("902-555-0100");
@@ -304,7 +313,14 @@ describe("tenant profile route", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body?.data).toEqual({
+    expect(res.body?.data).toEqual(expect.objectContaining({
+      projectionProfile: expect.objectContaining({
+        projectionName: "tenant_safe_application_reuse_projection",
+        audience: "tenant_workspace",
+        authorityBasis: "authenticated_tenant_scope",
+      }),
+      projectionVersion: "tenant_safe_projection_v1",
+      sensitivityClass: "sensitive",
       applicant: {
         firstName: "Taylor",
         lastName: "Tenant",
@@ -338,10 +354,10 @@ describe("tenant profile route", () => {
         phone: "9025550175",
         address: "99 Willow St",
       },
-    });
+    }));
     expect(JSON.stringify(res.body)).not.toContain("applicantNotes");
     expect(JSON.stringify(res.body)).not.toContain("signature");
-    expect(JSON.stringify(res.body)).not.toContain("consent");
+    expect(JSON.stringify(res.body)).not.toContain("creditConsent");
     expect(JSON.stringify(res.body)).not.toContain("screeningSummary");
     expect(JSON.stringify(res.body)).not.toContain("coApplicant");
     expect(JSON.stringify(res.body)).not.toContain("reasonForMoving");
@@ -373,7 +389,13 @@ describe("tenant profile route", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body?.data).toEqual({
+    expect(res.body?.data).toEqual(expect.objectContaining({
+      projectionProfile: expect.objectContaining({
+        projectionName: "tenant_safe_application_reuse_projection",
+        audience: "tenant_workspace",
+        authorityBasis: "authenticated_tenant_scope",
+      }),
+      projectionVersion: "tenant_safe_projection_v1",
       applicant: {
         firstName: "Taylor",
         lastName: "Tenant",
@@ -386,7 +408,7 @@ describe("tenant profile route", () => {
       employment: null,
       workReference: null,
       nextOfKin: null,
-    });
+    }));
   });
 
   it("keeps safe unit display labels when the context unit value is already a unit number", async () => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -14,6 +14,11 @@ import {
   projectTenantMaintenance,
   projectTenantProperty,
 } from "../services/tenantPortal/tenantProjectionService";
+import {
+  deriveTenantSafeProjectionMetadata,
+  deriveTenantSafeSourceRefs,
+  type TenantSafeProjectionSourceReference,
+} from "../services/tenantPortal/tenantSafeProjectionContract";
 import { deriveLeaseExecution } from "../services/leaseExecution/deriveLeaseExecution";
 import { recordTenantEvent } from "../services/tenantPortal/tenantEventLogService";
 import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteService";
@@ -2477,6 +2482,41 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
   };
 }
 
+function buildTenantWorkspaceContextMetadata(
+  context: Awaited<ReturnType<typeof resolveTenancyContext>>,
+  workspace: Awaited<ReturnType<typeof loadTenantWorkspaceData>>
+) {
+  const sourceRefs: TenantSafeProjectionSourceReference[] = deriveTenantSafeSourceRefs({
+    leaseId: context.leaseId,
+    propertyId: context.propertyId,
+    unitId: context.unitId,
+    tenantId: context.tenantId,
+  });
+  if (context.applicationId) {
+    sourceRefs.push({ sourceCollection: "applications", sourceId: context.applicationId });
+  }
+  for (const item of workspace.maintenance || []) {
+    if (item?.requestId) {
+      sourceRefs.push({ sourceCollection: "maintenanceRequests", sourceId: item.requestId });
+    }
+  }
+  const byKey = new Map<string, TenantSafeProjectionSourceReference>();
+  for (const ref of sourceRefs) byKey.set(`${ref.sourceCollection}:${ref.sourceId}`, ref);
+  const normalizedRefs = Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}`.localeCompare(`${b.sourceCollection}:${b.sourceId}`)
+  );
+  const sourceCollections = Array.from(new Set(normalizedRefs.map((item) => item.sourceCollection))).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_workspace_context_projection",
+    scopeType: "tenant_workspace_context",
+    sourceCollections,
+    relationshipBasis: "Workspace context projection must be derived from authenticated tenant authority resolution.",
+  });
+  return { ...metadata, sourceCollections, sourceRefs: normalizedRefs };
+}
+
 async function buildTenantWorkspaceDisplayProjection(
   context: Awaited<ReturnType<typeof resolveTenancyContext>>,
   workspace: Awaited<ReturnType<typeof loadTenantWorkspaceData>>,
@@ -4024,6 +4064,7 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
     },
   });
   const displayProjection = await buildTenantWorkspaceDisplayProjection(context, workspace, req);
+  const workspaceProjectionMetadata = buildTenantWorkspaceContextMetadata(context, workspace);
   await recordTenantEvent({
     eventType: "tenant_workspace_viewed",
     entityType: "tenant_workspace",
@@ -4044,6 +4085,7 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
   return res.json({
     ok: true,
     data: {
+      ...workspaceProjectionMetadata,
       context,
       tenant: displayProjection.tenant,
       landlord: displayProjection.landlord,
@@ -7776,7 +7818,6 @@ async function buildTenantMaintenanceDetailResponse(docId: string, maintenanceDa
     ...projectTenantMaintenance(docId, maintenanceData || {}),
     evidence: workOrderExists ? await serializeEvidenceForAudience(workOrderData?.evidence, "tenant") : [],
     reopenedAt: toMillis(workOrderData?.reopenedAt),
-    reopenedByActorId: String(workOrderData?.reopenedByActorId || "").trim() || null,
     reopenedByActorRole:
       workOrderData?.reopenedByActorRole === "tenant" ||
       workOrderData?.reopenedByActorRole === "landlord" ||

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantProjectionService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantProjectionService.test.ts
@@ -4,7 +4,12 @@ import {
   expectNoRestrictedProjectionFields,
   expectPayloadDoesNotContainValues,
 } from "../../../__tests__/helpers/projectionSafetyAssertions";
-import { projectTenantLease } from "../tenantProjectionService";
+import {
+  projectTenantApplication,
+  projectTenantLease,
+  projectTenantMaintenance,
+  projectTenantProperty,
+} from "../tenantProjectionService";
 
 describe("tenantProjectionService", () => {
   it("adds deterministic tenant-safe projection contract metadata to current lease projections", () => {
@@ -124,5 +129,47 @@ describe("tenantProjectionService", () => {
       "other@example.test",
       "raw screening report",
     ]);
+  });
+
+  it("adds tenant-safe metadata to property, application, and maintenance projections", () => {
+    const property = projectTenantProperty("prop-1", {
+      rc_prop_id: "rc-prop-1",
+      street1: "123 Main St",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      internalNotes: "private",
+    });
+    const application = projectTenantApplication("app-1", {
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      status: "submitted",
+      missingSteps: ["upload_id"],
+      rawProviderPayload: "private",
+    });
+    const maintenance = projectTenantMaintenance("maint-1", {
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      status: "reopened",
+      reopenedByActorId: "raw-user-id",
+      reopenedByActorRole: "landlord",
+      evidence: [
+        { id: "tenant-safe", visibility: "tenant_safe", url: "https://example.test/photo.jpg" },
+        { id: "internal", visibility: "internal", url: "https://example.test/internal.jpg" },
+      ],
+    });
+
+    expect(property.projectionProfile.projectionName).toBe("tenant_safe_property_projection");
+    expect(property.authorityBasis).toBe("authenticated_tenant_scope");
+    expect(application.projectionProfile.projectionName).toBe("tenant_safe_application_projection");
+    expect(application.redactionSummary.redactedFieldGroups).toContain("raw_provider_payloads");
+    expect(maintenance.projectionProfile.projectionName).toBe("tenant_safe_maintenance_projection");
+    expect(maintenance.reopenedByActorRole).toBe("landlord");
+    expect((maintenance as any).reopenedByActorId).toBeUndefined();
+    expect(maintenance.evidence).toEqual([
+      expect.objectContaining({ id: "tenant-safe", visibility: "tenant_safe" }),
+    ]);
+    expectPayloadDoesNotContainValues(maintenance, ["raw-user-id", "https://example.test/internal.jpg"]);
   });
 });

--- a/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
@@ -3,8 +3,19 @@ import { buildEmailHtml, buildEmailText } from "../../email/templates/baseEmailT
 import { sendEmail } from "../emailService";
 import type { TenancyContext } from "./tenancyContextService";
 import { recordTenantEvent } from "./tenantEventLogService";
+import {
+  deriveTenantSafeProjectionMetadata,
+  deriveTenantSafeSourceRefs,
+  type TenantSafeProjectionMetadata,
+  type TenantSafeProjectionSourceReference,
+} from "./tenantSafeProjectionContract";
 
-export type TenantCommunicationsWorkspace = {
+type TenantProjectionMetadataFields = TenantSafeProjectionMetadata & {
+  sourceCollections: string[];
+  sourceRefs: TenantSafeProjectionSourceReference[];
+};
+
+export type TenantCommunicationsWorkspace = TenantProjectionMetadataFields & {
   canSend: boolean;
   canSendReason: string | null;
   thread: {
@@ -97,6 +108,25 @@ function buildConversationId(params: {
 }) {
   const scopeId = asString(params.context.tenantId) || asString(params.context.applicationId) || params.userId;
   return `${params.landlordId}__${scopeId}__${asString(params.context.unitId) || "na"}`;
+}
+
+function buildCommunicationsMetadata(context: TenancyContext) {
+  const sourceRefs = deriveTenantSafeSourceRefs({
+    leaseId: context.leaseId,
+    propertyId: context.propertyId,
+    unitId: context.unitId,
+    tenantId: context.tenantId,
+  });
+  const sourceCollections = Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_communications_projection",
+    scopeType: "tenant_communications",
+    sourceCollections,
+    relationshipBasis: "Communications projection must be derived from the authenticated tenant workspace context.",
+  });
+  return { ...metadata, sourceCollections, sourceRefs };
 }
 
 function conversationMatchesContext(conversation: any, context: TenancyContext, landlordId: string) {
@@ -242,6 +272,7 @@ export async function loadTenantCommunicationsWorkspace(params: {
   context: TenancyContext;
   userId: string;
 }) : Promise<TenantCommunicationsWorkspace> {
+  const projectionMetadata = buildCommunicationsMetadata(params.context);
   const propertyLandlord = await loadPropertyLandlord(params.context.propertyId);
   const landlordId = propertyLandlord?.landlordId;
   const canSend =
@@ -250,6 +281,7 @@ export async function loadTenantCommunicationsWorkspace(params: {
 
   if (!landlordId) {
     return {
+      ...projectionMetadata,
       canSend: false,
       canSendReason: "No landlord communication context is linked to this workspace yet.",
       thread: null,
@@ -296,6 +328,7 @@ export async function loadTenantCommunicationsWorkspace(params: {
   }).length;
 
   return {
+    ...projectionMetadata,
     canSend,
     canSendReason: canSend ? null : "Messaging becomes available once your tenancy or application context is fully linked.",
     thread: {

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -1,14 +1,25 @@
 import { db } from "../../config/firebase";
 import type { TenancyContext } from "./tenancyContextService";
 import {
+  deriveTenantSafeProjectionMetadata,
+  deriveTenantSafeSourceRefs,
+  type TenantSafeProjectionMetadata,
+  type TenantSafeProjectionSourceReference,
+} from "./tenantSafeProjectionContract";
+import {
   projectTenantApplication,
   projectTenantLease,
   projectTenantProperty,
 } from "./tenantProjectionService";
 
+type TenantProjectionMetadataFields = TenantSafeProjectionMetadata & {
+  sourceCollections: string[];
+  sourceRefs: TenantSafeProjectionSourceReference[];
+};
+
 export type TenantVisibleStatus = "verified" | "pending" | "missing" | "needs_review";
 
-export type TenantProfileProjection = {
+export type TenantProfileProjection = TenantProjectionMetadataFields & {
   context: Pick<
     TenancyContext,
     "authority" | "propertyId" | "rc_prop_id" | "applicationId" | "leaseId" | "tenantId" | "unitId" | "invitedEmail"
@@ -47,7 +58,7 @@ export type TenantProfileProjection = {
   };
 };
 
-export type TenantApplicationReuseProjection = {
+export type TenantApplicationReuseProjection = TenantProjectionMetadataFields & {
   applicant: {
     firstName: string | null;
     lastName: string | null;
@@ -178,6 +189,19 @@ function splitNameParts(value: string | null) {
     firstName: parts[0] || null,
     lastName: parts.slice(1).join(" ") || null,
   };
+}
+
+function contextSourceRefs(context: TenancyContext): TenantSafeProjectionSourceReference[] {
+  return deriveTenantSafeSourceRefs({
+    leaseId: context.leaseId,
+    propertyId: context.propertyId,
+    unitId: context.unitId,
+    tenantId: context.tenantId,
+  });
+}
+
+function sourceCollectionsFromRefs(sourceRefs: TenantSafeProjectionSourceReference[]): string[] {
+  return Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) => a.localeCompare(b));
 }
 
 async function loadDocument(collectionName: string, docId: string | null) {
@@ -912,8 +936,22 @@ export async function loadTenantProfileProjection(params: {
     tenantData: tenant?.data,
     leaseData: lease?.data,
   });
+  const sourceRefs = contextSourceRefs(context);
+  if (context.applicationId) {
+    sourceRefs.push({ sourceCollection: "applications", sourceId: context.applicationId });
+  }
+  const sourceCollections = sourceCollectionsFromRefs(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_profile_projection",
+    scopeType: "tenant_profile",
+    sourceCollections,
+    relationshipBasis: "Profile projection must be derived from the authenticated tenant workspace context.",
+  });
 
   return {
+    ...metadata,
+    sourceCollections,
+    sourceRefs,
     context: {
       authority: context.authority,
       propertyId: context.propertyId,
@@ -980,8 +1018,22 @@ export async function loadTenantApplicationReuseProjection(params: {
     asString(application?.data?.applicantName) ||
     asString(application?.data?.fullName);
   const name = splitNameParts(candidateName);
+  const sourceRefs = contextSourceRefs(params.context);
+  if (params.context.applicationId) {
+    sourceRefs.push({ sourceCollection: "applications", sourceId: params.context.applicationId });
+  }
+  const sourceCollections = sourceCollectionsFromRefs(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_application_reuse_projection",
+    scopeType: "tenant_application_reuse",
+    sourceCollections,
+    relationshipBasis: "Application reuse projection must be derived from tenant-owned application context.",
+  });
 
   return {
+    ...metadata,
+    sourceCollections,
+    sourceRefs,
     applicant: {
       firstName: asString(application?.data?.firstName) || name.firstName,
       lastName: asString(application?.data?.lastName) || name.lastName,

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -1,13 +1,20 @@
 import { deriveLeaseExecution, type LeaseExecution } from "../leaseExecution/deriveLeaseExecution";
 import { derivePaymentReadiness, type PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
 import {
+  deriveTenantSafeProjectionMetadata,
   deriveTenantSafeProjectionProfile,
   deriveTenantSafeSourceRefs,
+  type TenantSafeProjectionMetadata,
   type TenantSafeProjectionProfile,
   type TenantSafeProjectionSourceReference,
 } from "./tenantSafeProjectionContract";
 
-type TenantPropertyProjection = {
+type TenantProjectionMetadataFields = TenantSafeProjectionMetadata & {
+  sourceCollections: string[];
+  sourceRefs: TenantSafeProjectionSourceReference[];
+};
+
+type TenantPropertyProjection = TenantProjectionMetadataFields & {
   propertyId: string;
   rc_prop_id: string | null;
   street1: string | null;
@@ -18,18 +25,8 @@ type TenantPropertyProjection = {
   features: string[];
 };
 
-type TenantLeaseProjection = {
+type TenantLeaseProjection = TenantProjectionMetadataFields & {
   leaseId: string;
-  projectionProfile: TenantSafeProjectionProfile;
-  projectionVersion: string;
-  sensitivityClass: TenantSafeProjectionProfile["sensitivityClass"];
-  sourceCollections: string[];
-  sourceRefs: TenantSafeProjectionSourceReference[];
-  redactionSummary: {
-    redactionPolicy: string;
-    redactedFieldGroups: string[];
-    redactionCount: number;
-  };
   startDate: string | null;
   endDate: string | null;
   monthlyRent: number | null;
@@ -56,7 +53,7 @@ type TenantLeaseProjection = {
   paymentReadiness: PaymentReadiness;
 };
 
-type TenantApplicationProjection = {
+type TenantApplicationProjection = TenantProjectionMetadataFields & {
   applicationId: string;
   status: string | null;
   missingSteps: string[];
@@ -65,7 +62,7 @@ type TenantApplicationProjection = {
   updatedAt: string | null;
 };
 
-type TenantMaintenanceProjection = {
+type TenantMaintenanceProjection = TenantProjectionMetadataFields & {
   requestId: string;
   status: string | null;
   category: string | null;
@@ -81,7 +78,6 @@ type TenantMaintenanceProjection = {
   completionOutcome: "completed" | "partially_completed" | "follow_up_required" | null;
   completionConfirmedByLandlordAt: number | null;
   reopenedAt: number | null;
-  reopenedByActorId: string | null;
   reopenedByActorRole: "tenant" | "landlord" | "admin" | null;
   reopenReason: string | null;
   serviceWindowStartAt: number | null;
@@ -394,8 +390,30 @@ function projectFeatureList(input: any): string[] {
     .slice(0, 8);
 }
 
+function uniqueSourceCollections(sourceRefs: TenantSafeProjectionSourceReference[]): string[] {
+  return Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) => a.localeCompare(b));
+}
+
 export function projectTenantProperty(recordId: string, data: any): TenantPropertyProjection {
+  const tenantId = asString(data?.tenantId) || asString(data?.primaryTenantId);
+  const unitId = asString(data?.unitId) || asString(data?.unitNumber) || asString(data?.unit);
+  const sourceRefs = deriveTenantSafeSourceRefs({
+    propertyId: recordId,
+    unitId,
+    tenantId,
+  });
+  const sourceCollections = uniqueSourceCollections(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_property_projection",
+    scopeType: "tenant_property",
+    sourceCollections,
+    relationshipBasis: "Property projection must be derived from the authenticated tenant workspace context.",
+  });
+
   return {
+    ...metadata,
+    sourceCollections,
+    sourceRefs,
     propertyId: recordId,
     rc_prop_id: asString(data?.rc_prop_id) || asString(data?.propertyId) || recordId,
     street1: asString(data?.street1) || asString(data?.addressLine1) || asString(data?.address),
@@ -429,26 +447,27 @@ export function projectTenantLease(recordId: string, data: any): TenantLeaseProj
     unitId,
     tenantId,
   });
-  const sourceCollections = Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) =>
-    a.localeCompare(b),
-  );
+  const sourceCollections = uniqueSourceCollections(sourceRefs);
   const projectionProfile = deriveTenantSafeProjectionProfile({
     scopeType: "tenant_current_lease",
     sourceCollections,
   });
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: projectionProfile.projectionName,
+    scopeType: projectionProfile.scopeType,
+    sourceCollections,
+    allowedFieldGroups: projectionProfile.allowedFieldGroups,
+    excludedFieldGroups: projectionProfile.excludedFieldGroups,
+    relationshipBasis: projectionProfile.relationshipBasis,
+    internalReferencePolicy: projectionProfile.internalReferencePolicy,
+    redactionPolicy: projectionProfile.redactionPolicy,
+  });
 
   return {
+    ...metadata,
     leaseId: recordId,
-    projectionProfile,
-    projectionVersion: projectionProfile.projectionVersion,
-    sensitivityClass: projectionProfile.sensitivityClass,
     sourceCollections,
     sourceRefs,
-    redactionSummary: {
-      redactionPolicy: projectionProfile.redactionPolicy,
-      redactedFieldGroups: projectionProfile.excludedFieldGroups,
-      redactionCount: projectionProfile.excludedFieldGroups.length,
-    },
     startDate,
     endDate,
     monthlyRent,
@@ -477,8 +496,25 @@ export function projectTenantApplication(recordId: string, data: any): TenantApp
   const nextActions = Array.isArray(data?.nextActions)
     ? data.nextActions.map((value: unknown) => asString(value)).filter((value: string | null): value is string => Boolean(value))
     : [];
+  const tenantId = asString(data?.tenantId) || asString(data?.applicantTenantId) || asString(data?.convertedTenantId);
+  const sourceRefs = deriveTenantSafeSourceRefs({
+    leaseId: asString(data?.leaseId),
+    propertyId: asString(data?.propertyId),
+    unitId: asString(data?.unitId) || asString(data?.unitApplied) || asString(data?.unit),
+    tenantId,
+  });
+  const sourceCollections = uniqueSourceCollections(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_application_projection",
+    scopeType: "tenant_application",
+    sourceCollections,
+    relationshipBasis: "Application projection must be derived from the authenticated tenant workspace context.",
+  });
 
   return {
+    ...metadata,
+    sourceCollections,
+    sourceRefs,
     applicationId: recordId,
     status: asString(data?.status),
     missingSteps,
@@ -502,8 +538,25 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
             Boolean(entry.status || entry.actorRole || entry.message || entry.createdAt)
         )
     : [];
+  const sourceRefs = deriveTenantSafeSourceRefs({
+    leaseId: asString(data?.leaseId),
+    propertyId: asString(data?.propertyId),
+    unitId: asString(data?.unitId) || asString(data?.unitNumber) || asString(data?.unit),
+    tenantId: asString(data?.tenantId),
+  });
+  sourceRefs.push({ sourceCollection: "maintenanceRequests", sourceId: recordId });
+  const sourceCollections = uniqueSourceCollections(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_maintenance_projection",
+    scopeType: "tenant_maintenance",
+    sourceCollections,
+    relationshipBasis: "Maintenance projection must be derived from the authenticated tenant workspace context.",
+  });
 
   return {
+    ...metadata,
+    sourceCollections,
+    sourceRefs,
     requestId: recordId,
     status: asString(data?.status),
     category: asString(data?.category),
@@ -524,7 +577,6 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
         : null,
     completionConfirmedByLandlordAt: toMillis(data?.completionConfirmedByLandlordAt),
     reopenedAt: toMillis(data?.reopenedAt),
-    reopenedByActorId: asString(data?.reopenedByActorId),
     reopenedByActorRole:
       data?.reopenedByActorRole === "tenant" ||
       data?.reopenedByActorRole === "landlord" ||

--- a/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
@@ -2,7 +2,25 @@ export const TENANT_SAFE_PROJECTION_VERSION = "tenant_safe_projection_v1";
 
 export type TenantSafeProjectionAudience = "tenant_workspace";
 
-export type TenantSafeProjectionScopeType = "tenant_current_lease";
+export type TenantSafeProjectionName =
+  | "tenant_safe_workspace_projection"
+  | "tenant_safe_workspace_context_projection"
+  | "tenant_safe_profile_projection"
+  | "tenant_safe_application_projection"
+  | "tenant_safe_application_reuse_projection"
+  | "tenant_safe_communications_projection"
+  | "tenant_safe_maintenance_projection"
+  | "tenant_safe_property_projection";
+
+export type TenantSafeProjectionScopeType =
+  | "tenant_current_lease"
+  | "tenant_workspace_context"
+  | "tenant_profile"
+  | "tenant_application"
+  | "tenant_application_reuse"
+  | "tenant_communications"
+  | "tenant_maintenance"
+  | "tenant_property";
 
 export type TenantSafeProjectionSensitivityClass = "sensitive";
 
@@ -12,7 +30,7 @@ export type TenantSafeProjectionSourceReference = {
 };
 
 export type TenantSafeProjectionProfile = {
-  projectionName: "tenant_safe_workspace_projection";
+  projectionName: TenantSafeProjectionName;
   projectionVersion: typeof TENANT_SAFE_PROJECTION_VERSION;
   audience: TenantSafeProjectionAudience;
   scopeType: TenantSafeProjectionScopeType;
@@ -26,6 +44,20 @@ export type TenantSafeProjectionProfile = {
   redactionPolicy: string;
 };
 
+export type TenantSafeRedactionSummary = {
+  redactionPolicy: string;
+  redactedFieldGroups: string[];
+  redactionCount: number;
+};
+
+export type TenantSafeProjectionMetadata = {
+  projectionProfile: TenantSafeProjectionProfile;
+  projectionVersion: typeof TENANT_SAFE_PROJECTION_VERSION;
+  sensitivityClass: TenantSafeProjectionProfile["sensitivityClass"];
+  authorityBasis: TenantSafeProjectionProfile["authorityBasis"];
+  redactionSummary: TenantSafeRedactionSummary;
+};
+
 const ALLOWED_FIELD_GROUPS = [
   "tenant_visible_lease_summary",
   "tenant_visible_document_status",
@@ -34,6 +66,61 @@ const ALLOWED_FIELD_GROUPS = [
   "scoped_source_references",
   "operational_labels",
 ];
+
+const SURFACE_ALLOWED_FIELD_GROUPS: Record<TenantSafeProjectionScopeType, string[]> = {
+  tenant_current_lease: ALLOWED_FIELD_GROUPS,
+  tenant_workspace_context: [
+    "tenant_workspace_context",
+    "tenant_visible_profile_summary",
+    "tenant_visible_application_summary",
+    "tenant_visible_lease_summary",
+    "tenant_visible_maintenance_summary",
+    "derived_identity_signals",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_profile: [
+    "tenant_visible_profile_summary",
+    "tenant_visible_identity_status",
+    "tenant_visible_document_status",
+    "tenant_visible_application_summary",
+    "tenant_visible_lease_summary",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_application: [
+    "tenant_visible_application_summary",
+    "tenant_visible_document_status",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_application_reuse: [
+    "tenant_owned_reuse_profile",
+    "tenant_visible_application_reuse_fields",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_communications: [
+    "tenant_visible_communications_thread",
+    "tenant_visible_message_bodies",
+    "tenant_read_state_summary",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_maintenance: [
+    "tenant_visible_maintenance_summary",
+    "tenant_visible_maintenance_lifecycle",
+    "tenant_safe_evidence",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_property: [
+    "tenant_visible_property_summary",
+    "tenant_visible_unit_summary",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+};
 
 const EXCLUDED_FIELD_GROUPS = [
   "landlord_only_notes",
@@ -48,27 +135,79 @@ const EXCLUDED_FIELD_GROUPS = [
   "private_message_bodies",
 ];
 
+const SURFACE_REDACTION_POLICIES: Record<TenantSafeProjectionScopeType, string> = {
+  tenant_current_lease: "Exclude landlord-only notes, raw/provider/payment/debug/private-message fields, and unrelated tenant data.",
+  tenant_workspace_context:
+    "Exclude landlord-only notes, raw/provider/payment/debug/private-message fields, unrelated tenant data, and raw internal actor references.",
+  tenant_profile:
+    "Exclude landlord-only notes, raw/provider/debug fields, unrelated tenant data, and raw screening payload references.",
+  tenant_application:
+    "Exclude raw application payloads, screening payloads, landlord-only notes, unrelated tenant data, and debug fields.",
+  tenant_application_reuse:
+    "Expose only tenant-owned reusable application fields; exclude screening payloads, consents, documents, notes, and unrelated tenant data.",
+  tenant_communications:
+    "Expose only tenant-visible conversation state and tenant-visible message bodies; exclude private/internal message bodies and debug fields.",
+  tenant_maintenance:
+    "Expose only tenant-visible maintenance lifecycle fields and tenant-safe evidence; exclude raw actor identifiers, internal costs, landlord-only notes, and storage paths.",
+  tenant_property:
+    "Expose only tenant-visible property and unit labels; exclude owner internals, management notes, and debug fields.",
+};
+
 function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
 }
 
 export function deriveTenantSafeProjectionProfile(input: {
+  projectionName?: TenantSafeProjectionName;
   scopeType: TenantSafeProjectionScopeType;
   sourceCollections: string[];
+  allowedFieldGroups?: string[];
+  excludedFieldGroups?: string[];
+  relationshipBasis?: string;
+  internalReferencePolicy?: string;
+  redactionPolicy?: string;
 }): TenantSafeProjectionProfile {
   return {
-    projectionName: "tenant_safe_workspace_projection",
+    projectionName: input.projectionName || "tenant_safe_workspace_projection",
     projectionVersion: TENANT_SAFE_PROJECTION_VERSION,
     audience: "tenant_workspace",
     scopeType: input.scopeType,
     allowedSourceCollections: uniqueSorted(input.sourceCollections),
-    allowedFieldGroups: ALLOWED_FIELD_GROUPS,
-    excludedFieldGroups: EXCLUDED_FIELD_GROUPS,
+    allowedFieldGroups: input.allowedFieldGroups || SURFACE_ALLOWED_FIELD_GROUPS[input.scopeType],
+    excludedFieldGroups: input.excludedFieldGroups || EXCLUDED_FIELD_GROUPS,
     sensitivityClass: "sensitive",
     authorityBasis: "authenticated_tenant_scope",
-    relationshipBasis: "Projection must be derived from the authenticated tenant's current lease relationship.",
-    internalReferencePolicy: "Internal IDs are scoped references for navigation/traceability, not primary display labels.",
-    redactionPolicy: "Exclude landlord-only notes, raw/provider/payment/debug/private-message fields, and unrelated tenant data.",
+    relationshipBasis:
+      input.relationshipBasis ||
+      "Projection must be derived from the authenticated tenant's current lease relationship.",
+    internalReferencePolicy:
+      input.internalReferencePolicy ||
+      "Internal IDs are scoped references for navigation/traceability, not primary display labels.",
+    redactionPolicy: input.redactionPolicy || SURFACE_REDACTION_POLICIES[input.scopeType],
+  };
+}
+
+export function deriveTenantSafeProjectionMetadata(input: {
+  projectionName?: TenantSafeProjectionName;
+  scopeType: TenantSafeProjectionScopeType;
+  sourceCollections: string[];
+  allowedFieldGroups?: string[];
+  excludedFieldGroups?: string[];
+  relationshipBasis?: string;
+  internalReferencePolicy?: string;
+  redactionPolicy?: string;
+}): TenantSafeProjectionMetadata {
+  const projectionProfile = deriveTenantSafeProjectionProfile(input);
+  return {
+    projectionProfile,
+    projectionVersion: projectionProfile.projectionVersion,
+    sensitivityClass: projectionProfile.sensitivityClass,
+    authorityBasis: projectionProfile.authorityBasis,
+    redactionSummary: {
+      redactionPolicy: projectionProfile.redactionPolicy,
+      redactedFieldGroups: projectionProfile.excludedFieldGroups,
+      redactionCount: projectionProfile.excludedFieldGroups.length,
+    },
   };
 }
 

--- a/rentchain-frontend/src/api/tenantApplicationReuse.ts
+++ b/rentchain-frontend/src/api/tenantApplicationReuse.ts
@@ -1,6 +1,7 @@
 import { tenantApiFetch } from "./tenantApiFetch";
+import type { TenantSafeProjectionMetadata } from "./tenantPortal";
 
-export type TenantApplicationReuseData = {
+export type TenantApplicationReuseData = TenantSafeProjectionMetadata & {
   applicant: {
     firstName: string | null;
     lastName: string | null;

--- a/rentchain-frontend/src/api/tenantCommunicationsApi.ts
+++ b/rentchain-frontend/src/api/tenantCommunicationsApi.ts
@@ -1,4 +1,5 @@
 import { tenantApiFetch } from "./tenantApiFetch";
+import type { TenantSafeProjectionMetadata } from "./tenantPortal";
 
 export type TenantCommunicationType = "notice" | "message" | "maintenance_update" | "screening_update" | "system";
 export type TenantCommunicationPriority = "low" | "normal" | "high";
@@ -35,7 +36,7 @@ export type TenantThreadMessage = {
   createdAtMs: number | null;
 };
 
-export type TenantCommunicationsWorkspace = {
+export type TenantCommunicationsWorkspace = TenantSafeProjectionMetadata & {
   canSend: boolean;
   canSendReason: string | null;
   thread: {

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -1,5 +1,35 @@
 import { tenantApiFetch } from "./tenantApiFetch";
 
+export type TenantSafeProjectionMetadata = {
+  projectionProfile?: {
+    projectionName: string;
+    projectionVersion: string;
+    audience: "tenant_workspace";
+    scopeType: string;
+    allowedSourceCollections: string[];
+    allowedFieldGroups: string[];
+    excludedFieldGroups: string[];
+    sensitivityClass: "sensitive";
+    authorityBasis: "authenticated_tenant_scope";
+    relationshipBasis: string;
+    internalReferencePolicy: string;
+    redactionPolicy: string;
+  };
+  projectionVersion?: string;
+  sensitivityClass?: "sensitive";
+  authorityBasis?: "authenticated_tenant_scope";
+  sourceCollections?: string[];
+  sourceRefs?: Array<{
+    sourceCollection: string;
+    sourceId: string;
+  }>;
+  redactionSummary?: {
+    redactionPolicy: string;
+    redactedFieldGroups: string[];
+    redactionCount: number;
+  };
+};
+
 export type TenantWorkspaceContext = {
   ok?: boolean;
   authority: "applicant" | "active_tenant" | "invite" | null;
@@ -12,7 +42,7 @@ export type TenantWorkspaceContext = {
   invitedEmail: string | null;
 };
 
-export type TenantWorkspaceProperty = {
+export type TenantWorkspaceProperty = TenantSafeProjectionMetadata & {
   propertyId: string;
   rc_prop_id: string | null;
   street1: string | null;
@@ -28,7 +58,7 @@ export type TenantWorkspaceUnit = {
   label: string | null;
 };
 
-export type TenantWorkspaceApplication = {
+export type TenantWorkspaceApplication = TenantSafeProjectionMetadata & {
   applicationId: string;
   status: string | null;
   missingSteps: string[];
@@ -37,7 +67,7 @@ export type TenantWorkspaceApplication = {
   updatedAt: string | null;
 };
 
-export type TenantWorkspaceLease = {
+export type TenantWorkspaceLease = TenantSafeProjectionMetadata & {
   leaseId: string;
   startDate: string | null;
   endDate: string | null;
@@ -167,7 +197,7 @@ export type PaymentReadiness = {
   };
 };
 
-export type TenantWorkspaceMaintenance = {
+export type TenantWorkspaceMaintenance = TenantSafeProjectionMetadata & {
   requestId: string;
   id?: string;
   status: string | null;
@@ -184,7 +214,6 @@ export type TenantWorkspaceMaintenance = {
   completionOutcome?: "completed" | "partially_completed" | "follow_up_required" | null;
   completionConfirmedByLandlordAt?: number | null;
   reopenedAt?: number | null;
-  reopenedByActorId?: string | null;
   reopenedByActorRole?: "tenant" | "landlord" | "admin" | null;
   reopenReason?: string | null;
   serviceWindowStartAt?: number | null;
@@ -523,7 +552,7 @@ export type InstitutionalHandoffSummary = {
   updatedAt: string;
 };
 
-export type TenantWorkspaceSummary = {
+export type TenantWorkspaceSummary = TenantSafeProjectionMetadata & {
   context: TenantWorkspaceContext;
   tenant?: {
     id?: string | null;

--- a/rentchain-frontend/src/api/tenantProfile.ts
+++ b/rentchain-frontend/src/api/tenantProfile.ts
@@ -1,8 +1,9 @@
 import { tenantApiFetch } from "./tenantApiFetch";
+import type { TenantSafeProjectionMetadata } from "./tenantPortal";
 
 export type TenantProfileStatus = "verified" | "pending" | "missing" | "needs_review";
 
-export type TenantProfileData = {
+export type TenantProfileData = TenantSafeProjectionMetadata & {
   context: {
     authority: "applicant" | "active_tenant" | "invite" | null;
     propertyId: string | null;
@@ -18,7 +19,7 @@ export type TenantProfileData = {
     email: string | null;
     phone: string | null;
     authorityLabel: string;
-    property: {
+    property: (TenantSafeProjectionMetadata & {
       propertyId: string;
       rc_prop_id: string | null;
       street1: string | null;
@@ -29,27 +30,27 @@ export type TenantProfileData = {
       unitNumber?: string | null;
       unitDisplayLabel?: string | null;
       features: string[];
-    } | null;
+    }) | null;
     unit: {
       unitId: string | null;
       label: string | null;
     } | null;
-    application: {
+    application: (TenantSafeProjectionMetadata & {
       applicationId: string;
       status: string | null;
       missingSteps: string[];
       nextActions: string[];
       createdAt: string | null;
       updatedAt: string | null;
-    } | null;
-    lease: {
+    }) | null;
+    lease: (TenantSafeProjectionMetadata & {
       leaseId: string;
       startDate: string | null;
       endDate: string | null;
       monthlyRent: number | null;
       status: string | null;
       documentUrl: string | null;
-    } | null;
+    }) | null;
   };
   identity: {
     overallStatus: TenantProfileStatus;


### PR DESCRIPTION
## Summary
Adds explicit tenant-safe projection contract metadata across tenant workspace context response surfaces.

## Changes
- Generalizes tenant-safe projection contract metadata for workspace context, profile, application, application reuse, communications, maintenance, and property projections
- Adds projection metadata, source references, authority basis, sensitivity class, and redaction summaries to tenant workspace response shapes
- Removes tenant-facing `reopenedByActorId` from maintenance projection and detail responses while preserving role-only `reopenedByActorRole`
- Updates frontend API types to accept the new backward-compatible metadata fields
- Adds focused backend route/service coverage for projection metadata and raw actor reference removal

## Validation
- Backend targeted tests: 91/91 passing
- Backend TypeScript build: pass
- Frontend targeted tests: 7/7 passing
- Frontend build: pass
- git diff --check: pass
- git diff --cached --check: pass
- Staged scope verified: 13 mission-scoped files only

## Scope
Projection contract hardening only. No auth logic, tenancy context resolver, duplicate route registrations, provider callback behavior, billing, pricing, Firestore rules, Terraform, CI/CD, or production data changed.

## Known Limitations
- Manual browser QA was not performed in this environment
- Duplicate tenant route registrations remain documented for a future mission
- Legacy frontend route drift remains documented for a future mission
- Provider callback behavior remains documented for separate review