### PR TITLE
fix: add notice automation validation rules and authorization enforcement

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,87 +1,94 @@
-PR: #1106
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1106
-Branch: feat/contractor-portal-v1
+PR: #1107
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1107
+Branch: fix/notice-automation-validation-v1
 
 # Implementation Summary
 
-Implemented Contractor Portal v1 as an additive contractor-scoped operational workspace foundation.
+Mission: Notice Automation Validation and Rule Enforcement
+
+Implemented deterministic notice automation validation for the existing lease notice workflow. The implementation stays inside the current notice service and landlord route surfaces, preserving the existing feature flag, landlord authorization middleware, tenant route protections, notice templates, delivery provider behavior, Firestore rules, billing, screening, and infrastructure.
 
 ## Confirmed Findings
 
-- Added `requireContractor` middleware that reuses existing authenticated session handling and accepts only contractor/admin roles.
-- Added contractor-scoped API routes under `/api/contractors/:contractorId/*` for assigned work orders, work-order detail, status updates, messages, and self-profile.
-- Added explicit contractor work-order projection allowlists that omit tenant identifiers, tenant household data, raw property IDs, raw unit IDs, payment data, screening data, and landlord billing data.
-- Added contractor status update handling with valid transition checks and append-safe `workOrderUpdates` event emission.
-- Added work-order-scoped contractor-landlord messaging through `contractorMessages`, with landlord/work-order relationship validation and companion `workOrderUpdates` audit notes.
-- Added contractor self-profile read/update through the scoped contractor route while keeping the existing profile page compatible with prior profile APIs.
-- Added `VITE_CONTRACTOR_PORTAL_ENABLED` and `CONTRACTOR_PORTAL_ENABLED` env documentation.
-- Added contractor portal governance/schema documentation in `.codex/docs/contractor-portal-v1.md` and `.codex/docs/database.md`.
+- Current notice automation uses `leaseNoticeWorkflowService.ts`, `leaseNoticeLandlordRoutes.ts`, and `tenantLeaseNoticeRoutes.ts`; the older mission names `noticeService.ts` and `noticeRoutes.ts` are not present in the current source tree.
+- Landlord notice routes remain behind `requireLandlord` and the lease notice feature flag.
+- Tenant notice routes remain behind authenticated tenant role checks.
+- Existing policy evaluation remains in place for preview/send actions.
+- Existing tenant notice projections already redact landlord-only notes, internal workflow state, and provider delivery payloads.
+
+## Changes Made
+
+- Added pure notice validation rules in `rentchain-api/src/services/noticeValidationRules.ts`.
+- Added validation checks for lease state, tenant context, landlord context, property/unit context, rent terms, supported jurisdiction, allowed notice type, term dates, and response deadline.
+- Added compatibility wrappers for eviction, cure, and termination notice validation paths.
+- Updated `buildPreview` to fail closed with `LEASE_NOTICE_VALIDATION_FAILED` and safe `failedRules` before preview generation succeeds.
+- Updated send flow to reject invalid prerequisites before notice document creation.
+- Moved tenant delivery contact resolution ahead of notice creation so a missing or invalid tenant delivery contact does not create a pending notice.
+- Added append-safe validation audit events through `leaseWorkflowEvents` for validation failures and included validation context in notice creation audit data.
+- Updated landlord preview route to return safe validation failure payloads and append validation audit events when preview validation fails.
+- Added unit coverage for notice validation rules and service validation gating.
 
 ## Files Changed
 
-- `.codex/docs/contractor-portal-v1.md`
-- `.codex/docs/database.md`
-- `.env.example`
-- `rentchain-api/.env.example`
-- `rentchain-api/src/app.build.ts`
-- `rentchain-api/src/middleware/requireContractor.ts`
-- `rentchain-api/src/middleware/__tests__/requireContractor.test.ts`
-- `rentchain-api/src/routes/contractorPortalRoutes.ts`
-- `rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts`
-- `rentchain-api/src/services/contractorPortalService.ts`
-- `rentchain-frontend/src/App.tsx`
-- `rentchain-frontend/src/api/contractorPortalApi.ts`
-- `rentchain-frontend/src/pages/contractor/ContractorProfilePage.tsx`
-- `rentchain-frontend/src/pages/contractor/ContractorProfilePage.test.tsx`
+- `rentchain-api/src/services/noticeValidationRules.ts`
+- `rentchain-api/src/services/leaseNoticeWorkflowService.ts`
+- `rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts`
+- `rentchain-api/src/services/__tests__/noticeValidationRules.test.ts`
+- `rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts`
+- `.handoff/impl-summary.md`
 
 ## Validation
 
