### PR TITLE
Notify tenant when viewing time is confirmed

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,52 +1,46 @@
-PR: #1119
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1119
-Branch: fix/contractor-invite-visibility-v1
+PR: #1120
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1120
+Branch: fix/viewing-request-tenant-notification-v1
 
 # Implementation Summary
 
 ## Mission
-Establish contractor invite portal visibility and normalize contractor message projection safety.
+Tenant Viewing Time Confirmation Notification.
 
 ## Files Changed
-- `rentchain-api/src/services/contractorPortalService.ts`
-- `rentchain-api/src/routes/__tests__/contractorPortalRoutes.test.ts`
-- `rentchain-frontend/src/App.tsx`
-- `rentchain-frontend/src/App.routes.test.tsx`
-- `rentchain-frontend/src/api/contractorPortalApi.ts`
+- `rentchain-api/src/services/viewings/viewingService.ts`
+- `rentchain-api/src/routes/__tests__/viewingRoutes.test.ts`
 
 ## What Changed
-- Routed `/contractor/invite/:token` and `/contractor/invite?invite=...` to `ContractorInviteAcceptPage`.
-- Removed sender display names from contractor-visible message projection to prevent stored landlord/operator names from being returned in contractor message responses.
-- Kept stored internal contractor message metadata unchanged for server-side authorization and audit continuity.
-- Removed obsolete `landlordId` and `senderName` fields from the contractor message frontend response type.
-- Added backend tests proving listed and embedded contractor messages exclude landlord identifiers, sender identifiers, recipient role metadata, and landlord/operator display names.
-- Added frontend route tests proving both contractor invite URL forms render the invite acceptance page.
+- Added tenant-facing viewing confirmation email delivery after a landlord-selected slot is successfully persisted.
+- Resolved the recipient only from `ViewingRequestDoc.applicantEmail` and skipped notification when the value is missing or fails email format validation.
+- Built email content through the existing base email template helpers and existing `sendEmail` infrastructure.
+- Included readable UTC viewing date and time, safe label-based property/unit context, and slot notes when present.
+- Avoided raw property or unit ID fallback in tenant-facing email content by using generic location text when labels are unavailable.
+- Kept email delivery failures non-blocking so viewing scheduling still succeeds after persistence.
 
 ## Governance
-- Scope limited to contractor invite routing and contractor message projection safety.
-- No auth, Firestore rules, billing, screening, pricing, deployment, dependency, landlord workflow, tenant workflow, or admin workflow changes.
-- Contractor routes still use existing `requireContractor` middleware and self-scope checks.
-- Message storage remains append-safe; only contractor-facing projection changed.
-- Contractor message responses now use explicit whitelist projection fields.
+- Scope limited to backend viewing service notification behavior and viewing route tests.
+- No auth, route, Firestore rules, billing, screening, pricing, deployment, dependency, frontend, or data model changes.
+- Viewing slot selection remains landlord-only through the existing route guard.
+- Notification is additive only and does not alter the viewing request document shape.
+- Tenant-facing email content avoids raw IDs, tokens, storage paths, provider payloads, or debug details.
 
 ## Validation
-- `npm --prefix rentchain-api run test -- src/routes/__tests__/contractorPortalRoutes.test.ts`: PASS, 6 tests.
+- `npm --prefix rentchain-api run test -- src/routes/__tests__/viewingRoutes.test.ts`: PASS, 14 tests.
 - `npm --prefix rentchain-api run build`: PASS.
-- `npm --prefix rentchain-frontend run test -- src/App.routes.test.tsx src/pages/contractor/ContractorJobsPage.test.tsx`: PASS, 56 tests.
-- `npm --prefix rentchain-frontend run test`: PASS, 294 files, 1157 tests.
-- `npm --prefix rentchain-frontend run build`: PASS.
 - `git diff --check`: PASS.
 
 ## Manual QA
-- Manual browser QA not completed in this environment.
-- Full invite acceptance QA requires seeded preview contractor invite tokens and authenticated contractor test accounts.
-- Automated route and projection tests verify the mission-critical routing and response-shape behavior.
+- Manual browser/email QA not completed locally.
+- Full manual QA requires seeded viewing request data, landlord preview access, and configured email provider credentials.
+- Automated tests verify the mission-critical notification behavior, skip behavior, failure handling, and invalid selection behavior.
 
 ## Known Limitations
-- `/contractor/signup` remains on the existing legacy onboarding redirect path; this mission only wires `/contractor/invite/:token` and `/contractor/invite?invite=...`.
-- Contractor invite acceptance still depends on existing backend invite token state and account setup.
-- Stored internal contractor message records still retain landlord scope metadata for authorization; the contractor-facing projection removes that metadata.
+- Datetime rendering uses deterministic UTC text and does not add complex timezone preference handling.
+- Email delivery depends on configured provider environment variables.
+- The notification link uses the existing viewing email link pattern.
 
 ## Recommended Follow-Up
