### PR TITLE
Implement evidence hash verification with cryptographic signing and chain validation

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,84 +1,88 @@
-# Implementation Summary - Phase 4 Mission 7: Attestation Framework
+# Implementation Summary - Phase 4C Mission 8: Evidence Hash Verification
 
-PR: #1098
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1098
-Branch: feat/attestation-framework-v1
+PR: #1099
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1099
+Branch: feat/evidence-hash-verification-v1
 
 ## Scope Delivered
 
-Implemented Attestation Framework v1 as a service-layer foundation for export package signature metadata, certificate references, evidence/package attestation links, and immutable attestation chain verification.
+Implemented Evidence Hash Verification v1 as a service-layer foundation for deterministic export package hashes, evidence record hashes, signature reference metadata, and fail-closed attestation hash-chain validation.
 
-The implementation extends the existing export audit trail with signature and attestation event types, emits those events through the existing canonicalEvents append path, adds deterministic metadata-only certificate references, adds pure evidence/package attestation linking helpers, and provides landlord-scoped chain reconstruction and allowlist projection helpers.
+The implementation adds pure SHA-256 hashing over canonical metadata, deterministic signature references from content hash and allowed algorithm, generated/verified signature event hash metadata, high-level signing workflow helpers in the attestation service, and hash-chain reconstruction/verification helpers.
 
-No routes, dashboards, signing execution, delivery mechanisms, recipient verification surfaces, external integrations, Firestore rules, background workers, dependency changes, or production data migrations were added.
+No routes, frontend surfaces, Firestore rules, deployment changes, dependency changes, external key integrations, background workers, production signing integrations, delivery mechanisms, recipient verification, or migrations were added.
 
 ## Files Changed
 
+- rentchain-api/src/lib/evidence-hash-service.ts
+- rentchain-api/src/lib/evidence-hash-service.test.ts
+- rentchain-api/src/services/signature-generation-service.ts
+- rentchain-api/src/services/hash-chain-validation-service.ts
+- rentchain-api/src/services/attestation-service.ts
+- rentchain-api/src/services/__tests__/signature-generation-service.test.ts
+- rentchain-api/src/services/__tests__/hash-chain-validation-service.test.ts
+- rentchain-api/src/services/__tests__/evidence-package-hash-integration.test.ts
+- rentchain-api/src/services/__tests__/attestation-service.test.ts
+- rentchain-api/src/services/__tests__/evidence-attestation-linker.test.ts
 - rentchain-api/src/types/attestation-types.ts
 - rentchain-api/src/types/export-audit-types.ts
-- rentchain-api/src/services/attestation-service.ts
-- rentchain-api/src/services/attestation-certificate-manager.ts
-- rentchain-api/src/services/evidence-attestation-linker.ts
-- rentchain-api/src/services/export-audit-trail-service.ts
 - rentchain-api/src/types/__tests__/attestation-types.test.ts
-- rentchain-api/src/services/__tests__/attestation-service.test.ts
-- rentchain-api/src/services/__tests__/attestation-certificate-manager.test.ts
-- rentchain-api/src/services/__tests__/evidence-attestation-linker.test.ts
-- rentchain-api/src/services/__tests__/attestation-integration.test.ts
-- rentchain-api/src/services/__tests__/export-audit-trail-integration.test.ts
+- docs/architecture/evidence-hash-verification-v1.md
 - docs/architecture/attestation-framework-v1.md
-- docs/architecture/export-audit-trail-v1.md
 - .handoff/impl-summary.md
 
 ## Tests Passed
 
-- `npm test -- src/types/__tests__/attestation-types.test.ts src/services/__tests__/attestation-service.test.ts src/services/__tests__/attestation-certificate-manager.test.ts src/services/__tests__/evidence-attestation-linker.test.ts src/services/__tests__/attestation-integration.test.ts src/services/__tests__/export-audit-trail-integration.test.ts`: PASS
-- `npm run test:single -- src/types/__tests__/attestation-types.test.ts src/services/__tests__/attestation-service.test.ts src/services/__tests__/attestation-certificate-manager.test.ts src/services/__tests__/evidence-attestation-linker.test.ts src/services/__tests__/attestation-integration.test.ts src/services/__tests__/export-audit-trail-integration.test.ts`: PASS
+- `npm test -- src/lib/evidence-hash-service.test.ts src/services/__tests__/signature-generation-service.test.ts src/services/__tests__/hash-chain-validation-service.test.ts src/services/__tests__/evidence-package-hash-integration.test.ts src/services/__tests__/attestation-service.test.ts`: PASS
+- `npm run test:single -- src/lib/evidence-hash-service.test.ts src/services/__tests__/signature-generation-service.test.ts src/services/__tests__/hash-chain-validation-service.test.ts src/services/__tests__/evidence-package-hash-integration.test.ts src/services/__tests__/attestation-service.test.ts`: PASS
 - `npm run build` in `rentchain-api`: PASS
 - `git diff --check`: PASS
 
 ## Acceptance Criteria Met
 
-- [x] Attestation type contracts added with safe references, immutable flags, and `rawIdsIncluded: false` / `payloadIncluded: false` constraints.
-- [x] Export audit event types extended with signature requested, signature generated, signature verified, attestation linked, and attestation revoked events.
-- [x] Non-blocking audit append helpers added for signature requested, generated, verified, and attestation linked events.
-- [x] Signature and attestation audit events are written through canonicalEvents with safe references and metadata-only payloads.
-- [x] Certificate manager generates deterministic safe certificate references and enforces `RSA-SHA256` / `ECDSA-SHA256` only.
-- [x] Certificate projection excludes certificate material and key material.
-- [x] Evidence/package attestation linker creates immutable metadata-only links without mutating evidence or package records.
-- [x] Chain builder reconstructs attestation lifecycle from canonical export audit events.
-- [x] Chain verifier rejects missing lifecycle steps, state regressions, invalid timestamps, reference mismatches, and raw/payload flags.
-- [x] Landlord projection helper returns allowlisted attestation data only and rejects landlord scope mismatch.
-- [x] Export audit integration tests confirm signature events appear in package audit trail without regressions.
-- [x] Architecture documentation describes implemented components, integration points, boundaries, validation, and deferred work.
+- [x] Deterministic SHA-256 hash computation added for export packages.
+- [x] Deterministic SHA-256 hash computation added for evidence records.
+- [x] Canonical normalization sorts object keys and normalizes undefined values to null.
+- [x] Package and evidence hash helpers are pure and do not mutate input objects.
+- [x] Signature reference generation is deterministic from hash and algorithm.
+- [x] `RSA-SHA256` and `ECDSA-SHA256` are accepted; unsupported algorithms are rejected.
+- [x] Signature metadata is metadata-only and excludes signature material, certificate material, and key material.
+- [x] Generated and verified signature audit events can carry content hashes.
+- [x] Attestation service helpers added for requesting, recording generated, and recording verified package signatures.
+- [x] Signing helpers validate `ExportAuthorizationContext` and enforce landlord scope.
+- [x] Hash-chain reconstruction and integrity validation added.
+- [x] Verification fails closed on invalid hash format, missing generated event, missing verified event, and hash mismatch.
+- [x] Full request -> generated -> verified workflow tested through canonical audit events.
+- [x] Evidence-attestation linking works with verified signature attestations.
+- [x] Mutation scan confirmed no evidence/package collection writes in new hash/signature services.
 - [x] No protected areas modified.
+- [x] No dependency changes.
 - [x] No unrelated files modified.
 
 ## Manual QA
 
-Manual preview QA is not required. This mission does not change frontend rendering, mobile layout, route behavior, auth flow, routing, or user-visible UI. Service-layer behavior is covered by targeted unit/integration tests and TypeScript build validation.
+Manual preview QA is not required. This mission does not change frontend rendering, mobile layout, routing, auth flow, API routes, or user-visible behavior. Service-layer behavior is covered by targeted unit/integration tests and TypeScript build validation.
 
 Manual checklist completed by code/test inspection:
 
