### PR TITLE
fix: resolve soft launch blockers

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,5 +1,5 @@
-PR: #PR_NUMBER_PENDING
-PR URL: PR_URL_PENDING
+PR: #1113
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1113
 Branch: fix/soft-launch-blockers-v1
 
 # Implementation Summary

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,83 +1,93 @@
-PR: #1111
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1111
-Branch: phase/firestore-rules-hardening-v1
+PR: #PR_NUMBER_PENDING
+PR URL: PR_URL_PENDING
+Branch: fix/soft-launch-blockers-v1
 
 # Implementation Summary
 
 Date completed: 2026-06-07
 
-Mission: Phase H - Firestore Production Rules Hardening
+Mission: Fix soft launch blockers (security, projection safety, governance)
 
 ## Scope Completed
 
-Replaced the permissive root Firestore rules file with a production-oriented ruleset that fails closed by default and enforces document-level separation across landlord, tenant, admin, support, and operator roles.
+Resolved the three soft launch blockers named in the mission:
 
-The implementation is limited to Firestore rules. No backend routes, frontend code, auth middleware, billing logic, screening provider code, deployment configuration, Terraform, dependencies, or Firestore indexes were changed.
+- Added explicit landlord authorization middleware to generic lease and ledger route handlers in `rentchain-api/src/routes/leaseRoutes.ts`.
+- Removed raw landlord identifier exposure from contractor-facing message response projections in `rentchain-api/src/services/contractorPortalService.ts`.
+- Updated registry filing retry behavior in `rentchain-api/src/services/registry/registrySubmissionLayerV3.ts` so stale ready-package state is refreshed once before retry creation, with fail-closed readiness validation.
 
-## Deliverables
+No frontend, billing, auth core, screening adapter, pricing, CI/CD, Firestore rules, Terraform, dependency, or migration files were changed.
 
-- /Users/rentchain/dev/rentchain/firestore.rules
-- /Users/rentchain/dev/rentchain/.handoff/impl-summary.md
+## Files And Functions Changed
 
-## Coverage
+Lease authorization:
+- `rentchain-api/src/routes/leaseRoutes.ts`
+  - `GET /`
+  - `POST /`
+  - `PUT /:id`
+  - `POST /:id/end`
+  - `GET /:leaseId/ledger`
+  - `POST /:leaseId/ledger/charge`
+  - `POST /:leaseId/ledger/payment`
+  - `GET /:leaseId/ledger/export.csv`
+  - `GET /:leaseId/ledger/export.pdf`
+- `rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts`
+  - Added negative-role coverage proving tenant-role requests are rejected before generic lease and ledger handlers execute.
 
-- Added helper functions for authenticated role checks, landlord claim resolution, tenant claim resolution, ownership checks, and stable scope checks.
-- Added explicit landlord-scoped rules for properties, units, leases, lease drafts, rent payments, applications, maintenance, financial records, usage, and export-adjacent records.
-- Added explicit tenant-scoped rules for tenants, tenant workspaces, tenant profiles, tenant documents, tenant events, notices, applications, screening consents, maintenance requests, messages, and threads.
-- Added admin-only or admin-controlled rules for protected operational collections including admin state, webhook logs, verified screening queue, telemetry, status management, and public content publishing.
-- Added append-only behavior for audit and event collections by allowing create while denying update and delete.
-- Added immutable handling for snapshot and event-style collections where production data must not be mutated after creation.
-- Replaced the prior root catch-all allow rule with a final deny-all fallback.
+Contractor message projection:
+- `rentchain-api/src/services/contractorPortalService.ts`
+  - Added `projectContractorMessage`.
+  - Applied the projection to work-order embedded messages, list responses, and create responses.
+  - Preserved stored internal scope metadata for server-side authorization while removing raw landlord identifiers from contractor-facing output.
+- `rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts`
+  - Added assertions that work-order and contractor message responses do not expose raw landlord identifiers.
+
+Properties registry retry:
+- `rentchain-api/src/services/registry/registrySubmissionLayerV3.ts`
+  - Updated `retryRegistryFilingAttempt` to refresh stale ready-package state once through `createRegistryFilingReadyPackage`.
+  - Added readiness validation after refresh so retry creation remains deterministic and fail-closed.
+- `rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts`
+  - Updated stale ready-package retry coverage to confirm a refreshed ready package creates attempt 2 successfully.
 
 ## Validation Results
 
 Passed:
