### PR TITLE
refactor: consolidate login page UI across tenant and landlord roles

### DIFF
--- a/rentchain-frontend/src/components/auth/LoginForm.test.tsx
+++ b/rentchain-frontend/src/components/auth/LoginForm.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LoginForm from "./LoginForm";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderForm(overrides: Partial<React.ComponentProps<typeof LoginForm>> = {}) {
+  const onSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) => event.preventDefault());
+  const onEmailChange = vi.fn();
+  const onPasswordChange = vi.fn();
+
+  render(
+    <MemoryRouter>
+      <LoginForm
+        title="Sign in to RentChain"
+        subtitle="Continue to your workspace."
+        roleLabel="Landlord access"
+        email=""
+        onEmailChange={onEmailChange}
+        password=""
+        onPasswordChange={onPasswordChange}
+        onSubmit={onSubmit}
+        {...overrides}
+      />
+    </MemoryRouter>
+  );
+
+  return { onSubmit, onEmailChange, onPasswordChange };
+}
+
+describe("LoginForm", () => {
+  it("renders shared password login fields and role context", () => {
+    renderForm();
+
+    expect(screen.getByRole("heading", { name: "Sign in to RentChain" })).toBeInTheDocument();
+    expect(screen.getByText("Landlord access")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Forgot password?" })).toHaveAttribute(
+      "href",
+      "/forgot-password"
+    );
+  });
+
+  it("delegates form submission and field changes", () => {
+    const { onSubmit, onEmailChange, onPasswordChange } = renderForm({
+      email: "initial@example.com",
+      password: "initial-password",
+    });
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "landlord@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "secret-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(onEmailChange).toHaveBeenCalledWith("landlord@example.com");
+    expect(onPasswordChange).toHaveBeenCalledWith("secret-password");
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports email-only login without forgot password", () => {
+    renderForm({
+      title: "Tenant login",
+      roleLabel: "Tenant access",
+      passwordRequired: false,
+      showForgotPassword: false,
+      submitLabel: "Email me a login link",
+    });
+
+    expect(screen.getByRole("heading", { name: "Tenant login" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Password")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Forgot password?" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Email me a login link" })).toBeEnabled();
+  });
+
+  it("renders safe status, error, and banner states", () => {
+    renderForm({
+      error: "Invalid email or password",
+      banner: {
+        title: "Session expired",
+        body: "Please log in again.",
+        tone: "warning",
+      },
+    });
+
+    expect(screen.getByText("Session expired")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Invalid email or password");
+  });
+
+  it("can disable submit separately from loading state", () => {
+    renderForm({ disabled: true, submitLabel: "Email me a login link" });
+
+    expect(screen.getByRole("button", { name: "Email me a login link" })).toBeDisabled();
+  });
+});

--- a/rentchain-frontend/src/components/auth/LoginForm.tsx
+++ b/rentchain-frontend/src/components/auth/LoginForm.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Button, Card, Input } from "../ui/Ui";
+import { colors, spacing, text } from "../../styles/tokens";
+
+export type LoginFormBanner = {
+  title: string;
+  body: string;
+  tone?: "info" | "warning";
+};
+
+type LoginFormProps = {
+  eyebrow?: string;
+  title: string;
+  subtitle: string;
+  roleLabel?: string;
+  email: string;
+  onEmailChange: (value: string) => void;
+  password?: string;
+  onPasswordChange?: (value: string) => void;
+  passwordRequired?: boolean;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  submitLabel?: string;
+  loadingLabel?: string;
+  isLoading?: boolean;
+  disabled?: boolean;
+  error?: string | null;
+  statusMessage?: string;
+  banner?: LoginFormBanner | null;
+  showForgotPassword?: boolean;
+  demoAction?: React.ReactNode;
+  footer?: React.ReactNode;
+  children?: React.ReactNode;
+};
+
+const shellStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  backgroundColor: colors.bg,
+  backgroundImage: colors.bgAmbient,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "clamp(16px, 5vw, 40px)",
+  overflowX: "hidden",
+};
+
+const fieldLabelStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: spacing.xs,
+  width: "100%",
+};
+
+const bannerStyle = (tone: LoginFormBanner["tone"] = "info"): React.CSSProperties => ({
+  marginBottom: spacing.sm,
+  padding: "8px 12px",
+  borderRadius: 10,
+  background: tone === "warning" ? "rgba(239,68,68,0.08)" : "rgba(37,99,235,0.08)",
+  border: tone === "warning" ? "1px solid rgba(239,68,68,0.3)" : "1px solid rgba(37,99,235,0.25)",
+  color: tone === "warning" ? colors.danger : "#1d4ed8",
+  fontSize: "0.9rem",
+});
+
+export const LoginForm: React.FC<LoginFormProps> = ({
+  eyebrow = "RentChain Secure Access",
+  title,
+  subtitle,
+  roleLabel,
+  email,
+  onEmailChange,
+  password = "",
+  onPasswordChange,
+  passwordRequired = true,
+  onSubmit,
+  submitLabel = "Sign in",
+  loadingLabel = "Signing in...",
+  isLoading = false,
+  disabled = false,
+  error = null,
+  statusMessage,
+  banner,
+  showForgotPassword = true,
+  demoAction,
+  footer,
+  children,
+}) => {
+  return (
+    <div style={shellStyle}>
+      <Card elevated style={{ width: "min(460px, 92vw)", padding: spacing.lg }}>
+        <div style={{ marginBottom: spacing.xs, color: text.subtle, fontSize: "0.9rem" }}>
+          {eyebrow}
+        </div>
+        <h1
+          style={{
+            fontSize: "1.6rem",
+            fontWeight: 700,
+            marginBottom: spacing.xs,
+            letterSpacing: "-0.01em",
+            color: text.primary,
+          }}
+        >
+          {title}
+        </h1>
+        {roleLabel ? (
+          <div
+            style={{
+              display: "inline-flex",
+              width: "fit-content",
+              marginBottom: spacing.sm,
+              padding: "5px 10px",
+              borderRadius: 999,
+              border: `1px solid ${colors.border}`,
+              background: colors.accentSoft,
+              color: text.primary,
+              fontSize: "0.82rem",
+              fontWeight: 700,
+            }}
+          >
+            {roleLabel}
+          </div>
+        ) : null}
+        <p style={{ marginTop: 0, marginBottom: spacing.sm, color: text.muted }}>
+          {subtitle}
+        </p>
+
+        {banner ? (
+          <div style={bannerStyle(banner.tone)}>
+            <div style={{ fontWeight: 700, marginBottom: 4 }}>{banner.title}</div>
+            <div>{banner.body}</div>
+          </div>
+        ) : null}
+
+        <form
+          onSubmit={onSubmit}
+          style={{ display: "flex", flexDirection: "column", gap: spacing.sm, width: "100%" }}
+        >
+          <label style={fieldLabelStyle}>
+            <span style={{ fontSize: "0.9rem", color: text.muted }}>Email</span>
+            <Input
+              type="email"
+              value={email}
+              onChange={(event) => onEmailChange(event.target.value)}
+              onClick={(event) => event.stopPropagation()}
+              placeholder="you@example.com"
+              autoComplete="email"
+              style={{ width: "100%" }}
+              required
+            />
+          </label>
+
+          {passwordRequired ? (
+            <label style={fieldLabelStyle}>
+              <span style={{ fontSize: "0.9rem", color: text.muted }}>Password</span>
+              <Input
+                type="password"
+                value={password}
+                onChange={(event) => onPasswordChange?.(event.target.value)}
+                onClick={(event) => event.stopPropagation()}
+                placeholder="Password"
+                autoComplete="current-password"
+                style={{ width: "100%" }}
+                required
+              />
+            </label>
+          ) : null}
+
+          {showForgotPassword ? (
+            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+              <Link
+                to="/forgot-password"
+                style={{ color: colors.accent, fontWeight: 600, fontSize: "0.9rem" }}
+              >
+                Forgot password?
+              </Link>
+            </div>
+          ) : null}
+
+          {children}
+
+          <Button
+            type="submit"
+            disabled={isLoading || disabled}
+            style={{
+              width: "100%",
+              opacity: isLoading || disabled ? 0.8 : 1,
+              cursor: isLoading || disabled ? "not-allowed" : "pointer",
+              justifyContent: "center",
+            }}
+          >
+            {isLoading ? loadingLabel : submitLabel}
+          </Button>
+
+          {demoAction}
+        </form>
+
+        <div
+          role={error ? "alert" : "status"}
+          aria-live="polite"
+          style={{
+            marginTop: spacing.sm,
+            minHeight: "1.2rem",
+            fontSize: "0.9rem",
+            color: error ? colors.danger : text.muted,
+          }}
+        >
+          {error || statusMessage || subtitle}
+        </div>
+
+        {footer ? (
+          <div style={{ marginTop: spacing.sm, display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            {footer}
+          </div>
+        ) : null}
+      </Card>
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/rentchain-frontend/src/pages/LoginPage.test.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LoginPage from "./LoginPage";
+
+const mocks = vi.hoisted(() => ({
+  login: vi.fn(),
+  loginDemo: vi.fn(),
+  showToast: vi.fn(),
+  trackAuthEvent: vi.fn(),
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: () => ({
+    login: mocks.login,
+    loginDemo: mocks.loginDemo,
+    user: null,
+    isLoading: false,
+    isTwoFactorRequired: false,
+  }),
+}));
+
+vi.mock("../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+vi.mock("../lib/authAnalytics", () => ({
+  trackAuthEvent: mocks.trackAuthEvent,
+}));
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.login.mockReset();
+    mocks.loginDemo.mockReset();
+    mocks.showToast.mockReset();
+    mocks.trackAuthEvent.mockReset();
+    mocks.login.mockResolvedValue({ requires2fa: false });
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("renders the shared landlord and contractor login form", () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Sign in to RentChain" })).toBeInTheDocument();
+    expect(screen.getByText("Landlord and contractor access")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Create free account" })).toHaveAttribute(
+      "href",
+      "/signup"
+    );
+    expect(screen.getByRole("link", { name: "Are you a tenant? Access your profile" })).toHaveAttribute(
+      "href",
+      "/tenant"
+    );
+  });
+
+  it("submits credentials through the existing auth hook", async () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "landlord@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "secret-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mocks.login).toHaveBeenCalledWith("landlord@example.com", "secret-password", undefined);
+    });
+  });
+
+  it("shows expired session context without changing auth behavior", () => {
+    render(
+      <MemoryRouter initialEntries={["/login?reason=expired"]}>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Session expired")).toBeInTheDocument();
+    expect(screen.getByText("Please log in again.")).toBeInTheDocument();
+  });
+
+  it("shows invite context when a contractor invite redirect is present", () => {
+    render(
+      <MemoryRouter initialEntries={["/login?next=/contractor/invite/safe-token"]}>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Contractor invitation detected")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/LoginPage.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.tsx
@@ -2,8 +2,9 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import { useAuth } from "../context/useAuth";
-import { colors, spacing, text } from "../styles/tokens";
-import { Card, Input, Button } from "../components/ui/Ui";
+import { colors, text } from "../styles/tokens";
+import { Button } from "../components/ui/Ui";
+import { LoginForm } from "../components/auth/LoginForm";
 import { DEBUG_AUTH_KEY, JUST_LOGGED_IN_KEY } from "../lib/authKeys";
 import { getAuthToken } from "../lib/authToken";
 import { useToast } from "../components/ui/ToastProvider";
@@ -207,153 +208,40 @@ export const LoginPage: React.FC = () => {
   };
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: colors.bg,
-        backgroundImage: colors.bgAmbient,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "clamp(16px, 5vw, 40px)",
-        overflowX: "hidden",
+    <LoginForm
+      title="Sign in to RentChain"
+      subtitle="Sign in to continue to your workspace."
+      roleLabel="Landlord and contractor access"
+      email={email}
+      onEmailChange={setEmail}
+      password={password}
+      onPasswordChange={setPassword}
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleLoginClick();
       }}
-    >
-      <Card elevated style={{ width: "min(460px, 92vw)", padding: spacing.lg }}>
-        <div style={{ marginBottom: spacing.xs, color: text.subtle, fontSize: "0.9rem" }}>
-          RentChain Secure Access
-        </div>
-        <h1
-          style={{
-            fontSize: "1.6rem",
-            fontWeight: 700,
-            marginBottom: spacing.md,
-            letterSpacing: "-0.01em",
-            color: text.primary,
-          }}
-        >
-          Sign in to RentChain
-        </h1>
-        <p style={{ marginTop: 0, marginBottom: spacing.sm, color: text.muted }}>
-          Sign in to continue to your workspace.
-        </p>
-        {new URLSearchParams(location.search).get("reason") === "expired" ? (
-          <div
-            style={{
-              marginBottom: spacing.sm,
-              padding: "8px 12px",
-              borderRadius: 10,
-              background: "rgba(239,68,68,0.08)",
-              border: "1px solid rgba(239,68,68,0.3)",
-              color: colors.danger,
-              fontWeight: 600,
-              fontSize: "0.9rem",
-            }}
-          >
-            Session expired. Please log in again.
-          </div>
-        ) : null}
-        {inviteBanner ? (
-          <div
-            style={{
-              marginBottom: spacing.sm,
-              padding: "8px 12px",
-              borderRadius: 10,
-              background: "rgba(37,99,235,0.08)",
-              border: "1px solid rgba(37,99,235,0.25)",
-              color: "#1d4ed8",
-              fontSize: "0.9rem",
-            }}
-          >
-            <div style={{ fontWeight: 700, marginBottom: 4 }}>{inviteBanner.title}</div>
-            <div>{inviteBanner.body}</div>
-          </div>
-        ) : null}
-
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleLoginClick();
-          }}
-          style={{ display: "flex", flexDirection: "column", gap: spacing.sm, width: "100%" }}
-        >
-          <label style={{ display: "flex", flexDirection: "column", gap: spacing.xs, width: "100%" }}>
-            <span style={{ fontSize: "0.9rem", color: text.muted }}>Email</span>
-            <Input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onClick={(e) => e.stopPropagation()}
-              placeholder="you@example.com"
-              autoComplete="email"
-              style={{ width: "100%" }}
-              required
-            />
-          </label>
-
-          <label style={{ display: "flex", flexDirection: "column", gap: spacing.xs, width: "100%" }}>
-            <span style={{ fontSize: "0.9rem", color: text.muted }}>Password</span>
-            <Input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              onClick={(e) => e.stopPropagation()}
-              placeholder="••••••••"
-              autoComplete="current-password"
-              style={{ width: "100%" }}
-              required
-            />
-          </label>
-          <div style={{ display: "flex", justifyContent: "flex-end" }}>
-            <Link
-              to="/forgot-password"
-              style={{ color: colors.accent, fontWeight: 600, fontSize: "0.9rem" }}
-            >
-              Forgot password?
-            </Link>
-          </div>
-
+      isLoading={submitting || isLoading}
+      error={error}
+      statusMessage={expired ? "Session expired. Please log in again." : "Sign in to continue to your workspace."}
+      banner={
+        expired
+          ? { title: "Session expired", body: "Please log in again.", tone: "warning" }
+          : inviteBanner
+      }
+      demoAction={
+        import.meta.env.DEV ? (
           <Button
-            type="submit"
-            onClick={() => handleLoginClick()}
-            disabled={submitting || isLoading}
-            style={{
-              width: "100%",
-              opacity: submitting || isLoading ? 0.8 : 1,
-              cursor: submitting || isLoading ? "not-allowed" : "pointer",
-              justifyContent: "center",
-            }}
+            type="button"
+            variant="ghost"
+            onClick={handleDemoLogin}
+            style={{ width: "100%" }}
           >
-            {submitting ? "Signing in..." : "Sign in"}
+            Login as Demo (dev)
           </Button>
-
-          {import.meta.env.DEV && (
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={handleDemoLogin}
-              style={{ width: "100%" }}
-            >
-              Login as Demo (dev)
-            </Button>
-          )}
-        </form>
-
-        <div
-          style={{
-            marginTop: spacing.sm,
-            minHeight: "1.2rem",
-            fontSize: "0.9rem",
-            color: error ? colors.danger : text.muted,
-          }}
-        >
-          {error
-            ? error
-            : expired
-            ? "Session expired. Please log in again."
-            : "Sign in to continue to your workspace."}
-        </div>
-        <div style={{ marginTop: spacing.sm, display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+        ) : null
+      }
+      footer={
+        <>
           <Link to="/signup" style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}>
             Create free account
           </Link>
@@ -366,9 +254,9 @@ export const LoginPage: React.FC = () => {
           <Link to="/invite" style={{ color: text.muted, textDecoration: "none" }}>
             Have an invite?
           </Link>
-        </div>
-      </Card>
-    </div>
+        </>
+      }
+    />
   );
 };
 

