### PR TITLE
feat: add landlord evidence export trust signoff routes

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,80 +1,91 @@
-# Implementation Summary - Trust Workspace v1
+# Implementation Summary - Evidence Export Trust Signoff v1
 
-PR: #1101
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1101
-Branch: feat/trust-workspace-v1
+PR: #1102
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1102
+Branch: feat/phase-4-evidence-export-trust-signoff-v1
 
 ## Scope Delivered
 
-Implemented Trust Workspace v1 as a backend service-layer read model for evidence trust chain management.
+Implemented landlord evidence export trust signoff routes for Phase 4 evidence trust operations.
 
-The implementation adds metadata-only workspace types, deterministic derivation helpers, role-specific projection helpers, non-blocking descriptor audit event emission, and the `getTrustWorkspaceForUser()` service entry point. It composes existing evidence records, attestation hash verification, institutional trust export policy evaluation, and cross-organization trust derivation.
+The implementation adds authenticated landlord endpoints for trust workspace context retrieval and evidence export trust signoff initiation. The signoff route validates landlord scope, safe evidence and package references, institutional package type, audience, purpose, trust workspace evidence visibility, export readiness, and verified attestation context before creating a metadata-only signature request through the existing attestation service.
 
-No HTTP routes, dashboard UI, mutation paths, background workers, signing execution, delivery mechanisms, external integrations, Firestore rules, deployment configuration, billing, auth core, screening, pricing, or entitlement changes were added.
+The routes remain metadata-only and use safe response shapes. They do not mutate evidence records, export packages, attestation metadata, Firestore rules, deployment configuration, billing, pricing, entitlement logic, screening adapters, frontend UI, background workers, private-key signing, external callbacks, or delivery mechanics.
 
 ## Files Changed
 
-- rentchain-api/src/lib/trustWorkspace/trustWorkspaceTypes.ts
+- rentchain-api/src/routes/landlordEvidenceExportTrustSignoffRoutes.ts
+- rentchain-api/src/routes/__tests__/landlordEvidenceExportTrustSignoffRoutes.test.ts
+- rentchain-api/src/app.build.ts
 - rentchain-api/src/lib/trustWorkspace/deriveTrustWorkspace.ts
-- rentchain-api/src/lib/trustWorkspace/trustWorkspaceProjections.ts
-- rentchain-api/src/lib/trustWorkspace/trustWorkspaceEventEmission.ts
-- rentchain-api/src/lib/trustWorkspace/__tests__/trustWorkspace.test.ts
 - rentchain-api/src/services/trust-workspace-service.ts
-- rentchain-api/src/services/__tests__/trust-workspace-service.test.ts
-- rentchain-api/src/types/export-audit-types.ts
-- docs/architecture/trust-workspace-v1.md
 - .handoff/impl-summary.md
 
-## Tests Passed
+## Tests and Validation
 
-- `npm test -- src/lib/trustWorkspace/__tests__/trustWorkspace.test.ts`: PASS
-- `npm test -- src/services/__tests__/trust-workspace-service.test.ts`: PASS
-- `npm run build` in `rentchain-api`: PASS
+- `cd rentchain-api && npm ci`: PASS
+- `cd rentchain-api && npm test -- src/routes/__tests__/landlordEvidenceExportTrustSignoffRoutes.test.ts`: PASS
+- `cd rentchain-api && npm run build`: PASS
 - `git diff --check`: PASS
+- Restricted-term scan on changed source and test files: PASS
 
-All Node-based commands were run under Node 20.11.1.
+Full backend suite was run with `cd rentchain-api && npm run test`: FAIL with pre-existing failures outside this mission scope.
+
+Known failing areas from the full suite:
+- `src/routes/__tests__/leaseDraftRoutes.test.ts`
+- `src/routes/__tests__/recipientTrustReviewRoutes.test.ts`
+- `src/routes/__tests__/supportConsoleRoutes.test.ts`
+- `src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts`
+- `src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts`
+
+The new route test passed during focused validation and did not introduce failures in its test file.
 
 ## Acceptance Criteria Met
 
