### PR TITLE
test: add lifecycle continuity fixtures

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,39 +1,65 @@
-PR: #1079
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1079
-Branch: feat/phase-2-review-continuity-signoff-v1
+PR: #1080
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1080
+Branch: test/lifecycle-continuity-fixtures-v1
 
 # Implementation Summary
 
 ## Scope
 
-Completed the Phase 2 review continuity signoff mission as a documentation and governance certification change. No backend source, frontend source, middleware, service, Firestore rule, infrastructure, or production data changes were made.
+Completed the Phase 2B lifecycle continuity fixtures mission as a fixture and test coverage change. The implementation extends existing backend lifecycle continuity fixtures and adds test coverage for synthetic recovery candidates, recovery intent capture, governed review workspace metadata, and landlord-scoped review timeline continuity.
+
+No backend routes, frontend routes, services, middleware, Firestore rules, infrastructure, dependencies, production data paths, or production source behavior were changed.
 
 ## Files Changed
 
-- `docs/phase-2/review-continuity-signoff-v1.md`
+- `rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.ts`
+- `rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts`
+- `rentchain-api/src/routes/__tests__/adminRecoveryRoutes.test.ts`
+- `rentchain-api/src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts`
+- `rentchain-api/src/routes/__tests__/landlordReviewTimelineRoutes.test.ts`
+- `rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts`
 - `.handoff/impl-summary.md`
-
-## Audit Findings
-
-- The mission prompt referenced `rentchain-api/src/routes/adminReviewWorkspacesRoutes.ts`, which is not present in the current repository.
-- The actual governed review workspace route source is `rentchain-api/src/routes/governedReviewWorkspaceRoutes.ts`.
-- The requested backend and frontend test files for the reviewed surfaces are present.
-- The current source posture remains documentation-only for this mission, with runtime behavior inherited from already merged Phase 2 work.
 
 ## Implementation
 
-- Added a Phase 2 review continuity signoff document.
-- Certified current internal review continuity boundaries for governed review workspaces, landlord review timeline, operator review sessions, decision continuity, canonical audit events, recovery intent, and frontend review queues.
-- Documented what is not certified, including production deployment freshness, legal attestation, full lifecycle fixtures, automated correction, and widened audience visibility.
-- Recommended the next mission as `test/lifecycle-continuity-fixtures-v1`.
+- Added deterministic lifecycle recovery candidate builders for lease, payment, maintenance, and decision workflows.
+- Added fixture seeding for existing recovery collections: `decisionContinuitySnapshots`, `canonicalRecoveryTimelineEntries`, and `transitionProvenanceEvents`.
+- Added fixture tests proving deterministic output, metadata-only provenance, append-safe metadata, raw payload exclusion, and isolated test-store seeding.
+- Added recovery intent coverage proving lifecycle fixture candidates can capture advisory intents and validate gates without creating recovery logs or mutating source state.
+- Added admin recovery route coverage proving synthetic lifecycle candidates can be inspected through existing recovery endpoints without exposing raw workflow IDs.
+- Added governed review workspace route coverage for a synthetic lifecycle recovery workspace candidate, preserving internal metadata-only read behavior.
+- Added landlord review timeline coverage for synthetic maintenance lifecycle divergence through existing landlord-scoped timeline semantics.
 
 ## Validation
 
-- `git diff --check` passed for the documentation-only change.
+- `cd rentchain-api && npm test -- --runInBand src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts src/services/recovery/__tests__/recoveryIntentService.test.ts src/routes/__tests__/adminRecoveryRoutes.test.ts src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts src/routes/__tests__/landlordReviewTimelineRoutes.test.ts` passed under Node 20.20.2.
+- `cd rentchain-api && npm test -- --runInBand src/routes/__tests__/landlordOperatorReviewRoutes.test.ts src/lib/canonicalAudit/__tests__/canonicalAuditEvent.test.ts src/services/stateMachines/__tests__/reviewWorkflowAudit.test.ts` passed under Node 20.20.2.
+- `cd rentchain-frontend && npm test -- --runInBand src/pages/admin/AdminReviewWorkspacesPage.test.tsx src/pages/ReviewTimelinePage.test.tsx src/pages/DecisionInboxPage.test.tsx src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx` was attempted under Node 20.20.2 and failed because the frontend Vitest version rejects `--runInBand`.
+- `cd rentchain-frontend && npm test -- src/pages/admin/AdminReviewWorkspacesPage.test.tsx src/pages/ReviewTimelinePage.test.tsx src/pages/DecisionInboxPage.test.tsx src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx` passed under Node 20.20.2.
+- `git diff --check` passed.
+- Prohibited artifact text scan passed for changed files.
+
+## Manual QA
+
+Manual QA required: no.
+
+Reason: the mission changed backend test fixtures and test coverage only. No frontend rendering, backend route implementation, auth flow, routing, mobile layout, or user-visible behavior was changed.
+
+Manual QA checklist reviewed from tests:
+
+- Synthetic fixture values are test-only and non-production.
+- Governed review workspace candidate remains metadata-only and admin/support internal.
+- Landlord review timeline fixture remains landlord-scoped and manual-review oriented.
+- Recovery intent fixture coverage captures advisory intent and validates gates without recovery logs or source-state mutation.
+- Tenant/landlord/admin separation is preserved by unchanged route guards and existing projection tests.
 
 ## Known Limitations
 
-- Runtime tests and builds are not required for this documentation-only mission unless source files are changed.
-- This signoff does not certify production deployment state.
-- This signoff does not certify full lifecycle fixtures across every reviewed workflow.
-- This signoff does not authorize automated source-state correction or expanded visibility.
+- The frontend mission command with `--runInBand` is incompatible with the installed frontend Vitest CLI, so the same frontend test files were rerun successfully without that flag.
+- Candidate listing through `/recovery/logs?includeCandidates=true` starts from snapshot records by current implementation, so timeline-only decision candidates are tested through direct inspect and intent capture rather than the list endpoint.
+- The governed review workspace persistence validator normalizes unsupported workspace types to existing canonical workspace types; the test asserts metadata-only behavior rather than introducing a new workspace type.
+- No production source files changed, so no package build was required by the mission rule.
+
+## Recommended Next Step
+
+Proceed to Gate 1 review for PR creation after commit and push. After this mission merges, continue toward Phase 3 security and operational hardening.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -10,6 +10,8 @@ Completed the Phase 2B lifecycle continuity fixtures mission as a fixture and te
 
 No backend routes, frontend routes, services, middleware, Firestore rules, infrastructure, dependencies, production data paths, or production source behavior were changed.
 
