### PR TITLE
docs: add operational incident readiness framework

### DIFF
--- a/docs/operations/incident-containment-procedures-v1.md
+++ b/docs/operations/incident-containment-procedures-v1.md
@@ -1,0 +1,167 @@
+# Incident Containment Procedures v1
+
+## Scope
+
+This document defines manual containment procedures for Phase 3 incident categories. It does not implement containment, revocation, rotation, alerting, storage, routes, infrastructure changes, or production data mutation.
+
+Containment must preserve evidence first unless active harm requires immediate action.
+
+## Containment Decision Tree
+
+1. Is there active production data exposure or credential exposure?
+   - Yes: classify `critical`, notify founder, preserve evidence, stop active surface, then rotate or disable manually.
+   - No: continue.
+2. Can additional impact occur if the workflow continues?
+   - Yes: freeze the affected workflow or deployment route.
+   - No: continue with audit-only investigation.
+3. Is the incident caused by wrong environment or deployment?
+   - Yes: follow environment containment and rollback verification.
+   - No: continue.
+4. Is authorization ambiguous?
+   - Yes: fail closed and escalate.
+   - No: continue.
+5. Is correction destructive or data-mutating?
+   - Yes: require explicit operator authorization and append-safe audit linkage.
+   - No: proceed with documented manual remediation.
+
+## Recovery Workflow Containment
+
+Use for `recovery_workflow`, recovery-impacting environment incidents, or recovery audit concerns.
+
+Immediate steps:
+
+1. Stop new manual recovery decisions for affected workflow type.
+2. Put reconciliation decisions on manual hold.
+3. Preserve `operatorRecoveryIntents`, `operatorRecoveryLogs`, `canonicalRecoveryTimelineEntries`, and `canonicalEvents`.
+4. Validate gate status for any in-flight recovery action.
+5. Confirm admin/support authority and affected workflow safe refs.
+6. Do not delete recovery logs or timeline entries.
+7. Do not rewrite source snapshots as rollback.
+
+Containment choices:
+
+| Choice | Use when | Authority |
+| --- | --- | --- |
+| Freeze new recovery actions | Gate mismatch, audit uncertainty, access ambiguity. | Ops lead. |
+| Hold reconciliation decision | Divergence classification is questionable. | Ops lead with security review if data risk exists. |
+| Audit-only monitoring | Signal is informational and no action is pending. | Support lead or ops lead. |
+| Rollback authorization review | Accepted reconciliation decision appears wrong. | Founder plus ops and security leads. |
+
+Rollback authorization is procedural only. It requires a separate reviewed mission or explicit data operation approval.
+
+## Environment Separation Containment
+
+Use for preview/staging/production routing, Firestore target, wrong auth project, or deployment drift incidents.
+
+Immediate steps:
+
+1. Stop new deployments.
+2. Identify deployment SHA, backend revision, and runtime environment.
+3. Preserve Vercel, Cloud Run, Firestore, Auth, and GitHub Actions evidence.
+4. Disable or roll back the active deployment if production traffic is affected.
+5. Verify `/api` route target and backend revision after rollback.
+6. If credentials may be exposed, escalate to credential containment.
+7. Document affected write/read window with safe refs only.
+
+Do not change CI/CD, Terraform, or deployment configuration in this mission. Live environment changes require operator approval outside this document.
+
+## Auth Session Containment
+
+Use for login/session/token incidents.
+
+Current manual options:
+
+- Password reset or password credential change where supported.
+- Manual account disablement where authority exists.
+- Admin permission removal for privileged users.
+- Support console timeline review.
+
+Steps:
+
+1. Confirm affected account safe ref and role.
+2. Review auth and support timeline.
+3. Remember logout does not revoke outstanding JWTs.
+4. Choose least broad manual mitigation.
+5. Record action and reason in append-safe audit metadata.
+6. Escalate to security lead for privileged, multi-user, or tenant data risk.
+
+Phase 3 does not include automated token revocation, active session lists, trusted-device revocation tables, or account locking automation.
+
+## Support Escalation Containment
+
+Use for privileged diagnostic or support-console access concerns.
+
+Steps:
+
+1. Review support console canonical event and admin audit timeline.
+2. Confirm actor, role, permission, and requested scope.
+3. Stop additional support diagnostic access for the affected resource until reviewed.
+4. Remove admin/support permission or disable account if unauthorized access is suspected and authority approves.
+5. Preserve telemetry as internal, metadata-only, and non-exportable.
+6. Keep tenant and landlord communications free of admin/support internals.
+
+## Credential Incident Containment
+
+Use for `credential_secret` incidents.
+
+Steps:
+
+1. Record credential family and affected system only.
+2. Do not copy or quote the exposed value.
+3. Remove accidental exposure from active surfaces where possible.
+4. Rotate or revoke in the owning provider console through approved manual procedure.
+5. Redeploy or restart affected runtime if required to load replacement value.
+6. Verify old value fails where safe to test.
+7. Review whether auth sessions remain trusted after signing-secret concern.
+
+Credential containment may require downtime or dual-token sequencing. Do not improvise rotation for production secrets without security and ops authority.
+
+## Data Exposure Containment
+
+Use for tenant, landlord, evidence, export, projection, or provider payload exposure.
+
+Steps:
+
+1. Freeze affected user-facing surface or export delivery.
+2. Preserve the exact response route, timestamp, audience, and safe refs.
+3. Do not copy the exposed payload into incident notes.
+4. Identify audience mismatch and projection helper or allowlist path.
+5. Notify security lead immediately.
+6. Notify founder for confirmed or plausible tenant data exposure.
+7. Prepare remediation plan with projection and test verification.
+
+## Webhook Provider Containment
+
+Steps:
+
+1. Preserve event ID safe ref, provider family, route, timestamp, and signature verification result.
+2. Do not copy provider payloads.
+3. Disable endpoint or rotate webhook secret only with approved authority.
+4. Review idempotency and retry behavior.
+5. Confirm no duplicate financial or screening action occurred.
+
+## Audit Integrity Containment
+
+Steps:
+
+1. Stop dependent recovery, export, evidence, or review decisions that require the questionable audit timeline.
+2. Preserve current audit records and related writer context.
+3. Identify writer path and collection family.
+4. Do not update or delete audit records.
+5. Reconstruct timeline from alternate append-safe sources where available.
+6. Escalate to security lead for high or critical incident reconstruction needs.
+
+## Communication During Containment
+
+Every containment update should include:
+
+- category
+- severity
+- response state
+- affected scope safe refs
+- containment action
+- authority
+- evidence refs
+- next review time
+
+Do not include raw IDs, tokens, secrets, credentials, provider payloads, raw documents, private messages, stack traces, storage paths, or unrestricted debug data.

