### PR TITLE
feat: add trust workspace read model

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,90 +1,80 @@
-# Implementation Summary - Attestation Hash Retrieval v1
+# Implementation Summary - Trust Workspace v1
 
-PR: #1100
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1100
-Branch: feat/attestation-hash-retrieval-v1
+PR: #1101
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1101
+Branch: feat/trust-workspace-v1
 
 ## Scope Delivered
 
-Implemented authorized attestation hash retrieval as a read-only backend API surface under `/api/attestation`.
+Implemented Trust Workspace v1 as a backend service-layer read model for evidence trust chain management.
 
-The implementation adds metadata-only response types, authenticated access-context resolution, canonical attestation event retrieval, role-aware projection checks, and three read routes:
+The implementation adds metadata-only workspace types, deterministic derivation helpers, role-specific projection helpers, non-blocking descriptor audit event emission, and the `getTrustWorkspaceForUser()` service entry point. It composes existing evidence records, attestation hash verification, institutional trust export policy evaluation, and cross-organization trust derivation.
 
-- `GET /api/attestation/hash/:hashValue`
-- `GET /api/attestation/evidence/:evidenceId/chain`
-- `GET /api/attestation/evidence/:evidenceId/verify`
-
-Responses use deterministic hash values and safe references only. The implementation does not add mutation paths, background processing, Firestore rule changes, deployment changes, new dependencies, signing integrations, external certificate authority integrations, dashboard UI, or protected-area changes.
+No HTTP routes, dashboard UI, mutation paths, background workers, signing execution, delivery mechanisms, external integrations, Firestore rules, deployment configuration, billing, auth core, screening, pricing, or entitlement changes were added.
 
 ## Files Changed
 
-- rentchain-api/src/app.build.ts
-- rentchain-api/src/types/attestation-api-types.ts
-- rentchain-api/src/middleware/attestationAuth.ts
-- rentchain-api/src/middleware/__tests__/attestation-auth.test.ts
-- rentchain-api/src/services/attestation-hash-retrieval-service.ts
-- rentchain-api/src/services/__tests__/attestation-hash-retrieval.test.ts
-- rentchain-api/src/routes/attestationRoutes.ts
-- rentchain-api/src/routes/__tests__/attestation-hash.test.ts
-- docs/architecture/attestation-hash-retrieval-v1.md
+- rentchain-api/src/lib/trustWorkspace/trustWorkspaceTypes.ts
+- rentchain-api/src/lib/trustWorkspace/deriveTrustWorkspace.ts
+- rentchain-api/src/lib/trustWorkspace/trustWorkspaceProjections.ts
+- rentchain-api/src/lib/trustWorkspace/trustWorkspaceEventEmission.ts
+- rentchain-api/src/lib/trustWorkspace/__tests__/trustWorkspace.test.ts
+- rentchain-api/src/services/trust-workspace-service.ts
+- rentchain-api/src/services/__tests__/trust-workspace-service.test.ts
+- rentchain-api/src/types/export-audit-types.ts
+- docs/architecture/trust-workspace-v1.md
 - .handoff/impl-summary.md
 
 ## Tests Passed
 
-- `npm test -- src/services/__tests__/attestation-hash-retrieval.test.ts`: PASS
-- `npm test -- src/middleware/__tests__/attestation-auth.test.ts`: PASS
-- `npm test -- src/routes/__tests__/attestation-hash.test.ts`: PASS
+- `npm test -- src/lib/trustWorkspace/__tests__/trustWorkspace.test.ts`: PASS
+- `npm test -- src/services/__tests__/trust-workspace-service.test.ts`: PASS
 - `npm run build` in `rentchain-api`: PASS
 - `git diff --check`: PASS
 
-All commands were run under Node 20.11.1 after the repo preflight rejected Node 25.8.1.
+All Node-based commands were run under Node 20.11.1.
 
 ## Acceptance Criteria Met
 
-- [x] Added authenticated read route for hash metadata lookup by SHA-256 hash value.
-- [x] Added authenticated read route for evidence attestation chain lookup by safe evidence reference.
-- [x] Added authenticated read route for evidence attestation verification by safe evidence reference.
-- [x] Preserved read-only behavior with no writes, appends, deletes, background jobs, or remediation actions.
-- [x] Added fixed response envelope with safe success and error codes.
-- [x] Validates hash format and safe evidence reference format before retrieval.
-- [x] Enforces landlord scope server-side for landlord access.
-- [x] Supports tenant access only when the authenticated session context contains an explicit safe evidence reference.
-- [x] Supports admin/support metadata inspection without exposing source material.
-- [x] Omits canonical event document identifiers from route responses.
-- [x] Keeps responses metadata-only with `rawIdsIncluded: false` and `payloadIncluded: false`.
-- [x] Rejects invalid references with safe 400 responses.
-- [x] Returns safe 403 and 404 responses without stack traces or internal identifiers.
-- [x] Added focused service, middleware, and route tests.
-- [x] Added architecture documentation for route scope, authorization, projection safety, and limitations.
+- [x] Added trust workspace type definitions with metadata-only, immutable, non-public, non-shareable flags.
+- [x] Added deterministic workspace context validation and workspace safe-reference generation.
+- [x] Added evidence chain summary derivation from evidence records with provenance safe references.
+- [x] Added attestation context derivation through existing attestation hash verification service.
+- [x] Added institutional export readiness summary using existing policy gate derivation.
+- [x] Added cross-organization trust context using existing trust derivation.
+- [x] Added landlord, tenant, admin, and support projection helpers.
+- [x] Tenant projection excludes attestation, export readiness, and cross-organization context.
+- [x] Landlord and support projections enforce landlord scope.
+- [x] Admin projection remains metadata-only.
+- [x] Added non-blocking `TrustWorkspaceDerived` audit event emission.
+- [x] Extended export audit event/target types for descriptor-only workspace derivation events.
+- [x] Added `getTrustWorkspaceForUser()` service entry point.
+- [x] Tests cover derivation, projection safety, role scope validation, export readiness, cross-org context, service integration, and event emission.
+- [x] No HTTP routes added.
 - [x] No protected areas modified.
 - [x] No dependency changes.
 - [x] No unrelated refactors.
 
 ## Manual QA
 
-Manual API QA is required because this mission adds backend routes.
+Manual preview QA is not required for this mission because no HTTP routes, frontend rendering, mobile layout, auth flow, routing, or user-visible dashboard behavior were added.
 
-Manual server QA was not run in this implementation pass. Route behavior was verified through focused route, middleware, service, and build validation. Recommended manual QA before merge:
+Manual code/test inspection completed:
 
-1. Start the local API with a valid authenticated landlord context.
-2. Request `GET /api/attestation/hash/:hashValue` with a known attestation hash and confirm a 200 metadata-only response.
-3. Request the same hash without authentication and confirm 401.
-4. Request the same hash with a cross-landlord user and confirm 403.
-5. Request an invalid hash value and confirm 400 with fixed error code only.
-6. Request an unknown hash value and confirm 404 with fixed error code only.
-7. Request `GET /api/attestation/evidence/:evidenceId/chain` using a safe evidence reference and confirm ordered metadata-only events.
-8. Request `GET /api/attestation/evidence/:evidenceId/verify` using a safe evidence reference and confirm verification metadata only.
-9. Confirm responses do not expose internal document identifiers, storage paths, source material, signature material, certificate material, or stack traces.
-10. Confirm no protected route, billing, auth core, Firestore rules, deployment, or pricing behavior changed.
+1. Confirmed no route files were added or mounted.
+2. Confirmed service layer only entry point: `getTrustWorkspaceForUser()`.
+3. Confirmed no Firestore rules, deployment, billing, auth core, screening, pricing, or entitlement files changed.
+4. Confirmed tenant projection excludes attestation, export readiness, and cross-organization context.
+5. Confirmed audit event emission is non-blocking and descriptor-only.
+6. Confirmed workspace summaries use safe references and metadata-only flags.
 
 ## Known Limitations
 
-- This route reads existing canonical attestation event metadata; it does not introduce a separate hash-record collection.
-- Tenant access depends on safe evidence references being present in authenticated session context.
-- Verification is metadata hash-chain verification only and does not add external certificate authority, HSM, KMS, notary, or timestamp authority checks.
-- No dashboard UI, export delivery flow, background worker, or recipient verification surface was added.
-- Manual server QA remains required before merge approval.
+- Trust Workspace v1 is a service-layer foundation only.
+- No HTTP route, dashboard UI, signing flow, delivery flow, institution integration, background worker, or external submission was added.
+- Event emission uses the existing export audit trail helper and descriptor-only count metadata.
+- Runtime Cloud Run verification is not applicable until a route or user-facing consumer is added.
 
 ## Recommended Next Mission
 
-Phase 4C attestation verification dashboard read model, or a narrow mission to add operational observability for attestation retrieval usage.
+Phase 4 evidence export trust signoff service, or a narrow route mission that exposes this workspace through authenticated read-only API endpoints.