-- [x] Added trust workspace type definitions with metadata-only, immutable, non-public, non-shareable flags.
-- [x] Added deterministic workspace context validation and workspace safe-reference generation.
-- [x] Added evidence chain summary derivation from evidence records with provenance safe references.
-- [x] Added attestation context derivation through existing attestation hash verification service.
-- [x] Added institutional export readiness summary using existing policy gate derivation.
-- [x] Added cross-organization trust context using existing trust derivation.
-- [x] Added landlord, tenant, admin, and support projection helpers.
-- [x] Tenant projection excludes attestation, export readiness, and cross-organization context.
-- [x] Landlord and support projections enforce landlord scope.
-- [x] Admin projection remains metadata-only.
-- [x] Added non-blocking `TrustWorkspaceDerived` audit event emission.
-- [x] Extended export audit event/target types for descriptor-only workspace derivation events.
-- [x] Added `getTrustWorkspaceForUser()` service entry point.
-- [x] Tests cover derivation, projection safety, role scope validation, export readiness, cross-org context, service integration, and event emission.
-- [x] No HTTP routes added.
-- [x] No protected areas modified.
-- [x] No dependency changes.
-- [x] No unrelated refactors.
+- [x] Added `GET /api/landlord/evidence-export-trust-context` with `requireAuth` and `requireLandlord`.
+- [x] Added `POST /api/landlord/evidence-export-trust-signoff` with `requireAuth` and `requireLandlord`.
+- [x] Integrated route registration through the backend app route mount.
+- [x] Used `getEffectiveLandlordId()` and `getTrustWorkspaceForUser()` for landlord-scoped trust context.
+- [x] Validated signoff request fields with bounded string handling.
+- [x] Enforced package type and institutional audience allowlists.
+- [x] Enforced safe evidence and package reference input format.
+- [x] Failed closed for missing evidence, missing package readiness, invalid attestation context, trust workspace failure, and signature request failure.
+- [x] Created signature request events through the existing attestation service.
+- [x] Used hashed safe actor and landlord references in attestation authorization context.
+- [x] Returned only safe error codes and safe attestation references.
+- [x] Avoided raw IDs, storage paths, provider payloads, tokens, and stack traces in responses.
+- [x] Added route tests for success, auth boundaries, validation, inaccessible evidence/package, invalid chain, workspace failure, and signature request failure.
+- [x] Preserved protected areas and avoided dependency changes.
 
 ## Manual QA
 
-Manual preview QA is not required for this mission because no HTTP routes, frontend rendering, mobile layout, auth flow, routing, or user-visible dashboard behavior were added.
+Manual QA is required because this mission adds backend routes and user-visible API behavior.
 
-Manual code/test inspection completed:
+Manual QA checklist for Gate 2:
 
-1. Confirmed no route files were added or mounted.
-2. Confirmed service layer only entry point: `getTrustWorkspaceForUser()`.
-3. Confirmed no Firestore rules, deployment, billing, auth core, screening, pricing, or entitlement files changed.
-4. Confirmed tenant projection excludes attestation, export readiness, and cross-organization context.
-5. Confirmed audit event emission is non-blocking and descriptor-only.
-6. Confirmed workspace summaries use safe references and metadata-only flags.
+1. `GET /api/landlord/evidence-export-trust-context` without auth returns 401.
+2. `GET /api/landlord/evidence-export-trust-context` with a non-landlord user returns 403.
+3. `GET /api/landlord/evidence-export-trust-context` with a landlord user returns a metadata-only trust workspace context.
+4. Context response contains no raw landlord IDs, tenant IDs, evidence IDs, package IDs, storage paths, tokens, provider payloads, or stack traces.
+5. `POST /api/landlord/evidence-export-trust-signoff` without auth returns 401.
+6. `POST /api/landlord/evidence-export-trust-signoff` with a non-landlord user returns 403.
+7. Signoff POST with missing `evidenceRef`, missing `packageRef`, invalid `packageType`, invalid `audience`, or unsafe reference returns 400 with `INVALID_SCOPE`.
+8. Signoff POST with inaccessible evidence returns 404 with `EVIDENCE_NOT_FOUND`.
+9. Signoff POST with no export-ready package context returns 404 with `PACKAGE_NOT_FOUND`.
+10. Signoff POST with unverified attestation context returns 400 with `ATTESTATION_CHAIN_INVALID`.
+11. Valid signoff POST returns `{ ok: true, attestationRef, timestamp, status: "signature_requested" }`.
+12. Valid signoff response contains only safe references and no raw internal identifiers.
+13. Confirm evidence records and export package records are not mutated by signoff.
+14. Confirm only append-safe signature request audit behavior occurs.
+15. Confirm no protected areas were modified.
 
 ## Known Limitations
 
-- Trust Workspace v1 is a service-layer foundation only.
-- No HTTP route, dashboard UI, signing flow, delivery flow, institution integration, background worker, or external submission was added.
-- Event emission uses the existing export audit trail helper and descriptor-only count metadata.
-- Runtime Cloud Run verification is not applicable until a route or user-facing consumer is added.
+- This mission creates a signature request event only; it does not perform private-key signing, certificate issuance, KMS/HSM operations, or external institution delivery.
+- Trust context is derived through the existing Trust Workspace service; no new persistence or Firestore rules were added.
+- Full backend suite still has unrelated pre-existing failures in lease draft, recipient trust review, support console, and landlord analytics tests.
+- `npm ci` reports existing dependency audit warnings; no package files were changed by this mission.
 
 ## Recommended Next Mission
 
