### PR TITLE
feat: add attestation hash retrieval routes

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,88 +1,90 @@
-# Implementation Summary - Phase 4C Mission 8: Evidence Hash Verification
+# Implementation Summary - Attestation Hash Retrieval v1
 
-PR: #1099
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1099
-Branch: feat/evidence-hash-verification-v1
+PR: #1100
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1100
+Branch: feat/attestation-hash-retrieval-v1
 
 ## Scope Delivered
 
-Implemented Evidence Hash Verification v1 as a service-layer foundation for deterministic export package hashes, evidence record hashes, signature reference metadata, and fail-closed attestation hash-chain validation.
+Implemented authorized attestation hash retrieval as a read-only backend API surface under `/api/attestation`.
 
-The implementation adds pure SHA-256 hashing over canonical metadata, deterministic signature references from content hash and allowed algorithm, generated/verified signature event hash metadata, high-level signing workflow helpers in the attestation service, and hash-chain reconstruction/verification helpers.
+The implementation adds metadata-only response types, authenticated access-context resolution, canonical attestation event retrieval, role-aware projection checks, and three read routes:
 
-No routes, frontend surfaces, Firestore rules, deployment changes, dependency changes, external key integrations, background workers, production signing integrations, delivery mechanisms, recipient verification, or migrations were added.
+- `GET /api/attestation/hash/:hashValue`
+- `GET /api/attestation/evidence/:evidenceId/chain`
+- `GET /api/attestation/evidence/:evidenceId/verify`
+
+Responses use deterministic hash values and safe references only. The implementation does not add mutation paths, background processing, Firestore rule changes, deployment changes, new dependencies, signing integrations, external certificate authority integrations, dashboard UI, or protected-area changes.
 
 ## Files Changed
 
-- rentchain-api/src/lib/evidence-hash-service.ts
-- rentchain-api/src/lib/evidence-hash-service.test.ts
-- rentchain-api/src/services/signature-generation-service.ts
-- rentchain-api/src/services/hash-chain-validation-service.ts
-- rentchain-api/src/services/attestation-service.ts
-- rentchain-api/src/services/__tests__/signature-generation-service.test.ts
-- rentchain-api/src/services/__tests__/hash-chain-validation-service.test.ts
-- rentchain-api/src/services/__tests__/evidence-package-hash-integration.test.ts
-- rentchain-api/src/services/__tests__/attestation-service.test.ts
-- rentchain-api/src/services/__tests__/evidence-attestation-linker.test.ts
-- rentchain-api/src/types/attestation-types.ts
-- rentchain-api/src/types/export-audit-types.ts
-- rentchain-api/src/types/__tests__/attestation-types.test.ts
-- docs/architecture/evidence-hash-verification-v1.md
-- docs/architecture/attestation-framework-v1.md
+- rentchain-api/src/app.build.ts
+- rentchain-api/src/types/attestation-api-types.ts
+- rentchain-api/src/middleware/attestationAuth.ts
+- rentchain-api/src/middleware/__tests__/attestation-auth.test.ts
+- rentchain-api/src/services/attestation-hash-retrieval-service.ts
+- rentchain-api/src/services/__tests__/attestation-hash-retrieval.test.ts
+- rentchain-api/src/routes/attestationRoutes.ts
+- rentchain-api/src/routes/__tests__/attestation-hash.test.ts
+- docs/architecture/attestation-hash-retrieval-v1.md
 - .handoff/impl-summary.md
 
 ## Tests Passed
 
-- `npm test -- src/lib/evidence-hash-service.test.ts src/services/__tests__/signature-generation-service.test.ts src/services/__tests__/hash-chain-validation-service.test.ts src/services/__tests__/evidence-package-hash-integration.test.ts src/services/__tests__/attestation-service.test.ts`: PASS
-- `npm run test:single -- src/lib/evidence-hash-service.test.ts src/services/__tests__/signature-generation-service.test.ts src/services/__tests__/hash-chain-validation-service.test.ts src/services/__tests__/evidence-package-hash-integration.test.ts src/services/__tests__/attestation-service.test.ts`: PASS
+- `npm test -- src/services/__tests__/attestation-hash-retrieval.test.ts`: PASS
+- `npm test -- src/middleware/__tests__/attestation-auth.test.ts`: PASS
+- `npm test -- src/routes/__tests__/attestation-hash.test.ts`: PASS
 - `npm run build` in `rentchain-api`: PASS
 - `git diff --check`: PASS
 
+All commands were run under Node 20.11.1 after the repo preflight rejected Node 25.8.1.
+
 ## Acceptance Criteria Met
 
-- [x] Deterministic SHA-256 hash computation added for export packages.
-- [x] Deterministic SHA-256 hash computation added for evidence records.
-- [x] Canonical normalization sorts object keys and normalizes undefined values to null.
-- [x] Package and evidence hash helpers are pure and do not mutate input objects.
-- [x] Signature reference generation is deterministic from hash and algorithm.
-- [x] `RSA-SHA256` and `ECDSA-SHA256` are accepted; unsupported algorithms are rejected.
-- [x] Signature metadata is metadata-only and excludes signature material, certificate material, and key material.
-- [x] Generated and verified signature audit events can carry content hashes.
-- [x] Attestation service helpers added for requesting, recording generated, and recording verified package signatures.
-- [x] Signing helpers validate `ExportAuthorizationContext` and enforce landlord scope.
-- [x] Hash-chain reconstruction and integrity validation added.
-- [x] Verification fails closed on invalid hash format, missing generated event, missing verified event, and hash mismatch.
-- [x] Full request -> generated -> verified workflow tested through canonical audit events.
-- [x] Evidence-attestation linking works with verified signature attestations.
-- [x] Mutation scan confirmed no evidence/package collection writes in new hash/signature services.
+- [x] Added authenticated read route for hash metadata lookup by SHA-256 hash value.
+- [x] Added authenticated read route for evidence attestation chain lookup by safe evidence reference.
+- [x] Added authenticated read route for evidence attestation verification by safe evidence reference.
+- [x] Preserved read-only behavior with no writes, appends, deletes, background jobs, or remediation actions.
+- [x] Added fixed response envelope with safe success and error codes.
+- [x] Validates hash format and safe evidence reference format before retrieval.
+- [x] Enforces landlord scope server-side for landlord access.
+- [x] Supports tenant access only when the authenticated session context contains an explicit safe evidence reference.
+- [x] Supports admin/support metadata inspection without exposing source material.
+- [x] Omits canonical event document identifiers from route responses.
+- [x] Keeps responses metadata-only with `rawIdsIncluded: false` and `payloadIncluded: false`.
+- [x] Rejects invalid references with safe 400 responses.
+- [x] Returns safe 403 and 404 responses without stack traces or internal identifiers.
+- [x] Added focused service, middleware, and route tests.
+- [x] Added architecture documentation for route scope, authorization, projection safety, and limitations.
 - [x] No protected areas modified.
 - [x] No dependency changes.