--- a/docs/operations/incident-detection-procedures-v1.md
+++ b/docs/operations/incident-detection-procedures-v1.md
@@ -1,0 +1,222 @@
+# Incident Detection Procedures v1
+
+## Scope
+
+This document gives manual detection procedures for Phase 3 incident categories. It is documentation only and does not add monitoring, alerting, storage, routes, or automation.
+
+All detection notes must use safe references. Do not copy raw IDs, bearer values, credentials, provider payloads, raw documents, storage paths, stack traces, or unrestricted debug payloads into incident notes.
+
+## Safe Reference Procedure
+
+1. Identify the affected surface using route name, collection family, deployment label, workflow type, or support-safe resource label.
+2. Convert raw resource details to safe labels before sharing outside the immediate authorized operator context.
+3. Prefer existing safe references:
+   - `audit_source:<hash>`
+   - `operator:<hash>`
+   - `recovery:<hash>`
+   - `recovery_intent:<hash>`
+   - support console resource labels
+   - deployment SHA or build ID
+4. Record audience and visibility:
+   - `admin_support_internal`
+   - `metadataOnly: true`
+   - `tenantVisible: false`
+   - `rawIdsIncluded: false`
+5. If a raw value is necessary for a live console lookup, keep it in the approved operator console only. Do not paste it into the incident summary.
+
+## Detection Checklist Template
+
+Use this shape for every manual detection note:
+
+```text
+Incident candidate:
+Category:
+Severity estimate:
+Detected at:
+Detected by:
+Affected surface:
+Affected scope safe refs:
+Observed signal:
+Immediate risk:
+Evidence refs:
+Raw payload copied: no
+Tenant visible: no
+Recommended escalation:
+```
+
+## Recovery Workflow Incidents
+
+Signals:
+
+- Recovery inspection unexpectedly returns `FORBIDDEN`, `RECOVERY_ROUTE_FAILED`, or inconsistent degraded state.
+- Reconciliation decision fails with `RECOVERY_ALREADY_LOGGED`, `RECOVERY_NOT_REQUIRED`, or repeated unexpected `RECOVERY_REQUEST_INVALID`.
+- Gate validation returns `intent_missing`, `authorization_invalid`, or `intent_stale` during an approved manual recovery window.
+- `operatorRecoveryLogs` and `canonicalRecoveryTimelineEntries` disagree on workflow instance key or timestamp.
+- Recovery audit events are absent for intent or gate validation.
+
+Detection procedure:
+
+1. Confirm route path and method from `docs/security/recovery-workflow-security-audit-v1.md`.
+2. Confirm caller role was admin or support through server-verified session context.
+3. Review `operatorRecoveryIntents`, `operatorRecoveryLogs`, `canonicalRecoveryTimelineEntries`, and `canonicalEvents`.
+4. Record only safe recovery refs and workflow type.
+5. If the signal could affect production recovery decisions, mark `recovery_workflow` and escalate to ops lead.
+
+Checklist:
+
+- [ ] Workflow type recorded.
+- [ ] Recovery safe ref recorded.
+- [ ] Intent or gate status recorded.
+- [ ] Canonical audit linkage checked.
+- [ ] No raw workflow ID copied.
+
+## Environment Separation Incidents
+
+Signals:
+
+- Preview or staging frontend reaches production API.
+- Production frontend routes to preview backend.
+- Backend starts against unexpected Firestore target.
+- Vercel, Cloud Run, or Terraform status indicates environment mismatch.
+- Secret, service account, or runtime config appears in output where it should not.
+
+Detection procedure:
+
+1. Identify frontend deployment, backend revision, and environment label.
+2. Compare expected API host and actual API host.
+3. Check Cloud Run revision metadata and Firestore guard output.
+4. Preserve deployment logs before changing config.
+5. Classify as `infrastructure_deployment`; add `credential_secret` if secrets are involved.
+
+Checklist:
+
+- [ ] Deployment SHA recorded.
+- [ ] Frontend environment recorded.
+- [ ] Backend revision recorded.
+- [ ] Firestore target verified.
+- [ ] Credential exposure assessed.
+
+## Auth Session Incidents
+
+Signals:
+
+- Unusual login failures or suspicious session reports.
+- Logout concern where access appears to persist.
+- Trusted-device or 2FA anomaly.
+- Scope mismatch from `requireAuth` hydration.
+- Admin/support account suspected of misuse.
+
+Detection procedure:
+
+1. Follow `docs/security/auth-incident-response-runbook-v1.md`.
+2. Review admin audit and support-console timeline.
+3. Confirm user, landlord, and tenant scope using safe internal references.
+4. Do not assume logout revoked outstanding JWTs.
+5. Escalate to security lead for privileged accounts, multi-user scope, or tenant data risk.
+
+Checklist:
+
+- [ ] Account scope safe ref recorded.
+- [ ] Token value not copied.
+- [ ] Logout limitation considered.
+- [ ] Admin/support privilege checked.
+- [ ] Manual mitigation identified.
+
+## Support Escalation Incidents
+
+Signals:
+
+- Support console opened without clear support reason.
+- Support-scoped diagnostics used without landlord scope.
+- Support runbook category indicates `projection_safety`, `credential_secret`, `tenant_data_exposure`, or `admin_support_access`.
+- Repeated wrong-recipient or lifecycle confusion in institution review operations.
+
+Detection procedure:
+
+1. Review support console canonical event and security telemetry summary.
+2. Confirm actor role and `system.admin` permission.
+3. Validate the support scope against `adminSupportAccessGovernance`.
+4. Classify severity by tenant data, credential, and projection impact.
+5. Escalate to security lead when access appears unauthorized or cross-scope.
+
+Checklist:
+
+- [ ] Actor role verified.
+- [ ] Access mode documented.
+- [ ] Resource refs scoped.
+- [ ] Sensitive payload excluded.
+- [ ] Approval requirement noted.
+
+## Audit Integrity Incidents
+
+Signals:
+
+- Expected `canonicalEvents` record missing after recovery intent or gate validation.
+- Canonical audit record lacks `metadataOnly`, `appendOnly`, `immutable`, or `rawIdsIncluded: false`.
+- Older event collection record appears overwritten or patched.
+- Audit read returns broader payload than expected.
+
+Detection procedure:
+
+1. Compare writer path to `docs/security/audit-immutability-contract-v1.md`.
+2. Identify whether record came from `appendCanonicalAuditEvent`, `writeCanonicalEvent`, or older event writer.
+3. Preserve current event state and related route/action context.
+4. Do not attempt deletion or correction before review.
+5. Escalate high if audit integrity affects recovery, export, evidence, or tenant data investigation.
+
+Checklist:
+
+- [ ] Collection family recorded.
+- [ ] Writer path identified.
+- [ ] Append markers checked.
+- [ ] Existing record preserved.
+- [ ] Remediation deferred until authorized.
+
+## Projection And Evidence Incidents
+
+Signals:
+
+- Restricted field appears in tenant, landlord, export, dashboard, or timeline surface.
+- Evidence or export package includes unrelated resource linkage.
+- Support/admin internals appear in user-safe payload.
+- Provider payload, raw report, token, secret, credential, storage path, stack, or authorization detail appears in response.
+
+Detection procedure:
+
+1. Identify audience: tenant, landlord, admin/support, export public, export user safe, or internal debug.
+2. Review projection helper or allowlist used by the surface.
+3. Capture only field names and safe surface labels.
+4. Freeze export/evidence delivery if user-facing leakage is plausible.
+5. Escalate to security lead for tenant, landlord, or external recipient exposure.
+
+Checklist:
+
+- [ ] Audience classified.
+- [ ] Restricted field class recorded.
+- [ ] Payload not copied.
+- [ ] Delivery freeze considered.
+- [ ] Projection owner identified.
+
+## Credential And Secret Incidents
+
+Signals:
+
+- Secret appears in code, docs, logs, deployment output, or support notes.
+- Webhook signature concern.
+- Service account, Firebase credential, JWT signing secret, provider credential, or API key exposure.
+
+Detection procedure:
+
+1. Record credential family and affected system only.
+2. Do not copy the secret value.
+3. Preserve where exposure was found using safe file/log/deployment reference.
+4. Notify security lead immediately.
+5. Follow containment procedures for manual rotation and redeploy.
+
+Checklist:
+
+- [ ] Credential family recorded.
+- [ ] Secret value not copied.
+- [ ] Exposure location safe ref recorded.
+- [ ] Rotation owner identified.
+- [ ] Post-rotation verification needed.

