### PR TITLE
Phase 2 evidence provenance infrastructure

### DIFF
--- a/docs/architecture/state-machines-v1.md
+++ b/docs/architecture/state-machines-v1.md
@@ -186,6 +186,7 @@ Implemented in this mission:
 - `rentchain-api/src/services/stateMachines/transitionValidation.ts`
 - `rentchain-api/src/services/stateMachines/stateMachineRegistry.ts`
 - Advisory markers in screening operations, lease detail, maintenance list, payment list, and decision list routes.
+- Evidence provenance helpers, builders, storage, and admin review projections for advisory transition context.
 
 Not implemented in this mission:
 
@@ -195,8 +196,56 @@ Not implemented in this mission:
 - Adding cross-workflow synchronization.
 - Adding external exports of state machine metadata.
 
+## Evidence Provenance
+
+Evidence provenance extends the V1 state machine layer with metadata-only records that describe what supported a proposed transition at validation time. It remains advisory infrastructure: existing route behavior is unchanged, evidence capture is optional, and validators still return the same `valid`, `allowedTransitions`, and `reason` contract unless capture is explicitly requested.
+
+### Capture Flow
+
+1. A caller computes current state from persisted records.
+2. The workflow validator checks authority, current state, proposed state, event, and required context.
+3. When `captureEvidence` is enabled, the validator builds a side-band provenance event using `captureTransitionEvidence()`.
+4. Workflow-specific evidence builders produce safe references for the records that informed the transition.
+5. Advisory route markers may append the event through `appendProvenanceEvent()`.
+6. Capture failure is logged and does not block the existing route response.
+
+The provenance event records the workflow type, hashed workflow instance key, from/to state, event name, validation outcome, actor role, safe actor reference, UTC timestamp, evidence reference count, and redaction summary. It does not store raw record payloads or browser form state.
+
+### Safe References
+
+Evidence references use opaque keys generated from workflow type, reference type, and a stable hash of the source reference. Labels are fixed metadata labels such as `lease lifecycle state` or `payment provider status`; raw Firestore IDs, storage paths, provider payloads, tokens, credentials, request bodies, response bodies, and sensitive field dumps are excluded.
+
+The five evidence builders are:
+
+- `buildScreeningEvidence()` for application, order, transaction, and result state.
+- `buildLeaseEvidence()` for lease lifecycle and notice context.
+- `buildMaintenanceEvidence()` for work order, cost review, and completion evidence count.
+- `buildPaymentEvidence()` for payment record and provider status metadata.
+- `buildDecisionEvidence()` for decision source, action record, and source validity.
+
+### Timestamp And Immutability Rules
+
+All provenance timestamps are ISO 8601 UTC strings. Events are append-only and immutable: storage uses create semantics where available and refuses to overwrite an existing provenance event. Integrity validation rejects events that are not metadata-only, are not append-only, have non-UTC timestamps, expose raw actor IDs, or include restricted payload-like content.
+
+### Storage And Review
+
+`provenanceStorage.ts` provides internal append and read functions:
+
+- `appendProvenanceEvent()` appends one immutable event.
+- `getProvenanceEvent()` reads one event by event key.
+- `getProvenanceChain()` returns a chronological chain for one workflow instance.
+- `queryProvenanceEvents()` filters by workflow type, actor role, outcome, and date range.
+
+`provenanceReviewService.ts` provides admin/support/landlord-safe projections for audit review. Admins can query all provenance events, support can query metadata-only review fields, and landlords can query only matching landlord-scoped provenance. Tenant-facing surfaces do not receive provenance metadata in this mission.
+
+### Audit And Compliance
+
+Provenance chains enable decision forensics by preserving the metadata that was available when a transition was validated. A screening chain can show application, order, transaction, and result references in chronological order. A lease chain can show draft activation, notice preparation, end, and restore transitions. Maintenance chains can show assignment, scheduling, cost review, completion, and rework metadata. Payment chains can show processing, confirmation, failure, refund, or retry context. Decision chains can show appearance, review, snooze, dismissal, execution, failure, and reopen context.
+
+These chains are not exported to tenants or external systems. They are internal review infrastructure for audit, compliance, recovery, and future operator workflows.
+
 ## Future Work
 
-- Phase 2 Mission 3 should attach evidence provenance to transition events and advisory snapshots.
-- Phase 2 Mission 4 should reconcile derived decisions with stored action state and canonical timeline entries.
+- Phase 2 Mission 4 should reconcile derived decisions with stored action state and canonical timeline entries, then add operator recovery workflows on top of provenance chains.
 - A later enforcement mission can convert advisory route markers into blocking transition checks once migration risks are reviewed.
+- A later review UI mission can expose provenance chains to admin/support workspaces with explicit role gates and redaction summaries.

--- a/rentchain-api/src/routes/decisionRoutes.ts
+++ b/rentchain-api/src/routes/decisionRoutes.ts
@@ -21,6 +21,7 @@ import {
 import type { RentPaymentRecord } from "../services/rentPayments/rentPaymentService";
 import { computeDecisionState } from "../services/stateMachines/stateComputation";
 import { decisionStateMachine } from "../services/stateMachines/decisionStateMachine";
+import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateDecisionTransition } from "../services/stateMachines/transitionValidation";
 import type { DecisionActionState, DecisionEvent } from "../services/stateMachines/types";
 
@@ -257,6 +258,7 @@ router.post("/validate-transition", requireAuth, async (req: any, res: Response)
     const validation = validateDecisionTransition((action || {}) as Record<string, unknown>, {
       to: String(req.body?.proposedTransition || req.body?.to || "") as DecisionActionState,
       event: String(req.body?.event || "") as DecisionEvent,
+      captureEvidence: req.body?.captureEvidence === true,
       context: {
         actorRole: isAdmin(req) ? "admin" : "landlord",
         actorId: actorIdFromReq(req),
@@ -268,6 +270,16 @@ router.post("/validate-transition", requireAuth, async (req: any, res: Response)
         snoozedUntil: asString(req.body?.snoozedUntil, 120) || null,
       },
     });
+    if (validation.provenanceEvent) {
+      try {
+        await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: isAdmin(req) ? "admin" : "landlord", landlordRef: model.landlordId },
+        });
+        res.setHeader("X-Provenance-Captured", "true");
+      } catch (error) {
+        console.warn("[provenance] decision capture skipped", { message: error instanceof Error ? error.message : "failed" });
+      }
+    }
     return res.status(200).json(buildValidationSummary(validation));
   } catch (err: any) {
     console.error("[state-machine] decision validation failed", { message: err?.message || "failed" });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -73,6 +73,7 @@ import { formatInternalReference, slugifyOperationalReference } from "../lib/ide
 import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
 import { computeLeaseState } from "../services/stateMachines/stateComputation";
 import { leaseStateMachine } from "../services/stateMachines/leaseStateMachine";
+import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateLeaseTransition } from "../services/stateMachines/transitionValidation";
 import type { LeaseEvent, LeaseLifecycleState } from "../services/stateMachines/types";
 