+Follow-up repair completed after PR CI: removed the frontend regression test dependency on backend lifecycle fixtures so frontend tests no longer import backend Firebase configuration or `firebase-admin`.
+
 ## Files Changed
 
 - `rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.ts`
@@ -18,6 +20,8 @@ No backend routes, frontend routes, services, middleware, Firestore rules, infra
 - `rentchain-api/src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts`
 - `rentchain-api/src/routes/__tests__/landlordReviewTimelineRoutes.test.ts`
 - `rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts`
+- `rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx`
+- `rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.ts`
 - `.handoff/impl-summary.md`
 
 ## Implementation
@@ -29,6 +33,8 @@ No backend routes, frontend routes, services, middleware, Firestore rules, infra
 - Added admin recovery route coverage proving synthetic lifecycle candidates can be inspected through existing recovery endpoints without exposing raw workflow IDs.
 - Added governed review workspace route coverage for a synthetic lifecycle recovery workspace candidate, preserving internal metadata-only read behavior.
 - Added landlord review timeline coverage for synthetic maintenance lifecycle divergence through existing landlord-scoped timeline semantics.
+- Repaired the frontend occupancy regression test to import pure frontend-local lifecycle fixture builders instead of backend test fixtures.
+- Extended the frontend lifecycle fixture module with pure property, unit, tenant, and lease builders used by the regression test.
 
 ## Validation
 
@@ -36,6 +42,10 @@ No backend routes, frontend routes, services, middleware, Firestore rules, infra
 - `cd rentchain-api && npm test -- --runInBand src/routes/__tests__/landlordOperatorReviewRoutes.test.ts src/lib/canonicalAudit/__tests__/canonicalAuditEvent.test.ts src/services/stateMachines/__tests__/reviewWorkflowAudit.test.ts` passed under Node 20.20.2.
 - `cd rentchain-frontend && npm test -- --runInBand src/pages/admin/AdminReviewWorkspacesPage.test.tsx src/pages/ReviewTimelinePage.test.tsx src/pages/DecisionInboxPage.test.tsx src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx` was attempted under Node 20.20.2 and failed because the frontend Vitest version rejects `--runInBand`.
 - `cd rentchain-frontend && npm test -- src/pages/admin/AdminReviewWorkspacesPage.test.tsx src/pages/ReviewTimelinePage.test.tsx src/pages/DecisionInboxPage.test.tsx src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx` passed under Node 20.20.2.
+- `cd rentchain-frontend && npm test -- src/components/properties/PropertyOccupancyRegression.test.tsx` passed under Node 20.20.2 after the import repair.
+- `cd rentchain-frontend && npm run test` passed under Node 20.20.2 after the import repair: 289 test files and 1146 tests passed.
+- `cd rentchain-api && npm test -- --runInBand src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts src/services/recovery/__tests__/recoveryIntentService.test.ts src/routes/__tests__/adminRecoveryRoutes.test.ts src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts src/routes/__tests__/landlordReviewTimelineRoutes.test.ts src/routes/__tests__/landlordOperatorReviewRoutes.test.ts src/lib/canonicalAudit/__tests__/canonicalAuditEvent.test.ts src/services/stateMachines/__tests__/reviewWorkflowAudit.test.ts` passed under Node 20.20.2 after the import repair.
+- Confirmed no frontend source or test file imports `rentchain-api/src/config/firebase`, `rentchain-api/src/firebase`, `firebase-admin`, or the backend lifecycle continuity fixture module.
 - `git diff --check` passed.
 - Prohibited artifact text scan passed for changed files.
 
@@ -43,7 +53,7 @@ No backend routes, frontend routes, services, middleware, Firestore rules, infra
 
 Manual QA required: no.
 
-Reason: the mission changed backend test fixtures and test coverage only. No frontend rendering, backend route implementation, auth flow, routing, mobile layout, or user-visible behavior was changed.
+Reason: the mission changed test fixtures and test coverage only. No frontend rendering implementation, backend route implementation, auth flow, routing, mobile layout, or user-visible behavior was changed.
 
 Manual QA checklist reviewed from tests:
 
@@ -59,7 +69,8 @@ Manual QA checklist reviewed from tests:
 - Candidate listing through `/recovery/logs?includeCandidates=true` starts from snapshot records by current implementation, so timeline-only decision candidates are tested through direct inspect and intent capture rather than the list endpoint.
 - The governed review workspace persistence validator normalizes unsupported workspace types to existing canonical workspace types; the test asserts metadata-only behavior rather than introducing a new workspace type.
 - No production source files changed, so no package build was required by the mission rule.
+- PR CI previously failed because `PropertyOccupancyRegression.test.tsx` imported the backend lifecycle fixture module, which pulled backend Firebase configuration into the frontend test graph. That import path has been removed and replaced with frontend-local pure fixture builders.
 
 ## Recommended Next Step
 
-Proceed to Gate 1 review for PR creation after commit and push. After this mission merges, continue toward Phase 3 security and operational hardening.
+Keep PR #1080 in draft until remote CI is fully green after the repair push. After this mission merges, continue toward Phase 3 security and operational hardening.

--- a/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts
+++ b/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildLifecycleRecoveryCandidates,
   buildLifecycleContinuityLease,
   buildLifecycleContinuityScenario,
   buildLifecycleContinuityTenant,
   lifecycleContinuityDates,
   lifecycleContinuityIds,
+  seedLifecycleRecoveryCandidates,
 } from "./lifecycleContinuityFixtures";