--- a/docs/operations/incident-escalation-authority-v1.md
+++ b/docs/operations/incident-escalation-authority-v1.md
@@ -1,0 +1,132 @@
+# Incident Escalation Authority v1
+
+## Scope
+
+This document defines manual escalation authority for Phase 3 incidents. It does not grant permissions, change roles, create routes, automate escalation, or mutate production data.
+
+## Authority Principles
+
+- Verify the operator's server-side role or permission before granting incident response authority.
+- Use the least broad response authority needed for the incident.
+- Treat missing, ambiguous, or cross-scope authority as denied until reviewed.
+- Keep all incident internals `admin_support_internal`.
+- Use safe references and metadata-only summaries in all escalation requests.
+
+## Escalation Roles
+
+| Role | May do | Must not do |
+| --- | --- | --- |
+| Initial detector | Report observed signal and safe scope. | Contain, rotate, disable, or modify production state without authority. |
+| Support operator | Triage support-safe diagnostics and gather metadata. | Access raw payloads, widen scope, or disclose internal details to tenants/landlords. |
+| Support lead | Approve support escalation, communication, and operational triage. | Approve credential or tenant-data critical containment alone. |
+| Security lead | Classify security incidents, approve privileged containment, review credential/access/projection risk. | Skip audit preservation or perform unapproved destructive changes. |
+| Ops lead | Coordinate deployment, environment, recovery workflow, and rollback procedure. | Change CI/CD or infrastructure outside approved runbook. |
+| Founder | Receive critical notifications and authorize exceptional business-impact containment. | Replace required technical verification and audit review. |
+| Product/engineering owner | Diagnose product defect and prepare controlled remediation. | Execute emergency response without incident authority. |
+
+## Category Authority Matrix
+
+| Category | Primary authority | Required escalation |
+| --- | --- | --- |
+| `auth_session` | Security lead | Founder for privileged, multi-user, or tenant data risk. |
+| `credential_secret` | Security lead | Founder for confirmed exposure or production credential scope. |
+| `api_abuse` | Ops lead | Security lead when authenticated or tenant-impacting. |
+| `document_upload` | Support lead | Security lead for malware, sensitive document, or exposure risk. |
+| `malware_suspected` | Security lead | Founder if production tenant document impact is plausible. |
+| `export_projection` | Security lead | Founder for external recipient or tenant data exposure. |
+| `evidence_access` | Security lead | Founder for cross-tenant, cross-landlord, or external exposure. |
+| `tenant_data_exposure` | Security lead | Founder always. |
+| `admin_support_access` | Security lead | Founder for confirmed unauthorized privileged access. |
+| `webhook_provider` | Ops lead | Security lead for signature, credential, or provider payload concerns. |
+| `dependency_supply_chain` | Engineering lead | Security lead for exploitable or production-impacting advisory. |
+| `infrastructure_deployment` | Ops lead | Founder for production traffic, production data, or credential impact. |
+| `recovery_workflow` | Ops lead | Security lead for authorization, audit, or projection risk. |
+| `audit_integrity` | Security lead | Founder for incident reconstruction failure or compliance-impacting gap. |
+| `suspicious_activity` | Support lead | Reclassify after triage. |
+
+## Escalation Triggers
+
+Escalate immediately when any of these are true:
+
+- Severity estimate is `high` or `critical`.
+- Tenant data, landlord data, evidence, export, credential, payment, screening, or privileged access is involved.
+- Production environment, production Firestore, production Auth, Cloud Run, Vercel production, or Terraform state may be affected.
+- Recovery decisions may have been accepted from wrong authority or without complete audit linkage.
+- Audit records needed for incident reconstruction are missing or appear mutable.
+- Support access crossed landlord, tenant, audience, or projection boundaries.
+
+## Timeline Expectations
+
+| Severity | Initial acknowledgement | Triage target | Containment target |
+| --- | --- | --- | --- |
+| `informational` | Next standard review cycle | Next standard review cycle | Not usually required. |
+| `low` | 1 business day | 2 business days | As scheduled. |
+| `medium` | Same business day | Same business day | Same or next business day. |
+| `high` | Immediate during operating hours | Immediate | As soon as authority and evidence are verified. |
+| `critical` | Immediate | Immediate | Immediate manual containment with founder notification. |
+
+## Escalation Request Template
+
+```text
+Escalation request:
+Category:
+Severity:
+Detected at:
+Requested authority:
+Affected scope safe refs:
+Affected audience:
+Observed signal:
+Initial containment recommendation:
+Evidence refs:
+Raw IDs included: no
+Secret or token included: no
+Provider payload included: no
+Tenant visible: no
+Decision needed:
+Requested response deadline:
+```
+
+## Authority Verification Procedure
+
+1. Confirm the operator is authenticated through server-side session context.
+2. Confirm relevant role or permission:
+   - `system.admin` for admin security incident review.
+   - Support lead assignment for support escalation review.
+   - Ops lead assignment for deployment or environment containment.
+   - Security lead assignment for credential, projection, tenant-data, audit, or privileged access incidents.
+3. Confirm scope:
+   - landlord scope where support-scoped diagnostic access is required.
+   - tenant scope only when needed and authorized.
+   - global review only for admin-global incidents.
+4. Confirm the action is manual and documented.
+5. Record actor, role, reason, timestamp, and safe affected refs.
+
+## Founder Notification Criteria
+
+Founder notification is required for:
+
+- Confirmed or plausible tenant data exposure.
+- Confirmed or plausible credential exposure in production.
+- Production data write from wrong environment.
+- Cross-landlord or cross-tenant exposure.
+- Confirmed unauthorized admin/support access.
+- Recovery workflow action with production-impacting state risk.
+- Any `critical` incident.
+
+## Operator Resolution Without Founder Notification
+
+Support or ops lead may resolve without founder notification when all are true:
+
+- Severity is `informational`, `low`, or routine `medium`.
+- No tenant data, credential, production data, evidence/export, or privileged misuse risk exists.
+- Affected scope is bounded and internal.
+- The action is audit-only, communication-only, or metadata-only.
+- No production data mutation is required.
+
+## Prohibited Escalation Shortcuts
+
+- Do not use client-side role claims as escalation authority.
+- Do not grant support diagnostic scope from a tenant report alone.
+- Do not disclose raw incident internals to tenants, landlords, recipients, or institutions.
+- Do not perform credential rotation, account disablement, deployment rollback, or recovery freeze without approved authority.
+- Do not skip audit linkage because the incident is urgent.

