### PR TITLE
fix: return degraded recovery inspect state for invalid lease ID

### DIFF
--- a/rentchain-api/src/routes/__tests__/adminRecoveryRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminRecoveryRoutes.test.ts
@@ -172,6 +172,32 @@ describe("adminRecoveryRoutes", () => {
     expect(JSON.stringify(inspected.body)).not.toContain("decision-route-1");
   });
 
+  it("returns safe degraded recovery diagnostics for unsafe lease references", async () => {
+    const router = (await import("../adminRecoveryRoutes")).default;
+
+    const inspected = await invokeRouter(router, {
+      method: "POST",
+      url: "/recovery/inspect",
+      user: { id: "admin-1", role: "admin" },
+      body: { workflowType: "lease", workflowId: "leases/raw-lease-1" },
+    });
+
+    expect(inspected.status).toBe(200);
+    expect(inspected.body).toMatchObject({
+      ok: true,
+      degraded: true,
+      degradedReason: "invalid_workflow_reference",
+      reconciliation: {
+        workflowType: "lease",
+        divergenceType: "NONE",
+        proposedDecision: "NO_ACTION",
+        reasonCode: "NO_RECOVERY_REQUIRED",
+        manualReviewRequired: false,
+      },
+    });
+    expect(JSON.stringify(inspected.body)).not.toContain("raw-lease-1");
+  });
+
   it("reconciles by append-only recovery log and exposes logs safely", async () => {
     const router = (await import("../adminRecoveryRoutes")).default;
     const key = workflowKey("payment", "payment-route-1");

--- a/rentchain-api/src/routes/adminRecoveryRoutes.ts
+++ b/rentchain-api/src/routes/adminRecoveryRoutes.ts
@@ -71,8 +71,13 @@ router.post("/recovery/inspect", requireAuth, async (req: AuthRequest, res) => {
     const id = workflowId(body.workflowId);
     if (!type || !id) return res.status(400).json({ ok: false, error: "WORKFLOW_REFERENCE_REQUIRED" });
     const inspection = await inspectWorkflowState({ workflowType: type, workflowId: id, authority });
-    if (!inspection.found) return res.status(404).json({ ok: false, error: "RECOVERY_WORKFLOW_NOT_FOUND" });
-    return res.json({ ok: true, reconciliation: buildDecisionReconciliation(inspection) });
+    if (!inspection.found && !inspection.degraded) return res.status(404).json({ ok: false, error: "RECOVERY_WORKFLOW_NOT_FOUND" });
+    return res.json({
+      ok: true,
+      reconciliation: buildDecisionReconciliation(inspection),
+      degraded: inspection.degraded === true,
+      degradedReason: inspection.degradedReason || null,
+    });
   } catch (error) {
     const mapped = mapError(error);
     return res.status(mapped.status).json({ ok: false, error: mapped.code });

--- a/rentchain-api/src/services/recovery/__tests__/decisionStateInspector.test.ts
+++ b/rentchain-api/src/services/recovery/__tests__/decisionStateInspector.test.ts
@@ -62,4 +62,35 @@ describe("decisionStateInspector", () => {
       })
     ).rejects.toThrow("recovery_inspection_forbidden");
   });
+
+  it("returns a degraded inspection for unsafe workflow reference formats", async () => {
+    const store = createRecoveryTestStore();
+    const inspection = await inspectWorkflowState({
+      workflowType: "lease",
+      workflowId: "leases/raw-lease-1",
+      authority: adminAuthority,
+      firestore: store,
+    });
+
+    expect(inspection).toMatchObject({
+      workflowType: "lease",
+      divergenceType: "NONE",
+      found: false,
+      degraded: true,
+      degradedReason: "invalid_workflow_reference",
+      evidence: {
+        evidenceRefCount: 0,
+        latestEvidenceAt: null,
+        evidenceState: null,
+        metadataOnly: true,
+      },
+    });
+    expect(inspection.workflowInstanceKey).toMatch(/^lease:instance:/);
+    expect(inspection.workflowInstanceKey).not.toContain("raw-lease-1");
+    expect(buildDecisionReconciliation(inspection)).toMatchObject({
+      proposedDecision: "NO_ACTION",
+      manualReviewRequired: false,
+      reasonCode: "NO_RECOVERY_REQUIRED",
+    });
+  });
 });

--- a/rentchain-api/src/services/recovery/decisionStateInspector.ts
+++ b/rentchain-api/src/services/recovery/decisionStateInspector.ts
@@ -31,6 +31,8 @@ export type WorkflowInspectionResult = {
   evidence: EvidenceSnapshot;
   divergenceType: DivergenceType;
   found: boolean;
+  degraded?: boolean;
+  degradedReason?: "invalid_workflow_reference";
 };
 
 function stateFromRecord(
@@ -73,6 +75,33 @@ function latestEvidence(events: TransitionProvenanceEvent[]): EvidenceSnapshot {
   };
 }
 
+function emptyEvidence(): EvidenceSnapshot {
+  return {
+    evidenceRefCount: 0,
+    latestEvidenceAt: null,
+    evidenceState: null,
+    metadataOnly: true,
+  };
+}
+
+function hasUnsafeWorkflowReference(value: string): boolean {
+  return value.includes("/") || value.includes("\\") || value.includes("\0");
+}
+
+function degradedInspection(input: WorkflowInspectionInput, reason: WorkflowInspectionResult["degradedReason"]): WorkflowInspectionResult {
+  return {
+    workflowType: input.workflowType,
+    workflowInstanceKey: workflowKey(input.workflowType, input.workflowId),
+    canonicalState: stateFromRecord(null, "none"),
+    derivedState: stateFromRecord(null, "none"),
+    evidence: emptyEvidence(),
+    divergenceType: "NONE",
+    found: false,
+    degraded: true,
+    degradedReason: reason,
+  };
+}
+
 export function detectDivergence(input: {
   canonicalState: RecoveryWorkflowState;
   derivedState: RecoveryWorkflowState;
@@ -97,6 +126,9 @@ export function detectDivergence(input: {
 export async function inspectWorkflowState(input: WorkflowInspectionInput): Promise<WorkflowInspectionResult> {
   if (!isOperatorAuthority(input.authority)) {
     throw new Error("recovery_inspection_forbidden");
+  }
+  if (hasUnsafeWorkflowReference(input.workflowId)) {
+    return degradedInspection(input, "invalid_workflow_reference");
   }
   const workflowInstanceKey = workflowKey(input.workflowType, input.workflowId);
   const [snapshot, timelineRecords, provenanceEvents] = await Promise.all([


### PR DESCRIPTION
## Summary
Fixes the recovery inspect endpoint so unsafe path-style lease workflow references return safe degraded diagnostics instead of falling through to the generic route failure path.

## Changes
- decisionStateInspector.ts — adds degraded inspection metadata for invalid workflow references
- adminRecoveryRoutes.ts — returns 200 OK with degraded diagnostics while preserving 404 for ordinary unknown workflows
- recovery tests — covers service and route behavior for unsafe lease references

## Validation
- Focused backend tests: 6/6 passing
- Backend build: pass
- git diff --check: pass

## Scope
Backend recovery inspect error handling only. No auth widening, no new routes, no recovery mutations, no UI changes, and no protected areas touched.