--- a/docs/architecture/trust-workspace-v1.md
+++ b/docs/architecture/trust-workspace-v1.md
@@ -1,0 +1,53 @@
+# Trust Workspace v1
+
+## Purpose
+
+Trust Workspace v1 is a backend service-layer read model for evidence trust chain management. It aggregates evidence record metadata, attestation lifecycle state, institutional export readiness, and cross-organization trust context into one deterministic projection.
+
+The workspace is read-only. It does not add dashboard UI, HTTP routes, signing execution, delivery, institution callbacks, public trust profiles, background workers, or production data mutations.
+
+## Components
+
+- `trustWorkspaceTypes.ts` defines metadata-only workspace context, evidence chain summaries, attestation context, export readiness summaries, cross-organization context, and service result types.
+- `deriveTrustWorkspace.ts` composes existing evidence records, attestation hash verification, institutional trust export policy evaluation, and cross-organization trust derivation.
+- `trustWorkspaceProjections.ts` applies role-specific allowlist projections for landlord, tenant, admin, and support access.
+- `trustWorkspaceEventEmission.ts` emits descriptor-only `TrustWorkspaceDerived` audit events through the existing export audit trail helper.
+- `trust-workspace-service.ts` provides `getTrustWorkspaceForUser()` for future route or dashboard consumers.
+
+## Data Model
+
+The workspace summary contains:
+
+- evidence summaries with safe evidence references, evidence class/type, resource type, status, metadata hash, provenance chain safe references, authority metadata, and attestation state
+- attestation contexts with attestation safe references, signature/certificate references, hash verification status, and linked evidence references
+- export readiness summaries with audience, purpose, policy gate status, blocked reason counts, and exportable/blocked attestation counts
+- cross-organization context with trust relationship safe references, status, evidence/review/settlement trust state, restriction counts, and manual review flags
+
+All workspace types are marked metadata-only, immutable, non-public, non-shareable, and payload-free.
+
+## Access Control
+
+Workspace access is projected by authenticated role:
+
+- landlord: own landlord-scoped evidence, attestation metadata, export readiness, and visible cross-organization trust context
+- tenant: own safe evidence references only; attestation, export readiness, and cross-organization context are excluded
+- admin: metadata-only inspection across provided workspace inputs
+- support: landlord-scoped metadata inspection with explicit support purpose tracking
+
+Scope validation fails closed for invalid roles, missing landlord scope, missing tenant evidence scope, ambiguous context, or unauthorized evidence visibility.
+
+## Safe References
+
+Workspace outputs use deterministic safe references for evidence, landlord scope, tenant scope, export packages, trust relationships, requesters, and workspace IDs. Raw source identifiers, document identifiers, storage paths, support notes, provider source material, and private source data are excluded from projections.
+
+## Audit Traceability
+
+`TrustWorkspaceDerived` is a descriptor-only audit event. It records role, count summaries, derivation state, and metadata safety flags. The event is non-blocking: append failure does not fail workspace derivation.
+
+## Deferred Work
+
+Deferred follow-on work includes HTTP route handlers, dashboard UI, trust signoff flows, signing execution, recipient delivery, institution integrations, operational observability, and Cloud Run preview verification for user-facing consumers.
+
+## Boundaries
+
+Trust Workspace v1 does not perform signing, delivery, autonomous approval, external submission, public exposure, Firestore rule changes, deployment changes, billing changes, screening changes, or auth core changes.

