### PR TITLE
feat: implement evidence provenance chain

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,75 +1,66 @@
-PR: #1089
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1089
-Branch: feat/phase-3-preview-staging-separation-v1
+PR: #1093
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1093
+Branch: feat/evidence-provenance-chain-v1
+Mission: Phase 4A Mission 2 - Evidence Provenance Chain Implementation
 
-# Implementation Summary
+## Summary
+Implemented the evidence provenance creation contract for Phase 4A evidence records.
 
-Completed Phase 3 Mission 8 as a documentation-only environment separation governance mission. No runtime source, routes, services, Firestore rules, Firestore indexes, deployment configuration, dependencies, auth behavior, frontend behavior, or production data were changed.
-
-## Scope Completed
-
-- Documented the current production, preview, development, and test environment separation model.
-- Documented current production-adjacent preview risk: committed Vercel rewrites route `/api` and `/health` to the production Cloud Run backend host unless deployment settings change behavior.
-- Documented local/test Firestore safety controls through emulator defaults and `firestoreEnvironmentGuard`.
-- Documented secret and credential classification, storage, rotation, audit, and incident response requirements.
-- Documented backend and frontend environment variable governance.
-- Documented Cloud Run/backend separation controls and deployment review checklist.
-- Documented Firestore database separation governance and recovery policy.
-- Documented authentication/token separation requirements and current limitations.
-- Documented frontend/Vercel routing, CSP, and `VITE_API_BASE_URL` review requirements.
-- Documented environment separation testing strategy.
-- Documented environment separation incident response procedures.
-- Documented operational dashboard metrics, alert triggers, and review cadence.
+The service now validates provenance metadata, authority scope, safe source references, sensitivity metadata, immutable flags, and duplicate append writes before persisting metadata-only evidence records.
 
 ## Files Changed
+- docs/architecture/evidence-provenance-emission-patterns-v1.md
+- rentchain-api/src/types/evidence-record-types.ts
+- rentchain-api/src/services/evidence-record-service.ts
+- rentchain-api/src/__tests__/evidenceIdentifier.test.ts
+- rentchain-api/src/__tests__/evidenceRecordService.test.ts
 
-- `docs/environment/preview-staging-separation-strategy-v1.md`
-- `docs/governance/environment-separation-policy-v1.md`
-- `docs/security/secret-credential-management-v1.md`
-- `docs/governance/environment-variable-governance-v1.md`
-- `docs/security/cloud-run-separation-enforcement-v1.md`
-- `docs/security/firestore-separation-governance-v1.md`
-- `docs/security/authentication-token-separation-v1.md`
-- `docs/deployment/frontend-environment-variable-routing-v1.md`
-- `docs/security/environment-separation-testing-strategy-v1.md`
-- `docs/security/environment-separation-operational-dashboard-v1.md`
-- `docs/runbooks/environment-separation-incident-response-v1.md`
-- `.handoff/impl-summary.md`
+## Implementation Details
+- Added `EvidenceCreationAuthorityContext` to capture server-side actor, landlord, tenant, support, and purpose context for evidence creation.
+- Implemented deterministic safe source reference generation from source collection, resource type, and source resource ID.
+- Implemented actor and authority resolution helpers that derive safe actor, landlord, and tenant references without exposing raw IDs in provenance metadata.
+- Implemented `EvidenceRecordService.createEvidenceRecord()` with creation-only persistence through Firestore `create()` semantics.
+- Enforced immutable, append-only, metadata-only evidence record creation.
+- Enforced landlord, tenant, admin, and support authority boundaries.
+- Required purpose for admin and support evidence creation.
+- Rejected unsafe provenance markers, missing authority scope, duplicate evidence IDs, and raw/payload inclusion flags.
+- Documented emission patterns for ApplicationEvidence, ScreeningEvidence, DecisionEvidence, PaymentEvidence, MaintenanceEvidence, and AuditEvidence.
+- Covered supersession through new append-only records with `supersedesEvidenceId` and provenance-chain references.
+
+## Scope Boundaries
+- No routes added.
+- No auth core changes.
+- No Firestore rules changes.
+- No deployment, CI, or infrastructure changes.
+- No evidence retrieval implementation.
+- No evidence pack derivation, export, signing, attestation, or sharing workflows.
+- No production data mutation or source collection migration.
 
 ## Validation
-
-- Passed: `git diff --check`
-- Passed: sensitive value scan for private-key markers, service account emails, API key patterns, live secret key patterns, and Firestore database path patterns in changed docs.
-- Passed: required deliverable existence check.
-- Passed: cross-reference validation for `docs/...md` references in new docs.
-- Passed: governance completeness keyword check across environment, secret, credential, Cloud Run, Firestore, Auth, Vercel, incident, dashboard, monitoring, rollback, rotation, emulator, CSP, and `VITE_API_BASE_URL` topics.
+- Passed: `npm --prefix rentchain-api run test:single -- src/__tests__/evidenceRecordService.test.ts src/__tests__/evidenceIdentifier.test.ts`
+- Passed: targeted TypeScript compile for evidence record types, service, identifier utility, fixtures, and tests.
 - Passed: `npm --prefix rentchain-api run build`
+- Passed: `git diff --check`
+- Checked: no `lint` script is defined in `rentchain-api/package.json`.
+- Checked: changed-file unsafe-marker scan found only policy text, service rejection patterns, and test sentinel values.
 
-## Protected Areas
+## Full Test Suite
+`npm --prefix rentchain-api run test` was run outside the local sandbox after the sandbox run hit an environment bind restriction.
 
-- Firestore rules unchanged.
-- Firestore indexes unchanged.
-- Cloud Run deployment configuration unchanged.
-- GitHub Actions unchanged.
-- Vercel configuration unchanged.
-- Backend source unchanged.
-- Frontend source unchanged.
-- Auth permissions unchanged.
-- Dependencies unchanged.
-- Production data untouched.
+The full backend suite still has unrelated existing failures outside this mission:
+- `leaseDraftRoutes.test.ts`
+- `recipientTrustReviewRoutes.test.ts`
+- `supportConsoleRoutes.test.ts`
+- `deriveDecisionExecutionMappings.test.ts`
+- `landlordAnalyticsSnapshot.test.ts`
 
-## Manual QA
-
-Manual QA required: no.
-
-Reason: this mission changed documentation only. No frontend rendering, backend route behavior, auth flow, routing behavior, mobile layout, deployment configuration, Firestore configuration, or user-visible runtime behavior was changed.
+The focused evidence tests and backend build passed.
 
 ## Known Limitations