-1. Attestation schema flags inspected: raw IDs, payloads, raw certificates, signature material, and key material are explicitly false where applicable.
-2. Certificate safe-reference determinism verified by tests with repeated registration inputs.
-3. Audit trail integration verified with mock canonicalEvents adapter for signature requested/generated events and full attestation chain events.
-4. Immutability verified through existing export audit create semantics and immutable/link flags.
-5. Projection safety verified through landlord projection tests and restricted literal scan of new attestation files.
-6. Landlord isolation verified through projection mismatch and linker query tests.
-7. Evidence linking verified through immutable link and evidence-attestation map tests.
-8. Certificate manager verified for accepted algorithms and rejected unsupported algorithms.
-9. Non-blocking append verified with failing Firestore-like adapter returning null.
+1. Hash determinism verified through repeated computation tests with identical package and evidence data.
+2. Hash stability verified by SHA-256 64-character lowercase hex checks.
+3. Signature reference generation verified as deterministic from content hash and algorithm.
+4. Chain integrity validation verified to reject missing events and hash mismatches.
+5. Authorization validation verified through raw flag, missing actor, missing landlord scope, and cross-landlord tests.
+6. Evidence/package immutability verified by tests and code inspection.
+7. Audit trail integration verified with mock canonicalEvents adapter for signature requested, generated, and verified events.
+8. Non-blocking append behavior verified with failing Firestore-like adapter returning null for request helper.
+9. Landlord scope enforcement verified through cross-landlord verification rejection.
 10. Architecture documentation reviewed for scope boundaries and deferred work.
 
 ## Known Limitations
 
-- No signing operation is implemented; only metadata lifecycle events and references are established.
-- No certificate storage, certificate content validation, HSM, KMS, PKI, recipient verification, delivery, or external integration was added.
+- Signature generation produces deterministic metadata references only; no private-key signing is implemented.
+- No certificate storage, external certificate validation, HSM, KMS, PKI, notary, timestamp authority, recipient verification, delivery, or external integration was added.
 - No HTTP routes, dashboards, Firestore rules, background workers, or migrations were added.
-- Chain verification validates event order and metadata integrity, not cryptographic signatures.
-- `npm run build:api` is not available in the repo root; `npm run build` was run in `rentchain-api` instead.
+- Hash-chain verification validates metadata hash integrity and lifecycle order, not external cryptographic proof.
 
 ## Recommended Next Mission
 
-Phase 4C signing execution planning or a narrow attestation route/read-model mission with explicit authorization requirements.
+Phase 4C trust workspace implementation or a narrow route/read-model mission for authorized attestation hash verification retrieval.

--- a/docs/architecture/attestation-framework-v1.md
+++ b/docs/architecture/attestation-framework-v1.md
@@ -9,6 +9,8 @@ Attestation Framework v1 establishes service-layer contracts for package signing
 
 The framework does not perform signing operations. It records lifecycle metadata, safe references, and immutable chain state so future signing and recipient verification missions can build on audited foundations.
 
+Evidence Hash Verification v1 adds deterministic package/evidence hashing and signature-reference metadata. It still does not perform private-key signing or external verification; it records and verifies metadata hashes through the same canonical event chain.
+
 ## Components
 
 The implementation adds:
@@ -17,6 +19,9 @@ The implementation adds:
 - `rentchain-api/src/services/attestation-service.ts`
 - `rentchain-api/src/services/attestation-certificate-manager.ts`
 - `rentchain-api/src/services/evidence-attestation-linker.ts`
+- `rentchain-api/src/lib/evidence-hash-service.ts`
+- `rentchain-api/src/services/signature-generation-service.ts`
+- `rentchain-api/src/services/hash-chain-validation-service.ts`
 
 The export audit event contract now includes:
 
