### PR TITLE
docs: add phase 2 review continuity signoff

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,0 +1,39 @@
+PR: #1079
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1079
+Branch: feat/phase-2-review-continuity-signoff-v1
+
+# Implementation Summary
+
+## Scope
+
+Completed the Phase 2 review continuity signoff mission as a documentation and governance certification change. No backend source, frontend source, middleware, service, Firestore rule, infrastructure, or production data changes were made.
+
+## Files Changed
+
+- `docs/phase-2/review-continuity-signoff-v1.md`
+- `.handoff/impl-summary.md`
+
+## Audit Findings
+
+- The mission prompt referenced `rentchain-api/src/routes/adminReviewWorkspacesRoutes.ts`, which is not present in the current repository.
+- The actual governed review workspace route source is `rentchain-api/src/routes/governedReviewWorkspaceRoutes.ts`.
+- The requested backend and frontend test files for the reviewed surfaces are present.
+- The current source posture remains documentation-only for this mission, with runtime behavior inherited from already merged Phase 2 work.
+
+## Implementation
+
+- Added a Phase 2 review continuity signoff document.
+- Certified current internal review continuity boundaries for governed review workspaces, landlord review timeline, operator review sessions, decision continuity, canonical audit events, recovery intent, and frontend review queues.
+- Documented what is not certified, including production deployment freshness, legal attestation, full lifecycle fixtures, automated correction, and widened audience visibility.
+- Recommended the next mission as `test/lifecycle-continuity-fixtures-v1`.
+
+## Validation
+
+- `git diff --check` passed for the documentation-only change.
+
+## Known Limitations
+
+- Runtime tests and builds are not required for this documentation-only mission unless source files are changed.
+- This signoff does not certify production deployment state.
+- This signoff does not certify full lifecycle fixtures across every reviewed workflow.
+- This signoff does not authorize automated source-state correction or expanded visibility.