--- a/docs/operations/incident-readiness-operations-framework-v1.md
+++ b/docs/operations/incident-readiness-operations-framework-v1.md
@@ -1,0 +1,141 @@
+# Incident Readiness Operations Framework v1
+
+## Scope
+
+This framework centralizes Phase 3 operational incident readiness. It is documentation only. It does not add routes, Firestore collections, alerting, automation, token revocation, credential rotation, account locking, deployment configuration, dependencies, or production data changes.
+
+Incident response remains manual, supervised, metadata-only, and internal to authorized operators.
+
+## Source Documents
+
+This framework consolidates:
+
+- `docs/reports/security-audit-and-incident-response-foundations-v1.md`
+- `docs/security/auth-incident-response-runbook-v1.md`
+- `docs/runbooks/environment-separation-incident-response-v1.md`
+- `docs/reports/support-escalation-runbooks-v1.md`
+- `docs/security/recovery-workflow-security-audit-v1.md`
+- `docs/security/audit-immutability-contract-v1.md`
+- `docs/security/session-revocation-incident-scenarios-v1.md`
+- `docs/operations/pilot-institution-operations-runbooks-v1.md`
+- `docs/architecture/operational-risk-layer-v1.md`
+
+## Incident Readiness Lifecycle
+
+| Phase | Operator goal | Required posture |
+| --- | --- | --- |
+| Detection | Identify a signal that may indicate operational, security, projection, or recovery risk. | Use logs, admin review surfaces, support reports, canonical audit, and support-safe diagnostics only. |
+| Triage | Classify category, severity, scope, and authority. | Use safe references and avoid raw IDs, tokens, provider payloads, storage paths, stack traces, or unrestricted debug data. |
+| Containment | Stop additional impact while preserving evidence. | Prefer freeze, disablement, rollback, routing correction, or manual gate hold only after authority verification. |
+| Remediation | Apply a reviewed manual correction or documented follow-up. | Do not perform destructive data changes without explicit authorization and append-safe audit linkage. |
+| Closure | Confirm containment, remediation, evidence, and lessons learned. | Preserve post-incident summary and follow-up control validation. |
+
+## Category Matrix
+
+| Category | Examples | Primary authority | First response |
+| --- | --- | --- | --- |
+| `auth_session` | Login anomaly, suspected copied bearer value, session conflict. | Security lead with admin operator support. | Review auth/support timelines, validate scope, consider password reset or account disablement. |
+| `credential_secret` | Signing secret, webhook secret, service account, provider credential concern. | Security lead, ops lead, founder for critical exposure. | Stop exposure, rotate manually through approved console, redeploy if needed, record credential family only. |
+| `api_abuse` | Rate-limit triggers, public token probing, diagnostics scraping. | Ops lead or support lead. | Validate affected route, preserve request metadata, throttle through existing controls where available. |
+| `document_upload` | Unsafe upload, oversized file, misleading extension. | Support lead with security review if sensitive. | Preserve metadata, block further handling, avoid copying raw document text. |
+| `malware_suspected` | Suspicious attachment metadata or future scanner signal. | Security lead. | Quarantine through manual storage procedure if available; no scanner automation exists in Phase 3. |
+| `export_projection` | Restricted field in export candidate, wrong audience projection. | Security lead and product owner. | Freeze export/review flow, inspect projection helpers, preserve affected safe refs. |
+| `evidence_access` | Evidence link mismatch or unauthorized evidence request. | Support lead and security lead. | Stop evidence delivery, review consent/scope, preserve lineage metadata. |
+| `tenant_data_exposure` | Cross-tenant or cross-landlord data visibility concern. | Founder and security lead. | Treat as critical, freeze affected surface, preserve evidence, avoid tenant-visible details until approved. |
+| `admin_support_access` | Unexpected support console review or privileged access concern. | Security lead. | Review admin audit/support console events, remove privilege or disable account if warranted. |
+| `webhook_provider` | Signature mismatch, provider retry anomaly, callback abuse. | Ops lead and security lead. | Preserve webhook metadata, verify signature posture, avoid provider payload copying. |
+| `dependency_supply_chain` | Advisory, lockfile anomaly, package compromise concern. | Engineering lead and security lead. | Freeze dependency changes, review lockfile and CI evidence. |
+| `infrastructure_deployment` | Wrong backend host, preview/prod mismatch, Terraform or Cloud Run drift. | Ops lead. | Follow environment separation response, preserve deployment metadata, roll back if active traffic is affected. |
+| `suspicious_activity` | Incomplete or unknown anomaly. | Initial detector then support lead. | Record observed state and escalate for categorization. |
+| `recovery_workflow` | Reconciliation failure, recovery gate anomaly, recovery log mismatch. | Ops lead with security lead for data risk. | Freeze recovery decisions, validate gate state, preserve `operatorRecovery*` and `canonicalEvents` evidence. |
+| `audit_integrity` | Missing canonical event, append-only violation concern, timeline gap. | Security lead. | Preserve current records, stop dependent review decisions, investigate collection writer path. |
+
+## Severity Classification
+
+| Severity | Use when | Target initial response |
+| --- | --- | --- |
+| `informational` | Signal is useful context with no known active risk. | Next standard review cycle. |
+| `low` | Limited or unconfirmed concern requiring tracking. | Same or next business day. |
+| `medium` | Meaningful operational concern without confirmed exposure. | Same business day. |
+| `high` | Sensitive data, privileged access, malware, evidence, or production-impact risk is plausible. | Immediate triage. |
+| `critical` | Confirmed credential exposure, tenant data exposure, cross-landlord exposure, or severe active production risk. | Immediate containment and founder notification. |
+
+## Manual Response States
+
+Use the Phase 3 manual states consistently:
+
+- `observed`
+- `triaged`
+- `investigating`
+- `contained`
+- `remediated`
+- `closed`
+- `false_positive`
+
+These states are governance labels. They do not trigger automated action.
+
+## Detection Signals
+
+Operators may use:
+
+- Admin security incident review at `/api/admin/security/incidents`.
+- Observability incident readiness at `/api/admin/observability-incident-readiness`.
+- Support console resource diagnostics.
+- Canonical audit events in `canonicalEvents`.
+- Recovery records in `operatorRecoveryLogs`, `operatorRecoveryIntents`, and `canonicalRecoveryTimelineEntries`.
+- Deployment metadata from Vercel, Cloud Run, Terraform, and GitHub Actions.
+- Manual support reports from tenants, landlords, internal operators, or institution recipients.
+
+## Operator Roles
+
+| Role | Responsibility | Limits |
+| --- | --- | --- |
+| Initial detector | Records signal and safe scope. | Does not contain or remediate without authority. |
+| Support operator | Performs support-safe diagnostics and intake. | No cross-landlord browsing, raw payload copying, or hidden remediation. |
+| Support lead | Owns support escalation and communication coordination. | Does not approve critical security containment alone. |
+| Security lead | Owns security classification, privileged access review, credential and exposure response. | Must preserve audit lineage and redaction boundaries. |
+| Ops lead | Owns deployment, environment separation, and recovery coordination. | Does not mutate production data without explicit authorization. |
+| Founder | Receives critical notifications and approves exceptional containment where required. | Does not replace technical verification. |
+
+## Multi-System Coordination
+
+When an incident spans systems, classify the highest-risk category first, then attach secondary categories. Examples:
+
+- Preview/staging separation plus recovery impact: `infrastructure_deployment` primary, `recovery_workflow` secondary.
+- Support console misuse plus tenant data visibility: `tenant_data_exposure` primary, `admin_support_access` secondary.
+- Credential exposure plus auth-session concern: `credential_secret` primary, `auth_session` secondary.
+- Audit timeline gap plus recovery decision: `audit_integrity` primary, `recovery_workflow` secondary.
+
+Contain the surface that can create additional impact first. Preserve evidence before changing settings or rotating credentials.
+
+## Communication Chain
+
+1. Initial detector notifies support lead or ops lead using safe incident summary.
+2. Support or ops lead confirms category, severity, and affected scope.
+3. Security lead is added for high, critical, access, credential, projection, evidence, or tenant-data incidents.
+4. Founder is notified for critical incidents or any incident with confirmed tenant data exposure, confirmed credential exposure, or production write risk.
+5. Product/engineering is assigned only after containment and evidence preservation.
+
+## Post-Incident Analysis
+
+Every high or critical incident requires:
+
+- Timeline reconstruction from canonical audit, admin audit, support telemetry, deployment logs, and recovery records where relevant.
+- Root cause classification: failed control, process gap, implementation gap, configuration drift, or unclear ownership.
+- Remediation owner and deadline.
+- Verification evidence.
+- Runbook update if the procedure was unclear or incomplete.
+
+## Phase 3 Boundaries
+
+Phase 3 incident readiness does not include:
+
+- Automated incident detection.
+- Automated alerting.
+- Automated token revocation.
+- Automated credential rotation.
+- Account locking automation.
+- Incident persistence schema.
+- Tenant-facing incident disclosure.
+- External SIEM or ticketing integration.
+- Autonomous remediation.

