### PR TITLE
Harden tenant profile continuity with whitelist projections and ownership validation

### DIFF
--- a/rentchain-api/src/__tests__/tenantWorkspaceLeaseLinkageContinuity.test.ts
+++ b/rentchain-api/src/__tests__/tenantWorkspaceLeaseLinkageContinuity.test.ts
@@ -314,12 +314,17 @@ describe("tenant workspace lease linkage continuity", () => {
     );
     expect(profile.body.data.profile.lease).toEqual(
       expect.objectContaining({
-        leaseId: lifecycleContinuityIds.activeLeaseId,
+        leaseId: expect.stringMatching(/^lease-ref-/),
         status: "active",
         startDate: lifecycleContinuityDates.activeLeaseStart,
         endDate: lifecycleContinuityDates.activeLeaseEnd,
       }),
     );
+    const serializedProfileLease = JSON.stringify(profile.body.data.profile.lease);
+    expect(serializedProfileLease).not.toContain(lifecycleContinuityIds.activeLeaseId);
+    expect(serializedProfileLease).not.toContain(lifecycleContinuityIds.tenantId);
+    expect(serializedProfileLease).not.toContain(lifecycleContinuityIds.propertyId);
+    expect(serializedProfileLease).not.toContain(lifecycleContinuityIds.unit101Id);
   });
 
   it("resolves tenant lease route to the canonical lease context without raw ID display labels", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -228,6 +228,10 @@ describe("tenantPortalRoutes foundation", () => {
       payment_intent: "pi_test_1",
     });
     setObservabilityWriteShouldFail(false);
+    setCollectionReadShouldFail("applications", false);
+    setCollectionReadShouldFail("rentalApplications", false);
+    setCollectionReadShouldFail("tenants", false);
+    setCollectionReadShouldFail("leases", false);
     setCollectionReadShouldFail("properties", false);
     setCollectionReadShouldFail("maintenanceRequests", false);
     process.env.EMAIL_FROM = "noreply@example.com";
@@ -4020,6 +4024,146 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.profile?.internalNotes).toBeUndefined();
     expect(res.body?.data?.actions?.editableFields).toEqual(["displayName", "phone"]);
     expect(res.body?.data?.actions?.documentEntry?.path).toBe("/tenant/attachments");
