### PR TITLE
prep: establish provider-neutral screening workflow

### DIFF
--- a/.handoff/audit-screening-readiness.md
+++ b/.handoff/audit-screening-readiness.md
@@ -1,0 +1,62 @@
+# Screening Provider Integration Readiness Audit
+
+Branch: prep/screening-provider-integration-readiness-v1
+Date: 2026-06-05
+
+## Scope Classification
+
+- Mission type: backend workflow foundation with frontend entry screens, tests, and documentation.
+- Runtime scope: new provider-neutral screening workflow surfaces only.
+- Protected areas: `rentchain-api/firestore.rules` is explicitly in scope for screening collection rules; auth core, billing, pricing, entitlement logic, deployment, and infrastructure remain out of scope.
+
+## Existing Backend Patterns
+
+1. Route mounting
+   - `rentchain-api/src/app.build.ts` mounts public webhooks before JSON parsing for Stripe and TransUnion.
+   - Auth decode is mounted globally with `authenticateJwt`, then feature routers are mounted under `/api`, `/api/landlord`, and `/api/admin`.
+   - Existing screening routes are mounted at `/api` through `screeningRoutes.ts`.
+
+2. Auth and role boundaries
+   - `requireAuth` enforces Bearer token presence and hydrates `req.user`.
+   - `requireLandlord` permits landlord/admin roles and resolves `user.landlordId`.
+   - `requireAdmin` permits admin role or allowlisted admin identity.
+   - Tenant-specific middleware exists elsewhere, but tenant routes commonly rely on `requireAuth` and server-side tenant ownership checks.
+
+3. Existing screening implementation
+   - `screeningRoutes.ts` is legacy/application-oriented and uses `@ts-nocheck`.
+   - Existing provider files include mock, single-key, TransUnion, manual, and bureau adapter concepts.
+   - Existing provider defaults can fall back to mock. This mission should not change those existing purchase/report paths.
+   - Existing frontend has screening components for workflow messaging, history, report viewing, and invite flows.
+
+4. Firestore and data access
+   - Existing services use `db.collection(...).doc(...).get/set/update/create` patterns.
+   - Current `rentchain-api/firestore.rules` is deny-all. Screening collection rules must be explicit and narrow.
+   - Unit ownership data is stored in `units` with `landlordId`, but not all tests need a real unit record if service-level ownership checks are injectable.
+
+5. Frontend patterns
+   - API helpers use `apiFetch`, which prefixes `/api` automatically and attaches the active token.
+   - Tenant routes are gated by `TENANT_PORTAL_ENABLED`; landlord routes use `RequireAuth`/`RequireRole` and `LandlordNav`.
+   - Existing screening UI uses tokenized inline styles and compact workflow cards.
+
+## Risks and Design Decisions
+
+1. The mission is broad enough to create a parallel screening system if not scoped carefully. The implementation should use explicit provider-neutral v1 workflow files and avoid modifying legacy screening checkout/report behavior.
+2. Provider webhook routes must remain unauthenticated, but signature verification must fail closed for unknown or unconfigured providers.
+3. Tenant consent must be explicit and revocable. Landlord request creation must require active consent.
+4. Tenant-facing projections must never expose screening results, decisions, raw payloads, reports, landlord private notes, or provider payloads.
+5. Manual report handling should avoid real storage side effects in Phase A; the service can create metadata-only report references and document future storage wiring.
+6. Full manual QA requires seeded landlord, tenant, admin accounts, webhook simulator access, and storage configuration.
+
+## Implementation Plan
+
+1. Add provider-neutral screening workflow types and provider registry.
+2. Add service-layer workflow helpers for consent, request initiation, webhook logging, result ingestion, decision recording, and manual report metadata.
+3. Add a new route file for Phase A endpoints and mount it without disturbing existing screening routes.
+4. Add Firestore rules for the new screening collections while keeping the default deny.
+5. Add frontend API helpers and lightweight tenant/landlord screens for consent, request initiation/status, decision, and manual report metadata upload.
+6. Add focused backend and frontend tests for the provider registry, workflow services, route auth/projection boundaries, and status component.
+7. Add provider contract and operations documentation.
+
+## Manual QA Requirement
+
+Manual QA is required because this mission adds backend routes, frontend screens, and user-visible screening workflow behavior. It requires seeded local or staging accounts and should follow the checklist in `.handoff/mission-current.md`.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -141,3 +141,14 @@ Manual QA was not completed in this run because seeded tenant, landlord, and adm
 - `rentchain-frontend/src/pages/landlord/ScreeningDecision.tsx`
 - `rentchain-frontend/src/pages/tenant/ScreeningConsent.tsx`
 - `rentchain-frontend/src/pages/tenant/ScreeningConsent.test.tsx`
+
+## Manual QA Results
+- All auth boundaries: 401 confirmed (items 6 complete) ✅
+- Webhook fail-closed: PROVIDER_NOT_CONFIGURED confirmed ✅
+- Error responses safe: no stack traces or internal paths ✅
+- Landlord screening page loads with correct empty state ✅
+- Tenant consent page loads with correct empty state ✅
+- FINDING: Consent page uses user?.id as fallback — may resolve to landlord ID if accessed by wrong role
+- FINDING: 403 on consent POST when landlord ID used as tenantId — correct backend rejection
+- Items 1-2 functional UI confirmed, full flow blocked by test data setup
+- Items 4-5 covered by automated tests (100 backend tests passing)

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,62 +1,143 @@
-PR: #1103
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1103
-Branch: audit/product-readiness-v1
-Audit Branch: audit/product-readiness-v1
-Audit Date: 2026-06-05
-Status: Complete
-Key Findings:
-- Production Firestore rules are emulator-only and allow all reads/writes.
-- Screening defaults to mock/provider placeholders unless production provider setup is explicitly configured.
-- Lease execution supports drafts, PDFs, and tenant signing state, but no provider-backed e-signature completion is evident.
-- Billing checkout/status has a frontend-backend route mismatch and does not prove active Stripe subscription lifecycle.
-- Tenant portal and application paths depend on frontend environment flags that are not documented by a frontend `.env.example`.
+PR: #PENDING
+PR URL: PENDING
+Branch: prep/screening-provider-integration-readiness-v1
 
-## Blockers (Revenue-Preventing)
+# Implementation Summary - Provider-Neutral Screening Integration Readiness v1
 
-- Firestore production enforcement is not represented in the root rules file.
-- Screening integration is not market-ready for advertised provider breadth.
-- Lease execution lacks provider-backed signing or explicit launch-safe in-app signing scope.
-- Billing subscription status and checkout route alignment are insufficient for paying landlord activation.
-- Landlord payout and statement lifecycle is not closed.
+## Scope Delivered
 
-## Critical (User-Visible Failures)
+Established the Phase A provider-neutral screening workflow foundation across backend services, routes, Firestore rules, frontend screens, focused tests, and operational documentation.
 
-- Tenant portal routes can resolve to coming-soon behavior when `VITE_TENANT_PORTAL_ENABLED` is absent or false.
-- Frontend `createCheckoutSession()` calls `/billing/create-checkout-session`, while backend exposes `/billing/checkout`, `/billing/subscribe`, and `/billing/upgrade`.
-- Application routes are split across legacy and newer route families, increasing QA/support ambiguity.
-- Frontend API base requirements are not documented by a frontend `.env.example`.
+The implementation adds consent tracking, landlord-initiated screening requests, webhook ingestion, result recording, decision recording, manual report metadata, safe landlord/admin projections, and provider registry scaffolding without adding a production provider adapter or changing existing legacy screening checkout/report behavior.
 
-## High-Priority (Adoption Friction)
+## Provider-Neutral Architecture
 
-- Property publish does not prove tenant discoverability through a canonical search workflow.
-- Property geocoding/maps readiness is not evident in the create/publish path.
-- Tenant payment readiness is honest but blocked unless payment rails are explicitly enabled.
-- Governance/readiness pages outnumber completed revenue workflow surfaces.
+- Added `IScreeningProvider` contract and provider-neutral workflow types in `rentchain-api/src/types/providerNeutralScreening.ts`.
+- Added `ScreeningProviderRegistry` in `rentchain-api/src/services/screening/providers/providerNeutralRegistry.ts`.
+- Added empty-by-default provider registry initialization in `rentchain-api/src/config/screening.ts`.
+- Added provider contract documentation in `rentchain-api/src/services/screening/providers/README.md` and `rentchain-api/docs/SCREENING_PROVIDER_INTEGRATION.md`.
+- Preserved provider-neutral design: no vendor-specific implementation was added.
 
-## Recommendations for v0.9 Sequencing
+## Backend Services and Routes
 
-1. Firestore production rules and cross-role denial tests.
-2. Billing checkout/status alignment and Stripe subscription verification.
-3. Screening provider completion for the selected v0.9 provider, with mock provider blocked outside approved test modes.
-4. Lease execution end-to-end decision and implementation: provider-backed signing or explicitly scoped in-app signing.
-5. Tenant portal configuration, frontend env example, and tenant application/discovery hardening.
-6. Landlord payout, statement, and rent payment reconciliation lifecycle.
+- Added provider-neutral workflow service logic in `rentchain-api/src/services/screening/providerNeutralWorkflowService.ts`.
+- Added named service entry points for consent, request, webhook, result, decision, and manual report flows.
+- Added Firestore schema metadata in `rentchain-api/src/services/screening/firestore-schema.ts`.
+- Added routes in `rentchain-api/src/routes/providerNeutralScreeningRoutes.ts`.
+- Mounted routes in `rentchain-api/src/app.build.ts`.
 
-See `.handoff/audit-product-readiness-findings.md` for the full detailed audit report.
+New API surfaces:
+- `POST /api/tenant/:tenantId/screeningConsent`
+- `DELETE /api/tenant/:tenantId/screeningConsent/:consentId`
+- `GET /api/tenant/:tenantId/screeningConsent`
+- `POST /api/landlord/units/:unitId/screeningRequest`
+- `GET /api/landlord/units/:unitId/screeningRequest`
+- `GET /api/landlord/units/:unitId/screeningRequest/:requestId`
+- `GET /api/landlord/units/:unitId/screeningRequest/:requestId/result`
+- `POST /api/landlord/units/:unitId/screeningRequest/:requestId/decision`
+- `POST /api/landlord/units/:unitId/screeningRequest/:requestId/manualReport`
+- `POST /api/webhook/screening/:providerId`
+- `GET /api/admin/screening/auditLog`
+- `GET /api/admin/screening/webhookLogs/:providerId`
+- `GET /api/admin/screening/webookLogs/:providerId`
+
+## Firestore Schema and Rules
+
+Updated `rentchain-api/firestore.rules` with explicit rules for:
+- `screeningConsents`
+- `screeningRequests`
+- `screeningResults`
+- `screeningWebhookLogs`
+
+Default deny remains in place. Tenant consent access, landlord request/result access, and admin audit access are scoped by role and ownership claims.
+
+## Frontend Surfaces
+
+- Added frontend API helper: `rentchain-frontend/src/api/providerNeutralScreeningApi.ts`.
+- Added tenant consent page: `rentchain-frontend/src/pages/tenant/ScreeningConsent.tsx`.
+- Added landlord request page: `rentchain-frontend/src/pages/landlord/ScreeningRequest.tsx`.
+- Added landlord decision page: `rentchain-frontend/src/pages/landlord/ScreeningDecision.tsx`.
+- Added shared status component: `rentchain-frontend/src/components/ScreeningStatus.tsx`.
+- Wired new routes in `rentchain-frontend/src/App.tsx`.
+
+Frontend routes:
+- `/tenant/screening/consent`
+- `/landlord/units/:unitId/screening`
+- `/landlord/units/:unitId/screening/:requestId/decision`
+
+## Projection and Safety Controls
+
+- Tenant endpoints expose consent state only.
+- Landlord endpoints expose safe request/result projections only.
+- Admin audit endpoints expose status, timestamps, safe audit entries, and payload digests.
+- Webhook logs store payload digests rather than raw provider payloads.
+- Webhook route fails closed for unregistered or unconfigured providers.
+- Manual report upload accepts PDF, JPEG, and PNG files only.
+- Existing screening checkout/report routes were not changed.
+
+## Tests Added
+
+Backend:
+- `rentchain-api/src/__tests__/services/screening/provider-registry.test.ts`
+- `rentchain-api/src/__tests__/services/screening/workflow.test.ts`
+- `rentchain-api/src/__tests__/routes/providerNeutralScreeningRoutes.test.ts`
+
+Frontend:
+- `rentchain-frontend/src/components/ScreeningStatus.test.tsx`
+- `rentchain-frontend/src/pages/tenant/ScreeningConsent.test.tsx`
 
 ## Validation
 
