### PR TITLE
Fix work order property dropdown binding

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,93 +1,49 @@
-PR: #1113
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1113
-Branch: fix/soft-launch-blockers-v1
+PR: #1118
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1118
+Branch: fix/work-order-property-dropdown-v1
 
 # Implementation Summary
 
-Date completed: 2026-06-07
+## Mission
+Fix work order property dropdown frontend binding bug.
 
-Mission: Fix soft launch blockers (security, projection safety, governance)
+## Files Changed
+- `rentchain-frontend/src/pages/landlord/WorkOrderNewPage.tsx`
+- `rentchain-frontend/src/pages/landlord/WorkOrderNewPage.test.tsx`
 
-## Scope Completed
+## What Changed
+- Added property option normalization for both `id` and `propertyId` response shapes.
+- Added fallback labels from `name`, `addressLine1`, `address`, `displayName`, and `propertyName`.
+- Deduplicated property options by normalized property ID.
+- Disabled the property dropdown with an explicit empty option when no properties are available.
+- Reset stale unit selection and unit options whenever the selected property changes.
+- Preserved the existing `createWorkOrder` request payload and backend `propertyId` contract.
+- Added regression tests covering dropdown population, visible selection, stale unit clearing, and submitted `propertyId`.
 
-Resolved the three soft launch blockers named in the mission:
+## Governance
+- Scope limited to frontend landlord work order creation UI and tests.
+- No backend route, service, auth, Firestore rules, billing, screening, pricing, deployment, or dependency changes.
+- No permission widening.
+- No raw IDs, tokens, secrets, storage paths, or provider payloads exposed.
+- Backend authorization remains server-side through existing work order and property ownership checks.
+- Projection safety preserved; the change consumes existing landlord-scoped property responses only.
 
-- Added explicit landlord authorization middleware to generic lease and ledger route handlers in `rentchain-api/src/routes/leaseRoutes.ts`.
-- Removed raw landlord identifier exposure from contractor-facing message response projections in `rentchain-api/src/services/contractorPortalService.ts`.
-- Updated registry filing retry behavior in `rentchain-api/src/services/registry/registrySubmissionLayerV3.ts` so stale ready-package state is refreshed once before retry creation, with fail-closed readiness validation.
-
-No frontend, billing, auth core, screening adapter, pricing, CI/CD, Firestore rules, Terraform, dependency, or migration files were changed.
-
-## Files And Functions Changed
-
-Lease authorization:
-- `rentchain-api/src/routes/leaseRoutes.ts`
-  - `GET /`
-  - `POST /`
-  - `PUT /:id`
-  - `POST /:id/end`
-  - `GET /:leaseId/ledger`
-  - `POST /:leaseId/ledger/charge`
-  - `POST /:leaseId/ledger/payment`
-  - `GET /:leaseId/ledger/export.csv`
-  - `GET /:leaseId/ledger/export.pdf`
-- `rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts`
-  - Added negative-role coverage proving tenant-role requests are rejected before generic lease and ledger handlers execute.
-
-Contractor message projection:
-- `rentchain-api/src/services/contractorPortalService.ts`
-  - Added `projectContractorMessage`.
-  - Applied the projection to work-order embedded messages, list responses, and create responses.
-  - Preserved stored internal scope metadata for server-side authorization while removing raw landlord identifiers from contractor-facing output.
-- `rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts`
-  - Added assertions that work-order and contractor message responses do not expose raw landlord identifiers.
-
-Properties registry retry:
-- `rentchain-api/src/services/registry/registrySubmissionLayerV3.ts`
-  - Updated `retryRegistryFilingAttempt` to refresh stale ready-package state once through `createRegistryFilingReadyPackage`.
-  - Added readiness validation after refresh so retry creation remains deterministic and fail-closed.
-- `rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts`
-  - Updated stale ready-package retry coverage to confirm a refreshed ready package creates attempt 2 successfully.
-
-## Validation Results
-
-Passed:
-- `npm run test -- src/routes/__tests__/leaseRoutes.active.test.ts` in `rentchain-api` using Node 20.20.2
-- `npm run test -- src/routes/__tests__/contractorPortalRoutes.test.ts` in `rentchain-api` using Node 20.20.2
-- `npm run test -- src/routes/__tests__/propertiesRoutes.test.ts` in `rentchain-api` using Node 20.20.2
-- `npm run build` in `rentchain-api` using Node 20.20.2
-- `git diff --check`
-
-Full backend suite:
-- `npm run test` in `rentchain-api` using Node 20.20.2 was run.
-- Result: 454 passed test files, 7 failed test files; 2215 passed tests, 20 failed tests.
-- The failed files are the existing unrelated areas already identified by the soft launch certification audit: `leaseDraftRoutes`, `recipientTrustReviewRoutes`, `supportConsoleRoutes`, `deriveDecisionExecutionMappings`, and `landlordAnalyticsSnapshot`.
-
-Initial local test attempts under Node 25 failed repo preflight, then were rerun under Node 20.20.2. The properties route suite needed elevated local-server execution because the sandbox blocked Supertest from binding an ephemeral local port.
+## Validation
+- `npm --prefix rentchain-frontend run test -- src/pages/landlord/WorkOrderNewPage.test.tsx`: PASS, 2 tests.
+- `npm --prefix rentchain-api run test -- src/routes/__tests__/workOrdersRoutes.test.ts`: PASS, 21 tests.
+- `npm --prefix rentchain-frontend run test`: PASS, 294 files, 1155 tests.
+- `npm --prefix rentchain-frontend run build`: PASS.
+- `git diff --check`: PASS.
 
 ## Manual QA
