### PR TITLE
Phase 2 review workspace inventory

### DIFF
--- a/docs/audit/decision-continuity-map-v1.md
+++ b/docs/audit/decision-continuity-map-v1.md
@@ -1,0 +1,128 @@
+# Phase 2 Decision Continuity Map V1
+
+## Scope
+
+This document maps decision continuity across review workflows observed for Phase 2 Mission 1. It focuses on where decisions originate, how state is persisted, what evidence survives reloads, what remains local to the browser, and where future hardening may be needed.
+
+This is a documentation-only audit. It does not modify routes, services, auth, billing, screening adapters, Firestore rules, Terraform, CI/CD, dependencies, or production data.
+
+## Continuity Model
+
+| Continuity layer | Meaning | Examples observed |
+| --- | --- | --- |
+| Derived read model | State is calculated from source records at request time. | Review timeline, evidence preview, audit readiness, decision inbox, lifecycle review queue. |
+| Current-state record | Latest status is stored in a mutable or replacing record. | Decision action state, lease status, work order status, screening operation status, payment status. |
+| Append history | Each transition records an event or history entry. | Canonical events, screening events, lease workflow events, maintenance status history, work order updates, audit events, payment events. |
+| Browser-only state | State exists only in React component state until submit or navigation. | Filters, selected records, in-progress forms, modal fields, unsaved notes, scheduling fields. |
+| URL state | Review context survives reload through route params or query params. | Review timeline scope filters, support operations status filter, lease ledger lease route parameter. |
+
+## Screening Continuity
+
+| Stage | Source route/service | Persisted state | Evidence | Continuity result |
+| --- | --- | --- | --- | --- |
+| Screening request/run | Screening routes and screening orchestration services | Application status, screening order, screening transaction status | Screening event records | APPEND-SAFE lifecycle evidence exists alongside current application/order state. |
+| Checkout | Screening checkout route and payment transaction service | Payment transaction status | Transaction lifecycle records and screening events | Payment status continuity exists, but provider-facing data requires projection checks. |
+| Completion/failure | Admin result routes and orchestration service | Application screening status and screening result | Screening event records | APPEND-SAFE event evidence exists for completed and failed transitions. |
+| History/detail/report | Screening history service and report routes | Derived normalized history and report availability | Application, order, result, and event sources | PROJECTION CONCERN: report views require continued payload redaction verification. |
+| Admin operation review | Screening operations routes and service | Operation status and detail | Operation status plus screening/application records | CONTINUITY GAP: in-progress admin review form values are browser-only until submit. |
+
+## Lease And Document Continuity
+
+| Stage | Source route/service | Persisted state | Evidence | Continuity result |
+| --- | --- | --- | --- | --- |
+| Lease create/update/end/restore | Lease routes and lease services | Lease current status and fields | Audit and workflow-related events where implemented | CURRENT STATE lease records are supported by selected event history. |
+| Lease lifecycle review | Admin lease lifecycle review page/API and backend lifecycle derivation | Review acknowledgement and decision action state | Recent history and derived decision context | Mixed derived review state and persisted acknowledgement/action records. |
+| Lease notices | Tenant and landlord lease notice routes, lease notice workflow service | Notice state, lease status updates | Lease workflow events | APPEND-SAFE notice lifecycle continuity. |
+| Lease documents and URLs | Lease document URL routes and document surfaces | Document reference state | Document metadata and audit history where available | PROJECTION CONCERN: document URL and storage-reference projection requires continued verification. |
+| Lease ledger | Lease ledger routes and ledger UI | Ledger entries and current modal outcomes after submit | Ledger exports and payment/charge records | CONTINUITY GAP: in-progress charge/payment/note modal state is browser-only. |
+
+## Maintenance Continuity
+
+| Stage | Source route/service | Persisted state | Evidence | Continuity result |
+| --- | --- | --- | --- | --- |
+| Request intake | Tenant/landlord maintenance routes | Work order current status and request fields | Status history and request metadata | CURRENT STATE request with append history. |
+| Landlord review and assignment | Maintenance workflow routes and frontend workspace | Status, contractor assignment, priority, notes after submit | Status history and work order updates | CONTINUITY GAP: notes, contractor selection, access, and scheduling fields are browser-only until submit. |
+| Scheduling and confirmation | Maintenance schedule and confirmation routes | Schedule fields and confirmation status | Confirmation history and updates | APPEND-SAFE history exists for completed transitions. |
+| Cost review | Maintenance cost routes and approval execution service | Cost review status and cost fields | Cost review history and work order updates | APPEND-SAFE review history supports current cost state. |
+| Completion/rework | Maintenance completion and rework routes | Work order final or rework status | Status history and updates | APPEND-SAFE lifecycle evidence for completed transitions. |
+
+## Payment And Ledger Continuity
+
+| Stage | Source route/service | Persisted state | Evidence | Continuity result |
+| --- | --- | --- | --- | --- |
+| Payment list | Payment route and payment service | Payment record state | Payment events where available | Read model depends on current payment records and event history. |
+| Rent checkout lifecycle | Rent payment service | Payment intent and rent payment status | Payment intent and rent payment events | APPEND-SAFE payment events support current status. |
+| Lease ledger charge/payment | Lease ledger routes | Ledger entry records | Ledger export and payment history | CURRENT STATE ledger records; export activity needs continued projection verification. |
+| Payment exports | Payment export routes | Export output generated on demand | Export events where implemented | PROJECTION CONCERN: exports need continued verification for safe identifiers and provider references. |
+
+## Decision Review Continuity
+
+| Stage | Source route/service | Persisted state | Evidence | Continuity result |
+| --- | --- | --- | --- | --- |
+| Decision derivation | Decision routes and decision inbox derivation | No separate source record for derived item | Source lease, payment, maintenance, compliance, and event records | Derived decisions are reproducible from current sources. |
+| Decision appearance | Decision appearance event service | Canonical event for new decision appearance | Canonical events | APPEND-SAFE appearance evidence. |
+| Decision action | Decision action route and landlord decision state service | Current action record keyed by decision | Decision action record plus timeline derivation | CONTINUITY GAP: action state is separate from derived decision source and is stored as current state. |
+| Decision timeline | Landlord review timeline route and decision history service | Derived timeline view | Canonical events, action state, source records | Read-only continuity surface with URL-based scope context. |
+
+## Governed Review Workspace Continuity
+
+| Stage | Source route/service | Persisted state | Evidence | Continuity result |
+| --- | --- | --- | --- | --- |
+| Workspace list/detail | Admin review workspace route and read service | Governed review workspace metadata | Safe evidence refs, append event refs, related workspace links | APPEND-SAFE metadata model for admin review context. |
+| Workspace UI review | Admin review workspace page and review workspace components | Filters, selected item, detail, local status/assignment controls | Backend workspace metadata | CONTINUITY GAP: manual status and assignment controls are local UI metadata in observed components. |
+| Support escalation linkage | Support escalation route/service | Escalation metadata and history count | Related governed review workspace metadata | PROJECTION CONCERN: future escalation writers must preserve metadata-only detail boundaries. |
+
+## Compliance, Support, And Governance Continuity
+
+| Stage | Source route/service | Persisted state | Evidence | Continuity result |
+| --- | --- | --- | --- | --- |
+| Audit readiness | Audit compliance route and compliance derivation service | Derived readiness only | Audit events, decisions, payments, leases, properties, maintenance | Read-only derivation; links to evidence and timeline previews. |
+| Compliance rules | Compliance route and engine | Rule data | Rule source data | Read-only rule lookup. |
+| Support operations | Support operations route/page | Derived support profile | Observability, status, and alert sources | Read-only profile continuity. |
+| Support resource access | Support console route | Access event | Audit event record | APPEND-SAFE read access evidence. |
+| Release governance | Release governance routes/page | Review governance records | Release governance artifacts and audit context | Review continuity depends on upstream release governance records. |
+
+## Frontend State Continuity
+
+| State type | Surfaces | Persistence behavior |
+| --- | --- | --- |
+| URL-carried state | Review timeline, support operations, route-parameter pages | Survives reload and can be shared internally when authorization allows. |
+| Server-persisted action state | Decision actions, lease notice responses, screening operations, maintenance transitions, payment checkout status | Survives reload after successful API response. |
+| Browser-only filters | Decision inbox, admin review workspaces, support escalations, screening queues, lease pages, maintenance pages | Usually resets on navigation unless also represented in URL. |
+| Browser-only form drafts | Screening operation details, lease ledger modals, maintenance scheduling/cost forms, lease conversion/payment rail forms | CONTINUITY GAP: draft state may be lost before submit. |
+
+## Projection Boundary Notes
+
+| Boundary | Current posture | Follow-up category |
+| --- | --- | --- |
+| Tenant-facing review inputs | Phase 1 hardening established tenant-safe projections for core tenant surfaces. | Continue verifying when tenant data is reused in landlord/admin review contexts. |
+| Landlord review surfaces | Landlord routes generally require authenticated landlord context and ownership checks. | Verify derived evidence and timeline sections do not expose admin-only or tenant-private details. |
+| Admin/support review surfaces | Admin routes require admin permission and emphasize metadata-only review. | Preserve metadata-only pattern before adding writers or external exports. |
+| Provider and payment references | Screening, report, checkout, and payment export surfaces touch external-provider-adjacent data. | PROJECTION CONCERN for future report/export hardening missions. |
+| Document and storage references | Lease documents and generated URLs are review inputs. | PROJECTION CONCERN for any future external evidence package or export work. |
+
+## Failure And Recovery Map
+
+| Failure mode | Current recovery behavior | Gap status |
+| --- | --- | --- |
+| Reload during review queue filtering | Server data reloads; local filters may reset unless URL-backed. | CONTINUITY GAP for non-URL filters. |
+| Reload during unsaved form entry | Submitted server state survives; unsaved draft values are lost. | CONTINUITY GAP for form drafts. |
+| Decision source data changes after action state | Derived decision may change while action record remains separate. | CONTINUITY GAP for action/source reconciliation. |
+| Report or export generation failure | Route-specific error responses and status fields surface failures. | PROJECTION CONCERN for safe failure payloads. |
+| Maintenance or payment provider callback delay | Current state remains pending until callback or service update. | APPEND-SAFE payment and work order events help reconstruct activity where emitted. |
+
+## Future Mission Candidates
+
+These candidates are audit observations, not implementation instructions for this mission:
+
+1. Add persisted draft continuity for high-risk review forms where losing browser-only state could interrupt operational review.
+2. Add explicit reconciliation metadata between derived decisions and stored decision action records.
+3. Extend projection verification for screening reports, payment exports, ledger exports, and document URL review surfaces.
+4. Add backend persistence for governed review workspace status and assignment metadata if those controls become operational requirements.
+5. Normalize URL-carried filter state across review queue surfaces where reload continuity is required.
+
+## Phase 2 Continuity Result
+
+Review continuity is strongest where source transitions emit append history and where read models derive deterministic review context from existing records. Continuity is weakest where frontend forms hold operational review context locally before submit, and where derived decisions are paired with separate current-state action records.
+
+No runtime defects are fixed by this audit. The observed gaps should be handled through separately scoped hardening missions.

