### PR TITLE
feat: add canonical audit foundations for supervised workflows

### DIFF
--- a/docs/audit/canonical-audit-events-v1.md
+++ b/docs/audit/canonical-audit-events-v1.md
@@ -1,0 +1,43 @@
+# Canonical Audit Events v1
+
+## Purpose
+
+Phase 2 canonical audit events provide append-safe evidence for supervised review workspace and recovery operations. They are metadata-only records written to the existing `canonicalEvents` collection with a typed event envelope, immutable document IDs, and safe references replacing raw actor, workflow, landlord, tenant, and data-store identifiers.
+
+## Event Types
+
+- `recovery_intent_captured`
+- `recovery_gate_validated`
+- `review_state_transitioned`
+- `operator_review_opened`
+- `operator_review_note_added`
+- `operator_review_outcome_recorded`
+- `operator_review_session_closed`
+
+## Required Envelope
+
+Each event includes:
+
+- `eventId`
+- `eventType`
+- `timestamp`
+- `actor`
+- `authority`
+- `sourceReferenceId`
+- `metadata`
+- `metadataOnly: true`
+- `appendOnly: true`
+- `immutable: true`
+- `rawIdsIncluded: false`
+
+## Append Semantics
+
+The canonical audit append helper writes with document creation semantics when Firestore supports `create()`. Existing event documents are not overwritten. This preserves immutable operational history while keeping audit append failures non-blocking for recovery intent and gate validation flows.
+
+## Projection Safety
+
+Audit metadata must not include raw Firestore IDs, tenant IDs, landlord IDs, tokens, provider payloads, storage paths, or credentials. Actor, authority, and source references are deterministic safe references. Operator review notes and summaries reuse existing sanitization before audit emission.
+
+## Current Limitations
+
+This foundation does not add audit retrieval APIs, audit dashboards, export generation, compliance report generation, real-time subscriptions, replay, or enforcement policy evaluation. State transition audit events are emitted beside existing provenance capture when transition evidence capture is requested.

--- a/rentchain-api/src/lib/canonicalAudit/__tests__/canonicalAuditEvent.test.ts
+++ b/rentchain-api/src/lib/canonicalAudit/__tests__/canonicalAuditEvent.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { CANONICAL_EVENTS_COLLECTION } from "../../events/buildEvent";
+import { appendCanonicalAuditEvent, safeAuditReference } from "../appendCanonicalAuditEvent";
+import { createRecoveryTestStore } from "../../../services/recovery/__tests__/recoveryTestStore";
+
+describe("canonical audit events", () => {
+  it("appends immutable typed audit events to the existing canonical events collection", async () => {
+    const store = createRecoveryTestStore();
+    const event = await appendCanonicalAuditEvent(
+      {
+        eventType: "recovery_gate_validated",
+        actor: { role: "admin", operatorRef: "operator-raw-1", rawIdsIncluded: false },
+        authority: { role: "admin", landlordRef: "landlord-raw-1", supportAllowed: false, rawIdsIncluded: false },
+        sourceReferenceId: "workflow-raw-1",
+        timestamp: "2026-06-02T10:00:00.000Z",
+        metadata: {
+          intentId: "intent-safe-1",
+          recoveryId: "recovery-safe-1",
+          gateType: "recovery_action_intent",
+          validationOutcome: "passed",
+          intentStatus: "captured",
+          authorizationValid: true,
+          intentFresh: true,
+          denialReason: null,
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        },
+      },
+      { firestore: store }
+    );
+
+    expect(event).toEqual(
+      expect.objectContaining({
+        eventType: "recovery_gate_validated",
+        timestamp: "2026-06-02T10:00:00.000Z",
+        sourceCollection: "canonicalEvents",
+        metadataOnly: true,
+        appendOnly: true,
+        immutable: true,
+        rawIdsIncluded: false,
+      })
+    );
+    expect(event.actor.operatorRef).not.toContain("operator-raw-1");
+    expect(event.authority.landlordRef).not.toContain("landlord-raw-1");
+    expect(event.sourceReferenceId).not.toContain("workflow-raw-1");
+    expect(store.read(CANONICAL_EVENTS_COLLECTION, event.eventId)).toEqual(event);
+  });
+
+  it("fails closed when the same immutable event id is appended twice", async () => {
+    const store = createRecoveryTestStore();
+    const input = {
+      eventType: "operator_review_opened" as const,
+      actor: { role: "landlord" as const, operatorRef: "landlord-user-1", rawIdsIncluded: false as const },
+      authority: { role: "landlord" as const, landlordRef: "landlord-1", supportAllowed: false, rawIdsIncluded: false as const },
+      sourceReferenceId: "review-session-1",
+      timestamp: "2026-06-02T10:05:00.000Z",
+      visibility: "landlord_operator_internal" as const,
+      metadata: {
+        reviewSessionId: safeAuditReference("review_session", "review-session-1"),
+        scope: "decision",
+        scopeId: safeAuditReference("review_scope", "decision-1"),
+        reviewStatus: "open",
+        noteSummary: "Operator review opened.",
+        manualOnly: true,
+        metadataOnly: true,
+        rawIdsIncluded: false,
+      },
+    };
+
+    await appendCanonicalAuditEvent(input, { firestore: store });
+    await expect(appendCanonicalAuditEvent(input, { firestore: store })).rejects.toThrow("already");
+  });
+});

