### PR TITLE
fix: align billing checkout route contract

### DIFF
--- a/.codex/docs/billing.md
+++ b/.codex/docs/billing.md
@@ -1,0 +1,49 @@
+# Billing Route Contract
+
+## Subscription Checkout
+
+Canonical checkout route: `POST /api/billing/checkout`.
+
+The route requires authenticated landlord scope through the billing route middleware. It accepts a paid plan tier and interval, resolves Stripe price configuration server-side, and returns a safe checkout redirect response:
+
+```json
+{
+  "ok": true,
+  "sessionId": "cs_...",
+  "url": "https://checkout.stripe.com/...",
+  "checkoutUrl": "https://checkout.stripe.com/..."
+}
+```
+
+`checkoutUrl` is retained for older frontend callers. New frontend code should use `url`, while `billingApi.createCheckoutSession` exposes both fields for compatibility.
+
+Compatibility routes `POST /api/billing/create-checkout-session`, `POST /api/billing/subscribe`, and `POST /api/billing/upgrade` share the same handler. They are compatibility aliases only; `/api/billing/checkout` remains canonical.
+
+## Subscription Status
+
+Canonical status route: `GET /api/billing/subscription-status`.
+
+The response intentionally excludes raw Stripe customer IDs, subscription IDs, invoice objects, payment tokens, checkout session IDs, and provider payloads.
+
+Safe response fields:
+
+```json
+{
+  "ok": true,
+  "tier": "free | starter | pro | elite",
+  "planId": "free | starter | pro | elite",
+  "status": "active | past_due | canceled",
+  "interval": "month | year | null",
+  "renewalDate": "ISO8601 | null",
+  "currentPeriodEnd": "ISO8601 | null",
+  "isActive": true,
+  "statusSource": "stripe_subscription | plan_tier",
+  "subscriptionStatusSource": "stripe_subscription | plan_tier"
+}
+```
+
+`statusSource: "stripe_subscription"` means the status was derived from stored Stripe subscription sync fields on the landlord record. `statusSource: "plan_tier"` means no synced Stripe subscription state was available and the status is inferred from the current plan tier for compatibility.
+
+## Deferred Track B
+
+Landlord payouts, statements, Stripe Connect, tenant rent payment settlement, and payout reconciliation are not part of subscription checkout alignment. Those remain Track B and require a separate mission.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,94 +1,128 @@
-PR: #1107
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1107
-Branch: fix/notice-automation-validation-v1
+PR: #1108
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1108
+Branch: fix/billing-checkout-alignment-v1
 
 # Implementation Summary
 
-Mission: Notice Automation Validation and Rule Enforcement
+Mission: Phase E - Billing Checkout Alignment for v0.9 Soft Launch
 
-Implemented deterministic notice automation validation for the existing lease notice workflow. The implementation stays inside the current notice service and landlord route surfaces, preserving the existing feature flag, landlord authorization middleware, tenant route protections, notice templates, delivery provider behavior, Firestore rules, billing, screening, and infrastructure.
+Aligned the subscription billing checkout contract across backend and frontend while preserving billing scope, landlord authorization, safe subscription status projection, and Track B deferral. The canonical subscription checkout route remains `POST /api/billing/checkout` because it was already registered in `app.build.ts`, documented by the public billing diagnostic probe, and used by the existing `startCheckout` helper. The stale frontend `billingApi.createCheckoutSession` path now calls the canonical route, while the backend keeps `/billing/create-checkout-session` as a compatibility alias for stale clients.
 
 ## Confirmed Findings
 
