### PR TITLE
fix: extend projection contract to tenant payment and ledger visibility

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -775,7 +775,7 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body?.data?.latestPayment?.id).toBe("rp-1");
+    expect(res.body?.data?.latestPayment?.id).toMatch(/^payment-ref-/);
     expect(res.body?.data?.paymentExperience?.history).toHaveLength(2);
     expect(res.body?.data?.paymentExperience?.latestStatus).toBe("failed");
     expect(res.body?.data?.paymentExperience?.retryAvailable).toBe(true);
@@ -784,8 +784,69 @@ describe("tenantPortalRoutes foundation", () => {
       label: "Payment summary available",
       amountCents: 180000,
       paidAt: "2026-04-27T10:02:00.000Z",
-      leaseReference: "lease-1",
+      leaseReference: expect.stringMatching(/^lease-ref-/),
     });
+    expect(JSON.stringify(res.body)).not.toContain("rp-1");
+    expect(JSON.stringify(res.body)).not.toContain("cs_");
+    expect(JSON.stringify(res.body)).not.toContain("pi_");
+  });
+
+  it("returns tenant ledger entries without raw financial identifiers", async () => {
+    ensureCollection("tenantEvents").set("raw-ledger-event-1", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      unitId: "unit-1",
+      type: "RentCharged",
+      title: "Monthly rent",
+      description: "June rent",
+      amountCents: 180000,
+      currency: "cad",
+      period: "2026-06",
+      providerPaymentId: "pi_raw_provider",
+      settlementBatchId: "set_raw_1",
+      occurredAt: "2026-06-01T10:00:00.000Z",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/ledger",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_ledger_projection",
+        scopeType: "tenant_ledger",
+      })
+    );
+    expect(res.body?.redactionSummary?.redactedFieldGroups).toEqual(
+      expect.arrayContaining(["internal_ledger_ids", "payment_provider_references", "settlement_metadata"])
+    );
+    expect(res.body?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.stringMatching(/^ledger-ref-/),
+          title: "Rent recorded",
+          amountCents: 180000,
+          period: "2026-06",
+        }),
+      ])
+    );
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("raw-ledger-event-1");
+    expect(payload).not.toContain("landlord-1");
+    expect(payload).not.toContain("unit-1");
+    expect(payload).not.toContain("pi_raw_provider");
+    expect(payload).not.toContain("set_raw_1");
   });
 
   it("does not show lease signing complete for an active lease without signature metadata", async () => {
@@ -1497,37 +1558,41 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      ok: true,
-      data: {
+    expect(res.body?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_payment_projection",
+        scopeType: "tenant_payment",
+      })
+    );
+    expect(res.body?.redactionSummary?.redactedFieldGroups).toEqual(
+      expect.arrayContaining(["raw_financial_transaction_ids", "payment_provider_references", "settlement_metadata"])
+    );
+    expect(res.body?.data).toEqual(
+      expect.objectContaining({
         paymentRail: {
           enabled: true,
           enabledAt: "2026-04-27T10:00:00.000Z",
           processor: "stripe",
           blockedReason: null,
         },
-        latestPayment: {
-          id: "rp-1",
+        latestPayment: expect.objectContaining({
           amountCents: 180000,
           currency: "cad",
           status: "paid",
-          paymentIntentId: null,
           createdAt: "2026-04-27T10:05:00.000Z",
           updatedAt: "2026-04-27T10:06:00.000Z",
           paidAt: "2026-04-27T10:06:00.000Z",
-        },
-        paymentExperience: {
+        }),
+        paymentExperience: expect.objectContaining({
           history: [
-            {
-              id: "rp-1",
+            expect.objectContaining({
               amountCents: 180000,
               currency: "cad",
               status: "paid",
-              paymentIntentId: null,
               createdAt: "2026-04-27T10:05:00.000Z",
               updatedAt: "2026-04-27T10:06:00.000Z",
               paidAt: "2026-04-27T10:06:00.000Z",
-            },
+            }),
           ],
           latestStatus: "paid",
           retryAvailable: false,
@@ -1536,11 +1601,15 @@ describe("tenantPortalRoutes foundation", () => {
             label: "Payment summary available",
             amountCents: 180000,
             paidAt: "2026-04-27T10:06:00.000Z",
-            leaseReference: "lease-1",
+            leaseReference: expect.stringMatching(/^lease-ref-/),
           },
-        },
-      },
-    });
+        }),
+      })
+    );
+    expect(res.body?.data?.latestPayment?.id).toMatch(/^payment-ref-/);
+    expect(JSON.stringify(res.body)).not.toContain("rp-1");
+    expect(JSON.stringify(res.body)).not.toContain("paymentIntentId");
+    expect(JSON.stringify(res.body)).not.toContain("lease-1");
   });
 
   it("records tenant lease signing metadata without storing raw signature data and stays idempotent", async () => {

--- a/rentchain-api/src/routes/tenantBalanceRoutes.ts
+++ b/rentchain-api/src/routes/tenantBalanceRoutes.ts
@@ -1,6 +1,10 @@
 // src/routes/tenantBalanceRoutes.ts
 import { Router, Request, Response } from "express";
 import { getTenantBalance } from "../services/tenantBalanceService";
+import {
+  buildTenantFinancialProjectionMetadata,
+  projectTenantBalanceSummary,
+} from "../services/tenantPortal/tenantFinancialProjectionService";
 
 const router = Router();
 
@@ -21,7 +25,16 @@ router.get(
       }
 
       const summary = await getTenantBalance(tenantId);
-      res.json(summary);
+      const metadata = buildTenantFinancialProjectionMetadata({
+        projectionName: "tenant_safe_balance_projection",
+        scopeType: "tenant_balance",
+        sourceCollections: ["events"],
+        relationshipBasis: "Balance projection must be derived from the requested tenant financial event scope.",
+      });
+      res.json({
+        ...metadata,
+        ...projectTenantBalanceSummary(summary),
+      });
     } catch (err) {
       console.error("[GET /tenant-balance/:tenantId] error", err);
       const message = err instanceof Error ? err.message : "Unknown error";

--- a/rentchain-api/src/routes/tenantLedger.ts
+++ b/rentchain-api/src/routes/tenantLedger.ts
@@ -1,6 +1,10 @@
 // src/routes/tenantLedger.ts
 import { Router, Request, Response } from "express";
 import { getTenantLedger } from "../services/tenantLedgerService";
+import {
+  buildTenantFinancialProjectionMetadata,
+  projectTenantLedgerItem,
+} from "../services/tenantPortal/tenantFinancialProjectionService";
 
 const router = Router();
 
@@ -15,8 +19,24 @@ router.get("/:tenantId", async (req: Request, res: Response) => {
   }
 
   try {
-    const events = await getTenantLedger(tenantId);
-    return res.json({ tenantId, events });
+    const events = (await getTenantLedger(tenantId)).map((entry) => {
+      const projected = projectTenantLedgerItem(entry);
+      const amount = typeof projected.amountCents === "number" ? projected.amountCents / 100 : 0;
+      return {
+        ...projected,
+        date: new Date(projected.occurredAt).toISOString(),
+        amount: projected.type === "payment" ? -Math.abs(amount) : Math.abs(amount),
+        description: projected.description || projected.title,
+        balanceAfter: typeof entry.runningBalance === "number" ? entry.runningBalance : undefined,
+      };
+    });
+    const metadata = buildTenantFinancialProjectionMetadata({
+      projectionName: "tenant_safe_ledger_projection",
+      scopeType: "tenant_ledger",
+      sourceCollections: ["ledgerEvents", "payments"],
+      relationshipBasis: "Ledger projection must be derived from the requested tenant ledger scope.",
+    });
+    return res.json({ ...metadata, events });
   } catch (err) {
     console.error("[GET /tenantLedger/:tenantId] error", err);
     const message =

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -19,6 +19,12 @@ import {
   deriveTenantSafeSourceRefs,
   type TenantSafeProjectionSourceReference,
 } from "../services/tenantPortal/tenantSafeProjectionContract";
+import {
+  buildTenantFinancialProjectionMetadata,
+  projectTenantFinancialEvent,
+  projectTenantLedgerItem,
+  projectTenantRentPaymentSummary,
+} from "../services/tenantPortal/tenantFinancialProjectionService";
 import { deriveLeaseExecution } from "../services/leaseExecution/deriveLeaseExecution";
 import { recordTenantEvent } from "../services/tenantPortal/tenantEventLogService";
 import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteService";
@@ -2471,11 +2477,12 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
         })
       ).rentPaymentSummary
     : null;
+  const tenantSafeRentPaymentSummary = rentPaymentSummary ? projectTenantRentPaymentSummary(rentPaymentSummary) : null;
 
   return {
     property: propertyDoc ? projectTenantProperty(propertyDoc.id, propertyDoc.data) : null,
     application: applicationDoc ? projectTenantApplication(applicationDoc.id, applicationDoc.data) : null,
-    lease: lease ? { ...lease, leaseDocumentContext, scheduleADocumentContext, rentPaymentSummary } : null,
+    lease: lease ? { ...lease, leaseDocumentContext, scheduleADocumentContext, rentPaymentSummary: tenantSafeRentPaymentSummary } : null,
     maintenance: maintenanceItems
       .map((item) => projectTenantMaintenance(item.id, item.data))
       .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0)),