--- a/rentchain-api/src/lib/canonicalAudit/appendCanonicalAuditEvent.ts
+++ b/rentchain-api/src/lib/canonicalAudit/appendCanonicalAuditEvent.ts
@@ -1,0 +1,154 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../events/buildEvent";
+import type {
+  CanonicalAuditActor,
+  CanonicalAuditAuthority,
+  CanonicalAuditEvent,
+  CanonicalAuditEventMetadata,
+  CanonicalAuditEventType,
+} from "../../types/canonicalAuditEvent";
+
+type SnapshotLike = {
+  exists?: boolean;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type DocumentRefLike<T> = {
+  get?: () => Promise<SnapshotLike>;
+  create?: (data: T) => Promise<unknown>;
+  set?: (data: T, options?: { merge?: boolean }) => Promise<unknown>;
+};
+
+type CollectionLike<T> = {
+  doc: (id: string) => DocumentRefLike<T>;
+};
+
+export type CanonicalAuditFirestoreLike = {
+  collection: <T = Record<string, unknown>>(name: string) => CollectionLike<T>;
+};
+
+export type AppendCanonicalAuditEventInput = {
+  eventType: CanonicalAuditEventType;
+  actor: CanonicalAuditActor;
+  authority: CanonicalAuditAuthority;
+  sourceReferenceId: string;
+  metadata: CanonicalAuditEventMetadata;
+  timestamp?: string;
+  visibility?: CanonicalAuditEvent["visibility"];
+};
+
+type AppendCanonicalAuditEventOptions = {
+  firestore?: CanonicalAuditFirestoreLike;
+};
+
+function toSafeText(value: unknown, max = 1000): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function toUtcIso(value: unknown): string {
+  const raw = toSafeText(value, 120);
+  if (!raw) return new Date().toISOString();
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function stableHash(parts: readonly unknown[]): string {
+  return crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 32);
+}
+
+export function safeAuditReference(prefix: string, value: unknown): string {
+  const cleanPrefix = toSafeText(prefix, 80).toLowerCase().replace(/[^a-z0-9_.:-]+/g, "_") || "ref";
+  const raw = toSafeText(value, 1000) || "unknown";
+  return `${cleanPrefix}:${stableHash([cleanPrefix, raw])}`;
+}
+
+function eventIdFor(input: {
+  eventType: CanonicalAuditEventType;
+  sourceReferenceId: string;
+  timestamp: string;
+  actor: CanonicalAuditActor;
+  metadata: CanonicalAuditEventMetadata;
+}): string {
+  return `canonical_audit:${stableHash([
+    input.eventType,
+    input.sourceReferenceId,
+    input.timestamp,
+    input.actor.role,
+    input.actor.operatorRef,
+    input.metadata,
+  ])}`;
+}
+
+function canonicalAuditDb(firestore?: CanonicalAuditFirestoreLike): CanonicalAuditFirestoreLike {
+  return firestore || (db as unknown as CanonicalAuditFirestoreLike);
+}
+
+/**
+ * Appends one immutable canonical audit event to the existing canonicalEvents collection.
+ * The write uses create() when available so existing audit documents cannot be overwritten.
+ */
+export async function appendCanonicalAuditEvent(
+  input: AppendCanonicalAuditEventInput,
+  options: AppendCanonicalAuditEventOptions = {}
+): Promise<CanonicalAuditEvent> {
+  const timestamp = toUtcIso(input.timestamp);
+  const sourceReferenceId = safeAuditReference("audit_source", input.sourceReferenceId);
+  const event: CanonicalAuditEvent = {
+    eventId: eventIdFor({
+      eventType: input.eventType,
+      sourceReferenceId,
+      timestamp,
+      actor: input.actor,
+      metadata: input.metadata,
+    }),
+    eventType: input.eventType,
+    timestamp,
+    actor: {
+      role: input.actor.role,
+      operatorRef: input.actor.operatorRef ? safeAuditReference("operator", input.actor.operatorRef) : null,
+      rawIdsIncluded: false,
+    },
+    authority: {
+      role: input.authority.role,
+      landlordRef: input.authority.landlordRef ? safeAuditReference("landlord", input.authority.landlordRef) : null,
+      supportAllowed: input.authority.supportAllowed,
+      rawIdsIncluded: false,
+    },
+    sourceReferenceId,
+    metadata: input.metadata,
+    sourceCollection: CANONICAL_EVENTS_COLLECTION,
+    visibility: input.visibility || "admin_support_internal",
+    metadataOnly: true,
+    appendOnly: true,
+    immutable: true,
+    rawIdsIncluded: false,
+    redactionSummary: "Raw actor, workflow, tenant, landlord, and data-store identifiers are replaced with safe references.",
+  };
+
+  const ref = canonicalAuditDb(options.firestore).collection<CanonicalAuditEvent>(CANONICAL_EVENTS_COLLECTION).doc(event.eventId);
+  if (ref.create) {
+    await ref.create(event);
+    return event;
+  }
+  const existing = ref.get ? await ref.get() : null;
+  if (existing?.exists) throw new Error("canonical_audit_event_already_exists");
+  if (!ref.set) throw new Error("canonical_audit_event_append_unavailable");
+  await ref.set(event, { merge: false });
+  return event;
+}
+
+/**
+ * Emits a canonical audit event without failing the caller if audit storage is unavailable.
+ */
+export async function appendCanonicalAuditEventSafely(
+  input: AppendCanonicalAuditEventInput,
+  options: AppendCanonicalAuditEventOptions = {}
+): Promise<CanonicalAuditEvent | null> {
+  try {
+    return await appendCanonicalAuditEvent(input, options);
+  } catch (error) {
+    console.warn("[canonical-audit] append skipped", { message: error instanceof Error ? error.message : "failed" });
+    return null;
+  }
+}

--- a/rentchain-api/src/lib/canonicalAudit/reviewStateTransitionAudit.ts
+++ b/rentchain-api/src/lib/canonicalAudit/reviewStateTransitionAudit.ts
@@ -1,0 +1,55 @@
+import { appendCanonicalAuditEventSafely, type CanonicalAuditFirestoreLike } from "./appendCanonicalAuditEvent";
+import type { CanonicalAuditAuthorityRole } from "../../types/canonicalAuditEvent";
+import type { ActorRole, TransitionProvenanceEvent } from "../../services/stateMachines/types";
+
+type ReviewStateTransitionAuditAuthority = {
+  actorRole: ActorRole;
+  landlordRef?: string | null;
+};
+
+function auditRole(role: ActorRole): CanonicalAuditAuthorityRole {
+  if (role === "admin" || role === "support" || role === "landlord" || role === "system") return role;
+  return "system";
+}
+
+/**
+ * Emits a canonical audit event for an existing state-machine provenance event.
+ * The state transition remains advisory; this helper only records validated metadata.
+ */
+export async function appendReviewStateTransitionAuditEvent(input: {
+  provenanceEvent: TransitionProvenanceEvent;
+  authority: ReviewStateTransitionAuditAuthority;
+  firestore?: CanonicalAuditFirestoreLike;
+}) {
+  const role = auditRole(input.authority.actorRole);
+  return appendCanonicalAuditEventSafely(
+    {
+      eventType: "review_state_transitioned",
+      actor: {
+        role,
+        operatorRef: input.provenanceEvent.actor.actorRef,
+        rawIdsIncluded: false,
+      },
+      authority: {
+        role,
+        landlordRef: input.authority.landlordRef || input.provenanceEvent.access.landlordRef || null,
+        supportAllowed: role === "support",
+        rawIdsIncluded: false,
+      },
+      sourceReferenceId: input.provenanceEvent.workflowInstanceKey,
+      timestamp: input.provenanceEvent.occurredAt,
+      metadata: {
+        workflowType: input.provenanceEvent.workflowType,
+        workflowInstanceKey: input.provenanceEvent.workflowInstanceKey,
+        fromState: input.provenanceEvent.transition.from,
+        toState: input.provenanceEvent.transition.to,
+        transitionEvent: input.provenanceEvent.transition.event,
+        transitionReason: input.provenanceEvent.transition.reason,
+        validationOutcome: input.provenanceEvent.transition.outcome === "valid" ? "valid" : "invalid",
+        metadataOnly: true,
+        rawIdsIncluded: false,
+      },
+    },
+    { firestore: input.firestore }
+  );
+}

--- a/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
@@ -148,9 +148,10 @@ describe("landlordOperatorReviewRoutes", () => {
     expect(listDocs("operatorReviewSessions")).toHaveLength(1);
     expect(listDocs("canonicalEvents")).toEqual([
       expect.objectContaining({
-        type: "operator_review_session_opened",
-        domain: "system",
-        visibility: "landlord",
+        eventType: "operator_review_opened",
+        visibility: "landlord_operator_internal",
+        appendOnly: true,
+        rawIdsIncluded: false,
       }),
     ]);
   });
@@ -184,8 +185,8 @@ describe("landlordOperatorReviewRoutes", () => {
         outcome: expect.objectContaining({ result: "needs_follow_up" }),
       })
     );
