### PR TITLE
Add logout and session revocation contract

### DIFF
--- a/docs/security/logout-session-revocation-contract-v1.md
+++ b/docs/security/logout-session-revocation-contract-v1.md
@@ -1,0 +1,102 @@
+# Logout Session Revocation Contract v1
+
+## Scope
+
+This contract records the current logout, session expiration, trusted-device, and session revocation posture for Phase 3 auth hardening. It does not introduce new runtime endpoints, new auth providers, server-side JWT revocation, Firestore rule changes, Firestore indexes, deployment configuration, dependencies, or production data changes.
+
+The current model is stateless for issued JWTs. Logout is client-side token clearing plus backend acknowledgement. Backend logout does not revoke outstanding JWTs, does not invalidate concurrent sessions, and does not clear trusted-device tokens server-side.
+
+## Current Supported Logout Routes
+
+`POST /api/auth/logout` is mounted from `rentchain-api/src/routes/authRoutes.ts` before global auth decoding (`rentchain-api/src/app.build.ts:370-382`). The route does not require `requireAuth`, does not inspect the Authorization header, and returns status 200 with `{ "message": "Logged out" }` (`rentchain-api/src/routes/authRoutes.ts:2144-2146`).
+
+`rentchain-api/src/routes/tenantAuthRoutes.ts` defines `POST /logout`, which returns status 200 with `{ "ok": true }` (`rentchain-api/src/routes/tenantAuthRoutes.ts:52-54`). The current `app.build.ts` route audit did not find this module mounted as `/api/tenant-auth/logout`; this document records the route module contract and does not change runtime mounting.
+
+Neither logout handler returns raw tokens, session identifiers, revocation metadata, storage paths, or provider payloads.
+
+## Logout Semantics
+
+Backend logout is an acknowledgement endpoint. For landlord, contractor, and admin-style auth, it succeeds with or without a Bearer token. Invalid and expired Bearer tokens also receive the same success acknowledgement because the route does not verify token state.
+
+Frontend logout records the practical session-ending behavior. `AuthContext.logout` reads the current stored token, clears browser token storage and in-memory auth state, resets 2FA pending state, and then calls the backend logout endpoint only when a token was present (`rentchain-frontend/src/context/AuthContext.tsx:496-513`). If the backend notification fails, frontend state remains cleared and the error is logged (`rentchain-frontend/src/context/AuthContext.tsx:506-512`).
+
+`authApi.logout` posts to `/api/auth/logout` and sends the current token in the Authorization header when one is supplied (`rentchain-frontend/src/api/authApi.ts:256-261`). The API call does not receive or process a replacement token.
+
+## Session Expiration Versus Logout Revocation
+
+JWT signing uses `JwtClaimsV1`, including subject, email, role, optional landlord and tenant scope, permissions, revoked permissions, impersonation attribution fields, and version `1` (`rentchain-api/src/auth/jwt.ts:4-20`). `signAuthToken` requires `JWT_SECRET` and defaults to a seven-day expiration unless a caller supplies an override (`rentchain-api/src/auth/jwt.ts:22-40`).
+
+`requireAuth` extracts a Bearer token, verifies it with `verifyAuthToken`, hydrates the canonical session user, attaches entitlements, and fails closed for unauthenticated, disabled-account, landlord-scope-mismatch, or tenant-scope-mismatch states (`rentchain-api/src/middleware/requireAuth.ts:5-40`). Token expiration is enforced when a protected route verifies the token.
+
+Logout and expiration are separate controls:
+
+- Expiration is automatic and enforced during token verification on protected routes.
+- Logout is an explicit client-side clearing action plus backend acknowledgement.
+- Logout does not add the token to a server-side deny list.
+- Logout does not shorten the token's remaining lifetime.
+
+## Frontend Token Storage
+
+Frontend token storage uses `rentchain_token` for the main auth token and `rentchain_tenant_token` for tenant-token storage (`rentchain-frontend/src/lib/authToken.ts:1-113`, `rentchain-frontend/src/lib/authKeys.ts:1-3`). The helper reads session and local storage, migrates legacy token keys into the current key, and removes legacy keys when clearing auth state (`rentchain-frontend/src/lib/authToken.ts:48-98`).
+
+`AuthContext` validates basic JWT shape and expiration with a short skew before restoring a session. Missing, invalid, or expired tokens are cleared locally and the user is treated as a guest (`rentchain-frontend/src/context/AuthContext.tsx:65-164`, `rentchain-frontend/src/context/AuthContext.tsx:212-339`).
+
+After logout, the frontend no longer sends the cleared token. If an already issued token is still available elsewhere, the backend has no revocation state that invalidates it solely because logout was called.
+
+## Trusted-Device And 2FA Lifecycle
+
+`POST /api/auth/2fa/verify` verifies a pending 2FA token and issues the session token after a valid code (`rentchain-api/src/routes/authRoutes.ts:1805-1881`). Pending 2FA tokens are separate from final session JWTs.
+
+`POST /api/auth/2fa/trust-device` requires authenticated context, validates a 2FA code, and returns a trusted-device token with a 30-day expiry (`rentchain-api/src/routes/authRoutes.ts:2063-2118`). Frontend pages store this value in `localStorage` under `rentchain_trusted_device` after the trust-device response (`rentchain-frontend/src/pages/AccountSecurityPage.tsx:69-76`, `rentchain-frontend/src/pages/TwoFactorPage.tsx:43-49`).
+
+`POST /api/auth/2fa/disable` clears the in-module 2FA fields for the loaded landlord user: enabled flag, methods, TOTP secret, and backup codes (`rentchain-api/src/routes/authRoutes.ts:2015-2060`). Frontend account security removes `rentchain_trusted_device` after a successful disable response (`rentchain-frontend/src/pages/AccountSecurityPage.tsx:85-98`). The backend disable route does not return session-revocation fields and does not revoke all outstanding JWTs.
+
+Logout does not call 2FA disablement and does not clear trusted-device tokens server-side.
+
+## Concurrent-Session And Multi-Device Implications
+
+The current implementation does not store active session records. As a result:
+
+- Logging out in one browser clears that browser's local auth state.
+- Another browser or device with a valid unexpired JWT remains authenticated until the token expires or another backend guard rejects it for a different reason.
+- The backend does not enumerate or revoke concurrent sessions on logout.
+- Tenant and landlord token storage are separate on the frontend, and logout of one surface should not be treated as proof that every possible token has been invalidated server-side.
+
+This is an explicit baseline, not a recommendation that server-side revocation should remain absent.
+
+## Contract Tests
+
+`rentchain-api/src/routes/__tests__/authRecoveryContract.test.ts` validates the logout baseline with mocked Firebase dependencies and in-memory router invocation. The tests assert:
+
+- `POST /api/auth/logout` returns 200 with `{ "message": "Logged out" }`.
+- Landlord logout succeeds with no token, invalid token, expired token, and valid token.
+- A valid token still succeeds on `/api/auth/me` after logout acknowledgement, proving logout does not revoke that token server-side.
+- A second valid token for another session remains usable after the first token is logged out.
+- Tenant logout route module returns 200 with `{ "ok": true }` and does not return token or revocation fields.
+- 2FA disablement does not return all-session or trusted-device revocation fields.
+
+These tests do not mutate production Firestore and do not require the emulator.
+
+## Limitations
+
+Current logout does not revoke:
+
+- Outstanding JWTs.
+- Concurrent sessions on other browsers or devices.
+- Trusted-device tokens stored outside the current frontend state.
+- Pending 2FA tokens solely by calling logout.
+- Tenant tokens stored separately from the main auth token unless the relevant client flow clears them.
+
+Current logout also does not write audit records, session records, or revocation records.
+
+## Future Revocation Considerations
+
+If operational policy requires stronger logout semantics, future work should be a separate mission. Candidate designs include:
+
+- A server-side JWT deny list keyed by token identifier or issued-at cutoff.
+- Per-user session records with active, revoked, and expired states.
+- A password-change or incident-response token version that invalidates older tokens.
+- Trusted-device records with server-side revocation and device-level listing.
+- Account-wide or device-specific logout endpoints with route-level authorization and audit events.
+
+Any future revocation implementation must preserve tenant, landlord, admin, and support separation; avoid raw token storage; use hashed token identifiers where identifiers are needed; and include append-safe audit records for security-sensitive revocation events.

