### PR TITLE
chore: add diagnostic logging to recovery inspect errors

### DIFF
--- a/rentchain-api/src/routes/adminRecoveryRoutes.ts
+++ b/rentchain-api/src/routes/adminRecoveryRoutes.ts
@@ -80,6 +80,9 @@ router.post("/recovery/inspect", requireAuth, async (req: AuthRequest, res) => {
     });
   } catch (error) {
     const mapped = mapError(error);
+    if (mapped.status === 500) {
+      console.error("[recovery/inspect] unhandled error:", error instanceof Error ? error.message : String(error), error instanceof Error ? error.stack : "");
+    }
     return res.status(mapped.status).json({ ok: false, error: mapped.code });
   }
 });


### PR DESCRIPTION
## Summary
Adds guarded diagnostic logging for unexpected 500 errors in the recovery inspect route handler.

## Changes
- adminRecoveryRoutes.ts — logs unhandled recovery inspect errors when mapped to 500

## Validation
- Backend build: pass with Node 20.11.1
- git diff --check: pass

## Scope
Diagnostic logging only. No response behavior changes, no auth changes, no new routes, and no recovery mutations.