--- a/docs/phase-2/review-continuity-signoff-v1.md
+++ b/docs/phase-2/review-continuity-signoff-v1.md
@@ -1,0 +1,173 @@
+# Phase 2 Review Continuity Signoff v1
+
+## Status
+
+This signoff certifies the current Phase 2 review continuity baseline after the merge of PR #1078. It is a documentation and governance certification only. No backend routes, frontend source, middleware, services, Firestore rules, infrastructure, or production data are changed by this mission.
+
+The current baseline is certified for internal review continuity, manual review visibility, append-safe audit posture, and projection-safe administrative evidence review. It is not certified as external legal attestation, institutional submission readiness, or automated remediation readiness.
+
+## Scope Reviewed
+
+The review covered the documentation, routes, services, frontend review surfaces, and tests that define the current review continuity path:
+
+- `.handoff/merge-log.md`
+- `.handoff/impl-summary.md`
+- `.handoff/audit-queue-performance.md`
+- `docs/audit/review-workspace-map-v1.md`
+- `docs/audit/decision-continuity-map-v1.md`
+- `docs/audit/canonical-audit-events-v1.md`
+- `docs/architecture/state-machines-v1.md`
+- `docs/architecture/operator-review-session-v1.md`
+- `docs/architecture/canonical-review-timeline-v1.md`
+- `docs/reports/review-workspace-foundations-v1.md`
+- `docs/testing/lifecycle-continuity-readiness-v1.md`
+- `docs/ai/claude-context/GOVERNANCE_REFERENCE.md`
+- `rentchain-api/src/routes/governedReviewWorkspaceRoutes.ts`
+- `rentchain-api/src/services/admin/governedReviewWorkspaceRead.ts`
+- `rentchain-api/src/routes/landlordReviewTimelineRoutes.ts`
+- `rentchain-api/src/routes/landlordOperatorReviewRoutes.ts`
+- `rentchain-api/src/routes/decisionRoutes.ts`
+- `rentchain-api/src/lib/canonicalAudit/appendCanonicalAuditEvent.ts`
+- `rentchain-api/src/lib/canonicalAudit/reviewStateTransitionAudit.ts`
+- `rentchain-api/src/services/recovery/recoveryIntentService.ts`
+- `rentchain-api/src/routes/leaseRoutes.ts`
+- `rentchain-api/src/routes/maintenanceRequestsRoutes.ts`
+- `rentchain-api/src/routes/paymentsRoutes.ts`
+- `rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.tsx`
+- `rentchain-frontend/src/pages/ReviewTimelinePage.tsx`
+- `rentchain-frontend/src/pages/DecisionInboxPage.tsx`
+- `rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.tsx`
+- `rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx`
+- `rentchain-frontend/src/components/analytics/DecisionQueueSummary.tsx`
+- `rentchain-frontend/src/components/admin/RegistryReviewQueueRow.tsx`
+- `rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx`
+
+The mission prompt listed `rentchain-api/src/routes/adminReviewWorkspacesRoutes.ts`; that file is not present in the current repository. The actual governed review workspace route file is `rentchain-api/src/routes/governedReviewWorkspaceRoutes.ts`, and this signoff uses that path as the source of truth.
+
+## Merged Phase 2 Evidence
+
+The active baseline includes the following merged review-continuity work:
+
+- PR #1066: review workspace inventory and governed workspace mapping.
+- PR #1068: lifecycle state machine audit coverage.
+- PR #1069: evidence provenance and review session evidence linkage.
+- PR #1070: decision continuity mapping.
+- PR #1071: administrative recovery workspace inspection.
+- PR #1072: recovery intent capture and advisory gate validation.
+- PR #1073: recovery inspection error handling.
+- PR #1074: recovery diagnostics logging.
+- PR #1075: mobile review continuity validation.
+- PR #1076: local emulator and production guard readiness.
+- PR #1077: canonical audit event foundations.
+- PR #1078: frontend review queue performance memoization.
+
+## Certified Behavior
+
+### Governed Review Workspaces
+
+The governed review workspace list and detail surfaces are admin/support internal and read-only. The backend uses authentication plus `system.admin` permission checks before returning metadata-only review workspace summaries and detail records.
+
+Workspace records preserve safe review metadata:
+
+- `metadataOnly: true`
+- `visibilityClass: "admin_support_internal"`
+- `tenantVisible: false`
+- `landlordVisible: false`
+- `appendOnly: true`
+- `mutationControlsEnabled: false`
+- `rawPayloadAccessEnabled: false`
+
+References and links are sanitized before presentation. The admin page presents the same constraints as user-visible posture: append-only, metadata-only, read-only, and no raw payload access.
+
+### Landlord Review Timeline
+
+The landlord review timeline is read-only and landlord scoped. It derives timeline entries from landlord-visible resources, review sessions, evidence packages, decisions, exports, and canonical audit readiness without granting broad administrative visibility.
+
+The timeline page states that manual review is required and that no automated approval or certification occurs. It supports review navigation and filtering without changing source workflow records.
+
+### Operator Review Sessions
+
+Operator review sessions are manual review envelopes. Opening sessions, adding notes, and recording outcomes use authenticated landlord routes and append review activity to canonical audit history. These actions do not mutate the underlying lease, maintenance, payment, or decision source records.
+
+The operator review panel links to evidence and timeline context and keeps the workflow explicitly manual. The panel can record review notes and outcomes, but it does not certify, auto-approve, or remediate the source record.
+
+### Decision Continuity
+
+Decision continuity separates decision visibility from decision action state. Decision routes validate access before returning decision records and store action state in a separate decision actions collection. Transition validation can capture review provenance and append a review state transition audit event without making the audit event a blocking dependency.
+
+This preserves continuity for review evidence while avoiding hidden workflow mutation.
+
+### Canonical Audit Events
+
+Canonical audit event capture is append-only, metadata-only, immutable, and safe-reference oriented. Audit events are written with create semantics and mark raw identifier inclusion as false. Review transition audit capture is advisory and non-blocking so operational workflows are not converted into hidden remediation paths.
+
+### Recovery Intent
+
+Recovery intent capture is admin/support only and metadata-only. It records intent, validates advisory gates, prevents duplicate active intents, and emits safe audit evidence. It does not directly apply state correction or mutate source workflow truth.
+
+### Frontend Review Queues
+
+The latest merged review queue performance work is frontend memoization only. It does not add routes, middleware, services, or backend behavior. Review queue, decision summary, registry review, and triage queue components preserve their existing manual review and visibility boundaries.
+
+## Projection And Authority Certification
+
+The current Phase 2 review continuity baseline preserves the following boundaries:
+
+- Tenant, landlord, and admin/support audiences remain separated.
+- Tenant-facing and landlord-facing views do not receive broad administrative review workspace data.
+- Governed review workspace data remains internal and metadata-only.
+- Raw tokens, provider payloads, storage paths, and unsanitized source identifiers are not introduced as display labels by this signoff.
+- Authority-sensitive access is resolved server-side through existing route guards.
+- Audit history remains append-safe.
+- Manual review remains supervised and does not become autonomous remediation.
+
+## Not Certified
+
+This signoff does not certify:
+
+- Production deployment freshness or runtime data quality.
+- External legal attestation or institutional certification.
+- Full end-to-end lifecycle fixtures across every lease, maintenance, payment, report, export, and document path.
+- Browser-only draft persistence beyond the current implemented behavior.
+- Assignment/status persistence for every review queue surface unless already implemented elsewhere.
+- Automated source-state correction or recovery remediation.
+- Expanded tenant or landlord visibility into internal review workspaces.
+- New backend APIs, Firestore rules, middleware, or service behavior.
+
+## Validation Position
+
+This mission is documentation-only. Required runtime tests and builds from the underlying source missions remain the relevant source validation for merged behavior. Because this mission does not modify backend or frontend source files, validation for this PR is limited to diff hygiene and artifact review.
+
+The runtime test files requested by the mission are present in the repository:
+
+- `rentchain-api/src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts`
+- `rentchain-api/src/routes/__tests__/landlordReviewTimelineRoutes.test.ts`
+- `rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts`
+- `rentchain-api/src/lib/canonicalAudit/__tests__/canonicalAuditEvent.test.ts`
+- `rentchain-api/src/services/stateMachines/__tests__/reviewWorkflowAudit.test.ts`
+- `rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts`
+- `rentchain-frontend/src/pages/admin/AdminReviewWorkspacesPage.test.tsx`
+- `rentchain-frontend/src/pages/ReviewTimelinePage.test.tsx`
+- `rentchain-frontend/src/pages/DecisionInboxPage.test.tsx`
+- `rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx`
+- `rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx`
+- `rentchain-frontend/src/components/analytics/DecisionQueueSummary.test.tsx`
+
+## Acceptance Decision
+
+Phase 2 review continuity is certified complete for the current internal governance baseline:
+
+- Review workspaces are visible through metadata-only internal surfaces.
+- Manual review sessions are auditable and append-safe.
+- Review timelines provide landlord-scoped operational continuity.
+- Decision state continuity remains separate from source workflow mutation.
+- Recovery intent remains advisory and gated.
+- Queue performance work is frontend-only and does not alter authority or backend behavior.
+
+The next phase should focus on full lifecycle fixtures and projection verification across report, export, and document URL surfaces before any broader institutional-readiness claim is made.
+
+## Recommended Next Mission
+
+Recommended next mission: `test/lifecycle-continuity-fixtures-v1`.
+
+The next mission should build deterministic lifecycle fixtures that exercise lease, maintenance, payment, decision, review timeline, operator review, evidence, export, and recovery-intent continuity without changing production data or widening access. It should verify projection safety at each audience boundary and preserve metadata-only audit posture.


### PR DESCRIPTION
## Summary
- Add the Phase 2 review continuity signoff document.
- Certify the current internal governance baseline for review workspaces, timelines, review sessions, decision continuity, audit events, recovery intent, and review queues.
- Document non-certified areas and recommend the next lifecycle fixture mission.

## Validation
- git diff --check
- Documentation-only change; runtime tests and builds were not rerun because no backend or frontend source files changed.

## Backend
No backend changed, so no Cloud Run action is required.