--- a/docs/audit/review-workspace-map-v1.md
+++ b/docs/audit/review-workspace-map-v1.md
@@ -1,0 +1,120 @@
+# Phase 2 Review Workspace Map V1
+
+## Scope
+
+This inventory maps review workspace infrastructure observed in the current repository for Phase 2 Mission 1. It is a documentation-only audit of route surfaces, service boundaries, frontend entry points, evidence sources, authority boundaries, and continuity gaps.
+
+No source route, service, auth, billing, screening adapter, Firestore rule, Terraform, CI/CD, dependency, or production data behavior is changed by this document.
+
+## Method
+
+Inspection covered backend route mounts, route handlers, read services, workflow services, and frontend pages/API helpers related to review workspaces, decisions, screening, leasing, maintenance, payments, compliance, support, release governance, evidence, and timelines.
+
+The audit uses these labels:
+
+- `CONTINUITY GAP`: a workflow or state transition has limited recovery, traceability, or cross-surface continuity.
+- `PROJECTION CONCERN`: a read or UI surface requires follow-up verification for tenant-safe, landlord-safe, admin-safe, or support-safe projection behavior.
+- `APPEND-SAFE`: source records preserve history through append events or immutable history entries.
+- `CURRENT STATE`: source records keep a mutable latest-state record and may rely on adjacent event history for continuity.
+
+## Backend Route Inventory
+
+| Surface | Route area | Authority | Behavior | Continuity notes |
+| --- | --- | --- | --- | --- |
+| Admin review workspaces | `/api/admin/review-workspaces` | Authenticated admin permission | Lists and reads metadata-only governed review workspaces. | APPEND-SAFE metadata is exposed through safe evidence references and related workspace links. |
+| Landlord review timeline | `/api/landlord/review-timeline` | Authenticated landlord | Derives chronological review history for supported scopes. | Read-only derivation from properties, leases, units, maintenance, payments, events, canonical events, decisions, and review sessions. |
+| Decision list and action state | `/api/decisions` | Authenticated landlord with lease ownership check | Lists derived lease decisions and records action state. | CURRENT STATE action records are stored separately from derived decisions. |
+| Landlord decision inbox | `/api/landlord/decision-inbox` | Authenticated landlord | Derives review queue and workflow preview data. | Read-only queue surface; continuity depends on decision state records and canonical events. |
+| Landlord review sessions | `/api/landlord/operator-reviews` | Authenticated landlord | Opens review sessions, appends notes, closes sessions. | APPEND-SAFE canonical events are emitted for session lifecycle activity. |
+| Screening user routes | `/api/screenings/*` | Authenticated account context for protected paths | Starts screening, requests screening, creates checkout, reads history, details, and reports. | APPEND-SAFE screening events supplement order/result records. |
+| Screening operations | `/api/admin/screening-ops/*` and rental application screening operations | Admin or scoped account authority by route | Starts, completes, cancels, and reads screening operations. | CURRENT STATE operation records use status transitions; history is available through screening events and application status. |
+| Verified screening review | `/api/admin/verified-screenings/*` and `/api/screening/report` | Authenticated account; admin for admin list/detail updates | Reads verified report data and admin review queue. | PROJECTION CONCERN: report views require continued verification that provider payloads remain summarized and redacted. |
+| Lease lifecycle and documents | `/api/leases/*`, landlord lease routes, admin lease review routes | Authenticated landlord/admin depending on route | Edits leases, ends/restores leases, reads lifecycle review, ledger, documents, and exports. | Lease status is CURRENT STATE; lease workflow events and export events provide append history for selected transitions. |
+| Tenant lease notices | `/api/tenant/lease-notices/*` | Tenant lease notice feature and tenant authority | Lists notices, reads detail, records viewed state, and records tenant response. | APPEND-SAFE lease workflow events accompany notice lifecycle transitions. |
+| Maintenance workflows | `/api/maintenance-requests/*` and work order routes | Tenant, landlord, contractor, or admin authority depending on route | Creates, reviews, assigns, schedules, confirms, costs, completes, reworks, and uploads evidence. | Mixed CURRENT STATE work order records and APPEND-SAFE status, cost, and update history. |
+| Payments and lease ledger | `/api/payments`, lease ledger routes, rent payment services | Authenticated landlord or tenant route authority depending on surface | Lists payments, exports payments, records lease ledger charges/payments, and supports payment checkout lifecycle. | Payment records are CURRENT STATE; ledger and payment events provide continuity for review. |
+| Compliance readiness | `/api/compliance/rules`, `/api/landlord/audit-compliance/readiness` | Authenticated account; landlord for readiness | Reads rules and derives audit readiness. | Read-only derivation; evidence links point to timeline and evidence preview surfaces. |
+| Support operations | `/api/admin/support-operations/*` | Authenticated admin permission | Reads support and operations profiles. | Read-only review profile; source observability and alert records remain upstream. |
+| Support escalations | `/api/admin/support/escalations/*` | Authenticated admin permission | Reads escalation metadata and detail. | Metadata-only review surface; history count and governed workspace linkage are exposed. |
+| Support console resource | `/api/admin/support-console/resource` | Authenticated admin permission | Reads a support resource and records access audit. | APPEND-SAFE access audit event is recorded on read. |
+| Release governance | `/api/admin/release-governance/*` | Authenticated admin permission | Reads release governance review state. | Review-state continuity depends on existing release governance records and audit artifacts. |
+
+## Backend Service Inventory
+
+| Service area | Representative files | Role in review infrastructure | Continuity classification |
+| --- | --- | --- | --- |
+| Governed review workspace read model | `rentchain-api/src/services/admin/governedReviewWorkspaceRead.ts` | Reads metadata-only review workspace records, safe evidence refs, append refs, and related workspace links. | APPEND-SAFE metadata read model. |
+| Support escalation review | `rentchain-api/src/services/admin/adminSupportEscalationReview.ts` | Derives admin support escalation queue/detail metadata. | CURRENT STATE summary with history metadata. |
+| Lease admin review | `rentchain-api/src/services/admin/adminLeaseView.ts` and admin lease lifecycle review services | Derives admin lease review queue, acknowledgement status, related decisions, and recent history. | Mixed CURRENT STATE acknowledgement and history events. |
+| Landlord decision state | `rentchain-api/src/services/landlord/landlordDecisionStates.ts` | Stores reviewed, snoozed, dismissed, executed, and failed decision action state. | CURRENT STATE records with deterministic identifiers. |
+| Landlord decision history | `rentchain-api/src/services/landlord/landlordDecisionHistory.ts` and appearance event service | Reads and emits canonical decision timeline events. | APPEND-SAFE canonical event usage. |
+| Screening history and orchestration | `rentchain-api/src/services/screening/*` | Normalizes screening applications, orders, results, and events; records screening state transitions. | APPEND-SAFE event stream plus CURRENT STATE application/order/result records. |
+| Screening operations | `rentchain-api/src/services/screeningOps/*` | Manages manual screening operation requests and admin status transitions. | CURRENT STATE operation status with transition validation. |
+| Screening payment transactions | `rentchain-api/src/services/screeningPaymentTransactionService.ts` | Records screening payment initiation, success, and failure. | CURRENT STATE transaction records with status history implied by events. |
+| Lease notice workflow | `rentchain-api/src/services/leaseNoticeWorkflowService.ts` | Sends lease notice workflow records and appends workflow events. | APPEND-SAFE workflow events. |
+| Lease lifecycle and drafts | `rentchain-api/src/services/leaseLifecycle/*`, `rentchain-api/src/services/leaseDraftsService.ts` | Derives lease lifecycle state and manages draft lifecycle. | Mixed derived lifecycle and CURRENT STATE draft records. |
+| Maintenance approval execution | `rentchain-api/src/services/maintenanceApprovalExecutionService.ts` | Applies approved maintenance cost review state and records work order updates. | CURRENT STATE work order updates plus APPEND-SAFE history entries. |
+| Payments | `rentchain-api/src/services/paymentsService.ts`, `rentchain-api/src/services/rentPayments/rentPaymentService.ts` | Reads payments, manages checkout lifecycle, and emits payment events. | CURRENT STATE payment records plus APPEND-SAFE payment events. |
+| Compliance derivation | `rentchain-api/src/services/compliance/*` | Derives rules and audit readiness. | Read-only derivation from source records. |
+| Audit event services | `rentchain-api/src/services/auditEventService.ts`, `rentchain-api/src/services/auditEventsService.ts` | Writes and reads audit events. | APPEND-SAFE event collection usage. |
+
+## Frontend Workspace Inventory
+
+| Surface | Representative files | State model | Continuity notes |
+| --- | --- | --- | --- |
+| Admin governed review workspaces | `rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx`, `rentchain-frontend/src/api/adminReviewWorkspacesApi.ts` | React state for filters, selection, detail, loading, and error. | Metadata-only display; no mutation controls observed. |
+| Review workspace panel and queue | `rentchain-frontend/src/components/reviewWorkspaces/*` | Local lifecycle and assignment control state. | CONTINUITY GAP: manual assignment/status selections are UI metadata only and do not persist to a backend writer in the observed components. |
+| Decision inbox | `rentchain-frontend/src/pages/DecisionInboxPage.tsx`, `rentchain-frontend/src/api/decisionInboxApi.ts` | React state for queue data, filters, loading, and error. | Links to evidence and timeline surfaces; no unsaved state persistence observed. |
+| Review timeline | `rentchain-frontend/src/pages/ReviewTimelinePage.tsx`, `rentchain-frontend/src/api/reviewTimelineApi.ts` | URL query parameters for scope, scope identifier, and filters; React state for loaded data. | URL carries review context for reload continuity. |
+| Screening review | `rentchain-frontend/src/pages/AdminScreeningsPage.tsx`, screening components and API helpers | React state for selected operation, result fields, flags, report fields, and action status. | CONTINUITY GAP: in-progress admin screening form entries are local until submit. |
+| Verified screenings | `rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx` | React state for queue, selected detail, search, and status update action. | Status updates persist through the API; filters are local. |
+| Lease lifecycle review | `rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx` | React state for queue, summary, busy item, and decision status. | Decision actions persist through decision API; acknowledgement state persists through lifecycle API. |
+| Lease ledger and decisions | `rentchain-frontend/src/pages/LeaseLedgerPage.tsx` | Route parameter for lease, React state for date filters, modal forms, decisions, notes, and ledger data. | CONTINUITY GAP: unsaved charge/payment/note modal state is local only. |
+| Active leases and lease summaries | landlord lease pages and lease API helpers | React state for searches, payment rails, document actions, conversion forms, and selected records. | Server state persists only after submit; in-progress forms are local. |
+| Tenant lease notices | `rentchain-frontend/src/pages/tenant/TenantLeaseNoticesPage.tsx`, tenant lease notice API helper | React state for notice list/detail and response action. | Notice view and response state persist server-side. |
+| Maintenance workspace | `rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx`, `rentchain-frontend/src/pages/MaintenancePage.tsx`, maintenance API helpers | React state for selected request, filters, scheduling forms, cost review fields, status action, and calendar view. | Mixed server continuity for submitted actions and local-only continuity for in-progress forms. |
+| Payments | `rentchain-frontend/src/pages/PaymentsPage.tsx`, payments API helper | React state for rows, export state, labels, and import preview. | Export and imported records depend on backend completion; UI table state is local. |
+| Audit compliance | `rentchain-frontend/src/pages/AuditCompliancePage.tsx`, audit compliance API helper | React state for readiness data, loading, and error. | Links to evidence and timeline context; read-only derivation. |
+| Support operations | `rentchain-frontend/src/pages/SupportOperationsPage.tsx` | URL status filter and React state for profiles. | URL carries status filter continuity. |
+| Support escalations | `rentchain-frontend/src/pages/admin/AdminSupportEscalationsPage.tsx` | React state for filters, selected escalation, detail, loading, and error. | Metadata-only review; no approval or note writer observed in page. |
+
+## Evidence And Provenance Sources
+
+| Source | Evidence role | Notes |
+| --- | --- | --- |
+| Canonical events | Timeline and decision appearance history. | Used by landlord review timeline and decision history derivation. |
+| Screening events | Screening lifecycle evidence. | Written during request, run, completion, failure, and report-related transitions. |
+| Lease workflow events | Lease notice lifecycle evidence. | Appended when notices are sent, viewed, responded to, and when lease status changes. |
+| Work order status and cost history | Maintenance lifecycle evidence. | Used for request status, contractor scheduling, cost review, approval, and completion continuity. |
+| Payment and ledger events | Payment lifecycle evidence. | Used to derive payment checkout and lease ledger continuity. |
+| Audit events | Admin/support/compliance evidence. | Access and operational audit records provide append-safe review history. |
+| Governed review workspace append refs | Admin review workspace provenance. | Metadata-only refs point to append-compatible source activity. |
+| Evidence pack previews | Review context envelope. | Read-only derived preview; does not create external share artifacts. |
+
+## Authority Boundary Map
+
+| Actor boundary | Review surfaces | Observed controls |
+| --- | --- | --- |
+| Tenant | Tenant lease notices, tenant documents, tenant payments, tenant maintenance, tenant messages, tenant notifications, tenant profile | Prior Phase 1 hardening established tenant-safe projections; Phase 2 audit treats tenant surfaces as downstream review inputs only. |
+| Landlord | Decision inbox, review timeline, evidence pack preview, lease ledger, maintenance workspace, payment list, audit readiness | Routes generally require authenticated landlord context and scoped ownership checks before review data is returned. |
+| Admin/support | Governed review workspaces, support operations, support escalations, screening operations, verified screenings, release governance, admin lease review | Admin routes use authenticated admin permission checks and metadata-only review models for sensitive support/review areas. |
+| External/provider boundary | Screening reports, payment checkout lifecycle, exported documents | Provider payloads and external references require continued projection checks before review or export use. |
+
+## Gaps And Concerns
+
+| Label | Area | Observation |
+| --- | --- | --- |
+| CONTINUITY GAP | Review workspace assignment controls | UI controls expose manual status and assignment metadata, but the observed component state is local and not backed by a writer. |
+| CONTINUITY GAP | Screening operation forms | Admin operation detail fields are local until submit; reloads or navigation can lose in-progress review notes, flags, and report fields. |
+| CONTINUITY GAP | Lease ledger modal forms | Charge, payment, note, and decision-related modal state is local until saved. |
+| CONTINUITY GAP | Maintenance scheduling and cost forms | Scheduling, access, cost, and contractor assignment inputs are local until the relevant action succeeds. |
+| CONTINUITY GAP | Mixed decision state model | Derived decisions are read-time outputs while action status is stored separately as mutable current state. |
+| PROJECTION CONCERN | Screening report and verified screening surfaces | Report-facing routes and UI require continued verification that provider payloads remain summarized and redacted. |
+| PROJECTION CONCERN | Support escalation details | Metadata-only design is present; future writers must preserve the same projection boundary. |
+| PROJECTION CONCERN | Payment exports and ledger exports | Export paths require continued verification that raw provider references and internal identifiers remain excluded from user-facing artifacts. |
+
+## Phase 2 Inventory Result
+
+The repository contains a broad review workspace layer spanning admin review workspaces, landlord decision review, screening operations, lease lifecycle review, maintenance review, payments, compliance readiness, support operations, and release governance.
+
+The strongest continuity mechanisms are append-safe event records, canonical timeline derivation, evidence preview envelopes, and lease/maintenance/payment workflow histories. The weakest continuity areas are local-only frontend review forms and split decision state where derived decisions and action records are stored separately.


### PR DESCRIPTION
## Summary
Adds Phase 2 Mission 1 documentation inventory for review workspace and decision continuity infrastructure.

## Changes
- docs/audit/review-workspace-map-v1.md — static inventory of review routes, services, UI surfaces, authorities, evidence patterns, and governance gaps
- docs/audit/decision-continuity-map-v1.md — lifecycle and continuity map for screening, leasing, maintenance, payments, compliance, support, and review workspaces

## Validation
- git diff --check: pass
- source tree unchanged check: pass
- deliverable existence check: pass
- restricted-reference scan: pass

## Scope
Documentation-only audit. No source, route, service, config, dependency, infrastructure, or production data changes.