-- `npm test --prefix rentchain-api -- src/middleware/__tests__/requireContractor.test.ts src/routes/__tests__/contractorPortalRoutes.test.ts`: PASS, 2 files / 7 tests.
-- `npm run build --prefix rentchain-api`: PASS.
-- `npm test --prefix rentchain-frontend -- ContractorJobsPage ContractorProfilePage`: PASS, 2 files / 8 tests.
-- `npm run build --prefix rentchain-frontend`: PASS, with existing Vite chunk-size warning.
-- `git diff --check --cached`: PASS.
-- `npm test --prefix rentchain-frontend`: FAIL, 290 files / 1148 tests passed, 1 unrelated failure in `LandlordLeaseSummaryPage.test.tsx` expecting `.print-only-summary`.
-- `npm test --prefix rentchain-api`: FAIL, 421 files / 2037 tests passed before known sandbox/pre-existing route-test `listen EPERM: operation not permitted 0.0.0.0` failures.
+- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/services/__tests__/noticeValidationRules.test.ts src/services/__tests__/leaseNoticeWorkflowService.test.ts src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts src/routes/__tests__/tenantLeaseNoticeRoutes.test.ts`
+  - PASS: 4 test files, 21 tests
+- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
+  - PASS
+- `git diff --check`
+  - PASS
+- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test`
+  - FAIL: full backend suite hit unrelated sandbox/pre-existing `listen EPERM: operation not permitted 0.0.0.0` failures in route tests outside the notice workflow. Targeted notice suites passed.
 
 ## Manual QA
 
-Manual QA is required because this mission touches backend routes, auth flow, frontend routing, and user-visible contractor behavior.
+Manual QA is required because this mission changes backend route behavior and user-visible API validation responses.
 
-Manual QA was not completed locally because no seeded contractor/landlord accounts, assigned work orders, or deployed preview session were available.
+Manual QA not completed in this local environment. Required preview QA:
 
-Recommended manual QA:
-1. Log in as a contractor and confirm `/contractor` loads the dashboard.
-2. Confirm contractor work-order list shows only assigned work.
-3. Confirm URL manipulation to another contractor id returns 403 through `/api/contractors/:contractorId/work-orders`.
-4. Open a work-order detail and confirm tenant names, tenant IDs, raw property IDs, raw unit IDs, rates, payments, screening, and billing data are absent.
-5. Update status from assigned to accepted, in-progress, and completed where applicable; confirm status history records append.
-6. Send a contractor-landlord message for an assigned work order; confirm unrelated landlord/work-order messages are denied.
-7. Update contractor profile fields and confirm they persist.
-8. Disable `VITE_CONTRACTOR_PORTAL_ENABLED` and confirm contractor routes show the coming-soon/fallback state.
-9. Check mobile layout for dashboard, jobs, detail, and profile.
+1. No auth on landlord notice preview/send endpoints returns 401.
+2. Landlord cannot preview/send notice for another landlord's lease; response is 403.
+3. Valid active lease with tenant contact, landlord context, property/unit context, rent terms, supported jurisdiction, term dates, and response deadline can generate a notice.
+4. Lease missing tenant context or tenant delivery contact fails with 400 and `LEASE_NOTICE_VALIDATION_FAILED`.
+5. Lease missing rent terms fails with 400 and safe `failedRules`.
+6. Unsupported jurisdiction or disallowed notice type fails with 400 and safe `failedRules`.
+7. Validation failures create append-safe `leaseWorkflowEvents` entries without creating notice documents.
+8. Tenant notice list/detail projections still exclude landlord-only notes, provider payloads, and internal workflow state.
+
+## Protected Areas
+
+- No billing changes.
+- No auth core changes.
+- No screening provider changes.
+- No pricing or entitlement changes.
+- No CI/CD, deployment, Firestore rules, Terraform, or migration changes.
+- No frontend, templates, notice delivery routing, SMS, or external legal service changes.
 
 ## Known Limitations
 
