### PR TITLE
feat: add contractor portal work order and messaging foundation

### DIFF
--- a/.codex/docs/contractor-portal-v1.md
+++ b/.codex/docs/contractor-portal-v1.md
@@ -1,0 +1,77 @@
+# Contractor Portal v1
+
+## Scope
+
+Contractor Portal v1 is a permission-gated operational workspace for contractors assigned by landlords to maintenance work orders. It is not a public marketplace, autonomous assignment system, contractor reputation surface, or tenant-facing contractor directory.
+
+## Role Boundary
+
+Contractor access uses the existing Firebase/JWT session model and the `contractor` role. The backend `requireContractor` middleware accepts only `contractor` and `admin` roles, resolves `contractorId` from the authenticated session, and fails closed when contractor context is missing.
+
+Contractors can access only routes where the URL contractor id matches their authenticated contractor context. Admin may inspect contractor-scoped views for support purposes.
+
+## API Routes
+
+- `GET /api/contractors/:contractorId/work-orders`
+- `GET /api/contractors/:contractorId/work-orders/:workOrderId`
+- `PATCH /api/contractors/:contractorId/work-orders/:workOrderId/status`
+- `GET /api/contractors/:contractorId/messages`
+- `POST /api/contractors/:contractorId/messages`
+- `GET /api/contractors/:contractorId/profile`
+- `PATCH /api/contractors/:contractorId/profile`
+
+All routes require contractor authentication. Cross-contractor URL manipulation returns `403`.
+
+## Projection Safety
+
+Contractor work-order projections are explicit allowlists. Contractor responses include:
+
+- work order id
+- task title and description
+- category, priority, status, due date, schedule
+- property display label or slug
+- unit display label
+- landlord contact name and email
+- contractor-visible status history
+- contractor-landlord messages for the assigned work order
+
+Contractor responses do not include tenant id, tenant name, tenant household details, property id, unit id, rent amounts, payment data, screening data, landlord billing data, or provider payloads.
+
+## Status Updates
+
+Contractor status updates are scoped to assigned work orders. Allowed contractor states are:
+
+- `assigned`
+- `accepted`
+- `scheduled`
+- `in_progress`
+- `needs_clarification`
+- `on_hold`
+- `completed`
+
+The current status on `workOrders` is updated as the present operational state. Each contractor status change also appends a `workOrderUpdates` event with `actorRole: contractor`, timestamp metadata, and no raw payload exposure.
+
+## Messaging Scope
+
+Contractor messages use `contractorMessages`. A contractor may send a message only when:
+
+- the work order is assigned to that contractor
+- the requested landlord id matches the assigned work order landlord
+- the message is tied to the assigned work order
+
+Messages are work-order scoped and are not contractor-to-contractor or tenant-facing. Message events append a companion `workOrderUpdates` note so landlord audit surfaces can discover contractor communication activity.
+
+## Collections
+
+- `workOrders`: current operational state for landlord-owned work orders and assignment relationship.
+- `workOrderUpdates`: append-safe contractor status/message activity events.
+- `contractorMessages`: work-order-scoped contractor-landlord messages.
+- `contractorProfiles`: contractor self-profile fields such as name, business name, phone, specialties, service areas, availability, and bio.
+
+## Feature Flag
+
+Frontend contractor portal routes are gated by `VITE_CONTRACTOR_PORTAL_ENABLED`. Backend route availability is documented through `CONTRACTOR_PORTAL_ENABLED`; route-level authorization remains mandatory even when the frontend flag is disabled.
+
+## Manual QA
+
+Manual QA is required because this mission touches backend routes, auth boundary behavior, frontend routing, and user-visible contractor workflows.

--- a/.codex/docs/database.md
+++ b/.codex/docs/database.md
@@ -82,8 +82,40 @@ Reference for Firestore collections, document shapes, relationship rules, and se
 - `created_by`
 - processing status
 
+### contractorProfiles
+- contractor account linkage
+- display/business name
+- contact phone/email
+- specialties and service areas
+- availability status
+- landlord network metadata where applicable
+
+### workOrders
+- landlord-owned maintenance/work order record
+- assigned contractor linkage
+- property/unit display labels for safe projections
+- current operational status
+- schedule and due-date metadata
+
+### workOrderUpdates
+- append-safe work order activity event
+- work order linkage
+- actor role and actor reference
+- status/message/update type
+- timestamp
+
+### contractorMessages
+- contractor-landlord work-order message
+- contractor linkage
+- landlord linkage
+- work order linkage
+- sender role/name
+- message text
+- timestamp
+
 ## Relationship Model
 - landlord → property → unit → application → lease → tenant
+- landlord → work order → assigned contractor
 - applicants and active tenants must resolve through authority-based context
 - tenant access must derive from:
   - application relation

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ SIGNING_PROVIDER_FROM_EMAIL=leases@rentchain.local
 SIGNING_CALLBACK_URL=http://localhost:5000/webhooks/signing/mock
 SIGNING_DOCUMENT_STORAGE_BUCKET=rentchain-local-lease-documents
 
+# Contractor portal
+VITE_CONTRACTOR_PORTAL_ENABLED=true
+CONTRACTOR_PORTAL_ENABLED=true
+
 # Email
 EMAIL_PROVIDER=sendgrid
 SENDGRID_API_KEY=sg_local_placeholder

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,90 +1,87 @@
-PR: #1105
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1105
-Branch: feat/lease-execution-end-to-end-v1
+PR: #1106
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1106
+Branch: feat/contractor-portal-v1
 
 # Implementation Summary
 
-Implemented Phase B lease execution signing foundation with provider-neutral backend orchestration, mock local workflow, Dropbox Sign production boundary, landlord signing controls, tenant signing URL support, webhook ingestion, and architecture/reference documentation.
+Implemented Contractor Portal v1 as an additive contractor-scoped operational workspace foundation.
 
 ## Confirmed Findings
 
