### PR TITLE
fix: harden tenant document access control and visibility projection

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -3453,6 +3453,16 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.summary?.pendingReview).toBeTypeOf("number");
     expect(res.body?.guidance?.headline).toBeTypeOf("string");
     expect(res.body?.data?.[0]?.internalNotes).toBeUndefined();
+    expect(res.body?.data?.[0]?.tenantId).toBeUndefined();
+    expect(res.body?.data?.[0]?.leaseId).toBeUndefined();
+    expect(res.body?.data?.[0]?.draftId).toBeUndefined();
+    expect(res.body?.data?.[0]?.ledgerItemId).toBeUndefined();
+    expect(
+      res.body?.data?.every((item: any) => String(item.id || "").startsWith("document-ref-"))
+    ).toBe(true);
+    expect(
+      res.body?.data?.some((item: any) => String(item.tenantReference || "").startsWith("tenant-ref-"))
+    ).toBe(true);
     expect(res.body?.data).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -3511,6 +3521,7 @@ describe("tenantPortalRoutes foundation", () => {
 
     expect(res.status).toBe(200);
     expect(res.body?.summary?.total).toBeGreaterThan(0);
+    expect(res.body?.data?.some((item: any) => item.tenantId || item.leaseId || item.ledgerItemId)).toBe(false);
     expect(res.body?.data).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -3667,6 +3678,72 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(res.status).toBe(401);
+  });
+
+  it("projects ledger attachment responses without raw document identifiers", async () => {
+    ensureCollection("ledgerAttachments").set("ledger-attachment-sensitive", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      draftId: "draft-1",
+      ledgerItemId: "ledger-1",
+      title: "Rent receipt",
+      fileName: "receipt.pdf",
+      purpose: "receipt",
+      purposeLabel: "Receipt",
+      url: "https://example.com/receipt.pdf",
+      storagePath: "ledgerAttachments/private/receipt.pdf",
+      providerPayload: { secret: true },
+      internalNotes: "do-not-expose",
+      createdAt: 900,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/ledger/ledger-1/attachments",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_attachment_projection",
+        scopeType: "tenant_attachment",
+      })
+    );
+    expect(res.body?.ledgerReference).toMatch(/^ledger-ref-/);
+    expect(res.body?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.stringMatching(/^document-ref-/),
+          documentReference: expect.stringMatching(/^document-ref-/),
+          tenantReference: expect.stringMatching(/^tenant-ref-/),
+          leaseReference: expect.stringMatching(/^lease-ref-/),
+          draftReference: expect.stringMatching(/^draft-ref-/),
+          ledgerReference: expect.stringMatching(/^ledger-ref-/),
+          title: "Rent receipt",
+          fileName: "receipt.pdf",
+          url: "https://example.com/receipt.pdf",
+        }),
+      ])
+    );
+    const payload = JSON.stringify(res.body?.data);
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("lease-1");
+    expect(payload).not.toContain("draft-1");
+    expect(payload).not.toContain("ledger-1");
+    expect(payload).not.toContain("landlord-1");
+    expect(payload).not.toContain("storagePath");
+    expect(payload).not.toContain("providerPayload");
+    expect(payload).not.toContain("do-not-expose");
   });
 
   it("returns tenant-safe profile data with edit and document entry actions", async () => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -137,6 +137,13 @@ function asString(value: unknown): string | null {
   return next || null;
 }
 
+function tenantPublicReference(kind: string, raw: unknown): string | null {
+  const value = String(raw || "").trim();
+  if (!value) return null;
+  const digest = createHash("sha256").update(`${kind}:${value}`).digest("hex").slice(0, 12);
+  return `${kind}-ref-${digest}`;
+}
+
 function displayStringUnlessId(value: unknown, rawId?: unknown): string | null {
   const next = asString(value);
   if (!next) return null;
@@ -238,6 +245,7 @@ type TenantDocumentStatus =
 
 type TenantDocumentItem = {
   id: string;
+  documentReference: string;
   label: string;
   category: string;
   status: TenantDocumentStatus;
@@ -245,10 +253,10 @@ type TenantDocumentItem = {
   title: string | null;
   purpose: string | null;
   purposeLabel: string | null;
-  tenantId: string | null;
-  leaseId: string | null;
-  draftId: string | null;
-  ledgerItemId: string | null;
+  tenantReference: string | null;
+  leaseReference: string | null;
+  draftReference: string | null;
+  ledgerReference: string | null;
   url: string | null;
   uploadedAt: number | null;
   nextAction: string | null;
@@ -3028,6 +3036,29 @@ function documentNextActionCopy(status: TenantDocumentStatus, nextAction: string
   }
 }
 
+function tenantDocumentReferences(raw: {
+  id?: unknown;
+  tenantId?: unknown;
+  leaseId?: unknown;
+  draftId?: unknown;
+  ledgerItemId?: unknown;
+}) {
+  const fallbackSeed =
+    asString(raw.id) ||
+    [raw.tenantId, raw.leaseId, raw.draftId, raw.ledgerItemId]
+      .map((value) => String(value || "").trim())
+      .filter(Boolean)
+      .join(":") ||
+    "document";
+  return {
+    documentReference: tenantPublicReference("document", fallbackSeed) || "document-ref-unavailable",
+    tenantReference: tenantPublicReference("tenant", raw.tenantId),
+    leaseReference: tenantPublicReference("lease", raw.leaseId),
+    draftReference: tenantPublicReference("draft", raw.draftId),
+    ledgerReference: tenantPublicReference("ledger", raw.ledgerItemId),
+  };
+}
+
 function isVisibleLeaseDocumentAttachment(raw: any): boolean {
   const category = String(raw?.category || "").trim().toLowerCase();
   const purpose = String(raw?.purpose || "").trim().toUpperCase();
@@ -3675,6 +3706,13 @@ function buildTenantDocumentWorkspace(params: {
     if (matchedAttachment?.id) {
       usedAttachmentIds.add(String(matchedAttachment.id));
     }
+    const references = tenantDocumentReferences({
+      id: matchedAttachment?.id || entry?.code || `document_${index + 1}`,
+      tenantId: matchedAttachment?.tenantId,
+      leaseId: matchedAttachment?.leaseId,
+      draftId: matchedAttachment?.draftId,
+      ledgerItemId: matchedAttachment?.ledgerItemId,
+    });
 
     const status = toTenantDocumentStatus({
       checklistStatus: String(entry?.status || ""),
@@ -3683,7 +3721,8 @@ function buildTenantDocumentWorkspace(params: {
     });
 
     return {
-      id: String(entry?.code || matchedAttachment?.id || `document_${index + 1}`),
+      id: references.documentReference,
+      documentReference: references.documentReference,
       label,
       category: documentCategoryForLabel(String(entry?.code || label)),
       status,
@@ -3691,10 +3730,10 @@ function buildTenantDocumentWorkspace(params: {
       title: matchedAttachment?.title ? String(matchedAttachment.title) : null,
       purpose: matchedAttachment?.purpose ? String(matchedAttachment.purpose) : null,
       purposeLabel: matchedAttachment?.purposeLabel ? String(matchedAttachment.purposeLabel) : null,
-      tenantId: matchedAttachment?.tenantId ? String(matchedAttachment.tenantId) : null,
-      leaseId: matchedAttachment?.leaseId ? String(matchedAttachment.leaseId) : null,
-      draftId: matchedAttachment?.draftId ? String(matchedAttachment.draftId) : null,
-      ledgerItemId: matchedAttachment?.ledgerItemId ? String(matchedAttachment.ledgerItemId) : null,
+      tenantReference: references.tenantReference,
+      leaseReference: references.leaseReference,
+      draftReference: references.draftReference,
+      ledgerReference: references.ledgerReference,
       url: matchedAttachment?.url ? String(matchedAttachment.url) : null,
       uploadedAt: Number(matchedAttachment?.createdAt || 0) || null,
       nextAction: documentNextActionCopy(status, String(entry?.nextStep || ""), Boolean(matchedAttachment?.url)),
@@ -3709,8 +3748,16 @@ function buildTenantDocumentWorkspace(params: {
   attachments.forEach((item, index) => {
     if (usedAttachmentIds.has(String(item?.id || ""))) return;
     const label = labelForAttachmentRecord(item);
+    const references = tenantDocumentReferences({
+      id: item?.id || `uploaded_document_${index + 1}`,
+      tenantId: item?.tenantId,
+      leaseId: item?.leaseId,
+      draftId: item?.draftId,
+      ledgerItemId: item?.ledgerItemId,
+    });
     items.push({
-      id: String(item?.id || `uploaded_document_${index + 1}`),
+      id: references.documentReference,
+      documentReference: references.documentReference,
       label,
       category: documentCategoryForLabel(label),
       status: "uploaded",
@@ -3718,10 +3765,10 @@ function buildTenantDocumentWorkspace(params: {
       title: item?.title ? String(item.title) : null,
       purpose: item?.purpose ? String(item.purpose) : null,
       purposeLabel: item?.purposeLabel ? String(item.purposeLabel) : null,
-      tenantId: item?.tenantId ? String(item.tenantId) : null,
-      leaseId: item?.leaseId ? String(item.leaseId) : null,
-      draftId: item?.draftId ? String(item.draftId) : null,
-      ledgerItemId: item?.ledgerItemId ? String(item.ledgerItemId) : null,
+      tenantReference: references.tenantReference,
+      leaseReference: references.leaseReference,
+      draftReference: references.draftReference,
+      ledgerReference: references.ledgerReference,
       url: item?.url ? String(item.url) : null,
       uploadedAt: Number(item?.createdAt || 0) || null,
       nextAction: "This file has been added to your record.",
@@ -5357,6 +5404,26 @@ router.get("/lease/document-url", requireTenantWorkspaceIdentity, async (req: an
     if (!documentContext.documentUrl || documentContext.documentStatus === "missing") {
       return res.status(404).json({ ok: false, error: "lease_document_not_found" });
     }
+    await recordTenantEvent({
+      eventType: "tenant_lease_document_accessed",
+      entityType: "tenant_lease_document",
+      entityId:
+        tenantPublicReference(
+          requestedDocument === "schedule-a" || requestedDocument === "schedule_a" || requestedDocument === "schedule"
+            ? "schedule-document"
+            : "lease-document",
+          `${context.leaseId}:${requestedDocument}`
+        ) || "document-ref-unavailable",
+      createdBy: String(req.user?.id || "").trim(),
+      context: {
+        authority: context.authority,
+        documentStatus: documentContext.documentStatus,
+        source: documentContext.source,
+      },
+      payload: {
+        displayLabel: documentContext.displayLabel,
+      },
+    });
     return res.json({
       ok: true,
       data: {
@@ -7205,6 +7272,19 @@ router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res)
       leaseDocumentContext: workspaceData.lease?.leaseDocumentContext || (profile.profile?.lease as any)?.leaseDocumentContext || null,
       scheduleADocumentContext: workspaceData.lease?.scheduleADocumentContext || (profile.profile?.lease as any)?.scheduleADocumentContext || null,
     });
+    await recordTenantEvent({
+      eventType: "tenant_documents_viewed",
+      entityType: "tenant_document_workspace",
+      entityId: tenantPublicReference("tenant", tenantId) || "tenant-ref-unavailable",
+      createdBy: String(req.user?.id || "").trim(),
+      context: {
+        authority: context.authority,
+        documentCount: documentWorkspace.items.length,
+      },
+      payload: {
+        summary: documentWorkspace.summary,
+      },
+    });
 
     return res.json({
       ok: true,
@@ -7242,13 +7322,65 @@ router.get("/ledger/:ledgerItemId/attachments", requireTenant, async (req: any, 
     const snap = await db
       .collection("ledgerAttachments")
       .where("tenantId", "==", tenantId)
-      .where("ledgerItemId", "==", ledgerItemId)
       .limit(25)
       .get();
 
-    const data = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
-    data.sort((a, b) => (Number(b.createdAt || 0) || 0) - (Number(a.createdAt || 0) || 0));
-    return res.json({ ok: true, data });
+    const rawAttachments = snap.docs
+      .map((d) => ({ id: d.id, ...(d.data() as any) }))
+      .filter((item) => String(item?.ledgerItemId || "").trim() === ledgerItemId);
+    rawAttachments.sort((a, b) => (Number(b.createdAt || 0) || 0) - (Number(a.createdAt || 0) || 0));
+    const data: TenantDocumentItem[] = rawAttachments.map((item, index) => {
+      const label = labelForAttachmentRecord(item);
+      const references = tenantDocumentReferences({
+        id: item?.id || `ledger_attachment_${index + 1}`,
+        tenantId: item?.tenantId,
+        leaseId: item?.leaseId,
+        draftId: item?.draftId,
+        ledgerItemId: item?.ledgerItemId,
+      });
+      return {
+        id: references.documentReference,
+        documentReference: references.documentReference,
+        label,
+        category: documentCategoryForLabel(label),
+        status: "uploaded",
+        fileName: item?.fileName ? String(item.fileName) : null,
+        title: item?.title ? String(item.title) : null,
+        purpose: item?.purpose ? String(item.purpose) : null,
+        purposeLabel: item?.purposeLabel ? String(item.purposeLabel) : null,
+        tenantReference: references.tenantReference,
+        leaseReference: references.leaseReference,
+        draftReference: references.draftReference,
+        ledgerReference: references.ledgerReference,
+        url: item?.url ? String(item.url) : null,
+        uploadedAt: Number(item?.createdAt || 0) || null,
+        nextAction: "This file has been added to your record.",
+        actionAvailable: false,
+        actionLabel: null,
+        actionPath: null,
+        helpLabel: null,
+        helpPath: null,
+      };
+    });
+    await recordTenantEvent({
+      eventType: "tenant_ledger_attachments_viewed",
+      entityType: "tenant_ledger_attachments",
+      entityId: tenantPublicReference("ledger", ledgerItemId) || "ledger-ref-unavailable",
+      createdBy: String(req.user?.id || "").trim(),
+      context: {
+        documentCount: data.length,
+      },
+      payload: null,
+    });
+    return res.json({
+      ok: true,
+      ...buildTenantAttachmentProjectionMetadata({
+        tenantId,
+        attachmentIds: data.map((item) => String(item?.id || "").trim()).filter(Boolean),
+      }),
+      ledgerReference: tenantPublicReference("ledger", ledgerItemId),
+      data,
+    });
   } catch (err) {
     console.error("[tenant/ledger/:id/attachments] failed", {
       tenantId: req.user?.tenantId,

--- a/rentchain-frontend/src/api/tenantAttachmentsApi.ts
+++ b/rentchain-frontend/src/api/tenantAttachmentsApi.ts
@@ -3,10 +3,11 @@ import type { TenantSafeProjectionMetadata } from "./tenantPortal";
 
 export type TenantAttachment = {
   id: string;
-  tenantId?: string | null;
-  leaseId?: string | null;
-  draftId?: string | null;
-  ledgerItemId?: string | null;
+  documentReference?: string | null;
+  tenantReference?: string | null;
+  leaseReference?: string | null;
+  draftReference?: string | null;
+  ledgerReference?: string | null;
   title?: string | null;
   url?: string | null;
   purpose?: string | null;

--- a/rentchain-frontend/src/pages/tenant/TenantDashboardPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantDashboardPage.tsx
@@ -300,10 +300,10 @@ export default function TenantDashboardPage() {
   const attachmentsByLedgerId = useMemo(() => {
     const map = new Map<string, Attachment[]>();
     attachments.forEach((att) => {
-      if (!att.ledgerItemId) return;
-      const list = map.get(att.ledgerItemId) || [];
+      if (!att.ledgerReference) return;
+      const list = map.get(att.ledgerReference) || [];
       list.push(att);
-      map.set(att.ledgerItemId, list);
+      map.set(att.ledgerReference, list);
     });
     return map;
   }, [attachments]);

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
@@ -50,11 +50,11 @@ function isVisibleLeaseAttachment(item: TenantAttachment): boolean {
 
 function visibleLeaseKeys(item: TenantAttachment): string[] {
   if (!isVisibleLeaseAttachment(item)) return [];
-  const tenantId = String(item.tenantId || "").trim() || "tenant";
-  const leaseId = String(item.leaseId || "").trim();
+  const tenantRef = String(item.tenantReference || "").trim() || "tenant";
+  const leaseRef = String(item.leaseReference || "").trim();
   return [
-    `${tenantId}|lease:current|LEASE`,
-    leaseId ? `${tenantId}|lease:${leaseId}|LEASE` : null,
+    `${tenantRef}|lease:current|LEASE`,
+    leaseRef ? `${tenantRef}|lease:${leaseRef}|LEASE` : null,
   ].filter((value): value is string => Boolean(value));
 }
 

--- a/rentchain-frontend/src/pages/tenant/tenantLeaseDocumentAttachments.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantLeaseDocumentAttachments.ts
@@ -1,17 +1,22 @@
 import type { TenantAttachment } from "../../api/tenantAttachmentsApi";
 import type { TenantLeaseDocumentContext, TenantWorkspaceLease } from "../../api/tenantPortal";
 
+function referenceFor(kind: string, value: string): string {
+  return `${kind}-ref-${value.trim() || "current"}`;
+}
+
 function documentContextToAttachment(
   context: TenantLeaseDocumentContext | null | undefined,
   kind: "lease" | "schedule-a"
 ): TenantAttachment | null {
   if (!context || !context.documentUrl || context.documentStatus === "missing") return null;
-  const leaseId = String(context.leaseId || "current").trim() || "current";
   if (kind === "lease") {
+    const documentReference = referenceFor("document", "lease-document-context-current");
     return {
-      id: `lease-document-context-${leaseId}`,
-      tenantId: context.tenantId || null,
-      leaseId: context.leaseId || null,
+      id: documentReference,
+      documentReference,
+      tenantReference: context.tenantId ? referenceFor("tenant", "current") : null,
+      leaseReference: context.leaseId ? referenceFor("lease", "current") : null,
       title: "Lease document",
       label: "Lease document",
       category: "Lease documents",
@@ -25,10 +30,12 @@ function documentContextToAttachment(
       nextAction: "This tenant-safe lease document is linked to your lease workspace.",
     };
   }
+  const documentReference = referenceFor("document", "schedule-a-context-current");
   return {
-    id: `schedule-a-context-${leaseId}`,
-    tenantId: context.tenantId || null,
-    leaseId: context.leaseId || null,
+    id: documentReference,
+    documentReference,
+    tenantReference: context.tenantId ? referenceFor("tenant", "current") : null,
+    leaseReference: context.leaseId ? referenceFor("lease", "current") : null,
     title: "Schedule A",
     label: "Schedule A",
     category: "Lease documents / attachments",
@@ -57,7 +64,7 @@ export function mergeTenantAttachments(items: TenantAttachment[], leaseWorkspace
   for (const item of [...leaseWorkspaceItems, ...items]) {
     const key = [
       String(item.purpose || "").trim().toUpperCase(),
-      String(item.leaseId || "").trim(),
+      String(item.leaseReference || "").trim(),
       String(item.fileName || item.title || item.label || "").trim().toLowerCase(),
       String(item.url || "").trim(),
     ].join("|");


### PR DESCRIPTION
## Summary
Hardens tenant document continuity surfaces by replacing raw attachment identifiers in tenant-visible document items with deterministic public references and by recording append-safe document access events.

## Changes
- Tenant attachment projections now return public document, tenant, lease, draft, and ledger references instead of raw tenant-visible identifier fields
- Legacy tenant ledger attachment reads now return tenant-safe projected attachment metadata
- Tenant document vault and lease workspace attachment merge logic now dedupe by public references
- Tenant dashboard attachment grouping now uses ledgerReference instead of raw ledger item IDs
- Document workspace and ledger attachment reads append access events to event_log
- Backend tests cover projected ledger attachment responses and raw identifier redaction

## Validation
- Backend targeted tenant document continuity tests: 86/86 passing
- Backend TypeScript build: pass
- Frontend targeted tenant document tests: 9/9 passing
- Frontend full tests: 1119/1119 passing
- Frontend build: pass
- git diff --check: pass
- Full backend suite: 1934/1941 passing; 7 pre-existing failures remain in lease draft and analytics expectation tests outside this mission scope

## Scope
Tenant-facing document and attachment visibility only. No auth core, billing, screening, pricing, Firestore rules, Terraform, CI/CD, upload pipelines, PDF generation, lease signing, payment checkout, provider callbacks, or production data changed.

## Known Limitations
- Manual browser QA on staging was not performed in this environment
- Tenant-scoped signed document URLs are preserved; storage backing and URL proxying were not changed
- Active route inventory differs from the mission's aspirational file paths, so no new tenant documents route module was introduced
- Duplicate tenant lease route registration remains out of scope