### PR TITLE
feat: establish institutional export framework

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,59 +1,69 @@
-PR: #1094
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1094
-Branch: feat/evidence-retention-policy-engine-v1
-Mission: Phase 4A Mission 3 - Evidence Retention Policy Engine Implementation
+PR: #1095
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1095
+Branch: feat/institutional-export-framework-v1
+Mission: Phase 4 Mission 4 - Institutional Export Framework
 
 ## Summary
-Implemented the evidence retention policy engine as a service-layer governance foundation for evidence lifecycle evaluation.
+Established the institutional export framework schema, validation, authorization, projection, and governance layer for future evidence export workflows.
 
-The engine defines immutable code-versioned retention policies, deterministic retention evaluation, lifecycle transition events, eligibility helpers, and audience-specific projection helpers without adding routes, workers, Firestore rules, deployment configuration, or production data mutation.
+The implementation is schema and pure service only. It does not add routes, persistence, evidence package assembly, export delivery, signing, external integrations, background jobs, Firestore rules, deployment changes, or production data mutation.
 
 ## Files Changed
-- docs/architecture/evidence-retention-policy-engine-v1.md
-- docs/governance/evidence-record-governance-v1.md
-- rentchain-api/src/types/evidence-record-types.ts
-- rentchain-api/src/services/evidence-record-service.ts
-- rentchain-api/src/services/evidence-retention-policy-registry.ts
-- rentchain-api/src/__tests__/evidenceRetentionPolicy.test.ts
-- rentchain-api/src/__tests__/fixtures/evidence-record-fixtures.ts
+- docs/architecture/export-framework-v1.md
+- docs/governance/export-governance-v1.md
+- rentchain-api/src/types/export-recipient-types.ts
+- rentchain-api/src/types/export-profile-types.ts
+- rentchain-api/src/types/export-request-types.ts
+- rentchain-api/src/types/export-package-types.ts
+- rentchain-api/src/types/export-authorization-types.ts
+- rentchain-api/src/types/export-audit-types.ts
+- rentchain-api/src/types/export-projections.ts
+- rentchain-api/src/services/export-service.ts
+- rentchain-api/src/__tests__/export-types.test.ts
+- rentchain-api/src/__tests__/export-projections.test.ts
+- rentchain-api/src/__tests__/export-authorization.test.ts
 
 ## Implementation Details
-- Added retention policy types, evaluation context/result types, lifecycle transition event types, and audience-specific retention metadata projection types.
-- Expanded evidence retention metadata with applied policy rule, evaluation timestamp, archival/deletion eligibility timestamps, legal hold status, and lifecycle events.
-- Added immutable code-based retention policy registry tagged with `evidence_retention_policy_v1`.
-- Defined default retention schedules for ApplicationEvidence, ScreeningEvidence, DecisionEvidence, PaymentEvidence, MaintenanceEvidence, and AuditEvidence.
-- Implemented retention schedule resolution with fail-closed policy version validation.
-- Implemented retention policy evaluation with legal hold blocking, landlord override support, eligibility calculations, evaluator validation, and metadata-only output.
-- Implemented lifecycle transition event creation and append-copy record lifecycle updates without mutating the original record object.
-- Implemented archival and deletion eligibility helpers.
-- Implemented tenant, landlord, admin, and audit retention metadata projection helpers using allowlisted outputs.
-- Updated evidence governance documentation with retention enforcement rules and deferred worker/legal-hold boundaries.
+- Added governed export recipient and purpose enumerations with explicit recipient-purpose mapping.
+- Added export profile, request, package, authorization, audit, and projection type contracts.
+- Implemented deterministic export profile, request, and package ID generation using hash-based `_v1_` identifiers.
+- Implemented pure validation helpers for export profiles, requests, and package skeletons.
+- Implemented pure entity constructors for export profiles, export requests, and export package skeletons with no Firestore persistence.
+- Implemented authorization validation for actor context, landlord scope, recipient-purpose mapping, request scope, and redaction override tightening.
+- Implemented allowlist landlord/admin projections for profiles, requests, and packages.
+- Added focused tests for ID determinism, schema validation, authorization rules, redaction tightening, projection safety, and purity.
+- Added export architecture and governance documentation with entity relationships, scope boundaries, recipient mapping, data minimization, audit accountability, and deferred work.
 
 ## Scope Boundaries
 - No routes added.
-- No auth core changes.
-- No Firestore rules changes.
-- No deployment, CI, or infrastructure changes.
-- No autonomous archival or deletion workers.
-- No legal hold management system.
-- No retention dashboard or operator interface.
-- No evidence retrieval by retention status.
-- No production evidence record mutation.
+- No existing route behavior changed.
+- No Firestore reads, writes, rules, indexes, or migrations added.
+- No export persistence added.
+- No package assembly logic added.
+- No delivery mechanics added.
+- No signing, attestation, webhook, external API, or recipient portal added.
+- No frontend changes.
+- No protected areas touched.
 
 ## Validation
-- Passed: `npm --prefix rentchain-api run test:single -- src/__tests__/evidenceRetentionPolicy.test.ts src/__tests__/evidenceRecordService.test.ts`
-- Passed: `npm --prefix rentchain-api run test:single -- src/__tests__/evidenceIdentifier.test.ts`
+- Passed: `npm --prefix rentchain-api run test:single -- src/__tests__/export-types.test.ts src/__tests__/export-projections.test.ts src/__tests__/export-authorization.test.ts`
+- Passed: `npm --prefix rentchain-api test -- export`
 - Passed: `npm --prefix rentchain-api run build`
 - Passed: `git diff --check`
-- Checked: changed-file unsafe-marker scan found governance text, service rejection patterns, and test sentinel values only.
+- Checked: changed-file unsafe-marker scan found governance prohibition text, validation regexes, and test sentinel values only.
+
+## Manual QA
+- Manual preview QA was not required because this mission adds backend schema, pure service helpers, docs, and tests only.
+- Schema, authorization, projection, service helper, documentation, and type-safety checks are covered by focused tests and backend build.
 
 ## Known Limitations
-- Archival workers remain deferred.
-- Deletion workers remain deferred.
-- Legal hold creation, release, and enforcement workflows remain deferred.
-- Retention status query routes remain deferred.
-- Evidence pack derivation using retention state remains deferred.
-- Firestore rule and index deployment remain deferred.
+- No API routes or route authorization are implemented in this mission.
+- No export persistence is implemented in this mission.
+- Evidence package assembly is deferred.
+- Export delivery and delivery audit trails are deferred.
+- Signing, attestation, and external sharing are deferred.
+- Recipient consent and legal signature workflows are deferred.
+- UI/dashboard workflows are deferred.
 
 ## Recommended Next Mission
-Phase 4A Mission 4 - source-service lifecycle integration or evidence pack derivation planning.
+Phase 4 Mission 5 - Evidence Package Builder using the institutional export profile and request framework.

