### PR TITLE
Harden token refresh and recovery contract

### DIFF
--- a/docs/security/token-refresh-recovery-contract-v1.md
+++ b/docs/security/token-refresh-recovery-contract-v1.md
@@ -1,0 +1,72 @@
+# Token Refresh And Recovery Contract v1
+
+## Scope
+
+This contract records the current token refresh, logout, password recovery, invite recovery, and two-factor recovery-adjacent behavior for the Phase 3 hardening pass. It does not introduce new runtime endpoints, auth providers, deployment configuration, Firestore rules, Firestore indexes, or production data changes.
+
+## Current Supported Auth Routes
+
+`rentchain-api/src/routes/authRoutes.ts` currently mounts these auth routes:
+
+- `POST /api/auth/signup` with auth-sensitive rate limiting and signup schema validation (`rentchain-api/src/routes/authRoutes.ts:697-972`).
+- `POST /api/auth/password-reset/confirmation` with a dedicated 15-minute, 20-request rate limit and email validation (`rentchain-api/src/routes/authRoutes.ts:42-47`, `rentchain-api/src/routes/authRoutes.ts:974-1016`).
+- `GET /api/auth/onboard/resolve` for invite token resolution (`rentchain-api/src/routes/authRoutes.ts:1018-1066`).
+- `POST /api/auth/onboard/accept` for invite acceptance (`rentchain-api/src/routes/authRoutes.ts:1068-1532`).
+- `POST /api/auth/login` with auth-sensitive rate limiting and login enablement checks (`rentchain-api/src/routes/authRoutes.ts:1534-1729`).
+- `GET /api/auth/health` for login configuration health (`rentchain-api/src/routes/authRoutes.ts:1731-1756`).
+- `POST /api/auth/login/demo`, disabled in production (`rentchain-api/src/routes/authRoutes.ts:1758-1803`).
+- `POST /api/auth/2fa/verify` with an in-module rate limit and pending-token verification (`rentchain-api/src/routes/authRoutes.ts:1805-1881`).
+- `POST /api/auth/2fa/totp/setup`, `POST /api/auth/2fa/totp/confirm`, `POST /api/auth/2fa/backup-codes/regenerate`, `POST /api/auth/2fa/disable`, and `POST /api/auth/2fa/trust-device`, each authenticated through `authenticateJwt` and rate limited (`rentchain-api/src/routes/authRoutes.ts:1883-2118`).
+- `GET /api/auth/me` through `requireAuth` (`rentchain-api/src/routes/authRoutes.ts:2121-2142`).
+- `POST /api/auth/logout`, which returns a success response and does not perform server-side JWT revocation (`rentchain-api/src/routes/authRoutes.ts:2144-2146`).
+- `GET /api/auth/demo` for demo email metadata (`rentchain-api/src/routes/authRoutes.ts:2148-2150`).
+
+Tenant auth has a separate login/logout route module. Tenant login verifies a stored password hash and signs a tenant JWT for seven days; tenant logout returns a local success response (`rentchain-api/src/routes/tenantAuthRoutes.ts:9-54`).
+
+## Unsupported Refresh And Recovery Endpoints
+
+The current auth route table does not define:
+
+- `POST /api/auth/refresh`
+- `POST /api/auth/resetPassword`
+- `POST /api/auth/verifyEmail`
+
+These routes must not silently succeed. The contract tests assert that these unsupported routes return a 404 through the mounted auth router fallback and do not return token, reset-link, or trusted-device fields.
+
+## Token Issuance And Lifetime
+
+The canonical JWT helper signs `JwtClaimsV1` with subject, email, role, optional landlord and tenant scope, permissions, revoked permissions, impersonation attribution fields, and version `1` (`rentchain-api/src/auth/jwt.ts:4-40`). The helper defaults to seven days unless a route supplies an override (`rentchain-api/src/auth/jwt.ts:28-36`).
+
+Current auth route issuance points include contractor signup, landlord signup, landlord/contractor login, tenant invite acceptance, 2FA verification, trusted-device creation, demo login, and tenant auth login (`rentchain-api/src/routes/authRoutes.ts:843-870`, `rentchain-api/src/routes/authRoutes.ts:920-960`, `rentchain-api/src/routes/authRoutes.ts:1314-1333`, `rentchain-api/src/routes/authRoutes.ts:1370-1398`, `rentchain-api/src/routes/authRoutes.ts:1418-1459`, `rentchain-api/src/routes/authRoutes.ts:1624-1637`, `rentchain-api/src/routes/authRoutes.ts:1665-1687`, `rentchain-api/src/routes/authRoutes.ts:1790-1802`, `rentchain-api/src/routes/authRoutes.ts:1871-1880`, `rentchain-api/src/routes/authRoutes.ts:2106-2117`, `rentchain-api/src/routes/tenantAuthRoutes.ts:35-50`).
+
+`requireAuth` verifies a Bearer token, hydrates the canonical session user, attaches entitlements, and fails closed for disabled account and landlord or tenant scope mismatch (`rentchain-api/src/middleware/requireAuth.ts:5-40`). `sessionUserService` can hydrate from claims or database records and rejects disabled or scope-mismatched accounts in the database-backed path (`rentchain-api/src/services/sessionUserService.ts:99-171`, `rentchain-api/src/services/sessionUserService.ts:240-270`).
+
+## Logout Semantics
+
+Backend logout currently returns `{ "message": "Logged out" }` and does not revoke outstanding JWTs server-side (`rentchain-api/src/routes/authRoutes.ts:2144-2146`). Frontend logout clears local token state before calling backend logout when a token exists (`rentchain-frontend/src/context/AuthContext.tsx:496-513`). The frontend API logout call posts to `/api/auth/logout` and sends the current token as an Authorization header when provided (`rentchain-frontend/src/api/authApi.ts:256-261`).
+
+This contract records logout as client-token clearing plus backend acknowledgement. It does not claim full server-side revocation.
+
+## Password Recovery Contract
+
+`POST /api/auth/password-reset/confirmation` is a post-change notification route. It validates email format, requires configured sender metadata, sends a confirmation email, logs masked email only, and returns 204 on success (`rentchain-api/src/routes/authRoutes.ts:974-1016`). It is not a reset-token issuance endpoint.
+
+The current frontend auth API does not call `/api/auth/refresh`, `/api/auth/resetPassword`, or `/api/auth/verifyEmail` (`rentchain-frontend/src/api/authApi.ts:59-265`).
+
+## Invite Recovery Contract
+
+Onboarding token resolution checks contractor, tenant, and landlord invite sources, uses hashed token lookup for landlord invites, reports expired or already accepted states, and returns redacted copy and masked email metadata where applicable (`rentchain-api/src/routes/authRoutes.ts:321-594`, `rentchain-api/src/routes/authRoutes.ts:1018-1066`).
+
+Onboarding acceptance checks invalid, expired, already accepted, signup-required, login-required, wrong-account, exact-email, and tenant invite states before issuing tenant or contractor session responses (`rentchain-api/src/routes/authRoutes.ts:1068-1532`). Existing tenant invite tests cover hashed tenancy invite resolution/acceptance, converted tenant linking, tenant ID precedence, occupancy safety, active lease occupancy sync, and replaced-token expiry (`rentchain-api/src/routes/__tests__/authOnboardTenantInvites.test.ts:119-430`).
+
+## Two-Factor Recovery-Adjacent Contract
+
+`POST /api/auth/2fa/verify` requires `pendingToken`, `method`, and `code`; invalid or expired pending tokens fail with 401 and do not issue a session token (`rentchain-api/src/routes/authRoutes.ts:1805-1881`). TOTP setup, confirmation, backup-code regeneration, disablement, and trusted-device creation require authenticated context and rate limiting (`rentchain-api/src/routes/authRoutes.ts:1883-2118`).
+
+Setup and confirmation currently expose TOTP setup materials and backup codes only in the intended setup/confirmation response contract (`rentchain-api/src/routes/authRoutes.ts:1903-1910`, `rentchain-api/src/routes/authRoutes.ts:1951-1962`). Trusted-device creation returns a trusted-device token only after authenticated 2FA validation (`rentchain-api/src/routes/authRoutes.ts:2063-2118`).
+
+## Frontend Contract
+
+Frontend auth API calls login, signup, demo login, 2FA verify/setup/confirm/regenerate/trust/disable, `/me`, restore-session fallback `/auth/me`, and logout (`rentchain-frontend/src/api/authApi.ts:59-265`). Frontend token storage separates main auth token handling from tenant token storage (`rentchain-frontend/src/lib/authToken.ts:3-113`). `AuthContext` validates token shape and expiry, restores sessions through `/api/me`, stores login/signup/2FA tokens, and clears local state on logout (`rentchain-frontend/src/context/AuthContext.tsx:65-164`, `rentchain-frontend/src/context/AuthContext.tsx:189-210`, `rentchain-frontend/src/context/AuthContext.tsx:212-339`, `rentchain-frontend/src/context/AuthContext.tsx:341-513`).
+
+No frontend source change is required for unsupported refresh/reset/verify endpoints because the audited frontend auth API does not call those endpoints.