--- a/docs/operations/incident-response-communication-templates-v1.md
+++ b/docs/operations/incident-response-communication-templates-v1.md
@@ -1,0 +1,200 @@
+# Incident Response Communication Templates v1
+
+## Scope
+
+These templates standardize internal incident communications. They are documentation only and do not create notification systems, tenant-facing notices, ticketing integrations, or external communications.
+
+Templates must preserve audience boundaries. Do not include raw IDs, tokens, secrets, credentials, provider payloads, storage paths, stack traces, raw documents, raw reports, private messages, or unrestricted debug data.
+
+## Audience Rules
+
+| Audience | Safe content | Prohibited content |
+| --- | --- | --- |
+| Operators | Category, severity, safe refs, route labels, deployment labels, containment status, evidence refs. | Secrets, bearer values, raw provider payloads, raw documents, stack traces. |
+| Support team | User-facing impact summary, support procedure, safe workflow labels, approved wording. | Admin-only internals, raw telemetry, IP addresses, full user agents, tenant-private rationale. |
+| Founder | Critical summary, business impact, containment status, timeline, owner, next decision. | Secret values, raw payloads, unnecessary raw identifiers. |
+| Product/engineering | Repro steps using safe refs, affected route/service labels, expected vs observed behavior. | Production data extracts, credentials, unrestricted debug dumps. |
+
+## Internal Operator Incident Report
+
+```text
+Incident report:
+Incident ID:
+Detected at:
+Detected by:
+Category:
+Severity:
+Response state:
+Affected systems:
+Affected scope safe refs:
+Tenant visible: no
+Landlord visible: no
+Raw IDs included: no
+Secret or token included: no
+Provider payload included: no
+
+Observed signal:
+Initial risk:
+Immediate containment:
+Authority:
+Evidence refs:
+Next review time:
+Owner:
+```
+
+## Founder Critical Notification
+
+```text
+Founder notification:
+Severity: critical
+Category:
+Detected at:
+Current response state:
+Affected system summary:
+Affected scope safe refs:
+Confirmed impact:
+Potential impact:
+Containment completed:
+Containment pending:
+Decision needed:
+Next update by:
+Owner:
+
+Redaction note:
+This summary excludes raw identifiers, secrets, tokens, provider payloads, raw documents, and internal debug output.
+```
+
+Use only when founder notification criteria in `docs/operations/incident-escalation-authority-v1.md` are met.
+
+## Support Team Notification
+
+```text
+Support notification:
+Category:
+Severity:
+Affected support procedure:
+User-facing impact summary:
+Approved support response:
+Do not disclose:
+Current status:
+Escalation owner:
+Next update:
+Safe resource labels:
+```
+
+Example approved wording for auth/access issues:
+
+```text
+Access is under manual review. Continue using the standard authenticated flow. Do not request or share credentials, tokens, private documents, or screenshots of restricted account data.
+```
+
+## Recovery Workflow Incident Update
+
+```text
+Recovery workflow incident update:
+Workflow family:
+Recovery safe ref:
+Gate or intent status:
+Affected endpoint label:
+Containment:
+Canonical audit linkage checked:
+Operator recovery records preserved:
+Next action:
+Owner:
+```
+
+Do not include raw workflow IDs, raw lease IDs, raw user IDs, raw state payloads, or private reasons.
+
+## Environment Separation Incident Update
+
+```text
+Environment incident update:
+Deployment SHA:
+Frontend environment:
+Backend revision:
+Expected API host label:
+Observed API host label:
+Firestore target verified:
+Credential exposure suspected:
+Containment:
+Rollback status:
+Next verification:
+Owner:
+```
+
+Do not include environment secret values, service account material, or raw credential paths.
+
+## Credential Incident Update
+
+```text
+Credential incident update:
+Credential family:
+Affected system:
+Exposure location safe ref:
+Rotation required:
+Rotation owner:
+Runtime reload required:
+Old value verification planned:
+Current status:
+Next update:
+```
+
+Never paste credential material into this template.
+
+## Post-Incident Summary
+
+```text
+Post-incident summary:
+Incident ID:
+Category:
+Severity:
+Opened at:
+Closed at:
+Owner:
+Affected systems:
+Affected scope safe refs:
+
+Timeline:
+- observed:
+- triaged:
+- investigating:
+- contained:
+- remediated:
+- closed:
+
+Root cause:
+Failed control:
+Containment actions:
+Remediation:
+Verification:
+Follow-up actions:
+Runbook updates:
+Residual risk:
+
+Redaction confirmation:
+- raw IDs excluded
+- tokens/secrets excluded
+- provider payloads excluded
+- raw documents excluded
+- stack traces excluded
+```
+
+## Redaction Procedure
+
+Before sending any incident communication:
+
+1. Search for bearer-like values, secret-like keys, provider payload labels, storage URLs, and stack trace fragments.
+2. Replace raw account, tenant, landlord, lease, unit, payment, evidence, export, and workflow IDs with safe refs or labels.
+3. Remove screenshots that show private payloads.
+4. Confirm audience is allowed to see the incident category and scope.
+5. Keep tenant-visible and landlord-visible fields out of internal incident communications unless an approved external notification model exists.
+
+## Communication Update Cadence
+
+| Severity | Update cadence |
+| --- | --- |
+| `informational` | At closure or next review. |
+| `low` | At triage and closure. |
+| `medium` | At triage, containment, and closure. |
+| `high` | At triage, containment, every material change, and closure. |
+| `critical` | Immediate initial notification, frequent updates during containment, closure summary, and post-incident review. |

--- a/docs/operations/multi-system-incident-coordination-v1.md
+++ b/docs/operations/multi-system-incident-coordination-v1.md
@@ -1,0 +1,142 @@
+# Multi-System Incident Coordination v1
+
+## Scope
+
+This document defines manual coordination for incidents that span multiple Phase 3 systems. It does not implement orchestration, alerting, ticketing, storage, routes, or automated remediation.
+
+## Multi-System Recognition
+
+Treat an incident as multi-system when one signal affects more than one of:
+
+- authentication/session;
+- credential or secret;
+- environment separation;
+- deployment or infrastructure;
+- recovery workflow;
+- support/admin access;
+- audit integrity;
+- evidence/export/projection;
+- institution review or support operations;
+- security telemetry or observability.
+
+## Common Multi-System Scenarios
+
+| Scenario | Primary category | Secondary categories | First freeze |
+| --- | --- | --- | --- |
+| Preview code affected recovery workflow | `infrastructure_deployment` | `recovery_workflow`, `audit_integrity` | Freeze recovery decisions for affected workflow. |
+| Production token used in staging recovery | `auth_session` | `infrastructure_deployment`, `recovery_workflow` | Freeze affected session/recovery path and inspect environment routing. |
+| Support console misuse exposed tenant metadata | `tenant_data_exposure` | `admin_support_access`, `projection_safety` | Stop support access to affected scope. |
+| Credential exposure affects webhook callbacks | `credential_secret` | `webhook_provider`, `infrastructure_deployment` | Rotate credential manually after evidence capture. |
+| Export projection leak found during incident review | `export_projection` | `evidence_access`, `audit_integrity` | Freeze export/evidence delivery. |
+| Canonical audit gap during recovery incident | `audit_integrity` | `recovery_workflow` | Hold reconciliation and preserve all audit sources. |
+
+## Coordination Procedure
+
+1. Assign one incident coordinator.
+2. Identify primary category by highest impact.
+3. Attach secondary categories.
+4. Assign authority owners for each category.
+5. Decide first freeze target.
+6. Preserve evidence from all systems before making configuration changes.
+7. Create one timeline with source-specific evidence refs.
+8. Communicate through the shared incident template.
+9. Close only after every system owner signs off.
+
+## First Freeze Decision Tree
+
+1. If tenant data or external recipient exposure is active, freeze user-facing projection/export/evidence surface first.
+2. If wrong environment may write production data, freeze deployment or route first.
+3. If recovery decisions may mutate or certify wrong state, freeze recovery workflow first.
+4. If credential exposure is confirmed, stop active exposure first, then rotate manually.
+5. If privileged access is suspicious, remove access or disable account after security lead approval.
+6. If audit evidence is at risk, stop dependent decisions and preserve records first.
+
+## Authority Coordination
+
+| System | Authority owner |
+| --- | --- |
+| Auth/session | Security lead |
+| Credential/secret | Security lead |
+| Deployment/environment | Ops lead |
+| Recovery workflow | Ops lead |
+| Support/admin access | Security lead |
+| Projection/evidence/export | Security lead with product owner |
+| Audit integrity | Security lead |
+| Institution operations | Support lead |
+
+The incident coordinator tracks decisions but does not inherit all authorities.
+
+## Timeline Reconciliation
+
+Build one timeline with entries from:
+
+- `canonicalEvents`;
+- admin audit events;
+- support console canonical events;
+- support security telemetry summaries;
+- recovery intents, logs, and timeline entries;
+- deployment events from GitHub Actions, Vercel, Terraform, and Cloud Run;
+- environment guard or runtime metadata;
+- manually reported support timestamps.
+
+Each timeline entry should include:
+
+- occurred at;
+- system;
+- source ref;
+- actor or system role;
+- action summary;
+- response state;
+- raw IDs included: no.
+
+## Evidence Collection
+
+Allowed evidence:
+
+- safe route labels;
+- deployment SHA;
+- backend revision;
+- canonical audit safe ref;
+- support diagnostic safe ref;
+- recovery safe ref;
+- incident category and severity;
+- redacted screenshots that show no private payloads.
+
+Prohibited evidence:
+
+- bearer tokens;
+- secret values;
+- raw provider payloads;
+- raw documents or reports;
+- raw Firestore document IDs shared outside authorized console context;
+- stack traces in shared incident notes;
+- private messages or unrestricted debug payloads.
+
+## Coordination Update Template
+
+```text
+Multi-system incident update:
+Primary category:
+Secondary categories:
+Severity:
+Coordinator:
+Authority owners:
+First freeze:
+Affected systems:
+Affected scope safe refs:
+Timeline sources:
+Containment status:
+Open decisions:
+Next update:
+```
+
+## Closure Criteria
+
+Close a multi-system incident only when:
+
+- primary and secondary category owners confirm containment;
+- affected surface is verified safe;
+- audit timeline is reconstructed or limitations are documented;
+- communication obligations are complete;
+- follow-up remediations have owners;
+- no unresolved high or critical decision remains.

