### PR TITLE
feat: implement evidence package builder

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,69 +1,72 @@
-PR: #1095
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1095
-Branch: feat/institutional-export-framework-v1
-Mission: Phase 4 Mission 4 - Institutional Export Framework
+# Implementation Summary - Phase 4 Mission 5: Evidence Package Builder
 
-## Summary
-Established the institutional export framework schema, validation, authorization, projection, and governance layer for future evidence export workflows.
+PR: #1096
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1096
+Branch: feat/evidence-package-builder-v1
 
-The implementation is schema and pure service only. It does not add routes, persistence, evidence package assembly, export delivery, signing, external integrations, background jobs, Firestore rules, deployment changes, or production data mutation.
+## Scope Delivered
+
+Implemented the Phase 4 evidence package builder as a backend service-layer foundation for institutional export package assembly.
+
+The implementation adds pure assembly helpers for authorized export requests, landlord-scoped evidence filtering, lifecycle status filtering, institutional export projections, metadata-only manifest generation, deterministic SHA256 checksums, package validation, and read-only Firestore materialization through a narrow query adapter.
+
+The builder preserves the Phase 4B export framework boundaries: no routes, no persistence, no signing, no delivery, no background workers, no external integrations, no Firestore rules, and no production data mutation.
 
 ## Files Changed
-- docs/architecture/export-framework-v1.md
-- docs/governance/export-governance-v1.md
-- rentchain-api/src/types/export-recipient-types.ts
-- rentchain-api/src/types/export-profile-types.ts
-- rentchain-api/src/types/export-request-types.ts
-- rentchain-api/src/types/export-package-types.ts
-- rentchain-api/src/types/export-authorization-types.ts
-- rentchain-api/src/types/export-audit-types.ts
-- rentchain-api/src/types/export-projections.ts
-- rentchain-api/src/services/export-service.ts
-- rentchain-api/src/__tests__/export-types.test.ts
-- rentchain-api/src/__tests__/export-projections.test.ts
-- rentchain-api/src/__tests__/export-authorization.test.ts
 
-## Implementation Details
-- Added governed export recipient and purpose enumerations with explicit recipient-purpose mapping.
-- Added export profile, request, package, authorization, audit, and projection type contracts.
-- Implemented deterministic export profile, request, and package ID generation using hash-based `_v1_` identifiers.
-- Implemented pure validation helpers for export profiles, requests, and package skeletons.
-- Implemented pure entity constructors for export profiles, export requests, and export package skeletons with no Firestore persistence.
-- Implemented authorization validation for actor context, landlord scope, recipient-purpose mapping, request scope, and redaction override tightening.
-- Implemented allowlist landlord/admin projections for profiles, requests, and packages.
-- Added focused tests for ID determinism, schema validation, authorization rules, redaction tightening, projection safety, and purity.
-- Added export architecture and governance documentation with entity relationships, scope boundaries, recipient mapping, data minimization, audit accountability, and deferred work.
+- rentchain-api/src/services/evidence-package-builder-service.ts (new)
+- rentchain-api/src/services/__tests__/evidence-package-builder.test.ts (new)
+- rentchain-api/src/services/__tests__/evidence-package-builder-integration.test.ts (new)
+- docs/architecture/evidence-package-builder-v1.md (new)
+- .handoff/impl-summary.md (updated)
 
-## Scope Boundaries
-- No routes added.
-- No existing route behavior changed.
-- No Firestore reads, writes, rules, indexes, or migrations added.
-- No export persistence added.
-- No package assembly logic added.
-- No delivery mechanics added.
-- No signing, attestation, webhook, external API, or recipient portal added.
-- No frontend changes.
-- No protected areas touched.
+## Tests Passed
 
-## Validation
-- Passed: `npm --prefix rentchain-api run test:single -- src/__tests__/export-types.test.ts src/__tests__/export-projections.test.ts src/__tests__/export-authorization.test.ts`
-- Passed: `npm --prefix rentchain-api test -- export`
-- Passed: `npm --prefix rentchain-api run build`
-- Passed: `git diff --check`
-- Checked: changed-file unsafe-marker scan found governance prohibition text, validation regexes, and test sentinel values only.
+- `npm run test -- src/services/__tests__/evidence-package-builder.test.ts`: PASS
+- `npm run test -- src/services/__tests__/evidence-package-builder-integration.test.ts`: PASS
+- `npm run build` in `rentchain-api`: PASS
+- `git diff --check`: PASS
 
-## Manual QA
-- Manual preview QA was not required because this mission adds backend schema, pure service helpers, docs, and tests only.
-- Schema, authorization, projection, service helper, documentation, and type-safety checks are covered by focused tests and backend build.
+## Validation Notes
+
+- Initial targeted test run without Node 20 failed the repo preflight because the shell was using Node v25.8.1. Validation was rerun under Node v20.20.2.
+- `npm run test` in `rentchain-api` was run under Node v20.20.2 with escalation after the sandbox produced `listen EPERM` socket failures. The escalated run completed and reported unrelated pre-existing failures: 7 failed files, 20 failed tests, 429 passed files, 2117 passed tests.
+- Unrelated failing files from the full backend suite:
+  - `src/__tests__/tenantWorkspaceLeaseLinkageContinuity.test.ts`
+  - `src/routes/__tests__/governedReviewWorkspaceSmoke.test.ts`
+  - `src/routes/__tests__/leaseDraftRoutes.test.ts`
+  - `src/routes/__tests__/recipientTrustReviewRoutes.test.ts`
+  - `src/routes/__tests__/supportConsoleRoutes.test.ts`
+  - `src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts`
+  - `src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts`
+- `npm run lint` was attempted in `rentchain-api`, but the package has no `lint` script.
+- Coverage percentage was not measured because the repo does not expose a coverage script for this package.
+
+## Acceptance Criteria Met
+
+- [x] Assembly engine implemented and tested.
+- [x] Evidence filtering by profile scope, request scope, date range, unit scope, retention status, and evidence class works correctly.
+- [x] Evidence projection applies Full, Redacted, and RedactedSensitive minimization with safe field allowlists.
+- [x] Raw IDs, storage paths, tokens, credentials, provider payloads, payment account details, and sensitive payloads are excluded from projected evidence.
+- [x] Package manifest generation and validation implemented.
+- [x] Deterministic SHA256 checksum generation implemented.
+- [x] Landlord scope validation rejects cross-landlord assembly.
+- [x] Export authorization validation is enforced through server-resolved assembly context.
+- [x] Redaction policy tightening is enforced through the export framework validation path.
+- [x] Empty evidence packages remain valid metadata-only package entities under the existing export package schema.
+- [x] No scope creep: no routes, persistence, signing, delivery, background workers, Firestore rules, deployment changes, or external integrations.
+- [x] TypeScript compilation succeeds.
+- [x] No unrelated source files modified.
 
 ## Known Limitations