--- a/rentchain-frontend/src/pages/TenantLoginPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantLoginPage.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TenantLoginPage from "./TenantLoginPage";
+
+const mocks = vi.hoisted(() => ({
+  tenantLogin: vi.fn(),
+  setAuthToken: vi.fn(),
+}));
+
+vi.mock("../api/tenantAuthApi", () => ({
+  tenantLogin: mocks.tenantLogin,
+}));
+
+vi.mock("../lib/apiClient", () => ({
+  setAuthToken: mocks.setAuthToken,
+}));
+
+describe("TenantLoginPage", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.tenantLogin.mockReset();
+    mocks.setAuthToken.mockReset();
+    mocks.tenantLogin.mockResolvedValue({ token: "tenant-token" });
+  });
+
+  it("renders the shared tenant password login form", () => {
+    render(
+      <MemoryRouter>
+        <TenantLoginPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Tenant login" })).toBeInTheDocument();
+    expect(screen.getByText("Tenant access")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+  });
+
+  it("preserves tenant login token storage and return navigation", async () => {
+    render(
+      <MemoryRouter initialEntries={["/tenant/login?returnTo=/tenant/documents"]}>
+        <Routes>
+          <Route path="/tenant/login" element={<TenantLoginPage />} />
+          <Route path="/tenant/documents" element={<h1>Tenant documents</h1>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "tenant@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "tenant-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mocks.tenantLogin).toHaveBeenCalledWith("tenant@example.com", "tenant-password");
+      expect(mocks.setAuthToken).toHaveBeenCalledWith("tenant-token");
+      expect(screen.getByRole("heading", { name: "Tenant documents" })).toBeInTheDocument();
+    });
+  });
+
+  it("renders a safe error when the tenant login request fails", async () => {
+    mocks.tenantLogin.mockRejectedValueOnce(new Error("Login failed"));
+
+    render(
+      <MemoryRouter>
+        <TenantLoginPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "tenant@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "bad-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Login failed");
+  });
+});

