### PR TITLE
Fix contractor invite visibility and message projection

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,49 +1,52 @@
-PR: #1118
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1118
-Branch: fix/work-order-property-dropdown-v1
+PR: #1119
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1119
+Branch: fix/contractor-invite-visibility-v1
 
 # Implementation Summary
 
 ## Mission
-Fix work order property dropdown frontend binding bug.
+Establish contractor invite portal visibility and normalize contractor message projection safety.
 
 ## Files Changed
-- `rentchain-frontend/src/pages/landlord/WorkOrderNewPage.tsx`
-- `rentchain-frontend/src/pages/landlord/WorkOrderNewPage.test.tsx`
+- `rentchain-api/src/services/contractorPortalService.ts`
+- `rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts`
+- `rentchain-frontend/src/App.tsx`
+- `rentchain-frontend/src/App.routes.test.tsx`
+- `rentchain-frontend/src/api/contractorPortalApi.ts`
 
 ## What Changed
-- Added property option normalization for both `id` and `propertyId` response shapes.
-- Added fallback labels from `name`, `addressLine1`, `address`, `displayName`, and `propertyName`.
-- Deduplicated property options by normalized property ID.
-- Disabled the property dropdown with an explicit empty option when no properties are available.
-- Reset stale unit selection and unit options whenever the selected property changes.
-- Preserved the existing `createWorkOrder` request payload and backend `propertyId` contract.
-- Added regression tests covering dropdown population, visible selection, stale unit clearing, and submitted `propertyId`.
+- Routed `/contractor/invite/:token` and `/contractor/invite?invite=...` to `ContractorInviteAcceptPage`.
+- Removed sender display names from contractor-visible message projection to prevent stored landlord/operator names from being returned in contractor message responses.
+- Kept stored internal contractor message metadata unchanged for server-side authorization and audit continuity.
+- Removed obsolete `landlordId` and `senderName` fields from the contractor message frontend response type.
+- Added backend tests proving listed and embedded contractor messages exclude landlord identifiers, sender identifiers, recipient role metadata, and landlord/operator display names.
+- Added frontend route tests proving both contractor invite URL forms render the invite acceptance page.
 
 ## Governance
-- Scope limited to frontend landlord work order creation UI and tests.
-- No backend route, service, auth, Firestore rules, billing, screening, pricing, deployment, or dependency changes.
-- No permission widening.
-- No raw IDs, tokens, secrets, storage paths, or provider payloads exposed.
-- Backend authorization remains server-side through existing work order and property ownership checks.
-- Projection safety preserved; the change consumes existing landlord-scoped property responses only.
+- Scope limited to contractor invite routing and contractor message projection safety.
+- No auth, Firestore rules, billing, screening, pricing, deployment, dependency, landlord workflow, tenant workflow, or admin workflow changes.
+- Contractor routes still use existing `requireContractor` middleware and self-scope checks.
+- Message storage remains append-safe; only contractor-facing projection changed.
+- Contractor message responses now use explicit whitelist projection fields.
 
 ## Validation
-- `npm --prefix rentchain-frontend run test -- src/pages/landlord/WorkOrderNewPage.test.tsx`: PASS, 2 tests.
-- `npm --prefix rentchain-api run test -- src/routes/__tests__/workOrdersRoutes.test.ts`: PASS, 21 tests.
-- `npm --prefix rentchain-frontend run test`: PASS, 294 files, 1155 tests.
+- `npm --prefix rentchain-api run test -- src/routes/__tests__/contractorPortalRoutes.test.ts`: PASS, 6 tests.
+- `npm --prefix rentchain-api run build`: PASS.
+- `npm --prefix rentchain-frontend run test -- src/App.routes.test.tsx src/pages/contractor/ContractorJobsPage.test.tsx`: PASS, 56 tests.
+- `npm --prefix rentchain-frontend run test`: PASS, 294 files, 1157 tests.
 - `npm --prefix rentchain-frontend run build`: PASS.
 - `git diff --check`: PASS.
 
 ## Manual QA
 - Manual browser QA not completed in this environment.
-- Full workflow requires seeded landlord, contractor, property, unit, and work order data with authenticated preview access.
-- Automated coverage verifies the frontend binding behavior and submitted payload for the affected form.
+- Full invite acceptance QA requires seeded preview contractor invite tokens and authenticated contractor test accounts.
+- Automated route and projection tests verify the mission-critical routing and response-shape behavior.
 
 ## Known Limitations