-- No API routes or route authorization are implemented in this mission.
-- No export persistence is implemented in this mission.
-- Evidence package assembly is deferred.
-- Export delivery and delivery audit trails are deferred.
-- Signing, attestation, and external sharing are deferred.
-- Recipient consent and legal signature workflows are deferred.
-- UI/dashboard workflows are deferred.
+
+- This mission implements the assembly engine only; no persistence, signing, delivery, or audit trail storage.
+- Packages are in-memory objects; future missions must implement persistence and delivery.
+- Tenant-facing export and consent workflows remain deferred.
+- External integrations and recipient access control are out of scope.
+- Full backend suite still has unrelated pre-existing failures outside this mission scope.
+- Lint and coverage could not be completed because no package lint or coverage script exists.
 
 ## Recommended Next Mission
-Phase 4 Mission 5 - Evidence Package Builder using the institutional export profile and request framework.
+
+Phase 4 Mission 6: Export Audit Trails - Implement append-only audit trail persistence for export package assembly, signing, and delivery events. Audit trails will reference the evidence packages created by this mission.

--- a/docs/architecture/evidence-package-builder-v1.md
+++ b/docs/architecture/evidence-package-builder-v1.md
@@ -1,0 +1,109 @@
+# Evidence Package Builder v1
+
+## Purpose
+
+Evidence Package Builder v1 implements the service-layer assembly engine for authorized institutional export requests.
+
+The builder converts an `ExportProfile`, `ExportRequest`, server-resolved assembly context, and landlord-scoped evidence records into an `ExportPackage` entity. It is metadata-only, projection-safe, and request-scoped. It does not add routes, persist packages, sign packages, deliver exports, call external systems, or mutate evidence records.
+
+## Assembly Algorithm
+
+The builder follows a deterministic five-step flow:
+
+1. Validate the export profile, export request, and assembly context.
+2. Authorize the request against the export framework authorization rules.
+3. Materialize landlord-scoped evidence records from the evidence record collection.
+4. Filter records by evidence class, date range, unit scope, lifecycle status, and retention metadata.
+5. Project included records into metadata-only institutional export evidence references, generate a manifest, calculate a checksum, construct an `ExportPackage`, and validate the package.
+
+The pure assembly helper accepts in-memory evidence records. The async entrypoint performs read-only materialization through a narrow Firestore-like query adapter and then delegates to the pure assembly helper.
+
+## Filtering Rules
+
+Evidence records must match all of the following:
+
+- `landlordId` must match the export profile, request, and assembly context.
+- `evidenceClass` must be approved by the profile.
+- request evidence class filters must be subsets of the approved profile classes.
+- `createdAt` must fall inside the request date range when supplied.
+- unit scope overrides must not include profile-excluded unit references.
+- default lifecycle status inclusion is `active` only.
+- `superseded`, `archived`, and `redacted` records are excluded by default.
+- audit status inclusion may include `superseded` and `archived` only through explicit audit context.
+- deletion-eligible records are excluded unless legal hold metadata is active.
+
+Filtering is deterministic and does not mutate source evidence records.
+
+## Projection Rules
+
+`projectEvidenceForExport` emits `ProjectedEvidenceRecord` objects for institutional export audience only. Projections include safe labels, safe evidence references, class/type metadata, source collection metadata, status, timestamps, sensitivity class, redaction summaries, and retention metadata.
+
+Projection never includes:
+
+- raw Firestore IDs
+- raw landlord, tenant, unit, or lease IDs
+- storage paths
+- tokens or credentials
+- provider payloads
+- screening reports
+- identity documents
+- payment account details
+- unrestricted message bodies
+- debug payloads
+
+The `Full` level still remains metadata-only. It includes allowed field group labels but not raw payloads. `Redacted` removes sensitive allowed field groups. `RedactedSensitive` emits only minimal status, timestamp, safe reference, and redaction category field groups.
+
+## Manifest And Checksum
+
+Package manifests record:
+
+- included evidence count
+- excluded evidence count
+- excluded evidence reasons
+- applied evidence classes
+- applied date range
+- applied unit scope
+- allowed lifecycle statuses
+- redaction policy applied
+
+The package checksum uses SHA256 over deterministic evidence record identity metadata and manifest metadata. It is intended for package integrity comparison only. It is not a signature, attestation, or delivery receipt.
+
+## Firestore Read Contract
+
+Materialization is read-only and uses landlord-scoped query patterns:
+
+- collection: `evidenceRecords`
+- filters: `landlordId == <context landlord>` and `evidenceClass == <approved class>`
+- order: `createdAt desc`
+- limit: 100 records per evidence class
+
+The materializer validates that every returned record still matches the requested landlord scope before assembly.
+
+## Governance Boundaries
+
+The builder preserves the institutional export framework boundaries:
+
+- authorization is server-resolved from `ExportAssemblyContext`
+- request scope must tighten, not widen, profile scope
+- redaction override must tighten, not loosen, profile minimization
+- exports are landlord-scoped only
+- tenant-facing export awareness and recipient visibility remain out of scope
+- raw IDs and raw payloads remain excluded from package and projection outputs
+- source records, evidence records, and audit trails are not mutated
+
+## Deferred Work
+
+This mission does not implement:
+
+- API routes
+- Firestore package persistence
+- audit trail persistence
+- package signing
+- delivery mechanics
+- recipient consent workflows
+- recipient access controls
+- tenant-facing workflows
+- external integrations
+- background workers, queues, scheduled jobs, or Pub/Sub flows
+
+Future missions should add append-only export audit trails first, then persistence, signing, and delivery mechanics behind explicit authorization and projection checks.

