### PR TITLE
feat: add recovery action intent capture and enforcement gates to recovery workspace

### DIFF
--- a/docs/architecture/state-machines-v1.md
+++ b/docs/architecture/state-machines-v1.md
@@ -270,8 +270,16 @@ Admin and support users can inspect and reconcile divergent workflows through `/
 
 - `operatorRecoveryLogs` stores the decision, reason, safe operator reference, evidence summary, and immutable recovery metadata.
 - `canonicalRecoveryTimelineEntries` stores a timeline entry that can be included in canonical review timeline projections.
+- `operatorRecoveryIntents` stores explicit operator intent before a future recovery action is invoked.
 
 The recovery service does not mutate underlying workflow records, decision action records, billing state, provider callback state, or tenant-facing read models. It records operator intent and evidence summary so a later enforcing workflow can consume the audit trail if explicitly authorized.
+
+### Recovery Intent And Gates
+
+The recovery workspace captures action intent through `POST /api/admin/recovery/:recoveryId/intent`.
+Intent capture requires an admin/support operator, a supported recovery action type, a required reason comment, and an explicit authorization confirmation flag. The stored intent is metadata-only, append-only, and keyed by deterministic safe recovery references.
+
+`POST /api/admin/recovery/:recoveryId/gate/validate` is a read-only enforcement gate diagnostic. It verifies that an intent exists, belongs to the current recovery reference, was captured by an operator role that remains valid for the request, and is still fresh within the configured gate window. Gate validation does not apply state correction; it only returns whether a future mutation workflow would be allowed to proceed.
 
 ### Access And Projection Rules
 
@@ -279,10 +287,12 @@ The recovery service does not mutate underlying workflow records, decision actio
 - Tenant and landlord users fail closed on recovery endpoints.
 - Recovery payloads use deterministic safe references and hashed workflow instance keys.
 - Evidence summaries contain counts, state labels, and timestamps only.
+- Recovery intent records expose action type, reason summary, operator role, and safe operator reference only.
 - Recovery logs are append-only; duplicate reconciliation actions for the same divergence, decision, and reason code are rejected.
+- Recovery intents are append-only; duplicate intent capture for the same recovery action is rejected.
 
 ## Future Work
 
-- A later enforcement mission can consume recovery logs to drive explicit workflow-state correction after migration risks are reviewed.
+- A later enforcement mission can consume recovery logs and satisfied recovery intent gates to drive explicit workflow-state correction after migration risks are reviewed.
 - A later enforcement mission can convert advisory route markers into blocking transition checks once migration risks are reviewed.
 - A later review UI mission can expose provenance chains to admin/support workspaces with explicit role gates and redaction summaries.

--- a/rentchain-api/src/routes/__tests__/adminRecoveryRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminRecoveryRoutes.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { workflowKey } from "../../services/recovery/recoveryShared";
 import {
   DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
+  OPERATOR_RECOVERY_INTENTS_COLLECTION,
   OPERATOR_RECOVERY_LOGS_COLLECTION,
   RECOVERY_TIMELINE_COLLECTION,
 } from "../../services/recovery/recoveryStore";
@@ -239,5 +240,81 @@ describe("adminRecoveryRoutes", () => {
     expect(listed.status).toBe(200);
     expect(listed.body.logs).toHaveLength(1);
     expect(collections.get(OPERATOR_RECOVERY_LOGS_COLLECTION)?.size).toBe(1);
+  });
+
+  it("captures recovery action intent and validates enforcement gates without mutating state", async () => {
+    const router = (await import("../adminRecoveryRoutes")).default;
+    const key = workflowKey("decision", "decision-route-intent-1");
+    seed(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, key, {
+      workflowType: "decision",
+      workflowId: "decision-route-intent-1",
+      state: "Reviewed",
+    });
+
+    const captured = await invokeRouter(router, {
+      method: "POST",
+      url: `/recovery/${encodeURIComponent(key)}/intent`,
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        actionType: "ACCEPT_CANONICAL",
+        reason: "Operator confirmed intent to accept canonical recovery state.",
+        authorizationConfirmed: true,
+      },
+    });
+    expect(captured.status).toBe(201);
+    expect(captured.body.intent).toMatchObject({
+      recoveryId: key,
+      actionType: "ACCEPT_CANONICAL",
+      status: "captured",
+      appendOnly: true,
+      rawIdsIncluded: false,
+    });
+    expect(JSON.stringify(captured.body)).not.toContain("decision-route-intent-1");
+    expect(collections.get(OPERATOR_RECOVERY_INTENTS_COLLECTION)?.size).toBe(1);
+    expect(collections.get(OPERATOR_RECOVERY_LOGS_COLLECTION)?.size || 0).toBe(0);
+
+    const intent = captured.body.intent as Record<string, unknown>;
+    const gate = await invokeRouter(router, {
+      method: "POST",
+      url: `/recovery/${encodeURIComponent(key)}/gate/validate`,
+      user: { id: "admin-1", role: "admin" },
+      body: { intentId: intent.intentId },
+    });
+    expect(gate.status).toBe(200);
+    expect(gate.body.gate).toMatchObject({
+      gateStatus: "satisfied",
+      authorizationValid: true,
+      intentFresh: true,
+    });
+  });
+
+  it("rejects recovery intent capture for unauthorized operators and invalid candidates", async () => {
+    const router = (await import("../adminRecoveryRoutes")).default;
+    const key = workflowKey("payment", "payment-route-intent-1");
+
+    const forbidden = await invokeRouter(router, {
+      method: "POST",
+      url: `/recovery/${encodeURIComponent(key)}/intent`,
+      user: { id: "tenant-1", role: "tenant" },
+      body: {
+        actionType: "ACCEPT_CANONICAL",
+        reason: "Tenant should not capture recovery intent.",
+        authorizationConfirmed: true,
+      },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const missing = await invokeRouter(router, {
+      method: "POST",
+      url: `/recovery/${encodeURIComponent(key)}/intent`,
+      user: { id: "support-1", role: "support" },
+      body: {
+        actionType: "ACCEPT_CANONICAL",
+        reason: "Missing candidate.",
+        authorizationConfirmed: true,
+      },
+    });
+    expect(missing.status).toBe(404);
+    expect(missing.body.error).toBe("RECOVERY_WORKFLOW_NOT_FOUND");
   });
 });

--- a/rentchain-api/src/routes/adminRecoveryRoutes.ts
+++ b/rentchain-api/src/routes/adminRecoveryRoutes.ts
@@ -8,11 +8,16 @@ import {
   listRecentRecoveryActions,
 } from "../services/recovery/decisionReconciliationService";
 import {
+  captureRecoveryActionIntent,
+  listRecentRecoveryIntents,
+  validateRecoveryActionGate,
+} from "../services/recovery/recoveryIntentService";
+import {
   OPERATOR_RECOVERY_LOGS_COLLECTION,
   loadSnapshot,
 } from "../services/recovery/recoveryStore";
 import { asSafeText, normalizeRecoveryAuthority, stableRecoveryHash } from "../services/recovery/recoveryShared";
-import type { ReconciliationRequest, RecoveryAuthority } from "../types/recovery";
+import type { ReconciliationRequest, RecoveryAuthority, RecoveryIntentCaptureRequest } from "../types/recovery";
 
 type AuthRequest = Request & {
   user?: unknown;
@@ -52,6 +57,7 @@ function mapError(error: unknown): { status: number; code: string } {
   if (message.includes("forbidden")) return { status: 403, code: "FORBIDDEN" };
   if (message === "recovery_workflow_not_found") return { status: 404, code: "RECOVERY_WORKFLOW_NOT_FOUND" };
   if (message === "recovery_already_logged") return { status: 409, code: "RECOVERY_ALREADY_LOGGED" };
+  if (message === "recovery_intent_already_captured") return { status: 409, code: "RECOVERY_INTENT_ALREADY_CAPTURED" };
   if (message === "recovery_not_required") return { status: 409, code: "RECOVERY_NOT_REQUIRED" };
   if (message.includes("invalid") || message.includes("required")) return { status: 400, code: "RECOVERY_REQUEST_INVALID" };
   return { status: 500, code: "RECOVERY_ROUTE_FAILED" };
@@ -115,8 +121,9 @@ router.get("/recovery/logs", requireAuth, async (req: AuthRequest, res) => {
     const includeCandidates = String(req.query?.includeCandidates || "").toLowerCase() === "true";
     const limit = Number(req.query?.limit || 25);
     const logs = await listRecentRecoveryActions({ authority, limit });
+    const intents = await listRecentRecoveryIntents({ authority, limit });
     const candidates = includeCandidates ? await findWorkflowsNeedingRecovery({ authority, limit }) : [];
-    return res.json({ ok: true, logs, candidates });
+    return res.json({ ok: true, logs, intents, candidates });
   } catch (error) {
     const mapped = mapError(error);
     return res.status(mapped.status).json({ ok: false, error: mapped.code });
@@ -132,6 +139,45 @@ router.get("/recovery/logs/:logId", requireAuth, async (req: AuthRequest, res) =
       return res.status(404).json({ ok: false, error: "RECOVERY_LOG_NOT_FOUND" });
     }
     return res.json({ ok: true, recoveryLog: log });
+  } catch (error) {
+    const mapped = mapError(error);
+    return res.status(mapped.status).json({ ok: false, error: mapped.code });
+  }
+});
+
+router.post("/recovery/:recoveryId/intent", requireAuth, async (req: AuthRequest, res) => {
+  try {
+    const authority = authorityFromRequest(req);
+    if (!requireOperator(authority)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    const body = requestBody(req);
+    const request: RecoveryIntentCaptureRequest = {
+      actionType: String(body.actionType || "") as RecoveryIntentCaptureRequest["actionType"],
+      reason: asSafeText(body.reason, 800),
+      authorizationConfirmed: body.authorizationConfirmed === true,
+    };
+    const intent = await captureRecoveryActionIntent({
+      recoveryId: req.params.recoveryId,
+      request,
+      authority,
+    });
+    return res.status(201).json({ ok: true, intent });
+  } catch (error) {
+    const mapped = mapError(error);
+    return res.status(mapped.status).json({ ok: false, error: mapped.code });
+  }
+});
+
+router.post("/recovery/:recoveryId/gate/validate", requireAuth, async (req: AuthRequest, res) => {
+  try {
+    const authority = authorityFromRequest(req);
+    if (!requireOperator(authority)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    const body = requestBody(req);
+    const gate = await validateRecoveryActionGate({
+      recoveryId: req.params.recoveryId,
+      intentId: asSafeText(body.intentId, 300),
+      authority,
+    });
+    return res.json({ ok: true, gate });
   } catch (error) {
     const mapped = mapError(error);
     return res.status(mapped.status).json({ ok: false, error: mapped.code });

--- a/rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts
+++ b/rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
+  OPERATOR_RECOVERY_INTENTS_COLLECTION,
+} from "../recoveryStore";
+import { captureRecoveryActionIntent, validateRecoveryActionGate } from "../recoveryIntentService";
+import { workflowKey } from "../recoveryShared";
+import { createRecoveryTestStore } from "./recoveryTestStore";
+
+const adminAuthority = {
+  role: "admin" as const,
+  operatorRef: "operator:admin-safe",
+  landlordRef: null,
+  supportAllowed: false,
+};
+
+const supportAuthority = {
+  role: "support" as const,
+  operatorRef: "operator:support-safe",
+  landlordRef: null,
+  supportAllowed: true,
+};
+
+const tenantAuthority = {
+  role: "tenant" as const,
+  operatorRef: "operator:tenant-safe",
+  landlordRef: null,
+  supportAllowed: false,
+};
+
+describe("recoveryIntentService", () => {
+  it("captures append-only recovery action intent for authorized operators", async () => {
+    const store = createRecoveryTestStore();
+    const recoveryId = workflowKey("decision", "decision-raw-intent-1");
+    store.seed(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, recoveryId, {
+      workflowType: "decision",
+      workflowId: "decision-raw-intent-1",
+      state: "Reviewed",
+    });
+
+    const intent = await captureRecoveryActionIntent({
+      recoveryId,
+      authority: adminAuthority,
+      firestore: store,
+      now: "2026-06-01T12:00:00.000Z",
+      request: {
+        actionType: "ACCEPT_CANONICAL",
+        reason: "Operator reviewed continuity evidence and intends canonical recovery.",
+        authorizationConfirmed: true,
+      },
+    });
+
+    expect(intent).toMatchObject({
+      recoveryId,
+      workflowInstanceKey: recoveryId,
+      actionType: "ACCEPT_CANONICAL",
+      status: "captured",
+      authorizationConfirmed: true,
+      appendOnly: true,
+      metadataOnly: true,
+      rawIdsIncluded: false,
+    });
+    expect(intent.intentId).toMatch(/^recovery_intent:/);
+    expect(intent.workflowInstanceKey).not.toContain("decision-raw-intent-1");
+    expect(store.read(OPERATOR_RECOVERY_INTENTS_COLLECTION, intent.intentId)).toBeTruthy();
+  });
+
+  it("rejects unauthorized and invalid recovery intent capture", async () => {
+    const store = createRecoveryTestStore();
+    const recoveryId = workflowKey("payment", "payment-raw-intent-1");
+
+    await expect(
+      captureRecoveryActionIntent({
+        recoveryId,
+        authority: tenantAuthority,
+        firestore: store,
+        request: {
+          actionType: "ACCEPT_CANONICAL",
+          reason: "Invalid tenant attempt.",
+          authorizationConfirmed: true,
+        },
+      })
+    ).rejects.toThrow("recovery_intent_forbidden");
+
+    await expect(
+      captureRecoveryActionIntent({
+        recoveryId,
+        authority: supportAuthority,
+        firestore: store,
+        request: {
+          actionType: "ACCEPT_CANONICAL",
+          reason: "Missing candidate.",
+          authorizationConfirmed: true,
+        },
+      })
+    ).rejects.toThrow("recovery_workflow_not_found");
+  });
+
+  it("rejects duplicate intent for the same recovery action", async () => {
+    const store = createRecoveryTestStore();
+    const recoveryId = workflowKey("lease", "lease-raw-intent-1");
+    store.seed(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, recoveryId, {
+      workflowType: "lease",
+      workflowId: "lease-raw-intent-1",
+      state: "Draft",
+    });
+    const request = {
+      actionType: "ACCEPT_CANONICAL" as const,
+      reason: "Lease continuity evidence reviewed.",
+      authorizationConfirmed: true,
+    };
+
+    await captureRecoveryActionIntent({ recoveryId, authority: supportAuthority, firestore: store, request });
+
+    await expect(
+      captureRecoveryActionIntent({ recoveryId, authority: supportAuthority, firestore: store, request })
+    ).rejects.toThrow("recovery_intent_already_captured");
+  });
+
+  it("validates enforcement gates for fresh, missing, stale, and mismatched intents", async () => {
+    const store = createRecoveryTestStore();
+    const recoveryId = workflowKey("maintenance", "maintenance-raw-intent-1");
+    store.seed(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, recoveryId, {
+      workflowType: "maintenance",
+      workflowId: "maintenance-raw-intent-1",
+      state: "Escalated",
+    });
+    const intent = await captureRecoveryActionIntent({
+      recoveryId,
+      authority: adminAuthority,
+      firestore: store,
+      now: "2026-06-01T12:00:00.000Z",
+      request: {
+        actionType: "EVIDENCE_REVIEW_REQUIRED",
+        reason: "Evidence needs manual review before correction.",
+        authorizationConfirmed: true,
+      },
+    });
+
+    await expect(
+      validateRecoveryActionGate({
+        recoveryId,
+        intentId: intent.intentId,
+        authority: tenantAuthority,
+        firestore: store,
+      })
+    ).rejects.toThrow("recovery_gate_forbidden");
+
+    await expect(
+      validateRecoveryActionGate({
+        recoveryId,
+        intentId: "",
+        authority: adminAuthority,
+        firestore: store,
+      })
+    ).rejects.toThrow("recovery_intent_required");
+
+    await expect(
+      validateRecoveryActionGate({
+        recoveryId,
+        intentId: "recovery_intent:missing",
+        authority: adminAuthority,
+        firestore: store,
+      })
+    ).resolves.toMatchObject({
+      gateStatus: "denied",
+      reason: "intent_missing",
+      authorizationValid: false,
+      intentFresh: false,
+    });
+
+    await expect(
+      validateRecoveryActionGate({
+        recoveryId,
+        intentId: intent.intentId,
+        authority: supportAuthority,
+        firestore: store,
+        now: "2026-06-01T13:00:00.000Z",
+      })
+    ).resolves.toMatchObject({
+      gateStatus: "denied",
+      reason: "authorization_invalid",
+      authorizationValid: false,
+      intentFresh: true,
+    });
+
+    await expect(
+      validateRecoveryActionGate({
+        recoveryId,
+        intentId: intent.intentId,
+        authority: adminAuthority,
+        firestore: store,
+        now: "2026-06-03T12:00:00.000Z",
+      })
+    ).resolves.toMatchObject({
+      gateStatus: "denied",
+      reason: "intent_stale",
+      authorizationValid: true,
+      intentFresh: false,
+    });
+
+    await expect(
+      validateRecoveryActionGate({
+        recoveryId,
+        intentId: intent.intentId,
+        authority: adminAuthority,
+        firestore: store,
+        now: "2026-06-01T13:00:00.000Z",
+      })
+    ).resolves.toMatchObject({
+      gateStatus: "satisfied",
+      authorizationValid: true,
+      intentFresh: true,
+    });
+  });
+});

--- a/rentchain-api/src/services/recovery/index.ts
+++ b/rentchain-api/src/services/recovery/index.ts
@@ -1,5 +1,6 @@
 export * from "./decisionReconciliationService";
 export * from "./decisionStateInspector";
+export * from "./recoveryIntentService";
 export * from "./recoveryStore";
 export * from "./recoveryShared";
 export * from "./timelineRecoveryService";

--- a/rentchain-api/src/services/recovery/recoveryIntentService.ts
+++ b/rentchain-api/src/services/recovery/recoveryIntentService.ts
@@ -1,0 +1,223 @@
+import type {
+  RecoveryActionIntent,
+  RecoveryActionType,
+  RecoveryAuthority,
+  RecoveryGateValidation,
+  RecoveryIntentCaptureRequest,
+} from "../../types/recovery";
+import type { ReviewWorkflowType } from "../stateMachines/types";
+import { asSafeText, isOperatorAuthority, stableRecoveryHash, toUtcIso } from "./recoveryShared";
+import {
+  DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
+  OPERATOR_RECOVERY_INTENTS_COLLECTION,
+  RECOVERY_TIMELINE_COLLECTION,
+  type RecoveryFirestoreLike,
+  appendDocument,
+  loadSnapshot,
+  queryByWorkflow,
+  recoveryDb,
+} from "./recoveryStore";
+
+export const RECOVERY_INTENT_FRESHNESS_MS = 24 * 60 * 60 * 1000;
+
+type RecoveryCandidateRecord = {
+  workflowType: ReviewWorkflowType;
+  workflowInstanceKey: string;
+};
+
+type CaptureIntentInput = {
+  recoveryId: string;
+  request: RecoveryIntentCaptureRequest;
+  authority: RecoveryAuthority;
+  firestore?: RecoveryFirestoreLike;
+  now?: string;
+};
+
+type ValidateGateInput = {
+  recoveryId: string;
+  intentId: string;
+  authority: RecoveryAuthority;
+  firestore?: RecoveryFirestoreLike;
+  now?: string;
+};
+
+const ACTION_TYPES: RecoveryActionType[] = ["ACCEPT_CANONICAL", "ACCEPT_DERIVED", "EVIDENCE_REVIEW_REQUIRED"];
+
+function normalizeRecoveryId(value: unknown): string {
+  const recoveryId = asSafeText(value, 300);
+  if (!recoveryId) throw new Error("recovery_id_required");
+  return recoveryId;
+}
+
+function normalizeActionType(value: unknown): RecoveryActionType {
+  const actionType = String(value || "").trim() as RecoveryActionType;
+  if (!ACTION_TYPES.includes(actionType)) throw new Error("recovery_intent_action_invalid");
+  return actionType;
+}
+
+function normalizeIntentRequest(request: RecoveryIntentCaptureRequest): {
+  actionType: RecoveryActionType;
+  reasonSummary: string;
+  authorizationConfirmed: true;
+} {
+  const actionType = normalizeActionType(request.actionType);
+  const reasonSummary = asSafeText(request.reason, 800);
+  if (!reasonSummary) throw new Error("recovery_intent_reason_required");
+  if (request.authorizationConfirmed !== true) throw new Error("recovery_intent_authorization_required");
+  return { actionType, reasonSummary, authorizationConfirmed: true };
+}
+
+async function loadRecoveryCandidate(
+  recoveryId: string,
+  firestore?: RecoveryFirestoreLike
+): Promise<RecoveryCandidateRecord | null> {
+  const snapshot = await loadSnapshot(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, recoveryId, firestore);
+  if (snapshot) {
+    return {
+      workflowType: String(snapshot.workflowType || "decision") as ReviewWorkflowType,
+      workflowInstanceKey: recoveryId,
+    };
+  }
+
+  const timelineRecords = await queryByWorkflow(RECOVERY_TIMELINE_COLLECTION, recoveryId, firestore);
+  const timeline = timelineRecords[0];
+  if (timeline) {
+    return {
+      workflowType: String(timeline.workflowType || "decision") as ReviewWorkflowType,
+      workflowInstanceKey: recoveryId,
+    };
+  }
+
+  return null;
+}
+
+function intentId(input: {
+  recoveryId: string;
+  actionType: RecoveryActionType;
+  operatorRef: string | null;
+  capturedAt: string;
+}): string {
+  return `recovery_intent:${stableRecoveryHash([
+    input.recoveryId,
+    input.actionType,
+    input.operatorRef,
+    input.capturedAt,
+  ])}`;
+}
+
+function expiresAt(capturedAt: string): string {
+  return new Date(Date.parse(capturedAt) + RECOVERY_INTENT_FRESHNESS_MS).toISOString();
+}
+
+export async function captureRecoveryActionIntent(input: CaptureIntentInput): Promise<RecoveryActionIntent> {
+  if (!isOperatorAuthority(input.authority)) throw new Error("recovery_intent_forbidden");
+  const recoveryId = normalizeRecoveryId(input.recoveryId);
+  const request = normalizeIntentRequest(input.request);
+  const candidate = await loadRecoveryCandidate(recoveryId, input.firestore);
+  if (!candidate) throw new Error("recovery_workflow_not_found");
+
+  const existingIntents = await queryByWorkflow(OPERATOR_RECOVERY_INTENTS_COLLECTION, candidate.workflowInstanceKey, input.firestore);
+  const duplicate = existingIntents.some(
+    (intent) => intent.status === "captured" && intent.actionType === request.actionType
+  );
+  if (duplicate) throw new Error("recovery_intent_already_captured");
+
+  const capturedAt = toUtcIso(input.now);
+  const id = intentId({
+    recoveryId,
+    actionType: request.actionType,
+    operatorRef: input.authority.operatorRef,
+    capturedAt,
+  });
+  const intent: RecoveryActionIntent = {
+    intentId: id,
+    recoveryId,
+    workflowType: candidate.workflowType,
+    workflowInstanceKey: candidate.workflowInstanceKey,
+    actionType: request.actionType,
+    reasonSummary: request.reasonSummary,
+    authorizationConfirmed: request.authorizationConfirmed,
+    status: "captured",
+    operator: {
+      role: input.authority.role,
+      operatorRef: input.authority.operatorRef,
+      rawIdsIncluded: false,
+    },
+    capturedAt,
+    expiresAt: expiresAt(capturedAt),
+    metadataOnly: true,
+    appendOnly: true,
+    rawIdsIncluded: false,
+    redactionSummary: "Raw workflow, actor, and data-store identifiers are replaced with deterministic safe references.",
+  };
+
+  await appendDocument(OPERATOR_RECOVERY_INTENTS_COLLECTION, intent.intentId, intent, input.firestore);
+  return intent;
+}
+
+export async function validateRecoveryActionGate(input: ValidateGateInput): Promise<RecoveryGateValidation> {
+  if (!isOperatorAuthority(input.authority)) throw new Error("recovery_gate_forbidden");
+  const recoveryId = normalizeRecoveryId(input.recoveryId);
+  const intentKey = asSafeText(input.intentId, 300);
+  if (!intentKey) throw new Error("recovery_intent_required");
+
+  const rawIntent = await loadSnapshot(OPERATOR_RECOVERY_INTENTS_COLLECTION, intentKey, input.firestore);
+  if (!rawIntent || rawIntent.metadataOnly !== true || rawIntent.appendOnly !== true || rawIntent.rawIdsIncluded !== false) {
+    return {
+      gateStatus: "denied",
+      reason: "intent_missing",
+      intentStatus: "missing",
+      authorizationValid: false,
+      intentFresh: false,
+    };
+  }
+
+  const intent = rawIntent as unknown as RecoveryActionIntent;
+  const authorizationValid =
+    intent.recoveryId === recoveryId &&
+    (intent.operator.role === "admin" || intent.operator.role === "support") &&
+    input.authority.role === intent.operator.role;
+  const now = Date.parse(toUtcIso(input.now));
+  const intentFresh = Number.isFinite(now) && Date.parse(intent.expiresAt) >= now;
+
+  if (!authorizationValid) {
+    return {
+      gateStatus: "denied",
+      reason: "authorization_invalid",
+      intentStatus: intent.status,
+      authorizationValid: false,
+      intentFresh,
+    };
+  }
+
+  if (!intentFresh) {
+    return {
+      gateStatus: "denied",
+      reason: "intent_stale",
+      intentStatus: intent.status,
+      authorizationValid,
+      intentFresh: false,
+    };
+  }
+
+  return {
+    gateStatus: "satisfied",
+    intentStatus: intent.status,
+    authorizationValid,
+    intentFresh,
+  };
+}
+
+export async function listRecentRecoveryIntents(input: {
+  authority: RecoveryAuthority;
+  limit?: number;
+  firestore?: RecoveryFirestoreLike;
+}): Promise<RecoveryActionIntent[]> {
+  if (!isOperatorAuthority(input.authority)) throw new Error("recovery_intent_forbidden");
+  const snap = await recoveryDb(input.firestore).collection(OPERATOR_RECOVERY_INTENTS_COLLECTION).get();
+  return snap.docs
+    .map((doc) => doc.data() as unknown as RecoveryActionIntent)
+    .filter((record) => record?.metadataOnly === true && record.rawIdsIncluded === false && record.status === "captured")
+    .sort((a, b) => b.capturedAt.localeCompare(a.capturedAt))
+    .slice(0, Math.min(Math.max(input.limit || 25, 1), 100));
+}

--- a/rentchain-api/src/services/recovery/recoveryStore.ts
+++ b/rentchain-api/src/services/recovery/recoveryStore.ts
@@ -1,5 +1,5 @@
 import { db } from "../../config/firebase";
-import type { OperatorRecoveryLog, RecoveryTimelineEntry } from "../../types/recovery";
+import type { OperatorRecoveryLog, RecoveryActionIntent, RecoveryTimelineEntry } from "../../types/recovery";
 
 type SnapshotLike = {
   exists?: boolean;
@@ -33,6 +33,7 @@ export type RecoveryFirestoreLike = {
 };
 
 export const OPERATOR_RECOVERY_LOGS_COLLECTION = "operatorRecoveryLogs";
+export const OPERATOR_RECOVERY_INTENTS_COLLECTION = "operatorRecoveryIntents";
 export const RECOVERY_TIMELINE_COLLECTION = "canonicalRecoveryTimelineEntries";
 export const DECISION_CONTINUITY_SNAPSHOTS_COLLECTION = "decisionContinuitySnapshots";
 
@@ -86,4 +87,8 @@ export function isRecoveryLog(value: Record<string, unknown>): value is Operator
 
 export function isRecoveryTimelineEntry(value: Record<string, unknown>): value is RecoveryTimelineEntry {
   return value.metadataOnly === true && value.appendOnly === true && value.entryType === "RECOVERY_ACTION";
+}
+
+export function isRecoveryActionIntent(value: Record<string, unknown>): value is RecoveryActionIntent {
+  return value.metadataOnly === true && value.appendOnly === true && value.status === "captured" && typeof value.intentId === "string";
 }

--- a/rentchain-api/src/types/recovery.ts
+++ b/rentchain-api/src/types/recovery.ts
@@ -15,6 +15,8 @@ export type RecoveryDecisionType =
   | "EVIDENCE_REVIEW_REQUIRED"
   | "NO_ACTION";
 
+export type RecoveryActionType = Exclude<RecoveryDecisionType, "NO_ACTION">;
+
 export type DivergenceType =
   | "NONE"
   | "MISSING_TRANSITION"
@@ -100,4 +102,40 @@ export type RecoveryTimelineEntry = {
   metadataOnly: true;
   appendOnly: true;
   rawIdsIncluded: false;
+};
+
+export type RecoveryActionIntent = {
+  intentId: string;
+  recoveryId: string;
+  workflowType: ReviewWorkflowType;
+  workflowInstanceKey: string;
+  actionType: RecoveryActionType;
+  reasonSummary: string;
+  authorizationConfirmed: true;
+  status: "captured";
+  operator: {
+    role: "admin" | "support";
+    operatorRef: string | null;
+    rawIdsIncluded: false;
+  };
+  capturedAt: string;
+  expiresAt: string;
+  metadataOnly: true;
+  appendOnly: true;
+  rawIdsIncluded: false;
+  redactionSummary: string;
+};
+
+export type RecoveryIntentCaptureRequest = {
+  actionType: RecoveryActionType;
+  reason: string;
+  authorizationConfirmed: boolean;
+};
+
+export type RecoveryGateValidation = {
+  gateStatus: "satisfied" | "denied";
+  reason?: string;
+  intentStatus: RecoveryActionIntent["status"] | "missing";
+  authorizationValid: boolean;
+  intentFresh: boolean;
 };

--- a/rentchain-frontend/src/api/adminRecoveryApi.test.ts
+++ b/rentchain-frontend/src/api/adminRecoveryApi.test.ts
@@ -43,4 +43,46 @@ describe("adminRecoveryApi", () => {
 
     expect(mocks.apiFetchMock).toHaveBeenCalledWith("/admin/recovery/logs/operator_recovery%3Asafe-log-key");
   });
+
+  it("captures recovery action intent with required authorization payload", async () => {
+    const { captureRecoveryIntent } = await import("./adminRecoveryApi");
+
+    await captureRecoveryIntent({
+      recoveryId: "decision:instance:safe-workflow-key",
+      actionType: "ACCEPT_CANONICAL",
+      reason: "Operator reviewed recovery evidence.",
+      authorizationConfirmed: true,
+    });
+
+    expect(mocks.apiFetchMock).toHaveBeenCalledWith(
+      "/admin/recovery/decision%3Ainstance%3Asafe-workflow-key/intent",
+      {
+        method: "POST",
+        body: {
+          actionType: "ACCEPT_CANONICAL",
+          reason: "Operator reviewed recovery evidence.",
+          authorizationConfirmed: true,
+        },
+      }
+    );
+  });
+
+  it("validates recovery gates by safe recovery and intent keys", async () => {
+    const { validateRecoveryGate } = await import("./adminRecoveryApi");
+
+    await validateRecoveryGate({
+      recoveryId: "decision:instance:safe-workflow-key",
+      intentId: "recovery_intent:safe-intent-key",
+    });
+
+    expect(mocks.apiFetchMock).toHaveBeenCalledWith(
+      "/admin/recovery/decision%3Ainstance%3Asafe-workflow-key/gate/validate",
+      {
+        method: "POST",
+        body: {
+          intentId: "recovery_intent:safe-intent-key",
+        },
+      }
+    );
+  });
 });

--- a/rentchain-frontend/src/api/adminRecoveryApi.ts
+++ b/rentchain-frontend/src/api/adminRecoveryApi.ts
@@ -8,6 +8,8 @@ export type RecoveryDecisionType =
   | "EVIDENCE_REVIEW_REQUIRED"
   | "NO_ACTION";
 
+export type RecoveryActionType = Exclude<RecoveryDecisionType, "NO_ACTION">;
+
 export type RecoveryDivergenceType =
   | "NONE"
   | "MISSING_TRANSITION"
@@ -70,9 +72,40 @@ export type OperatorRecoveryLog = {
   redactionSummary: string;
 };
 
+export type RecoveryActionIntent = {
+  intentId: string;
+  recoveryId: string;
+  workflowType: RecoveryWorkflowType;
+  workflowInstanceKey: string;
+  actionType: RecoveryActionType;
+  reasonSummary: string;
+  authorizationConfirmed: true;
+  status: "captured";
+  operator: {
+    role: "admin" | "support";
+    operatorRef: string | null;
+    rawIdsIncluded: false;
+  };
+  capturedAt: string;
+  expiresAt: string;
+  metadataOnly: true;
+  appendOnly: true;
+  rawIdsIncluded: false;
+  redactionSummary: string;
+};
+
+export type RecoveryGateValidation = {
+  gateStatus: "satisfied" | "denied";
+  reason?: string;
+  intentStatus: RecoveryActionIntent["status"] | "missing";
+  authorizationValid: boolean;
+  intentFresh: boolean;
+};
+
 export type RecoveryLogsResponse = {
   ok: true;
   logs: OperatorRecoveryLog[];
+  intents: RecoveryActionIntent[];
   candidates: DecisionRecoveryInspection[];
 };
 
@@ -111,5 +144,39 @@ export async function fetchRecoveryLog(logId: string): Promise<{
 }> {
   return apiFetch<{ ok: true; recoveryLog: OperatorRecoveryLog }>(
     `/admin/recovery/logs/${encodeURIComponent(logId)}`
+  );
+}
+
+export async function captureRecoveryIntent(input: {
+  recoveryId: string;
+  actionType: RecoveryActionType;
+  reason: string;
+  authorizationConfirmed: boolean;
+}): Promise<{ ok: true; intent: RecoveryActionIntent }> {
+  return apiFetch<{ ok: true; intent: RecoveryActionIntent }>(
+    `/admin/recovery/${encodeURIComponent(input.recoveryId)}/intent`,
+    {
+      method: "POST",
+      body: {
+        actionType: input.actionType,
+        reason: input.reason,
+        authorizationConfirmed: input.authorizationConfirmed,
+      },
+    }
+  );
+}
+
+export async function validateRecoveryGate(input: {
+  recoveryId: string;
+  intentId: string;
+}): Promise<{ ok: true; gate: RecoveryGateValidation }> {
+  return apiFetch<{ ok: true; gate: RecoveryGateValidation }>(
+    `/admin/recovery/${encodeURIComponent(input.recoveryId)}/gate/validate`,
+    {
+      method: "POST",
+      body: {
+        intentId: input.intentId,
+      },
+    }
   );
 }

--- a/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.test.tsx
@@ -8,12 +8,17 @@ import {
 } from "../../test/fixtures/recoveryWorkspaceFixtures";
 
 const showToast = vi.fn();
+const captureRecoveryIntent = vi.fn();
 const fetchRecoveryLogs = vi.fn();
 const inspectRecoveryWorkflow = vi.fn();
+const validateRecoveryGate = vi.fn();
 
 vi.mock("../../api/adminRecoveryApi", () => ({
+  captureRecoveryIntent: (input: { recoveryId: string; actionType: string; reason: string; authorizationConfirmed: boolean }) =>
+    captureRecoveryIntent(input),
   fetchRecoveryLogs: (params: { includeCandidates?: boolean; limit?: number }) => fetchRecoveryLogs(params),
   inspectRecoveryWorkflow: (input: { workflowType: string; workflowId: string }) => inspectRecoveryWorkflow(input),
+  validateRecoveryGate: (input: { recoveryId: string; intentId: string }) => validateRecoveryGate(input),
 }));
 
 vi.mock("../../components/ui/ToastProvider", () => ({
@@ -38,10 +43,25 @@ vi.mock("../../components/ui/Ui", () => ({
 
 beforeEach(() => {
   showToast.mockReset();
+  captureRecoveryIntent.mockReset();
   fetchRecoveryLogs.mockReset();
   inspectRecoveryWorkflow.mockReset();
+  validateRecoveryGate.mockReset();
   fetchRecoveryLogs.mockResolvedValue(getRecoveryLogsFixtureResponse());
   inspectRecoveryWorkflow.mockResolvedValue({ ok: true, reconciliation: recoveryInspectionFixture });
+  captureRecoveryIntent.mockResolvedValue({
+    ok: true,
+    intent: getRecoveryLogsFixtureResponse().intents[0],
+  });
+  validateRecoveryGate.mockResolvedValue({
+    ok: true,
+    gate: {
+      gateStatus: "satisfied",
+      intentStatus: "captured",
+      authorizationValid: true,
+      intentFresh: true,
+    },
+  });
 });
 
 afterEach(() => {
@@ -57,8 +77,11 @@ describe("AdminRecoveryWorkspacePage", () => {
     expect(screen.getByText("Immutable recovery history")).toBeInTheDocument();
     expect(await screen.findByText("Canonical timeline reviewed and accepted.")).toBeInTheDocument();
     expect(screen.getAllByText("Metadata divergence").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: /Decision Metadata divergence/i }));
     expect(screen.getByText("Timeline entry recovery_timeline:safe-entry-key")).toBeInTheDocument();
     expect(screen.getByText(/Raw workflow and actor identifiers are replaced/)).toBeInTheDocument();
+    expect(screen.getByText("Recovery action intent")).toBeInTheDocument();
+    expect(screen.getByText("Operator intends to accept canonical state after reviewing recovery evidence.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /reconcile/i })).not.toBeInTheDocument();
@@ -88,12 +111,13 @@ describe("AdminRecoveryWorkspacePage", () => {
   });
 
   it("renders empty states without mutation affordances", async () => {
-    fetchRecoveryLogs.mockResolvedValueOnce({ ok: true, logs: [], candidates: [] });
+    fetchRecoveryLogs.mockResolvedValueOnce({ ok: true, logs: [], intents: [], candidates: [] });
 
     render(<AdminRecoveryWorkspacePage />);
 
     expect(await screen.findByText("No recovery candidates are available.")).toBeInTheDocument();
     expect(screen.getByText("No recovery actions recorded.")).toBeInTheDocument();
+    expect(screen.getByText("No recovery candidate selected.")).toBeInTheDocument();
     expect(screen.getByText("Select a recovery log to review its timeline linkage.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /create/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
@@ -116,5 +140,40 @@ describe("AdminRecoveryWorkspacePage", () => {
         variant: "error",
       })
     );
+  });
+
+  it("validates and submits recovery intent without mutation affordances", async () => {
+    render(<AdminRecoveryWorkspacePage />);
+
+    await screen.findByText("Canonical timeline reviewed and accepted.");
+    fireEvent.click(screen.getByRole("button", { name: /Decision Metadata divergence/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Capture intent" }));
+
+    expect(await screen.findByText("Intent reason is required.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Intent reason"), {
+      target: { value: "Operator reviewed recovery evidence and intends canonical recovery." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Capture intent" }));
+
+    expect(await screen.findByText("Authorization confirmation is required.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Authorization confirmation"));
+    fireEvent.click(screen.getByRole("button", { name: "Capture intent" }));
+
+    await waitFor(() =>
+      expect(captureRecoveryIntent).toHaveBeenCalledWith({
+        recoveryId: "decision:instance:safe-workflow-key",
+        actionType: "ACCEPT_CANONICAL",
+        reason: "Operator reviewed recovery evidence and intends canonical recovery.",
+        authorizationConfirmed: true,
+      })
+    );
+    expect(validateRecoveryGate).toHaveBeenCalledWith({
+      recoveryId: "decision:instance:safe-workflow-key",
+      intentId: "recovery_intent:safe-intent-key",
+    });
+    expect(await screen.findByText("Gate status Satisfied")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reconcile/i })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminRecoveryWorkspacePage.tsx
@@ -3,11 +3,16 @@ import { MacShell } from "../../components/layout/MacShell";
 import { Button, Card, Input, Pill, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
 import {
+  captureRecoveryIntent,
   fetchRecoveryLogs,
   inspectRecoveryWorkflow,
+  validateRecoveryGate,
   type DecisionRecoveryInspection,
   type OperatorRecoveryLog,
+  type RecoveryActionIntent,
+  type RecoveryActionType,
   type RecoveryDivergenceType,
+  type RecoveryGateValidation,
   type RecoveryWorkflowType,
 } from "../../api/adminRecoveryApi";
 
@@ -20,6 +25,8 @@ const DIVERGENCE_LABELS: Record<RecoveryDivergenceType, string> = {
   EVIDENCE_MISMATCH: "Evidence mismatch",
   METADATA_DIVERGENCE: "Metadata divergence",
 };
+
+const ACTION_TYPES: RecoveryActionType[] = ["ACCEPT_CANONICAL", "ACCEPT_DERIVED", "EVIDENCE_REVIEW_REQUIRED"];
 
 function label(value: string | null | undefined) {
   const raw = String(value || "").trim();
@@ -166,14 +173,131 @@ function RecoveryTimeline({ log }: { log: OperatorRecoveryLog | null }) {
   );
 }
 
+function RecoveryIntentPanel({
+  inspection,
+  intents,
+  gate,
+  actionType,
+  reason,
+  authorizationConfirmed,
+  submitting,
+  onActionTypeChange,
+  onReasonChange,
+  onAuthorizationChange,
+  onSubmit,
+}: {
+  inspection: DecisionRecoveryInspection | null;
+  intents: RecoveryActionIntent[];
+  gate: RecoveryGateValidation | null;
+  actionType: RecoveryActionType;
+  reason: string;
+  authorizationConfirmed: boolean;
+  submitting: boolean;
+  onActionTypeChange: (value: RecoveryActionType) => void;
+  onReasonChange: (value: string) => void;
+  onAuthorizationChange: (value: boolean) => void;
+  onSubmit: () => void;
+}) {
+  if (!inspection) {
+    return (
+      <Card>
+        <div style={{ fontWeight: 700 }}>No recovery candidate selected.</div>
+        <div style={{ color: "#64748b", marginTop: 6 }}>Select or inspect a recovery workflow to capture operator intent.</div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 14 }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Recovery action intent</h2>
+          <Pill tone="muted">Append only</Pill>
+          <Pill tone="muted">Gate validation</Pill>
+        </div>
+        <div style={{ color: "#475569" }}>
+          Capture operator intent before future recovery action. This records authorization intent only; diagnostics remain read-only.
+        </div>
+        <div style={{ display: "grid", gap: 10 }}>
+          <label style={{ display: "grid", gap: 4 }}>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Action type</div>
+            <select
+              aria-label="Recovery action type"
+              value={actionType}
+              onChange={(event) => onActionTypeChange(event.target.value as RecoveryActionType)}
+              style={{ width: "100%", minHeight: 42 }}
+            >
+              {ACTION_TYPES.map((item) => <option key={item} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4 }}>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Reason comment</div>
+            <textarea
+              aria-label="Intent reason"
+              value={reason}
+              onChange={(event) => onReasonChange(event.target.value)}
+              placeholder="Describe the operator review basis for this recovery intent"
+              rows={4}
+              style={{ width: "100%", boxSizing: "border-box", resize: "vertical" }}
+            />
+          </label>
+          <label style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+            <input
+              aria-label="Authorization confirmation"
+              type="checkbox"
+              checked={authorizationConfirmed}
+              onChange={(event) => onAuthorizationChange(event.target.checked)}
+            />
+            <span>I confirm this records operator intent only and does not mutate recovery state.</span>
+          </label>
+          <Button onClick={onSubmit} disabled={submitting}>
+            Capture intent
+          </Button>
+        </div>
+        {gate ? (
+          <div style={{ border: "1px solid rgba(15, 23, 42, 0.12)", borderRadius: 8, padding: 12 }}>
+            <strong>Gate status {label(gate.gateStatus)}</strong>
+            <div style={{ color: "#475569", marginTop: 4 }}>
+              Authorization {gate.authorizationValid ? "valid" : "not valid"} · intent {gate.intentFresh ? "fresh" : "not fresh"}
+              {gate.reason ? ` · ${label(gate.reason)}` : ""}
+            </div>
+          </div>
+        ) : null}
+        <div style={{ display: "grid", gap: 8 }}>
+          <strong>Intent history</strong>
+          {intents.length ? intents.map((intent) => (
+            <div key={intent.intentId} style={{ border: "1px solid rgba(15, 23, 42, 0.12)", borderRadius: 8, padding: 10 }}>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <Pill tone="muted">{label(intent.actionType)}</Pill>
+                <Pill tone="muted">{label(intent.operator.role)}</Pill>
+                <Pill tone="muted">{label(intent.status)}</Pill>
+              </div>
+              <div style={{ color: "#475569", marginTop: 6 }}>{intent.reasonSummary}</div>
+              <div style={{ color: "#64748b", marginTop: 4, fontSize: 13 }}>
+                Captured {formatTime(intent.capturedAt)} · expires {formatTime(intent.expiresAt)}
+              </div>
+            </div>
+          )) : <div style={{ color: "#64748b" }}>No intent has been captured for this recovery candidate.</div>}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 export default function AdminRecoveryWorkspacePage() {
   const { showToast } = useToast();
   const [workflowType, setWorkflowType] = React.useState<RecoveryWorkflowType>("decision");
   const [workflowId, setWorkflowId] = React.useState("");
   const [inspection, setInspection] = React.useState<DecisionRecoveryInspection | null>(null);
   const [logs, setLogs] = React.useState<OperatorRecoveryLog[]>([]);
+  const [intents, setIntents] = React.useState<RecoveryActionIntent[]>([]);
   const [candidates, setCandidates] = React.useState<DecisionRecoveryInspection[]>([]);
   const [selectedLog, setSelectedLog] = React.useState<OperatorRecoveryLog | null>(null);
+  const [intentActionType, setIntentActionType] = React.useState<RecoveryActionType>("ACCEPT_CANONICAL");
+  const [intentReason, setIntentReason] = React.useState("");
+  const [intentConfirmed, setIntentConfirmed] = React.useState(false);
+  const [intentSubmitting, setIntentSubmitting] = React.useState(false);
+  const [gate, setGate] = React.useState<RecoveryGateValidation | null>(null);
   const [loadingLogs, setLoadingLogs] = React.useState(false);
   const [inspecting, setInspecting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -184,6 +308,7 @@ export default function AdminRecoveryWorkspacePage() {
       setError(null);
       const response = await fetchRecoveryLogs({ includeCandidates: true, limit: 25 });
       setLogs(response.logs || []);
+      setIntents(response.intents || []);
       setCandidates(response.candidates || []);
       setSelectedLog((current) => {
         if (!current) return response.logs?.[0] || null;
@@ -213,12 +338,59 @@ export default function AdminRecoveryWorkspacePage() {
       setError(null);
       const response = await inspectRecoveryWorkflow({ workflowType, workflowId: trimmed });
       setInspection(response.reconciliation);
+      if (response.reconciliation.proposedDecision !== "NO_ACTION") setIntentActionType(response.reconciliation.proposedDecision);
+      setGate(null);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to inspect recovery state";
       setError(message);
       showToast({ message: "Failed to inspect recovery state", description: message, variant: "error" });
     } finally {
       setInspecting(false);
+    }
+  };
+
+  const selectedIntents = React.useMemo(() => {
+    if (!inspection) return [];
+    return intents.filter((intent) => intent.workflowInstanceKey === inspection.workflowInstanceKey);
+  }, [inspection, intents]);
+
+  const captureIntent = async () => {
+    if (!inspection) {
+      setError("Select a recovery candidate before capturing intent.");
+      return;
+    }
+    if (!intentReason.trim()) {
+      setError("Intent reason is required.");
+      return;
+    }
+    if (!intentConfirmed) {
+      setError("Authorization confirmation is required.");
+      return;
+    }
+    try {
+      setIntentSubmitting(true);
+      setError(null);
+      const captured = await captureRecoveryIntent({
+        recoveryId: inspection.workflowInstanceKey,
+        actionType: intentActionType,
+        reason: intentReason.trim(),
+        authorizationConfirmed: intentConfirmed,
+      });
+      setIntents((current) => [captured.intent, ...current.filter((intent) => intent.intentId !== captured.intent.intentId)]);
+      const validated = await validateRecoveryGate({
+        recoveryId: inspection.workflowInstanceKey,
+        intentId: captured.intent.intentId,
+      });
+      setGate(validated.gate);
+      setIntentReason("");
+      setIntentConfirmed(false);
+      showToast({ message: "Recovery intent captured", description: "Gate validation completed without mutating recovery state." });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to capture recovery intent";
+      setError(message);
+      showToast({ message: "Failed to capture recovery intent", description: message, variant: "error" });
+    } finally {
+      setIntentSubmitting(false);
     }
   };
 
@@ -286,7 +458,11 @@ export default function AdminRecoveryWorkspacePage() {
                     <button
                       key={`${candidate.workflowType}:${candidate.workflowInstanceKey}`}
                       type="button"
-                      onClick={() => setInspection(candidate)}
+                      onClick={() => {
+                        setInspection(candidate);
+                        if (candidate.proposedDecision !== "NO_ACTION") setIntentActionType(candidate.proposedDecision);
+                        setGate(null);
+                      }}
                       style={{
                         textAlign: "left",
                         border: "1px solid rgba(15, 23, 42, 0.12)",
@@ -307,6 +483,20 @@ export default function AdminRecoveryWorkspacePage() {
             </div>
           </Card>
         </div>
+
+        <RecoveryIntentPanel
+          inspection={inspection}
+          intents={selectedIntents}
+          gate={gate}
+          actionType={intentActionType}
+          reason={intentReason}
+          authorizationConfirmed={intentConfirmed}
+          submitting={intentSubmitting}
+          onActionTypeChange={setIntentActionType}
+          onReasonChange={setIntentReason}
+          onAuthorizationChange={setIntentConfirmed}
+          onSubmit={() => void captureIntent()}
+        />
 
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(300px, 100%), 1fr))", gap: 16 }}>
           <div style={{ display: "grid", gap: 10 }}>

--- a/rentchain-frontend/src/test/fixtures/recoveryWorkspaceFixtures.ts
+++ b/rentchain-frontend/src/test/fixtures/recoveryWorkspaceFixtures.ts
@@ -1,6 +1,7 @@
 import type {
   DecisionRecoveryInspection,
   OperatorRecoveryLog,
+  RecoveryActionIntent,
   RecoveryLogsResponse,
 } from "../../api/adminRecoveryApi";
 
@@ -65,10 +66,33 @@ export const recoveryLogFixture: OperatorRecoveryLog = {
   redactionSummary: "Raw workflow and actor identifiers are replaced with deterministic safe references.",
 };
 
+export const recoveryIntentFixture: RecoveryActionIntent = {
+  intentId: "recovery_intent:safe-intent-key",
+  recoveryId: "decision:instance:safe-workflow-key",
+  workflowType: "decision",
+  workflowInstanceKey: "decision:instance:safe-workflow-key",
+  actionType: "ACCEPT_CANONICAL",
+  reasonSummary: "Operator intends to accept canonical state after reviewing recovery evidence.",
+  authorizationConfirmed: true,
+  status: "captured",
+  operator: {
+    role: "admin",
+    operatorRef: "operator:safe-operator-key",
+    rawIdsIncluded: false,
+  },
+  capturedAt: "2026-06-01T12:10:00.000Z",
+  expiresAt: "2026-06-02T12:10:00.000Z",
+  metadataOnly: true,
+  appendOnly: true,
+  rawIdsIncluded: false,
+  redactionSummary: "Raw workflow and actor identifiers are replaced with deterministic safe references.",
+};
+
 export function getRecoveryLogsFixtureResponse(): RecoveryLogsResponse {
   return {
     ok: true,
     logs: [recoveryLogFixture],
+    intents: [recoveryIntentFixture],
     candidates: [recoveryInspectionFixture],
   };
 }


### PR DESCRIPTION
## Summary
Adds recovery action intent capture and read-only enforcement gate validation for the admin/support recovery workspace.

## Changes
- Adds append-only recovery intent records with deterministic safe references
- Adds admin/support intent capture endpoint and read-only gate validation endpoint
- Adds duplicate intent rejection, required reason comments, authorization confirmation, and freshness validation
- Extends recovery logs response with recent intent history for workspace reload persistence
- Adds recovery workspace intent form, intent history display, and gate status display
- Updates recovery architecture documentation for intent and gate flow

## Validation
- Backend npm ci: pass
- Frontend npm ci: pass
- Backend targeted tests: 10/10 passing
- Frontend targeted tests: 10/10 passing
- Backend build: pass
- Frontend build: pass with existing large chunk warning
- Frontend full suite: 1135/1135 passing on rerun
- git diff --check: pass
- Added-line restricted-reference scan: pass
- New recovery intent type scan: pass

## Scope
Recovery intent capture and read-only gate validation only. No recovery state correction, workflow mutation, billing, auth core, screening adapters, provider callbacks, Firestore rules, Terraform, CI/CD, or production data migration changes.

## Notes
Gate validation is diagnostic in this mission. Future mutation workflows must explicitly consume satisfied gates before applying state correction.