--- a/docs/architecture/export-framework-v1.md
+++ b/docs/architecture/export-framework-v1.md
@@ -1,0 +1,90 @@
+# Export Framework v1
+
+## Purpose
+
+Export Framework v1 establishes the schema, validation, authorization, and projection foundation for future institutional evidence exports.
+
+Exports are explicit, scoped, authorized, metadata-first, and auditable. This framework does not assemble evidence, persist export records, add routes, deliver packages, sign packages, notify recipients, or integrate with external systems.
+
+## Entity Relationships
+
+The framework models four governed layers:
+
+1. `ExportProfile`: approved recipient, purpose, evidence class scope, minimization level, and audit reference.
+2. `ExportRequest`: explicit export intent, scope parameters, redaction override, status, and authorization status.
+3. `ExportPackage`: package skeleton and manifest shape for future assembly.
+4. `ExportAuditEvent`: event schema for future append-only audit trails.
+
+The relationship is:
+
+```text
+ExportProfile -> ExportRequest -> ExportPackage -> ExportAuditEvent
+```
+
+Each entity has deterministic `_v1_` identifiers based on hashes. The identifiers do not expose raw Firestore IDs, landlord IDs, tenant IDs, unit IDs, lease IDs, storage paths, tokens, credentials, provider payloads, or evidence payloads.
+
+## Authorization Model
+
+A valid export requires:
+
+- server-resolved actor context
+- landlord scope matching the export profile
+- enumerated recipient type
+- enumerated export purpose
+- recipient-purpose mapping approval
+- non-empty approved evidence class scope
+- valid date range when scope dates are supplied
+- redaction override that tightens, not loosens, the profile minimization level
+
+Authorization functions are pure. They return decisions and do not mutate Firestore, evidence records, source records, or audit trails.
+
+## Recipient and Purpose Mapping
+
+Supported recipient types:
+
+- `ThirdPartyPropertyManager`
+- `InsuranceAdjuster`
+- `LegalRepresentative`
+- `Regulator`
+- `Arbitrator`
+- `SelfArchive`
+- reserved future institution type
+
+Supported purposes:
+
+- `LitigationDiscovery`
+- `InsuranceClaim`
+- `RegulatoryCompliance`
+- `AuditReview`
+- `ArbitrationEvidence`
+- `SelfReview`
+- reserved future purpose
+
+Purpose-to-recipient mappings are explicit. Freeform recipient purpose strings are not permitted.
+
+## Projection Rules
+
+Projection helpers are allowlist-based.
+
+Landlord projections include operational export state and scope metadata, but omit internal actor details, system decision details, checksum values, and audit internals.
+
+Admin projections include full metadata-safe entities for governed review. Raw IDs and payloads remain excluded by schema and validation.
+
+## Relationship To Evidence Foundations
+
+The framework references evidence classes and retention policy versioning from the evidence record foundation. It does not implement evidence record retrieval, evidence package assembly, or retention enforcement.
+
+Future package assembly must use landlord-scoped evidence queries and evidence projection allowlists. Export profiles and requests do not grant broader evidence visibility than the landlord already has.
+
+## Deferred Work
+
+- route handlers
+- Firestore persistence
+- evidence package assembly
+- export delivery
+- audit trail persistence
+- signing and attestation
+- recipient consent workflows
+- external webhooks or direct integrations
+- tenant-facing export UI
+- scheduled exports, queues, workers, or Pub/Sub

--- a/docs/governance/export-governance-v1.md
+++ b/docs/governance/export-governance-v1.md
@@ -1,0 +1,116 @@
+# Export Governance v1
+
+## Governance Philosophy
+
+Institutional exports are controlled evidence workflows. They must be landlord-scoped, recipient-validated, purpose-bound, minimized, and audit-ready before any future assembly or delivery occurs.
+
+This policy governs the framework layer only. It does not authorize live export delivery, evidence assembly, external submission, signing, recipient portals, or background workers.
+
+## Authorization Boundaries
+
+Exports may be requested only by server-resolved landlord or admin/support authority.
+
+Required boundaries:
+
+- landlord roles must have matching landlord scope
+- admin/support roles require explicit purpose
+- system roles may prepare framework entities only for governed service operations
+- tenant-initiated institutional exports are out of scope
+- cross-landlord and cross-tenant export scope is prohibited
+
+The authorization layer must fail closed when actor, purpose, recipient, scope, or policy information is missing or ambiguous.
+
+## Recipient Types And Purposes
+
+Recipient types are enumerated:
+
+- `ThirdPartyPropertyManager`
+- `InsuranceAdjuster`
+- `LegalRepresentative`
+- `Regulator`
+- `Arbitrator`
+- `SelfArchive`
+
+Purposes are enumerated:
+
+- `LitigationDiscovery`
+- `InsuranceClaim`
+- `RegulatoryCompliance`
+- `AuditReview`
+- `ArbitrationEvidence`
+- `SelfReview`
+
+Purpose mappings:
+
+| Purpose | Allowed recipient types |
+| --- | --- |
+| `LitigationDiscovery` | `LegalRepresentative` |
+| `InsuranceClaim` | `InsuranceAdjuster` |
+| `RegulatoryCompliance` | `Regulator` |
+| `AuditReview` | `ThirdPartyPropertyManager`, `Regulator` |
+| `ArbitrationEvidence` | `Arbitrator`, `LegalRepresentative` |
+| `SelfReview` | `SelfArchive` |
+
+Freeform recipient or purpose values are not permitted.
+
+## Evidence Scope Rules
+
+Export profiles must define approved evidence classes. Absence of approved evidence classes means no evidence is exportable.
+
+Export requests may narrow scope by:
+
+- date range
+- evidence class filters
+- unit safe references
+- redaction policy override
+
+Export requests may not widen beyond the profile's approved evidence classes or loosen the profile's data minimization level.
+
+## Redaction And Data Minimization
+
+Data minimization levels are:
+
+- `Full`
+- `Redacted`
+- `RedactedSensitive`
+
+Overrides may only tighten the level. For example, a `Redacted` profile may be tightened to `RedactedSensitive`, but it may not be loosened to `Full`.
+
+Export framework entities must not include:
+
+- raw Firestore IDs
+- raw tenant, landlord, lease, or unit IDs
+- storage paths
+- tokens, credentials, or secrets
+- raw provider payloads
+- raw screening reports
+- identity documents
+- payment account values
+- unrestricted message bodies
+
+## Audit Accountability
+
+Every profile, request, package, and future lifecycle transition must carry an audit trail reference.
+
+The framework defines export audit event schema for future append-only persistence. This mission does not emit or persist audit events.
+
+## Tenant Privacy
+
+Institutional landlord exports are landlord-scoped operational workflows. Tenants are not granted visibility into landlord export profiles, recipient details, legal hold status, system authorization decisions, or export audit internals by this framework.
+
+Tenant-facing export or self-archive behavior requires a separate mission with explicit consent, projection, and privacy rules.
+
+## Deferred Enforcement
+
+Future missions must implement:
+
+- route authorization
+- persistence
+- evidence package assembly
+- export delivery
+- audit trail storage
+- signing and attestation
+- recipient access controls
+- external integrations
+
+No future mission may bypass the recipient-purpose mapping, landlord scope validation, redaction tightening rule, or evidence projection allowlists.

--- a/rentchain-api/src/__tests__/export-authorization.test.ts
+++ b/rentchain-api/src/__tests__/export-authorization.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createExportProfileEntity,
+  createExportRequestEntity,
+} from "../services/export-service";
+import {
+  validateExportAuthorizationContext,
+  validateExportProfileAuthorization,
+  validateExportRequestAuthorization,
+  validateRedactionPolicyOverride,
+  type ExportAuthorizationContext,
+} from "../types/export-authorization-types";
+
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const otherLandlordRef = "landlord:bbbbbbbbbbbbbbbbbbbb";
+const actorRef = "actor:cccccccccccccccccccc";
+const timestamp = "2026-06-04T12:00:00.000Z";
+
+function context(overrides: Partial<ExportAuthorizationContext> = {}): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp,
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+function profile() {
+  return createExportProfileEntity(
+    {
+      landlordId: landlordRef,
+      recipientType: "InsuranceAdjuster",
+      recipientName: "Acme Insurance Adjusters LLC",
+      recipientReference: "acme-insurance-adjusters",
+      purpose: "InsuranceClaim",
+      description: "Insurance claim review.",
+      approvedEvidenceClasses: ["PaymentEvidence", "MaintenanceEvidence"],
+      dataMinimizationLevel: "Redacted",
+      createdReason: "Insurance claim package review.",
+    },
+    context()
+  );
+}
+
+describe("export authorization validation", () => {
+  it("validates authorization context", () => {
+    expect(validateExportAuthorizationContext(context())).toEqual({ ok: true, errors: [] });
+    expect(
+      validateExportAuthorizationContext(context({
+        requestingActorId: "raw-actor-id",
+        requestingActorScope: "",
+        timestamp: "not-a-date",
+      })).errors
+    ).toEqual([
+      "requesting_actor_id_must_be_safe_reference",
+      "requesting_actor_scope_required",
+      "timestamp_must_be_utc_iso",
+    ]);
+  });
+
+  it("approves valid profile and request authorization", () => {
+    const exportProfile = profile();
+    const exportRequest = createExportRequestEntity(
+      {
+        profile: exportProfile,
+        requestedAt: "2026-06-04T12:05:00.000Z",
+        requestedBy: actorRef,
+        requestReason: "Claim review.",
+        scopeParameters: {
+          evidenceClassFilters: ["PaymentEvidence"],
+        },
+      },
+      context()
+    );
+
+    expect(validateExportProfileAuthorization(exportProfile, context()).decision).toBe("Approved");
+    expect(validateExportRequestAuthorization(exportRequest, exportProfile, context()).decision).toBe("Approved");
+  });
+
+  it("denies invalid recipient-purpose mapping and cross-landlord scope", () => {
+    const exportProfile = {
+      ...profile(),
+      recipientType: "Regulator" as const,
+    };
+
+    expect(validateExportProfileAuthorization(exportProfile, context()).decision).toBe("DeniedInvalidPurpose");
+    expect(validateExportProfileAuthorization(profile(), context({ requestingActorScope: otherLandlordRef })).decision).toBe("DeniedOutOfScope");
+  });
+
+  it("denies request evidence classes outside profile scope", () => {
+    const exportProfile = profile();
+    const exportRequest = createExportRequestEntity(
+      {
+        profile: exportProfile,
+        requestedAt: "2026-06-04T12:05:00.000Z",
+        requestedBy: actorRef,
+        requestReason: "Claim review.",
+        scopeParameters: {
+          evidenceClassFilters: ["ScreeningEvidence"],
+        },
+      },
+      context()
+    );
+
+    expect(validateExportRequestAuthorization(exportRequest, exportProfile, context())).toMatchObject({
+      isApproved: false,
+      decision: "DeniedOutOfScope",
+      denialReason: "requested_evidence_class_not_approved",
+    });
+  });
+
+  it("requires redaction overrides to tighten profile policy", () => {
+    const exportProfile = profile();
+
+    expect(validateRedactionPolicyOverride({ dataMinimizationLevel: "RedactedSensitive", reason: "tighten" }, exportProfile).ok).toBe(true);
+    expect(validateRedactionPolicyOverride({ dataMinimizationLevel: "Full", reason: "loosen" }, exportProfile)).toEqual({
+      ok: false,
+      errors: ["redaction_override_cannot_loosen_profile"],
+    });
+  });
+});