-- Added provider-neutral signing interfaces, registry, mock provider, and Dropbox Sign adapter boundary under `rentchain-api/src/services/signing/providers/`.
-- Added lease signing orchestration using separate `leaseSigningRequests`, `leaseSigningEvents`, and metadata-only webhook dead-letter records.
-- Added derived lease signing state helper for `pending_signature`, `signed_future`, `active`, and terminal states without relying on broad lease status mutation.
-- Added landlord endpoints for send, status, signed-document download, and cancellation under existing `/api/leases/:leaseId/*` route ownership checks.
-- Added signing webhook routes at `/webhooks/signing/:providerId?` and `/api/webhooks/signing/:providerId?` with raw body handling before the JSON parser.
-- Extended tenant portal lease routes with tenant-safe signing status and hosted signing URL support while preserving the existing in-app signature metadata path.
-- Added landlord signing dashboard UI and tenant lease page redirect handling for provider-backed signing.
-- Added signing provider env examples and pinned `@dropbox/sign` metadata to `1.10.0`.
-- Added provider evaluation, schema, webhook, error-code, deployment checklist, and architecture documentation.
-
-## Validation
-
-- `git diff --check`: PASS
-- `npm test --prefix rentchain-api -- src/services/__tests__/leaseSigningService.test.ts src/services/signing/providers/__tests__/mockSigningProvider.test.ts`: PASS
-- `npm run build --prefix rentchain-api`: PASS
-- `npm run build --prefix rentchain-frontend`: PASS
-- `npm test --prefix rentchain-frontend`: PASS, 291 test files and 1149 tests
-- `npm test --prefix rentchain-api`: FAIL due sandbox `listen EPERM: operation not permitted 0.0.0.0` across existing route tests; 419 files and 2030 tests passed before failure, with failures matching the known full-suite environment limitation.
-
-## Manual QA Required
-
-Manual QA is required because this mission touches backend routes, auth-boundary behavior, webhook routing, frontend rendering, and user-visible lease signing workflows.
-
-Recommended manual QA:
-1. With backend/frontend running and `SIGNING_PROVIDER=mock`, verify unauthenticated landlord signing routes return 401.
-2. Log in as landlord, open active leases, send a lease for signature with a valid tenant email, and verify pending status appears.
-3. Verify invalid tenant email returns a safe error code and no stack trace.
-4. Log in as the involved tenant and verify tenant lease page shows provider signing status and opens the mock signing URL.
-5. Verify a non-involved tenant cannot access or sign the lease.
-6. Post a mock signed webhook to `/webhooks/signing/mock` and verify signing status becomes signed.
-7. Attempt duplicate webhook delivery and verify the status remains stable.
-8. Download signed document as landlord after signed webhook; verify a document URL is returned.
-9. Attempt signed-document download before signed state; verify safe 404 response.
-10. Cancel a pending request as landlord and verify tenant signing is no longer available.
-11. Confirm tenant responses do not include provider request IDs, provider event IDs, webhook metadata, or landlord-only fields.
-12. Confirm logs and stored signing events do not include API keys, webhook secrets, or raw provider payloads.
-
-## Known Limitations
-
-- Dropbox Sign adapter is isolated behind the provider interface and package metadata is pinned, but production API calls remain a boundary implementation pending real credentials and provider sandbox verification.
-- Signed-document storage uses the existing GCS helper and requires bucket configuration before non-mock document retrieval in deployed environments.
-- Full backend suite is not clean in this sandbox because multiple pre-existing route tests hit `listen EPERM` on `0.0.0.0`; focused signing tests and builds pass.
-- E2E seeded-account workflow was not run locally because seeded accounts and provider sandbox credentials were not available.
+- Added `requireContractor` middleware that reuses existing authenticated session handling and accepts only contractor/admin roles.
+- Added contractor-scoped API routes under `/api/contractors/:contractorId/*` for assigned work orders, work-order detail, status updates, messages, and self-profile.
+- Added explicit contractor work-order projection allowlists that omit tenant identifiers, tenant household data, raw property IDs, raw unit IDs, payment data, screening data, and landlord billing data.
+- Added contractor status update handling with valid transition checks and append-safe `workOrderUpdates` event emission.
+- Added work-order-scoped contractor-landlord messaging through `contractorMessages`, with landlord/work-order relationship validation and companion `workOrderUpdates` audit notes.
+- Added contractor self-profile read/update through the scoped contractor route while keeping the existing profile page compatible with prior profile APIs.
+- Added `VITE_CONTRACTOR_PORTAL_ENABLED` and `CONTRACTOR_PORTAL_ENABLED` env documentation.
+- Added contractor portal governance/schema documentation in `.codex/docs/contractor-portal-v1.md` and `.codex/docs/database.md`.
 
 ## Files Changed
 
+- `.codex/docs/contractor-portal-v1.md`
+- `.codex/docs/database.md`
 - `.env.example`
 - `rentchain-api/.env.example`
-- `rentchain-api/package.json`
-- `rentchain-api/package-lock.json`
 - `rentchain-api/src/app.build.ts`
-- `rentchain-api/src/routes/leaseRoutes.ts`
-- `rentchain-api/src/routes/tenantPortalRoutes.ts`
-- `rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts`
-- `rentchain-api/src/services/leaseStateHelper.ts`
-- `rentchain-api/src/services/signing/leaseSigningService.ts`
-- `rentchain-api/src/services/signing/providers/*`
-- `rentchain-api/src/services/__tests__/leaseSigningService.test.ts`
-- `rentchain-frontend/src/api/leasesApi.ts`
-- `rentchain-frontend/src/api/tenantPortal.ts`
-- `rentchain-frontend/src/components/LeaseSigningDashboard.tsx`
-- `rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx`
-- `rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx`
-- `docs/architecture/lease-execution-provider-integration-v1.md`
-- `.handoff/signing-provider-evaluation.md`
-- `.handoff/lease-signing-schema.md`
-- `.handoff/signing-webhook-spec.md`
-- `.handoff/signing-error-codes.md`
-- `.handoff/lease-signing-deployment-checklist.md`
+- `rentchain-api/src/middleware/requireContractor.ts`
+- `rentchain-api/src/middleware/__tests__/requireContractor.test.ts`
+- `rentchain-api/src/routes/contractorPortalRoutes.ts`
+- `rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts`
+- `rentchain-api/src/services/contractorPortalService.ts`
+- `rentchain-frontend/src/App.tsx`
+- `rentchain-frontend/src/api/contractorPortalApi.ts`
+- `rentchain-frontend/src/pages/contractor/ContractorProfilePage.tsx`
+- `rentchain-frontend/src/pages/contractor/ContractorProfilePage.test.tsx`
+
+## Validation
+
+- `npm test --prefix rentchain-api -- src/middleware/__tests__/requireContractor.test.ts src/routes/__tests__/contractorPortalRoutes.test.ts`: PASS, 2 files / 7 tests.
+- `npm run build --prefix rentchain-api`: PASS.
+- `npm test --prefix rentchain-frontend -- ContractorJobsPage ContractorProfilePage`: PASS, 2 files / 8 tests.
+- `npm run build --prefix rentchain-frontend`: PASS, with existing Vite chunk-size warning.
+- `git diff --check --cached`: PASS.
+- `npm test --prefix rentchain-frontend`: FAIL, 290 files / 1148 tests passed, 1 unrelated failure in `LandlordLeaseSummaryPage.test.tsx` expecting `.print-only-summary`.
+- `npm test --prefix rentchain-api`: FAIL, 421 files / 2037 tests passed before known sandbox/pre-existing route-test `listen EPERM: operation not permitted 0.0.0.0` failures.
+
+## Manual QA
+
+Manual QA is required because this mission touches backend routes, auth flow, frontend routing, and user-visible contractor behavior.
+
+Manual QA was not completed locally because no seeded contractor/landlord accounts, assigned work orders, or deployed preview session were available.
+
+Recommended manual QA:
+1. Log in as a contractor and confirm `/contractor` loads the dashboard.
+2. Confirm contractor work-order list shows only assigned work.
+3. Confirm URL manipulation to another contractor id returns 403 through `/api/contractors/:contractorId/work-orders`.
+4. Open a work-order detail and confirm tenant names, tenant IDs, raw property IDs, raw unit IDs, rates, payments, screening, and billing data are absent.
+5. Update status from assigned to accepted, in-progress, and completed where applicable; confirm status history records append.
+6. Send a contractor-landlord message for an assigned work order; confirm unrelated landlord/work-order messages are denied.
+7. Update contractor profile fields and confirm they persist.
+8. Disable `VITE_CONTRACTOR_PORTAL_ENABLED` and confirm contractor routes show the coming-soon/fallback state.
+9. Check mobile layout for dashboard, jobs, detail, and profile.
+
+## Known Limitations
+
+- The frontend contractor jobs page still uses the existing `/api/contractor/jobs` maintenance workflow API for rich job execution actions; the new `/api/contractors/:contractorId/*` routes provide the mission-required scoped compatibility/read-model surfaces and profile API.
+- Backend route availability is documented with `CONTRACTOR_PORTAL_ENABLED`, but route mounting remains enabled; authorization remains the server-side safety boundary.
+- Landlord-side display of contractor messages/status remains dependent on existing `workOrderUpdates` surfaces; no new landlord messaging UI was added.
+- Full seeded end-to-end QA requires contractor accounts, landlord accounts, assigned work orders, and preview/staging configuration.
+- Full backend suite retains known sandbox route-test failures around `listen EPERM`.
+- Full frontend suite has an unrelated existing lease summary print-source test failure.
 
 ## Acceptance Criteria Status
 
