### PR TITLE
feat: implement admin/support recovery workspace UI with inspection, timeline, and immutable history views

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -18,6 +18,10 @@ vi.mock("./components/auth/RequireAdmin", () => ({
   RequireAdmin: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("./components/auth/RequireRole", () => ({
+  RequireRole: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 vi.mock("./components/layout/LandlordNav", () => ({
   LandlordNav: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -88,6 +92,10 @@ vi.mock("./pages/admin/AdminSupportEscalationsPage", () => ({
 
 vi.mock("./pages/admin/AdminReviewWorkspacesPage", () => ({
   default: () => <h1>Governed review workspaces</h1>,
+}));
+
+vi.mock("./pages/admin/AdminRecoveryWorkspacePage", () => ({
+  default: () => <h1>Recovery workspace</h1>,
 }));
 
 vi.mock("./pages/ReleaseGovernancePage", () => ({
@@ -663,6 +671,18 @@ describe("Routes: governed review workspace surfaces", () => {
     );
 
     expect(await screen.findByText(/Governed review workspaces/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the recovery workspace surface available for admin and support review", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/recovery"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Recovery workspace/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -114,6 +114,7 @@ const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificatio
 const AdminSecurityIncidentsPage = lazy(() => import("./pages/admin/AdminSecurityIncidentsPage"));
 const AdminSupportEscalationsPage = lazy(() => import("./pages/admin/AdminSupportEscalationsPage"));
 const AdminReviewWorkspacesPage = lazy(() => import("./pages/admin/AdminReviewWorkspacesPage"));
+const AdminRecoveryWorkspacePage = lazy(() => import("./pages/admin/AdminRecoveryWorkspacePage"));
 const ObservabilityIncidentReadinessPage = lazy(() => import("./pages/ObservabilityIncidentReadinessPage"));
 const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
 const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
@@ -1086,6 +1087,18 @@ function App() {
                   <AdminReviewWorkspacesPage />
                 </Suspense>
               </RequireAdmin>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/admin/recovery"
+          element={
+            <RequireAuth>
+              <RequireRole allowed={["admin", "support"]} fallbackTo="/dashboard">
+                <Suspense fallback={null}>
+                  <AdminRecoveryWorkspacePage />
+                </Suspense>
+              </RequireRole>
             </RequireAuth>
           }
         />

--- a/rentchain-frontend/src/api/adminRecoveryApi.test.ts
+++ b/rentchain-frontend/src/api/adminRecoveryApi.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  apiFetchMock: vi.fn(),
+}));
+
+vi.mock("./apiFetch", () => ({
+  apiFetch: mocks.apiFetchMock,
+}));
+
+describe("adminRecoveryApi", () => {
+  beforeEach(() => {
+    mocks.apiFetchMock.mockReset();
+    mocks.apiFetchMock.mockResolvedValue({ ok: true, logs: [], candidates: [] });
+  });
+
+  it("calls the read-only recovery inspection endpoint with workflow reference payload", async () => {
+    const { inspectRecoveryWorkflow } = await import("./adminRecoveryApi");
+
+    await inspectRecoveryWorkflow({ workflowType: "decision", workflowId: "workflow-reference" });
+
+    expect(mocks.apiFetchMock).toHaveBeenCalledWith("/admin/recovery/inspect", {
+      method: "POST",
+      body: {
+        workflowType: "decision",
+        workflowId: "workflow-reference",
+      },
+    });
+  });
+
+  it("loads recovery logs with candidate discovery parameters", async () => {
+    const { fetchRecoveryLogs } = await import("./adminRecoveryApi");
+
+    await fetchRecoveryLogs({ includeCandidates: true, limit: 25 });
+
+    expect(mocks.apiFetchMock).toHaveBeenCalledWith("/admin/recovery/logs?includeCandidates=true&limit=25");
+  });
+
+  it("loads a single immutable recovery log by safe key", async () => {
+    const { fetchRecoveryLog } = await import("./adminRecoveryApi");
+
+    await fetchRecoveryLog("operator_recovery:safe-log-key");
+
+    expect(mocks.apiFetchMock).toHaveBeenCalledWith("/admin/recovery/logs/operator_recovery%3Asafe-log-key");
+  });
+});

--- a/rentchain-frontend/src/api/adminRecoveryApi.ts
+++ b/rentchain-frontend/src/api/adminRecoveryApi.ts
@@ -1,0 +1,115 @@
+import { apiFetch } from "./apiFetch";
+
+export type RecoveryWorkflowType = "screening" | "lease" | "maintenance" | "payment" | "decision";
+
+export type RecoveryDecisionType =
+  | "ACCEPT_CANONICAL"
+  | "ACCEPT_DERIVED"
+  | "EVIDENCE_REVIEW_REQUIRED"
+  | "NO_ACTION";
+
+export type RecoveryDivergenceType =
+  | "NONE"
+  | "MISSING_TRANSITION"
+  | "ORPHANED_DECISION"
+  | "EVIDENCE_MISMATCH"
+  | "METADATA_DIVERGENCE";
+
+export type RecoveryWorkflowState = {
+  state: string;
+  status: "known" | "missing" | "unknown";
+  observedAt: string | null;
+  source: "timeline" | "decision" | "provenance" | "none";
+};
+
+export type RecoveryEvidenceSnapshot = {
+  evidenceRefCount: number;
+  latestEvidenceAt: string | null;
+  evidenceState: string | null;
+  metadataOnly: true;
+};
+
+export type DecisionRecoveryInspection = {
+  workflowType: RecoveryWorkflowType;
+  workflowInstanceKey: string;
+  divergenceType: RecoveryDivergenceType;
+  canonicalState: RecoveryWorkflowState;
+  derivedState: RecoveryWorkflowState;
+  evidence: RecoveryEvidenceSnapshot;
+  proposedDecision: RecoveryDecisionType;
+  reasonCode: string;
+  manualReviewRequired: boolean;
+};
+
+export type OperatorRecoveryLog = {
+  logId: string;
+  workflowType: RecoveryWorkflowType;
+  workflowInstanceKey: string;
+  divergenceType: RecoveryDivergenceType;
+  reconciliationDecision: Exclude<RecoveryDecisionType, "NO_ACTION">;
+  reasonCode: string;
+  reasonSummary: string;
+  operator: {
+    role: "admin" | "support";
+    operatorRef: string | null;
+    rawIdsIncluded: false;
+  };
+  evidence: RecoveryEvidenceSnapshot;
+  recoveryMetadata: {
+    recoveryAttemptCount: number;
+    lastRecoveryTimestamp: string;
+    reconciliationDecision: RecoveryDecisionType;
+    associatedTimelineEntryIds: string[];
+    immutable: true;
+  };
+  timelineEntryId: string;
+  createdAt: string;
+  metadataOnly: true;
+  appendOnly: true;
+  rawIdsIncluded: false;
+  redactionSummary: string;
+};
+
+export type RecoveryLogsResponse = {
+  ok: true;
+  logs: OperatorRecoveryLog[];
+  candidates: DecisionRecoveryInspection[];
+};
+
+export type RecoveryInspectResponse = {
+  ok: true;
+  reconciliation: DecisionRecoveryInspection;
+};
+
+export async function inspectRecoveryWorkflow(input: {
+  workflowType: RecoveryWorkflowType;
+  workflowId: string;
+}): Promise<RecoveryInspectResponse> {
+  return apiFetch<RecoveryInspectResponse>("/admin/recovery/inspect", {
+    method: "POST",
+    body: {
+      workflowType: input.workflowType,
+      workflowId: input.workflowId,
+    },
+  });
+}
+
+export async function fetchRecoveryLogs(params?: {
+  includeCandidates?: boolean;
+  limit?: number;
+}): Promise<RecoveryLogsResponse> {
+  const query = new URLSearchParams();
+  if (params?.includeCandidates) query.set("includeCandidates", "true");
+  if (params?.limit) query.set("limit", String(params.limit));
+  const suffix = query.toString() ? `?${query.toString()}` : "";
+  return apiFetch<RecoveryLogsResponse>(`/admin/recovery/logs${suffix}`);
+}
+
+export async function fetchRecoveryLog(logId: string): Promise<{
+  ok: true;
+  recoveryLog: OperatorRecoveryLog;
+}> {
+  return apiFetch<{ ok: true; recoveryLog: OperatorRecoveryLog }>(
+    `/admin/recovery/logs/${encodeURIComponent(logId)}`
+  );
+}

--- a/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AdminRecoveryWorkspacePage from "./AdminRecoveryWorkspacePage";
+import {
+  getRecoveryLogsFixtureResponse,
+  recoveryInspectionFixture,
+} from "../../test/fixtures/recoveryWorkspaceFixtures";
+
+const showToast = vi.fn();
+const fetchRecoveryLogs = vi.fn();
+const inspectRecoveryWorkflow = vi.fn();
+
+vi.mock("../../api/adminRecoveryApi", () => ({
+  fetchRecoveryLogs: (params: { includeCandidates?: boolean; limit?: number }) => fetchRecoveryLogs(params),
+  inspectRecoveryWorkflow: (input: { workflowType: string; workflowId: string }) => inspectRecoveryWorkflow(input),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: string;
+};
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, variant: _variant, ...props }: ButtonProps) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Pill: ({ children }: React.HTMLAttributes<HTMLSpanElement>) => <span>{children}</span>,
+  Section: ({ children }: React.HTMLAttributes<HTMLElement>) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+  fetchRecoveryLogs.mockReset();
+  inspectRecoveryWorkflow.mockReset();
+  fetchRecoveryLogs.mockResolvedValue(getRecoveryLogsFixtureResponse());
+  inspectRecoveryWorkflow.mockResolvedValue({ ok: true, reconciliation: recoveryInspectionFixture });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminRecoveryWorkspacePage", () => {
+  it("renders recovery history, candidate inspection, and safe timeline linkage", async () => {
+    render(<AdminRecoveryWorkspacePage />);
+
+    expect(await screen.findByRole("heading", { name: "Recovery workspace" })).toBeInTheDocument();
+    expect(screen.getByText("Immutable recovery history")).toBeInTheDocument();
+    expect(await screen.findByText("Canonical timeline reviewed and accepted.")).toBeInTheDocument();
+    expect(screen.getAllByText("Metadata divergence").length).toBeGreaterThan(0);
+    expect(screen.getByText("Timeline entry recovery_timeline:safe-entry-key")).toBeInTheDocument();
+    expect(screen.getByText(/Raw workflow and actor identifiers are replaced/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reconcile/i })).not.toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("tenant-raw-id");
+    expect(document.body.textContent).not.toContain("gs://");
+    expect(document.body.textContent).not.toContain("secret-token");
+  });
+
+  it("submits read-only inspection requests and renders state comparison", async () => {
+    render(<AdminRecoveryWorkspacePage />);
+
+    await screen.findByText("Canonical timeline reviewed and accepted.");
+    fireEvent.change(screen.getByLabelText("Workflow type"), { target: { value: "payment" } });
+    fireEvent.change(screen.getByLabelText("Workflow reference"), { target: { value: "payment-reference" } });
+    fireEvent.click(screen.getByRole("button", { name: "Inspect" }));
+
+    await waitFor(() =>
+      expect(inspectRecoveryWorkflow).toHaveBeenCalledWith({
+        workflowType: "payment",
+        workflowId: "payment-reference",
+      })
+    );
+    expect(await screen.findByText("Recovery inspection")).toBeInTheDocument();
+    expect(screen.getByText("Canonical state")).toBeInTheDocument();
+    expect(screen.getByText("Derived state")).toBeInTheDocument();
+    expect(screen.getByText("Proposal Accept Canonical")).toBeInTheDocument();
+  });
+
+  it("renders empty states without mutation affordances", async () => {
+    fetchRecoveryLogs.mockResolvedValueOnce({ ok: true, logs: [], candidates: [] });
+
+    render(<AdminRecoveryWorkspacePage />);
+
+    expect(await screen.findByText("No recovery candidates are available.")).toBeInTheDocument();
+    expect(screen.getByText("No recovery actions recorded.")).toBeInTheDocument();
+    expect(screen.getByText("Select a recovery log to review its timeline linkage.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reconcile/i })).not.toBeInTheDocument();
+  });
+
+  it("shows safe error states for failed inspection", async () => {
+    inspectRecoveryWorkflow.mockRejectedValueOnce(new Error("RECOVERY_WORKFLOW_NOT_FOUND"));
+
+    render(<AdminRecoveryWorkspacePage />);
+
+    await screen.findByText("Canonical timeline reviewed and accepted.");
+    fireEvent.change(screen.getByLabelText("Workflow reference"), { target: { value: "missing-reference" } });
+    fireEvent.click(screen.getByRole("button", { name: "Inspect" }));
+
+    expect(await screen.findByText("RECOVERY_WORKFLOW_NOT_FOUND")).toBeInTheDocument();
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Failed to inspect recovery state",
+        variant: "error",
+      })
+    );
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.tsx
@@ -1,0 +1,324 @@
+import React from "react";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Input, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import {
+  fetchRecoveryLogs,
+  inspectRecoveryWorkflow,
+  type DecisionRecoveryInspection,
+  type OperatorRecoveryLog,
+  type RecoveryDivergenceType,
+  type RecoveryWorkflowType,
+} from "../../api/adminRecoveryApi";
+
+const WORKFLOW_TYPES: RecoveryWorkflowType[] = ["screening", "lease", "maintenance", "payment", "decision"];
+
+const DIVERGENCE_LABELS: Record<RecoveryDivergenceType, string> = {
+  NONE: "No divergence",
+  MISSING_TRANSITION: "Missing transition",
+  ORPHANED_DECISION: "Orphaned decision",
+  EVIDENCE_MISMATCH: "Evidence mismatch",
+  METADATA_DIVERGENCE: "Metadata divergence",
+};
+
+function label(value: string | null | undefined) {
+  const raw = String(value || "").trim();
+  if (!raw) return "Not available";
+  return raw
+    .toLowerCase()
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatTime(value: string | null | undefined) {
+  const parsed = Date.parse(String(value || ""));
+  if (!Number.isFinite(parsed)) return "Not recorded";
+  return new Date(parsed).toLocaleString();
+}
+
+function StateComparison({ inspection }: { inspection: DecisionRecoveryInspection | null }) {
+  if (!inspection) {
+    return (
+      <Card>
+        <div style={{ fontWeight: 700 }}>No workflow inspection selected.</div>
+        <div style={{ color: "#64748b", marginTop: 6 }}>Enter a workflow type and reference to inspect current recovery state.</div>
+      </Card>
+    );
+  }
+
+  const rows = [
+    { label: "Canonical state", state: inspection.canonicalState },
+    { label: "Derived state", state: inspection.derivedState },
+  ];
+
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 14 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Recovery inspection</h2>
+          <Pill tone={inspection.manualReviewRequired ? "accent" : "muted"}>{DIVERGENCE_LABELS[inspection.divergenceType]}</Pill>
+          <Pill tone="muted">{label(inspection.workflowType)}</Pill>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
+          {rows.map((row) => (
+            <div key={row.label} style={{ border: "1px solid rgba(15, 23, 42, 0.12)", borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12 }}>{row.label}</div>
+              <div style={{ fontWeight: 800, marginTop: 4 }}>{label(row.state.state)}</div>
+              <div style={{ color: "#475569", marginTop: 4 }}>
+                {label(row.state.status)} · {label(row.state.source)} · {formatTime(row.state.observedAt)}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Pill tone="muted">{inspection.evidence.evidenceRefCount} evidence refs</Pill>
+          <Pill tone="muted">Latest evidence {formatTime(inspection.evidence.latestEvidenceAt)}</Pill>
+          <Pill tone="muted">Evidence state {label(inspection.evidence.evidenceState)}</Pill>
+          <Pill tone="muted">Proposal {label(inspection.proposedDecision)}</Pill>
+        </div>
+        <div style={{ color: "#475569" }}>{label(inspection.reasonCode)}</div>
+      </div>
+    </Card>
+  );
+}
+
+function RecoveryHistory({
+  logs,
+  selectedLogId,
+  onSelect,
+}: {
+  logs: OperatorRecoveryLog[];
+  selectedLogId: string | null;
+  onSelect: (log: OperatorRecoveryLog) => void;
+}) {
+  if (logs.length === 0) {
+    return (
+      <Card>
+        <div style={{ fontWeight: 700 }}>No recovery actions recorded.</div>
+        <div style={{ color: "#64748b", marginTop: 6 }}>Immutable recovery history will appear after supervised reconciliation is logged.</div>
+      </Card>
+    );
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {logs.map((log) => (
+        <button
+          key={log.logId}
+          type="button"
+          onClick={() => onSelect(log)}
+          style={{
+            textAlign: "left",
+            border: selectedLogId === log.logId ? "1px solid #2563eb" : "1px solid rgba(15, 23, 42, 0.12)",
+            background: selectedLogId === log.logId ? "#eff6ff" : "#fff",
+            borderRadius: 8,
+            padding: 12,
+            display: "grid",
+            gap: 8,
+            cursor: "pointer",
+          }}
+        >
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <strong>{label(log.reconciliationDecision)}</strong>
+            <Pill tone="muted">{DIVERGENCE_LABELS[log.divergenceType]}</Pill>
+            <Pill tone="muted">{label(log.operator.role)}</Pill>
+          </div>
+          <div style={{ color: "#475569" }}>{log.reasonSummary}</div>
+          <div style={{ color: "#64748b", fontSize: 13 }}>
+            {formatTime(log.createdAt)} · {log.evidence.evidenceRefCount} evidence refs · attempt {log.recoveryMetadata.recoveryAttemptCount}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RecoveryTimeline({ log }: { log: OperatorRecoveryLog | null }) {
+  if (!log) {
+    return (
+      <Card>
+        <div style={{ color: "#64748b" }}>Select a recovery log to review its timeline linkage.</div>
+      </Card>
+    );
+  }
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Recovery timeline</h2>
+          <Pill tone="muted">Append only</Pill>
+          <Pill tone="muted">Metadata only</Pill>
+        </div>
+        <div style={{ borderLeft: "3px solid #2563eb", paddingLeft: 12, display: "grid", gap: 4 }}>
+          <strong>{label(log.reconciliationDecision)}</strong>
+          <div style={{ color: "#475569" }}>{formatTime(log.recoveryMetadata.lastRecoveryTimestamp)}</div>
+          <div style={{ color: "#475569" }}>Timeline entry {log.timelineEntryId}</div>
+          <div style={{ color: "#64748b" }}>{log.redactionSummary}</div>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {log.recoveryMetadata.associatedTimelineEntryIds.map((entryId) => (
+            <Pill key={entryId} tone="muted">{entryId}</Pill>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default function AdminRecoveryWorkspacePage() {
+  const { showToast } = useToast();
+  const [workflowType, setWorkflowType] = React.useState<RecoveryWorkflowType>("decision");
+  const [workflowId, setWorkflowId] = React.useState("");
+  const [inspection, setInspection] = React.useState<DecisionRecoveryInspection | null>(null);
+  const [logs, setLogs] = React.useState<OperatorRecoveryLog[]>([]);
+  const [candidates, setCandidates] = React.useState<DecisionRecoveryInspection[]>([]);
+  const [selectedLog, setSelectedLog] = React.useState<OperatorRecoveryLog | null>(null);
+  const [loadingLogs, setLoadingLogs] = React.useState(false);
+  const [inspecting, setInspecting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const loadLogs = React.useCallback(async () => {
+    try {
+      setLoadingLogs(true);
+      setError(null);
+      const response = await fetchRecoveryLogs({ includeCandidates: true, limit: 25 });
+      setLogs(response.logs || []);
+      setCandidates(response.candidates || []);
+      setSelectedLog((current) => {
+        if (!current) return response.logs?.[0] || null;
+        return response.logs.find((item) => item.logId === current.logId) || response.logs?.[0] || null;
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to load recovery history";
+      setError(message);
+      showToast({ message: "Failed to load recovery history", description: message, variant: "error" });
+    } finally {
+      setLoadingLogs(false);
+    }
+  }, [showToast]);
+
+  React.useEffect(() => {
+    void loadLogs();
+  }, [loadLogs]);
+
+  const inspect = async () => {
+    const trimmed = workflowId.trim();
+    if (!trimmed) {
+      setError("Workflow reference is required.");
+      return;
+    }
+    try {
+      setInspecting(true);
+      setError(null);
+      const response = await inspectRecoveryWorkflow({ workflowType, workflowId: trimmed });
+      setInspection(response.reconciliation);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to inspect recovery state";
+      setError(message);
+      showToast({ message: "Failed to inspect recovery state", description: message, variant: "error" });
+    } finally {
+      setInspecting(false);
+    }
+  };
+
+  return (
+    <MacShell title="Admin · Recovery workspace">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Recovery workspace</h1>
+                <Pill tone="accent">Admin/support</Pill>
+                <Pill tone="muted">Read only</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 860 }}>
+                Inspect workflow divergence, review recovery history, and follow immutable timeline references from existing recovery records.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void loadLogs()} disabled={loadingLogs}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        <Card>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(220px, 100%), 1fr))", gap: 12, minWidth: 0 }}>
+            <label style={{ display: "grid", gap: 4, minWidth: 0 }}>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Workflow type</div>
+              <select
+                aria-label="Workflow type"
+                value={workflowType}
+                onChange={(event) => setWorkflowType(event.target.value as RecoveryWorkflowType)}
+                style={{ width: "100%", minWidth: 0, boxSizing: "border-box", minHeight: 42 }}
+              >
+                {WORKFLOW_TYPES.map((item) => <option key={item} value={item}>{label(item)}</option>)}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4, minWidth: 0 }}>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Workflow reference</div>
+              <Input
+                aria-label="Workflow reference"
+                value={workflowId}
+                onChange={(event) => setWorkflowId(event.target.value)}
+                placeholder="Enter workflow reference"
+              />
+            </label>
+            <div style={{ display: "flex", alignItems: "end" }}>
+              <Button onClick={() => void inspect()} disabled={inspecting} style={{ width: "100%" }}>
+                Inspect
+              </Button>
+            </div>
+          </div>
+        </Card>
+
+        {error ? <Card><div style={{ color: "#b91c1c" }}>{error}</div></Card> : null}
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(300px, 100%), 1fr))", gap: 16 }}>
+          <StateComparison inspection={inspection} />
+          <Card>
+            <div style={{ display: "grid", gap: 10 }}>
+              <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Recovery candidates</h2>
+              {candidates.length ? (
+                <div style={{ display: "grid", gap: 8 }}>
+                  {candidates.map((candidate) => (
+                    <button
+                      key={`${candidate.workflowType}:${candidate.workflowInstanceKey}`}
+                      type="button"
+                      onClick={() => setInspection(candidate)}
+                      style={{
+                        textAlign: "left",
+                        border: "1px solid rgba(15, 23, 42, 0.12)",
+                        background: "#fff",
+                        borderRadius: 8,
+                        padding: 10,
+                        cursor: "pointer",
+                      }}
+                    >
+                      <strong>{label(candidate.workflowType)}</strong>
+                      <div style={{ color: "#475569" }}>{DIVERGENCE_LABELS[candidate.divergenceType]}</div>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ color: "#64748b" }}>No recovery candidates are available.</div>
+              )}
+            </div>
+          </Card>
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(300px, 100%), 1fr))", gap: 16 }}>
+          <div style={{ display: "grid", gap: 10 }}>
+            <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Immutable recovery history</h2>
+            {loadingLogs ? <Card><div>Loading recovery history...</div></Card> : null}
+            {!loadingLogs ? (
+              <RecoveryHistory logs={logs} selectedLogId={selectedLog?.logId || null} onSelect={setSelectedLog} />
+            ) : null}
+          </div>
+          <RecoveryTimeline log={selectedLog} />
+        </div>
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx
@@ -249,9 +249,28 @@ export default function AdminReviewWorkspacesPage() {
                 storage paths, tokens, secrets, debug payloads, and mutation controls are excluded.
               </div>
             </div>
-            <Button variant="secondary" onClick={() => void load()} disabled={loading}>
-              Refresh
-            </Button>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <Button variant="secondary" onClick={() => void load()} disabled={loading}>
+                Refresh
+              </Button>
+              <a
+                href="/admin/recovery"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  borderRadius: 999,
+                  padding: "10px 14px",
+                  fontWeight: 600,
+                  fontSize: "0.95rem",
+                  textDecoration: "none",
+                  border: "1px solid rgba(15, 23, 42, 0.12)",
+                  color: "#0f172a",
+                  background: "#f8fafc",
+                }}
+              >
+                Recovery workspace
+              </a>
+            </div>
           </div>
         </Section>
 

--- a/rentchain-frontend/src/test/fixtures/recoveryWorkspaceFixtures.ts
+++ b/rentchain-frontend/src/test/fixtures/recoveryWorkspaceFixtures.ts
@@ -1,0 +1,74 @@
+import type {
+  DecisionRecoveryInspection,
+  OperatorRecoveryLog,
+  RecoveryLogsResponse,
+} from "../../api/adminRecoveryApi";
+
+export const recoveryInspectionFixture: DecisionRecoveryInspection = {
+  workflowType: "decision",
+  workflowInstanceKey: "decision:instance:safe-workflow-key",
+  divergenceType: "METADATA_DIVERGENCE",
+  canonicalState: {
+    state: "Reviewed",
+    status: "known",
+    observedAt: "2026-06-01T12:00:00.000Z",
+    source: "timeline",
+  },
+  derivedState: {
+    state: "Appeared",
+    status: "known",
+    observedAt: "2026-06-01T11:45:00.000Z",
+    source: "decision",
+  },
+  evidence: {
+    evidenceRefCount: 3,
+    latestEvidenceAt: "2026-06-01T11:59:00.000Z",
+    evidenceState: "Reviewed",
+    metadataOnly: true,
+  },
+  proposedDecision: "ACCEPT_CANONICAL",
+  reasonCode: "RECOVERY_METADATA_DIVERGENCE",
+  manualReviewRequired: true,
+};
+
+export const recoveryLogFixture: OperatorRecoveryLog = {
+  logId: "operator_recovery:safe-log-key",
+  workflowType: "decision",
+  workflowInstanceKey: "decision:instance:safe-workflow-key",
+  divergenceType: "METADATA_DIVERGENCE",
+  reconciliationDecision: "ACCEPT_CANONICAL",
+  reasonCode: "RECOVERY_METADATA_DIVERGENCE",
+  reasonSummary: "Canonical timeline reviewed and accepted.",
+  operator: {
+    role: "admin",
+    operatorRef: "operator:safe-operator-key",
+    rawIdsIncluded: false,
+  },
+  evidence: {
+    evidenceRefCount: 3,
+    latestEvidenceAt: "2026-06-01T11:59:00.000Z",
+    evidenceState: "Reviewed",
+    metadataOnly: true,
+  },
+  recoveryMetadata: {
+    recoveryAttemptCount: 1,
+    lastRecoveryTimestamp: "2026-06-01T12:05:00.000Z",
+    reconciliationDecision: "ACCEPT_CANONICAL",
+    associatedTimelineEntryIds: ["recovery_timeline:safe-entry-key"],
+    immutable: true,
+  },
+  timelineEntryId: "recovery_timeline:safe-entry-key",
+  createdAt: "2026-06-01T12:05:00.000Z",
+  metadataOnly: true,
+  appendOnly: true,
+  rawIdsIncluded: false,
+  redactionSummary: "Raw workflow and actor identifiers are replaced with deterministic safe references.",
+};
+
+export function getRecoveryLogsFixtureResponse(): RecoveryLogsResponse {
+  return {
+    ok: true,
+    logs: [recoveryLogFixture],
+    candidates: [recoveryInspectionFixture],
+  };
+}


### PR DESCRIPTION
## Summary
Implements admin/support recovery workspace UI for Phase 2 decision continuity recovery workflows.

## Changes
- adminRecoveryApi.ts — typed frontend client for recovery inspection and log reads
- AdminRecoveryWorkspacePage.tsx — read-only recovery inspection, candidates, immutable history, and timeline linkage view
- AdminReviewWorkspacesPage.tsx — adds discovery link to recovery workspace
- App.tsx — adds /admin/recovery route guarded for admin/support
- Tests and fixtures for API calls, UI rendering, route availability, empty/error states, and projection-safety assertions

## Validation
- Frontend npm ci: pass (Node 20.20.2 used for frontend due dependency engine requirements)
- Frontend targeted tests: 57/57 passing
- Frontend full suite: 1132/1132 passing
- Frontend build: pass (existing Vite large chunk warning only)
- Backend regression: state-machine 38/38, recovery 7/7, admin 3/3, build pass
- git diff --check: pass

## Scope
Frontend recovery workspace UI only, plus route and tests. No backend routes, recovery business logic, auth core, billing, provider callbacks, Firestore rules, Terraform, CI/CD, or production data changed.

## Notes
Recovery UI is read-only and does not call the reconciliation mutation endpoint. Support scoping remains enforced by backend recovery projections.