--- a/rentchain-api/src/__tests__/export-projections.test.ts
+++ b/rentchain-api/src/__tests__/export-projections.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createExportPackageEntity,
+  createExportProfileEntity,
+  createExportRequestEntity,
+} from "../services/export-service";
+import {
+  projectExportPackageForAdmin,
+  projectExportPackageForLandlord,
+  projectExportProfileForAdmin,
+  projectExportProfileForLandlord,
+  projectExportRequestForAdmin,
+  projectExportRequestForLandlord,
+} from "../types/export-projections";
+import type { ExportAuthorizationContext } from "../types/export-authorization-types";
+
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const unitRef = "unit:cccccccccccccccccccc";
+
+function context(): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp: "2026-06-04T12:00:00.000Z",
+    rawIdsIncluded: false,
+  };
+}
+
+function entities() {
+  const profile = createExportProfileEntity(
+    {
+      landlordId: landlordRef,
+      recipientType: "InsuranceAdjuster",
+      recipientName: "Acme Insurance Adjusters LLC",
+      recipientReference: "acme-insurance-adjusters",
+      purpose: "InsuranceClaim",
+      description: "Insurance claim review.",
+      approvedEvidenceClasses: ["PaymentEvidence", "MaintenanceEvidence"],
+      excludedUnitIds: [unitRef],
+      dataMinimizationLevel: "Redacted",
+      createdReason: "Insurance claim package review.",
+    },
+    context()
+  );
+  const request = createExportRequestEntity(
+    {
+      profile,
+      requestedAt: "2026-06-04T12:05:00.000Z",
+      requestedBy: actorRef,
+      requestReason: "Claim settlement review.",
+      scopeParameters: {
+        dateRangeStart: "2026-01-01T00:00:00.000Z",
+        dateRangeEnd: "2026-06-01T00:00:00.000Z",
+        evidenceClassFilters: ["PaymentEvidence"],
+        unitScopeOverride: [unitRef],
+      },
+    },
+    context()
+  );
+  const pkg = createExportPackageEntity({
+    request,
+    recipientType: profile.recipientType,
+    purpose: profile.purpose,
+    assembledAt: "2026-06-04T12:10:00.000Z",
+    assembledBy: "service:dddddddddddddddddddd",
+    evidenceClasses: ["PaymentEvidence"],
+    unitsScopeApplied: [unitRef],
+    redactionPolicyApplied: "Redacted",
+    includedEvidenceCount: 1,
+  });
+  return { profile, request, pkg };
+}
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+describe("export projection rules", () => {
+  it("projects landlord-safe and admin-safe profile views", () => {
+    const { profile } = entities();
+    const landlord = projectExportProfileForLandlord(profile, landlordRef);
+    const admin = projectExportProfileForAdmin(profile);
+
+    expect(landlord).not.toHaveProperty("createdBy");
+    expect(landlord).not.toHaveProperty("auditTrailReference");
+    expect(admin).toHaveProperty("auditTrailReference");
+    expect(serialized(landlord)).not.toMatch(/raw-|secret|token|credential|provider payload/i);
+  });
+
+  it("projects landlord-safe and admin-safe request views", () => {
+    const { request } = entities();
+    const landlord = projectExportRequestForLandlord(request, landlordRef);
+    const admin = projectExportRequestForAdmin(request);
+
+    expect(landlord.authorizationStatus).not.toHaveProperty("authorizedBy");
+    expect(landlord).not.toHaveProperty("auditTrailReference");
+    expect(admin).toHaveProperty("auditTrailReference");
+    expect(serialized(landlord)).not.toMatch(/secret|token|credential|provider payload/i);
+  });
+
+  it("projects landlord-safe package views without checksum values or internal audit references", () => {
+    const { pkg } = entities();
+    const landlord = projectExportPackageForLandlord(pkg, landlordRef);
+    const admin = projectExportPackageForAdmin(pkg);
+
+    expect(landlord.packageMetadata).not.toHaveProperty("checksumValue");
+    expect(landlord).not.toHaveProperty("auditTrailReference");
+    expect(admin).toHaveProperty("auditTrailReference");
+    expect(serialized(landlord)).not.toMatch(/secret|token|credential|provider payload/i);
+  });
+
+  it("rejects cross-landlord projection attempts", () => {
+    const { profile, request, pkg } = entities();
+
+    expect(() => projectExportProfileForLandlord(profile, "landlord:ffffffffffffffffffff")).toThrow("export_projection_landlord_scope_mismatch");
+    expect(() => projectExportRequestForLandlord(request, "landlord:ffffffffffffffffffff")).toThrow("export_projection_landlord_scope_mismatch");
+    expect(() => projectExportPackageForLandlord(pkg, "landlord:ffffffffffffffffffff")).toThrow("export_projection_landlord_scope_mismatch");
+  });
+
+  it("keeps projections deterministic", () => {
+    const { profile } = entities();
+
+    expect(projectExportProfileForLandlord(profile, landlordRef)).toEqual(projectExportProfileForLandlord(profile, landlordRef));
+  });
+});

