### PR TITLE
Phase 2 review state machine infrastructure

### DIFF
--- a/docs/architecture/state-machines-v1.md
+++ b/docs/architecture/state-machines-v1.md
@@ -1,0 +1,202 @@
+# State Machines V1
+
+## Purpose
+
+State Machines V1 defines deterministic review-state semantics for screening, lease, maintenance, payment, and decision workflows. The implementation is infrastructure-only for Phase 2 Mission 2: it computes state from existing records, validates proposed transitions, and adds advisory route markers without changing current route behavior.
+
+## Shared Rules
+
+- State computation is pure and uses existing persisted records.
+- Validators return `{ valid, allowedTransitions, reason }` through a consistent public API.
+- Validators fail closed when authority, current state, or required context is missing.
+- No state machine definition is stored in Firestore.
+- No transition enforcement is enabled in this mission.
+- Browser-only form state remains distinct from persisted workflow state.
+- State machine metadata is not added to tenant-facing exports, documents, or dashboards.
+
+## Screening
+
+```mermaid
+stateDiagram-v2
+  NotRequested --> ApplicationStarted: start_application
+  ApplicationStarted --> OrderCreated: create_order
+  OrderCreated --> CheckoutInitiated: initiate_checkout
+  CheckoutInitiated --> CheckoutCompleted: complete_checkout
+  CheckoutInitiated --> Failed: fail
+  CheckoutCompleted --> ResultAvailable: publish_result
+  NotRequested --> Cancelled: cancel
+  ApplicationStarted --> Cancelled: cancel
+  OrderCreated --> Cancelled: cancel
+  CheckoutInitiated --> Cancelled: cancel
+  CheckoutCompleted --> Cancelled: cancel
+  ResultAvailable --> Cancelled: cancel
+  Failed --> Cancelled: cancel
+```
+
+| State | Meaning | Required context for forward transitions |
+| --- | --- | --- |
+| `NotRequested` | No application/order/payment/result state exists. | `applicationId`, `landlordId` |
+| `ApplicationStarted` | Application state exists before an order. | `applicationId`, `orderId` |
+| `OrderCreated` | Screening order exists before checkout. | `orderId`, `checkoutSessionId` |
+| `CheckoutInitiated` | Checkout was created and is awaiting completion/failure. | `orderId`, payment result context |
+| `CheckoutCompleted` | Payment is complete; result is not yet available. | `applicationId`, `resultId` |
+| `ResultAvailable` | Screening result is available. | terminal for normal flow |
+| `Failed` | Screening or payment failed. | terminal unless cancelled for administrative closure |
+| `Cancelled` | Workflow was cancelled. | terminal |
+
+Authority: landlord or admin context with explicit authorization.
+
+Idempotency: repeated terminal transitions should be treated by caller services as no-op or invalid according to existing route behavior; the V1 validator only reports allowed next states.
+
+Event continuity: screening events and transaction records remain the append-safe history source.
+
+## Lease
+
+```mermaid
+stateDiagram-v2
+  Draft --> Active: activate
+  Active --> NoticePending: prepare_notice
+  Active --> Ended: end
+  NoticePending --> Ended: end
+  Ended --> Restored: restore
+  Restored --> Active: reactivate
+```
+
+| State | Meaning | Required context |
+| --- | --- | --- |
+| `Draft` | Draft or generated lease record before activation. | `leaseId`, `landlordId` |
+| `Active` | Current active lease. | `leaseId`, `landlordId`; optional notice context |
+| `NoticePending` | Lease notice or renewal workflow is pending. | `leaseId`, `landlordId`, `noticeId` |
+| `Ended` | Lease was ended, expired, or terminated. | explicit restore context for reversal |
+| `Restored` | Ended lease has been restored and can reactivate. | `leaseId`, `landlordId` |
+
+Authority: landlord or admin context with explicit authorization.
+
+Idempotency: direct `Ended -> Active` is invalid; restoration must pass through `Restored`.
+
+Event continuity: lease status is mutable current state. Lease notices and selected lifecycle actions preserve append-safe workflow events.
+
+## Maintenance
+
+```mermaid
+stateDiagram-v2
+  Open --> Assigned: assign
+  Assigned --> Scheduled: schedule
+  Assigned --> CostReview: request_cost_review
+  Scheduled --> InProgress: start
+  InProgress --> CostReview: request_cost_review
+  InProgress --> Completed: complete
+  CostReview --> Completed: complete
+  CostReview --> Rework: request_rework
+  Completed --> Rework: request_rework
+  Rework --> Assigned: return_to_assignment
+  Rework --> Completed: complete
+```
+
+| State | Meaning | Required context |
+| --- | --- | --- |
+| `Open` | Submitted request not yet assigned. | `workOrderId`, `assignedContractorId` |
+| `Assigned` | Contractor or operational owner is assigned. | schedule or cost context |
+| `Scheduled` | Work is scheduled. | `workOrderId` |
+| `InProgress` | Work has started. | cost or evidence context depending on transition |
+| `CostReview` | Cost review is pending or revision/rejection is active. | `workOrderId`; cost approval context |
+| `Completed` | Work is complete. | rework context if reopening |
+| `Rework` | Rework cycle is active. | assignment or completion context |
+
+Authority: landlord/admin for assignment and review; contractor/landlord/admin for schedule, start, cost submission, and completion; tenant/landlord/admin for rework request.
+
+Idempotency: repeated completion should be handled by caller services using existing work order history. V1 reports valid next states only.
+
+Event continuity: status history, cost review history, rework history, and work order updates remain the append-safe evidence source.
+
+## Payment
+
+```mermaid
+stateDiagram-v2
+  Pending --> Processing: start_processing
+  Processing --> Confirmed: confirm
+  Processing --> Failed: fail
+  Confirmed --> Refunded: refund
+  Failed --> Pending: retry
+  Refunded --> Pending: reattempt
+```
+
+| State | Meaning | Required context |
+| --- | --- | --- |
+| `Pending` | Payment exists or is ready for processing. | `paymentId`, `paymentIntentId` |
+| `Processing` | Checkout or payment is awaiting confirmation/failure. | persisted transaction status |
+| `Confirmed` | Payment is recorded as paid, confirmed, completed, or recorded. | refund context for reversal |
+| `Failed` | Payment failed, expired, or was cancelled. | retry context |
+| `Refunded` | Payment has been refunded. | reattempt context |
+
+Authority: authenticated tenant, landlord, admin, or system context depending on caller surface.
+
+Idempotency: final-state protection remains in existing payment services. V1 does not call external payment APIs.
+
+Event continuity: payment events and payment intent events remain the append-safe evidence source.
+
+## Decision
+
+```mermaid
+stateDiagram-v2
+  Derived --> Appeared: appear
+  Appeared --> Reviewed: review
+  Appeared --> Dismissed: dismiss
+  Reviewed --> Snoozed: snooze
+  Reviewed --> Executed: execute
+  Reviewed --> Failed: mark_failed
+  Snoozed --> Reviewed: review
+  Dismissed --> Reviewed: reopen
+  Executed --> Failed: mark_failed
+  Failed --> Reviewed: reopen
+```
+
+| State | Meaning | Required context |
+| --- | --- | --- |
+| `Derived` | Decision exists only as a derived read model. | `decisionId`, `landlordId`, valid source |
+| `Appeared` | Decision appearance has been recorded or action state has started. | review or dismissal context |
+| `Reviewed` | Operator reviewed the decision. | action record for downstream action |
+| `Snoozed` | Decision is deferred until a future time. | `snoozedUntil` |
+| `Dismissed` | Decision was dismissed and can be reopened. | action record |
+| `Executed` | Decision action was executed. | failure context if operation fails |
+| `Failed` | Execution failed and can be reopened for review. | valid source |
+
+Authority: landlord or admin context with explicit authorization and ownership.
+
+Idempotency: decision appearance is append-safe through canonical events. Action state remains a current-state record until a future mission extends event emission.
+
+## Error Cases
+
+| Error | Meaning | Expected caller behavior |
+| --- | --- | --- |
+| `invalid_transition` | Proposed state is not allowed from current state. | Return or log clear validation reason; do not mutate state. |
+| `insufficient_authority` | Actor context is missing or role is not allowed. | Fail closed in enforcing callers. Advisory markers log only. |
+| `missing_context` | Required identifiers or transition fields are absent. | Request more context before attempting mutation. |
+| `ambiguous_state` | Persisted state is not enough to safely validate the transition. | Keep existing behavior in Phase 2; enforce later only with explicit migration plan. |
+| `terminal_state` | Terminal workflow state cannot proceed. | Treat as no-op or error according to existing route contract. |
+| `source_invalid` | Source decision or workflow context is stale or invalid. | Refresh source model before attempting action. |
+
+## Integration Points
+
+Implemented in this mission:
+
+- `rentchain-api/src/services/stateMachines/types.ts`
+- `rentchain-api/src/services/stateMachines/*StateMachine.ts`
+- `rentchain-api/src/services/stateMachines/stateComputation.ts`
+- `rentchain-api/src/services/stateMachines/transitionValidation.ts`
+- `rentchain-api/src/services/stateMachines/stateMachineRegistry.ts`
+- Advisory markers in screening operations, lease detail, maintenance list, payment list, and decision list routes.
+
+Not implemented in this mission:
+
+- Enforcing state transitions in existing mutation routes.
+- Persisting state machine snapshots.
+- Persisting browser form drafts.
+- Adding cross-workflow synchronization.
+- Adding external exports of state machine metadata.
+
+## Future Work
+
+- Phase 2 Mission 3 should attach evidence provenance to transition events and advisory snapshots.
+- Phase 2 Mission 4 should reconcile derived decisions with stored action state and canonical timeline entries.
+- A later enforcement mission can convert advisory route markers into blocking transition checks once migration risks are reviewed.

--- a/rentchain-api/src/routes/decisionRoutes.ts
+++ b/rentchain-api/src/routes/decisionRoutes.ts
@@ -19,6 +19,10 @@ import {
   summarizeDelinquencySignals,
 } from "../lib/payments/delinquencySignals";
 import type { RentPaymentRecord } from "../services/rentPayments/rentPaymentService";
+import { computeDecisionState } from "../services/stateMachines/stateComputation";
+import { decisionStateMachine } from "../services/stateMachines/decisionStateMachine";
+import { buildValidationSummary, validateDecisionTransition } from "../services/stateMachines/transitionValidation";
+import type { DecisionActionState, DecisionEvent } from "../services/stateMachines/types";
 
 const router = Router();
 