--- a/rentchain-api/src/lib/trustWorkspace/__tests__/trustWorkspace.test.ts
+++ b/rentchain-api/src/lib/trustWorkspace/__tests__/trustWorkspace.test.ts
@@ -1,0 +1,472 @@
+import { describe, expect, it } from "vitest";
+import type { EvidenceRecord } from "../../../types/evidence-record-types";
+import type { ExportAuthorizationContext } from "../../../types/export-authorization-types";
+import type { ExportAuditEventPayload } from "../../../types/export-audit-types";
+import type { ExportPackage } from "../../../types/export-package-types";
+import type { PortableAttestation } from "../../portableAttestations/portableAttestationTypes";
+import type { ExportAuditTrailFirestoreLike } from "../../../services/export-audit-trail-service";
+import { generateExportAuditSafeReference } from "../../../services/export-audit-trail-service";
+import {
+  appendAttestationLinkedAuditEvent,
+  appendSignatureGeneratedAuditEvent,
+  appendSignatureRequestedAuditEvent,
+  appendSignatureVerifiedAuditEvent,
+} from "../../../services/attestation-service";
+import {
+  assembleTrustWorkspaceSummary,
+  buildTrustWorkspaceContext,
+  deriveCrossOrgContext,
+  deriveExportReadinessSummary,
+} from "../deriveTrustWorkspace";
+import {
+  projectTrustWorkspaceForAdmin,
+  projectTrustWorkspaceForLandlord,
+  projectTrustWorkspaceForTenant,
+} from "../trustWorkspaceProjections";
+
+const landlordId = "landlord-workspace-1";
+const tenantId = "tenant-workspace-1";
+const actorRef = "actor:bbbbbbbbbbbbbbbbbbbb";
+const evidenceRef = "evidence:eeeeeeeeeeeeeeeeeeee";
+const hashValue = "c".repeat(64);
+const timestamp = "2026-06-05T12:00:00.000Z";
+
+type Filter = { field: string; value: unknown };
+
+function auditStore() {
+  const events = new Map<string, ExportAuditEventPayload>();
+
+  function getField(event: ExportAuditEventPayload, field: string) {
+    if (field === "metadata.details.contentHash") return event.metadata.details.contentHash;
+    if (field === "metadata.details.linkedEvidenceRef") return event.metadata.details.linkedEvidenceRef;
+    return event[field as keyof ExportAuditEventPayload];
+  }
+
+  class Query {
+    constructor(private readonly filters: Filter[] = []) {}
+
+    where(field: string, _op: string, value: unknown) {
+      return new Query([...this.filters, { field, value }]);
+    }
+
+    orderBy() {
+      return this;
+    }
+
+    limit() {
+      return this;
+    }
+
+    async get() {
+      return {
+        docs: Array.from(events.values())
+          .filter((event) => this.filters.every((filter) => getField(event, filter.field) === filter.value))
+          .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+          .map((event) => ({ data: () => event })),
+      };
+    }
+  }
+
+  const firestore: ExportAuditTrailFirestoreLike = {
+    collection() {
+      const query = new Query();
+      return {
+        doc(id: string) {
+          return {
+            async get() {
+              const event = events.get(id);
+              return { exists: Boolean(event), data: () => event };
+            },
+            async create(data: ExportAuditEventPayload) {
+              if (events.has(id)) throw new Error("already_exists");
+              events.set(id, data);
+            },
+            async set(data: ExportAuditEventPayload) {
+              events.set(id, data);
+            },
+          };
+        },
+        where: query.where.bind(query),
+        orderBy: query.orderBy.bind(query),
+        limit: query.limit.bind(query),
+        get: query.get.bind(query),
+      };
+    },
+  };
+
+  return { firestore, list: () => Array.from(events.values()) };
+}
+
+function authContext(): ExportAuthorizationContext {
+  return {
+    requestingActorId: actorRef,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordId,
+    requestingPurpose: "InsuranceClaim",
+    timestamp,
+    rawIdsIncluded: false,
+  };
+}
+
+function exportPackage(): ExportPackage {
+  return {
+    exportPackageId: "exp_pkg_v1_workspace",
+    exportRequestId: "exp_req_v1_workspace",
+    landlordId,
+    recipientType: "InsuranceAdjuster",
+    purpose: "InsuranceClaim",
+    packageMetadata: {
+      assembledAt: timestamp,
+      assembledBy: actorRef,
+      assemblyVersion: "evidence_package_builder_v1",
+      includedEvidenceCount: 1,
+      totalPackageSize: 1,
+      checksumAlgorithm: "sha256",
+      checksumValue: hashValue,
+    },
+    evidenceManifest: {
+      evidenceClasses: ["PaymentEvidence"],
+      dateRangeApplied: { start: null, end: null },
+      unitsScopeApplied: [],
+      redactionPolicyApplied: "Redacted",
+      excludedEvidence: [],
+    },
+    status: "Assembled",
+    auditTrailReference: "export_audit:workspace",
+    metadata: { metadataOnly: true },
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+function evidenceRecord(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  const landlordRef = generateExportAuditSafeReference("landlord", landlordId);
+  const tenantRef = generateExportAuditSafeReference("tenant", tenantId);
+  return {
+    evidenceId: "ev-workspace-1",
+    evidenceClass: "PaymentEvidence",
+    evidenceType: "rent_payment_metadata",
+    schemaVersion: "evidence_record_v1",
+    landlordId,
+    resourceType: "payment",
+    resourceId: "payment-workspace-1",
+    safeReference: {
+      evidenceId: "ev-workspace-1",
+      evidenceClass: "PaymentEvidence",
+      resourceType: "payment",
+      safeReferenceKey: evidenceRef,
+      label: "Payment evidence",
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+    provenanceMetadata: {
+      createdAt: timestamp,
+      createdBy: { actorRole: "landlord", actorRef, rawActorIdsIncluded: false },
+      authority: { authorityRole: "landlord", landlordRef, tenantRef, supportAllowed: true, rawIdsIncluded: false },
+      source: {
+        sourceCollection: "payments",
+        sourceReferenceKey: "payment:aaaaaaaaaaaaaaaaaaaa",
+        sourceObservedAt: timestamp,
+        sourceVersion: "v1",
+        rawSourceIdsIncluded: false,
+        rawPayloadIncluded: false,
+      },
+      reason: "Workspace trust chain test.",
+      provenanceChain: [{
+        evidenceId: "ev-source",
+        evidenceClass: "AuditEvidence",
+        resourceType: "canonicalEvent",
+        safeReferenceKey: "evidence:dddddddddddddddddddd",
+        label: "Source event",
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      }],
+      metadataOnly: true,
+    },
+    sensitivityMetadata: {
+      sensitivityClass: "Operational",
+      projectionCategories: ["landlord_operational", "admin_support", "institutional_export"],
+      redactionPolicy: "metadata_only",
+      excludedFieldGroups: [],
+      allowedFieldGroups: ["metadata"],
+      containsRestrictedProviderData: false,
+      containsRawPaymentData: false,
+      containsMessageBody: false,
+      containsIdentityDocument: false,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+    retentionMetadata: {
+      retentionPolicy: "evidence_retention_policy_v1",
+      retentionReviewRequired: false,
+      archiveAfter: null,
+      deleteAfter: null,
+      appliedRetentionPolicyRule: null,
+      evaluatedAt: timestamp,
+      eligibleForArchivalAt: null,
+      eligibleForDeletionAt: null,
+      legalHoldStatus: "none",
+      lifecycleEvents: [],
+    },
+    status: "active",
+    createdAt: timestamp,
+    supersedesEvidenceId: null,
+    supersededByEvidenceId: null,
+    immutable: true,
+    appendOnly: true,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    redactionSummary: "Metadata-only payment evidence.",
+    ...overrides,
+  };
+}
+
+function portableAttestation(): PortableAttestation {
+  return {
+    attestationId: "attestation:portable-workspace",
+    attestationType: "tenant_portability",
+    subjectType: "tenant",
+    subjectId: "tenant:aaaaaaaaaaaaaaaaaaaa",
+    claimCategory: "tenant_portability",
+    claimLabel: "Tenant portability metadata",
+    claimDescription: "Tenant portability claim.",
+    status: "active",
+    lifecycleState: "export_ready",
+    issuerCategory: "rentchain",
+    audience: "insurer",
+    consentScope: {
+      consentId: "consent:aaaaaaaaaaaaaaaaaaaa",
+      purpose: "insurance_review",
+      audience: "insurer",
+      grantedAt: timestamp,
+      expiresAt: null,
+      revokedAt: null,
+      claimCategories: ["tenant_portability"],
+      attributeScopes: ["metadata"],
+    },
+    retentionClass: "portable_metadata",
+    evidenceSummary: {
+      evidenceCategory: "metadata_only",
+      sourceSystem: "tenant_share_package",
+      sourceCategory: "tenant_portability",
+      sourceVersion: "v1",
+      auditEventRef: "audit:aaaaaaaaaaaaaaaaaaaa",
+      rawEvidenceIncluded: false,
+    },
+    sourceReference: {
+      sourceSystem: "tenant_share_package",
+      sourceId: "tenant_share:aaaaaaaaaaaaaaaaaaaa",
+      sourceAttestationId: null,
+      sourceVersion: "v1",
+    },
+    confidence: "high",
+    issuedAt: timestamp,
+    effectiveAt: timestamp,
+    expiresAt: null,
+    revokedAt: null,
+    supersededAt: null,
+    nextReverificationAt: null,
+    jurisdiction: "CA",
+    redactionProfile: "strict",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    unsupportedClaim: false,
+    supportVisible: true,
+    reviewRequired: false,
+    nonAuthorityDisclaimers: [],
+    internalReferenceId: null,
+    providerReferenceId: null,
+  };
+}
+
+async function seedAttestation() {
+  const store = auditStore();
+  await appendSignatureRequestedAuditEvent(exportPackage(), authContext(), {
+    attestationId: "attestation:workspace",
+    timestamp: "2026-06-05T12:01:00.000Z",
+    firestore: store.firestore,
+  });
+  await appendSignatureGeneratedAuditEvent(exportPackage(), authContext(), {
+    attestationId: "attestation:workspace",
+    signatureId: "signature:workspace",
+    certificateId: "certificate:workspace",
+    signatureAlgorithm: "RSA-SHA256",
+    contentHash: hashValue,
+    timestamp: "2026-06-05T12:02:00.000Z",
+    firestore: store.firestore,
+  });
+  await appendSignatureVerifiedAuditEvent(exportPackage(), authContext(), {
+    attestationId: "attestation:workspace",
+    signatureId: "signature:workspace",
+    certificateId: "certificate:workspace",
+    signatureAlgorithm: "RSA-SHA256",
+    contentHash: hashValue,
+    timestamp: "2026-06-05T12:03:00.000Z",
+    firestore: store.firestore,
+  });
+  await appendAttestationLinkedAuditEvent(exportPackage(), authContext(), {
+    attestationId: "attestation:workspace",
+    evidenceReference: evidenceRef,
+    timestamp: "2026-06-05T12:04:00.000Z",
+    firestore: store.firestore,
+  });
+  return store;
+}
+
+describe("trust workspace derivation", () => {
+  it("assembles landlord workspace with evidence, attestation, export, and cross-org context", async () => {
+    const store = await seedAttestation();
+    const context = buildTrustWorkspaceContext({
+      context: {
+        role: "landlord",
+        requesterRef: actorRef,
+        landlordRef: generateExportAuditSafeReference("landlord", landlordId),
+        tenantRef: null,
+        allowedEvidenceRefs: [],
+        supportPurpose: null,
+        rawIdsIncluded: false,
+      },
+      derivedAt: timestamp,
+    });
+
+    const summary = await assembleTrustWorkspaceSummary({
+      context,
+      evidenceRecords: [evidenceRecord()],
+      auditEvents: store.list(),
+      portableAttestations: [portableAttestation()],
+      exportReadinessRequests: [{ audience: "insurer", purpose: "insurance_review" }],
+      crossOrgInput: {
+        relationshipType: "evidence_trust",
+        evidencePacks: [{ evidencePackId: "pack-1", status: "ready_for_review" }],
+        consentRecords: [{ consentId: "consent-1" }],
+      },
+      derivedAt: timestamp,
+    });
+
+    expect(summary.evidenceSummaries).toHaveLength(1);
+    expect(summary.attestationContexts[0]).toEqual(expect.objectContaining({
+      attestationRef: "attestation:workspace",
+      hashVerificationStatus: "verified",
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    }));
+    expect(summary.exportReadinessStates[0]).toEqual(expect.objectContaining({
+      policyGateStatus: "ready",
+      exportableAttestationCount: 1,
+    }));
+    expect(summary.crossOrgContexts[0].evidenceTrustState).toBe("verified");
+    expect(JSON.stringify(summary)).not.toContain(landlordId);
+  });
+
+  it("projects landlord and tenant workspaces with role-safe visibility", async () => {
+    const store = await seedAttestation();
+    const landlordContext = {
+      role: "landlord" as const,
+      requesterRef: actorRef,
+      landlordRef: generateExportAuditSafeReference("landlord", landlordId),
+      tenantRef: null,
+      allowedEvidenceRefs: [],
+      supportPurpose: null,
+      rawIdsIncluded: false as const,
+    };
+    const summary = await assembleTrustWorkspaceSummary({
+      context: landlordContext,
+      evidenceRecords: [evidenceRecord()],
+      auditEvents: store.list(),
+      exportReadinessRequests: [{ audience: "insurer", purpose: "insurance_review" }],
+      crossOrgInput: { relationshipType: "evidence_trust", consentRecords: [{ consentId: "consent-1" }] },
+      derivedAt: timestamp,
+    });
+    const landlord = projectTrustWorkspaceForLandlord(summary, landlordContext);
+    const tenant = projectTrustWorkspaceForTenant(
+      { ...summary, role: "tenant" },
+      {
+        role: "tenant",
+        requesterRef: "actor:tenanttenanttenant",
+        landlordRef: null,
+        tenantRef: generateExportAuditSafeReference("tenant", tenantId),
+        allowedEvidenceRefs: [evidenceRef],
+        supportPurpose: null,
+        rawIdsIncluded: false,
+      }
+    );
+
+    expect(landlord.evidenceSummaries[0].authority.tenantRef).toBeNull();
+    expect(tenant.attestationContexts).toEqual([]);
+    expect(tenant.exportReadinessStates).toEqual([]);
+    expect(tenant.crossOrgContexts).toEqual([]);
+    expect(tenant.evidenceSummaries[0].contentHash).toBeNull();
+  });
+
+  it("allows admin metadata projection while preserving safety flags", async () => {
+    const summary = await assembleTrustWorkspaceSummary({
+      context: {
+        role: "admin",
+        requesterRef: "actor:adminadminadmin",
+        landlordRef: null,
+        tenantRef: null,
+        allowedEvidenceRefs: [],
+        supportPurpose: "trust_workspace_admin_review",
+        rawIdsIncluded: false,
+      },
+      evidenceRecords: [evidenceRecord()],
+      derivedAt: timestamp,
+    });
+    const projected = projectTrustWorkspaceForAdmin(summary, {
+      role: "admin",
+      requesterRef: "actor:adminadminadmin",
+      landlordRef: null,
+      tenantRef: null,
+      allowedEvidenceRefs: [],
+      supportPurpose: "trust_workspace_admin_review",
+      rawIdsIncluded: false,
+    });
+
+    expect(projected.metadataOnly).toBe(true);
+    expect(projected.rawIdsIncluded).toBe(false);
+    expect(projected.payloadIncluded).toBe(false);
+  });
+
+  it("fails closed on missing tenant evidence scope", async () => {
+    await expect(
+      assembleTrustWorkspaceSummary({
+        context: {
+          role: "tenant",
+          requesterRef: "actor:tenanttenanttenant",
+          landlordRef: null,
+          tenantRef: generateExportAuditSafeReference("tenant", tenantId),
+          allowedEvidenceRefs: [],
+          supportPurpose: null,
+          rawIdsIncluded: false,
+        },
+        evidenceRecords: [evidenceRecord()],
+      })
+    ).rejects.toThrow("trust_workspace_missing_tenant_scope");
+  });
+
+  it("derives export readiness and cross-org summaries without exposing source values", () => {
+    const readiness = deriveExportReadinessSummary({
+      audience: "insurer",
+      purpose: "insurance_review",
+      attestations: [portableAttestation()],
+      derivedAt: timestamp,
+    });
+    const crossOrg = deriveCrossOrgContext(generateExportAuditSafeReference("landlord", landlordId), {
+      relationshipType: "sharing_trust",
+      consentRecords: [],
+      sharingRooms: [{ sharingRoomId: "share-1", publiclyAccessible: true, externalExecutionEnabled: false, status: "active" }],
+    }, timestamp);
+
+    expect(readiness.policyGateStatus).toBe("ready");
+    expect(crossOrg[0]).toEqual(expect.objectContaining({
+      status: "blocked",
+      manualReviewRequired: true,
+      publicTrustExposureEnabled: false,
+    }));
+    expect(JSON.stringify({ readiness, crossOrg })).not.toContain("share-1");
+  });
+});

--- a/rentchain-api/src/lib/trustWorkspace/deriveTrustWorkspace.ts
+++ b/rentchain-api/src/lib/trustWorkspace/deriveTrustWorkspace.ts
@@ -1,0 +1,308 @@
+import crypto from "crypto";
+import { computeEvidenceRecordHash, isSha256Hash } from "../../lib/evidence-hash-service";
+import { verifyAttestationEvidenceChain } from "../../services/attestation-hash-retrieval-service";
+import { generateExportAuditSafeReference } from "../../services/export-audit-trail-service";
+import type { AttestationAccessContext } from "../../types/attestation-api-types";
+import type { ExportAuditEventPayload } from "../../types/export-audit-types";
+import type { EvidenceRecord } from "../../types/evidence-record-types";
+import type { PortableAttestation } from "../portableAttestations/portableAttestationTypes";
+import { deriveInstitutionalTrustExportPackage } from "../institutionTrustExports/deriveInstitutionalTrustExportPackage";
+import type {
+  InstitutionalTrustExportAudience,
+  InstitutionalTrustExportPurpose,
+} from "../institutionTrustExports/institutionTrustExportTypes";
+import { deriveCrossOrganizationTrust } from "../crossOrganizationTrust/deriveCrossOrganizationTrust";
+import type { DeriveCrossOrganizationTrustInput } from "../crossOrganizationTrust/crossOrganizationTrustTypes";
+import type {
+  TrustWorkspaceAccessContext,
+  TrustWorkspaceAttestationContext,
+  TrustWorkspaceCrossOrgContext,
+  TrustWorkspaceEvidenceChainSummary,
+  TrustWorkspaceExportReadinessSummary,
+  TrustWorkspaceLandlordContext,
+  TrustWorkspaceSummary,
+} from "./trustWorkspaceTypes";
+
+export type TrustWorkspaceDerivationInput = {
+  context: TrustWorkspaceAccessContext;
+  evidenceRecords?: readonly EvidenceRecord[];
+  auditEvents?: readonly ExportAuditEventPayload[];
+  portableAttestations?: readonly PortableAttestation[];
+  exportReadinessRequests?: readonly Array<{
+    audience: InstitutionalTrustExportAudience;
+    purpose: InstitutionalTrustExportPurpose;
+    exportRef?: string | null;
+  }>;
+  crossOrgInput?: Omit<DeriveCrossOrganizationTrustInput, "landlordId" | "generatedAt"> | null;
+  derivedAt?: string;
+};
+
+function stableHash(value: unknown, length = 32): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, length);
+}
+
+function toIso(value: unknown): string {
+  const raw = String(value ?? "").trim();
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function safeEvidenceRef(value: unknown): string {
+  const text = String(value ?? "").trim();
+  return text.startsWith("evidence:") ? text : `evidence:${stableHash(["evidence", text], 24)}`;
+}
+
+function accessForAttestation(context: TrustWorkspaceAccessContext): AttestationAccessContext {
+  return {
+    role: context.role,
+    subjectRef: context.requesterRef,
+    landlordRef: context.landlordRef,
+    allowedEvidenceRefs: context.allowedEvidenceRefs,
+    supportPurpose: context.supportPurpose,
+    rawIdsIncluded: false,
+  };
+}
+
+function assertContext(context: TrustWorkspaceAccessContext): void {
+  if (!context.requesterRef || context.rawIdsIncluded !== false) throw new Error("trust_workspace_invalid_context");
+  if (!["tenant", "landlord", "admin", "support"].includes(context.role)) throw new Error("trust_workspace_invalid_role");
+  if ((context.role === "landlord" || context.role === "support") && !context.landlordRef) {
+    throw new Error("trust_workspace_missing_landlord_scope");
+  }
+  if (context.role === "tenant" && !context.allowedEvidenceRefs.length) throw new Error("trust_workspace_missing_tenant_scope");
+}
+
+export function buildTrustWorkspaceContext(input: {
+  context: TrustWorkspaceAccessContext;
+  derivedAt?: string;
+}): TrustWorkspaceLandlordContext {
+  assertContext(input.context);
+  const derivedAt = toIso(input.derivedAt);
+  const workspaceRef = `trust_workspace:${stableHash([
+    input.context.role,
+    input.context.landlordRef,
+    input.context.tenantRef,
+    input.context.allowedEvidenceRefs,
+    derivedAt.slice(0, 10),
+  ])}`;
+  return {
+    ...input.context,
+    derivedAt,
+    workspaceRef,
+    metadataOnly: true,
+    immutable: true,
+    nonPublic: true,
+    nonShareable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+function isEvidenceVisible(record: EvidenceRecord, context: TrustWorkspaceLandlordContext): boolean {
+  const recordLandlordRef = generateExportAuditSafeReference("landlord", record.landlordId);
+  const evidenceRef = safeEvidenceRef(record.safeReference.safeReferenceKey) as TrustWorkspaceEvidenceChainSummary["evidenceRef"];
+  if (context.role === "admin") return true;
+  if (context.role === "support") return Boolean(context.landlordRef && context.landlordRef === recordLandlordRef);
+  if (context.role === "landlord") return Boolean(context.landlordRef && context.landlordRef === recordLandlordRef);
+  if (context.role === "tenant") return context.allowedEvidenceRefs.includes(evidenceRef);
+  return false;
+}
+
+export async function deriveEvidenceChainSummary(
+  record: EvidenceRecord,
+  context: TrustWorkspaceLandlordContext,
+  options: { auditEvents?: readonly ExportAuditEventPayload[] } = {}
+): Promise<TrustWorkspaceEvidenceChainSummary> {
+  if (!isEvidenceVisible(record, context)) throw new Error("trust_workspace_evidence_forbidden");
+  const evidenceRef = safeEvidenceRef(record.safeReference.safeReferenceKey) as TrustWorkspaceEvidenceChainSummary["evidenceRef"];
+  const attestation = await verifyAttestationEvidenceChain(evidenceRef, accessForAttestation(context), {
+    events: options.auditEvents,
+  }).catch(() => null);
+  const contentHash = record.rawIdsIncluded === false && record.metadataOnly === true ? computeEvidenceRecordHash(record) : null;
+  return {
+    evidenceRef,
+    evidenceClass: record.evidenceClass,
+    evidenceType: record.evidenceType,
+    resourceType: record.resourceType,
+    status: record.status,
+    contentHash: isSha256Hash(contentHash) ? contentHash : null,
+    provenanceChain: record.provenanceMetadata.provenanceChain.map((item) => safeEvidenceRef(item.safeReferenceKey) as TrustWorkspaceEvidenceChainSummary["evidenceRef"]),
+    authority: {
+      authorityRole: record.provenanceMetadata.authority.authorityRole,
+      landlordRef: record.provenanceMetadata.authority.landlordRef,
+      tenantRef: context.role === "admin" || context.role === "support" ? record.provenanceMetadata.authority.tenantRef : null,
+      supportAllowed: record.provenanceMetadata.authority.supportAllowed,
+      rawIdsIncluded: false,
+    },
+    attestationStatus: attestation?.chain?.currentState || (attestation?.verified ? "SignatureVerified" : "Unlinked"),
+    policyEvaluationState: attestation?.verified ? "export_ready" : "unavailable",
+    metadataOnly: true,
+    immutable: true,
+    nonPublic: true,
+    nonShareable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export async function deriveAttestationContext(
+  evidenceRef: string,
+  context: TrustWorkspaceLandlordContext,
+  options: { auditEvents?: readonly ExportAuditEventPayload[] } = {}
+): Promise<TrustWorkspaceAttestationContext | null> {
+  const verified = await verifyAttestationEvidenceChain(evidenceRef, accessForAttestation(context), {
+    events: options.auditEvents,
+  }).catch(() => null);
+  if (!verified) return null;
+  const lastEvent = verified.chain?.events.at(-1) || null;
+  return {
+    attestationRef: verified.attestationRef || "attestation:unavailable",
+    evidenceRef: verified.evidenceRef,
+    lifecycleState: verified.chain?.currentState || null,
+    signatureRef: lastEvent?.signatureRef || null,
+    certificateRef: lastEvent?.certificateRef || null,
+    signatureAlgorithm: lastEvent?.signatureAlgorithm || null,
+    hashValue: verified.matchedHash,
+    hashVerificationStatus: verified.verified ? "verified" : verified.verificationErrors.length ? "invalid" : "unavailable",
+    linkedEvidence: [verified.evidenceRef],
+    metadataOnly: true,
+    immutable: true,
+    nonPublic: true,
+    nonShareable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function deriveExportReadinessSummary(input: {
+  audience: InstitutionalTrustExportAudience;
+  purpose: InstitutionalTrustExportPurpose;
+  exportRef?: string | null;
+  attestations?: readonly PortableAttestation[];
+  derivedAt?: string;
+}): TrustWorkspaceExportReadinessSummary {
+  const pkg = deriveInstitutionalTrustExportPackage({
+    exportId: input.exportRef || `trust_workspace_export:${input.audience}:${input.purpose}`,
+    audience: input.audience,
+    purpose: input.purpose,
+    generatedAt: input.derivedAt,
+    attestations: [...(input.attestations || [])],
+  });
+  return {
+    exportPackageRef: generateExportAuditSafeReference("TrustWorkspace", pkg.exportId),
+    audience: pkg.audience,
+    purpose: pkg.purpose,
+    status: pkg.status,
+    policyGateStatus: pkg.status === "export_ready" ? "ready" : pkg.status === "blocked" ? "blocked" : "unavailable",
+    blockedReasonCount: pkg.blockedReasons.length,
+    exportableAttestationCount: pkg.auditMetadata.exportableAttestationCount,
+    blockedAttestationCount: pkg.auditMetadata.blockedAttestationCount,
+    manualOnly: true,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    metadataOnly: true,
+    immutable: true,
+    nonPublic: true,
+    nonShareable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+function stateFromCount(verified: number, blocked: number, unavailable: number): TrustWorkspaceCrossOrgContext["evidenceTrustState"] {
+  if (blocked > 0) return "blocked";
+  if (unavailable > 0) return "review_required";
+  return verified > 0 ? "verified" : "unknown";
+}
+
+export function deriveCrossOrgContext(
+  landlordRef: string,
+  input: Omit<DeriveCrossOrganizationTrustInput, "landlordId" | "generatedAt"> | null | undefined,
+  derivedAt?: string
+): TrustWorkspaceCrossOrgContext[] {
+  if (!input) return [];
+  const relationship = deriveCrossOrganizationTrust({
+    ...input,
+    landlordId: landlordRef,
+    generatedAt: derivedAt,
+  });
+  return [
+    {
+      trustRelationshipRef: generateExportAuditSafeReference("TrustWorkspace", relationship.trustRelationshipId),
+      relationshipType: relationship.relationshipType,
+      status: relationship.status,
+      evidenceTrustState: stateFromCount(
+        relationship.evidenceReferences.filter((item) => item.status === "verified").length,
+        relationship.evidenceReferences.filter((item) => item.status === "blocked").length,
+        relationship.evidenceReferences.filter((item) => item.status === "unavailable").length
+      ),
+      reviewTrustState: stateFromCount(
+        relationship.reviewReferences.filter((item) => item.status === "verified").length,
+        relationship.reviewReferences.filter((item) => item.status === "blocked").length,
+        relationship.reviewReferences.filter((item) => item.status === "unavailable").length
+      ),
+      settlementTrustState: stateFromCount(
+        relationship.settlementReferences.filter((item) => item.status === "verified").length,
+        relationship.settlementReferences.filter((item) => item.status === "blocked").length,
+        relationship.settlementReferences.filter((item) => item.status === "unavailable").length
+      ),
+      restrictionCount: relationship.trustRestrictions.length,
+      blockedReasonCount: relationship.blockedReasons.length,
+      manualReviewRequired: true,
+      publicTrustExposureEnabled: false,
+      autonomousTrustApprovalEnabled: false,
+      metadataOnly: true,
+      immutable: true,
+      nonPublic: true,
+      nonShareable: true,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+  ];
+}
+
+export async function assembleTrustWorkspaceSummary(input: TrustWorkspaceDerivationInput): Promise<TrustWorkspaceSummary> {
+  const context = buildTrustWorkspaceContext({ context: input.context, derivedAt: input.derivedAt });
+  const evidenceRecords = (input.evidenceRecords || []).filter((record) => isEvidenceVisible(record, context));
+  if (context.role === "tenant" && !evidenceRecords.length) throw new Error("trust_workspace_no_tenant_evidence");
+  const evidenceSummaries = await Promise.all(
+    evidenceRecords.map((record) => deriveEvidenceChainSummary(record, context, { auditEvents: input.auditEvents }))
+  );
+  const attestationContexts = (
+    await Promise.all(evidenceSummaries.map((summary) => deriveAttestationContext(summary.evidenceRef, context, { auditEvents: input.auditEvents })))
+  ).filter((item): item is TrustWorkspaceAttestationContext => item !== null);
+  const exportReadinessStates =
+    context.role === "tenant"
+      ? []
+      : (input.exportReadinessRequests || []).map((request) =>
+          deriveExportReadinessSummary({
+            ...request,
+            attestations: input.portableAttestations,
+            derivedAt: context.derivedAt,
+          })
+        );
+  const crossOrgContexts =
+    context.role === "tenant" ? [] : deriveCrossOrgContext(context.landlordRef || "landlord:unavailable", input.crossOrgInput, context.derivedAt);
+  return {
+    workspaceRef: context.workspaceRef,
+    derivedAt: context.derivedAt,
+    role: context.role,
+    landlordRef: context.landlordRef,
+    tenantRef: context.role === "admin" || context.role === "support" || context.role === "tenant" ? context.tenantRef : null,
+    evidenceSummaries,
+    attestationContexts: context.role === "tenant" ? [] : attestationContexts,
+    exportReadinessStates,
+    crossOrgContexts,
+    errorFlags: [
+      ...(evidenceSummaries.some((summary) => summary.attestationStatus === "Invalid") ? ["attestation_invalid"] : []),
+      ...(exportReadinessStates.some((summary) => summary.policyGateStatus === "blocked") ? ["export_policy_blocked"] : []),
+      ...(crossOrgContexts.some((summary) => summary.status === "blocked") ? ["cross_org_blocked"] : []),
+    ],
+    metadataOnly: true,
+    immutable: true,
+    nonPublic: true,
+    nonShareable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}

--- a/rentchain-api/src/lib/trustWorkspace/trustWorkspaceEventEmission.ts
+++ b/rentchain-api/src/lib/trustWorkspace/trustWorkspaceEventEmission.ts
@@ -1,0 +1,59 @@
+import {
+  appendAuditEventSafely,
+  type ExportAuditTrailFirestoreLike,
+} from "../../services/export-audit-trail-service";
+import type { ExportAuthorizationContext } from "../../types/export-authorization-types";
+import type { ExportAuditEventPayload } from "../../types/export-audit-types";
+import type { TrustWorkspaceSummary } from "./trustWorkspaceTypes";
+
+function roleForExportAudit(role: TrustWorkspaceSummary["role"]): ExportAuthorizationContext["requestingActorRole"] {
+  if (role === "support") return "AdminSupport";
+  if (role === "admin") return "AdminSupport";
+  if (role === "landlord") return "LandlordAdmin";
+  return "SystemService";
+}
+
+export async function emitTrustWorkspaceDerivedEvent(
+  summary: TrustWorkspaceSummary,
+  input: {
+    requesterRef: string;
+    landlordScope: string;
+    purpose?: string | null;
+    firestore?: ExportAuditTrailFirestoreLike;
+  }
+): Promise<ExportAuditEventPayload | null> {
+  const context: ExportAuthorizationContext = {
+    requestingActorId: input.requesterRef,
+    requestingActorRole: roleForExportAudit(summary.role),
+    requestingActorScope: summary.role === "tenant" ? null : input.landlordScope,
+    requestingPurpose: input.purpose || "trust_workspace_derivation",
+    timestamp: summary.derivedAt,
+    rawIdsIncluded: false,
+  };
+  return appendAuditEventSafely(
+    {
+      eventType: "TrustWorkspaceDerived",
+      targetType: "TrustWorkspace",
+      targetId: summary.workspaceRef,
+      landlordId: input.landlordScope,
+      context,
+      eventSummary: "Trust workspace read model derived.",
+      statusSummary: summary.errorFlags.length ? "derived_with_flags" : "derived",
+      reason: input.purpose || "trust_workspace_derivation",
+      details: {
+        role: summary.role,
+        evidenceCount: summary.evidenceSummaries.length,
+        attestationCount: summary.attestationContexts.length,
+        exportReadinessCount: summary.exportReadinessStates.length,
+        crossOrgContextCount: summary.crossOrgContexts.length,
+        errorFlagCount: summary.errorFlags.length,
+        metadataOnly: true,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      },
+      timestamp: summary.derivedAt,
+      visibility: summary.role === "admin" || summary.role === "support" ? "admin_support_internal" : "landlord_operator_internal",
+    },
+    { firestore: input.firestore }
+  );
+}

--- a/rentchain-api/src/lib/trustWorkspace/trustWorkspaceProjections.ts
+++ b/rentchain-api/src/lib/trustWorkspace/trustWorkspaceProjections.ts
@@ -1,0 +1,136 @@
+import type {
+  TrustWorkspaceAccessContext,
+  TrustWorkspaceSummary,
+} from "./trustWorkspaceTypes";
+
+function assertSummary(summary: TrustWorkspaceSummary): void {
+  if (
+    summary.metadataOnly !== true ||
+    summary.rawIdsIncluded !== false ||
+    summary.payloadIncluded !== false ||
+    summary.nonPublic !== true ||
+    summary.nonShareable !== true
+  ) {
+    throw new Error("trust_workspace_projection_flags_invalid");
+  }
+}
+
+function assertLandlordScope(summary: TrustWorkspaceSummary, context: TrustWorkspaceAccessContext): void {
+  if (context.role === "admin") return;
+  if (!summary.landlordRef || !context.landlordRef || summary.landlordRef !== context.landlordRef) {
+    throw new Error("trust_workspace_projection_scope_mismatch");
+  }
+}
+
+export function projectTrustWorkspaceForLandlord(
+  summary: TrustWorkspaceSummary,
+  context: TrustWorkspaceAccessContext
+): TrustWorkspaceSummary {
+  assertSummary(summary);
+  assertLandlordScope(summary, context);
+  if (context.role !== "landlord") throw new Error("trust_workspace_projection_role_invalid");
+  return {
+    ...summary,
+    role: "landlord",
+    tenantRef: null,
+    evidenceSummaries: summary.evidenceSummaries.map((item) => ({
+      ...item,
+      authority: {
+        ...item.authority,
+        tenantRef: null,
+        rawIdsIncluded: false,
+      },
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    })),
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function projectTrustWorkspaceForTenant(
+  summary: TrustWorkspaceSummary,
+  context: TrustWorkspaceAccessContext
+): TrustWorkspaceSummary {
+  assertSummary(summary);
+  if (context.role !== "tenant") throw new Error("trust_workspace_projection_role_invalid");
+  const allowed = new Set(context.allowedEvidenceRefs);
+  return {
+    ...summary,
+    role: "tenant",
+    landlordRef: null,
+    evidenceSummaries: summary.evidenceSummaries
+      .filter((item) => allowed.has(item.evidenceRef))
+      .map((item) => ({
+        ...item,
+        contentHash: null,
+        provenanceChain: [],
+        authority: {
+          authorityRole: item.authority.authorityRole,
+          landlordRef: null,
+          tenantRef: context.tenantRef,
+          supportAllowed: false,
+          rawIdsIncluded: false,
+        },
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      })),
+    attestationContexts: [],
+    exportReadinessStates: [],
+    crossOrgContexts: [],
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function projectTrustWorkspaceForAdmin(
+  summary: TrustWorkspaceSummary,
+  context: TrustWorkspaceAccessContext
+): TrustWorkspaceSummary {
+  assertSummary(summary);
+  if (context.role !== "admin") throw new Error("trust_workspace_projection_role_invalid");
+  return {
+    ...summary,
+    role: "admin",
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function projectTrustWorkspaceForSupport(
+  summary: TrustWorkspaceSummary,
+  context: TrustWorkspaceAccessContext
+): TrustWorkspaceSummary {
+  assertSummary(summary);
+  assertLandlordScope(summary, context);
+  if (context.role !== "support" || !context.supportPurpose) throw new Error("trust_workspace_projection_role_invalid");
+  return {
+    ...summary,
+    role: "support",
+    exportReadinessStates: summary.exportReadinessStates.map((item) => ({
+      ...item,
+      nonShareable: true,
+      publicAccessEnabled: false,
+      externalSubmissionEnabled: false,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    })),
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export function projectTrustWorkspace(
+  summary: TrustWorkspaceSummary,
+  context: TrustWorkspaceAccessContext
+): TrustWorkspaceSummary {
+  if (context.role === "tenant") return projectTrustWorkspaceForTenant(summary, context);
+  if (context.role === "landlord") return projectTrustWorkspaceForLandlord(summary, context);
+  if (context.role === "admin") return projectTrustWorkspaceForAdmin(summary, context);
+  if (context.role === "support") return projectTrustWorkspaceForSupport(summary, context);
+  throw new Error("trust_workspace_projection_role_invalid");
+}

--- a/rentchain-api/src/lib/trustWorkspace/trustWorkspaceTypes.ts
+++ b/rentchain-api/src/lib/trustWorkspace/trustWorkspaceTypes.ts
@@ -1,0 +1,164 @@
+import type {
+  AttestationLifecycleState,
+  CertificateSafeReference,
+  SafeEvidenceReference,
+  SignatureAlgorithm,
+} from "../../types/attestation-types";
+import type {
+  EvidenceClass,
+  EvidenceRecordStatus,
+  EvidenceResourceType,
+} from "../../types/evidence-record-types";
+import type {
+  InstitutionalTrustExportAudience,
+  InstitutionalTrustExportPurpose,
+  InstitutionalTrustExportStatus,
+} from "../institutionTrustExports/institutionTrustExportTypes";
+import type {
+  CrossOrganizationTrustRelationshipType,
+  CrossOrganizationTrustStatus,
+} from "../crossOrganizationTrust/crossOrganizationTrustTypes";
+
+export const TRUST_WORKSPACE_ROLES = ["tenant", "landlord", "admin", "support"] as const;
+
+export type TrustWorkspaceRole = (typeof TRUST_WORKSPACE_ROLES)[number];
+
+export type TrustWorkspaceAccessContext = {
+  role: TrustWorkspaceRole;
+  requesterRef: string;
+  landlordRef: string | null;
+  tenantRef: string | null;
+  allowedEvidenceRefs: SafeEvidenceReference[];
+  supportPurpose: string | null;
+  rawIdsIncluded: false;
+};
+
+export type TrustWorkspaceLandlordContext = TrustWorkspaceAccessContext & {
+  derivedAt: string;
+  workspaceRef: string;
+  metadataOnly: true;
+  immutable: true;
+  nonPublic: true;
+  nonShareable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type TrustWorkspaceEvidenceChainSummary = {
+  evidenceRef: SafeEvidenceReference;
+  evidenceClass: EvidenceClass;
+  evidenceType: string;
+  resourceType: EvidenceResourceType;
+  status: EvidenceRecordStatus;
+  contentHash: string | null;
+  provenanceChain: SafeEvidenceReference[];
+  authority: {
+    authorityRole: string;
+    landlordRef: string | null;
+    tenantRef: string | null;
+    supportAllowed: boolean;
+    rawIdsIncluded: false;
+  };
+  attestationStatus: AttestationLifecycleState | "Unlinked" | "Invalid";
+  policyEvaluationState: "export_ready" | "blocked" | "unavailable";
+  metadataOnly: true;
+  immutable: true;
+  nonPublic: true;
+  nonShareable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type TrustWorkspaceAttestationContext = {
+  attestationRef: string;
+  evidenceRef: SafeEvidenceReference | null;
+  lifecycleState: AttestationLifecycleState | null;
+  signatureRef: string | null;
+  certificateRef: CertificateSafeReference | null;
+  signatureAlgorithm: SignatureAlgorithm | null;
+  hashValue: string | null;
+  hashVerificationStatus: "verified" | "unverified" | "invalid" | "unavailable";
+  linkedEvidence: SafeEvidenceReference[];
+  metadataOnly: true;
+  immutable: true;
+  nonPublic: true;
+  nonShareable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type TrustWorkspaceExportReadinessSummary = {
+  exportPackageRef: string;
+  audience: InstitutionalTrustExportAudience;
+  purpose: InstitutionalTrustExportPurpose;
+  status: InstitutionalTrustExportStatus;
+  policyGateStatus: "ready" | "blocked" | "unavailable";
+  blockedReasonCount: number;
+  exportableAttestationCount: number;
+  blockedAttestationCount: number;
+  manualOnly: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  metadataOnly: true;
+  immutable: true;
+  nonPublic: true;
+  nonShareable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type TrustWorkspaceCrossOrgContext = {
+  trustRelationshipRef: string;
+  relationshipType: CrossOrganizationTrustRelationshipType;
+  status: CrossOrganizationTrustStatus;
+  evidenceTrustState: CrossOrganizationTrustStatus;
+  reviewTrustState: CrossOrganizationTrustStatus;
+  settlementTrustState: CrossOrganizationTrustStatus;
+  restrictionCount: number;
+  blockedReasonCount: number;
+  manualReviewRequired: true;
+  publicTrustExposureEnabled: false;
+  autonomousTrustApprovalEnabled: false;
+  metadataOnly: true;
+  immutable: true;
+  nonPublic: true;
+  nonShareable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type TrustWorkspaceSummary = {
+  workspaceRef: string;
+  derivedAt: string;
+  role: TrustWorkspaceRole;
+  landlordRef: string | null;
+  tenantRef: string | null;
+  evidenceSummaries: TrustWorkspaceEvidenceChainSummary[];
+  attestationContexts: TrustWorkspaceAttestationContext[];
+  exportReadinessStates: TrustWorkspaceExportReadinessSummary[];
+  crossOrgContexts: TrustWorkspaceCrossOrgContext[];
+  errorFlags: string[];
+  metadataOnly: true;
+  immutable: true;
+  nonPublic: true;
+  nonShareable: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type TrustWorkspaceErrorResponse = {
+  ok: false;
+  code:
+    | "TRUST_WORKSPACE_INVALID_ROLE"
+    | "TRUST_WORKSPACE_MISSING_SCOPE"
+    | "TRUST_WORKSPACE_FORBIDDEN"
+    | "TRUST_WORKSPACE_DERIVATION_FAILED";
+  error: string;
+  metadataOnly: true;
+  rawIdsIncluded: false;
+  payloadIncluded: false;
+};
+
+export type TrustWorkspaceServiceResult =
+  | { ok: true; workspace: TrustWorkspaceSummary }
+  | TrustWorkspaceErrorResponse;

--- a/rentchain-api/src/services/__tests__/trust-workspace-service.test.ts
+++ b/rentchain-api/src/services/__tests__/trust-workspace-service.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { EvidenceRecord } from "../../types/evidence-record-types";
+import type { ExportAuditEventPayload } from "../../types/export-audit-types";
+import type { ExportAuditTrailFirestoreLike } from "../export-audit-trail-service";
+import { generateExportAuditSafeReference } from "../export-audit-trail-service";
+import {
+  buildTrustWorkspaceAccessContext,
+  getTrustWorkspaceForUser,
+} from "../trust-workspace-service";
+
+const landlordId = "landlord-service-1";
+const tenantId = "tenant-service-1";
+const evidenceRef = "evidence:ffffffffffffffffffff";
+const timestamp = "2026-06-05T12:00:00.000Z";
+
+function evidenceRecord(): EvidenceRecord {
+  const landlordRef = generateExportAuditSafeReference("landlord", landlordId);
+  const tenantRef = generateExportAuditSafeReference("tenant", tenantId);
+  return {
+    evidenceId: "ev-service-1",
+    evidenceClass: "AuditEvidence",
+    evidenceType: "workspace_audit_metadata",
+    schemaVersion: "evidence_record_v1",
+    landlordId,
+    resourceType: "canonicalEvent",
+    resourceId: "event-service-1",
+    safeReference: {
+      evidenceId: "ev-service-1",
+      evidenceClass: "AuditEvidence",
+      resourceType: "canonicalEvent",
+      safeReferenceKey: evidenceRef,
+      label: "Workspace audit evidence",
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+    provenanceMetadata: {
+      createdAt: timestamp,
+      createdBy: { actorRole: "system", actorRef: "actor:systemsystemsystem", rawActorIdsIncluded: false },
+      authority: { authorityRole: "system", landlordRef, tenantRef, supportAllowed: true, rawIdsIncluded: false },
+      source: {
+        sourceCollection: "canonicalEvents",
+        sourceReferenceKey: "event:ffffffffffffffffffff",
+        sourceObservedAt: timestamp,
+        sourceVersion: "v1",
+        rawSourceIdsIncluded: false,
+        rawPayloadIncluded: false,
+      },
+      reason: "Workspace service test.",
+      provenanceChain: [],
+      metadataOnly: true,
+    },
+    sensitivityMetadata: {
+      sensitivityClass: "Operational",
+      projectionCategories: ["landlord_operational", "tenant_safe", "admin_support"],
+      redactionPolicy: "metadata_only",
+      excludedFieldGroups: [],
+      allowedFieldGroups: ["metadata"],
+      containsRestrictedProviderData: false,
+      containsRawPaymentData: false,
+      containsMessageBody: false,
+      containsIdentityDocument: false,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    },
+    retentionMetadata: {
+      retentionPolicy: "evidence_retention_policy_v1",
+      retentionReviewRequired: false,
+      archiveAfter: null,
+      deleteAfter: null,
+      appliedRetentionPolicyRule: null,
+      evaluatedAt: timestamp,
+      eligibleForArchivalAt: null,
+      eligibleForDeletionAt: null,
+      legalHoldStatus: "none",
+      lifecycleEvents: [],
+    },
+    status: "active",
+    createdAt: timestamp,
+    supersedesEvidenceId: null,
+    supersededByEvidenceId: null,
+    immutable: true,
+    appendOnly: true,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    redactionSummary: "Metadata-only audit evidence.",
+  };
+}
+
+function eventStore() {
+  const events = new Map<string, ExportAuditEventPayload>();
+  const firestore: ExportAuditTrailFirestoreLike = {
+    collection() {
+      return {
+        doc(id: string) {
+          return {
+            async get() {
+              const event = events.get(id);
+              return { exists: Boolean(event), data: () => event };
+            },
+            async create(data: ExportAuditEventPayload) {
+              events.set(id, data);
+            },
+            async set(data: ExportAuditEventPayload) {
+              events.set(id, data);
+            },
+          };
+        },
+        where() {
+          return {
+            async get() {
+              return { docs: Array.from(events.values()).map((event) => ({ data: () => event })) };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { firestore, list: () => Array.from(events.values()) };
+}
+
+describe("trust workspace service", () => {
+  it("builds access context from landlord user without exposing user id", () => {
+    const context = buildTrustWorkspaceAccessContext({ id: landlordId, role: "landlord", landlordId });
+
+    expect(context).toEqual(expect.objectContaining({
+      role: "landlord",
+      landlordRef: generateExportAuditSafeReference("landlord", landlordId),
+      rawIdsIncluded: false,
+    }));
+    expect(context?.requesterRef).toMatch(/^actor:/);
+    expect(JSON.stringify(context)).not.toContain(landlordId);
+  });
+
+  it("returns projected landlord workspace and emits descriptor event", async () => {
+    const store = eventStore();
+    const result = await getTrustWorkspaceForUser(
+      { id: landlordId, role: "landlord", landlordId },
+      {
+        evidenceRecords: [evidenceRecord()],
+        auditEvents: [],
+        firestore: store.firestore,
+        derivedAt: timestamp,
+        exportReadinessRequests: [{ audience: "insurer", purpose: "insurance_review" }],
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.workspace.evidenceSummaries).toHaveLength(1);
+      expect(result.workspace.attestationContexts).toEqual([]);
+      expect(result.workspace.metadataOnly).toBe(true);
+    }
+    expect(store.list()).toEqual([
+      expect.objectContaining({
+        eventType: "TrustWorkspaceDerived",
+        metadataOnly: true,
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      }),
+    ]);
+    expect(JSON.stringify({ result, events: store.list() })).not.toContain(landlordId);
+  });
+
+  it("returns tenant projection with evidence-only visibility", async () => {
+    const result = await getTrustWorkspaceForUser(
+      { id: tenantId, role: "tenant", tenantId, tenantEvidenceRefs: [evidenceRef] },
+      {
+        evidenceRecords: [evidenceRecord()],
+        auditEvents: [],
+        emitEvent: false,
+        derivedAt: timestamp,
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.workspace.landlordRef).toBeNull();
+      expect(result.workspace.evidenceSummaries).toHaveLength(1);
+      expect(result.workspace.attestationContexts).toEqual([]);
+      expect(result.workspace.exportReadinessStates).toEqual([]);
+      expect(result.workspace.crossOrgContexts).toEqual([]);
+    }
+  });
+
+  it("fails closed on invalid role and missing tenant evidence scope", async () => {
+    await expect(getTrustWorkspaceForUser({ id: "viewer-1", role: "viewer" })).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      code: "TRUST_WORKSPACE_INVALID_ROLE",
+    }));
+    await expect(getTrustWorkspaceForUser({ id: tenantId, role: "tenant", tenantId })).resolves.toEqual(expect.objectContaining({
+      ok: false,
+      code: "TRUST_WORKSPACE_MISSING_SCOPE",
+    }));
+  });
+});

--- a/rentchain-api/src/services/trust-workspace-service.ts
+++ b/rentchain-api/src/services/trust-workspace-service.ts
@@ -1,0 +1,157 @@
+import { db } from "../firebase";
+import { EVIDENCE_RECORD_COLLECTION, type EvidenceRecord } from "../types/evidence-record-types";
+import type { ExportAuditEventPayload } from "../types/export-audit-types";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import { generateExportAuditSafeReference, type ExportAuditTrailFirestoreLike } from "./export-audit-trail-service";
+import type { PortableAttestation } from "../lib/portableAttestations/portableAttestationTypes";
+import type {
+  InstitutionalTrustExportAudience,
+  InstitutionalTrustExportPurpose,
+} from "../lib/institutionTrustExports/institutionTrustExportTypes";
+import type { DeriveCrossOrganizationTrustInput } from "../lib/crossOrganizationTrust/crossOrganizationTrustTypes";
+import {
+  assembleTrustWorkspaceSummary,
+  type TrustWorkspaceDerivationInput,
+} from "../lib/trustWorkspace/deriveTrustWorkspace";
+import { emitTrustWorkspaceDerivedEvent } from "../lib/trustWorkspace/trustWorkspaceEventEmission";
+import { projectTrustWorkspace } from "../lib/trustWorkspace/trustWorkspaceProjections";
+import type {
+  TrustWorkspaceAccessContext,
+  TrustWorkspaceErrorResponse,
+  TrustWorkspaceRole,
+  TrustWorkspaceServiceResult,
+} from "../lib/trustWorkspace/trustWorkspaceTypes";
+
+export type TrustWorkspaceUser = {
+  id?: string | null;
+  sub?: string | null;
+  role?: string | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  evidenceRefs?: string[] | null;
+  tenantEvidenceRefs?: string[] | null;
+  attestationEvidenceRefs?: string[] | null;
+};
+
+export type TrustWorkspaceServiceOptions = Omit<TrustWorkspaceDerivationInput, "context"> & {
+  firestore?: ExportAuditTrailFirestoreLike;
+  emitEvent?: boolean;
+};
+
+type QuerySnapshot<T> = {
+  docs?: Array<{ data: () => T }>;
+};
+
+function roleFromUser(user: TrustWorkspaceUser): TrustWorkspaceRole | null {
+  const role = String(user.role || "").toLowerCase();
+  if (role === "tenant") return "tenant";
+  if (role === "landlord") return "landlord";
+  if (role === "admin") return "admin";
+  if (role === "support" || role === "adminsupport") return "support";
+  return null;
+}
+
+function safeEvidenceRefs(user: TrustWorkspaceUser): TrustWorkspaceAccessContext["allowedEvidenceRefs"] {
+  const refs = [
+    ...(user.evidenceRefs || []),
+    ...(user.tenantEvidenceRefs || []),
+    ...(user.attestationEvidenceRefs || []),
+  ];
+  return refs
+    .map((value) => String(value || "").trim())
+    .filter((value): value is TrustWorkspaceAccessContext["allowedEvidenceRefs"][number] =>
+      /^[a-z][a-z0-9_.:-]*:[a-f0-9][a-z0-9_.:-]{11,160}$/i.test(value)
+    );
+}
+
+export function buildTrustWorkspaceAccessContext(user: TrustWorkspaceUser): TrustWorkspaceAccessContext | null {
+  const role = roleFromUser(user);
+  if (!role) return null;
+  const landlordId = String(user.landlordId || (role === "landlord" ? user.id || "" : "")).trim();
+  const tenantId = String(user.tenantId || (role === "tenant" ? user.id || "" : "")).trim();
+  return {
+    role,
+    requesterRef: generateExportAuditSafeReference("actor", user.id || user.sub || "unknown"),
+    landlordRef: landlordId ? generateExportAuditSafeReference("landlord", landlordId) : null,
+    tenantRef: tenantId ? generateExportAuditSafeReference("tenant", tenantId) : null,
+    allowedEvidenceRefs: safeEvidenceRefs(user),
+    supportPurpose: role === "support" ? "trust_workspace_support_review" : role === "admin" ? "trust_workspace_admin_review" : null,
+    rawIdsIncluded: false,
+  };
+}
+
+async function loadEvidenceRecords(landlordId: string, firestore?: ExportAuditTrailFirestoreLike): Promise<EvidenceRecord[]> {
+  const store = firestore || (db as unknown as ExportAuditTrailFirestoreLike);
+  const collection = store.collection<EvidenceRecord>(EVIDENCE_RECORD_COLLECTION);
+  const query = collection.where?.("landlordId", "==", landlordId);
+  if (!query?.get) return [];
+  const snap = (await query.get()) as QuerySnapshot<EvidenceRecord>;
+  return snap.docs?.map((doc) => doc.data()) || [];
+}
+
+async function loadAuditEvents(landlordRef: string, firestore?: ExportAuditTrailFirestoreLike): Promise<ExportAuditEventPayload[]> {
+  const store = firestore || (db as unknown as ExportAuditTrailFirestoreLike);
+  const collection = store.collection<ExportAuditEventPayload>(CANONICAL_EVENTS_COLLECTION);
+  const query = collection.where?.("landlordReferenceId", "==", landlordRef);
+  if (!query?.get) return [];
+  const snap = (await query.get()) as QuerySnapshot<ExportAuditEventPayload>;
+  return snap.docs?.map((doc) => doc.data()) || [];
+}
+
+function error(code: TrustWorkspaceErrorResponse["code"]): TrustWorkspaceServiceResult {
+  return {
+    ok: false,
+    code,
+    error: code,
+    metadataOnly: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+export async function getTrustWorkspaceForUser(
+  user: TrustWorkspaceUser,
+  options: TrustWorkspaceServiceOptions = {}
+): Promise<TrustWorkspaceServiceResult> {
+  const context = buildTrustWorkspaceAccessContext(user);
+  if (!context) return error("TRUST_WORKSPACE_INVALID_ROLE");
+  const landlordId = String(user.landlordId || (context.role === "landlord" ? user.id || "" : "")).trim();
+  if ((context.role === "landlord" || context.role === "support") && !landlordId) return error("TRUST_WORKSPACE_MISSING_SCOPE");
+  if (context.role === "tenant" && !context.allowedEvidenceRefs.length) return error("TRUST_WORKSPACE_MISSING_SCOPE");
+  try {
+    const evidenceRecords =
+      options.evidenceRecords || (landlordId ? await loadEvidenceRecords(landlordId, options.firestore) : []);
+    const auditEvents =
+      options.auditEvents || (context.landlordRef ? await loadAuditEvents(context.landlordRef, options.firestore) : []);
+    const summary = await assembleTrustWorkspaceSummary({
+      ...options,
+      context,
+      evidenceRecords,
+      auditEvents,
+      portableAttestations: options.portableAttestations as readonly PortableAttestation[] | undefined,
+      exportReadinessRequests: options.exportReadinessRequests as
+        | readonly Array<{
+            audience: InstitutionalTrustExportAudience;
+            purpose: InstitutionalTrustExportPurpose;
+            exportRef?: string | null;
+          }>
+        | undefined,
+      crossOrgInput: options.crossOrgInput as Omit<DeriveCrossOrganizationTrustInput, "landlordId" | "generatedAt"> | null | undefined,
+    });
+    const projected = projectTrustWorkspace(summary, context);
+    if (options.emitEvent !== false && context.landlordRef) {
+      await emitTrustWorkspaceDerivedEvent(projected, {
+        requesterRef: context.requesterRef,
+        landlordScope: context.landlordRef,
+        purpose: context.supportPurpose,
+        firestore: options.firestore,
+      });
+    }
+    return { ok: true, workspace: projected };
+  } catch (serviceError) {
+    const message = serviceError instanceof Error ? serviceError.message : "";
+    if (message.includes("forbidden")) return error("TRUST_WORKSPACE_FORBIDDEN");
+    if (message.includes("scope") || message.includes("context")) return error("TRUST_WORKSPACE_MISSING_SCOPE");
+    return error("TRUST_WORKSPACE_DERIVATION_FAILED");
+  }
+}

--- a/rentchain-api/src/types/export-audit-types.ts
+++ b/rentchain-api/src/types/export-audit-types.ts
@@ -16,11 +16,12 @@ export const EXPORT_AUDIT_EVENT_TYPES = [
   "ExportPackageDelivered",
   "ExportPackageArchived",
   "ExportPackageRevoked",
+  "TrustWorkspaceDerived",
 ] as const;
 
 export type ExportAuditEventType = (typeof EXPORT_AUDIT_EVENT_TYPES)[number];
 
-export const EXPORT_AUDIT_TARGET_TYPES = ["ExportProfile", "ExportRequest", "ExportPackage"] as const;
+export const EXPORT_AUDIT_TARGET_TYPES = ["ExportProfile", "ExportRequest", "ExportPackage", "TrustWorkspace"] as const;
 
 export type ExportAuditTargetType = (typeof EXPORT_AUDIT_TARGET_TYPES)[number];
 


### PR DESCRIPTION
## Summary
- Add Trust Workspace v1 service-layer read model for evidence, attestation, export readiness, and cross-organization trust context.
- Add metadata-only type contracts, deterministic derivation helpers, role-specific projection helpers, and descriptor audit event emission.
- Add service entry point plus focused library and service tests.

## Validation
- `npm test -- src/lib/trustWorkspace/__tests__/trustWorkspace.test.ts`
- `npm test -- src/services/__tests__/trust-workspace-service.test.ts`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Scope Notes
- No HTTP routes or dashboard UI added.
- No mutation paths, background workers, signing execution, delivery flow, institution integration, Firestore rules, deployment changes, or protected-area changes.
- Manual preview QA is not required because this is a backend service-layer mission only.