-- [x] No unrelated files modified.
+- [x] No unrelated refactors.
 
 ## Manual QA
 
-Manual preview QA is not required. This mission does not change frontend rendering, mobile layout, routing, auth flow, API routes, or user-visible behavior. Service-layer behavior is covered by targeted unit/integration tests and TypeScript build validation.
+Manual API QA is required because this mission adds backend routes.
 
-Manual checklist completed by code/test inspection:
+Manual server QA was not run in this implementation pass. Route behavior was verified through focused route, middleware, service, and build validation. Recommended manual QA before merge:
 
-1. Hash determinism verified through repeated computation tests with identical package and evidence data.
-2. Hash stability verified by SHA-256 64-character lowercase hex checks.
-3. Signature reference generation verified as deterministic from content hash and algorithm.
-4. Chain integrity validation verified to reject missing events and hash mismatches.
-5. Authorization validation verified through raw flag, missing actor, missing landlord scope, and cross-landlord tests.
-6. Evidence/package immutability verified by tests and code inspection.
-7. Audit trail integration verified with mock canonicalEvents adapter for signature requested, generated, and verified events.
-8. Non-blocking append behavior verified with failing Firestore-like adapter returning null for request helper.
-9. Landlord scope enforcement verified through cross-landlord verification rejection.
-10. Architecture documentation reviewed for scope boundaries and deferred work.
+1. Start the local API with a valid authenticated landlord context.
+2. Request `GET /api/attestation/hash/:hashValue` with a known attestation hash and confirm a 200 metadata-only response.
+3. Request the same hash without authentication and confirm 401.
+4. Request the same hash with a cross-landlord user and confirm 403.
+5. Request an invalid hash value and confirm 400 with fixed error code only.
+6. Request an unknown hash value and confirm 404 with fixed error code only.
+7. Request `GET /api/attestation/evidence/:evidenceId/chain` using a safe evidence reference and confirm ordered metadata-only events.
+8. Request `GET /api/attestation/evidence/:evidenceId/verify` using a safe evidence reference and confirm verification metadata only.
+9. Confirm responses do not expose internal document identifiers, storage paths, source material, signature material, certificate material, or stack traces.
+10. Confirm no protected route, billing, auth core, Firestore rules, deployment, or pricing behavior changed.
 
 ## Known Limitations
 
-- Signature generation produces deterministic metadata references only; no private-key signing is implemented.
-- No certificate storage, external certificate validation, HSM, KMS, PKI, notary, timestamp authority, recipient verification, delivery, or external integration was added.
-- No HTTP routes, dashboards, Firestore rules, background workers, or migrations were added.
-- Hash-chain verification validates metadata hash integrity and lifecycle order, not external cryptographic proof.
+- This route reads existing canonical attestation event metadata; it does not introduce a separate hash-record collection.
+- Tenant access depends on safe evidence references being present in authenticated session context.
+- Verification is metadata hash-chain verification only and does not add external certificate authority, HSM, KMS, notary, or timestamp authority checks.
+- No dashboard UI, export delivery flow, background worker, or recipient verification surface was added.
+- Manual server QA remains required before merge approval.
 
 ## Recommended Next Mission
 
-Phase 4C trust workspace implementation or a narrow route/read-model mission for authorized attestation hash verification retrieval.
+Phase 4C attestation verification dashboard read model, or a narrow mission to add operational observability for attestation retrieval usage.

--- a/docs/architecture/attestation-hash-retrieval-v1.md
+++ b/docs/architecture/attestation-hash-retrieval-v1.md
@@ -1,0 +1,57 @@
+# Attestation Hash Retrieval v1
+
+## Scope
+
+Attestation hash retrieval exposes read-only metadata for existing attestation hash records through `/api/attestation`. The surface is limited to immutable canonical event metadata created by the attestation and hash verification services.
+
+The route does not create, update, delete, re-sign, re-hash, deliver, or remediate evidence records. It does not expose source material, signature material, certificate material, storage paths, or internal document identifiers.
+
+## Routes
+
+- `GET /api/attestation/hash/:hashValue`
+- `GET /api/attestation/evidence/:evidenceId/chain`
+- `GET /api/attestation/evidence/:evidenceId/verify`
+
+`hashValue` must be a SHA-256 hex value. `evidenceId` is accepted only as a safe evidence reference such as `evidence:<hash-like-reference>`; raw document identifiers are rejected.
+
+## Authorization
+
+All routes require authenticated context. Access is resolved server-side:
+
+- landlord users must match the event landlord safe reference
+- tenant users must have an explicit safe evidence reference in their session context
+- admin and support users may inspect metadata-only attestation state
+- unknown roles fail closed
+
+The route does not widen existing auth core or entitlement behavior.
+
+## Projection Safety
+
+Responses use a fixed envelope:
+
+```json
+{ "success": true, "data": {}, "error": null, "code": "OK" }
+```
+
+Error responses use fixed codes only. Successful responses include only:
+
+- hash values
+- attestation safe references
+- export package safe references
+- evidence safe references
+- signature metadata references
+- certificate metadata references
+- lifecycle state
+- verification status
+- timestamps
+- metadata safety flags
+
+Responses do not include raw Firestore document IDs, source object IDs, storage paths, provider source material, request bodies, response bodies, or cryptographic internals.
+
+## Append Safety
+
+This is a read-model route only. Verification calls read existing hash-chain metadata and return a computed result without appending events or mutating stored evidence, hash, export, or attestation records.
+
+## Known Limitations
+
+The route depends on canonical attestation audit events produced by existing attestation workflows. It does not introduce independent hash-record persistence, external certificate authorities, timestamp authorities, HSM/KMS integrations, package delivery, dashboard UI, or background processing.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -183,6 +183,7 @@ import screeningOpsRoutes from "./routes/screeningOpsRoutes";
 import leaseOverlapCleanupRoutes from "./routes/leaseOverlapCleanupRoutes";
 import riskAgentRoutes from "./routes/riskAgentRoutes";
 import decisionRoutes from "./routes/decisionRoutes";