-- The frontend contractor jobs page still uses the existing `/api/contractor/jobs` maintenance workflow API for rich job execution actions; the new `/api/contractors/:contractorId/*` routes provide the mission-required scoped compatibility/read-model surfaces and profile API.
-- Backend route availability is documented with `CONTRACTOR_PORTAL_ENABLED`, but route mounting remains enabled; authorization remains the server-side safety boundary.
-- Landlord-side display of contractor messages/status remains dependent on existing `workOrderUpdates` surfaces; no new landlord messaging UI was added.
-- Full seeded end-to-end QA requires contractor accounts, landlord accounts, assigned work orders, and preview/staging configuration.
-- Full backend suite retains known sandbox route-test failures around `listen EPERM`.
-- Full frontend suite has an unrelated existing lease summary print-source test failure.
+- Validation treats canonical tenant/landlord context plus resolved tenant delivery email as the available contact boundary; deeper contact profile validation remains future work.
+- Full manual E2E requires seeded landlord/tenant leases and a configured preview email environment.
+- Full backend suite remains blocked locally by unrelated `listen EPERM` route-test failures.
 
 ## Acceptance Criteria Status
 
-- Contractor role middleware: PASS.
-- Contractor work-order list and detail route: PASS.
-- Contractor status update route with transition validation and append event: PASS.
-- Contractor-landlord message routes with assigned-work authorization: PASS.
-- Contractor self-profile routes: PASS.
-- Projection safety for contractor work-order response: PASS by explicit route/service allowlist and focused tests.
-- Contractor feature flag: PASS for frontend route gating.
-- Documentation: PASS.
-- Manual QA: NOT RUN, environment limitation.
+- Pure deterministic validation helpers: completed.
+- Validation gate before notice generation: completed.
+- Safe validation error payloads: completed.
+- Append-safe validation audit context: completed.
+- Authorization boundaries preserved: completed by existing route middleware and tests.
+- Projection safety preserved: completed by existing tenant projection tests.
+- No protected areas modified: completed.
+- Manual QA: pending preview environment.
 
 ## Recommended Next Mission
 