@@ -5495,7 +5502,7 @@ router.get("/leases/:leaseId/payments", requireTenantWorkspaceIdentity, async (r
     }
     const leaseData = (leaseSnap.data() as any) || {};
     const projectedLease = projectTenantLease(leaseId, leaseData);
-    const data = (
+    const data = projectTenantRentPaymentSummary((
       await buildLeasePaymentProjection({
         rawLease: leaseData,
         lease: {
@@ -5515,8 +5522,14 @@ router.get("/leases/:leaseId/payments", requireTenantWorkspaceIdentity, async (r
         leaseId,
         documentUrl: projectedLease.documentUrl,
       })
-    ).rentPaymentSummary;
-    return res.json({ ok: true, data });
+    ).rentPaymentSummary);
+    const paymentProjectionMetadata = buildTenantFinancialProjectionMetadata({
+      projectionName: "tenant_safe_payment_projection",
+      scopeType: "tenant_payment",
+      sourceCollections: ["leases", "rentPayments"],
+      relationshipBasis: "Payment projection must be derived from authenticated tenant lease ownership.",
+    });
+    return res.json({ ok: true, ...paymentProjectionMetadata, data });
   } catch (err: any) {
     console.error("[tenant/leases/:leaseId/payments] failed", {
       tenantId: context.tenantId,
@@ -7050,19 +7063,6 @@ router.get("/ledger", requireTenant, async (req: any, res) => {
       return null;
     };
 
-    const normalizeAmount = (amount: any): number | null => {
-      if (typeof amount !== "number" || Number.isNaN(amount)) return null;
-      return Math.round(amount * 100);
-    };
-
-    const mapType = (t: string): "rent" | "fee" | "adjustment" | "payment" => {
-      const type = (t || "").toLowerCase();
-      if (type.includes("payment")) return "payment";
-      if (type.includes("fee")) return "fee";
-      if (type.includes("adjust")) return "adjustment";
-      return "rent";
-    };
-
     const toPeriod = (date: any): string | null => {
       const ts = toMillis(date);
       if (!ts) return null;
@@ -7083,6 +7083,13 @@ router.get("/ledger", requireTenant, async (req: any, res) => {
       return "OTHER";
     };
 
+    const ledgerProjectionMetadata = buildTenantFinancialProjectionMetadata({
+      projectionName: "tenant_safe_ledger_projection",
+      scopeType: "tenant_ledger",
+      sourceCollections: ["ledgerEvents", "payments", "tenantEvents"],
+      relationshipBasis: "Ledger projection must be derived from authenticated tenant scope and tenant-owned financial events.",
+    });
+
     const items = (entries || []).map((entry: any) => {
       const occurredAt = toMillis(entry.date ?? entry.occurredAt);
       const purpose =
@@ -7092,25 +7099,13 @@ router.get("/ledger", requireTenant, async (req: any, res) => {
         "OTHER";
       const purposeLabel =
         entry.purposeLabel ?? entry?.meta?.purposeLabel ?? entry.period ?? null;
-      return {
-        id: entry.id,
-        type: mapType(entry.type || ""),
-        title:
-          mapType(entry.type || "") === "payment"
-            ? "Payment recorded"
-            : mapType(entry.type || "") === "fee"
-            ? "Fee recorded"
-            : mapType(entry.type || "") === "adjustment"
-            ? "Adjustment recorded"
-            : "Rent recorded",
-        description: entry.notes ?? entry.label ?? entry.description ?? undefined,
-        amountCents: normalizeAmount(entry.amount),
-        currency: entry.currency ?? null,
+      return projectTenantLedgerItem({
+        ...entry,
         period: entry.period ?? toPeriod(entry.date ?? entry.occurredAt),
-        purpose: purpose ?? null,
-        purposeLabel: purposeLabel ?? null,
+        purpose,
+        purposeLabel,
         occurredAt: occurredAt ?? Date.now(),
-      };
+      });
     });
 
     const fetchTenantEventsForLedger = async () => {
@@ -7147,29 +7142,14 @@ router.get("/ledger", requireTenant, async (req: any, res) => {
             const occurredAt = toMillis(ev.occurredAt ?? ev.createdAt);
             const purpose = ev.purpose ?? inferPurpose(ev.type || "");
             const purposeLabel = ev.purposeLabel ?? ev.period ?? null;
-            const mapType = (t: string): "rent" | "fee" | "adjustment" | "payment" => {
-              const type = (t || "").toLowerCase();
-              if (type.includes("payment") || type.includes("pay")) return "payment";
-              if (type.includes("fee")) return "fee";
-              if (type.includes("adjust") || type.includes("credit")) return "adjustment";
-              return "rent";
-            };
-            const normalizeAmount = (amount: any): number | null => {
-              if (typeof amount !== "number" || Number.isNaN(amount)) return null;
-              return Math.round(amount * 100);
-            };
-            return {
-              id: ev.id,
-              type: mapType(ev.type || ""),
-              title: ev.title || "Ledger entry",
-              description: ev.description || undefined,
-              amountCents: normalizeAmount(ev.amount ?? ev.amountCents),
-              currency: ev.currency ?? null,
+            return projectTenantFinancialEvent({
+              ...ev,
+              amount: typeof ev.amount === "number" ? ev.amount : typeof ev.amountCents === "number" ? ev.amountCents / 100 : null,
               period: ev.period ?? null,
               purpose: purpose ?? null,
               purposeLabel: purposeLabel ?? null,
               occurredAt: occurredAt ?? Date.now(),
-            };
+            });
           }) || [];
       const mergedMap = new Map<string, any>();
       [...items, ...eventItems].forEach((it) => {
@@ -7178,14 +7158,14 @@ router.get("/ledger", requireTenant, async (req: any, res) => {
       });
       const merged = Array.from(mergedMap.values());
       merged.sort((a, b) => b.occurredAt - a.occurredAt);
-      return res.json({ ok: true, data: merged.slice(0, 25) });
+      return res.json({ ok: true, ...ledgerProjectionMetadata, data: merged.slice(0, 25) });
     } catch (err) {
       console.warn("[tenant/ledger] event bridge failed; returning base ledger", {
         tenantId,
         err: (err as any)?.message,
       });
       items.sort((a, b) => b.occurredAt - a.occurredAt);
-      return res.json({ ok: true, data: items.slice(0, 25) });
+      return res.json({ ok: true, ...ledgerProjectionMetadata, data: items.slice(0, 25) });
     }
   } catch (err) {
     console.error("[tenantPortalRoutes] /tenant/ledger error", {

--- a/rentchain-api/src/services/tenantPortal/tenantFinancialProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantFinancialProjectionService.ts
@@ -1,0 +1,176 @@
+import { createHash } from "crypto";
+import type { TenantLedgerEntry } from "../tenantLedgerService";
+import type { RentPaymentSummary } from "../rentPayments/rentPaymentService";
+import type { TenantBalanceSummary } from "../tenantBalanceService";
+import {
+  deriveTenantSafeProjectionMetadata,
+  type TenantSafeProjectionName,
+  type TenantSafeProjectionScopeType,
+} from "./tenantSafeProjectionContract";
+
+export type TenantFinancialProjectionKind = "ledger" | "payment" | "balance";
+
+type TenantFinancialMetadataInput = {
+  projectionName: TenantSafeProjectionName;
+  scopeType: TenantSafeProjectionScopeType;
+  sourceCollections: string[];
+  relationshipBasis: string;
+};
+
+function publicReference(kind: string, raw: unknown): string | null {
+  const value = String(raw || "").trim();
+  if (!value) return null;
+  const digest = createHash("sha256").update(`${kind}:${value}`).digest("hex").slice(0, 12);
+  return `${kind}-ref-${digest}`;
+}
+
+function safeString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function safeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const next = Number(value);
+  return Number.isFinite(next) ? next : null;
+}
+
+function toMillis(value: unknown): number | null {
+  if (!value) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (typeof (value as any)?.toMillis === "function") return (value as any).toMillis();
+  if (typeof (value as any)?.seconds === "number") return (value as any).seconds * 1000;
+  return null;
+}
+
+function normalizeAmountToCents(value: unknown): number | null {
+  const amount = safeNumber(value);
+  if (amount == null) return null;
+  return Math.round(amount * 100);
+}
+
+export function buildTenantFinancialProjectionMetadata(input: TenantFinancialMetadataInput) {
+  const sourceCollections = Array.from(new Set(input.sourceCollections.filter(Boolean))).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  return {
+    ...deriveTenantSafeProjectionMetadata({
+      projectionName: input.projectionName,
+      scopeType: input.scopeType,
+      sourceCollections,
+      relationshipBasis: input.relationshipBasis,
+      internalReferencePolicy:
+        "Tenant financial responses use derived display references and never expose raw ledger, transaction, provider, landlord, or unit identifiers.",
+    }),
+    sourceCollections,
+    sourceRefs: [],
+  };
+}
+
+export function projectTenantLedgerItem(entry: TenantLedgerEntry | Record<string, any>) {
+  const type = String(entry?.type || "").toLowerCase();
+  const mappedType: "rent" | "fee" | "adjustment" | "payment" = type.includes("payment")
+    ? "payment"
+    : type.includes("fee")
+    ? "fee"
+    : type.includes("adjust")
+    ? "adjustment"
+    : "rent";
+  const occurredAt = toMillis((entry as any).date ?? (entry as any).occurredAt) ?? Date.now();
+  const amount = safeNumber((entry as any).amount);
+  return {
+    id:
+      publicReference("ledger", (entry as any).id ?? (entry as any).referenceId ?? `${type}:${occurredAt}:${amount}`) ||
+      "ledger-ref-unavailable",
+    type: mappedType,
+    title:
+      mappedType === "payment"
+        ? "Payment recorded"
+        : mappedType === "fee"
+        ? "Fee recorded"
+        : mappedType === "adjustment"
+        ? "Adjustment recorded"
+        : "Rent recorded",
+    description: safeString((entry as any).notes ?? (entry as any).label ?? (entry as any).description) || undefined,
+    amountCents: normalizeAmountToCents(Math.abs(amount ?? 0)),
+    currency: safeString((entry as any).currency),
+    period: safeString((entry as any).period),
+    purpose: safeString((entry as any).purpose ?? (entry as any)?.meta?.purpose),
+    purposeLabel: safeString((entry as any).purposeLabel ?? (entry as any)?.meta?.purposeLabel),
+    occurredAt,
+  };
+}
+
+export function projectTenantFinancialEvent(event: Record<string, any>) {
+  return projectTenantLedgerItem({
+    id: event.id,
+    type: event.type,
+    amount: event.amount ?? event.amountCents,
+    currency: event.currency,
+    period: event.period,
+    purpose: event.purpose,
+    purposeLabel: event.purposeLabel,
+    date: event.occurredAt ?? event.createdAt,
+    label: event.title,
+    notes: event.description,
+  });
+}
+
+function projectPaymentItem(item: NonNullable<RentPaymentSummary["latestPayment"]> | null) {
+  if (!item) return null;
+  return {
+    id: publicReference("payment", item.id) || "payment-ref-unavailable",
+    amountCents: item.amountCents,
+    currency: item.currency,
+    status: item.status,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    paidAt: item.paidAt || null,
+  };
+}
+
+export function projectTenantRentPaymentSummary(summary: RentPaymentSummary): RentPaymentSummary {
+  const history = summary.paymentExperience.history.map((item) => projectPaymentItem(item)).filter(Boolean) as NonNullable<
+    RentPaymentSummary["latestPayment"]
+  >[];
+  return {
+    paymentRail: {
+      enabled: summary.paymentRail.enabled,
+      enabledAt: summary.paymentRail.enabledAt,
+      processor: summary.paymentRail.processor,
+      blockedReason: summary.paymentRail.blockedReason,
+    },
+    latestPayment: projectPaymentItem(summary.latestPayment),
+    paymentExperience: {
+      history,
+      latestStatus: summary.paymentExperience.latestStatus,
+      retryAvailable: summary.paymentExperience.retryAvailable,
+      receiptSummary: {
+        available: summary.paymentExperience.receiptSummary.available,
+        label: summary.paymentExperience.receiptSummary.label,
+        amountCents: summary.paymentExperience.receiptSummary.amountCents,
+        paidAt: summary.paymentExperience.receiptSummary.paidAt,
+        leaseReference: publicReference("lease", summary.paymentExperience.receiptSummary.leaseReference),
+      },
+    },
+  };
+}
+
+export function projectTenantBalanceSummary(summary: TenantBalanceSummary) {
+  return {
+    tenantReference: publicReference("tenant", summary.tenantId),
+    totalCharges: summary.totalCharges,
+    totalPayments: summary.totalPayments,
+    totalAdjustments: summary.totalAdjustments,
+    totalNsfFees: summary.totalNsfFees,
+    currentBalance: summary.currentBalance,
+    lastPaymentDate: summary.lastPaymentDate,
+    lastPaymentAmount: summary.lastPaymentAmount,
+    nextChargeDate: summary.nextChargeDate,
+    nextChargeAmount: summary.nextChargeAmount,
+  };
+}

--- a/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSafeProjectionContract.ts
@@ -13,7 +13,10 @@ export type TenantSafeProjectionName =
   | "tenant_safe_property_projection"
   | "tenant_safe_lease_notice_projection"
   | "tenant_safe_document_access_projection"
-  | "tenant_safe_attachment_projection";
+  | "tenant_safe_attachment_projection"
+  | "tenant_safe_ledger_projection"
+  | "tenant_safe_payment_projection"
+  | "tenant_safe_balance_projection";
 
 export type TenantSafeProjectionScopeType =
   | "tenant_current_lease"
@@ -26,7 +29,10 @@ export type TenantSafeProjectionScopeType =
   | "tenant_property"
   | "tenant_lease_notice"
   | "tenant_document_access"
-  | "tenant_attachment";
+  | "tenant_attachment"
+  | "tenant_ledger"
+  | "tenant_payment"
+  | "tenant_balance";
 
 export type TenantSafeProjectionSensitivityClass = "sensitive";
 
@@ -148,6 +154,25 @@ const SURFACE_ALLOWED_FIELD_GROUPS: Record<TenantSafeProjectionScopeType, string
     "scoped_source_references",
     "operational_labels",
   ],
+  tenant_ledger: [
+    "tenant_visible_ledger_summary",
+    "tenant_visible_payment_lifecycle",
+    "tenant_visible_charge_summary",
+    "tenant_visible_balance_summary",
+    "operational_labels",
+  ],
+  tenant_payment: [
+    "tenant_visible_payment_lifecycle",
+    "tenant_visible_receipt_summary",
+    "tenant_visible_payment_rail_status",
+    "operational_labels",
+  ],
+  tenant_balance: [
+    "tenant_visible_balance_summary",
+    "tenant_visible_payment_lifecycle",
+    "tenant_visible_charge_summary",
+    "operational_labels",
+  ],
 };
 
 const EXCLUDED_FIELD_GROUPS = [
@@ -164,6 +189,10 @@ const EXCLUDED_FIELD_GROUPS = [
   "storage_paths",
   "provider_delivery_payloads",
   "landlord_internal_workflow_state",
+  "raw_financial_transaction_ids",
+  "payment_provider_references",
+  "settlement_metadata",
+  "internal_ledger_ids",
 ];
 
 const SURFACE_REDACTION_POLICIES: Record<TenantSafeProjectionScopeType, string> = {
@@ -188,6 +217,12 @@ const SURFACE_REDACTION_POLICIES: Record<TenantSafeProjectionScopeType, string> 
     "Expose only tenant-scoped document URL, status, label, and expiry; exclude storage paths, bucket names, provider payloads, raw document metadata, and unrelated documents.",
   tenant_attachment:
     "Expose only tenant-safe attachment labels, status, dates, and tenant-visible document links; exclude storage paths, bucket names, provider payloads, raw metadata, and unrelated evidence.",
+  tenant_ledger:
+    "Expose only tenant-visible ledger amounts, dates, labels, lifecycle, and derived display references; exclude raw ledger IDs, transaction IDs, landlord IDs, unit IDs, provider references, payment tokens, and settlement metadata.",
+  tenant_payment:
+    "Expose only tenant-visible payment rail status, lifecycle, receipt state, amount, and derived display references; exclude raw payment IDs, payment intent IDs, provider references, payment tokens, landlord IDs, unit IDs, and settlement metadata.",
+  tenant_balance:
+    "Expose only tenant-visible balance totals, dates, and derived display references; exclude raw event IDs, tenant IDs, landlord IDs, unit IDs, provider references, payment tokens, and settlement metadata.",
 };
 
 function uniqueSorted(values: string[]): string[] {

--- a/rentchain-frontend/src/components/tenants/TenantBalanceSummary.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantBalanceSummary.tsx
@@ -5,7 +5,6 @@ import {
   fetchTenantBalance,
   TenantBalanceSummary as BalanceSummary,
 } from "../../services/tenantBalanceApi";
-import { formatInternalReference } from "@/lib/identityReferences";
 
 interface TenantBalanceSummaryProps {
   tenantId: string | null;
@@ -180,7 +179,7 @@ export const TenantBalanceSummary: React.FC<TenantBalanceSummaryProps> = ({
             textAlign: "right",
           }}
         >
-          {formatInternalReference("tenant", tenantId)}
+          {summary?.tenantReference || "Tenant account"}
           {summary && (
             <div
               style={{
@@ -188,7 +187,7 @@ export const TenantBalanceSummary: React.FC<TenantBalanceSummaryProps> = ({
                 color: "#6b7280",
               }}
             >
-              {summary.eventCount} ledger events
+              Tenant-visible balance
             </div>
           )}
         </div>

--- a/rentchain-frontend/src/services/tenantBalanceApi.ts
+++ b/rentchain-frontend/src/services/tenantBalanceApi.ts
@@ -2,7 +2,7 @@
 import { apiFetch } from "@/api/apiFetch";
 
 export interface TenantBalanceSummary {
-  tenantId: string;
+  tenantReference: string | null;
   totalCharges: number;
   totalPayments: number;
   totalAdjustments: number;
@@ -12,7 +12,6 @@ export interface TenantBalanceSummary {
   lastPaymentAmount: number | null;
   nextChargeDate: string | null;
   nextChargeAmount: number | null;
-  eventCount: number;
 }
 
 export async function fetchTenantBalance(

--- a/rentchain-frontend/src/services/tenantLedgerApi.ts
+++ b/rentchain-frontend/src/services/tenantLedgerApi.ts
@@ -6,16 +6,18 @@ const API_BASE_URL = API_BASE.replace(/\/$/, "");
 
 export interface TenantLedgerEvent {
   id: string;
-  tenantId: string;
   type: string; // e.g. "payment", "charge", "ai_insight"
-  occurredAt: string;
+  occurredAt: number;
+  date?: string;
+  amount: number;
+  balanceAfter?: number;
   description: string;
   meta?: Record<string, any>;
 }
 
 export async function fetchTenantLedger(
   tenantId: string
-): Promise<TenantLedgerEvent[]> {
+): Promise<{ events: TenantLedgerEvent[] }> {
   const url = `${API_BASE_URL}/tenantLedger/${tenantId}`;
   console.log("[Ledger] Fetching:", url);
 
@@ -26,7 +28,7 @@ export async function fetchTenantLedger(
     console.log(
       "[Ledger] No tenantLedger endpoint yet; returning empty events array."
     );
-    return [];
+    return { events: [] };
   }
 
   if (!res.ok) {
@@ -35,6 +37,6 @@ export async function fetchTenantLedger(
     throw new Error(`Failed to fetch tenant ledger: ${res.status}`);
   }
 
-  const data = (await res.json()) as TenantLedgerEvent[];
-  return data;
+  const data = (await res.json()) as { events?: TenantLedgerEvent[] } | TenantLedgerEvent[];
+  return Array.isArray(data) ? { events: data } : { events: Array.isArray(data.events) ? data.events : [] };
 }


### PR DESCRIPTION
## Summary
Extends tenant-safe projection contracts to financial tenant surfaces for ledger entries, payment summaries, and balance displays.

## Changes
- Adds tenant financial projection helpers with derived display references for ledger, payment, lease, tenant, and balance records
- Adds ledger, payment, and balance projection scopes with redaction policy metadata
- Applies tenant financial projections to tenant ledger, tenant lease payment summary, legacy tenant ledger, and tenant balance responses
- Updates frontend tenant ledger and balance clients to consume projected response shapes
- Adds regression coverage for tenant ledger and payment redaction boundaries

## Validation
- Backend targeted financial and lease tests: 107/107 passing
- Backend TypeScript build: pass
- Frontend build: pass
- Frontend tests: 1119/1119 passing
- git diff --check: pass
- Full backend suite: 1933/1940 passing, with 7 unrelated existing failures in lease draft and analytics expectation tests

## Scope
Tenant financial read projection only. No auth core, billing checkout, provider callbacks, settlement workflows, pricing, Firestore rules, Terraform, or CI/CD changed.

## Known Limitations
- Manual browser QA not performed in this environment
- Full backend suite still has unrelated failures in lease draft and analytics tests; targeted mission coverage is passing
- Stale mission-listed rent charge route paths were not introduced; this hardens the active tenant financial read surfaces present in the current tree