-    expect(listDocs("canonicalEvents").map((event: any) => event.type)).toEqual([
-      "operator_review_session_opened",
+    expect(listDocs("canonicalEvents").map((event: any) => event.eventType)).toEqual([
+      "operator_review_opened",
       "operator_review_note_added",
       "operator_review_outcome_recorded",
       "operator_review_session_closed",

--- a/rentchain-api/src/routes/decisionRoutes.ts
+++ b/rentchain-api/src/routes/decisionRoutes.ts
@@ -23,6 +23,7 @@ import { computeDecisionState } from "../services/stateMachines/stateComputation
 import { decisionStateMachine } from "../services/stateMachines/decisionStateMachine";
 import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateDecisionTransition } from "../services/stateMachines/transitionValidation";
+import { appendReviewStateTransitionAuditEvent } from "../lib/canonicalAudit/reviewStateTransitionAudit";
 import type { DecisionActionState, DecisionEvent } from "../services/stateMachines/types";
 
 const router = Router();
@@ -273,6 +274,10 @@ router.post("/validate-transition", requireAuth, async (req: any, res: Response)
     if (validation.provenanceEvent) {
       try {
         await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: isAdmin(req) ? "admin" : "landlord", landlordRef: model.landlordId },
+        });
+        await appendReviewStateTransitionAuditEvent({
+          provenanceEvent: validation.provenanceEvent,
           authority: { actorRole: isAdmin(req) ? "admin" : "landlord", landlordRef: model.landlordId },
         });
         res.setHeader("X-Provenance-Captured", "true");

--- a/rentchain-api/src/routes/landlordOperatorReviewRoutes.ts
+++ b/rentchain-api/src/routes/landlordOperatorReviewRoutes.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { db } from "../config/firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
-import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { appendCanonicalAuditEvent, safeAuditReference } from "../lib/canonicalAudit/appendCanonicalAuditEvent";
 import {
   addOperatorReviewNote,
   buildOperatorReviewSession,
@@ -19,6 +19,7 @@ import {
   type OperatorReviewScope,
   type OperatorReviewSession,
 } from "../lib/operatorReviews/operatorReviewTypes";
+import type { CanonicalAuditEventType } from "../types/canonicalAuditEvent";
 
 const router = Router();
 
@@ -39,13 +40,9 @@ function actorFromReq(req: any) {
   });
 }
 
-function eventIdFor(input: { eventType: OperatorReviewEventType; reviewSessionId: string; at: string }) {
-  return [input.eventType, input.reviewSessionId, input.at]
-    .join(":")
-    .toLowerCase()
-    .replace(/[\/\\#?]+/g, "_")
-    .replace(/[^a-z0-9_.:-]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+function auditEventTypeFor(eventType: OperatorReviewEventType): CanonicalAuditEventType {
+  if (eventType === "operator_review_session_opened") return "operator_review_opened";
+  return eventType;
 }
 
 async function writeReviewEvent(input: {
@@ -55,39 +52,33 @@ async function writeReviewEvent(input: {
   summary: string;
 }) {
   const occurredAt = input.session.updatedAt || new Date().toISOString();
-  await writeCanonicalEvent({
-    id: eventIdFor({
-      eventType: input.eventType,
-      reviewSessionId: input.session.reviewSessionId,
-      at: occurredAt,
-    }),
-    type: input.eventType,
-    domain: "system",
-    action: input.eventType,
-    status: input.session.status,
+  await appendCanonicalAuditEvent({
+    eventType: auditEventTypeFor(input.eventType),
     actor: {
-      type: input.actor.role === "admin" ? "admin" : "landlord",
-      id: input.actor.userId,
       role: input.actor.role,
-      displayName: input.actor.email || null,
+      operatorRef: input.actor.userId,
+      rawIdsIncluded: false,
     },
-    resource: {
-      type: "operator_review_session",
-      id: input.session.reviewSessionId,
-      parentType: input.session.scope,
-      parentId: input.session.scopeId,
+    authority: {
+      role: input.actor.role,
+      landlordRef: input.session.landlordId,
+      supportAllowed: false,
+      rawIdsIncluded: false,
     },
-    occurredAt,
-    visibility: "landlord",
-    summary: input.summary,
+    sourceReferenceId: input.session.reviewSessionId,
+    timestamp: occurredAt,
+    visibility: "landlord_operator_internal",
     metadata: {
-      landlordId: input.session.landlordId,
+      reviewSessionId: safeAuditReference("review_session", input.session.reviewSessionId),
       scope: input.session.scope,
-      scopeId: input.session.scopeId,
+      scopeId: safeAuditReference("review_scope", input.session.scopeId),
+      reviewStatus: input.session.status,
+      noteSummary: input.summary,
+      outcome: input.session.outcome?.result || null,
       manualOnly: true,
-      systemGenerated: false,
+      metadataOnly: true,
+      rawIdsIncluded: false,
     },
-    tags: ["operator_review", input.session.scope],
   });
 }
 

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -75,6 +75,7 @@ import { computeLeaseState } from "../services/stateMachines/stateComputation";
 import { leaseStateMachine } from "../services/stateMachines/leaseStateMachine";
 import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateLeaseTransition } from "../services/stateMachines/transitionValidation";
+import { appendReviewStateTransitionAuditEvent } from "../lib/canonicalAudit/reviewStateTransitionAudit";
 import type { LeaseEvent, LeaseLifecycleState } from "../services/stateMachines/types";
 
 const router = Router();
@@ -3103,6 +3104,10 @@ router.post("/validate-transition", requireLandlord, async (req: any, res: Respo
     if (validation.provenanceEvent) {
       try {
         await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: "landlord", landlordRef: landlordId },
+        });
+        await appendReviewStateTransitionAuditEvent({
+          provenanceEvent: validation.provenanceEvent,
           authority: { actorRole: "landlord", landlordRef: landlordId },
         });
         res.setHeader("X-Provenance-Captured", "true");

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -33,6 +33,7 @@ import { computeMaintenanceState } from "../services/stateMachines/stateComputat
 import { maintenanceStateMachine } from "../services/stateMachines/maintenanceStateMachine";
 import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateMaintenanceTransition } from "../services/stateMachines/transitionValidation";
+import { appendReviewStateTransitionAuditEvent } from "../lib/canonicalAudit/reviewStateTransitionAudit";
 import type { MaintenanceEvent, MaintenanceRequestState } from "../services/stateMachines/types";
 
 const router = Router();
@@ -1284,6 +1285,10 @@ router.post("/maintenance-requests/validate-transition", async (req: any, res) =
     if (validation.provenanceEvent) {
       try {
         await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: role === "admin" ? "admin" : "landlord", landlordRef: landlordId },
+        });
+        await appendReviewStateTransitionAuditEvent({
+          provenanceEvent: validation.provenanceEvent,
           authority: { actorRole: role === "admin" ? "admin" : "landlord", landlordRef: landlordId },
         });
         res.setHeader("X-Provenance-Captured", "true");

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -17,6 +17,7 @@ import { computePaymentState } from "../services/stateMachines/stateComputation"
 import { paymentStateMachine } from "../services/stateMachines/paymentStateMachine";
 import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validatePaymentTransition } from "../services/stateMachines/transitionValidation";
+import { appendReviewStateTransitionAuditEvent } from "../lib/canonicalAudit/reviewStateTransitionAudit";
 import type { PaymentEvent, PaymentState } from "../services/stateMachines/types";
 
 const router = Router();
@@ -782,6 +783,10 @@ router.post("/payments/validate-transition", requireAuth, requirePermission("pay
     if (validation.provenanceEvent) {
       try {
         await appendProvenanceEvent(validation.provenanceEvent, {
+          authority: { actorRole: roleForReq(req) === "admin" ? "admin" : "landlord", landlordRef: landlordId },
+        });
+        await appendReviewStateTransitionAuditEvent({
+          provenanceEvent: validation.provenanceEvent,
           authority: { actorRole: roleForReq(req) === "admin" ? "admin" : "landlord", landlordRef: landlordId },
         });
         res.setHeader("X-Provenance-Captured", "true");

--- a/rentchain-api/src/routes/screeningOpsRoutes.ts
+++ b/rentchain-api/src/routes/screeningOpsRoutes.ts
@@ -13,6 +13,7 @@ import {
 } from "../services/screeningOps/screeningOpsController";
 import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
 import { buildValidationSummary, validateScreeningTransition } from "../services/stateMachines/transitionValidation";
+import { appendReviewStateTransitionAuditEvent } from "../lib/canonicalAudit/reviewStateTransitionAudit";
 import type { ScreeningApplicationState, ScreeningEvent } from "../services/stateMachines/types";
 
 const router = Router();
@@ -43,6 +44,10 @@ router.post("/screening/validate-transition", requireAdmin, async (req: any, res
     if (result.provenanceEvent) {
       try {
         await appendProvenanceEvent(result.provenanceEvent, {
+          authority: { actorRole: "admin" },
+        });
+        await appendReviewStateTransitionAuditEvent({
+          provenanceEvent: result.provenanceEvent,
           authority: { actorRole: "admin" },
         });
         res.setHeader("X-Provenance-Captured", "true");

--- a/rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts
+++ b/rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CANONICAL_EVENTS_COLLECTION } from "../../../lib/events/buildEvent";
 import {
   DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
   OPERATOR_RECOVERY_INTENTS_COLLECTION,
@@ -63,6 +64,22 @@ describe("recoveryIntentService", () => {
     expect(intent.intentId).toMatch(/^recovery_intent:/);
     expect(intent.workflowInstanceKey).not.toContain("decision-raw-intent-1");
     expect(store.read(OPERATOR_RECOVERY_INTENTS_COLLECTION, intent.intentId)).toBeTruthy();
+    const auditEvents = await store.collection(CANONICAL_EVENTS_COLLECTION).get();
+    expect(auditEvents.docs.map((doc) => doc.data())).toEqual([
+      expect.objectContaining({
+        eventType: "recovery_intent_captured",
+        sourceCollection: "canonicalEvents",
+        appendOnly: true,
+        rawIdsIncluded: false,
+        metadata: expect.objectContaining({
+          intentId: expect.stringMatching(/^recovery_intent:/),
+          actionType: "ACCEPT_CANONICAL",
+          reasonSummary: "Operator reviewed continuity evidence and intends canonical recovery.",
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        }),
+      }),
+    ]);
   });
 
   it("rejects unauthorized and invalid recovery intent capture", async () => {
@@ -212,5 +229,27 @@ describe("recoveryIntentService", () => {
       authorizationValid: true,
       intentFresh: true,
     });
+
+    const auditEvents = (await store.collection(CANONICAL_EVENTS_COLLECTION).get()).docs.map((doc) => doc.data());
+    expect(auditEvents.filter((event) => event.eventType === "recovery_gate_validated")).toHaveLength(4);
+    expect(auditEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "recovery_gate_validated",
+          metadata: expect.objectContaining({
+            validationOutcome: "passed",
+            authorizationValid: true,
+            intentFresh: true,
+          }),
+        }),
+        expect.objectContaining({
+          eventType: "recovery_gate_validated",
+          metadata: expect.objectContaining({
+            validationOutcome: "failed",
+            denialReason: "intent_stale",
+          }),
+        }),
+      ])
+    );
   });
 });

--- a/rentchain-api/src/services/recovery/recoveryIntentService.ts
+++ b/rentchain-api/src/services/recovery/recoveryIntentService.ts
@@ -1,4 +1,9 @@
 import type {
+  CanonicalAuditActor,
+  CanonicalAuditAuthority,
+  CanonicalAuditAuthorityRole,
+} from "../../types/canonicalAuditEvent";
+import type {
   RecoveryActionIntent,
   RecoveryActionType,
   RecoveryAuthority,
@@ -6,6 +11,7 @@ import type {
   RecoveryIntentCaptureRequest,
 } from "../../types/recovery";
 import type { ReviewWorkflowType } from "../stateMachines/types";
+import { appendCanonicalAuditEventSafely, safeAuditReference } from "../../lib/canonicalAudit/appendCanonicalAuditEvent";
 import { asSafeText, isOperatorAuthority, stableRecoveryHash, toUtcIso } from "./recoveryShared";
 import {
   DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
@@ -40,6 +46,27 @@ type ValidateGateInput = {
   firestore?: RecoveryFirestoreLike;
   now?: string;
 };
+
+function recoveryAuditRole(authority: RecoveryAuthority): CanonicalAuditAuthorityRole {
+  return authority.role === "admin" || authority.role === "support" ? authority.role : "system";
+}
+
+function auditAuthority(authority: RecoveryAuthority): CanonicalAuditAuthority {
+  return {
+    role: recoveryAuditRole(authority),
+    landlordRef: authority.landlordRef,
+    supportAllowed: authority.supportAllowed,
+    rawIdsIncluded: false as const,
+  };
+}
+
+function auditActor(authority: RecoveryAuthority): CanonicalAuditActor {
+  return {
+    role: recoveryAuditRole(authority),
+    operatorRef: authority.operatorRef,
+    rawIdsIncluded: false as const,
+  };
+}
 
 const ACTION_TYPES: RecoveryActionType[] = ["ACCEPT_CANONICAL", "ACCEPT_DERIVED", "EVIDENCE_REVIEW_REQUIRED"];
 
@@ -152,6 +179,26 @@ export async function captureRecoveryActionIntent(input: CaptureIntentInput): Pr
   };
 
   await appendDocument(OPERATOR_RECOVERY_INTENTS_COLLECTION, intent.intentId, intent, input.firestore);
+  await appendCanonicalAuditEventSafely(
+    {
+      eventType: "recovery_intent_captured",
+      actor: auditActor(input.authority),
+      authority: auditAuthority(input.authority),
+      sourceReferenceId: recoveryId,
+      timestamp: capturedAt,
+      metadata: {
+        intentId: intent.intentId,
+        recoveryId: safeAuditReference("recovery", recoveryId),
+        workflowType: candidate.workflowType,
+        actionType: request.actionType,
+        reasonSummary: request.reasonSummary,
+        authorityRole: recoveryAuditRole(input.authority),
+        metadataOnly: true,
+        rawIdsIncluded: false,
+      },
+    },
+    { firestore: input.firestore }
+  );
   return intent;
 }
 
@@ -163,13 +210,35 @@ export async function validateRecoveryActionGate(input: ValidateGateInput): Prom
 
   const rawIntent = await loadSnapshot(OPERATOR_RECOVERY_INTENTS_COLLECTION, intentKey, input.firestore);
   if (!rawIntent || rawIntent.metadataOnly !== true || rawIntent.appendOnly !== true || rawIntent.rawIdsIncluded !== false) {
-    return {
+    const result: RecoveryGateValidation = {
       gateStatus: "denied",
       reason: "intent_missing",
       intentStatus: "missing",
       authorizationValid: false,
       intentFresh: false,
     };
+    await appendCanonicalAuditEventSafely(
+      {
+        eventType: "recovery_gate_validated",
+        actor: auditActor(input.authority),
+        authority: auditAuthority(input.authority),
+        sourceReferenceId: recoveryId,
+        metadata: {
+          intentId: safeAuditReference("recovery_intent", intentKey),
+          recoveryId: safeAuditReference("recovery", recoveryId),
+          gateType: "recovery_action_intent",
+          validationOutcome: "failed",
+          intentStatus: result.intentStatus,
+          authorizationValid: result.authorizationValid,
+          intentFresh: result.intentFresh,
+          denialReason: result.reason || null,
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        },
+      },
+      { firestore: input.firestore }
+    );
+    return result;
   }
 
   const intent = rawIntent as unknown as RecoveryActionIntent;
@@ -181,31 +250,97 @@ export async function validateRecoveryActionGate(input: ValidateGateInput): Prom
   const intentFresh = Number.isFinite(now) && Date.parse(intent.expiresAt) >= now;
 
   if (!authorizationValid) {
-    return {
+    const result: RecoveryGateValidation = {
       gateStatus: "denied",
       reason: "authorization_invalid",
       intentStatus: intent.status,
       authorizationValid: false,
       intentFresh,
     };
+    await appendCanonicalAuditEventSafely(
+      {
+        eventType: "recovery_gate_validated",
+        actor: auditActor(input.authority),
+        authority: auditAuthority(input.authority),
+        sourceReferenceId: recoveryId,
+        metadata: {
+          intentId: safeAuditReference("recovery_intent", intent.intentId),
+          recoveryId: safeAuditReference("recovery", recoveryId),
+          gateType: "recovery_action_intent",
+          validationOutcome: "failed",
+          intentStatus: result.intentStatus,
+          authorizationValid: result.authorizationValid,
+          intentFresh: result.intentFresh,
+          denialReason: result.reason || null,
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        },
+      },
+      { firestore: input.firestore }
+    );
+    return result;
   }
 
   if (!intentFresh) {
-    return {
+    const result: RecoveryGateValidation = {
       gateStatus: "denied",
       reason: "intent_stale",
       intentStatus: intent.status,
       authorizationValid,
       intentFresh: false,
     };
+    await appendCanonicalAuditEventSafely(
+      {
+        eventType: "recovery_gate_validated",
+        actor: auditActor(input.authority),
+        authority: auditAuthority(input.authority),
+        sourceReferenceId: recoveryId,
+        metadata: {
+          intentId: safeAuditReference("recovery_intent", intent.intentId),
+          recoveryId: safeAuditReference("recovery", recoveryId),
+          gateType: "recovery_action_intent",
+          validationOutcome: "failed",
+          intentStatus: result.intentStatus,
+          authorizationValid: result.authorizationValid,
+          intentFresh: result.intentFresh,
+          denialReason: result.reason || null,
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        },
+      },
+      { firestore: input.firestore }
+    );
+    return result;
   }
 
-  return {
+  const result: RecoveryGateValidation = {
     gateStatus: "satisfied",
     intentStatus: intent.status,
     authorizationValid,
     intentFresh,
   };
+  await appendCanonicalAuditEventSafely(
+    {
+      eventType: "recovery_gate_validated",
+      actor: auditActor(input.authority),
+      authority: auditAuthority(input.authority),
+      sourceReferenceId: recoveryId,
+      metadata: {
+        intentId: safeAuditReference("recovery_intent", intent.intentId),
+        recoveryId: safeAuditReference("recovery", recoveryId),
+        gateType: "recovery_action_intent",
+        validationOutcome: "passed",
+        intentStatus: result.intentStatus,
+        authorizationValid: result.authorizationValid,
+        intentFresh: result.intentFresh,
+        denialReason: result.reason || null,
+        metadataOnly: true,
+        rawIdsIncluded: false,
+      },
+    },
+    { firestore: input.firestore }
+  );
+  return result;
 }
 
 export async function listRecentRecoveryIntents(input: {

--- a/rentchain-api/src/services/stateMachines/__tests__/reviewWorkflowAudit.test.ts
+++ b/rentchain-api/src/services/stateMachines/__tests__/reviewWorkflowAudit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { CANONICAL_EVENTS_COLLECTION } from "../../../lib/events/buildEvent";
+import { appendReviewStateTransitionAuditEvent } from "../../../lib/canonicalAudit/reviewStateTransitionAudit";
+import { createRecoveryTestStore } from "../../recovery/__tests__/recoveryTestStore";
+import { validateDecisionTransition } from "../transitionValidation";
+
+describe("review workflow audit events", () => {
+  it("appends canonical audit events from state-machine provenance without changing validation", async () => {
+    const store = createRecoveryTestStore();
+    const validation = validateDecisionTransition(
+      { state: "reviewed" },
+      {
+        to: "Executed",
+        event: "execute",
+        captureEvidence: true,
+        occurredAt: "2026-06-02T11:00:00.000Z",
+        context: {
+          actorRole: "landlord",
+          actorId: "landlord-user-raw",
+          authorized: true,
+          decisionId: "decision-raw-1",
+          landlordId: "landlord-raw-1",
+          actionRecordExists: true,
+          sourceValid: true,
+        },
+      }
+    );
+
+    expect(validation.valid).toBe(true);
+    expect(validation.provenanceEvent).toBeTruthy();
+    const event = await appendReviewStateTransitionAuditEvent({
+      provenanceEvent: validation.provenanceEvent!,
+      authority: { actorRole: "landlord", landlordRef: "landlord-raw-1" },
+      firestore: store,
+    });
+
+    expect(event).not.toBeNull();
+    expect(event).toEqual(
+      expect.objectContaining({
+        eventType: "review_state_transitioned",
+        appendOnly: true,
+        rawIdsIncluded: false,
+        metadata: expect.objectContaining({
+          workflowType: "decision",
+          fromState: "Reviewed",
+          toState: "Executed",
+          transitionEvent: "execute",
+          validationOutcome: "valid",
+          metadataOnly: true,
+          rawIdsIncluded: false,
+        }),
+      })
+    );
+    expect(JSON.stringify(event)).not.toContain("decision-raw-1");
+    expect(JSON.stringify(event)).not.toContain("landlord-raw-1");
+    expect(store.read(CANONICAL_EVENTS_COLLECTION, event!.eventId)).toBeTruthy();
+  });
+});

--- a/rentchain-api/src/types/canonicalAuditEvent.ts
+++ b/rentchain-api/src/types/canonicalAuditEvent.ts
@@ -1,0 +1,100 @@
+import type { RecoveryActionType } from "./recovery";
+import type { ReviewWorkflowType } from "../services/stateMachines/types";
+
+export const CANONICAL_AUDIT_EVENT_TYPES = [
+  "recovery_intent_captured",
+  "recovery_gate_validated",
+  "review_state_transitioned",
+  "operator_review_opened",
+  "operator_review_note_added",
+  "operator_review_outcome_recorded",
+  "operator_review_session_closed",
+] as const;
+
+export type CanonicalAuditEventType = (typeof CANONICAL_AUDIT_EVENT_TYPES)[number];
+
+export type CanonicalAuditAuthorityRole = "admin" | "support" | "landlord" | "operator" | "system";
+
+export type CanonicalAuditActor = {
+  role: CanonicalAuditAuthorityRole;
+  operatorRef: string | null;
+  rawIdsIncluded: false;
+};
+
+export type CanonicalAuditAuthority = {
+  role: CanonicalAuditAuthorityRole;
+  landlordRef: string | null;
+  supportAllowed: boolean;
+  rawIdsIncluded: false;
+};
+
+export type RecoveryIntentCapturedAuditMetadata = {
+  intentId: string;
+  recoveryId: string;
+  workflowType: ReviewWorkflowType;
+  actionType: RecoveryActionType;
+  reasonSummary: string;
+  authorityRole: CanonicalAuditAuthorityRole;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+};
+
+export type RecoveryGateValidatedAuditMetadata = {
+  intentId: string;
+  recoveryId: string;
+  gateType: "recovery_action_intent";
+  validationOutcome: "passed" | "failed";
+  intentStatus: "captured" | "missing";
+  authorizationValid: boolean;
+  intentFresh: boolean;
+  denialReason: string | null;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+};
+
+export type ReviewStateTransitionedAuditMetadata = {
+  workflowType: ReviewWorkflowType;
+  workflowInstanceKey: string;
+  fromState: string;
+  toState: string;
+  transitionEvent: string;
+  transitionReason: string | null;
+  validationOutcome: "valid" | "invalid";
+  metadataOnly: true;
+  rawIdsIncluded: false;
+};
+
+export type OperatorReviewAuditMetadata = {
+  reviewSessionId: string;
+  scope: string;
+  scopeId: string;
+  reviewStatus: string;
+  noteSummary?: string;
+  outcome?: string | null;
+  manualOnly: true;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+};
+
+export type CanonicalAuditEventMetadata =
+  | RecoveryIntentCapturedAuditMetadata
+  | RecoveryGateValidatedAuditMetadata
+  | ReviewStateTransitionedAuditMetadata
+  | OperatorReviewAuditMetadata;
+
+export type CanonicalAuditEvent = {
+  eventId: string;
+  eventType: CanonicalAuditEventType;
+  timestamp: string;
+  actor: CanonicalAuditActor;
+  authority: CanonicalAuditAuthority;
+  sourceReferenceId: string;
+  metadata: CanonicalAuditEventMetadata;
+  sourceCollection: "canonicalEvents";
+  visibility: "admin_support_internal" | "landlord_operator_internal";
+  metadataOnly: true;
+  appendOnly: true;
+  immutable: true;
+  rawIdsIncluded: false;
+  redactionSummary: string;
+};


### PR DESCRIPTION
## Summary
Adds typed canonical audit event foundations for supervised review workspace and recovery operations.

## Changes
- Adds canonical audit event types for recovery intent, recovery gate, review state transition, and operator review lifecycle events
- Adds append-safe canonical audit persistence using the existing canonicalEvents collection
- Emits recovery intent and gate validation audit events after successful operations
- Emits review state transition audit events beside existing provenance capture
- Migrates operator review lifecycle event writes to the typed audit append helper
- Documents the canonical audit event contract

## Validation
- Focused backend tests: 11/11 passing
- Backend build: pass
- git diff --check: pass
- New audit code scan for any: pass
- Restricted tooling-reference scan: pass

## Full Suite Status
- Full backend suite: 2017/2033 passing
- 16 failures remain in unrelated lease draft, recipient trust review, support console, and analytics expectations
- Initial sandbox run also hit local listen EPERM errors; rerun with unrestricted local execution removed those binding errors

## Scope
Backend audit infrastructure only. No new routes, middleware, auth mechanisms, dependencies, production mutations, or legacy audit service changes.

Do not merge until explicit authorization.