-Contractor portal landlord-side activity visibility and seeded preview QA.
+Run manual preview QA for notice validation with seeded lease fixtures, then continue to Phase E billing checkout alignment if Gate 2 approves this mission.

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -265,7 +265,30 @@ router.post("/:id/notice-preview", async (req: any, res) => {
       noticeType: (String(req.body?.noticeType || "").trim().toLowerCase() || undefined) as LeaseNoticeType | undefined,
     });
     if (!previewResult.ok) {
-      return res.status(400).json({ ok: false, error: previewResult.error });
+      if (previewResult.validation) {
+        await appendLeaseWorkflowEvent({
+          entityType: "lease",
+          entityId: leaseId,
+          leaseId,
+          landlordId,
+          tenantId: leaseResult.lease.tenantId,
+          propertyId: leaseResult.lease.propertyId,
+          unitId: leaseResult.lease.unitId,
+          actorType: "landlord",
+          actorId,
+          eventType: "lease_notice_validation_checked",
+          eventData: {
+            ok: previewResult.validation.ok,
+            checkedRules: previewResult.validation.checkedRules,
+            failedRules: previewResult.validation.failedRules,
+          },
+        });
+      }
+      return res.status(400).json({
+        ok: false,
+        error: previewResult.error,
+        failedRules: previewResult.failedRules,
+      });
     }
 
     console.info("[lease-notice] preview-generated", {

--- a/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
@@ -138,6 +138,7 @@ describe("leaseNoticeWorkflowService renewal operator inputs", () => {
       leaseType: "fixed_term",
       province: "NS",
       currentRent: 1650,
+      leaseStartDate: "2025-05-11",
       leaseEndDate: "2026-05-10",
       status: "active",
     });
@@ -164,6 +165,39 @@ describe("leaseNoticeWorkflowService renewal operator inputs", () => {
       version: "ns-v1",
       sensitivity: "restricted",
     });
+  });
+
+  it("fails preview generation before notice creation when lease prerequisites are incomplete", () => {
+    const lease = normalizeLeaseRecord("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseType: "fixed_term",
+      province: "NS",
+      currentRent: 1650,
+      leaseStartDate: "2025-05-11",
+      leaseEndDate: "2026-05-10",
+      status: "active",
+    });
+
+    const previewResult = buildPreview(lease, {
+      rentChangeMode: "no_change",
+      newTermType: "fixed_term",
+      newLeaseStartDate: "2026-05-11",
+      newLeaseEndDate: "2027-05-10",
+      responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+    });
+
+    expect(previewResult.ok).toBe(false);
+    expect(previewResult.error).toBe("LEASE_NOTICE_VALIDATION_FAILED");
+    expect(previewResult.failedRules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "tenant_context_present",
+        }),
+      ])
+    );
   });
 
   it("builds one landlord-visible renewal dataset from end-date eligibility and preserves response buckets", async () => {

--- a/rentchain-api/src/services/__tests__/noticeValidationRules.test.ts
+++ b/rentchain-api/src/services/__tests__/noticeValidationRules.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canGenerateCureNotice,
+  canGenerateEvictionNotice,
+  canGenerateTerminationNotice,
+  validateNoticeAutomationPrerequisites,
+} from "../noticeValidationRules";
+
+function validLease(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "lease-1",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    status: "active",
+    leaseType: "fixed_term",
+    province: "NS",
+    leaseStartDate: "2026-02-01",
+    leaseEndDate: "2027-01-31",
+    currentRent: 1800,
+    currency: "CAD",
+    autoNoticeEnabled: true,
+    noticeRuleVersion: "ns-v1",
+    noticeLeadDays: 90,
+    nextNoticeDueAt: Date.UTC(2026, 10, 1, 12, 0, 0, 0),
+    latestNoticeId: null,
+    latestRenewalIntent: null,
+    latestRenewalIntentAt: null,
+    renewalRentChangeMode: null,
+    renewalOfferedRent: null,
+    renewalDecisionDeadlineAt: null,
+    renewalNewTermType: null,
+    renewalNewLeaseStartDate: null,
+    renewalNewLeaseEndDate: null,
+    moveOutDate: null,
+    createdAt: Date.UTC(2026, 0, 1, 12, 0, 0, 0),
+    updatedAt: Date.UTC(2026, 0, 1, 12, 0, 0, 0),
+    tenantName: "Tenant One",
+    unitLabel: "Unit 1",
+    propertyLabel: "Property One",
+    propertyAddress: "1 Main St",
+    jurisdictionWorkflow: null,
+    ...overrides,
+  } as any;
+}
+
+const validPreviewInput = {
+  rentChangeMode: "no_change" as const,
+  proposedRent: null,
+  newTermType: "fixed_term" as const,
+  newLeaseStartDate: "2027-02-01",
+  newLeaseEndDate: "2028-01-31",
+  responseDeadlineAt: Date.UTC(2027, 0, 15, 12, 0, 0, 0),
+  noticeType: "renewal_offer" as const,
+};
+
+describe("noticeValidationRules", () => {
+  it("allows complete active leases with supported jurisdiction rules", () => {
+    const result = validateNoticeAutomationPrerequisites({
+      lease: validLease(),
+      previewInput: validPreviewInput,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.failedRules).toEqual([]);
+    expect(result.checkedRules).toEqual(
+      expect.arrayContaining([
+        "lease_state_allowed",
+        "tenant_context_present",
+        "landlord_context_present",
+        "jurisdiction_supported",
+        "notice_type_allowed",
+      ])
+    );
+  });
+
+  it("fails closed for blocked lease states", () => {
+    const result = canGenerateEvictionNotice(validLease({ status: "ended" }), validPreviewInput);
+
+    expect(result.ok).toBe(false);
+    expect(result.failedRules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "lease_state_allowed",
+        }),
+      ])
+    );
+  });
+
+  it("requires tenant, landlord, property, unit, and rent context", () => {
+    const result = canGenerateCureNotice(
+      validLease({
+        tenantId: "",
+        landlordId: "",
+        propertyId: "",
+        unitId: "",
+        currentRent: null,
+      }),
+      validPreviewInput
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failedRules.map((rule) => rule.code)).toEqual(
+      expect.arrayContaining([
+        "tenant_context_present",
+        "landlord_context_present",
+        "lease_property_context_present",
+        "rent_terms_present",
+      ])
+    );
+  });
+
+  it("rejects unsupported jurisdictions and disallowed notice types", () => {
+    const unsupported = canGenerateTerminationNotice(validLease({ province: "ZZ" }), validPreviewInput);
+    expect(unsupported.ok).toBe(false);
+    expect(unsupported.failedRules.map((rule) => rule.code)).toEqual(
+      expect.arrayContaining(["jurisdiction_supported", "notice_type_allowed"])
+    );
+
+    const wrongType = validateNoticeAutomationPrerequisites({
+      lease: validLease({ leaseType: "month_to_month", leaseEndDate: null }),
+      previewInput: {
+        ...validPreviewInput,
+        noticeType: "renewal_offer",
+        newLeaseEndDate: null,
+      },
+    });
+    expect(wrongType.ok).toBe(false);
+    expect(wrongType.failedRules.map((rule) => rule.code)).toContain("notice_type_allowed");
+  });
+
+  it("requires term dates and response deadlines required by the notice rule", () => {
+    const result = validateNoticeAutomationPrerequisites({
+      lease: validLease({ leaseStartDate: null, leaseEndDate: null }),
+      previewInput: {
+        ...validPreviewInput,
+        newLeaseStartDate: "",
+        newLeaseEndDate: null,
+        responseDeadlineAt: 0,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failedRules.map((rule) => rule.code)).toEqual(
+      expect.arrayContaining(["term_dates_present", "response_deadline_present"])
+    );
+  });
+});

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -17,11 +17,13 @@ import { toAutopilotPolicySummary } from "../lib/policy/policyEvaluator";
 import { loadUnitsForProperty, resolveUnitReference } from "./leaseCanonicalizationService";
 import { isTargetedHiddenLeaseId } from "../lib/testDataVisibilityTargets";
 import { composeLeaseNoticeLegalDocument } from "../lib/legalDocuments/leaseNoticeComposition";
