### PR TITLE
perf: memoize review queue components

### DIFF
--- a/.handoff/audit-queue-performance.md
+++ b/.handoff/audit-queue-performance.md
@@ -1,0 +1,141 @@
+# Review Queue Performance Audit
+
+## Scope
+
+Mission: Phase 2 Mission 8, Review Queue Frontend Performance Optimization.
+
+Scope is frontend-only memoization for:
+
+- `OperationalReviewQueue`
+- `DecisionQueueSummary`
+- `RegistryReviewQueueRow`
+- `TriageQueueTable`
+- immediate parent/dependency surfaces where prop stability affects those queues
+
+No API routes, middleware, services, collections, auth rules, permissions, backend code, dependency versions, or visual designs were changed.
+
+## Files Reviewed
+
+- `rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx`
+- `rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx`
+- `rentchain-frontend/src/components/analytics/DecisionQueueSummary.tsx`
+- `rentchain-frontend/src/components/analytics/DecisionQueueSummary.test.tsx`
+- `rentchain-frontend/src/components/admin/RegistryReviewQueueRow.tsx`
+- `rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx`
+- `rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.tsx`
+- `rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.tsx`
+- `rentchain-frontend/src/components/reviewTimeline/CanonicalReviewTimeline.tsx`
+- `rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx`
+- `rentchain-frontend/src/pages/admin/AdminRegistryReviewPage.tsx`
+- `rentchain-frontend/src/pages/admin/AdminTriageQueuePage.tsx`
+- `rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx`
+- `rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx`
+- `rentchain-frontend/src/api/adminReviewWorkspacesApi.ts`
+- `rentchain-frontend/src/api/operatorReviewApi.ts`
+- `rentchain-frontend/src/hooks/`
+
+## Baseline Profiling Notes
+
+Browser React DevTools profiling was not completed in this terminal-only run. A live browser pass is still needed to record exact baseline and after-change render counts/timings.
+
+Static render audit found these likely re-render triggers:
+
+- `OperationalReviewQueue` received memoized `reviewQueueItems` from `OperationalCommandCenterPage`, but each queue item rendered inline metadata and safe label derivations on every queue render.
+- `DecisionQueueSummary` recalculated decision state aggregation and recreated inline filter button callbacks on each render.
+- `RegistryReviewQueueRow` was already wrapped in `memo`, but row address formatting and destination encoding were recalculated every render. Its parent virtual list calculated all row metrics and visible row slices during render.
+- `TriageQueueTable` rendered each row inline, recalculated signal text and formatted timestamps during every table render, and had no row-level memo boundary.
+
+## Existing Memoization Patterns
+
+Observed conventions:
+
+- Components and hooks use `React.useMemo`, `React.useCallback`, and imported `useMemo` / `useCallback` depending on file style.
+- Existing hooks such as dashboard, onboarding, ledger, billing, and property hooks use callback-stable loaders and memoized return derivations.
+- `OperatorReviewSessionPanel` already uses `React.useCallback` for session loading.
+- `RegistryReviewQueueRow` already used `memo`, making row-level optimization a local extension rather than a new pattern.
+- Parent pages already use memoized derived lists in several places, including `OperationalCommandCenterPage`.
+
+## Prop and Dependency Map
+
+### OperationalReviewQueue
+
+- Props: `items`
+- Parent: `OperationalCommandCenterPage`
+- Parent derivation: `reviewQueueItems` is derived with `React.useMemo` from `visibleSignals`.
+- Optimization target: queue shell, assigned count, and individual item card derivations.
+- Risk to avoid: stale safe labels and stale review assignment control props.
+
+### DecisionQueueSummary
+
+- Props: `decisions`, `filter`, `onFilterChange`
+- Parents: landlord action recommendations and landlord analytics pages.
+- Parent callback: state setter is stable.
+- Optimization target: aggregate counts and filter button callbacks.
+- Risk to avoid: stale active filter state.
+
+### RegistryReviewQueueRow
+
+- Props: `item`
+- Parent: `AdminRegistryReviewPage` virtualized list.
+- Parent dependencies: item array from registry review API and paginated append.
+- Optimization target: derived address strings, encoded paths, measured row boundary, virtual metrics, visible slice, and scroll callback.
+- Risk to avoid: changing virtual list reset behavior, row keys, or navigation targets.
+
+### TriageQueueTable
+
+- Props: `items`
+- Parent: `AdminTriageQueuePage`
+- Parent dependencies: triage API response array and filter state.
+- Optimization target: table shell, row boundary, formatted timestamp, signal summary line.
+- Risk to avoid: stale signal text if nested signal fields change.
+
+## Hook and API Audit
+
+No queue component imports a custom hook directly.
+
+API helpers inspected:
+
+- `adminReviewWorkspacesApi.ts` constructs query strings and returns projected admin-only review workspace data. No client-side memoization change was needed.
+- `operatorReviewApi.ts` exposes operator review session fetch/mutation helpers. `OperatorReviewSessionPanel` already wraps its loader in `useCallback`; no API change was needed.
+
+No unnecessary refetch loop was introduced or found in the touched queue components.
+
+## Auth and Data Safety
+
+Safety checks preserved:
+
+- No auth or permission logic changed.
+- No backend route, middleware, service, collection, or API response shape changed.
+- No tenant, landlord, admin, or support visibility boundary changed.
+- No sorting, filtering, status workflow, status controls, or data display behavior intentionally changed.
+- Existing safe display label fallback behavior in `OperationalReviewQueue` is preserved.
+- Memoization uses prop/object identity and scalar field dependencies. No custom comparator was added that could hide legitimate data updates.
+
+Existing note:
+
+- Some admin registry labels already display internal registry/property identifiers. This mission did not add new labels or exports and did not broaden that existing display surface.
+
+## Optimization Targets Implemented
+
+- Wrapped `OperationalReviewQueue` in `memo`.
+- Added memoized `OperationalReviewQueueCard` rows with memoized display labels and metadata descriptors.
+- Memoized operational assigned count.
+- Wrapped `DecisionQueueSummary` in `memo`.
+- Memoized decision state aggregation and state filter descriptors.
+- Added memoized `DecisionQueueFilterButton` with stable per-button click handlers.
+- Kept `RegistryReviewQueueRow` memoized and memoized row address/path derivations.
+- Wrapped registry virtual rows and virtual list in `memo`.
+- Memoized registry virtual metrics and visible slice.
+- Added a stable registry virtual list scroll handler.
+- Wrapped `TriageQueueTable` in `memo`.
+- Added memoized `TriageQueueRow` with memoized timestamp and signal summary derivations.
+
+## Browser QA Still Needed
+
+Run a live browser/React DevTools pass after local validation:
+
+- Admin operational command center: record queue filter interactions and compare row renders.
+- Decision queue summary page: toggle unrelated page state and verify summary does not repaint unless props change.
+- Registry review queue: select/filter/scroll and verify virtual rows remain stable.
+- Admin triage queue: filter and scroll with update highlighting enabled.
+- Mobile viewport at 375 px for operational/admin queue surfaces.