-Phase 4 evidence export trust signoff service, or a narrow route mission that exposes this workspace through authenticated read-only API endpoints.
+Phase 4 signoff validation and Gate 2 manual QA, followed by Phase 5 planning for signing execution and institutional delivery surfaces.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -157,6 +157,7 @@ import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExport
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
 import landlordOperatorReviewRoutes from "./routes/landlordOperatorReviewRoutes";
 import landlordEvidencePackRoutes from "./routes/landlordEvidencePackRoutes";
+import landlordEvidenceExportTrustSignoffRoutes from "./routes/landlordEvidenceExportTrustSignoffRoutes";
 import landlordReviewTimelineRoutes from "./routes/landlordReviewTimelineRoutes";
 import landlordIdentityLayerRoutes from "./routes/landlordIdentityLayerRoutes";
 import landlordSharingRoomRoutes from "./routes/landlordSharingRoomRoutes";
@@ -485,6 +486,9 @@ console.log("[route-mount] landlordOperatorReviewRoutes mounted at /api/landlord
 app.use("/api/landlord/evidence-packs", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
 console.log("[route-mount] landlordEvidencePackRoutes mounted at /api/landlord");
+app.use("/api/landlord/evidence-export-trust-signoff", rateLimitEvidenceExportReview);
+app.use("/api/landlord", routeSource("landlordEvidenceExportTrustSignoffRoutes.ts"), landlordEvidenceExportTrustSignoffRoutes);
+console.log("[route-mount] landlordEvidenceExportTrustSignoffRoutes mounted at /api/landlord");
 app.use("/api/landlord/review-timeline", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordReviewTimelineRoutes.ts"), landlordReviewTimelineRoutes);
 console.log("[route-mount] landlordReviewTimelineRoutes mounted at /api/landlord");

--- a/rentchain-api/src/lib/trustWorkspace/deriveTrustWorkspace.ts
+++ b/rentchain-api/src/lib/trustWorkspace/deriveTrustWorkspace.ts
@@ -28,7 +28,7 @@ export type TrustWorkspaceDerivationInput = {
   evidenceRecords?: readonly EvidenceRecord[];
   auditEvents?: readonly ExportAuditEventPayload[];
   portableAttestations?: readonly PortableAttestation[];
-  exportReadinessRequests?: readonly Array<{
+  exportReadinessRequests?: ReadonlyArray<{
     audience: InstitutionalTrustExportAudience;
     purpose: InstitutionalTrustExportPurpose;
     exportRef?: string | null;

--- a/rentchain-api/src/routes/__tests__/landlordEvidenceExportTrustSignoffRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordEvidenceExportTrustSignoffRoutes.test.ts
@@ -1,0 +1,303 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrustWorkspaceSummary } from "../../lib/trustWorkspace/trustWorkspaceTypes";
+
+type MockUser = {
+  id?: string;
+  role?: string;
+  landlordId?: string;
+};
+
+let mockUser: MockUser | null = { id: "landlord-1", role: "landlord", landlordId: "landlord-1" };
+let workspaceMode: "success" | "failure" | "noEvidence" | "noPackage" | "wrongPackage" | "invalidChain" = "success";
+let signatureMode: "success" | "failure" = "success";
+
+const evidenceRef = "evidence:eeeeeeeeeeeeeeeeeeee";
+const packageRef = "exportpackage:pppppppppppppppppppp";
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: express.Request & { user?: MockUser }, res: express.Response, next: express.NextFunction) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: express.Request & { user?: MockUser }, res: express.Response, next: express.NextFunction) => {
+    const role = String(req.user?.role || "").toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user = { ...req.user, landlordId };
+    return next();
+  },
+}));
+
+vi.mock("../../auth/requestAuthority", () => ({
+  getEffectiveLandlordId: (req: express.Request & { user?: MockUser }) => req.user?.landlordId || null,
+}));
+
+function workspace(overrides: Partial<TrustWorkspaceSummary> = {}): TrustWorkspaceSummary {
+  return {
+    workspaceRef: "trust_workspace:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    derivedAt: "2026-06-05T12:00:00.000Z",
+    role: "landlord",
+    landlordRef: "landlord:aaaaaaaaaaaaaaaaaaaa",
+    tenantRef: null,
+    evidenceSummaries:
+      workspaceMode === "noEvidence"
+        ? []
+        : [
+            {
+              evidenceRef,
+              evidenceClass: "AuditEvidence",
+              evidenceType: "trust_signoff",
+              resourceType: "canonicalEvent",
+              status: "active",
+              contentHash: "a".repeat(64),
+              provenanceChain: [],
+              authority: {
+                authorityRole: "landlord",
+                landlordRef: "landlord:aaaaaaaaaaaaaaaaaaaa",
+                tenantRef: null,
+                supportAllowed: false,
+                rawIdsIncluded: false,
+              },
+              attestationStatus: workspaceMode === "invalidChain" ? "Unlinked" : "SignatureVerified",
+              policyEvaluationState: "export_ready",
+              metadataOnly: true,
+              immutable: true,
+              nonPublic: true,
+              nonShareable: true,
+              rawIdsIncluded: false,
+              payloadIncluded: false,
+            },
+          ],
+    attestationContexts:
+      workspaceMode === "invalidChain"
+        ? []
+        : [
+            {
+              attestationRef: "attestation:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              evidenceRef,
+              lifecycleState: "SignatureVerified",
+              signatureRef: "signature:aaaaaaaaaaaaaaaaaaaa",
+              certificateRef: "certificate:aaaaaaaaaaaaaaaaaaaa",
+              signatureAlgorithm: "RSA-SHA256",
+              hashValue: "a".repeat(64),
+              hashVerificationStatus: "verified",
+              linkedEvidence: [evidenceRef],
+              metadataOnly: true,
+              immutable: true,
+              nonPublic: true,
+              nonShareable: true,
+              rawIdsIncluded: false,
+              payloadIncluded: false,
+            },
+          ],
+    exportReadinessStates:
+      workspaceMode === "noPackage"
+        ? []
+        : [
+            {
+              exportPackageRef: workspaceMode === "wrongPackage" ? "exportpackage:qqqqqqqqqqqqqqqqqqqq" : packageRef,
+              audience: "insurer",
+              purpose: "insurance_review",
+              status: "export_ready",
+              policyGateStatus: "ready",
+              blockedReasonCount: 0,
+              exportableAttestationCount: 1,
+              blockedAttestationCount: 0,
+              manualOnly: true,
+              publicAccessEnabled: false,
+              externalSubmissionEnabled: false,
+              metadataOnly: true,
+              immutable: true,
+              nonPublic: true,
+              nonShareable: true,
+              rawIdsIncluded: false,
+              payloadIncluded: false,
+            },
+          ],
+    crossOrgContexts: [],
+    errorFlags: [],
+    metadataOnly: true,
+    immutable: true,
+    nonPublic: true,
+    nonShareable: true,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+    ...overrides,
+  };
+}
+
+const getTrustWorkspaceForUserMock = vi.fn(async () => {
+  if (workspaceMode === "failure") {
+    return { ok: false, code: "TRUST_WORKSPACE_DERIVATION_FAILED", error: "TRUST_WORKSPACE_DERIVATION_FAILED" };
+  }
+  return { ok: true, workspace: workspace() };
+});
+
+const requestSignatureForPackageMock = vi.fn(async () => {
+  if (signatureMode === "failure") return null;
+  return {
+    timestamp: "2026-06-05T12:10:00.000Z",
+    metadata: {
+      details: {
+        attestationRef: "attestation:ssssssssssssssssssssssssssssssss",
+      },
+    },
+  };
+});
+
+vi.mock("../../services/trust-workspace-service", () => ({
+  getTrustWorkspaceForUser: getTrustWorkspaceForUserMock,
+}));
+
+vi.mock("../../services/attestation-service", () => ({
+  requestSignatureForPackage: requestSignatureForPackageMock,
+}));
+
+async function testApp() {
+  const router = (await import("../landlordEvidenceExportTrustSignoffRoutes")).default;
+  const app = express();
+  app.use(express.json());
+  app.use("/landlord", router);
+  return app;
+}
+
+describe("landlord evidence export trust signoff routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockUser = { id: "landlord-1", role: "landlord", landlordId: "landlord-1" };
+    workspaceMode = "success";
+    signatureMode = "success";
+  });
+
+  it("returns landlord trust context with safe metadata-only projection", async () => {
+    const res = await request(await testApp()).get("/landlord/evidence-export-trust-context");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ ok: true }));
+    expect(res.body.context).toEqual(expect.objectContaining({
+      metadataOnly: true,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    }));
+    expect(JSON.stringify(res.body)).not.toContain("landlord-1");
+  });
+
+  it("requires authentication and landlord scope for context retrieval", async () => {
+    mockUser = null;
+    const unauthenticated = await request(await testApp()).get("/landlord/evidence-export-trust-context");
+    expect(unauthenticated.status).toBe(401);
+    expect(unauthenticated.body).toEqual({ ok: false, error: "UNAUTHORIZED" });
+
+    mockUser = { id: "tenant-1", role: "tenant" };
+    const forbidden = await request(await testApp()).get("/landlord/evidence-export-trust-context");
+    expect(forbidden.status).toBe(403);
+  });
+
+  it("returns safe context derivation error", async () => {
+    workspaceMode = "failure";
+    const res = await request(await testApp()).get("/landlord/evidence-export-trust-context");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ ok: false, error: "TRUST_CONTEXT_FAILED" });
+  });
+
+  it("requests signature signoff for valid landlord evidence and package", async () => {
+    const res = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({
+        evidenceRef,
+        packageRef,
+        packageType: "insurance_review",
+        audience: "insurer",
+        purpose: "InsuranceClaim",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      attestationRef: "attestation:ssssssssssssssssssssssssssssssss",
+      timestamp: Date.parse("2026-06-05T12:10:00.000Z"),
+      status: "signature_requested",
+    });
+    expect(requestSignatureForPackageMock).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(res.body)).not.toContain("landlord-1");
+  });
+
+  it("validates required signoff inputs", async () => {
+    const missingEvidence = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ packageRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(missingEvidence.status).toBe(400);
+    expect(missingEvidence.body).toEqual({ ok: false, error: "INVALID_SCOPE" });
+
+    const missingPackage = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(missingPackage.status).toBe(400);
+
+    const invalidType = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "unknown_type", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(invalidType.status).toBe(400);
+
+    const invalidAudience = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "insurance_review", audience: "public", purpose: "InsuranceClaim" });
+    expect(invalidAudience.status).toBe(400);
+  });
+
+  it("fails closed when evidence, package, or attestation chain is inaccessible", async () => {
+    workspaceMode = "noEvidence";
+    const noEvidence = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(noEvidence.status).toBe(404);
+    expect(noEvidence.body).toEqual({ ok: false, error: "EVIDENCE_NOT_FOUND" });
+
+    workspaceMode = "noPackage";
+    const noPackage = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(noPackage.status).toBe(404);
+    expect(noPackage.body).toEqual({ ok: false, error: "PACKAGE_NOT_FOUND" });
+
+    workspaceMode = "wrongPackage";
+    const wrongPackage = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(wrongPackage.status).toBe(404);
+    expect(wrongPackage.body).toEqual({ ok: false, error: "PACKAGE_NOT_FOUND" });
+
+    workspaceMode = "invalidChain";
+    const invalidChain = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(invalidChain.status).toBe(400);
+    expect(invalidChain.body).toEqual({ ok: false, error: "ATTESTATION_CHAIN_INVALID" });
+  });
+
+  it("returns safe service errors for workspace and signature request failures", async () => {
+    workspaceMode = "failure";
+    const contextFailed = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(contextFailed.status).toBe(500);
+    expect(contextFailed.body).toEqual({ ok: false, error: "TRUST_CONTEXT_FAILED" });
+
+    workspaceMode = "success";
+    signatureMode = "failure";
+    const signatureFailed = await request(await testApp())
+      .post("/landlord/evidence-export-trust-signoff")
+      .send({ evidenceRef, packageRef, packageType: "insurance_review", audience: "insurer", purpose: "InsuranceClaim" });
+    expect(signatureFailed.status).toBe(500);
+    expect(signatureFailed.body).toEqual({ ok: false, error: "SIGNATURE_REQUEST_FAILED" });
+  });
+});