--- a/rentchain-frontend/src/pages/TenantLoginPage.tsx
+++ b/rentchain-frontend/src/pages/TenantLoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { tenantLogin } from "../api/tenantAuthApi";
+import { LoginForm } from "../components/auth/LoginForm";
 import { setAuthToken } from "../lib/apiClient";
 
 const TenantLoginPage: React.FC = () => {
@@ -32,87 +33,20 @@ const TenantLoginPage: React.FC = () => {
   };
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        background: "radial-gradient(circle at top left, #111827 0, #020617 45%, #000000 100%)",
-        color: "#e5e7eb",
-        padding: 24,
-      }}
-    >
-      <form
-        onSubmit={handleSubmit}
-        style={{
-          background: "rgba(17,24,39,0.8)",
-          border: "1px solid rgba(255,255,255,0.08)",
-          borderRadius: 16,
-          padding: "24px 28px",
-          width: "100%",
-          maxWidth: 360,
-          boxShadow: "0 24px 60px rgba(0,0,0,0.4)",
-        }}
-      >
-        <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 16 }}>Tenant Login</div>
-        <label style={{ display: "block", fontSize: 12, color: "#9ca3af", marginBottom: 6 }}>
-          Email
-        </label>
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-          style={{
-            width: "100%",
-            padding: "10px 12px",
-            borderRadius: 10,
-            border: "1px solid rgba(255,255,255,0.08)",
-            background: "rgba(0,0,0,0.2)",
-            color: "#e5e7eb",
-            marginBottom: 12,
-          }}
-        />
-        <label style={{ display: "block", fontSize: 12, color: "#9ca3af", marginBottom: 6 }}>
-          Password
-        </label>
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          style={{
-            width: "100%",
-            padding: "10px 12px",
-            borderRadius: 10,
-            border: "1px solid rgba(255,255,255,0.08)",
-            background: "rgba(0,0,0,0.2)",
-            color: "#e5e7eb",
-            marginBottom: 16,
-          }}
-        />
-        {error ? (
-          <div style={{ color: "#fca5a5", fontSize: 12, marginBottom: 10 }}>{error}</div>
-        ) : null}
-        <button
-          type="submit"
-          disabled={loading}
-          style={{
-            width: "100%",
-            padding: "10px 12px",
-            borderRadius: 10,
-            border: "1px solid rgba(59,130,246,0.35)",
-            background: "rgba(59,130,246,0.12)",
-            color: "#bfdbfe",
-            fontWeight: 700,
-            cursor: loading ? "wait" : "pointer",
-          }}
-        >
-          {loading ? "Signing in…" : "Sign in"}
-        </button>
-      </form>
-    </div>
+    <LoginForm
+      title="Tenant login"
+      subtitle="Sign in to continue to your tenant workspace."
+      roleLabel="Tenant access"
+      email={email}
+      onEmailChange={setEmail}
+      password={password}
+      onPasswordChange={setPassword}
+      onSubmit={handleSubmit}
+      isLoading={loading}
+      error={error}
+      loadingLabel="Signing in..."
+      statusMessage="Use the email associated with your tenant profile."
+    />
   );
 };
 