--- a/rentchain-frontend/src/components/admin/RegistryReviewQueueRow.tsx
+++ b/rentchain-frontend/src/components/admin/RegistryReviewQueueRow.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { Button, Pill } from "../ui/Ui";
 import type { RegistryReviewItem } from "../../api/adminRegistryApi";
@@ -36,12 +36,37 @@ function formatLocation(parts: Array<string | null | undefined>) {
 }
 
 export const RegistryReviewQueueRow = memo(function RegistryReviewQueueRow({ item }: { item: RegistryReviewItem }) {
-  const propertyAddress = item.property
-    ? formatLocation([item.property.addressLine1, item.property.city, item.property.province, item.property.postalCode])
-    : "";
-  const candidateAddress = item.topCandidate
-    ? formatLocation([item.topCandidate.addressLine1, item.topCandidate.city, item.topCandidate.province, item.topCandidate.postalCode])
-    : "";
+  const propertyAddress = useMemo(
+    () =>
+      item.property
+        ? formatLocation([item.property.addressLine1, item.property.city, item.property.province, item.property.postalCode])
+        : "",
+    [item.property]
+  );
+  const candidateAddress = useMemo(
+    () =>
+      item.topCandidate
+        ? formatLocation([item.topCandidate.addressLine1, item.topCandidate.city, item.topCandidate.province, item.topCandidate.postalCode])
+        : "",
+    [item.topCandidate]
+  );
+  const recordPath = useMemo(
+    () => `/admin/registry/records/${encodeURIComponent(item.match.normalizedRecordId)}`,
+    [item.match.normalizedRecordId]
+  );
+  const propertyReviewPath = useMemo(
+    () => (item.match.propertyId ? `/admin/registry/properties/${encodeURIComponent(item.match.propertyId)}` : null),
+    [item.match.propertyId]
+  );
+  const candidateReviewPath = useMemo(
+    () =>
+      item.topCandidate
+        ? `/admin/registry/properties/${encodeURIComponent(item.topCandidate.propertyId)}?normalizedRecordId=${encodeURIComponent(
+            item.match.normalizedRecordId
+          )}`
+        : null,
+    [item.match.normalizedRecordId, item.topCandidate]
+  );
 
   return (
     <div style={rowStyle}>
@@ -81,19 +106,15 @@ export const RegistryReviewQueueRow = memo(function RegistryReviewQueueRow({ ite
       {item.reasonSummary?.length ? <div style={notesStyle}>Review notes: {item.reasonSummary.join(" ")}</div> : null}
       {!item.property && item.topCandidate ? <div style={bodyTextStyle}>Candidate score: {item.topCandidate.score}</div> : null}
       <div style={actionRowStyle}>
-        <Link to={`/admin/registry/records/${encodeURIComponent(item.match.normalizedRecordId)}`}>
+        <Link to={recordPath}>
           <Button variant="secondary">Open record</Button>
         </Link>
-        {item.match.propertyId ? (
-          <Link to={`/admin/registry/properties/${encodeURIComponent(item.match.propertyId)}`}>
+        {propertyReviewPath ? (
+          <Link to={propertyReviewPath}>
             <Button variant="secondary">Open property review</Button>
           </Link>
-        ) : item.topCandidate ? (
-          <Link
-            to={`/admin/registry/properties/${encodeURIComponent(item.topCandidate.propertyId)}?normalizedRecordId=${encodeURIComponent(
-              item.match.normalizedRecordId
-            )}`}
-          >
+        ) : candidateReviewPath ? (
+          <Link to={candidateReviewPath}>
             <Button variant="secondary">Open candidate review</Button>
           </Link>
         ) : null}

--- a/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
+++ b/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo, useMemo } from "react";
 import { Link } from "react-router-dom";
 import type { AdminTriageItemV1 } from "../../api/adminTriageApi";
 import ResolutionStatusBadge from "../adminResolution/ResolutionStatusBadge";
@@ -30,7 +30,75 @@ function signalLine(item: AdminTriageItemV1) {
   return parts.join(" • ");
 }
 
-export function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
+const TriageQueueRow = memo(function TriageQueueRow({ item }: { item: AdminTriageItemV1 }) {
+  const surfacedAt = useMemo(() => formatTimestamp(item.timestamps.surfacedAt), [item.timestamps.surfacedAt]);
+  const signals = useMemo(() => signalLine(item), [
+    item.signals.automationAction,
+    item.signals.blockedCount,
+    item.signals.lifecycleState,
+    item.signals.policyOutcome,
+    item.signals.reconciliationStatus,
+    item.signals.reopenCount,
+  ]);
+
+  return (
+    <article style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: 14, background: "rgba(255,255,255,0.92)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start", flexWrap: "wrap" }}>
+        <div style={{ display: "grid", gap: 6 }}>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <TriageSeverityBadge severity={item.severity} />
+            <span style={{ color: "#475569", fontSize: 12, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              {item.category.replace(/_/g, " ")}
+            </span>
+          </div>
+          <strong>{item.resource.title || `${item.resource.type} ${item.resource.id}`}</strong>
+          <div style={{ color: "#475569" }}>
+            {item.reason.summary}
+          </div>
+          <div style={{ color: "#64748b", fontSize: 13 }}>
+            {item.resource.type} • {item.resource.id}
+            {item.resource.status ? ` • ${item.resource.status}` : ""}
+            {item.resource.subtitle ? ` • ${item.resource.subtitle}` : ""}
+          </div>
+          {signals ? (
+            <div style={{ color: "#334155", fontSize: 13 }}>{signals}</div>
+          ) : null}
+          {item.resolution ? (
+            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+              <span style={{ color: "#64748b", fontSize: 13 }}>Resolution</span>
+              <ResolutionStatusBadge status={item.resolution.status} />
+            </div>
+          ) : null}
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <span style={{ color: "#64748b", fontSize: 13 }}>Owner</span>
+            <AssignmentBadge
+              ownerId={item.assignment?.ownerId || null}
+              ownerLabel={item.assignment?.ownerLabel || null}
+            />
+          </div>
+          {item.sla ? (
+            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+              <SlaStageBadge stage={item.sla.stage} />
+              <EscalationBadge level={item.sla.escalationLevel} />
+              <span style={{ color: "#64748b", fontSize: 13 }}>{item.sla.ageHours}h</span>
+            </div>
+          ) : null}
+          {item.watch?.isActive ? (
+            <div style={{ color: "#1d4ed8", fontSize: 13, fontWeight: 600 }}>Watched</div>
+          ) : null}
+        </div>
+        <div style={{ display: "grid", gap: 8, justifyItems: "end" }}>
+          <div style={{ color: "#64748b", fontSize: 12 }}>Surfaced {surfacedAt}</div>
+          {item.navigation.supportConsolePath ? (
+            <Link to={item.navigation.supportConsolePath}>Open support console</Link>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+});
+
+export const TriageQueueTable = memo(function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
   if (!items.length) {
     return <div style={{ color: "#64748b" }}>No triage items need attention right now.</div>;
   }
@@ -38,62 +106,10 @@ export function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
   return (
     <div style={{ display: "grid", gap: 12 }}>
       {items.map((item) => (
-        <article key={item.id} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: 14, background: "rgba(255,255,255,0.92)" }}>
-          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start", flexWrap: "wrap" }}>
-            <div style={{ display: "grid", gap: 6 }}>
-              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-                <TriageSeverityBadge severity={item.severity} />
-                <span style={{ color: "#475569", fontSize: 12, textTransform: "uppercase", letterSpacing: "0.04em" }}>
-                  {item.category.replace(/_/g, " ")}
-                </span>
-              </div>
-              <strong>{item.resource.title || `${item.resource.type} ${item.resource.id}`}</strong>
-              <div style={{ color: "#475569" }}>
-                {item.reason.summary}
-              </div>
-              <div style={{ color: "#64748b", fontSize: 13 }}>
-                {item.resource.type} • {item.resource.id}
-                {item.resource.status ? ` • ${item.resource.status}` : ""}
-                {item.resource.subtitle ? ` • ${item.resource.subtitle}` : ""}
-              </div>
-              {signalLine(item) ? (
-                <div style={{ color: "#334155", fontSize: 13 }}>{signalLine(item)}</div>
-              ) : null}
-              {item.resolution ? (
-                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-                  <span style={{ color: "#64748b", fontSize: 13 }}>Resolution</span>
-                  <ResolutionStatusBadge status={item.resolution.status} />
-                </div>
-              ) : null}
-              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-                <span style={{ color: "#64748b", fontSize: 13 }}>Owner</span>
-                <AssignmentBadge
-                  ownerId={item.assignment?.ownerId || null}
-                  ownerLabel={item.assignment?.ownerLabel || null}
-                />
-              </div>
-              {item.sla ? (
-                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-                  <SlaStageBadge stage={item.sla.stage} />
-                  <EscalationBadge level={item.sla.escalationLevel} />
-                  <span style={{ color: "#64748b", fontSize: 13 }}>{item.sla.ageHours}h</span>
-                </div>
-              ) : null}
-              {item.watch?.isActive ? (
-                <div style={{ color: "#1d4ed8", fontSize: 13, fontWeight: 600 }}>Watched</div>
-              ) : null}
-            </div>
-            <div style={{ display: "grid", gap: 8, justifyItems: "end" }}>
-              <div style={{ color: "#64748b", fontSize: 12 }}>Surfaced {formatTimestamp(item.timestamps.surfacedAt)}</div>
-              {item.navigation.supportConsolePath ? (
-                <Link to={item.navigation.supportConsolePath}>Open support console</Link>
-              ) : null}
-            </div>
-          </div>
-        </article>
+        <TriageQueueRow key={item.id} item={item} />
       ))}
     </div>
   );
-}
+});
 
 export default TriageQueueTable;

--- a/rentchain-frontend/src/components/analytics/DecisionQueueSummary.tsx
+++ b/rentchain-frontend/src/components/analytics/DecisionQueueSummary.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo, useCallback, useMemo } from "react";
 import type { LandlordAgentDecision } from "@/api/landlordAnalyticsApi";
 import { aggregateDecisionStates, type DecisionExecutionFilter } from "./decisionExecutionAggregation";
 import { executionStateDisplay } from "./decisionExecutionDisplay";
@@ -20,9 +20,65 @@ function countLabel(value: number) {
   return value === 1 ? "1 decision" : `${value} decisions`;
 }
 
-export default function DecisionQueueSummary(props: Props) {
+type FilterButtonProps = {
+  value: DecisionExecutionFilter;
+  label: string;
+  count: number;
+  active: boolean;
+  onSelect: (filter: DecisionExecutionFilter) => void;
+  tone?: {
+    bg: string;
+    border: string;
+    text: string;
+  };
+};
+
+const DecisionQueueFilterButton = memo(function DecisionQueueFilterButton({
+  value,
+  label,
+  count,
+  active,
+  onSelect,
+  tone,
+}: FilterButtonProps) {
+  const handleClick = useCallback(() => onSelect(value), [onSelect, value]);
+  const activeBorder = tone?.border || "#0f172a";
+  const activeBackground = tone?.bg || "#0f172a";
+  const activeColor = tone?.text || "#fff";
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={active}
+      style={{
+        borderRadius: 999,
+        border: active ? `1px solid ${activeBorder}` : "1px solid #cbd5e1",
+        background: active ? activeBackground : "#fff",
+        color: active ? activeColor : "#334155",
+        fontWeight: 700,
+        padding: "7px 12px",
+        cursor: "pointer",
+      }}
+    >
+      {label} · {count}
+    </button>
+  );
+});
+
+const DecisionQueueSummary = memo(function DecisionQueueSummary(props: Props) {
   const { decisions, filter, onFilterChange } = props;
-  const summary = aggregateDecisionStates(decisions);
+  const summary = useMemo(() => aggregateDecisionStates(decisions), [decisions]);
+  const stateFilters = useMemo(
+    () =>
+      ORDERED_STATES.map((state) => ({
+        state,
+        display: executionStateDisplay[state],
+        count: summary.counts[state],
+      })),
+    [summary]
+  );
+  const handleFilterChange = useCallback((nextFilter: DecisionExecutionFilter) => onFilterChange(nextFilter), [onFilterChange]);
 
   return (
     <section
@@ -49,73 +105,51 @@ export default function DecisionQueueSummary(props: Props) {
       </div>
 
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        <button
-          type="button"
-          onClick={() => onFilterChange("all")}
-          aria-pressed={filter === "all"}
-          style={{
-            borderRadius: 999,
-            border: filter === "all" ? "1px solid #0f172a" : "1px solid #cbd5e1",
-            background: filter === "all" ? "#0f172a" : "#fff",
-            color: filter === "all" ? "#fff" : "#334155",
-            fontWeight: 700,
-            padding: "7px 12px",
-            cursor: "pointer",
-          }}
-        >
-          All decisions · {summary.total}
-        </button>
-        {ORDERED_STATES.map((state) => {
-          const display = executionStateDisplay[state];
-          const isActive = filter === state;
-          return (
-            <button
-              key={state}
-              type="button"
-              onClick={() => onFilterChange(state)}
-              aria-pressed={isActive}
-              style={{
-                borderRadius: 999,
-                border: `1px solid ${isActive ? display.badgeTone.border : "#cbd5e1"}`,
-                background: isActive ? display.badgeTone.bg : "#fff",
-                color: isActive ? display.badgeTone.text : "#334155",
-                fontWeight: 700,
-                padding: "7px 12px",
-                cursor: "pointer",
-              }}
-            >
-              {display.label} · {summary.counts[state]}
-            </button>
-          );
-        })}
+        <DecisionQueueFilterButton
+          value="all"
+          label="All decisions"
+          count={summary.total}
+          active={filter === "all"}
+          onSelect={handleFilterChange}
+        />
+        {stateFilters.map(({ state, display, count }) => (
+          <DecisionQueueFilterButton
+            key={state}
+            value={state}
+            label={display.label}
+            count={count}
+            active={filter === state}
+            onSelect={handleFilterChange}
+            tone={display.badgeTone}
+          />
+        ))}
       </div>
 
       <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))" }}>
-        {ORDERED_STATES.map((state) => {
-          const display = executionStateDisplay[state];
-          return (
-            <div
-              key={state}
-              style={{
-                display: "grid",
-                gap: 4,
-                padding: 12,
-                borderRadius: 12,
-                border: `1px solid ${display.badgeTone.border}`,
-                background: display.badgeTone.bg,
-              }}
-            >
-              <div style={{ fontSize: "0.82rem", fontWeight: 700, color: display.badgeTone.text }}>
-                {display.label}
-              </div>
-              <div style={{ fontSize: "1.3rem", fontWeight: 800, color: "#0f172a" }}>
-                {summary.counts[state]}
-              </div>
-              <div style={{ fontSize: "0.84rem", color: "#475569" }}>{countLabel(summary.counts[state])}</div>
+        {stateFilters.map(({ state, display, count }) => (
+          <div
+            key={state}
+            style={{
+              display: "grid",
+              gap: 4,
+              padding: 12,
+              borderRadius: 12,
+              border: `1px solid ${display.badgeTone.border}`,
+              background: display.badgeTone.bg,
+            }}
+          >
+            <div style={{ fontSize: "0.82rem", fontWeight: 700, color: display.badgeTone.text }}>
+              {display.label}
             </div>
-          );
-        })}
+            <div style={{ fontSize: "1.3rem", fontWeight: 800, color: "#0f172a" }}>
+              {count}
+            </div>
+            <div style={{ fontSize: "0.84rem", color: "#475569" }}>{countLabel(count)}</div>
+          </div>
+        ))}
       </div>
     </section>
   );
-}
+});
+
+export default DecisionQueueSummary;

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
 import { ReviewAssignmentStatusControls } from "./ReviewAssignmentStatusControls";
@@ -47,8 +47,136 @@ function metadata(labelText: string, value: string | null | undefined) {
   );
 }
 
-export function OperationalReviewQueue({ items }: { items: OperationalReviewQueueItem[] }) {
-  const assignedCount = items.filter((item) => !/^unassigned$/i.test(item.assignmentLabel)).length;
+const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({ item }: { item: OperationalReviewQueueItem }) {
+  const display = useMemo(
+    () => ({
+      title: safeDisplayLabel(item.title, "Operational review item"),
+      context: safeDisplayLabel(item.contextLabel, "Operational review context"),
+      workspaceType: label(item.workspaceType),
+      sensitivity: label(item.sensitivityClass),
+      visibility: label(item.visibilityClass),
+      evidence: safeDisplayLabel(item.evidenceLabel, "Open source workflow evidence"),
+      relatedResource: safeDisplayLabel(item.relatedResourceLabel, "Scoped resource context"),
+    }),
+    [
+      item.contextLabel,
+      item.evidenceLabel,
+      item.relatedResourceLabel,
+      item.sensitivityClass,
+      item.title,
+      item.visibilityClass,
+      item.workspaceType,
+    ]
+  );
+
+  const metadataItems = useMemo(
+    () => [
+      { labelText: "Routing reason", value: item.routingReason },
+      { labelText: "Source", value: item.sourceLabel },
+      { labelText: "Review status", value: item.reviewStatus },
+      { labelText: "Assignment", value: item.assignmentLabel },
+      { labelText: "Workflow status", value: item.workflowStatus },
+      { labelText: "Financial status", value: item.financialStatus || null },
+      { labelText: "Sensitivity", value: display.sensitivity },
+      { labelText: "Visibility", value: display.visibility },
+    ],
+    [
+      display.sensitivity,
+      display.visibility,
+      item.assignmentLabel,
+      item.financialStatus,
+      item.reviewStatus,
+      item.routingReason,
+      item.sourceLabel,
+      item.workflowStatus,
+    ]
+  );
+
+  return (
+    <Card
+      style={{
+        borderRadius: 8,
+        padding: 12,
+        border: "1px solid rgba(15, 23, 42, 0.08)",
+        display: "grid",
+        gap: 10,
+        minWidth: 0,
+        overflowWrap: "anywhere",
+      }}
+    >
+      <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <span style={pillStyle("#fef3c7", "#92400e", "#fde68a")}>{item.reviewPriority}</span>
+          <span style={{ color: "#64748b", fontSize: 12, fontWeight: 900 }}>{display.workspaceType}</span>
+        </div>
+        <strong style={{ color: "#0f172a", fontSize: 15 }}>{display.title}</strong>
+        <span style={{ color: "#475569", fontSize: 13 }}>{display.context}</span>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+          gap: 8,
+          minWidth: 0,
+        }}
+      >
+        {metadataItems.map((entry) => (
+          <React.Fragment key={entry.labelText}>{metadata(entry.labelText, entry.value)}</React.Fragment>
+        ))}
+      </div>
+
+      <ReviewAssignmentStatusControls
+        itemId={item.queueItemId}
+        title={display.title}
+        initialStatus={item.reviewStatus}
+        initialAssignment={item.assignmentLabel}
+      />
+
+      <div style={{ display: "grid", gap: 5 }}>
+        <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Scoped evidence/resource links</span>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <Link to={item.destination} style={{
+            color: "#2563eb",
+            fontSize: 14,
+            fontWeight: 900,
+            padding: "8px 0",
+            minHeight: 44,
+            display: "inline-flex",
+            alignItems: "center",
+            textDecoration: "none",
+            borderRadius: 4
+          }}>
+            {display.evidence}
+          </Link>
+          <span
+            style={{
+              border: "1px solid #e2e8f0",
+              borderRadius: 999,
+              padding: "8px 12px",
+              color: "#475569",
+              fontSize: 13,
+              fontWeight: 800,
+              background: "#fff",
+              minHeight: 44,
+              display: "inline-flex",
+              alignItems: "center",
+              lineHeight: 1.4,
+            }}
+          >
+            {display.relatedResource}
+          </span>
+        </div>
+      </div>
+    </Card>
+  );
+});
+
+export const OperationalReviewQueue = memo(function OperationalReviewQueue({ items }: { items: OperationalReviewQueueItem[] }) {
+  const assignedCount = useMemo(
+    () => items.filter((item) => !/^unassigned$/i.test(item.assignmentLabel)).length,
+    [items]
+  );
 
   return (
     <Card
@@ -88,90 +216,7 @@ export function OperationalReviewQueue({ items }: { items: OperationalReviewQueu
           }}
         >
           {items.map((item) => (
-            <Card
-              key={item.queueItemId}
-              style={{
-                borderRadius: 8,
-                padding: 12,
-                border: "1px solid rgba(15, 23, 42, 0.08)",
-                display: "grid",
-                gap: 10,
-                minWidth: 0,
-                overflowWrap: "anywhere",
-              }}
-            >
-              <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-                  <span style={pillStyle("#fef3c7", "#92400e", "#fde68a")}>{item.reviewPriority}</span>
-                  <span style={{ color: "#64748b", fontSize: 12, fontWeight: 900 }}>{label(item.workspaceType)}</span>
-                </div>
-                <strong style={{ color: "#0f172a", fontSize: 15 }}>{safeDisplayLabel(item.title, "Operational review item")}</strong>
-                <span style={{ color: "#475569", fontSize: 13 }}>
-                  {safeDisplayLabel(item.contextLabel, "Operational review context")}
-                </span>
-              </div>
-
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
-                  gap: 8,
-                  minWidth: 0,
-                }}
-              >
-                {metadata("Routing reason", item.routingReason)}
-                {metadata("Source", item.sourceLabel)}
-                {metadata("Review status", item.reviewStatus)}
-                {metadata("Assignment", item.assignmentLabel)}
-                {metadata("Workflow status", item.workflowStatus)}
-                {metadata("Financial status", item.financialStatus || null)}
-                {metadata("Sensitivity", label(item.sensitivityClass))}
-                {metadata("Visibility", label(item.visibilityClass))}
-              </div>
-
-              <ReviewAssignmentStatusControls
-                itemId={item.queueItemId}
-                title={safeDisplayLabel(item.title, "Operational review item")}
-                initialStatus={item.reviewStatus}
-                initialAssignment={item.assignmentLabel}
-              />
-
-              <div style={{ display: "grid", gap: 5 }}>
-                <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Scoped evidence/resource links</span>
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-                  <Link to={item.destination} style={{
-                    color: "#2563eb",
-                    fontSize: 14,
-                    fontWeight: 900,
-                    padding: "8px 0",
-                    minHeight: 44,
-                    display: "inline-flex",
-                    alignItems: "center",
-                    textDecoration: "none",
-                    borderRadius: 4
-                  }}>
-                    {safeDisplayLabel(item.evidenceLabel, "Open source workflow evidence")}
-                  </Link>
-                  <span
-                    style={{
-                      border: "1px solid #e2e8f0",
-                      borderRadius: 999,
-                      padding: "8px 12px",
-                      color: "#475569",
-                      fontSize: 13,
-                      fontWeight: 800,
-                      background: "#fff",
-                      minHeight: 44,
-                      display: "inline-flex",
-                      alignItems: "center",
-                      lineHeight: 1.4,
-                    }}
-                  >
-                    {safeDisplayLabel(item.relatedResourceLabel, "Scoped resource context")}
-                  </span>
-                </div>
-              </div>
-            </Card>
+            <OperationalReviewQueueCard key={item.queueItemId} item={item} />
           ))}
         </div>
       ) : (
@@ -182,7 +227,7 @@ export function OperationalReviewQueue({ items }: { items: OperationalReviewQueu
       )}
     </Card>
   );