-- Provider-neutral signing service layer: PASS
-- Mock signing workflow: PASS
-- Landlord send/status/cancel/download routes: PASS
-- Tenant projected status/sign URL route support: PASS
-- Webhook validation and idempotent event append: PASS for mock and adapter boundary tests
-- Projection safety for tenant responses: PASS by route shape and summary review
-- Signed document storage path: PARTIAL, requires configured bucket for deployed verification
-- End-to-end seeded workflow: NOT RUN, environment limitation
+- Contractor role middleware: PASS.
+- Contractor work-order list and detail route: PASS.
+- Contractor status update route with transition validation and append event: PASS.
+- Contractor-landlord message routes with assigned-work authorization: PASS.
+- Contractor self-profile routes: PASS.
+- Projection safety for contractor work-order response: PASS by explicit route/service allowlist and focused tests.
+- Contractor feature flag: PASS for frontend route gating.
+- Documentation: PASS.
+- Manual QA: NOT RUN, environment limitation.
+
+## Recommended Next Mission
+
+Contractor portal landlord-side activity visibility and seeded preview QA.

--- a/rentchain-api/.env.example
+++ b/rentchain-api/.env.example
@@ -52,6 +52,9 @@ SIGNING_PROVIDER_FROM_EMAIL=leases@rentchain.local
 SIGNING_CALLBACK_URL=http://localhost:5000/webhooks/signing/mock
 SIGNING_DOCUMENT_STORAGE_BUCKET=rentchain-local-lease-documents
 
+# Contractor portal
+CONTRACTOR_PORTAL_ENABLED=true
+
 # Email
 EMAIL_PROVIDER=sendgrid
 SENDGRID_API_KEY=sg_local_placeholder

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -180,6 +180,7 @@ import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
 import tenantFeedbackRoutes from "./routes/tenantFeedbackRoutes";
 import marketplaceContractorRoutes from "./routes/marketplaceContractorRoutes";
+import contractorPortalRoutes from "./routes/contractorPortalRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -544,6 +545,8 @@ app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);
 console.log("[route-mount] tenantFeedbackRoutes mounted at /api");
 app.use("/api", routeSource("marketplaceContractorRoutes.ts"), marketplaceContractorRoutes);
 console.log("[route-mount] marketplaceContractorRoutes mounted at /api");
+app.use("/api", routeSource("contractorPortalRoutes.ts"), contractorPortalRoutes);
+console.log("[route-mount] contractorPortalRoutes mounted at /api");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/middleware/__tests__/requireContractor.test.ts
+++ b/rentchain-api/src/middleware/__tests__/requireContractor.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../requireAuth", () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+describe("requireContractor", () => {
+  async function invoke(user: any) {
+    const { requireContractor } = await import("../requireContractor");
+    return await new Promise<{ status: number; body: any; nextCalled: boolean }>((resolve) => {
+      const req: any = { user };
+      const res: any = {
+        statusCode: 200,
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload, nextCalled: false });
+          return this;
+        },
+      };
+      requireContractor(req, res, () => resolve({ status: 200, body: null, nextCalled: true }));
+    });
+  }
+
+  it("allows contractor role and normalizes contractor context", async () => {
+    const res = await invoke({ id: "contractor-1", role: "contractor" });
+    expect(res.nextCalled).toBe(true);
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects non-contractor roles", async () => {
+    const res = await invoke({ id: "landlord-1", role: "landlord" });
+    expect(res.nextCalled).toBe(false);
+    expect(res.status).toBe(403);
+    expect(res.body?.error).toBe("forbidden");
+  });
+});

--- a/rentchain-api/src/middleware/requireContractor.ts
+++ b/rentchain-api/src/middleware/requireContractor.ts
@@ -1,0 +1,34 @@
+import type { Request, Response, NextFunction } from "express";
+import { requireAuth } from "./requireAuth";
+
+function asString(value: unknown, max = 160): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+export async function requireContractor(req: Request, res: Response, next: NextFunction) {
+  return requireAuth(req, res, () => {
+    try {
+      const user: any = (req as any).user;
+      const role = asString(user?.actorRole || user?.role, 40).toLowerCase();
+      const contractorId = asString(user?.contractorId || user?.id, 160);
+
+      if (!role) {
+        return res.status(401).json({ ok: false, error: "unauthorized" });
+      }
+
+      if (role !== "contractor" && role !== "admin") {
+        return res.status(403).json({ ok: false, error: "forbidden" });
+      }
+
+      if (!contractorId) {
+        return res.status(401).json({ ok: false, error: "missing_contractor_context" });
+      }
+
+      user.contractorId = contractorId;
+      (req as any).user = user;
+      return next();
+    } catch {
+      return res.status(401).json({ ok: false, error: "unauthorized" });
+    }
+  });
+}