-- git diff --check
-- Firebase emulator syntax load using the root firestore.rules file on isolated local port 18080
-- npm --prefix rentchain-api run build
+- `npm run test -- src/routes/__tests__/leaseRoutes.active.test.ts` in `rentchain-api` using Node 20.20.2
+- `npm run test -- src/routes/__tests__/contractorPortalRoutes.test.ts` in `rentchain-api` using Node 20.20.2
+- `npm run test -- src/routes/__tests__/propertiesRoutes.test.ts` in `rentchain-api` using Node 20.20.2
+- `npm run build` in `rentchain-api` using Node 20.20.2
+- `git diff --check`
 
-Backend full-suite status:
-- npm --prefix rentchain-api run test -- --run was executed.
-- Result: 453 test files passed, 8 failed; 2213 tests passed, 21 failed.
-- The remaining failures are unrelated to firestore.rules and match known pre-existing backend suite failures in lease draft, recipient trust review, support console, property registry retry, decision mapping, and landlord analytics tests.
+Full backend suite:
+- `npm run test` in `rentchain-api` using Node 20.20.2 was run.
+- Result: 454 passed test files, 7 failed test files; 2215 passed tests, 20 failed tests.
+- The failed files are the existing unrelated areas already identified by the soft launch certification audit: `leaseDraftRoutes`, `recipientTrustReviewRoutes`, `supportConsoleRoutes`, `deriveDecisionExecutionMappings`, and `landlordAnalyticsSnapshot`.
+
+Initial local test attempts under Node 25 failed repo preflight, then were rerun under Node 20.20.2. The properties route suite needed elevated local-server execution because the sandbox blocked Supertest from binding an ephemeral local port.
 
 ## Manual QA
 
-Manual browser QA is not required for this mission because the change is a Firestore rules hardening mission with no frontend rendering, routes, navigation, mobile layout, or user-visible UI behavior changes.
+Manual preview/staging QA was not completed in this local environment. The mission-specific manual QA still requires a deployed preview/staging backend with seeded landlord, tenant, contractor, and admin accounts.
 
-Rules validation completed:
-- Root rules file loaded successfully through the Firebase Firestore emulator.
-- The ruleset denies all unmatched collections by default.
-- Audit and event collections deny update and delete.
-- Landlord and tenant reads/writes are scoped through claim-based ownership checks.
-- Sensitive provider, webhook, admin, telemetry, and verified queue collections are restricted to admin-controlled access.
+Recommended manual QA before merge:
+1. Confirm unauthorized lease generic and ledger routes reject tenant/non-landlord roles.
+2. Confirm contractor message list, create, and work-order detail responses do not expose raw landlord identifiers.
+3. Confirm registry filing retry succeeds after a stale ready package refresh and remains bounded to a single refresh.
 
-## Protected Areas
+## Acceptance Criteria Status
 
-Untouched:
-- backend routes and services
-- frontend components and pages
-- auth middleware and token issuance
-- billing flows
-- screening provider adapters
-- pricing and entitlement logic
-- CI/CD and deployment configuration
-- Terraform infrastructure
-- dependencies
-- Firestore indexes
-- production migrations
+- Lease route authorization blocker: resolved with explicit `requireLandlord` guards and focused negative-role tests.
+- Contractor raw identifier projection blocker: resolved with a shared contractor message projection and focused response-shape tests.
+- Properties retry blocker: resolved with single-refresh stale ready-package retry behavior and focused route test coverage.
+- Full backend test suite: still not clean because of unrelated pre-existing failures.
+- Diff scope: limited to the three named blocker areas and tests.
 
-## Known Limitations And Gaps
+## Known Limitations
 
-- No rules-unit-testing suite was added because the mission prohibits dependency drift and requires the source change to remain limited to firestore.rules.
-- Firestore rules cannot redact individual fields from a readable document. Tenant-safe field projection remains enforced by API projections and tenant-safe persistence design.
-- This mission prepares the ruleset for review only. It does not deploy rules to production.
-- Backend full-suite failures remain pre-existing and unrelated to the rules change.
+- Full seeded preview/staging QA remains required before soft launch re-certification.
+- Full backend test suite remains blocked by unrelated pre-existing failures outside this mission scope.
+- Registry stale retry refresh is intentionally bounded to one ready-package regeneration and remains fail-closed if the refreshed package is not ready to file.
 
-## Readiness
+## Recommended Next Phase
 
-The scoped Firestore rules hardening change is ready for Gate 1 review. Syntax validation and backend build passed, the ruleset fails closed by default, protected areas remain untouched, and known limitations are documented.
-
-## Blockers
-
-No mission blockers found.
+After Gate 1 review and PR checks, run preview/staging manual QA for the three blocker fixes, then proceed to a dedicated seeded soft launch re-certification mission.