-
-Manual preview/staging QA was not completed in this local environment. The mission-specific manual QA still requires a deployed preview/staging backend with seeded landlord, tenant, contractor, and admin accounts.
-
-Recommended manual QA before merge:
-1. Confirm unauthorized lease generic and ledger routes reject tenant/non-landlord roles.
-2. Confirm contractor message list, create, and work-order detail responses do not expose raw landlord identifiers.
-3. Confirm registry filing retry succeeds after a stale ready package refresh and remains bounded to a single refresh.
-
-## Acceptance Criteria Status
-
-- Lease route authorization blocker: resolved with explicit `requireLandlord` guards and focused negative-role tests.
-- Contractor raw identifier projection blocker: resolved with a shared contractor message projection and focused response-shape tests.
-- Properties retry blocker: resolved with single-refresh stale ready-package retry behavior and focused route test coverage.
-- Full backend test suite: still not clean because of unrelated pre-existing failures.
-- Diff scope: limited to the three named blocker areas and tests.
+- Manual browser QA not completed in this environment.
+- Full workflow requires seeded landlord, contractor, property, unit, and work order data with authenticated preview access.
+- Automated coverage verifies the frontend binding behavior and submitted payload for the affected form.
 
 ## Known Limitations
+- Existing work order edit UI does not expose property reassignment, and the backend patch route does not currently accept `propertyId`; no new route or API surface was added.
+- Contractor invite visibility in the contractor portal remains out of scope for a separate mission.
 
-- Full seeded preview/staging QA remains required before soft launch re-certification.
-- Full backend test suite remains blocked by unrelated pre-existing failures outside this mission scope.
-- Registry stale retry refresh is intentionally bounded to one ready-package regeneration and remains fail-closed if the refreshed package is not ready to file.
-
-## Recommended Next Phase
-
-After Gate 1 review and PR checks, run preview/staging manual QA for the three blocker fixes, then proceed to a dedicated seeded soft launch re-certification mission.
+## Recommended Follow-Up
+- Run preview manual QA with seeded accounts for the landlord work order creation flow.
+- Address contractor invite portal visibility as a separate scoped mission.