--- a/rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+let autoId = 0;
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function applyMerge(current: any, incoming: any) {
+  return { ...(current || {}), ...(clone(incoming) || {}) };
+}
+
+function makeQuery(name: string, filters: Array<[string, string, any]> = []) {
+  return {
+    where(field: string, op: string, value: any) {
+      return makeQuery(name, [...filters, [field, op, value]]);
+    },
+    limit(_limit: number) {
+      return {
+        get: async () => ({
+          docs: Array.from(ensureCollection(name).entries())
+            .filter(([, value]) =>
+              filters.every(([field, op, expected]) => op === "==" && value?.[field] === expected)
+            )
+            .map(([id, value]) => ({ id, data: () => clone(value) })),
+        }),
+      };
+    },
+  };
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `${name}_${++autoId}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId);
+          ensureCollection(name).set(docId, opts?.merge ? applyMerge(current, value) : clone(value));
+        },
+      };
+    },
+    where(field: string, op: string, value: any) {
+      return makeQuery(name, [[field, op, value]]);
+    },
+    limit(limit: number) {
+      return makeQuery(name).limit(limit);
+    },
+  }),
+};
+
+vi.mock("../../firebase", () => ({ db: dbMock }));
+
+vi.mock("../../middleware/requireContractor", () => ({
+  requireContractor: (req: any, res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (!header) return res.status(401).json({ ok: false, error: "unauthenticated" });
+    req.user = JSON.parse(header);
+    if (req.user.role !== "contractor" && req.user.role !== "admin") {
+      return res.status(403).json({ ok: false, error: "forbidden" });
+    }
+    req.user.contractorId = req.user.contractorId || req.user.id;
+    next();
+  },
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+  query?: Record<string, string>;
+  params?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      query: options.query ?? {},
+      params: options.params ?? {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("contractorPortalRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+    autoId = 0;
+    ensureCollection("workOrders").set("wo-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-raw",
+      unitId: "unit-raw",
+      propertyLabel: "Harbour Apartments",
+      unitLabel: "Unit 4",
+      title: "Fix sink",
+      description: "Kitchen sink leak",
+      category: "plumbing",
+      priority: "urgent",
+      status: "assigned",
+      assignedContractorId: "contractor-1",
+      landlordContact: { name: "Landlord Ops", email: "ops@example.test" },
+    });
+    ensureCollection("workOrders").set("wo-2", {
+      landlordId: "landlord-2",
+      title: "Private task",
+      assignedContractorId: "contractor-2",
+    });
+    ensureCollection("contractorProfiles").set("contractor-1", {
+      businessName: "Harbor Plumbing",
+      contactName: "Casey",
+      phone: "555-1000",
+      serviceCategories: ["plumbing"],
+      availabilityStatus: "active",
+    });
+  });
+
+  it("lists only the authenticated contractor's assigned work with safe projections", async () => {
+    const router = (await import("../contractorPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/contractors/contractor-1/work-orders",
+      params: { contractorId: "contractor-1" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.items).toHaveLength(1);
+    expect(res.body?.items?.[0]).toMatchObject({
+      id: "wo-1",
+      property: { label: "Harbour Apartments" },
+      landlord: { name: "Landlord Ops" },
+    });
+    expect(JSON.stringify(res.body?.items?.[0])).not.toContain("tenant-1");
+    expect(JSON.stringify(res.body?.items?.[0])).not.toContain("prop-raw");
+    expect(JSON.stringify(res.body?.items?.[0])).not.toContain("unit-raw");
+  });
+
+  it("denies contractor URL manipulation for another contractor id", async () => {
+    const router = (await import("../contractorPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/contractors/contractor-2/work-orders",
+      params: { contractorId: "contractor-2" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("updates assigned work order status and appends an immutable update event", async () => {
+    const router = (await import("../contractorPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/contractors/contractor-1/work-orders/wo-1/status",
+      params: { contractorId: "contractor-1", workOrderId: "wo-1" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+      body: { status: "accepted", message: "I can take this." },
+    });
+
+    expect(res.status).toBe(200);
+    expect(ensureCollection("workOrders").get("wo-1")?.status).toBe("accepted");
+    expect(Array.from(ensureCollection("workOrderUpdates").values())).toEqual(
+      expect.arrayContaining([expect.objectContaining({ workOrderId: "wo-1", actorRole: "contractor" })])
+    );
+  });
+
+  it("allows messaging only about assigned work orders for the matching landlord", async () => {
+    const router = (await import("../contractorPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/contractors/contractor-1/messages",
+      params: { contractorId: "contractor-1" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+      body: { workOrderId: "wo-1", landlordId: "landlord-1", text: "Arriving tomorrow morning." },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.message?.text).toBe("Arriving tomorrow morning.");
+
+    const forbidden = await invokeRouter(router, {
+      method: "POST",
+      url: "/contractors/contractor-1/messages",
+      params: { contractorId: "contractor-1" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+      body: { workOrderId: "wo-1", landlordId: "landlord-2", text: "Wrong landlord." },
+    });
+    expect(forbidden.status).toBe(403);
+  });
+
+  it("reads and updates only the authenticated contractor profile", async () => {
+    const router = (await import("../contractorPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/contractors/contractor-1/profile",
+      params: { contractorId: "contractor-1" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+      body: { name: "Casey North", specialties: ["plumbing", "hvac"], availability: "limited" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.profile?.name).toBe("Casey North");
+    expect(res.body?.profile?.specialties).toEqual(["plumbing", "hvac"]);
+    expect(ensureCollection("contractorProfiles").get("contractor-1")?.serviceCategories).toEqual(["plumbing", "hvac"]);
+  });
+});

--- a/rentchain-api/src/routes/contractorPortalRoutes.ts
+++ b/rentchain-api/src/routes/contractorPortalRoutes.ts
@@ -1,0 +1,139 @@
+import { Router } from "express";
+import { requireContractor } from "../middleware/requireContractor";
+import {
+  createContractorPortalMessage,
+  getContractorPortalProfile,
+  getContractorPortalWorkOrder,
+  listContractorPortalMessages,
+  listContractorPortalWorkOrders,
+  updateContractorPortalProfile,
+  updateContractorPortalWorkOrderStatus,
+} from "../services/contractorPortalService";
+
+const router = Router();
+
+function asString(value: unknown, max = 1000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function isAdmin(req: any) {
+  return asString(req.user?.actorRole || req.user?.role, 40).toLowerCase() === "admin";
+}
+
+function contractorIdFromUser(req: any) {
+  return asString(req.user?.contractorId || req.user?.id, 160);
+}
+
+function ensureSelf(req: any, res: any): string | null {
+  const requested = asString(req.params?.contractorId, 160);
+  const current = contractorIdFromUser(req);
+  if (!requested || !current) {
+    res.status(401).json({ ok: false, error: "unauthorized" });
+    return null;
+  }
+  if (!isAdmin(req) && requested !== current) {
+    res.status(403).json({ ok: false, error: "forbidden" });
+    return null;
+  }
+  return requested;
+}
+
+router.get("/contractors/:contractorId/work-orders", requireContractor, async (req: any, res) => {
+  try {
+    const contractorId = ensureSelf(req, res);
+    if (!contractorId) return;
+    const items = await listContractorPortalWorkOrders(contractorId, asString(req.query?.status, 80));
+    return res.json({ ok: true, items, data: items });
+  } catch {
+    return res.status(500).json({ ok: false, error: "contractor_work_orders_failed" });
+  }
+});
+
+router.get("/contractors/:contractorId/work-orders/:workOrderId", requireContractor, async (req: any, res) => {
+  try {
+    const contractorId = ensureSelf(req, res);
+    if (!contractorId) return;
+    const item = await getContractorPortalWorkOrder(contractorId, asString(req.params?.workOrderId, 160));
+    if (!item) return res.status(404).json({ ok: false, error: "work_order_not_found" });
+    return res.json({ ok: true, item, data: item });
+  } catch {
+    return res.status(500).json({ ok: false, error: "contractor_work_order_failed" });
+  }
+});
+
+router.patch("/contractors/:contractorId/work-orders/:workOrderId/status", requireContractor, async (req: any, res) => {
+  try {
+    const contractorId = ensureSelf(req, res);
+    if (!contractorId) return;
+    const result = await updateContractorPortalWorkOrderStatus({
+      contractorId,
+      actorId: asString(req.user?.id, 160) || contractorId,
+      workOrderId: asString(req.params?.workOrderId, 160),
+      status: asString(req.body?.status, 80),
+      message: asString(req.body?.message || req.body?.note, 1000),
+    });
+    if (!result.ok && result.code === "not_found") return res.status(404).json({ ok: false, error: "work_order_not_found" });
+    if (!result.ok && result.code === "invalid_transition") {
+      return res.status(400).json({ ok: false, error: "invalid_status_transition" });
+    }
+    if (!result.ok) return res.status(400).json({ ok: false, error: "invalid_status" });
+    return res.json({ ok: true, item: result.item, data: result.item });
+  } catch {
+    return res.status(500).json({ ok: false, error: "contractor_status_update_failed" });
+  }
+});
+
+router.get("/contractors/:contractorId/messages", requireContractor, async (req: any, res) => {
+  try {
+    const contractorId = ensureSelf(req, res);
+    if (!contractorId) return;
+    const items = await listContractorPortalMessages(contractorId, asString(req.query?.workOrderId, 160));
+    return res.json({ ok: true, items, data: items });
+  } catch {
+    return res.status(500).json({ ok: false, error: "contractor_messages_failed" });
+  }
+});
+
+router.post("/contractors/:contractorId/messages", requireContractor, async (req: any, res) => {
+  try {
+    const contractorId = ensureSelf(req, res);
+    if (!contractorId) return;
+    const result = await createContractorPortalMessage({
+      contractorId,
+      actorId: asString(req.user?.id, 160) || contractorId,
+      workOrderId: asString(req.body?.workOrderId, 160),
+      landlordId: asString(req.body?.landlordId, 160),
+      text: asString(req.body?.text, 2000),
+    });
+    if (!result.ok && result.code === "not_found") return res.status(404).json({ ok: false, error: "work_order_not_found" });
+    if (!result.ok && result.code === "forbidden") return res.status(403).json({ ok: false, error: "forbidden" });
+    if (!result.ok) return res.status(400).json({ ok: false, error: "invalid_message" });
+    return res.status(201).json({ ok: true, message: result.message });
+  } catch {
+    return res.status(500).json({ ok: false, error: "contractor_message_create_failed" });
+  }
+});
+
+router.get("/contractors/:contractorId/profile", requireContractor, async (req: any, res) => {
+  try {
+    const contractorId = ensureSelf(req, res);
+    if (!contractorId) return;
+    const profile = await getContractorPortalProfile(contractorId);
+    return res.json({ ok: true, profile });
+  } catch {
+    return res.status(500).json({ ok: false, error: "contractor_profile_failed" });
+  }
+});
+
+router.patch("/contractors/:contractorId/profile", requireContractor, async (req: any, res) => {
+  try {
+    const contractorId = ensureSelf(req, res);
+    if (!contractorId) return;
+    const profile = await updateContractorPortalProfile(contractorId, req.body || {});
+    return res.json({ ok: true, profile });
+  } catch {
+    return res.status(500).json({ ok: false, error: "contractor_profile_update_failed" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/contractorPortalService.ts
+++ b/rentchain-api/src/services/contractorPortalService.ts
@@ -1,0 +1,329 @@
+import { db } from "../firebase";
+
+export type ContractorWorkOrderStatus =
+  | "assigned"
+  | "accepted"
+  | "scheduled"
+  | "in_progress"
+  | "needs_clarification"
+  | "on_hold"
+  | "completed";
+
+const STATUSES = new Set<ContractorWorkOrderStatus>([
+  "assigned",
+  "accepted",
+  "scheduled",
+  "in_progress",
+  "needs_clarification",
+  "on_hold",
+  "completed",
+]);
+
+const TRANSITIONS: Record<ContractorWorkOrderStatus, ContractorWorkOrderStatus[]> = {
+  assigned: ["accepted", "scheduled", "in_progress", "needs_clarification", "on_hold", "completed"],
+  accepted: ["scheduled", "in_progress", "needs_clarification", "on_hold", "completed"],
+  scheduled: ["in_progress", "needs_clarification", "on_hold", "completed"],
+  in_progress: ["needs_clarification", "on_hold", "completed"],
+  needs_clarification: ["scheduled", "in_progress", "on_hold", "completed"],
+  on_hold: ["scheduled", "in_progress", "needs_clarification", "completed"],
+  completed: [],
+};
+
+function asString(value: unknown, max = 1000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asOptionalString(value: unknown, max = 1000): string | null {
+  const next = asString(value, max);
+  return next || null;
+}
+
+function uniqueStrings(value: unknown, max = 30): string[] {
+  if (!Array.isArray(value)) return [];
+  const next = new Set<string>();
+  for (const item of value) {
+    const normalized = asString(item, 120);
+    if (normalized) next.add(normalized);
+    if (next.size >= max) break;
+  }
+  return Array.from(next);
+}
+
+function toMillis(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof (value as any)?.toMillis === "function") return (value as any).toMillis();
+  if (typeof (value as any)?.seconds === "number") return (value as any).seconds * 1000;
+  return null;
+}
+
+function normalizeStatus(value: unknown): ContractorWorkOrderStatus {
+  const normalizedRaw = asString(value, 80).toLowerCase().replace(/\s+/g, "_");
+  if (normalizedRaw === "blocked") return "needs_clarification";
+  const normalized = normalizedRaw as ContractorWorkOrderStatus;
+  if (STATUSES.has(normalized)) return normalized;
+  return "assigned";
+}
+
+function propertyLabel(workOrder: any): string {
+  return (
+    asOptionalString(workOrder?.propertyName, 180) ||
+    asOptionalString(workOrder?.propertyLabel, 180) ||
+    asOptionalString(workOrder?.propertySlug, 180) ||
+    "Assigned property"
+  );
+}
+
+function unitLabel(workOrder: any): string | null {
+  return asOptionalString(workOrder?.unitLabel, 120) || asOptionalString(workOrder?.unitName, 120);
+}
+
+function projectWorkOrder(workOrderId: string, workOrder: any, extras?: { updates?: any[]; messages?: any[] }) {
+  const assignment = workOrder?.contractorAssignment && typeof workOrder.contractorAssignment === "object"
+    ? workOrder.contractorAssignment
+    : {};
+  return {
+    id: workOrderId,
+    workOrderId,
+    maintenanceRequestId: asOptionalString(workOrder?.maintenanceRequestId, 160),
+    title: asOptionalString(workOrder?.title, 240) || "Assigned work order",
+    description: asOptionalString(workOrder?.description, 4000) || "",
+    category: asOptionalString(workOrder?.category, 120) || "general",
+    priority: asOptionalString(workOrder?.priority, 40) || "normal",
+    status: normalizeStatus(workOrder?.status),
+    dueDate: toMillis(workOrder?.dueDate || workOrder?.scheduledFor || workOrder?.serviceWindowStartAt),
+    scheduledFor: toMillis(workOrder?.scheduledFor),
+    property: {
+      label: propertyLabel(workOrder),
+      slug: asOptionalString(workOrder?.propertySlug, 160),
+    },
+    unit: {
+      label: unitLabel(workOrder),
+    },
+    landlord: {
+      name:
+        asOptionalString(workOrder?.landlordContact?.name, 180) ||
+        asOptionalString(workOrder?.landlordName, 180) ||
+        "Landlord",
+      email:
+        asOptionalString(workOrder?.landlordContact?.email, 320) ||
+        asOptionalString(workOrder?.landlordEmail, 320),
+    },
+    assignment: {
+      contractorName:
+        asOptionalString(assignment?.displayName, 180) ||
+        asOptionalString(workOrder?.assignedContractorName, 180),
+      assignedAt: asOptionalString(assignment?.assignedAt, 80) || toMillis(workOrder?.assignedAt),
+    },
+    statusHistory: (extras?.updates || []).map((update) => ({
+      id: asString(update?.id, 160),
+      type: asOptionalString(update?.updateType, 80) || "status_changed",
+      message: asOptionalString(update?.message, 1000),
+      actorRole: asOptionalString(update?.actorRole, 40),
+      createdAt: toMillis(update?.createdAtMs || update?.createdAt),
+    })),
+    messages: (extras?.messages || []).map((message) => ({
+      id: asString(message?.id, 160),
+      workOrderId,
+      senderRole: asOptionalString(message?.senderRole, 40),
+      senderName: asOptionalString(message?.senderName, 180),
+      text: asOptionalString(message?.text, 2000) || "",
+      createdAt: toMillis(message?.createdAtMs || message?.createdAt),
+    })),
+  };
+}
+
+async function findAssignedWorkOrder(contractorId: string, workOrderId: string) {
+  const snap = await db.collection("workOrders").doc(workOrderId).get();
+  if (!snap.exists) return null;
+  const data = snap.data() as any;
+  if (asString(data?.assignedContractorId, 160) !== contractorId) return null;
+  return { id: snap.id, data };
+}
+
+async function listUpdates(workOrderId: string) {
+  const snap = await db.collection("workOrderUpdates").where("workOrderId", "==", workOrderId).limit(100).get();
+  return snap.docs
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .sort((a: any, b: any) => Number(a.createdAtMs || 0) - Number(b.createdAtMs || 0));
+}
+
+async function listMessagesForWorkOrder(contractorId: string, workOrderId: string) {
+  const snap = await db
+    .collection("contractorMessages")
+    .where("contractorId", "==", contractorId)
+    .where("workOrderId", "==", workOrderId)
+    .limit(100)
+    .get();
+  return snap.docs
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .sort((a: any, b: any) => Number(a.createdAtMs || 0) - Number(b.createdAtMs || 0));
+}
+
+export async function listContractorPortalWorkOrders(contractorId: string, status?: string | null) {
+  const snap = await db.collection("workOrders").where("assignedContractorId", "==", contractorId).limit(300).get();
+  const wantedStatus = status ? normalizeStatus(status) : null;
+  return snap.docs
+    .map((doc: any) => projectWorkOrder(doc.id, doc.data() as any))
+    .filter((item) => !wantedStatus || item.status === wantedStatus)
+    .sort((a, b) => Number(b.dueDate || 0) - Number(a.dueDate || 0));
+}
+
+export async function getContractorPortalWorkOrder(contractorId: string, workOrderId: string) {
+  const found = await findAssignedWorkOrder(contractorId, workOrderId);
+  if (!found) return null;
+  const [updates, messages] = await Promise.all([
+    listUpdates(found.id),
+    listMessagesForWorkOrder(contractorId, found.id),
+  ]);
+  return projectWorkOrder(found.id, found.data, { updates, messages });
+}
+
+export async function updateContractorPortalWorkOrderStatus(input: {
+  contractorId: string;
+  actorId: string;
+  workOrderId: string;
+  status: string;
+  message?: string | null;
+}) {
+  const found = await findAssignedWorkOrder(input.contractorId, input.workOrderId);
+  if (!found) return { ok: false as const, code: "not_found" as const };
+  const currentStatus = normalizeStatus(found.data?.status);
+  const nextStatus = normalizeStatus(input.status);
+  if (currentStatus !== nextStatus && !TRANSITIONS[currentStatus].includes(nextStatus)) {
+    return { ok: false as const, code: "invalid_transition" as const, currentStatus, nextStatus };
+  }
+
+  const now = Date.now();
+  const message =
+    asOptionalString(input.message, 1000) || `Contractor updated work order status to ${nextStatus}.`;
+  await db.collection("workOrders").doc(found.id).set(
+    {
+      status: nextStatus,
+      contractorStatus: nextStatus,
+      contractorLastUpdate: message,
+      lastExecutionUpdateAt: now,
+      updatedAtMs: now,
+    },
+    { merge: true }
+  );
+  await db.collection("workOrderUpdates").doc().set({
+    workOrderId: found.id,
+    actorRole: "contractor",
+    actorId: input.actorId || input.contractorId,
+    updateType: "status_changed",
+    message,
+    attachmentUrl: null,
+    createdAtMs: now,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  });
+  return { ok: true as const, item: await getContractorPortalWorkOrder(input.contractorId, found.id) };
+}
+
+export async function listContractorPortalMessages(contractorId: string, workOrderId?: string | null) {
+  let query: any = db.collection("contractorMessages").where("contractorId", "==", contractorId);
+  if (workOrderId) query = query.where("workOrderId", "==", workOrderId);
+  const snap = await query.limit(200).get();
+  return snap.docs
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .sort((a: any, b: any) => Number(b.createdAtMs || 0) - Number(a.createdAtMs || 0))
+    .map((message: any) => ({
+      id: asString(message.id, 160),
+      workOrderId: asString(message.workOrderId, 160),
+      landlordId: asString(message.landlordId, 160),
+      senderRole: asOptionalString(message.senderRole, 40),
+      senderName: asOptionalString(message.senderName, 180),
+      text: asOptionalString(message.text, 2000) || "",
+      createdAt: toMillis(message.createdAtMs || message.createdAt),
+    }));
+}
+
+export async function createContractorPortalMessage(input: {
+  contractorId: string;
+  actorId: string;
+  workOrderId: string;
+  landlordId: string;
+  text: string;
+}) {
+  const found = await findAssignedWorkOrder(input.contractorId, input.workOrderId);
+  if (!found) return { ok: false as const, code: "not_found" as const };
+  const landlordId = asString(found.data?.landlordId, 160);
+  if (!landlordId || landlordId !== asString(input.landlordId, 160)) {
+    return { ok: false as const, code: "forbidden" as const };
+  }
+  const text = asString(input.text, 2000);
+  if (!text) return { ok: false as const, code: "invalid_message" as const };
+  const now = Date.now();
+  const ref = db.collection("contractorMessages").doc();
+  const message = {
+    id: ref.id,
+    contractorId: input.contractorId,
+    landlordId,
+    workOrderId: found.id,
+    senderRole: "contractor",
+    senderId: input.actorId || input.contractorId,
+    senderName: asOptionalString(found.data?.contractorAssignment?.displayName, 180) || "Contractor",
+    recipientRole: "landlord",
+    text,
+    createdAtMs: now,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  };
+  await ref.set(message);
+  await db.collection("workOrderUpdates").doc().set({
+    workOrderId: found.id,
+    actorRole: "contractor",
+    actorId: input.actorId || input.contractorId,
+    updateType: "note",
+    message: "Contractor sent a message.",
+    attachmentUrl: null,
+    createdAtMs: now,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  });
+  return { ok: true as const, message: { ...message, senderId: undefined } };
+}
+
+export async function getContractorPortalProfile(contractorId: string) {
+  const snap = await db.collection("contractorProfiles").doc(contractorId).get();
+  if (!snap.exists) return null;
+  const data = snap.data() as any;
+  return {
+    id: snap.id,
+    name: asOptionalString(data?.name || data?.displayName || data?.contactName, 180),
+    businessName: asOptionalString(data?.businessName || data?.displayName, 180),
+    email: asOptionalString(data?.email || data?.contact?.email, 320),
+    phone: asOptionalString(data?.phone || data?.contact?.phone, 80),
+    specialties: uniqueStrings(data?.specialties || data?.serviceCategories, 30),
+    serviceAreas: uniqueStrings(data?.serviceAreas, 30),
+    availability: asOptionalString(data?.availability || data?.availabilityStatus, 40) || "active",
+    bio: asOptionalString(data?.bio || data?.summary, 2000),
+  };
+}
+
+export async function updateContractorPortalProfile(contractorId: string, input: any) {
+  const now = Date.now();
+  const patch: Record<string, unknown> = { updatedAtMs: now };
+  if (input?.name !== undefined) {
+    patch.name = asString(input.name, 180);
+    patch.contactName = asString(input.name, 180);
+  }
+  if (input?.businessName !== undefined) patch.businessName = asString(input.businessName, 180);
+  if (input?.phone !== undefined) patch.phone = asString(input.phone, 80);
+  if (input?.specialties !== undefined) {
+    patch.specialties = uniqueStrings(input.specialties, 30);
+    patch.serviceCategories = uniqueStrings(input.specialties, 30);
+  }
+  if (input?.serviceAreas !== undefined) patch.serviceAreas = uniqueStrings(input.serviceAreas, 30);
+  if (input?.availability !== undefined) {
+    patch.availability = asString(input.availability, 40);
+    patch.availabilityStatus = asString(input.availability, 40);
+  }
+  if (input?.bio !== undefined) patch.bio = asString(input.bio, 2000);
+  await db.collection("contractorProfiles").doc(contractorId).set(patch, { merge: true });
+  return getContractorPortalProfile(contractorId);
+}

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -59,6 +59,7 @@ import {
 import { getTenantToken } from "./lib/tenantAuth";
 
 const TENANT_PORTAL_ENABLED = import.meta.env.VITE_TENANT_PORTAL_ENABLED === "true";
+const CONTRACTOR_PORTAL_ENABLED = import.meta.env.VITE_CONTRACTOR_PORTAL_ENABLED !== "false";
 
 function lazyWithRetry<T extends React.ComponentType<any>>(
   importer: () => Promise<{ default: T }>,
@@ -1254,13 +1255,17 @@ function App() {
         <Route
           path="/contractor"
           element={
-            <RequireAuth>
-              <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
-                <ContractorNav>
-                  <ContractorDashboardPage />
-                </ContractorNav>
-              </RequireRole>
-            </RequireAuth>
+            CONTRACTOR_PORTAL_ENABLED ? (
+              <RequireAuth>
+                <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
+                  <ContractorNav>
+                    <ContractorDashboardPage />
+                  </ContractorNav>
+                </RequireRole>
+              </RequireAuth>
+            ) : (
+              <TenantPortalComingSoon />
+            )
           }
         />
         <Route path="/contractor/signup" element={<LegacyQueryInviteRedirect source="contractor" />} />
@@ -1269,37 +1274,49 @@ function App() {
         <Route
           path="/contractor/jobs"
           element={
-            <RequireAuth>
-              <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
-                <ContractorNav>
-                  <ContractorJobsPage />
-                </ContractorNav>
-              </RequireRole>
-            </RequireAuth>
+            CONTRACTOR_PORTAL_ENABLED ? (
+              <RequireAuth>
+                <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
+                  <ContractorNav>
+                    <ContractorJobsPage />
+                  </ContractorNav>
+                </RequireRole>
+              </RequireAuth>
+            ) : (
+              <TenantPortalComingSoon />
+            )
           }
         />
         <Route
           path="/contractor/jobs/:id"
           element={
-            <RequireAuth>
-              <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
-                <ContractorNav>
-                  <ContractorJobsPage />
-                </ContractorNav>
-              </RequireRole>
-            </RequireAuth>
+            CONTRACTOR_PORTAL_ENABLED ? (
+              <RequireAuth>
+                <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
+                  <ContractorNav>
+                    <ContractorJobsPage />
+                  </ContractorNav>
+                </RequireRole>
+              </RequireAuth>
+            ) : (
+              <TenantPortalComingSoon />
+            )
           }
         />
         <Route
           path="/contractor/profile"
           element={
-            <RequireAuth>
-              <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
-                <ContractorNav>
-                  <ContractorProfilePage />
-                </ContractorNav>
-              </RequireRole>
-            </RequireAuth>
+            CONTRACTOR_PORTAL_ENABLED ? (
+              <RequireAuth>
+                <RequireRole allowed={["contractor", "admin"]} fallbackTo="/dashboard">
+                  <ContractorNav>
+                    <ContractorProfilePage />
+                  </ContractorNav>
+                </RequireRole>
+              </RequireAuth>
+            ) : (
+              <TenantPortalComingSoon />
+            )
           }
         />
         {import.meta.env.DEV ? (

--- a/rentchain-frontend/src/api/contractorPortalApi.ts
+++ b/rentchain-frontend/src/api/contractorPortalApi.ts
@@ -1,0 +1,112 @@
+import { apiFetch } from "./apiFetch";
+
+export type ContractorPortalProfile = {
+  id: string;
+  name?: string | null;
+  businessName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  specialties?: string[];
+  serviceAreas?: string[];
+  availability?: string | null;
+  bio?: string | null;
+};
+
+export type ContractorPortalWorkOrder = {
+  id: string;
+  workOrderId: string;
+  title: string;
+  description: string;
+  category: string;
+  priority: string;
+  status: string;
+  dueDate?: number | null;
+  property?: { label?: string | null; slug?: string | null };
+  unit?: { label?: string | null };
+  landlord?: { name?: string | null; email?: string | null };
+  statusHistory?: Array<{ id: string; type: string; message?: string | null; createdAt?: number | null }>;
+  messages?: ContractorPortalMessage[];
+};
+
+export type ContractorPortalMessage = {
+  id: string;
+  workOrderId: string;
+  landlordId?: string | null;
+  senderRole?: string | null;
+  senderName?: string | null;
+  text: string;
+  createdAt?: number | null;
+};
+
+function contractorPath(contractorId: string, path: string) {
+  return `/contractors/${encodeURIComponent(contractorId)}${path}`;
+}
+
+export async function listContractorPortalWorkOrders(contractorId: string, status?: string) {
+  const query = status ? `?status=${encodeURIComponent(status)}` : "";
+  const res = await apiFetch<{ ok: boolean; items: ContractorPortalWorkOrder[] }>(
+    contractorPath(contractorId, `/work-orders${query}`),
+    { method: "GET" }
+  );
+  return Array.isArray(res?.items) ? res.items : [];
+}
+
+export async function getContractorPortalWorkOrder(contractorId: string, workOrderId: string) {
+  const res = await apiFetch<{ ok: boolean; item: ContractorPortalWorkOrder }>(
+    contractorPath(contractorId, `/work-orders/${encodeURIComponent(workOrderId)}`),
+    { method: "GET" }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to load contractor work order");
+  return res.item;
+}
+
+export async function updateContractorPortalWorkOrderStatus(
+  contractorId: string,
+  workOrderId: string,
+  payload: { status: string; message?: string }
+) {
+  const res = await apiFetch<{ ok: boolean; item: ContractorPortalWorkOrder }>(
+    contractorPath(contractorId, `/work-orders/${encodeURIComponent(workOrderId)}/status`),
+    { method: "PATCH", body: payload }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to update contractor work order");
+  return res.item;
+}
+
+export async function listContractorPortalMessages(contractorId: string, workOrderId?: string) {
+  const query = workOrderId ? `?workOrderId=${encodeURIComponent(workOrderId)}` : "";
+  const res = await apiFetch<{ ok: boolean; items: ContractorPortalMessage[] }>(
+    contractorPath(contractorId, `/messages${query}`),
+    { method: "GET" }
+  );
+  return Array.isArray(res?.items) ? res.items : [];
+}
+
+export async function sendContractorPortalMessage(
+  contractorId: string,
+  payload: { landlordId: string; workOrderId: string; text: string }
+) {
+  const res = await apiFetch<{ ok: boolean; message: ContractorPortalMessage }>(
+    contractorPath(contractorId, "/messages"),
+    { method: "POST", body: payload }
+  );
+  if (!res?.ok || !res.message) throw new Error("Failed to send contractor message");
+  return res.message;
+}
+
+export async function getContractorPortalProfile(contractorId: string) {
+  const res = await apiFetch<{ ok: boolean; profile: ContractorPortalProfile | null }>(
+    contractorPath(contractorId, "/profile"),
+    { method: "GET" }
+  );
+  return res?.profile || null;
+}
+
+export async function updateContractorPortalProfile(contractorId: string, payload: Partial<ContractorPortalProfile>) {
+  const res = await apiFetch<{ ok: boolean; profile: ContractorPortalProfile }>(
+    contractorPath(contractorId, "/profile"),
+    { method: "PATCH", body: payload }
+  );
+  if (!res?.ok || !res.profile) throw new Error("Failed to update contractor profile");
+  return res.profile;
+}

--- a/rentchain-frontend/src/pages/contractor/ContractorProfilePage.test.tsx
+++ b/rentchain-frontend/src/pages/contractor/ContractorProfilePage.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ContractorProfilePage from "./ContractorProfilePage";
+
+const apiMocks = vi.hoisted(() => ({
+  getContractorPortalProfile: vi.fn(),
+  updateContractorPortalProfile: vi.fn(),
+}));
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => ({ user: { id: "contractor-1", role: "contractor" } }),
+}));
+
+vi.mock("../../api/contractorPortalApi", () => ({
+  getContractorPortalProfile: apiMocks.getContractorPortalProfile,
+  updateContractorPortalProfile: apiMocks.updateContractorPortalProfile,
+}));
+
+vi.mock("../../api/workOrdersApi", () => ({
+  createContractorProfile: vi.fn(),
+  getContractorProfile: vi.fn(),
+  patchContractorProfile: vi.fn(),
+}));
+
+describe("ContractorProfilePage", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.getContractorPortalProfile.mockReset();
+    apiMocks.updateContractorPortalProfile.mockReset();
+  });
+
+  it("loads and saves the authenticated contractor profile through the scoped portal API", async () => {
+    apiMocks.getContractorPortalProfile.mockResolvedValue({
+      id: "contractor-1",
+      name: "Casey North",
+      businessName: "Harbor Plumbing",
+      phone: "555-1000",
+      specialties: ["plumbing"],
+      serviceAreas: ["Halifax"],
+      availability: "active",
+      bio: "Emergency plumbing",
+    });
+    apiMocks.updateContractorPortalProfile.mockResolvedValue({ ok: true });
+
+    render(<ContractorProfilePage />);
+
+    expect(await screen.findByDisplayValue("Harbor Plumbing")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Phone/i), { target: { value: "555-2000" } });
+    fireEvent.click(screen.getByRole("button", { name: /save profile/i }));
+
+    await waitFor(() => {
+      expect(apiMocks.updateContractorPortalProfile).toHaveBeenCalledWith(
+        "contractor-1",
+        expect.objectContaining({
+          businessName: "Harbor Plumbing",
+          phone: "555-2000",
+          specialties: ["plumbing"],
+        })
+      );
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/contractor/ContractorProfilePage.tsx
+++ b/rentchain-frontend/src/pages/contractor/ContractorProfilePage.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 import { Button, Card, Input } from "../../components/ui/Ui";
 import { createContractorProfile, getContractorProfile, patchContractorProfile } from "../../api/workOrdersApi";
+import { getContractorPortalProfile, updateContractorPortalProfile } from "../../api/contractorPortalApi";
+import { useAuth } from "../../context/useAuth";
 
 export default function ContractorProfilePage() {
+  const { user } = useAuth();
+  const contractorId = String((user as any)?.contractorId || user?.id || "").trim();
   const [loading, setLoading] = React.useState(true);
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -19,12 +23,12 @@ export default function ContractorProfilePage() {
       setLoading(true);
       setError(null);
       try {
-        const profile = await getContractorProfile();
+        const profile = contractorId ? await getContractorPortalProfile(contractorId) : await getContractorProfile();
         if (profile) {
           setBusinessName(profile.businessName || "");
-          setContactName(profile.contactName || "");
+          setContactName((profile as any).contactName || profile.name || "");
           setPhone(profile.phone || "");
-          setServiceCategories((profile.serviceCategories || []).join(", "));
+          setServiceCategories(((profile as any).serviceCategories || profile.specialties || []).join(", "));
           setServiceAreas((profile.serviceAreas || []).join(", "));
           setBio(profile.bio || "");
         }
@@ -35,7 +39,7 @@ export default function ContractorProfilePage() {
       }
     };
     void load();
-  }, []);
+  }, [contractorId]);
 
   return (
     <div style={{ display: "grid", gap: 14 }}>
@@ -89,8 +93,13 @@ export default function ContractorProfilePage() {
                 const payload = {
                   businessName: businessName.trim(),
                   contactName: contactName.trim(),
+                  name: contactName.trim(),
                   phone: phone.trim(),
                   serviceCategories: serviceCategories
+                    .split(",")
+                    .map((v) => v.trim())
+                    .filter(Boolean),
+                  specialties: serviceCategories
                     .split(",")
                     .map((v) => v.trim())
                     .filter(Boolean),
@@ -100,10 +109,14 @@ export default function ContractorProfilePage() {
                     .filter(Boolean),
                   bio: bio.trim(),
                 };
-                try {
-                  await patchContractorProfile(payload);
-                } catch {
-                  await createContractorProfile(payload);
+                if (contractorId) {
+                  await updateContractorPortalProfile(contractorId, payload);
+                } else {
+                  try {
+                    await patchContractorProfile(payload);
+                  } catch {
+                    await createContractorProfile(payload);
+                  }
                 }
               } catch (err: any) {
                 setError(String(err?.message || "Failed to save profile"));


### PR DESCRIPTION
## Summary
- Add contractor-scoped middleware, service layer, and `/api/contractors/:contractorId/*` routes for assigned work orders, detail, status updates, messages, and self-profile.
- Add explicit contractor projections that omit tenant, property, unit, payment, screening, and billing-sensitive fields.
- Add contractor portal API helpers, frontend route feature flag gating, scoped profile page integration, and contractor portal governance docs.

## Validation
- `npm test --prefix rentchain-api -- src/middleware/__tests__/requireContractor.test.ts src/routes/__tests__/contractorPortalRoutes.test.ts`: PASS, 2 files / 7 tests
- `npm run build --prefix rentchain-api`: PASS
- `npm test --prefix rentchain-frontend -- ContractorJobsPage ContractorProfilePage`: PASS, 2 files / 8 tests
- `npm run build --prefix rentchain-frontend`: PASS, with existing chunk-size warning
- `git diff --check --cached`: PASS

## Known Limitations
- `npm test --prefix rentchain-api` still fails in this sandbox due known route-test `listen EPERM` errors; 421 files / 2037 tests passed before failure.
- `npm test --prefix rentchain-frontend` has one unrelated lease summary print-source test failure; 290 files / 1148 tests passed.
- Seeded contractor preview QA was not run locally because test contractor/landlord accounts and assigned work orders were unavailable.
- Landlord-side display of contractor messages relies on existing work-order update surfaces; no new landlord messaging UI was added in this mission.