--- a/docs/operations/phase-3-operational-incident-readiness-summary-v1.md
+++ b/docs/operations/phase-3-operational-incident-readiness-summary-v1.md
@@ -1,0 +1,91 @@
+# Phase 3 Operational Incident Readiness Summary v1
+
+## Executive Summary
+
+Phase 3 now includes both technical governance foundations and operational incident procedures. Existing foundations define recovery workflows, environment separation, auth incident response, support-safe diagnostics, audit immutability, projection safety, security telemetry, and admin incident review. The Phase 3 operational incident readiness layer centralizes those foundations into manual detection, escalation, containment, communication, coordination, and post-incident analysis procedures.
+
+This is documentation-only readiness. It does not introduce runtime incident automation, alerting, revocation, credential rotation, storage, routes, dashboards, external integrations, or tenant-facing incident disclosure.
+
+## Readiness Status
+
+| Area | Status | Source |
+| --- | --- | --- |
+| Incident taxonomy | Covered | `security-audit-and-incident-response-foundations-v1.md`, `incident-readiness-operations-framework-v1.md` |
+| Detection procedures | Covered | `incident-detection-procedures-v1.md` |
+| Escalation authority | Covered | `incident-escalation-authority-v1.md` |
+| Containment procedures | Covered | `incident-containment-procedures-v1.md` |
+| Communication templates | Covered | `incident-response-communication-templates-v1.md` |
+| Recovery workflow incidents | Covered | `recovery-workflow-incident-response-v1.md` |
+| Multi-system coordination | Covered | `multi-system-incident-coordination-v1.md` |
+| Post-incident analysis | Covered | `post-incident-analysis-procedures-v1.md` |
+| Readiness checklist | Covered | `phase-3-operational-readiness-checklist-v1.md` |
+| Auth incident handling | Covered with current limitations | `auth-incident-response-runbook-v1.md` |
+| Environment separation | Covered | `environment-separation-incident-response-v1.md` |
+| Support escalation | Covered | `support-escalation-runbooks-v1.md` |
+| Audit immutability | Covered with known older-writer limitations | `audit-immutability-contract-v1.md` |
+
+## Operational Assumptions
+
+- Incident response is manual and operator-supervised.
+- Incident internals are admin/support internal unless a future external notification model is explicitly designed.
+- Safe references are used for all affected resources.
+- Confirmed tenant data exposure and confirmed credential exposure are critical incidents.
+- Support and admin access must remain permission-scoped and audit-linked.
+- Recovery workflows can be paused procedurally but no runtime freeze switch is added by this mission.
+- Credential rotation, token revocation, account disablement, deployment rollback, and data correction require separate authority and approved operational execution.
+
+## Production Incident Readiness
+
+Phase 3 is ready for production incident scenarios in the following sense:
+
+- Operators have a unified lifecycle for detection, triage, containment, remediation, closure, and post-incident review.
+- Incident categories and severities are mapped to authority owners.
+- Recovery workflow incidents have dedicated response procedures.
+- Environment separation incidents have containment and investigation procedures.
+- Auth incidents account for current logout and revocation limitations.
+- Support access and projection incidents preserve tenant/landlord/admin/support boundaries.
+- Communication templates enforce redaction and audience boundaries.
+- Multi-system incident coordination defines first-freeze decisions and timeline reconciliation.
+- Post-incident analysis captures failed controls, remediation, verification, residual risk, and runbook updates.
+
+## Known Limitations
+
+Current Phase 3 limitations remain:
+
+- No automated incident detection.
+- No external alerting integration.
+- No SIEM integration.
+- No ticketing integration.
+- No incident persistence schema.
+- No incident dashboard mutation workflow.
+- No automated token revocation.
+- No active session inventory.
+- No trusted-device revocation table.
+- No automated credential rotation.
+- No automated account locking.
+- No malware scanner integration.
+- No tenant-facing incident disclosure model.
+- No runtime recovery freeze switch.
+- Recovery routes still have hardening follow-ups from `recovery-workflow-security-audit-v1.md`.
+- Older audit/event collections do not uniformly use the canonical append helper.
+
+## Phase 4 Recommendations
+
+Recommended Phase 4 work:
+
+1. Add server-side session revocation using one reviewed model from `session-revocation-design-options-v1.md`.
+2. Add report-only incident signal monitoring before alert automation.
+3. Add append-only incident review notes or status history with explicit retention rules.
+4. Add controlled credential rotation runbooks with dual-token sequencing where required.
+5. Add recovery endpoint hardening from Mission 9: permission guard, rate limiting, projection helper use, and reconciliation canonical audit event.
+6. Add immutable audit verification monitoring before Firestore rules enforcement.
+7. Add external notification model only after tenant-safe disclosure requirements are designed.
+8. Add support escalation persistence and review UI only after projection and retention contracts are approved.
+9. Add deployment/environment drift checks that report without mutating configuration.
+10. Add malware scanning integration only after document handling and quarantine workflows are approved.
+
+## Completion Statement
+
+Phase 3 now has a documented operational incident readiness framework that binds recovery workflows, auth incident handling, environment separation, support access governance, audit immutability, projection safety, communication discipline, multi-system coordination, and post-incident analysis into one manual response posture.
+
+The readiness posture is governance-first and production-aware, but intentionally manual. Future automation must be separately scoped, reviewed, permissioned, audited, and projection-safe.

