### PR TITLE
fix: restore /tenant/payments route to resolve 404 error

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -205,6 +205,10 @@ vi.mock("./pages/tenant/TenantApplicationStatusPage", () => ({
   },
 }));
 
+vi.mock("./pages/tenant/TenantPaymentsPage", () => ({
+  default: () => <h1>Tenant Payments</h1>,
+}));
+
 describe("Routes: /tenant", () => {
   it("renders the tenant-first landing page without landlord pricing content", async () => {
     const { default: App } = await import("./App");
@@ -801,6 +805,20 @@ describe("Routes: /tenant/application", () => {
 
     expect(await screen.findByText(/Tenant Application Status/i)).toBeInTheDocument();
     expect(screen.queryByText(/Dashboard/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /tenant/payments", () => {
+  it("renders the tenant payments route without falling through to not found", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant/payments"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Tenant Payments/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });
 

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -195,6 +195,7 @@ const TenantLandingPage = lazy(() => import("./pages/tenant/TenantLandingPage"))
 const TenantWorkspacePage = lazy(() => import("./pages/tenant/TenantWorkspacePage"));
 const TenantApplicationStatusPage = lazy(() => import("./pages/tenant/TenantApplicationStatusPage"));
 const TenantLeasePage = lazy(() => import("./pages/tenant/TenantLeasePage"));
+const TenantPaymentsPage = lazy(() => import("./pages/tenant/TenantPaymentsPage"));
 const TenantLedgerPage = lazy(() => import("./pages/tenant/TenantLedgerPage"));
 const TenantActivityPage = lazy(() => import("./pages/tenant/TenantActivityPage"));
 const TenantParticipationPage = lazy(() => import("./pages/TenantParticipationPage"));
@@ -1659,6 +1660,10 @@ function App() {
         <Route
           path="/tenant/lease"
           element={renderTenantShell(suspensePage(<TenantLeasePage />))}
+        />
+        <Route
+          path="/tenant/payments"
+          element={renderTenantShell(suspensePage(<TenantPaymentsPage />))}
         />
         <Route
           path="/tenant/activity"

--- a/rentchain-frontend/src/api/tenantPortalApi.ts
+++ b/rentchain-frontend/src/api/tenantPortalApi.ts
@@ -205,7 +205,12 @@ export async function signTenantLease(leaseId: string): Promise<TenantLease> {
 }
 
 export async function getTenantPayments(): Promise<TenantPayment[]> {
-  return apiFetch<TenantPayment[]>("/tenant/payments");
+  const res = await apiFetch<any>("/tenant/payments");
+  if (Array.isArray(res)) return res as TenantPayment[];
+  if (Array.isArray(res?.data)) return res.data as TenantPayment[];
+  if (Array.isArray(res?.items)) return res.items as TenantPayment[];
+  if (Array.isArray(res?.payments)) return res.payments as TenantPayment[];
+  return [];
 }
 
 export async function getTenantLedger(): Promise<TenantLedgerEntry[]> {
@@ -217,7 +222,10 @@ export async function getTenantDocuments(): Promise<TenantDocument[]> {
 }
 
 export async function getTenantPaymentsSummary(): Promise<TenantPaymentsSummary> {
-  return apiFetch<TenantPaymentsSummary>("/tenant/payments/summary");
+  const res = await apiFetch<any>("/tenant/payments/summary");
+  if (res?.data && typeof res.data === "object") return res.data as TenantPaymentsSummary;
+  if (res?.summary && typeof res.summary === "object") return res.summary as TenantPaymentsSummary;
+  return res as TenantPaymentsSummary;
 }
 
 export interface TenantRentCharge {
@@ -232,7 +240,12 @@ export interface TenantRentCharge {
 }
 
 export async function getTenantRentCharges(): Promise<TenantRentCharge[]> {
-  return apiFetch<TenantRentCharge[]>("/tenant/rent-charges");
+  const res = await apiFetch<any>("/tenant/rent-charges");
+  if (Array.isArray(res)) return res as TenantRentCharge[];
+  if (Array.isArray(res?.data)) return res.data as TenantRentCharge[];
+  if (Array.isArray(res?.items)) return res.items as TenantRentCharge[];
+  if (Array.isArray(res?.charges)) return res.charges as TenantRentCharge[];
+  return [];
 }
 
 export async function confirmTenantRentCharge(id: string): Promise<{ ok: boolean; confirmedAt?: string }> {

--- a/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TenantPaymentsPage from "./TenantPaymentsPage";
+
+const tenantPortalApi = vi.hoisted(() => ({
+  getTenantPayments: vi.fn(),
+  getTenantPaymentsSummary: vi.fn(),
+  getTenantRentCharges: vi.fn(),
+  confirmTenantRentCharge: vi.fn(),
+}));
+
+vi.mock("../../api/tenantPortalApi", () => tenantPortalApi);
+
+vi.mock("./TenantLayout.clean", () => ({
+  useTenantOutletContext: () => ({
+    lease: {
+      propertyName: "123 Main St",
+      unitNumber: "2",
+    },
+  }),
+}));
+
+describe("TenantPaymentsPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders tenant payment history when auxiliary payment surfaces are unavailable", async () => {
+    const notFound = Object.assign(new Error("Request failed (404)"), { status: 404 });
+    tenantPortalApi.getTenantPayments.mockResolvedValue([
+      {
+        id: "internal-payment-id-1",
+        amount: 1200,
+        dueDate: "2026-05-01",
+        paidAt: "2026-05-02",
+        method: "e-transfer",
+        status: "paid",
+        notes: "May rent",
+      },
+    ]);
+    tenantPortalApi.getTenantPaymentsSummary.mockRejectedValue(notFound);
+    tenantPortalApi.getTenantRentCharges.mockRejectedValue(notFound);
+
+    render(<TenantPaymentsPage />);
+
+    expect(await screen.findByText(/Rent payments/i)).toBeInTheDocument();
+    expect(screen.getByText("$1,200")).toBeInTheDocument();
+    expect(screen.getByText("e-transfer")).toBeInTheDocument();
+    expect(screen.getByText("May rent")).toBeInTheDocument();
+    expect(screen.queryByText(/Request failed \(404\)/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/No rent charges issued yet/i)).toBeInTheDocument();
+    expect(screen.queryByText("internal-payment-id-1")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.test.tsx
@@ -10,21 +10,31 @@ const tenantPortalApi = vi.hoisted(() => ({
   confirmTenantRentCharge: vi.fn(),
 }));
 
-vi.mock("../../api/tenantPortalApi", () => tenantPortalApi);
-
-vi.mock("./TenantLayout.clean", () => ({
-  useTenantOutletContext: () => ({
+const tenantLayout = vi.hoisted(() => ({
+  context: {
     lease: {
       propertyName: "123 Main St",
       unitNumber: "2",
     },
-  }),
+  } as { lease: { propertyName: string; unitNumber: string } | null } | null,
+}));
+
+vi.mock("../../api/tenantPortalApi", () => tenantPortalApi);
+
+vi.mock("./TenantLayout.clean", () => ({
+  useTenantOutletContext: () => tenantLayout.context,
 }));
 
 describe("TenantPaymentsPage", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    tenantLayout.context = {
+      lease: {
+        propertyName: "123 Main St",
+        unitNumber: "2",
+      },
+    };
   });
 
   it("renders tenant payment history when auxiliary payment surfaces are unavailable", async () => {
@@ -52,5 +62,18 @@ describe("TenantPaymentsPage", () => {
     expect(screen.queryByText(/Request failed \(404\)/i)).not.toBeInTheDocument();
     expect(screen.getByText(/No rent charges issued yet/i)).toBeInTheDocument();
     expect(screen.queryByText("internal-payment-id-1")).not.toBeInTheDocument();
+  });
+
+  it("renders a safe empty state when tenant layout context is not ready", async () => {
+    tenantLayout.context = null;
+    tenantPortalApi.getTenantPayments.mockResolvedValue([]);
+    tenantPortalApi.getTenantPaymentsSummary.mockResolvedValue(null);
+    tenantPortalApi.getTenantRentCharges.mockResolvedValue([]);
+
+    render(<TenantPaymentsPage />);
+
+    expect(await screen.findByText(/Rent payments/i)).toBeInTheDocument();
+    expect(screen.getByText(/Your lease/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No active lease found/i)).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.tsx
@@ -24,6 +24,10 @@ function formatDate(value?: string | null) {
   return Number.isNaN(d.getTime()) ? "—" : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
+function optionalSurfaceError(reason: any, fallback: string): string | null {
+  return reason?.status === 404 ? null : reason?.message || fallback;
+}
+
 export const TenantPaymentsPage: React.FC = () => {
   const { lease } = useTenantOutletContext();
   const [payments, setPayments] = useState<TenantPayment[]>([]);
@@ -42,14 +46,29 @@ export const TenantPaymentsPage: React.FC = () => {
       setSummaryError(null);
       setChargesError(null);
       try {
-        const [history, summaryData, chargesData] = await Promise.all([
+        const [historyResult, summaryResult, chargesResult] = await Promise.allSettled([
           getTenantPayments(),
           getTenantPaymentsSummary(),
           getTenantRentCharges(),
         ]);
-        setPayments(history);
-        setSummary(summaryData);
-        setCharges(chargesData);
+        if (historyResult.status === "fulfilled") {
+          setPayments(Array.isArray(historyResult.value) ? historyResult.value : []);
+        } else {
+          setError(historyResult.reason?.message || "Failed to load payments");
+          setPayments([]);
+        }
+        if (summaryResult.status === "fulfilled") {
+          setSummary(summaryResult.value);
+        } else {
+          setSummary(null);
+          setSummaryError(optionalSurfaceError(summaryResult.reason, "Payment summary is unavailable"));
+        }
+        if (chargesResult.status === "fulfilled") {
+          setCharges(Array.isArray(chargesResult.value) ? chargesResult.value : []);
+        } else {
+          setCharges([]);
+          setChargesError(optionalSurfaceError(chargesResult.reason, "Rent charges are unavailable"));
+        }
       } catch (err: any) {
         setError(err?.message || "Failed to load payments");
         setSummaryError(err?.message || "Failed to load payments summary");

--- a/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPaymentsPage.tsx
@@ -29,7 +29,8 @@ function optionalSurfaceError(reason: any, fallback: string): string | null {
 }
 
 export const TenantPaymentsPage: React.FC = () => {
-  const { lease } = useTenantOutletContext();
+  const tenantContext = useTenantOutletContext();
+  const lease = tenantContext?.lease ?? null;
   const [payments, setPayments] = useState<TenantPayment[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
Restores the tenant payments frontend route so /tenant/payments resolves to the existing tenant payments page instead of falling through to 404.

## Changes
- App.tsx - mounts TenantPaymentsPage at /tenant/payments
- App.routes.test.tsx - adds route regression coverage for /tenant/payments
- tenantPortalApi.ts - accepts current tenant payments response envelopes while preserving request paths
- TenantPaymentsPage.tsx - keeps payment history rendering when optional summary or rent-charge endpoints are unavailable
- TenantPaymentsPage.test.tsx - verifies degraded optional surfaces do not block payment history rendering or expose raw payment ids

## Validation
- Focused route/page tests: 47/47 passing
- Full frontend tests: 1123/1123 passing across 287 files
- Frontend build: pass
- git diff --check: pass

## Scope
Frontend routing and rendering only. No backend API, payment service, authorization, billing, Firestore rules, pricing, entitlement, provider callback, or data model changes.