+import attestationRoutes from "./routes/attestationRoutes";
 
 process.on("unhandledRejection", (reason) => {
   console.error("[FATAL] unhandledRejection", reason);
@@ -515,6 +516,9 @@ app.use("/api/landlord", routeSource("landlordOperationalRiskRoutes.ts"), landlo
 console.log("[route-mount] landlordOperationalRiskRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordInteroperabilityAdapterRoutes.ts"), landlordInteroperabilityAdapterRoutes);
 console.log("[route-mount] landlordInteroperabilityAdapterRoutes mounted at /api/landlord");
+app.use("/api/attestation", rateLimitEvidenceExportReview);
+app.use("/api/attestation", routeSource("attestationRoutes.ts"), attestationRoutes);
+console.log("[route-mount] attestationRoutes mounted at /api/attestation");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/middleware/__tests__/attestation-auth.test.ts
+++ b/rentchain-api/src/middleware/__tests__/attestation-auth.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildAttestationAccessContext } from "../attestationAuth";
+import { buildAttestationLandlordRef } from "../../services/attestation-hash-retrieval-service";
+
+describe("attestation access context", () => {
+  it("builds landlord context from authenticated user scope", () => {
+    const context = buildAttestationAccessContext({
+      id: "landlord-1",
+      role: "landlord",
+      landlordId: "landlord-1",
+    });
+
+    expect(context).toEqual(expect.objectContaining({
+      role: "landlord",
+      landlordRef: buildAttestationLandlordRef("landlord-1"),
+      rawIdsIncluded: false,
+    }));
+    expect(context?.subjectRef).toMatch(/^actor:/);
+  });
+
+  it("limits tenant context to explicit safe evidence references", () => {
+    const context = buildAttestationAccessContext({
+      id: "tenant-1",
+      role: "tenant",
+      tenantEvidenceRefs: ["evidence:eeeeeeeeeeeeeeeeeeee", "invalid_reference"],
+    });
+
+    expect(context).toEqual(expect.objectContaining({
+      role: "tenant",
+      landlordRef: null,
+      allowedEvidenceRefs: ["evidence:eeeeeeeeeeeeeeeeeeee"],
+      rawIdsIncluded: false,
+    }));
+  });
+
+  it("rejects unsupported roles", () => {
+    expect(buildAttestationAccessContext({ id: "viewer-1", role: "viewer" })).toBeNull();
+  });
+});

--- a/rentchain-api/src/middleware/attestationAuth.ts
+++ b/rentchain-api/src/middleware/attestationAuth.ts
@@ -1,0 +1,77 @@
+import type { NextFunction, Request, Response } from "express";
+import { requireAuth } from "./requireAuth";
+import type { SafeEvidenceReference } from "../types/attestation-types";
+import type { AttestationAccessContext, AttestationAccessRole } from "../types/attestation-api-types";
+import { buildAttestationLandlordRef } from "../services/attestation-hash-retrieval-service";
+import { generateExportAuditSafeReference } from "../services/export-audit-trail-service";
+
+type AttestationUser = {
+  id?: string;
+  sub?: string;
+  role?: string;
+  landlordId?: string;
+  evidenceRefs?: string[];
+  tenantEvidenceRefs?: string[];
+  attestationEvidenceRefs?: string[];
+};
+
+export type AttestationRequest = Request & {
+  user?: AttestationUser;
+  attestationAccess?: AttestationAccessContext;
+};
+
+function roleFromUser(user: AttestationUser): AttestationAccessRole | null {
+  const role = String(user.role || "").toLowerCase();
+  if (role === "tenant") return "tenant";
+  if (role === "landlord") return "landlord";
+  if (role === "admin") return "admin";
+  if (role === "support" || role === "adminsupport") return "support";
+  return null;
+}
+
+function safeSubjectRef(user: AttestationUser): string {
+  const id = user.id || user.sub;
+  return generateExportAuditSafeReference("actor", id || "unknown");
+}
+
+function safeEvidenceRefs(user: AttestationUser): SafeEvidenceReference[] {
+  const refs = [
+    ...(user.evidenceRefs || []),
+    ...(user.tenantEvidenceRefs || []),
+    ...(user.attestationEvidenceRefs || []),
+  ];
+  return refs
+    .map((value) => String(value || "").trim())
+    .filter((value): value is SafeEvidenceReference => /^[a-z][a-z0-9_.:-]*:[a-f0-9][a-z0-9_.:-]{11,160}$/i.test(value));
+}
+
+export function buildAttestationAccessContext(user: AttestationUser | null | undefined): AttestationAccessContext | null {
+  if (!user) return null;
+  const role = roleFromUser(user);
+  if (!role) return null;
+  const landlordId = String(user.landlordId || (role === "landlord" ? user.id || "" : "")).trim();
+  return {
+    role,
+    subjectRef: safeSubjectRef(user),
+    landlordRef: landlordId ? buildAttestationLandlordRef(landlordId) : null,
+    allowedEvidenceRefs: safeEvidenceRefs(user),
+    supportPurpose: role === "admin" || role === "support" ? "attestation_metadata_review" : null,
+    rawIdsIncluded: false,
+  };
+}
+
+export async function requireAttestationAccess(req: AttestationRequest, res: Response, next: NextFunction) {
+  return requireAuth(req, res, () => {
+    const context = buildAttestationAccessContext(req.user);
+    if (!context) {
+      return res.status(403).json({
+        success: false,
+        data: null,
+        error: "ATTESTATION_FORBIDDEN",
+        code: "ATTESTATION_FORBIDDEN",
+      });
+    }
+    req.attestationAccess = context;
+    return next();
+  });
+}

--- a/rentchain-api/src/routes/__tests__/attestation-hash.test.ts
+++ b/rentchain-api/src/routes/__tests__/attestation-hash.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockUser: Record<string, unknown> | null = null;
+const hashValue = "b".repeat(64);
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: { user?: unknown }, res: { status: (code: number) => { json: (body: unknown) => unknown } }, next: () => unknown) => {
+    if (!mockUser) return res.status(401).json({ success: false, data: null, error: "ATTESTATION_UNAUTHORIZED", code: "ATTESTATION_UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../services/attestation-hash-retrieval-service", async () => {
+  const actual = await vi.importActual<typeof import("../../services/attestation-hash-retrieval-service")>(
+    "../../services/attestation-hash-retrieval-service"
+  );
+  return {
+    ...actual,
+    getAttestationHashMetadata: vi.fn(async (hash: string) => {
+      if (hash === "bad") throw new Error("attestation_hash_invalid");
+      if (hash === "0".repeat(64)) return null;
+      if (hash === "f".repeat(64)) throw new Error("attestation_access_forbidden");
+      return {
+        hashValue: hash,
+        attestationRef: "attestation:routehash",
+        exportPackageRef: "exportpackage:eeeeeeeeeeeeeeeeeeee",
+        evidenceRef: "evidence:eeeeeeeeeeeeeeeeeeee",
+        lifecycleState: "SignatureVerified",
+        signature: {
+          signatureRef: "signature:routehash",
+          certificateRef: "certificate:routehash",
+          signatureAlgorithm: "RSA-SHA256",
+        },
+        verificationStatus: "verified",
+        observedAt: "2026-06-05T12:04:00.000Z",
+        metadataOnly: true,
+        immutable: true,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      };
+    }),
+    getAttestationEvidenceChain: vi.fn(async (evidenceRef: string) => {
+      if (evidenceRef === "invalid_reference") throw new Error("attestation_evidence_ref_invalid");
+      return {
+        attestationRef: "attestation:routehash",
+        exportPackageRef: "exportpackage:eeeeeeeeeeeeeeeeeeee",
+        currentState: "SignatureVerified",
+        events: [
+          {
+            eventType: "ExportPackageSignatureGenerated",
+            lifecycleState: "SignatureGenerated",
+            timestamp: "2026-06-05T12:03:00.000Z",
+            hashValue,
+            signatureRef: "signature:routehash",
+            certificateRef: "certificate:routehash",
+            signatureAlgorithm: "RSA-SHA256",
+            evidenceRef: null,
+            metadataOnly: true,
+            immutable: true,
+            rawIdsIncluded: false,
+            payloadIncluded: false,
+          },
+        ],
+        pagination: { limit: 50, returned: 1, hasMore: false },
+        metadataOnly: true,
+        appendOnly: true,
+        immutable: true,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      };
+    }),
+    verifyAttestationEvidenceChain: vi.fn(async () => ({
+      evidenceRef: "evidence:eeeeeeeeeeeeeeeeeeee",
+      verified: true,
+      matchedHash: hashValue,
+      attestationRef: "attestation:routehash",
+      verificationErrors: [],
+      chain: null,
+      metadataOnly: true,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    })),
+  };
+});
+
+async function invokeRouter(router: { handle: (req: unknown, res: unknown, next: (error?: unknown) => void) => void }, url: string) {
+  return await new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
+    const req = {
+      method: "GET",
+      url,
+      originalUrl: url,
+      path: url.split("?")[0],
+      params: {},
+      query: {},
+      headers: {},
+    };
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: Record<string, unknown>) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error?: unknown) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("attestation hash routes", () => {
+  beforeEach(() => {
+    mockUser = { id: "landlord-1", role: "landlord", landlordId: "landlord-1" };
+  });
+
+  it("returns hash metadata in the standard envelope", async () => {
+    const router = (await import("../attestationRoutes")).default;
+    const response = await invokeRouter(router, `/hash/${hashValue}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      success: true,
+      code: "OK",
+      error: null,
+    }));
+    expect(response.body.data).toEqual(expect.objectContaining({
+      hashValue,
+      verificationStatus: "verified",
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    }));
+    expect(JSON.stringify(response.body)).not.toContain("landlord-1");
+  });
+
+  it("returns fixed error codes for missing auth, bad request, forbidden, and not found", async () => {
+    const router = (await import("../attestationRoutes")).default;
+    mockUser = null;
+    expect(await invokeRouter(router, `/hash/${hashValue}`)).toEqual({
+      status: 401,
+      body: { success: false, data: null, error: "ATTESTATION_UNAUTHORIZED", code: "ATTESTATION_UNAUTHORIZED" },
+    });
+
+    mockUser = { id: "landlord-1", role: "landlord", landlordId: "landlord-1" };
+    expect(await invokeRouter(router, "/hash/bad")).toEqual({
+      status: 400,
+      body: { success: false, data: null, error: "ATTESTATION_BAD_REQUEST", code: "ATTESTATION_BAD_REQUEST" },
+    });
+    expect(await invokeRouter(router, `/hash/${"f".repeat(64)}`)).toEqual({
+      status: 403,
+      body: { success: false, data: null, error: "ATTESTATION_FORBIDDEN", code: "ATTESTATION_FORBIDDEN" },
+    });
+    expect(await invokeRouter(router, `/hash/${"0".repeat(64)}`)).toEqual({
+      status: 404,
+      body: { success: false, data: null, error: "ATTESTATION_NOT_FOUND", code: "ATTESTATION_NOT_FOUND" },
+    });
+  });
+
+  it("returns chain and verification responses", async () => {
+    const router = (await import("../attestationRoutes")).default;
+    const chain = await invokeRouter(router, "/evidence/evidence:eeeeeeeeeeeeeeeeeeee/chain");
+    const verified = await invokeRouter(router, "/evidence/evidence:eeeeeeeeeeeeeeeeeeee/verify");
+
+    expect(chain.status).toBe(200);
+    expect(chain.body.data).toEqual(expect.objectContaining({
+      currentState: "SignatureVerified",
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    }));
+    expect(verified.status).toBe(200);
+    expect(verified.body.data).toEqual(expect.objectContaining({
+      verified: true,
+      matchedHash: hashValue,
+    }));
+  });
+});

--- a/rentchain-api/src/routes/attestationRoutes.ts
+++ b/rentchain-api/src/routes/attestationRoutes.ts
@@ -1,0 +1,83 @@
+import { Router, type Response } from "express";
+import {
+  requireAttestationAccess,
+  type AttestationRequest,
+} from "../middleware/attestationAuth";
+import {
+  getAttestationEvidenceChain,
+  getAttestationHashMetadata,
+  verifyAttestationEvidenceChain,
+} from "../services/attestation-hash-retrieval-service";
+import type { AttestationApiEnvelope } from "../types/attestation-api-types";
+
+const router = Router();
+
+function ok<T>(res: Response, data: T) {
+  const body: AttestationApiEnvelope<T> = {
+    success: true,
+    data,
+    error: null,
+    code: "OK",
+  };
+  return res.json(body);
+}
+
+function error(res: Response, status: number, code: Exclude<AttestationApiEnvelope<never>["code"], "OK">) {
+  return res.status(status).json({
+    success: false,
+    data: null,
+    error: code,
+    code,
+  });
+}
+
+function isForbidden(message: string): boolean {
+  return message === "attestation_access_forbidden" || message === "attestation_access_context_invalid";
+}
+
+function isBadRequest(message: string): boolean {
+  return message === "attestation_hash_invalid" || message === "attestation_evidence_ref_invalid";
+}
+
+function handleRouteError(res: Response, routeError: unknown) {
+  const message = routeError instanceof Error ? routeError.message : "";
+  if (isBadRequest(message)) return error(res, 400, "ATTESTATION_BAD_REQUEST");
+  if (isForbidden(message)) return error(res, 403, "ATTESTATION_FORBIDDEN");
+  return error(res, 500, "ATTESTATION_INTERNAL_ERROR");
+}
+
+router.get("/hash/:hashValue", requireAttestationAccess, async (req: AttestationRequest, res) => {
+  try {
+    const result = await getAttestationHashMetadata(String(req.params.hashValue || ""), req.attestationAccess!);
+    if (!result) return error(res, 404, "ATTESTATION_NOT_FOUND");
+    return ok(res, result);
+  } catch (routeError) {
+    return handleRouteError(res, routeError);
+  }
+});
+
+router.get("/evidence/:evidenceId/chain", requireAttestationAccess, async (req: AttestationRequest, res) => {
+  try {
+    const result = await getAttestationEvidenceChain(String(req.params.evidenceId || ""), req.attestationAccess!, {
+      limit: req.query.limit,
+    });
+    if (!result) return error(res, 404, "ATTESTATION_NOT_FOUND");
+    return ok(res, result);
+  } catch (routeError) {
+    return handleRouteError(res, routeError);
+  }
+});
+
+router.get("/evidence/:evidenceId/verify", requireAttestationAccess, async (req: AttestationRequest, res) => {
+  try {
+    const result = await verifyAttestationEvidenceChain(String(req.params.evidenceId || ""), req.attestationAccess!, {
+      limit: req.query.limit,
+    });
+    if (!result) return error(res, 404, "ATTESTATION_NOT_FOUND");
+    return ok(res, result);
+  } catch (routeError) {
+    return handleRouteError(res, routeError);
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/__tests__/attestation-hash-retrieval.test.ts
+++ b/rentchain-api/src/services/__tests__/attestation-hash-retrieval.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendAttestationLinkedAuditEvent,
+  appendSignatureGeneratedAuditEvent,
+  appendSignatureRequestedAuditEvent,
+  appendSignatureVerifiedAuditEvent,
+} from "../attestation-service";
+import {
+  buildAttestationLandlordRef,
+  getAttestationEvidenceChain,
+  getAttestationHashMetadata,
+  verifyAttestationEvidenceChain,
+} from "../attestation-hash-retrieval-service";
+import type { ExportAuthorizationContext } from "../../types/export-authorization-types";
+import type { ExportAuditEventPayload } from "../../types/export-audit-types";
+import type { ExportPackage } from "../../types/export-package-types";
+import type { ExportAuditTrailFirestoreLike } from "../export-audit-trail-service";
+import type { AttestationAccessContext } from "../../types/attestation-api-types";
+
+const landlordId = "landlord-route-1";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const evidenceRef = "evidence:eeeeeeeeeeeeeeeeeeee";
+const hashValue = "a".repeat(64);
+
+type Filter = { field: string; value: unknown };
+
+function createAuditStore() {
+  const events = new Map<string, ExportAuditEventPayload>();
+
+  function getField(event: ExportAuditEventPayload, field: string): unknown {
+    if (field === "metadata.details.contentHash") return event.metadata.details.contentHash;
+    if (field === "metadata.details.linkedEvidenceRef") return event.metadata.details.linkedEvidenceRef;
+    return event[field as keyof ExportAuditEventPayload];
+  }
+
+  class Query {
+    constructor(private readonly filters: Filter[] = [], private readonly limitCount: number | null = null) {}
+
+    where(field: string, _op: string, value: unknown) {
+      return new Query([...this.filters, { field, value }], this.limitCount);
+    }
+
+    orderBy() {
+      return this;
+    }
+
+    limit(limitCount: number) {
+      return new Query(this.filters, limitCount);
+    }
+
+    async get() {
+      return {
+        docs: Array.from(events.values())
+          .filter((event) => this.filters.every((filter) => getField(event, filter.field) === filter.value))
+          .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+          .slice(0, this.limitCount || Number.MAX_SAFE_INTEGER)
+          .map((event) => ({ data: () => event })),
+      };
+    }
+  }
+
+  const firestore: ExportAuditTrailFirestoreLike = {
+    collection() {
+      const query = new Query();
+      return {
+        doc(id: string) {
+          return {
+            async get() {
+              const event = events.get(id);
+              return { exists: Boolean(event), data: () => event };
+            },
+            async create(data: ExportAuditEventPayload) {
+              if (events.has(id)) throw new Error("already_exists");
+              events.set(id, data);
+            },
+            async set(data: ExportAuditEventPayload) {
+              events.set(id, data);
+            },
+          };
+        },
+        where: query.where.bind(query),
+        orderBy: query.orderBy.bind(query),
+        limit: query.limit.bind(query),
+        get: query.get.bind(query),
+      };
+    },
+  };
+
+  return { firestore, list: () => Array.from(events.values()) };
+}
+
+function context(): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordId,
+    requestingPurpose: "InsuranceClaim",
+    timestamp: "2026-06-05T12:00:00.000Z",
+    rawIdsIncluded: false,
+  };
+}
+
+function pkg(): ExportPackage {
+  return {
+    exportPackageId: "exp_pkg_v1_routehash",
+    exportRequestId: "exp_req_v1_routehash",
+    landlordId,
+    recipientType: "InsuranceAdjuster",
+    purpose: "InsuranceClaim",
+    packageMetadata: {
+      assembledAt: "2026-06-05T12:01:00.000Z",
+      assembledBy: actorRef,
+      assemblyVersion: "evidence_package_builder_v1",
+      includedEvidenceCount: 1,
+      totalPackageSize: 1,
+      checksumAlgorithm: "sha256",
+      checksumValue: hashValue,
+    },
+    evidenceManifest: {
+      evidenceClasses: ["PaymentEvidence"],
+      dateRangeApplied: { start: null, end: null },
+      unitsScopeApplied: [],
+      redactionPolicyApplied: "Redacted",
+      excludedEvidence: [],
+    },
+    status: "Assembled",
+    auditTrailReference: "export_audit:routehash",
+    metadata: { metadataOnly: true },
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+function landlordAccess(overrides: Partial<AttestationAccessContext> = {}): AttestationAccessContext {
+  return {
+    role: "landlord",
+    subjectRef: actorRef,
+    landlordRef: buildAttestationLandlordRef(landlordId),
+    allowedEvidenceRefs: [],
+    supportPurpose: null,
+    rawIdsIncluded: false,
+    ...overrides,
+  };
+}
+
+async function seedAttestation() {
+  const audit = createAuditStore();
+  const exportPackage = pkg();
+  await appendSignatureRequestedAuditEvent(exportPackage, context(), {
+    attestationId: "attestation:routehash",
+    timestamp: "2026-06-05T12:02:00.000Z",
+    firestore: audit.firestore,
+  });
+  await appendSignatureGeneratedAuditEvent(exportPackage, context(), {
+    attestationId: "attestation:routehash",
+    signatureId: "signature:routehash",
+    certificateId: "certificate:routehash",
+    signatureAlgorithm: "RSA-SHA256",
+    contentHash: hashValue,
+    timestamp: "2026-06-05T12:03:00.000Z",
+    firestore: audit.firestore,
+  });
+  await appendSignatureVerifiedAuditEvent(exportPackage, context(), {
+    attestationId: "attestation:routehash",
+    signatureId: "signature:routehash",
+    certificateId: "certificate:routehash",
+    signatureAlgorithm: "RSA-SHA256",
+    contentHash: hashValue,
+    timestamp: "2026-06-05T12:04:00.000Z",
+    firestore: audit.firestore,
+  });
+  await appendAttestationLinkedAuditEvent(exportPackage, context(), {
+    attestationId: "attestation:routehash",
+    evidenceReference: evidenceRef,
+    timestamp: "2026-06-05T12:05:00.000Z",
+    firestore: audit.firestore,
+  });
+  return audit;
+}
+
+describe("attestation hash retrieval service", () => {
+  it("returns projection-safe hash metadata for authorized landlord scope", async () => {
+    const audit = await seedAttestation();
+    const result = await getAttestationHashMetadata(hashValue, landlordAccess(), { firestore: audit.firestore });
+
+    expect(result).toEqual(expect.objectContaining({
+      hashValue,
+      attestationRef: "attestation:routehash",
+      verificationStatus: "verified",
+      metadataOnly: true,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    }));
+    expect(JSON.stringify(result)).not.toContain(landlordId);
+    expect(JSON.stringify(result)).not.toContain("exp_pkg_v1_routehash");
+  });
+
+  it("returns ordered evidence chain and verification metadata without event document ids", async () => {
+    const audit = await seedAttestation();
+    const chain = await getAttestationEvidenceChain(evidenceRef, landlordAccess(), { firestore: audit.firestore, limit: 2 });
+    const verification = await verifyAttestationEvidenceChain(evidenceRef, landlordAccess(), { firestore: audit.firestore });
+
+    expect(chain?.events.map((event) => event.lifecycleState)).toEqual(["SignatureRequested", "SignatureGenerated"]);
+    expect(chain?.pagination).toEqual({ limit: 2, returned: 2, hasMore: true });
+    expect(verification).toEqual(expect.objectContaining({
+      evidenceRef,
+      verified: true,
+      matchedHash: hashValue,
+      metadataOnly: true,
+    }));
+    expect(JSON.stringify({ chain, verification })).not.toContain("export_audit:");
+  });
+
+  it("fails closed for cross-scope and invalid references", async () => {
+    const audit = await seedAttestation();
+    await expect(
+      getAttestationHashMetadata(hashValue, landlordAccess({ landlordRef: buildAttestationLandlordRef("landlord-other") }), {
+        firestore: audit.firestore,
+      })
+    ).rejects.toThrow("attestation_access_forbidden");
+    await expect(getAttestationEvidenceChain("invalid_reference", landlordAccess(), { firestore: audit.firestore })).rejects.toThrow(
+      "attestation_evidence_ref_invalid"
+    );
+  });
+});

--- a/rentchain-api/src/services/attestation-hash-retrieval-service.ts
+++ b/rentchain-api/src/services/attestation-hash-retrieval-service.ts
@@ -1,0 +1,342 @@
+import { db } from "../firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import { isSha256Hash } from "../lib/evidence-hash-service";
+import {
+  buildHashChainFromAttestation,
+  validateHashChainIntegrity,
+  verifyEvidenceHashAgainstChain,
+} from "./hash-chain-validation-service";
+import { verifyAttestationChainIntegrity } from "./attestation-service";
+import {
+  generateExportAuditSafeReference,
+  type ExportAuditTrailFirestoreLike,
+} from "./export-audit-trail-service";
+import type {
+  AttestationChain,
+  AttestationChainEvent,
+  AttestationLifecycleState,
+  AttestationSafeReference,
+  CertificateSafeReference,
+  SafeEvidenceReference,
+  SignatureAlgorithm,
+} from "../types/attestation-types";
+import type { ExportAuditEventPayload } from "../types/export-audit-types";
+import type {
+  AttestationAccessContext,
+  AttestationChainEventResponse,
+  AttestationChainResponse,
+  AttestationHashMetadataResponse,
+  AttestationVerifyResponse,
+} from "../types/attestation-api-types";
+
+type QuerySnapshotLike<T> = {
+  docs?: Array<{ data: () => T }>;
+};
+
+type QueryLike<T> = {
+  where?: (fieldPath: string, opStr: string, value: unknown) => QueryLike<T>;
+  orderBy?: (fieldPath: string, directionStr?: "asc" | "desc") => QueryLike<T>;
+  limit?: (limit: number) => QueryLike<T>;
+  get: () => Promise<QuerySnapshotLike<T>>;
+};
+
+type RetrievalOptions = {
+  firestore?: ExportAuditTrailFirestoreLike;
+  events?: readonly ExportAuditEventPayload[];
+};
+
+type ChainLookup = {
+  chain: AttestationChain;
+  events: ExportAuditEventPayload[];
+};
+
+const ATTESTATION_EVENTS = new Set([
+  "ExportPackageSignatureRequested",
+  "ExportPackageSignatureGenerated",
+  "ExportPackageSignatureVerified",
+  "ExportPackageAttestationLinked",
+  "ExportPackageAttestationRevoked",
+]);
+
+const STATE_BY_EVENT_TYPE: Partial<Record<ExportAuditEventPayload["eventType"], AttestationLifecycleState>> = {
+  ExportPackageSignatureRequested: "SignatureRequested",
+  ExportPackageSignatureGenerated: "SignatureGenerated",
+  ExportPackageSignatureVerified: "SignatureVerified",
+  ExportPackageAttestationLinked: "AttestationLinked",
+  ExportPackageAttestationRevoked: "AttestationRevoked",
+};
+
+const SAFE_EVIDENCE_REF = /^[a-z][a-z0-9_.:-]*:[a-f0-9][a-z0-9_.:-]{11,160}$/i;
+
+function firestore(options: RetrievalOptions): ExportAuditTrailFirestoreLike {
+  return options.firestore || (db as unknown as ExportAuditTrailFirestoreLike);
+}
+
+function queryWhere<T>(query: QueryLike<T>, field: string, value: unknown): QueryLike<T> {
+  if (!query.where) throw new Error("attestation_query_unavailable");
+  return query.where(field, "==", value);
+}
+
+async function runQuery(
+  options: RetrievalOptions,
+  filters: Array<{ field: string; value: unknown }>,
+  limit?: number
+): Promise<ExportAuditEventPayload[]> {
+  if (options.events) {
+    return options.events
+      .filter((event) =>
+        filters.every((filter) => {
+          if (filter.field === "metadata.details.contentHash") return event.metadata.details.contentHash === filter.value;
+          if (filter.field === "metadata.details.linkedEvidenceRef") return event.metadata.details.linkedEvidenceRef === filter.value;
+          return event[filter.field as keyof ExportAuditEventPayload] === filter.value;
+        })
+      )
+      .slice(0, limit || Number.MAX_SAFE_INTEGER);
+  }
+
+  const collection = firestore(options).collection<ExportAuditEventPayload>(CANONICAL_EVENTS_COLLECTION);
+  let query = collection.get ? (collection as unknown as QueryLike<ExportAuditEventPayload>) : null;
+  for (const filter of filters) {
+    query = queryWhere(query || (collection as unknown as QueryLike<ExportAuditEventPayload>), filter.field, filter.value);
+  }
+  if (query?.orderBy) query = query.orderBy("timestamp", "asc");
+  if (limit && query?.limit) query = query.limit(limit);
+  if (!query?.get) throw new Error("attestation_query_unavailable");
+  return (await query.get()).docs?.map((doc) => doc.data()) || [];
+}
+
+function isAttestationEvent(event: ExportAuditEventPayload): boolean {
+  return ATTESTATION_EVENTS.has(event.eventType);
+}
+
+function isSafeEvidenceReference(value: unknown): value is AttestationVerifyResponse["evidenceRef"] {
+  const text = String(value ?? "").trim();
+  return SAFE_EVIDENCE_REF.test(text);
+}
+
+function safeSignatureAlgorithm(value: unknown): SignatureAlgorithm | null {
+  return value === "RSA-SHA256" || value === "ECDSA-SHA256" ? value : null;
+}
+
+function safeCertificateRef(value: unknown): CertificateSafeReference | null {
+  const text = String(value ?? "").trim();
+  return text.startsWith("certificate:") ? (text as CertificateSafeReference) : null;
+}
+
+function safeEvidenceRef(value: unknown): SafeEvidenceReference | null {
+  return isSafeEvidenceReference(value) ? value : null;
+}
+
+function chainEventFromAudit(event: ExportAuditEventPayload): AttestationChainEvent | null {
+  const lifecycleState = STATE_BY_EVENT_TYPE[event.eventType];
+  if (!lifecycleState) return null;
+  const details = event.metadata.details;
+  const attestationRef = String(details.attestationRef || "").trim();
+  if (!attestationRef.startsWith("attestation:")) return null;
+  return {
+    eventId: event.eventId,
+    eventType: event.eventType,
+    lifecycleState,
+    timestamp: event.timestamp,
+    attestationRef: attestationRef as AttestationSafeReference,
+    signatureRef: details.signatureRef ? String(details.signatureRef) : null,
+    certificateRef: safeCertificateRef(details.certificateRef),
+    signatureAlgorithm: safeSignatureAlgorithm(details.signatureAlgorithm),
+    contentHash: isSha256Hash(details.contentHash) ? String(details.contentHash) : null,
+    evidenceRef: safeEvidenceRef(details.linkedEvidenceRef),
+    eventSummary: event.metadata.eventSummary,
+    metadataOnly: true,
+    immutable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+function normalizeLimit(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) return 50;
+  return Math.min(parsed, 100);
+}
+
+function assertAccess(context: AttestationAccessContext, chain: AttestationChain): void {
+  if (context.rawIdsIncluded !== false || !context.subjectRef) throw new Error("attestation_access_context_invalid");
+  if (context.role === "admin" || context.role === "support") return;
+  if (context.role === "landlord" && context.landlordRef && context.landlordRef === chain.landlordRef) return;
+  if (
+    context.role === "tenant" &&
+    chain.events.some((event) => event.evidenceRef && context.allowedEvidenceRefs.includes(event.evidenceRef))
+  ) {
+    return;
+  }
+  throw new Error("attestation_access_forbidden");
+}
+
+function eventResponse(event: AttestationChain["events"][number]): AttestationChainEventResponse {
+  return {
+    eventType: event.eventType,
+    lifecycleState: event.lifecycleState,
+    timestamp: event.timestamp,
+    hashValue: event.contentHash,
+    signatureRef: event.signatureRef,
+    certificateRef: event.certificateRef,
+    signatureAlgorithm: event.signatureAlgorithm,
+    evidenceRef: event.evidenceRef,
+    metadataOnly: true,
+    immutable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+function chainResponse(chain: AttestationChain, limit: number): AttestationChainResponse {
+  const events = chain.events.map(eventResponse);
+  const limited = events.slice(0, limit);
+  return {
+    attestationRef: chain.attestationRef,
+    exportPackageRef: chain.exportPackageRef,
+    currentState: chain.currentState,
+    events: limited,
+    pagination: {
+      limit,
+      returned: limited.length,
+      hasMore: events.length > limit,
+    },
+    metadataOnly: true,
+    appendOnly: true,
+    immutable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+async function buildChainForEvent(event: ExportAuditEventPayload, options: RetrievalOptions): Promise<ChainLookup> {
+  const events = await runQuery(options, [
+    { field: "landlordReferenceId", value: event.landlordReferenceId },
+    { field: "targetReferenceId", value: event.targetReferenceId },
+  ]);
+  const filtered = events.filter(isAttestationEvent);
+  const wantedAttestationRef = String(event.metadata.details.attestationRef || "").trim();
+  const chainEvents = filtered
+    .map(chainEventFromAudit)
+    .filter((entry): entry is AttestationChainEvent => Boolean(entry))
+    .filter((entry) => !wantedAttestationRef || entry.attestationRef === wantedAttestationRef)
+    .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  const chain: AttestationChain = {
+    attestationRef: (wantedAttestationRef || chainEvents[0]?.attestationRef || "attestation:unavailable") as AttestationSafeReference,
+    landlordRef: event.landlordReferenceId,
+    exportPackageRef: event.targetReferenceId,
+    events: chainEvents,
+    currentState: chainEvents.at(-1)?.lifecycleState || null,
+    metadataOnly: true,
+    appendOnly: true,
+    immutable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+  return { chain, events: filtered };
+}
+
+async function findChainsForEvidence(
+  evidenceRef: AttestationVerifyResponse["evidenceRef"],
+  options: RetrievalOptions
+): Promise<ChainLookup[]> {
+  const linkEvents = await runQuery(options, [{ field: "metadata.details.linkedEvidenceRef", value: evidenceRef }]);
+  const lookups: ChainLookup[] = [];
+  const seen = new Set<string>();
+  for (const event of linkEvents.filter(isAttestationEvent)) {
+    const key = `${event.landlordReferenceId}:${event.targetReferenceId}:${event.metadata.details.attestationRef || ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lookups.push(await buildChainForEvent(event, options));
+  }
+  return lookups;
+}
+
+export function buildAttestationLandlordRef(landlordId: string): string {
+  return generateExportAuditSafeReference("landlord", landlordId);
+}
+
+export async function getAttestationHashMetadata(
+  hashValue: string,
+  access: AttestationAccessContext,
+  options: RetrievalOptions = {}
+): Promise<AttestationHashMetadataResponse | null> {
+  if (!isSha256Hash(hashValue)) throw new Error("attestation_hash_invalid");
+  const matches = await runQuery(options, [{ field: "metadata.details.contentHash", value: hashValue }], 20);
+  const event = matches.filter(isAttestationEvent).sort((a, b) => a.timestamp.localeCompare(b.timestamp))[0];
+  if (!event) return null;
+  const { chain } = await buildChainForEvent(event, options);
+  assertAccess(access, chain);
+  const integrity = verifyAttestationChainIntegrity(chain);
+  const hashChain = buildHashChainFromAttestation(chain);
+  const hashIntegrity = validateHashChainIntegrity(hashChain);
+  const responseEvent = chain.events.find((entry) => entry.contentHash === hashValue) || chain.events.at(-1) || null;
+  return {
+    hashValue,
+    attestationRef: chain.attestationRef,
+    exportPackageRef: chain.exportPackageRef,
+    evidenceRef: responseEvent?.evidenceRef || chain.events.find((entry) => entry.evidenceRef)?.evidenceRef || null,
+    lifecycleState: responseEvent?.lifecycleState || chain.currentState,
+    signature: {
+      signatureRef: responseEvent?.signatureRef || null,
+      certificateRef: responseEvent?.certificateRef || null,
+      signatureAlgorithm: responseEvent?.signatureAlgorithm || null,
+    },
+    verificationStatus: integrity.valid && hashIntegrity.success && hashChain.verifiedHash === hashValue ? "verified" : "unverified",
+    observedAt: responseEvent?.timestamp || null,
+    metadataOnly: true,
+    immutable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export async function getAttestationEvidenceChain(
+  evidenceRefInput: string,
+  access: AttestationAccessContext,
+  options: RetrievalOptions & { limit?: unknown } = {}
+): Promise<AttestationChainResponse | null> {
+  if (!isSafeEvidenceReference(evidenceRefInput)) throw new Error("attestation_evidence_ref_invalid");
+  const lookups = await findChainsForEvidence(evidenceRefInput, options);
+  const lookup = lookups[0];
+  if (!lookup) return null;
+  assertAccess(access, lookup.chain);
+  return chainResponse(lookup.chain, normalizeLimit(options.limit));
+}
+
+export async function verifyAttestationEvidenceChain(
+  evidenceRefInput: string,
+  access: AttestationAccessContext,
+  options: RetrievalOptions & { limit?: unknown } = {}
+): Promise<AttestationVerifyResponse | null> {
+  if (!isSafeEvidenceReference(evidenceRefInput)) throw new Error("attestation_evidence_ref_invalid");
+  const lookups = await findChainsForEvidence(evidenceRefInput, options);
+  const lookup = lookups[0];
+  if (!lookup) return null;
+  assertAccess(access, lookup.chain);
+  const hashChain = buildHashChainFromAttestation(lookup.chain);
+  const hashValue = hashChain.verifiedHash || hashChain.generatedHash;
+  const verification = hashValue
+    ? verifyEvidenceHashAgainstChain(hashValue, lookup.chain)
+    : {
+        success: false,
+        matchedHash: null,
+        attestationRef: lookup.chain.attestationRef,
+        chainEventReferences: [],
+        errors: ["verification_hash_missing"],
+        metadataOnly: true as const,
+        rawIdsIncluded: false as const,
+        payloadIncluded: false as const,
+      };
+  return {
+    evidenceRef: evidenceRefInput,
+    verified: verification.success,
+    matchedHash: verification.matchedHash,
+    attestationRef: lookup.chain.attestationRef,
+    verificationErrors: verification.errors,
+    chain: chainResponse(lookup.chain, normalizeLimit(options.limit)),
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}

--- a/rentchain-api/src/types/attestation-api-types.ts
+++ b/rentchain-api/src/types/attestation-api-types.ts
@@ -1,0 +1,108 @@
+import type {
+  AttestationLifecycleState,
+  CertificateSafeReference,
+  SafeEvidenceReference,
+  SignatureAlgorithm,
+} from "./attestation-types";
+import type { ExportAuditEventType } from "./export-audit-types";
+
+export type AttestationAccessRole = "tenant" | "landlord" | "admin" | "support";
+
+export type AttestationAccessContext = {
+  role: AttestationAccessRole;
+  subjectRef: string;
+  landlordRef: string | null;
+  allowedEvidenceRefs: SafeEvidenceReference[];
+  supportPurpose: string | null;
+  rawIdsIncluded: false;
+};
+
+export type AttestationHashRouteParams = {
+  hashValue: string;
+};
+
+export type AttestationEvidenceRouteParams = {
+  evidenceId: string;
+};
+
+export type AttestationApiEnvelope<T> =
+  | {
+      success: true;
+      data: T;
+      error: null;
+      code: "OK";
+    }
+  | {
+      success: false;
+      data: null;
+      error: string;
+      code:
+        | "ATTESTATION_BAD_REQUEST"
+        | "ATTESTATION_UNAUTHORIZED"
+        | "ATTESTATION_FORBIDDEN"
+        | "ATTESTATION_NOT_FOUND"
+        | "ATTESTATION_INTERNAL_ERROR";
+    };
+
+export type AttestationHashMetadataResponse = {
+  hashValue: string;
+  attestationRef: string;
+  exportPackageRef: string;
+  evidenceRef: SafeEvidenceReference | null;
+  lifecycleState: AttestationLifecycleState | null;
+  signature: {
+    signatureRef: string | null;
+    certificateRef: CertificateSafeReference | null;
+    signatureAlgorithm: SignatureAlgorithm | null;
+  };
+  verificationStatus: "verified" | "unverified" | "invalid";
+  observedAt: string | null;
+  metadataOnly: true;
+  immutable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type AttestationChainEventResponse = {
+  eventType: ExportAuditEventType;
+  lifecycleState: AttestationLifecycleState;
+  timestamp: string;
+  hashValue: string | null;
+  signatureRef: string | null;
+  certificateRef: CertificateSafeReference | null;
+  signatureAlgorithm: SignatureAlgorithm | null;
+  evidenceRef: SafeEvidenceReference | null;
+  metadataOnly: true;
+  immutable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type AttestationChainResponse = {
+  attestationRef: string;
+  exportPackageRef: string;
+  currentState: AttestationLifecycleState | null;
+  events: AttestationChainEventResponse[];
+  pagination: {
+    limit: number;
+    returned: number;
+    hasMore: boolean;
+  };
+  metadataOnly: true;
+  appendOnly: true;
+  immutable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type AttestationVerifyResponse = {
+  evidenceRef: SafeEvidenceReference;
+  verified: boolean;
+  matchedHash: string | null;
+  attestationRef: string | null;
+  verificationErrors: string[];
+  chain: AttestationChainResponse | null;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};


### PR DESCRIPTION
## Summary
- Add read-only `/api/attestation` routes for hash metadata, evidence chain, and verification lookup.
- Add metadata-only API types, access-context middleware, and canonical attestation event retrieval service.
- Add focused route, middleware, and service coverage plus architecture documentation.

## Validation
- `npm test -- src/services/__tests__/attestation-hash-retrieval.test.ts`
- `npm test -- src/middleware/__tests__/attestation-auth.test.ts`
- `npm test -- src/routes/__tests__/attestation-hash.test.ts`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Manual QA
Manual server QA is still required before merge because this adds backend routes. Focused route, middleware, service, build, and diff validation passed locally.

## Scope Notes
- No protected areas changed.
- No dependency changes.
- No Firestore rules, deployment, signing integration, dashboard UI, background worker, or mutation path added.