### PR TITLE
feat: harden tenant lease and document projection contracts

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantLeaseNoticeRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantLeaseNoticeRoutes.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  leaseNotices,
+  leases,
+  getLeaseForTenantWorkflowMock,
+  appendLeaseWorkflowEventMock,
+  lookupUserEmailMock,
+  sendLeaseWorkflowEmailMock,
+} = vi.hoisted(() => ({
+  leaseNotices: new Map<string, any>(),
+  leases: new Map<string, any>(),
+  getLeaseForTenantWorkflowMock: vi.fn(),
+  appendLeaseWorkflowEventMock: vi.fn(),
+  lookupUserEmailMock: vi.fn(),
+  sendLeaseWorkflowEmailMock: vi.fn(),
+}));
+
+function clone(value: any) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function docRef(collectionName: string, id?: string) {
+  const docId = id || `${collectionName}-${leaseNotices.size + leases.size + 1}`;
+  const collection = collectionName === "leases" ? leases : leaseNotices;
+  return {
+    id: docId,
+    get: async () => ({
+      id: docId,
+      exists: collection.has(docId),
+      data: () => clone(collection.get(docId)),
+    }),
+    set: async (value: any, opts?: { merge?: boolean }) => {
+      const current = collection.get(docId) || {};
+      collection.set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+    },
+  };
+}
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    batch: () => {
+      const writes: Array<() => Promise<void>> = [];
+      return {
+        set(ref: any, value: any, opts?: { merge?: boolean }) {
+          writes.push(() => ref.set(value, opts));
+        },
+        async commit() {
+          await Promise.all(writes.map((write) => write()));
+        },
+      };
+    },
+    collection: (name: string) => ({
+      doc: (id?: string) => docRef(name, id),
+      where: (field: string, op: string, value: any) => ({
+        limit: (_count: number) => ({
+          get: async () => {
+            const source = name === "leases" ? leases : leaseNotices;
+            const docs = Array.from(source.entries())
+              .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
+              .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+            return { docs, empty: docs.length === 0 };
+          },
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) req.user = JSON.parse(header);
+    next();
+  },
+}));
+
+vi.mock("../../config/leaseNoticeRules", () => ({
+  getLeaseNoticeWorkflowFlag: () => ({ enabled: true, source: "test" }),
+}));
+
+vi.mock("../../services/leaseNoticeWorkflowService", () => ({
+  appendLeaseWorkflowEvent: appendLeaseWorkflowEventMock,
+  computeNoResponseState: () => false,
+  getLeaseForTenantWorkflow: getLeaseForTenantWorkflowMock,
+  lookupUserEmail: lookupUserEmailMock,
+  sendLeaseWorkflowEmail: sendLeaseWorkflowEmailMock,
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      params: {},
+    };
+    const match = options.url.match(/^\/([^/?]+)(?:\/([^/?]+))?/);
+    if (match?.[1]) req.params.id = decodeURIComponent(match[1]);
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function tenantHeaders() {
+  return {
+    "x-test-user": JSON.stringify({
+      id: "user-tenant-1",
+      role: "tenant",
+      tenantId: "tenant-1",
+      email: "tenant@example.test",
+    }),
+  };
+}
+
+function noticeFixture(overrides: Record<string, any> = {}) {
+  return {
+    id: "notice-1",
+    leaseId: "lease-1",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    noticeType: "renewal_offer",
+    legalTemplateKey: "ns-fixed-term-renewal",
+    province: "NS",
+    leaseType: "fixed_term",
+    noticeDueAt: 100,
+    sentAt: 110,
+    deliveryStatus: "sent",
+    deliveryChannel: "email",
+    rentChangeMode: "increase",
+    currentRent: 1800,
+    proposedRent: 1900,
+    newTermType: "fixed_term",
+    newTermStartDate: "2027-02-01",
+    newTermEndDate: "2028-01-31",
+    responseRequired: true,
+    responseDeadlineAt: 200,
+    tenantResponse: "pending",
+    tenantRespondedAt: null,
+    tenantViewedAt: 120,
+    createdAt: 90,
+    updatedAt: 110,
+    metadata: {
+      noticeRuleVersion: "v1",
+      summary: {
+        title: "Lease renewal offer",
+        body: "Review your next-term options.",
+      },
+      landlordInternalNotes: "private landlord note",
+    },
+    landlordDecisionNotes: "private decision note",
+    internalWorkflowState: "operator-only",
+    providerDeliveryPayload: { messageId: "provider-message-id" },
+    ...overrides,
+  };
+}
+
+describe("tenantLeaseNoticeRoutes tenant-safe projections", () => {
+  beforeEach(() => {
+    leaseNotices.clear();
+    leases.clear();
+    getLeaseForTenantWorkflowMock.mockReset();
+    appendLeaseWorkflowEventMock.mockReset();
+    lookupUserEmailMock.mockReset();
+    sendLeaseWorkflowEmailMock.mockReset();
+    lookupUserEmailMock.mockResolvedValue("landlord@example.test");
+    sendLeaseWorkflowEmailMock.mockResolvedValue({
+      ok: true,
+      attempted: true,
+      provider: "mailgun",
+      reason: null,
+      rawPayload: "provider-private",
+    });
+  });
+
+  it("adds tenant-safe projection metadata and redacts internal lease notice fields from list responses", async () => {
+    leaseNotices.set("notice-1", noticeFixture());
+
+    const router = (await import("../tenantLeaseNoticeRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/",
+      headers: tenantHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_lease_notice_projection",
+        scopeType: "tenant_lease_notice",
+      })
+    );
+    expect(res.body?.items?.[0]?.projectionProfile?.projectionName).toBe("tenant_safe_lease_notice_projection");
+    expect(res.body?.items?.[0]?.metadata?.summary?.body).toBe("Review your next-term options.");
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("private landlord note");
+    expect(payload).not.toContain("private decision note");
+    expect(payload).not.toContain("operator-only");
+    expect(payload).not.toContain("provider-message-id");
+  });
+
+  it("adds projection metadata to detail responses and preserves append-safe viewed state", async () => {
+    const notice = noticeFixture();
+    getLeaseForTenantWorkflowMock.mockResolvedValue({ ok: true, notice: { ...notice } });
+
+    const router = (await import("../tenantLeaseNoticeRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/notice-1",
+      headers: tenantHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.projectionProfile?.projectionName).toBe("tenant_safe_lease_notice_projection");
+    expect(res.body?.redactionSummary?.redactedFieldGroups).toEqual(
+      expect.arrayContaining(["landlord_internal_workflow_state", "provider_delivery_payloads"])
+    );
+    expect(appendLeaseWorkflowEventMock).not.toHaveBeenCalled();
+    expect(JSON.stringify(res.body)).not.toContain("private decision note");
+  });
+
+  it("adds projection metadata to tenant response mutations without returning provider payloads", async () => {
+    const notice = noticeFixture({ tenantViewedAt: 120 });
+    getLeaseForTenantWorkflowMock.mockResolvedValue({ ok: true, notice: { ...notice } });
+    leases.set("lease-1", { endDate: "2027-01-31" });
+
+    const router = (await import("../tenantLeaseNoticeRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/notice-1/respond",
+      body: { decision: "renew" },
+      headers: tenantHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.projectionProfile?.projectionName).toBe("tenant_safe_lease_notice_projection");
+    expect(res.body?.decision).toBe("renew");
+    expect(res.body?.landlordNotification).toEqual({
+      ok: true,
+      attempted: true,
+      reason: null,
+    });
+    expect(JSON.stringify(res.body)).not.toContain("mailgun");
+    expect(JSON.stringify(res.body)).not.toContain("provider-private");
+    expect(appendLeaseWorkflowEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "leaseNotice",
+        entityId: "notice-1",
+        eventType: "tenant_renewed",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -664,6 +664,9 @@ describe("tenantPortalRoutes foundation", () => {
 
     expect(res.status).toBe(200);
     expect(res.body?.data?.leaseId).toBe("lease-1");
+    expect(res.body?.data?.projectionProfile?.projectionName).toBe("tenant_safe_workspace_projection");
+    expect(res.body?.data?.projectionProfile?.scopeType).toBe("tenant_current_lease");
+    expect(res.body?.data?.redactionSummary?.redactedFieldGroups).toContain("payment_account_details");
     expect(res.body?.data?.signatureStatus).toBe("signed");
     expect(res.body?.data?.signatureReadinessDescription).toMatch(/current signing stage as complete/i);
     expect(res.body?.data?.tenantSignature).toEqual({
@@ -964,6 +967,13 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data).toEqual(
       expect.objectContaining({
+        projectionProfile: expect.objectContaining({
+          projectionName: "tenant_safe_document_access_projection",
+          scopeType: "tenant_document_access",
+        }),
+        redactionSummary: expect.objectContaining({
+          redactedFieldGroups: expect.arrayContaining(["storage_paths", "provider_delivery_payloads"]),
+        }),
         documentUrl: "https://signed.example/leases/landlord-1/lease-1/lease-v1.pdf",
         displayLabel: "Signed lease document",
         documentStatus: "signed",
@@ -3359,6 +3369,15 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.body?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_attachment_projection",
+        scopeType: "tenant_attachment",
+      })
+    );
+    expect(res.body?.redactionSummary?.redactedFieldGroups).toEqual(
+      expect.arrayContaining(["storage_paths", "provider_delivery_payloads"])
+    );
     expect(Array.isArray(res.body?.data)).toBe(true);
     expect(res.body?.summary?.total).toBeGreaterThan(0);
     expect(res.body?.summary?.uploaded).toBeGreaterThanOrEqual(2);

--- a/rentchain-api/src/routes/tenantLeaseNoticeRoutes.ts
+++ b/rentchain-api/src/routes/tenantLeaseNoticeRoutes.ts
@@ -9,6 +9,11 @@ import {
   lookupUserEmail,
   sendLeaseWorkflowEmail,
 } from "../services/leaseNoticeWorkflowService";
+import {
+  deriveTenantSafeProjectionMetadata,
+  deriveTenantSafeSourceRefs,
+  type TenantSafeProjectionSourceReference,
+} from "../services/tenantPortal/tenantSafeProjectionContract";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -40,6 +45,87 @@ function appBaseUrl() {
   return String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
 }
 
+function uniqueSourceCollections(sourceRefs: TenantSafeProjectionSourceReference[]) {
+  return Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) => a.localeCompare(b));
+}
+
+function buildLeaseNoticeProjectionMetadata(notice: any) {
+  const sourceRefs = deriveTenantSafeSourceRefs({
+    leaseId: String(notice?.leaseId || "").trim() || null,
+    propertyId: String(notice?.propertyId || "").trim() || null,
+    unitId: String(notice?.unitId || "").trim() || null,
+    tenantId: String(notice?.tenantId || "").trim() || null,
+  });
+  const noticeId = String(notice?.id || "").trim();
+  if (noticeId) sourceRefs.push({ sourceCollection: "leaseNotices", sourceId: noticeId });
+  const sourceCollections = uniqueSourceCollections(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_lease_notice_projection",
+    scopeType: "tenant_lease_notice",
+    sourceCollections,
+    relationshipBasis: "Lease notice projection must be derived from the authenticated tenant's lease notice relationship.",
+  });
+  return { ...metadata, sourceCollections, sourceRefs };
+}
+
+function projectTenantLeaseNotice(notice: any) {
+  const projected = {
+    id: String(notice?.id || "").trim(),
+    leaseId: String(notice?.leaseId || "").trim(),
+    landlordId: String(notice?.landlordId || "").trim() || null,
+    tenantId: String(notice?.tenantId || "").trim() || null,
+    propertyId: String(notice?.propertyId || "").trim() || null,
+    unitId: String(notice?.unitId || "").trim() || null,
+    noticeType: String(notice?.noticeType || "").trim() || "lease_notice",
+    legalTemplateKey: String(notice?.legalTemplateKey || "").trim() || null,
+    province: String(notice?.province || "").trim() || null,
+    leaseType: String(notice?.leaseType || "").trim() || null,
+    noticeDueAt: typeof notice?.noticeDueAt === "number" ? notice.noticeDueAt : null,
+    sentAt: typeof notice?.sentAt === "number" ? notice.sentAt : null,
+    deliveryStatus: String(notice?.deliveryStatus || "pending").trim() || "pending",
+    deliveryChannel: String(notice?.deliveryChannel || "").trim() || null,
+    rentChangeMode: String(notice?.rentChangeMode || "no_change").trim() || "no_change",
+    currentRent: typeof notice?.currentRent === "number" ? notice.currentRent : null,
+    proposedRent: typeof notice?.proposedRent === "number" ? notice.proposedRent : null,
+    newTermType: String(notice?.newTermType || "").trim() || null,
+    newTermStartDate: String(notice?.newTermStartDate || "").trim() || null,
+    newTermEndDate: String(notice?.newTermEndDate || "").trim() || null,
+    responseRequired: notice?.responseRequired !== false,
+    responseDeadlineAt: typeof notice?.responseDeadlineAt === "number" ? notice.responseDeadlineAt : null,
+    tenantResponse: String(notice?.tenantResponse || "pending").trim() || "pending",
+    tenantRespondedAt: typeof notice?.tenantRespondedAt === "number" ? notice.tenantRespondedAt : null,
+    tenantViewedAt: typeof notice?.tenantViewedAt === "number" ? notice.tenantViewedAt : null,
+    createdAt: typeof notice?.createdAt === "number" ? notice.createdAt : null,
+    updatedAt: typeof notice?.updatedAt === "number" ? notice.updatedAt : null,
+    metadata: {
+      noticeRuleVersion: String(notice?.metadata?.noticeRuleVersion || "").trim() || null,
+      summary: notice?.metadata?.summary
+        ? {
+            title: String(notice.metadata.summary.title || "").trim() || null,
+            body: String(notice.metadata.summary.body || "").trim() || null,
+          }
+        : null,
+    },
+  };
+  return { ...buildLeaseNoticeProjectionMetadata(projected), ...projected };
+}
+
+function buildLeaseNoticeCollectionMetadata(tenantId: string, items: any[]) {
+  const sourceRefs = deriveTenantSafeSourceRefs({ tenantId });
+  for (const item of items) {
+    const noticeId = String(item?.id || "").trim();
+    if (noticeId) sourceRefs.push({ sourceCollection: "leaseNotices", sourceId: noticeId });
+  }
+  const sourceCollections = uniqueSourceCollections(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_lease_notice_projection",
+    scopeType: "tenant_lease_notice",
+    sourceCollections,
+    relationshipBasis: "Lease notice list projection must be scoped to the authenticated tenant's notice records.",
+  });
+  return { ...metadata, sourceCollections, sourceRefs };
+}
+
 router.get("/", async (req: any, res) => {
   try {
     const tenantId = getCanonicalTenantId(req);
@@ -47,7 +133,13 @@ router.get("/", async (req: any, res) => {
     const items = snap.docs
       .map((doc) => ({ id: doc.id, ...(doc.data() as any) }))
       .sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0));
-    return res.json({ ok: true, items, data: items });
+    const projectedItems = items.map(projectTenantLeaseNotice);
+    return res.json({
+      ok: true,
+      ...buildLeaseNoticeCollectionMetadata(tenantId, projectedItems),
+      items: projectedItems,
+      data: projectedItems,
+    });
   } catch (err: any) {
     console.error("[lease-notice] tenant-list failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "TENANT_LEASE_NOTICE_LIST_FAILED" });
@@ -103,7 +195,14 @@ router.get("/:id", async (req: any, res) => {
       notice.deliveryStatus = notice.deliveryStatus === "sent" ? "viewed" : notice.deliveryStatus;
     }
 
-    return res.json({ ok: true, item: notice, data: notice, noResponse: computeNoResponseState(notice) });
+    const projectedNotice = projectTenantLeaseNotice(notice);
+    return res.json({
+      ok: true,
+      ...buildLeaseNoticeProjectionMetadata(projectedNotice),
+      item: projectedNotice,
+      data: projectedNotice,
+      noResponse: computeNoResponseState(notice),
+    });
   } catch (err: any) {
     console.error("[lease-notice] tenant-detail failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "TENANT_LEASE_NOTICE_GET_FAILED" });
@@ -238,10 +337,15 @@ router.post("/:id/respond", async (req: any, res) => {
 
     return res.json({
       ok: true,
+      ...buildLeaseNoticeProjectionMetadata({ ...notice, tenantResponse: decision, tenantRespondedAt: now, updatedAt: now }),
       decision,
       noticeId,
       leaseId,
-      landlordNotification: notification,
+      landlordNotification: {
+        ok: notification?.ok,
+        attempted: notification?.attempted,
+        reason: notification?.reason || null,
+      },
       nextStatus: decision === "renew" ? "renewal_accepted" : "move_out_pending",
     });
   } catch (err: any) {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2517,6 +2517,76 @@ function buildTenantWorkspaceContextMetadata(
   return { ...metadata, sourceCollections, sourceRefs: normalizedRefs };
 }
 
+function normalizeTenantSourceRefs(sourceRefs: TenantSafeProjectionSourceReference[]) {
+  const byKey = new Map<string, TenantSafeProjectionSourceReference>();
+  for (const ref of sourceRefs) {
+    if (ref.sourceCollection && ref.sourceId) byKey.set(`${ref.sourceCollection}:${ref.sourceId}`, ref);
+  }
+  return Array.from(byKey.values()).sort((a, b) =>
+    `${a.sourceCollection}:${a.sourceId}`.localeCompare(`${b.sourceCollection}:${b.sourceId}`)
+  );
+}
+
+function tenantSourceCollections(sourceRefs: TenantSafeProjectionSourceReference[]) {
+  return Array.from(new Set(sourceRefs.map((item) => item.sourceCollection))).sort((a, b) => a.localeCompare(b));
+}
+
+function buildTenantDocumentAccessMetadata(params: {
+  leaseId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+}) {
+  const sourceRefs = normalizeTenantSourceRefs(deriveTenantSafeSourceRefs(params));
+  const sourceCollections = tenantSourceCollections(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_document_access_projection",
+    scopeType: "tenant_document_access",
+    sourceCollections,
+    relationshipBasis: "Document access projection must be derived from authenticated tenant lease ownership.",
+  });
+  return { ...metadata, sourceCollections, sourceRefs };
+}
+
+function buildTenantLeaseProjectionMetadata(params: {
+  leaseId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+}) {
+  const sourceRefs = normalizeTenantSourceRefs(deriveTenantSafeSourceRefs(params));
+  const sourceCollections = tenantSourceCollections(sourceRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_workspace_projection",
+    scopeType: "tenant_current_lease",
+    sourceCollections,
+    relationshipBasis: "Projection must be derived from the authenticated tenant's current lease relationship.",
+  });
+  return { ...metadata, sourceCollections, sourceRefs };
+}
+
+function buildTenantAttachmentProjectionMetadata(params: {
+  leaseId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  attachmentIds?: string[];
+}) {
+  const sourceRefs = deriveTenantSafeSourceRefs(params);
+  for (const attachmentId of params.attachmentIds || []) {
+    if (attachmentId) sourceRefs.push({ sourceCollection: "ledgerAttachments", sourceId: attachmentId });
+  }
+  const normalizedRefs = normalizeTenantSourceRefs(sourceRefs);
+  const sourceCollections = tenantSourceCollections(normalizedRefs);
+  const metadata = deriveTenantSafeProjectionMetadata({
+    projectionName: "tenant_safe_attachment_projection",
+    scopeType: "tenant_attachment",
+    sourceCollections,
+    relationshipBasis: "Attachment projection must be derived from authenticated tenant workspace and tenant-safe document visibility.",
+  });
+  return { ...metadata, sourceCollections, sourceRefs: normalizedRefs };
+}
+
 async function buildTenantWorkspaceDisplayProjection(
   context: Awaited<ReturnType<typeof resolveTenancyContext>>,
   workspace: Awaited<ReturnType<typeof loadTenantWorkspaceData>>,
@@ -5237,6 +5307,7 @@ router.get("/application-completion", requireTenantWorkspaceIdentity, async (req
   }
 });
 
+// Primary tenant-safe lease projection route. A legacy duplicate registration exists below; keep this route first until a separate consolidation mission retires the duplicate.
 router.get("/lease", requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
@@ -5282,6 +5353,12 @@ router.get("/lease/document-url", requireTenantWorkspaceIdentity, async (req: an
     return res.json({
       ok: true,
       data: {
+        ...buildTenantDocumentAccessMetadata({
+          leaseId: context.leaseId,
+          propertyId: context.propertyId,
+          unitId: context.unitId,
+          tenantId: context.tenantId,
+        }),
         documentUrl: documentContext.documentUrl,
         displayLabel: documentContext.displayLabel,
         documentStatus: documentContext.documentStatus,
@@ -5527,6 +5604,7 @@ router.post("/leases/:leaseId/sign", requireTenantWorkspaceIdentity, async (req:
     const signatureMethod = req.body?.signatureMethod === "drawn" ? "drawn" : "typed";
     const nowIso = new Date().toISOString();
 
+    // Signature writes update tenant-visible state and append canonical events; historical signing evidence remains preserved.
     await leaseRef.set(
       {
         tenantSignedAt: nowIso,
@@ -7150,6 +7228,13 @@ router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res)
 
     return res.json({
       ok: true,
+      ...buildTenantAttachmentProjectionMetadata({
+        leaseId: context.leaseId,
+        propertyId: context.propertyId,
+        unitId: context.unitId,
+        tenantId,
+        attachmentIds: documentWorkspace.items.map((item: any) => String(item?.id || "").trim()).filter(Boolean),
+      }),
       data: documentWorkspace.items,
       summary: documentWorkspace.summary,
       guidance: documentWorkspace.guidance,
@@ -7195,6 +7280,7 @@ router.get("/ledger/:ledgerItemId/attachments", requireTenant, async (req: any, 
   }
 });
 
+// Legacy duplicate lease route shadowed by the workspace-context route above. Preserve route order and leave consolidation to a separately scoped cleanup.
 router.get("/lease", requireTenant, async (req: any, res) => {
   try {
     const tenantId = req.user?.tenantId;
@@ -7309,6 +7395,12 @@ router.get("/lease", requireTenant, async (req: any, res) => {
 
     const lease = {
       ...(projectedLease || {
+        ...buildTenantLeaseProjectionMetadata({
+          leaseId,
+          propertyId,
+          unitId,
+          tenantId,
+        }),
         leaseId,
         startDate: null,
         endDate: null,

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -1013,6 +1013,7 @@ export async function appendLeaseWorkflowEvent(input: {
   eventType: LeaseWorkflowEventType;
   eventData?: Record<string, unknown>;
 }) {
+  // Lease notice state changes keep the original notice fields intact and append workflow events for audit continuity.
   const ref = db.collection("leaseWorkflowEvents").doc();
   const payload = {
     id: ref.id,

--- a/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
@@ -10,7 +10,10 @@ export type TenantSafeProjectionName =
   | "tenant_safe_application_reuse_projection"
   | "tenant_safe_communications_projection"
   | "tenant_safe_maintenance_projection"
-  | "tenant_safe_property_projection";
+  | "tenant_safe_property_projection"
+  | "tenant_safe_lease_notice_projection"
+  | "tenant_safe_document_access_projection"
+  | "tenant_safe_attachment_projection";
 
 export type TenantSafeProjectionScopeType =
   | "tenant_current_lease"
@@ -20,7 +23,10 @@ export type TenantSafeProjectionScopeType =
   | "tenant_application_reuse"
   | "tenant_communications"
   | "tenant_maintenance"
-  | "tenant_property";
+  | "tenant_property"
+  | "tenant_lease_notice"
+  | "tenant_document_access"
+  | "tenant_attachment";
 
 export type TenantSafeProjectionSensitivityClass = "sensitive";
 
@@ -120,6 +126,28 @@ const SURFACE_ALLOWED_FIELD_GROUPS: Record<TenantSafeProjectionScopeType, string
     "scoped_source_references",
     "operational_labels",
   ],
+  tenant_lease_notice: [
+    "tenant_visible_lease_notice_summary",
+    "tenant_visible_notice_text",
+    "tenant_visible_response_options",
+    "tenant_response_state",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_document_access: [
+    "tenant_visible_document_status",
+    "tenant_scoped_signed_url",
+    "tenant_visible_document_labels",
+    "scoped_source_references",
+    "operational_labels",
+  ],
+  tenant_attachment: [
+    "tenant_visible_attachment_summary",
+    "tenant_visible_document_status",
+    "tenant_safe_evidence",
+    "scoped_source_references",
+    "operational_labels",
+  ],
 };
 
 const EXCLUDED_FIELD_GROUPS = [
@@ -133,6 +161,9 @@ const EXCLUDED_FIELD_GROUPS = [
   "route_source_metadata",
   "stack_traces",
   "private_message_bodies",
+  "storage_paths",
+  "provider_delivery_payloads",
+  "landlord_internal_workflow_state",
 ];
 
 const SURFACE_REDACTION_POLICIES: Record<TenantSafeProjectionScopeType, string> = {
@@ -151,6 +182,12 @@ const SURFACE_REDACTION_POLICIES: Record<TenantSafeProjectionScopeType, string> 
     "Expose only tenant-visible maintenance lifecycle fields and tenant-safe evidence; exclude raw actor identifiers, internal costs, landlord-only notes, and storage paths.",
   tenant_property:
     "Expose only tenant-visible property and unit labels; exclude owner internals, management notes, and debug fields.",
+  tenant_lease_notice:
+    "Expose notice text, deadlines, tenant response options, and tenant-owned response state; exclude landlord internal notes, processing state, provider delivery payloads, and unrelated notices.",
+  tenant_document_access:
+    "Expose only tenant-scoped document URL, status, label, and expiry; exclude storage paths, bucket names, provider payloads, raw document metadata, and unrelated documents.",
+  tenant_attachment:
+    "Expose only tenant-safe attachment labels, status, dates, and tenant-visible document links; exclude storage paths, bucket names, provider payloads, raw metadata, and unrelated evidence.",
 };
 
 function uniqueSorted(values: string[]): string[] {

--- a/rentchain-frontend/src/api/tenantAttachmentsApi.ts
+++ b/rentchain-frontend/src/api/tenantAttachmentsApi.ts
@@ -1,4 +1,5 @@
 import { tenantApiFetch } from "./tenantApiFetch";
+import type { TenantSafeProjectionMetadata } from "./tenantPortal";
 
 export type TenantAttachment = {
   id: string;
@@ -46,6 +47,7 @@ export type TenantAttachmentGuidance = {
 
 export async function getTenantAttachments(): Promise<{
   ok: boolean;
+} & TenantSafeProjectionMetadata & {
   data: TenantAttachment[];
   summary?: TenantAttachmentSummary;
   guidance?: TenantAttachmentGuidance;
@@ -53,6 +55,7 @@ export async function getTenantAttachments(): Promise<{
 }> {
   return tenantApiFetch<{
     ok: boolean;
+  } & TenantSafeProjectionMetadata & {
     data: TenantAttachment[];
     summary?: TenantAttachmentSummary;
     guidance?: TenantAttachmentGuidance;

--- a/rentchain-frontend/src/api/tenantLeaseNoticeApi.ts
+++ b/rentchain-frontend/src/api/tenantLeaseNoticeApi.ts
@@ -1,6 +1,7 @@
 import { tenantApiFetch } from "./tenantApiFetch";
+import type { TenantSafeProjectionMetadata } from "./tenantPortal";
 
-export type TenantLeaseNoticeSummary = {
+export type TenantLeaseNoticeSummary = TenantSafeProjectionMetadata & {
   id: string;
   leaseId: string;
   landlordId: string | null;
@@ -38,14 +39,14 @@ export type TenantLeaseNoticeSummary = {
   } | null;
 };
 
-export type TenantLeaseNoticeDetailResponse = {
+export type TenantLeaseNoticeDetailResponse = TenantSafeProjectionMetadata & {
   ok: boolean;
   item: TenantLeaseNoticeSummary;
   data: TenantLeaseNoticeSummary;
   noResponse: boolean;
 };
 
-export type TenantLeaseNoticeRespondResponse = {
+export type TenantLeaseNoticeRespondResponse = TenantSafeProjectionMetadata & {
   ok: boolean;
   decision: "renew" | "quit";
   noticeId: string;
@@ -60,7 +61,7 @@ export type TenantLeaseNoticeRespondResponse = {
 };
 
 export function getTenantLeaseNotices() {
-  return tenantApiFetch<{ ok: boolean; items: TenantLeaseNoticeSummary[]; data: TenantLeaseNoticeSummary[] }>(
+  return tenantApiFetch<TenantSafeProjectionMetadata & { ok: boolean; items: TenantLeaseNoticeSummary[]; data: TenantLeaseNoticeSummary[] }>(
     "/tenant/lease-notices"
   );
 }

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -643,7 +643,7 @@ export async function refreshTenantLeaseDocumentUrl(options?: { document?: "leas
   documentStatus: string;
   source: string;
   expiresInSeconds: number;
-}> {
+} & TenantSafeProjectionMetadata> {
   const query = options?.document ? `?document=${encodeURIComponent(options.document)}` : "";
   const res = await tenantApiFetch<{
     ok: boolean;
@@ -653,7 +653,7 @@ export async function refreshTenantLeaseDocumentUrl(options?: { document?: "leas
       documentStatus: string;
       source: string;
       expiresInSeconds: number;
-    };
+    } & TenantSafeProjectionMetadata;
   }>(`/tenant/lease/document-url${query}`);
   return res.data;
 }

--- a/rentchain-frontend/src/api/tenantPortalApi.ts
+++ b/rentchain-frontend/src/api/tenantPortalApi.ts
@@ -1,6 +1,36 @@
 import { apiFetch } from "./http";
 import { DEBUG_AUTH_KEY } from "../lib/authKeys";
 
+export type TenantSafeProjectionMetadata = {
+  projectionProfile?: {
+    projectionName: string;
+    projectionVersion: string;
+    audience: "tenant_workspace";
+    scopeType: string;
+    allowedSourceCollections: string[];
+    allowedFieldGroups: string[];
+    excludedFieldGroups: string[];
+    sensitivityClass: "sensitive";
+    authorityBasis: "authenticated_tenant_scope";
+    relationshipBasis: string;
+    internalReferencePolicy: string;
+    redactionPolicy: string;
+  };
+  projectionVersion?: string;
+  sensitivityClass?: "sensitive";
+  authorityBasis?: "authenticated_tenant_scope";
+  sourceCollections?: string[];
+  sourceRefs?: Array<{
+    sourceCollection: string;
+    sourceId: string;
+  }>;
+  redactionSummary?: {
+    redactionPolicy: string;
+    redactedFieldGroups: string[];
+    redactionCount: number;
+  };
+};
+
 export interface TenantProfile {
   id: string;
   fullName: string;
@@ -11,7 +41,7 @@ export interface TenantProfile {
   createdAt?: string | null;
 }
 
-export interface TenantLease {
+export interface TenantLease extends TenantSafeProjectionMetadata {
   leaseId: string | null;
   propertyId: string | null;
   propertyName: string | null;


### PR DESCRIPTION
## Summary
Hardens tenant lease, lease notice, document URL, and attachment response surfaces with explicit tenant-safe projection metadata and redaction summaries.

## Changes
- Extends tenant-safe projection contracts for lease notices, document access, and attachments
- Adds redaction metadata to tenant lease notice list, detail, and response mutation payloads
- Adds document access projection metadata to tenant lease document URL responses
- Adds attachment projection metadata to tenant document vault responses
- Documents duplicate tenant lease route ordering without consolidating routes
- Documents append-safe lease signature and lease notice workflow behavior
- Updates frontend API types for backward-compatible projection metadata
- Adds targeted backend coverage for lease notice redaction, document URL metadata, attachment metadata, and lease projection metadata

## Validation
- Backend targeted tests: 86/86 passing
- Backend TypeScript build: pass
- Frontend build: pass
- Frontend tests: 1119/1119 passing
- git diff --check: pass
- git diff --cached --check: pass
- Staged scope verified: 10 mission-scoped files only

## Scope
Projection contract hardening only. No auth logic, tenancy resolver, route registration consolidation, provider callback behavior, billing, pricing, Firestore rules, Terraform, CI/CD, dependencies, or production data changed.

## Known Limitations
- Manual browser QA was not performed in this environment
- Duplicate tenant lease routes remain documented for a separate consolidation mission
- Frontend route drift for tenant documents, payments summary, and rent charges remains out of scope
- Lease signing ceremony, payment checkout creation, and notice response lifecycle were not changed