--- a/rentchain-frontend/src/pages/landlord/WorkOrderNewPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrderNewPage.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import WorkOrderNewPage from "./WorkOrderNewPage";
+
+const mocks = vi.hoisted(() => ({
+  createWorkOrder: vi.fn(),
+  fetchProperties: vi.fn(),
+  fetchUnitsForProperty: vi.fn(),
+  listContractorInvites: vi.fn(),
+  navigate: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock("../../api/propertiesApi", () => ({
+  fetchProperties: mocks.fetchProperties,
+}));
+
+vi.mock("../../api/unitsApi", () => ({
+  fetchUnitsForProperty: mocks.fetchUnitsForProperty,
+}));
+
+vi.mock("../../api/workOrdersApi", async () => {
+  const actual = await vi.importActual<typeof import("../../api/workOrdersApi")>("../../api/workOrdersApi");
+  return {
+    ...actual,
+    createWorkOrder: mocks.createWorkOrder,
+    listContractorInvites: mocks.listContractorInvites,
+  };
+});
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => ({
+    user: { id: "landlord-1", role: "landlord", plan: "starter" },
+  }),
+}));
+
+vi.mock("../../lib/analytics", () => ({
+  track: (...args: unknown[]) => mocks.track(...args),
+}));
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={["/work-orders/new"]}>
+      <Routes>
+        <Route path="/work-orders/new" element={<WorkOrderNewPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("WorkOrderNewPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.fetchProperties.mockResolvedValue({
+      items: [
+        { propertyId: "property-safe-1", address: "Harbour View" },
+        { id: "property-safe-2", name: "North Point" },
+      ],
+    });
+    mocks.fetchUnitsForProperty.mockImplementation(async (propertyId: string) => {
+      if (propertyId === "property-safe-1") {
+        return [{ unitId: "unit-1", unitNumber: "101" }];
+      }
+      if (propertyId === "property-safe-2") {
+        return [{ id: "unit-2", unitNumber: "202" }];
+      }
+      return [];
+    });
+    mocks.listContractorInvites.mockResolvedValue([]);
+    mocks.createWorkOrder.mockResolvedValue({
+      id: "work-order-1",
+      propertyId: "property-safe-2",
+    });
+  });
+
+  it("populates the property dropdown from id and propertyId response shapes", async () => {
+    renderPage();
+
+    const propertySelect = await screen.findByLabelText("Property");
+
+    await waitFor(() => {
+      expect(propertySelect).toHaveValue("property-safe-1");
+    });
+    expect(screen.getByRole("option", { name: "Harbour View" })).toHaveValue("property-safe-1");
+    expect(screen.getByRole("option", { name: "North Point" })).toHaveValue("property-safe-2");
+    expect(mocks.fetchUnitsForProperty).toHaveBeenCalledWith("property-safe-1");
+  });
+
+  it("syncs selected property state, clears stale units, and submits the selected propertyId", async () => {
+    renderPage();
+
+    const propertySelect = await screen.findByLabelText("Property");
+    expect(await screen.findByRole("option", { name: "101" })).toBeInTheDocument();
+
+    fireEvent.change(propertySelect, { target: { value: "property-safe-2" } });
+
+    await waitFor(() => {
+      expect(propertySelect).toHaveValue("property-safe-2");
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "202" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("option", { name: "101" })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Repair kitchen sink" } });
+    fireEvent.change(screen.getByLabelText("Description"), { target: { value: "Water is leaking under the basin." } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Work Order" }));
+
+    await waitFor(() => {
+      expect(mocks.createWorkOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyId: "property-safe-2",
+          unitId: null,
+          title: "Repair kitchen sink",
+          description: "Water is leaking under the basin.",
+        })
+      );
+    });
+    expect(mocks.navigate).toHaveBeenCalledWith("/work-orders");
+  });
+});

--- a/rentchain-frontend/src/pages/landlord/WorkOrderNewPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrderNewPage.tsx
@@ -9,12 +9,49 @@ import { useAuth } from "../../context/useAuth";
 
 const priorities: WorkOrderPriority[] = ["low", "medium", "high", "urgent"];
 