-}
+});
 
 function pillStyle(background: string, color: string, border: string): React.CSSProperties {
   return {

--- a/rentchain-frontend/src/pages/admin/AdminRegistryReviewPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminRegistryReviewPage.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition, useDeferredValue, useEffect, useRef, useState } from "react";
+import React, { memo, startTransition, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { MacShell } from "../../components/layout/MacShell";
 import { Button, Card, Input, Pill, Section } from "../../components/ui/Ui";
@@ -18,7 +18,7 @@ const VIRTUAL_OVERSCAN = 3;
 
 type HeightMap = Record<string, number>;
 
-function MeasuredVirtualRow(props: {
+const MeasuredVirtualRow = memo(function MeasuredVirtualRow(props: {
   item: RegistryReviewItem;
   top: number;
   setHeightMap: React.Dispatch<React.SetStateAction<HeightMap>>;
@@ -55,9 +55,9 @@ function MeasuredVirtualRow(props: {
       <RegistryReviewQueueRow item={props.item} />
     </div>
   );
-}
+});
 
-function VirtualizedRegistryReviewList(props: {
+const VirtualizedRegistryReviewList = memo(function VirtualizedRegistryReviewList(props: {
   items: RegistryReviewItem[];
   resetKey: string;
 }) {
@@ -93,29 +93,40 @@ function VirtualizedRegistryReviewList(props: {
     return () => observer.disconnect();
   }, []);
 
-  const itemMetrics: Array<{ item: RegistryReviewItem; top: number; height: number }> = [];
-  let totalHeight = 0;
-  for (const item of props.items) {
-    const height = heightMap[item.match.id] || VIRTUAL_ROW_ESTIMATE;
-    itemMetrics.push({ item, top: totalHeight, height });
-    totalHeight += height + VIRTUAL_ROW_GAP;
-  }
-  totalHeight = Math.max(totalHeight - VIRTUAL_ROW_GAP, 0);
+  const { itemMetrics, totalHeight } = useMemo(() => {
+    const metrics: Array<{ item: RegistryReviewItem; top: number; height: number }> = [];
+    let nextTotalHeight = 0;
+    for (const item of props.items) {
+      const height = heightMap[item.match.id] || VIRTUAL_ROW_ESTIMATE;
+      metrics.push({ item, top: nextTotalHeight, height });
+      nextTotalHeight += height + VIRTUAL_ROW_GAP;
+    }
+    return {
+      itemMetrics: metrics,
+      totalHeight: Math.max(nextTotalHeight - VIRTUAL_ROW_GAP, 0),
+    };
+  }, [heightMap, props.items]);
 
   const viewportBottom = scrollTop + viewportHeight;
-  let startIndex = 0;
-  while (startIndex < itemMetrics.length && itemMetrics[startIndex].top + itemMetrics[startIndex].height < scrollTop) {
-    startIndex += 1;
-  }
-  startIndex = Math.max(0, startIndex - VIRTUAL_OVERSCAN);
+  const visibleItems = useMemo(() => {
+    let startIndex = 0;
+    while (startIndex < itemMetrics.length && itemMetrics[startIndex].top + itemMetrics[startIndex].height < scrollTop) {
+      startIndex += 1;
+    }
+    startIndex = Math.max(0, startIndex - VIRTUAL_OVERSCAN);
 
-  let endIndex = startIndex;
-  while (endIndex < itemMetrics.length && itemMetrics[endIndex].top < viewportBottom) {
-    endIndex += 1;
-  }
-  endIndex = Math.min(itemMetrics.length, endIndex + VIRTUAL_OVERSCAN);
+    let endIndex = startIndex;
+    while (endIndex < itemMetrics.length && itemMetrics[endIndex].top < viewportBottom) {
+      endIndex += 1;
+    }
+    endIndex = Math.min(itemMetrics.length, endIndex + VIRTUAL_OVERSCAN);
 
-  const visibleItems = itemMetrics.slice(startIndex, endIndex);
+    return itemMetrics.slice(startIndex, endIndex);
+  }, [itemMetrics, scrollTop, viewportBottom]);
+
+  const handleScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    setScrollTop(event.currentTarget.scrollTop);
+  }, []);
 
   return (
     <div
@@ -128,9 +139,7 @@ function VirtualizedRegistryReviewList(props: {
         minHeight: Math.min(VIRTUAL_LIST_HEIGHT, Math.max(280, props.items.length * 120)),
         paddingRight: 4,
       }}
-      onScroll={(event) => {
-        setScrollTop(event.currentTarget.scrollTop);
-      }}
+      onScroll={handleScroll}
     >
       <div style={{ position: "relative", height: totalHeight }}>
         {visibleItems.map((entry) => (
@@ -144,7 +153,7 @@ function VirtualizedRegistryReviewList(props: {
       </div>
     </div>
   );
-}
+});
 
 export default function AdminRegistryReviewPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -210,9 +219,9 @@ export default function AdminRegistryReviewPage() {
     };
   }, [matchStatus, searchQuery]);
 
-  const resetKey = `${matchStatus}:${searchQuery}`;
+  const resetKey = useMemo(() => `${matchStatus}:${searchQuery}`, [matchStatus, searchQuery]);
 
-  const loadMore = async () => {
+  const loadMore = useCallback(async () => {
     if (!nextCursor || loadingMore) return;
     try {
       setLoadingMore(true);
@@ -232,7 +241,7 @@ export default function AdminRegistryReviewPage() {
     } finally {
       setLoadingMore(false);
     }
-  };
+  }, [loadingMore, matchStatus, nextCursor, searchQuery]);
 
   return (
     <MacShell title="Admin · Registry Review">


### PR DESCRIPTION
## Summary
- Memoize review queue shells, rows, derived labels, counts, and callbacks across operational, decision, registry, and triage queue surfaces.
- Stabilize registry virtual list metrics, visible slices, measured rows, and scroll handling.
- Add the required review queue performance audit handoff.

## Validation
- `npm test -- OperationalReviewQueue.test.tsx --no-coverage`
- `npm test -- DecisionQueueSummary.test.tsx --no-coverage`
- `npm test -- OperatorReviewSessionPanel.test.tsx --no-coverage`
- `npm test -- AdminRegistryReviewPage.test.tsx --no-coverage`
- `npm test -- AdminTriageQueuePage.test.tsx --no-coverage`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Notes
- Browser React DevTools profiling was not completed in this terminal-only pass; the audit handoff lists the required live profiling checks.
- No backend changed — skip Cloud Run steps.