+import { validateNoticeAutomationPrerequisites, type NoticeValidationResult } from "./noticeValidationRules";
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export type LeaseWorkflowEventType =
   | "lease_notice_due"
+  | "lease_notice_validation_checked"
   | "lease_notice_preview_generated"
   | "lease_notice_sent"
   | "tenant_viewed_notice"
@@ -84,6 +86,7 @@ export type LeaseNoticeSendResult = {
   payload: {
     ok: boolean;
     error?: string;
+    failedRules?: NoticeValidationResult["failedRules"];
     noticeId?: string;
     delivery?: {
       ok?: boolean;
@@ -119,6 +122,14 @@ export type LeaseNoticeExecutionInputSnapshot = {
   newLeaseEndDate: string | null;
   responseDeadlineAt: number | null;
 };
+
+function serializeNoticeValidationResult(result: NoticeValidationResult) {
+  return {
+    ok: result.ok,
+    checkedRules: result.checkedRules,
+    failedRules: result.failedRules,
+  };
+}
 
 export type LeaseRenewalWorkflowBucket = "expiring" | "pending-response" | "no-response";
 
@@ -694,33 +705,42 @@ export async function getLeaseForTenantWorkflow(noticeId: string, tenantId: stri
 export function buildPreview(lease: LeaseWorkflowLease, input: LeaseNoticePreviewInput) {
   const rule = resolveLeaseNoticeRule({ province: lease.province, leaseType: lease.leaseType });
   if (!rule) {
-    return { ok: false as const, error: "RULE_NOT_SUPPORTED" };
+    return { ok: false as const, error: "RULE_NOT_SUPPORTED", failedRules: [], validation: null };
+  }
+  const validation = validateNoticeAutomationPrerequisites({ lease, previewInput: input });
+  if (!validation.ok) {
+    return {
+      ok: false as const,
+      error: "LEASE_NOTICE_VALIDATION_FAILED",
+      failedRules: validation.failedRules,
+      validation,
+    };
   }
   const noticeType = input.noticeType || determineNoticeType(lease);
   if (!rule.allowedNoticeTypes.includes(noticeType)) {
-    return { ok: false as const, error: "NOTICE_TYPE_NOT_ALLOWED" };
+    return { ok: false as const, error: "NOTICE_TYPE_NOT_ALLOWED", failedRules: [], validation: null };
   }
   if (!["no_change", "increase", "decrease", "undecided"].includes(input.rentChangeMode)) {
-    return { ok: false as const, error: "INVALID_RENT_CHANGE_MODE" };
+    return { ok: false as const, error: "INVALID_RENT_CHANGE_MODE", failedRules: [], validation: null };
   }
   const proposedRent = input.proposedRent ?? null;
   if ((input.rentChangeMode === "increase" || input.rentChangeMode === "decrease") && !(typeof proposedRent === "number" && Number.isFinite(proposedRent) && proposedRent > 0)) {
-    return { ok: false as const, error: "PROPOSED_RENT_REQUIRED" };
+    return { ok: false as const, error: "PROPOSED_RENT_REQUIRED", failedRules: [], validation: null };
   }
   if (input.rentChangeMode === "undecided" && !rule.allowUndecidedRent) {
-    return { ok: false as const, error: "UNDECIDED_RENT_NOT_ALLOWED" };
+    return { ok: false as const, error: "UNDECIDED_RENT_NOT_ALLOWED", failedRules: [], validation: null };
   }
   const newLeaseStartDate = toDateOnly(input.newLeaseStartDate);
   const newLeaseEndDate = toDateOnly(input.newLeaseEndDate || null);
   if (!newLeaseStartDate) {
-    return { ok: false as const, error: "NEW_LEASE_START_DATE_REQUIRED" };
+    return { ok: false as const, error: "NEW_LEASE_START_DATE_REQUIRED", failedRules: [], validation: null };
   }
   if (rule.requireTermDates && !newLeaseEndDate) {
-    return { ok: false as const, error: "NEW_LEASE_END_DATE_REQUIRED" };
+    return { ok: false as const, error: "NEW_LEASE_END_DATE_REQUIRED", failedRules: [], validation: null };
   }
   const responseDeadlineAt = toMillis(input.responseDeadlineAt);
   if (!responseDeadlineAt) {
-    return { ok: false as const, error: "RESPONSE_DEADLINE_REQUIRED" };
+    return { ok: false as const, error: "RESPONSE_DEADLINE_REQUIRED", failedRules: [], validation: null };
   }
   const noticeDueAt = lease.nextNoticeDueAt || (lease.leaseEndDate ? minusDays(lease.leaseEndDate, rule.noticeLeadDays) : null);
   const effectiveProposedRent =
@@ -775,7 +795,7 @@ export function buildPreview(lease: LeaseWorkflowLease, input: LeaseNoticePrevie
     },
     legalDocumentMetadata: legalDocument.metadata,
   };
-  return { ok: true as const, rule, preview };
+  return { ok: true as const, rule, preview, validation };
 }
 
 export async function performLeaseNoticeSendFromPreviewInput(params: {
@@ -789,7 +809,64 @@ export async function performLeaseNoticeSendFromPreviewInput(params: {
   const { leaseId, landlordId, actorId, lease, previewInput, autopilotPolicy } = params;
   const previewResult = buildPreview(lease, previewInput);
   if (!previewResult.ok) {
-    return { status: 400, payload: { ok: false, error: previewResult.error, autopilotPolicy } };
+    if (previewResult.validation) {
+      await appendLeaseWorkflowEvent({
+        entityType: "lease",
+        entityId: leaseId,
+        leaseId,
+        landlordId,
+        tenantId: lease.tenantId,
+        propertyId: lease.propertyId,
+        unitId: lease.unitId,
+        actorType: "landlord",
+        actorId,
+        eventType: "lease_notice_validation_checked",
+        eventData: serializeNoticeValidationResult(previewResult.validation),
+      });
+    }
+    return {
+      status: 400,
+      payload: {
+        ok: false,
+        error: previewResult.error,
+        failedRules: previewResult.failedRules,
+        autopilotPolicy,
+      },
+    };
+  }
+
+  const tenantEmail = await lookupUserEmail(lease.tenantId, ["tenants", "users"]);
+  if (!tenantEmail || !emailRegex.test(tenantEmail)) {
+    const contactFailure = {
+      code: "tenant_context_present" as const,
+      message: "Tenant delivery contact must resolve before notice generation.",
+    };
+    await appendLeaseWorkflowEvent({
+      entityType: "lease",
+      entityId: leaseId,
+      leaseId,
+      landlordId,
+      tenantId: lease.tenantId,
+      propertyId: lease.propertyId,
+      unitId: lease.unitId,
+      actorType: "landlord",
+      actorId,
+      eventType: "lease_notice_validation_checked",
+      eventData: {
+        ok: false,
+        checkedRules: [...previewResult.validation.checkedRules, "tenant_delivery_contact_resolved"],
+        failedRules: [contactFailure],
+      },
+    });
+    return {
+      status: 400,
+      payload: {
+        ok: false,
+        error: "LEASE_NOTICE_VALIDATION_FAILED",
+        failedRules: [contactFailure],
+        autopilotPolicy,
+      },
+    };
   }
 
   const noticeRef = db.collection("leaseNotices").doc();
@@ -864,11 +941,11 @@ export async function performLeaseNoticeSendFromPreviewInput(params: {
     eventData: {
       noticeType: baseNotice.noticeType,
       responseDeadlineAt: baseNotice.responseDeadlineAt,
+      validation: serializeNoticeValidationResult(previewResult.validation),
     },
   });
   await batch.commit();
 
-  const tenantEmail = await lookupUserEmail(lease.tenantId, ["tenants", "users"]);
   const tenantUrl = `${String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "")}/tenant/login?next=${encodeURIComponent(`/tenant/lease-notices/${noticeRef.id}`)}`;
   const emailResult = await sendLeaseWorkflowEmail({
     eventKey: "lease_notice_sent_tenant",

--- a/rentchain-api/src/services/noticeValidationRules.ts
+++ b/rentchain-api/src/services/noticeValidationRules.ts
@@ -1,0 +1,170 @@
+import { resolveLeaseNoticeRule, type LeaseNoticeType } from "../config/leaseNoticeRules";
+import type { LeaseNoticePreviewInput, LeaseWorkflowLease } from "./leaseNoticeWorkflowService";
+
+export type NoticeValidationRuleCode =
+  | "lease_state_allowed"
+  | "tenant_context_present"
+  | "landlord_context_present"
+  | "lease_property_context_present"
+  | "rent_terms_present"
+  | "jurisdiction_supported"
+  | "notice_type_allowed"
+  | "term_dates_present"
+  | "response_deadline_present";
+
+export type NoticeValidationFailure = {
+  code: NoticeValidationRuleCode;
+  message: string;
+};
+
+export type NoticeValidationResult = {
+  ok: boolean;
+  checkedRules: NoticeValidationRuleCode[];
+  failedRules: NoticeValidationFailure[];
+};
+
+const ALLOWED_GENERATION_STATES = new Set(["active", "notice_pending", "renewal_pending"]);
+const BLOCKED_GENERATION_STATES = new Set(["ended", "archived", "terminated", "disputed"]);
+
+function addFailure(
+  failures: NoticeValidationFailure[],
+  code: NoticeValidationRuleCode,
+  message: string,
+  condition: boolean
+) {
+  if (!condition) failures.push({ code, message });
+}
+
+function hasPositiveNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function hasDateOnly(value: unknown) {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function normalizeNoticeType(value: unknown): LeaseNoticeType | null {
+  const raw = String(value || "").trim().toLowerCase();
+  if (
+    raw === "renewal_offer" ||
+    raw === "end_of_term_notice" ||
+    raw === "non_renewal" ||
+    raw === "month_to_month_notice"
+  ) {
+    return raw;
+  }
+  return null;
+}
+
+function defaultNoticeType(lease: LeaseWorkflowLease): LeaseNoticeType {
+  return lease.leaseType === "month_to_month" ? "month_to_month_notice" : "renewal_offer";
+}
+
+export function validateNoticeAutomationPrerequisites(input: {
+  lease: LeaseWorkflowLease;
+  previewInput: LeaseNoticePreviewInput;
+}): NoticeValidationResult {
+  const { lease, previewInput } = input;
+  const checkedRules: NoticeValidationRuleCode[] = [
+    "lease_state_allowed",
+    "tenant_context_present",
+    "landlord_context_present",
+    "lease_property_context_present",
+    "rent_terms_present",
+    "jurisdiction_supported",
+    "notice_type_allowed",
+    "term_dates_present",
+    "response_deadline_present",
+  ];
+  const failedRules: NoticeValidationFailure[] = [];
+  const status = String(lease.status || "").trim().toLowerCase();
+  const rule = resolveLeaseNoticeRule({ province: lease.province, leaseType: lease.leaseType });
+  const noticeType = normalizeNoticeType(previewInput.noticeType) || defaultNoticeType(lease);
+
+  addFailure(
+    failedRules,
+    "lease_state_allowed",
+    "Lease must be in an active notice workflow state.",
+    ALLOWED_GENERATION_STATES.has(status) && !BLOCKED_GENERATION_STATES.has(status)
+  );
+  addFailure(
+    failedRules,
+    "tenant_context_present",
+    "Lease must include tenant context before a notice can be generated.",
+    Boolean(String(lease.tenantId || "").trim())
+  );
+  addFailure(
+    failedRules,
+    "landlord_context_present",
+    "Lease must include landlord context before a notice can be generated.",
+    Boolean(String(lease.landlordId || "").trim())
+  );
+  addFailure(
+    failedRules,
+    "lease_property_context_present",
+    "Lease must include property and unit context before a notice can be generated.",
+    Boolean(String(lease.propertyId || "").trim() && String(lease.unitId || "").trim())
+  );
+  addFailure(
+    failedRules,
+    "rent_terms_present",
+    "Lease must include valid rent terms before a notice can be generated.",
+    hasPositiveNumber(lease.currentRent) && Boolean(String(lease.currency || "").trim())
+  );
+  addFailure(
+    failedRules,
+    "jurisdiction_supported",
+    "Lease jurisdiction and lease type must resolve to a supported notice rule.",
+    Boolean(rule)
+  );
+  addFailure(
+    failedRules,
+    "notice_type_allowed",
+    "Notice type must be allowed for the resolved jurisdiction rule.",
+    Boolean(rule?.allowedNoticeTypes.includes(noticeType))
+  );
+  addFailure(
+    failedRules,
+    "term_dates_present",
+    "Lease term dates and next-term dates must satisfy the resolved notice rule.",
+    Boolean(
+      hasDateOnly(lease.leaseStartDate) &&
+        (lease.leaseType === "month_to_month" || hasDateOnly(lease.leaseEndDate)) &&
+        hasDateOnly(previewInput.newLeaseStartDate) &&
+        (!rule?.requireTermDates || hasDateOnly(previewInput.newLeaseEndDate))
+    )
+  );
+  addFailure(
+    failedRules,
+    "response_deadline_present",
+    "Notice response deadline must be present and valid.",
+    hasPositiveNumber(previewInput.responseDeadlineAt)
+  );
+
+  return {
+    ok: failedRules.length === 0,
+    checkedRules,
+    failedRules,
+  };
+}
+
+/**
+ * Validates the renewal/eviction-style notice generation path before any notice document is created.
+ */
+export function canGenerateEvictionNotice(lease: LeaseWorkflowLease, previewInput: LeaseNoticePreviewInput) {
+  return validateNoticeAutomationPrerequisites({ lease, previewInput });
+}
+
+/**
+ * Validates cure notice prerequisites without adding cure-specific provider or delivery side effects.
+ */
+export function canGenerateCureNotice(lease: LeaseWorkflowLease, previewInput: LeaseNoticePreviewInput) {
+  return validateNoticeAutomationPrerequisites({ lease, previewInput });
+}
+
+/**
+ * Validates end-of-term and non-renewal notice prerequisites for deterministic service-layer gating.
+ */
+export function canGenerateTerminationNotice(lease: LeaseWorkflowLease, previewInput: LeaseNoticePreviewInput) {
+  return validateNoticeAutomationPrerequisites({ lease, previewInput });
+}


### PR DESCRIPTION
## Summary
- Add pure notice automation validation rules for lease state, tenant/landlord context, property/unit context, rent terms, jurisdiction support, notice type, term dates, and response deadline.
- Gate preview/send notice generation with safe validation failures and append-safe validation audit events.
- Resolve tenant delivery contact before creating a notice so missing contact fails closed without creating pending notice records.

## Validation
- PASS: `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/services/__tests__/noticeValidationRules.test.ts src/services/__tests__/leaseNoticeWorkflowService.test.ts src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts src/routes/__tests__/tenantLeaseNoticeRoutes.test.ts`
- PASS: `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- PASS: `git diff --check`
- FULL SUITE: `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test` fails locally on unrelated sandbox/pre-existing `listen EPERM: operation not permitted 0.0.0.0` route-test failures outside the notice workflow.

## Manual QA
Pending preview environment because this changes backend route behavior and user-visible validation responses.

Required checks:
- No auth on landlord notice preview/send endpoints returns 401.
- Cross-landlord notice preview/send returns 403.
- Valid active lease with full notice prerequisites can generate a notice.
- Missing tenant context or tenant delivery contact returns 400 with `LEASE_NOTICE_VALIDATION_FAILED`.
- Missing rent terms returns 400 with safe `failedRules`.
- Unsupported jurisdiction or disallowed notice type returns 400 with safe `failedRules`.
- Validation failures append `leaseWorkflowEvents` and do not create notice documents.
- Tenant notice list/detail projections still exclude landlord-only notes, provider payloads, and internal workflow state.

## Scope
- No billing, auth core, screening provider, pricing, entitlement, CI/CD, deployment, Firestore rules, Terraform, migration, frontend, template, notice delivery routing, SMS, or external legal service changes.