+type PropertyOption = {
+  id: string;
+  name: string;
+};
+
+function normalizePropertyOption(property: any): PropertyOption | null {
+  const id = String(property?.id || property?.propertyId || "").trim();
+  if (!id) return null;
+
+  const name = String(
+    property?.name ||
+      property?.addressLine1 ||
+      property?.address ||
+      property?.displayName ||
+      property?.propertyName ||
+      "Property"
+  ).trim();
+
+  return { id, name: name || "Property" };
+}
+
+function normalizePropertyOptions(input: any): PropertyOption[] {
+  const items = Array.isArray(input?.items)
+    ? input.items
+    : Array.isArray(input?.properties)
+    ? input.properties
+    : Array.isArray(input)
+    ? input
+    : [];
+
+  const options = items
+    .map((property: any) => normalizePropertyOption(property))
+    .filter((property: PropertyOption | null): property is PropertyOption => Boolean(property));
+
+  return Array.from(new Map(options.map((property) => [property.id, property])).values());
+}
+
 export default function WorkOrderNewPage() {
   const nav = useNavigate();
   const { user } = useAuth();
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
-  const [properties, setProperties] = React.useState<Array<{ id: string; name: string }>>([]);
+  const [properties, setProperties] = React.useState<PropertyOption[]>([]);
   const [units, setUnits] = React.useState<Array<{ id: string; unitNumber?: string }>>([]);
   const [invites, setInvites] = React.useState<ContractorInvite[]>([]);
 
@@ -34,17 +71,7 @@ export default function WorkOrderNewPage() {
     const run = async () => {
       try {
         const propRes = await fetchProperties();
-        const propItems = Array.isArray((propRes as any)?.items)
-          ? (propRes as any).items
-          : Array.isArray((propRes as any)?.properties)
-          ? (propRes as any).properties
-          : [];
-        const normalized = propItems
-          .map((p: any) => ({
-            id: String(p?.id || ""),
-            name: String(p?.name || p?.addressLine1 || "Property"),
-          }))
-          .filter((p: any) => p.id);
+        const normalized = normalizePropertyOptions(propRes);
         setProperties(normalized);
         setPropertyId(normalized[0]?.id || "");
       } catch {
@@ -60,6 +87,8 @@ export default function WorkOrderNewPage() {
   }, []);
 
   React.useEffect(() => {
+    setUnitId("");
+    setUnits([]);
     if (!propertyId) return;
     const load = async () => {
       try {
@@ -89,7 +118,13 @@ export default function WorkOrderNewPage() {
         {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
         <label style={{ display: "grid", gap: 6 }}>
           Property
-          <select value={propertyId} onChange={(e) => setPropertyId(e.target.value)} style={{ padding: 10, borderRadius: 8, border: "1px solid #cbd5e1" }}>
+          <select
+            value={propertyId}
+            onChange={(e) => setPropertyId(e.target.value)}
+            disabled={properties.length === 0}
+            style={{ padding: 10, borderRadius: 8, border: "1px solid #cbd5e1" }}
+          >
+            {properties.length === 0 ? <option value="">No properties available</option> : null}
             {properties.map((p) => (
               <option key={p.id} value={p.id}>
                 {p.name}


### PR DESCRIPTION
## Summary
- Normalize work order property dropdown options from both id and propertyId response shapes.
- Keep selected property state synchronized and clear stale unit selection when the property changes.
- Add regression coverage for dropdown population, selection, unit reset, and create payload propertyId submission.

## Validation
- npm --prefix rentchain-frontend run test -- src/pages/landlord/WorkOrderNewPage.test.tsx
- npm --prefix rentchain-api run test -- src/routes/__tests__/workOrdersRoutes.test.ts
- npm --prefix rentchain-frontend run test
- npm --prefix rentchain-frontend run build
- git diff --check

## Notes
- Backend work order create/update contracts were not changed.
- Existing work order edit UI does not expose property reassignment; no new route or API surface was added.