--- a/docs/operations/phase-3-operational-readiness-checklist-v1.md
+++ b/docs/operations/phase-3-operational-readiness-checklist-v1.md
@@ -1,0 +1,108 @@
+# Phase 3 Operational Readiness Checklist v1
+
+## Scope
+
+This checklist verifies that Phase 3 has documentation coverage for incident readiness. It does not certify runtime automation, production deployment, external integrations, or tenant-facing incident disclosure.
+
+## Governance And Taxonomy
+
+- [ ] Incident categories from `security-audit-and-incident-response-foundations-v1.md` are mapped.
+- [ ] Severity levels from `informational` through `critical` are defined.
+- [ ] Manual response states are documented.
+- [ ] `recovery_workflow` and `audit_integrity` are included as Phase 3 operational categories.
+- [ ] Known future-only capabilities are labeled as Phase 4 or future work.
+
+## Detection Procedures
+
+- [ ] Recovery workflow detection procedures exist.
+- [ ] Environment separation detection procedures exist.
+- [ ] Auth/session detection procedures exist.
+- [ ] Support escalation detection procedures exist.
+- [ ] Audit integrity detection procedures exist.
+- [ ] Projection/evidence/export detection procedures exist.
+- [ ] Credential and secret detection procedures exist.
+- [ ] Safe reference procedure is documented.
+
+## Escalation Procedures
+
+- [ ] Category-to-authority matrix exists.
+- [ ] Founder notification criteria are documented.
+- [ ] Security lead, ops lead, support lead, and product/engineering responsibilities are separated.
+- [ ] Authority verification is server-side and role/permission based.
+- [ ] Escalation request template excludes raw identifiers and secrets.
+- [ ] Escalation timelines are severity-based.
+
+## Containment Procedures
+
+- [ ] Recovery freeze and gate hold procedures are documented.
+- [ ] Environment rollback and deployment containment procedures are documented.
+- [ ] Auth/session manual mitigation limits are documented.
+- [ ] Support access containment is documented.
+- [ ] Credential containment excludes secret values from notes.
+- [ ] Data exposure containment freezes affected projection/export/evidence surfaces.
+- [ ] Audit integrity containment preserves records and stops dependent decisions.
+
+## Recovery Workflow Readiness
+
+- [ ] Recovery endpoints are documented in `recovery-workflow-security-audit-v1.md`.
+- [ ] Recovery incident response preserves `operatorRecovery*` and `canonicalEvents`.
+- [ ] Recovery rollback is explicitly authorization-only and not implemented by runbook.
+- [ ] Recovery communication excludes raw workflow IDs and private reason text.
+- [ ] Recovery incidents link to environment and auth procedures.
+
+## Environment Separation Readiness
+
+- [ ] Preview/staging/production incident types are documented.
+- [ ] Wrong backend host, wrong Firestore target, wrong auth project, and credential exposure scenarios are covered.
+- [ ] Deployment SHA, backend revision, and Firestore target verification are required.
+- [ ] Production data write concerns require evidence preservation before correction.
+
+## Auth Incident Readiness
+
+- [ ] Auth session incidents account for the current lack of server-side JWT revocation.
+- [ ] Trusted-device and multi-session scenarios are documented as future design inputs.
+- [ ] Manual mitigations include password reset, account disablement, or permission removal where authorized.
+- [ ] Privileged account incidents escalate to security lead.
+
+## Support Access Governance
+
+- [ ] Support escalation categories and approval expectations are documented.
+- [ ] Support access incidents preserve metadata-only support telemetry.
+- [ ] Support diagnostic scope requires authority review.
+- [ ] Tenant and landlord communications exclude admin/support internals.
+
+## Audit Integrity
+
+- [ ] `canonicalEvents` helper semantics are documented.
+- [ ] Older event collection limitations are documented.
+- [ ] Incident procedures preserve append-safe audit trails.
+- [ ] Audit gaps stop dependent recovery, export, evidence, or review decisions.
+
+## Projection Safety
+
+- [ ] Incident procedures use safe refs only.
+- [ ] Templates exclude tokens, secrets, provider payloads, storage paths, raw documents, and stack traces.
+- [ ] Tenant, landlord, admin/support, export, dashboard, and timeline audience boundaries are preserved.
+- [ ] Communication guidance distinguishes operators, support, founder, and product/engineering audiences.
+
+## Post-Incident Analysis
+
+- [ ] Timeline reconstruction procedure exists.
+- [ ] Root cause template exists.
+- [ ] Remediation tracking template exists.
+- [ ] Closure criteria exist.
+- [ ] Runbook update and lessons-learned capture are required.
+
+## Manual Verification
+
+For this documentation mission, verify:
+
+- [ ] No runtime files changed.
+- [ ] No auth, Firestore rules, deployment, CI/CD, or billing files changed.
+- [ ] New documents cross-reference existing implemented systems.
+- [ ] No raw secrets, tokens, provider payloads, or raw IDs appear in templates.
+- [ ] `git diff --check` passes.
+
+## Readiness Status
+
+Phase 3 operational incident readiness is complete when all items are checked or explicitly marked as future work with owner and follow-up mission.

--- a/docs/operations/post-incident-analysis-procedures-v1.md
+++ b/docs/operations/post-incident-analysis-procedures-v1.md
@@ -1,0 +1,196 @@
+# Post-Incident Analysis Procedures v1
+
+## Scope
+
+This document defines manual post-incident analysis for Phase 3 incidents. It does not create post-incident storage, routes, status mutation, dashboards, or automation.
+
+## When Required
+
+Run post-incident analysis for:
+
+- every `high` or `critical` incident;
+- any confirmed tenant data exposure;
+- any credential or secret exposure;
+- any production environment separation failure;
+- any recovery workflow incident that affects production state;
+- any audit integrity concern;
+- any support/admin unauthorized access concern;
+- any incident where containment was delayed by unclear procedure.
+
+## Timeline Reconstruction
+
+Use append-safe and metadata-only sources first:
+
+- `canonicalEvents`;
+- admin audit events;
+- support console canonical events;
+- support telemetry summaries;
+- recovery intents, logs, and timeline entries;
+- deployment events from approved platforms;
+- environment separation runbook evidence;
+- manual support intake timestamps.
+
+Timeline entry format:
+
+```text
+Time:
+State:
+System:
+Safe source ref:
+Actor role:
+Action:
+Evidence ref:
+Raw IDs included: no
+```
+
+## Affected Resource Enumeration
+
+List affected resources by safe reference only.
+
+Allowed:
+
+- resource type;
+- safe label;
+- safe ref;
+- landlord scope as safe ref where required;
+- tenant scope as safe ref only when necessary and authorized;
+- visibility class;
+- sensitivity class.
+
+Prohibited:
+
+- raw tenant IDs;
+- raw landlord IDs;
+- raw lease/unit/payment IDs;
+- raw document paths;
+- provider payloads;
+- credential values.
+
+## Root Cause Template
+
+```text
+Root cause analysis:
+Incident ID:
+Category:
+Severity:
+Primary failed control:
+Secondary failed controls:
+Human/process factors:
+Technical factors:
+Configuration factors:
+Detection gap:
+Containment gap:
+Audit gap:
+Projection gap:
+What worked:
+What failed:
+```
+
+## Failed Control Types
+
+Use one or more:
+
+- auth/session boundary;
+- support/admin scope governance;
+- projection allowlist;
+- recovery gate or intent;
+- audit append linkage;
+- deployment/environment separation;
+- credential management;
+- runbook clarity;
+- test coverage;
+- operational ownership;
+- communication timing.
+
+## Remediation Tracking
+
+Every remediation item must include:
+
+```text
+Remediation:
+Control improvement:
+Owner:
+Deadline:
+Verification plan:
+Deployment or docs impact:
+Risk if deferred:
+Status:
+```
+
+Do not perform remediation inside the analysis unless separately authorized.
+
+## Lessons Learned
+
+Capture:
+
+- what signal detected the incident;
+- whether severity was correct;
+- whether escalation was timely;
+- whether safe references were sufficient;
+- whether containment preserved evidence;
+- whether any audience boundary was unclear;
+- which runbook needs an update;
+- what future mission should address.
+
+## Follow-Up Control Validation
+
+Validation may include:
+
+- focused route or service tests after an approved fix;
+- `git diff --check` for documentation updates;
+- manual preview QA for user-visible changes;
+- Cloud Run revision verification for backend deployment freshness;
+- audit event review for append-safe evidence;
+- projection review for tenant, landlord, admin/support, export, dashboard, and timeline audiences.
+
+## Closure Criteria
+
+An incident can close only when:
+
+- category and severity are final;
+- containment is verified;
+- affected scope is documented with safe refs;
+- root cause is recorded;
+- remediation is complete or tracked with owner and deadline;
+- audit and evidence refs are preserved;
+- communications are complete;
+- residual risk is documented;
+- follow-up mission is named when needed.
+
+## Post-Incident Summary Template
+
+```text
+Post-incident analysis:
+Incident ID:
+Category:
+Severity:
+Opened:
+Closed:
+Owner:
+
+Summary:
+Affected systems:
+Affected scope safe refs:
+
+Timeline:
+- observed:
+- triaged:
+- investigating:
+- contained:
+- remediated:
+- closed:
+
+Root cause:
+Failed controls:
+Containment actions:
+Remediation completed:
+Remediation deferred:
+Verification:
+Residual risk:
+Runbook updates:
+Recommended next mission:
+```
+
+## Retention And Redaction
+
+Post-incident analysis records must remain internal unless a future tenant-safe notification model is explicitly approved. Redact raw identifiers, credentials, provider payloads, raw documents, storage paths, stack traces, private messages, and unrestricted debug data.