-Validation commands were run after the audit files were written.
+- Backend focused tests: PASS — `npm test -- providerNeutralScreening provider-registry workflow`
+- Backend screening tests: PASS — `npm test -- screening` with 25 files and 100 tests passing
+- Backend build: PASS — `npm run build`
+- Backend full suite: FAIL — 7 pre-existing failing test files, 20 failing tests, 449 files passing, 2192 tests passing
+- Backend lint: FAIL — `rentchain-api` has no `lint` script
+- Frontend focused tests: PASS — `npm test -- ScreeningStatus ScreeningConsent`
+- Frontend screening tests: PASS — `npm test -- screening` with 12 files and 39 tests passing
+- Frontend full suite: PASS — 291 files and 1149 tests passing
+- Frontend build: PASS — `npm run build`
+- Frontend lint: PASS — `npm run lint`
+- `git diff --check`: PASS
 
-- Backend `npm test -- --coverage`: FAIL. Existing full-suite baseline failures remain: 7 test files failed, 20 tests failed, 446 files passed, 2183 tests passed. Failing areas include lease draft routes, recipient trust review routes, support console routes, analytics decision mapping, and landlord analytics snapshot coverage.
-- Backend `npm run build`: PASS.
-- Backend `npm run lint`: FAIL. `rentchain-api` does not define a `lint` script.
-- Frontend `npm test -- --coverage`: FAIL. Vitest coverage could not start because `@vitest/coverage-v8` is missing.
-- Frontend `npm run build`: PASS. Vite emitted a Node version warning for Node 20.11.1 and a large chunk warning, but the production build completed.
-- Frontend `npm run lint`: PASS.
-- `git diff --check`: PASS.
-- Handoff artifact restricted-term scan: PASS.
+Backend full-suite failures are outside this mission scope and match known baseline areas: lease draft routes, recipient trust review routes, support console routes, analytics decision mapping, and landlord analytics snapshot.
 
 ## Manual QA
 
-Manual QA was not completed in a running local or staging environment because this audit turn did not include seeded accounts, credentials, or a running deployment. The audit provides code-reference reproduction steps and a required manual QA checklist for pre-launch validation.
+Manual QA is required because this mission adds backend routes, frontend routes, and user-visible workflow behavior.
+
+Manual QA was not completed in this run because seeded tenant, landlord, and admin accounts plus local or staging storage configuration were not provided. Required scenarios are listed in `.handoff/mission-current.md` and include tenant consent, landlord request initiation, webhook simulator, decision workflow, manual report upload, role isolation, and provider registry checks.
+
+## Known Limitations and Future Work
+
+- Provider registry starts empty by design; production provider registration remains future work.
+- No vendor-specific adapter was added in this mission.
+- Manual report upload requires `GCS_UPLOAD_BUCKET` at runtime.
+- Webhook logs intentionally store payload digests, not raw payloads, to preserve privacy boundaries.
+- Firestore rules rely on role and ownership claims being present in auth tokens.
+- Full backend suite still has pre-existing failures outside the screening workflow changes.
+- Backend lint remains unavailable until a backend lint script is added.
+
+## Files Changed
+
+- `.handoff/audit-screening-readiness.md`
+- `.handoff/impl-summary.md`
+- `rentchain-api/firestore.rules`
+- `rentchain-api/docs/SCREENING_OPERATIONS.md`
+- `rentchain-api/docs/SCREENING_PROVIDER_INTEGRATION.md`
+- `rentchain-api/src/app.build.ts`
+- `rentchain-api/src/config/screening.ts`
+- `rentchain-api/src/routes/providerNeutralScreeningRoutes.ts`
+- `rentchain-api/src/services/screening/*`
+- `rentchain-api/src/services/screening/providers/*`
+- `rentchain-api/src/types/providerNeutralScreening.ts`
+- `rentchain-api/src/__tests__/routes/providerNeutralScreeningRoutes.test.ts`
+- `rentchain-api/src/__tests__/services/screening/*`
+- `rentchain-frontend/src/App.tsx`
+- `rentchain-frontend/src/api/providerNeutralScreeningApi.ts`
+- `rentchain-frontend/src/components/ScreeningStatus.tsx`
+- `rentchain-frontend/src/components/ScreeningStatus.test.tsx`
+- `rentchain-frontend/src/pages/landlord/ScreeningRequest.tsx`
+- `rentchain-frontend/src/pages/landlord/ScreeningDecision.tsx`
+- `rentchain-frontend/src/pages/tenant/ScreeningConsent.tsx`
+- `rentchain-frontend/src/pages/tenant/ScreeningConsent.test.tsx`

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,5 +1,5 @@
-PR: #PENDING
-PR URL: PENDING
+PR: #1104
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1104
 Branch: prep/screening-provider-integration-readiness-v1
 
 # Implementation Summary - Provider-Neutral Screening Integration Readiness v1

--- a/rentchain-api/docs/SCREENING_OPERATIONS.md
+++ b/rentchain-api/docs/SCREENING_OPERATIONS.md
@@ -1,0 +1,45 @@
+# Screening Operations Runbook
+
+## Local Webhook Test
+
+Register a local test provider in the runtime process, then POST a provider-shaped payload:
+
+```bash
+curl -X POST "$API_BASE_URL/api/webhook/screening/test-provider" \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: test-signature" \
+  -d '{"requestId":"screening_request","status":"completed"}'
+```
+
+Expected result for an unregistered provider:
+
+```json
+{ "ok": false, "code": "PROVIDER_NOT_CONFIGURED", "error": "PROVIDER_NOT_CONFIGURED" }
+```
+
+## Backlog Monitoring
+
+Query `screeningRequests` for statuses:
+
+- `pending`
+- `provider_pending`
+- `failed`
+
+Requests in pending states should have an active consent and a recent `requestedAt` timestamp.
+
+## Webhook Failure Handling
+
+Review `screeningWebhookLogs` by provider id. Each log contains a payload digest and safe status, not raw provider payload content. Rejected logs indicate missing provider configuration, invalid signature, or parser failure.
+
+## Audit Export
+
+Admin review uses:
+
+- `GET /api/admin/screening/auditLog`
+- `GET /api/admin/screening/webhookLogs/:providerId`
+
+Export only safe metadata, status values, payload digests, and audit entries. Do not export raw provider payloads or tenant private documents.
+
+## Manual Report Fallback
+
+Landlords may upload PDF, JPEG, or PNG report files to complete a request manually when provider integration is unavailable. Storage requires `GCS_UPLOAD_BUCKET` to be configured.

--- a/rentchain-api/docs/SCREENING_PROVIDER_INTEGRATION.md
+++ b/rentchain-api/docs/SCREENING_PROVIDER_INTEGRATION.md
@@ -1,0 +1,57 @@
+# Screening Provider Integration Contract
+
+This contract defines the provider-neutral screening workflow foundation.
+
+## Interface
+
+Provider modules implement `IScreeningProvider` from `src/types/providerNeutralScreening.ts`.
+
+The interface supports:
+
+- request initiation
+- webhook signature validation
+- webhook payload parsing
+- provider-neutral result retrieval
+- provider readiness checks
+
+## Webhook Contract
+
+Webhook handlers receive provider-specific payloads at:
+
+`POST /api/webhook/screening/:providerId`
+
+The route is unauthenticated because it is provider-to-server traffic. It fails closed unless a registered provider exists, reports configured readiness, and validates the incoming signature.
+
+Webhook logs store:
+
+- provider id
+- timestamp
+- signature presence
+- verification status
+- payload digest
+- parsed request reference
+- safe error code
+
+Webhook logs do not store raw payloads.
+
+## Result Contract
+
+Providers map their payloads into:
+
+- request id
+- status
+- risk score
+- decision recommendation
+- summary
+- flags
+- provider request reference
+
+Landlord projections expose only provider-neutral summaries. Tenant projections expose consent state only.
+
+## Error Handling
+
+Provider integrations should return deterministic safe error codes. Unknown providers, unconfigured providers, invalid signatures, missing requests, and parse failures must fail closed.
+
+## Configuration
+
+The provider registry starts empty. Production provider setup must explicitly register providers from environment-aware configuration. Do not hardcode provider credentials or provider-specific defaults in routes.

--- a/rentchain-api/firestore.rules
+++ b/rentchain-api/firestore.rules
@@ -1,6 +1,73 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function signedIn() {
+      return request.auth != null;
+    }
+
+    function role() {
+      return request.auth.token.role;
+    }
+
+    function userId() {
+      return request.auth.uid;
+    }
+
+    function tenantId() {
+      return request.auth.token.tenantId != null ? request.auth.token.tenantId : request.auth.uid;
+    }
+
+    function landlordId() {
+      return request.auth.token.landlordId != null ? request.auth.token.landlordId : request.auth.uid;
+    }
+
+    function isAdmin() {
+      return signedIn() && role() == "admin";
+    }
+
+    function isTenantOwner(resourceData) {
+      return signedIn() && role() == "tenant" && resourceData.tenantId == tenantId();
+    }
+
+    function isLandlordOwner(resourceData) {
+      return signedIn() && (role() == "landlord" || role() == "admin") && resourceData.landlordId == landlordId();
+    }
+
+    match /screeningConsents/{consentId} {
+      allow create: if signedIn()
+        && role() == "tenant"
+        && request.resource.data.tenantId == tenantId()
+        && request.resource.data.status == "active";
+      allow read: if isAdmin() || isTenantOwner(resource.data) || isLandlordOwner(resource.data);
+      allow update: if signedIn()
+        && role() == "tenant"
+        && resource.data.tenantId == tenantId()
+        && request.resource.data.tenantId == resource.data.tenantId
+        && request.resource.data.status == "revoked";
+      allow delete: if false;
+    }
+
+    match /screeningRequests/{requestId} {
+      allow create: if signedIn()
+        && (role() == "landlord" || role() == "admin")
+        && request.resource.data.landlordId == landlordId();
+      allow read: if isAdmin() || isLandlordOwner(resource.data);
+      allow update: if isAdmin() || isLandlordOwner(resource.data);
+      allow delete: if false;
+    }
+
+    match /screeningResults/{resultId} {
+      allow create, update: if isAdmin();
+      allow read: if isAdmin() || isLandlordOwner(resource.data);
+      allow delete: if false;
+    }
+
+    match /screeningWebhookLogs/{logId} {
+      allow create: if isAdmin();
+      allow read: if isAdmin();
+      allow update, delete: if false;
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/rentchain-api/src/__tests__/routes/providerNeutralScreeningRoutes.test.ts
+++ b/rentchain-api/src/__tests__/routes/providerNeutralScreeningRoutes.test.ts
@@ -1,0 +1,150 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, upsertDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensure(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function docRef(collectionName: string, id: string) {
+    const col = ensure(collectionName);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any, options?: { merge?: boolean }) => {
+        if (options?.merge && col.has(id)) {
+          col.set(id, { id, data: { ...col.get(id)!.data, ...data } });
+        } else {
+          col.set(id, { id, data });
+        }
+      },
+    };
+  }
+
+  const dbMock = {
+    collection: (name: string) => ({
+      doc: (id: string) => docRef(name, id),
+      where: (field: string, op: string, value: any) => ({
+        get: async () => {
+          const docs = Array.from(ensure(name).values())
+            .filter((entry) => op === "==" && entry.data?.[field] === value)
+            .map((entry) => ({ id: entry.id, data: () => entry.data }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
+      get: async () => {
+        const docs = Array.from(ensure(name).values()).map((entry) => ({ id: entry.id, data: () => entry.data }));
+        return { docs, empty: docs.length === 0 };
+      },
+    }),
+  };
+
+  return {
+    dbMock,
+    resetDb: () => collections.clear(),
+    upsertDoc: (collectionName: string, id: string, data: any) => ensure(collectionName).set(id, { id, data }),
+  };
+});
+
+vi.mock("../../firebase", () => ({ db: dbMock }));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    const token = String(req.headers.authorization || "").replace(/^Bearer\s+/i, "");
+    if (!token) return res.status(401).json({ ok: false, error: "unauthenticated" });
+    req.user = { id: token, tenantId: token, role: token === "admin-1" ? "admin" : "tenant" };
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const token = String(req.headers.authorization || "").replace(/^Bearer\s+/i, "");
+    if (!token) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (token === "tenant-1") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user = { id: token, landlordId: token, role: token === "admin-1" ? "admin" : "landlord" };
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireAdmin", () => ({
+  requireAdmin: (req: any, res: any, next: any) => {
+    const token = String(req.headers.authorization || "").replace(/^Bearer\s+/i, "");
+    if (token !== "admin-1") return res.status(401).json({ ok: false, error: "Unauthorized" });
+    req.user = { id: token, role: "admin" };
+    return next();
+  },
+}));
+
+vi.mock("../../lib/gcs", () => ({
+  uploadBufferToGcs: vi.fn(async (input: any) => ({ bucket: "test-bucket", path: input.path })),
+}));
+
+async function createApp() {
+  const router = (await import("../../routes/providerNeutralScreeningRoutes")).default;
+  const app = express();
+  app.use(express.json());
+  app.use("/api", router);
+  return app;
+}
+
+describe("provider-neutral screening routes", () => {
+  beforeEach(() => {
+    resetDb();
+    upsertDoc("units", "unit-1", { landlordId: "landlord-1" });
+  });
+
+  it("returns 401 for tenant consent without auth", async () => {
+    const app = await createApp();
+    const res = await request(app).post("/api/tenant/tenant-1/screeningConsent").send({});
+    expect(res.status).toBe(401);
+  });
+
+  it("creates consent and landlord request with safe response shape", async () => {
+    const app = await createApp();
+    const consentRes = await request(app)
+      .post("/api/tenant/tenant-1/screeningConsent")
+      .set("Authorization", "Bearer tenant-1")
+      .send({ landlordId: "landlord-1", unitId: "unit-1" });
+    expect(consentRes.status).toBe(201);
+    expect(consentRes.body.consent.consentId).toMatch(/^consent_/);
+
+    const requestRes = await request(app)
+      .post("/api/landlord/units/unit-1/screeningRequest")
+      .set("Authorization", "Bearer landlord-1")
+      .send({ tenantId: "tenant-1", consentId: consentRes.body.consent.consentId });
+
+    expect(requestRes.status).toBe(201);
+    expect(requestRes.body).toMatchObject({ ok: true, status: "pending" });
+    expect(JSON.stringify(requestRes.body)).not.toContain("auditLog");
+  });
+
+  it("rejects landlord access to another landlord unit", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/landlord/units/unit-1/screeningRequest")
+      .set("Authorization", "Bearer landlord-2")
+      .send({ tenantId: "tenant-1", consentId: "consent-missing" });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("UNIT_FORBIDDEN");
+  });
+
+  it("fails closed for unregistered webhook provider", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/webhook/screening/provider-x")
+      .set("X-Signature", "bad")
+      .send({ requestId: "request-1" });
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("PROVIDER_NOT_CONFIGURED");
+  });
+});