-
-- Cloud Run IAM bindings, Secret Manager access grants, Firebase project separation, and Vercel project settings are not fully inspectable from repository source and require authorized console review.
-- `rentchain-frontend/.env.example` is absent in the current tree and is documented as a gap.
-- Current committed Vercel rewrites point preview-capable routes at the production backend host; documentation treats that as production-adjacent rather than changing behavior.
+- Evidence retrieval routes remain deferred.
+- Evidence pack derivation remains deferred.
+- Retention, archival, deletion, legal hold, signing, attestation, and external sharing remain future work.
+- Source-service emission integrations are documented but not wired into runtime service flows in this mission.
 
 ## Recommended Next Mission
-
-Phase 3 Mission 9: resolve existing backend assertion failures and restore full backend suite green status, or run a focused infrastructure console review to verify environment separation controls outside source.
+Phase 4A Mission 3 - source-service evidence emission integration or evidence pack derivation planning.

--- a/docs/architecture/evidence-provenance-emission-patterns-v1.md
+++ b/docs/architecture/evidence-provenance-emission-patterns-v1.md
@@ -1,0 +1,243 @@
+# Evidence Provenance Emission Patterns v1
+
+## Purpose
+
+Evidence Provenance Emission Patterns v1 documents how platform services should create immutable `evidenceRecords` through `EvidenceRecordService.createEvidenceRecord()`.
+
+This mission implements the creation contract and validation helpers only. It does not add route handlers, background emission loops, evidence pack derivation, institutional export packages, external sharing, signing, verification, retention enforcement, Firestore rule changes, or Firestore index deployment.
+
+## Pre-Implementation Audit Findings
+
+The current codebase already has compatible append-safe patterns:
+
+- Canonical audit events use deterministic safe references and `create()` semantics through `appendCanonicalAuditEvent()`.
+- Recovery and transition provenance storage use append-only document writes and metadata-only safe references.
+- Request authority is carried through authenticated `req.user` fields including role, landlord scope, tenant scope, and actor role.
+- Existing evidence pack previews are derived read models and do not persist evidence as source of truth.
+- Evidence record model v1 already defines immutable metadata-only records, safe identifiers, redaction metadata, and future projection categories.
+
+The missing implementation layer was a creation service that validates provenance metadata and writes evidence records through creation-only storage.
+
+## Creation Contract
+
+`EvidenceRecordService.createEvidenceRecord(input)` must:
+
+- validate the evidence class and type
+- validate UTC timestamps
+- validate actor role and authority role
+- validate landlord, tenant, admin, and support authority boundaries
+- require purpose for admin and support evidence creation
+- validate source collection and deterministic safe source reference key
+- validate redaction and sensitivity metadata
+- generate deterministic `evidenceId` values through `generateEvidenceId()`
+- populate immutable, append-only, metadata-only flags
+- write to `evidenceRecords` with `create()` semantics only
+- fail closed on ambiguous authority, unsafe payload markers, duplicate evidence IDs, or missing scope
+
+The service may use internal `landlordId` and `resourceId` fields for server-side joins. External-facing fields use safe references and must not expose raw IDs.
+
+## Safe Source References
+
+Source references are generated as:
+
+```text
+<sourceCollection>:<resourceType>:<hash>
+```
+
+The hash is deterministic from source collection, resource type, and raw source ID. Raw Firestore document IDs, tenant IDs, landlord IDs, unit IDs, lease IDs, provider IDs, storage paths, tokens, credentials, and payload values are not embedded in the reference key.
+
+## Actor and Authority Resolution
+
+Evidence creation uses `EvidenceCreationAuthorityContext`:
+
+| Field | Purpose |
+| --- | --- |
+| `actorRole` | `tenant`, `landlord`, `admin`, `support`, or `system`. |
+| `actorId` | Internal actor ID used only to derive `actorRef`. |
+| `landlordId` | Internal landlord scope used only to derive `landlordRef` and validate scope. |
+| `tenantId` | Internal tenant scope used only to derive `tenantRef` and validate tenant context. |
+| `supportAllowed` | Required for support evidence creation. |
+| `purpose` | Required for admin and support evidence creation. |
+
+The helper produces safe actor, landlord, and tenant references. It does not expose raw IDs in provenance metadata.
+
+## Emission Patterns by Evidence Class
+
+### ApplicationEvidence
+
+Typical sources:
+
+- `rentalApplications`
+- legacy `applications`
+
+Emission moments:
+
+- application submitted
+- application status becomes review-ready
+- applicant-to-tenant continuity is established
+
+Required metadata:
+
+- actor role: tenant, landlord, or system depending on initiating service
+- authority: landlord scope and tenant scope when tenant-initiated
+- source collection: `rentalApplications`
+- reason examples: `application_submitted`, `application_review_ready`
+- sensitivity: Sensitive
+- excluded fields: applicant contact values, identity documents, raw screening payloads
+
+### ScreeningEvidence
+
+Typical sources:
+
+- `screeningOrders`
+- `screeningResults`
+- `screeningEvents`
+
+Emission moments:
+
+- screening order created
+- consent captured
+- screening workflow completed or failed
+
+Required metadata:
+
+- actor role: tenant, landlord, support, or system depending on service path
+- authority: landlord scope and tenant scope where applicant consent is involved
+- source collection: `screeningOrders` or `screeningEvents`
+- reason examples: `screening_order_created`, `screening_consent_captured`, `screening_completed`
+- sensitivity: Restricted
+- excluded fields: raw report, provider payload, identity values, provider credentials
+
+### DecisionEvidence
+
+Typical sources:
+
+- `landlordDecisionStates`
+- `decisionActions`
+- `operatorReviewSessions`
+
+Emission moments:
+
+- landlord decision appears
+- decision outcome is manually reviewed
+- operator review session records an outcome
+
+Required metadata:
+
+- actor role: landlord, admin, support, or system
+- authority: landlord scope; admin/support purpose when applicable
+- source collection: `decisionActions`
+- reason examples: `decision_workflow_created`, `manual_decision_reviewed`, `operator_review_outcome_recorded`
+- sensitivity: Sensitive
+- excluded fields: operator internal notes, raw workflow serialization, unrelated financial records
+
+### PaymentEvidence
+
+Typical sources:
+
+- `payments`
+- `ledgerEntries`
+- `rentPayments`
+- `paymentReconciliationRecords`
+
+Emission moments:
+
+- payment record created
+- ledger entry appended
+- reconciliation record created
+
+Required metadata:
+
+- actor role: landlord, tenant, system, admin, or support depending on source service
+- authority: landlord scope; tenant scope for tenant-initiated payment evidence
+- source collection: `ledgerEntries` or `paymentReconciliationRecords`
+- reason examples: `payment_record_created`, `ledger_entry_appended`, `payment_reconciled`
+- sensitivity: Sensitive or Restricted depending on source
+- excluded fields: bank account values, card details, raw processor payloads, raw CSV values
+
+### MaintenanceEvidence
+
+Typical sources:
+
+- `workOrders`
+- `maintenanceRequests`
+- `workOrderUpdates`
+
+Emission moments:
+
+- maintenance request created
+- work order assigned or scheduled
+- completion evidence recorded
+
+Required metadata:
+
+- actor role: tenant, landlord, support, contractor-adjacent service as system, or admin
+- authority: landlord scope and tenant scope for tenant-created requests
+- source collection: `workOrders` or `maintenanceRequests`
+- reason examples: `maintenance_request_created`, `work_order_completed`, `maintenance_update_recorded`
+- sensitivity: Sensitive
+- excluded fields: private message bodies, tenant contact values, attachment payloads
+
+### AuditEvidence
+
+Typical sources:
+
+- `canonicalEvents`
+- `events`
+- `tenantEvents`
+- `leaseWorkflowEvents`
+
+Emission moments:
+
+- canonical audit event appended
+- lease workflow event appended
+- recovery or review timeline event captured
+
+Required metadata:
+
+- actor role: system, admin, support, landlord, or tenant depending on event source
+- authority: same safe scope as the source audit event
+- source collection: `canonicalEvents`
+- reason examples: `canonical_audit_event_captured`, `lease_workflow_event_captured`
+- sensitivity: Sensitive
+- excluded fields: raw payload, raw actor ID, debug context, request bodies, response bodies
+
+## Supersession Pattern
+
+Evidence corrections use new records.
+
+Allowed:
+
+- create a new evidence record with `supersedesEvidenceId`
+- include the prior record's safe reference in `provenanceChain`
+- leave the original record intact
+
+Not allowed:
+
+- updating the prior record to rewrite source metadata
+- deleting prior evidence
+- mutating source collections to force evidence continuity
+
+The `supersededByEvidenceId` field remains `null` at creation time unless a later append-only lifecycle model is explicitly introduced.
+
+## Integration Guidance
+
+Future source-service integration should call evidence creation only from explicit service actions:
+
+- application service: after submission or review-ready status change
+- screening service: after order, consent, or status event
+- decision service: after manual decision action or review outcome
+- payment service: after ledger append or reconciliation event
+- maintenance service: after request, work order update, or completion
+- canonical audit layer: after canonical audit event append
+
+Services must resolve authority before calling evidence creation. If authority is ambiguous, evidence creation should be skipped or rejected with an internal error code; it should not infer cross-tenant or cross-landlord access.
+
+## Deferred Work
+
+- source-service integrations
+- evidence retrieval and projection routes
+- evidence pack derivation from persisted evidence records
+- retention, archival, deletion, and legal hold lifecycle services
+- external export package builders
+- signing, verification, attestation, and trust workspaces