--- a/rentchain-api/src/routes/__tests__/authRecoveryContract.test.ts
+++ b/rentchain-api/src/routes/__tests__/authRecoveryContract.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sendEmail: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: () => ({
+      doc: () => ({
+        get: vi.fn(async () => ({ exists: false, data: () => undefined })),
+        set: vi.fn(async () => undefined),
+      }),
+      where: () => ({
+        limit: () => ({
+          get: vi.fn(async () => ({ empty: true, docs: [] })),
+        }),
+      }),
+    }),
+  },
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+    arrayUnion: (...values: unknown[]) => values,
+  },
+}));
+
+vi.mock("../../services/emailService", () => ({
+  sendEmail: mocks.sendEmail,
+  sendLandlordWelcomeEmail: vi.fn(async () => ({ ok: true })),
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; body?: any; headers?: Record<string, string> }
+) {
+  return await new Promise<{ status: number; body: any; text: string }>((resolve, reject) => {
+    const [pathWithQuery, queryRaw = ""] = options.url.split("?");
+    const query = Object.fromEntries(new URLSearchParams(queryRaw));
+    const headers = options.headers ?? {};
+    let resolved = false;
+    const finish = (response: { status: number; body: any; text: string }) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(response);
+    };
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: pathWithQuery,
+      body: options.body ?? {},
+      headers,
+      query,
+      ip: "127.0.0.1",
+      socket: { remoteAddress: "127.0.0.1" },
+      get(name: string) {
+        return headers[name] ?? headers[name.toLowerCase()];
+      },
+      header(name: string) {
+        return headers[name] ?? headers[name.toLowerCase()];
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      getHeader(name: string) {
+        return this.headers[name.toLowerCase()];
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        finish({ status: this.statusCode, body: payload, text: JSON.stringify(payload) });
+        return this;
+      },
+      send(payload?: any) {
+        finish({ status: this.statusCode, body: payload, text: payload === undefined ? "" : String(payload) });
+        return this;
+      },
+      end(payload?: any) {
+        finish({ status: this.statusCode, body: payload, text: payload === undefined ? "" : String(payload) });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      finish({
+        status: 404,
+        body: {
+          ok: false,
+          error: "not_found",
+          path: req.path,
+        },
+        text: JSON.stringify({
+          ok: false,
+          error: "not_found",
+          path: req.path,
+        }),
+      });
+    });
+  });
+}
+
+async function invokeAuth(options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await invokeRouter(authRoutes, options);
+}
+
+let authRoutes: typeof import("../authRoutes").default;
+
+describe("auth recovery contract", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.JWT_SECRET = "test-secret";
+    delete process.env.EMAIL_FROM;
+    delete process.env.FROM_EMAIL;
+    authRoutes = (await import("../authRoutes")).default;
+  });
+
+  it.each(["/refresh", "/resetPassword", "/verifyEmail"])(
+    "keeps POST /api/auth%s unsupported and fail-closed",
+    async (path) => {
+      const res = await invokeAuth({
+        method: "POST",
+        url: path,
+        body: { token: "not-returned" },
+      });
+
+      expect(res.status).toBe(404);
+      expect(res.body).toMatchObject({
+        ok: false,
+        error: "not_found",
+      });
+      expect(JSON.stringify(res.body)).not.toContain("token");
+      expect(JSON.stringify(res.body)).not.toContain("resetLink");
+      expect(JSON.stringify(res.body)).not.toContain("trustedDeviceToken");
+    }
+  );
+
+  it("documents logout as backend acknowledgement without token internals", async () => {
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/logout",
+      headers: { Authorization: "Bearer header.payload.signature" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: "Logged out" });
+    expect(JSON.stringify(res.body)).not.toContain("token");
+    expect(JSON.stringify(res.body)).not.toContain("session");
+    expect(JSON.stringify(res.body)).not.toContain("revoked");
+  });
+
+  it("rejects password-reset confirmation notification with invalid email", async () => {
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/password-reset/confirmation",
+      body: { email: "invalid" },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: "invalid_email" });
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("requires configured sender metadata before password-reset confirmation notification", async () => {
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/password-reset/confirmation",
+      body: { email: "tenant@example.test" },
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ ok: false, error: "email_not_configured" });
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends password-reset confirmation notification without returning sensitive payloads", async () => {
+    process.env.EMAIL_FROM = "dev@example.test";
+
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/password-reset/confirmation",
+      body: { email: "tenant@example.test" },
+    });
+
+    expect(res.status).toBe(204);
+    expect(res.text).toBe("");
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "tenant@example.test",
+        from: "dev@example.test",
+      })
+    );
+  });
+
+  it("rejects invalid pending 2FA token without issuing auth or trusted-device tokens", async () => {
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/2fa/verify",
+      body: {
+        pendingToken: "invalid.pending.token",
+        method: "totp",
+        code: "123456",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Invalid or expired 2FA token" });
+    expect(res.body).not.toHaveProperty("token");
+    expect(res.body).not.toHaveProperty("tenantToken");
+    expect(res.body).not.toHaveProperty("trustedDeviceToken");
+  });
+});


### PR DESCRIPTION
## Summary
- Added a token refresh and recovery contract document for current auth route behavior.
- Added backend route-contract coverage for unsupported refresh/reset/verify endpoints, logout acknowledgement, password-reset confirmation notification behavior, and invalid 2FA pending-token handling.
- Kept scope to documentation and tests; no runtime auth behavior, Firestore rules, dependencies, or production data paths changed.

## Validation
- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/authRecoveryContract.test.ts src/routes/__tests__/authOnboardTenantInvites.test.ts`
- `npm --prefix rentchain-api run build`
- `rg -n "firebase-admin|rentchain-api/src/config/firebase|rentchain-api/src/firebase" rentchain-frontend/src` returned no matches
- `git diff --check`
- staged diff hygiene scan completed with no prohibited text or sensitive credential patterns found

## Safety
- Unsupported refresh/reset/verify endpoints remain fail-closed.
- Logout is documented as backend acknowledgement plus client-side token clearing, not server-side JWT revocation.
- No production behavior changes were introduced.