--- a/rentchain-api/src/__tests__/services/screening/provider-registry.test.ts
+++ b/rentchain-api/src/__tests__/services/screening/provider-registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { ScreeningProviderRegistry } from "../../../services/screening/providers/providerNeutralRegistry";
+import type { IScreeningProvider } from "../../../types/providerNeutralScreening";
+
+const provider: IScreeningProvider = {
+  getName: () => "Test Provider",
+  isConfigured: () => true,
+  initiateScreening: async () => ({ providerRequestRef: "provider_ref" }),
+  verifyWebhookSignature: async () => true,
+  parseWebhookPayload: async (input: any) => ({
+    requestId: String(input.requestId || ""),
+    status: "completed",
+    summary: "completed",
+  }),
+  getScreeningResult: async () => ({ status: "completed", summary: "completed", flags: [] }),
+};
+
+describe("ScreeningProviderRegistry", () => {
+  it("starts empty and reports missing providers", () => {
+    const registry = new ScreeningProviderRegistry();
+    expect(registry.listProviders()).toEqual([]);
+    expect(registry.getProvider("missing")).toBeNull();
+  });
+
+  it("registers and retrieves providers by normalized id", () => {
+    const registry = new ScreeningProviderRegistry();
+    registry.register("Test_Provider", provider);
+    expect(registry.hasProvider("test_provider")).toBe(true);
+    expect(registry.getProvider("test_provider")?.getName()).toBe("Test Provider");
+    expect(registry.listProviders()).toEqual([
+      { providerId: "test_provider", name: "Test Provider", configured: true },
+    ]);
+  });
+});