--- a/rentchain-api/src/services/__tests__/evidence-package-builder-integration.test.ts
+++ b/rentchain-api/src/services/__tests__/evidence-package-builder-integration.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEvidencePackage,
+  materializeEvidenceRecords,
+  type EvidenceRecordFirestoreLike,
+  type ExportAssemblyContext,
+} from "../evidence-package-builder-service";
+import {
+  createExportProfileEntity,
+  createExportRequestEntity,
+  validateExportPackage,
+} from "../../services/export-service";
+import type { ExportAuthorizationContext } from "../../types/export-authorization-types";
+import type { ExportProfile } from "../../types/export-profile-types";
+import type { ExportRequest } from "../../types/export-request-types";
+import type { EvidenceRecord } from "../../types/evidence-record-types";
+import { EVIDENCE_RECORD_COLLECTION } from "../../types/evidence-record-types";
+import { evidenceRecordFixtures } from "../../__tests__/fixtures/evidence-record-fixtures";
+
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const otherLandlordRef = "landlord:eeeeeeeeeeeeeeeeeeee";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const unitRef = "unit:cccccccccccccccccccc";
+const timestamp = "2026-06-04T15:00:00.000Z";
+
+type Filter = {
+  field: string;
+  op: string;
+  value: unknown;
+};
+
+class QueryLike {
+  private readonly filters: Filter[];
+  private readonly max: number | null;
+
+  constructor(private readonly data: EvidenceRecord[], filters: Filter[] = [], max: number | null = null) {
+    this.filters = filters;
+    this.max = max;
+  }
+
+  where(field: string, op: string, value: unknown) {
+    return new QueryLike(this.data, [...this.filters, { field, op, value }], this.max);
+  }
+
+  orderBy() {
+    return this;
+  }
+
+  limit(limit: number) {
+    return new QueryLike(this.data, this.filters, limit);
+  }
+
+  async get() {
+    const filtered = this.data
+      .filter((record) =>
+        this.filters.every((filter) => {
+          const value = record[filter.field as keyof EvidenceRecord];
+          if (filter.op === "==") return value === filter.value;
+          if (filter.op === ">=") return String(value) >= String(filter.value);
+          if (filter.op === "<=") return String(value) <= String(filter.value);
+          return true;
+        })
+      )
+      .slice(0, this.max || undefined);
+    return {
+      docs: filtered.map((record) => ({
+        data: () => record,
+      })),
+    };
+  }
+}
+
+function firestore(records: EvidenceRecord[]): EvidenceRecordFirestoreLike {
+  return {
+    collection(name: string) {
+      if (name !== EVIDENCE_RECORD_COLLECTION) throw new Error("unexpected_collection");
+      return new QueryLike(records) as unknown as ReturnType<EvidenceRecordFirestoreLike["collection"]>;
+    },
+  };
+}
+
+function authorizationContext(overrides: Partial<ExportAuthorizationContext> = {}): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp,
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+function assemblyContext(records: EvidenceRecord[], overrides: Partial<ExportAssemblyContext> = {}): ExportAssemblyContext {
+  return {
+    timestamp: "2026-06-04T15:15:00.000Z",
+    actorId: actorRef,
+    actorRole: "LandlordAdmin",
+    landlordId: landlordRef,
+    purpose: "InsuranceClaim",
+    firestore: firestore(records),
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+function profile(overrides: Partial<ExportProfile> = {}): ExportProfile {
+  const created = createExportProfileEntity(
+    {
+      landlordId: landlordRef,
+      recipientType: "InsuranceAdjuster",
+      recipientName: "Acme Insurance Adjusters LLC",
+      recipientReference: "acme-insurance-adjusters",
+      purpose: "InsuranceClaim",
+      description: "Insurance claim review.",
+      approvedEvidenceClasses: ["PaymentEvidence", "MaintenanceEvidence"],
+      dataMinimizationLevel: "Redacted",
+      createdReason: "Insurance claim package review.",
+    },
+    authorizationContext()
+  );
+  return { ...created, ...overrides };
+}
+
+function request(exportProfile = profile(), overrides: Partial<ExportRequest> = {}): ExportRequest {
+  const created = createExportRequestEntity(
+    {
+      profile: exportProfile,
+      requestedAt: "2026-06-04T15:05:00.000Z",
+      requestedBy: actorRef,
+      requestReason: "Claim settlement review.",
+      scopeParameters: {
+        dateRangeStart: "2026-01-01T00:00:00.000Z",
+        dateRangeEnd: "2026-06-30T00:00:00.000Z",
+        evidenceClassFilters: ["PaymentEvidence", "MaintenanceEvidence"],
+      },
+      redactionPolicyOverride: {
+        dataMinimizationLevel: "RedactedSensitive",
+        reason: "Tighten projection for external recipient.",
+      },
+    },
+    authorizationContext()
+  );
+  return { ...created, ...overrides };
+}
+
+function record(base: EvidenceRecord, overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  return {
+    ...base,
+    landlordId: landlordRef,
+    ...overrides,
+  };
+}
+
+function records(): EvidenceRecord[] {
+  return [
+    record(evidenceRecordFixtures.paymentEvidence),
+    record(evidenceRecordFixtures.maintenanceEvidence),
+    record(evidenceRecordFixtures.screeningEvidence),
+    record(evidenceRecordFixtures.paymentEvidence, {
+      evidenceId: "evidence:other-landlord-fixture",
+      landlordId: otherLandlordRef,
+    }),
+  ];
+}
+
+describe("evidence package builder integration", () => {
+  it("builds an export package through profile, request, materialization, and validation", async () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const pkg = await buildEvidencePackage(exportRequest, exportProfile, assemblyContext(records()));
+
+    expect(pkg.packageMetadata.includedEvidenceCount).toBe(2);
+    expect(pkg.evidenceManifest.evidenceClasses).toEqual(["MaintenanceEvidence", "PaymentEvidence"]);
+    expect(pkg.evidenceManifest.redactionPolicyApplied).toBe("RedactedSensitive");
+    expect(pkg.packageMetadata.checksumValue).toMatch(/^[a-f0-9]{64}$/);
+    expect(validateExportPackage(pkg)).toEqual({ ok: true, errors: [] });
+    expect(JSON.stringify(pkg)).not.toContain(otherLandlordRef);
+  });
+
+  it("keeps package IDs and checksums deterministic for identical inputs", async () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const context = assemblyContext(records());
+    const first = await buildEvidencePackage(exportRequest, exportProfile, context);
+    const second = await buildEvidencePackage(exportRequest, exportProfile, context);
+
+    expect(second.exportPackageId).toBe(first.exportPackageId);
+    expect(second.packageMetadata.checksumValue).toBe(first.packageMetadata.checksumValue);
+  });
+
+  it("materializes landlord-scoped evidence records only", async () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const materialized = await materializeEvidenceRecords(landlordRef, exportRequest, exportProfile, firestore(records()));
+
+    expect(materialized).toHaveLength(2);
+    expect(materialized.every((record) => record.landlordId === landlordRef)).toBe(true);
+    expect(materialized.map((record) => record.evidenceClass).sort()).toEqual(["MaintenanceEvidence", "PaymentEvidence"]);
+  });
+
+  it("rejects unauthorized actors and cross-landlord requests", async () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+
+    await expect(buildEvidencePackage(exportRequest, exportProfile, assemblyContext(records(), { actorRole: "AdminSupport", landlordId: null as unknown as string })))
+      .rejects.toThrow("requesting_actor_scope_required");
+    await expect(buildEvidencePackage({ ...exportRequest, landlordId: otherLandlordRef }, exportProfile, assemblyContext(records())))
+      .rejects.toThrow("landlord_id_mismatch");
+  });
+
+  it("rejects request scope that widens beyond the export profile", async () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile, {
+      scopeParameters: {
+        evidenceClassFilters: ["ScreeningEvidence"],
+      },
+    });
+
+    await expect(buildEvidencePackage(exportRequest, exportProfile, assemblyContext(records())))
+      .rejects.toThrow("requested_evidence_class_not_approved");
+  });
+});

