### PR TITLE
fix: remove duplicate documents display and fix label rendering in tenant documents page

### DIFF
--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
@@ -203,6 +203,7 @@ describe("tenant attachments page", () => {
     expect(screen.getAllByText(/Schedule A/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/schedule-a\.pdf/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Open file/i })).toHaveAttribute("href", "https://signed.example/schedule-a.pdf");
+    expect(screen.queryByText(/SCHEDULE_A/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/support-operator/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/realActorId/i)).not.toBeInTheDocument();
   });
@@ -266,8 +267,71 @@ describe("tenant attachments page", () => {
     expect(screen.getAllByText(/Schedule A/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/schedule-a\.pdf/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Open file/i })).toHaveAttribute("href", "https://signed.example/schedule-a.pdf");
+    expect(screen.queryByText(/SCHEDULE_A/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lease documents \/ attachments/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/tenant-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/schedule-a-doc/i)).not.toBeInTheDocument();
+  });
+
+  it("links lease document groups to lease details without exposing raw purpose keys", async () => {
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [],
+      summary: {
+        total: 0,
+        missing: 0,
+        uploaded: 0,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "Your current tenant-safe document record is up to date.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: null,
+    });
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-1",
+      startDate: null,
+      endDate: null,
+      monthlyRent: null,
+      status: "active",
+      documentUrl: null,
+      leaseDocumentContext: {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        leaseStatus: "active",
+        signingStatus: "signed",
+        documentStatus: "signed",
+        documentId: "lease-doc",
+        documentUrl: "https://signed.example/lease.pdf",
+        displayLabel: "Signed lease document",
+        source: "tenant-safe-lease-workspace",
+        confidence: "high",
+        warnings: [],
+      },
+      scheduleADocumentContext: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantAttachmentsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Document Vault Summary/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open lease details/i })).toHaveAttribute("href", "/tenant/lease");
+    expect(screen.getAllByText(/Lease document/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/LEASE — Lease/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("lease-doc")).not.toBeInTheDocument();
   });
 
   it("renders unauthorized state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
@@ -327,6 +327,16 @@ export default function TenantAttachmentsPage() {
           {vault.groupedItems.map((group) => (
             <TenantInfoCard key={group.category} heading={group.category} accent="#0f766e">
               <div style={{ display: "grid", gap: spacing.sm }}>
+                {group.actionPath && group.actionLabel ? (
+                  <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+                    <Link to={group.actionPath} style={{ fontWeight: 700 }}>
+                      {group.actionLabel}
+                    </Link>
+                    <span style={{ color: textTokens.muted }}>
+                      Lease package details live in the lease workspace; this list only shows tenant-visible files.
+                    </span>
+                  </div>
+                ) : null}
                 {group.items.map((item) => {
                   const tone = statusTone(item.status);
                   return (

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
@@ -66,7 +66,7 @@ describe("buildTenantDocumentVaultView", () => {
     expect(result.metrics.map((item) => item.value)).toEqual([3, 2, 1, 1]);
     expect(result.readyItems.map((item) => item.id)).toEqual(["doc-1", "doc-3"]);
     expect(result.missingItems.map((item) => item.id)).toEqual(["doc-2"]);
-    expect(result.groupedItems.map((group) => group.category)).toEqual(["Identity", "Income", "Lease"]);
+    expect(result.groupedItems.map((group) => group.category)).toEqual(["Identity", "Income", "Lease documents"]);
     expect(result.shareInsights[0]).toMatchObject({
       label: "Rental history",
       status: "shared",
@@ -183,7 +183,7 @@ describe("buildTenantDocumentVaultView", () => {
     expect(sourceItems).toHaveLength(5);
     expect(result.metrics.map((item) => item.value).slice(0, 3)).toEqual([2, 2, 0]);
     expect(result.readyItems.map((item) => item.id)).toEqual(["lease-generated-url", "identity-doc"]);
-    expect(result.groupedItems.find((group) => group.category === "Lease")?.items).toHaveLength(1);
+    expect(result.groupedItems.find((group) => group.category === "Lease documents")?.items).toHaveLength(1);
     expect(result.groupedItems.find((group) => group.category === "Identity")?.items).toHaveLength(1);
     expect(result.recentItems.map((item) => item.id)).toEqual(["lease-generated-url", "identity-doc"]);
   });
@@ -247,5 +247,48 @@ describe("buildTenantDocumentVaultView", () => {
     expect(result.groupedItems).toHaveLength(1);
     expect(result.groupedItems[0].items.map((item) => item.id)).toEqual(["lease-snapshot-4"]);
     expect(result.recentItems.map((item) => item.id)).toEqual(["lease-snapshot-4"]);
+  });
+
+  it("normalizes raw document keys and collapses duplicate Schedule A rows", () => {
+    const result = buildTenantDocumentVaultView({
+      items: [
+        {
+          id: "schedule-from-attachments",
+          label: "SCHEDULE_A — Schedule A",
+          title: "Schedule A",
+          category: "Attachments",
+          purpose: "SCHEDULE_A",
+          purposeLabel: "Schedule A",
+          fileName: "schedule-a.pdf",
+          url: "https://example.com/schedule-from-attachments.pdf",
+          status: "uploaded",
+          uploadedAt: 200,
+        },
+        {
+          id: "schedule-from-lease-context",
+          label: "SCHEDULE_A",
+          title: "Schedule A",
+          category: "Lease documents / attachments",
+          purpose: "SCHEDULE_A",
+          purposeLabel: "Schedule A",
+          fileName: "schedule-a.pdf",
+          url: "https://example.com/schedule-from-lease-context.pdf",
+          status: "uploaded",
+          uploadedAt: 100,
+        },
+      ],
+    });
+
+    expect(result.metrics[0].value).toBe(1);
+    expect(result.readyItems.map((item) => item.label)).toEqual(["Schedule A"]);
+    expect(result.recentItems.map((item) => item.label)).toEqual(["Schedule A"]);
+    expect(result.groupedItems).toEqual([
+      expect.objectContaining({
+        category: "Attachments",
+        items: [expect.objectContaining({ label: "Schedule A" })],
+      }),
+    ]);
+    expect(result.groupedItems.map((group) => group.category)).not.toContain("Lease documents / attachments");
+    expect(result.groupedItems.flatMap((group) => group.items.map((item) => item.label))).not.toContain("SCHEDULE_A");
   });
 });

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
@@ -11,6 +11,8 @@ type VaultMetric = {
 type VaultDocumentGroup = {
   category: string;
   items: TenantAttachment[];
+  actionPath?: string;
+  actionLabel?: string;
 };
 
 type VaultShareInsight = {
@@ -35,6 +37,93 @@ function isReadyToShare(item: TenantAttachment): boolean {
   return item.status === "uploaded" || item.status === "verified";
 }
 
+const DOCUMENT_LABELS: Record<string, string> = {
+  AGREEMENT: "Agreement",
+  APPLICATION: "Application",
+  BANK_STATEMENT: "Bank statement",
+  GOVERNMENT_ID: "Government ID",
+  IDENTITY: "Identity document",
+  INCOME: "Income document",
+  INSURANCE: "Insurance document",
+  LEASE: "Lease document",
+  PAYSTUB: "Paystub",
+  PHOTO_ID: "Photo ID",
+  PROOF_OF_INCOME: "Proof of income",
+  RENTAL_APPLICATION: "Rental application",
+  SCHEDULE_A: "Schedule A",
+};
+
+function normalizeDocumentToken(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .replace(/[-\s]+/g, "_")
+    .replace(/[^a-zA-Z0-9_]/g, "")
+    .replace(/_+/g, "_")
+    .toUpperCase();
+}
+
+function titleCaseDocumentToken(value: string): string {
+  return value
+    .toLowerCase()
+    .split("_")
+    .filter(Boolean)
+    .map((part) => (part.length <= 2 ? part.toUpperCase() : `${part.charAt(0).toUpperCase()}${part.slice(1)}`))
+    .join(" ");
+}
+
+function readableDocumentLabel(value: unknown): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const normalized = normalizeDocumentToken(raw);
+  if (!normalized) return null;
+  if (DOCUMENT_LABELS[normalized]) return DOCUMENT_LABELS[normalized];
+  if (/^[A-Z0-9]+(?:_[A-Z0-9]+)+$/.test(normalized) && raw === raw.toUpperCase()) return titleCaseDocumentToken(normalized);
+  return raw;
+}
+
+function tenantDocumentDisplayLabel(item: TenantAttachment): string {
+  const rawLabel = String(item.label || "").trim();
+  if (rawLabel && !rawLabel.includes("—") && rawLabel !== rawLabel.toUpperCase()) {
+    return readableDocumentLabel(rawLabel) || rawLabel;
+  }
+
+  const purposeLabel = readableDocumentLabel(item.purposeLabel);
+  if (purposeLabel) return purposeLabel;
+
+  const purpose = readableDocumentLabel(item.purpose);
+  const title = readableDocumentLabel(item.title);
+  if (rawLabel.includes("—")) {
+    const [, suffix] = rawLabel.split("—").map((part) => part.trim());
+    const suffixLabel = readableDocumentLabel(suffix);
+    if (suffixLabel) return suffixLabel;
+  }
+  const label = readableDocumentLabel(rawLabel);
+  if (label) return label;
+  if (title) return title;
+  if (purpose) return purpose;
+  return "Document";
+}
+
+function tenantDocumentCategory(item: TenantAttachment): string {
+  const category = String(item.category || "").trim();
+  const normalizedCategory = category.toLowerCase();
+  const purpose = normalizeDocumentToken(item.purpose);
+  const label = tenantDocumentDisplayLabel(item).toLowerCase();
+
+  if (normalizedCategory === "lease documents / attachments") return "Attachments";
+  if (purpose === "SCHEDULE_A" || label === "schedule a") return "Attachments";
+  if (purpose === "LEASE" || normalizedCategory === "lease") return "Lease documents";
+  return category || "Documents";
+}
+
+function normalizeTenantDocumentItem(item: TenantAttachment): TenantAttachment {
+  return {
+    ...item,
+    label: tenantDocumentDisplayLabel(item),
+    category: tenantDocumentCategory(item),
+  };
+}
+
 function needsAttention(item: TenantAttachment): boolean {
   return item.status === "missing" || item.status === "needs_attention" || item.status === "reupload_requested";
 }
@@ -45,16 +134,31 @@ function isVisibleLeaseAttachment(item: TenantAttachment): boolean {
   const purposeLabel = String(item.purposeLabel || "").trim().toLowerCase();
   const title = String(item.title || "").trim().toLowerCase();
   const label = String(item.label || "").trim().toLowerCase();
-  return category === "lease" || purpose === "LEASE" || purposeLabel === "lease" || title === "lease document" || label.includes("lease");
+  return (
+    category === "lease" ||
+    category === "lease documents" ||
+    purpose === "LEASE" ||
+    purpose === "SCHEDULE_A" ||
+    purposeLabel === "lease" ||
+    purposeLabel === "schedule a" ||
+    title === "lease document" ||
+    title === "schedule a" ||
+    label.includes("lease") ||
+    label === "schedule a"
+  );
 }
 
 function visibleLeaseKeys(item: TenantAttachment): string[] {
   if (!isVisibleLeaseAttachment(item)) return [];
   const tenantRef = String(item.tenantReference || "").trim() || "tenant";
   const leaseRef = String(item.leaseReference || "").trim();
+  const purpose = normalizeDocumentToken(item.purpose) || normalizeDocumentToken(item.label);
+  const fileName = String(item.fileName || item.title || item.label || "").trim().toLowerCase();
   return [
-    `${tenantRef}|lease:current|LEASE`,
-    leaseRef ? `${tenantRef}|lease:${leaseRef}|LEASE` : null,
+    purpose ? `${tenantRef}|document-purpose:${purpose}` : null,
+    purpose && fileName ? `${tenantRef}|document-purpose:${purpose}|file:${fileName}` : null,
+    `${tenantRef}|lease:current|${purpose || "LEASE"}`,
+    leaseRef ? `${tenantRef}|lease:${leaseRef}|${purpose || "LEASE"}` : null,
   ].filter((value): value is string => Boolean(value));
 }
 
@@ -151,7 +255,7 @@ export function buildTenantDocumentVaultView(params: {
   updatedAt?: number | null;
   access?: TenantAccessWorkspace | null;
 }): TenantDocumentVaultView {
-  const items = dedupeVisibleLeaseItems(Array.isArray(params.items) ? [...params.items] : []);
+  const items = dedupeVisibleLeaseItems(Array.isArray(params.items) ? params.items.map(normalizeTenantDocumentItem) : []);
   const readyItems = items.filter(isReadyToShare);
   const missingItems = items.filter(needsAttention);
   const recentItems = [...items]
@@ -169,6 +273,8 @@ export function buildTenantDocumentVaultView(params: {
   )
     .map(([category, grouped]) => ({
       category,
+      actionPath: category === "Lease documents" ? "/tenant/lease" : undefined,
+      actionLabel: category === "Lease documents" ? "Open lease details" : undefined,
       items: [...grouped].sort((a, b) => {
         const priority = statusRank(a.status) - statusRank(b.status);
         if (priority !== 0) return priority;

--- a/rentchain-frontend/src/pages/tenant/tenantLeaseDocumentAttachments.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantLeaseDocumentAttachments.ts
@@ -38,7 +38,7 @@ function documentContextToAttachment(
     leaseReference: context.leaseId ? referenceFor("lease", "current") : null,
     title: "Schedule A",
     label: "Schedule A",
-    category: "Lease documents / attachments",
+    category: "Attachments",
     status: context.documentStatus === "pending" ? "pending_review" : "uploaded",
     purpose: "SCHEDULE_A",
     purposeLabel: "Schedule A",
@@ -62,11 +62,13 @@ export function mergeTenantAttachments(items: TenantAttachment[], leaseWorkspace
   const merged: TenantAttachment[] = [];
   const seen = new Set<string>();
   for (const item of [...leaseWorkspaceItems, ...items]) {
+    const purpose = String(item.purpose || item.purposeLabel || item.label || "").trim().toUpperCase();
+    const isLeasePackageDocument = purpose === "LEASE" || purpose === "SCHEDULE_A";
     const key = [
-      String(item.purpose || "").trim().toUpperCase(),
-      String(item.leaseReference || "").trim(),
+      purpose,
+      isLeasePackageDocument ? "lease-workspace" : String(item.leaseReference || "").trim(),
       String(item.fileName || item.title || item.label || "").trim().toLowerCase(),
-      String(item.url || "").trim(),
+      isLeasePackageDocument ? "" : String(item.url || "").trim(),
     ].join("|");
     const fallbackKey = String(item.id || key).trim();
     const finalKey = key.replace(/\|/g, "") ? key : fallbackKey;


### PR DESCRIPTION
## Summary
Fixes tenant documents page display issues found during manual QA after the tenant document continuity hardening work.

## Changes
- Normalizes tenant document labels at render time so raw purpose keys such as SCHEDULE_A display as human-readable labels.
- Collapses duplicate Schedule A and lease package rows across attachment projection data and lease workspace context data.
- Normalizes the Schedule A section category from Lease documents / attachments to Attachments.
- Adds a lease document group link to /tenant/lease for lease workspace navigation.
- Adds focused tests for label normalization, duplicate suppression, and lease detail navigation.

## Validation
- Focused frontend tests: 11/11 passing
- Full frontend tests: 1121/1121 passing
- Frontend build: pass
- git diff --check: pass

## Scope
Frontend rendering and frontend tests only. No backend API, authorization, Firestore rules, billing, screening, infrastructure, or data model changes.

## Known Limitations
Manual browser QA was not performed in this environment; preview verification is still recommended before Phase 1 sign-off.