--- a/rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts
@@ -166,6 +166,7 @@ describe("contractorPortalRoutes", () => {
       landlord: { name: "Landlord Ops" },
     });
     expect(JSON.stringify(res.body?.items?.[0])).not.toContain("tenant-1");
+    expect(JSON.stringify(res.body?.items?.[0])).not.toContain("landlord-1");
     expect(JSON.stringify(res.body?.items?.[0])).not.toContain("prop-raw");
     expect(JSON.stringify(res.body?.items?.[0])).not.toContain("unit-raw");
   });
@@ -211,6 +212,18 @@ describe("contractorPortalRoutes", () => {
 
     expect(res.status).toBe(201);
     expect(res.body?.message?.text).toBe("Arriving tomorrow morning.");
+    expect(res.body?.message?.landlordId).toBeUndefined();
+    expect(JSON.stringify(res.body?.message)).not.toContain("landlord-1");
+
+    const listRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/contractors/contractor-1/messages",
+      params: { contractorId: "contractor-1" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+    });
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.items?.[0]?.landlordId).toBeUndefined();
+    expect(JSON.stringify(listRes.body?.items?.[0])).not.toContain("landlord-1");
 
     const forbidden = await invokeRouter(router, {
       method: "POST",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -87,8 +87,15 @@ vi.mock("../../services/capabilityGuard", () => ({
 }));
 
 vi.mock("../../middleware/requireLandlord", () => ({
-  requireLandlord: (req: any, _res: any, next: any) => {
-    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  requireLandlord: (req: any, res: any, next: any) => {
+    const header = String(req.headers?.["x-test-user"] || "").trim();
+    req.user = header
+      ? JSON.parse(header)
+      : { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    if (req.user.role !== "landlord" && req.user.role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    req.user.landlordId = req.user.landlordId || req.user.id;
     next();
   },
 }));
@@ -164,6 +171,29 @@ describe("leaseRoutes GET /active", () => {
     sendEmailMock.mockClear();
     sendEmailMock.mockResolvedValue(undefined);
     process.env.EMAIL_FROM = "noreply@example.com";
+  });
+
+  it("requires landlord authority before generic lease and ledger handlers execute", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const tenantHeaders = {
+      "x-test-user": JSON.stringify({ id: "tenant-1", tenantId: "tenant-1", role: "tenant" }),
+    };
+    const requests = [
+      { method: "GET", url: "/" },
+      { method: "POST", url: "/", body: { tenantId: "tenant-1", propertyId: "prop-1", unitNumber: "101", monthlyRent: 1000, startDate: "2026-01-01" } },
+      { method: "PUT", url: "/lease-1", body: { monthlyRent: 1100 } },
+      { method: "POST", url: "/lease-1/end", body: {} },
+      { method: "GET", url: "/lease-1/ledger" },
+      { method: "POST", url: "/lease-1/ledger/charge", body: { amountCents: 1000, date: "2026-01-01", type: "rent" } },
+      { method: "POST", url: "/lease-1/ledger/payment", body: { amountCents: 1000, date: "2026-01-01", method: "cash" } },
+      { method: "GET", url: "/lease-1/ledger/export.csv" },
+      { method: "GET", url: "/lease-1/ledger/export.pdf" },
+    ];
+
+    for (const item of requests) {
+      const res = await invokeRouter(router, { ...item, headers: tenantHeaders });
+      expect(res.status).toBe(403);
+    }
   });
 
   it("returns landlord-scoped active leases with tenant and document details", async () => {

--- a/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
@@ -1071,7 +1071,7 @@ describe("properties routes publish + defaults", () => {
     expect(statusRes.body.filing.latestAttempt.attemptNumber).toBe(2);
   });
 
-  it("blocks retry when the ready package is stale relative to the draft", async () => {
+  it("refreshes a stale ready package once before retrying a failed attempt", async () => {
     const app = await createApp();
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",
@@ -1115,8 +1115,11 @@ describe("properties routes publish + defaults", () => {
       .post("/api/properties/prop-1/registry-submission/filing-attempts/retry")
       .send({ attemptId: requestRes.body.request.attemptId });
 
-    expect(retryRes.status).toBe(400);
-    expect(String(retryRes.body.message || "")).toContain("Regenerate the ready package");
+    expect(retryRes.status).toBe(200);
+    expect(retryRes.body.ready.status).toBe("ready_to_file");
+    expect(retryRes.body.ready.audit.sourceDraftUpdatedAt).toEqual(expect.any(String));
+    expect(retryRes.body.attempt.attemptNumber).toBe(2);
+    expect(retryRes.body.request.attemptId).toBe(retryRes.body.attempt.attemptId);
   });
 
   it("does not allow retrying a confirmed attempt", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -2008,7 +2008,7 @@ async function enforceLeaseCapability(req: any, res: Response): Promise<boolean>
   return true;
 }
 
-router.get("/", (_req: Request, res: Response) => {
+router.get("/", requireLandlord, (_req: Request, res: Response) => {
   const leases = leaseService.getAll();
   res.json({ leases });
 });
@@ -3399,7 +3399,7 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
   }
 });
 
-router.post("/", async (req: Request, res: Response) => {
+router.post("/", requireLandlord, async (req: Request, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
     const body = req.body as Partial<CreateLeasePayload>;
@@ -3541,7 +3541,7 @@ router.post("/", async (req: Request, res: Response) => {
   }
 });
 
-router.put("/:id", async (req: any, res: Response) => {
+router.put("/:id", requireLandlord, async (req: any, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
     const payload = req.body as UpdateLeasePayload;
@@ -3578,7 +3578,7 @@ router.put("/:id", async (req: any, res: Response) => {
   }
 });
 
-router.post("/:id/end", async (req: any, res: Response) => {
+router.post("/:id/end", requireLandlord, async (req: any, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
     const endDate: string = req.body?.endDate || new Date().toISOString();
@@ -3734,7 +3734,7 @@ router.post("/:id/restore-active", requireLandlord, async (req: any, res: Respon
   }
 });
 
-router.get("/:leaseId/ledger", async (req: any, res: Response) => {
+router.get("/:leaseId/ledger", requireLandlord, async (req: any, res: Response) => {
   try {
     const landlordId = req.user?.landlordId || req.user?.id;
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
@@ -3859,7 +3859,7 @@ router.get("/:leaseId/ledger", async (req: any, res: Response) => {
   }
 });
 
-router.post("/:leaseId/ledger/charge", async (req: any, res: Response) => {
+router.post("/:leaseId/ledger/charge", requireLandlord, async (req: any, res: Response) => {
   try {
     const landlordId = req.user?.landlordId || req.user?.id;
     const createdBy = req.user?.id || req.user?.email || landlordId;
@@ -3905,7 +3905,7 @@ router.post("/:leaseId/ledger/charge", async (req: any, res: Response) => {
   }
 });
 
-router.post("/:leaseId/ledger/payment", async (req: any, res: Response) => {
+router.post("/:leaseId/ledger/payment", requireLandlord, async (req: any, res: Response) => {
   res.setHeader("x-route-source", "leaseRoutes.ts");
   res.setHeader("x-lease-payment-write-version", "canonical-payments-ledger-link-v1");
   try {
@@ -3995,7 +3995,7 @@ router.post("/:leaseId/ledger/payment", async (req: any, res: Response) => {
   }
 });
 
-router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
+router.get("/:leaseId/ledger/export.csv", requireLandlord, async (req: any, res: Response) => {
   try {
     const landlordId = req.user?.landlordId || req.user?.id;
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
@@ -4053,7 +4053,7 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
   }
 });
 
-router.get("/:leaseId/ledger/export.pdf", async (req: any, res: Response) => {
+router.get("/:leaseId/ledger/export.pdf", requireLandlord, async (req: any, res: Response) => {
   const startedAt = Date.now();
   try {
     const landlordId = req.user?.landlordId || req.user?.id;

--- a/rentchain-api/src/services/contractorPortalService.ts
+++ b/rentchain-api/src/services/contractorPortalService.ts
@@ -81,6 +81,17 @@ function unitLabel(workOrder: any): string | null {
   return asOptionalString(workOrder?.unitLabel, 120) || asOptionalString(workOrder?.unitName, 120);
 }
 
+function projectContractorMessage(message: any, workOrderId?: string | null) {
+  return {
+    id: asString(message?.id, 160),
+    workOrderId: asString(workOrderId || message?.workOrderId, 160),
+    senderRole: asOptionalString(message?.senderRole, 40),
+    senderName: asOptionalString(message?.senderName, 180),
+    text: asOptionalString(message?.text, 2000) || "",
+    createdAt: toMillis(message?.createdAtMs || message?.createdAt),
+  };
+}
+
 function projectWorkOrder(workOrderId: string, workOrder: any, extras?: { updates?: any[]; messages?: any[] }) {
   const assignment = workOrder?.contractorAssignment && typeof workOrder.contractorAssignment === "object"
     ? workOrder.contractorAssignment
@@ -125,14 +136,7 @@ function projectWorkOrder(workOrderId: string, workOrder: any, extras?: { update
       actorRole: asOptionalString(update?.actorRole, 40),
       createdAt: toMillis(update?.createdAtMs || update?.createdAt),
     })),
-    messages: (extras?.messages || []).map((message) => ({
-      id: asString(message?.id, 160),
-      workOrderId,
-      senderRole: asOptionalString(message?.senderRole, 40),
-      senderName: asOptionalString(message?.senderName, 180),
-      text: asOptionalString(message?.text, 2000) || "",
-      createdAt: toMillis(message?.createdAtMs || message?.createdAt),
-    })),
+    messages: (extras?.messages || []).map((message) => projectContractorMessage(message, workOrderId)),
   };
 }
 
@@ -231,15 +235,7 @@ export async function listContractorPortalMessages(contractorId: string, workOrd
   return snap.docs
     .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
     .sort((a: any, b: any) => Number(b.createdAtMs || 0) - Number(a.createdAtMs || 0))
-    .map((message: any) => ({
-      id: asString(message.id, 160),
-      workOrderId: asString(message.workOrderId, 160),
-      landlordId: asString(message.landlordId, 160),
-      senderRole: asOptionalString(message.senderRole, 40),
-      senderName: asOptionalString(message.senderName, 180),
-      text: asOptionalString(message.text, 2000) || "",
-      createdAt: toMillis(message.createdAtMs || message.createdAt),
-    }));
+    .map((message: any) => projectContractorMessage(message));
 }
 
 export async function createContractorPortalMessage(input: {
@@ -285,7 +281,7 @@ export async function createContractorPortalMessage(input: {
     rawIdsIncluded: false,
     payloadIncluded: false,
   });
-  return { ok: true as const, message: { ...message, senderId: undefined } };
+  return { ok: true as const, message: projectContractorMessage(message) };
 }
 
 export async function getContractorPortalProfile(contractorId: string) {

--- a/rentchain-api/src/services/registry/registrySubmissionLayerV3.ts
+++ b/rentchain-api/src/services/registry/registrySubmissionLayerV3.ts
@@ -644,12 +644,15 @@ export async function retryRegistryFilingAttempt(input: {
   attemptId?: string | null;
 }): Promise<{ attempt: RegistrySubmissionAttemptV3; request: RegistrySubmissionRequestV3; ready: RegistrySubmissionReadyV3 }> {
   const draft = await loadRegistrySubmissionDraft(input);
-  const ready = await loadDoc<RegistrySubmissionReadyV3>(REGISTRY_SUBMISSION_READY_COLLECTION, draft.draftId);
+  let ready = await loadDoc<RegistrySubmissionReadyV3>(REGISTRY_SUBMISSION_READY_COLLECTION, draft.draftId);
   if (!ready) {
     throw new Error("A filing package does not exist yet. Prepare a ready package before retrying.");
   }
   if (await isReadyPackageStale(draft.draftId, ready)) {
-    throw new Error("Draft has changed since this ready package was prepared. Regenerate the ready package before retrying.");
+    ready = await createRegistryFilingReadyPackage(input);
+  }
+  if (ready.status !== "ready_to_file") {
+    throw new Error("Registry submission retry cannot be created until the draft is ready to file.");
   }
 
   const baseAttempt =


### PR DESCRIPTION
## Summary
- add explicit landlord guards to generic lease and ledger routes
- remove raw landlord identifiers from contractor-facing message projections
- refresh stale registry ready-package state once before retry creation, with readiness validation

## Validation
- npm run test -- src/routes/__tests__/leaseRoutes.active.test.ts (rentchain-api, Node 20.20.2): pass
- npm run test -- src/routes/__tests__/contractorPortalRoutes.test.ts (rentchain-api, Node 20.20.2): pass
- npm run test -- src/routes/__tests__/propertiesRoutes.test.ts (rentchain-api, Node 20.20.2): pass
- npm run build (rentchain-api, Node 20.20.2): pass
- git diff --check: pass

## Full backend suite
- npm run test (rentchain-api, Node 20.20.2): known unrelated failures remain
- Result: 454 passed test files, 7 failed test files; 2215 passed tests, 20 failed tests

## Manual QA
Manual preview/staging QA remains required for seeded landlord, tenant, contractor, and admin flows before soft launch re-certification.