--- a/rentchain-api/src/__tests__/export-types.test.ts
+++ b/rentchain-api/src/__tests__/export-types.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createExportPackageEntity,
+  createExportProfileEntity,
+  createExportRequestEntity,
+  generateExportPackageId,
+  generateExportProfileId,
+  generateExportRequestId,
+  validateExportPackage,
+  validateExportProfile,
+  validateExportRequest,
+} from "../services/export-service";
+import type { ExportAuthorizationContext } from "../types/export-authorization-types";
+import type { ExportProfile } from "../types/export-profile-types";
+import type { ExportRequest } from "../types/export-request-types";
+
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const unitRef = "unit:cccccccccccccccccccc";
+const timestamp = "2026-06-04T12:00:00.000Z";
+
+function context(overrides: Partial<ExportAuthorizationContext> = {}): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp,
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+function profile(): ExportProfile {
+  return createExportProfileEntity(
+    {
+      landlordId: landlordRef,
+      recipientType: "InsuranceAdjuster",
+      recipientName: "Acme Insurance Adjusters LLC",
+      recipientReference: "acme-insurance-adjusters",
+      purpose: "InsuranceClaim",
+      description: "Insurance claim review for property flooding.",
+      approvedEvidenceClasses: ["ApplicationEvidence", "PaymentEvidence", "MaintenanceEvidence"],
+      excludedUnitIds: [unitRef],
+      dataMinimizationLevel: "Redacted",
+      createdReason: "Insurance claim package review.",
+    },
+    context()
+  );
+}
+
+function request(profileEntity = profile()): ExportRequest {
+  return createExportRequestEntity(
+    {
+      profile: profileEntity,
+      requestedAt: "2026-06-04T12:05:00.000Z",
+      requestedBy: actorRef,
+      requestReason: "Claim settlement review.",
+      scopeParameters: {
+        dateRangeStart: "2026-01-01T00:00:00.000Z",
+        dateRangeEnd: "2026-06-01T00:00:00.000Z",
+        evidenceClassFilters: ["PaymentEvidence", "MaintenanceEvidence"],
+        unitScopeOverride: [unitRef],
+      },
+      redactionPolicyOverride: {
+        dataMinimizationLevel: "RedactedSensitive",
+        reason: "Tighten export for external adjuster.",
+      },
+    },
+    context()
+  );
+}
+
+describe("export framework entity types and service helpers", () => {
+  it("generates deterministic export identifiers without raw input values", () => {
+    const profileId = generateExportProfileId(landlordRef, "recipient:raw-reference", "InsuranceClaim");
+    const repeatedProfileId = generateExportProfileId(landlordRef, "recipient:raw-reference", "InsuranceClaim");
+    const requestId = generateExportRequestId(profileId, timestamp, landlordRef);
+    const repeatedRequestId = generateExportRequestId(profileId, timestamp, landlordRef);
+    const packageId = generateExportPackageId(requestId, timestamp);
+
+    expect(profileId).toBe(repeatedProfileId);
+    expect(requestId).toBe(repeatedRequestId);
+    expect(profileId).toMatch(/^exp_profile_v1_/);
+    expect(requestId).toMatch(/^exp_req_v1_/);
+    expect(packageId).toMatch(/^exp_pkg_v1_/);
+    expect(`${profileId} ${requestId} ${packageId}`).not.toContain("raw-reference");
+    expect(`${profileId} ${requestId} ${packageId}`).not.toContain(landlordRef);
+  });
+
+  it("creates and validates export profile, request, and package entities", () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const exportPackage = createExportPackageEntity({
+      request: exportRequest,
+      recipientType: exportProfile.recipientType,
+      purpose: exportProfile.purpose,
+      assembledAt: "2026-06-04T12:10:00.000Z",
+      assembledBy: "service:dddddddddddddddddddd",
+      evidenceClasses: ["PaymentEvidence", "MaintenanceEvidence"],
+      unitsScopeApplied: [unitRef],
+      redactionPolicyApplied: "RedactedSensitive",
+      includedEvidenceCount: 2,
+    });
+
+    expect(validateExportProfile(exportProfile)).toEqual({ ok: true, errors: [] });
+    expect(validateExportRequest(exportRequest, exportProfile)).toEqual({ ok: true, errors: [] });
+    expect(validateExportPackage(exportPackage)).toEqual({ ok: true, errors: [] });
+    expect(exportPackage.packageMetadata.checksumAlgorithm).toBe("sha256");
+  });
+
+  it("fails validation for invalid profile purpose mapping and unsafe profile content", () => {
+    const exportProfile = profile();
+    const invalid: ExportProfile = {
+      ...exportProfile,
+      recipientType: "Regulator",
+      description: "contains secret token",
+    };
+    const result = validateExportProfile(invalid);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("purpose_not_allowed_for_recipient");
+    expect(result.errors).toContain("description_invalid");
+  });
+
+  it("fails validation for invalid request scope and loose redaction override", () => {
+    const exportProfile = profile();
+    const exportRequest: ExportRequest = {
+      ...request(exportProfile),
+      scopeParameters: {
+        dateRangeStart: "2026-06-01T00:00:00.000Z",
+        dateRangeEnd: "2026-01-01T00:00:00.000Z",
+        evidenceClassFilters: ["ScreeningEvidence"],
+      },
+      redactionPolicyOverride: {
+        dataMinimizationLevel: "Full",
+        reason: "loosen policy",
+      },
+    };
+    const result = validateExportRequest(exportRequest, exportProfile);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("scope_date_range_invalid");
+    expect(result.errors).toContain("redaction_override_cannot_loosen_profile");
+  });
+
+  it("keeps validation pure and deterministic", () => {
+    const exportProfile = profile();
+    const before = JSON.stringify(exportProfile);
+
+    expect(validateExportProfile(exportProfile)).toEqual(validateExportProfile(exportProfile));
+    expect(JSON.stringify(exportProfile)).toBe(before);
+  });
+});