--- a/rentchain-api/src/routes/landlordEvidenceExportTrustSignoffRoutes.ts
+++ b/rentchain-api/src/routes/landlordEvidenceExportTrustSignoffRoutes.ts
@@ -1,0 +1,272 @@
+import crypto from "crypto";
+import { Router, type Request, type Response } from "express";
+import { getEffectiveLandlordId } from "../auth/requestAuthority";
+import type { InstitutionalTrustExportAudience, InstitutionalTrustExportPurpose } from "../lib/institutionTrustExports/institutionTrustExportTypes";
+import type { InstitutionExportPackageType } from "../lib/institutionExports/institutionExportTypes";
+import type { TrustWorkspaceSummary } from "../lib/trustWorkspace/trustWorkspaceTypes";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { requestSignatureForPackage } from "../services/attestation-service";
+import { getTrustWorkspaceForUser } from "../services/trust-workspace-service";
+import type { ExportAuthorizationContext } from "../types/export-authorization-types";
+import type { ExportPackage } from "../types/export-package-types";
+import type { ExportPurpose, ExportRecipientType } from "../types/export-recipient-types";
+
+const router = Router();
+
+const PACKAGE_TYPES = new Set<InstitutionExportPackageType>([
+  "lender_due_diligence",
+  "insurance_review",
+  "government_program_review",
+  "auditor_review",
+  "internal_admin_review",
+]);
+
+const AUDIENCES = new Set<InstitutionalTrustExportAudience>([
+  "insurer",
+  "lender",
+  "institutional_landlord",
+  "subsidy_program",
+  "government_review",
+  "tenant_portability",
+  "auditor",
+  "internal_review",
+]);
+
+type SignoffRequestBody = {
+  evidenceRef?: unknown;
+  packageRef?: unknown;
+  packageType?: unknown;
+  audience?: unknown;
+  purpose?: unknown;
+};
+
+type SignoffSuccessResponse = {
+  ok: true;
+  attestationRef: string;
+  timestamp: number;
+  status: "signature_requested";
+};
+
+type TrustContextResponse = {
+  ok: true;
+  context: TrustWorkspaceSummary;
+};
+
+type ErrorResponse = {
+  ok: false;
+  error:
+    | "UNAUTHORIZED"
+    | "INVALID_SCOPE"
+    | "ATTESTATION_FORBIDDEN"
+    | "EVIDENCE_NOT_FOUND"
+    | "PACKAGE_NOT_FOUND"
+    | "ATTESTATION_CHAIN_INVALID"
+    | "TRUST_CONTEXT_FAILED"
+    | "SIGNATURE_REQUEST_FAILED";
+};
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").replace(/[<>]/g, "").trim().slice(0, max);
+}
+
+function stableHash(value: unknown, length = 32): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, length);
+}
+
+function validatePackageType(value: unknown): InstitutionExportPackageType | null {
+  const raw = asString(value, 120) as InstitutionExportPackageType;
+  return PACKAGE_TYPES.has(raw) ? raw : null;
+}
+
+function validateAudience(value: unknown): InstitutionalTrustExportAudience | null {
+  const raw = asString(value, 120) as InstitutionalTrustExportAudience;
+  return AUDIENCES.has(raw) ? raw : null;
+}
+
+function purposeForPackageType(packageType: InstitutionExportPackageType): InstitutionalTrustExportPurpose {
+  if (packageType === "insurance_review") return "insurance_review";
+  if (packageType === "lender_due_diligence") return "lender_review";
+  if (packageType === "government_program_review") return "government_program_review";
+  if (packageType === "auditor_review") return "auditor_review";
+  return "internal_review";
+}
+
+function isSafeReference(value: string): boolean {
+  return /^[a-z][a-z0-9_.:-]*:[a-z0-9_.:-]{12,180}$/i.test(value) || /^exp_[a-z0-9_:-]{12,180}$/i.test(value);
+}
+
+function makeErrorResponse(res: Response, status: number, error: ErrorResponse["error"]) {
+  return res.status(status).json({ ok: false, error } satisfies ErrorResponse);
+}
+
+function makeSignoffResult(res: Response, input: { attestationRef: string; timestamp: number }) {
+  return res.json({
+    ok: true,
+    attestationRef: input.attestationRef,
+    timestamp: input.timestamp,
+    status: "signature_requested",
+  } satisfies SignoffSuccessResponse);
+}
+
+function workspaceHasEvidence(workspace: TrustWorkspaceSummary, evidenceRef: string): boolean {
+  return workspace.evidenceSummaries.some((summary) => summary.evidenceRef === evidenceRef);
+}
+
+function workspaceHasPackage(workspace: TrustWorkspaceSummary, packageRef: string): boolean {
+  return workspace.exportReadinessStates.some(
+    (summary) => summary.exportPackageRef === packageRef && summary.policyGateStatus !== "unavailable"
+  );
+}
+
+function workspaceHasVerifiedAttestation(workspace: TrustWorkspaceSummary, evidenceRef: string): boolean {
+  const evidence = workspace.evidenceSummaries.find((summary) => summary.evidenceRef === evidenceRef);
+  if (!evidence || evidence.attestationStatus !== "SignatureVerified") return false;
+  return workspace.attestationContexts.some((context) => context.evidenceRef === evidenceRef && context.hashVerificationStatus === "verified");
+}
+
+function exportRecipientForAudience(audience: InstitutionalTrustExportAudience): ExportRecipientType {
+  if (audience === "insurer") return "InsuranceAdjuster";
+  if (audience === "government_review" || audience === "subsidy_program" || audience === "auditor") return "Regulator";
+  if (audience === "internal_review") return "SelfArchive";
+  return "ReservedFutureInstitution";
+}
+
+function exportPurposeForAudience(audience: InstitutionalTrustExportAudience): ExportPurpose {
+  if (audience === "insurer") return "InsuranceClaim";
+  if (audience === "government_review" || audience === "subsidy_program") return "RegulatoryCompliance";
+  if (audience === "auditor") return "AuditReview";
+  if (audience === "internal_review") return "SelfReview";
+  return "ReservedFuturePurpose";
+}
+
+function exportPackageForSignoff(input: {
+  packageRef: string;
+  packageType: InstitutionExportPackageType;
+  audience: InstitutionalTrustExportAudience;
+  landlordId: string;
+  timestamp: string;
+}): ExportPackage {
+  return {
+    exportPackageId: input.packageRef,
+    exportRequestId: `exp_req_v1_${stableHash(["signoff_request", input.packageRef], 20)}`,
+    landlordId: input.landlordId,
+    recipientType: exportRecipientForAudience(input.audience),
+    purpose: exportPurposeForAudience(input.audience),
+    packageMetadata: {
+      assembledAt: input.timestamp,
+      assembledBy: "landlord_operator",
+      assemblyVersion: `trust_signoff_${input.packageType}`,
+      includedEvidenceCount: 1,
+      totalPackageSize: 1,
+      checksumAlgorithm: "sha256",
+      checksumValue: null,
+    },
+    evidenceManifest: {
+      evidenceClasses: ["AuditEvidence"],
+      dateRangeApplied: { start: null, end: null },
+      unitsScopeApplied: [],
+      redactionPolicyApplied: "Redacted",
+      excludedEvidence: [],
+    },
+    status: "Assembled",
+    auditTrailReference: `export_audit:${stableHash(["trust_signoff", input.packageRef], 24)}`,
+    metadata: {
+      packageType: input.packageType,
+      audience: input.audience,
+      metadataOnly: true,
+    },
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+}
+
+function authorizationContext(input: { req: Request; landlordId: string; purpose: string; timestamp: string }): ExportAuthorizationContext {
+  const user = (input.req as Request & { user?: { id?: string; uid?: string; sub?: string } }).user;
+  const actor = user?.id || user?.uid || user?.sub || "landlord_operator";
+  const landlordScope = `landlord:${stableHash(["landlord_scope", input.landlordId], 24)}`;
+  return {
+    requestingActorId: `actor:${stableHash(["landlord_actor", actor], 24)}`,
+    requestingActorRole: "LandlordAdmin",
+    requestingActorScope: landlordScope,
+    requestingPurpose: input.purpose || "evidence_export_trust_signoff",
+    timestamp: input.timestamp,
+    rawIdsIncluded: false,
+  };
+}
+
+router.get("/evidence-export-trust-context", requireAuth, requireLandlord, async (req: Request, res: Response) => {
+  try {
+    const landlordId = asString(getEffectiveLandlordId(req), 240);
+    if (!landlordId) return makeErrorResponse(res, 401, "UNAUTHORIZED");
+    const result = await getTrustWorkspaceForUser({
+      id: ((req as Request & { user?: { id?: string } }).user?.id || landlordId),
+      role: "landlord",
+      landlordId,
+    });
+    if (!result.ok) return makeErrorResponse(res, 500, "TRUST_CONTEXT_FAILED");
+    return res.json({ ok: true, context: result.workspace } satisfies TrustContextResponse);
+  } catch (error) {
+    console.error("[landlord-evidence-export-trust-signoff] context failed", {
+      message: error instanceof Error ? error.message : "failed",
+    });
+    return makeErrorResponse(res, 500, "TRUST_CONTEXT_FAILED");
+  }
+});
+
+router.post("/evidence-export-trust-signoff", requireAuth, requireLandlord, async (req: Request, res: Response) => {
+  try {
+    const landlordId = asString(getEffectiveLandlordId(req), 240);
+    if (!landlordId) return makeErrorResponse(res, 401, "UNAUTHORIZED");
+    const body = (req.body || {}) as SignoffRequestBody;
+    const evidenceRef = asString(body.evidenceRef, 240);
+    const packageRef = asString(body.packageRef, 240);
+    const packageType = validatePackageType(body.packageType);
+    const audience = validateAudience(body.audience);
+    const purpose = asString(body.purpose, 120);
+    if (!evidenceRef || !packageRef || !packageType || !audience || !purpose) {
+      return makeErrorResponse(res, 400, "INVALID_SCOPE");
+    }
+    if (!isSafeReference(evidenceRef) || !isSafeReference(packageRef)) {
+      return makeErrorResponse(res, 400, "INVALID_SCOPE");
+    }
+
+    const workspace = await getTrustWorkspaceForUser(
+      {
+        id: ((req as Request & { user?: { id?: string } }).user?.id || landlordId),
+        role: "landlord",
+        landlordId,
+      },
+      {
+        exportReadinessRequests: [{ audience, purpose: purposeForPackageType(packageType), exportRef: packageRef }],
+      }
+    );
+    if (!workspace.ok) return makeErrorResponse(res, 500, "TRUST_CONTEXT_FAILED");
+    if (!workspaceHasEvidence(workspace.workspace, evidenceRef)) return makeErrorResponse(res, 404, "EVIDENCE_NOT_FOUND");
+    if (!workspaceHasPackage(workspace.workspace, packageRef)) return makeErrorResponse(res, 404, "PACKAGE_NOT_FOUND");
+    if (!workspaceHasVerifiedAttestation(workspace.workspace, evidenceRef)) {
+      return makeErrorResponse(res, 400, "ATTESTATION_CHAIN_INVALID");
+    }
+
+    const timestamp = new Date().toISOString();
+    const landlordScope = `landlord:${stableHash(["landlord_scope", landlordId], 24)}`;
+    const pkg = exportPackageForSignoff({ packageRef, packageType, audience, landlordId: landlordScope, timestamp });
+    const event = await requestSignatureForPackage(pkg, authorizationContext({ req, landlordId, purpose, timestamp }), {
+      attestationId: `attestation:${stableHash(["trust_signoff", landlordId, packageRef, evidenceRef], 32)}`,
+      reason: "evidence_export_trust_signoff",
+      timestamp,
+    });
+    const attestationRef = asString(event?.metadata.details.attestationRef, 160);
+    if (!event || !attestationRef.startsWith("attestation:")) {
+      return makeErrorResponse(res, 500, "SIGNATURE_REQUEST_FAILED");
+    }
+    return makeSignoffResult(res, { attestationRef, timestamp: Date.parse(event.timestamp) });
+  } catch (error) {
+    console.error("[landlord-evidence-export-trust-signoff] signoff failed", {
+      message: error instanceof Error ? error.message : "failed",
+    });
+    return makeErrorResponse(res, 500, "SIGNATURE_REQUEST_FAILED");
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/trust-workspace-service.ts
+++ b/rentchain-api/src/services/trust-workspace-service.ts
@@ -130,7 +130,7 @@ export async function getTrustWorkspaceForUser(
       auditEvents,
       portableAttestations: options.portableAttestations as readonly PortableAttestation[] | undefined,
       exportReadinessRequests: options.exportReadinessRequests as
-        | readonly Array<{
+        | ReadonlyArray<{
             audience: InstitutionalTrustExportAudience;
             purpose: InstitutionalTrustExportPurpose;
             exportRef?: string | null;


### PR DESCRIPTION
## Scope

Adds landlord evidence export trust signoff routes for Phase 4 evidence trust operations.

## Changes

- Adds `GET /api/landlord/evidence-export-trust-context` for landlord-scoped trust workspace context retrieval.
- Adds `POST /api/landlord/evidence-export-trust-signoff` for metadata-only signature request initiation.
- Mounts the new landlord routes in the backend app.
- Adds focused route tests for auth boundaries, validation failures, inaccessible evidence/package cases, invalid attestation context, workspace failures, signature request failures, and success responses.
- Fixes two Trust Workspace `ReadonlyArray` type forms required for TypeScript build compatibility.

## Safety

- Uses `requireAuth`, `requireLandlord`, and `getEffectiveLandlordId()`.
- Validates safe evidence and package references, package type, audience, and purpose.
- Uses Trust Workspace context for evidence visibility, package readiness, and verified attestation status.
- Uses hashed safe actor and landlord references in the attestation authorization context.
- Returns safe error codes and safe attestation references only.
- Does not mutate evidence records or export package records.
- Does not add private-key signing, external callbacks, delivery mechanics, Firestore rules, deployment config, billing, pricing, entitlement, screening, or frontend changes.

## Validation

- `cd rentchain-api && npm ci`: PASS
- `cd rentchain-api && npm test -- src/routes/__tests__/landlordEvidenceExportTrustSignoffRoutes.test.ts`: PASS
- `cd rentchain-api && npm run build`: PASS
- `git diff --check`: PASS
- Restricted-term scan on changed source and test files: PASS

Full backend suite was run with `cd rentchain-api && npm run test`: FAIL with pre-existing failures outside this mission scope in lease draft, recipient trust review, support console, and landlord analytics tests.

## Manual QA

Required for Gate 2 because this adds backend routes and user-visible API behavior. Checklist is documented in `.handoff/impl-summary.md`.