@@ -3087,6 +3088,7 @@ router.post("/validate-transition", requireLandlord, async (req: any, res: Respo
     const validation = validateLeaseTransition(result.lease as Record<string, unknown>, {
       to: String(req.body?.proposedTransition || req.body?.to || "") as LeaseLifecycleState,
       event: String(req.body?.event || "") as LeaseEvent,
+      captureEvidence: req.body?.captureEvidence === true,
       context: {
         actorRole: "landlord",
         actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
@@ -3098,6 +3100,16 @@ router.post("/validate-transition", requireLandlord, async (req: any, res: Respo
         restoreRequested: req.body?.restoreRequested === true,
       },
     });
+    if (validation.provenanceEvent) {
+      try {
+        await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: "landlord", landlordRef: landlordId },
+        });
+        res.setHeader("X-Provenance-Captured", "true");
+      } catch (error) {
+        console.warn("[provenance] lease capture skipped", { message: error instanceof Error ? error.message : "failed" });
+      }
+    }
     return res.status(200).json(buildValidationSummary(validation));
   } catch (err: any) {
     console.error("[state-machine] lease validation failed", { message: err?.message || "failed" });

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -31,6 +31,7 @@ import {
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { computeMaintenanceState } from "../services/stateMachines/stateComputation";
 import { maintenanceStateMachine } from "../services/stateMachines/maintenanceStateMachine";
+import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateMaintenanceTransition } from "../services/stateMachines/transitionValidation";
 import type { MaintenanceEvent, MaintenanceRequestState } from "../services/stateMachines/types";
 
@@ -1267,6 +1268,7 @@ router.post("/maintenance-requests/validate-transition", async (req: any, res) =
     const validation = validateMaintenanceTransition(workOrder, {
       to: String(req.body?.proposedTransition || req.body?.to || "") as MaintenanceRequestState,
       event: String(req.body?.event || "") as MaintenanceEvent,
+      captureEvidence: req.body?.captureEvidence === true,
       context: {
         actorRole: role === "admin" ? "admin" : "landlord",
         actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
@@ -1279,6 +1281,16 @@ router.post("/maintenance-requests/validate-transition", async (req: any, res) =
         evidenceCount: typeof req.body?.evidenceCount === "number" ? req.body.evidenceCount : null,
       },
     });
+    if (validation.provenanceEvent) {
+      try {
+        await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: role === "admin" ? "admin" : "landlord", landlordRef: landlordId },
+        });
+        res.setHeader("X-Provenance-Captured", "true");
+      } catch (error) {
+        console.warn("[provenance] maintenance capture skipped", { message: error instanceof Error ? error.message : "failed" });
+      }
+    }
     return res.status(200).json(buildValidationSummary(validation));
   } catch (err: any) {
     console.error("[state-machine] maintenance validation failed", { message: err?.message || "failed" });

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -15,6 +15,7 @@ import { db } from "../config/firebase";
 import { getEffectiveLandlordId, resolveRequestAuthority } from "../auth/requestAuthority";
 import { computePaymentState } from "../services/stateMachines/stateComputation";
 import { paymentStateMachine } from "../services/stateMachines/paymentStateMachine";
+import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validatePaymentTransition } from "../services/stateMachines/transitionValidation";
 import type { PaymentEvent, PaymentState } from "../services/stateMachines/types";
 
@@ -767,6 +768,7 @@ router.post("/payments/validate-transition", requireAuth, requirePermission("pay
     const validation = validatePaymentTransition(payment as unknown as Record<string, unknown>, {
       to: String(req.body?.proposedTransition || req.body?.to || "") as PaymentState,
       event: String(req.body?.event || "") as PaymentEvent,
+      captureEvidence: req.body?.captureEvidence === true,
       context: {
         actorRole: roleForReq(req) === "admin" ? "admin" : "landlord",
         actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
@@ -777,6 +779,16 @@ router.post("/payments/validate-transition", requireAuth, requirePermission("pay
         providerStatus: String(req.body?.providerStatus || payment.status || "").trim() || null,
       },
     });
+    if (validation.provenanceEvent) {
+      try {
+        await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: roleForReq(req) === "admin" ? "admin" : "landlord", landlordRef: landlordId },
+        });
+        res.setHeader("X-Provenance-Captured", "true");
+      } catch (error) {
+        console.warn("[provenance] payment capture skipped", { message: error instanceof Error ? error.message : "failed" });
+      }
+    }
     return res.status(200).json(buildValidationSummary(validation));
   } catch (err: any) {
     console.error("[state-machine] payment validation failed", { message: err?.message || "failed" });

--- a/rentchain-api/src/routes/screeningOpsRoutes.ts
+++ b/rentchain-api/src/routes/screeningOpsRoutes.ts
@@ -11,6 +11,7 @@ import {
   postAdminScreeningOpStart,
   postManualScreeningRequest,
 } from "../services/screeningOps/screeningOpsController";
+import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateScreeningTransition } from "../services/stateMachines/transitionValidation";
 import type { ScreeningApplicationState, ScreeningEvent } from "../services/stateMachines/types";
 