--- a/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TenantLoginPageV2 from "./TenantLoginPage.v2";
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  trackAuthEvent: vi.fn(),
+}));
+
+vi.mock("../../api/apiFetch", () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+vi.mock("../../lib/authAnalytics", () => ({
+  trackAuthEvent: mocks.trackAuthEvent,
+}));
+
+describe("TenantLoginPageV2", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.apiFetch.mockReset();
+    mocks.trackAuthEvent.mockReset();
+    mocks.apiFetch.mockResolvedValue({});
+  });
+
+  it("renders the shared tenant magic-link login form", () => {
+    render(
+      <MemoryRouter>
+        <TenantLoginPageV2 />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Tenant login" })).toBeInTheDocument();
+    expect(screen.getByText("Tenant access")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Password")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Email me a login link" })).toBeDisabled();
+  });
+
+  it("requests a tenant magic link with the resolved safe return destination", async () => {
+    render(
+      <MemoryRouter initialEntries={["/tenant/login?next=/tenant/documents&token=safe-token"]}>
+        <TenantLoginPageV2 />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Invite context detected")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "Tenant@Example.com " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Email me a login link" }));
+
+    await waitFor(() => {
+      expect(mocks.apiFetch).toHaveBeenCalledWith("/tenant/auth/magic-link", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "tenant@example.com",
+          next: "/tenant/documents",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    expect(mocks.trackAuthEvent).toHaveBeenCalledWith(
+      "auth.onboard.magic_link_requested",
+      expect.objectContaining({
+        source: "tenant-login",
+        destination: "/tenant/documents",
+      })
+    );
+    expect(
+      screen.getByText("If an account exists for that email, we sent a login link.")
+    ).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { apiFetch } from "../../api/apiFetch";
+import { LoginForm } from "../../components/auth/LoginForm";
 import {
   resolveTenantPostAuthDestination,
   TENANT_DEFAULT_DESTINATION,
@@ -63,52 +64,45 @@ const TenantLoginPageV2: React.FC = () => {
     }
   }
 
+  if (!sent) {
+    return (
+      <LoginForm
+        title="Tenant login"
+        subtitle="We will email you a one-time login link."
+        roleLabel="Tenant access"
+        email={email}
+        onEmailChange={setEmail}
+        passwordRequired={false}
+        showForgotPassword={false}
+        onSubmit={onSubmit}
+        isLoading={isSending}
+        disabled={!email.trim()}
+        error={error}
+        submitLabel="Email me a login link"
+        loadingLabel="Sending..."
+        statusMessage="Use the email associated with your tenant profile."
+        banner={
+          inviteToken
+            ? {
+                title: "Invite context detected",
+                body: "We will return you to onboarding after sign-in.",
+              }
+            : null
+        }
+        footer={
+          <div style={{ fontSize: 13, color: "#64748b" }}>
+            Have an invite link? Open it to accept your invite. <Link to="/">Back to main</Link>
+          </div>
+        }
+      />
+    );
+  }
+
   return (
     <div style={{ maxWidth: 480, margin: "48px auto", padding: 16 }}>
       <Card>
         <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800 }}>Tenant login</h1>
-        <p style={{ marginTop: 8, opacity: 0.75 }}>We’ll email you a one-time login link.</p>
-
-        {!sent ? (
-          <form onSubmit={onSubmit} style={{ display: "grid", gap: 12, marginTop: 16 }}>
-            <label style={{ display: "grid", gap: 6 }}>
-              <span style={{ fontSize: 13, opacity: 0.75 }}>Email</span>
-              <input
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="tenant@email.com"
-                style={{ padding: 10, borderRadius: 10, border: "1px solid rgba(0,0,0,0.15)" }}
-              />
-            </label>
-
-            {error ? <div style={{ color: "crimson" }}>{error}</div> : null}
-
-            <button
-              type="submit"
-              disabled={isSending || !email.trim()}
-              style={{
-                padding: "10px 12px",
-                borderRadius: 10,
-                border: "1px solid rgba(0,0,0,0.15)",
-                background: "black",
-                color: "white",
-                fontWeight: 700,
-                cursor: isSending || !email.trim() ? "not-allowed" : "pointer",
-              }}
-            >
-              {isSending ? "Sending…" : "Email me a login link"}
-            </button>
-
-          <div style={{ fontSize: 13, opacity: 0.75 }}>
-            Have an invite link? Open it to accept your invite. <Link to="/">Back to main</Link>
-          </div>
-          {inviteToken ? (
-            <div style={{ fontSize: 13, opacity: 0.75 }}>
-              Invite context detected. We will return you to onboarding after sign-in.
-            </div>
-          ) : null}
-        </form>
-        ) : (
+        <p style={{ marginTop: 8, opacity: 0.75 }}>We will email you a one-time login link.</p>
           <div style={{ marginTop: 16, display: "grid", gap: 10 }}>
             <div style={{ color: "green", fontWeight: 700 }}>
               If an account exists for that email, we sent a login link.
@@ -146,7 +140,6 @@ const TenantLoginPageV2: React.FC = () => {
               </button>
             </div>
           </div>
-        )}
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
- Added a shared frontend login form used by landlord/contractor and tenant login pages.
- Refactored the legacy tenant password login and current tenant magic-link login to use the shared light-theme form while preserving existing submit behavior and route handling.
- Added focused frontend tests for shared rendering, submit delegation, tenant password login, and tenant magic-link login.

## Validation
- npm --prefix rentchain-frontend run test
- npm --prefix rentchain-frontend run build
- git diff --check

## Notes
- Backend auth logic, routes, permissions, Firestore rules, and deployment configuration were not changed.
- .handoff/merge-log.md remains unstaged and was not included in this PR.