+    expect(res.body?.data?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_profile_projection",
+        scopeType: "tenant_profile",
+        audience: "tenant_workspace",
+        authorityBasis: "authenticated_tenant_scope",
+      })
+    );
+    expect(res.body?.data?.context).toEqual(
+      expect.objectContaining({
+        tenantId: expect.stringMatching(/^tenant-ref-/),
+        propertyId: expect.stringMatching(/^property-ref-/),
+        applicationId: expect.stringMatching(/^application-ref-/),
+        leaseId: expect.stringMatching(/^lease-ref-/),
+        unitId: expect.stringMatching(/^unit-ref-/),
+      })
+    );
+    expect(res.body?.data?.profile?.property?.propertyId).toMatch(/^property-ref-/);
+    expect(res.body?.data?.profile?.property?.rc_prop_id).toMatch(/^property-ref-/);
+    expect(res.body?.data?.profile?.application?.applicationId).toMatch(/^application-ref-/);
+    expect(res.body?.data?.profile?.lease?.leaseId).toMatch(/^lease-ref-/);
+    if (res.body?.data?.profile?.unit?.unitId) {
+      expect(res.body.data.profile.unit.unitId).toMatch(/^unit-ref-/);
+    }
+    expect(res.body?.data?.sourceRefs?.every((ref: any) => /-ref-/.test(String(ref.sourceId || "")))).toBe(true);
+    const serialized = JSON.stringify(res.body?.data);
+    expect(serialized).not.toContain("tenant-1");
+    expect(serialized).not.toContain("prop-1");
+    expect(serialized).not.toContain("rc-prop-1");
+    expect(serialized).not.toContain("app-1");
+    expect(serialized).not.toContain("lease-1");
+    expect(serialized).not.toContain("unit-1");
+    expect(serialized).not.toContain("landlord-1");
+    expect(serialized).not.toContain("do-not-expose");
+    expect(serialized).not.toContain("123-45-6789");
+    expect(["verified", "pending", "missing", "needs_review"]).toContain(res.body?.data?.identity?.overallStatus);
+    expect(
+      res.body?.data?.identity?.documentChecklist?.every((item: any) =>
+        ["verified", "pending", "missing", "needs_review"].includes(item.status)
+      )
+    ).toBe(true);
+  });
+
+  it("returns application reuse data with metadata and no raw context identifiers", async () => {
+    ensureCollection("applications").set("app-1", {
+      ...ensureCollection("applications").get("app-1"),
+      applicantEmail: "tenant@example.com",
+      firstName: "Taylor",
+      lastName: "Tenant",
+      applicantProfile: {
+        currentAddress: {
+          line1: "10 Harbour Road",
+          city: "Halifax",
+          provinceState: "NS",
+          postalCode: "B3H1A1",
+          country: "CA",
+        },
+        employment: {
+          employerName: "Harbour Clinic",
+          jobTitle: "Coordinator",
+          incomeAmountCents: 6400000,
+          incomeFrequency: "annual",
+          monthsAtJob: 18,
+        },
+        workReference: {
+          name: "Riley Manager",
+          phone: "902-555-0199",
+        },
+      },
+      nextOfKin: {
+        name: "Casey Contact",
+        relationship: "Sibling",
+        phone: "902-555-0188",
+        address: "Halifax",
+      },
+      landlordNotes: "private",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      leaseId: "lease-1",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/application-reuse",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.projectionProfile).toEqual(
+      expect.objectContaining({
+        projectionName: "tenant_safe_application_reuse_projection",
+        scopeType: "tenant_application_reuse",
+      })
+    );
+    expect(res.body?.data?.applicant).toEqual(
+      expect.objectContaining({
+        firstName: "Taylor",
+        lastName: "Tenant",
+        email: "tenant@example.com",
+      })
+    );
+    expect(res.body?.data?.employment?.employerName).toBe("Harbour Clinic");
+    expect(res.body?.data?.sourceRefs?.every((ref: any) => /-ref-/.test(String(ref.sourceId || "")))).toBe(true);
+    const serialized = JSON.stringify(res.body?.data);
+    expect(serialized).not.toContain("app-1");
+    expect(serialized).not.toContain("tenant-1");
+    expect(serialized).not.toContain("prop-1");
+    expect(serialized).not.toContain("lease-1");
+    expect(serialized).not.toContain("landlordNotes");
+  });
+
+  it("loads tenant profile safely when lease document context lookup fails", async () => {
+    setCollectionReadShouldFail("leases", true);
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.profile?.displayName).toBe("Taylor Tenant");
+    expect(JSON.stringify(res.body?.data)).not.toContain("lease-1");
+    expect(JSON.stringify(res.body)).not.toContain("leases_read_failed");
   });
 
   it("hydrates tenant me unit labels without exposing raw unit ids", async () => {
@@ -4235,9 +4379,15 @@ describe("tenantPortalRoutes foundation", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body?.data?.context?.applicationId).toBe("app-converted");
-    expect(res.body?.data?.profile?.application?.applicationId).toBe("app-converted");
+    expect(res.body?.data?.context?.applicationId).toMatch(/^application-ref-/);
+    expect(res.body?.data?.profile?.application?.applicationId).toMatch(/^application-ref-/);
     expect(res.body?.data?.profile?.lease?.leaseId).toBeTruthy();
+    const serialized = JSON.stringify(res.body?.data);
+    expect(serialized).not.toContain("app-converted");
+    expect(serialized).not.toContain("lease-array");
+    expect(serialized).not.toContain("tenant-1");
+    expect(serialized).not.toContain("prop-1");
+    expect(serialized).not.toContain("unit-1");
   });
 
   it("returns tenant-safe access visibility from existing share records", async () => {
@@ -4310,7 +4460,6 @@ describe("tenantPortalRoutes foundation", () => {
       body: {
         displayName: "Taylor Updated",
         phone: "902-555-0111",
-        internalNotes: "should-not-stick",
       },
     });
 
@@ -4326,9 +4475,76 @@ describe("tenantPortalRoutes foundation", () => {
     expect(ensureCollection("tenants").get("tenant-1")?.propertyId).toBeUndefined();
     expect(ensureCollection("tenants").get("tenant-1")?.unitId).toBeUndefined();
     expect(ensureCollection("tenants").get("tenant-1")?.currentLeaseId).toBeUndefined();
+    expect(JSON.stringify(res.body?.data)).not.toContain("tenant-1");
+    expect(JSON.stringify(res.body?.data)).not.toContain("prop-1");
+    expect(JSON.stringify(res.body?.data)).not.toContain("lease-1");
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
-    expect(eventDocs.some((event) => event.event_type === "tenant_profile_updated")).toBe(true);
+    const updateEvent = eventDocs.find((event) => event.event_type === "tenant_profile_updated");
+    expect(updateEvent).toBeTruthy();
+    expect(updateEvent?.payload?.updatedFields).toEqual(["displayName", "phone"]);
+    expect(JSON.stringify(updateEvent?.payload || {})).not.toContain("Taylor Updated");
+    expect(JSON.stringify(updateEvent?.payload || {})).not.toContain("902-555-0111");
+  });
+
+  it("rejects unknown tenant profile patch fields with a generic error before writing", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        displayName: "Taylor Updated",
+        internalNotes: "should-not-stick",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("TENANT_PROFILE_INVALID_FIELDS");
+    expect(JSON.stringify(res.body)).not.toContain("internalNotes");
+    expect(ensureCollection("tenants").get("tenant-1")?.fullName).toBe("Taylor Tenant");
+    expect(ensureCollection("tenants").get("tenant-1")?.internalNotes).toBe("do-not-expose");
+    expect(ensureCollection("applications").get("app-1")?.applicantName).toBeUndefined();
+  });
+
+  it("rejects forged tenant profile context fields before writing", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        displayName: "Taylor Forged",
+        tenantId: "tenant-2",
+        leaseId: "lease-2",
+        propertyId: "prop-2",
+        unitId: "unit-2",
+        applicationId: "app-2",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("TENANT_PROFILE_INVALID_FIELDS");
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("tenantId");
+    expect(serialized).not.toContain("leaseId");
+    expect(serialized).not.toContain("propertyId");
+    expect(ensureCollection("tenants").get("tenant-1")?.fullName).toBe("Taylor Tenant");
+    expect(ensureCollection("tenants").has("tenant-2")).toBe(false);
   });
 
   it("allows phone-only tenant profile updates", async () => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -33,6 +33,8 @@ import {
   loadTenantApplicationReuseProjection,
   loadTenantIdentityRecord,
   loadTenantProfileProjection,
+  sanitizeTenantApplicationReuseProjection,
+  sanitizeTenantProfileProjection,
 } from "../services/tenantPortal/tenantProfileService";
 import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
 import { deriveIdentityTimeline } from "../services/identityTimeline/deriveIdentityTimeline";
@@ -2975,6 +2977,12 @@ function cleanProfileField(value: unknown, max = 120): string | null {
   return next || null;
 }
 
+const TENANT_PROFILE_PATCH_ALLOWED_FIELDS = new Set(["displayName", "phone"]);
+
+function getTenantProfilePatchFieldNames(body: any) {
+  return Object.keys(body && typeof body === "object" && !Array.isArray(body) ? body : {});
+}
+
 async function queryFirstDocument(collectionName: string, field: string, value: string | null) {
   const normalized = cleanProfileField(value, 160);
   if (!normalized) return null;
@@ -3010,9 +3018,10 @@ function buildTenantProfileActions(profile: Awaited<ReturnType<typeof loadTenant
 }
 
 function shapeTenantProfileResponse(profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>) {
+  const tenantSafeProfile = sanitizeTenantProfileProjection(profile);
   return {
-    ...profile,
-    actions: buildTenantProfileActions(profile),
+    ...tenantSafeProfile,
+    actions: buildTenantProfileActions(tenantSafeProfile),
   };
 }
 
@@ -3021,7 +3030,15 @@ async function withTenantLeaseDocumentContext(profile: Awaited<ReturnType<typeof
   const leaseId = String(lease?.leaseId || profile?.context?.leaseId || "").trim();
   const tenantId = String(profile?.context?.tenantId || "").trim();
   if (!leaseId || !tenantId) return profile;
-  const leaseSnap = await db.collection("leases").doc(leaseId).get();
+  let leaseSnap: any = null;
+  try {
+    leaseSnap = await db.collection("leases").doc(leaseId).get();
+  } catch (err: any) {
+    console.warn("[tenant/profile] lease document context unavailable", {
+      message: err?.message || "failed",
+    });
+    return profile;
+  }
   if (!leaseSnap.exists) return profile;
   const leaseData = leaseSnap.data() as any;
   const leaseDocumentContext = await getTenantLeaseDocumentContext({
@@ -5086,7 +5103,7 @@ router.get("/application-reuse", requireTenantWorkspaceIdentity, async (req: any
       context,
       userEmail: String(req.user?.email || "").trim() || null,
     });
-    return res.json({ ok: true, data: projection });
+    return res.json({ ok: true, data: sanitizeTenantApplicationReuseProjection(projection) });
   } catch (err: any) {
     console.error("[tenant/application-reuse] failed", {
       userId: req.user?.id,
@@ -5100,9 +5117,13 @@ router.patch("/profile", requireTenantWorkspaceIdentity, async (req: any, res) =
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
 
+  const bodyFields = getTenantProfilePatchFieldNames(req.body);
+  if (bodyFields.some((field) => !TENANT_PROFILE_PATCH_ALLOWED_FIELDS.has(field))) {
+    return res.status(400).json({ ok: false, error: "TENANT_PROFILE_INVALID_FIELDS" });
+  }
   const displayName = cleanProfileField(req.body?.displayName, 120);
   const phone = cleanProfileField(req.body?.phone, 40);
-  const requestedFields = Object.keys(req.body || {}).filter((field) => ["displayName", "phone"].includes(field));
+  const requestedFields = bodyFields.filter((field) => TENANT_PROFILE_PATCH_ALLOWED_FIELDS.has(field));
   if (!requestedFields.length) {
     return res.status(400).json({ ok: false, error: "TENANT_PROFILE_FIELDS_REQUIRED" });
   }

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { db } from "../../config/firebase";
 import type { TenancyContext } from "./tenancyContextService";
 import {
@@ -143,6 +144,37 @@ export type TenantIdentitySummary = Pick<
 function asString(value: unknown): string | null {
   const next = String(value || "").trim();
   return next || null;
+}
+
+function safeHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function safeReferenceKey(kind: string, value: unknown): string | null {
+  const normalized = asString(value);
+  if (!normalized) return null;
+  return `${kind}-ref-${safeHash(`${kind}:${normalized}`)}`;
+}
+
+function safeSourceRef(ref: TenantSafeProjectionSourceReference): TenantSafeProjectionSourceReference | null {
+  const sourceCollection = asString(ref?.sourceCollection);
+  const sourceId = asString(ref?.sourceId);
+  if (!sourceCollection || !sourceId) return null;
+  return {
+    sourceCollection,
+    sourceId: `${sourceCollection}-ref-${safeHash(`${sourceCollection}:${sourceId}`)}`,
+  };
+}
+
+function safeSourceRefs(sourceRefs: TenantSafeProjectionSourceReference[]): TenantSafeProjectionSourceReference[] {
+  const byKey = new Map<string, TenantSafeProjectionSourceReference>();
+  for (const ref of sourceRefs || []) {
+    const next = safeSourceRef(ref);
+    if (next) byKey.set(`${next.sourceCollection}:${next.sourceId}`, next);
+  }
+  return Array.from(byKey.values()).sort((left, right) =>
+    `${left.sourceCollection}:${left.sourceId}`.localeCompare(`${right.sourceCollection}:${right.sourceId}`)
+  );
 }
 
 function normalizeEmail(value: unknown): string | null {
@@ -1088,6 +1120,123 @@ export async function loadTenantApplicationReuseProjection(params: {
           address: asString(nextOfKin?.address),
         }
       : null,
+  };
+}
+
+function safeProjectionMetadataFields<T extends TenantProjectionMetadataFields>(projection: T) {
+  const sourceRefs = safeSourceRefs(projection.sourceRefs || []);
+  return {
+    sourceCollections: sourceCollectionsFromRefs(sourceRefs),
+    sourceRefs,
+  };
+}
+
+function sanitizeProfileContext(context: TenantProfileProjection["context"]): TenantProfileProjection["context"] {
+  return {
+    authority: context.authority,
+    propertyId: safeReferenceKey("property", context.propertyId),
+    rc_prop_id: safeReferenceKey("property", context.rc_prop_id),
+    applicationId: safeReferenceKey("application", context.applicationId),
+    leaseId: safeReferenceKey("lease", context.leaseId),
+    tenantId: safeReferenceKey("tenant", context.tenantId),
+    unitId: safeReferenceKey("unit", context.unitId),
+    invitedEmail: normalizeEmail(context.invitedEmail),
+  };
+}
+
+function sanitizeNestedMetadata<T extends TenantProjectionMetadataFields>(projection: T | null): T | null {
+  if (!projection) return null;
+  return {
+    ...projection,
+    ...safeProjectionMetadataFields(projection),
+  };
+}
+
+function sanitizeProfileProperty(
+  property: TenantProfileProjection["profile"]["property"]
+): TenantProfileProjection["profile"]["property"] {
+  if (!property) return null;
+  return {
+    ...sanitizeNestedMetadata(property)!,
+    propertyId: safeReferenceKey("property", property.propertyId) || "",
+    rc_prop_id: safeReferenceKey("property", property.rc_prop_id),
+  };
+}
+
+function sanitizeProfileUnit(unit: TenantProfileProjection["profile"]["unit"]): TenantProfileProjection["profile"]["unit"] {
+  if (!unit) return null;
+  return {
+    unitId: safeReferenceKey("unit", unit.unitId),
+    label: unit.label,
+  };
+}
+
+function sanitizeProfileApplication(
+  application: TenantProfileProjection["profile"]["application"]
+): TenantProfileProjection["profile"]["application"] {
+  if (!application) return null;
+  return {
+    ...sanitizeNestedMetadata(application)!,
+    applicationId: safeReferenceKey("application", application.applicationId) || "",
+  };
+}
+
+function sanitizeLeaseDocumentContext(value: any) {
+  if (!value || typeof value !== "object") return value || null;
+  return {
+    ...value,
+    leaseId: safeReferenceKey("lease", value.leaseId) || undefined,
+    tenantId: safeReferenceKey("tenant", value.tenantId) || undefined,
+    propertyId: safeReferenceKey("property", value.propertyId) || undefined,
+    unitId: safeReferenceKey("unit", value.unitId) || undefined,
+    documentId: safeReferenceKey("document", value.documentId) || undefined,
+  };
+}
+
+function sanitizeProfileLease(
+  lease: TenantProfileProjection["profile"]["lease"]
+): TenantProfileProjection["profile"]["lease"] {
+  if (!lease) return null;
+  return {
+    ...sanitizeNestedMetadata(lease)!,
+    leaseId: safeReferenceKey("lease", lease.leaseId) || "",
+    leaseDocumentContext: sanitizeLeaseDocumentContext((lease as any).leaseDocumentContext),
+    scheduleADocumentContext: sanitizeLeaseDocumentContext((lease as any).scheduleADocumentContext),
+  } as TenantProfileProjection["profile"]["lease"];
+}
+
+export function sanitizeTenantProfileProjection(profile: TenantProfileProjection): TenantProfileProjection {
+  return {
+    ...profile,
+    ...safeProjectionMetadataFields(profile),
+    context: sanitizeProfileContext(profile.context),
+    profile: {
+      displayName: profile.profile.displayName,
+      email: profile.profile.email,
+      phone: profile.profile.phone,
+      authorityLabel: profile.profile.authorityLabel,
+      property: sanitizeProfileProperty(profile.profile.property),
+      unit: sanitizeProfileUnit(profile.profile.unit),
+      application: sanitizeProfileApplication(profile.profile.application),
+      lease: sanitizeProfileLease(profile.profile.lease),
+    },
+    identity: profile.identity,
+  };
+}
+
+export function sanitizeTenantApplicationReuseProjection(
+  projection: TenantApplicationReuseProjection
+): TenantApplicationReuseProjection {
+  return {
+    ...projection,
+    ...safeProjectionMetadataFields(projection),
+    applicant: projection.applicant,
+    currentAddress: projection.currentAddress,
+    timeAtCurrentAddressMonths: projection.timeAtCurrentAddressMonths,
+    currentRentAmountCents: projection.currentRentAmountCents,
+    employment: projection.employment,
+    workReference: projection.workReference,
+    nextOfKin: projection.nextOfKin,
   };
 }
 

--- a/rentchain-frontend/src/api/tenantProfile.ts
+++ b/rentchain-frontend/src/api/tenantProfile.ts
@@ -2,16 +2,17 @@ import { tenantApiFetch } from "./tenantApiFetch";
 import type { TenantSafeProjectionMetadata } from "./tenantPortal";
 
 export type TenantProfileStatus = "verified" | "pending" | "missing" | "needs_review";
+export type TenantProfileSafeReference = string | null;
 
 export type TenantProfileData = TenantSafeProjectionMetadata & {
   context: {
     authority: "applicant" | "active_tenant" | "invite" | null;
-    propertyId: string | null;
-    rc_prop_id: string | null;
-    applicationId: string | null;
-    leaseId: string | null;
-    tenantId: string | null;
-    unitId: string | null;
+    propertyId: TenantProfileSafeReference;
+    rc_prop_id: TenantProfileSafeReference;
+    applicationId: TenantProfileSafeReference;
+    leaseId: TenantProfileSafeReference;
+    tenantId: TenantProfileSafeReference;
+    unitId: TenantProfileSafeReference;
     invitedEmail: string | null;
   };
   profile: {
@@ -20,8 +21,8 @@ export type TenantProfileData = TenantSafeProjectionMetadata & {
     phone: string | null;
     authorityLabel: string;
     property: (TenantSafeProjectionMetadata & {
-      propertyId: string;
-      rc_prop_id: string | null;
+      propertyId: Exclude<TenantProfileSafeReference, null>;
+      rc_prop_id: TenantProfileSafeReference;
       street1: string | null;
       street2: string | null;
       city: string | null;
@@ -32,11 +33,11 @@ export type TenantProfileData = TenantSafeProjectionMetadata & {
       features: string[];
     }) | null;
     unit: {
-      unitId: string | null;
+      unitId: TenantProfileSafeReference;
       label: string | null;
     } | null;
     application: (TenantSafeProjectionMetadata & {
-      applicationId: string;
+      applicationId: Exclude<TenantProfileSafeReference, null>;
       status: string | null;
       missingSteps: string[];
       nextActions: string[];
@@ -44,7 +45,7 @@ export type TenantProfileData = TenantSafeProjectionMetadata & {
       updatedAt: string | null;
     }) | null;
     lease: (TenantSafeProjectionMetadata & {
-      leaseId: string;
+      leaseId: Exclude<TenantProfileSafeReference, null>;
       startDate: string | null;
       endDate: string | null;
       monthlyRent: number | null;


### PR DESCRIPTION
## Summary
Hardens tenant profile continuity with server-side ownership validation, whitelist projections, and strict PATCH field authorization.

## Changes
- tenantProfileService.ts — adds tenant-safe profile and application reuse sanitizers with deterministic safe reference keys
- tenantPortalRoutes.ts — routes profile and application reuse responses through safe projections, rejects unknown or forged profile PATCH fields, and fails safely on lease document context lookup errors
- tenantPortalRoutes.test.ts — adds profile projection, application reuse, fail-safe lookup, PATCH validation, and event payload assertions
- tenantWorkspaceLeaseLinkageContinuity.test.ts — aligns profile lease continuity assertions with safe reference output
- tenantProfile.ts — aligns frontend profile API types with tenant-safe reference fields

## Validation
- Backend tenant portal route suite: 93/93 passing
- Backend lease linkage continuity suite: 9/9 passing
- Backend build: pass
- Frontend full suite: 1124/1124 passing
- Frontend build: pass
- Backend full suite: 1962/1969 passing, with 7 unrelated baseline failures in lease draft and analytics tests
- git diff --check: pass
- git diff --cached --check: pass

## Scope
Tenant profile and application reuse continuity hardening only. No auth core, billing, screening provider, pricing, Firestore rules, Terraform, deployment, CI/CD, landlord/admin surfaces, or unrelated tenant surfaces changed.

## Known Limitations
- Manual preview QA remains pending for tenant profile display, PATCH update flow, identity status, document checklist, and network payload inspection.
- Profile PATCH documents fail-safe partial-write behavior rather than adding cross-document rollback if the linked application update fails after the tenant update succeeds.