### PR TITLE
Add audit immutability contract and verification checklist

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,70 +1,70 @@
-PR: #1085
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1085
-Branch: feat/phase-3-auth-session-revocation-design-v1
+PR: #1086
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1086
+Branch: feat/phase-3-audit-immutability-verification-v1
 
 # Implementation Summary
 
 ## Scope
 
-Completed Phase 3 Mission 4 as a documentation and design-validation test mission. The work documents future auth session revocation design options, incident response readiness, and current logout/session limitations without changing runtime auth behavior.
+Completed Phase 3 Mission 5 as a documentation and pure contract-test mission for audit immutability verification. The work documents the current audit collection landscape, immutability expectations, current compliance levels, operator verification checks, and non-binding Phase 4 enforcement options.
 
-No auth routes, middleware, services, Firestore rules, Firestore indexes, infrastructure, dependencies, frontend behavior, production data, or runtime revocation behavior were changed.
+No runtime audit behavior, routes, services, Firestore rules, Firestore indexes, infrastructure, dependencies, frontend behavior, production data, or production guard behavior was changed.
 
 ## Files Changed
 
-- `docs/security/auth-incident-response-runbook-v1.md`
-- `docs/security/auth-session-revocation-glossary-v1.md`
-- `docs/security/logout-session-revocation-contract-v1.md`
+- `docs/security/audit-immutability-contract-v1.md`
+- `docs/security/audit-immutability-status-v1.md`
+- `docs/security/audit-immutability-verification-checklist-v1.md`
+- `docs/security/audit-immutability-roadmap-v1.md`
 - `docs/security/security-inventory.md`
-- `docs/security/session-revocation-design-options-v1.md`
-- `docs/security/session-revocation-incident-scenarios-v1.md`
-- `rentchain-api/src/routes/__tests__/sessionRevocationDesignValidation.test.ts`
+- `rentchain-api/src/routes/__tests__/auditImmutabilityContract.test.ts`
+- `.handoff/impl-summary.md`
 
 ## Implementation
 
-- Added session revocation design options for session-record, JWT deny-list, and token-version models.
-- Added current-state versus future-design boundaries for each revocation model.
-- Added Firestore, audit, incident-response, and multi-device considerations for each design option.
-- Added an auth incident response runbook covering `auth_session`, `credential_secret`, and `admin_support_access` incident types.
-- Added incident scenario documentation for account compromise, malicious device registration, support console abuse, multi-tenant scope concern, and bulk auth incident handling.
-- Added a glossary defining session, token, token revocation, token fingerprint, token hash, session identity, device identity, incident response, mitigation, containment, remediation, audit linkage, audit immutability, and append-safe terminology.
-- Extended the logout/session revocation contract with current revocation gaps, design roadmap, and incident response integration.
-- Added pure design-validation tests asserting revocation design invariants without importing runtime auth modules or Firestore clients.
-- Normalized one pre-existing security inventory phrase so the mission's broad security-doc scan has zero `raw token`, `raw credential`, or `raw secret` matches.
+- Added a formal audit immutability contract for `events`, `adminAuditEvents`, `registryAuditLog`, `canonicalEvents`, and audit-adjacent ledger event collections.
+- Documented that `canonicalAuditEvents` is a mission-listed name not found in the current source tree; canonical audit records currently write to `canonicalEvents`.
+- Documented current write semantics for canonical audit helper writes, canonical event writes, older `events` writers, admin audit events, registry audit events, and ledger-style operational events.
+- Identified current compliance levels: full for the `appendCanonicalAuditEvent` helper path, partial for `writeCanonicalEvent`, partial for older append-like audit collections, and absent for `canonicalAuditEvents`.
+- Added a verification checklist with design-time PR checks, read-only operator checks, collection sequence scan templates, role/scope spot checks, and curl templates.
+- Added a non-binding Phase 4 roadmap recommending report-only index-based verification before Firestore rules enforcement or schema-level normalization.
+- Updated the Security Inventory audit immutability section with links to the new contract, status audit, checklist, and roadmap.
+- Added pure contract tests that inspect source text and model audit immutability invariants without importing Firestore clients, auth routes, runtime services, or production write paths.
 
 ## Validation
 
-- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/sessionRevocationDesignValidation.test.ts src/routes/__tests__/authRecoveryContract.test.ts` passed: 2 test files and 41 tests passed.
+- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/auditImmutabilityContract.test.ts` passed: 1 test file and 10 tests passed.
+- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/authRecoveryContract.test.ts` passed: 1 test file and 16 tests passed.
 - `npm --prefix rentchain-api run build` passed.
-- `rg -n "raw token|raw credential|raw secret" docs/security/*.md` passed with zero matches.
-- `rg -n "export.*session|export.*revocation|export.*incident" docs/security/*.md` passed with zero matches.
+- `rg -n "export.*audit|export.*event|raw token|raw credential|raw secret" docs/security/*.md` passed with zero matches.
 - `git diff --check` passed.
-- `git diff --cached --check` passed.
 - Prohibited artifact text and credential-pattern scan passed for changed files.
-- Confirmed no package files, Firestore rules, runtime auth files, frontend files, infrastructure files, or production guard files were modified.
+- Confirmed no package files, Firestore rules, Firestore indexes, runtime audit services, auth routes, frontend files, infrastructure files, or production guard files were modified.
+- Closest existing route coverage was run because the mission-listed `adminAuditRoutes.test.ts` and `auditEventsRoutes.test.ts` files do not exist in the current tree:
+  - First sandboxed attempt failed in `adminRouteAuth.test.ts` with `listen EPERM: operation not permitted 0.0.0.0`; `eventsRoutes.test.ts` passed in that run.
+  - Rerun with elevated execution passed: `npm --prefix rentchain-api run test:single -- src/routes/__tests__/adminRouteAuth.test.ts src/routes/__tests__/eventsRoutes.test.ts` passed with 2 test files and 13 tests passed.
 
 ## Manual QA
 
 Manual QA required: no.
 
-Reason: the mission changed documentation and backend design-validation tests only. No frontend rendering, backend route implementation, auth flow behavior, routing, mobile layout, or user-visible behavior was changed.
+Reason: the mission changed documentation and pure backend contract tests only. No frontend rendering, backend route implementation, auth flow behavior, routing, mobile layout, or user-visible behavior was changed.
 
-Manual QA checklist reviewed from tests and documentation:
+Manual review performed:
 
-- Current logout remains acknowledgement-only.
-- Current JWTs remain stateless and expiration-based unless future work implements revocation.
-- Future revocation designs are documented as non-runtime options.
-- Incident response guidance is manual and does not introduce automated containment.
-- Tenant, landlord, admin, and support separation remains unchanged.
+- Reviewed the audit immutability contract for collection coverage and current compliance levels.
+- Reviewed the status audit against source paths for write semantics and current route guard posture.
+- Reviewed the verification checklist for human-operable, read-only checks.
+- Reviewed the roadmap to confirm it does not commit Phase 3 to Firestore rules, schema refactors, indexes, or production data changes.
 
 ## Known Limitations
 
-- This mission does not implement server-side session revocation.
-- This mission does not add session records, token denial records, token version fields, Firestore collections, indexes, or Firestore rules.
-- This mission does not add incident automation, revocation endpoints, account-wide logout, device listing, or device-specific logout.
-- Current logout semantics remain unchanged: frontend token clearing plus backend acknowledgement, without invalidating outstanding JWTs server-side.
-- PR #1085 is open as a draft for review and CI validation.
+- This mission documents and verifies immutability contracts but does not enforce audit immutability at runtime.
+- Firestore rules, indexes, routes, services, and write helpers remain unchanged.
+- `eventDispatcher.recordDomainEvent` still uses merge-based persistence on `events`; it is documented as partial compliance and a future normalization candidate.
+- General audit event routes still rely on global auth decode and mount order rather than visible route-level permission guards; this is documented as a future review item.
+- The mission-listed route test files `adminAuditRoutes.test.ts` and `auditEventsRoutes.test.ts` are not present in the current repository; existing nearest route coverage was run instead.
 
 ## Recommended Next Step
 
-Review PR #1085 and wait for CI. If approved and green, proceed through the normal QA gate. The recommended follow-up mission is Phase 4 implementation planning for a selected auth session revocation model.
+Open the PR and wait for CI. The recommended follow-up is Phase 4 report-only audit immutability verification planning, starting with index-based read-only scans before enforcement changes.

--- a/docs/security/audit-immutability-contract-v1.md
+++ b/docs/security/audit-immutability-contract-v1.md
@@ -1,0 +1,66 @@
+# Audit Immutability Contract v1
+
+## Goals
+
+This contract defines how RentChain audit and event records should behave when they are used as governance evidence. The goal is a clear append-only posture: audit records are created once, never overwritten, never patched, and never deleted by product flows.
+
+This document is a contract and verification reference only. It does not change Firestore rules, indexes, route behavior, write helpers, deployment configuration, dependencies, or production data.
+
+## Current State
+
+RentChain currently has one strong canonical audit helper and several older append-like writers. The strongest path is `appendCanonicalAuditEvent`, which writes to `canonicalEvents`, marks records `metadataOnly`, `appendOnly`, `immutable`, and `rawIdsIncluded: false`, and uses `create()` when available. If `create()` is unavailable, it checks for an existing document before calling `set(..., { merge: false })`.
+
+Older audit/event collections are append-like by convention but do not share one formal helper contract. Some use auto-generated document IDs through `add()` or `doc()` plus `set()`. One event dispatcher path writes deterministic event IDs with `set(..., { merge: true })`, which is useful for idempotent event persistence but is only partial immutability because it can patch an existing event document.
+
+## Contract
+
+Audit immutability means:
+
+- Creation is the only product write operation allowed for an audit record.
+- Product code must not call `update()` or `delete()` on audit collections.
+- Product code must not overwrite an existing audit record.
+- `create()` is preferred for deterministic IDs.
+- `add()` is acceptable for auto-ID append-like records when the caller never reuses the document ID.
+- `set(..., { merge: false })` is acceptable only when paired with deterministic uniqueness or an existence precheck.
+- `set(..., { merge: true })` is partial compliance and must be documented as a mutation risk.
+- Audit records must preserve creation time, actor context, resource context, and redaction posture.
+- Audit reads must remain scoped by role and resource authority.
+
+## Collection Contract Table
+
+| Collection | Current writers | Current semantics | Compliance | Exceptions |
+| --- | --- | --- | --- | --- |
+| `canonicalEvents` via `appendCanonicalAuditEvent` | `reviewStateTransitionAudit`, recovery intent service, landlord operator review route | `create()` where available; fallback existence precheck plus `set(..., { merge: false })` | Full for this helper path | Safe wrapper may skip append on storage failure rather than failing caller |
+| `canonicalEvents` via `writeCanonicalEvent` | screening, lease, maintenance, alerting, analytics, policy, support, work order, rental application, payment, sharing-room paths | `set(..., { merge: false })` with no existence precheck | Partial | Deterministic ID collisions would overwrite, though most calls use generated IDs |
+| `canonicalAuditEvents` | None found in current source | No active writer found | None / absent | Mission-listed collection name is not implemented; canonical audit records currently share `canonicalEvents` |
+| `events` | `auditEventsService`, `auditEventService`, event dispatcher, payment/ledger/tenant/workflow services, tenant and debug event routes | Mixed `doc().set()`, deterministic `doc(id).set(..., { merge: true })`, and `add()` | Partial | Event dispatcher uses merge semantics; route-level audit reads depend on mount order and global auth decode |
+| `adminAuditEvents` | admin audit event service from admin saved filters, tenants, leases, properties, integrity, overview paths | `add()` with auto-generated document ID | Partial | Append-like by convention, not protected by canonical helper or Firestore rules |
+| `registryAuditLog` | registry audit service and registry import service batch writes | `add()` and `batch.set(doc(), auditDoc)` | Partial | Append-like by convention, not protected by canonical helper or Firestore rules |
+| `ledgerEvents` and `ledgerEventsV2` | ledger, dashboard, payment, and reporting paths | Event-like writes and reads with index support | Partial | Included as operational event evidence, but outside the primary Phase 3 audit helper contract |
+
+## Access Control And Projection Safety
+
+Admin audit reads use `GET /api/admin/audit` and require both `requireAuth` and `requirePermission("system.admin")`. The admin audit view returns sectioned summaries for admin actions, administrative data downloads, integrity events, and saved-filter activity. It does not return unrestricted Firestore documents.
+
+General audit event routes are mounted after global JWT decoding in `app.build.ts`. The individual handlers in `auditEventsRoutes.ts` do not add route-level `requireAuth` or permission checks. This is a documented gap: future work should either add explicit route guards or document why the global mount order is sufficient for each route.
+
+Landlord and tenant visibility must remain scoped by resource context. Landlord-facing audit reads should require landlord authority and filter by landlord-owned property/application context. Tenant-facing reads should be limited to records directly involving that tenant. Admin/support-only audit metadata must not be shown to tenant, landlord, public, or user-safe output surfaces.
+
+Canonical audit records use metadata-only and unredacted-identifier-excluded markers. Older audit/event collections may contain broader payload fields and should be treated as internal unless a route applies explicit allowlist projection and resource-scope checks.
+
+## Risks
+
+- Older collections do not uniformly use the canonical append helper.
+- Firestore rules in `rentchain-api/firestore.rules` are fail-closed, but no production immutability-specific rule is added by this mission.
+- `events` has one merge-based dispatcher path, which means a repeated deterministic event ID can patch an existing record.
+- General event read routes have weaker visible route-level guards than admin audit routes.
+- Existing indexes support timestamp and scope queries, but indexes do not enforce immutability.
+
+## Roadmap
+
+Future implementation work should strengthen immutability in this order:
+
+1. Add verification-only monitoring that reports suspicious update/delete patterns without changing writes.
+2. Normalize new audit writes through canonical append helpers or require an explicit exception note.
+3. Add Firestore rules or service-layer guards after a migration plan confirms existing write paths will not be blocked.
+4. Add optional cryptographic integrity checks only after the append-only service contract is stable.

--- a/docs/security/audit-immutability-roadmap-v1.md
+++ b/docs/security/audit-immutability-roadmap-v1.md
@@ -1,0 +1,96 @@
+# Audit Immutability Roadmap v1
+
+## Goals
+
+This roadmap records non-binding future options for strengthening audit immutability. It does not authorize implementation in Phase 3 and does not change current routes, services, Firestore rules, indexes, or production data.
+
+## Current State
+
+Canonical audit helper writes are the strongest current path. Older event collections remain append-like by convention, with partial risk from merge-based event persistence and uneven route-level guards. The immediate Phase 3 need is verification and planning, not enforcement.
+
+## Option 1: Firestore Rules Enforcement
+
+Add Firestore rules that deny update and delete operations on audit collections. Where feasible, require creation markers such as `metadataOnly`, `appendOnly`, `immutable`, and `rawIdsIncluded: false` for canonical audit records.
+
+Benefits:
+
+- Strong direct protection against client or service attempts to modify audit evidence.
+- Clear enforcement boundary for audit collections.
+- Good fit after write paths are normalized.
+
+Risks:
+
+- Rules changes can block legitimate existing writes if not staged carefully.
+- Current API-local rules are fail-closed; production rules and deployment policy need a separate review.
+- Rules cannot easily validate every service-layer projection or safe-reference decision.
+
+Phase 4 readiness: defer until legacy writers are inventoried and test coverage proves no legitimate create path is blocked.
+
+## Option 2: Schema-Level Enforcement
+
+Normalize all audit writers through canonical helpers. Require all audit records to include an immutability schema version, creation timestamp, source collection, metadata-only posture, and unredacted-identifier-excluded markers.
+
+Benefits:
+
+- Consistent write contract across old and new collections.
+- Easier tests for new audit records.
+- Easier operator verification because records share common fields.
+
+Risks:
+
+- Refactor scope is broad because events, admin audit, registry audit, ledger events, and domain event writers are spread across routes and services.
+- Some existing event records may not map cleanly to canonical audit semantics.
+- Migration pressure could create accidental behavior changes.
+
+Phase 4 readiness: recommended only after report-only verification identifies the most important legacy paths to normalize first.
+
+## Option 3: Index-Based Verification
+
+Add or reuse indexes that support read-only scans by scope and creation time. Run a report-only verification job that samples audit collections, checks timestamp/document-name stability, flags missing immutable markers, and reports merge-risk paths.
+
+Benefits:
+
+- Lowest operational risk.
+- Does not block writes.
+- Produces evidence for a later enforcement plan.
+- Aligns with current collection indexes for `events` and `registryAuditLog`.
+
+Risks:
+
+- Detects suspicious state but does not prevent mutations.
+- Needs careful report redaction and scope controls.
+- Requires future implementation and operational ownership.
+
+Phase 4 readiness: recommended first.
+
+## Option 4: Integrity Digest Verification
+
+Add a digest over stable audit fields and write it at creation time. Verification can recompute the digest during read-only scans and report mismatches.
+
+Benefits:
+
+- Stronger evidence of record changes.
+- Can be added gradually to canonical audit records.
+
+Risks:
+
+- Requires schema change and careful handling of server timestamp fields.
+- Does not prevent deletion by itself.
+- Historical records without digests need a separate treatment plan.
+
+Phase 4 readiness: defer until the append-only write contract is stable.
+
+## Contract
+
+Future enforcement work must preserve:
+
+- Tenant, landlord, admin, and support separation.
+- Metadata-only posture for internal audit surfaces.
+- No production data mutation during verification.
+- No hidden remediation or automated containment.
+- No dependency drift unless explicitly approved.
+- No direct user-facing exposure of sensitive audit internals.
+
+## Recommended Phase 4 Path
+
+Start with Option 3: report-only index-based verification. Use its findings to decide whether Firestore rules enforcement, schema-level normalization, or digest verification should follow.

--- a/docs/security/audit-immutability-status-v1.md
+++ b/docs/security/audit-immutability-status-v1.md
@@ -1,0 +1,99 @@
+# Audit Immutability Status v1
+
+## Goals
+
+This status audit records the current write paths, mutation risks, and safety level for RentChain audit and event collections. It is source-aligned documentation only and does not change runtime behavior.
+
+## Current State
+
+The audit landscape has five primary implemented collections for this mission: `canonicalEvents`, `events`, `adminAuditEvents`, `registryAuditLog`, and ledger-style operational event collections. The mission-listed name `canonicalAuditEvents` was not found in the current source tree; canonical audit records currently share `canonicalEvents`. The current strongest immutability semantics are in `appendCanonicalAuditEvent`; older paths are append-like but not uniformly enforced.
+
+## Collection Status
+
+### `canonicalEvents`
+
+`appendCanonicalAuditEvent` writes canonical audit records into `canonicalEvents`. It builds safe references, marks records `metadataOnly`, `appendOnly`, `immutable`, and `rawIdsIncluded: false`, and writes with `create()` where available. Its fallback checks document existence before `set(..., { merge: false })`. `appendCanonicalAuditEventSafely` catches storage errors and logs a skipped append rather than failing the caller.
+
+`writeCanonicalEvent` also writes to `canonicalEvents`. It builds a canonical event and writes `doc(event.id).set(event, { merge: false })`. It does not precheck for existing documents, so it is partial compliance. Generated IDs reduce collision risk, but callers that supply a repeated ID could overwrite an existing canonical event.
+
+Current writers include review state transition audit, recovery intent service, landlord operator review routes, screening orchestration, lease routes, maintenance routes, landlord analytics, policy evaluation, support console, rental applications, work orders, payment flows, and alerting routes.
+
+Safety level: full for `appendCanonicalAuditEvent`; partial for `writeCanonicalEvent`.
+
+### `canonicalAuditEvents`
+
+No active collection, writer, read route, index, or rule reference named `canonicalAuditEvents` was found during the current source audit. This is documented as an absent mission-listed name rather than an implemented collection. Future work should avoid creating a duplicate collection unless it is part of a deliberate audit storage migration.
+
+Safety level: none / absent.
+
+### `events`
+
+`auditEventsService.logAuditEvent` creates a new document reference with `doc()`, then calls `set()` with generated `id`, `createdAt`, and `occurredAt`.
+
+`auditEventService.recordAuditEvent` creates a UUID and writes `collection("events").doc(id).set(full)` with no merge option.
+
+`eventDispatcher.recordDomainEvent` writes deterministic event IDs with `collection("events").doc(docId).set(event, { merge: true })`. This is the most visible mutation risk in the audited event write paths because a repeated event ID can patch the existing event document.
+
+Other `events` collection uses include tenant balance, move-in readiness, plan limits, rent charges, PAP mandate/scheduler routes, monthly charge scheduler routes, debug blockchain routes, admin analytics, subscription conversion views, application conversion, screening, and application routes.
+
+Safety level: partial. The collection is append-like in many writers, but merge-based persistence and route-level reads are not uniformly protected.
+
+### `adminAuditEvents`
+
+`recordAdminAuditEvent` trims required fields and returns without writing when user, label, or action are missing. Valid records are added with `collection("adminAuditEvents").add(...)`, using Firestore auto-generated IDs.
+
+Read access is through `adminAuditRoutes`, which requires `requireAuth` plus `requirePermission("system.admin")`. `loadAdminAudit` reads records and returns sectioned summaries rather than unrestricted Firestore documents.
+
+Current writers include admin saved filters, admin tenants, admin leases, admin properties, admin integrity, and admin overview routes.
+
+Safety level: partial. The path is append-like, admin-gated on reads, and scoped to admin surfaces, but it is not backed by a canonical immutable helper or immutability-specific Firestore rule.
+
+### `registryAuditLog`
+
+`recordRegistryAuditEvent` adds records to `registryAuditLog` with source key, import batch reference, registry record reference, property reference, actor type, event type, compact event data, and creation time.
+
+`registryImportService` also writes registry audit documents through batched `set()` calls on new document references. Registry indexes support queries by registry record, property, import batch, and creation time.
+
+Safety level: partial. The path is append-like and indexed for review, but it is not protected by a canonical immutable helper.
+
+### `ledgerEvents` And `ledgerEventsV2`
+
+Ledger event collections are operational event evidence rather than the primary audit collections for this mission. They have indexes for tenant, property, landlord, event type, and timestamp queries. They should be treated as audit-adjacent and should not be patched by verification tooling.
+
+Safety level: partial and audit-adjacent.
+
+## Mutation Risk Assessment
+
+Known risks found during audit:
+
+- `eventDispatcher.recordDomainEvent` uses `set(..., { merge: true })` on `events`.
+- `writeCanonicalEvent` uses `set(..., { merge: false })` but does not precheck for existing documents.
+- Older collections use append-like calls but lack one shared helper contract.
+- General event read routes do not declare route-level `requireAuth` or `requirePermission` guards.
+- Firestore indexes support verification queries but cannot prove immutability by themselves.
+
+No product `update()` or `delete()` calls were identified directly on the mission's primary audit collections during the targeted scan. Broad merge usage exists across many non-audit collections and is out of scope for this mission.
+
+## Authorization And Scope
+
+Admin audit reads are strongest: `GET /api/admin/audit` requires authentication and `system.admin`.
+
+General audit event reads are weaker: recent, tenant, property, and debug relay routes rely on global auth decode because they are mounted after `authenticateJwt`; the route module itself does not require an authenticated user or check landlord/tenant authority.
+
+Canonical audit and canonical event records are read indirectly by admin, analytics, support, reporting, and review surfaces. These should remain internal or route-projected unless a future route adds explicit role and resource-scope checks.
+
+## Index Coverage
+
+`events` has indexes for landlord plus `occurredAt`, property plus `timestamp`, and tenant plus `timestamp`.
+
+`registryAuditLog` has indexes for registry record plus `createdAt`, property plus `createdAt`, and import batch plus `createdAt`.
+
+`ledgerEvents` and `ledgerEventsV2` have indexes for tenant, property, landlord, event type, date, and occurrence time. These are useful for operator review but do not enforce append-only writes.
+
+## Firestore Rules And Local Protection
+
+`rentchain-api/firestore.rules` is fail-closed for all reads and writes. Local development and tests must use the Firestore emulator unless an explicit local override is set. The Firestore guard runs before backend Admin initialization and before direct Firestore clients in identified modules.
+
+## Roadmap
+
+Future work should first add verification-only monitoring for event update/delete patterns. Enforcement should wait until legacy event writers are normalized or explicitly excepted.

--- a/docs/security/audit-immutability-verification-checklist-v1.md
+++ b/docs/security/audit-immutability-verification-checklist-v1.md
@@ -1,0 +1,111 @@
+# Audit Immutability Verification Checklist v1
+
+## Goals
+
+This checklist gives reviewers, QA, and operators practical steps to verify audit immutability without changing production data. It is designed for manual use and does not require new tooling.
+
+## Current State
+
+Audit verification currently depends on source review, local tests, index-supported Firestore queries, and role/scope spot checks. This mission adds a contract test and documentation checklist, but it does not add production scanners or enforcement jobs.
+
+## Design-Time PR Checks
+
+Use these checks during code review:
+
+- New audit writes should use `appendCanonicalAuditEvent` where possible.
+- If a new writer uses `writeCanonicalEvent`, confirm generated IDs or document why deterministic IDs cannot collide.
+- New audit writes must not use `update()`.
+- New audit writes must not use `delete()`.
+- New audit writes must not use `set(..., { merge: true })` unless the PR documents why idempotent patching is required and how evidence integrity is preserved.
+- New audit records must carry creation time and actor/resource context.
+- Tenant-facing audit reads must use explicit tenant scope.
+- Landlord-facing audit reads must use explicit landlord or property scope.
+- Admin/support audit reads must require authenticated admin authority.
+- User-safe projections must not include sensitive payloads, bearer values, provider payloads, storage paths, or unrestricted internal metadata.
+
+## Operator Runtime Checks
+
+These checks are read-only. Run them in staging first, then production only with the approved operational access model.
+
+### Collection Sequence Scan
+
+For each collection, query by the collection's creation timestamp and document name:
+
+```text
+collection: events
+order: occurredAt descending, __name__ descending
+sample size: 100
+check: no duplicate document names in the sample; timestamps are present; records are not rewritten during repeated reads
+```
+
+```text
+collection: adminAuditEvents
+order: occurredAt descending, __name__ descending
+sample size: 100
+check: every record has category, action, label, occurredAt or createdAt
+```
+
+```text
+collection: registryAuditLog
+order: createdAt descending, __name__ descending
+sample size: 100
+check: every record has sourceKey, eventType, actorType, createdAt
+```
+
+```text
+collection: canonicalEvents
+order: recordedAt or timestamp descending, __name__ descending
+sample size: 100
+check: canonical audit records include metadataOnly, appendOnly, immutable, and rawIdsIncluded false when written by the canonical audit helper
+```
+
+### Repeat-Read Stability Check
+
+Run the same read-only query twice five minutes apart. Compare document names, creation timestamps, event types, and immutable markers. A changed record requires manual investigation.
+
+### Role And Scope Spot Checks
+
+- Admin audit: sign in as an admin and verify `/api/admin/audit` returns sectioned admin audit summaries. Then try a non-admin account and confirm access is denied.
+- Tenant audit: verify a tenant-scoped route only returns events for the requested tenant and does not show another tenant's events.
+- Property audit: verify a landlord-scoped property event route only returns events for a property owned by that landlord.
+- Debug relay: verify debug event relay remains internal-review-only and is not used as a user-facing audit surface.
+
+### Curl Templates
+
+Use approved test tokens in staging only:
+
+```bash
+curl -H "Authorization: Bearer <admin-token>" https://<api-host>/api/admin/audit
+```
+
+```bash
+curl -H "Authorization: Bearer <tenant-token>" https://<api-host>/api/events/tenants/<tenant-ref>/events
+```
+
+```bash
+curl -H "Authorization: Bearer <landlord-token>" https://<api-host>/api/events/properties/<property-ref>/events
+```
+
+Expected result: responses are scoped, redacted, and limited to the caller's authorized resource context. If a route cannot prove that scope, record the finding as a future fix rather than altering data.
+
+## Risks
+
+- Query stability does not prove no historical mutation occurred; it only detects current drift and visible inconsistencies.
+- Index support helps operator queries but does not enforce append-only writes.
+- Route spot checks are only as strong as the test identities and seeded data chosen.
+- Debug routes require extra caution because they may expose broader event details.
+
+## Contract
+
+A verification pass requires:
+
+- Source scan shows no `update()` or `delete()` on primary audit collections.
+- Source scan shows no undocumented `merge: true` on primary audit writes.
+- Admin audit routes remain permission-gated.
+- General event routes are flagged if they lack visible route-level guards.
+- Canonical audit helper records include metadata-only and immutable markers.
+- No verification step writes, patches, deletes, or backfills production data.
+
+## Roadmap
+
+Phase 4 should turn this checklist into a report-only scheduled verification job. Enforcement should wait until legacy event paths are normalized or explicitly excepted.

--- a/docs/security/security-inventory.md
+++ b/docs/security/security-inventory.md
@@ -85,6 +85,17 @@ Security telemetry retention is defined as internal, non-portable, non-exportabl
 
 Current risk posture: the strongest immutability semantics are in canonical audit helpers. Other audit/event collections are append-like by convention in the audited writers but are not uniformly protected by immutable helper semantics.
 
+### Verification
+
+Phase 3 audit immutability verification is documented in four companion files:
+
+- `docs/security/audit-immutability-contract-v1.md` defines the append-only contract for `events`, `adminAuditEvents`, `registryAuditLog`, `canonicalEvents`, and audit-adjacent ledger event collections.
+- `docs/security/audit-immutability-status-v1.md` records current writer semantics, including the full compliance of `appendCanonicalAuditEvent`, partial compliance of `writeCanonicalEvent`, and merge-risk posture of `eventDispatcher.recordDomainEvent`.
+- `docs/security/audit-immutability-verification-checklist-v1.md` gives design-time PR checks and read-only operator checks for staging and production.
+- `docs/security/audit-immutability-roadmap-v1.md` recommends report-only index-based verification as the next Phase 4 step before Firestore rules or schema-level enforcement.
+
+The verification contract does not implement runtime enforcement. It documents the current state: canonical audit records have explicit immutable markers, older event collections remain append-like by convention, and general event read routes should be reviewed for explicit route-level scope guards in a future mission.
+
 ## Firebase Initialization Security
 
 Backend Firebase Admin initialization runs the Firestore environment guard before initialization in both the canonical config path and the legacy wrapper (`rentchain-api/src/config/firebase.ts:3-18`, `rentchain-api/src/firebase.ts:1-18`). The canonical config exports Firestore, `db`, and `FieldValue`, and sets `ignoreUndefinedProperties` (`rentchain-api/src/config/firebase.ts:20-25`). It logs the configured project ID at startup (`rentchain-api/src/config/firebase.ts:27-28`).

--- a/rentchain-api/src/routes/__tests__/auditImmutabilityContract.test.ts
+++ b/rentchain-api/src/routes/__tests__/auditImmutabilityContract.test.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+type CollectionContract = {
+  collection: "canonicalEvents" | "canonicalAuditEvents" | "events" | "adminAuditEvents" | "registryAuditLog";
+  allowedWrites: Array<"create" | "add" | "set_merge_false" | "set_auto_id">;
+  disallowedWrites: Array<"update" | "delete" | "set_merge_true">;
+  compliance: "full" | "partial" | "absent";
+  requiresScopedReads: boolean;
+};
+
+const repoRoot = resolve(__dirname, "../../../..");
+
+function source(path: string) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+const contracts: CollectionContract[] = [
+  {
+    collection: "canonicalEvents",
+    allowedWrites: ["create", "set_merge_false"],
+    disallowedWrites: ["update", "delete", "set_merge_true"],
+    compliance: "full",
+    requiresScopedReads: true,
+  },
+  {
+    collection: "canonicalAuditEvents",
+    allowedWrites: [],
+    disallowedWrites: ["update", "delete", "set_merge_true"],
+    compliance: "absent",
+    requiresScopedReads: true,
+  },
+  {
+    collection: "events",
+    allowedWrites: ["set_auto_id", "set_merge_false", "add"],
+    disallowedWrites: ["update", "delete", "set_merge_true"],
+    compliance: "partial",
+    requiresScopedReads: true,
+  },
+  {
+    collection: "adminAuditEvents",
+    allowedWrites: ["add"],
+    disallowedWrites: ["update", "delete", "set_merge_true"],
+    compliance: "partial",
+    requiresScopedReads: true,
+  },
+  {
+    collection: "registryAuditLog",
+    allowedWrites: ["add", "set_auto_id"],
+    disallowedWrites: ["update", "delete", "set_merge_true"],
+    compliance: "partial",
+    requiresScopedReads: true,
+  },
+];
+
+function contractFor(collection: CollectionContract["collection"]) {
+  const contract = contracts.find((item) => item.collection === collection);
+  if (!contract) throw new Error(`missing_contract:${collection}`);
+  return contract;
+}
+
+function containsSensitiveProjection(value: unknown) {
+  const serialized = JSON.stringify(value).toLowerCase();
+  return (
+    serialized.includes("bearer ") ||
+    serialized.includes("password=") ||
+    serialized.includes("secret=") ||
+    serialized.includes("credential=")
+  );
+}
+
+describe("audit immutability contract", () => {
+  it("models canonical audit records as append-only, immutable, and metadata-only", () => {
+    const record = {
+      sourceCollection: "canonicalEvents",
+      metadataOnly: true,
+      appendOnly: true,
+      immutable: true,
+      rawIdsIncluded: false,
+      actor: { rawIdsIncluded: false },
+      authority: { rawIdsIncluded: false },
+    };
+
+    expect(record).toEqual(
+      expect.objectContaining({
+        metadataOnly: true,
+        appendOnly: true,
+        immutable: true,
+        rawIdsIncluded: false,
+      })
+    );
+    expect(record.actor.rawIdsIncluded).toBe(false);
+    expect(record.authority.rawIdsIncluded).toBe(false);
+  });
+
+  it("documents every primary audit collection with scoped read requirements", () => {
+    expect(contracts.map((contract) => contract.collection).sort()).toEqual([
+      "adminAuditEvents",
+      "canonicalAuditEvents",
+      "canonicalEvents",
+      "events",
+      "registryAuditLog",
+    ]);
+
+    expect(contracts.every((contract) => contract.requiresScopedReads)).toBe(true);
+    expect(contractFor("canonicalAuditEvents").compliance).toBe("absent");
+  });
+
+  it("treats merge-based audit writes as partial compliance only", () => {
+    const events = contractFor("events");
+    const canonical = contractFor("canonicalEvents");
+
+    expect(events.disallowedWrites).toContain("set_merge_true");
+    expect(events.compliance).toBe("partial");
+    expect(canonical.compliance).toBe("full");
+  });
+
+  it("does not include sensitive material in the contract model", () => {
+    expect(containsSensitiveProjection(contracts)).toBe(false);
+  });
+});
+
+describe("audit immutability source checks", () => {
+  it("keeps appendCanonicalAuditEvent protected by create or existence precheck plus merge false", () => {
+    const body = source("rentchain-api/src/lib/canonicalAudit/appendCanonicalAuditEvent.ts");
+
+    expect(body).toContain("ref.create");
+    expect(body).toContain("existing?.exists");
+    expect(body).toContain("merge: false");
+    expect(body).toContain("appendOnly: true");
+    expect(body).toContain("immutable: true");
+    expect(body).toContain("metadataOnly: true");
+    expect(body).toContain("rawIdsIncluded: false");
+  });
+
+  it("documents writeCanonicalEvent as merge false without the canonical precheck", () => {
+    const body = source("rentchain-api/src/lib/events/buildEvent.ts");
+
+    expect(body).toContain("set(event, { merge: false })");
+    expect(body).not.toContain("canonical_event_already_exists");
+  });
+
+  it("keeps admin audit reads gated by authentication and system admin permission", () => {
+    const body = source("rentchain-api/src/routes/adminAuditRoutes.ts");
+
+    expect(body).toContain("requireAuth");
+    expect(body).toContain('requirePermission("system.admin")');
+    expect(body).toContain('router.get("/audit"');
+  });
+
+  it("records general audit event route guard limitations as a design risk", () => {
+    const body = source("rentchain-api/src/routes/auditEventsRoutes.ts");
+    const mountedAfterAuthDecode = source("rentchain-api/src/app.build.ts");
+
+    expect(body).toContain('router.get("/events/recent"');
+    expect(body).toContain('router.get("/tenants/:tenantId/events"');
+    expect(body).toContain('router.get("/properties/:propertyId/events"');
+    expect(body).not.toContain("requirePermission(");
+    expect(mountedAfterAuthDecode).toContain("app.use(authenticateJwt)");
+    expect(mountedAfterAuthDecode).toContain('app.use("/api/events"');
+  });
+
+  it("captures the current merge-based event dispatcher risk", () => {
+    const body = source("rentchain-api/src/events/eventDispatcher.ts");
+
+    expect(body).toContain('collection("events").doc(docId).set(event');
+    expect(body).toContain("merge: true");
+  });
+
+  it("keeps registry and admin audit writers append-like through add or new document refs", () => {
+    const admin = source("rentchain-api/src/services/admin/adminAuditEvents.ts");
+    const registry = source("rentchain-api/src/services/registry/registryAuditService.ts");
+    const registryImport = source("rentchain-api/src/services/registry/registryImportService.ts");
+
+    expect(admin).toContain('collection("adminAuditEvents")');
+    expect(admin).toContain(".add({");
+    expect(registry).toContain('collection("registryAuditLog")');
+    expect(registry).toContain(".add({");
+    expect(registryImport).toContain('batch.set(db.collection("registryAuditLog").doc(), auditDoc)');
+  });
+});


### PR DESCRIPTION
## Summary
- Added audit immutability contract, current status audit, verification checklist, and Phase 4 roadmap documentation.
- Updated the security inventory with links to the new immutability verification documents.
- Added pure contract tests for audit immutability invariants and current source-level guard posture.

## Validation
- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/auditImmutabilityContract.test.ts`
- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/authRecoveryContract.test.ts`
- `npm --prefix rentchain-api run build`
- `rg -n "export.*audit|export.*event|raw token|raw credential|raw secret" docs/security/*.md`
- `git diff --check`
- `git diff --cached --check`
- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/adminRouteAuth.test.ts src/routes/__tests__/eventsRoutes.test.ts` rerun with elevated local execution after sandbox listener restriction; passed.

## Safety
- Documentation and pure contract tests only.
- No runtime audit behavior, routes, services, Firestore rules, Firestore indexes, infrastructure, dependencies, frontend behavior, production data, or production guard behavior changed.
- No new audit collections or write paths were added.