@@ -26,6 +27,7 @@ router.post("/screening/validate-transition", requireAdmin, async (req: any, res
     const result = validateScreeningTransition(application, {
       to: String(req.body?.proposedTransition || req.body?.to || "") as ScreeningApplicationState,
       event: String(req.body?.event || "") as ScreeningEvent,
+      captureEvidence: req.body?.captureEvidence === true,
       context: {
         actorRole: "admin",
         actorId: String(req.user?.id || req.user?.uid || req.user?.sub || "").trim() || null,
@@ -38,6 +40,16 @@ router.post("/screening/validate-transition", requireAdmin, async (req: any, res
         failureCode: String(req.body?.failureCode || "").trim() || null,
       },
     });
+    if (result.provenanceEvent) {
+      try {
+        await appendProvenanceEvent(result.provenanceEvent, {
+          authority: { actorRole: "admin" },
+        });
+        res.setHeader("X-Provenance-Captured", "true");
+      } catch (error) {
+        console.warn("[provenance] screening capture skipped", { message: error instanceof Error ? error.message : "failed" });
+      }
+    }
     return res.status(200).json(buildValidationSummary(result));
   } catch (err: any) {
     console.error("[state-machine] screening validation failed", { message: err?.message || "failed" });

--- a/rentchain-api/src/services/admin/__tests__/provenanceReviewService.test.ts
+++ b/rentchain-api/src/services/admin/__tests__/provenanceReviewService.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { captureTransitionEvidence, stableProvenanceHash } from "../../stateMachines/evidenceProvenance";
+import { createProvenanceFirestore } from "../../stateMachines/__tests__/testProvenanceStore";
+import type { TransitionValidationResult } from "../../stateMachines/types";
+import { loadProvenanceReviewChain, queryProvenanceReviewEvents } from "../provenanceReviewService";
+
+function leaseEvent() {
+  const validation: TransitionValidationResult<"Draft" | "Active"> = {
+    valid: true,
+    currentState: "Draft",
+    proposedState: "Active",
+    allowedTransitions: ["Active"],
+  };
+  return captureTransitionEvidence({
+    workflowType: "lease",
+    workflowInstanceId: "lease-raw-id",
+    currentState: "Draft",
+    proposedState: "Active",
+    event: "activate",
+    context: {
+      actorRole: "landlord",
+      actorId: "landlord-raw-id",
+      authorized: true,
+      landlordId: "landlord-raw-id",
+    },
+    validation,
+    occurredAt: "2026-06-01T12:00:00.000Z",
+  });
+}
+
+describe("provenance review service", () => {
+  it("projects admin chains without raw identifiers", async () => {
+    const firestore = createProvenanceFirestore([leaseEvent()]);
+    const chain = await loadProvenanceReviewChain({
+      workflowType: "lease",
+      workflowInstanceId: "lease-raw-id",
+      role: "admin",
+      firestore,
+    });
+
+    expect(chain.events).toHaveLength(1);
+    expect(chain.events[0].metadataOnly).toBe(true);
+    expect(JSON.stringify(chain)).not.toContain("lease-raw-id");
+    expect(JSON.stringify(chain)).not.toContain("landlord-raw-id");
+  });
+
+  it("allows landlord review only for matching authority reference", async () => {
+    const firestore = createProvenanceFirestore([leaseEvent()]);
+    const allowed = await queryProvenanceReviewEvents({
+      workflowType: "lease",
+      role: "landlord",
+      landlordRef: "landlord-raw-id",
+      firestore,
+    });
+    const denied = await queryProvenanceReviewEvents({
+      workflowType: "lease",
+      role: "landlord",
+      landlordRef: "other-landlord",
+      firestore,
+    });
+
+    expect(allowed).toHaveLength(1);
+    expect(denied).toHaveLength(0);
+    expect(allowed[0].workflowInstanceKey).toContain(stableProvenanceHash("lease-raw-id"));
+  });
+
+  it("allows support metadata review without exposing actor references", async () => {
+    const firestore = createProvenanceFirestore([leaseEvent()]);
+    const events = await queryProvenanceReviewEvents({ workflowType: "lease", role: "support", firestore });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].actorRole).toBe("landlord");
+    expect(JSON.stringify(events[0])).not.toContain("actor:");
+  });
+});

--- a/rentchain-api/src/services/admin/provenanceReviewService.ts
+++ b/rentchain-api/src/services/admin/provenanceReviewService.ts
@@ -1,0 +1,115 @@
+import {
+  getProvenanceChain,
+  queryProvenanceEvents,
+  type FirestoreLike,
+  type ProvenanceAuthority,
+} from "../stateMachines/provenanceStorage";
+import type {
+  ActorRole,
+  EvidenceChain,
+  EvidenceReference,
+  ReviewWorkflowType,
+  TransitionProvenanceEvent,
+} from "../stateMachines/types";
+
+export type ProvenanceReviewRole = "admin" | "support" | "landlord";
+
+export type ProvenanceReviewEvent = {
+  eventId: string;
+  workflowType: ReviewWorkflowType;
+  workflowInstanceKey: string;
+  fromState: string;
+  toState: string;
+  event: string;
+  outcome: "valid" | "invalid";
+  reason: string | null;
+  actorRole: ActorRole;
+  occurredAt: string;
+  evidenceRefs: EvidenceReference[];
+  metadataOnly: true;
+  redactionSummary: string;
+};
+
+export type ProvenanceReviewChain = {
+  workflowType: ReviewWorkflowType;
+  workflowInstanceKey: string;
+  events: ProvenanceReviewEvent[];
+  metadataOnly: true;
+};
+
+export type ProvenanceReviewQuery = {
+  workflowType?: ReviewWorkflowType;
+  workflowInstanceId?: string;
+  actorRole?: ActorRole;
+  outcome?: "valid" | "invalid";
+  from?: string;
+  to?: string;
+  role: ProvenanceReviewRole;
+  landlordRef?: string | null;
+  firestore?: FirestoreLike;
+};
+
+function authorityFor(input: { role: ProvenanceReviewRole; landlordRef?: string | null }): ProvenanceAuthority {
+  return {
+    actorRole: input.role,
+    landlordRef: input.landlordRef || null,
+    supportAllowed: input.role === "support",
+  };
+}
+
+function projectEvent(event: TransitionProvenanceEvent, role: ProvenanceReviewRole): ProvenanceReviewEvent {
+  return {
+    eventId: event.eventId,
+    workflowType: event.workflowType,
+    workflowInstanceKey: event.workflowInstanceKey,
+    fromState: event.transition.from,
+    toState: event.transition.to,
+    event: event.transition.event,
+    outcome: event.transition.outcome,
+    reason: role === "support" ? event.transition.reason : event.transition.reason,
+    actorRole: event.actor.actorRole,
+    occurredAt: event.occurredAt,
+    evidenceRefs: event.evidenceRefs,
+    metadataOnly: true,
+    redactionSummary: event.redactionSummary,
+  };
+}
+
+function projectChain(chain: EvidenceChain, role: ProvenanceReviewRole): ProvenanceReviewChain {
+  return {
+    workflowType: chain.workflowType,
+    workflowInstanceKey: chain.workflowInstanceKey,
+    events: chain.events.map((event) => projectEvent(event, role)),
+    metadataOnly: true,
+  };
+}
+
+export async function loadProvenanceReviewChain(input: {
+  workflowType: ReviewWorkflowType;
+  workflowInstanceId: string;
+  role: ProvenanceReviewRole;
+  landlordRef?: string | null;
+  firestore?: FirestoreLike;
+}): Promise<ProvenanceReviewChain> {
+  const chain = await getProvenanceChain({
+    workflowType: input.workflowType,
+    workflowInstanceId: input.workflowInstanceId,
+    authority: authorityFor(input),
+    firestore: input.firestore,
+  });
+  return projectChain(chain, input.role);
+}
+
+export async function queryProvenanceReviewEvents(input: ProvenanceReviewQuery): Promise<ProvenanceReviewEvent[]> {
+  const events = await queryProvenanceEvents({
+    workflowType: input.workflowType,
+    workflowInstanceId: input.workflowInstanceId,
+    actorRole: input.actorRole,
+    outcome: input.outcome,
+    from: input.from,
+    to: input.to,
+    authority: authorityFor(input),
+    firestore: input.firestore,
+  });
+  return events.map((event) => projectEvent(event, input.role));
+}

--- a/rentchain-api/src/services/stateMachines/__tests__/evidenceBuilders.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/evidenceBuilders.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDecisionEvidence,
+  buildLeaseEvidence,
+  buildMaintenanceEvidence,
+  buildPaymentEvidence,
+  buildScreeningEvidence,
+} from "../evidenceBuilders";
+
+describe("workflow evidence builders", () => {
+  it("builds screening evidence without raw identifiers", () => {
+    const refs = buildScreeningEvidence({
+      application: { id: "application-raw-id" },
+      order: { id: "order-raw-id" },
+      result: { id: "result-raw-id" },
+    });
+    expect(refs.map((ref) => ref.referenceType)).toEqual(["application", "order", "result"]);
+    expect(JSON.stringify(refs)).not.toContain("application-raw-id");
+  });
+
+  it("builds lease evidence with notice context", () => {
+    const refs = buildLeaseEvidence({ lease: { id: "lease-raw-id", latestNoticeId: "notice-raw-id" } });
+    expect(refs.map((ref) => ref.referenceType)).toEqual(["lease", "notice"]);
+    expect(refs.every((ref) => ref.metadataOnly && !ref.rawIdsIncluded)).toBe(true);
+  });
+
+  it("builds maintenance evidence for work order, cost, and completion evidence", () => {
+    const refs = buildMaintenanceEvidence({
+      workOrder: { id: "work-order-raw-id" },
+      context: {
+        actorRole: "landlord",
+        authorized: true,
+        workOrderId: "work-order-raw-id",
+        costTotalCents: 12000,
+        evidenceCount: 2,
+      },
+    });
+    expect(refs.map((ref) => ref.referenceType)).toEqual(["work_order", "cost", "attachment"]);
+  });
+
+  it("builds payment evidence with provider status as metadata-only reference", () => {
+    const refs = buildPaymentEvidence({
+      payment: { id: "payment-raw-id" },
+      context: {
+        actorRole: "landlord",
+        authorized: true,
+        paymentId: "payment-raw-id",
+        paymentIntentId: "intent-raw-id",
+        providerStatus: "confirmed",
+      },
+    });
+    expect(refs.map((ref) => ref.referenceType)).toEqual(["payment", "provider_status"]);
+    expect(JSON.stringify(refs)).not.toContain("intent-raw-id");
+  });
+
+  it("builds decision evidence for source and action records", () => {
+    const refs = buildDecisionEvidence({
+      context: {
+        actorRole: "landlord",
+        authorized: true,
+        decisionId: "decision-raw-id",
+        actionRecordExists: true,
+        sourceValid: true,
+      },
+    });
+    expect(refs.map((ref) => ref.referenceType)).toEqual(["decision", "action", "source"]);
+    expect(JSON.stringify(refs)).not.toContain("decision-raw-id");
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/evidenceProvenance.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/evidenceProvenance.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureTransitionEvidence,
+  hasRestrictedProvenanceContent,
+  validateProvenanceIntegrity,
+} from "../evidenceProvenance";
+import type { TransitionValidationResult } from "../types";
+
+describe("evidence provenance capture", () => {
+  it("creates immutable metadata-only transition events with safe actor references", () => {
+    const validation: TransitionValidationResult<"Pending" | "Processing"> = {
+      valid: true,
+      currentState: "Pending",
+      proposedState: "Processing",
+      allowedTransitions: ["Pending"],
+    };
+
+    const event = captureTransitionEvidence({
+      workflowType: "payment",
+      workflowInstanceId: "payment-raw-id",
+      currentState: "Pending",
+      proposedState: "Processing",
+      event: "start_processing",
+      context: {
+        actorRole: "landlord",
+        actorId: "landlord-raw-id",
+        authorized: true,
+        landlordId: "landlord-raw-id",
+      },
+      validation,
+      occurredAt: "2026-06-01T12:00:00.000Z",
+    });
+
+    expect(event.immutable).toBe(true);
+    expect(event.metadata.metadataOnly).toBe(true);
+    expect(event.metadata.tenantVisible).toBe(false);
+    expect(event.metadata.landlordVisible).toBe(false);
+    expect(event.actor.actorRef).toMatch(/^actor:/);
+    expect(JSON.stringify(event)).not.toContain("landlord-raw-id");
+    expect(JSON.stringify(event)).not.toContain("payment-raw-id");
+    expect(validateProvenanceIntegrity(event)).toEqual({ valid: true });
+  });
+
+  it("marks invalid transitions without exposing sensitive context", () => {
+    const validation: TransitionValidationResult<"Pending" | "Confirmed" | "Processing"> = {
+      valid: false,
+      currentState: "Pending",
+      proposedState: "Confirmed",
+      allowedTransitions: ["Processing"],
+      reason: "Transition from Pending to Confirmed is not allowed.",
+    };
+
+    const event = captureTransitionEvidence({
+      workflowType: "payment",
+      workflowInstanceId: "payment-raw-id",
+      currentState: "Pending",
+      proposedState: "Confirmed",
+      event: "confirm",
+      context: { actorRole: "tenant", authorized: false },
+      validation,
+      occurredAt: "2026-06-01T12:00:00.000Z",
+    });
+
+    expect(event.transition.outcome).toBe("invalid");
+    expect(event.contextSummary.authorityResolved).toBe(false);
+    expect(validateProvenanceIntegrity(event).valid).toBe(true);
+  });
+
+  it("detects restricted payload-like evidence content", () => {
+    expect(hasRestrictedProvenanceContent({ label: "token secret" })).toBe(true);
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/provenanceStorage.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/provenanceStorage.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { captureTransitionEvidence, workflowInstanceKey } from "../evidenceProvenance";
+import {
+  appendProvenanceEvent,
+  getProvenanceChain,
+  getProvenanceEvent,
+  queryProvenanceEvents,
+} from "../provenanceStorage";
+import type { TransitionValidationResult } from "../types";
+import { createProvenanceFirestore } from "./testProvenanceStore";
+
+function eventFor(occurredAt: string) {
+  const validation: TransitionValidationResult<"Draft" | "Active"> = {
+    valid: true,
+    currentState: "Draft",
+    proposedState: "Active",
+    allowedTransitions: ["Active"],
+  };
+  return captureTransitionEvidence({
+    workflowType: "lease",
+    workflowInstanceId: "lease-raw-id",
+    currentState: "Draft",
+    proposedState: "Active",
+    event: "activate",
+    context: {
+      actorRole: "landlord",
+      actorId: "landlord-raw-id",
+      authorized: true,
+      landlordId: "landlord-raw-id",
+    },
+    validation,
+    occurredAt,
+  });
+}
+
+describe("provenance storage", () => {
+  it("appends events immutably and retrieves a single event", async () => {
+    const firestore = createProvenanceFirestore();
+    const event = eventFor("2026-06-01T12:00:00.000Z");
+
+    await appendProvenanceEvent(event, { authority: { actorRole: "landlord", landlordRef: "landlord-raw-id" }, firestore });
+    await expect(
+      appendProvenanceEvent(event, { authority: { actorRole: "landlord", landlordRef: "landlord-raw-id" }, firestore })
+    ).rejects.toThrow(
+      "already_exists"
+    );
+
+    const loaded = await getProvenanceEvent(event.eventId, { authority: { actorRole: "admin" }, firestore });
+    expect(loaded?.eventId).toBe(event.eventId);
+  });
+
+  it("returns chains in chronological order for authorized readers", async () => {
+    const later = eventFor("2026-06-01T13:00:00.000Z");
+    const earlier = eventFor("2026-06-01T12:00:00.000Z");
+    const firestore = createProvenanceFirestore([later, earlier]);
+
+    const chain = await getProvenanceChain({
+      workflowType: "lease",
+      workflowInstanceId: "lease-raw-id",
+      authority: { actorRole: "admin" },
+      firestore,
+    });
+
+    expect(chain.workflowInstanceKey).toBe(workflowInstanceKey("lease", "lease-raw-id"));
+    expect(chain.events.map((event) => event.occurredAt)).toEqual([
+      "2026-06-01T12:00:00.000Z",
+      "2026-06-01T13:00:00.000Z",
+    ]);
+  });
+
+  it("filters audit queries by workflow and outcome", async () => {
+    const firestore = createProvenanceFirestore([eventFor("2026-06-01T12:00:00.000Z")]);
+    const events = await queryProvenanceEvents({
+      workflowType: "lease",
+      outcome: "valid",
+      authority: { actorRole: "admin" },
+      firestore,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].workflowType).toBe("lease");
+  });
+
+  it("denies tenant access to landlord provenance", async () => {
+    const event = eventFor("2026-06-01T12:00:00.000Z");
+    const firestore = createProvenanceFirestore([event]);
+    const loaded = await getProvenanceEvent(event.eventId, {
+      authority: { actorRole: "tenant", tenantRef: "access:not-matching" },
+      firestore,
+    });
+    expect(loaded).toBeNull();
+  });
+});

--- a/rentchain-api/src/services/stateMachines/__tests__/testProvenanceStore.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/testProvenanceStore.ts
@@ -1,0 +1,58 @@
+import type { FirestoreLike } from "../provenanceStorage";
+import type { TransitionProvenanceEvent } from "../types";
+
+type Stored = TransitionProvenanceEvent;
+
+type Filter = {
+  field: string;
+  value: unknown;
+};
+
+type Store = Map<string, Stored>;
+
+function valueAt(record: Record<string, unknown>, field: string): unknown {
+  return field.split(".").reduce<unknown>((current, key) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[key];
+  }, record);
+}
+
+function collectionFor(store: Store, filters: Filter[] = []) {
+  const nextFilters = filters;
+  return {
+    doc: (id?: string) => {
+      const docId = id || `doc-${store.size + 1}`;
+      return {
+        async get() {
+          const data = store.get(docId);
+          return { exists: Boolean(data), id: docId, data: () => data };
+        },
+        async create(data: Stored) {
+          if (store.has(docId)) throw new Error("already_exists");
+          store.set(docId, data);
+        },
+        async set(data: Stored) {
+          store.set(docId, data);
+        },
+      };
+    },
+    where: (field: string, _op: string, value: unknown) => collectionFor(store, [...nextFilters, { field, value }]),
+    orderBy: () => collectionFor(store, nextFilters),
+    limit: () => collectionFor(store, nextFilters),
+    async get() {
+      const docs = [...store.entries()]
+        .filter(([, event]) =>
+          nextFilters.every((filter) => valueAt(event as unknown as Record<string, unknown>, filter.field) === filter.value)
+        )
+        .map(([id, event]) => ({ exists: true, id, data: () => event }));
+      return { docs };
+    },
+  };
+}
+
+export function createProvenanceFirestore(events: TransitionProvenanceEvent[] = []): FirestoreLike {
+  const store: Store = new Map(events.map((event) => [event.eventId, event]));
+  return {
+    collection: () => collectionFor(store),
+  };
+}

--- a/rentchain-api/src/services/stateMachines/evidenceBuilders/decisionEvidence.ts
+++ b/rentchain-api/src/services/stateMachines/evidenceBuilders/decisionEvidence.ts
@@ -1,0 +1,34 @@
+import { buildEvidenceReference, compactEvidenceRefs, readRecordId } from "../evidenceProvenance";
+import type { DecisionContext, EvidenceReference, RecordLike } from "../types";
+
+export function buildDecisionEvidence(input: {
+  decisionAction?: RecordLike | null;
+  context?: DecisionContext;
+}): EvidenceReference[] {
+  return compactEvidenceRefs([
+    buildEvidenceReference({
+      workflowType: "decision",
+      referenceType: "decision",
+      referenceId: input.context?.decisionId || readRecordId(input.decisionAction, ["decisionId", "id"]),
+      label: "decision source state",
+    }),
+    buildEvidenceReference({
+      workflowType: "decision",
+      referenceType: "action",
+      referenceId:
+        input.context?.actionRecordExists === true
+          ? input.context.decisionId || readRecordId(input.decisionAction, ["decisionId", "id"])
+          : null,
+      label: "decision action record",
+    }),
+    buildEvidenceReference({
+      workflowType: "decision",
+      referenceType: "source",
+      referenceId:
+        input.context?.sourceValid === true
+          ? input.context.decisionId || readRecordId(input.decisionAction, ["decisionId", "id"])
+          : null,
+      label: "decision source validity",
+    }),
+  ]);
+}

--- a/rentchain-api/src/services/stateMachines/evidenceBuilders/index.ts
+++ b/rentchain-api/src/services/stateMachines/evidenceBuilders/index.ts
@@ -1,0 +1,5 @@
+export { buildDecisionEvidence } from "./decisionEvidence";
+export { buildLeaseEvidence } from "./leaseEvidence";
+export { buildMaintenanceEvidence } from "./maintenanceEvidence";
+export { buildPaymentEvidence } from "./paymentEvidence";
+export { buildScreeningEvidence } from "./screeningEvidence";

--- a/rentchain-api/src/services/stateMachines/evidenceBuilders/leaseEvidence.ts
+++ b/rentchain-api/src/services/stateMachines/evidenceBuilders/leaseEvidence.ts
@@ -1,0 +1,19 @@
+import { buildEvidenceReference, compactEvidenceRefs, readRecordId } from "../evidenceProvenance";
+import type { EvidenceReference, LeaseContext, RecordLike } from "../types";
+
+export function buildLeaseEvidence(input: { lease?: RecordLike | null; context?: LeaseContext }): EvidenceReference[] {
+  return compactEvidenceRefs([
+    buildEvidenceReference({
+      workflowType: "lease",
+      referenceType: "lease",
+      referenceId: input.context?.leaseId || readRecordId(input.lease, ["id", "leaseId"]),
+      label: "lease lifecycle state",
+    }),
+    buildEvidenceReference({
+      workflowType: "lease",
+      referenceType: "notice",
+      referenceId: input.context?.noticeId || readRecordId(input.lease, ["latestNoticeId", "noticeId"]),
+      label: "lease notice context",
+    }),
+  ]);
+}

--- a/rentchain-api/src/services/stateMachines/evidenceBuilders/maintenanceEvidence.ts
+++ b/rentchain-api/src/services/stateMachines/evidenceBuilders/maintenanceEvidence.ts
@@ -1,0 +1,32 @@
+import { buildEvidenceReference, compactEvidenceRefs, readRecordId } from "../evidenceProvenance";
+import type { EvidenceReference, MaintenanceContext, RecordLike } from "../types";
+
+export function buildMaintenanceEvidence(input: {
+  workOrder?: RecordLike | null;
+  context?: MaintenanceContext;
+}): EvidenceReference[] {
+  const workOrder = input.workOrder || {};
+  return compactEvidenceRefs([
+    buildEvidenceReference({
+      workflowType: "maintenance",
+      referenceType: "work_order",
+      referenceId: input.context?.workOrderId || readRecordId(workOrder, ["id", "workOrderId", "requestId"]),
+      label: "maintenance request state",
+    }),
+    buildEvidenceReference({
+      workflowType: "maintenance",
+      referenceType: "cost",
+      referenceId: input.context?.costTotalCents != null ? `${input.context.workOrderId || readRecordId(workOrder, ["id"])}:cost` : null,
+      label: "maintenance cost review context",
+    }),
+    buildEvidenceReference({
+      workflowType: "maintenance",
+      referenceType: "attachment",
+      referenceId:
+        input.context?.evidenceCount != null
+          ? `${input.context.workOrderId || readRecordId(workOrder, ["id"])}:evidence:${input.context.evidenceCount}`
+          : null,
+      label: "maintenance completion evidence count",
+    }),
+  ]);
+}

--- a/rentchain-api/src/services/stateMachines/evidenceBuilders/paymentEvidence.ts
+++ b/rentchain-api/src/services/stateMachines/evidenceBuilders/paymentEvidence.ts
@@ -1,0 +1,22 @@
+import { buildEvidenceReference, compactEvidenceRefs, readRecordId } from "../evidenceProvenance";
+import type { EvidenceReference, PaymentContext, RecordLike } from "../types";
+
+export function buildPaymentEvidence(input: { payment?: RecordLike | null; context?: PaymentContext }): EvidenceReference[] {
+  return compactEvidenceRefs([
+    buildEvidenceReference({
+      workflowType: "payment",
+      referenceType: "payment",
+      referenceId: input.context?.paymentId || readRecordId(input.payment, ["id", "paymentId"]),
+      label: "payment record state",
+    }),
+    buildEvidenceReference({
+      workflowType: "payment",
+      referenceType: "provider_status",
+      referenceId:
+        input.context?.providerStatus && (input.context?.paymentId || readRecordId(input.payment, ["id", "paymentId"]))
+          ? `${input.context.paymentId || readRecordId(input.payment, ["id", "paymentId"])}:${input.context.providerStatus}`
+          : null,
+      label: "payment provider status",
+    }),
+  ]);
+}

--- a/rentchain-api/src/services/stateMachines/evidenceBuilders/screeningEvidence.ts
+++ b/rentchain-api/src/services/stateMachines/evidenceBuilders/screeningEvidence.ts
@@ -1,0 +1,37 @@
+import { buildEvidenceReference, compactEvidenceRefs, readRecordId } from "../evidenceProvenance";
+import type { EvidenceReference, RecordLike, ScreeningContext } from "../types";
+
+export function buildScreeningEvidence(input: {
+  application?: RecordLike | null;
+  order?: RecordLike | null;
+  transaction?: RecordLike | null;
+  result?: RecordLike | null;
+  context?: ScreeningContext;
+}): EvidenceReference[] {
+  return compactEvidenceRefs([
+    buildEvidenceReference({
+      workflowType: "screening",
+      referenceType: "application",
+      referenceId: input.context?.applicationId || readRecordId(input.application, ["id", "applicationId"]),
+      label: "screening application state",
+    }),
+    buildEvidenceReference({
+      workflowType: "screening",
+      referenceType: "order",
+      referenceId: input.context?.orderId || readRecordId(input.order, ["id", "orderId"]),
+      label: "screening order state",
+    }),
+    buildEvidenceReference({
+      workflowType: "screening",
+      referenceType: "transaction",
+      referenceId: readRecordId(input.transaction, ["id", "transactionId", "paymentId"]),
+      label: "screening transaction status",
+    }),
+    buildEvidenceReference({
+      workflowType: "screening",
+      referenceType: "result",
+      referenceId: input.context?.resultId || readRecordId(input.result, ["id", "resultId"]),
+      label: "screening result availability",
+    }),
+  ]);
+}

--- a/rentchain-api/src/services/stateMachines/evidenceProvenance.ts
+++ b/rentchain-api/src/services/stateMachines/evidenceProvenance.ts
@@ -1,0 +1,192 @@
+import crypto from "crypto";
+import type {
+  ActorRole,
+  AuthorityContext,
+  EvidenceReference,
+  EvidenceReferenceType,
+  ProvenanceMetadata,
+  RecordLike,
+  ReviewWorkflowType,
+  TransitionProvenanceEvent,
+  TransitionValidationResult,
+  WorkflowEvent,
+  WorkflowState,
+} from "./types";
+
+const PROVENANCE_REDACTION_SUMMARY =
+  "Evidence provenance is metadata-only. Raw Firestore IDs, storage paths, provider payloads, tokens, credentials, request bodies, response bodies, and sensitive field dumps are excluded.";
+
+const RESTRICTED_VALUE_PATTERN =
+  /token|secret|credential|authorization|cookie|password|bearer|provider payload|raw report|request body|response body|stacktrace|stack trace|gs:\/\/|storage\.googleapis\.com/i;
+
+export function stableProvenanceHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex").slice(0, 20);
+}
+
+export function provenanceMetadata(): ProvenanceMetadata {
+  return {
+    metadataOnly: true,
+    appendOnly: true,
+    visibilityClass: "admin_support_internal",
+    tenantVisible: false,
+    landlordVisible: false,
+    source: "state_machine_advisory",
+    timestampFormat: "iso_8601_utc",
+  };
+}
+
+export function toUtcIso(value?: unknown): string {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+export function safeProvenanceLabel(value: unknown, fallback: string, max = 120): string {
+  const label = String(value ?? "").replace(/[<>]/g, "").replace(/\s+/g, " ").trim().slice(0, max);
+  if (!label || RESTRICTED_VALUE_PATTERN.test(label)) return fallback;
+  if (/^[A-Za-z0-9_-]{16,}$/.test(label)) return fallback;
+  return label;
+}
+
+export function safeReferenceKey(workflowType: ReviewWorkflowType, referenceType: EvidenceReferenceType, value: unknown): string {
+  return `${workflowType}:${referenceType}:${stableProvenanceHash(value)}`;
+}
+
+export function workflowInstanceKey(workflowType: ReviewWorkflowType, instanceId: unknown): string {
+  return `${workflowType}:instance:${stableProvenanceHash(instanceId)}`;
+}
+
+export function actorSummary(context: AuthorityContext): TransitionProvenanceEvent["actor"] {
+  const actorId = String(context.actorId ?? "").trim();
+  return {
+    actorRole: context.actorRole,
+    actorRef: actorId ? `actor:${stableProvenanceHash([context.actorRole, actorId])}` : null,
+    rawActorIdsIncluded: false,
+  };
+}
+
+function accessRef(value: unknown): string | null {
+  const raw = String(value ?? "").trim();
+  return raw ? `access:${stableProvenanceHash(raw)}` : null;
+}
+
+function contextValue(context: AuthorityContext & Record<string, unknown>, key: "landlordId" | "ownerId" | "tenantId"): unknown {
+  return (context as Record<string, unknown>)[key];
+}
+
+export function buildEvidenceReference(input: {
+  workflowType: ReviewWorkflowType;
+  referenceType: EvidenceReferenceType;
+  referenceId?: unknown;
+  label?: unknown;
+}): EvidenceReference | null {
+  const referenceId = String(input.referenceId ?? "").trim();
+  if (!referenceId) return null;
+  return {
+    referenceKey: safeReferenceKey(input.workflowType, input.referenceType, referenceId),
+    referenceType: input.referenceType,
+    label: safeProvenanceLabel(input.label, `${input.referenceType} reference`),
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function compactEvidenceRefs(refs: Array<EvidenceReference | null | undefined>): EvidenceReference[] {
+  const byKey = new Map<string, EvidenceReference>();
+  for (const ref of refs) {
+    if (!ref?.referenceKey) continue;
+    byKey.set(ref.referenceKey, ref);
+  }
+  return [...byKey.values()].slice(0, 25);
+}
+
+export function readRecordId(record: RecordLike | null | undefined, fields: readonly string[]): string | null {
+  if (!record) return null;
+  for (const field of fields) {
+    const value = String(record[field] ?? "").trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+export function hasRestrictedProvenanceContent(value: unknown): boolean {
+  return RESTRICTED_VALUE_PATTERN.test(JSON.stringify(value ?? {}));
+}
+
+export function captureTransitionEvidence<S extends WorkflowState, E extends WorkflowEvent>(input: {
+  workflowType: ReviewWorkflowType;
+  workflowInstanceId: string;
+  currentState: S;
+  proposedState: S;
+  event: E;
+  context: AuthorityContext & Record<string, unknown>;
+  validation: TransitionValidationResult<S>;
+  evidenceRefs?: EvidenceReference[];
+  occurredAt?: unknown;
+}): TransitionProvenanceEvent<S, E> {
+  const occurredAt = toUtcIso(input.occurredAt);
+  const instanceKey = workflowInstanceKey(input.workflowType, input.workflowInstanceId);
+  const refs = compactEvidenceRefs(input.evidenceRefs || []);
+  return {
+    eventId: `transition_provenance:${stableProvenanceHash([
+      input.workflowType,
+      instanceKey,
+      input.currentState,
+      input.proposedState,
+      input.event,
+      occurredAt,
+      input.context.actorRole,
+      input.context.actorId || null,
+    ])}`,
+    workflowType: input.workflowType,
+    workflowInstanceKey: instanceKey,
+    transition: {
+      from: input.currentState,
+      to: input.proposedState,
+      event: input.event,
+      outcome: input.validation.valid ? "valid" : "invalid",
+      reason: input.validation.reason || null,
+    },
+    actor: actorSummary(input.context),
+    access: {
+      landlordRef: accessRef(contextValue(input.context, "landlordId") || contextValue(input.context, "ownerId")),
+      tenantRef: accessRef(contextValue(input.context, "tenantId")),
+      rawIdsIncluded: false,
+    },
+    occurredAt,
+    evidenceRefs: refs,
+    contextSummary: {
+      requiredContextPresent: !input.validation.reason?.toLowerCase().includes("missing required context"),
+      authorityResolved: input.context.authorized === true,
+      evidenceRefCount: refs.length,
+      rawPayloadIncluded: false,
+    },
+    metadata: provenanceMetadata(),
+    immutable: true,
+    redactionSummary: PROVENANCE_REDACTION_SUMMARY,
+  };
+}
+
+export function validateProvenanceIntegrity(event: TransitionProvenanceEvent): { valid: boolean; reason?: string } {
+  if (!event.immutable || event.metadata.appendOnly !== true || event.metadata.metadataOnly !== true) {
+    return { valid: false, reason: "provenance_event_not_append_safe" };
+  }
+  if (!event.occurredAt.endsWith("Z") || Number.isNaN(Date.parse(event.occurredAt))) {
+    return { valid: false, reason: "provenance_timestamp_not_iso_utc" };
+  }
+  if (event.metadata.tenantVisible || event.metadata.landlordVisible) {
+    return { valid: false, reason: "provenance_visibility_not_internal" };
+  }
+  if (event.actor.rawActorIdsIncluded || event.contextSummary.rawPayloadIncluded) {
+    return { valid: false, reason: "provenance_raw_identifier_or_payload_included" };
+  }
+  if (hasRestrictedProvenanceContent(event.evidenceRefs)) {
+    return { valid: false, reason: "provenance_restricted_content_detected" };
+  }
+  return { valid: true };
+}

--- a/rentchain-api/src/services/stateMachines/provenanceStorage.ts
+++ b/rentchain-api/src/services/stateMachines/provenanceStorage.ts
@@ -1,0 +1,188 @@
+import { db } from "../../config/firebase";
+import {
+  provenanceMetadata,
+  stableProvenanceHash,
+  validateProvenanceIntegrity,
+  workflowInstanceKey,
+} from "./evidenceProvenance";
+import type {
+  ActorRole,
+  EvidenceChain,
+  ReviewWorkflowType,
+  TransitionProvenanceEvent,
+} from "./types";
+
+export const PROVENANCE_EVENTS_COLLECTION = "transitionProvenanceEvents";
+
+export type ProvenanceAuthority = {
+  actorRole: ActorRole;
+  actorRef?: string | null;
+  landlordRef?: string | null;
+  tenantRef?: string | null;
+  supportAllowed?: boolean;
+};
+
+type DocSnapshotLike = {
+  exists?: boolean;
+  id?: string;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type QuerySnapshotLike = {
+  docs: DocSnapshotLike[];
+};
+
+type DocumentRefLike = {
+  get?: () => Promise<DocSnapshotLike>;
+  set?: (data: TransitionProvenanceEvent, options?: { merge?: boolean }) => Promise<unknown>;
+  create?: (data: TransitionProvenanceEvent) => Promise<unknown>;
+};
+
+type QueryLike = {
+  where: (field: string, op: string, value: unknown) => QueryLike;
+  orderBy?: (field: string, direction?: "asc" | "desc") => QueryLike;
+  limit?: (count: number) => QueryLike;
+  get: () => Promise<QuerySnapshotLike>;
+};
+
+type CollectionLike = QueryLike & {
+  doc: (id?: string) => DocumentRefLike;
+};
+
+export type FirestoreLike = {
+  collection: (name: string) => CollectionLike;
+};
+
+export type ProvenanceQuery = {
+  workflowType?: ReviewWorkflowType;
+  workflowInstanceId?: string;
+  actorRole?: ActorRole;
+  outcome?: "valid" | "invalid";
+  from?: string;
+  to?: string;
+  limit?: number;
+  authority: ProvenanceAuthority;
+  firestore?: FirestoreLike;
+};
+
+function collection(firestore?: FirestoreLike): CollectionLike {
+  return (firestore || (db as unknown as FirestoreLike)).collection(PROVENANCE_EVENTS_COLLECTION);
+}
+
+function normalizedAccessRef(value: string | null | undefined): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  return raw.startsWith("access:") ? raw : `access:${stableProvenanceHash(raw)}`;
+}
+
+function canAccessProvenance(authority: ProvenanceAuthority, event: TransitionProvenanceEvent): boolean {
+  if (authority.actorRole === "admin") return true;
+  if (authority.actorRole === "support") return authority.supportAllowed === true;
+  if (authority.actorRole === "landlord") {
+    return Boolean(normalizedAccessRef(authority.landlordRef) && event.access.landlordRef === normalizedAccessRef(authority.landlordRef));
+  }
+  if (authority.actorRole === "tenant") {
+    return Boolean(normalizedAccessRef(authority.tenantRef) && event.access.tenantRef === normalizedAccessRef(authority.tenantRef));
+  }
+  return false;
+}
+
+function eventFromSnapshot(snapshot: DocSnapshotLike): TransitionProvenanceEvent | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  const candidate = data as unknown as TransitionProvenanceEvent;
+  const integrity = validateProvenanceIntegrity(candidate);
+  return integrity.valid ? candidate : null;
+}
+
+function sortEvents(events: TransitionProvenanceEvent[]): TransitionProvenanceEvent[] {
+  return [...events].sort((a, b) => `${a.occurredAt}:${a.eventId}`.localeCompare(`${b.occurredAt}:${b.eventId}`));
+}
+
+export async function appendProvenanceEvent(
+  event: TransitionProvenanceEvent,
+  options: { authority: ProvenanceAuthority; firestore?: FirestoreLike }
+): Promise<TransitionProvenanceEvent> {
+  if (options.authority.actorRole !== "admin" && options.authority.actorRole !== "landlord" && options.authority.actorRole !== "system") {
+    throw new Error("provenance_append_forbidden");
+  }
+  const integrity = validateProvenanceIntegrity(event);
+  if (!integrity.valid) throw new Error(integrity.reason || "provenance_integrity_failed");
+  if (options.authority.actorRole === "landlord" && !canAccessProvenance(options.authority, event)) {
+    throw new Error("provenance_append_forbidden");
+  }
+  const ref = collection(options.firestore).doc(event.eventId);
+  if (ref.create) {
+    await ref.create(event);
+    return event;
+  }
+  const existing = ref.get ? await ref.get() : null;
+  if (existing?.exists) throw new Error("provenance_event_already_exists");
+  if (!ref.set) throw new Error("provenance_storage_unavailable");
+  await ref.set(event, { merge: false });
+  return event;
+}
+
+export async function getProvenanceEvent(
+  eventId: string,
+  options: { authority: ProvenanceAuthority; firestore?: FirestoreLike }
+): Promise<TransitionProvenanceEvent | null> {
+  const snap = await collection(options.firestore).doc(eventId).get?.();
+  if (!snap?.exists) return null;
+  const event = eventFromSnapshot(snap);
+  if (!event || !canAccessProvenance(options.authority, event)) return null;
+  return event;
+}
+
+export async function getProvenanceChain(input: {
+  workflowType: ReviewWorkflowType;
+  workflowInstanceId: string;
+  authority: ProvenanceAuthority;
+  firestore?: FirestoreLike;
+}): Promise<EvidenceChain> {
+  const instanceKey = workflowInstanceKey(input.workflowType, input.workflowInstanceId);
+  let query = collection(input.firestore)
+    .where("workflowType", "==", input.workflowType)
+    .where("workflowInstanceKey", "==", instanceKey);
+  if (query.orderBy) query = query.orderBy("occurredAt", "asc");
+  const snap = await query.get();
+  const events = sortEvents(
+    snap.docs
+      .map(eventFromSnapshot)
+      .filter((event): event is TransitionProvenanceEvent => Boolean(event))
+      .filter((event) => canAccessProvenance(input.authority, event))
+  );
+  return {
+    workflowType: input.workflowType,
+    workflowInstanceKey: instanceKey,
+    events,
+    metadata: provenanceMetadata(),
+  };
+}
+
+export async function queryProvenanceEvents(input: ProvenanceQuery): Promise<TransitionProvenanceEvent[]> {
+  let query = collection(input.firestore) as QueryLike;
+  if (input.workflowType) query = query.where("workflowType", "==", input.workflowType);
+  if (input.workflowInstanceId && input.workflowType) {
+    query = query.where("workflowInstanceKey", "==", workflowInstanceKey(input.workflowType, input.workflowInstanceId));
+  }
+  if (query.orderBy) query = query.orderBy("occurredAt", "asc");
+  if (query.limit) query = query.limit(Math.min(Math.max(input.limit || 100, 1), 500));
+  const snap = await query.get();
+  const from = input.from ? Date.parse(input.from) : null;
+  const to = input.to ? Date.parse(input.to) : null;
+  return sortEvents(
+    snap.docs
+      .map(eventFromSnapshot)
+      .filter((event): event is TransitionProvenanceEvent => Boolean(event))
+      .filter((event) => canAccessProvenance(input.authority, event))
+      .filter((event) => !input.actorRole || event.actor.actorRole === input.actorRole)
+      .filter((event) => !input.outcome || event.transition.outcome === input.outcome)
+      .filter((event) => {
+        const occurred = Date.parse(event.occurredAt);
+        if (from != null && Number.isFinite(from) && occurred < from) return false;
+        if (to != null && Number.isFinite(to) && occurred > to) return false;
+        return true;
+      })
+  );
+}

--- a/rentchain-api/src/services/stateMachines/transitionValidation.ts
+++ b/rentchain-api/src/services/stateMachines/transitionValidation.ts
@@ -1,5 +1,13 @@
 import { computeDecisionState, computeLeaseState, computeMaintenanceState, computePaymentState, computeScreeningState } from "./stateComputation";
 import { decisionStateMachine } from "./decisionStateMachine";
+import {
+  buildDecisionEvidence,
+  buildLeaseEvidence,
+  buildMaintenanceEvidence,
+  buildPaymentEvidence,
+  buildScreeningEvidence,
+} from "./evidenceBuilders";
+import { captureTransitionEvidence } from "./evidenceProvenance";
 import { leaseStateMachine } from "./leaseStateMachine";
 import { maintenanceStateMachine } from "./maintenanceStateMachine";
 import { paymentStateMachine } from "./paymentStateMachine";
@@ -28,30 +36,40 @@ export type ScreeningTransitionRequest = {
   to: ScreeningApplicationState;
   event: ScreeningEvent;
   context: ScreeningContext;
+  captureEvidence?: boolean;
+  occurredAt?: unknown;
 };
 
 export type LeaseTransitionRequest = {
   to: LeaseLifecycleState;
   event: LeaseEvent;
   context: LeaseContext;
+  captureEvidence?: boolean;
+  occurredAt?: unknown;
 };
 
 export type MaintenanceTransitionRequest = {
   to: MaintenanceRequestState;
   event: MaintenanceEvent;
   context: MaintenanceContext;
+  captureEvidence?: boolean;
+  occurredAt?: unknown;
 };
 
 export type PaymentTransitionRequest = {
   to: PaymentState;
   event: PaymentEvent;
   context: PaymentContext;
+  captureEvidence?: boolean;
+  occurredAt?: unknown;
 };
 
 export type DecisionTransitionRequest = {
   to: DecisionActionState;
   event: DecisionEvent;
   context: DecisionContext;
+  captureEvidence?: boolean;
+  occurredAt?: unknown;
 };
 
 export function validateScreeningTransition(
@@ -65,12 +83,35 @@ export function validateScreeningTransition(
     transaction: relatedRecords.transaction,
     result: relatedRecords.result,
   });
-  return screeningStateMachine.validateTransition({
+  const validation = screeningStateMachine.validateTransition({
     currentState,
     proposedState: proposedTransition.to,
     event: proposedTransition.event,
     context: proposedTransition.context,
   });
+  if (!proposedTransition.captureEvidence) return validation;
+  const workflowInstanceId = proposedTransition.context.applicationId || String(currentApplication?.id || "");
+  if (!workflowInstanceId) return validation;
+  return {
+    ...validation,
+    provenanceEvent: captureTransitionEvidence({
+      workflowType: "screening",
+      workflowInstanceId,
+      currentState,
+      proposedState: proposedTransition.to,
+      event: proposedTransition.event,
+      context: proposedTransition.context,
+      validation,
+      occurredAt: proposedTransition.occurredAt,
+      evidenceRefs: buildScreeningEvidence({
+        application: currentApplication,
+        order: relatedRecords.order,
+        transaction: relatedRecords.transaction,
+        result: relatedRecords.result,
+        context: proposedTransition.context,
+      }),
+    }),
+  };
 }
 
 export function validateLeaseTransition(
@@ -78,12 +119,29 @@ export function validateLeaseTransition(
   proposedTransition: LeaseTransitionRequest
 ): TransitionValidationResult<LeaseLifecycleState> {
   const currentState = computeLeaseState(lease);
-  return leaseStateMachine.validateTransition({
+  const validation = leaseStateMachine.validateTransition({
     currentState,
     proposedState: proposedTransition.to,
     event: proposedTransition.event,
     context: proposedTransition.context,
   });
+  if (!proposedTransition.captureEvidence) return validation;
+  const workflowInstanceId = proposedTransition.context.leaseId || String(lease?.id || "");
+  if (!workflowInstanceId) return validation;
+  return {
+    ...validation,
+    provenanceEvent: captureTransitionEvidence({
+      workflowType: "lease",
+      workflowInstanceId,
+      currentState,
+      proposedState: proposedTransition.to,
+      event: proposedTransition.event,
+      context: proposedTransition.context,
+      validation,
+      occurredAt: proposedTransition.occurredAt,
+      evidenceRefs: buildLeaseEvidence({ lease, context: proposedTransition.context }),
+    }),
+  };
 }
 
 export function validateMaintenanceTransition(
@@ -91,12 +149,29 @@ export function validateMaintenanceTransition(
   proposedTransition: MaintenanceTransitionRequest
 ): TransitionValidationResult<MaintenanceRequestState> {
   const currentState = computeMaintenanceState(workOrder);
-  return maintenanceStateMachine.validateTransition({
+  const validation = maintenanceStateMachine.validateTransition({
     currentState,
     proposedState: proposedTransition.to,
     event: proposedTransition.event,
     context: proposedTransition.context,
   });
+  if (!proposedTransition.captureEvidence) return validation;
+  const workflowInstanceId = proposedTransition.context.workOrderId || String(workOrder?.id || "");
+  if (!workflowInstanceId) return validation;
+  return {
+    ...validation,
+    provenanceEvent: captureTransitionEvidence({
+      workflowType: "maintenance",
+      workflowInstanceId,
+      currentState,
+      proposedState: proposedTransition.to,
+      event: proposedTransition.event,
+      context: proposedTransition.context,
+      validation,
+      occurredAt: proposedTransition.occurredAt,
+      evidenceRefs: buildMaintenanceEvidence({ workOrder, context: proposedTransition.context }),
+    }),
+  };
 }
 
 export function validatePaymentTransition(
@@ -104,12 +179,29 @@ export function validatePaymentTransition(
   proposedTransition: PaymentTransitionRequest
 ): TransitionValidationResult<PaymentState> {
   const currentState = computePaymentState(payment);
-  return paymentStateMachine.validateTransition({
+  const validation = paymentStateMachine.validateTransition({
     currentState,
     proposedState: proposedTransition.to,
     event: proposedTransition.event,
     context: proposedTransition.context,
   });
+  if (!proposedTransition.captureEvidence) return validation;
+  const workflowInstanceId = proposedTransition.context.paymentId || String(payment?.id || "");
+  if (!workflowInstanceId) return validation;
+  return {
+    ...validation,
+    provenanceEvent: captureTransitionEvidence({
+      workflowType: "payment",
+      workflowInstanceId,
+      currentState,
+      proposedState: proposedTransition.to,
+      event: proposedTransition.event,
+      context: proposedTransition.context,
+      validation,
+      occurredAt: proposedTransition.occurredAt,
+      evidenceRefs: buildPaymentEvidence({ payment, context: proposedTransition.context }),
+    }),
+  };
 }
 
 export function validateDecisionTransition(
@@ -117,12 +209,29 @@ export function validateDecisionTransition(
   proposedTransition: DecisionTransitionRequest
 ): TransitionValidationResult<DecisionActionState> {
   const currentState = computeDecisionState(decisionAction);
-  return decisionStateMachine.validateTransition({
+  const validation = decisionStateMachine.validateTransition({
     currentState,
     proposedState: proposedTransition.to,
     event: proposedTransition.event,
     context: proposedTransition.context,
   });
+  if (!proposedTransition.captureEvidence) return validation;
+  const workflowInstanceId = proposedTransition.context.decisionId || String(decisionAction?.decisionId || decisionAction?.id || "");
+  if (!workflowInstanceId) return validation;
+  return {
+    ...validation,
+    provenanceEvent: captureTransitionEvidence({
+      workflowType: "decision",
+      workflowInstanceId,
+      currentState,
+      proposedState: proposedTransition.to,
+      event: proposedTransition.event,
+      context: proposedTransition.context,
+      validation,
+      occurredAt: proposedTransition.occurredAt,
+      evidenceRefs: buildDecisionEvidence({ decisionAction, context: proposedTransition.context }),
+    }),
+  };
 }
 
 export function buildValidationSummary(result: TransitionValidationResult): {
@@ -134,5 +243,6 @@ export function buildValidationSummary(result: TransitionValidationResult): {
     valid: result.valid,
     allowedTransitions: result.allowedTransitions,
     ...(result.reason ? { reason: result.reason } : {}),
+    ...(result.provenanceEvent ? { provenanceCaptured: true, provenanceEventId: result.provenanceEvent.eventId } : {}),
   };
 }

--- a/rentchain-api/src/services/stateMachines/types.ts
+++ b/rentchain-api/src/services/stateMachines/types.ts
@@ -2,6 +2,8 @@ export type ActorRole = "tenant" | "landlord" | "admin" | "contractor" | "suppor
 
 export type RecordLike = Record<string, unknown>;
 
+export type ReviewWorkflowType = "screening" | "lease" | "maintenance" | "payment" | "decision";
+
 export type ScreeningApplicationState =
   | "NotRequested"
   | "ApplicationStarted"
@@ -151,6 +153,87 @@ export type TransitionValidationResult<S extends string = string> = {
   proposedState: S;
   allowedTransitions: S[];
   reason?: string;
+  provenanceEvent?: TransitionProvenanceEvent<S, string>;
+};
+
+export type EvidenceReferenceType =
+  | "application"
+  | "order"
+  | "transaction"
+  | "result"
+  | "lease"
+  | "notice"
+  | "work_order"
+  | "cost"
+  | "attachment"
+  | "payment"
+  | "provider_status"
+  | "decision"
+  | "action"
+  | "source";
+
+export type EvidenceReference = {
+  referenceKey: string;
+  referenceType: EvidenceReferenceType;
+  label: string;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type ProvenanceActorSummary = {
+  actorRole: ActorRole;
+  actorRef: string | null;
+  rawActorIdsIncluded: false;
+};
+
+export type ProvenanceOutcome = "valid" | "invalid";
+
+export type ProvenanceMetadata = {
+  metadataOnly: true;
+  appendOnly: true;
+  visibilityClass: "admin_support_internal";
+  tenantVisible: false;
+  landlordVisible: false;
+  source: "state_machine_advisory";
+  timestampFormat: "iso_8601_utc";
+};
+
+export type TransitionProvenanceEvent<S extends string = string, E extends string = string> = {
+  eventId: string;
+  workflowType: ReviewWorkflowType;
+  workflowInstanceKey: string;
+  transition: {
+    from: S;
+    to: S;
+    event: E;
+    outcome: ProvenanceOutcome;
+    reason: string | null;
+  };
+  actor: ProvenanceActorSummary;
+  access: {
+    landlordRef: string | null;
+    tenantRef: string | null;
+    rawIdsIncluded: false;
+  };
+  occurredAt: string;
+  evidenceRefs: EvidenceReference[];
+  contextSummary: {
+    requiredContextPresent: boolean;
+    authorityResolved: boolean;
+    evidenceRefCount: number;
+    rawPayloadIncluded: false;
+  };
+  metadata: ProvenanceMetadata;
+  immutable: true;
+  redactionSummary: string;
+};
+
+export type EvidenceChain<S extends string = string, E extends string = string> = {
+  workflowType: ReviewWorkflowType;
+  workflowInstanceKey: string;
+  events: TransitionProvenanceEvent<S, E>[];
+  metadata: ProvenanceMetadata;
 };
 
 export type TransitionValidator<S extends string, C, E extends string> = (input: {


### PR DESCRIPTION
## Summary
Adds evidence provenance infrastructure for review state machine workflows.

## Changes
- Adds metadata-only transition provenance event types and integrity validation
- Adds safe evidence builders for screening, lease, maintenance, payment, and decision workflows
- Adds append-safe provenance storage and query helpers
- Adds admin/support/landlord-safe provenance review projections
- Extends transition validation with optional advisory evidence capture
- Adds optional provenance capture markers to existing internal transition validation endpoints
- Updates state machine architecture documentation with provenance flow, safe references, and audit usage

## Validation
- npm ci: pass
- State machine and admin service tests: 41/41 passing
- Baseline state machine tests: 26/26 passing
- New provenance/admin tests: 15/15 passing
- Backend build: pass
- Project-local TypeScript check for new provenance files/tests: pass
- git diff --check: pass
- Restricted-reference scan: pass
- No any type matches in new state machine/admin provenance code

## Scope
Backend infrastructure and documentation only. No frontend code, auth rules, billing, provider adapters, Firestore rules, Terraform, or deployment configuration changed.

## Limitations
Coverage instrumentation was not run because the local Vitest coverage provider is not installed and this mission does not allow dependency drift. Evidence provenance remains advisory and optional; no persisted workflow transition enforcement or review UI is added in this mission.

Do not merge until explicitly authorized.