-- Current notice automation uses `leaseNoticeWorkflowService.ts`, `leaseNoticeLandlordRoutes.ts`, and `tenantLeaseNoticeRoutes.ts`; the older mission names `noticeService.ts` and `noticeRoutes.ts` are not present in the current source tree.
-- Landlord notice routes remain behind `requireLandlord` and the lease notice feature flag.
-- Tenant notice routes remain behind authenticated tenant role checks.
-- Existing policy evaluation remains in place for preview/send actions.
-- Existing tenant notice projections already redact landlord-only notes, internal workflow state, and provider delivery payloads.
+- Backend billing routes are mounted at `/api/billing` through `rentchain-api/src/app.build.ts`.
+- Current backend checkout route was `POST /billing/checkout`; frontend `billingApi.createCheckoutSession` was still calling `/billing/create-checkout-session`.
+- Existing `startCheckout` already called `/billing/checkout`, so keeping `/billing/checkout` as canonical avoids creating a second checkout contract.
+- Billing route auth previously used `requireAuth` directly on billing state and checkout routes; this mission moved those protected routes to `requireLandlord`.
+- Pricing and health routes remain public as non-sensitive read surfaces.
+- Subscription status previously inferred status from plan tier and returned null renewal fields without source labeling.
 
 ## Changes Made
 
-- Added pure notice validation rules in `rentchain-api/src/services/noticeValidationRules.ts`.
-- Added validation checks for lease state, tenant context, landlord context, property/unit context, rent terms, supported jurisdiction, allowed notice type, term dates, and response deadline.
-- Added compatibility wrappers for eviction, cure, and termination notice validation paths.
-- Updated `buildPreview` to fail closed with `LEASE_NOTICE_VALIDATION_FAILED` and safe `failedRules` before preview generation succeeds.
-- Updated send flow to reject invalid prerequisites before notice document creation.
-- Moved tenant delivery contact resolution ahead of notice creation so a missing or invalid tenant delivery contact does not create a pending notice.
-- Added append-safe validation audit events through `leaseWorkflowEvents` for validation failures and included validation context in notice creation audit data.
-- Updated landlord preview route to return safe validation failure payloads and append validation audit events when preview validation fails.
-- Added unit coverage for notice validation rules and service validation gating.
+- Updated protected backend billing routes to use `requireLandlord`:
+  - `GET /billing`
+  - `GET /billing/receipts/:id`
+  - `GET /billing/subscription-status`
+  - `GET /billing/billing/subscription-status`
+  - `POST /billing/checkout`
+  - `POST /billing/create-checkout-session`
+  - `POST /billing/subscribe`
+  - `POST /billing/upgrade`
+  - `GET /billing/session-status`
+  - `POST /billing/portal`
+- Added `POST /billing/create-checkout-session` as a compatibility alias to the shared checkout handler.
+- Updated checkout response to include `sessionId`, `url`, and `checkoutUrl` for compatibility with existing callers.
+- Added safe subscription status fields:
+  - `currentPeriodEnd`
+  - `statusSource`
+  - `subscriptionStatusSource`
+- Subscription status now uses stored synced subscription fields when present and labels the source as `stripe_subscription`; otherwise it labels plan-tier inference as `plan_tier`.
+- Updated `rentchain-frontend/src/api/billingApi.ts` so `createCheckoutSession` posts to `/billing/checkout`.
+- Added focused frontend API tests for checkout route alignment and safe subscription status normalization.
+- Updated backend billing route tests for landlord-only access, tenant denial, canonical checkout response, compatibility alias, and safe subscription status fields.
+- Added `.codex/docs/billing.md` documenting canonical subscription checkout, compatibility aliases, safe subscription status fields, and Track B deferral.
 
 ## Files Changed
 
-- `rentchain-api/src/services/noticeValidationRules.ts`
-- `rentchain-api/src/services/leaseNoticeWorkflowService.ts`
-- `rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts`
-- `rentchain-api/src/services/__tests__/noticeValidationRules.test.ts`
-- `rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts`
+- `rentchain-api/src/routes/billingRoutes.ts`
+- `rentchain-api/src/routes/__tests__/billingRoutes.test.ts`
+- `rentchain-frontend/src/api/billingApi.ts`
+- `rentchain-frontend/src/api/billingApi.test.ts`
+- `.codex/docs/billing.md`
 - `.handoff/impl-summary.md`
 
 ## Validation
 
-- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/services/__tests__/noticeValidationRules.test.ts src/services/__tests__/leaseNoticeWorkflowService.test.ts src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts src/routes/__tests__/tenantLeaseNoticeRoutes.test.ts`
-  - PASS: 4 test files, 21 tests
+- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/routes/__tests__/billingRoutes.test.ts`
+  - PASS: 1 test file, 13 tests
+- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/api/billingApi.test.ts`
+  - PASS: 1 test file, 3 tests
+- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/pages/BillingPage.test.tsx src/hooks/useBillingStatus.test.tsx src/billing/openUpgradeFlow.test.ts`
+  - PASS: 3 test files, 8 tests
 - `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
   - PASS
+- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
+  - PASS
+- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test`
+  - PASS: 293 test files, 1153 tests
 - `git diff --check`
   - PASS
 - `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test`
-  - FAIL: full backend suite hit unrelated sandbox/pre-existing `listen EPERM: operation not permitted 0.0.0.0` failures in route tests outside the notice workflow. Targeted notice suites passed.
+  - FAIL: full backend suite hit unrelated local `listen EPERM: operation not permitted 0.0.0.0` failures in route tests outside billing. Focused billing backend tests passed.
 
 ## Manual QA
 
-Manual QA is required because this mission changes backend route behavior and user-visible API validation responses.
+Manual QA is required because this mission changes frontend checkout routing, backend billing route authorization, and user-visible billing/subscription behavior.
 
 Manual QA not completed in this local environment. Required preview QA:
 
-1. No auth on landlord notice preview/send endpoints returns 401.
-2. Landlord cannot preview/send notice for another landlord's lease; response is 403.
-3. Valid active lease with tenant contact, landlord context, property/unit context, rent terms, supported jurisdiction, term dates, and response deadline can generate a notice.
-4. Lease missing tenant context or tenant delivery contact fails with 400 and `LEASE_NOTICE_VALIDATION_FAILED`.
-5. Lease missing rent terms fails with 400 and safe `failedRules`.
-6. Unsupported jurisdiction or disallowed notice type fails with 400 and safe `failedRules`.
-7. Validation failures create append-safe `leaseWorkflowEvents` entries without creating notice documents.
-8. Tenant notice list/detail projections still exclude landlord-only notes, provider payloads, and internal workflow state.
+1. Log in as landlord and trigger checkout from billing/upgrade flow.
+   - Confirm the Network tab shows `POST /api/billing/checkout`.
+   - Confirm the request is not sent to `/api/billing/create-checkout-session`.
+   - Confirm the response includes a checkout redirect URL.
+2. Log in as landlord and load billing/account page.
+   - Confirm tier, status, interval, and renewal date display without raw Stripe customer IDs, subscription IDs, invoices, or provider payloads.
+3. Log in as tenant and attempt billing routes.
+   - Confirm subscription status and checkout creation are denied.
+4. Log out and attempt billing checkout/status routes.
+   - Confirm unauthenticated access is denied.
+5. Simulate Stripe unavailable or missing price configuration.
+   - Confirm checkout errors are safe and do not expose raw Stripe error details or stack traces.
+6. Confirm pricing display still loads from public billing pricing route.
+7. Confirm Track B payout/statement flows are not introduced or exposed.
 
 ## Protected Areas
 
-- No billing changes.
-- No auth core changes.
-- No screening provider changes.
-- No pricing or entitlement changes.
-- No CI/CD, deployment, Firestore rules, Terraform, or migration changes.
-- No frontend, templates, notice delivery routing, SMS, or external legal service changes.
+- No pricing or entitlement configuration changes.
+- No Stripe webhook changes.
+- No Stripe Connect, payout, statement, tenant rent payment settlement, or Track B implementation.
+- No Firestore rules changes.
+- No CI/CD, deployment, Terraform, or migration changes.
+- No new dependencies.
 
 ## Known Limitations
 
