### PR TITLE
fix: add tenant payment read surfaces

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1612,6 +1612,234 @@ describe("tenantPortalRoutes foundation", () => {
     expect(JSON.stringify(res.body)).not.toContain("lease-1");
   });
 
+  it("returns tenant payment summary at the current tenant payments summary surface", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      landlordId: "landlord-1",
+      paymentRailEnabled: true,
+      paymentRailEnabledAt: "2026-04-27T10:00:00.000Z",
+      paymentRailProcessor: "stripe",
+      dueDay: 1,
+    });
+    ensureCollection("rentPayments").set("rp-summary-1", {
+      id: "rp-summary-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      amountCents: 180000,
+      currency: "cad",
+      status: "paid",
+      processor: "stripe",
+      processorCheckoutSessionId: "cs_should_not_leak",
+      processorPaymentIntentId: "pi_should_not_leak",
+      paymentIntentId: "intent_should_not_leak",
+      createdAt: "2026-04-27T10:05:00.000Z",
+      updatedAt: "2026-04-27T10:06:00.000Z",
+      paidAt: "2026-04-27T10:06:00.000Z",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/payments/summary",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_payment_projection",
+        scopeType: "tenant_payment",
+      })
+    );
+    expect(res.body?.data).toEqual(
+      expect.objectContaining({
+        tenantReference: expect.stringMatching(/^tenant-ref-/),
+        leaseReference: expect.stringMatching(/^lease-ref-/),
+        rentAmount: 1800,
+        rentDayOfMonth: 1,
+        lastPayment: expect.objectContaining({
+          paymentReference: expect.stringMatching(/^payment-ref-/),
+          amount: 1800,
+          paidAt: "2026-04-27T10:06:00.000Z",
+          status: "on_time",
+        }),
+        currentPeriod: expect.objectContaining({
+          amountDue: 1800,
+          amountPaid: 1800,
+          status: "on_time",
+        }),
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("rp-summary-1");
+    expect(JSON.stringify(res.body)).not.toContain("tenant-1");
+    expect(JSON.stringify(res.body)).not.toContain("lease-1");
+    expect(JSON.stringify(res.body)).not.toContain("landlord-1");
+    expect(JSON.stringify(res.body)).not.toContain("cs_should_not_leak");
+    expect(JSON.stringify(res.body)).not.toContain("pi_should_not_leak");
+    expect(JSON.stringify(res.body)).not.toContain("intent_should_not_leak");
+  });
+
+  it("returns empty zero tenant payment summary data when no rent payments exist", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/payments/summary",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.lastPayment).toBeNull();
+    expect(res.body?.data?.currentPeriod).toEqual(
+      expect.objectContaining({
+        amountDue: 1800,
+        amountPaid: null,
+        status: "unknown",
+      })
+    );
+    expect(res.body?.data?.paymentExperience?.history).toEqual([]);
+  });
+
+  it("returns tenant-scoped rent charges without exposing internal charge identifiers", async () => {
+    ensureCollection("rentCharges").set("charge-1", {
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      amount: 1800,
+      dueDate: "2026-05-01",
+      period: "2026-05",
+      status: "issued",
+      storagePath: "gs://private/charge-1.pdf",
+      providerPayload: { hidden: true },
+      createdAt: "2026-04-20T00:00:00.000Z",
+    });
+    ensureCollection("rentCharges").set("charge-other-tenant", {
+      tenantId: "tenant-2",
+      landlordId: "landlord-2",
+      leaseId: "lease-2",
+      amount: 2500,
+      dueDate: "2026-05-01",
+      status: "issued",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/rent-charges",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_balance_projection",
+        scopeType: "tenant_balance",
+      })
+    );
+    expect(res.body?.data).toEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(/^rent-charge-ref-/),
+        amount: 1800,
+        dueDate: "2026-05-01",
+        period: "2026-05",
+        status: "issued",
+        leaseReference: expect.stringMatching(/^lease-ref-/),
+        propertyReference: expect.stringMatching(/^property-ref-/),
+        unitReference: expect.stringMatching(/^unit-ref-/),
+      }),
+    ]);
+    expect(JSON.stringify(res.body)).not.toContain("charge-1");
+    expect(JSON.stringify(res.body)).not.toContain("charge-other-tenant");
+    expect(JSON.stringify(res.body)).not.toContain("tenant-1");
+    expect(JSON.stringify(res.body)).not.toContain("tenant-2");
+    expect(JSON.stringify(res.body)).not.toContain("landlord-1");
+    expect(JSON.stringify(res.body)).not.toContain("gs://private");
+    expect(JSON.stringify(res.body)).not.toContain("providerPayload");
+  });
+
+  it("returns an empty tenant rent charge list when no tenant charges exist", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/rent-charges",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data).toEqual([]);
+    expect(res.body?.charges).toEqual([]);
+  });
+
+  it("rejects unauthenticated tenant payment read surfaces", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+
+    const summary = await invokeRouter(router, { method: "GET", url: "/payments/summary" });
+    const charges = await invokeRouter(router, { method: "GET", url: "/rent-charges" });
+
+    expect(summary.status).toBe(401);
+    expect(charges.status).toBe(401);
+  });
+
+  it("rejects tenant payment read surfaces when requested lease context is not owned by the tenant", async () => {
+    ensureCollection("tenants").set("tenant-2", {
+      email: "other@example.com",
+      fullName: "Other Tenant",
+      propertyId: "prop-1",
+      currentLeaseId: "lease-1",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-2",
+        email: "other@example.com",
+        role: "tenant",
+        tenantId: "tenant-2",
+        leaseId: "lease-1",
+      }),
+    };
+
+    const summary = await invokeRouter(router, { method: "GET", url: "/payments/summary", headers });
+    const charges = await invokeRouter(router, { method: "GET", url: "/rent-charges", headers });
+
+    expect(summary.status).toBe(403);
+    expect(charges.status).toBe(403);
+  });
+
   it("records tenant lease signing metadata without storing raw signature data and stays idempotent", async () => {
     ensureCollection("leases").set("lease-1", {
       tenantId: "tenant-1",

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -144,6 +144,79 @@ function tenantPublicReference(kind: string, raw: unknown): string | null {
   return `${kind}-ref-${digest}`;
 }
 
+function dollarsFromCents(value: unknown): number | null {
+  const cents = Number(value);
+  if (!Number.isFinite(cents)) return null;
+  return Math.round(cents) / 100;
+}
+
+function normalizePaymentStatusForTenant(status: unknown): "on_time" | "late" | "partial" | "unpaid" | "unknown" {
+  const next = String(status || "").trim().toLowerCase();
+  if (next === "paid") return "on_time";
+  if (next === "payment_pending" || next === "checkout_created") return "partial";
+  if (next === "failed" || next === "expired") return "late";
+  if (next === "canceled") return "unpaid";
+  return "unknown";
+}
+
+function buildTenantPaymentsSummaryResponse(params: {
+  tenantId: string;
+  leaseId: string;
+  leaseData: any;
+  projectedSummary: ReturnType<typeof projectTenantRentPaymentSummary>;
+}) {
+  const monthlyRent = typeof params.leaseData?.monthlyRent === "number" ? params.leaseData.monthlyRent : null;
+  const rentDayOfMonth = typeof params.leaseData?.dueDay === "number" ? params.leaseData.dueDay : null;
+  const history = params.projectedSummary.paymentExperience.history || [];
+  const latestPaid = history.find((payment: any) => payment?.status === "paid") || null;
+  const latest = params.projectedSummary.latestPayment || history[0] || null;
+  const latestAmount = dollarsFromCents(latestPaid?.amountCents ?? latest?.amountCents);
+
+  return {
+    tenantReference: tenantPublicReference("tenant", params.tenantId),
+    leaseReference: tenantPublicReference("lease", params.leaseId),
+    rentAmount: monthlyRent,
+    rentDayOfMonth,
+    nextDueDate: null,
+    lastPayment: latest
+      ? {
+          paymentReference: latest?.id || null,
+          amount: latestAmount,
+          paidAt: latestPaid?.paidAt || latest?.paidAt || null,
+          dueDate: null,
+          status: normalizePaymentStatusForTenant(latestPaid?.status || latest?.status),
+        }
+      : null,
+    currentPeriod: {
+      periodStart: null,
+      periodEnd: null,
+      amountDue: monthlyRent,
+      amountPaid: latestPaid?.amountCents != null ? dollarsFromCents(latestPaid.amountCents) : null,
+      status: normalizePaymentStatusForTenant(params.projectedSummary.paymentExperience.latestStatus),
+    },
+    paymentRail: params.projectedSummary.paymentRail,
+    paymentExperience: params.projectedSummary.paymentExperience,
+  };
+}
+
+function projectTenantRentCharge(doc: any) {
+  const data = (doc?.data?.() || {}) as any;
+  return {
+    id: tenantPublicReference("rent-charge", doc?.id) || "rent-charge-ref-unavailable",
+    amount: typeof data?.amount === "number" && Number.isFinite(data.amount) ? data.amount : 0,
+    dueDate: asString(data?.dueDate),
+    period: asString(data?.period),
+    status: asString(data?.status) || "issued",
+    issuedAt: asString(data?.issuedAt) || asString(data?.createdAt),
+    confirmedAt: asString(data?.confirmedAt),
+    paidAt: asString(data?.paidAt),
+    description: asString(data?.description),
+    leaseReference: tenantPublicReference("lease", data?.leaseId),
+    propertyReference: tenantPublicReference("property", data?.propertyId),
+    unitReference: tenantPublicReference("unit", data?.unitId),
+  };
+}
+
 function displayStringUnlessId(value: unknown, rawId?: unknown): string | null {
   const next = asString(value);
   if (!next) return null;
@@ -7554,6 +7627,161 @@ router.get("/lease", requireTenant, async (req: any, res) => {
   } catch (err) {
     console.error("[tenantPortalRoutes] /tenant/lease error", err);
     return res.status(500).json({ ok: false, error: "TENANT_LEASE_FAILED" });
+  }
+});
+
+router.get("/payments/summary", requireTenantWorkspaceIdentity, async (req: any, res: any) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+  if (context.authority !== "active_tenant" || !context.tenantId) {
+    return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+  }
+
+  if (!context.leaseId) {
+    const emptySummary = buildTenantPaymentsSummaryResponse({
+      tenantId: context.tenantId,
+      leaseId: "",
+      leaseData: {},
+      projectedSummary: projectTenantRentPaymentSummary({
+        paymentRail: {
+          enabled: false,
+          enabledAt: null,
+          processor: null,
+          blockedReason: null,
+        },
+        latestPayment: null,
+        paymentExperience: {
+          history: [],
+          latestStatus: null,
+          retryAvailable: false,
+          receiptSummary: {
+            available: false,
+            label: "No payment summary available yet",
+            amountCents: null,
+            paidAt: null,
+            leaseReference: null,
+          },
+        },
+      }),
+    });
+    const paymentProjectionMetadata = buildTenantFinancialProjectionMetadata({
+      projectionName: "tenant_safe_payment_projection",
+      scopeType: "tenant_payment",
+      sourceCollections: ["leases", "rentPayments"],
+      relationshipBasis: "Payment summary must be derived from authenticated tenant lease ownership.",
+    });
+    return res.json({ ok: true, ...paymentProjectionMetadata, data: emptySummary, summary: emptySummary });
+  }
+
+  try {
+    const leaseSnap = await db.collection("leases").doc(context.leaseId).get();
+    if (!leaseSnap.exists) {
+      return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+    }
+    const leaseData = (leaseSnap.data() as any) || {};
+    const leaseTenantIds = [
+      asString(leaseData?.tenantId),
+      asString(leaseData?.primaryTenantId),
+      ...(Array.isArray(leaseData?.tenantIds) ? leaseData.tenantIds.map((value: any) => asString(value)) : []),
+    ].filter(Boolean);
+    if (!leaseTenantIds.includes(context.tenantId)) {
+      return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+    }
+
+    const projectedLease = projectTenantLease(context.leaseId, leaseData);
+    const projectedPaymentSummary = projectTenantRentPaymentSummary(
+      (
+        await buildLeasePaymentProjection({
+          rawLease: leaseData,
+          lease: {
+            id: context.leaseId,
+            landlordId: asString(leaseData?.landlordId),
+            tenantId: asString(leaseData?.tenantId),
+            tenantIds: Array.isArray(leaseData?.tenantIds) ? leaseData.tenantIds : [],
+            primaryTenantId: asString(leaseData?.primaryTenantId),
+            propertyId: asString(leaseData?.propertyId),
+            unitId: asString(leaseData?.unitId),
+            unitNumber: asString(leaseData?.unitNumber),
+            monthlyRent: projectedLease.monthlyRent,
+            startDate: projectedLease.startDate,
+            endDate: projectedLease.endDate,
+            status: projectedLease.status,
+          },
+          leaseId: context.leaseId,
+          documentUrl: projectedLease.documentUrl,
+        })
+      ).rentPaymentSummary
+    );
+    const summary = buildTenantPaymentsSummaryResponse({
+      tenantId: context.tenantId,
+      leaseId: context.leaseId,
+      leaseData,
+      projectedSummary: projectedPaymentSummary,
+    });
+    const paymentProjectionMetadata = buildTenantFinancialProjectionMetadata({
+      projectionName: "tenant_safe_payment_projection",
+      scopeType: "tenant_payment",
+      sourceCollections: ["leases", "rentPayments"],
+      relationshipBasis: "Payment summary must be derived from authenticated tenant lease ownership.",
+    });
+    return res.json({ ok: true, ...paymentProjectionMetadata, data: summary, summary });
+  } catch (err: any) {
+    console.error("[tenant/payments/summary] failed", {
+      tenantId: context.tenantId,
+      leaseId: context.leaseId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_PAYMENT_SUMMARY_FAILED" });
+  }
+});
+
+router.get("/rent-charges", requireTenantWorkspaceIdentity, async (req: any, res: any) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+  if (context.authority !== "active_tenant" || !context.tenantId) {
+    return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+  }
+
+  try {
+    if (context.leaseId) {
+      const leaseSnap = await db.collection("leases").doc(context.leaseId).get();
+      if (!leaseSnap.exists) {
+        return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+      }
+      const leaseData = (leaseSnap.data() as any) || {};
+      const leaseTenantIds = [
+        asString(leaseData?.tenantId),
+        asString(leaseData?.primaryTenantId),
+        ...(Array.isArray(leaseData?.tenantIds) ? leaseData.tenantIds.map((value: any) => asString(value)) : []),
+      ].filter(Boolean);
+      if (!leaseTenantIds.includes(context.tenantId)) {
+        return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+      }
+    }
+
+    const snap = await db.collection("rentCharges").where("tenantId", "==", context.tenantId).get();
+    const charges = ((snap.docs || []) as any[])
+      .filter((doc) => {
+        const data = (doc.data() as any) || {};
+        const chargeLeaseId = asString(data?.leaseId);
+        return !chargeLeaseId || !context.leaseId || chargeLeaseId === context.leaseId;
+      })
+      .map(projectTenantRentCharge)
+      .sort((left, right) => timestampToSort(right.dueDate || right.issuedAt) - timestampToSort(left.dueDate || left.issuedAt));
+    const chargeProjectionMetadata = buildTenantFinancialProjectionMetadata({
+      projectionName: "tenant_safe_balance_projection",
+      scopeType: "tenant_balance",
+      sourceCollections: ["rentCharges"],
+      relationshipBasis: "Rent charges must be derived from authenticated tenant ownership.",
+    });
+    return res.json({ ok: true, ...chargeProjectionMetadata, charges, items: charges, data: charges });
+  } catch (err: any) {
+    console.error("[tenant/rent-charges] failed", {
+      tenantId: context.tenantId,
+      leaseId: context.leaseId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_RENT_CHARGES_FAILED" });
   }
 });
 


### PR DESCRIPTION
## Summary
Adds read-only tenant payment compatibility surfaces for the tenant payments page.

## Changes
- tenantPortalRoutes.ts - adds GET /api/tenant/payments/summary using the existing lease payment projection flow
- tenantPortalRoutes.ts - adds GET /api/tenant/rent-charges with tenant-scoped charge projection
- tenantPortalRoutes.test.ts - adds smoke, access-control, empty-state, and redaction coverage for both routes

## Validation
- Backend focused tests: tenantPortalRoutes.test.ts 83/83 passing
- Backend build: pass
- Frontend TenantPaymentsPage compatibility test: 2/2 passing
- Full frontend tests: 1124/1124 passing
- git diff --check: pass
- Full backend suite: 1940/1947 passing; 7 unrelated pre-existing failures remain in lease draft and analytics tests

## Scope
Backend read-only compatibility only. No payment mutations, checkout flows, provider callbacks, auth core, billing, pricing, Firestore rules, infrastructure, or frontend code changed.

## Known Limitations
- POST /api/tenant/rent-charges/:id/confirm remains deferred
- Existing /api/tenant/payments history stub remains unchanged
- Manual browser/network QA was not performed in this environment