@@ -46,6 +50,19 @@ function actorEmailFromReq(req: any) {
 function isActiveDecisionStatus(status: unknown) {
   const normalized = asString(status || "detected", 40);
   return !["reviewed", "snoozed", "accepted", "dismissed", "resolved"].includes(normalized);
+}
+
+function logDecisionStateMarkers(actions: Array<Record<string, unknown>>) {
+  if (process.env.STATE_MACHINE_DEBUG !== "1") return;
+  const counts = new Map<string, number>();
+  for (const action of actions) {
+    const state = computeDecisionState(action);
+    counts.set(state, (counts.get(state) || 0) + 1);
+    if (!decisionStateMachine.states.includes(state)) {
+      console.warn("[state-machine] decision advisory invalid", { route: "decision_list" });
+    }
+  }
+  console.info("[state-machine] decision advisory", { count: actions.length, states: Object.fromEntries(counts) });
 }
 
 async function loadLeaseForDecisionAccess(req: any, leaseId: string) {
@@ -209,6 +226,7 @@ router.get("/", requireAuth, async (req: any, res: Response) => {
     if (!leaseId) return res.status(400).json({ ok: false, error: "decision_lease_id_required" });
     const model = await deriveLeaseDecisionReadModel(req, leaseId);
     if (!model.ok) return res.status(model.status).json({ ok: false, error: model.error });
+    logDecisionStateMarkers(model.actions as Array<Record<string, unknown>>);
     return res.json({
       ok: true,
       decisions: model.decisions,
@@ -225,6 +243,35 @@ router.get("/", requireAuth, async (req: any, res: Response) => {
   } catch (err: any) {
     console.error("[decisionRoutes] GET /api/decisions failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "decision_list_failed" });
+  }
+});
+
+router.post("/validate-transition", requireAuth, async (req: any, res: Response) => {
+  try {
+    const leaseId = asString(req.body?.leaseId, 240);
+    const decisionId = asString(req.body?.decisionId, 600);
+    if (!leaseId || !decisionId) return res.status(400).json({ ok: false, error: "decision_validation_invalid" });
+    const model = await deriveLeaseDecisionReadModel(req, leaseId);
+    if (!model.ok) return res.status(model.status).json({ ok: false, error: model.error });
+    const action = model.actions.find((candidate: any) => asString(candidate?.decisionId, 600) === decisionId) || null;
+    const validation = validateDecisionTransition((action || {}) as Record<string, unknown>, {
+      to: String(req.body?.proposedTransition || req.body?.to || "") as DecisionActionState,
+      event: String(req.body?.event || "") as DecisionEvent,
+      context: {
+        actorRole: isAdmin(req) ? "admin" : "landlord",
+        actorId: actorIdFromReq(req),
+        authorized: true,
+        decisionId,
+        landlordId: model.landlordId,
+        actionRecordExists: Boolean(action),
+        sourceValid: model.decisions.some((decision) => decision.decisionId === decisionId),
+        snoozedUntil: asString(req.body?.snoozedUntil, 120) || null,
+      },
+    });
+    return res.status(200).json(buildValidationSummary(validation));
+  } catch (err: any) {
+    console.error("[state-machine] decision validation failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "decision_transition_validation_failed" });
   }
 });
 

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -71,6 +71,10 @@ import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupanc
 import { evaluateJurisdictionPolicy } from "../lib/jurisdiction/operationalPolicyEvaluator";
 import { formatInternalReference, slugifyOperationalReference } from "../lib/identityReferences";
 import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
+import { computeLeaseState } from "../services/stateMachines/stateComputation";
+import { leaseStateMachine } from "../services/stateMachines/leaseStateMachine";
+import { buildValidationSummary, validateLeaseTransition } from "../services/stateMachines/transitionValidation";
+import type { LeaseEvent, LeaseLifecycleState } from "../services/stateMachines/types";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
@@ -3072,6 +3076,35 @@ router.post("/:leaseId/restore", requireLandlord, async (req: any, res: Response
   }
 });
 
+router.post("/validate-transition", requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.body?.leaseId || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
+    const result = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!result.ok) return res.status(result.status).json({ ok: false, error: result.error });
+    const validation = validateLeaseTransition(result.lease as Record<string, unknown>, {
+      to: String(req.body?.proposedTransition || req.body?.to || "") as LeaseLifecycleState,
+      event: String(req.body?.event || "") as LeaseEvent,
+      context: {
+        actorRole: "landlord",
+        actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
+        authorized: true,
+        leaseId,
+        landlordId,
+        noticeId: String(req.body?.noticeId || "").trim() || null,
+        noticeRequired: req.body?.noticeRequired !== false,
+        restoreRequested: req.body?.restoreRequested === true,
+      },
+    });
+    return res.status(200).json(buildValidationSummary(validation));
+  } catch (err: any) {
+    console.error("[state-machine] lease validation failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "lease_transition_validation_failed" });
+  }
+});
+
 router.get("/:id", requireLandlord, async (req: any, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
@@ -3079,6 +3112,10 @@ router.get("/:id", requireLandlord, async (req: any, res: Response) => {
     const result = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
     if (!result.ok) {
       return res.status(result.status).json({ error: result.error });
+    }
+    const leaseState = computeLeaseState(result.lease as Record<string, unknown>);
+    if (!leaseStateMachine.states.includes(leaseState)) {
+      console.warn("[state-machine] lease advisory invalid", { route: "lease_detail" });
     }
     if (result.source === "firestore") {
       return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(result.lease as any) }) });

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -29,6 +29,10 @@ import {
   computeWorkOrderNotifications,
 } from "../lib/maintenanceNotifications";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { computeMaintenanceState } from "../services/stateMachines/stateComputation";
+import { maintenanceStateMachine } from "../services/stateMachines/maintenanceStateMachine";
+import { buildValidationSummary, validateMaintenanceTransition } from "../services/stateMachines/transitionValidation";
+import type { MaintenanceEvent, MaintenanceRequestState } from "../services/stateMachines/types";
 
 const router = Router();
 
@@ -118,6 +122,19 @@ const ALLOWED_COST_ATTACHMENT_MIME_TYPES = new Set([
 ]);
 
 router.use(authenticateJwt);
+
+function logMaintenanceStateMarkers(records: Array<Record<string, unknown>>, route: string) {
+  if (process.env.STATE_MACHINE_DEBUG !== "1") return;
+  const counts = new Map<string, number>();
+  for (const record of records) {
+    const state = computeMaintenanceState(record);
+    counts.set(state, (counts.get(state) || 0) + 1);
+    if (!maintenanceStateMachine.states.includes(state)) {
+      console.warn("[state-machine] maintenance advisory invalid", { route });
+    }
+  }
+  console.info("[state-machine] maintenance advisory", { route, count: records.length, states: Object.fromEntries(counts) });
+}
 
 function roleOf(req: any): string {
   return String(req.user?.actorRole || req.user?.role || "").trim().toLowerCase();
@@ -1223,10 +1240,49 @@ router.get("/maintenance-requests", async (req: any, res) => {
     const snap = await query.get();
     const items = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
     items.sort((a, b) => (Number(b.updatedAt || 0) || 0) - (Number(a.updatedAt || 0) || 0));
+    logMaintenanceStateMarkers(items, "maintenance_requests_list");
     return res.json({ ok: true, data: items });
   } catch (err) {
     console.error("[maintenance-requests] list failed", { err });
     return res.status(500).json({ ok: false, error: "MAINT_REQUEST_LIST_FAILED" });
+  }
+});
+
+router.post("/maintenance-requests/validate-transition", async (req: any, res) => {
+  try {
+    const role = roleOf(req);
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const landlordId = landlordIdOf(req);
+    const workOrderId = String(req.body?.workOrderId || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    if (!workOrderId) return res.status(400).json({ ok: false, error: "workOrderId is required" });
+    const snap = await db.collection("workOrders").doc(workOrderId).get();
+    if (!snap.exists) return res.status(404).json({ ok: false, error: "WORK_ORDER_NOT_FOUND" });
+    const workOrder: Record<string, unknown> = { id: snap.id, ...((snap.data() as Record<string, unknown>) || {}) };
+    if (String(workOrder.landlordId || "").trim() !== landlordId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const validation = validateMaintenanceTransition(workOrder, {
+      to: String(req.body?.proposedTransition || req.body?.to || "") as MaintenanceRequestState,
+      event: String(req.body?.event || "") as MaintenanceEvent,
+      context: {
+        actorRole: role === "admin" ? "admin" : "landlord",
+        actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
+        authorized: true,
+        workOrderId,
+        landlordId,
+        assignedContractorId: String(req.body?.assignedContractorId || workOrder.assignedContractorId || "").trim() || null,
+        scheduledFor: req.body?.scheduledFor ?? null,
+        costTotalCents: typeof req.body?.costTotalCents === "number" ? req.body.costTotalCents : null,
+        evidenceCount: typeof req.body?.evidenceCount === "number" ? req.body.evidenceCount : null,
+      },
+    });
+    return res.status(200).json(buildValidationSummary(validation));
+  } catch (err: any) {
+    console.error("[state-machine] maintenance validation failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "MAINTENANCE_TRANSITION_VALIDATION_FAILED" });
   }
 });
 
@@ -1538,6 +1594,7 @@ router.get("/landlord/maintenance", async (req: any, res) => {
     if (statusFilter) {
       items = items.filter((item) => normalizeWorkflowStatus(item.status) === statusFilter);
     }
+    logMaintenanceStateMarkers(items, "landlord_maintenance_list");
     items = await normalizeLandlordMaintenanceLabels(items);
     items.sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0));
     return res.json({ ok: true, items, data: items });

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -13,6 +13,10 @@ import { requirePermission } from "../middleware/requireAuthz";
 import { buildDatedExportFilename, setAttachmentExportHeaders } from "../lib/exports/exportResponse";
 import { db } from "../config/firebase";
 import { getEffectiveLandlordId, resolveRequestAuthority } from "../auth/requestAuthority";
+import { computePaymentState } from "../services/stateMachines/stateComputation";
+import { paymentStateMachine } from "../services/stateMachines/paymentStateMachine";
+import { buildValidationSummary, validatePaymentTransition } from "../services/stateMachines/transitionValidation";
+import type { PaymentEvent, PaymentState } from "../services/stateMachines/types";
 
 const router = Router();
 const paymentsEditRouter = Router();
@@ -29,6 +33,19 @@ const roleForReq = (req: any) => resolveRequestAuthority(req).actorRole;
 
 function landlordIdForReq(req: any): string {
   return String(getEffectiveLandlordId(req) || "").trim();
+}
+
+function logPaymentStateMarkers(records: Payment[]) {
+  if (process.env.STATE_MACHINE_DEBUG !== "1") return;
+  const counts = new Map<string, number>();
+  for (const record of records) {
+    const state = computePaymentState(record as unknown as Record<string, unknown>);
+    counts.set(state, (counts.get(state) || 0) + 1);
+    if (!paymentStateMachine.states.includes(state)) {
+      console.warn("[state-machine] payment advisory invalid", { route: "payments_list" });
+    }
+  }
+  console.info("[state-machine] payment advisory", { count: records.length, states: Object.fromEntries(counts) });
 }
 
 const PAYMENT_OWNER_FIELDS = ["landlordId", "ownerId", "userId", "createdByLandlordId"] as const;
@@ -682,6 +699,7 @@ router.get("/payments", requireAuth, async (req: any, res: Response) => {
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   try {
     const results = await listVisiblePayments(landlordId, tenantId);
+    logPaymentStateMarkers(results);
     res.setHeader("x-payments-result-count", String(results.length));
     return res.json(results);
   } catch (err) {
@@ -737,6 +755,34 @@ async function handlePaymentSpreadsheetExport(req: any, res: Response) {
 
 router.get("/payments/export.xls", requireAuth, handlePaymentSpreadsheetExport);
 router.get("/payments/export.xlsx", requireAuth, handlePaymentSpreadsheetExport);
+
+router.post("/payments/validate-transition", requireAuth, requirePermission("payments.edit"), async (req: any, res: Response) => {
+  try {
+    const landlordId = landlordIdForReq(req);
+    const paymentId = String(req.body?.paymentId || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (!paymentId) return res.status(400).json({ ok: false, error: "paymentId is required" });
+    const payment = await getPersistedPaymentById(paymentId);
+    if (!payment) return res.status(404).json({ ok: false, error: "PAYMENT_NOT_FOUND" });
+    const validation = validatePaymentTransition(payment as unknown as Record<string, unknown>, {
+      to: String(req.body?.proposedTransition || req.body?.to || "") as PaymentState,
+      event: String(req.body?.event || "") as PaymentEvent,
+      context: {
+        actorRole: roleForReq(req) === "admin" ? "admin" : "landlord",
+        actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
+        authorized: hasProvenPaymentOwnership(payment, landlordId, emptyPaymentOwnershipContext()),
+        paymentId,
+        paymentIntentId: String(req.body?.paymentIntentId || payment.paymentIntentId || "").trim() || null,
+        landlordId,
+        providerStatus: String(req.body?.providerStatus || payment.status || "").trim() || null,
+      },
+    });
+    return res.status(200).json(buildValidationSummary(validation));
+  } catch (err: any) {
+    console.error("[state-machine] payment validation failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "PAYMENT_TRANSITION_VALIDATION_FAILED" });
+  }
+});
 
 // POST /api/payments
 router.post(

--- a/rentchain-api/src/routes/screeningOpsRoutes.ts
+++ b/rentchain-api/src/routes/screeningOpsRoutes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { db } from "../config/firebase";
 import { requireAdmin } from "../middleware/requireAdmin";
 import { requireLandlordOrAdmin } from "../middleware/requireLandlordOrAdmin";
 import {
@@ -10,8 +11,39 @@ import {
   postAdminScreeningOpStart,
   postManualScreeningRequest,
 } from "../services/screeningOps/screeningOpsController";
+import { buildValidationSummary, validateScreeningTransition } from "../services/stateMachines/transitionValidation";
+import type { ScreeningApplicationState, ScreeningEvent } from "../services/stateMachines/types";
 
 const router = Router();
+
+router.post("/screening/validate-transition", requireAdmin, async (req: any, res) => {
+  try {
+    const applicationId = String(req.body?.applicationId || "").trim();
+    if (!applicationId) return res.status(400).json({ ok: false, error: "applicationId is required" });
+    const applicationSnap = await db.collection("rentalApplications").doc(applicationId).get();
+    if (!applicationSnap.exists) return res.status(404).json({ ok: false, error: "application_not_found" });
+    const application: Record<string, unknown> = { id: applicationSnap.id, ...((applicationSnap.data() as Record<string, unknown>) || {}) };
+    const result = validateScreeningTransition(application, {
+      to: String(req.body?.proposedTransition || req.body?.to || "") as ScreeningApplicationState,
+      event: String(req.body?.event || "") as ScreeningEvent,
+      context: {
+        actorRole: "admin",
+        actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
+        authorized: true,
+        applicationId,
+        landlordId: String(application.landlordId || "").trim() || null,
+        orderId: String(req.body?.orderId || "").trim() || null,
+        checkoutSessionId: String(req.body?.checkoutSessionId || "").trim() || null,
+        resultId: String(req.body?.resultId || "").trim() || null,
+        failureCode: String(req.body?.failureCode || "").trim() || null,
+      },
+    });
+    return res.status(200).json(buildValidationSummary(result));
+  } catch (err: any) {
+    console.error("[state-machine] screening validation failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "screening_transition_validation_failed" });
+  }
+});
 
 router.post(
   "/rental-applications/:id/screening/request",

--- a/rentchain-api/src/services/screeningOps/screeningOpsController.ts
+++ b/rentchain-api/src/services/screeningOps/screeningOpsController.ts
@@ -9,6 +9,22 @@ import {
   ScreeningOpsError,
   startAdminScreeningOperation,
 } from "./screeningOpsService";
+import { computeScreeningState } from "../stateMachines/stateComputation";
+
+function logScreeningStateMarker(records: Array<{ status?: string | null }>) {
+  if (process.env.STATE_MACHINE_DEBUG !== "1") return;
+  const counts = new Map<string, number>();
+  for (const record of records) {
+    const status = String(record.status || "").trim().toLowerCase();
+    const state = computeScreeningState({
+      application: status === "cancelled" ? { screeningStatus: "cancelled" } : status === "blocked_transunion_not_connected" ? { screeningStatus: "failed" } : { id: "present" },
+      order: status === "requested" ? null : { id: "present", status: status === "completed" ? "paid" : "unpaid" },
+      result: status === "completed" ? { status: "complete" } : null,
+    });
+    counts.set(state, (counts.get(state) || 0) + 1);
+  }
+  console.info("[state-machine] screening advisory", { count: records.length, states: Object.fromEntries(counts) });
+}
 
 function handleError(res: Response, error: unknown) {
   if (error instanceof ScreeningOpsError) {
@@ -45,6 +61,7 @@ export async function getManualScreeningStatus(req: Request, res: Response) {
 export async function getAdminScreeningOps(req: Request, res: Response) {
   try {
     const operations = await listAdminScreeningOperations(String(req.query?.status || "").trim());
+    logScreeningStateMarker(operations);
     return res.status(200).json({ operations });
   } catch (error) {
     return handleError(res, error);
@@ -54,6 +71,7 @@ export async function getAdminScreeningOps(req: Request, res: Response) {
 export async function getAdminScreeningOp(req: Request, res: Response) {
   try {
     const operation = await getAdminScreeningOperation(req.params.id);
+    logScreeningStateMarker([operation]);
     return res.status(200).json({ operation });
   } catch (error) {
     return handleError(res, error);

--- a/rentchain-api/src/services/stateMachines/__tests__/decisionStateMachine.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/decisionStateMachine.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { decisionStateMachine } from "../decisionStateMachine";
+import type { DecisionContext } from "../types";
+
+const context: DecisionContext = {
+  actorRole: "landlord",
+  actorId: "actor-1",
+  authorized: true,
+  decisionId: "decision-1",
+  landlordId: "landlord-1",
+  actionRecordExists: true,
+  sourceValid: true,
+  snoozedUntil: "2026-07-01T00:00:00.000Z",
+};
+
+describe("decisionStateMachine", () => {
+  it("allows appearance, review, execution, failure, and reopen paths", () => {
+    const results = [
+      decisionStateMachine.validateTransition({ currentState: "Derived", proposedState: "Appeared", event: "appear", context }),
+      decisionStateMachine.validateTransition({ currentState: "Appeared", proposedState: "Reviewed", event: "review", context }),
+      decisionStateMachine.validateTransition({ currentState: "Reviewed", proposedState: "Executed", event: "execute", context }),
+      decisionStateMachine.validateTransition({ currentState: "Executed", proposedState: "Failed", event: "mark_failed", context }),
+      decisionStateMachine.validateTransition({ currentState: "Failed", proposedState: "Reviewed", event: "reopen", context }),
+    ];
+
+    expect(results.every((result) => result.valid)).toBe(true);
+  });
+
+  it("allows snooze, dismiss, and reopen flows", () => {
+    const results = [
+      decisionStateMachine.validateTransition({ currentState: "Reviewed", proposedState: "Snoozed", event: "snooze", context }),
+      decisionStateMachine.validateTransition({ currentState: "Snoozed", proposedState: "Reviewed", event: "review", context }),
+      decisionStateMachine.validateTransition({ currentState: "Appeared", proposedState: "Dismissed", event: "dismiss", context }),
+      decisionStateMachine.validateTransition({ currentState: "Dismissed", proposedState: "Reviewed", event: "reopen", context }),
+    ];
+
+    expect(results.every((result) => result.valid)).toBe(true);
+  });
+
+  it("requires valid source and action records", () => {
+    const invalidSource = decisionStateMachine.validateTransition({
+      currentState: "Appeared",
+      proposedState: "Reviewed",
+      event: "review",
+      context: { ...context, sourceValid: false },
+    });
+    const missingRecord = decisionStateMachine.validateTransition({
+      currentState: "Reviewed",
+      proposedState: "Executed",
+      event: "execute",
+      context: { ...context, actionRecordExists: false },
+    });
+
+    expect(invalidSource.valid).toBe(false);
+    expect(missingRecord.valid).toBe(false);
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/leaseStateMachine.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/leaseStateMachine.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { leaseStateMachine } from "../leaseStateMachine";
+import type { LeaseContext } from "../types";
+
+const context: LeaseContext = {
+  actorRole: "landlord",
+  actorId: "actor-1",
+  authorized: true,
+  leaseId: "lease-1",
+  landlordId: "landlord-1",
+  noticeId: "notice-1",
+  noticeRequired: true,
+  restoreRequested: true,
+};
+
+describe("leaseStateMachine", () => {
+  it("allows lifecycle movement through notice, end, restore, and reactivate", () => {
+    const results = [
+      leaseStateMachine.validateTransition({ currentState: "Draft", proposedState: "Active", event: "activate", context }),
+      leaseStateMachine.validateTransition({ currentState: "Active", proposedState: "NoticePending", event: "prepare_notice", context }),
+      leaseStateMachine.validateTransition({ currentState: "NoticePending", proposedState: "Ended", event: "end", context }),
+      leaseStateMachine.validateTransition({ currentState: "Ended", proposedState: "Restored", event: "restore", context }),
+      leaseStateMachine.validateTransition({ currentState: "Restored", proposedState: "Active", event: "reactivate", context }),
+    ];
+
+    expect(results.every((result) => result.valid)).toBe(true);
+  });
+
+  it("rejects direct reversal from ended to active", () => {
+    const result = leaseStateMachine.validateTransition({
+      currentState: "Ended",
+      proposedState: "Active",
+      event: "reactivate",
+      context,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.allowedTransitions).toEqual(["Restored"]);
+  });
+
+  it("requires restore intent and notice context", () => {
+    const restore = leaseStateMachine.validateTransition({
+      currentState: "Ended",
+      proposedState: "Restored",
+      event: "restore",
+      context: { ...context, restoreRequested: false },
+    });
+    const notice = leaseStateMachine.validateTransition({
+      currentState: "Active",
+      proposedState: "NoticePending",
+      event: "prepare_notice",
+      context: { ...context, noticeId: null },
+    });
+
+    expect(restore.valid).toBe(false);
+    expect(restore.reason).toContain("restore");
+    expect(notice.valid).toBe(false);
+    expect(notice.reason).toContain("noticeId");
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/maintenanceStateMachine.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/maintenanceStateMachine.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { maintenanceStateMachine } from "../maintenanceStateMachine";
+import type { MaintenanceContext } from "../types";
+
+const context: MaintenanceContext = {
+  actorRole: "landlord",
+  actorId: "actor-1",
+  authorized: true,
+  workOrderId: "work-order-1",
+  assignedContractorId: "contractor-1",
+  scheduledFor: "2026-06-10T12:00:00.000Z",
+  costTotalCents: 12500,
+  evidenceCount: 2,
+};
+
+describe("maintenanceStateMachine", () => {
+  it("allows the expected review path", () => {
+    const results = [
+      maintenanceStateMachine.validateTransition({ currentState: "Open", proposedState: "Assigned", event: "assign", context }),
+      maintenanceStateMachine.validateTransition({ currentState: "Assigned", proposedState: "Scheduled", event: "schedule", context }),
+      maintenanceStateMachine.validateTransition({ currentState: "Scheduled", proposedState: "InProgress", event: "start", context }),
+      maintenanceStateMachine.validateTransition({
+        currentState: "InProgress",
+        proposedState: "CostReview",
+        event: "request_cost_review",
+        context,
+      }),
+      maintenanceStateMachine.validateTransition({ currentState: "CostReview", proposedState: "Completed", event: "complete", context }),
+    ];
+
+    expect(results.every((result) => result.valid)).toBe(true);
+  });
+
+  it("detects missing contractor, schedule, cost, and evidence context", () => {
+    const assign = maintenanceStateMachine.validateTransition({
+      currentState: "Open",
+      proposedState: "Assigned",
+      event: "assign",
+      context: { ...context, assignedContractorId: null },
+    });
+    const schedule = maintenanceStateMachine.validateTransition({
+      currentState: "Assigned",
+      proposedState: "Scheduled",
+      event: "schedule",
+      context: { ...context, scheduledFor: null },
+    });
+    const cost = maintenanceStateMachine.validateTransition({
+      currentState: "InProgress",
+      proposedState: "CostReview",
+      event: "request_cost_review",
+      context: { ...context, costTotalCents: null },
+    });
+    const evidence = maintenanceStateMachine.validateTransition({
+      currentState: "InProgress",
+      proposedState: "Completed",
+      event: "complete",
+      context: { ...context, evidenceCount: 0 },
+    });
+
+    expect(assign.valid).toBe(false);
+    expect(schedule.valid).toBe(false);
+    expect(cost.valid).toBe(false);
+    expect(evidence.valid).toBe(false);
+  });
+
+  it("allows rework from completed and back to assignment", () => {
+    const rework = maintenanceStateMachine.validateTransition({
+      currentState: "Completed",
+      proposedState: "Rework",
+      event: "request_rework",
+      context,
+    });
+    const assigned = maintenanceStateMachine.validateTransition({
+      currentState: "Rework",
+      proposedState: "Assigned",
+      event: "return_to_assignment",
+      context,
+    });
+
+    expect(rework.valid).toBe(true);
+    expect(assigned.valid).toBe(true);
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/paymentStateMachine.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/paymentStateMachine.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { paymentStateMachine } from "../paymentStateMachine";
+import type { PaymentContext } from "../types";
+
+const context: PaymentContext = {
+  actorRole: "landlord",
+  actorId: "actor-1",
+  authorized: true,
+  paymentId: "payment-1",
+  paymentIntentId: "intent-1",
+  providerStatus: "succeeded",
+};
+
+describe("paymentStateMachine", () => {
+  it("allows processing, confirmation, refund, and retry paths", () => {
+    const results = [
+      paymentStateMachine.validateTransition({ currentState: "Pending", proposedState: "Processing", event: "start_processing", context }),
+      paymentStateMachine.validateTransition({ currentState: "Processing", proposedState: "Confirmed", event: "confirm", context }),
+      paymentStateMachine.validateTransition({ currentState: "Confirmed", proposedState: "Refunded", event: "refund", context }),
+      paymentStateMachine.validateTransition({ currentState: "Refunded", proposedState: "Pending", event: "reattempt", context }),
+      paymentStateMachine.validateTransition({ currentState: "Processing", proposedState: "Failed", event: "fail", context }),
+      paymentStateMachine.validateTransition({ currentState: "Failed", proposedState: "Pending", event: "retry", context }),
+    ];
+
+    expect(results.every((result) => result.valid)).toBe(true);
+  });
+
+  it("rejects skipped confirmation and ambiguous processor state", () => {
+    const skipped = paymentStateMachine.validateTransition({
+      currentState: "Pending",
+      proposedState: "Confirmed",
+      event: "confirm",
+      context,
+    });
+    const ambiguous = paymentStateMachine.validateTransition({
+      currentState: "Processing",
+      proposedState: "Confirmed",
+      event: "confirm",
+      context: { ...context, providerStatus: null },
+    });
+
+    expect(skipped.valid).toBe(false);
+    expect(ambiguous.valid).toBe(false);
+    expect(ambiguous.reason).toContain("Persisted payment transaction status");
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/screeningStateMachine.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/screeningStateMachine.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { screeningStateMachine } from "../screeningStateMachine";
+import type { ScreeningContext, ScreeningEvent } from "../types";
+
+const baseContext: ScreeningContext = {
+  actorRole: "landlord",
+  actorId: "actor-1",
+  authorized: true,
+  applicationId: "application-1",
+  landlordId: "landlord-1",
+  orderId: "order-1",
+  checkoutSessionId: "checkout-1",
+  resultId: "result-1",
+  failureCode: "provider_failed",
+};
+
+function validate(to: Parameters<typeof screeningStateMachine.validateTransition>[0]["proposedState"], event: ScreeningEvent) {
+  return screeningStateMachine.validateTransition({
+    currentState: "CheckoutInitiated",
+    proposedState: to,
+    event,
+    context: baseContext,
+  });
+}
+
+describe("screeningStateMachine", () => {
+  it("allows the ordered checkout flow", () => {
+    const transitions = [
+      screeningStateMachine.validateTransition({
+        currentState: "NotRequested",
+        proposedState: "ApplicationStarted",
+        event: "start_application",
+        context: baseContext,
+      }),
+      screeningStateMachine.validateTransition({
+        currentState: "ApplicationStarted",
+        proposedState: "OrderCreated",
+        event: "create_order",
+        context: baseContext,
+      }),
+      screeningStateMachine.validateTransition({
+        currentState: "OrderCreated",
+        proposedState: "CheckoutInitiated",
+        event: "initiate_checkout",
+        context: baseContext,
+      }),
+      validate("CheckoutCompleted", "complete_checkout"),
+      screeningStateMachine.validateTransition({
+        currentState: "CheckoutCompleted",
+        proposedState: "ResultAvailable",
+        event: "publish_result",
+        context: baseContext,
+      }),
+    ];
+
+    expect(transitions.every((transition) => transition.valid)).toBe(true);
+  });
+
+  it("rejects skipped states", () => {
+    const result = screeningStateMachine.validateTransition({
+      currentState: "NotRequested",
+      proposedState: "OrderCreated",
+      event: "create_order",
+      context: baseContext,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("not allowed");
+  });
+
+  it("rejects missing authority and missing context", () => {
+    const unauthorized = screeningStateMachine.validateTransition({
+      currentState: "ApplicationStarted",
+      proposedState: "OrderCreated",
+      event: "create_order",
+      context: { ...baseContext, authorized: false },
+    });
+    const missingOrder = screeningStateMachine.validateTransition({
+      currentState: "ApplicationStarted",
+      proposedState: "OrderCreated",
+      event: "create_order",
+      context: { ...baseContext, orderId: null },
+    });
+
+    expect(unauthorized.valid).toBe(false);
+    expect(unauthorized.reason).toContain("not authorized");
+    expect(missingOrder.valid).toBe(false);
+    expect(missingOrder.reason).toContain("orderId");
+  });
+
+  it("allows cancellation from every non-cancelled state", () => {
+    const states = screeningStateMachine.states.filter((state) => state !== "Cancelled");
+    const results = states.map((state) =>
+      screeningStateMachine.validateTransition({
+        currentState: state,
+        proposedState: "Cancelled",
+        event: "cancel",
+        context: baseContext,
+      })
+    );
+
+    expect(results.every((result) => result.valid)).toBe(true);
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/stateComputation.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/stateComputation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeDecisionState,
+  computeLeaseState,
+  computeMaintenanceState,
+  computePaymentState,
+  computeScreeningState,
+} from "../stateComputation";
+
+describe("stateComputation", () => {
+  it("computes screening state deterministically from available records", () => {
+    expect(computeScreeningState({})).toBe("NotRequested");
+    expect(computeScreeningState({ application: { id: "application-1" } })).toBe("ApplicationStarted");
+    expect(computeScreeningState({ application: { id: "application-1" }, order: { id: "order-1" } })).toBe("OrderCreated");
+    expect(
+      computeScreeningState({
+        application: { id: "application-1" },
+        order: { id: "order-1", stripeCheckoutSessionId: "checkout-1" },
+      })
+    ).toBe("CheckoutInitiated");
+    expect(computeScreeningState({ application: { screeningStatus: "paid" }, order: { id: "order-1" } })).toBe("CheckoutCompleted");
+    expect(computeScreeningState({ application: { screeningResultId: "result-1" } })).toBe("ResultAvailable");
+    expect(computeScreeningState({ application: { screeningStatus: "failed" } })).toBe("Failed");
+    expect(computeScreeningState({ application: { screeningStatus: "cancelled" } })).toBe("Cancelled");
+  });
+
+  it("computes lease state from current lease fields", () => {
+    expect(computeLeaseState(null)).toBe("Draft");
+    expect(computeLeaseState({ status: "draft" })).toBe("Draft");
+    expect(computeLeaseState({ status: "active" })).toBe("Active");
+    expect(computeLeaseState({ status: "renewal_pending" })).toBe("NoticePending");
+    expect(computeLeaseState({ latestNoticeId: "notice-1" })).toBe("NoticePending");
+    expect(computeLeaseState({ status: "ended" })).toBe("Ended");
+    expect(computeLeaseState({ status: "restored" })).toBe("Restored");
+  });
+
+  it("computes maintenance state from status, cost review, and rework fields", () => {
+    expect(computeMaintenanceState({ status: "submitted" })).toBe("Open");
+    expect(computeMaintenanceState({ assignedContractorId: "contractor-1" })).toBe("Assigned");
+    expect(computeMaintenanceState({ status: "scheduled" })).toBe("Scheduled");
+    expect(computeMaintenanceState({ status: "in_progress" })).toBe("InProgress");
+    expect(computeMaintenanceState({ cost: { reviewStatus: "pending_review" } })).toBe("CostReview");
+    expect(computeMaintenanceState({ status: "completed" })).toBe("Completed");
+    expect(computeMaintenanceState({ status: "completed", reworkCycle: { status: "assigned" } })).toBe("Rework");
+  });
+
+  it("computes payment state from persisted payment status", () => {
+    expect(computePaymentState({ status: "checkout_created" })).toBe("Processing");
+    expect(computePaymentState({ status: "paid" })).toBe("Confirmed");
+    expect(computePaymentState({ status: "Recorded" })).toBe("Confirmed");
+    expect(computePaymentState({ status: "failed" })).toBe("Failed");
+    expect(computePaymentState({ status: "refunded" })).toBe("Refunded");
+    expect(computePaymentState({ amountCents: 1200 })).toBe("Pending");
+  });
+
+  it("computes decision state from action records", () => {
+    expect(computeDecisionState(null)).toBe("Derived");
+    expect(computeDecisionState({ state: "appeared" })).toBe("Appeared");
+    expect(computeDecisionState({ state: "reviewed" })).toBe("Reviewed");
+    expect(computeDecisionState({ state: "snoozed" })).toBe("Snoozed");
+    expect(computeDecisionState({ state: "dismissed" })).toBe("Dismissed");
+    expect(computeDecisionState({ state: "executed" })).toBe("Executed");
+    expect(computeDecisionState({ state: "executed", executionOutcomeStatus: "failed" })).toBe("Failed");
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/transitionValidation.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/transitionValidation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { getStateMachine, listStateMachineWorkflowTypes } from "../stateMachineRegistry";
+import {
+  buildValidationSummary,
+  validateDecisionTransition,
+  validateLeaseTransition,
+  validateMaintenanceTransition,
+  validatePaymentTransition,
+  validateScreeningTransition,
+} from "../transitionValidation";
+
+describe("transitionValidation", () => {
+  it("validates screening transitions from computed records", () => {
+    const result = validateScreeningTransition(
+      { id: "application-1" },
+      {
+        to: "OrderCreated",
+        event: "create_order",
+        context: {
+          actorRole: "landlord",
+          authorized: true,
+          applicationId: "application-1",
+          landlordId: "landlord-1",
+          orderId: "order-1",
+        },
+      }
+    );
+
+    expect(result.valid).toBe(true);
+    expect(buildValidationSummary(result)).toEqual({ valid: true, allowedTransitions: ["OrderCreated", "Cancelled"] });
+  });
+
+  it("validates lease transitions from computed records", () => {
+    const result = validateLeaseTransition(
+      { status: "ended" },
+      {
+        to: "Restored",
+        event: "restore",
+        context: {
+          actorRole: "landlord",
+          authorized: true,
+          leaseId: "lease-1",
+          landlordId: "landlord-1",
+          restoreRequested: true,
+        },
+      }
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates maintenance transitions from computed records", () => {
+    const result = validateMaintenanceTransition(
+      { status: "in_progress" },
+      {
+        to: "CostReview",
+        event: "request_cost_review",
+        context: {
+          actorRole: "contractor",
+          authorized: true,
+          workOrderId: "work-order-1",
+          costTotalCents: 5000,
+        },
+      }
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates payment transitions from computed records", () => {
+    const result = validatePaymentTransition(
+      { status: "payment_pending" },
+      {
+        to: "Confirmed",
+        event: "confirm",
+        context: {
+          actorRole: "system",
+          authorized: true,
+          paymentId: "payment-1",
+          paymentIntentId: "intent-1",
+          providerStatus: "succeeded",
+        },
+      }
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates decision transitions from computed records", () => {
+    const result = validateDecisionTransition(
+      { state: "reviewed" },
+      {
+        to: "Executed",
+        event: "execute",
+        context: {
+          actorRole: "landlord",
+          authorized: true,
+          decisionId: "decision-1",
+          landlordId: "landlord-1",
+          actionRecordExists: true,
+          sourceValid: true,
+        },
+      }
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("exposes immutable registry descriptors", () => {
+    expect(listStateMachineWorkflowTypes()).toEqual(["screening", "lease", "maintenance", "payment", "decision"]);
+    expect(getStateMachine("screening").workflowType).toBe("screening");
+    expect(getStateMachine("decision").snapshot("Derived").allowedTransitions).toEqual(["Appeared"]);
+  });
+});

--- a/rentchain-api/src/services/stateMachines/common.ts
+++ b/rentchain-api/src/services/stateMachines/common.ts
@@ -1,0 +1,132 @@
+import type {
+  StateMachine,
+  StateSnapshot,
+  StateTransition,
+  TransitionValidator,
+  TransitionError,
+  TransitionValidationResult,
+} from "./types";
+
+export function text(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function lower(value: unknown, max = 240): string {
+  return text(value, max).toLowerCase();
+}
+
+export function positiveNumber(value: unknown): number | null {
+  const next = Number(value);
+  return Number.isFinite(next) && next > 0 ? next : null;
+}
+
+export function hasValue(value: unknown): boolean {
+  return text(value).length > 0;
+}
+
+export function invalid<S extends string>(
+  state: S,
+  code: TransitionError<S>["code"],
+  reason: string
+): TransitionError<S> {
+  return { state, code, reason };
+}
+
+export function createStateMachine<S extends string, C, E extends string>(params: {
+  workflowType: string;
+  states: readonly S[];
+  terminalStates: readonly S[];
+  transitions: readonly StateTransition<S, C, E>[];
+}): StateMachine<S, C, E> {
+  const getAllowedTransitions = (state: S): S[] =>
+    params.transitions.filter((transition) => transition.from === state).map((transition) => transition.to);
+
+  const snapshot = (state: S): StateSnapshot<S> => ({
+    state,
+    terminal: params.terminalStates.includes(state),
+    allowedTransitions: getAllowedTransitions(state),
+  });
+
+  const validateTransition = (input: {
+    currentState: S;
+    proposedState: S;
+    event: E;
+    context: C;
+  }): TransitionValidationResult<S> => {
+    const allowedTransitions = getAllowedTransitions(input.currentState);
+    const transition = params.transitions.find(
+      (candidate) =>
+        candidate.from === input.currentState &&
+        candidate.to === input.proposedState &&
+        candidate.event === input.event
+    );
+
+    if (!transition) {
+      return {
+        valid: false,
+        currentState: input.currentState,
+        proposedState: input.proposedState,
+        allowedTransitions,
+        reason: allowedTransitions.includes(input.proposedState)
+          ? `Transition event ${input.event} is not valid for ${input.currentState} to ${input.proposedState}.`
+          : `Transition from ${input.currentState} to ${input.proposedState} is not allowed.`,
+      };
+    }
+
+    for (const validator of transition.validators) {
+      const error = validator(input);
+      if (error) {
+        return {
+          valid: false,
+          currentState: input.currentState,
+          proposedState: input.proposedState,
+          allowedTransitions,
+          reason: error.reason,
+        };
+      }
+    }
+
+    return {
+      valid: true,
+      currentState: input.currentState,
+      proposedState: input.proposedState,
+      allowedTransitions,
+    };
+  };
+
+  return Object.freeze({
+    workflowType: params.workflowType,
+    states: Object.freeze([...params.states]),
+    terminalStates: Object.freeze([...params.terminalStates]),
+    transitions: Object.freeze([...params.transitions]),
+    getAllowedTransitions,
+    validateTransition,
+    snapshot,
+  });
+}
+
+export function authorityValidator<S extends string, C extends { authorized?: boolean; actorRole?: string }, E extends string>(
+  roles: readonly string[]
+) {
+  return ({ currentState, context }: { currentState: S; proposedState: S; event: E; context: C }) => {
+    if (context.authorized !== true) {
+      return invalid(currentState, "insufficient_authority", "Actor is not authorized for this transition.");
+    }
+    if (!roles.includes(context.actorRole || "")) {
+      return invalid(currentState, "insufficient_authority", "Actor role is not allowed for this transition.");
+    }
+    return null;
+  };
+}
+
+export function requiredFieldsValidator<S extends string, C extends object, E extends string>(
+  fields: readonly string[]
+): TransitionValidator<S, C, E> {
+  return ({ currentState, context }: { currentState: S; proposedState: S; event: E; context: C }) => {
+    const missing = fields.filter((field) => !hasValue(context[field as keyof C]));
+    if (missing.length) {
+      return invalid(currentState, "missing_context", `Missing required context: ${missing.join(", ")}.`);
+    }
+    return null;
+  };
+}

--- a/rentchain-api/src/services/stateMachines/decisionStateMachine.ts
+++ b/rentchain-api/src/services/stateMachines/decisionStateMachine.ts
@@ -1,0 +1,108 @@
+import { authorityValidator, createStateMachine, invalid, requiredFieldsValidator } from "./common";
+import type { DecisionActionState, DecisionContext, DecisionEvent, StateTransition } from "./types";
+
+export const decisionStates = [
+  "Derived",
+  "Appeared",
+  "Reviewed",
+  "Snoozed",
+  "Dismissed",
+  "Executed",
+  "Failed",
+] as const satisfies readonly DecisionActionState[];
+
+const landlordOrAdmin = authorityValidator<DecisionActionState, DecisionContext, DecisionEvent>(["landlord", "admin"]);
+
+const requiresValidSource = ({ currentState, context }: {
+  currentState: DecisionActionState;
+  proposedState: DecisionActionState;
+  event: DecisionEvent;
+  context: DecisionContext;
+}) => {
+  if (context.sourceValid === false) {
+    return invalid(currentState, "source_invalid", "Source decision context is no longer valid.");
+  }
+  return null;
+};
+
+const requiresActionRecord = ({ currentState, context }: {
+  currentState: DecisionActionState;
+  proposedState: DecisionActionState;
+  event: DecisionEvent;
+  context: DecisionContext;
+}) => {
+  if (context.actionRecordExists !== true) {
+    return invalid(currentState, "missing_context", "Decision action record is required for this transition.");
+  }
+  return null;
+};
+
+const transitions: StateTransition<DecisionActionState, DecisionContext, DecisionEvent>[] = [
+  {
+    from: "Derived",
+    to: "Appeared",
+    event: "appear",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresValidSource],
+  },
+  {
+    from: "Appeared",
+    to: "Reviewed",
+    event: "review",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresValidSource],
+  },
+  {
+    from: "Appeared",
+    to: "Dismissed",
+    event: "dismiss",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresValidSource],
+  },
+  {
+    from: "Reviewed",
+    to: "Snoozed",
+    event: "snooze",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId", "snoozedUntil"]), requiresActionRecord],
+  },
+  {
+    from: "Reviewed",
+    to: "Executed",
+    event: "execute",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresActionRecord, requiresValidSource],
+  },
+  {
+    from: "Reviewed",
+    to: "Failed",
+    event: "mark_failed",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresActionRecord],
+  },
+  {
+    from: "Snoozed",
+    to: "Reviewed",
+    event: "review",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresActionRecord],
+  },
+  {
+    from: "Dismissed",
+    to: "Reviewed",
+    event: "reopen",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresActionRecord, requiresValidSource],
+  },
+  {
+    from: "Executed",
+    to: "Failed",
+    event: "mark_failed",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresActionRecord],
+  },
+  {
+    from: "Failed",
+    to: "Reviewed",
+    event: "reopen",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["decisionId", "landlordId"]), requiresActionRecord, requiresValidSource],
+  },
+];
+
+export const decisionStateMachine = createStateMachine<DecisionActionState, DecisionContext, DecisionEvent>({
+  workflowType: "decision",
+  states: decisionStates,
+  terminalStates: [],
+  transitions,
+});

--- a/rentchain-api/src/services/stateMachines/leaseStateMachine.ts
+++ b/rentchain-api/src/services/stateMachines/leaseStateMachine.ts
@@ -1,0 +1,77 @@
+import { authorityValidator, createStateMachine, invalid, requiredFieldsValidator } from "./common";
+import type { LeaseContext, LeaseEvent, LeaseLifecycleState, StateTransition } from "./types";
+
+export const leaseStates = ["Draft", "Active", "NoticePending", "Ended", "Restored"] as const satisfies readonly LeaseLifecycleState[];
+
+const landlordOrAdmin = authorityValidator<LeaseLifecycleState, LeaseContext, LeaseEvent>(["landlord", "admin"]);
+
+const requiresNotice = ({ currentState, proposedState, context }: {
+  currentState: LeaseLifecycleState;
+  proposedState: LeaseLifecycleState;
+  event: LeaseEvent;
+  context: LeaseContext;
+}) => {
+  if (proposedState !== "NoticePending") return null;
+  if (context.noticeRequired === false) {
+    return invalid(currentState, "missing_context", "Notice transition requires an applicable notice rule.");
+  }
+  return null;
+};
+
+const requiresRestoreIntent = ({ currentState, context }: {
+  currentState: LeaseLifecycleState;
+  proposedState: LeaseLifecycleState;
+  event: LeaseEvent;
+  context: LeaseContext;
+}) => {
+  if (context.restoreRequested !== true) {
+    return invalid(currentState, "missing_context", "Ended lease restore requires explicit restore context.");
+  }
+  return null;
+};
+
+const transitions: StateTransition<LeaseLifecycleState, LeaseContext, LeaseEvent>[] = [
+  {
+    from: "Draft",
+    to: "Active",
+    event: "activate",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["leaseId", "landlordId"])],
+  },
+  {
+    from: "Active",
+    to: "NoticePending",
+    event: "prepare_notice",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["leaseId", "landlordId", "noticeId"]), requiresNotice],
+  },
+  {
+    from: "Active",
+    to: "Ended",
+    event: "end",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["leaseId", "landlordId"])],
+  },
+  {
+    from: "NoticePending",
+    to: "Ended",
+    event: "end",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["leaseId", "landlordId"])],
+  },
+  {
+    from: "Ended",
+    to: "Restored",
+    event: "restore",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["leaseId", "landlordId"]), requiresRestoreIntent],
+  },
+  {
+    from: "Restored",
+    to: "Active",
+    event: "reactivate",
+    validators: [landlordOrAdmin, requiredFieldsValidator(["leaseId", "landlordId"])],
+  },
+];
+
+export const leaseStateMachine = createStateMachine<LeaseLifecycleState, LeaseContext, LeaseEvent>({
+  workflowType: "lease",
+  states: leaseStates,
+  terminalStates: [],
+  transitions,
+});

--- a/rentchain-api/src/services/stateMachines/maintenanceStateMachine.ts
+++ b/rentchain-api/src/services/stateMachines/maintenanceStateMachine.ts
@@ -1,0 +1,124 @@
+import { authorityValidator, createStateMachine, invalid, positiveNumber, requiredFieldsValidator } from "./common";
+import type { MaintenanceContext, MaintenanceEvent, MaintenanceRequestState, StateTransition } from "./types";
+
+export const maintenanceStates = [
+  "Open",
+  "Assigned",
+  "Scheduled",
+  "InProgress",
+  "CostReview",
+  "Completed",
+  "Rework",
+] as const satisfies readonly MaintenanceRequestState[];
+
+const tenantLandlordAdmin = authorityValidator<MaintenanceRequestState, MaintenanceContext, MaintenanceEvent>([
+  "tenant",
+  "landlord",
+  "admin",
+]);
+const landlordAdmin = authorityValidator<MaintenanceRequestState, MaintenanceContext, MaintenanceEvent>(["landlord", "admin"]);
+const contractorLandlordAdmin = authorityValidator<MaintenanceRequestState, MaintenanceContext, MaintenanceEvent>([
+  "contractor",
+  "landlord",
+  "admin",
+]);
+
+const requiresCost = ({ currentState, context }: {
+  currentState: MaintenanceRequestState;
+  proposedState: MaintenanceRequestState;
+  event: MaintenanceEvent;
+  context: MaintenanceContext;
+}) => {
+  if (positiveNumber(context.costTotalCents) == null) {
+    return invalid(currentState, "missing_context", "Cost review requires a positive cost amount.");
+  }
+  return null;
+};
+
+const requiresEvidence = ({ currentState, context }: {
+  currentState: MaintenanceRequestState;
+  proposedState: MaintenanceRequestState;
+  event: MaintenanceEvent;
+  context: MaintenanceContext;
+}) => {
+  if (positiveNumber(context.evidenceCount) == null) {
+    return invalid(currentState, "missing_context", "Completion requires at least one evidence item.");
+  }
+  return null;
+};
+
+const transitions: StateTransition<MaintenanceRequestState, MaintenanceContext, MaintenanceEvent>[] = [
+  {
+    from: "Open",
+    to: "Assigned",
+    event: "assign",
+    validators: [landlordAdmin, requiredFieldsValidator(["workOrderId", "assignedContractorId"])],
+  },
+  {
+    from: "Assigned",
+    to: "Scheduled",
+    event: "schedule",
+    validators: [contractorLandlordAdmin, requiredFieldsValidator(["workOrderId", "scheduledFor"])],
+  },
+  {
+    from: "Assigned",
+    to: "CostReview",
+    event: "request_cost_review",
+    validators: [contractorLandlordAdmin, requiredFieldsValidator(["workOrderId"]), requiresCost],
+  },
+  {
+    from: "Scheduled",
+    to: "InProgress",
+    event: "start",
+    validators: [contractorLandlordAdmin, requiredFieldsValidator(["workOrderId"])],
+  },
+  {
+    from: "InProgress",
+    to: "CostReview",
+    event: "request_cost_review",
+    validators: [contractorLandlordAdmin, requiredFieldsValidator(["workOrderId"]), requiresCost],
+  },
+  {
+    from: "InProgress",
+    to: "Completed",
+    event: "complete",
+    validators: [contractorLandlordAdmin, requiredFieldsValidator(["workOrderId"]), requiresEvidence],
+  },
+  {
+    from: "CostReview",
+    to: "Completed",
+    event: "complete",
+    validators: [landlordAdmin, requiredFieldsValidator(["workOrderId"])],
+  },
+  {
+    from: "CostReview",
+    to: "Rework",
+    event: "request_rework",
+    validators: [landlordAdmin, requiredFieldsValidator(["workOrderId"])],
+  },
+  {
+    from: "Completed",
+    to: "Rework",
+    event: "request_rework",
+    validators: [tenantLandlordAdmin, requiredFieldsValidator(["workOrderId"])],
+  },
+  {
+    from: "Rework",
+    to: "Assigned",
+    event: "return_to_assignment",
+    validators: [landlordAdmin, requiredFieldsValidator(["workOrderId", "assignedContractorId"])],
+  },
+  {
+    from: "Rework",
+    to: "Completed",
+    event: "complete",
+    validators: [contractorLandlordAdmin, requiredFieldsValidator(["workOrderId"]), requiresEvidence],
+  },
+];
+
+export const maintenanceStateMachine = createStateMachine<MaintenanceRequestState, MaintenanceContext, MaintenanceEvent>({
+  workflowType: "maintenance",
+  states: maintenanceStates,
+  terminalStates: [],
+  transitions,
+});

--- a/rentchain-api/src/services/stateMachines/paymentStateMachine.ts
+++ b/rentchain-api/src/services/stateMachines/paymentStateMachine.ts
@@ -1,0 +1,65 @@
+import { authorityValidator, createStateMachine, invalid, requiredFieldsValidator } from "./common";
+import type { PaymentContext, PaymentEvent, PaymentState, StateTransition } from "./types";
+
+export const paymentStates = ["Pending", "Processing", "Confirmed", "Failed", "Refunded"] as const satisfies readonly PaymentState[];
+
+const accountAuthority = authorityValidator<PaymentState, PaymentContext, PaymentEvent>(["tenant", "landlord", "admin", "system"]);
+
+const requiresUnambiguousProviderState = ({ currentState, context }: {
+  currentState: PaymentState;
+  proposedState: PaymentState;
+  event: PaymentEvent;
+  context: PaymentContext;
+}) => {
+  const providerStatus = String(context.providerStatus || "").trim().toLowerCase();
+  if (!providerStatus && currentState === "Processing") {
+    return invalid(currentState, "ambiguous_state", "Persisted payment transaction status is required for processing transitions.");
+  }
+  return null;
+};
+
+const transitions: StateTransition<PaymentState, PaymentContext, PaymentEvent>[] = [
+  {
+    from: "Pending",
+    to: "Processing",
+    event: "start_processing",
+    validators: [accountAuthority, requiredFieldsValidator(["paymentId", "paymentIntentId"])],
+  },
+  {
+    from: "Processing",
+    to: "Confirmed",
+    event: "confirm",
+    validators: [accountAuthority, requiredFieldsValidator(["paymentId", "paymentIntentId"]), requiresUnambiguousProviderState],
+  },
+  {
+    from: "Processing",
+    to: "Failed",
+    event: "fail",
+    validators: [accountAuthority, requiredFieldsValidator(["paymentId", "paymentIntentId"]), requiresUnambiguousProviderState],
+  },
+  {
+    from: "Confirmed",
+    to: "Refunded",
+    event: "refund",
+    validators: [accountAuthority, requiredFieldsValidator(["paymentId"])],
+  },
+  {
+    from: "Failed",
+    to: "Pending",
+    event: "retry",
+    validators: [accountAuthority, requiredFieldsValidator(["paymentId"])],
+  },
+  {
+    from: "Refunded",
+    to: "Pending",
+    event: "reattempt",
+    validators: [accountAuthority, requiredFieldsValidator(["paymentId"])],
+  },
+];
+
+export const paymentStateMachine = createStateMachine<PaymentState, PaymentContext, PaymentEvent>({
+  workflowType: "payment",
+  states: paymentStates,
+  terminalStates: [],
+  transitions,
+});

--- a/rentchain-api/src/services/stateMachines/screeningStateMachine.ts
+++ b/rentchain-api/src/services/stateMachines/screeningStateMachine.ts
@@ -1,0 +1,74 @@
+import { authorityValidator, createStateMachine, requiredFieldsValidator } from "./common";
+import type { ScreeningApplicationState, ScreeningContext, ScreeningEvent, StateTransition } from "./types";
+
+export const screeningStates = [
+  "NotRequested",
+  "ApplicationStarted",
+  "OrderCreated",
+  "CheckoutInitiated",
+  "CheckoutCompleted",
+  "ResultAvailable",
+  "Failed",
+  "Cancelled",
+] as const satisfies readonly ScreeningApplicationState[];
+
+const landlordOrAdmin = authorityValidator<ScreeningApplicationState, ScreeningContext, ScreeningEvent>([
+  "landlord",
+  "admin",
+]);
+const requiredScreeningFields = (fields: readonly string[]) =>
+  requiredFieldsValidator<ScreeningApplicationState, ScreeningContext, ScreeningEvent>(fields);
+
+const transitions: StateTransition<ScreeningApplicationState, ScreeningContext, ScreeningEvent>[] = [
+  {
+    from: "NotRequested",
+    to: "ApplicationStarted",
+    event: "start_application",
+    validators: [landlordOrAdmin, requiredScreeningFields(["applicationId", "landlordId"])],
+  },
+  {
+    from: "ApplicationStarted",
+    to: "OrderCreated",
+    event: "create_order",
+    validators: [landlordOrAdmin, requiredScreeningFields(["applicationId", "orderId"])],
+  },
+  {
+    from: "OrderCreated",
+    to: "CheckoutInitiated",
+    event: "initiate_checkout",
+    validators: [landlordOrAdmin, requiredScreeningFields(["orderId", "checkoutSessionId"])],
+  },
+  {
+    from: "CheckoutInitiated",
+    to: "CheckoutCompleted",
+    event: "complete_checkout",
+    validators: [landlordOrAdmin, requiredScreeningFields(["orderId"])],
+  },
+  {
+    from: "CheckoutInitiated",
+    to: "Failed",
+    event: "fail",
+    validators: [landlordOrAdmin, requiredScreeningFields(["orderId", "failureCode"])],
+  },
+  {
+    from: "CheckoutCompleted",
+    to: "ResultAvailable",
+    event: "publish_result",
+    validators: [landlordOrAdmin, requiredScreeningFields(["applicationId", "resultId"])],
+  },
+  ...screeningStates
+    .filter((state) => state !== "Cancelled")
+    .map((from) => ({
+      from,
+      to: "Cancelled" as const,
+      event: "cancel" as const,
+      validators: [landlordOrAdmin, requiredScreeningFields(["applicationId"])],
+    })),
+];
+
+export const screeningStateMachine = createStateMachine<ScreeningApplicationState, ScreeningContext, ScreeningEvent>({
+  workflowType: "screening",
+  states: screeningStates,
+  terminalStates: ["ResultAvailable", "Failed", "Cancelled"],
+  transitions,
+});

--- a/rentchain-api/src/services/stateMachines/stateComputation.ts
+++ b/rentchain-api/src/services/stateMachines/stateComputation.ts
@@ -1,0 +1,94 @@
+import { lower, positiveNumber, text } from "./common";
+import type {
+  DecisionActionState,
+  LeaseLifecycleState,
+  MaintenanceRequestState,
+  PaymentState,
+  RecordLike,
+  ScreeningApplicationState,
+} from "./types";
+
+export function computeScreeningState(params: {
+  application?: RecordLike | null;
+  order?: RecordLike | null;
+  transaction?: RecordLike | null;
+  result?: RecordLike | null;
+}): ScreeningApplicationState {
+  const applicationStatus = lower(params.application?.screeningStatus || params.application?.status, 80);
+  const orderStatus = lower(params.order?.status || params.order?.orderStatus, 80);
+  const transactionStatus = lower(params.transaction?.status || params.transaction?.paymentStatus, 80);
+  const resultStatus = lower(params.result?.status || params.application?.screeningResultSummary, 80);
+
+  if (applicationStatus === "cancelled" || orderStatus === "cancelled") return "Cancelled";
+  if (applicationStatus === "failed" || orderStatus === "failed" || transactionStatus === "failed") return "Failed";
+  if (
+    text(params.application?.screeningResultId) ||
+    resultStatus === "complete" ||
+    resultStatus === "completed" ||
+    resultStatus === "available"
+  ) {
+    return "ResultAvailable";
+  }
+  if (transactionStatus === "completed" || applicationStatus === "paid" || orderStatus === "paid") return "CheckoutCompleted";
+  if (
+    transactionStatus === "pending" ||
+    orderStatus === "unpaid" ||
+    text(params.order?.stripeCheckoutSessionId || params.order?.checkoutSessionId)
+  ) {
+    return "CheckoutInitiated";
+  }
+  if (params.order && Object.keys(params.order).length > 0) return "OrderCreated";
+  if (params.application && Object.keys(params.application).length > 0) return "ApplicationStarted";
+  return "NotRequested";
+}
+
+export function computeLeaseState(lease?: RecordLike | null): LeaseLifecycleState {
+  const status = lower(lease?.status || lease?.leaseStatus, 80);
+  if (!lease || Object.keys(lease).length === 0) return "Draft";
+  if (status === "draft" || status === "generated") return "Draft";
+  if (status === "ended" || status === "expired" || status === "terminated") return "Ended";
+  if (status === "restored") return "Restored";
+  if (status === "notice_pending" || status === "renewal_pending" || text(lease?.latestNoticeId)) return "NoticePending";
+  return "Active";
+}
+
+export function computeMaintenanceState(workOrder?: RecordLike | null): MaintenanceRequestState {
+  const status = lower(workOrder?.status, 80);
+  const costStatus = lower((workOrder?.cost as RecordLike | undefined)?.reviewStatus || workOrder?.costReviewStatus, 80);
+  const rework = workOrder?.reworkCycle as RecordLike | undefined;
+  const reworkStatus = lower(rework?.status, 80);
+
+  if (rework && reworkStatus !== "completed" && reworkStatus !== "cancelled") return "Rework";
+  if (costStatus === "pending_review" || costStatus === "revision_requested" || costStatus === "rejected") return "CostReview";
+  if (status === "completed" || status === "resolved" || status === "closed") return "Completed";
+  if (status === "in_progress" || status === "blocked") return "InProgress";
+  if (status === "scheduled") return "Scheduled";
+  if (status === "assigned" || text(workOrder?.assignedContractorId)) return "Assigned";
+  return "Open";
+}
+
+export function computePaymentState(payment?: RecordLike | null): PaymentState {
+  const status = lower(payment?.status || payment?.paymentStatus, 80);
+  if (status === "refunded") return "Refunded";
+  if (status === "paid" || status === "confirmed" || status === "recorded" || status === "completed") return "Confirmed";
+  if (status === "failed" || status === "canceled" || status === "cancelled" || status === "expired") return "Failed";
+  if (status === "checkout_created" || status === "payment_pending" || status === "processing" || status === "provider_session_created") {
+    return "Processing";
+  }
+  if (positiveNumber(payment?.amountCents) != null || positiveNumber(payment?.amount) != null) return "Pending";
+  return "Pending";
+}
+
+export function computeDecisionState(decisionAction?: RecordLike | null): DecisionActionState {
+  const state = lower(decisionAction?.state || decisionAction?.status, 80);
+  const outcome = lower(decisionAction?.executionOutcomeStatus, 80);
+  if (!decisionAction || Object.keys(decisionAction).length === 0) return "Derived";
+  if (state === "executed" && outcome === "failed") return "Failed";
+  if (state === "executed") return "Executed";
+  if (state === "failed") return "Failed";
+  if (state === "dismissed") return "Dismissed";
+  if (state === "snoozed") return "Snoozed";
+  if (state === "reviewed" || state === "accepted" || state === "resolved") return "Reviewed";
+  if (state === "appeared" || text(decisionAction?.appearedAt)) return "Appeared";
+  return "Appeared";
+}

--- a/rentchain-api/src/services/stateMachines/stateMachineRegistry.ts
+++ b/rentchain-api/src/services/stateMachines/stateMachineRegistry.ts
@@ -1,0 +1,26 @@
+import { decisionStateMachine } from "./decisionStateMachine";
+import { leaseStateMachine } from "./leaseStateMachine";
+import { maintenanceStateMachine } from "./maintenanceStateMachine";
+import { paymentStateMachine } from "./paymentStateMachine";
+import { screeningStateMachine } from "./screeningStateMachine";
+
+export type ReviewWorkflowType = "screening" | "lease" | "maintenance" | "payment" | "decision";
+
+export function getStateMachine(workflowType: ReviewWorkflowType) {
+  switch (workflowType) {
+    case "screening":
+      return screeningStateMachine;
+    case "lease":
+      return leaseStateMachine;
+    case "maintenance":
+      return maintenanceStateMachine;
+    case "payment":
+      return paymentStateMachine;
+    case "decision":
+      return decisionStateMachine;
+  }
+}
+
+export function listStateMachineWorkflowTypes(): ReviewWorkflowType[] {
+  return ["screening", "lease", "maintenance", "payment", "decision"];
+}

--- a/rentchain-api/src/services/stateMachines/transitionValidation.ts
+++ b/rentchain-api/src/services/stateMachines/transitionValidation.ts
@@ -1,0 +1,138 @@
+import { computeDecisionState, computeLeaseState, computeMaintenanceState, computePaymentState, computeScreeningState } from "./stateComputation";
+import { decisionStateMachine } from "./decisionStateMachine";
+import { leaseStateMachine } from "./leaseStateMachine";
+import { maintenanceStateMachine } from "./maintenanceStateMachine";
+import { paymentStateMachine } from "./paymentStateMachine";
+import { screeningStateMachine } from "./screeningStateMachine";
+import type {
+  DecisionActionState,
+  DecisionContext,
+  DecisionEvent,
+  LeaseContext,
+  LeaseEvent,
+  LeaseLifecycleState,
+  MaintenanceContext,
+  MaintenanceEvent,
+  MaintenanceRequestState,
+  PaymentContext,
+  PaymentEvent,
+  PaymentState,
+  RecordLike,
+  ScreeningApplicationState,
+  ScreeningContext,
+  ScreeningEvent,
+  TransitionValidationResult,
+} from "./types";
+
+export type ScreeningTransitionRequest = {
+  to: ScreeningApplicationState;
+  event: ScreeningEvent;
+  context: ScreeningContext;
+};
+
+export type LeaseTransitionRequest = {
+  to: LeaseLifecycleState;
+  event: LeaseEvent;
+  context: LeaseContext;
+};
+
+export type MaintenanceTransitionRequest = {
+  to: MaintenanceRequestState;
+  event: MaintenanceEvent;
+  context: MaintenanceContext;
+};
+
+export type PaymentTransitionRequest = {
+  to: PaymentState;
+  event: PaymentEvent;
+  context: PaymentContext;
+};
+
+export type DecisionTransitionRequest = {
+  to: DecisionActionState;
+  event: DecisionEvent;
+  context: DecisionContext;
+};
+
+export function validateScreeningTransition(
+  currentApplication: RecordLike | null | undefined,
+  proposedTransition: ScreeningTransitionRequest,
+  relatedRecords: { order?: RecordLike | null; transaction?: RecordLike | null; result?: RecordLike | null } = {}
+): TransitionValidationResult<ScreeningApplicationState> {
+  const currentState = computeScreeningState({
+    application: currentApplication,
+    order: relatedRecords.order,
+    transaction: relatedRecords.transaction,
+    result: relatedRecords.result,
+  });
+  return screeningStateMachine.validateTransition({
+    currentState,
+    proposedState: proposedTransition.to,
+    event: proposedTransition.event,
+    context: proposedTransition.context,
+  });
+}
+
+export function validateLeaseTransition(
+  lease: RecordLike | null | undefined,
+  proposedTransition: LeaseTransitionRequest
+): TransitionValidationResult<LeaseLifecycleState> {
+  const currentState = computeLeaseState(lease);
+  return leaseStateMachine.validateTransition({
+    currentState,
+    proposedState: proposedTransition.to,
+    event: proposedTransition.event,
+    context: proposedTransition.context,
+  });
+}
+
+export function validateMaintenanceTransition(
+  workOrder: RecordLike | null | undefined,
+  proposedTransition: MaintenanceTransitionRequest
+): TransitionValidationResult<MaintenanceRequestState> {
+  const currentState = computeMaintenanceState(workOrder);
+  return maintenanceStateMachine.validateTransition({
+    currentState,
+    proposedState: proposedTransition.to,
+    event: proposedTransition.event,
+    context: proposedTransition.context,
+  });
+}
+
+export function validatePaymentTransition(
+  payment: RecordLike | null | undefined,
+  proposedTransition: PaymentTransitionRequest
+): TransitionValidationResult<PaymentState> {
+  const currentState = computePaymentState(payment);
+  return paymentStateMachine.validateTransition({
+    currentState,
+    proposedState: proposedTransition.to,
+    event: proposedTransition.event,
+    context: proposedTransition.context,
+  });
+}
+
+export function validateDecisionTransition(
+  decisionAction: RecordLike | null | undefined,
+  proposedTransition: DecisionTransitionRequest
+): TransitionValidationResult<DecisionActionState> {
+  const currentState = computeDecisionState(decisionAction);
+  return decisionStateMachine.validateTransition({
+    currentState,
+    proposedState: proposedTransition.to,
+    event: proposedTransition.event,
+    context: proposedTransition.context,
+  });
+}
+
+export function buildValidationSummary(result: TransitionValidationResult): {
+  valid: boolean;
+  allowedTransitions: string[];
+  reason?: string;
+} {
+  return {
+    valid: result.valid,
+    allowedTransitions: result.allowedTransitions,
+    ...(result.reason ? { reason: result.reason } : {}),
+  };
+}

--- a/rentchain-api/src/services/stateMachines/types.ts
+++ b/rentchain-api/src/services/stateMachines/types.ts
@@ -1,0 +1,190 @@
+export type ActorRole = "tenant" | "landlord" | "admin" | "contractor" | "support" | "system";
+
+export type RecordLike = Record<string, unknown>;
+
+export type ScreeningApplicationState =
+  | "NotRequested"
+  | "ApplicationStarted"
+  | "OrderCreated"
+  | "CheckoutInitiated"
+  | "CheckoutCompleted"
+  | "ResultAvailable"
+  | "Failed"
+  | "Cancelled";
+
+export type ScreeningOperationState = "Requested" | "InProgress" | "Completed" | "Cancelled" | "Blocked";
+
+export type LeaseLifecycleState = "Draft" | "Active" | "NoticePending" | "Ended" | "Restored";
+
+export type MaintenanceRequestState =
+  | "Open"
+  | "Assigned"
+  | "Scheduled"
+  | "InProgress"
+  | "CostReview"
+  | "Completed"
+  | "Rework";
+
+export type PaymentState = "Pending" | "Processing" | "Confirmed" | "Failed" | "Refunded";
+
+export type DecisionActionState = "Derived" | "Appeared" | "Reviewed" | "Snoozed" | "Dismissed" | "Executed" | "Failed";
+
+export type ScreeningEvent =
+  | "start_application"
+  | "create_order"
+  | "initiate_checkout"
+  | "complete_checkout"
+  | "publish_result"
+  | "fail"
+  | "cancel";
+
+export type LeaseEvent = "activate" | "prepare_notice" | "end" | "restore" | "reactivate";
+
+export type MaintenanceEvent =
+  | "assign"
+  | "schedule"
+  | "start"
+  | "request_cost_review"
+  | "complete"
+  | "request_rework"
+  | "return_to_assignment";
+
+export type PaymentEvent = "start_processing" | "confirm" | "fail" | "refund" | "retry" | "reattempt";
+
+export type DecisionEvent = "appear" | "review" | "snooze" | "dismiss" | "execute" | "mark_failed" | "reopen";
+
+export type WorkflowState =
+  | ScreeningApplicationState
+  | ScreeningOperationState
+  | LeaseLifecycleState
+  | MaintenanceRequestState
+  | PaymentState
+  | DecisionActionState;
+
+export type WorkflowEvent = ScreeningEvent | LeaseEvent | MaintenanceEvent | PaymentEvent | DecisionEvent;
+
+export type AuthorityContext = {
+  actorRole: ActorRole;
+  actorId?: string | null;
+  authorized?: boolean;
+};
+
+export type ScreeningContext = AuthorityContext & {
+  applicationId?: string | null;
+  landlordId?: string | null;
+  accountOwnerId?: string | null;
+  orderId?: string | null;
+  checkoutSessionId?: string | null;
+  transactionStatus?: string | null;
+  resultId?: string | null;
+  failureCode?: string | null;
+};
+
+export type LeaseContext = AuthorityContext & {
+  leaseId?: string | null;
+  landlordId?: string | null;
+  leaseOwnerId?: string | null;
+  noticeId?: string | null;
+  noticeRequired?: boolean;
+  restoreRequested?: boolean;
+};
+
+export type MaintenanceContext = AuthorityContext & {
+  workOrderId?: string | null;
+  tenantId?: string | null;
+  landlordId?: string | null;
+  contractorId?: string | null;
+  assignedContractorId?: string | null;
+  scheduledFor?: string | number | null;
+  costTotalCents?: number | null;
+  evidenceCount?: number | null;
+};
+
+export type PaymentContext = AuthorityContext & {
+  paymentId?: string | null;
+  paymentIntentId?: string | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  ownerId?: string | null;
+  providerStatus?: string | null;
+};
+
+export type DecisionContext = AuthorityContext & {
+  decisionId?: string | null;
+  landlordId?: string | null;
+  decisionOwnerId?: string | null;
+  actionRecordExists?: boolean;
+  sourceValid?: boolean;
+  snoozedUntil?: string | null;
+};
+
+export type StateSnapshot<S extends string> = {
+  state: S;
+  terminal: boolean;
+  allowedTransitions: S[];
+  computedAt?: string;
+};
+
+export type TransitionEvent<S extends string, E extends string> = {
+  from: S;
+  to: S;
+  event: E;
+  occurredAt?: string;
+  reason?: string;
+};
+
+export type TransitionError<S extends string> = {
+  state: S;
+  reason: string;
+  code:
+    | "invalid_transition"
+    | "insufficient_authority"
+    | "missing_context"
+    | "ambiguous_state"
+    | "terminal_state"
+    | "source_invalid";
+};
+
+export type TransitionValidationResult<S extends string = string> = {
+  valid: boolean;
+  currentState: S;
+  proposedState: S;
+  allowedTransitions: S[];
+  reason?: string;
+};
+
+export type TransitionValidator<S extends string, C, E extends string> = (input: {
+  currentState: S;
+  proposedState: S;
+  event: E;
+  context: C;
+}) => TransitionError<S> | null;
+
+export type StateHandler<S extends string, C, E extends string> = (input: {
+  currentState: S;
+  proposedState: S;
+  event: E;
+  context: C;
+}) => StateSnapshot<S>;
+
+export type StateTransition<S extends string, C, E extends string> = {
+  from: S;
+  to: S;
+  event: E;
+  validators: Array<TransitionValidator<S, C, E>>;
+};
+
+export type StateMachine<S extends string, C, E extends string> = {
+  workflowType: string;
+  states: readonly S[];
+  terminalStates: readonly S[];
+  transitions: readonly StateTransition<S, C, E>[];
+  getAllowedTransitions: (state: S) => S[];
+  validateTransition: (input: {
+    currentState: S;
+    proposedState: S;
+    event: E;
+    context: C;
+  }) => TransitionValidationResult<S>;
+  snapshot: (state: S) => StateSnapshot<S>;
+};


### PR DESCRIPTION
## Summary
Implements Phase 2 review state machine infrastructure for screening, lease, maintenance, payment, and decision workflows.

## Changes
- Adds canonical state machine types, states, events, contexts, snapshots, transition errors, and validation result contracts
- Adds deterministic state computation helpers for existing persisted records
- Adds five workflow state machines: screening, lease, maintenance, payment, decision
- Adds public read-only transition validators and a state machine registry
- Adds internal validation endpoints for screening, lease, maintenance, payment, and decision transitions
- Adds debug-gated advisory markers to existing review routes without changing route behavior
- Adds isolated unit tests for state machines, state computation, validator exports, and registry behavior
- Adds docs/architecture/state-machines-v1.md with diagrams, transition rules, authority requirements, and future enforcement notes

## Validation
- npm ci: pass
- npm run test -- src/services/stateMachines/: pass, 26/26
- npm run test -- src/services/stateMachines/__tests__/: pass, 26/26
- npm run build: pass
- git diff --check: pass
- Restricted-reference scan: pass
- Full backend suite: 1979/1995 passing; 16 unrelated existing failures remain in lease draft, recipient trust/support, and analytics tests

## Scope
Backend state machine infrastructure only. No auth widening, no production data mutation, no dependency changes, no Firestore rules, no CI/CD changes, no external calls, and no frontend user-visible changes.

## Known Limitations
- State machines are advisory in this mission; mutation routes do not enforce transitions yet
- Browser form drafts and state snapshots are not persisted
- Full backend suite has unrelated existing failures documented in .handoff/impl-summary.md