-- Run manual preview QA with seeded contractor invite tokens.
-- Verify contractor invite acceptance across unauthenticated, contractor-authenticated, and wrong-role authenticated sessions.
+- Run preview manual QA with seeded viewing requests and a configured email provider.
+- Confirm actual email delivery to a test applicant address after selecting a proposed viewing slot.

--- a/rentchain-api/src/routes/__tests__/viewingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/viewingRoutes.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { sendEmailMock } = vi.hoisted(() => ({
+const { buildEmailHtmlMock, buildEmailTextMock, sendEmailMock } = vi.hoisted(() => ({
+  buildEmailHtmlMock: vi.fn(() => "<p>email</p>"),
+  buildEmailTextMock: vi.fn(() => "email"),
   sendEmailMock: vi.fn(),
 }));
 
@@ -75,8 +77,8 @@ vi.mock("../../services/emailService", () => ({
   sendEmail: sendEmailMock,
 }));
 vi.mock("../../email/templates/baseEmailTemplate", () => ({
-  buildEmailHtml: vi.fn(() => "<p>email</p>"),
-  buildEmailText: vi.fn(() => "email"),
+  buildEmailHtml: buildEmailHtmlMock,
+  buildEmailText: buildEmailTextMock,
 }));
 vi.mock("../../middleware/rateLimit", () => ({
   rateLimitPublicApply: (_req: any, _res: any, next: any) => next(),
@@ -136,6 +138,8 @@ async function invokeRouter(router: any, options: {
 describe("viewingRoutes", () => {
   beforeEach(() => {
     resetDb();
+    buildEmailHtmlMock.mockClear();
+    buildEmailTextMock.mockClear();
     sendEmailMock.mockReset();
     sendEmailMock.mockResolvedValue(undefined);
     process.env.EMAIL_FROM = "noreply@example.com";
@@ -309,7 +313,203 @@ describe("viewingRoutes", () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("scheduled");
     expect(res.body.selectedSlotId).toBe("slot-1");
+    expect(res.body.selectedSlot).toEqual(expect.objectContaining({
+      id: "slot-1",
+      startAt: "2026-04-02T18:00:00.000Z",
+      endAt: "2026-04-02T18:30:00.000Z",
+    }));
     expect(res.body.proposedSlots[0].isSelected).toBe(true);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      to: "jordan@example.com",
+      from: "noreply@example.com",
+      replyTo: "noreply@example.com",
+      subject: "Viewing confirmed for Harbour House • Unit 2A",
+    }));
+    expect(buildEmailTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      intro: "Your viewing time has been confirmed.",
+      bullets: [
+        "When: 2026-04-02 from 18:00 to 18:30 UTC",
+        "Location: Harbour House • Unit 2A",
+        "Note: Front entrance",
+      ],
+      ctaText: "Open viewings",
+      ctaUrl: "https://www.rentchain.ai/viewings",
+    }));
+    expect(buildEmailHtmlMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Viewing time confirmed",
+      preheader: "Viewing confirmed for 2026-04-02 from 18:00 to 18:30 UTC.",
+    }));
+  });
+
+  it("schedules a selected slot without notification when applicant email is missing", async () => {
+    const router = await createRouter();
+    seedCollection("viewingRequests", "view-missing-email", {
+      id: "view-missing-email",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      applicationId: null,
+      applicantName: "Jordan Lee",
+      applicantEmail: null,
+      applicantPhone: null,
+      requestedMessage: null,
+      status: "slots_proposed",
+      proposedSlots: [
+        {
+          id: "slot-1",
+          startAt: "2026-04-02T18:00:00.000Z",
+          endAt: "2026-04-02T18:30:00.000Z",
+          isSelected: false,
+        },
+      ],
+      selectedSlotId: null,
+      selectedSlot: null,
+      requestedAt: "2026-03-28T10:00:00.000Z",
+      slotsProposedAt: "2026-03-28T11:00:00.000Z",
+      createdAt: "2026-03-28T10:00:00.000Z",
+      updatedAt: "2026-03-28T11:00:00.000Z",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/viewings/view-missing-email/select-slot",
+      body: { slotId: "slot-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("scheduled");
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("schedules a selected slot without notification when applicant email is invalid", async () => {
+    const router = await createRouter();
+    seedCollection("viewingRequests", "view-invalid-email", {
+      id: "view-invalid-email",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      applicationId: null,
+      applicantName: "Jordan Lee",
+      applicantEmail: "not-an-email",
+      applicantPhone: null,
+      requestedMessage: null,
+      status: "slots_proposed",
+      proposedSlots: [
+        {
+          id: "slot-1",
+          startAt: "2026-04-02T18:00:00.000Z",
+          endAt: "2026-04-02T18:30:00.000Z",
+          isSelected: false,
+        },
+      ],
+      selectedSlotId: null,
+      selectedSlot: null,
+      requestedAt: "2026-03-28T10:00:00.000Z",
+      slotsProposedAt: "2026-03-28T11:00:00.000Z",
+      createdAt: "2026-03-28T10:00:00.000Z",
+      updatedAt: "2026-03-28T11:00:00.000Z",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/viewings/view-invalid-email/select-slot",
+      body: { slotId: "slot-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("scheduled");
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps selected slot scheduling when confirmation email delivery fails", async () => {
+    sendEmailMock.mockRejectedValueOnce(new Error("mail_failed"));
+    const router = await createRouter();
+    seedCollection("viewingRequests", "view-email-failure", {
+      id: "view-email-failure",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      applicationId: null,
+      applicantName: "Jordan Lee",
+      applicantEmail: "jordan@example.com",
+      applicantPhone: null,
+      requestedMessage: null,
+      status: "slots_proposed",
+      proposedSlots: [
+        {
+          id: "slot-1",
+          startAt: "2026-04-02T18:00:00.000Z",
+          endAt: "2026-04-02T18:30:00.000Z",
+          note: null,
+          isSelected: false,
+        },
+      ],
+      selectedSlotId: null,
+      selectedSlot: null,
+      requestedAt: "2026-03-28T10:00:00.000Z",
+      slotsProposedAt: "2026-03-28T11:00:00.000Z",
+      createdAt: "2026-03-28T10:00:00.000Z",
+      updatedAt: "2026-03-28T11:00:00.000Z",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/viewings/view-email-failure/select-slot",
+      body: { slotId: "slot-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("scheduled");
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(getCollection("viewingRequests").get("view-email-failure")?.data?.status).toBe("scheduled");
+  });
+
+  it("uses safe generic location text when property and unit labels are unavailable", async () => {
+    const router = await createRouter();
+    seedCollection("viewingRequests", "view-generic-location", {
+      id: "view-generic-location",
+      landlordId: "landlord-1",
+      propertyId: "property-missing",
+      unitId: "unit-missing",
+      applicationId: null,
+      applicantName: "Jordan Lee",
+      applicantEmail: "jordan@example.com",
+      applicantPhone: null,
+      requestedMessage: null,
+      status: "slots_proposed",
+      proposedSlots: [
+        {
+          id: "slot-1",
+          startAt: "2026-04-02T18:00:00.000Z",
+          endAt: "2026-04-02T18:30:00.000Z",
+          isSelected: false,
+        },
+      ],
+      selectedSlotId: null,
+      selectedSlot: null,
+      requestedAt: "2026-03-28T10:00:00.000Z",
+      slotsProposedAt: "2026-03-28T11:00:00.000Z",
+      createdAt: "2026-03-28T10:00:00.000Z",
+      updatedAt: "2026-03-28T11:00:00.000Z",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/viewings/view-generic-location/select-slot",
+      body: { slotId: "slot-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      subject: "Viewing confirmed for the requested property",
+    }));
+    expect(buildEmailTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      bullets: [
+        "When: 2026-04-02 from 18:00 to 18:30 UTC",
+        "Location: the requested property",
+      ],
+    }));
   });
 
   it("rejects selection of an unknown slot", async () => {
@@ -345,6 +545,7 @@ describe("viewingRoutes", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("invalid_slot_selection");
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("only completes from scheduled", async () => {

--- a/rentchain-api/src/services/viewings/viewingService.ts
+++ b/rentchain-api/src/services/viewings/viewingService.ts
@@ -147,6 +147,112 @@ async function notifyViewingRequestCreated(viewingRequest: ViewingRequestDoc) {
   });
 }
 
+async function resolveViewingLocationSummary(viewingRequest: ViewingRequestDoc): Promise<string> {
+  let propertyLabel: string | null = null;
+  let unitLabel: string | null = null;
+  const propertyId = optionalString(viewingRequest.propertyId);
+  const unitId = optionalString(viewingRequest.unitId);
+
+  if (propertyId) {
+    try {
+      const propertySnap = await db.collection("properties").doc(propertyId).get();
+      if (propertySnap.exists) {
+        const property = (propertySnap.data() as any) || {};
+        propertyLabel =
+          optionalString(property?.name) ||
+          optionalString(property?.addressLine1) ||
+          optionalString(property?.address) ||
+          optionalString(property?.displayName);
+      }
+    } catch {
+      // ignore property label lookup failure
+    }
+  }
+
+  if (unitId) {
+    try {
+      const unitSnap = await db.collection("units").doc(unitId).get();
+      if (unitSnap.exists) {
+        const unit = (unitSnap.data() as any) || {};
+        const unitNumber =
+          optionalString(unit?.unitNumber) ||
+          optionalString(unit?.number) ||
+          optionalString(unit?.name) ||
+          optionalString(unit?.displayName);
+        unitLabel = unitNumber ? `Unit ${unitNumber}` : null;
+      }
+    } catch {
+      // ignore unit label lookup failure
+    }
+  }
+
+  return [propertyLabel, unitLabel].filter(Boolean).join(" • ") || "the requested property";
+}
+
+function formatViewingSlotRange(slot: NonNullable<SelectedViewingSlot>): string {
+  const start = new Date(slot.startAt);
+  const end = new Date(slot.endAt);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return "the selected viewing time";
+  }
+
+  const startDate = start.toISOString().slice(0, 10);
+  const startTime = start.toISOString().slice(11, 16);
+  const endDate = end.toISOString().slice(0, 10);
+  const endTime = end.toISOString().slice(11, 16);
+  if (startDate === endDate) {
+    return `${startDate} from ${startTime} to ${endTime} UTC`;
+  }
+  return `${startDate} ${startTime} UTC to ${endDate} ${endTime} UTC`;
+}
+
+async function notifyViewingSlotSelected(viewingRequest: ViewingRequestDoc) {
+  const applicantEmail = optionalString(viewingRequest.applicantEmail)?.toLowerCase();
+  if (!applicantEmail || !EMAIL_REGEX.test(applicantEmail)) return;
+
+  const selectedSlot = viewingRequest.selectedSlot;
+  if (!selectedSlot) return;
+
+  const from =
+    process.env.EMAIL_FROM ||
+    process.env.SENDGRID_FROM_EMAIL ||
+    process.env.SENDGRID_FROM ||
+    process.env.FROM_EMAIL;
+  if (!from) return;
+
+  const baseUrl = (process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+  const locationSummary = await resolveViewingLocationSummary(viewingRequest);
+  const slotRange = formatViewingSlotRange(selectedSlot);
+  const requestLink = `${baseUrl}/viewings`;
+  const bullets = [`When: ${slotRange}`, `Location: ${locationSummary}`];
+  if (selectedSlot.note) {
+    bullets.push(`Note: ${selectedSlot.note}`);
+  }
+
+  await sendEmail({
+    to: applicantEmail,
+    from,
+    replyTo: from,
+    subject: `Viewing confirmed for ${locationSummary}`,
+    text: buildEmailText({
+      intro: "Your viewing time has been confirmed.",
+      bullets,
+      ctaText: "Open viewings",
+      ctaUrl: requestLink,
+      footerNote: "You're receiving this because you requested a viewing through RentChain.",
+    }),
+    html: buildEmailHtml({
+      title: "Viewing time confirmed",
+      intro: "Your viewing time has been confirmed.",
+      bullets,
+      ctaText: "Open viewings",
+      ctaUrl: requestLink,
+      footerNote: "You're receiving this because you requested a viewing through RentChain.",
+      preheader: `Viewing confirmed for ${slotRange}.`,
+    }),
+  });
+}
+
 export class ViewingServiceError extends Error {
   statusCode: number;
   code: ViewingErrorCode;
@@ -399,7 +505,15 @@ export async function selectViewingSlot(
     updatedAt: now,
     updatedByUserId: userId,
   };
-  return saveViewingRequestDoc(next);
+  const saved = await saveViewingRequestDoc(next);
+  try {
+    await notifyViewingSlotSelected(saved);
+  } catch (error: any) {
+    console.error("[viewings] viewing slot confirmation email failed", {
+      message: error?.message || "send_failed",
+    });
+  }
+  return saved;
 }
 
 export async function completeViewingRequest(


### PR DESCRIPTION
## Summary
- send applicant email after a landlord-selected viewing slot is persisted
- use applicantEmail from the viewing request with format validation and safe label-based location content
- keep delivery failures non-blocking for the scheduling response
- add viewing route coverage for send, skip, failure, and invalid selection cases

## Validation
- npm --prefix rentchain-api run test -- src/routes/__tests__/viewingRoutes.test.ts
- npm --prefix rentchain-api run build
- git diff --check

## Manual QA
- Not completed locally. Requires seeded viewing request data and a configured email provider in preview.