--- a/rentchain-api/src/__tests__/evidenceIdentifier.test.ts
+++ b/rentchain-api/src/__tests__/evidenceIdentifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { evidenceRecordFixtureList } from "./fixtures/evidence-record-fixtures";
+import { EVIDENCE_CLASSES } from "../types/evidence-record-types";
 import {
   generateEvidenceId,
   parseEvidenceId,
@@ -50,6 +51,22 @@ describe("evidence identifier utilities", () => {
     expect(validateEvidenceId("screening-order-secret-id")).toBe(false);
     expect(validateEvidenceId("evr_v1_type_short_hash")).toBe(false);
     expect(parseEvidenceId("screening-order-secret-id").valid).toBe(false);
+  });
+
+  it("supports every evidence class without exposing raw source values", () => {
+    for (const evidenceClass of EVIDENCE_CLASSES) {
+      const evidenceId = generateEvidenceId(evidenceClass, `${evidenceClass}:raw-source-id`, {
+        evidenceClass,
+        projection: "metadata_only",
+        schemaVersion: "evidence_record_v1",
+      });
+      const parsed = parseEvidenceId(evidenceId);
+
+      expect(validateEvidenceId(evidenceId)).toBe(true);
+      expect(parsed.valid).toBe(true);
+      expect(evidenceId).not.toContain("raw-source-id");
+      expect(evidenceId).not.toContain(evidenceClass);
+    }
   });
 });
 