--- a/docs/security/token-refresh-recovery-contract-v1.md
+++ b/docs/security/token-refresh-recovery-contract-v1.md
@@ -45,7 +45,7 @@ Current auth route issuance points include contractor signup, landlord signup, l
 
 Backend logout currently returns `{ "message": "Logged out" }` and does not revoke outstanding JWTs server-side (`rentchain-api/src/routes/authRoutes.ts:2144-2146`). Frontend logout clears local token state before calling backend logout when a token exists (`rentchain-frontend/src/context/AuthContext.tsx:496-513`). The frontend API logout call posts to `/api/auth/logout` and sends the current token as an Authorization header when provided (`rentchain-frontend/src/api/authApi.ts:256-261`).
 
-This contract records logout as client-token clearing plus backend acknowledgement. It does not claim full server-side revocation.
+This contract records logout as client-token clearing plus backend acknowledgement. It does not claim full server-side revocation. See `docs/security/logout-session-revocation-contract-v1.md` for the detailed logout, concurrent-session, trusted-device, and revocation-boundary contract.
 
 ## Password Recovery Contract
 

--- a/rentchain-api/src/routes/__tests__/authRecoveryContract.test.ts
+++ b/rentchain-api/src/routes/__tests__/authRecoveryContract.test.ts
@@ -1,26 +1,48 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import jwt from "jsonwebtoken";
 
 const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(async () => ({ ok: true })),
 }));
 