--- a/docs/operations/recovery-workflow-incident-response-v1.md
+++ b/docs/operations/recovery-workflow-incident-response-v1.md
@@ -1,0 +1,155 @@
+# Recovery Workflow Incident Response v1
+
+## Scope
+
+This document defines manual incident procedures for recovery workflows. It does not change recovery services, routes, audit writers, Firestore rules, rate limits, or admin/support permissions.
+
+Recovery incidents must preserve append-safe recovery history and must not delete or rewrite recovery records.
+
+## Current Recovery Surface
+
+Current recovery endpoints are documented in `docs/security/recovery-workflow-security-audit-v1.md` and implemented in `rentchain-api/src/routes/adminRecoveryRoutes.ts`.
+
+Primary records:
+
+- `operatorRecoveryIntents`
+- `operatorRecoveryLogs`
+- `canonicalRecoveryTimelineEntries`
+- `decisionContinuitySnapshots`
+- `canonicalEvents`
+
+## Recovery Incident Categories
+
+| Type | Signal | Severity driver |
+| --- | --- | --- |
+| Access denial anomaly | Admin/support recovery request returns unexpected auth error. | Privileged access or support-scope risk. |
+| Gate validation anomaly | Intent missing, stale, or authorization mismatch during approved work. | Wrong actor or stale authorization. |
+| Reconciliation failure | Duplicate, invalid, or unexpected recovery decision result. | Operational state and audit impact. |
+| Audit linkage gap | Recovery intent or gate validation missing canonical event. | Audit integrity impact. |
+| Projection concern | Recovery response includes raw workflow ID or sensitive marker. | Data exposure impact. |
+| Rate-limit gap abuse | Repeated inspection or mutation attempts. | Abuse and privileged endpoint risk. |
+| Environment-recovery overlap | Preview/staging issue affects recovery workflow. | Production data or environment separation impact. |
+
+## Detection Procedure
+
+1. Identify endpoint label, method, and workflow type.
+2. Confirm server-verified actor role and permission context.
+3. Record recovery safe ref, not raw workflow ID.
+4. Check recovery intent status and gate status.
+5. Check recovery log and timeline entry for `metadataOnly`, `appendOnly`, and `rawIdsIncluded: false`.
+6. Check `canonicalEvents` for recovery intent and gate validation events.
+7. Classify category and severity.
+
+## Immediate Containment
+
+Use a recovery freeze when:
+
+- actor authority is ambiguous;
+- gate validation result is inconsistent;
+- recovery audit linkage is missing;
+- environment separation may have affected recovery;
+- raw ID or sensitive payload exposure is suspected;
+- a recovery action may mutate or influence production state incorrectly.
+
+Freeze procedure:
+
+1. Stop new manual recovery actions for affected workflow family.
+2. Place in-flight reconciliation decisions on hold.
+3. Preserve `operatorRecovery*`, `canonicalRecoveryTimelineEntries`, and `canonicalEvents`.
+4. Notify ops lead and security lead.
+5. Document safe refs and current response state.
+6. Resume only after audit linkage and authority are verified.
+
+## Gate Validation Holds
+
+Apply a manual gate hold when:
+
+- `intent_missing` appears unexpectedly;
+- `authorization_invalid` appears for an operator expected to own the recovery intent;
+- `intent_stale` appears during an active incident;
+- actor role changed between intent capture and gate validation;
+- support access lacks landlord scope where scoped diagnostic review is required.
+
+Hold steps:
+
+1. Do not capture replacement intent until root cause is reviewed.
+2. Preserve failed gate validation event.
+3. Verify actor role and support scope.
+4. Confirm whether the original intent is stale by design.
+5. Require ops lead approval before recapturing intent.
+
+## Reconciliation Incident Procedure
+
+1. Confirm workflow type and safe recovery ref.
+2. Compare decision continuity snapshot, recovery timeline, and state-machine provenance.
+3. Confirm whether divergence is `MISSING_TRANSITION`, `ORPHANED_DECISION`, `EVIDENCE_MISMATCH`, or `METADATA_DIVERGENCE`.
+4. Check whether a duplicate recovery log already exists.
+5. Do not edit or delete recovery logs.
+6. If accepted reconciliation appears wrong, open rollback authorization review. Do not execute rollback through this procedure.
+
+## Recovery History Preservation
+
+Never:
+
+- delete `operatorRecoveryLogs`;
+- delete `operatorRecoveryIntents`;
+- rewrite `canonicalRecoveryTimelineEntries`;
+- overwrite `canonicalEvents`;
+- remove failed gate validation records;
+- copy raw recovery payloads into incident notes.
+
+Preserve:
+
+- actor safe ref;
+- authority role;
+- recovery safe ref;
+- workflow type;
+- decision type;
+- reason code only when safe;
+- timestamp;
+- canonical audit event safe ref.
+
+## Recovery Rollback Authorization
+
+Rollback is not implemented by this mission. If a recovery decision may need reversal:
+
+1. Classify the incident as `recovery_workflow`.
+2. Escalate to ops lead, security lead, and founder if production state or tenant data is affected.
+3. Reconstruct timeline from append-safe records.
+4. Define the exact correction and risk.
+5. Require explicit data-operation authorization before any state change.
+6. Record follow-up as a future mission or approved data operation.
+
+## Escalation
+
+| Condition | Escalation |
+| --- | --- |
+| Missing audit event only, no active impact | Security lead. |
+| Gate mismatch during active recovery | Ops lead and security lead. |
+| Support scope ambiguity | Support lead and security lead. |
+| Production state may be wrong | Founder, ops lead, security lead. |
+| Raw ID or sensitive data exposure | Security lead, founder if tenant data involved. |
+| Environment separation overlap | Ops lead and security lead. |
+
+## Communication
+
+Use `docs/operations/incident-response-communication-templates-v1.md`.
+
+Recovery communication must not include:
+
+- raw workflow IDs;
+- raw lease, tenant, landlord, unit, payment, or user IDs;
+- private reason text;
+- provider payloads;
+- screening reports;
+- financial details;
+- storage paths;
+- bearer or credential values.
+
+## Cross-Links
+
+- Environment overlap: `docs/runbooks/environment-separation-incident-response-v1.md`
+- Auth/session overlap: `docs/security/auth-incident-response-runbook-v1.md`
+- Audit integrity: `docs/security/audit-immutability-contract-v1.md`
+- Recovery security posture: `docs/security/recovery-workflow-security-audit-v1.md`
+- Multi-system coordination: `docs/operations/multi-system-incident-coordination-v1.md`


### PR DESCRIPTION
## Summary
- Adds the Phase 3 operational incident readiness framework and companion operating procedures under `docs/operations/`.
- Covers incident lifecycle, detection, escalation authority, containment, communication templates, recovery workflow response, multi-system coordination, post-incident analysis, readiness checklist, and final readiness summary.
- Keeps the mission documentation-only: no runtime code, routes, Firestore rules, auth, deployment, CI/CD, dependencies, or production data changes.

## Validation
- `git diff --check` passed.
- Verified changed files are limited to `docs/operations/`.
- Verified referenced source documents exist.
- Scanned new templates for unsafe positive markers such as raw IDs, secrets, provider payloads, tenant visibility, landlord visibility, or autonomous remediation being enabled.

## Manual QA
- Not required for this documentation-only mission. No frontend, backend, route, auth, or API behavior changed.

## Known limitations
- This mission intentionally does not implement incident automation, alerting, token revocation, credential rotation, account locking, incident storage, tenant-facing incident disclosure, or recovery runtime hardening.
- Recovery endpoint hardening follow-ups remain as documented in `docs/security/recovery-workflow-security-audit-v1.md`.