--- a/rentchain-api/src/__tests__/evidenceRecordService.test.ts
+++ b/rentchain-api/src/__tests__/evidenceRecordService.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEvidenceProvenanceMetadata,
+  EvidenceRecordService,
+  safeEvidenceScopeReference,
+} from "../services/evidence-record-service";
+import {
+  EVIDENCE_CLASSES,
+  EVIDENCE_RECORD_COLLECTION,
+  EVIDENCE_RECORD_SCHEMA_VERSION,
+  type CreateEvidenceRecordInput,
+  type EvidenceClass,
+  type EvidenceProjectionCategory,
+  type EvidenceRecord,
+  type EvidenceResourceType,
+  type EvidenceSensitivityClass,
+  type EvidenceSourceCollection,
+} from "../types/evidence-record-types";
+import { validateEvidenceId } from "../utils/evidence-identifier";
+
+type StoredRecord = Record<string, unknown>;
+
+function createEvidenceTestStore() {
+  const collections = new Map<string, Map<string, StoredRecord>>();
+
+  function ensure(name: string): Map<string, StoredRecord> {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  return {
+    read(collection: string, id: string): StoredRecord | null {
+      return ensure(collection).get(id) || null;
+    },
+    collection<T = StoredRecord>(name: string) {
+      return {
+        doc(id: string) {
+          return {
+            async get() {
+              return {
+                id,
+                exists: ensure(name).has(id),
+                data: () => ensure(name).get(id),
+              };
+            },
+            async create(data: T) {
+              if (ensure(name).has(id)) throw new Error("already_exists");
+              ensure(name).set(id, data as StoredRecord);
+            },
+            async set(data: T) {
+              ensure(name).set(id, data as StoredRecord);
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+type EvidenceCase = {
+  evidenceClass: EvidenceClass;
+  evidenceType: string;
+  sourceCollection: EvidenceSourceCollection;
+  resourceType: EvidenceResourceType;
+  resourceId: string;
+  sensitivityClass: EvidenceSensitivityClass;
+};
+
+const evidenceCases: EvidenceCase[] = [
+  {
+    evidenceClass: "ApplicationEvidence",
+    evidenceType: "ApplicationEvidence",
+    sourceCollection: "rentalApplications",
+    resourceType: "rentalApplication",
+    resourceId: "application-raw-id-001",
+    sensitivityClass: "Sensitive",
+  },
+  {
+    evidenceClass: "ScreeningEvidence",
+    evidenceType: "ScreeningEvidence",
+    sourceCollection: "screeningOrders",
+    resourceType: "screeningOrder",
+    resourceId: "screening-order-raw-id-001",
+    sensitivityClass: "Restricted",
+  },
+  {
+    evidenceClass: "DecisionEvidence",
+    evidenceType: "DecisionEvidence",
+    sourceCollection: "decisionActions",
+    resourceType: "decisionWorkflow",
+    resourceId: "decision-action-raw-id-001",
+    sensitivityClass: "Sensitive",
+  },
+  {
+    evidenceClass: "PaymentEvidence",
+    evidenceType: "PaymentEvidence",
+    sourceCollection: "ledgerEntries",
+    resourceType: "ledgerEntry",
+    resourceId: "ledger-entry-raw-id-001",
+    sensitivityClass: "Sensitive",
+  },
+  {
+    evidenceClass: "MaintenanceEvidence",
+    evidenceType: "MaintenanceEvidence",
+    sourceCollection: "workOrders",
+    resourceType: "workOrder",
+    resourceId: "work-order-raw-id-001",
+    sensitivityClass: "Sensitive",
+  },
+  {
+    evidenceClass: "AuditEvidence",
+    evidenceType: "AuditEvidence",
+    sourceCollection: "canonicalEvents",
+    resourceType: "canonicalEvent",
+    resourceId: "canonical-event-raw-id-001",
+    sensitivityClass: "Sensitive",
+  },
+];
+
+function sensitivityMetadata(sensitivityClass: EvidenceSensitivityClass) {
+  return {
+    sensitivityClass,
+    projectionCategories: ["audit_only", "landlord_operational"] as EvidenceProjectionCategory[],
+    redactionPolicy: "allowlist_required" as const,
+    excludedFieldGroups: ["rawPayload", "providerPayload", "credentialValues"],
+    allowedFieldGroups: ["status", "timestamp", "safeReference"],
+    containsRestrictedProviderData: false as const,
+    containsRawPaymentData: false as const,
+    containsMessageBody: false as const,
+    containsIdentityDocument: false as const,
+    rawIdsIncluded: false as const,
+    payloadIncluded: false as const,
+  };
+}
+
+function buildInput(overrides: Partial<CreateEvidenceRecordInput> = {}, evidenceCase: EvidenceCase = evidenceCases[0]): CreateEvidenceRecordInput {
+  const createdAt = "2026-06-04T02:00:00.000Z";
+  const creationAuthority = overrides.creationAuthority || {
+    actorRole: "landlord" as const,
+    actorId: "landlord-user-raw-id",
+    landlordId: "landlord-raw-id-001",
+    purpose: "landlord evidence capture",
+  };
+  return {
+    evidenceClass: evidenceCase.evidenceClass,
+    evidenceType: evidenceCase.evidenceType,
+    landlordId: "landlord-raw-id-001",
+    resourceType: evidenceCase.resourceType,
+    resourceId: evidenceCase.resourceId,
+    label: `${evidenceCase.evidenceClass} fixture`,
+    creationAuthority,
+    provenanceMetadata:
+      overrides.provenanceMetadata ||
+      buildEvidenceProvenanceMetadata({
+        authority: creationAuthority,
+        sourceCollection: evidenceCase.sourceCollection,
+        resourceType: evidenceCase.resourceType,
+        resourceId: evidenceCase.resourceId,
+        reason: `${evidenceCase.evidenceClass} created for governed evidence capture`,
+        createdAt,
+        sourceObservedAt: createdAt,
+        sourceVersion: "test_v1",
+      }),
+    sensitivityMetadata: overrides.sensitivityMetadata || sensitivityMetadata(evidenceCase.sensitivityClass),
+    createdAt,
+    ...overrides,
+  };
+}
+
+function externalRecordFields(record: EvidenceRecord) {
+  return {
+    evidenceId: record.evidenceId,
+    safeReference: record.safeReference,
+    provenanceMetadata: record.provenanceMetadata,
+    sensitivityMetadata: record.sensitivityMetadata,
+    redactionSummary: record.redactionSummary,
+  };
+}
+
+describe("EvidenceRecordService", () => {
+  it("creates immutable metadata-only records for all evidence classes", async () => {
+    expect(evidenceCases.map((item) => item.evidenceClass)).toEqual([...EVIDENCE_CLASSES]);
+    for (const evidenceCase of evidenceCases) {
+      const store = createEvidenceTestStore();
+      const service = new EvidenceRecordService({ firestore: store });
+      const record = await service.createEvidenceRecord(buildInput({}, evidenceCase));
+
+      expect(record).toMatchObject({
+        evidenceClass: evidenceCase.evidenceClass,
+        evidenceType: evidenceCase.evidenceType,
+        schemaVersion: EVIDENCE_RECORD_SCHEMA_VERSION,
+        immutable: true,
+        appendOnly: true,
+        metadataOnly: true,
+        rawIdsIncluded: false,
+        status: "active",
+      });
+      expect(validateEvidenceId(record.evidenceId)).toBe(true);
+      expect(record.safeReference.rawIdsIncluded).toBe(false);
+      expect(record.safeReference.payloadIncluded).toBe(false);
+      expect(store.read(EVIDENCE_RECORD_COLLECTION, record.evidenceId)).toEqual(record);
+    }
+  });
+
+  it("generates deterministic evidence identifiers and rejects duplicate append writes", async () => {
+    const store = createEvidenceTestStore();
+    const service = new EvidenceRecordService({ firestore: store });
+    const input = buildInput();
+    const first = await service.createEvidenceRecord(input);
+    const repeatedService = new EvidenceRecordService({ firestore: createEvidenceTestStore() });
+    const repeated = await repeatedService.createEvidenceRecord(input);
+
+    expect(first.evidenceId).toBe(repeated.evidenceId);
+    await expect(service.createEvidenceRecord(input)).rejects.toThrow("already_exists");
+  });
+
+  it("keeps raw IDs out of external-facing evidence fields", async () => {
+    const store = createEvidenceTestStore();
+    const service = new EvidenceRecordService({ firestore: store });
+    const record = await service.createEvidenceRecord(buildInput());
+    const serializedExternalFields = JSON.stringify(externalRecordFields(record));
+
+    expect(serializedExternalFields).not.toContain("landlord-raw-id-001");
+    expect(serializedExternalFields).not.toContain("application-raw-id-001");
+    expect(serializedExternalFields).not.toContain("landlord-user-raw-id");
+    expect(serializedExternalFields).not.toMatch(/bearer-secret|secret-token|gs:\/\/|storage\.googleapis\.com/i);
+    expect(record.landlordId).toBe("landlord-raw-id-001");
+    expect(record.resourceId).toBe("application-raw-id-001");
+  });
+
+  it("fails closed on landlord scope mismatch", async () => {
+    const store = createEvidenceTestStore();
+    const service = new EvidenceRecordService({ firestore: store });
+    const input = buildInput({
+      provenanceMetadata: buildEvidenceProvenanceMetadata({
+        authority: {
+          actorRole: "landlord",
+          actorId: "landlord-user-raw-id",
+          landlordId: "other-landlord-raw-id",
+          purpose: "landlord evidence capture",
+        },
+        sourceCollection: "rentalApplications",
+        resourceType: "rentalApplication",
+        resourceId: "application-raw-id-001",
+        reason: "ApplicationEvidence created for governed evidence capture",
+        createdAt: "2026-06-04T02:00:00.000Z",
+      }),
+    });
+
+    await expect(service.createEvidenceRecord(input)).rejects.toThrow("evidence_landlord_scope_mismatch");
+  });
+
+  it("requires tenant scope for tenant-created evidence", async () => {
+    const store = createEvidenceTestStore();
+    const service = new EvidenceRecordService({ firestore: store });
+    const tenantAuthority = {
+      actorRole: "tenant" as const,
+      actorId: "tenant-user-raw-id",
+      landlordId: "landlord-raw-id-001",
+      tenantId: "tenant-raw-id-001",
+      purpose: "tenant evidence capture",
+    };
+    const record = await service.createEvidenceRecord(buildInput({
+      creationAuthority: tenantAuthority,
+      provenanceMetadata: buildEvidenceProvenanceMetadata({
+        authority: tenantAuthority,
+        sourceCollection: "rentalApplications",
+        resourceType: "rentalApplication",
+        resourceId: "application-raw-id-001",
+        reason: "Tenant application evidence capture",
+        createdAt: "2026-06-04T02:00:00.000Z",
+      }),
+    }));
+
+    expect(record.provenanceMetadata.authority.tenantRef).toBe(safeEvidenceScopeReference("tenant", "tenant-raw-id-001"));
+
+    const missingTenantScope = buildInput({
+      creationAuthority: { actorRole: "tenant", actorId: "tenant-user-raw-id", landlordId: "landlord-raw-id-001" },
+      provenanceMetadata: {
+        ...record.provenanceMetadata,
+        authority: {
+          authorityRole: "tenant",
+          landlordRef: safeEvidenceScopeReference("landlord", "landlord-raw-id-001"),
+          tenantRef: null,
+          supportAllowed: false,
+          rawIdsIncluded: false,
+        },
+      },
+    });
+    await expect(service.createEvidenceRecord(missingTenantScope)).rejects.toThrow("evidence_tenant_scope_missing");
+  });
+
+  it("requires purpose and support allowance for admin/support evidence", async () => {
+    const store = createEvidenceTestStore();
+    const service = new EvidenceRecordService({ firestore: store });
+    const supportAuthority = {
+      actorRole: "support" as const,
+      actorId: "support-user-raw-id",
+      landlordId: "landlord-raw-id-001",
+      supportAllowed: true,
+      purpose: "support evidence capture",
+    };
+    const supportRecord = await service.createEvidenceRecord(buildInput({
+      creationAuthority: supportAuthority,
+      provenanceMetadata: buildEvidenceProvenanceMetadata({
+        authority: supportAuthority,
+        sourceCollection: "canonicalEvents",
+        resourceType: "canonicalEvent",
+        resourceId: "canonical-event-raw-id-001",
+        reason: "Support audit evidence capture",
+        createdAt: "2026-06-04T02:00:00.000Z",
+      }),
+    }, evidenceCases[5]));
+
+    expect(supportRecord.provenanceMetadata.authority.supportAllowed).toBe(true);
+
+    const deniedSupport = buildInput({
+      resourceId: "canonical-event-raw-id-002",
+      creationAuthority: { actorRole: "support", actorId: "support-user-raw-id", landlordId: "landlord-raw-id-001" },
+      provenanceMetadata: buildEvidenceProvenanceMetadata({
+        authority: { actorRole: "support", actorId: "support-user-raw-id", landlordId: "landlord-raw-id-001" },
+        sourceCollection: "canonicalEvents",
+        resourceType: "canonicalEvent",
+        resourceId: "canonical-event-raw-id-002",
+        reason: "Support audit evidence capture",
+        createdAt: "2026-06-04T02:00:00.000Z",
+      }),
+    }, evidenceCases[5]);
+    await expect(service.createEvidenceRecord(deniedSupport)).rejects.toThrow("evidence_support_not_allowed");
+
+    const adminWithoutPurpose = buildInput({
+      resourceId: "canonical-event-raw-id-003",
+      creationAuthority: { actorRole: "admin", actorId: "admin-user-raw-id", landlordId: "landlord-raw-id-001" },
+      provenanceMetadata: buildEvidenceProvenanceMetadata({
+        authority: { actorRole: "admin", actorId: "admin-user-raw-id", landlordId: "landlord-raw-id-001" },
+        sourceCollection: "canonicalEvents",
+        resourceType: "canonicalEvent",
+        resourceId: "canonical-event-raw-id-003",
+        reason: "Admin audit evidence capture",
+        createdAt: "2026-06-04T02:00:00.000Z",
+      }),
+    }, evidenceCases[5]);
+    await expect(service.createEvidenceRecord(adminWithoutPurpose)).rejects.toThrow("evidence_admin_purpose_missing");
+  });
+
+  it("creates superseding evidence as a new append-only record without mutating the original", async () => {
+    const store = createEvidenceTestStore();
+    const service = new EvidenceRecordService({ firestore: store });
+    const original = await service.createEvidenceRecord(buildInput({}, evidenceCases[3]));
+    const superseding = await service.createEvidenceRecord(buildInput({
+      resourceId: "ledger-entry-raw-id-002",
+      supersedesEvidenceId: original.evidenceId,
+      provenanceMetadata: buildEvidenceProvenanceMetadata({
+        authority: {
+          actorRole: "landlord",
+          actorId: "landlord-user-raw-id",
+          landlordId: "landlord-raw-id-001",
+          purpose: "landlord evidence correction",
+        },
+        sourceCollection: "ledgerEntries",
+        resourceType: "ledgerEntry",
+        resourceId: "ledger-entry-raw-id-002",
+        reason: "PaymentEvidence supersession capture",
+        createdAt: "2026-06-04T02:05:00.000Z",
+        provenanceChain: [original.safeReference],
+      }),
+      createdAt: "2026-06-04T02:05:00.000Z",
+    }, evidenceCases[3]));
+
+    expect(superseding.supersedesEvidenceId).toBe(original.evidenceId);
+    expect(superseding.supersededByEvidenceId).toBeNull();
+    expect(store.read(EVIDENCE_RECORD_COLLECTION, original.evidenceId)).toEqual(original);
+    expect((store.read(EVIDENCE_RECORD_COLLECTION, original.evidenceId) as EvidenceRecord).status).toBe("active");
+  });
+
+  it("rejects unsafe provenance payload markers", async () => {
+    const store = createEvidenceTestStore();
+    const service = new EvidenceRecordService({ firestore: store });
+    const input = buildInput({
+      provenanceMetadata: {
+        ...buildInput().provenanceMetadata,
+        reason: "contains bearer-secret",
+      },
+    });
+
+    await expect(service.createEvidenceRecord(input)).rejects.toThrow("evidence_reason_invalid");
+  });
+});

--- a/rentchain-api/src/services/evidence-record-service.ts
+++ b/rentchain-api/src/services/evidence-record-service.ts
@@ -1,12 +1,342 @@
+import crypto from "crypto";
+import { db } from "../firebase";
 import type {
   CreateEvidenceRecordInput,
+  EvidenceActorRole,
+  EvidenceAuthorityRole,
+  EvidenceCreationAuthorityContext,
+  EvidenceProvenanceMetadata,
+  EvidenceReference,
   EvidenceRecord,
   EvidenceRecordProjection,
   EvidenceRecordQuery,
   EvidenceProjectionAudience,
+  EvidenceRetentionMetadata,
+  EvidenceSensitivityMetadata,
 } from "../types/evidence-record-types";
+import {
+  EVIDENCE_CLASSES,
+  EVIDENCE_RECORD_COLLECTION,
+  EVIDENCE_RECORD_SCHEMA_VERSION,
+  EVIDENCE_RECORD_STATUSES,
+} from "../types/evidence-record-types";
+import {
+  generateEvidenceId,
+  type EvidenceIdentifierMetadata,
+} from "../utils/evidence-identifier";
+
+type SnapshotLike = {
+  exists?: boolean;
+  id?: string;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type DocumentRefLike<T> = {
+  get?: () => Promise<SnapshotLike>;
+  create?: (data: T) => Promise<unknown>;
+  set?: (data: T, options?: { merge?: boolean }) => Promise<unknown>;
+};
+
+type CollectionLike<T> = {
+  doc: (id: string) => DocumentRefLike<T>;
+};
+
+export type EvidenceRecordFirestoreLike = {
+  collection: <T = Record<string, unknown>>(name: string) => CollectionLike<T>;
+};
+
+type EvidenceRecordServiceOptions = {
+  firestore?: EvidenceRecordFirestoreLike;
+};
+
+type EvidenceValidationResult = {
+  valid: boolean;
+  reason?: string;
+};
+
+const SAFE_REFERENCE_HASH_LENGTH = 20;
+
+const RESTRICTED_CONTENT_PATTERN =
+  /token|secret|credential|authorization|cookie|password|bearer|provider payload|raw report|request body|response body|stacktrace|stack trace|gs:\/\/|storage\.googleapis\.com|bank account|card number/i;
+
+const RAW_IDENTIFIER_PATTERN = /^[A-Za-z0-9_-]{16,}$/;
+
+function stableHash(parts: readonly unknown[]): string {
+  return crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, SAFE_REFERENCE_HASH_LENGTH);
+}
+
+function cleanPrefix(prefix: string): string {
+  return String(prefix || "evidence")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .slice(0, 80) || "evidence";
+}
+
+function safeReference(prefix: string, value: unknown): string {
+  const normalizedPrefix = cleanPrefix(prefix);
+  return `${normalizedPrefix}:${stableHash([normalizedPrefix, String(value ?? "unknown")])}`;
+}
+
+function safeLabel(value: unknown, fallback: string): string {
+  const label = String(value ?? "")
+    .replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+  if (!label || RESTRICTED_CONTENT_PATTERN.test(label) || RAW_IDENTIFIER_PATTERN.test(label)) return fallback;
+  return label;
+}
+
+function toUtcIso(value: unknown): string {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function hasRestrictedContent(value: unknown): boolean {
+  return RESTRICTED_CONTENT_PATTERN.test(JSON.stringify(value ?? {}));
+}
+
+function isEvidenceActorRole(value: unknown): value is EvidenceActorRole {
+  return value === "tenant" || value === "landlord" || value === "admin" || value === "support" || value === "system";
+}
+
+function isEvidenceAuthorityRole(value: unknown): value is EvidenceAuthorityRole {
+  return isEvidenceActorRole(value);
+}
+
+function defaultRetentionMetadata(): EvidenceRetentionMetadata {
+  return {
+    retentionPolicy: "deferred_phase_4",
+    retentionReviewRequired: true,
+    archiveAfter: null,
+    deleteAfter: null,
+  };
+}
+
+function evidenceDb(firestore?: EvidenceRecordFirestoreLike): EvidenceRecordFirestoreLike {
+  return firestore || (db as unknown as EvidenceRecordFirestoreLike);
+}
+
+export function safeEvidenceScopeReference(prefix: "actor" | "landlord" | "tenant" | "source", value: unknown): string {
+  return safeReference(prefix, value);
+}
+
+export function buildEvidenceSourceReferenceKey(input: {
+  sourceCollection: string;
+  resourceType: string;
+  resourceId: string;
+}): string {
+  return safeReference(`${input.sourceCollection}:${input.resourceType}`, input.resourceId);
+}
+
+export function resolveEvidenceCreationAuthority(input: EvidenceCreationAuthorityContext): {
+  actorRole: EvidenceActorRole;
+  actorRef: string | null;
+  authorityRole: EvidenceAuthorityRole;
+  landlordRef: string | null;
+  tenantRef: string | null;
+  supportAllowed: boolean;
+  purpose: string | null;
+} {
+  if (!isEvidenceActorRole(input.actorRole)) throw new Error("evidence_authority_actor_role_invalid");
+  const actorRef = input.actorId ? safeEvidenceScopeReference("actor", `${input.actorRole}:${input.actorId}`) : null;
+  return {
+    actorRole: input.actorRole,
+    actorRef,
+    authorityRole: input.actorRole,
+    landlordRef: input.landlordId ? safeEvidenceScopeReference("landlord", input.landlordId) : null,
+    tenantRef: input.tenantId ? safeEvidenceScopeReference("tenant", input.tenantId) : null,
+    supportAllowed: input.supportAllowed === true,
+    purpose: input.purpose ? safeLabel(input.purpose, "Evidence creation purpose") : null,
+  };
+}
+
+export function buildEvidenceProvenanceMetadata(input: {
+  authority: EvidenceCreationAuthorityContext;
+  sourceCollection: EvidenceProvenanceMetadata["source"]["sourceCollection"];
+  resourceType: string;
+  resourceId: string;
+  reason: string;
+  createdAt?: string;
+  sourceObservedAt?: string | null;
+  sourceVersion?: string | null;
+  provenanceChain?: EvidenceReference[];
+}): EvidenceProvenanceMetadata {
+  const authority = resolveEvidenceCreationAuthority(input.authority);
+  return {
+    createdAt: toUtcIso(input.createdAt),
+    createdBy: {
+      actorRole: authority.actorRole,
+      actorRef: authority.actorRef,
+      rawActorIdsIncluded: false,
+    },
+    authority: {
+      authorityRole: authority.authorityRole,
+      landlordRef: authority.landlordRef,
+      tenantRef: authority.tenantRef,
+      supportAllowed: authority.supportAllowed,
+      rawIdsIncluded: false,
+    },
+    source: {
+      sourceCollection: input.sourceCollection,
+      sourceReferenceKey: buildEvidenceSourceReferenceKey({
+        sourceCollection: input.sourceCollection,
+        resourceType: input.resourceType,
+        resourceId: input.resourceId,
+      }),
+      sourceObservedAt: input.sourceObservedAt ? toUtcIso(input.sourceObservedAt) : null,
+      sourceVersion: input.sourceVersion || null,
+      rawSourceIdsIncluded: false,
+      rawPayloadIncluded: false,
+    },
+    reason: safeLabel(input.reason, "Evidence record creation"),
+    provenanceChain: input.provenanceChain || [],
+    metadataOnly: true,
+  };
+}
+
+function validateUtcIso(value: string): boolean {
+  return Boolean(value && value.endsWith("Z") && Number.isFinite(Date.parse(value)));
+}
+
+function validateSensitivityMetadata(metadata: EvidenceSensitivityMetadata): EvidenceValidationResult {
+  if (!metadata?.sensitivityClass) return { valid: false, reason: "evidence_sensitivity_class_missing" };
+  if (!Array.isArray(metadata.projectionCategories) || metadata.projectionCategories.length === 0) {
+    return { valid: false, reason: "evidence_projection_categories_missing" };
+  }
+  if (metadata.rawIdsIncluded !== false || metadata.payloadIncluded !== false) {
+    return { valid: false, reason: "evidence_sensitivity_raw_ids_or_payload_included" };
+  }
+  if (
+    metadata.containsRestrictedProviderData !== false ||
+    metadata.containsRawPaymentData !== false ||
+    metadata.containsMessageBody !== false ||
+    metadata.containsIdentityDocument !== false
+  ) {
+    return { valid: false, reason: "evidence_sensitive_payload_flag_enabled" };
+  }
+  if (!Array.isArray(metadata.allowedFieldGroups) || !Array.isArray(metadata.excludedFieldGroups)) {
+    return { valid: false, reason: "evidence_field_group_metadata_invalid" };
+  }
+  if (hasRestrictedContent(metadata.allowedFieldGroups)) {
+    return { valid: false, reason: "evidence_allowed_field_groups_restricted_content" };
+  }
+  return { valid: true };
+}
+
+function validateProvenanceMetadata(
+  input: CreateEvidenceRecordInput,
+  metadata: EvidenceProvenanceMetadata
+): EvidenceValidationResult {
+  if (!validateUtcIso(metadata.createdAt)) return { valid: false, reason: "evidence_created_at_invalid" };
+  if (!isEvidenceActorRole(metadata.createdBy?.actorRole)) return { valid: false, reason: "evidence_actor_role_invalid" };
+  if (metadata.createdBy.rawActorIdsIncluded !== false) return { valid: false, reason: "evidence_actor_raw_ids_included" };
+  if (!isEvidenceAuthorityRole(metadata.authority?.authorityRole)) return { valid: false, reason: "evidence_authority_role_invalid" };
+  if (metadata.authority.rawIdsIncluded !== false) return { valid: false, reason: "evidence_authority_raw_ids_included" };
+  if (!metadata.source?.sourceCollection || !metadata.source.sourceReferenceKey) {
+    return { valid: false, reason: "evidence_source_reference_missing" };
+  }
+  if (metadata.source.rawSourceIdsIncluded !== false || metadata.source.rawPayloadIncluded !== false) {
+    return { valid: false, reason: "evidence_source_raw_ids_or_payload_included" };
+  }
+  if (metadata.source.sourceReferenceKey !== buildEvidenceSourceReferenceKey({
+    sourceCollection: metadata.source.sourceCollection,
+    resourceType: input.resourceType,
+    resourceId: input.resourceId,
+  })) {
+    return { valid: false, reason: "evidence_source_reference_not_deterministic" };
+  }
+  if (metadata.source.sourceObservedAt && !validateUtcIso(metadata.source.sourceObservedAt)) {
+    return { valid: false, reason: "evidence_source_observed_at_invalid" };
+  }
+  if (!metadata.reason || hasRestrictedContent(metadata.reason)) {
+    return { valid: false, reason: "evidence_reason_invalid" };
+  }
+  if (!Array.isArray(metadata.provenanceChain)) return { valid: false, reason: "evidence_provenance_chain_invalid" };
+  if (metadata.provenanceChain.some((ref) => ref.rawIdsIncluded !== false || ref.payloadIncluded !== false)) {
+    return { valid: false, reason: "evidence_provenance_chain_raw_ids_or_payload_included" };
+  }
+  if (metadata.metadataOnly !== true) return { valid: false, reason: "evidence_provenance_not_metadata_only" };
+  if (hasRestrictedContent(metadata)) return { valid: false, reason: "evidence_provenance_restricted_content" };
+  return { valid: true };
+}
+
+function validateAuthorityBoundary(input: CreateEvidenceRecordInput): EvidenceValidationResult {
+  const provenance = input.provenanceMetadata;
+  const role = provenance.authority.authorityRole;
+  const expectedLandlordRef = safeEvidenceScopeReference("landlord", input.landlordId);
+  const creationAuthority = input.creationAuthority;
+
+  if (role === "landlord") {
+    if (provenance.authority.landlordRef !== expectedLandlordRef) {
+      return { valid: false, reason: "evidence_landlord_scope_mismatch" };
+    }
+  }
+
+  if (role === "tenant") {
+    if (!provenance.authority.tenantRef) return { valid: false, reason: "evidence_tenant_scope_missing" };
+    if (creationAuthority?.tenantId) {
+      const expectedTenantRef = safeEvidenceScopeReference("tenant", creationAuthority.tenantId);
+      if (provenance.authority.tenantRef !== expectedTenantRef) {
+        return { valid: false, reason: "evidence_tenant_scope_mismatch" };
+      }
+    }
+    if (creationAuthority?.landlordId && creationAuthority.landlordId !== input.landlordId) {
+      return { valid: false, reason: "evidence_tenant_landlord_scope_mismatch" };
+    }
+  }
+
+  if (role === "support") {
+    if (provenance.authority.supportAllowed !== true) {
+      return { valid: false, reason: "evidence_support_not_allowed" };
+    }
+    if (!creationAuthority?.purpose) return { valid: false, reason: "evidence_support_purpose_missing" };
+  }
+
+  if (role === "admin") {
+    if (!creationAuthority?.purpose) return { valid: false, reason: "evidence_admin_purpose_missing" };
+  }
+
+  if (creationAuthority) {
+    if (creationAuthority.actorRole !== role) return { valid: false, reason: "evidence_authority_context_role_mismatch" };
+    if (creationAuthority.landlordId && provenance.authority.landlordRef !== expectedLandlordRef) {
+      return { valid: false, reason: "evidence_authority_context_landlord_mismatch" };
+    }
+  }
+
+  return { valid: true };
+}
+
+function validateEvidenceRecordInput(input: CreateEvidenceRecordInput): EvidenceValidationResult {
+  if (!EVIDENCE_CLASSES.includes(input.evidenceClass)) return { valid: false, reason: "evidence_class_invalid" };
+  if (!input.evidenceType.trim()) return { valid: false, reason: "evidence_type_missing" };
+  if (!input.landlordId.trim()) return { valid: false, reason: "evidence_landlord_id_missing" };
+  if (!input.resourceId.trim()) return { valid: false, reason: "evidence_resource_id_missing" };
+  if (hasRestrictedContent(input.evidenceType) || hasRestrictedContent(input.resourceType)) {
+    return { valid: false, reason: "evidence_type_restricted_content" };
+  }
+  const provenance = validateProvenanceMetadata(input, input.provenanceMetadata);
+  if (!provenance.valid) return provenance;
+  const sensitivity = validateSensitivityMetadata(input.sensitivityMetadata);
+  if (!sensitivity.valid) return sensitivity;
+  const authority = validateAuthorityBoundary(input);
+  if (!authority.valid) return authority;
+  return { valid: true };
+}
 
 export class EvidenceRecordService {
+  private readonly firestore?: EvidenceRecordFirestoreLike;
+
+  constructor(options: EvidenceRecordServiceOptions = {}) {
+    this.firestore = options.firestore;
+  }
+
   /**
    * Future creation contract:
    * - use Firestore create() semantics only
@@ -14,8 +344,64 @@ export class EvidenceRecordService {
    * - emit metadata-only evidence records with safe identifiers
    * - preserve source records and audit trails without mutation
    */
-  async createEvidenceRecord(_input: CreateEvidenceRecordInput): Promise<EvidenceRecord> {
-    throw new Error("evidence_record_creation_deferred_to_phase_4a_followup");
+  async createEvidenceRecord(input: CreateEvidenceRecordInput): Promise<EvidenceRecord> {
+    const validation = validateEvidenceRecordInput(input);
+    if (!validation.valid) throw new Error(validation.reason || "evidence_record_validation_failed");
+
+    const createdAt = toUtcIso(input.createdAt || input.provenanceMetadata.createdAt);
+    const identifierMetadata: EvidenceIdentifierMetadata = {
+      evidenceClass: input.evidenceClass,
+      landlordRef: safeEvidenceScopeReference("landlord", input.landlordId),
+      resourceType: input.resourceType,
+      schemaVersion: EVIDENCE_RECORD_SCHEMA_VERSION,
+      sourceCollection: input.provenanceMetadata.source.sourceCollection,
+      sourceReferenceKey: input.provenanceMetadata.source.sourceReferenceKey,
+    };
+    const evidenceId = generateEvidenceId(input.evidenceType, input.resourceId, identifierMetadata);
+    const safeReference: EvidenceReference = {
+      evidenceId,
+      evidenceClass: input.evidenceClass,
+      resourceType: input.resourceType,
+      safeReferenceKey: input.provenanceMetadata.source.sourceReferenceKey,
+      label: safeLabel(input.label, `${input.evidenceClass} record`),
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    };
+    const record: EvidenceRecord = {
+      evidenceId,
+      evidenceClass: input.evidenceClass,
+      evidenceType: input.evidenceType,
+      schemaVersion: EVIDENCE_RECORD_SCHEMA_VERSION,
+      landlordId: input.landlordId,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+      safeReference,
+      provenanceMetadata: input.provenanceMetadata,
+      sensitivityMetadata: input.sensitivityMetadata,
+      retentionMetadata: input.retentionMetadata || defaultRetentionMetadata(),
+      status: "active",
+      createdAt,
+      supersedesEvidenceId: input.supersedesEvidenceId || null,
+      supersededByEvidenceId: null,
+      immutable: true,
+      appendOnly: true,
+      metadataOnly: true,
+      rawIdsIncluded: false,
+      redactionSummary:
+        "Evidence record is metadata-only. Raw actor, tenant, landlord, resource, storage, provider, credential, payment-account, and payload values are excluded from external-facing fields.",
+    };
+
+    if (!EVIDENCE_RECORD_STATUSES.includes(record.status)) throw new Error("evidence_record_status_invalid");
+    const ref = evidenceDb(this.firestore).collection<EvidenceRecord>(EVIDENCE_RECORD_COLLECTION).doc(record.evidenceId);
+    if (ref.create) {
+      await ref.create(record);
+      return record;
+    }
+    const existing = ref.get ? await ref.get() : null;
+    if (existing?.exists) throw new Error("evidence_record_already_exists");
+    if (!ref.set) throw new Error("evidence_record_storage_unavailable");
+    await ref.set(record, { merge: false });
+    return record;
   }
 
   /**

--- a/rentchain-api/src/types/evidence-record-types.ts
+++ b/rentchain-api/src/types/evidence-record-types.ts
@@ -139,12 +139,23 @@ export type EvidenceRecord = {
   redactionSummary: string;
 };
 
+export type EvidenceCreationAuthorityContext = {
+  actorRole: EvidenceActorRole;
+  actorId?: string | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  supportAllowed?: boolean;
+  purpose?: string | null;
+};
+
 export type CreateEvidenceRecordInput = {
   evidenceClass: EvidenceClass;
   evidenceType: string;
   landlordId: string;
   resourceType: EvidenceResourceType;
   resourceId: string;
+  label?: string;
+  creationAuthority?: EvidenceCreationAuthorityContext;
   provenanceMetadata: EvidenceProvenanceMetadata;
   sensitivityMetadata: EvidenceSensitivityMetadata;
   retentionMetadata?: EvidenceRetentionMetadata;


### PR DESCRIPTION
## Summary
- implement evidence record creation with provenance, sensitivity, safe-reference, and authority validation
- add deterministic safe source reference helpers and server-side authority context typing
- document emission patterns for all six evidence classes
- add focused service coverage for all evidence classes, authority boundaries, external-safe fields, duplicate writes, and supersession

## Validation
- npm --prefix rentchain-api run test:single -- src/__tests__/evidenceRecordService.test.ts src/__tests__/evidenceIdentifier.test.ts
- targeted TypeScript compile for evidence record types, service, identifier utility, fixtures, and tests
- npm --prefix rentchain-api run build
- git diff --check
- changed-file unsafe-marker scan

## Known Limitations
- no routes, retrieval, evidence pack derivation, export, signing, attestation, sharing, or retention workflows in this mission
- source-service emission integrations are documented but not wired into runtime flows
- full backend suite still has unrelated pre-existing failures outside this mission