--- a/rentchain-api/src/__tests__/services/screening/workflow.test.ts
+++ b/rentchain-api/src/__tests__/services/screening/workflow.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, upsertDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensure(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function docRef(collectionName: string, id: string) {
+    const col = ensure(collectionName);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any, options?: { merge?: boolean }) => {
+        if (options?.merge && col.has(id)) {
+          col.set(id, { id, data: { ...col.get(id)!.data, ...data } });
+        } else {
+          col.set(id, { id, data });
+        }
+      },
+    };
+  }
+
+  const dbMock = {
+    collection: (name: string) => ({
+      doc: (id: string) => docRef(name, id),
+      where: (field: string, op: string, value: any) => ({
+        get: async () => {
+          const docs = Array.from(ensure(name).values())
+            .filter((entry) => op === "==" && entry.data?.[field] === value)
+            .map((entry) => ({ id: entry.id, data: () => entry.data }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
+    }),
+  };
+
+  return {
+    dbMock,
+    resetDb: () => collections.clear(),
+    upsertDoc: (collectionName: string, id: string, data: any) => ensure(collectionName).set(id, { id, data }),
+  };
+});
+
+vi.mock("../../../firebase", () => ({ db: dbMock }));
+
+describe("provider-neutral screening workflow services", () => {
+  beforeEach(() => {
+    resetDb();
+    upsertDoc("units", "unit-1", { landlordId: "landlord-1" });
+  });
+
+  it("grants consent and creates a landlord-owned screening request", async () => {
+    const { ScreeningConsentService, ScreeningRequestService } = await import("../../../services/screening/providerNeutralWorkflowService");
+    const consentService = new ScreeningConsentService();
+    const requestService = new ScreeningRequestService(consentService);
+
+    const consent = await consentService.grantConsent({
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      unitId: "unit-1",
+      actorTenantId: "tenant-1",
+    });
+
+    const request = await requestService.initiateScreening({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      consentId: consent.id,
+    });
+
+    expect(request.status).toBe("pending");
+    expect(request.consentId).toBe(consent.id);
+    expect(request.auditLog[0].action).toBe("request_created");
+  });
+
+  it("rejects cross-landlord request creation", async () => {
+    const { ScreeningConsentService, ScreeningRequestService } = await import("../../../services/screening/providerNeutralWorkflowService");
+    const consentService = new ScreeningConsentService();
+    const requestService = new ScreeningRequestService(consentService);
+    const consent = await consentService.grantConsent({
+      tenantId: "tenant-1",
+      landlordId: "landlord-2",
+      unitId: "unit-1",
+      actorTenantId: "tenant-1",
+    });
+
+    await expect(
+      requestService.initiateScreening({
+        landlordId: "landlord-2",
+        tenantId: "tenant-1",
+        unitId: "unit-1",
+        consentId: consent.id,
+      }),
+    ).rejects.toMatchObject({ code: "UNIT_FORBIDDEN" });
+  });
+
+  it("records provider results and safe projections", async () => {
+    const workflow = await import("../../../services/screening/providerNeutralWorkflowService");
+    const consentService = new workflow.ScreeningConsentService();
+    const requestService = new workflow.ScreeningRequestService(consentService);
+    const resultService = new workflow.ScreeningResultService(requestService);
+    const consent = await consentService.grantConsent({
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      unitId: "unit-1",
+      actorTenantId: "tenant-1",
+    });
+    const request = await requestService.initiateScreening({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      consentId: consent.id,
+      providerId: "test-provider",
+    });
+
+    const result = await resultService.recordResult({
+      providerId: "test-provider",
+      payload: { requestId: request.id, secret: "not exposed" },
+      parsed: {
+        requestId: request.id,
+        status: "completed",
+        riskScore: 42,
+        decisionRecommendation: "review_needed",
+        summary: "review recommended",
+        flags: ["income_review"],
+      },
+    });
+
+    expect(result.payloadDigest).toHaveLength(64);
+    expect(workflow.projectResult(result)).toEqual({
+      requestId: request.id,
+      riskScore: 42,
+      decisionRecommendation: "review_needed",
+      summary: "review recommended",
+      flags: ["income_review"],
+    });
+  });
+});

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -106,6 +106,7 @@ import adminScreeningResultsRoutes from "./routes/adminScreeningResultsRoutes";
 import adminScreeningUsageRoutes from "./routes/adminScreeningUsageRoutes";
 import screeningReportRoutes from "./routes/screeningReportRoutes";
 import screeningRoutes from "./routes/screeningRoutes";
+import providerNeutralScreeningRoutes from "./routes/providerNeutralScreeningRoutes";
 import telemetryRoutes from "./routes/telemetryRoutes";
 import invitesRoutes from "./routes/invitesRoutes";
 import accessRoutes from "./routes/accessRoutes";
@@ -391,6 +392,7 @@ app.use("/api/internal", rateLimitInternalJob);
 app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
 app.use("/api/internal", routeSource("identityOracleInternalRoutes.ts"), identityOracleInternalRoutes);
 app.use("/api/internal", routeSource("applicationReminderInternalRoutes.ts"), applicationReminderInternalRoutes);
+app.use("/api", routeSource("providerNeutralScreeningRoutes.ts"), providerNeutralScreeningRoutes);
 
 // Auth decode (non-blocking if header missing)
 app.use(authenticateJwt);

--- a/rentchain-api/src/config/screening.ts
+++ b/rentchain-api/src/config/screening.ts
@@ -1,0 +1,7 @@
+import { screeningProviderRegistry } from "../services/screening/providers/providerNeutralRegistry";
+
+export function initializeScreeningProviderRegistry() {
+  return screeningProviderRegistry;
+}
+
+export { screeningProviderRegistry };

--- a/rentchain-api/src/routes/providerNeutralScreeningRoutes.ts
+++ b/rentchain-api/src/routes/providerNeutralScreeningRoutes.ts
@@ -1,0 +1,304 @@
+import { Router } from "express";
+import multer from "multer";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { requireAdmin } from "../middleware/requireAdmin";
+import { db } from "../firebase";
+import { uploadBufferToGcs } from "../lib/gcs";
+import {
+  ScreeningConsentService,
+  ScreeningDecisionService,
+  ScreeningManualReportService,
+  ScreeningRequestService,
+  ScreeningResultService,
+  ScreeningWebhookService,
+  ScreeningWorkflowError,
+  projectRequest,
+  projectResult,
+} from "../services/screening/providerNeutralWorkflowService";
+import { screeningProviderRegistry } from "../services/screening/providers/providerNeutralRegistry";
+
+const router = Router();
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+});
+
+const consentService = new ScreeningConsentService();
+const requestService = new ScreeningRequestService(consentService);
+const webhookService = new ScreeningWebhookService();
+const resultService = new ScreeningResultService(requestService);
+const decisionService = new ScreeningDecisionService(requestService);
+const manualReportService = new ScreeningManualReportService(requestService);
+
+function tenantIdFromUser(user: any) {
+  return String(user?.tenantId || user?.id || "").trim();
+}
+
+function landlordIdFromUser(user: any) {
+  return String(user?.landlordId || user?.id || "").trim();
+}
+
+function safeError(res: any, error: unknown) {
+  if (error instanceof ScreeningWorkflowError) {
+    return res.status(error.status).json({ ok: false, code: error.code, error: error.code });
+  }
+  return res.status(500).json({ ok: false, code: "SCREENING_WORKFLOW_ERROR", error: "SCREENING_WORKFLOW_ERROR" });
+}
+
+function projectConsent(consent: any) {
+  return {
+    consentId: consent.id,
+    tenantId: consent.tenantId,
+    landlordId: consent.landlordId,
+    unitId: consent.unitId,
+    status: consent.status,
+    grantedAt: consent.grantedAt,
+    revokedAt: consent.revokedAt || null,
+  };
+}
+
+router.post("/tenant/:tenantId/screeningConsent", requireAuth, async (req: any, res) => {
+  try {
+    const consent = await consentService.grantConsent({
+      tenantId: String(req.params.tenantId || ""),
+      landlordId: String(req.body?.landlordId || ""),
+      unitId: String(req.body?.unitId || ""),
+      actorTenantId: tenantIdFromUser(req.user),
+    });
+    return res.status(201).json({ ok: true, consent: projectConsent(consent) });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.delete("/tenant/:tenantId/screeningConsent/:consentId", requireAuth, async (req: any, res) => {
+  try {
+    const consent = await consentService.revokeConsent({
+      tenantId: String(req.params.tenantId || ""),
+      consentId: String(req.params.consentId || ""),
+      actorTenantId: tenantIdFromUser(req.user),
+    });
+    return res.status(200).json({ ok: true, consent: projectConsent(consent) });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.get("/tenant/:tenantId/screeningConsent", requireAuth, async (req: any, res) => {
+  try {
+    const tenantId = String(req.params.tenantId || "");
+    if (tenantId !== tenantIdFromUser(req.user)) {
+      return res.status(403).json({ ok: false, code: "TENANT_FORBIDDEN", error: "TENANT_FORBIDDEN" });
+    }
+    const consents = await consentService.listActiveConsents(tenantId);
+    return res.status(200).json({ ok: true, consents: consents.map(projectConsent) });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.post("/landlord/units/:unitId/screeningRequest", requireLandlord, async (req: any, res) => {
+  try {
+    const request = await requestService.initiateScreening({
+      landlordId: landlordIdFromUser(req.user),
+      unitId: String(req.params.unitId || ""),
+      tenantId: String(req.body?.tenantId || ""),
+      consentId: String(req.body?.consentId || ""),
+      providerId: req.body?.providerId ? String(req.body.providerId) : null,
+    });
+    return res.status(201).json({
+      ok: true,
+      requestId: request.id,
+      status: request.status,
+      initiatedAt: request.requestedAt,
+    });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.get("/landlord/units/:unitId/screeningRequest", requireLandlord, async (req: any, res) => {
+  try {
+    const requests = await requestService.listUnitRequests(landlordIdFromUser(req.user), String(req.params.unitId || ""));
+    return res.status(200).json({ ok: true, requests: requests.map(projectRequest) });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.get("/landlord/units/:unitId/screeningRequest/:requestId", requireLandlord, async (req: any, res) => {
+  try {
+    const request = await requestService.getOwnedRequest(
+      String(req.params.requestId || ""),
+      landlordIdFromUser(req.user),
+      String(req.params.unitId || ""),
+    );
+    return res.status(200).json({ ok: true, request: projectRequest(request) });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.get("/landlord/units/:unitId/screeningRequest/:requestId/result", requireLandlord, async (req: any, res) => {
+  try {
+    const request = await requestService.getOwnedRequest(
+      String(req.params.requestId || ""),
+      landlordIdFromUser(req.user),
+      String(req.params.unitId || ""),
+    );
+    const result = await resultService.getResultForRequest(request.id, landlordIdFromUser(req.user));
+    if (!result) return res.status(404).json({ ok: false, code: "RESULT_NOT_FOUND", error: "RESULT_NOT_FOUND" });
+    return res.status(200).json({ ok: true, result: projectResult(result) });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.post("/landlord/units/:unitId/screeningRequest/:requestId/decision", requireLandlord, async (req: any, res) => {
+  try {
+    const request = await decisionService.recordDecision({
+      landlordId: landlordIdFromUser(req.user),
+      unitId: String(req.params.unitId || ""),
+      requestId: String(req.params.requestId || ""),
+      decision: req.body?.decision,
+      reason: req.body?.reason,
+      notes: req.body?.notes,
+    });
+    return res.status(200).json({
+      ok: true,
+      decisionId: request.id,
+      decisionStatus: request.decisionStatus,
+      decidedAt: request.decisionMadeAt,
+    });
+  } catch (error) {
+    return safeError(res, error);
+  }
+});
+
+router.post(
+  "/landlord/units/:unitId/screeningRequest/:requestId/manualReport",
+  requireLandlord,
+  upload.single("file"),
+  async (req: any, res) => {
+    try {
+      const file = req.file;
+      if (!file) return res.status(400).json({ ok: false, code: "REPORT_FILE_REQUIRED", error: "REPORT_FILE_REQUIRED" });
+      const safeName = String(file.originalname || "report").replace(/[^a-zA-Z0-9._-]/g, "-").slice(0, 120);
+      const storagePath = `screening-reports/${landlordIdFromUser(req.user)}/${String(req.params.requestId || "")}/${Date.now()}-${safeName}`;
+      const uploaded = await uploadBufferToGcs({
+        path: storagePath,
+        contentType: file.mimetype,
+        buffer: file.buffer,
+        metadata: {
+          requestId: String(req.params.requestId || ""),
+          unitId: String(req.params.unitId || ""),
+        },
+      });
+      const request = await manualReportService.recordManualReport({
+        landlordId: landlordIdFromUser(req.user),
+        unitId: String(req.params.unitId || ""),
+        requestId: String(req.params.requestId || ""),
+        fileName: safeName,
+        contentType: file.mimetype,
+        storageUrl: `gs://${uploaded.bucket}/${uploaded.path}`,
+      });
+      return res.status(200).json({
+        ok: true,
+        reportUrl: request.manualReportUrl,
+        uploadedAt: request.manualReportUploadedAt,
+      });
+    } catch (error) {
+      return safeError(res, error);
+    }
+  },
+);
+
+router.post("/webhook/screening/:providerId", async (req: any, res) => {
+  const providerId = String(req.params.providerId || "");
+  const provider = screeningProviderRegistry.getProvider(providerId);
+  if (!provider || !provider.isConfigured()) {
+    await webhookService.recordWebhookLog({
+      providerId,
+      headers: req.headers,
+      payload: req.body,
+      verified: false,
+      status: "rejected",
+      errorCode: "PROVIDER_NOT_CONFIGURED",
+    });
+    return res.status(401).json({ ok: false, code: "PROVIDER_NOT_CONFIGURED", error: "PROVIDER_NOT_CONFIGURED" });
+  }
+
+  try {
+    const verified = await provider.verifyWebhookSignature({ headers: req.headers, body: req.body, rawBody: req.rawBody });
+    if (!verified) {
+      await webhookService.recordWebhookLog({ providerId, headers: req.headers, payload: req.body, verified: false, status: "rejected" });
+      return res.status(401).json({ ok: false, code: "WEBHOOK_SIGNATURE_INVALID", error: "WEBHOOK_SIGNATURE_INVALID" });
+    }
+    const parsed = await provider.parseWebhookPayload(req.body);
+    await webhookService.recordWebhookLog({
+      providerId,
+      headers: req.headers,
+      payload: req.body,
+      verified: true,
+      status: "verified",
+      parsedRequestId: parsed.requestId,
+    });
+    await resultService.recordResult({ providerId, parsed, payload: req.body });
+    return res.status(200).json({ status: "success" });
+  } catch (error) {
+    await webhookService.recordWebhookLog({
+      providerId,
+      headers: req.headers,
+      payload: req.body,
+      verified: true,
+      status: "parse_failed",
+      errorCode: error instanceof ScreeningWorkflowError ? error.code : "WEBHOOK_PARSE_FAILED",
+    });
+    return safeError(res, error);
+  }
+});
+
+router.get("/admin/screening/auditLog", requireAdmin, async (_req, res) => {
+  const snap = await db.collection("screeningRequests").get();
+  const requests = snap.docs.map((doc: any) => {
+    const data = doc.data() || {};
+    return {
+      requestId: doc.id,
+      status: data.status || null,
+      requestedAt: data.requestedAt || null,
+      resultReceivedAt: data.resultReceivedAt || null,
+      decisionStatus: data.decisionStatus || null,
+      auditLog: Array.isArray(data.auditLog) ? data.auditLog : [],
+    };
+  });
+  return res.status(200).json({ ok: true, requests });
+});
+
+async function listWebhookLogs(providerId: string, res: any) {
+  const snap = await db.collection("screeningWebhookLogs").where("providerId", "==", providerId).get();
+  const logs = snap.docs.map((doc: any) => {
+    const data = doc.data() || {};
+    return {
+      logId: doc.id,
+      providerId: data.providerId || null,
+      timestamp: data.timestamp || null,
+      verified: Boolean(data.verified),
+      status: data.status || null,
+      payloadDigest: data.payloadDigest || null,
+      parsedRequestId: data.parsedRequestId || null,
+      errorCode: data.errorCode || null,
+    };
+  });
+  return res.status(200).json({ ok: true, logs });
+}
+
+router.get("/admin/screening/webhookLogs/:providerId", requireAdmin, async (req, res) => {
+  return listWebhookLogs(String(req.params.providerId || ""), res);
+});
+
+router.get("/admin/screening/webookLogs/:providerId", requireAdmin, async (req, res) => {
+  return listWebhookLogs(String(req.params.providerId || ""), res);
+});
+
+export default router;

--- a/rentchain-api/src/services/screening/ScreeningConsentService.ts
+++ b/rentchain-api/src/services/screening/ScreeningConsentService.ts
@@ -1,0 +1,1 @@
+export { ScreeningConsentService } from "./providerNeutralWorkflowService";

--- a/rentchain-api/src/services/screening/ScreeningDecisionService.ts
+++ b/rentchain-api/src/services/screening/ScreeningDecisionService.ts
@@ -1,0 +1,1 @@
+export { ScreeningDecisionService } from "./providerNeutralWorkflowService";

--- a/rentchain-api/src/services/screening/ScreeningManualReportService.ts
+++ b/rentchain-api/src/services/screening/ScreeningManualReportService.ts
@@ -1,0 +1,1 @@
+export { ScreeningManualReportService } from "./providerNeutralWorkflowService";

--- a/rentchain-api/src/services/screening/ScreeningRequestService.ts
+++ b/rentchain-api/src/services/screening/ScreeningRequestService.ts
@@ -1,0 +1,1 @@
+export { ScreeningRequestService } from "./providerNeutralWorkflowService";

--- a/rentchain-api/src/services/screening/ScreeningResultService.ts
+++ b/rentchain-api/src/services/screening/ScreeningResultService.ts
@@ -1,0 +1,1 @@
+export { ScreeningResultService } from "./providerNeutralWorkflowService";

--- a/rentchain-api/src/services/screening/ScreeningWebhookService.ts
+++ b/rentchain-api/src/services/screening/ScreeningWebhookService.ts
@@ -1,0 +1,1 @@
+export { ScreeningWebhookService } from "./providerNeutralWorkflowService";

--- a/rentchain-api/src/services/screening/firestore-schema.ts
+++ b/rentchain-api/src/services/screening/firestore-schema.ts
@@ -1,0 +1,13 @@
+export const providerNeutralScreeningCollections = {
+  requests: "screeningRequests",
+  results: "screeningResults",
+  consents: "screeningConsents",
+  webhookLogs: "screeningWebhookLogs",
+} as const;
+
+export const providerNeutralScreeningIndexes = [
+  { collection: "screeningConsents", fields: ["tenantId", "status"] },
+  { collection: "screeningRequests", fields: ["landlordId", "unitId", "status"] },
+  { collection: "screeningResults", fields: ["requestId", "landlordId"] },
+  { collection: "screeningWebhookLogs", fields: ["providerId", "timestamp"] },
+] as const;

--- a/rentchain-api/src/services/screening/providerNeutralWorkflowService.ts
+++ b/rentchain-api/src/services/screening/providerNeutralWorkflowService.ts
@@ -1,0 +1,426 @@
+import crypto from "crypto";
+import { db } from "../../firebase";
+import type {
+  ScreeningConsent,
+  ScreeningConsentStatus,
+  ScreeningDecisionStatus,
+  ScreeningProviderParsedWebhook,
+  ScreeningRequest,
+  ScreeningRequestProjection,
+  ScreeningResult,
+  ScreeningResultProjection,
+  ScreeningWebhookLog,
+  ScreeningWorkflowAuditEntry,
+  ScreeningWorkflowStatus,
+} from "../../types/providerNeutralScreening";
+
+const CONSENTS = "screeningConsents";
+const REQUESTS = "screeningRequests";
+const RESULTS = "screeningResults";
+const WEBHOOK_LOGS = "screeningWebhookLogs";
+const UNITS = "units";
+
+type ActorRole = ScreeningWorkflowAuditEntry["actorRole"];
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function digest(value: unknown) {
+  return crypto.createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex");
+}
+
+function safeId(prefix: string) {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+function audit(action: ScreeningWorkflowAuditEntry["action"], actorRole: ActorRole, actorRef: string, note?: string) {
+  return {
+    action,
+    actorRole,
+    actorRef: hashRef(actorRef),
+    at: nowIso(),
+    ...(note ? { note } : {}),
+  };
+}
+
+export function hashRef(value: string) {
+  return crypto.createHash("sha256").update(String(value || "")).digest("hex").slice(0, 24);
+}
+
+function coerceString(value: unknown, max = 160) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function assertRequired(value: unknown, code: string) {
+  const normalized = coerceString(value);
+  if (!normalized) throw new ScreeningWorkflowError(400, code);
+  return normalized;
+}
+
+function normalizeDecision(value: unknown): Exclude<ScreeningDecisionStatus, "not_started"> {
+  const decision = coerceString(value, 40);
+  if (decision === "approve" || decision === "deny" || decision === "review_needed") return decision;
+  throw new ScreeningWorkflowError(400, "INVALID_DECISION");
+}
+
+function normalizeStatus(value: unknown): ScreeningWorkflowStatus {
+  const status = coerceString(value, 40);
+  if (
+    status === "pending" ||
+    status === "provider_pending" ||
+    status === "completed" ||
+    status === "manual_completed" ||
+    status === "failed" ||
+    status === "expired"
+  ) {
+    return status;
+  }
+  return "pending";
+}
+
+function normalizeConsentStatus(value: unknown): ScreeningConsentStatus {
+  return value === "revoked" ? "revoked" : "active";
+}
+
+function consentFromDoc(id: string, data: any): ScreeningConsent {
+  return {
+    id,
+    tenantId: String(data?.tenantId || ""),
+    landlordId: String(data?.landlordId || ""),
+    unitId: String(data?.unitId || ""),
+    consentType: "screening",
+    status: normalizeConsentStatus(data?.status),
+    grantedAt: String(data?.grantedAt || ""),
+    revokedAt: data?.revokedAt ? String(data.revokedAt) : null,
+    auditLog: Array.isArray(data?.auditLog) ? data.auditLog : [],
+  };
+}
+
+function requestFromDoc(id: string, data: any): ScreeningRequest {
+  return {
+    id,
+    landlordId: String(data?.landlordId || ""),
+    unitId: String(data?.unitId || ""),
+    tenantId: String(data?.tenantId || ""),
+    consentId: String(data?.consentId || ""),
+    providerId: data?.providerId ? String(data.providerId) : null,
+    status: normalizeStatus(data?.status),
+    requestedAt: String(data?.requestedAt || ""),
+    resultReceivedAt: data?.resultReceivedAt ? String(data.resultReceivedAt) : null,
+    manualReportUrl: data?.manualReportUrl ? String(data.manualReportUrl) : null,
+    manualReportUploadedAt: data?.manualReportUploadedAt ? String(data.manualReportUploadedAt) : null,
+    decisionStatus: data?.decisionStatus === "approve" || data?.decisionStatus === "deny" || data?.decisionStatus === "review_needed"
+      ? data.decisionStatus
+      : "not_started",
+    decisionReason: data?.decisionReason ? String(data.decisionReason) : null,
+    decisionNotes: data?.decisionNotes ? String(data.decisionNotes) : null,
+    decisionMadeAt: data?.decisionMadeAt ? String(data.decisionMadeAt) : null,
+    auditLog: Array.isArray(data?.auditLog) ? data.auditLog : [],
+  };
+}
+
+function resultFromDoc(id: string, data: any): ScreeningResult {
+  return {
+    id,
+    requestId: String(data?.requestId || ""),
+    tenantId: String(data?.tenantId || ""),
+    landlordId: String(data?.landlordId || ""),
+    providerId: String(data?.providerId || ""),
+    payloadDigest: String(data?.payloadDigest || ""),
+    parsedResult: data?.parsedResult || { status: "completed", flags: [] },
+    riskScore: typeof data?.riskScore === "number" ? data.riskScore : null,
+    decisionRecommendation:
+      data?.decisionRecommendation === "approve" ||
+      data?.decisionRecommendation === "deny" ||
+      data?.decisionRecommendation === "review_needed"
+        ? data.decisionRecommendation
+        : null,
+    receivedAt: String(data?.receivedAt || ""),
+    expiresAt: String(data?.expiresAt || ""),
+  };
+}
+
+export class ScreeningWorkflowError extends Error {
+  constructor(public status: number, public code: string) {
+    super(code);
+  }
+}
+
+export async function assertUnitOwnedByLandlord(unitId: string, landlordId: string) {
+  const snap = await db.collection(UNITS).doc(unitId).get();
+  if (!snap.exists) throw new ScreeningWorkflowError(404, "UNIT_NOT_FOUND");
+  const data = snap.data() as any;
+  if (String(data?.landlordId || "") !== landlordId) {
+    throw new ScreeningWorkflowError(403, "UNIT_FORBIDDEN");
+  }
+}
+
+export class ScreeningConsentService {
+  async grantConsent(input: { tenantId: string; landlordId: string; unitId: string; actorTenantId: string }) {
+    const tenantId = assertRequired(input.tenantId, "TENANT_REQUIRED");
+    if (tenantId !== input.actorTenantId) throw new ScreeningWorkflowError(403, "TENANT_FORBIDDEN");
+    const landlordId = assertRequired(input.landlordId, "LANDLORD_REQUIRED");
+    const unitId = assertRequired(input.unitId, "UNIT_REQUIRED");
+    const id = safeId("consent");
+    const grantedAt = nowIso();
+    const consent: ScreeningConsent = {
+      id,
+      tenantId,
+      landlordId,
+      unitId,
+      consentType: "screening",
+      status: "active",
+      grantedAt,
+      revokedAt: null,
+      auditLog: [audit("consent_granted", "tenant", tenantId)],
+    };
+    await db.collection(CONSENTS).doc(id).set(consent);
+    return consent;
+  }
+
+  async revokeConsent(input: { tenantId: string; consentId: string; actorTenantId: string }) {
+    const tenantId = assertRequired(input.tenantId, "TENANT_REQUIRED");
+    if (tenantId !== input.actorTenantId) throw new ScreeningWorkflowError(403, "TENANT_FORBIDDEN");
+    const consent = await this.getConsent(input.consentId);
+    if (!consent || consent.tenantId !== tenantId) throw new ScreeningWorkflowError(404, "CONSENT_NOT_FOUND");
+    const revokedAt = nowIso();
+    const updated: ScreeningConsent = {
+      ...consent,
+      status: "revoked",
+      revokedAt,
+      auditLog: [...consent.auditLog, audit("consent_revoked", "tenant", tenantId)],
+    };
+    await db.collection(CONSENTS).doc(consent.id).set(updated, { merge: true });
+    return updated;
+  }
+
+  async getConsent(consentId: string) {
+    const snap = await db.collection(CONSENTS).doc(assertRequired(consentId, "CONSENT_REQUIRED")).get();
+    if (!snap.exists) return null;
+    return consentFromDoc(snap.id, snap.data());
+  }
+
+  async listActiveConsents(tenantId: string) {
+    const snap = await db.collection(CONSENTS).where("tenantId", "==", tenantId).get();
+    return snap.docs.map((doc: any) => consentFromDoc(doc.id, doc.data())).filter((consent) => consent.status === "active");
+  }
+}
+
+export class ScreeningRequestService {
+  constructor(private consentService = new ScreeningConsentService()) {}
+
+  async initiateScreening(input: {
+    landlordId: string;
+    unitId: string;
+    tenantId: string;
+    consentId: string;
+    providerId?: string | null;
+  }) {
+    const landlordId = assertRequired(input.landlordId, "LANDLORD_REQUIRED");
+    const unitId = assertRequired(input.unitId, "UNIT_REQUIRED");
+    const tenantId = assertRequired(input.tenantId, "TENANT_REQUIRED");
+    const consentId = assertRequired(input.consentId, "CONSENT_REQUIRED");
+    await assertUnitOwnedByLandlord(unitId, landlordId);
+    const consent = await this.consentService.getConsent(consentId);
+    if (!consent || consent.status !== "active") throw new ScreeningWorkflowError(400, "CONSENT_NOT_ACTIVE");
+    if (consent.tenantId !== tenantId || consent.landlordId !== landlordId || consent.unitId !== unitId) {
+      throw new ScreeningWorkflowError(400, "CONSENT_SCOPE_MISMATCH");
+    }
+    const request: ScreeningRequest = {
+      id: safeId("screening"),
+      landlordId,
+      unitId,
+      tenantId,
+      consentId,
+      providerId: input.providerId ? coerceString(input.providerId, 80) : null,
+      status: input.providerId ? "provider_pending" : "pending",
+      requestedAt: nowIso(),
+      resultReceivedAt: null,
+      manualReportUrl: null,
+      manualReportUploadedAt: null,
+      decisionStatus: "not_started",
+      decisionReason: null,
+      decisionNotes: null,
+      decisionMadeAt: null,
+      auditLog: [audit("request_created", "landlord", landlordId)],
+    };
+    await db.collection(REQUESTS).doc(request.id).set(request);
+    return request;
+  }
+
+  async getRequest(requestId: string) {
+    const snap = await db.collection(REQUESTS).doc(assertRequired(requestId, "REQUEST_REQUIRED")).get();
+    if (!snap.exists) return null;
+    return requestFromDoc(snap.id, snap.data());
+  }
+
+  async getOwnedRequest(requestId: string, landlordId: string, unitId: string) {
+    const request = await this.getRequest(requestId);
+    if (!request) throw new ScreeningWorkflowError(404, "REQUEST_NOT_FOUND");
+    if (request.landlordId !== landlordId || request.unitId !== unitId) {
+      throw new ScreeningWorkflowError(403, "REQUEST_FORBIDDEN");
+    }
+    return request;
+  }
+
+  async listUnitRequests(landlordId: string, unitId: string) {
+    await assertUnitOwnedByLandlord(unitId, landlordId);
+    const snap = await db.collection(REQUESTS).where("unitId", "==", unitId).get();
+    return snap.docs
+      .map((doc: any) => requestFromDoc(doc.id, doc.data()))
+      .filter((request) => request.landlordId === landlordId);
+  }
+
+  async saveRequest(request: ScreeningRequest) {
+    await db.collection(REQUESTS).doc(request.id).set(request, { merge: true });
+    return request;
+  }
+}
+
+export class ScreeningWebhookService {
+  async recordWebhookLog(input: {
+    providerId: string;
+    headers: Record<string, string | string[] | undefined>;
+    payload: unknown;
+    verified: boolean;
+    status: ScreeningWebhookLog["status"];
+    parsedRequestId?: string | null;
+    errorCode?: string | null;
+  }) {
+    const log: ScreeningWebhookLog = {
+      id: safeId("webhook"),
+      providerId: coerceString(input.providerId, 80),
+      timestamp: nowIso(),
+      signatureHeaderPresent: Boolean(input.headers["x-signature"] || input.headers["X-Signature"]),
+      verified: input.verified,
+      status: input.status,
+      payloadDigest: digest(input.payload),
+      parsedRequestId: input.parsedRequestId || null,
+      errorCode: input.errorCode || null,
+    };
+    await db.collection(WEBHOOK_LOGS).doc(log.id).set(log);
+    return log;
+  }
+}
+
+export class ScreeningResultService {
+  constructor(private requestService = new ScreeningRequestService()) {}
+
+  async recordResult(input: { providerId: string; parsed: ScreeningProviderParsedWebhook; payload: unknown }) {
+    const request = await this.requestService.getRequest(input.parsed.requestId);
+    if (!request) throw new ScreeningWorkflowError(404, "REQUEST_NOT_FOUND");
+    const receivedAt = nowIso();
+    const result: ScreeningResult = {
+      id: safeId("result"),
+      requestId: request.id,
+      tenantId: request.tenantId,
+      landlordId: request.landlordId,
+      providerId: coerceString(input.providerId, 80),
+      payloadDigest: digest(input.payload),
+      parsedResult: {
+        status: input.parsed.status === "failed" ? "failed" : input.parsed.status === "pending" ? "provider_pending" : "completed",
+        riskScore: typeof input.parsed.riskScore === "number" ? input.parsed.riskScore : null,
+        decisionRecommendation: input.parsed.decisionRecommendation || null,
+        summary: input.parsed.summary || null,
+        flags: Array.isArray(input.parsed.flags) ? input.parsed.flags.map((flag) => coerceString(flag, 80)).filter(Boolean) : [],
+      },
+      riskScore: typeof input.parsed.riskScore === "number" ? input.parsed.riskScore : null,
+      decisionRecommendation: input.parsed.decisionRecommendation || null,
+      receivedAt,
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 90).toISOString(),
+    };
+    await db.collection(RESULTS).doc(result.id).set(result);
+    await this.requestService.saveRequest({
+      ...request,
+      providerId: input.providerId,
+      status: input.parsed.status === "failed" ? "failed" : input.parsed.status === "pending" ? "provider_pending" : "completed",
+      resultReceivedAt: receivedAt,
+      auditLog: [...request.auditLog, audit("result_recorded", "provider", input.providerId)],
+    });
+    return result;
+  }
+
+  async getResultForRequest(requestId: string, landlordId: string) {
+    const snap = await db.collection(RESULTS).where("requestId", "==", requestId).get();
+    const results = snap.docs.map((doc: any) => resultFromDoc(doc.id, doc.data()));
+    return results.find((result) => result.landlordId === landlordId) || null;
+  }
+}
+
+export class ScreeningDecisionService {
+  constructor(private requestService = new ScreeningRequestService()) {}
+
+  async recordDecision(input: {
+    landlordId: string;
+    unitId: string;
+    requestId: string;
+    decision: unknown;
+    reason: unknown;
+    notes?: unknown;
+  }) {
+    const request = await this.requestService.getOwnedRequest(input.requestId, input.landlordId, input.unitId);
+    const decidedAt = nowIso();
+    const decision = normalizeDecision(input.decision);
+    const updated: ScreeningRequest = {
+      ...request,
+      decisionStatus: decision,
+      decisionReason: coerceString(input.reason, 400),
+      decisionNotes: input.notes ? coerceString(input.notes, 1000) : null,
+      decisionMadeAt: decidedAt,
+      auditLog: [...request.auditLog, audit("decision_recorded", "landlord", input.landlordId)],
+    };
+    await this.requestService.saveRequest(updated);
+    return updated;
+  }
+}
+
+export class ScreeningManualReportService {
+  constructor(private requestService = new ScreeningRequestService()) {}
+
+  async recordManualReport(input: {
+    landlordId: string;
+    unitId: string;
+    requestId: string;
+    fileName: string;
+    contentType: string;
+    storageUrl: string;
+  }) {
+    const request = await this.requestService.getOwnedRequest(input.requestId, input.landlordId, input.unitId);
+    const allowed = ["application/pdf", "image/jpeg", "image/png"];
+    if (!allowed.includes(input.contentType)) throw new ScreeningWorkflowError(400, "UNSUPPORTED_REPORT_TYPE");
+    const uploadedAt = nowIso();
+    const updated: ScreeningRequest = {
+      ...request,
+      status: "manual_completed",
+      manualReportUrl: input.storageUrl,
+      manualReportUploadedAt: uploadedAt,
+      auditLog: [...request.auditLog, audit("manual_report_recorded", "landlord", input.landlordId, coerceString(input.fileName, 120))],
+    };
+    await this.requestService.saveRequest(updated);
+    return updated;
+  }
+}
+
+export function projectRequest(request: ScreeningRequest): ScreeningRequestProjection {
+  return {
+    requestId: request.id,
+    unitId: request.unitId,
+    tenantId: request.tenantId,
+    status: request.status,
+    initiatedAt: request.requestedAt,
+    resultReceivedAt: request.resultReceivedAt || null,
+    decisionStatus: request.decisionStatus,
+    manualReportUploadedAt: request.manualReportUploadedAt || null,
+  };
+}
+
+export function projectResult(result: ScreeningResult): ScreeningResultProjection {
+  return {
+    requestId: result.requestId,
+    riskScore: typeof result.riskScore === "number" ? result.riskScore : null,
+    decisionRecommendation: result.decisionRecommendation || null,
+    summary: result.parsedResult.summary || null,
+    flags: Array.isArray(result.parsedResult.flags) ? result.parsedResult.flags : [],
+  };
+}

--- a/rentchain-api/src/services/screening/providers/README.md
+++ b/rentchain-api/src/services/screening/providers/README.md
@@ -1,0 +1,16 @@
+# Provider-Neutral Screening Provider Contract
+
+Phase A screening providers implement `IScreeningProvider` from `src/types/providerNeutralScreening.ts`.
+
+Required methods:
+
+- `getName()` returns a display-safe provider name for internal operations.
+- `isConfigured()` returns whether required environment settings are present.
+- `initiateScreening(input)` starts a provider request and returns safe references only.
+- `verifyWebhookSignature(input)` validates the provider webhook signature.
+- `parseWebhookPayload(input)` maps a provider payload into a provider-neutral request result.
+- `getScreeningResult(requestId)` retrieves a provider-neutral result summary when supported.
+
+Provider implementations must not expose raw provider IDs, payloads, tokens, credentials, or private report content to tenant-facing or landlord-facing projections. Store only safe references, hashes, status values, and summary fields.
+
+The registry starts empty by default. Provider configuration must register implementations explicitly through `screeningProviderRegistry.register(providerId, provider)`.

--- a/rentchain-api/src/services/screening/providers/providerNeutralRegistry.ts
+++ b/rentchain-api/src/services/screening/providers/providerNeutralRegistry.ts
@@ -1,0 +1,42 @@
+import type { IScreeningProvider } from "../../../types/providerNeutralScreening";
+
+export class ScreeningProviderRegistry {
+  private providers = new Map<string, IScreeningProvider>();
+
+  register(providerId: string, provider: IScreeningProvider) {
+    const key = normalizeProviderId(providerId);
+    if (!key) throw new Error("provider_id_required");
+    this.providers.set(key, provider);
+  }
+
+  getProvider(providerId: string): IScreeningProvider | null {
+    const key = normalizeProviderId(providerId);
+    if (!key) return null;
+    return this.providers.get(key) || null;
+  }
+
+  hasProvider(providerId: string): boolean {
+    return Boolean(this.getProvider(providerId));
+  }
+
+  listProviders() {
+    return Array.from(this.providers.entries()).map(([providerId, provider]) => ({
+      providerId,
+      name: provider.getName(),
+      configured: provider.isConfigured(),
+    }));
+  }
+
+  clearForTests() {
+    this.providers.clear();
+  }
+}
+
+export function normalizeProviderId(value: string) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "");
+}
+
+export const screeningProviderRegistry = new ScreeningProviderRegistry();

--- a/rentchain-api/src/types/providerNeutralScreening.ts
+++ b/rentchain-api/src/types/providerNeutralScreening.ts
@@ -1,0 +1,150 @@
+export type ScreeningWorkflowStatus =
+  | "pending"
+  | "provider_pending"
+  | "completed"
+  | "manual_completed"
+  | "failed"
+  | "expired";
+
+export type ScreeningConsentStatus = "active" | "revoked";
+
+export type ScreeningDecisionStatus = "not_started" | "approve" | "deny" | "review_needed";
+
+export type ScreeningProviderWebhookStatus = "verified" | "rejected" | "parse_failed";
+
+export type ScreeningWorkflowAuditAction =
+  | "consent_granted"
+  | "consent_revoked"
+  | "request_created"
+  | "webhook_received"
+  | "result_recorded"
+  | "decision_recorded"
+  | "manual_report_recorded";
+
+export type ScreeningWorkflowAuditEntry = {
+  action: ScreeningWorkflowAuditAction;
+  actorRole: "tenant" | "landlord" | "admin" | "provider" | "system";
+  actorRef: string;
+  at: string;
+  note?: string;
+};
+
+export type ScreeningProviderStartInput = {
+  requestId: string;
+  landlordRef: string;
+  tenantRef: string;
+  unitRef: string;
+  consentRef: string;
+};
+
+export type ScreeningProviderStartResult = {
+  providerRequestRef?: string;
+  redirectUrl?: string;
+};
+
+export type ScreeningProviderParsedWebhook = {
+  requestId: string;
+  status: "completed" | "failed" | "pending";
+  riskScore?: number | null;
+  decisionRecommendation?: "approve" | "deny" | "review_needed" | null;
+  summary?: string | null;
+  flags?: string[];
+  providerRequestRef?: string | null;
+};
+
+export type ScreeningProviderResult = {
+  status: ScreeningWorkflowStatus;
+  riskScore?: number | null;
+  decisionRecommendation?: "approve" | "deny" | "review_needed" | null;
+  summary?: string | null;
+  flags?: string[];
+};
+
+export interface IScreeningProvider {
+  getName(): string;
+  isConfigured(): boolean;
+  initiateScreening(input: ScreeningProviderStartInput): Promise<ScreeningProviderStartResult>;
+  verifyWebhookSignature(input: {
+    headers: Record<string, string | string[] | undefined>;
+    body: unknown;
+    rawBody?: Buffer;
+  }): Promise<boolean>;
+  parseWebhookPayload(input: unknown): Promise<ScreeningProviderParsedWebhook>;
+  getScreeningResult(requestId: string): Promise<ScreeningProviderResult | null>;
+}
+
+export type ScreeningConsent = {
+  id: string;
+  tenantId: string;
+  landlordId: string;
+  unitId: string;
+  consentType: "screening";
+  status: ScreeningConsentStatus;
+  grantedAt: string;
+  revokedAt?: string | null;
+  auditLog: ScreeningWorkflowAuditEntry[];
+};
+
+export type ScreeningRequest = {
+  id: string;
+  landlordId: string;
+  unitId: string;
+  tenantId: string;
+  consentId: string;
+  providerId: string | null;
+  status: ScreeningWorkflowStatus;
+  requestedAt: string;
+  resultReceivedAt?: string | null;
+  manualReportUrl?: string | null;
+  manualReportUploadedAt?: string | null;
+  decisionStatus: ScreeningDecisionStatus;
+  decisionReason?: string | null;
+  decisionNotes?: string | null;
+  decisionMadeAt?: string | null;
+  auditLog: ScreeningWorkflowAuditEntry[];
+};
+
+export type ScreeningResult = {
+  id: string;
+  requestId: string;
+  tenantId: string;
+  landlordId: string;
+  providerId: string;
+  payloadDigest: string;
+  parsedResult: ScreeningProviderResult;
+  riskScore?: number | null;
+  decisionRecommendation?: "approve" | "deny" | "review_needed" | null;
+  receivedAt: string;
+  expiresAt: string;
+};
+
+export type ScreeningWebhookLog = {
+  id: string;
+  providerId: string;
+  timestamp: string;
+  signatureHeaderPresent: boolean;
+  verified: boolean;
+  status: ScreeningProviderWebhookStatus;
+  payloadDigest: string;
+  parsedRequestId?: string | null;
+  errorCode?: string | null;
+};
+
+export type ScreeningRequestProjection = {
+  requestId: string;
+  unitId: string;
+  tenantId: string;
+  status: ScreeningWorkflowStatus;
+  initiatedAt: string;
+  resultReceivedAt: string | null;
+  decisionStatus: ScreeningDecisionStatus;
+  manualReportUploadedAt: string | null;
+};
+
+export type ScreeningResultProjection = {
+  requestId: string;
+  riskScore: number | null;
+  decisionRecommendation: "approve" | "deny" | "review_needed" | null;
+  summary: string | null;
+  flags: string[];
+};

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -159,6 +159,8 @@ const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfol
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
 const ActionRecommendationsPage = lazy(() => import("./pages/landlord/ActionRecommendationsPage"));
 const InvitesPage = lazy(() => import("./pages/landlord/InvitesPage"));
+const LandlordScreeningRequestPage = lazy(() => import("./pages/landlord/ScreeningRequest"));
+const LandlordScreeningDecisionPage = lazy(() => import("./pages/landlord/ScreeningDecision"));
 const MessagesPage = lazy(() => import("./pages/MessagesPage"));
 const MaintenanceRequestsPage = lazy(() => import("./pages/MaintenanceRequestsPage"));
 const LeaseLedgerPage = lazy(() => import("./pages/LeaseLedgerPage"));
@@ -206,6 +208,7 @@ const TenantProfilePage = lazy(() => import("./pages/tenant/TenantProfilePage"))
 const TenantAccessPage = lazy(() => import("./pages/tenant/TenantAccessPage"));
 const TenantAccountPage = lazy(() => import("./pages/tenant/TenantAccountPage"));
 const TenantScreeningInboxPage = lazy(() => import("./pages/tenant/TenantScreeningInboxPage"));
+const TenantScreeningConsentPage = lazy(() => import("./pages/tenant/ScreeningConsent"));
 const TenantMagicRedeemPage = lazy(() => import("./pages/tenant/TenantMagicRedeemPage"));
 const TenantInviteRedeemPage = lazy(() => import("./pages/tenant/TenantInviteRedeemPage"));
 const TenantMaintenanceRequestDetailPage = lazy(() => import("./pages/tenant/TenantMaintenanceRequestDetailPage"));
@@ -504,6 +507,30 @@ function App() {
             <RequireAuth>
               <LandlordNav>
                 <ApplicationsPage />
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/landlord/units/:unitId/screening"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <LandlordScreeningRequestPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/landlord/units/:unitId/screening/:requestId/decision"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <LandlordScreeningDecisionPage />
+                </Suspense>
               </LandlordNav>
             </RequireAuth>
           }
@@ -1669,6 +1696,10 @@ function App() {
         <Route
           path="/tenant/application"
           element={renderTenantShell(suspensePage(<TenantApplicationStatusPage />))}
+        />
+        <Route
+          path="/tenant/screening/consent"
+          element={renderTenantShell(suspensePage(<TenantScreeningConsentPage />))}
         />
         <Route
           path="/tenant/lease"

--- a/rentchain-frontend/src/api/providerNeutralScreeningApi.ts
+++ b/rentchain-frontend/src/api/providerNeutralScreeningApi.ts
@@ -1,0 +1,142 @@
+import { apiFetch } from "./apiFetch";
+
+export type ProviderNeutralScreeningStatus =
+  | "pending"
+  | "provider_pending"
+  | "completed"
+  | "manual_completed"
+  | "failed"
+  | "expired";
+
+export type ScreeningConsentProjection = {
+  consentId: string;
+  tenantId: string;
+  landlordId: string;
+  unitId: string;
+  status: "active" | "revoked";
+  grantedAt: string;
+  revokedAt: string | null;
+};
+
+export type ScreeningRequestProjection = {
+  requestId: string;
+  unitId: string;
+  tenantId: string;
+  status: ProviderNeutralScreeningStatus;
+  initiatedAt: string;
+  resultReceivedAt: string | null;
+  decisionStatus: "not_started" | "approve" | "deny" | "review_needed";
+  manualReportUploadedAt: string | null;
+};
+
+export type ScreeningResultProjection = {
+  requestId: string;
+  riskScore: number | null;
+  decisionRecommendation: "approve" | "deny" | "review_needed" | null;
+  summary: string | null;
+  flags: string[];
+};
+
+export async function grantScreeningConsent(input: {
+  tenantId: string;
+  landlordId: string;
+  unitId: string;
+}) {
+  return apiFetch<{ ok: true; consent: ScreeningConsentProjection }>(
+    `/tenant/${encodeURIComponent(input.tenantId)}/screeningConsent`,
+    {
+      method: "POST",
+      body: {
+        landlordId: input.landlordId,
+        unitId: input.unitId,
+      },
+    },
+  );
+}
+
+export async function revokeScreeningConsent(tenantId: string, consentId: string) {
+  return apiFetch<{ ok: true; consent: ScreeningConsentProjection }>(
+    `/tenant/${encodeURIComponent(tenantId)}/screeningConsent/${encodeURIComponent(consentId)}`,
+    { method: "DELETE" },
+  );
+}
+
+export async function listScreeningConsents(tenantId: string) {
+  return apiFetch<{ ok: true; consents: ScreeningConsentProjection[] }>(
+    `/tenant/${encodeURIComponent(tenantId)}/screeningConsent`,
+  );
+}
+
+export async function initiateScreeningRequest(input: {
+  unitId: string;
+  tenantId: string;
+  consentId: string;
+  providerId?: string;
+}) {
+  return apiFetch<{ ok: true; requestId: string; status: ProviderNeutralScreeningStatus; initiatedAt: string }>(
+    `/landlord/units/${encodeURIComponent(input.unitId)}/screeningRequest`,
+    {
+      method: "POST",
+      body: {
+        tenantId: input.tenantId,
+        consentId: input.consentId,
+        providerId: input.providerId || undefined,
+      },
+    },
+  );
+}
+
+export async function listScreeningRequests(unitId: string) {
+  return apiFetch<{ ok: true; requests: ScreeningRequestProjection[] }>(
+    `/landlord/units/${encodeURIComponent(unitId)}/screeningRequest`,
+  );
+}
+
+export async function getScreeningRequest(unitId: string, requestId: string) {
+  return apiFetch<{ ok: true; request: ScreeningRequestProjection }>(
+    `/landlord/units/${encodeURIComponent(unitId)}/screeningRequest/${encodeURIComponent(requestId)}`,
+  );
+}
+
+export async function getScreeningResult(unitId: string, requestId: string) {
+  return apiFetch<{ ok: true; result: ScreeningResultProjection }>(
+    `/landlord/units/${encodeURIComponent(unitId)}/screeningRequest/${encodeURIComponent(requestId)}/result`,
+    { allow404: true },
+  );
+}
+
+export async function recordScreeningDecision(input: {
+  unitId: string;
+  requestId: string;
+  decision: "approve" | "deny" | "review_needed";
+  reason: string;
+  notes?: string;
+}) {
+  return apiFetch<{ ok: true; decisionId: string; decisionStatus: string; decidedAt: string }>(
+    `/landlord/units/${encodeURIComponent(input.unitId)}/screeningRequest/${encodeURIComponent(input.requestId)}/decision`,
+    {
+      method: "POST",
+      body: {
+        decision: input.decision,
+        reason: input.reason,
+        notes: input.notes || "",
+      },
+    },
+  );
+}
+
+export async function uploadManualScreeningReport(input: {
+  unitId: string;
+  requestId: string;
+  file: File;
+}) {
+  const body = new FormData();
+  body.append("file", input.file);
+  return apiFetch<{ ok: true; reportUrl: string; uploadedAt: string }>(
+    `/landlord/units/${encodeURIComponent(input.unitId)}/screeningRequest/${encodeURIComponent(input.requestId)}/manualReport`,
+    {
+      method: "POST",
+      body,
+    },
+  );
+}

--- a/rentchain-frontend/src/components/ScreeningStatus.test.tsx
+++ b/rentchain-frontend/src/components/ScreeningStatus.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ScreeningStatus } from "./ScreeningStatus";
+
+afterEach(() => cleanup());
+
+describe("ScreeningStatus", () => {
+  it("renders empty state", () => {
+    render(<ScreeningStatus request={null} />);
+    expect(screen.getByTestId("screening-status-empty")).toHaveTextContent("No screening request selected.");
+  });
+
+  it("renders request status without result payload details", () => {
+    render(
+      <ScreeningStatus
+        request={{
+          requestId: "screening-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          status: "completed",
+          initiatedAt: "2026-06-05T00:00:00.000Z",
+          resultReceivedAt: "2026-06-05T01:00:00.000Z",
+          decisionStatus: "review_needed",
+          manualReportUploadedAt: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Result available")).toBeInTheDocument();
+    expect(screen.getByText("screening-1")).toBeInTheDocument();
+    expect(screen.queryByText(/payload/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/ScreeningStatus.tsx
+++ b/rentchain-frontend/src/components/ScreeningStatus.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import type { ScreeningRequestProjection } from "../api/providerNeutralScreeningApi";
+
+const labelByStatus: Record<string, string> = {
+  pending: "Pending",
+  provider_pending: "Awaiting provider",
+  completed: "Result available",
+  manual_completed: "Manual report uploaded",
+  failed: "Failed",
+  expired: "Expired",
+};
+
+export function ScreeningStatus({ request }: { request: ScreeningRequestProjection | null }) {
+  if (!request) {
+    return (
+      <div data-testid="screening-status-empty" style={panelStyle}>
+        No screening request selected.
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="screening-status" style={panelStyle}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
+        <div>
+          <div style={{ fontWeight: 800 }}>Screening request</div>
+          <div style={{ color: "#64748b", fontSize: 13 }}>{request.requestId}</div>
+        </div>
+        <span style={badgeStyle}>{labelByStatus[request.status] || request.status}</span>
+      </div>
+      <div style={gridStyle}>
+        <span>Tenant</span>
+        <strong>{request.tenantId}</strong>
+        <span>Decision</span>
+        <strong>{request.decisionStatus.replace("_", " ")}</strong>
+        <span>Requested</span>
+        <strong>{request.initiatedAt}</strong>
+        <span>Result</span>
+        <strong>{request.resultReceivedAt || "Not received"}</strong>
+      </div>
+    </div>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  border: "1px solid #dbe3ef",
+  borderRadius: 8,
+  background: "#fff",
+  padding: 16,
+  display: "grid",
+  gap: 12,
+};
+
+const badgeStyle: React.CSSProperties = {
+  border: "1px solid #bfdbfe",
+  borderRadius: 999,
+  background: "#eff6ff",
+  color: "#1d4ed8",
+  padding: "5px 10px",
+  fontSize: 12,
+  fontWeight: 800,
+  whiteSpace: "nowrap",
+};
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "minmax(90px, 140px) minmax(0, 1fr)",
+  gap: 8,
+  color: "#475569",
+  fontSize: 13,
+};
+
+export default ScreeningStatus;

--- a/rentchain-frontend/src/pages/landlord/ScreeningDecision.tsx
+++ b/rentchain-frontend/src/pages/landlord/ScreeningDecision.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getScreeningRequest, getScreeningResult, recordScreeningDecision, type ScreeningRequestProjection, type ScreeningResultProjection } from "../../api/providerNeutralScreeningApi";
+import { ScreeningStatus } from "../../components/ScreeningStatus";
+
+export default function ScreeningDecisionPage() {
+  const { unitId = "", requestId = "" } = useParams();
+  const [request, setRequest] = useState<ScreeningRequestProjection | null>(null);
+  const [result, setResult] = useState<ScreeningResultProjection | null>(null);
+  const [decision, setDecision] = useState<"approve" | "deny" | "review_needed">("review_needed");
+  const [reason, setReason] = useState("");
+  const [notes, setNotes] = useState("");
+  const [message, setMessage] = useState("");
+
+  async function refresh() {
+    if (!unitId || !requestId) return;
+    const requestData = await getScreeningRequest(unitId, requestId);
+    setRequest(requestData.request);
+    const resultData = await getScreeningResult(unitId, requestId);
+    setResult(resultData?.result || null);
+  }
+
+  useEffect(() => {
+    void refresh().catch(() => setMessage("Unable to load screening decision context."));
+  }, [unitId, requestId]);
+
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    const data = await recordScreeningDecision({ unitId, requestId, decision, reason, notes });
+    setMessage(`Decision recorded: ${data.decisionStatus}`);
+    await refresh();
+  }
+
+  return (
+    <main style={pageStyle}>
+      <ScreeningStatus request={request} />
+      <section style={surfaceStyle}>
+        <h1 style={titleStyle}>Screening decision</h1>
+        <div style={resultStyle}>
+          <strong>Result summary</strong>
+          <span>{result?.summary || "No result summary available."}</span>
+          <span>Risk score: {result?.riskScore ?? "Not available"}</span>
+          <span>Recommendation: {result?.decisionRecommendation || "Not available"}</span>
+        </div>
+        <form onSubmit={onSubmit} style={{ display: "grid", gap: 12 }}>
+          <fieldset style={fieldsetStyle}>
+            <legend style={{ fontWeight: 800 }}>Decision</legend>
+            <label><input type="radio" checked={decision === "approve"} onChange={() => setDecision("approve")} /> Approve</label>
+            <label><input type="radio" checked={decision === "deny"} onChange={() => setDecision("deny")} /> Deny</label>
+            <label><input type="radio" checked={decision === "review_needed"} onChange={() => setDecision("review_needed")} /> Review needed</label>
+          </fieldset>
+          <label style={labelStyle}>
+            Reason
+            <input value={reason} onChange={(event) => setReason(event.target.value)} style={inputStyle} />
+          </label>
+          <label style={labelStyle}>
+            Notes
+            <textarea value={notes} onChange={(event) => setNotes(event.target.value)} style={{ ...inputStyle, minHeight: 100 }} />
+          </label>
+          <button type="submit" disabled={!reason.trim()} style={primaryButtonStyle}>Record decision</button>
+        </form>
+        {message && <p role="status" style={statusStyle}>{message}</p>}
+      </section>
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = { padding: 24, display: "grid", gap: 16, maxWidth: 960, margin: "0 auto" };
+const surfaceStyle: React.CSSProperties = { border: "1px solid #dbe3ef", borderRadius: 8, background: "#fff", padding: 18, display: "grid", gap: 12 };
+const titleStyle: React.CSSProperties = { margin: 0, fontSize: 24, color: "#0f172a" };
+const resultStyle: React.CSSProperties = { border: "1px solid #e2e8f0", borderRadius: 8, padding: 12, display: "grid", gap: 6, color: "#475569" };
+const fieldsetStyle: React.CSSProperties = { border: "1px solid #e2e8f0", borderRadius: 8, padding: 12, display: "grid", gap: 8 };
+const labelStyle: React.CSSProperties = { display: "grid", gap: 6, color: "#334155", fontWeight: 700 };
+const inputStyle: React.CSSProperties = { border: "1px solid #cbd5e1", borderRadius: 8, padding: "10px 12px" };
+const primaryButtonStyle: React.CSSProperties = { justifySelf: "start", border: 0, borderRadius: 8, background: "#2563eb", color: "#fff", padding: "10px 14px", fontWeight: 800 };
+const statusStyle: React.CSSProperties = { margin: 0, color: "#047857", fontWeight: 700 };

--- a/rentchain-frontend/src/pages/landlord/ScreeningRequest.tsx
+++ b/rentchain-frontend/src/pages/landlord/ScreeningRequest.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { initiateScreeningRequest, listScreeningRequests, uploadManualScreeningReport, type ScreeningRequestProjection } from "../../api/providerNeutralScreeningApi";
+import { ScreeningStatus } from "../../components/ScreeningStatus";
+
+export default function ScreeningRequestPage() {
+  const { unitId = "" } = useParams();
+  const [params] = useSearchParams();
+  const [tenantId, setTenantId] = useState(params.get("tenantId") || "");
+  const [consentId, setConsentId] = useState(params.get("consentId") || "");
+  const [requests, setRequests] = useState<ScreeningRequestProjection[]>([]);
+  const [selected, setSelected] = useState<ScreeningRequestProjection | null>(null);
+  const [message, setMessage] = useState("");
+
+  async function refresh() {
+    if (!unitId) return;
+    const data = await listScreeningRequests(unitId);
+    setRequests(data.requests || []);
+    setSelected(data.requests?.[0] || null);
+  }
+
+  useEffect(() => {
+    void refresh().catch(() => setMessage("Unable to load screening requests."));
+  }, [unitId]);
+
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setMessage("");
+    const data = await initiateScreeningRequest({ unitId, tenantId, consentId });
+    setMessage(`Screening request created: ${data.requestId}`);
+    await refresh();
+  }
+
+  async function onManualReport(event: React.ChangeEvent<HTMLInputElement>, requestId: string) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const data = await uploadManualScreeningReport({ unitId, requestId, file });
+    setMessage(`Manual report uploaded: ${data.uploadedAt}`);
+    await refresh();
+  }
+
+  return (
+    <main style={pageStyle}>
+      <section style={surfaceStyle}>
+        <h1 style={titleStyle}>Screening request</h1>
+        <form onSubmit={onSubmit} style={{ display: "grid", gap: 12 }}>
+          <label style={labelStyle}>
+            Tenant reference
+            <input value={tenantId} onChange={(event) => setTenantId(event.target.value)} style={inputStyle} />
+          </label>
+          <label style={labelStyle}>
+            Consent reference
+            <input value={consentId} onChange={(event) => setConsentId(event.target.value)} style={inputStyle} />
+          </label>
+          <button type="submit" disabled={!unitId || !tenantId || !consentId} style={primaryButtonStyle}>
+            Initiate screening
+          </button>
+        </form>
+        {message && <p role="status" style={statusStyle}>{message}</p>}
+      </section>
+
+      <ScreeningStatus request={selected} />
+
+      <section style={surfaceStyle}>
+        <h2 style={sectionTitleStyle}>Requests for unit {unitId}</h2>
+        {requests.length === 0 ? (
+          <p style={mutedStyle}>No requests yet.</p>
+        ) : (
+          requests.map((request) => (
+            <div key={request.requestId} style={itemStyle}>
+              <button type="button" onClick={() => setSelected(request)} style={linkButtonStyle}>
+                {request.requestId}
+              </button>
+              <span>{request.status}</span>
+              <label style={uploadLabelStyle}>
+                Manual report
+                <input type="file" accept="application/pdf,image/png,image/jpeg" onChange={(event) => onManualReport(event, request.requestId)} />
+              </label>
+            </div>
+          ))
+        )}
+      </section>
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = { padding: 24, display: "grid", gap: 16, maxWidth: 960, margin: "0 auto" };
+const surfaceStyle: React.CSSProperties = { border: "1px solid #dbe3ef", borderRadius: 8, background: "#fff", padding: 18, display: "grid", gap: 12 };
+const titleStyle: React.CSSProperties = { margin: 0, fontSize: 24, color: "#0f172a" };
+const sectionTitleStyle: React.CSSProperties = { margin: 0, fontSize: 18, color: "#0f172a" };
+const mutedStyle: React.CSSProperties = { margin: 0, color: "#64748b", fontSize: 13 };
+const statusStyle: React.CSSProperties = { margin: 0, color: "#047857", fontWeight: 700 };
+const labelStyle: React.CSSProperties = { display: "grid", gap: 6, color: "#334155", fontWeight: 700 };
+const inputStyle: React.CSSProperties = { border: "1px solid #cbd5e1", borderRadius: 8, padding: "10px 12px" };
+const primaryButtonStyle: React.CSSProperties = { justifySelf: "start", border: 0, borderRadius: 8, background: "#2563eb", color: "#fff", padding: "10px 14px", fontWeight: 800 };
+const itemStyle: React.CSSProperties = { border: "1px solid #e2e8f0", borderRadius: 8, padding: 12, display: "grid", gridTemplateColumns: "minmax(0, 1fr) auto auto", gap: 12, alignItems: "center" };
+const linkButtonStyle: React.CSSProperties = { border: 0, background: "transparent", color: "#1d4ed8", fontWeight: 800, textAlign: "left" };
+const uploadLabelStyle: React.CSSProperties = { display: "grid", gap: 4, color: "#334155", fontSize: 12, fontWeight: 700 };

--- a/rentchain-frontend/src/pages/tenant/ScreeningConsent.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/ScreeningConsent.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import ScreeningConsentPage from "./ScreeningConsent";
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  grant: vi.fn(),
+  list: vi.fn(),
+  revoke: vi.fn(),
+}));
+
+vi.mock("../../context/useAuth", () => ({ useAuth: mocks.useAuth }));
+vi.mock("../../api/providerNeutralScreeningApi", () => ({
+  grantScreeningConsent: mocks.grant,
+  listScreeningConsents: mocks.list,
+  revokeScreeningConsent: mocks.revoke,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ScreeningConsentPage", () => {
+  beforeEach(() => {
+    mocks.useAuth.mockReturnValue({ user: { id: "tenant-1", tenantId: "tenant-1", role: "tenant" } });
+    mocks.list.mockResolvedValue({ ok: true, consents: [] });
+    mocks.grant.mockResolvedValue({
+      ok: true,
+      consent: {
+        consentId: "consent-1",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        unitId: "unit-1",
+        status: "active",
+        grantedAt: "now",
+        revokedAt: null,
+      },
+    });
+  });
+
+  it("grants screening consent when scope references are present", async () => {
+    render(
+      <MemoryRouter initialEntries={["/tenant/screening/consent?landlordId=landlord-1&unitId=unit-1"]}>
+        <ScreeningConsentPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Grant consent" }));
+
+    await waitFor(() => expect(mocks.grant).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      unitId: "unit-1",
+    }));
+    expect(await screen.findByText(/Consent granted/)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/ScreeningConsent.tsx
+++ b/rentchain-frontend/src/pages/tenant/ScreeningConsent.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { grantScreeningConsent, listScreeningConsents, revokeScreeningConsent, type ScreeningConsentProjection } from "../../api/providerNeutralScreeningApi";
+import { useAuth } from "../../context/useAuth";
+
+export default function ScreeningConsentPage() {
+  const { user } = useAuth();
+  const [params] = useSearchParams();
+  const tenantId = user?.tenantId || user?.id || params.get("tenantId") || "";
+  const landlordId = params.get("landlordId") || "";
+  const unitId = params.get("unitId") || "";
+  const [consents, setConsents] = useState<ScreeningConsentProjection[]>([]);
+  const [message, setMessage] = useState("");
+
+  async function refresh() {
+    if (!tenantId) return;
+    const data = await listScreeningConsents(tenantId);
+    setConsents(data.consents || []);
+  }
+
+  useEffect(() => {
+    void refresh().catch(() => setMessage("Unable to load screening consents."));
+  }, [tenantId]);
+
+  async function onGrant() {
+    setMessage("");
+    const data = await grantScreeningConsent({ tenantId, landlordId, unitId });
+    setMessage(`Consent granted: ${data.consent.consentId}`);
+    await refresh();
+  }
+
+  async function onRevoke(consentId: string) {
+    setMessage("");
+    await revokeScreeningConsent(tenantId, consentId);
+    setMessage("Consent revoked.");
+    await refresh();
+  }
+
+  const canGrant = Boolean(tenantId && landlordId && unitId);
+
+  return (
+    <main style={pageStyle}>
+      <section style={surfaceStyle}>
+        <h1 style={titleStyle}>Screening consent</h1>
+        <p style={copyStyle}>
+          Grant consent only when you authorize a landlord to start a screening workflow for the selected unit. Consent can be revoked before a request is initiated.
+        </p>
+        <button type="button" onClick={onGrant} disabled={!canGrant} style={primaryButtonStyle}>
+          Grant consent
+        </button>
+        {!canGrant && <p style={mutedStyle}>A tenant, landlord, and unit reference are required.</p>}
+        {message && <p role="status" style={statusStyle}>{message}</p>}
+      </section>
+
+      <section style={surfaceStyle}>
+        <h2 style={sectionTitleStyle}>Active consents</h2>
+        <div style={{ display: "grid", gap: 10 }}>
+          {consents.length === 0 ? (
+            <p style={mutedStyle}>No active consents.</p>
+          ) : (
+            consents.map((consent) => (
+              <div key={consent.consentId} style={itemStyle}>
+                <div>
+                  <strong>{consent.unitId}</strong>
+                  <div style={mutedStyle}>Granted {consent.grantedAt}</div>
+                </div>
+                <button type="button" onClick={() => onRevoke(consent.consentId)} style={secondaryButtonStyle}>
+                  Revoke
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = { padding: 24, display: "grid", gap: 16, maxWidth: 880, margin: "0 auto" };
+const surfaceStyle: React.CSSProperties = { border: "1px solid #dbe3ef", borderRadius: 8, background: "#fff", padding: 18, display: "grid", gap: 12 };
+const titleStyle: React.CSSProperties = { margin: 0, fontSize: 24, color: "#0f172a" };
+const sectionTitleStyle: React.CSSProperties = { margin: 0, fontSize: 18, color: "#0f172a" };
+const copyStyle: React.CSSProperties = { margin: 0, color: "#475569", lineHeight: 1.6 };
+const mutedStyle: React.CSSProperties = { margin: 0, color: "#64748b", fontSize: 13 };
+const statusStyle: React.CSSProperties = { margin: 0, color: "#047857", fontWeight: 700 };
+const itemStyle: React.CSSProperties = { border: "1px solid #e2e8f0", borderRadius: 8, padding: 12, display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" };
+const primaryButtonStyle: React.CSSProperties = { justifySelf: "start", border: 0, borderRadius: 8, background: "#2563eb", color: "#fff", padding: "10px 14px", fontWeight: 800 };
+const secondaryButtonStyle: React.CSSProperties = { border: "1px solid #cbd5e1", borderRadius: 8, background: "#fff", color: "#0f172a", padding: "8px 12px", fontWeight: 700 };


### PR DESCRIPTION
## Scope

Establishes the Phase A provider-neutral screening workflow foundation.

This PR adds backend workflow services, routes, Firestore rules, frontend screening screens, focused tests, and provider integration documentation. It does not add a production provider adapter, change existing screening checkout/report behavior, change billing/pricing/entitlements, or add dependencies.

## Delivered

- Provider-neutral `IScreeningProvider` contract and registry.
- Consent, request, webhook, result, decision, and manual report workflow services.
- Tenant consent, landlord request/status/result/decision/manual report, webhook, and admin audit endpoints.
- Narrow Firestore rules for new screening collections with default deny preserved.
- Tenant consent page, landlord request page, landlord decision page, and shared status component.
- Provider integration contract and operations runbook.
- Pre-implementation audit and implementation summary handoff files.

## Safety

- Tenant endpoints expose consent state only.
- Landlord endpoints expose safe request/result projections only.
- Admin audit endpoints expose safe metadata and payload digests.
- Webhook logs store payload digests, not raw provider payloads.
- Webhook ingestion fails closed for unregistered or unconfigured providers.
- Existing screening checkout/report routes are unchanged.

## Validation

- Backend focused tests: PASS — `npm test -- providerNeutralScreening provider-registry workflow`
- Backend screening tests: PASS — `npm test -- screening` with 25 files and 100 tests passing
- Backend build: PASS — `npm run build`
- Backend full suite: FAIL — 7 known baseline test files, 20 failing tests, 449 files passing, 2192 tests passing
- Backend lint: FAIL — `rentchain-api` has no `lint` script
- Frontend focused tests: PASS — `npm test -- ScreeningStatus ScreeningConsent`
- Frontend screening tests: PASS — `npm test -- screening` with 12 files and 39 tests passing
- Frontend full suite: PASS — 291 files and 1149 tests passing
- Frontend build: PASS — `npm run build`
- Frontend lint: PASS — `npm run lint`
- `git diff --check`: PASS

Backend full-suite failures are outside this mission scope and match known baseline areas: lease draft routes, recipient trust review routes, support console routes, analytics decision mapping, and landlord analytics snapshot.

## Manual QA

Manual QA is required because this PR adds backend routes, frontend routes, and user-visible workflow behavior. It was not completed locally because seeded tenant, landlord, and admin accounts plus storage configuration were not provided.

## Known Limitations

- Provider registry starts empty by design.
- No production provider adapter is included.
- Manual report upload requires `GCS_UPLOAD_BUCKET` at runtime.
- Firestore rules rely on role and ownership claims being present in auth tokens.
- Backend lint remains unavailable until a backend lint script is added.

Do not merge without explicit operator authorization.