-- Validation treats canonical tenant/landlord context plus resolved tenant delivery email as the available contact boundary; deeper contact profile validation remains future work.
-- Full manual E2E requires seeded landlord/tenant leases and a configured preview email environment.
+- Subscription status can only be Stripe-derived when synced subscription fields are already stored on the landlord record.
+- When no synced subscription fields exist, status remains plan-tier inferred and is explicitly labeled with `statusSource: "plan_tier"`.
 - Full backend suite remains blocked locally by unrelated `listen EPERM` route-test failures.
+- Full checkout manual E2E requires seeded landlord accounts, configured Stripe price IDs, and a preview billing environment.
 
 ## Acceptance Criteria Status
 
-- Pure deterministic validation helpers: completed.
-- Validation gate before notice generation: completed.
-- Safe validation error payloads: completed.
-- Append-safe validation audit context: completed.
-- Authorization boundaries preserved: completed by existing route middleware and tests.
-- Projection safety preserved: completed by existing tenant projection tests.
-- No protected areas modified: completed.
+- Frontend checkout route alignment: completed.
+- Backend canonical checkout route: completed.
+- Compatibility alias for stale checkout clients: completed.
+- Landlord-only billing route access: completed.
+- Tenant billing route denial: completed in tests.
+- Safe subscription status response without raw Stripe IDs: completed.
+- Subscription status source labeling: completed.
+- Billing route documentation: completed.
+- Track B deferral documented: completed.
+- Backend focused billing tests: completed.
+- Frontend focused and full tests: completed.
+- Backend build and frontend build: completed.
 - Manual QA: pending preview environment.
 
 ## Recommended Next Mission
 
-Run manual preview QA for notice validation with seeded lease fixtures, then continue to Phase E billing checkout alignment if Gate 2 approves this mission.
+Run billing checkout manual preview QA with seeded landlord accounts and Stripe test price configuration, then continue to Phase F tenant portal environment documentation.

--- a/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
@@ -16,6 +16,22 @@ vi.mock("../../middleware/requireAuth", () => ({
   },
 }));
 
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (!header) return res.status(401).json({ ok: false, error: "unauthenticated" });
+    req.user = JSON.parse(header);
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    next();
+  },
+}));
+
 vi.mock("../../lib/landlordResolver", () => ({
   resolveLandlordAndTier: resolveLandlordAndTierMock,
 }));
@@ -142,7 +158,70 @@ describe("billingRoutes subscription status", () => {
       isActive: true,
       interval: null,
       renewalDate: null,
+      currentPeriodEnd: null,
+      statusSource: "plan_tier",
+      subscriptionStatusSource: "plan_tier",
     });
+  });
+
+  it("returns Stripe-derived subscription status fields without raw Stripe identifiers", async () => {
+    resolveLandlordAndTierMock.mockResolvedValue({
+      tier: "pro",
+      landlordIdResolved: "landlord-1",
+      landlordDocId: "landlord-1",
+      landlordPlanRaw: "pro",
+      source: "landlordId",
+    });
+    landlordDocGetMock.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        plan: "pro",
+        stripeCustomerId: "cus_secret_123",
+        stripeSubscriptionId: "sub_secret_123",
+        subscriptionStatus: "active",
+        subscriptionInterval: "yearly",
+        currentPeriodEnd: 1_767_225_600_000,
+      }),
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/subscription-status",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "free" }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      tier: "pro",
+      planId: "pro",
+      status: "active",
+      interval: "year",
+      renewalDate: "2026-01-01T00:00:00.000Z",
+      currentPeriodEnd: "2026-01-01T00:00:00.000Z",
+      isActive: true,
+      statusSource: "stripe_subscription",
+    });
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("cus_secret_123");
+    expect(payload).not.toContain("sub_secret_123");
+  });
+
+  it("denies tenant access to billing status", async () => {
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/subscription-status",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "tenant-user", tenantId: "tenant-1", role: "tenant" }),
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ ok: false, error: "Forbidden" });
   });
 
   it("keeps the compatibility alias route and falls back to the token plan when needed", async () => {
@@ -237,6 +316,107 @@ describe("billingRoutes subscription status", () => {
         ],
       })
     );