--- a/rentchain-api/src/services/__tests__/evidence-package-builder.test.ts
+++ b/rentchain-api/src/services/__tests__/evidence-package-builder.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assembleEvidencePackage,
+  filterEvidenceByRetentionStatus,
+  filterEvidenceByScope,
+  generatePackageChecksum,
+  projectEvidenceForExport,
+  validatePackageManifest,
+  type ExportAssemblyContext,
+} from "../evidence-package-builder-service";
+import {
+  createExportProfileEntity,
+  createExportRequestEntity,
+} from "../../services/export-service";
+import type { ExportAuthorizationContext } from "../../types/export-authorization-types";
+import type { ExportProfile } from "../../types/export-profile-types";
+import type { ExportRequest } from "../../types/export-request-types";
+import type { EvidenceRecord } from "../../types/evidence-record-types";
+import { evidenceRecordFixtures } from "../../__tests__/fixtures/evidence-record-fixtures";
+
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const unitRef = "unit:cccccccccccccccccccc";
+const otherUnitRef = "unit:dddddddddddddddddddd";
+const timestamp = "2026-06-04T14:00:00.000Z";
+
+function authorizationContext(overrides: Partial<ExportAuthorizationContext> = {}): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp,
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+function assemblyContext(overrides: Partial<ExportAssemblyContext> = {}): ExportAssemblyContext {
+  return {
+    timestamp: "2026-06-04T14:15:00.000Z",
+    actorId: actorRef,
+    actorRole: "LandlordAdmin",
+    landlordId: landlordRef,
+    purpose: "InsuranceClaim",
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+function profile(overrides: Partial<ExportProfile> = {}): ExportProfile {
+  const created = createExportProfileEntity(
+    {
+      landlordId: landlordRef,
+      recipientType: "InsuranceAdjuster",
+      recipientName: "Acme Insurance Adjusters LLC",
+      recipientReference: "acme-insurance-adjusters",
+      purpose: "InsuranceClaim",
+      description: "Insurance claim review.",
+      approvedEvidenceClasses: ["ApplicationEvidence", "PaymentEvidence", "MaintenanceEvidence"],
+      excludedUnitIds: [otherUnitRef],
+      dataMinimizationLevel: "Redacted",
+      createdReason: "Insurance claim package review.",
+    },
+    authorizationContext()
+  );
+  return { ...created, ...overrides };
+}
+
+function request(exportProfile = profile(), overrides: Partial<ExportRequest> = {}): ExportRequest {
+  const created = createExportRequestEntity(
+    {
+      profile: exportProfile,
+      requestedAt: "2026-06-04T14:05:00.000Z",
+      requestedBy: actorRef,
+      requestReason: "Claim settlement review.",
+      scopeParameters: {
+        dateRangeStart: "2026-01-01T00:00:00.000Z",
+        dateRangeEnd: "2026-06-30T00:00:00.000Z",
+        evidenceClassFilters: ["PaymentEvidence", "MaintenanceEvidence"],
+        unitScopeOverride: [unitRef],
+      },
+      redactionPolicyOverride: {
+        dataMinimizationLevel: "RedactedSensitive",
+        reason: "Tighten projection for external review.",
+      },
+    },
+    authorizationContext()
+  );
+  return { ...created, ...overrides };
+}
+
+function record(base: EvidenceRecord, overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  return {
+    ...base,
+    landlordId: landlordRef,
+    safeReference: {
+      ...base.safeReference,
+      safeReferenceKey: unitRef,
+    },
+    provenanceMetadata: {
+      ...base.provenanceMetadata,
+      source: {
+        ...base.provenanceMetadata.source,
+        sourceReferenceKey: unitRef,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function records(): EvidenceRecord[] {
+  return [
+    record(evidenceRecordFixtures.paymentEvidence),
+    record(evidenceRecordFixtures.maintenanceEvidence),
+    record(evidenceRecordFixtures.applicationEvidence),
+    record(evidenceRecordFixtures.screeningEvidence),
+    record(evidenceRecordFixtures.paymentEvidence, {
+      evidenceId: "evidence:superseded-safe-fixture",
+      status: "superseded",
+      createdAt: "2026-03-01T00:00:00.000Z",
+    }),
+    record(evidenceRecordFixtures.maintenanceEvidence, {
+      evidenceId: "evidence:old-safe-fixture",
+      createdAt: "2025-01-01T00:00:00.000Z",
+    }),
+  ];
+}
+
+describe("evidence package builder unit helpers", () => {
+  it("assembles metadata-only packages with manifest counts and checksum", () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const pkg = assembleEvidencePackage(exportRequest, exportProfile, records(), assemblyContext());
+
+    expect(pkg.packageMetadata.includedEvidenceCount).toBe(2);
+    expect(pkg.packageMetadata.checksumAlgorithm).toBe("sha256");
+    expect(pkg.packageMetadata.checksumValue).toMatch(/^[a-f0-9]{64}$/);
+    expect(pkg.evidenceManifest.evidenceClasses).toEqual(["MaintenanceEvidence", "PaymentEvidence"]);
+    expect(pkg.evidenceManifest.redactionPolicyApplied).toBe("RedactedSensitive");
+    expect(pkg.evidenceManifest.excludedEvidence?.map((item) => item.reason)).toEqual([
+      "evidence_class_not_requested",
+      "evidence_class_not_approved",
+      "evidence_status_not_allowed",
+      "evidence_before_requested_date_range",
+    ]);
+    expect(pkg.rawIdsIncluded).toBe(false);
+    expect(pkg.payloadIncluded).toBe(false);
+  });
+
+  it("filters records by profile evidence class, request class, date range, and unit scope", () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const scoped = filterEvidenceByScope(records(), exportRequest.scopeParameters, exportProfile);
+
+    expect(scoped.map((item) => item.evidenceClass)).toEqual([
+      "PaymentEvidence",
+      "MaintenanceEvidence",
+      "PaymentEvidence",
+    ]);
+    expect(filterEvidenceByRetentionStatus(scoped, ["active"]).map((item) => item.evidenceClass)).toEqual([
+      "PaymentEvidence",
+      "MaintenanceEvidence",
+    ]);
+  });
+
+  it("excludes archived, superseded, and redacted records by default", () => {
+    const mixed = [
+      record(evidenceRecordFixtures.paymentEvidence),
+      record(evidenceRecordFixtures.paymentEvidence, { evidenceId: "evidence:archived", status: "archived" }),
+      record(evidenceRecordFixtures.paymentEvidence, { evidenceId: "evidence:redacted", status: "redacted" }),
+      record(evidenceRecordFixtures.paymentEvidence, { evidenceId: "evidence:superseded", status: "superseded" }),
+    ];
+
+    expect(filterEvidenceByRetentionStatus(mixed, ["active"]).map((item) => item.status)).toEqual(["active"]);
+  });
+
+  it("projects evidence using safe allowlists for each redaction level", () => {
+    const payment = record(evidenceRecordFixtures.paymentEvidence);
+    const full = projectEvidenceForExport(payment, "Full");
+    const redacted = projectEvidenceForExport(payment, "Redacted");
+    const sensitive = projectEvidenceForExport(payment, "RedactedSensitive");
+
+    expect(full.allowedFieldGroups).toContain("ledgerStatus");
+    expect(redacted.allowedFieldGroups).toEqual(["currency", "ledgerStatus", "paidAt"]);
+    expect(sensitive.allowedFieldGroups).toEqual(["status", "timestamp", "safeReference", "redactionCategories"]);
+    expect(sensitive.redactedFieldGroups).toContain("amount");
+    expect(JSON.stringify(sensitive)).not.toContain(payment.resourceId);
+    expect(JSON.stringify(sensitive)).not.toMatch(/gs:\/\/|storage\.googleapis\.com|secret|token|credential/i);
+    expect(sensitive.rawIdsIncluded).toBe(false);
+    expect(sensitive.payloadIncluded).toBe(false);
+  });
+
+  it("generates deterministic checksums and changes when manifest data changes", () => {
+    const included = records().slice(0, 2);
+    const checksum = generatePackageChecksum(included, { manifest: "a" });
+
+    expect(generatePackageChecksum([...included].reverse(), { manifest: "a" })).toBe(checksum);
+    expect(generatePackageChecksum(included, { manifest: "b" })).not.toBe(checksum);
+  });
+
+  it("validates package manifests against collected records", () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const included = filterEvidenceByRetentionStatus(filterEvidenceByScope(records(), exportRequest.scopeParameters, exportProfile), ["active"]);
+    const pkg = assembleEvidencePackage(exportRequest, exportProfile, records(), assemblyContext());
+
+    expect(validatePackageManifest(pkg, included)).toEqual({ ok: true, errors: [] });
+    expect(validatePackageManifest({ ...pkg, packageMetadata: { ...pkg.packageMetadata, includedEvidenceCount: 99 } }, included).errors)
+      .toContain("package_manifest_included_count_mismatch");
+  });
+
+  it("assembles a valid empty package when no evidence matches scope", () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+    const pkg = assembleEvidencePackage(exportRequest, exportProfile, [], assemblyContext());
+
+    expect(pkg.packageMetadata.includedEvidenceCount).toBe(0);
+    expect(pkg.evidenceManifest.evidenceClasses).toEqual(exportProfile.approvedEvidenceClasses);
+    expect(validatePackageManifest(pkg, [])).toEqual({ ok: true, errors: [] });
+  });
+
+  it("rejects cross-landlord assembly and out-of-profile evidence class requests", () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile);
+
+    expect(() => assembleEvidencePackage(exportRequest, exportProfile, records(), assemblyContext({ landlordId: "landlord:ffffffffffffffffffff" })))
+      .toThrow("landlord_scope_mismatch");
+    expect(() =>
+      assembleEvidencePackage(
+        { ...exportRequest, scopeParameters: { evidenceClassFilters: ["ScreeningEvidence"] } },
+        exportProfile,
+        records(),
+        assemblyContext()
+      )
+    ).toThrow("requested_evidence_class_not_approved");
+  });
+
+  it("rejects redaction policy loosening and invalid actor contexts", () => {
+    const exportProfile = profile();
+    const exportRequest = request(exportProfile, {
+      redactionPolicyOverride: {
+        dataMinimizationLevel: "Full",
+        reason: "loosen",
+      },
+    });
+
+    expect(() => assembleEvidencePackage(exportRequest, exportProfile, records(), assemblyContext()))
+      .toThrow("redaction_override_cannot_loosen_profile");
+    expect(() => assembleEvidencePackage(request(exportProfile), exportProfile, records(), assemblyContext({ actorRole: "AdminSupport", landlordId: "" })))
+      .toThrow("requesting_actor_scope_required");
+  });
+});