+import {
+  DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
+  RECOVERY_TIMELINE_COLLECTION,
+} from "../../services/recovery/recoveryStore";
+import { PROVENANCE_EVENTS_COLLECTION } from "../../services/stateMachines/provenanceStorage";
+import { createRecoveryTestStore } from "../../services/recovery/__tests__/recoveryTestStore";
 
 describe("lifecycle continuity fixtures", () => {
   it("builds deterministic cross-system records for the canonical lifecycle scenario", () => {
@@ -51,5 +59,62 @@ describe("lifecycle continuity fixtures", () => {
     expect(unchangedTenant.fullName).toBe("John Smith");
     expect(changedLease.rentCents).toBe(175000);
     expect(unchangedLease.rentCents).toBe(164000);
+  });
+
+  it("builds deterministic metadata-only recovery candidates for lifecycle divergence QA", () => {
+    const candidates = buildLifecycleRecoveryCandidates();
+    const repeatedCandidates = buildLifecycleRecoveryCandidates();
+
+    expect(candidates).toEqual(repeatedCandidates);
+    expect(candidates.map((candidate) => candidate.workflowType)).toEqual([
+      "lease",
+      "payment",
+      "maintenance",
+      "decision",
+    ]);
+    expect(candidates.map((candidate) => candidate.expectedDivergenceType)).toEqual([
+      "METADATA_DIVERGENCE",
+      "EVIDENCE_MISMATCH",
+      "ORPHANED_DECISION",
+      "MISSING_TRANSITION",
+    ]);
+    expect(candidates.every((candidate) => candidate.workflowInstanceKey.includes(":instance:"))).toBe(true);
+    expect(candidates.every((candidate) => candidate.provenanceEvent.metadata.metadataOnly === true)).toBe(true);
+    expect(candidates.every((candidate) => candidate.provenanceEvent.metadata.appendOnly === true)).toBe(true);
+    expect(candidates.every((candidate) => candidate.provenanceEvent.access.rawIdsIncluded === false)).toBe(true);
+    expect(candidates.every((candidate) => candidate.provenanceEvent.contextSummary.rawPayloadIncluded === false)).toBe(true);
+    expect(candidates.every((candidate) => candidate.provenanceEvent.evidenceRefs.every((ref) => ref.metadataOnly === true && ref.rawIdsIncluded === false && ref.payloadIncluded === false))).toBe(true);
+    expect(JSON.stringify(candidates)).not.toMatch(/secret-token|bearer-secret|gs:\/\/|storage\.googleapis\.com|raw-provider-payload/i);
+  });
+
+  it("seeds recovery candidates into existing recovery collections only", () => {
+    const store = createRecoveryTestStore();
+    const candidates = seedLifecycleRecoveryCandidates(store);
+    const leaseCandidate = candidates.find((candidate) => candidate.workflowType === "lease")!;
+    const decisionCandidate = candidates.find((candidate) => candidate.workflowType === "decision")!;
+
+    expect(store.read(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, leaseCandidate.snapshotId)).toMatchObject({
+      workflowType: "lease",
+      metadataOnly: true,
+      rawIdsIncluded: false,
+      fixtureOnly: true,
+    });
+    expect(store.read(RECOVERY_TIMELINE_COLLECTION, leaseCandidate.timelineEntryId)).toMatchObject({
+      workflowType: "lease",
+      metadataOnly: true,
+      appendOnly: true,
+      rawIdsIncluded: false,
+      fixtureOnly: true,
+    });
+    expect(store.read(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, decisionCandidate.snapshotId)).toBeNull();
+    expect(store.read(RECOVERY_TIMELINE_COLLECTION, decisionCandidate.timelineEntryId)).toMatchObject({
+      workflowType: "decision",
+      state: "Reviewed",
+      fixtureOnly: true,
+    });
+    expect(store.read(PROVENANCE_EVENTS_COLLECTION, leaseCandidate.provenanceEvent.eventId)).toMatchObject({
+      workflowType: "lease",
+      immutable: true,
+    });
   });
 });

--- a/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.ts
+++ b/rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures.ts
@@ -1,3 +1,12 @@
+import {
+  DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
+  RECOVERY_TIMELINE_COLLECTION,
+} from "../../services/recovery/recoveryStore";
+import { workflowKey } from "../../services/recovery/recoveryShared";
+import { buildEvidenceReference, captureTransitionEvidence } from "../../services/stateMachines/evidenceProvenance";
+import { PROVENANCE_EVENTS_COLLECTION } from "../../services/stateMachines/provenanceStorage";
+import type { EvidenceReference, ReviewWorkflowType, TransitionProvenanceEvent, WorkflowEvent, WorkflowState } from "../../services/stateMachines/types";
+
 export type LifecycleContinuityRecord = Record<string, unknown>;
 
 export type LifecycleContinuityLeaseKind = "active" | "upcoming" | "archived";
@@ -27,6 +36,11 @@ export const lifecycleContinuityIds = {
   ledgerEntryId: "lc_ledger_payment_001",
   obligationId: "lc_obligation_2026_06",
   decisionId: "lc_decision_manual_review_001",
+  maintenanceId: "lc_maintenance_cost_review_001",
+  recoveryLeaseId: "lc_recovery_lease_divergence_001",
+  recoveryPaymentId: "lc_recovery_payment_divergence_001",
+  recoveryDecisionId: "lc_recovery_decision_divergence_001",
+  recoveryMaintenanceId: "lc_recovery_maintenance_divergence_001",
   signedDocumentId: "lc_doc_signed_lease_001",
   generatedDocumentId: "lc_doc_generated_lease_001",
   importBatchId: "lc_import_batch_001",
@@ -45,6 +59,9 @@ export const lifecycleContinuityDates = {
   paymentDate: "2026-06-01",
   obligationDueDate: "2026-06-01T00:00:00.000Z",
   decisionCreatedAt: "2026-06-02T10:00:00.000Z",
+  recoveryTimelineAt: "2026-06-02T12:00:00.000Z",
+  recoverySnapshotAt: "2026-06-02T12:05:00.000Z",
+  recoveryEvidenceAt: "2026-06-02T12:10:00.000Z",
 } as const;
 
 export const lifecycleContinuityLabels = {
@@ -59,7 +76,42 @@ export const lifecycleContinuityLabels = {
   archivedTenantName: "Casey Past",
   activeLeaseLabel: "North Towers - Unit 101 Lease",
   upcomingLeaseLabel: "North Towers - Unit 103 Lease",
+  recoveryWorkspaceLabel: "Lifecycle continuity recovery workspace",
 } as const;
+
+type LifecycleRecoveryTransition = {
+  from: WorkflowState;
+  to: WorkflowState;
+  event: WorkflowEvent;
+};
+
+export type LifecycleRecoveryCandidate = {
+  workflowType: ReviewWorkflowType;
+  workflowId: string;
+  workflowInstanceKey: string;
+  snapshotId: string;
+  timelineEntryId: string;
+  expectedDivergenceType: "METADATA_DIVERGENCE" | "EVIDENCE_MISMATCH" | "MISSING_TRANSITION" | "ORPHANED_DECISION";
+  expectedDecision: "ACCEPT_CANONICAL" | "EVIDENCE_REVIEW_REQUIRED";
+  snapshot: LifecycleContinuityRecord;
+  timelineEntry: LifecycleContinuityRecord;
+  provenanceEvent: TransitionProvenanceEvent;
+  evidenceLabel: string;
+};
+
+type LifecycleRecoveryCandidateInput = {
+  workflowType: ReviewWorkflowType;
+  workflowId: string;
+  derivedState?: WorkflowState | null;
+  canonicalState?: WorkflowState | null;
+  evidenceState?: WorkflowState | null;
+  transition: LifecycleRecoveryTransition;
+  expectedDivergenceType: LifecycleRecoveryCandidate["expectedDivergenceType"];
+  expectedDecision: LifecycleRecoveryCandidate["expectedDecision"];
+  evidenceReferenceType: EvidenceReference["referenceType"];
+  evidenceLabel: string;
+  reasonSummary: string;
+};
 
 function cloneRecord<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -455,4 +507,166 @@ export function buildLifecycleContinuityScenario(): {
     signedDocument: buildLifecycleContinuityLeaseDocument("signed"),
     generatedDocument: buildLifecycleContinuityLeaseDocument("generated"),
   };
+}
+
+function recoveryEvidenceReference(input: LifecycleRecoveryCandidateInput): EvidenceReference {
+  const reference = buildEvidenceReference({
+    workflowType: input.workflowType,
+    referenceType: input.evidenceReferenceType,
+    referenceId: input.workflowId,
+    label: input.evidenceLabel,
+  });
+  if (!reference) throw new Error("lifecycle_recovery_fixture_evidence_missing");
+  return reference;
+}
+
+function buildLifecycleRecoveryCandidate(input: LifecycleRecoveryCandidateInput): LifecycleRecoveryCandidate {
+  const workflowInstanceKey = workflowKey(input.workflowType, input.workflowId);
+  const snapshotId = workflowInstanceKey;
+  const timelineEntryId = `lc_recovery_timeline:${input.workflowType}:${workflowInstanceKey.split(":").pop()}`;
+  const snapshot =
+    input.derivedState == null
+      ? null
+      : {
+          workflowType: input.workflowType,
+          workflowId: input.workflowId,
+          workflowInstanceKey,
+          state: input.derivedState,
+          status: input.derivedState,
+          lifecycleContinuityFixture: true,
+          fixtureOnly: true,
+          metadataOnly: true,
+          rawIdsIncluded: false,
+          createdAt: lifecycleContinuityDates.recoverySnapshotAt,
+          updatedAt: lifecycleContinuityDates.recoverySnapshotAt,
+        };
+  const timelineEntry =
+    input.canonicalState == null
+      ? null
+      : {
+          timelineEntryId,
+          workflowType: input.workflowType,
+          workflowInstanceKey,
+          state: input.canonicalState,
+          status: input.canonicalState,
+          timestamp: lifecycleContinuityDates.recoveryTimelineAt,
+          occurredAt: lifecycleContinuityDates.recoveryTimelineAt,
+          entryType: "LIFECYCLE_DIVERGENCE_FIXTURE",
+          reasonSummary: input.reasonSummary,
+          lifecycleContinuityFixture: true,
+          fixtureOnly: true,
+          metadataOnly: true,
+          appendOnly: true,
+          rawIdsIncluded: false,
+        };
+  const evidenceState = input.evidenceState || input.transition.to;
+  const provenanceEvent = captureTransitionEvidence({
+    workflowType: input.workflowType,
+    workflowInstanceId: input.workflowId,
+    currentState: input.transition.from,
+    proposedState: evidenceState,
+    event: input.transition.event,
+    context: {
+      actorRole: "landlord",
+      actorId: lifecycleContinuityIds.landlordId,
+      landlordId: lifecycleContinuityIds.landlordId,
+      tenantId: lifecycleContinuityIds.activeTenantId,
+      authorized: true,
+    },
+    validation: {
+      valid: true,
+      currentState: input.transition.from,
+      proposedState: evidenceState,
+      allowedTransitions: [evidenceState],
+    },
+    evidenceRefs: [recoveryEvidenceReference(input)],
+    occurredAt: lifecycleContinuityDates.recoveryEvidenceAt,
+  });
+
+  return {
+    workflowType: input.workflowType,
+    workflowId: input.workflowId,
+    workflowInstanceKey,
+    snapshotId,
+    timelineEntryId,
+    expectedDivergenceType: input.expectedDivergenceType,
+    expectedDecision: input.expectedDecision,
+    snapshot: snapshot || {},
+    timelineEntry: timelineEntry || {},
+    provenanceEvent,
+    evidenceLabel: input.evidenceLabel,
+  };
+}
+
+export function buildLifecycleRecoveryCandidates(): LifecycleRecoveryCandidate[] {
+  return [
+    buildLifecycleRecoveryCandidate({
+      workflowType: "lease",
+      workflowId: lifecycleContinuityIds.recoveryLeaseId,
+      derivedState: "Draft",
+      canonicalState: "Active",
+      evidenceState: "Draft",
+      transition: { from: "Draft", to: "Active", event: "activate" },
+      expectedDivergenceType: "METADATA_DIVERGENCE",
+      expectedDecision: "ACCEPT_CANONICAL",
+      evidenceReferenceType: "lease",
+      evidenceLabel: "Synthetic lease activation evidence",
+      reasonSummary: "Synthetic lease fixture diverges between draft snapshot and active timeline state.",
+    }),
+    buildLifecycleRecoveryCandidate({
+      workflowType: "payment",
+      workflowId: lifecycleContinuityIds.recoveryPaymentId,
+      derivedState: "Processing",
+      canonicalState: "Confirmed",
+      evidenceState: "Failed",
+      transition: { from: "Processing", to: "Failed", event: "fail" },
+      expectedDivergenceType: "EVIDENCE_MISMATCH",
+      expectedDecision: "EVIDENCE_REVIEW_REQUIRED",
+      evidenceReferenceType: "payment",
+      evidenceLabel: "Synthetic payment reconciliation evidence",
+      reasonSummary: "Synthetic payment fixture has evidence that conflicts with the derived payment state.",
+    }),
+    buildLifecycleRecoveryCandidate({
+      workflowType: "maintenance",
+      workflowId: lifecycleContinuityIds.recoveryMaintenanceId,
+      derivedState: "CostReview",
+      canonicalState: null,
+      transition: { from: "InProgress", to: "CostReview", event: "request_cost_review" },
+      expectedDivergenceType: "ORPHANED_DECISION",
+      expectedDecision: "EVIDENCE_REVIEW_REQUIRED",
+      evidenceReferenceType: "work_order",
+      evidenceLabel: "Synthetic maintenance cost review evidence",
+      reasonSummary: "Synthetic maintenance fixture has a derived state without a canonical timeline state.",
+    }),
+    buildLifecycleRecoveryCandidate({
+      workflowType: "decision",
+      workflowId: lifecycleContinuityIds.recoveryDecisionId,
+      derivedState: null,
+      canonicalState: "Reviewed",
+      transition: { from: "Appeared", to: "Reviewed", event: "review" },
+      expectedDivergenceType: "MISSING_TRANSITION",
+      expectedDecision: "ACCEPT_CANONICAL",
+      evidenceReferenceType: "decision",
+      evidenceLabel: "Synthetic decision review evidence",
+      reasonSummary: "Synthetic decision fixture has canonical review timeline state without a derived snapshot.",
+    }),
+  ];
+}
+
+export function seedLifecycleRecoveryCandidates(
+  store: {
+    seed: (collection: string, id: string, data: LifecycleContinuityRecord) => void;
+  },
+  candidates: LifecycleRecoveryCandidate[] = buildLifecycleRecoveryCandidates(),
+): LifecycleRecoveryCandidate[] {
+  for (const candidate of candidates) {
+    if (Object.keys(candidate.snapshot).length > 0) {
+      store.seed(DECISION_CONTINUITY_SNAPSHOTS_COLLECTION, candidate.snapshotId, candidate.snapshot);
+    }
+    if (Object.keys(candidate.timelineEntry).length > 0) {
+      store.seed(RECOVERY_TIMELINE_COLLECTION, candidate.timelineEntryId, candidate.timelineEntry);
+    }
+    store.seed(PROVENANCE_EVENTS_COLLECTION, candidate.provenanceEvent.eventId, candidate.provenanceEvent as unknown as LifecycleContinuityRecord);
+  }
+  return candidates;
 }

--- a/rentchain-api/src/routes/__tests__/adminRecoveryRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminRecoveryRoutes.test.ts
@@ -6,6 +6,7 @@ import {
   OPERATOR_RECOVERY_LOGS_COLLECTION,
   RECOVERY_TIMELINE_COLLECTION,
 } from "../../services/recovery/recoveryStore";
+import { seedLifecycleRecoveryCandidates } from "../../__tests__/fixtures/lifecycleContinuityFixtures";
 
 const { collections, dbMock } = vi.hoisted(() => {
   type StoredRecord = Record<string, unknown>;
@@ -286,6 +287,46 @@ describe("adminRecoveryRoutes", () => {
       authorizationValid: true,
       intentFresh: true,
     });
+  });
+
+  it("inspects deterministic lifecycle recovery fixture candidates without exposing raw workflow ids", async () => {
+    const candidates = seedLifecycleRecoveryCandidates({ seed });
+    const router = (await import("../adminRecoveryRoutes")).default;
+
+    for (const candidate of candidates) {
+      const inspected = await invokeRouter(router, {
+        method: "POST",
+        url: "/recovery/inspect",
+        user: { id: "admin-1", role: "admin" },
+        body: { workflowType: candidate.workflowType, workflowId: candidate.workflowId },
+      });
+
+      expect(inspected.status).toBe(200);
+      expect(inspected.body.reconciliation).toMatchObject({
+        workflowType: candidate.workflowType,
+        workflowInstanceKey: candidate.workflowInstanceKey,
+        divergenceType: candidate.expectedDivergenceType,
+        proposedDecision: candidate.expectedDecision,
+        manualReviewRequired: true,
+      });
+      expect(JSON.stringify(inspected.body)).not.toContain(candidate.workflowId);
+    }
+
+    const listed = await invokeRouter(router, {
+      method: "GET",
+      url: "/recovery/logs?includeCandidates=true&limit=10",
+      user: { id: "support-1", role: "support" },
+    });
+    const listedBody = JSON.stringify(listed.body);
+    expect(listed.status).toBe(200);
+    expect((listed.body.candidates as unknown[]).length).toBe(
+      candidates.filter((candidate) => Object.keys(candidate.snapshot).length > 0).length
+    );
+    expect(listedBody).not.toMatch(/secret-token|bearer-secret|gs:\/\/|storage\.googleapis\.com|raw-provider-payload/i);
+    for (const candidate of candidates) {
+      expect(listedBody).not.toContain(candidate.workflowId);
+    }
+    expect(collections.get(OPERATOR_RECOVERY_LOGS_COLLECTION)?.size || 0).toBe(0);
   });
 
   it("rejects recovery intent capture for unauthorized operators and invalid candidates", async () => {

--- a/rentchain-api/src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { lifecycleContinuityDates, lifecycleContinuityIds } from "../../__tests__/fixtures/lifecycleContinuityFixtures";
 
 const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
@@ -151,6 +152,71 @@ describe("governedReviewWorkspaceRoutes", () => {
     });
   }
 
+  function seedLifecycleRecoveryWorkspace() {
+    seedDoc("governedReviewWorkspaceAppendLog", "lifecycle-recovery-workspace", {
+      record: {
+        workspaceType: "recovery_review",
+        title: "Lifecycle continuity recovery workspace",
+        summary: "Synthetic lifecycle recovery candidate for metadata-only review.",
+        workflowFamily: "lifecycle_continuity_recovery",
+        retentionClass: "recovery_review",
+        retentionReason: "fixture only lifecycle continuity review",
+        createdAt: lifecycleContinuityDates.recoveryTimelineAt,
+        lastAppendedAt: lifecycleContinuityDates.recoveryEvidenceAt,
+        safeEvidenceRefs: [
+          {
+            referenceType: "workflow",
+            referenceId: "lifecycle-recovery-safe-ref",
+            label: "Synthetic lease, payment, maintenance, and decision continuity evidence",
+          },
+        ],
+        appendEventRefs: [
+          {
+            eventType: "workspace_candidate_created",
+            eventSummary: "Synthetic lifecycle recovery candidate created for manual review.",
+            occurredAt: lifecycleContinuityDates.recoveryTimelineAt,
+          },
+        ],
+        relatedWorkspaceLinks: [
+          {
+            linkType: "lifecycle_recovery_candidate",
+            sourceSummary: {
+              kind: "recovery_candidate",
+              label: "Lifecycle continuity recovery candidate",
+              category: "recovery_review",
+              severity: "medium",
+              state: "manual_review_required",
+              metadataOnly: true,
+              rawIdsIncluded: false,
+            },
+            targetSummary: {
+              kind: "governed_review_workspace",
+              label: "Lifecycle continuity recovery workspace",
+              category: "recovery_review",
+              severity: "medium",
+              state: "metadata_review_ready",
+              metadataOnly: true,
+              rawIdsIncluded: false,
+            },
+            workflowFamily: "lifecycle_continuity_recovery",
+            metadataOnly: true,
+            visibilityClass: "admin_support_internal",
+            tenantVisible: false,
+            landlordVisible: false,
+            appendCompatible: true,
+            mutationControlsEnabled: false,
+          },
+        ],
+        fixtureIds: [
+          lifecycleContinuityIds.recoveryLeaseId,
+          lifecycleContinuityIds.recoveryPaymentId,
+          lifecycleContinuityIds.recoveryMaintenanceId,
+          lifecycleContinuityIds.recoveryDecisionId,
+        ],
+      },
+    });
+  }
+
   it("denies unauthenticated and non-admin access with route source headers", async () => {
     seedWorkspace();
     const router = (await import("../governedReviewWorkspaceRoutes")).default;
@@ -261,6 +327,47 @@ describe("governedReviewWorkspaceRoutes", () => {
     const post = await invokeRouter(router, { method: "POST", url: "/review-workspaces" });
     expect(post.status).toBe(404);
     expect(post.headers["x-route-source"]).toBe("governedReviewWorkspaceRoutes.ts");
+  });
+
+  it("returns lifecycle recovery workspace candidates as internal metadata only", async () => {
+    seedLifecycleRecoveryWorkspace();
+    const router = (await import("../governedReviewWorkspaceRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/review-workspaces?q=lifecycle",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.workspaces).toHaveLength(1);
+    expect(res.body.workspaces[0]).toEqual(
+      expect.objectContaining({
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        appendOnly: true,
+        mutationControlsEnabled: false,
+        rawPayloadAccessEnabled: false,
+      })
+    );
+    const detail = await invokeRouter(router, {
+      method: "GET",
+      url: `/review-workspaces/${encodeURIComponent(res.body.workspaces[0].workspaceId)}`,
+    });
+    expect(detail.status).toBe(200);
+    expect(detail.body.workspace.relatedWorkspaceLinks[0]).toEqual(
+      expect.objectContaining({
+        linkType: "incident_to_evidence",
+        metadataOnly: true,
+        visibilityClass: "admin_support_internal",
+        tenantVisible: false,
+        landlordVisible: false,
+        mutationControlsEnabled: false,
+      })
+    );
+    expect(detail.body.workspace.title).toBe("Lifecycle continuity recovery workspace");
+    expect(JSON.stringify(detail.body)).not.toMatch(/secret-token|bearer-secret|gs:\/\/|storage\.googleapis\.com|raw-provider-payload/i);
   });
 
   it("returns a safe empty state when no append records exist", async () => {

--- a/rentchain-api/src/routes/__tests__/landlordReviewTimelineRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordReviewTimelineRoutes.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
+import { lifecycleContinuityDates, lifecycleContinuityIds } from "../../__tests__/fixtures/lifecycleContinuityFixtures";
 
 const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
@@ -202,6 +204,64 @@ describe("landlordReviewTimelineRoutes", () => {
       expect.arrayContaining([expect.objectContaining({ entryType: "redaction_note", status: "redacted", source: "evidence_packs" })])
     );
     expect(res.body.timeline.entries.every((item: any) => item.entryType === "redaction_note" && item.status === "redacted" && item.source === "evidence_packs")).toBe(true);
+  });
+
+  it("renders synthetic lifecycle divergence context through landlord-scoped timeline semantics", async () => {
+    seedDoc("properties", lifecycleContinuityIds.propertyId, {
+      landlordId: lifecycleContinuityIds.landlordId,
+      name: "Lifecycle fixture property",
+    });
+    seedDoc("maintenanceRequests", lifecycleContinuityIds.recoveryMaintenanceId, {
+      landlordId: lifecycleContinuityIds.landlordId,
+      propertyId: lifecycleContinuityIds.propertyId,
+      maintenanceRequestId: lifecycleContinuityIds.recoveryMaintenanceId,
+      workOrderId: lifecycleContinuityIds.recoveryMaintenanceId,
+      status: "cost_review",
+      title: "Lifecycle continuity fixture maintenance review",
+      createdAt: lifecycleContinuityDates.recoveryTimelineAt,
+      updatedAt: lifecycleContinuityDates.recoveryTimelineAt,
+    });
+    seedDoc(CANONICAL_EVENTS_COLLECTION, "lc-maintenance-review-event", {
+      landlordId: lifecycleContinuityIds.landlordId,
+      metadata: { landlordId: lifecycleContinuityIds.landlordId },
+      type: "lifecycle_fixture_maintenance_review",
+      summary: "Synthetic maintenance lifecycle divergence requires manual review.",
+      maintenanceRequestId: lifecycleContinuityIds.recoveryMaintenanceId,
+      workOrderId: lifecycleContinuityIds.recoveryMaintenanceId,
+      resource: { id: lifecycleContinuityIds.recoveryMaintenanceId },
+      actor: { type: "landlord", id: lifecycleContinuityIds.landlordId },
+      occurredAt: lifecycleContinuityDates.recoveryTimelineAt,
+    });
+    const router = (await import("../landlordReviewTimelineRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: `/review-timeline?scope=maintenance&scopeId=${encodeURIComponent(lifecycleContinuityIds.recoveryMaintenanceId)}`,
+      user: {
+        id: lifecycleContinuityIds.landlordId,
+        landlordId: lifecycleContinuityIds.landlordId,
+        role: "landlord",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.timeline).toMatchObject({
+      scope: "maintenance",
+      scopeId: lifecycleContinuityIds.recoveryMaintenanceId,
+      manualReviewRequired: true,
+      externalSharingEnabled: false,
+      certificationIssued: false,
+    });
+    expect(res.body.timeline.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          entryType: "canonical_event",
+          source: "canonical_events",
+          label: "lifecycle_fixture_maintenance_review",
+        }),
+      ])
+    );
+    expect(JSON.stringify(res.body.timeline)).not.toMatch(/token|secret|credential|bearer|gs:\/\/|storage\.googleapis\.com|providerPayload/i);
   });
 
   it("requires landlord scope and does not expose another landlord's source context", async () => {

--- a/rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts
+++ b/rentchain-api/src/services/recovery/__tests__/recoveryIntentService.test.ts
@@ -3,10 +3,12 @@ import { CANONICAL_EVENTS_COLLECTION } from "../../../lib/events/buildEvent";
 import {
   DECISION_CONTINUITY_SNAPSHOTS_COLLECTION,
   OPERATOR_RECOVERY_INTENTS_COLLECTION,
+  OPERATOR_RECOVERY_LOGS_COLLECTION,
 } from "../recoveryStore";
 import { captureRecoveryActionIntent, validateRecoveryActionGate } from "../recoveryIntentService";
 import { workflowKey } from "../recoveryShared";
 import { createRecoveryTestStore } from "./recoveryTestStore";
+import { seedLifecycleRecoveryCandidates } from "../../../__tests__/fixtures/lifecycleContinuityFixtures";
 
 const adminAuthority = {
   role: "admin" as const,
@@ -250,6 +252,56 @@ describe("recoveryIntentService", () => {
           }),
         }),
       ])
+    );
+  });
+
+  it("captures advisory intents for deterministic lifecycle recovery candidates without mutating source state", async () => {
+    const store = createRecoveryTestStore();
+    const candidates = seedLifecycleRecoveryCandidates(store);
+
+    for (const candidate of candidates) {
+      const intent = await captureRecoveryActionIntent({
+        recoveryId: candidate.workflowInstanceKey,
+        authority: adminAuthority,
+        firestore: store,
+        now: "2026-06-02T13:00:00.000Z",
+        request: {
+          actionType: candidate.expectedDecision,
+          reason: `Lifecycle continuity fixture reviewed for ${candidate.workflowType}.`,
+          authorizationConfirmed: true,
+        },
+      });
+
+      expect(intent).toMatchObject({
+        recoveryId: candidate.workflowInstanceKey,
+        workflowType: candidate.workflowType,
+        workflowInstanceKey: candidate.workflowInstanceKey,
+        actionType: candidate.expectedDecision,
+        status: "captured",
+        metadataOnly: true,
+        appendOnly: true,
+        rawIdsIncluded: false,
+      });
+      await expect(
+        validateRecoveryActionGate({
+          recoveryId: candidate.workflowInstanceKey,
+          intentId: intent.intentId,
+          authority: adminAuthority,
+          firestore: store,
+          now: "2026-06-02T13:30:00.000Z",
+        })
+      ).resolves.toMatchObject({
+        gateStatus: "satisfied",
+        authorizationValid: true,
+        intentFresh: true,
+      });
+    }
+
+    const intents = await store.collection(OPERATOR_RECOVERY_INTENTS_COLLECTION).get();
+    expect(intents.docs).toHaveLength(candidates.length);
+    expect((await store.collection(OPERATOR_RECOVERY_LOGS_COLLECTION).get()).docs).toHaveLength(0);
+    expect(JSON.stringify(intents.docs.map((doc) => doc.data()))).not.toMatch(
+      /token|secret|credential|bearer|gs:\/\/|storage\.googleapis\.com|providerPayload/i
     );
   });
 });