+  });
+
+  it("creates checkout sessions through the canonical route with safe compatibility fields", async () => {
+    const createMock = vi.fn(async () => ({
+      id: "cs_test_123",
+      url: "https://checkout.stripe.test/session",
+    }));
+    getStripeClientMock.mockReturnValue({
+      checkout: {
+        sessions: {
+          create: createMock,
+        },
+      },
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/checkout",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "free" }),
+      },
+      body: {
+        tier: "starter",
+        interval: "monthly",
+        featureKey: "billing",
+        source: "billing_page",
+        redirectTo: "/billing",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      sessionId: "cs_test_123",
+      url: "https://checkout.stripe.test/session",
+      checkoutUrl: "https://checkout.stripe.test/session",
+    });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "subscription",
+        payment_method_types: ["card"],
+        metadata: expect.objectContaining({
+          landlordId: "landlord-1",
+          tier: "starter",
+          interval: "monthly",
+        }),
+      })
+    );
+  });
+
+  it("keeps create-checkout-session as a compatibility alias for stale clients", async () => {
+    getStripeClientMock.mockReturnValue({
+      checkout: {
+        sessions: {
+          create: vi.fn(async () => ({
+            id: "cs_alias_123",
+            url: "https://checkout.stripe.test/alias",
+          })),
+        },
+      },
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/create-checkout-session",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "free" }),
+      },
+      body: {
+        tier: "starter",
+        interval: "monthly",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      sessionId: "cs_alias_123",
+      url: "https://checkout.stripe.test/alias",
+      checkoutUrl: "https://checkout.stripe.test/alias",
+    });
+  });
+
+  it("denies tenant access to checkout creation", async () => {
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/checkout",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "tenant-user", tenantId: "tenant-1", role: "tenant" }),
+      },
+      body: {
+        tier: "starter",
+        interval: "monthly",
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(getStripeClientMock).not.toHaveBeenCalled();
   });
 
   it("returns the same controlled 503 when /subscribe hits the shared Stripe checkout failure path", async () => {

--- a/rentchain-api/src/routes/billingRoutes.ts
+++ b/rentchain-api/src/routes/billingRoutes.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { listRecordsForLandlord } from "../services/billingService";
 import { db } from "../firebase";
-import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
 import { getStripeClient } from "../services/stripeService";
 import { stripeNotConfiguredResponse, isStripeNotConfiguredError } from "../lib/stripeNotConfigured";
 import { FRONTEND_URL } from "../config/screeningConfig";
@@ -33,18 +33,64 @@ router.get("/health", (_req, res) => {
 
 type SubscriptionStatusTier = "free" | "starter" | "pro" | "elite";
 type SubscriptionStatusInterval = "month" | "year" | null;
+type SubscriptionStatusSource = "stripe_subscription" | "plan_tier";
 
 function normalizeSubscriptionStatusTier(input: any): SubscriptionStatusTier {
   return resolvePaidBillingPlan(input) || "free";
 }
 
+function toIsoDate(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  const raw = typeof value === "number" ? value : String(value).trim();
+  const parsed =
+    typeof raw === "number"
+      ? raw
+      : /^\d+$/.test(raw)
+      ? Number(raw)
+      : Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function toSubscriptionStatusInterval(value: unknown): SubscriptionStatusInterval {
+  const normalized = normalizeBillingInterval(value);
+  if (normalized === "monthly") return "month";
+  if (normalized === "yearly") return "year";
+  return null;
+}
+
+function normalizeSubscriptionStatus(value: unknown, tier: SubscriptionStatusTier): "active" | "past_due" | "canceled" {
+  const raw = String(value || "").trim().toLowerCase();
+  if (raw === "active" || raw === "trialing") return "active";
+  if (raw === "past_due") return "past_due";
+  if (raw === "canceled" || raw === "cancelled" || raw === "unpaid" || raw === "incomplete_expired") return "canceled";
+  return tier !== "free" ? "active" : "canceled";
+}
+
+async function loadSafeLandlordBillingState(landlordId: string | null) {
+  const id = String(landlordId || "").trim();
+  if (!id) return null;
+  try {
+    const snap = await db.collection("landlords").doc(id).get();
+    if (!snap.exists) return null;
+    return snap.data() as any;
+  } catch {
+    return null;
+  }
+}
+
 async function sendSubscriptionStatus(req: any, res: any) {
   const resolved = await resolveLandlordAndTier(req.user);
+  const landlordId = String(resolved?.landlordIdResolved || req.user?.landlordId || req.user?.id || "").trim() || null;
+  const landlord = await loadSafeLandlordBillingState(landlordId);
   const tier = normalizeSubscriptionStatusTier(resolved?.tier || req.user?.plan);
-  const interval: SubscriptionStatusInterval = null;
-  const renewalDate: string | null = null;
-  const isActive = tier !== "free";
-  const status = isActive ? "active" : "canceled";
+  const interval = toSubscriptionStatusInterval(landlord?.subscriptionInterval);
+  const currentPeriodEnd = toIsoDate(landlord?.currentPeriodEnd);
+  const renewalDate = currentPeriodEnd;
+  const subscriptionStatus = String(landlord?.subscriptionStatus || "").trim() || null;
+  const status = normalizeSubscriptionStatus(subscriptionStatus, tier);
+  const isActive = status === "active";
+  const statusSource: SubscriptionStatusSource = subscriptionStatus ? "stripe_subscription" : "plan_tier";
 
   return res.status(200).json({
     ok: true,
@@ -53,13 +99,16 @@ async function sendSubscriptionStatus(req: any, res: any) {
     status,
     interval,
     renewalDate,
+    currentPeriodEnd,
     isActive,
+    statusSource,
+    subscriptionStatusSource: statusSource,
   });
 }
 
-router.get("/subscription-status", requireAuth, sendSubscriptionStatus);
+router.get("/subscription-status", requireLandlord, sendSubscriptionStatus);
 // Compatibility alias in case any client still calls /api/billing/billing/subscription-status.
-router.get("/billing/subscription-status", requireAuth, sendSubscriptionStatus);
+router.get("/billing/subscription-status", requireLandlord, sendSubscriptionStatus);
 
 router.get("/pricing", (_req, res) => {
   res.setHeader("x-route-source", "billingRoutes.ts");
@@ -368,7 +417,7 @@ router.use((req, res, next) => {
 
 router.get(
   "/",
-  requireAuth,
+  requireLandlord,
   async (req: any, res) => {
     const landlordId = req.user?.landlordId || req.user?.id;
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
@@ -382,7 +431,7 @@ router.get(
 
 router.get(
   "/receipts/:id",
-  requireAuth,
+  requireLandlord,
   async (req: any, res) => {
     // NOTE: ensure the receipt belongs to this landlordId before exposing content
     res.type("html").send(`
@@ -455,7 +504,7 @@ async function handleCheckout(req: any, res: any) {
       cancel_url: `${frontendUrl}${appendBillingCanceled(redirectToValue)}`,
     });
 
-    return res.status(200).json({ ok: true, url: session.url });
+    return res.status(200).json({ ok: true, sessionId: session.id, url: session.url, checkoutUrl: session.url });
   } catch (err: any) {
     return sendStripeRouteError(
       res,
@@ -469,11 +518,12 @@ async function handleCheckout(req: any, res: any) {
   }
 }
 
-router.post("/checkout", requireAuth, handleCheckout);
-router.post("/subscribe", requireAuth, handleCheckout);
-router.post("/upgrade", requireAuth, handleCheckout);
+router.post("/checkout", requireLandlord, handleCheckout);
+router.post("/create-checkout-session", requireLandlord, handleCheckout);
+router.post("/subscribe", requireLandlord, handleCheckout);
+router.post("/upgrade", requireLandlord, handleCheckout);
 
-router.get("/session-status", requireAuth, async (req: any, res) => {
+router.get("/session-status", requireLandlord, async (req: any, res) => {
   const sessionId = String(req.query?.session_id || "").trim();
   if (!sessionId) {
     return res.status(400).json({ ok: false, error: "missing_session_id" });
@@ -557,7 +607,7 @@ router.get("/session-status", requireAuth, async (req: any, res) => {
   }
 });
 
-router.post("/portal", requireAuth, async (req: any, res) => {
+router.post("/portal", requireLandlord, async (req: any, res) => {
   try {
     const landlordId = req.user?.landlordId || req.user?.id;
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });

--- a/rentchain-frontend/src/api/billingApi.test.ts
+++ b/rentchain-frontend/src/api/billingApi.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { apiFetchMock, apiJsonMock, apiGetJsonMock } = vi.hoisted(() => ({
+  apiFetchMock: vi.fn(),
+  apiJsonMock: vi.fn(),
+  apiGetJsonMock: vi.fn(),
+}));
+
+vi.mock("@/lib/apiClient", () => ({
+  apiFetch: apiFetchMock,
+  apiJson: apiJsonMock,
+}));
+
+vi.mock("./http", () => ({
+  apiGetJson: apiGetJsonMock,
+}));
+
+describe("billingApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates checkout sessions through the canonical billing checkout route", async () => {
+    apiJsonMock.mockResolvedValue({
+      ok: true,
+      sessionId: "cs_test_123",
+      url: "https://checkout.stripe.test/session",
+    });
+    const { createCheckoutSession } = await import("./billingApi");
+
+    const result = await createCheckoutSession({
+      tier: "pro",
+      interval: "yearly",
+      featureKey: "billing",
+      source: "billing_page",
+      redirectTo: "/billing",
+    });
+
+    expect(apiJsonMock).toHaveBeenCalledWith("/billing/checkout", {
+      method: "POST",
+      body: JSON.stringify({
+        tier: "pro",
+        interval: "yearly",
+        featureKey: "billing",
+        source: "billing_page",
+        redirectTo: "/billing",
+      }),
+    });
+    expect(result).toEqual({
+      sessionId: "cs_test_123",
+      url: "https://checkout.stripe.test/session",
+      checkoutUrl: "https://checkout.stripe.test/session",
+    });
+  });
+
+  it("normalizes subscription status without requiring raw provider identifiers", async () => {
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      tier: "enterprise",
+      planId: "enterprise",
+      status: "active",
+      interval: "year",
+      renewalDate: "2027-01-01T00:00:00.000Z",
+      currentPeriodEnd: "2027-01-01T00:00:00.000Z",
+      statusSource: "stripe_subscription",
+    });
+    const { fetchSubscriptionStatus } = await import("./billingApi");
+
+    const result = await fetchSubscriptionStatus();
+
+    expect(apiFetchMock).toHaveBeenCalledWith("/billing/subscription-status", { method: "GET" });
+    expect(result).toMatchObject({
+      tier: "elite",
+      planId: "elite",
+      status: "active",
+      interval: "year",
+      renewalDate: "2027-01-01T00:00:00.000Z",
+      currentPeriodEnd: "2027-01-01T00:00:00.000Z",
+      statusSource: "stripe_subscription",
+    });
+    expect(JSON.stringify(result)).not.toContain("cus_");
+    expect(JSON.stringify(result)).not.toContain("sub_");
+  });
+
+  it("returns a canceled fallback when subscription status cannot be loaded", async () => {
+    apiFetchMock.mockRejectedValue(new Error("network failed"));
+    const { fetchSubscriptionStatus } = await import("./billingApi");
+
+    await expect(fetchSubscriptionStatus()).resolves.toEqual({
+      tier: null,
+      planId: null,
+      status: "canceled",
+    });
+  });
+});

--- a/rentchain-frontend/src/api/billingApi.ts
+++ b/rentchain-frontend/src/api/billingApi.ts
@@ -41,7 +41,10 @@ export interface SubscriptionStatus {
   status: "active" | "past_due" | "canceled";
   interval?: "month" | "year" | null;
   renewalDate?: string | null;
+  currentPeriodEnd?: string | null;
   isActive?: boolean;
+  statusSource?: "stripe_subscription" | "plan_tier";
+  subscriptionStatusSource?: "stripe_subscription" | "plan_tier";
 }
 
 export async function fetchSubscriptionStatus(): Promise<SubscriptionStatus> {
@@ -61,11 +64,25 @@ export async function fetchSubscriptionStatus(): Promise<SubscriptionStatus> {
   }
 }
 
-export async function createCheckoutSession(): Promise<{ checkoutUrl: string }> {
-  const data = await apiJson<any>("/billing/create-checkout-session", {
+export type CreateCheckoutSessionInput = {
+  tier?: PaidPlan;
+  interval?: "monthly" | "yearly" | "month" | "year";
+  featureKey?: string;
+  source?: string;
+  redirectTo?: string;
+};
+
+export async function createCheckoutSession(input: CreateCheckoutSessionInput = {}): Promise<{
+  sessionId: string | null;
+  url: string;
+  checkoutUrl: string;
+}> {
+  const data = await apiJson<any>("/billing/checkout", {
     method: "POST",
+    body: JSON.stringify(input),
   });
-  return { checkoutUrl: data?.checkoutUrl ?? "" };
+  const url = data?.url ?? data?.checkoutUrl ?? "";
+  return { sessionId: data?.sessionId ?? null, url, checkoutUrl: url };
 }
 
 export async function createBillingPortalSession(): Promise<{ url: string }> {


### PR DESCRIPTION
## Summary
- Align frontend checkout creation to the canonical `POST /api/billing/checkout` route while keeping `/api/billing/create-checkout-session` as a compatibility alias.
- Protect billing status, checkout, session status, portal, receipt, and history routes with landlord-scoped middleware.
- Return safe subscription status source fields and checkout compatibility fields without exposing raw provider identifiers in status responses.
- Document the billing route contract and Track B payout deferral.

## Validation
- PASS: `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/routes/__tests__/billingRoutes.test.ts`
- PASS: `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/api/billingApi.test.ts`
- PASS: `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/pages/BillingPage.test.tsx src/hooks/useBillingStatus.test.tsx src/billing/openUpgradeFlow.test.ts`
- PASS: `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- PASS: `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- PASS: `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && npm run test`
- PASS: `git diff --check`
- FULL BACKEND SUITE: `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && npm run test` fails locally on unrelated `listen EPERM: operation not permitted 0.0.0.0` route-test failures outside billing.

## Manual QA
Pending preview environment because this changes frontend checkout routing, backend billing route authorization, and user-visible billing/subscription behavior.

Required checks:
- Landlord checkout posts to `/api/billing/checkout` and receives a redirect URL.
- Billing status UI shows tier/status/interval/renewal date without raw provider IDs.
- Tenant access to billing status and checkout is denied.
- Unauthenticated access to billing status and checkout is denied.
- Stripe unavailable or missing price configuration returns safe checkout errors.
- Public pricing still loads.
- Track B payout/statement flows are not exposed.

## Scope
- No pricing or entitlement configuration changes.
- No webhook changes.
- No payout, statement, Stripe Connect, settlement, Firestore rules, CI/CD, deployment, Terraform, migration, or dependency changes.