### PR TITLE
fix: guard properties route for landlord access

### DIFF
--- a/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
@@ -482,6 +482,22 @@ describe("properties routes publish + defaults", () => {
     expect(res.body.items.map((item: any) => item.id).sort()).toEqual(["prop-a-managed", "prop-a-owned"]);
   });
 
+  it("blocks tenant users from the landlord property collection endpoint", async () => {
+    seedDoc("properties", "prop-a-owned", {
+      landlordId: "landlord-a",
+      ownerUserId: "landlord-a",
+      name: "A Owned",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      portfolioStatus: "active",
+    });
+
+    const app = await createAppForUser({ id: "tenant-a", tenantId: "tenant-a", role: "tenant" });
+    const res = await request(app).get("/api/properties");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ ok: false, error: "Forbidden" });
+  });
+
   it("does not allow landlord query params to widen access to another landlord's properties", async () => {
     seedDoc("properties", "prop-a-owned", {
       landlordId: "landlord-a",

--- a/rentchain-api/src/routes/propertiesRoutes.ts
+++ b/rentchain-api/src/routes/propertiesRoutes.ts
@@ -4,6 +4,7 @@ import { CAPABILITIES, resolvePlanTier } from "../config/capabilities";
 import { requireCapability } from "../entitlements/entitlements.middleware";
 import { db, FieldValue } from "../firebase";
 import { normalizeProvince } from "../lib/province";
+import { requireLandlord } from "../middleware/requireLandlord";
 import { ensureRegistrySource } from "../services/registry/registryImportService";
 import { getPropertyRegistryProjection, upsertPropertyRegistryProjection } from "../services/registry/registryStatusProjectionService";
 import {
@@ -201,7 +202,8 @@ async function loadPropertyOr404(propertyId: string) {
  * GET /api/properties
  * Returns properties for the authenticated landlord.
  */
-router.get("/", async (req: any, res) => {
+// Keep the collection route role-gated before landlord-scoped projection logic runs.
+router.get("/", requireLandlord, async (req: any, res) => {
   const role = String(req.user?.role || "").toLowerCase();
   const userId = String(req.user?.id || "").trim();
   const landlordId = resolveLandlordId(req);


### PR DESCRIPTION
## Summary
- Add the existing landlord/admin guard to `GET /api/properties` before landlord-scoped projection logic runs.
- Add regression coverage proving tenant-role requests receive `403` on the landlord property collection endpoint.
- Preserve existing landlord and admin property route behavior.

## Validation
- `npm run test -- src/routes/__tests__/propertiesRoutes.test.ts` from `rentchain-api`: PASS, 26 tests
- `npm run test -- src/middleware/__tests__/authMiddleware.test.ts` from `rentchain-api`: PASS, 3 tests
- `npm run build` from `rentchain-api`: PASS
- `git diff --check`: PASS

## Manual QA
- Pending after preview/staging deploy: landlord property list, tenant `403`, tenant portal safe property context, landlord dashboard/property pages, and no sensitive identifiers in user-facing output.