--- a/rentchain-api/src/services/export-service.ts
+++ b/rentchain-api/src/services/export-service.ts
@@ -1,0 +1,295 @@
+import crypto from "crypto";
+import type { EvidenceClass } from "../types/evidence-record-types";
+import { EVIDENCE_CLASSES } from "../types/evidence-record-types";
+import type { ExportAuthorizationContext, ExportValidationResult } from "../types/export-authorization-types";
+import {
+  validateExportAuthorizationContext,
+  validateRedactionPolicyOverride,
+} from "../types/export-authorization-types";
+import type { ExportPackage } from "../types/export-package-types";
+import type {
+  ExportDataMinimizationLevel,
+  ExportProfile,
+  ExportProfileMetadata,
+} from "../types/export-profile-types";
+import { EXPORT_DATA_MINIMIZATION_LEVELS } from "../types/export-profile-types";
+import type { ExportPurpose, ExportRecipientType } from "../types/export-recipient-types";
+import {
+  isExportPurpose,
+  isExportRecipientType,
+  isPurposeAllowedForRecipient,
+} from "../types/export-recipient-types";
+import type {
+  ExportRedactionPolicyOverride,
+  ExportRequest,
+  ExportScopeParameters,
+} from "../types/export-request-types";
+import { EVIDENCE_RETENTION_POLICY_VERSION } from "./evidence-retention-policy-registry";
+
+const RESTRICTED_EXPORT_CONTENT =
+  /token|secret|credential|password|bearer|provider payload|raw report|request body|response body|gs:\/\/|storage\.googleapis\.com|bank account|card number/i;
+
+function stableHash(parts: readonly unknown[]): string {
+  return crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 20);
+}
+
+function normalizeSafeLabel(value: unknown, max = 240): string {
+  return String(value ?? "").replace(/[<>]/g, "").replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+function safeReference(prefix: string, value: unknown): string {
+  return `${prefix}:${stableHash([prefix, value])}`;
+}
+
+function validation(errors: string[]): ExportValidationResult {
+  return { ok: errors.length === 0, errors };
+}
+
+function isUtcIso(value: unknown): boolean {
+  return typeof value === "string" && value.endsWith("Z") && Number.isFinite(Date.parse(value));
+}
+
+function hasRestrictedContent(value: unknown): boolean {
+  return RESTRICTED_EXPORT_CONTENT.test(JSON.stringify(value ?? {}));
+}
+
+function isSafeRef(value: unknown): boolean {
+  const text = String(value ?? "").trim();
+  return /^[a-z][a-z0-9_.:-]*:[a-f0-9]{12,64}$/i.test(text) || /^exp_(profile|req|pkg)_v1_[a-f0-9_]+$/i.test(text);
+}
+
+function evidenceClassesValid(values: EvidenceClass[]): boolean {
+  return values.length > 0 && values.every((item) => EVIDENCE_CLASSES.includes(item));
+}
+
+function minimizationValid(value: unknown): value is ExportDataMinimizationLevel {
+  return EXPORT_DATA_MINIMIZATION_LEVELS.includes(value as ExportDataMinimizationLevel);
+}
+
+export function generateExportProfileId(
+  landlordId: string,
+  recipientReference: string,
+  purpose: ExportPurpose
+): string {
+  return `exp_profile_v1_${stableHash([landlordId])}_${stableHash([recipientReference])}_${stableHash([purpose])}`;
+}
+
+export function generateExportRequestId(profileId: string, timestamp: string, landlordId: string): string {
+  return `exp_req_v1_${stableHash([profileId])}_${stableHash([timestamp])}_${stableHash([landlordId])}`;
+}
+
+export function generateExportPackageId(requestId: string, assemblyTimestamp: string): string {
+  return `exp_pkg_v1_${stableHash([requestId])}_${stableHash([assemblyTimestamp])}`;
+}
+
+export type CreateExportProfileInput = {
+  landlordId: string;
+  recipientType: ExportRecipientType;
+  recipientName: string;
+  recipientReference: string;
+  purpose: ExportPurpose;
+  description: string;
+  approvedEvidenceClasses: EvidenceClass[];
+  excludedUnitIds?: string[];
+  dataMinimizationLevel: ExportDataMinimizationLevel;
+  createdReason: string;
+  metadata?: ExportProfileMetadata;
+};
+
+export type CreateExportRequestInput = {
+  profile: ExportProfile;
+  requestedAt: string;
+  requestedBy: string;
+  requestReason: string;
+  scopeParameters: ExportScopeParameters;
+  redactionPolicyOverride?: ExportRedactionPolicyOverride | null;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export type CreateExportPackageInput = {
+  request: ExportRequest;
+  recipientType: ExportRecipientType;
+  purpose: ExportPurpose;
+  assembledAt: string;
+  assembledBy: string;
+  evidenceClasses: EvidenceClass[];
+  unitsScopeApplied?: string[];
+  redactionPolicyApplied: ExportDataMinimizationLevel;
+  includedEvidenceCount: number;
+  totalPackageSize?: number;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export function validateExportProfile(profile: ExportProfile): ExportValidationResult {
+  const errors: string[] = [];
+  if (!/^exp_profile_v1_[a-f0-9_]+$/.test(profile.exportProfileId)) errors.push("export_profile_id_invalid");
+  if (!isSafeRef(profile.landlordId)) errors.push("landlord_id_must_be_safe_reference");
+  if (!isExportRecipientType(profile.recipientType)) errors.push("recipient_type_invalid");
+  if (!profile.recipientName || hasRestrictedContent(profile.recipientName)) errors.push("recipient_name_invalid");
+  if (!isSafeRef(profile.recipientSafeReference)) errors.push("recipient_reference_invalid");
+  if (!isExportPurpose(profile.purpose)) errors.push("purpose_invalid");
+  if (isExportPurpose(profile.purpose) && isExportRecipientType(profile.recipientType) && !isPurposeAllowedForRecipient(profile.purpose, profile.recipientType)) {
+    errors.push("purpose_not_allowed_for_recipient");
+  }
+  if (!profile.description || profile.description.length > 500 || hasRestrictedContent(profile.description)) errors.push("description_invalid");
+  if (!evidenceClassesValid(profile.approvedEvidenceClasses)) errors.push("approved_evidence_classes_invalid");
+  if (profile.excludedUnitIds.some((item) => !isSafeRef(item))) errors.push("excluded_unit_ids_must_be_safe_references");
+  if (!minimizationValid(profile.dataMinimizationLevel)) errors.push("data_minimization_level_invalid");
+  if (profile.retentionPolicyVersion !== EVIDENCE_RETENTION_POLICY_VERSION) errors.push("retention_policy_version_invalid");
+  if (!isUtcIso(profile.createdAt)) errors.push("created_at_invalid");
+  if (!isSafeRef(profile.createdBy.actorRef)) errors.push("created_by_actor_ref_invalid");
+  if (!profile.createdReason || hasRestrictedContent(profile.createdReason)) errors.push("created_reason_invalid");
+  if (!isSafeRef(profile.auditTrailReference)) errors.push("audit_trail_reference_invalid");
+  if (profile.rawIdsIncluded !== false || profile.payloadIncluded !== false) errors.push("raw_or_payload_flags_invalid");
+  return validation(errors);
+}
+
+export function validateExportRequest(request: ExportRequest, profile: ExportProfile): ExportValidationResult {
+  const errors: string[] = [];
+  if (!/^exp_req_v1_[a-f0-9_]+$/.test(request.exportRequestId)) errors.push("export_request_id_invalid");
+  if (request.exportProfileId !== profile.exportProfileId) errors.push("export_profile_id_mismatch");
+  if (request.landlordId !== profile.landlordId) errors.push("landlord_id_mismatch");
+  if (!isUtcIso(request.requestedAt)) errors.push("requested_at_invalid");
+  if (!isSafeRef(request.requestedBy)) errors.push("requested_by_invalid");
+  if (!request.requestReason || hasRestrictedContent(request.requestReason)) errors.push("request_reason_invalid");
+  if (
+    request.scopeParameters.dateRangeStart &&
+    request.scopeParameters.dateRangeEnd &&
+    Date.parse(request.scopeParameters.dateRangeStart) > Date.parse(request.scopeParameters.dateRangeEnd)
+  ) {
+    errors.push("scope_date_range_invalid");
+  }
+  if (request.scopeParameters.evidenceClassFilters && !evidenceClassesValid(request.scopeParameters.evidenceClassFilters)) {
+    errors.push("scope_evidence_class_filters_invalid");
+  }
+  if (request.scopeParameters.unitScopeOverride?.some((item) => !isSafeRef(item))) errors.push("unit_scope_override_invalid");
+  const redaction = validateRedactionPolicyOverride(request.redactionPolicyOverride, profile);
+  errors.push(...redaction.errors);
+  if (!isSafeRef(request.auditTrailReference)) errors.push("audit_trail_reference_invalid");
+  if (request.rawIdsIncluded !== false || request.payloadIncluded !== false) errors.push("raw_or_payload_flags_invalid");
+  return validation(errors);
+}
+
+export function validateExportPackage(pkg: ExportPackage): ExportValidationResult {
+  const errors: string[] = [];
+  if (!/^exp_pkg_v1_[a-f0-9_]+$/.test(pkg.exportPackageId)) errors.push("export_package_id_invalid");
+  if (!/^exp_req_v1_[a-f0-9_]+$/.test(pkg.exportRequestId)) errors.push("export_request_id_invalid");
+  if (!isSafeRef(pkg.landlordId)) errors.push("landlord_id_must_be_safe_reference");
+  if (!isExportRecipientType(pkg.recipientType)) errors.push("recipient_type_invalid");
+  if (!isExportPurpose(pkg.purpose)) errors.push("purpose_invalid");
+  if (!isUtcIso(pkg.packageMetadata.assembledAt)) errors.push("assembled_at_invalid");
+  if (!isSafeRef(pkg.packageMetadata.assembledBy)) errors.push("assembled_by_invalid");
+  if (pkg.packageMetadata.includedEvidenceCount < 0) errors.push("included_evidence_count_invalid");
+  if (pkg.packageMetadata.totalPackageSize < 0) errors.push("total_package_size_invalid");
+  if (pkg.packageMetadata.checksumAlgorithm !== "sha256") errors.push("checksum_algorithm_invalid");
+  if (!evidenceClassesValid(pkg.evidenceManifest.evidenceClasses)) errors.push("manifest_evidence_classes_invalid");
+  if (pkg.evidenceManifest.unitsScopeApplied.some((item) => !isSafeRef(item))) errors.push("units_scope_invalid");
+  if (!minimizationValid(pkg.evidenceManifest.redactionPolicyApplied)) errors.push("redaction_policy_invalid");
+  if (!isSafeRef(pkg.auditTrailReference)) errors.push("audit_trail_reference_invalid");
+  if (pkg.rawIdsIncluded !== false || pkg.payloadIncluded !== false) errors.push("raw_or_payload_flags_invalid");
+  return validation(errors);
+}
+
+export function createExportProfileEntity(input: CreateExportProfileInput, context: ExportAuthorizationContext): ExportProfile {
+  const contextResult = validateExportAuthorizationContext(context);
+  if (!contextResult.ok) throw new Error(contextResult.errors[0] || "export_authorization_context_invalid");
+  const recipientName = normalizeSafeLabel(input.recipientName, 160);
+  const description = normalizeSafeLabel(input.description, 500);
+  const recipientSafeReference = safeReference("export_recipient", input.recipientReference);
+  const profile: ExportProfile = {
+    exportProfileId: generateExportProfileId(input.landlordId, recipientSafeReference, input.purpose),
+    landlordId: input.landlordId,
+    recipientType: input.recipientType,
+    recipientName,
+    recipientSafeReference,
+    purpose: input.purpose,
+    description,
+    approvedEvidenceClasses: [...input.approvedEvidenceClasses],
+    excludedUnitIds: input.excludedUnitIds || [],
+    dataMinimizationLevel: input.dataMinimizationLevel,
+    retentionPolicyVersion: EVIDENCE_RETENTION_POLICY_VERSION,
+    createdAt: context.timestamp,
+    createdBy: {
+      actorRef: context.requestingActorId,
+      actorRole: context.requestingActorRole,
+      rawIdsIncluded: false,
+    },
+    createdReason: normalizeSafeLabel(input.createdReason, 240),
+    isActive: true,
+    auditTrailReference: safeReference("export_audit", [input.landlordId, recipientSafeReference, input.purpose, context.timestamp]),
+    metadata: input.metadata || {},
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+  const result = validateExportProfile(profile);
+  if (!result.ok) throw new Error(result.errors[0] || "export_profile_invalid");
+  return profile;
+}
+
+export function createExportRequestEntity(input: CreateExportRequestInput, context: ExportAuthorizationContext): ExportRequest {
+  const contextResult = validateExportAuthorizationContext(context);
+  if (!contextResult.ok) throw new Error(contextResult.errors[0] || "export_authorization_context_invalid");
+  const request: ExportRequest = {
+    exportRequestId: generateExportRequestId(input.profile.exportProfileId, input.requestedAt, input.profile.landlordId),
+    exportProfileId: input.profile.exportProfileId,
+    landlordId: input.profile.landlordId,
+    requestedAt: input.requestedAt,
+    requestedBy: input.requestedBy,
+    requestReason: normalizeSafeLabel(input.requestReason, 240),
+    scopeParameters: input.scopeParameters,
+    redactionPolicyOverride: input.redactionPolicyOverride || null,
+    status: "Pending",
+    authorizationStatus: {
+      isAuthorized: false,
+      rawIdsIncluded: false,
+    },
+    auditTrailReference: safeReference("export_audit", [input.profile.exportProfileId, input.requestedAt, input.requestedBy]),
+    metadata: input.metadata || {},
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+  const result = validateExportRequest(request, input.profile);
+  if (!result.ok) throw new Error(result.errors[0] || "export_request_invalid");
+  return request;
+}
+
+export function createExportPackageEntity(input: CreateExportPackageInput): ExportPackage {
+  const pkg: ExportPackage = {
+    exportPackageId: generateExportPackageId(input.request.exportRequestId, input.assembledAt),
+    exportRequestId: input.request.exportRequestId,
+    landlordId: input.request.landlordId,
+    recipientType: input.recipientType,
+    purpose: input.purpose,
+    packageMetadata: {
+      assembledAt: input.assembledAt,
+      assembledBy: input.assembledBy,
+      assemblyVersion: "export_package_builder_schema_v1",
+      includedEvidenceCount: Math.max(0, Math.floor(input.includedEvidenceCount)),
+      totalPackageSize: Math.max(0, Math.floor(input.totalPackageSize || 0)),
+      checksumAlgorithm: "sha256",
+      checksumValue: null,
+    },
+    evidenceManifest: {
+      evidenceClasses: [...input.evidenceClasses],
+      dateRangeApplied: {
+        start: input.request.scopeParameters.dateRangeStart || null,
+        end: input.request.scopeParameters.dateRangeEnd || null,
+      },
+      unitsScopeApplied: input.unitsScopeApplied || [],
+      redactionPolicyApplied: input.redactionPolicyApplied,
+      excludedEvidence: [],
+    },
+    signatureMetadata: {
+      isSigned: false,
+    },
+    deliveryMetadata: null,
+    status: "Assembled",
+    auditTrailReference: safeReference("export_audit", [input.request.exportRequestId, input.assembledAt]),
+    metadata: input.metadata || {},
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+  const result = validateExportPackage(pkg);
+  if (!result.ok) throw new Error(result.errors[0] || "export_package_invalid");
+  return pkg;
+}

--- a/rentchain-api/src/types/export-audit-types.ts
+++ b/rentchain-api/src/types/export-audit-types.ts
@@ -1,0 +1,36 @@
+export const EXPORT_AUDIT_EVENT_TYPES = [
+  "ExportProfileCreated",
+  "ExportProfileArchived",
+  "ExportProfileModified",
+  "ExportRequestInitiated",
+  "ExportRequestAuthorized",
+  "ExportRequestDenied",
+  "ExportRequestCancelled",
+  "ExportPackageAssembled",
+  "ExportPackageSigned",
+  "ExportPackageDelivered",
+  "ExportPackageArchived",
+  "ExportPackageRevoked",
+] as const;
+
+export type ExportAuditEventType = (typeof EXPORT_AUDIT_EVENT_TYPES)[number];
+
+export const EXPORT_AUDIT_TARGET_TYPES = ["ExportProfile", "ExportRequest", "ExportPackage"] as const;
+
+export type ExportAuditTargetType = (typeof EXPORT_AUDIT_TARGET_TYPES)[number];
+
+export type ExportAuditActorRole = "LandlordAdmin" | "PropertyManager" | "AdminSupport" | "SystemService";
+
+export type ExportAuditEvent = {
+  auditEventId: string;
+  eventType: ExportAuditEventType;
+  timestamp: string;
+  actor: string;
+  actorRole: ExportAuditActorRole;
+  targetType: ExportAuditTargetType;
+  targetId: string;
+  landlordId: string;
+  eventDetails: Record<string, string | number | boolean | null>;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};

--- a/rentchain-api/src/types/export-authorization-types.ts
+++ b/rentchain-api/src/types/export-authorization-types.ts
@@ -1,0 +1,181 @@
+import type { EvidenceClass } from "./evidence-record-types";
+import type { ExportDataMinimizationLevel, ExportProfile } from "./export-profile-types";
+import type { ExportRedactionPolicyOverride, ExportRequest } from "./export-request-types";
+import {
+  isExportPurpose,
+  isExportRecipientType,
+  isPurposeAllowedForRecipient,
+} from "./export-recipient-types";
+
+export const EXPORT_AUTHORIZATION_ACTOR_ROLES = [
+  "LandlordAdmin",
+  "PropertyManager",
+  "AdminSupport",
+  "SystemService",
+] as const;
+
+export type ExportAuthorizationActorRole = (typeof EXPORT_AUTHORIZATION_ACTOR_ROLES)[number];
+
+export const EXPORT_AUTHORIZATION_DECISIONS = [
+  "Approved",
+  "DeniedInvalidRecipient",
+  "DeniedInvalidPurpose",
+  "DeniedOutOfScope",
+  "DeniedRetentionBlock",
+  "DeniedAdminReview",
+  "SystemError",
+] as const;
+
+export type ExportAuthorizationDecisionCode = (typeof EXPORT_AUTHORIZATION_DECISIONS)[number];
+
+export type ExportAuthorizationContext = {
+  requestingActorId: string;
+  requestingActorRole: ExportAuthorizationActorRole;
+  requestingActorScope: string | null;
+  requestingPurpose: string;
+  timestamp: string;
+  rawIdsIncluded: false;
+};
+
+export type ExportAuthorizationDecision = {
+  isApproved: boolean;
+  decision: ExportAuthorizationDecisionCode;
+  denialReason?: string | null;
+  decidedAt: string;
+  decidedBy: string;
+  policyRuleName: string;
+  rawIdsIncluded: false;
+};
+
+export type ExportValidationResult = {
+  ok: boolean;
+  errors: string[];
+};
+
+const MINIMIZATION_RANK: Record<ExportDataMinimizationLevel, number> = {
+  Full: 0,
+  Redacted: 1,
+  RedactedSensitive: 2,
+};
+
+function isSafeReference(value: unknown): boolean {
+  const text = String(value ?? "").trim();
+  return /^[a-z][a-z0-9_.:-]*:[a-f0-9]{12,64}$/i.test(text) || /^exp_(profile|req|pkg)_v1_[a-f0-9_]+$/i.test(text);
+}
+
+function isIsoDate(value: unknown): boolean {
+  return typeof value === "string" && value.endsWith("Z") && Number.isFinite(Date.parse(value));
+}
+
+function denied(
+  decision: ExportAuthorizationDecisionCode,
+  reason: string,
+  context: ExportAuthorizationContext,
+  policyRuleName: string
+): ExportAuthorizationDecision {
+  return {
+    isApproved: false,
+    decision,
+    denialReason: reason,
+    decidedAt: isIsoDate(context.timestamp) ? context.timestamp : new Date(0).toISOString(),
+    decidedBy: context.requestingActorId || "actor:unknown",
+    policyRuleName,
+    rawIdsIncluded: false,
+  };
+}
+
+export function validateExportAuthorizationContext(context: ExportAuthorizationContext): ExportValidationResult {
+  const errors: string[] = [];
+  if (!isSafeReference(context.requestingActorId)) errors.push("requesting_actor_id_must_be_safe_reference");
+  if (!EXPORT_AUTHORIZATION_ACTOR_ROLES.includes(context.requestingActorRole)) errors.push("requesting_actor_role_invalid");
+  if (context.requestingActorRole !== "SystemService" && !isSafeReference(context.requestingActorScope)) {
+    errors.push("requesting_actor_scope_required");
+  }
+  if (!context.requestingPurpose.trim()) errors.push("requesting_purpose_required");
+  if (!isIsoDate(context.timestamp)) errors.push("timestamp_must_be_utc_iso");
+  if (context.rawIdsIncluded !== false) errors.push("raw_ids_must_be_false");
+  return { ok: errors.length === 0, errors };
+}
+
+export function validateRedactionPolicyOverride(
+  override: ExportRedactionPolicyOverride | null | undefined,
+  profile: Pick<ExportProfile, "dataMinimizationLevel">
+): ExportValidationResult {
+  if (!override) return { ok: true, errors: [] };
+  const errors: string[] = [];
+  if (!(override.dataMinimizationLevel in MINIMIZATION_RANK)) errors.push("redaction_override_level_invalid");
+  if (!override.reason.trim()) errors.push("redaction_override_reason_required");
+  if (MINIMIZATION_RANK[override.dataMinimizationLevel] < MINIMIZATION_RANK[profile.dataMinimizationLevel]) {
+    errors.push("redaction_override_cannot_loosen_profile");
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+export function validateExportProfileAuthorization(
+  profile: ExportProfile,
+  context: ExportAuthorizationContext
+): ExportAuthorizationDecision {
+  const contextResult = validateExportAuthorizationContext(context);
+  if (!contextResult.ok) return denied("DeniedAdminReview", contextResult.errors.join(","), context, "export_context_required");
+  if (!profile.isActive) return denied("DeniedOutOfScope", "export_profile_inactive", context, "export_profile_active");
+  if (!isExportRecipientType(profile.recipientType)) {
+    return denied("DeniedInvalidRecipient", "recipient_type_invalid", context, "recipient_type_enum");
+  }
+  if (!isExportPurpose(profile.purpose)) return denied("DeniedInvalidPurpose", "purpose_invalid", context, "purpose_enum");
+  if (!isPurposeAllowedForRecipient(profile.purpose, profile.recipientType)) {
+    return denied("DeniedInvalidPurpose", "purpose_not_allowed_for_recipient", context, "purpose_recipient_mapping");
+  }
+  if (context.requestingActorRole !== "SystemService" && context.requestingActorScope !== profile.landlordId) {
+    return denied("DeniedOutOfScope", "landlord_scope_mismatch", context, "landlord_scope_match");
+  }
+  if (!profile.approvedEvidenceClasses.length) {
+    return denied("DeniedOutOfScope", "approved_evidence_classes_required", context, "evidence_class_scope");
+  }
+  return {
+    isApproved: true,
+    decision: "Approved",
+    denialReason: null,
+    decidedAt: context.timestamp,
+    decidedBy: context.requestingActorId,
+    policyRuleName: "export_profile_authorization_v1",
+    rawIdsIncluded: false,
+  };
+}
+
+export function validateExportRequestAuthorization(
+  request: ExportRequest,
+  profile: ExportProfile,
+  context: ExportAuthorizationContext
+): ExportAuthorizationDecision {
+  const profileDecision = validateExportProfileAuthorization(profile, context);
+  if (!profileDecision.isApproved) return profileDecision;
+  if (request.landlordId !== profile.landlordId) {
+    return denied("DeniedOutOfScope", "request_profile_landlord_mismatch", context, "request_profile_scope_match");
+  }
+  if (request.exportProfileId !== profile.exportProfileId) {
+    return denied("DeniedOutOfScope", "request_profile_id_mismatch", context, "request_profile_id_match");
+  }
+  const redaction = validateRedactionPolicyOverride(request.redactionPolicyOverride, profile);
+  if (!redaction.ok) return denied("DeniedOutOfScope", redaction.errors.join(","), context, "redaction_override_tightening");
+  const requestedClasses = request.scopeParameters.evidenceClassFilters || profile.approvedEvidenceClasses;
+  const approved = new Set<EvidenceClass>(profile.approvedEvidenceClasses);
+  if (requestedClasses.some((item) => !approved.has(item))) {
+    return denied("DeniedOutOfScope", "requested_evidence_class_not_approved", context, "requested_evidence_scope");
+  }
+  if (
+    request.scopeParameters.dateRangeStart &&
+    request.scopeParameters.dateRangeEnd &&
+    Date.parse(request.scopeParameters.dateRangeStart) > Date.parse(request.scopeParameters.dateRangeEnd)
+  ) {
+    return denied("DeniedOutOfScope", "date_range_invalid", context, "request_date_scope");
+  }
+  return {
+    isApproved: true,
+    decision: "Approved",
+    denialReason: null,
+    decidedAt: context.timestamp,
+    decidedBy: context.requestingActorId,
+    policyRuleName: "export_request_authorization_v1",
+    rawIdsIncluded: false,
+  };
+}

--- a/rentchain-api/src/types/export-package-types.ts
+++ b/rentchain-api/src/types/export-package-types.ts
@@ -1,0 +1,65 @@
+import type { EvidenceClass } from "./evidence-record-types";
+import type { ExportPurpose, ExportRecipientType } from "./export-recipient-types";
+import type { ExportDataMinimizationLevel } from "./export-profile-types";
+
+export const EXPORT_PACKAGE_STATUSES = ["Assembled", "Signed", "Delivered", "Archived", "Revoked"] as const;
+
+export type ExportPackageStatus = (typeof EXPORT_PACKAGE_STATUSES)[number];
+
+export const EXPORT_DELIVERY_METHODS = ["Email", "SecurePortal", "DirectAPI", "SecureDropbox"] as const;
+
+export type ExportDeliveryMethod = (typeof EXPORT_DELIVERY_METHODS)[number];
+
+export type ExportPackageMetadata = {
+  assembledAt: string;
+  assembledBy: string;
+  assemblyVersion: string;
+  includedEvidenceCount: number;
+  totalPackageSize: number;
+  checksumAlgorithm: "sha256";
+  checksumValue?: string | null;
+};
+
+export type ExportEvidenceManifest = {
+  evidenceClasses: EvidenceClass[];
+  dateRangeApplied: {
+    start: string | null;
+    end: string | null;
+  };
+  unitsScopeApplied: string[];
+  redactionPolicyApplied: ExportDataMinimizationLevel;
+  excludedEvidence?: Array<{
+    evidenceId: string;
+    reason: string;
+  }>;
+};
+
+export type ExportSignatureMetadata = {
+  isSigned: boolean;
+  signatureAlgorithm?: string | null;
+  signedAt?: string | null;
+  signatureReference?: string | null;
+};
+
+export type ExportDeliveryMetadata = {
+  deliveryMethod?: ExportDeliveryMethod | null;
+  deliveryAddress?: string | null;
+  deliveredAt?: string | null;
+};
+
+export type ExportPackage = {
+  exportPackageId: string;
+  exportRequestId: string;
+  landlordId: string;
+  recipientType: ExportRecipientType;
+  purpose: ExportPurpose;
+  packageMetadata: ExportPackageMetadata;
+  evidenceManifest: ExportEvidenceManifest;
+  signatureMetadata?: ExportSignatureMetadata | null;
+  deliveryMetadata?: ExportDeliveryMetadata | null;
+  status: ExportPackageStatus;
+  auditTrailReference: string;
+  metadata: Record<string, string | number | boolean | null>;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};

--- a/rentchain-api/src/types/export-profile-types.ts
+++ b/rentchain-api/src/types/export-profile-types.ts
@@ -1,0 +1,36 @@
+import type { EvidenceClass, EvidenceRetentionPolicyVersion } from "./evidence-record-types";
+import type { ExportPurpose, ExportRecipientType } from "./export-recipient-types";
+
+export const EXPORT_DATA_MINIMIZATION_LEVELS = ["Full", "Redacted", "RedactedSensitive"] as const;
+
+export type ExportDataMinimizationLevel = (typeof EXPORT_DATA_MINIMIZATION_LEVELS)[number];
+
+export type ExportProfileMetadata = Record<string, string | number | boolean | null>;
+
+export type ExportCreatedBy = {
+  actorRef: string;
+  actorRole: "LandlordAdmin" | "PropertyManager" | "AdminSupport" | "SystemService";
+  rawIdsIncluded: false;
+};
+
+export type ExportProfile = {
+  exportProfileId: string;
+  landlordId: string;
+  recipientType: ExportRecipientType;
+  recipientName: string;
+  recipientSafeReference: string;
+  purpose: ExportPurpose;
+  description: string;
+  approvedEvidenceClasses: EvidenceClass[];
+  excludedUnitIds: string[];
+  dataMinimizationLevel: ExportDataMinimizationLevel;
+  retentionPolicyVersion: EvidenceRetentionPolicyVersion;
+  createdAt: string;
+  createdBy: ExportCreatedBy;
+  createdReason: string;
+  isActive: boolean;
+  auditTrailReference: string;
+  metadata: ExportProfileMetadata;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};

--- a/rentchain-api/src/types/export-projections.ts
+++ b/rentchain-api/src/types/export-projections.ts
@@ -1,0 +1,96 @@
+import type { ExportPackage } from "./export-package-types";
+import type { ExportProfile } from "./export-profile-types";
+import type { ExportRequest } from "./export-request-types";
+
+function assertLandlordScope(entityLandlordId: string, landlordId: string): void {
+  if (entityLandlordId !== landlordId) throw new Error("export_projection_landlord_scope_mismatch");
+}
+
+export function projectExportProfileForLandlord(profile: ExportProfile, landlordId: string) {
+  assertLandlordScope(profile.landlordId, landlordId);
+  return {
+    exportProfileId: profile.exportProfileId,
+    recipientType: profile.recipientType,
+    recipientName: profile.recipientName,
+    purpose: profile.purpose,
+    description: profile.description,
+    approvedEvidenceClasses: profile.approvedEvidenceClasses,
+    excludedUnitIds: profile.excludedUnitIds,
+    dataMinimizationLevel: profile.dataMinimizationLevel,
+    retentionPolicyVersion: profile.retentionPolicyVersion,
+    createdAt: profile.createdAt,
+    isActive: profile.isActive,
+    rawIdsIncluded: false as const,
+  };
+}
+
+export function projectExportProfileForAdmin(profile: ExportProfile) {
+  return {
+    ...profile,
+    rawIdsIncluded: false as const,
+    payloadIncluded: false as const,
+  };
+}
+
+export function projectExportRequestForLandlord(request: ExportRequest, landlordId: string) {
+  assertLandlordScope(request.landlordId, landlordId);
+  return {
+    exportRequestId: request.exportRequestId,
+    exportProfileId: request.exportProfileId,
+    requestedAt: request.requestedAt,
+    requestReason: request.requestReason,
+    scopeParameters: request.scopeParameters,
+    redactionPolicyOverride: request.redactionPolicyOverride,
+    status: request.status,
+    authorizationStatus: {
+      isAuthorized: request.authorizationStatus.isAuthorized,
+      authorizedAt: request.authorizationStatus.authorizedAt || null,
+      rawIdsIncluded: false as const,
+    },
+    rawIdsIncluded: false as const,
+  };
+}
+
+export function projectExportRequestForAdmin(request: ExportRequest) {
+  return {
+    ...request,
+    rawIdsIncluded: false as const,
+    payloadIncluded: false as const,
+  };
+}
+
+export function projectExportPackageForLandlord(pkg: ExportPackage, landlordId: string) {
+  assertLandlordScope(pkg.landlordId, landlordId);
+  return {
+    exportPackageId: pkg.exportPackageId,
+    exportRequestId: pkg.exportRequestId,
+    recipientType: pkg.recipientType,
+    purpose: pkg.purpose,
+    packageMetadata: {
+      assembledAt: pkg.packageMetadata.assembledAt,
+      assemblyVersion: pkg.packageMetadata.assemblyVersion,
+      includedEvidenceCount: pkg.packageMetadata.includedEvidenceCount,
+      totalPackageSize: pkg.packageMetadata.totalPackageSize,
+      checksumAlgorithm: pkg.packageMetadata.checksumAlgorithm,
+    },
+    evidenceManifest: pkg.evidenceManifest,
+    signatureStatus: {
+      isSigned: pkg.signatureMetadata?.isSigned === true,
+      signedAt: pkg.signatureMetadata?.signedAt || null,
+    },
+    deliveryStatus: {
+      deliveryMethod: pkg.deliveryMetadata?.deliveryMethod || null,
+      deliveredAt: pkg.deliveryMetadata?.deliveredAt || null,
+    },
+    status: pkg.status,
+    rawIdsIncluded: false as const,
+  };
+}
+
+export function projectExportPackageForAdmin(pkg: ExportPackage) {
+  return {
+    ...pkg,
+    rawIdsIncluded: false as const,
+    payloadIncluded: false as const,
+  };
+}

--- a/rentchain-api/src/types/export-recipient-types.ts
+++ b/rentchain-api/src/types/export-recipient-types.ts
@@ -1,0 +1,45 @@
+export const EXPORT_RECIPIENT_TYPES = [
+  "ThirdPartyPropertyManager",
+  "InsuranceAdjuster",
+  "LegalRepresentative",
+  "Regulator",
+  "Arbitrator",
+  "SelfArchive",
+  "ReservedFutureInstitution",
+] as const;
+
+export type ExportRecipientType = (typeof EXPORT_RECIPIENT_TYPES)[number];
+
+export const EXPORT_PURPOSES = [
+  "LitigationDiscovery",
+  "InsuranceClaim",
+  "RegulatoryCompliance",
+  "AuditReview",
+  "ArbitrationEvidence",
+  "SelfReview",
+  "ReservedFuturePurpose",
+] as const;
+
+export type ExportPurpose = (typeof EXPORT_PURPOSES)[number];
+
+export const EXPORT_PURPOSE_RECIPIENTS: Readonly<Record<ExportPurpose, readonly ExportRecipientType[]>> = {
+  LitigationDiscovery: ["LegalRepresentative"],
+  InsuranceClaim: ["InsuranceAdjuster"],
+  RegulatoryCompliance: ["Regulator"],
+  AuditReview: ["ThirdPartyPropertyManager", "Regulator"],
+  ArbitrationEvidence: ["Arbitrator", "LegalRepresentative"],
+  SelfReview: ["SelfArchive"],
+  ReservedFuturePurpose: ["ReservedFutureInstitution"],
+};
+
+export function isExportRecipientType(value: unknown): value is ExportRecipientType {
+  return EXPORT_RECIPIENT_TYPES.includes(value as ExportRecipientType);
+}
+
+export function isExportPurpose(value: unknown): value is ExportPurpose {
+  return EXPORT_PURPOSES.includes(value as ExportPurpose);
+}
+
+export function isPurposeAllowedForRecipient(purpose: ExportPurpose, recipientType: ExportRecipientType): boolean {
+  return EXPORT_PURPOSE_RECIPIENTS[purpose].includes(recipientType);
+}

--- a/rentchain-api/src/types/export-request-types.ts
+++ b/rentchain-api/src/types/export-request-types.ts
@@ -1,0 +1,46 @@
+import type { EvidenceClass } from "./evidence-record-types";
+import type { ExportDataMinimizationLevel } from "./export-profile-types";
+
+export const EXPORT_REQUEST_STATUSES = ["Pending", "Authorized", "Assembled", "Signed", "Delivered", "Archived"] as const;
+
+export type ExportRequestStatus = (typeof EXPORT_REQUEST_STATUSES)[number];
+
+export type ExportScopeParameters = {
+  dateRangeStart?: string | null;
+  dateRangeEnd?: string | null;
+  evidenceClassFilters?: EvidenceClass[] | null;
+  unitScopeOverride?: string[] | null;
+};
+
+export type ExportRedactionPolicyOverride = {
+  dataMinimizationLevel: ExportDataMinimizationLevel;
+  reason: string;
+};
+
+export type ExportAuthorizationStatus = {
+  isAuthorized: boolean;
+  authorizedAt?: string | null;
+  authorizedBy?: string | null;
+  authorizationReason?: string | null;
+  denialReason?: string | null;
+  rawIdsIncluded: false;
+};
+
+export type ExportRequestMetadata = Record<string, string | number | boolean | null>;
+
+export type ExportRequest = {
+  exportRequestId: string;
+  exportProfileId: string;
+  landlordId: string;
+  requestedAt: string;
+  requestedBy: string;
+  requestReason: string;
+  scopeParameters: ExportScopeParameters;
+  redactionPolicyOverride?: ExportRedactionPolicyOverride | null;
+  status: ExportRequestStatus;
+  authorizationStatus: ExportAuthorizationStatus;
+  auditTrailReference: string;
+  metadata: ExportRequestMetadata;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};


### PR DESCRIPTION
## Summary
- add institutional export recipient, profile, request, package, authorization, audit, and projection contracts
- add pure export service helpers for deterministic IDs, validation, and entity construction without persistence
- add allowlist landlord/admin projection helpers and authorization validation for scope, recipient purpose, and redaction tightening
- document export architecture and governance boundaries for future package assembly and audit trail work

## Validation
- npm --prefix rentchain-api run test:single -- src/__tests__/export-types.test.ts src/__tests__/export-projections.test.ts src/__tests__/export-authorization.test.ts
- npm --prefix rentchain-api test -- export
- npm --prefix rentchain-api run build
- git diff --check
- changed-file unsafe-marker scan

## Known Limitations
- no routes, persistence, package assembly, delivery, signing, external integrations, background jobs, Firestore rules, deployment changes, or frontend changes in this mission
- evidence package assembly, delivery audit trails, signing, recipient consent, and UI workflows remain deferred