-vi.mock("../../config/firebase", () => ({
-  db: {
-    collection: () => ({
-      doc: () => ({
-        get: vi.fn(async () => ({ exists: false, data: () => undefined })),
-        set: vi.fn(async () => undefined),
-      }),
-      where: () => ({
-        limit: () => ({
-          get: vi.fn(async () => ({ empty: true, docs: [] })),
-        }),
+const dbMock = {
+  collection: () => ({
+    doc: () => ({
+      get: vi.fn(async () => ({ exists: false, data: () => undefined })),
+      set: vi.fn(async () => undefined),
+    }),
+    where: () => ({
+      limit: () => ({
+        get: vi.fn(async () => ({ empty: true, docs: [] })),
       }),
     }),
+  }),
+};
+
+const fieldValueMock = {
+  serverTimestamp: () => "__server_timestamp__",
+  arrayUnion: (...values: unknown[]) => values,
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: fieldValueMock,
+}));
+
+vi.mock("../../firebase", () => ({
+  db: dbMock,
+  firestore: dbMock,
+  FieldValue: fieldValueMock,
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    firestore: {
+      FieldValue: fieldValueMock,
+    },
   },
-  FieldValue: {
-    serverTimestamp: () => "__server_timestamp__",
-    arrayUnion: (...values: unknown[]) => values,
+  db: {
+    collection: dbMock.collection,
   },
 }));
 
@@ -31,7 +53,13 @@ vi.mock("../../services/emailService", () => ({
 
 async function invokeRouter(
   router: any,
-  options: { method: string; url: string; body?: any; headers?: Record<string, string> }
+  options: {
+    method: string;
+    url: string;
+    body?: any;
+    headers?: Record<string, string>;
+    path?: string;
+  }
 ) {
   return await new Promise<{ status: number; body: any; text: string }>((resolve, reject) => {
     const [pathWithQuery, queryRaw = ""] = options.url.split("?");
@@ -47,7 +75,7 @@ async function invokeRouter(
       method: options.method,
       url: options.url,
       originalUrl: options.url,
-      path: pathWithQuery,
+      path: options.path ?? pathWithQuery,
       body: options.body ?? {},
       headers,
       query,
@@ -113,11 +141,40 @@ async function invokeAuth(options: {
   url: string;
   body?: any;
   headers?: Record<string, string>;
+  path?: string;
 }) {
   return await invokeRouter(authRoutes, options);
 }
 
+async function invokeTenantAuth(options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await invokeRouter(tenantAuthRoutes, options);
+}
+
+function makeAuthToken(options?: { expiresIn?: string; subject?: string }) {
+  return makeAuthTokenWithSecret("test-secret", options);
+}
+
+function makeAuthTokenWithSecret(secret: string, options?: { expiresIn?: string; subject?: string }) {
+  return jwt.sign(
+    {
+      sub: options?.subject ?? "landlord-session-1",
+      email: "landlord@example.test",
+      role: "landlord",
+      landlordId: options?.subject ?? "landlord-session-1",
+      ver: 1,
+    },
+    secret,
+    { expiresIn: options?.expiresIn ?? "7d" }
+  );
+}
+
 let authRoutes: typeof import("../authRoutes").default;
+let tenantAuthRoutes: typeof import("../tenantAuthRoutes").default;
 
 describe("auth recovery contract", () => {
   beforeEach(async () => {
@@ -126,6 +183,7 @@ describe("auth recovery contract", () => {
     delete process.env.EMAIL_FROM;
     delete process.env.FROM_EMAIL;
     authRoutes = (await import("../authRoutes")).default;
+    tenantAuthRoutes = (await import("../tenantAuthRoutes")).default;
   });
 
   it.each(["/refresh", "/resetPassword", "/verifyEmail"])(
@@ -160,6 +218,137 @@ describe("auth recovery contract", () => {
     expect(JSON.stringify(res.body)).not.toContain("token");
     expect(JSON.stringify(res.body)).not.toContain("session");
     expect(JSON.stringify(res.body)).not.toContain("revoked");
+  });
+
+  it("allows landlord logout without an authorization header", async () => {
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/logout",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: "Logged out" });
+  });
+
+  it("allows landlord logout with an invalid token because logout does not verify session state", async () => {
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/logout",
+      headers: { Authorization: "Bearer invalid.token.value" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: "Logged out" });
+  });
+
+  it("allows landlord logout with an expired token because logout does not check expiry", async () => {
+    const expiredToken = makeAuthToken({ expiresIn: "-1s" });
+
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/logout",
+      headers: { Authorization: `Bearer ${expiredToken}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: "Logged out" });
+  });
+
+  it("does not revoke the submitted landlord token server-side after logout acknowledgement", async () => {
+    const token = makeAuthToken();
+
+    const logoutRes = await invokeAuth({
+      method: "POST",
+      url: "/logout",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(logoutRes.status).toBe(200);
+
+    const meRes = await invokeAuth({
+      method: "GET",
+      url: "/me",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(meRes.status).toBe(200);
+    expect(meRes.body).toMatchObject({
+      ok: true,
+      user: {
+        id: "landlord-session-1",
+        role: "landlord",
+        landlordId: "landlord-session-1",
+      },
+    });
+  });
+
+  it("does not invalidate concurrent landlord sessions when one token is logged out", async () => {
+    const firstToken = makeAuthToken({ subject: "landlord-session-1" });
+    const secondToken = makeAuthToken({ subject: "landlord-session-2" });
+
+    const logoutRes = await invokeAuth({
+      method: "POST",
+      url: "/logout",
+      headers: { Authorization: `Bearer ${firstToken}` },
+    });
+    expect(logoutRes.status).toBe(200);
+
+    const secondSessionRes = await invokeAuth({
+      method: "GET",
+      url: "/me",
+      headers: { Authorization: `Bearer ${secondToken}` },
+    });
+
+    expect(secondSessionRes.status).toBe(200);
+    expect(secondSessionRes.body?.user?.id).toBe("landlord-session-2");
+  });
+
+  it("documents tenant logout as acknowledgement-only without token internals", async () => {
+    const res = await invokeTenantAuth({
+      method: "POST",
+      url: "/logout",
+      headers: { Authorization: "Bearer tenant.header.payload" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(JSON.stringify(res.body)).not.toContain("token");
+    expect(JSON.stringify(res.body)).not.toContain("session");
+    expect(JSON.stringify(res.body)).not.toContain("revoked");
+  });
+
+  it("allows tenant logout without token validation", async () => {
+    const noTokenRes = await invokeTenantAuth({
+      method: "POST",
+      url: "/logout",
+    });
+    const invalidTokenRes = await invokeTenantAuth({
+      method: "POST",
+      url: "/logout",
+      headers: { Authorization: "Bearer invalid.tenant.token" },
+    });
+
+    expect(noTokenRes.status).toBe(200);
+    expect(noTokenRes.body).toEqual({ ok: true });
+    expect(invalidTokenRes.status).toBe(200);
+    expect(invalidTokenRes.body).toEqual({ ok: true });
+  });
+
+  it("documents 2FA disablement as authenticated and without session revocation fields", async () => {
+    const token = makeAuthTokenWithSecret("rentchain-dev-jwt-secret", { subject: "landlord-demo" });
+
+    const res = await invokeAuth({
+      method: "POST",
+      url: "/2fa/disable",
+      path: "/api/auth/2fa/disable",
+      headers: { Authorization: `Bearer ${token}` },
+      body: { code: "123456" },
+    });
+
+    expect([400, 401]).toContain(res.status);
+    expect(res.body).toEqual(expect.objectContaining({ error: expect.any(String) }));
+    expect(res.body).not.toHaveProperty("revoked");
+    expect(res.body).not.toHaveProperty("revokedSessions");
+    expect(res.body).not.toHaveProperty("revokedTrustedDevices");
   });
 
   it("rejects password-reset confirmation notification with invalid email", async () => {


### PR DESCRIPTION
## Summary
- Added `docs/security/logout-session-revocation-contract-v1.md` documenting current logout, session expiration, trusted-device, concurrent-session, and revocation boundaries.
- Extended `authRecoveryContract.test.ts` with logout contract coverage for no-token, invalid-token, expired-token, valid-token, post-logout token usability, concurrent sessions, tenant logout, and 2FA disablement boundaries.
- Linked the prior token refresh and recovery contract to the new logout/session revocation contract.

## Validation
- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/authRecoveryContract.test.ts src/routes/__tests__/authOnboardTenantInvites.test.ts`
- `npm --prefix rentchain-api run build`
- `git diff --check`
- Confirmed no dependency or Firestore rules diff
- Staged diff hygiene scan completed with no prohibited wording or sensitive credential patterns found

## Safety
- Documentation and backend tests only.
- No runtime logout behavior, auth routes, session management, Firestore rules, dependencies, infrastructure, or production data paths changed.
- Server-side JWT revocation remains explicitly documented as out of scope.