--- a/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
@@ -11,7 +11,7 @@ import {
   lifecycleContinuityDates,
   lifecycleContinuityIds,
   lifecycleContinuityLabels,
-} from "../../../../rentchain-api/src/__tests__/fixtures/lifecycleContinuityFixtures";
+} from "../../test/fixtures/lifecycleContinuityFixtures";
 
 const mocks = vi.hoisted(() => ({
   updateProperty: vi.fn(),

--- a/rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.ts
+++ b/rentchain-frontend/src/test/fixtures/lifecycleContinuityFixtures.ts
@@ -4,11 +4,15 @@ export const lifecycleContinuityUiIds = {
   landlordId: "lc_landlord_001",
   propertyId: "lc_property_north_towers",
   unit101Id: "lc_unit_101",
+  unit102Id: "lc_unit_102",
   unit103Id: "lc_unit_103",
+  applicantId: "lc_applicant_001",
   activeTenantId: "lc_tenant_active_001",
   upcomingTenantId: "lc_tenant_upcoming_001",
+  archivedTenantId: "lc_tenant_archived_001",
   activeLeaseId: "lc_lease_active_001",
   upcomingLeaseId: "lc_lease_upcoming_001",
+  archivedLeaseId: "lc_lease_archived_001",
   paymentId: "lc_payment_import_001",
   ledgerEntryId: "lc_ledger_payment_001",
   obligationId: "lc_obligation_2026_06",
@@ -22,9 +26,28 @@ export const lifecycleContinuityUiDates = {
   activeLeaseEnd: "2027-05-31",
   upcomingLeaseStart: "2026-07-01",
   upcomingLeaseEnd: "2027-06-30",
+  archivedLeaseStart: "2025-06-01",
+  archivedLeaseEnd: "2026-05-31",
   paymentDate: "2026-06-01",
   obligationDueDate: "2026-06-01T00:00:00.000Z",
 } as const;
+
+export const lifecycleContinuityUiLabels = {
+  propertyName: "North Towers",
+  propertyAddress: "10 Harbour Road, Halifax, NS",
+  unit101: "Unit 101",
+  unit102: "Unit 102",
+  unit103: "Unit 103",
+  activeTenantName: "John Smith",
+  upcomingTenantName: "Bailey Blinkers",
+  archivedTenantName: "Casey Past",
+  activeLeaseLabel: "North Towers - Unit 101 Lease",
+  upcomingLeaseLabel: "North Towers - Unit 103 Lease",
+} as const;
+
+export const lifecycleContinuityIds = lifecycleContinuityUiIds;
+export const lifecycleContinuityDates = lifecycleContinuityUiDates;
+export const lifecycleContinuityLabels = lifecycleContinuityUiLabels;
 
 function cloneRecord<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -60,6 +83,161 @@ export function buildLifecycleContinuityTenantRow(
     },
     overrides,
   );
+}
+
+export function buildLifecycleContinuityProperty(
+  overrides?: Partial<LifecycleContinuityUiRecord>,
+): LifecycleContinuityUiRecord {
+  return withOverrides(
+    {
+      id: lifecycleContinuityUiIds.propertyId,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      name: lifecycleContinuityUiLabels.propertyName,
+      address: lifecycleContinuityUiLabels.propertyAddress,
+      province: "NS",
+      jurisdictionProvince: "NS",
+      status: "active",
+      createdAt: lifecycleContinuityUiDates.now,
+      updatedAt: lifecycleContinuityUiDates.now,
+    },
+    overrides,
+  );
+}
+
+export function buildLifecycleContinuityUnits(): LifecycleContinuityUiRecord[] {
+  return [
+    {
+      id: lifecycleContinuityUiIds.unit101Id,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      label: lifecycleContinuityUiLabels.unit101,
+      unitNumber: "101",
+      configuredRentCents: 164000,
+      occupancyDisplayStatus: "occupied",
+      activeLeaseId: lifecycleContinuityUiIds.activeLeaseId,
+      tenantId: lifecycleContinuityUiIds.activeTenantId,
+    },
+    {
+      id: lifecycleContinuityUiIds.unit102Id,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      label: lifecycleContinuityUiLabels.unit102,
+      unitNumber: "102",
+      configuredRentCents: 154000,
+      occupancyDisplayStatus: "vacant",
+    },
+    {
+      id: lifecycleContinuityUiIds.unit103Id,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      label: lifecycleContinuityUiLabels.unit103,
+      unitNumber: "103",
+      configuredRentCents: 198000,
+      occupancyDisplayStatus: "upcoming",
+      activeLeaseId: lifecycleContinuityUiIds.upcomingLeaseId,
+      tenantId: lifecycleContinuityUiIds.upcomingTenantId,
+    },
+  ];
+}
+
+export function buildLifecycleContinuityTenant(
+  kind: "active" | "upcoming" | "archived" = "active",
+  overrides?: Partial<LifecycleContinuityUiRecord>,
+): LifecycleContinuityUiRecord {
+  const baseByKind: Record<"active" | "upcoming" | "archived", LifecycleContinuityUiRecord> = {
+    active: {
+      id: lifecycleContinuityUiIds.activeTenantId,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      fullName: lifecycleContinuityUiLabels.activeTenantName,
+      email: "john.smith@example.test",
+      status: "active",
+      lifecycleState: "active",
+      currentLeaseId: lifecycleContinuityUiIds.activeLeaseId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      unitId: lifecycleContinuityUiIds.unit101Id,
+    },
+    upcoming: {
+      id: lifecycleContinuityUiIds.upcomingTenantId,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      fullName: lifecycleContinuityUiLabels.upcomingTenantName,
+      email: "bailey.blinkers@example.test",
+      status: "lease_signed",
+      lifecycleState: "lease_signed",
+      currentLeaseId: lifecycleContinuityUiIds.upcomingLeaseId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      unitId: lifecycleContinuityUiIds.unit103Id,
+    },
+    archived: {
+      id: lifecycleContinuityUiIds.archivedTenantId,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      fullName: lifecycleContinuityUiLabels.archivedTenantName,
+      email: "casey.past@example.test",
+      status: "archived",
+      lifecycleState: "past",
+      archived: true,
+      previousLeaseId: lifecycleContinuityUiIds.archivedLeaseId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      unitId: lifecycleContinuityUiIds.unit101Id,
+    },
+  };
+
+  return withOverrides(baseByKind[kind], overrides);
+}
+
+export function buildLifecycleContinuityLease(
+  kind: "active" | "upcoming" | "archived" = "active",
+  overrides?: Partial<LifecycleContinuityUiRecord>,
+): LifecycleContinuityUiRecord {
+  const baseByKind: Record<"active" | "upcoming" | "archived", LifecycleContinuityUiRecord> = {
+    active: {
+      id: lifecycleContinuityUiIds.activeLeaseId,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      tenantId: lifecycleContinuityUiIds.activeTenantId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      unitId: lifecycleContinuityUiIds.unit101Id,
+      status: "active",
+      signingStatus: "signed",
+      startDate: lifecycleContinuityUiDates.activeLeaseStart,
+      endDate: lifecycleContinuityUiDates.activeLeaseEnd,
+      rentCents: 164000,
+      rentDueDay: 1,
+      paymentFrequency: "monthly",
+      label: lifecycleContinuityUiLabels.activeLeaseLabel,
+    },
+    upcoming: {
+      id: lifecycleContinuityUiIds.upcomingLeaseId,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      tenantId: lifecycleContinuityUiIds.upcomingTenantId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      unitId: lifecycleContinuityUiIds.unit103Id,
+      status: "signed",
+      signingStatus: "signed",
+      startDate: lifecycleContinuityUiDates.upcomingLeaseStart,
+      endDate: lifecycleContinuityUiDates.upcomingLeaseEnd,
+      rentCents: 198000,
+      rentDueDay: 1,
+      paymentFrequency: "monthly",
+      label: lifecycleContinuityUiLabels.upcomingLeaseLabel,
+    },
+    archived: {
+      id: lifecycleContinuityUiIds.archivedLeaseId,
+      landlordId: lifecycleContinuityUiIds.landlordId,
+      tenantId: lifecycleContinuityUiIds.archivedTenantId,
+      propertyId: lifecycleContinuityUiIds.propertyId,
+      unitId: lifecycleContinuityUiIds.unit101Id,
+      status: "archived",
+      signingStatus: "signed",
+      startDate: lifecycleContinuityUiDates.archivedLeaseStart,
+      endDate: lifecycleContinuityUiDates.archivedLeaseEnd,
+      rentCents: 150000,
+      rentDueDay: 1,
+      paymentFrequency: "monthly",
+      label: "North Towers - Unit 101 Archived Lease",
+      archived: true,
+    },
+  };
+
+  return withOverrides(baseByKind[kind], overrides);
 }
 
 export function buildLifecycleContinuityLeaseSummary(


### PR DESCRIPTION
## Summary
- Extend the existing lifecycle continuity fixture with deterministic synthetic recovery candidates for lease, payment, maintenance, and decision workflows.
- Add recovery intent, admin recovery, governed review workspace, and landlord review timeline coverage using fixture-only data.
- Keep the change limited to test fixtures, tests, and the required handoff summary.

## Validation
- cd rentchain-api && npm test -- --runInBand src/__tests__/fixtures/lifecycleContinuityFixtures.test.ts src/services/recovery/__tests__/recoveryIntentService.test.ts src/routes/__tests__/adminRecoveryRoutes.test.ts src/routes/__tests__/governedReviewWorkspaceRoutes.test.ts src/routes/__tests__/landlordReviewTimelineRoutes.test.ts
- cd rentchain-api && npm test -- --runInBand src/routes/__tests__/landlordOperatorReviewRoutes.test.ts src/lib/canonicalAudit/__tests__/canonicalAuditEvent.test.ts src/services/stateMachines/__tests__/reviewWorkflowAudit.test.ts
- cd rentchain-frontend && npm test -- src/pages/admin/AdminReviewWorkspacesPage.test.tsx src/pages/ReviewTimelinePage.test.tsx src/pages/DecisionInboxPage.test.tsx src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx
- git diff --check

## Backend
No backend route, service, middleware, Firestore rule, infrastructure, dependency, or production data path changed.