--- a/rentchain-api/src/services/evidence-package-builder-service.ts
+++ b/rentchain-api/src/services/evidence-package-builder-service.ts
@@ -1,0 +1,477 @@
+import crypto from "crypto";
+import { db } from "../firebase";
+import type {
+  EvidenceClass,
+  EvidenceRecord,
+  EvidenceRecordStatus,
+  EvidenceSensitivityClass,
+} from "../types/evidence-record-types";
+import { EVIDENCE_RECORD_COLLECTION } from "../types/evidence-record-types";
+import type { ExportAuthorizationActorRole } from "../types/export-authorization-types";
+import {
+  validateExportAuthorizationContext,
+  validateExportRequestAuthorization,
+} from "../types/export-authorization-types";
+import type { ExportPackage } from "../types/export-package-types";
+import type {
+  ExportDataMinimizationLevel,
+  ExportProfile,
+} from "../types/export-profile-types";
+import type {
+  ExportRequest,
+  ExportScopeParameters,
+} from "../types/export-request-types";
+import {
+  createExportPackageEntity,
+  validateExportPackage,
+  validateExportProfile,
+  validateExportRequest,
+} from "./export-service";
+
+const DEFAULT_ALLOWED_STATUSES: EvidenceRecordStatus[] = ["active"];
+const AUDIT_ALLOWED_STATUSES: EvidenceRecordStatus[] = ["active", "superseded", "archived"];
+const BATCH_SIZE = 100;
+
+const SENSITIVE_FIELD_GROUP_PATTERN =
+  /applicant|identity|document|provider|payload|report|payment|amount|bank|card|account|message|contact|debug|credential|token|secret|internal/i;
+
+type QuerySnapshotLike<T> = {
+  docs?: Array<{
+    data: () => T;
+  }>;
+};
+
+type EvidenceRecordQueryLike<T> = {
+  where?: (fieldPath: string, opStr: string, value: unknown) => EvidenceRecordQueryLike<T>;
+  orderBy?: (fieldPath: string, directionStr?: "asc" | "desc") => EvidenceRecordQueryLike<T>;
+  limit?: (limit: number) => EvidenceRecordQueryLike<T>;
+  get: () => Promise<QuerySnapshotLike<T>>;
+};
+
+export type EvidenceRecordFirestoreLike = {
+  collection: <T = Record<string, unknown>>(name: string) => EvidenceRecordQueryLike<T>;
+};
+
+export type ExportAssemblyContext = {
+  timestamp: string;
+  actorId: string;
+  actorRole: ExportAuthorizationActorRole;
+  landlordId: string;
+  purpose: string;
+  allowAuditStatusInclusion?: boolean;
+  firestore?: EvidenceRecordFirestoreLike;
+  rawIdsIncluded: false;
+};
+
+export type ProjectedEvidenceRecord = {
+  evidenceSafeReference: string;
+  evidenceClass: EvidenceClass;
+  evidenceType: string;
+  resourceType: EvidenceRecord["resourceType"];
+  label: string;
+  status: EvidenceRecordStatus;
+  createdAt: string;
+  sourceObservedAt: string | null;
+  sensitivityClass: EvidenceSensitivityClass;
+  allowedFieldGroups: string[];
+  redactedFieldGroups: string[];
+  redactionLevel: ExportDataMinimizationLevel;
+  redactionReason: string;
+  retentionStatus: {
+    legalHoldStatus: EvidenceRecord["retentionMetadata"]["legalHoldStatus"];
+    evaluatedAt: string | null;
+    rawIdsIncluded: false;
+  };
+  provenance: {
+    sourceCollection: EvidenceRecord["provenanceMetadata"]["source"]["sourceCollection"];
+    sourceReferenceKey: string;
+    sourceVersion: string | null;
+    rawIdsIncluded: false;
+    payloadIncluded: false;
+  };
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type EvidencePackageManifest = {
+  includedCount: number;
+  excludedCount: number;
+  excludedReasons: Array<{
+    evidenceId: string;
+    reason: string;
+  }>;
+  appliedFilters: {
+    evidenceClasses: EvidenceClass[];
+    dateRangeStart: string | null;
+    dateRangeEnd: string | null;
+    unitsScopeApplied: string[];
+    allowedStatuses: EvidenceRecordStatus[];
+    redactionPolicyApplied: ExportDataMinimizationLevel;
+    rawIdsIncluded: false;
+  };
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type EvidencePackageValidationResult = {
+  ok: boolean;
+  errors: string[];
+};
+
+function stableHash(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): T[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+function parseTime(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isScopeSubset(request: ExportRequest, profile: ExportProfile): boolean {
+  const approved = new Set(profile.approvedEvidenceClasses);
+  const requested = request.scopeParameters.evidenceClassFilters || profile.approvedEvidenceClasses;
+  if (requested.some((item) => !approved.has(item))) return false;
+  const excluded = new Set(profile.excludedUnitIds);
+  return !(request.scopeParameters.unitScopeOverride || []).some((item) => excluded.has(item));
+}
+
+function redactionLevelFor(request: ExportRequest, profile: ExportProfile): ExportDataMinimizationLevel {
+  return request.redactionPolicyOverride?.dataMinimizationLevel || profile.dataMinimizationLevel;
+}
+
+function allowedStatusesFor(context: ExportAssemblyContext): EvidenceRecordStatus[] {
+  return context.allowAuditStatusInclusion ? AUDIT_ALLOWED_STATUSES : DEFAULT_ALLOWED_STATUSES;
+}
+
+function validateAssemblyInputs(
+  request: ExportRequest,
+  profile: ExportProfile,
+  context: ExportAssemblyContext
+): void {
+  const profileValidation = validateExportProfile(profile);
+  if (!profileValidation.ok) throw new Error(profileValidation.errors[0] || "export_profile_invalid");
+
+  const requestValidation = validateExportRequest(request, profile);
+  if (!requestValidation.ok) throw new Error(requestValidation.errors[0] || "export_request_invalid");
+
+  const contextValidation = validateExportAuthorizationContext({
+    requestingActorId: context.actorId,
+    requestingActorRole: context.actorRole,
+    requestingActorScope: context.landlordId,
+    requestingPurpose: context.purpose,
+    timestamp: context.timestamp,
+    rawIdsIncluded: false,
+  });
+  if (!contextValidation.ok) throw new Error(contextValidation.errors[0] || "export_authorization_context_invalid");
+
+  const authorization = validateExportRequestAuthorization(request, profile, {
+    requestingActorId: context.actorId,
+    requestingActorRole: context.actorRole,
+    requestingActorScope: context.landlordId,
+    requestingPurpose: context.purpose,
+    timestamp: context.timestamp,
+    rawIdsIncluded: false,
+  });
+  if (!authorization.isApproved) throw new Error(authorization.denialReason || "export_request_authorization_denied");
+
+  if (context.landlordId !== profile.landlordId || request.landlordId !== context.landlordId) {
+    throw new Error("export_assembly_landlord_scope_mismatch");
+  }
+  if (!isScopeSubset(request, profile)) throw new Error("export_assembly_scope_must_not_widen_profile");
+  if (context.rawIdsIncluded !== false) throw new Error("export_assembly_raw_ids_must_be_false");
+}
+
+function recordUnitCandidates(record: EvidenceRecord): string[] {
+  return [
+    record.safeReference.safeReferenceKey,
+    record.provenanceMetadata.source.sourceReferenceKey,
+    ...record.sensitivityMetadata.allowedFieldGroups,
+  ].filter(Boolean);
+}
+
+function matchesUnitScope(record: EvidenceRecord, scope: ExportScopeParameters, profile: ExportProfile): boolean {
+  const candidates = recordUnitCandidates(record);
+  if (profile.excludedUnitIds.some((unitRef) => candidates.includes(unitRef))) return false;
+  const override = scope.unitScopeOverride || [];
+  if (!override.length) return true;
+  return override.some((unitRef) => candidates.includes(unitRef));
+}
+
+function exclusionReason(record: EvidenceRecord, scope: ExportScopeParameters, profile: ExportProfile): string | null {
+  const requestedClasses = scope.evidenceClassFilters || profile.approvedEvidenceClasses;
+  if (!profile.approvedEvidenceClasses.includes(record.evidenceClass)) return "evidence_class_not_approved";
+  if (!requestedClasses.includes(record.evidenceClass)) return "evidence_class_not_requested";
+  const start = parseTime(scope.dateRangeStart);
+  const end = parseTime(scope.dateRangeEnd);
+  const createdAt = parseTime(record.createdAt);
+  if (createdAt === null) return "evidence_created_at_invalid";
+  if (start !== null && createdAt < start) return "evidence_before_requested_date_range";
+  if (end !== null && createdAt > end) return "evidence_after_requested_date_range";
+  if (!matchesUnitScope(record, scope, profile)) return "evidence_unit_scope_excluded";
+  if (record.retentionMetadata.legalHoldStatus !== "active" && deletionEligible(record)) return "evidence_deletion_eligible";
+  return null;
+}
+
+function deletionEligible(record: EvidenceRecord): boolean {
+  const deletionAt = record.retentionMetadata.eligibleForDeletionAt || record.retentionMetadata.deleteAfter;
+  if (!deletionAt) return false;
+  const parsed = Date.parse(deletionAt);
+  return Number.isFinite(parsed) && parsed <= Date.parse(record.createdAt);
+}
+
+function safeEvidenceId(record: EvidenceRecord): string {
+  return `evidence:${stableHash([
+    record.evidenceId,
+    record.safeReference.safeReferenceKey,
+    record.evidenceClass,
+  ]).slice(0, 20)}`;
+}
+
+function redactedFieldsFor(record: EvidenceRecord, level: ExportDataMinimizationLevel): string[] {
+  const excluded = record.sensitivityMetadata.excludedFieldGroups;
+  if (level === "Full") return uniqueSorted(excluded);
+  if (level === "Redacted") {
+    return uniqueSorted([
+      ...excluded,
+      ...record.sensitivityMetadata.allowedFieldGroups.filter((field) => SENSITIVE_FIELD_GROUP_PATTERN.test(field)),
+    ]);
+  }
+  return uniqueSorted([
+    ...excluded,
+    ...record.sensitivityMetadata.allowedFieldGroups,
+    "sensitivity_metadata_details",
+    "source_lineage_detail",
+  ]);
+}
+
+function allowedFieldsFor(record: EvidenceRecord, level: ExportDataMinimizationLevel): string[] {
+  if (level === "Full") return uniqueSorted(record.sensitivityMetadata.allowedFieldGroups);
+  if (level === "Redacted") {
+    return uniqueSorted(record.sensitivityMetadata.allowedFieldGroups.filter((field) => !SENSITIVE_FIELD_GROUP_PATTERN.test(field)));
+  }
+  return ["status", "timestamp", "safeReference", "redactionCategories"];
+}
+
+function exportDb(firestore?: EvidenceRecordFirestoreLike): EvidenceRecordFirestoreLike {
+  return firestore || (db as unknown as EvidenceRecordFirestoreLike);
+}
+
+function docsToRecords(snapshot: QuerySnapshotLike<EvidenceRecord>): EvidenceRecord[] {
+  return (snapshot.docs || []).map((doc) => doc.data()).filter(Boolean);
+}
+
+export function filterEvidenceByRetentionStatus(
+  records: EvidenceRecord[],
+  allowedStatuses: EvidenceRecordStatus[]
+): EvidenceRecord[] {
+  const allowed = new Set(allowedStatuses);
+  return records.filter((record) => allowed.has(record.status));
+}
+
+export function filterEvidenceByScope(
+  records: EvidenceRecord[],
+  scopeParameters: ExportScopeParameters,
+  profile: ExportProfile
+): EvidenceRecord[] {
+  return records.filter((record) => exclusionReason(record, scopeParameters, profile) === null);
+}
+
+export function projectEvidenceForExport(
+  record: EvidenceRecord,
+  redactionLevel: ExportDataMinimizationLevel
+): ProjectedEvidenceRecord {
+  return {
+    evidenceSafeReference: safeEvidenceId(record),
+    evidenceClass: record.evidenceClass,
+    evidenceType: record.evidenceType,
+    resourceType: record.resourceType,
+    label: record.safeReference.label,
+    status: record.status,
+    createdAt: record.createdAt,
+    sourceObservedAt: record.provenanceMetadata.source.sourceObservedAt,
+    sensitivityClass: record.sensitivityMetadata.sensitivityClass,
+    allowedFieldGroups: allowedFieldsFor(record, redactionLevel),
+    redactedFieldGroups: redactedFieldsFor(record, redactionLevel),
+    redactionLevel,
+    redactionReason:
+      redactionLevel === "Full"
+        ? "Metadata-only export projection excludes raw and payload field groups."
+        : `Export projection applies ${redactionLevel} minimization for institutional recipient scope.`,
+    retentionStatus: {
+      legalHoldStatus: record.retentionMetadata.legalHoldStatus,
+      evaluatedAt: record.retentionMetadata.evaluatedAt,
+      rawIdsIncluded: false,
+    },
+    provenance: {
+      sourceCollection: record.provenanceMetadata.source.sourceCollection,
+      sourceReferenceKey: record.provenanceMetadata.source.sourceReferenceKey,
+      sourceVersion: record.provenanceMetadata.source.sourceVersion,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function generatePackageChecksum(
+  records: EvidenceRecord[],
+  metadata: Record<string, unknown>
+): string {
+  return stableHash({
+    records: records
+      .map((record) => ({
+        evidenceId: record.evidenceId,
+        evidenceClass: record.evidenceClass,
+        status: record.status,
+        createdAt: record.createdAt,
+        safeReferenceKey: record.safeReference.safeReferenceKey,
+      }))
+      .sort((a, b) => `${a.evidenceClass}:${a.createdAt}:${a.evidenceId}`.localeCompare(`${b.evidenceClass}:${b.createdAt}:${b.evidenceId}`)),
+    metadata,
+  });
+}
+
+export function validatePackageManifest(
+  pkg: ExportPackage,
+  collectedRecords: EvidenceRecord[]
+): EvidencePackageValidationResult {
+  const errors: string[] = [];
+  const pkgValidation = validateExportPackage(pkg);
+  errors.push(...pkgValidation.errors);
+  if (pkg.packageMetadata.includedEvidenceCount !== collectedRecords.length) {
+    errors.push("package_manifest_included_count_mismatch");
+  }
+  const recordClasses = uniqueSorted(collectedRecords.map((record) => record.evidenceClass));
+  const manifestClasses = uniqueSorted(pkg.evidenceManifest.evidenceClasses);
+  if (collectedRecords.length > 0 && JSON.stringify(recordClasses) !== JSON.stringify(manifestClasses)) {
+    errors.push("package_manifest_evidence_classes_mismatch");
+  }
+  if (pkg.rawIdsIncluded !== false || pkg.payloadIncluded !== false) errors.push("package_manifest_raw_or_payload_included");
+  if (!pkg.packageMetadata.checksumValue) errors.push("package_manifest_checksum_missing");
+  return { ok: errors.length === 0, errors };
+}
+
+export function assembleEvidencePackage(
+  request: ExportRequest,
+  profile: ExportProfile,
+  evidenceRecords: EvidenceRecord[],
+  context: ExportAssemblyContext
+): ExportPackage {
+  validateAssemblyInputs(request, profile, context);
+  const allowedStatuses = allowedStatusesFor(context);
+  const scoped = filterEvidenceByScope(
+    filterEvidenceByRetentionStatus(evidenceRecords, allowedStatuses),
+    request.scopeParameters,
+    profile
+  );
+  const projected = scoped.map((record) => projectEvidenceForExport(record, redactionLevelFor(request, profile)));
+  const evidenceClasses = uniqueSorted(scoped.map((record) => record.evidenceClass));
+  const excludedEvidence = evidenceRecords
+    .map((record) => {
+      if (!allowedStatuses.includes(record.status)) return { evidenceId: safeEvidenceId(record), reason: "evidence_status_not_allowed" };
+      const reason = exclusionReason(record, request.scopeParameters, profile);
+      return reason ? { evidenceId: safeEvidenceId(record), reason } : null;
+    })
+    .filter((item): item is { evidenceId: string; reason: string } => item !== null);
+  const manifest: EvidencePackageManifest = {
+    includedCount: scoped.length,
+    excludedCount: excludedEvidence.length,
+    excludedReasons: excludedEvidence,
+    appliedFilters: {
+      evidenceClasses,
+      dateRangeStart: request.scopeParameters.dateRangeStart || null,
+      dateRangeEnd: request.scopeParameters.dateRangeEnd || null,
+      unitsScopeApplied: request.scopeParameters.unitScopeOverride || [],
+      allowedStatuses,
+      redactionPolicyApplied: redactionLevelFor(request, profile),
+      rawIdsIncluded: false,
+    },
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+  const checksum = generatePackageChecksum(scoped, manifest);
+  const pkg = createExportPackageEntity({
+    request,
+    recipientType: profile.recipientType,
+    purpose: profile.purpose,
+    assembledAt: context.timestamp,
+    assembledBy: context.actorId,
+    evidenceClasses: evidenceClasses.length ? evidenceClasses : profile.approvedEvidenceClasses.slice(0, 1),
+    unitsScopeApplied: request.scopeParameters.unitScopeOverride || [],
+    redactionPolicyApplied: redactionLevelFor(request, profile),
+    includedEvidenceCount: projected.length,
+    totalPackageSize: JSON.stringify(projected).length,
+    metadata: {
+      builderVersion: "evidence_package_builder_v1",
+      manifestIncludedCount: manifest.includedCount,
+      manifestExcludedCount: manifest.excludedCount,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+  });
+  const finalized: ExportPackage = {
+    ...pkg,
+    packageMetadata: {
+      ...pkg.packageMetadata,
+      checksumValue: checksum,
+    },
+    evidenceManifest: {
+      ...pkg.evidenceManifest,
+      evidenceClasses: evidenceClasses.length ? evidenceClasses : profile.approvedEvidenceClasses,
+      excludedEvidence,
+    },
+  };
+  const result = validatePackageManifest(finalized, scoped);
+  if (!result.ok) throw new Error(result.errors[0] || "evidence_package_manifest_invalid");
+  return finalized;
+}
+
+export async function materializeEvidenceRecords(
+  landlordId: string,
+  request: ExportRequest,
+  profile: ExportProfile,
+  firestore: EvidenceRecordFirestoreLike
+): Promise<EvidenceRecord[]> {
+  if (landlordId !== request.landlordId || landlordId !== profile.landlordId) {
+    throw new Error("evidence_materialization_landlord_scope_mismatch");
+  }
+  if (!isScopeSubset(request, profile)) throw new Error("evidence_materialization_scope_must_not_widen_profile");
+  const requestedClasses = request.scopeParameters.evidenceClassFilters || profile.approvedEvidenceClasses;
+  const byId = new Map<string, EvidenceRecord>();
+  for (const evidenceClass of requestedClasses) {
+    const collection = firestore.collection<EvidenceRecord>(EVIDENCE_RECORD_COLLECTION);
+    let query = collection.where?.("landlordId", "==", landlordId);
+    query = query?.where?.("evidenceClass", "==", evidenceClass);
+    if (request.scopeParameters.dateRangeStart) {
+      query = query?.where?.("createdAt", ">=", request.scopeParameters.dateRangeStart);
+    }
+    if (request.scopeParameters.dateRangeEnd) {
+      query = query?.where?.("createdAt", "<=", request.scopeParameters.dateRangeEnd);
+    }
+    query = query?.orderBy?.("createdAt", "desc");
+    query = query?.limit?.(BATCH_SIZE);
+    if (!query?.get) throw new Error("evidence_materialization_query_unavailable");
+    const records = docsToRecords(await query.get());
+    for (const record of records) {
+      if (record.landlordId !== landlordId) throw new Error("evidence_materialization_record_landlord_mismatch");
+      byId.set(record.evidenceId, record);
+    }
+  }
+  return filterEvidenceByScope(Array.from(byId.values()), request.scopeParameters, profile);
+}
+
+export async function buildEvidencePackage(
+  request: ExportRequest,
+  profile: ExportProfile,
+  context: ExportAssemblyContext
+): Promise<ExportPackage> {
+  validateAssemblyInputs(request, profile, context);
+  const records = await materializeEvidenceRecords(context.landlordId, request, profile, exportDb(context.firestore));
+  return assembleEvidencePackage(request, profile, records, context);
+}


### PR DESCRIPTION
## Summary
- Implement evidence package builder service for authorized institutional export assembly
- Add scope, retention status, redaction projection, manifest validation, and checksum helpers
- Add unit and integration coverage plus architecture documentation

## Validation
- PASS: npm run test -- src/services/__tests__/evidence-package-builder.test.ts
- PASS: npm run test -- src/services/__tests__/evidence-package-builder-integration.test.ts
- PASS: npm run build
- PASS: git diff --check
- ATTEMPTED: npm run lint (package has no lint script)
- ATTEMPTED: npm run test (full backend suite has unrelated pre-existing failures outside this mission scope)

## Known Limitations
- Service-layer only: no routes, persistence, signing, delivery, audit trail storage, workers, Firestore rules, or external integrations
- Full backend suite still reports unrelated failures in lease draft, governed review workspace, recipient trust review, support console, tenant workspace continuity, and analytics tests