-- Existing work order edit UI does not expose property reassignment, and the backend patch route does not currently accept `propertyId`; no new route or API surface was added.
-- Contractor invite visibility in the contractor portal remains out of scope for a separate mission.
+- `/contractor/signup` remains on the existing legacy onboarding redirect path; this mission only wires `/contractor/invite/:token` and `/contractor/invite?invite=...`.
+- Contractor invite acceptance still depends on existing backend invite token state and account setup.
+- Stored internal contractor message records still retain landlord scope metadata for authorization; the contractor-facing projection removes that metadata.
 
 ## Recommended Follow-Up
-- Run preview manual QA with seeded accounts for the landlord work order creation flow.
-- Address contractor invite portal visibility as a separate scoped mission.
+- Run manual preview QA with seeded contractor invite tokens.
+- Verify contractor invite acceptance across unauthenticated, contractor-authenticated, and wrong-role authenticated sessions.

--- a/rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts
@@ -147,6 +147,32 @@ describe("contractorPortalRoutes", () => {
       serviceCategories: ["plumbing"],
       availabilityStatus: "active",
     });
+    ensureCollection("contractorMessages").set("msg-1", {
+      id: "msg-1",
+      contractorId: "contractor-1",
+      landlordId: "landlord-1",
+      workOrderId: "wo-1",
+      senderRole: "landlord",
+      senderId: "landlord-1",
+      senderName: "Landlord Ops",
+      recipientRole: "contractor",
+      text: "Please confirm the appointment window.",
+      createdAtMs: 200,
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    });
+    ensureCollection("contractorMessages").set("msg-2", {
+      id: "msg-2",
+      contractorId: "contractor-2",
+      landlordId: "landlord-2",
+      workOrderId: "wo-2",
+      senderRole: "landlord",
+      senderId: "landlord-2",
+      senderName: "Other Landlord Ops",
+      recipientRole: "contractor",
+      text: "Private message for another contractor.",
+      createdAtMs: 300,
+    });
   });
 
   it("lists only the authenticated contractor's assigned work with safe projections", async () => {
@@ -213,6 +239,7 @@ describe("contractorPortalRoutes", () => {
     expect(res.status).toBe(201);
     expect(res.body?.message?.text).toBe("Arriving tomorrow morning.");
     expect(res.body?.message?.landlordId).toBeUndefined();
+    expect(res.body?.message?.senderName).toBeUndefined();
     expect(JSON.stringify(res.body?.message)).not.toContain("landlord-1");
 
     const listRes = await invokeRouter(router, {
@@ -222,8 +249,12 @@ describe("contractorPortalRoutes", () => {
       headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
     });
     expect(listRes.status).toBe(200);
-    expect(listRes.body?.items?.[0]?.landlordId).toBeUndefined();
-    expect(JSON.stringify(listRes.body?.items?.[0])).not.toContain("landlord-1");
+    const listJson = JSON.stringify(listRes.body?.items || []);
+    expect(listJson).toContain("Please confirm the appointment window.");
+    expect(listJson).toContain("Arriving tomorrow morning.");
+    expect(listJson).not.toContain("landlord-1");
+    expect(listJson).not.toContain("Landlord Ops");
+    expect(listJson).not.toContain("Private message for another contractor.");
 
     const forbidden = await invokeRouter(router, {
       method: "POST",
@@ -233,6 +264,32 @@ describe("contractorPortalRoutes", () => {
       body: { workOrderId: "wo-1", landlordId: "landlord-2", text: "Wrong landlord." },
     });
     expect(forbidden.status).toBe(403);
+  });
+
+  it("projects embedded work-order messages without raw landlord context", async () => {
+    const router = (await import("../contractorPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/contractors/contractor-1/work-orders/wo-1",
+      params: { contractorId: "contractor-1", workOrderId: "wo-1" },
+      headers: { "x-test-user": JSON.stringify({ id: "contractor-1", role: "contractor" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.messages).toEqual([
+      expect.objectContaining({
+        id: "msg-1",
+        workOrderId: "wo-1",
+        senderRole: "landlord",
+        text: "Please confirm the appointment window.",
+        createdAt: 200,
+      }),
+    ]);
+    const embeddedMessagesJson = JSON.stringify(res.body?.item?.messages || []);
+    expect(embeddedMessagesJson).not.toContain("landlord-1");
+    expect(embeddedMessagesJson).not.toContain("Landlord Ops");
+    expect(embeddedMessagesJson).not.toContain("senderId");
+    expect(embeddedMessagesJson).not.toContain("recipientRole");
   });
 
   it("reads and updates only the authenticated contractor profile", async () => {

--- a/rentchain-api/src/services/contractorPortalService.ts
+++ b/rentchain-api/src/services/contractorPortalService.ts
@@ -86,7 +86,6 @@ function projectContractorMessage(message: any, workOrderId?: string | null) {
     id: asString(message?.id, 160),
     workOrderId: asString(workOrderId || message?.workOrderId, 160),
     senderRole: asOptionalString(message?.senderRole, 40),
-    senderName: asOptionalString(message?.senderName, 180),
     text: asOptionalString(message?.text, 2000) || "",
     createdAt: toMillis(message?.createdAtMs || message?.createdAt),
   };

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -34,6 +34,13 @@ vi.mock("./components/layout/TenantNav", () => ({
   TenantNav: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("./pages/contractor/ContractorInviteAcceptPage", () => ({
+  default: () => {
+    const location = useLocation();
+    return <h1>Contractor Invite Accept {location.pathname}{location.search}</h1>;
+  },
+}));
+
 let mockTenantToken: string | null = null;
 
 vi.mock("./context/useAuth", () => ({
@@ -838,6 +845,32 @@ describe("Routes: /tenant/payments", () => {
     );
 
     expect(await screen.findByText(/Tenant Payments/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: contractor invite acceptance", () => {
+  it("renders the contractor invite acceptance page for tokenized links", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/contractor/invite/invite-123"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Contractor Invite Accept \/contractor\/invite\/invite-123/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the contractor invite acceptance page for query invite links", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/contractor/invite?invite=invite-123"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Contractor Invite Accept \/contractor\/invite\?invite=invite-123/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -48,6 +48,7 @@ import TenantLeaseNoticesPage from "./pages/tenant/TenantLeaseNoticesPage";
 import TenantLeaseNoticeDetailPage from "./pages/tenant/TenantLeaseNoticeDetailPage";
 import PdfSamplePage from "./pages/PdfSamplePage";
 import ContractorDashboardPage from "./pages/contractor/ContractorDashboardPage";
+import ContractorInviteAcceptPage from "./pages/contractor/ContractorInviteAcceptPage";
 import ContractorJobsPage from "./pages/contractor/ContractorJobsPage";
 import ContractorProfilePage from "./pages/contractor/ContractorProfilePage";
 import { ContractorNav } from "./components/layout/ContractorNav";
@@ -1269,8 +1270,8 @@ function App() {
           }
         />
         <Route path="/contractor/signup" element={<LegacyQueryInviteRedirect source="contractor" />} />
-        <Route path="/contractor/invite/:token" element={<LegacyTokenInviteRedirect source="contractor" />} />
-        <Route path="/contractor/invite" element={<LegacyQueryInviteRedirect source="contractor" />} />
+        <Route path="/contractor/invite/:token" element={<ContractorInviteAcceptPage />} />
+        <Route path="/contractor/invite" element={<ContractorInviteAcceptPage />} />
         <Route
           path="/contractor/jobs"
           element={

--- a/rentchain-frontend/src/api/contractorPortalApi.ts
+++ b/rentchain-frontend/src/api/contractorPortalApi.ts
@@ -31,9 +31,7 @@ export type ContractorPortalWorkOrder = {
 export type ContractorPortalMessage = {
   id: string;
   workOrderId: string;
-  landlordId?: string | null;
   senderRole?: string | null;
-  senderName?: string | null;
   text: string;
   createdAt?: number | null;
 };


### PR DESCRIPTION
## Summary
- Route contractor invite token and query links to the contractor invite acceptance page.
- Remove sender display names from contractor message projections so stored landlord/operator names are not returned in contractor message responses.
- Tighten contractor portal response types and add regression coverage for embedded and listed message projections.

## Validation
- npm --prefix rentchain-api run test -- src/routes/__tests__/contractorPortalRoutes.test.ts
- npm --prefix rentchain-api run build
- npm --prefix rentchain-frontend run test -- src/App.routes.test.tsx src/pages/contractor/ContractorJobsPage.test.tsx
- npm --prefix rentchain-frontend run test
- npm --prefix rentchain-frontend run build
- git diff --check

## Notes
- No auth, Firestore rules, billing, screening, pricing, deployment, or dependency changes.
- Manual invite acceptance QA still requires seeded preview invite tokens and authenticated contractor test accounts.