@@ -71,6 +76,24 @@ Landlord-scoped query helpers filter by safe landlord and package references. `b
 
 `projectAttestationForLandlord()` returns an allowlisted landlord projection with only safe references, lifecycle state, timestamps, and algorithm labels.
 
+## Hash Verification
+
+Evidence Hash Verification v1 adds:
+
+- deterministic package hash computation from stable export metadata
+- deterministic evidence record hash computation from safe metadata fields
+- signature reference generation from package hash and algorithm
+- generated and verified signature events carrying the content hash
+- fail-closed hash-chain validation for missing lifecycle steps or hash mismatches
+
+Hash verification does not mutate evidence records or export packages. It reads package/evidence metadata, emits canonical audit events for signature lifecycle, and reconstructs chain state from immutable audit events.
+
+## Signing Execution
+
+The current signing layer creates metadata references only. It does not perform private-key operations, external certificate validation, or external timestamping. `recordGeneratedSignature()` creates a deterministic signature reference from the content hash and allowed algorithm. `recordVerifiedSignature()` validates the generated hash against the current package hash before appending a verified event.
+
+Verification failure is fail-closed: invalid hash format, missing generated event, missing signature reference, missing certificate reference, algorithm gaps, or hash mismatch returns an unsuccessful verification result and does not append a verified event.
+
 ## Portable Attestation Alignment
 
 This framework does not replace portable attestations. It complements them by adding package-level lifecycle evidence for future institutional export signing and trust-chain review.
@@ -107,3 +130,6 @@ Tests cover:
 - chain integrity failures for missing lifecycle steps
 - landlord-scoped attestation projections
 - export audit trail integration for signature event types
+- deterministic package/evidence hash computation
+- signature reference generation
+- hash-chain reconstruction and fail-closed verification

--- a/docs/architecture/evidence-hash-verification-v1.md
+++ b/docs/architecture/evidence-hash-verification-v1.md
@@ -1,0 +1,115 @@
+# Evidence Hash Verification v1
+
+Status: implemented service foundation
+Scope: deterministic package/evidence hashing, signature reference generation, and attestation hash-chain verification
+
+## Purpose
+
+Evidence Hash Verification v1 adds a deterministic integrity layer for export packages and evidence records. It computes SHA-256 hashes over canonical metadata, generates safe signature references from those hashes, records package signing lifecycle through canonical export audit events, and verifies attestation chains fail closed when hashes or lifecycle steps do not match.
+
+This mission remains service-layer only. It does not add routes, dashboards, delivery, recipient verification, external key infrastructure, Firestore rules, workers, migrations, or production signing integrations.
+
+## Components
+
+The implementation adds:
+
+- `rentchain-api/src/lib/evidence-hash-service.ts`
+- `rentchain-api/src/services/signature-generation-service.ts`
+- `rentchain-api/src/services/hash-chain-validation-service.ts`
+
+It also extends:
+
+- `rentchain-api/src/services/attestation-service.ts`
+- `rentchain-api/src/types/attestation-types.ts`
+- `rentchain-api/src/types/export-audit-types.ts`
+
+## Hash Computation
+
+`computeEvidencePackageHash()` hashes a canonical package representation with stable sorted keys and explicit null handling. The package hash includes the package id, request id, landlord safe reference, recipient type, purpose, stable package metadata, evidence manifest scope, status, and metadata-only flags.
+
+`computeEvidenceRecordHash()` hashes stable evidence metadata including evidence class, type, schema version, landlord scope, resource type, safe reference metadata, source collection/reference, sensitivity metadata, retention summary, lifecycle status, and immutable flags.
+
+Hash inputs intentionally exclude volatile or internal fields such as audit trail references, delivery metadata, signature metadata, raw resource ids, lifecycle event arrays, and mutable timestamps that would make verification unstable.
+
+All hashes must be 64-character lowercase SHA-256 hex strings.
+
+## Signature References
+
+`signature-generation-service.ts` creates deterministic metadata-only signature records:
+
+- signature reference from content hash and algorithm
+- algorithm allowlist: `RSA-SHA256`, `ECDSA-SHA256`
+- certificate safe reference
+- signer safe reference
+- content hash
+- metadata-only and raw-material exclusion flags
+
+The service does not perform private-key operations. It produces signing metadata references only. External key management, certificate authorities, and signing execution remain future work.
+
+## Attestation Integration
+
+`attestation-service.ts` now includes:
+
+- `requestSignatureForPackage()`
+- `recordGeneratedSignature()`
+- `recordVerifiedSignature()`
+
+These helpers validate `ExportAuthorizationContext`, enforce landlord scope, generate deterministic attestation/signature references, and emit existing canonical export audit events. Generated and verified signature events include the package hash as metadata.
+
+Evidence and package objects are never mutated. The only write path is the existing non-blocking canonical audit append helper.
+
+## Hash Chain Verification
+
+`hash-chain-validation-service.ts` reconstructs hash-chain state from an `AttestationChain`.
+
+Validation checks:
+
+- generated signature event exists
+- verified signature event exists
+- content hashes are valid SHA-256 hex
+- generated and verified hashes match
+- timestamps are monotonic
+- metadata flags remain projection-safe
+
+`verifyEvidenceHashAgainstChain()` fails closed. Any invalid hash, missing lifecycle step, generated/verified mismatch, or package hash mismatch returns `success: false` with explicit error codes and no partial acceptance.
+
+## Data Flow
+
+1. Export package is assembled.
+2. `computeEvidencePackageHash()` produces a deterministic SHA-256 hash.
+3. `requestSignatureForPackage()` appends `ExportPackageSignatureRequested`.
+4. `recordGeneratedSignature()` creates a safe signature reference and appends `ExportPackageSignatureGenerated` with the package hash.
+5. `recordVerifiedSignature()` validates the generated hash, appends `ExportPackageSignatureVerified`, and may create an immutable evidence-attestation link.
+6. `buildAttestationChain()` reconstructs the canonical event chain.
+7. `verifyEvidenceHashAgainstChain()` validates hash-chain integrity for the current package hash.
+
+## Boundaries
+
+This framework does not add:
+
+- HTTP routes
+- frontend surfaces
+- recipient verification portals
+- delivery mechanisms
+- external KMS, HSM, PKI, certificate authority, notary, or timestamp integrations
+- background signing workers
+- Firestore rule changes
+- production data migrations
+- key rotation or revocation workflows
+- signature material, key material, certificate content, or provider source material in projections
+
+## Validation
+
+Tests cover:
+
+- canonical JSON normalization
+- deterministic package and evidence hashes
+- SHA-256 format validation
+- read-only package/evidence behavior
+- deterministic signature references
+- algorithm rejection
+- signing context validation
+- hash-chain reconstruction and fail-closed verification
+- request, generated, and verified signature workflow through canonical events
+- landlord scope rejection
+- non-blocking append behavior

--- a/rentchain-api/src/lib/evidence-hash-service.test.ts
+++ b/rentchain-api/src/lib/evidence-hash-service.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeEvidencePackageHash,
+  computeEvidenceRecordHash,
+  isSha256Hash,
+  normalizeForHashing,
+} from "./evidence-hash-service";
+import { createExportPackageEntity, createExportProfileEntity, createExportRequestEntity } from "../services/export-service";
+import type { ExportAuthorizationContext } from "../types/export-authorization-types";
+import { evidenceRecordFixtures } from "../__tests__/fixtures/evidence-record-fixtures";
+
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const timestamp = "2026-06-05T14:00:00.000Z";
+
+function context(): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp,
+    rawIdsIncluded: false,
+  };
+}
+
+function exportPackage() {
+  const auth = context();
+  const profile = createExportProfileEntity(
+    {
+      landlordId: landlordRef,
+      recipientType: "InsuranceAdjuster",
+      recipientName: "Acme Insurance Adjusters LLC",
+      recipientReference: "acme-insurance-adjusters",
+      purpose: "InsuranceClaim",
+      description: "Insurance claim review.",
+      approvedEvidenceClasses: ["PaymentEvidence"],
+      dataMinimizationLevel: "Redacted",
+      createdReason: "Insurance claim package review.",
+    },
+    auth
+  );
+  const request = createExportRequestEntity(
+    {
+      profile,
+      requestedAt: "2026-06-05T14:01:00.000Z",
+      requestedBy: actorRef,
+      requestReason: "Claim settlement review.",
+      scopeParameters: { evidenceClassFilters: ["PaymentEvidence"] },
+    },
+    auth
+  );
+  return createExportPackageEntity({
+    request,
+    recipientType: profile.recipientType,
+    purpose: profile.purpose,
+    assembledAt: "2026-06-05T14:02:00.000Z",
+    assembledBy: actorRef,
+    evidenceClasses: ["PaymentEvidence"],
+    redactionPolicyApplied: "Redacted",
+    includedEvidenceCount: 1,
+  });
+}
+
+describe("evidence hash service", () => {
+  it("normalizes values with stable key ordering and null handling", () => {
+    expect(normalizeForHashing({ b: 2, a: { d: undefined, c: 1 } })).toBe(
+      normalizeForHashing({ a: { c: 1, d: null }, b: 2 })
+    );
+  });
+
+  it("computes deterministic package hashes without mutating packages", () => {
+    const pkg = exportPackage();
+    const before = JSON.stringify(pkg);
+    const first = computeEvidencePackageHash(pkg);
+    const second = computeEvidencePackageHash({
+      ...pkg,
+      evidenceManifest: {
+        ...pkg.evidenceManifest,
+        evidenceClasses: [...pkg.evidenceManifest.evidenceClasses].reverse(),
+      },
+    });
+
+    expect(first).toBe(second);
+    expect(isSha256Hash(first)).toBe(true);
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(pkg)).toBe(before);
+  });
+
+  it("computes deterministic evidence record hashes without mutating records", () => {
+    const record = evidenceRecordFixtures.paymentEvidence;
+    const before = JSON.stringify(record);
+    const first = computeEvidenceRecordHash(record);
+    const second = computeEvidenceRecordHash({ ...record, createdAt: "2030-01-01T00:00:00.000Z" });
+
+    expect(first).toBe(second);
+    expect(isSha256Hash(first)).toBe(true);
+    expect(JSON.stringify(record)).toBe(before);
+  });
+
+  it("rejects invalid package and evidence inputs", () => {
+    expect(() => computeEvidencePackageHash({ ...exportPackage(), rawIdsIncluded: true as false })).toThrow(
+      "export_package_hash_flags_invalid"
+    );
+    expect(() =>
+      computeEvidenceRecordHash({ ...evidenceRecordFixtures.paymentEvidence, metadataOnly: false as true })
+    ).toThrow("evidence_record_hash_flags_invalid");
+  });
+});

--- a/rentchain-api/src/lib/evidence-hash-service.ts
+++ b/rentchain-api/src/lib/evidence-hash-service.ts
@@ -1,0 +1,130 @@
+import { sha256Hex } from "./hash";
+import type { EvidenceRecord } from "../types/evidence-record-types";
+import type { ExportPackage } from "../types/export-package-types";
+
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+function normalizeValue(value: unknown): JsonValue {
+  if (value === undefined) return null;
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(normalizeValue);
+  if (typeof value === "object") {
+    const result: Record<string, JsonValue> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      result[key] = normalizeValue((value as Record<string, unknown>)[key]);
+    }
+    return result;
+  }
+  return String(value);
+}
+
+export function normalizeForHashing(value: unknown): string {
+  return JSON.stringify(normalizeValue(value));
+}
+
+export function isSha256Hash(value: unknown): value is string {
+  return typeof value === "string" && SHA256_HEX.test(value);
+}
+
+function hashNormalized(value: unknown): string {
+  const hash = sha256Hex(Buffer.from(normalizeForHashing(value)));
+  if (!isSha256Hash(hash)) throw new Error("evidence_hash_invalid_output");
+  return hash;
+}
+
+export function computeEvidencePackageHash(pkg: ExportPackage): string {
+  if (!pkg || typeof pkg !== "object") throw new Error("export_package_required");
+  if (!pkg.exportPackageId) throw new Error("export_package_id_required");
+  if (!pkg.landlordId) throw new Error("export_package_landlord_required");
+  if (pkg.rawIdsIncluded !== false || pkg.payloadIncluded !== false) throw new Error("export_package_hash_flags_invalid");
+  return hashNormalized({
+    schemaVersion: "export_package_hash_v1",
+    exportPackageId: pkg.exportPackageId,
+    exportRequestId: pkg.exportRequestId,
+    landlordId: pkg.landlordId,
+    recipientType: pkg.recipientType,
+    purpose: pkg.purpose,
+    packageMetadata: {
+      assemblyVersion: pkg.packageMetadata.assemblyVersion,
+      includedEvidenceCount: pkg.packageMetadata.includedEvidenceCount,
+      totalPackageSize: pkg.packageMetadata.totalPackageSize,
+      checksumAlgorithm: pkg.packageMetadata.checksumAlgorithm,
+      checksumValue: pkg.packageMetadata.checksumValue || null,
+    },
+    evidenceManifest: {
+      evidenceClasses: [...pkg.evidenceManifest.evidenceClasses].sort(),
+      dateRangeApplied: pkg.evidenceManifest.dateRangeApplied,
+      unitsScopeApplied: [...pkg.evidenceManifest.unitsScopeApplied].sort(),
+      redactionPolicyApplied: pkg.evidenceManifest.redactionPolicyApplied,
+      excludedEvidence: (pkg.evidenceManifest.excludedEvidence || [])
+        .map((item) => ({ evidenceId: item.evidenceId, reason: item.reason }))
+        .sort((a, b) => `${a.evidenceId}:${a.reason}`.localeCompare(`${b.evidenceId}:${b.reason}`)),
+    },
+    status: pkg.status,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  });
+}
+
+export function computeEvidenceRecordHash(record: EvidenceRecord): string {
+  if (!record || typeof record !== "object") throw new Error("evidence_record_required");
+  if (!record.landlordId) throw new Error("evidence_record_landlord_required");
+  if (record.rawIdsIncluded !== false || record.metadataOnly !== true || record.appendOnly !== true) {
+    throw new Error("evidence_record_hash_flags_invalid");
+  }
+  return hashNormalized({
+    schemaVersion: "evidence_record_hash_v1",
+    evidenceClass: record.evidenceClass,
+    evidenceType: record.evidenceType,
+    recordSchemaVersion: record.schemaVersion,
+    landlordId: record.landlordId,
+    resourceType: record.resourceType,
+    safeReference: {
+      evidenceClass: record.safeReference.evidenceClass,
+      resourceType: record.safeReference.resourceType,
+      safeReferenceKey: record.safeReference.safeReferenceKey,
+      label: record.safeReference.label,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+    provenance: {
+      authority: record.provenanceMetadata.authority,
+      source: {
+        sourceCollection: record.provenanceMetadata.source.sourceCollection,
+        sourceReferenceKey: record.provenanceMetadata.source.sourceReferenceKey,
+        sourceVersion: record.provenanceMetadata.source.sourceVersion,
+        rawSourceIdsIncluded: false,
+        rawPayloadIncluded: false,
+      },
+      reason: record.provenanceMetadata.reason,
+      provenanceChain: record.provenanceMetadata.provenanceChain.map((item) => ({
+        evidenceClass: item.evidenceClass,
+        resourceType: item.resourceType,
+        safeReferenceKey: item.safeReferenceKey,
+        label: item.label,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      })),
+      metadataOnly: true,
+    },
+    sensitivityMetadata: record.sensitivityMetadata,
+    retention: {
+      retentionPolicy: record.retentionMetadata.retentionPolicy,
+      retentionReviewRequired: record.retentionMetadata.retentionReviewRequired,
+      appliedRetentionPolicyRule: record.retentionMetadata.appliedRetentionPolicyRule,
+      legalHoldStatus: record.retentionMetadata.legalHoldStatus,
+    },
+    status: record.status,
+    supersedesEvidenceId: record.supersedesEvidenceId,
+    supersededByEvidenceId: record.supersededByEvidenceId,
+    immutable: true,
+    appendOnly: true,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+  });
+}

--- a/rentchain-api/src/services/__tests__/attestation-service.test.ts
+++ b/rentchain-api/src/services/__tests__/attestation-service.test.ts
@@ -7,8 +7,12 @@ import {
   appendSignatureVerifiedAuditEvent,
   buildAttestationChain,
   projectAttestationForLandlord,
+  recordGeneratedSignature,
+  recordVerifiedSignature,
+  requestSignatureForPackage,
   verifyAttestationChainIntegrity,
 } from "../attestation-service";
+import { computeEvidencePackageHash } from "../../lib/evidence-hash-service";
 import type { ExportAuthorizationContext } from "../../types/export-authorization-types";
 import type { ExportAuditEventPayload } from "../../types/export-audit-types";
 import type { ExportPackage } from "../../types/export-package-types";
@@ -268,5 +272,78 @@ describe("attestation service", () => {
       valid: false,
       errors: ["attestation_chain_missing_signature_generation"],
     });
+  });
+
+  it("requests and records generated package signatures with deterministic hash metadata", async () => {
+    const audit = createAuditStore();
+    const exportPackage = pkg();
+    const packageHash = computeEvidencePackageHash(exportPackage);
+
+    await requestSignatureForPackage(exportPackage, context(), {
+      attestationId: "attestation:helper",
+      timestamp: "2026-06-05T12:03:00.000Z",
+      firestore: audit.firestore,
+    });
+    await recordGeneratedSignature(exportPackage, packageHash, "RSA-SHA256", "certificate:helper", context(), {
+      attestationId: "attestation:helper",
+      timestamp: "2026-06-05T12:04:00.000Z",
+      firestore: audit.firestore,
+    });
+
+    const chain = await buildAttestationChain({
+      landlordId: landlordRef,
+      exportPackageId: exportPackage.exportPackageId,
+      attestationId: "attestation:helper",
+      firestore: audit.firestore,
+    });
+
+    expect(chain.events.map((event) => event.lifecycleState)).toEqual(["SignatureRequested", "SignatureGenerated"]);
+    expect(chain.events[1].contentHash).toBe(packageHash);
+    expect(JSON.stringify(exportPackage)).not.toContain("certificate-content");
+  });
+
+  it("records verified signatures only when generated hash matches", async () => {
+    const audit = createAuditStore();
+    const exportPackage = pkg();
+    const packageHash = computeEvidencePackageHash(exportPackage);
+
+    await requestSignatureForPackage(exportPackage, context(), {
+      attestationId: "attestation:verify",
+      timestamp: "2026-06-05T12:03:00.000Z",
+      firestore: audit.firestore,
+    });
+    await recordGeneratedSignature(exportPackage, packageHash, "ECDSA-SHA256", "certificate:verify", context(), {
+      attestationId: "attestation:verify",
+      timestamp: "2026-06-05T12:04:00.000Z",
+      firestore: audit.firestore,
+    });
+
+    const verified = await recordVerifiedSignature(exportPackage, packageHash, "attestation:verify", context(), {
+      timestamp: "2026-06-05T12:05:00.000Z",
+      firestore: audit.firestore,
+      evidenceReference: "evidence:eeeeeeeeeeeeeeeeeeee",
+    });
+    const mismatch = await recordVerifiedSignature(exportPackage, "b".repeat(64), "attestation:verify", context(), {
+      timestamp: "2026-06-05T12:06:00.000Z",
+      firestore: audit.firestore,
+    });
+
+    expect(verified).toMatchObject({ success: true, matchedHash: packageHash, errors: [] });
+    expect(mismatch.success).toBe(false);
+    expect(mismatch.errors).toContain("verification_hash_mismatch");
+    expect(audit.list().map((event) => event.eventType)).toEqual([
+      "ExportPackageSignatureRequested",
+      "ExportPackageSignatureGenerated",
+      "ExportPackageSignatureVerified",
+    ]);
+  });
+
+  it("rejects signing helper calls with invalid authorization context", async () => {
+    await expect(requestSignatureForPackage(pkg(), context({ rawIdsIncluded: true as false }))).rejects.toThrow(
+      "attestation_context_invalid"
+    );
+    await expect(requestSignatureForPackage(pkg(), context({ requestingActorScope: otherLandlordRef }))).rejects.toThrow(
+      "attestation_landlord_scope_mismatch"
+    );
   });
 });

--- a/rentchain-api/src/services/__tests__/evidence-attestation-linker.test.ts
+++ b/rentchain-api/src/services/__tests__/evidence-attestation-linker.test.ts
@@ -22,6 +22,7 @@ function event(attestationRef: string): AttestationChainEvent {
     signatureRef: "signature:bbbbbbbbbbbbbbbbbbbb",
     certificateRef: "certificate:cccccccccccccccccccccccccccccccc",
     signatureAlgorithm: "RSA-SHA256",
+    contentHash: "a".repeat(64),
     evidenceRef: null,
     eventSummary: "Export package signature metadata verified.",
     metadataOnly: true,

--- a/rentchain-api/src/services/__tests__/evidence-package-hash-integration.test.ts
+++ b/rentchain-api/src/services/__tests__/evidence-package-hash-integration.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+
+import { computeEvidencePackageHash, computeEvidenceRecordHash } from "../../lib/evidence-hash-service";
+import {
+  buildAttestationChain,
+  recordGeneratedSignature,
+  recordVerifiedSignature,
+  requestSignatureForPackage,
+} from "../attestation-service";
+import { buildEvidenceAttestationMap, linkEvidenceToAttestation } from "../evidence-attestation-linker";
+import { verifyEvidenceHashAgainstChain } from "../hash-chain-validation-service";
+import { createExportPackageEntity, createExportProfileEntity, createExportRequestEntity } from "../export-service";
+import type { ExportAuthorizationContext } from "../../types/export-authorization-types";
+import type { ExportAuditEventPayload } from "../../types/export-audit-types";
+import type { ExportAuditTrailFirestoreLike } from "../export-audit-trail-service";
+import { evidenceRecordFixtures } from "../../__tests__/fixtures/evidence-record-fixtures";
+
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const otherLandlordRef = "landlord:ffffffffffffffffffff";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const timestamp = "2026-06-05T15:00:00.000Z";
+
+type Filter = { field: string; op: string; value: unknown };
+
+function createAuditStore() {
+  const events = new Map<string, ExportAuditEventPayload>();
+
+  class Query {
+    constructor(private readonly filters: Filter[] = []) {}
+
+    where(field: string, op: string, value: unknown) {
+      return new Query([...this.filters, { field, op, value }]);
+    }
+
+    orderBy() {
+      return this;
+    }
+
+    limit() {
+      return this;
+    }
+
+    async get() {
+      return {
+        docs: Array.from(events.values())
+          .filter((event) =>
+            this.filters.every((filter) => {
+              const value = event[filter.field as keyof ExportAuditEventPayload];
+              return filter.op === "==" ? value === filter.value : true;
+            })
+          )
+          .map((event) => ({ data: () => event })),
+      };
+    }
+  }
+
+  const firestore: ExportAuditTrailFirestoreLike = {
+    collection() {
+      const query = new Query();
+      return {
+        doc(id: string) {
+          return {
+            async get() {
+              const event = events.get(id);
+              return { exists: Boolean(event), data: () => event };
+            },
+            async create(data: ExportAuditEventPayload) {
+              if (events.has(id)) throw new Error("already_exists");
+              events.set(id, data);
+            },
+            async set(data: ExportAuditEventPayload) {
+              events.set(id, data);
+            },
+          };
+        },
+        where: query.where.bind(query),
+        orderBy: query.orderBy.bind(query),
+        limit: query.limit.bind(query),
+        get: query.get.bind(query),
+      };
+    },
+  };
+
+  return { firestore, list: () => Array.from(events.values()) };
+}
+
+function context(overrides: Partial<ExportAuthorizationContext> = {}): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp,
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+function exportPackage() {
+  const auth = context();
+  const profile = createExportProfileEntity(
+    {
+      landlordId: landlordRef,
+      recipientType: "InsuranceAdjuster",
+      recipientName: "Acme Insurance Adjusters LLC",
+      recipientReference: "acme-insurance-adjusters",
+      purpose: "InsuranceClaim",
+      description: "Insurance claim review.",
+      approvedEvidenceClasses: ["PaymentEvidence"],
+      dataMinimizationLevel: "Redacted",
+      createdReason: "Insurance claim package review.",
+    },
+    auth
+  );
+  const request = createExportRequestEntity(
+    {
+      profile,
+      requestedAt: "2026-06-05T15:01:00.000Z",
+      requestedBy: actorRef,
+      requestReason: "Claim settlement review.",
+      scopeParameters: { evidenceClassFilters: ["PaymentEvidence"] },
+    },
+    auth
+  );
+  return createExportPackageEntity({
+    request,
+    recipientType: profile.recipientType,
+    purpose: profile.purpose,
+    assembledAt: "2026-06-05T15:02:00.000Z",
+    assembledBy: actorRef,
+    evidenceClasses: ["PaymentEvidence"],
+    redactionPolicyApplied: "Redacted",
+    includedEvidenceCount: 1,
+  });
+}
+
+describe("evidence package hash integration", () => {
+  it("runs request, generated, and verified signature workflow through canonical events", async () => {
+    const audit = createAuditStore();
+    const pkg = exportPackage();
+    const before = JSON.stringify(pkg);
+    const recordBefore = JSON.stringify(evidenceRecordFixtures.paymentEvidence);
+    const packageHash = computeEvidencePackageHash(pkg);
+    const evidenceHash = computeEvidenceRecordHash(evidenceRecordFixtures.paymentEvidence);
+
+    await requestSignatureForPackage(pkg, context(), {
+      attestationId: "attestation:package-hash",
+      timestamp: "2026-06-05T15:03:00.000Z",
+      firestore: audit.firestore,
+    });
+    await recordGeneratedSignature(pkg, packageHash, "RSA-SHA256", "certificate:package-hash", context(), {
+      attestationId: "attestation:package-hash",
+      timestamp: "2026-06-05T15:04:00.000Z",
+      firestore: audit.firestore,
+    });
+    const verified = await recordVerifiedSignature(pkg, packageHash, "attestation:package-hash", context(), {
+      timestamp: "2026-06-05T15:05:00.000Z",
+      firestore: audit.firestore,
+      evidenceReference: `evidence:${evidenceHash.slice(0, 20)}`,
+    });
+    const chain = await buildAttestationChain({
+      landlordId: landlordRef,
+      exportPackageId: pkg.exportPackageId,
+      attestationId: "attestation:package-hash",
+      firestore: audit.firestore,
+    });
+    const link = linkEvidenceToAttestation({
+      landlordId: landlordRef,
+      attestationId: chain.attestationRef,
+      evidenceRef: `evidence:${evidenceHash.slice(0, 20)}`,
+      exportPackageId: pkg.exportPackageId,
+    });
+    const mapped = buildEvidenceAttestationMap(landlordRef, pkg.exportPackageId, [link], chain.events);
+
+    expect(verified.success).toBe(true);
+    expect(verifyEvidenceHashAgainstChain(packageHash, chain).success).toBe(true);
+    expect(audit.list().map((event) => event.eventType)).toEqual([
+      "ExportPackageSignatureRequested",
+      "ExportPackageSignatureGenerated",
+      "ExportPackageSignatureVerified",
+    ]);
+    expect(mapped.get(link.evidenceRef)?.map((event) => event.lifecycleState)).toEqual([
+      "SignatureRequested",
+      "SignatureGenerated",
+      "SignatureVerified",
+    ]);
+    expect(JSON.stringify(pkg)).toBe(before);
+    expect(JSON.stringify(evidenceRecordFixtures.paymentEvidence)).toBe(recordBefore);
+  });
+
+  it("rejects cross-landlord verification attempts", async () => {
+    const audit = createAuditStore();
+    const pkg = exportPackage();
+    const packageHash = computeEvidencePackageHash(pkg);
+    await requestSignatureForPackage(pkg, context(), {
+      attestationId: "attestation:scope",
+      firestore: audit.firestore,
+    });
+    await recordGeneratedSignature(pkg, packageHash, "RSA-SHA256", "certificate:scope", context(), {
+      attestationId: "attestation:scope",
+      firestore: audit.firestore,
+    });
+
+    await expect(
+      recordVerifiedSignature(pkg, packageHash, "attestation:scope", context({ requestingActorScope: otherLandlordRef }), {
+        firestore: audit.firestore,
+      })
+    ).rejects.toThrow("attestation_landlord_scope_mismatch");
+  });
+
+  it("keeps request append non-blocking when audit storage fails", async () => {
+    const failingStore: ExportAuditTrailFirestoreLike = {
+      collection() {
+        return {
+          doc() {
+            return {
+              async create() {
+                throw new Error("write_failed");
+              },
+            };
+          },
+        };
+      },
+    };
+
+    await expect(requestSignatureForPackage(exportPackage(), context(), { firestore: failingStore })).resolves.toBeNull();
+  });
+});

--- a/rentchain-api/src/services/__tests__/hash-chain-validation-service.test.ts
+++ b/rentchain-api/src/services/__tests__/hash-chain-validation-service.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHashChainFromAttestation,
+  validateHashChainIntegrity,
+  verifyEvidenceHashAgainstChain,
+} from "../hash-chain-validation-service";
+import type { AttestationChain } from "../../types/attestation-types";
+
+const hash = "a".repeat(64);
+const otherHash = "b".repeat(64);
+
+function chain(overrides: Partial<AttestationChain> = {}): AttestationChain {
+  return {
+    attestationRef: "attestation:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    landlordRef: "landlord:bbbbbbbbbbbbbbbbbbbb",
+    exportPackageRef: "exportpackage:cccccccccccccccccccc",
+    events: [
+      {
+        eventId: "event:requested",
+        eventType: "ExportPackageSignatureRequested",
+        lifecycleState: "SignatureRequested",
+        timestamp: "2026-06-05T14:01:00.000Z",
+        attestationRef: "attestation:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        signatureRef: null,
+        certificateRef: null,
+        signatureAlgorithm: null,
+        contentHash: null,
+        evidenceRef: null,
+        eventSummary: "requested",
+        metadataOnly: true,
+        immutable: true,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      },
+      {
+        eventId: "event:generated",
+        eventType: "ExportPackageSignatureGenerated",
+        lifecycleState: "SignatureGenerated",
+        timestamp: "2026-06-05T14:02:00.000Z",
+        attestationRef: "attestation:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        signatureRef: "signature:dddddddddddddddddddddddddddddddd",
+        certificateRef: "certificate:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        signatureAlgorithm: "RSA-SHA256",
+        contentHash: hash,
+        evidenceRef: null,
+        eventSummary: "generated",
+        metadataOnly: true,
+        immutable: true,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      },
+      {
+        eventId: "event:verified",
+        eventType: "ExportPackageSignatureVerified",
+        lifecycleState: "SignatureVerified",
+        timestamp: "2026-06-05T14:03:00.000Z",
+        attestationRef: "attestation:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        signatureRef: "signature:dddddddddddddddddddddddddddddddd",
+        certificateRef: "certificate:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        signatureAlgorithm: "RSA-SHA256",
+        contentHash: hash,
+        evidenceRef: null,
+        eventSummary: "verified",
+        metadataOnly: true,
+        immutable: true,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      },
+    ],
+    currentState: "SignatureVerified",
+    metadataOnly: true,
+    appendOnly: true,
+    immutable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+    ...overrides,
+  };
+}
+
+describe("hash chain validation service", () => {
+  it("reconstructs hash chain state from attestation events", () => {
+    const hashChain = buildHashChainFromAttestation(chain());
+
+    expect(hashChain.generatedHash).toBe(hash);
+    expect(hashChain.verifiedHash).toBe(hash);
+    expect(validateHashChainIntegrity(hashChain)).toEqual({
+      success: true,
+      errorCount: 0,
+      errors: [],
+      metadataOnly: true,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    });
+  });
+
+  it("verifies matching evidence hashes against the chain", () => {
+    expect(verifyEvidenceHashAgainstChain(hash, chain())).toMatchObject({
+      success: true,
+      matchedHash: hash,
+      errors: [],
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    });
+  });
+
+  it("fails closed for mismatched hashes and missing lifecycle steps", () => {
+    expect(verifyEvidenceHashAgainstChain(otherHash, chain()).errors).toContain("verification_hash_mismatch");
+    expect(
+      validateHashChainIntegrity(
+        buildHashChainFromAttestation({
+          ...chain(),
+          events: chain().events.filter((event) => event.lifecycleState !== "SignatureVerified"),
+        })
+      ).errors
+    ).toContain("hash_chain_signature_verified_missing");
+  });
+
+  it("rejects invalid hash formats and generated/verified mismatch", () => {
+    const invalid = chain({
+      events: chain().events.map((event) =>
+        event.lifecycleState === "SignatureVerified" ? { ...event, contentHash: otherHash } : event
+      ),
+    });
+    expect(validateHashChainIntegrity(buildHashChainFromAttestation(invalid)).errors).toContain(
+      "hash_chain_generated_verified_mismatch"
+    );
+    expect(verifyEvidenceHashAgainstChain("bad-hash", chain()).errors).toContain("verification_hash_invalid");
+  });
+});

--- a/rentchain-api/src/services/__tests__/signature-generation-service.test.ts
+++ b/rentchain-api/src/services/__tests__/signature-generation-service.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  generateSignature,
+  generateSignatureReference,
+  validateSignatureAlgorithm,
+} from "../signature-generation-service";
+import type { ExportAuthorizationContext } from "../../types/export-authorization-types";
+
+const hash = "a".repeat(64);
+const landlordRef = "landlord:aaaaaaaaaaaaaaaaaaaa";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+
+function context(overrides: Partial<ExportAuthorizationContext> = {}): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordRef,
+    requestingPurpose: "InsuranceClaim",
+    timestamp: "2026-06-05T14:00:00.000Z",
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+describe("signature generation service", () => {
+  it("generates deterministic signature references from hash and algorithm", () => {
+    expect(generateSignatureReference(hash, "RSA-SHA256")).toBe(generateSignatureReference(hash, "RSA-SHA256"));
+    expect(generateSignatureReference(hash, "RSA-SHA256")).toMatch(/^signature:[a-f0-9]{32}$/);
+    expect(generateSignatureReference(hash, "RSA-SHA256")).not.toBe(generateSignatureReference(hash, "ECDSA-SHA256"));
+  });
+
+  it("returns metadata-only signature records", () => {
+    const signature = generateSignature(hash, "ECDSA-SHA256", context(), {
+      certificateRef: "certificate:cccccccccccccccccccccccccccccccc",
+    });
+
+    expect(signature).toMatchObject({
+      signatureAlgorithm: "ECDSA-SHA256",
+      certificateRef: "certificate:cccccccccccccccccccccccccccccccc",
+      contentHash: hash,
+      metadataOnly: true,
+      rawSignatureIncluded: false,
+      rawCertificateIncluded: false,
+      keyMaterialIncluded: false,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    });
+    expect(JSON.stringify(signature)).not.toContain(actorRef);
+  });
+
+  it("rejects unsupported algorithms and invalid hashes", () => {
+    expect(validateSignatureAlgorithm("RSA-SHA256")).toBe(true);
+    expect(validateSignatureAlgorithm("SHA1")).toBe(false);
+    expect(() => generateSignatureReference("not-a-hash", "RSA-SHA256")).toThrow("signature_hash_invalid");
+    expect(() => generateSignature(hash, "SHA1" as never, context())).toThrow("signature_algorithm_unsupported");
+  });
+
+  it("rejects invalid signing context", () => {
+    expect(() => generateSignature(hash, "RSA-SHA256", context({ rawIdsIncluded: true as false }))).toThrow(
+      "signature_context_invalid"
+    );
+    expect(() => generateSignature(hash, "RSA-SHA256", context({ requestingActorId: "" }))).toThrow(
+      "signature_actor_required"
+    );
+    expect(() => generateSignature(hash, "RSA-SHA256", context({ requestingActorScope: "" }))).toThrow(
+      "signature_landlord_scope_required"
+    );
+  });
+});

--- a/rentchain-api/src/services/attestation-service.ts
+++ b/rentchain-api/src/services/attestation-service.ts
@@ -20,6 +20,9 @@ import {
   type ExportAuditTrailFirestoreLike,
 } from "./export-audit-trail-service";
 import { linkEvidenceToAttestation as createEvidenceAttestationLink } from "./evidence-attestation-linker";
+import { isSha256Hash } from "../lib/evidence-hash-service";
+import { generateSignature } from "./signature-generation-service";
+import type { VerificationResult } from "./hash-chain-validation-service";
 
 const ATTESTATION_EVENT_TYPES = new Set<ExportAuditEventType>([
   "ExportPackageSignatureRequested",
@@ -87,6 +90,10 @@ function algorithm(value: unknown): SignatureAlgorithm | null {
   return SIGNATURE_ALGORITHMS.includes(value as SignatureAlgorithm) ? (value as SignatureAlgorithm) : null;
 }
 
+function safeContentHash(value: unknown): string | null {
+  return isSha256Hash(value) ? value : null;
+}
+
 function assertContext(context: ExportAuthorizationContext, landlordId: string): void {
   if (context.rawIdsIncluded !== false || !context.requestingActorId) throw new Error("attestation_context_invalid");
   if (context.requestingActorScope !== landlordId && context.requestingActorRole !== "SystemService") {
@@ -100,13 +107,18 @@ function attestationDetails(input: {
   signatureId?: string | null;
   certificateId?: string | null;
   signatureAlgorithm?: SignatureAlgorithm | null;
+  contentHash?: string | null;
   evidenceReference?: string | null;
 }) {
+  if (input.contentHash !== undefined && input.contentHash !== null && !isSha256Hash(input.contentHash)) {
+    throw new Error("attestation_content_hash_invalid");
+  }
   return {
     attestationRef: attestationRef(input.attestationId),
     signatureRef: signatureRef(input.signatureId),
     certificateRef: certificateRef(input.certificateId),
     signatureAlgorithm: input.signatureAlgorithm || null,
+    contentHash: input.contentHash || null,
     lifecycleState: input.lifecycleState,
     linkedEvidenceRef: evidenceRef(input.evidenceReference),
     metadataOnly: true,
@@ -127,6 +139,7 @@ async function appendAttestationAuditEvent(input: {
   signatureId?: string | null;
   certificateId?: string | null;
   signatureAlgorithm?: SignatureAlgorithm | null;
+  contentHash?: string | null;
   evidenceReference?: string | null;
   timestamp?: string;
   firestore?: ExportAuditTrailFirestoreLike;
@@ -176,6 +189,7 @@ export async function appendSignatureGeneratedAuditEvent(
     signatureId: string;
     certificateId: string;
     signatureAlgorithm: SignatureAlgorithm;
+    contentHash?: string | null;
     reason?: string | null;
     timestamp?: string;
     firestore?: ExportAuditTrailFirestoreLike;
@@ -194,6 +208,7 @@ export async function appendSignatureGeneratedAuditEvent(
     signatureId: input.signatureId,
     certificateId: input.certificateId,
     signatureAlgorithm: input.signatureAlgorithm,
+    contentHash: input.contentHash,
     timestamp: input.timestamp,
     firestore: input.firestore,
   });
@@ -207,6 +222,7 @@ export async function appendSignatureVerifiedAuditEvent(
     signatureId: string;
     certificateId: string;
     signatureAlgorithm: SignatureAlgorithm;
+    contentHash?: string | null;
     reason?: string | null;
     timestamp?: string;
     firestore?: ExportAuditTrailFirestoreLike;
@@ -225,6 +241,7 @@ export async function appendSignatureVerifiedAuditEvent(
     signatureId: input.signatureId,
     certificateId: input.certificateId,
     signatureAlgorithm: input.signatureAlgorithm,
+    contentHash: input.contentHash,
     timestamp: input.timestamp,
     firestore: input.firestore,
   });
@@ -260,6 +277,115 @@ export function linkEvidenceToAttestation(input: Parameters<typeof createEvidenc
   return createEvidenceAttestationLink(input);
 }
 
+function packageAttestationId(pkg: ExportPackage, context: ExportAuthorizationContext): string {
+  return `attestation:${stableHash(["export_package_signature", pkg.exportPackageId, pkg.landlordId, context.requestingActorId])}`;
+}
+
+export async function requestSignatureForPackage(
+  pkg: ExportPackage,
+  context: ExportAuthorizationContext,
+  options: { attestationId?: string; reason?: string | null; timestamp?: string; firestore?: ExportAuditTrailFirestoreLike } = {}
+): Promise<ExportAuditEventPayload | null> {
+  assertContext(context, pkg.landlordId);
+  return appendSignatureRequestedAuditEvent(pkg, context, {
+    attestationId: options.attestationId || packageAttestationId(pkg, context),
+    reason: options.reason,
+    timestamp: options.timestamp,
+    firestore: options.firestore,
+  });
+}
+
+export async function recordGeneratedSignature(
+  pkg: ExportPackage,
+  hash: string,
+  signatureAlgorithm: SignatureAlgorithm,
+  certificateId: string,
+  context: ExportAuthorizationContext,
+  options: { attestationId?: string; reason?: string | null; timestamp?: string; firestore?: ExportAuditTrailFirestoreLike } = {}
+): Promise<ExportAuditEventPayload | null> {
+  assertContext(context, pkg.landlordId);
+  const signature = generateSignature(hash, signatureAlgorithm, context, {
+    certificateRef: certificateId,
+    signedAt: options.timestamp || context.timestamp,
+  });
+  return appendSignatureGeneratedAuditEvent(pkg, context, {
+    attestationId: options.attestationId || packageAttestationId(pkg, context),
+    signatureId: signature.signatureRef,
+    certificateId: signature.certificateRef,
+    signatureAlgorithm: signature.signatureAlgorithm,
+    contentHash: signature.contentHash,
+    reason: options.reason,
+    timestamp: options.timestamp,
+    firestore: options.firestore,
+  });
+}
+
+export async function recordVerifiedSignature(
+  pkg: ExportPackage,
+  hash: string,
+  attestationId: string,
+  context: ExportAuthorizationContext,
+  options: {
+    events?: readonly ExportAuditEventPayload[];
+    firestore?: ExportAuditTrailFirestoreLike;
+    evidenceReference?: string | null;
+    reason?: string | null;
+    timestamp?: string;
+  } = {}
+): Promise<VerificationResult> {
+  assertContext(context, pkg.landlordId);
+  const errors: string[] = [];
+  if (!isSha256Hash(hash)) errors.push("verification_hash_invalid");
+  const chain = await buildAttestationChain({
+    landlordId: pkg.landlordId,
+    exportPackageId: pkg.exportPackageId,
+    attestationId,
+    events: options.events,
+    firestore: options.firestore,
+  });
+  const chainIntegrity = verifyAttestationChainIntegrity(chain);
+  if (!chainIntegrity.valid) errors.push(...chainIntegrity.errors);
+  const generated = chain.events.find((event) => event.lifecycleState === "SignatureGenerated");
+  if (!generated) errors.push("verification_signature_generated_missing");
+  if (generated?.contentHash && generated.contentHash !== hash) errors.push("verification_hash_mismatch");
+  if (!generated?.contentHash) errors.push("verification_generated_hash_missing");
+  if (!generated?.signatureRef) errors.push("verification_signature_reference_missing");
+  if (!generated?.certificateRef) errors.push("verification_certificate_reference_missing");
+  if (!generated?.signatureAlgorithm) errors.push("verification_signature_algorithm_missing");
+  if (errors.length === 0 && generated) {
+    const event = await appendSignatureVerifiedAuditEvent(pkg, context, {
+      attestationId,
+      signatureId: generated.signatureRef as string,
+      certificateId: generated.certificateRef as string,
+      signatureAlgorithm: generated.signatureAlgorithm as SignatureAlgorithm,
+      contentHash: hash,
+      reason: options.reason,
+      timestamp: options.timestamp,
+      firestore: options.firestore,
+    });
+    if (!event) errors.push("verification_audit_append_failed");
+    if (options.evidenceReference) {
+      createEvidenceAttestationLink({
+        landlordId: pkg.landlordId,
+        attestationId,
+        evidenceRef: options.evidenceReference,
+        exportPackageId: pkg.exportPackageId,
+        linkedAt: options.timestamp || context.timestamp,
+      });
+    }
+  }
+  return {
+    success: errors.length === 0,
+    matchedHash: errors.length === 0 ? hash : null,
+    attestationRef: attestationRef(attestationId),
+    chainEventReferences: chain.events.map((event) => event.eventId),
+    errors,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
 function chainEventFromAuditEvent(event: ExportAuditEventPayload): AttestationChainEvent | null {
   if (!ATTESTATION_EVENT_TYPES.has(event.eventType)) return null;
   const state = STATE_BY_EVENT_TYPE[event.eventType];
@@ -275,6 +401,7 @@ function chainEventFromAuditEvent(event: ExportAuditEventPayload): AttestationCh
     signatureRef: signatureRef(details.signatureRef),
     certificateRef: certificateRef(details.certificateRef),
     signatureAlgorithm: algorithm(details.signatureAlgorithm),
+    contentHash: safeContentHash(details.contentHash),
     evidenceRef: evidenceRef(details.linkedEvidenceRef),
     eventSummary: event.metadata.eventSummary,
     metadataOnly: true,
@@ -373,6 +500,7 @@ export function projectAttestationForLandlord(landlordId: string, chain: Attesta
       timestamp: event.timestamp,
       signatureAlgorithm: event.signatureAlgorithm,
       certificateRef: event.certificateRef,
+      contentHash: event.contentHash,
       evidenceRef: event.evidenceRef,
     })),
     metadataOnly: true,

--- a/rentchain-api/src/services/hash-chain-validation-service.ts
+++ b/rentchain-api/src/services/hash-chain-validation-service.ts
@@ -1,0 +1,121 @@
+import type { AttestationChain, AttestationChainEvent } from "../types/attestation-types";
+import { isSha256Hash } from "../lib/evidence-hash-service";
+
+export type HashChainEntry = {
+  eventId: string;
+  lifecycleState: AttestationChainEvent["lifecycleState"];
+  timestamp: string;
+  contentHash: string | null;
+  signatureRef: string | null;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type HashChain = {
+  attestationRef: string;
+  exportPackageRef: string;
+  entries: HashChainEntry[];
+  generatedHash: string | null;
+  verifiedHash: string | null;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type VerificationResult = {
+  success: boolean;
+  matchedHash: string | null;
+  attestationRef: string;
+  chainEventReferences: string[];
+  errors: string[];
+  metadataOnly: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type ValidationResult = {
+  success: boolean;
+  errorCount: number;
+  errors: string[];
+  metadataOnly: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export function buildHashChainFromAttestation(chain: AttestationChain): HashChain {
+  const entries = chain.events
+    .filter((event) => event.lifecycleState === "SignatureGenerated" || event.lifecycleState === "SignatureVerified")
+    .map((event) => ({
+      eventId: event.eventId,
+      lifecycleState: event.lifecycleState,
+      timestamp: event.timestamp,
+      contentHash: event.contentHash,
+      signatureRef: event.signatureRef,
+      rawIdsIncluded: false as const,
+      payloadIncluded: false as const,
+    }));
+  return {
+    attestationRef: chain.attestationRef,
+    exportPackageRef: chain.exportPackageRef,
+    entries,
+    generatedHash: entries.find((entry) => entry.lifecycleState === "SignatureGenerated")?.contentHash || null,
+    verifiedHash: entries.find((entry) => entry.lifecycleState === "SignatureVerified")?.contentHash || null,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function validateHashChainIntegrity(chain: HashChain): ValidationResult {
+  const errors: string[] = [];
+  if (chain.rawIdsIncluded !== false || chain.payloadIncluded !== false) errors.push("hash_chain_raw_or_payload_included");
+  if (!chain.entries.length) errors.push("hash_chain_empty");
+  let previousTime = 0;
+  const generated = chain.entries.filter((entry) => entry.lifecycleState === "SignatureGenerated");
+  const verified = chain.entries.filter((entry) => entry.lifecycleState === "SignatureVerified");
+  if (!generated.length) errors.push("hash_chain_signature_generated_missing");
+  if (!verified.length) errors.push("hash_chain_signature_verified_missing");
+  for (const entry of chain.entries) {
+    const parsed = Date.parse(entry.timestamp);
+    if (!Number.isFinite(parsed)) errors.push("hash_chain_timestamp_invalid");
+    if (parsed < previousTime) errors.push("hash_chain_timestamp_out_of_order");
+    previousTime = parsed;
+    if (!entry.contentHash || !isSha256Hash(entry.contentHash)) errors.push("hash_chain_content_hash_invalid");
+    if (entry.rawIdsIncluded !== false || entry.payloadIncluded !== false) errors.push("hash_chain_entry_raw_or_payload_included");
+  }
+  if (chain.generatedHash && chain.verifiedHash && chain.generatedHash !== chain.verifiedHash) {
+    errors.push("hash_chain_generated_verified_mismatch");
+  }
+  return {
+    success: errors.length === 0,
+    errorCount: errors.length,
+    errors,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function verifyEvidenceHashAgainstChain(hash: string, chain: AttestationChain): VerificationResult {
+  const errors: string[] = [];
+  if (!isSha256Hash(hash)) errors.push("verification_hash_invalid");
+  if (chain.rawIdsIncluded !== false || chain.payloadIncluded !== false) errors.push("attestation_chain_raw_or_payload_included");
+  if (!chain.events.length) errors.push("attestation_chain_empty");
+  const states = chain.events.map((event) => event.lifecycleState);
+  if (states.includes("SignatureGenerated") && !states.includes("SignatureRequested")) errors.push("attestation_chain_missing_signature_request");
+  if (states.includes("SignatureVerified") && !states.includes("SignatureGenerated")) errors.push("attestation_chain_missing_signature_generation");
+  const hashChain = buildHashChainFromAttestation(chain);
+  const chainIntegrity = validateHashChainIntegrity(hashChain);
+  if (!chainIntegrity.success) errors.push(...chainIntegrity.errors);
+  if (hashChain.generatedHash && hashChain.generatedHash !== hash) errors.push("verification_hash_mismatch");
+  return {
+    success: errors.length === 0,
+    matchedHash: errors.length === 0 ? hash : null,
+    attestationRef: chain.attestationRef,
+    chainEventReferences: hashChain.entries.map((entry) => entry.eventId),
+    errors,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}

--- a/rentchain-api/src/services/signature-generation-service.ts
+++ b/rentchain-api/src/services/signature-generation-service.ts
@@ -1,0 +1,64 @@
+import crypto from "crypto";
+import type { ExportAuthorizationContext } from "../types/export-authorization-types";
+import type { CertificateSafeReference, SignatureAlgorithm, SignatureMetadata } from "../types/attestation-types";
+import { SIGNATURE_ALGORITHMS } from "../types/attestation-types";
+import { isSha256Hash } from "../lib/evidence-hash-service";
+
+function stableHash(value: unknown, length = 32): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, length);
+}
+
+function safeRef(prefix: string, value: unknown): string {
+  return `${prefix}:${stableHash([prefix, value])}`;
+}
+
+function toUtcIso(value: unknown): string {
+  const parsed = Date.parse(String(value ?? ""));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+export function validateSignatureAlgorithm(value: unknown): value is SignatureAlgorithm {
+  return SIGNATURE_ALGORITHMS.includes(value as SignatureAlgorithm);
+}
+
+export function generateSignatureReference(hash: string, algorithm: SignatureAlgorithm): string {
+  if (!isSha256Hash(hash)) throw new Error("signature_hash_invalid");
+  if (!validateSignatureAlgorithm(algorithm)) throw new Error("signature_algorithm_unsupported");
+  return safeRef("signature", [hash, algorithm]);
+}
+
+function validateSignatureContext(context: ExportAuthorizationContext): void {
+  if (!context || context.rawIdsIncluded !== false) throw new Error("signature_context_invalid");
+  if (!context.requestingActorId) throw new Error("signature_actor_required");
+  if (!context.requestingActorScope) throw new Error("signature_landlord_scope_required");
+  if (!context.requestingPurpose) throw new Error("signature_purpose_required");
+}
+
+export function generateSignature(
+  hash: string,
+  algorithm: SignatureAlgorithm,
+  context: ExportAuthorizationContext,
+  options: { certificateRef?: string | null; signedAt?: string | null } = {}
+): SignatureMetadata {
+  validateSignatureContext(context);
+  if (!isSha256Hash(hash)) throw new Error("signature_hash_invalid");
+  if (!validateSignatureAlgorithm(algorithm)) throw new Error("signature_algorithm_unsupported");
+  const certificateRef = (options.certificateRef && String(options.certificateRef).startsWith("certificate:")
+    ? options.certificateRef
+    : safeRef("certificate", [context.requestingActorScope, algorithm])) as CertificateSafeReference;
+  return {
+    signatureRef: generateSignatureReference(hash, algorithm),
+    signatureAlgorithm: algorithm,
+    certificateRef,
+    contentHash: hash,
+    signedAt: toUtcIso(options.signedAt || context.timestamp),
+    verifiedAt: null,
+    signerRef: safeRef("signer", [context.requestingActorId, context.requestingActorRole]),
+    metadataOnly: true,
+    rawSignatureIncluded: false,
+    rawCertificateIncluded: false,
+    keyMaterialIncluded: false,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}

--- a/rentchain-api/src/types/__tests__/attestation-types.test.ts
+++ b/rentchain-api/src/types/__tests__/attestation-types.test.ts
@@ -38,6 +38,7 @@ describe("attestation types", () => {
       signatureRef: "signature:cccccccccccccccccccc",
       signatureAlgorithm: "ECDSA-SHA256",
       certificateRef: certificate.certificateRef,
+      contentHash: "a".repeat(64),
       signedAt: "2026-06-05T00:01:00.000Z",
       verifiedAt: null,
       signerRef: "signer:dddddddddddddddddddd",

--- a/rentchain-api/src/types/attestation-types.ts
+++ b/rentchain-api/src/types/attestation-types.ts
@@ -51,6 +51,7 @@ export type SignatureMetadata = {
   signatureRef: string;
   signatureAlgorithm: SignatureAlgorithm;
   certificateRef: CertificateSafeReference;
+  contentHash: string;
   signedAt: string | null;
   verifiedAt: string | null;
   signerRef: string;
@@ -67,6 +68,7 @@ export type AttestationAuditMetadata = {
   signatureRef: string | null;
   certificateRef: CertificateSafeReference | null;
   signatureAlgorithm: SignatureAlgorithm | null;
+  contentHash: string | null;
   portableAttestationType: PortableAttestationType | null;
   lifecycleState: AttestationLifecycleState;
   linkedEvidenceRef: SafeEvidenceReference | null;
@@ -98,6 +100,7 @@ export type AttestationChainEvent = {
   signatureRef: string | null;
   certificateRef: CertificateSafeReference | null;
   signatureAlgorithm: SignatureAlgorithm | null;
+  contentHash: string | null;
   evidenceRef: SafeEvidenceReference | null;
   eventSummary: string;
   metadataOnly: true;
@@ -129,6 +132,7 @@ export type AttestationProjection = {
     timestamp: string;
     signatureAlgorithm: SignatureAlgorithm | null;
     certificateRef: CertificateSafeReference | null;
+    contentHash: string | null;
     evidenceRef: SafeEvidenceReference | null;
   }>;
   metadataOnly: true;

--- a/rentchain-api/src/types/export-audit-types.ts
+++ b/rentchain-api/src/types/export-audit-types.ts
@@ -104,6 +104,7 @@ export type ExportAttestationAuditDetails = {
   signatureRef: string | null;
   certificateRef: string | null;
   signatureAlgorithm: "RSA-SHA256" | "ECDSA-SHA256" | null;
+  contentHash: string | null;
   lifecycleState:
     | "SignatureRequested"
     | "SignatureGenerated"


### PR DESCRIPTION
## Summary

- Add deterministic SHA-256 hashing for export packages and evidence records using canonical metadata normalization.
- Add deterministic signature reference generation with strict `RSA-SHA256` and `ECDSA-SHA256` algorithm validation.
- Extend attestation signing helpers to request, record generated, and record verified package signatures through canonical audit events.
- Add hash-chain reconstruction and fail-closed verification for generated and verified signature events.
- Document Evidence Hash Verification v1 and update the attestation architecture note.

## Validation

- `npm test -- src/lib/evidence-hash-service.test.ts src/services/__tests__/signature-generation-service.test.ts src/services/__tests__/hash-chain-validation-service.test.ts src/services/__tests__/evidence-package-hash-integration.test.ts src/services/__tests__/attestation-service.test.ts`
- `npm run test:single -- src/lib/evidence-hash-service.test.ts src/services/__tests__/signature-generation-service.test.ts src/services/__tests__/hash-chain-validation-service.test.ts src/services/__tests__/evidence-package-hash-integration.test.ts src/services/__tests__/attestation-service.test.ts`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Scope Boundaries

- No routes, frontend surfaces, Firestore rules, deployment changes, dependency changes, delivery mechanisms, recipient verification, background workers, migrations, or external key integrations.
- Signature generation produces metadata references only; external signing infrastructure remains deferred.