### PR TITLE
feat: implement unified inbox data layer

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,47 +1,57 @@
-PR: #1121
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1121
-Branch: fix/landing-page-login-cta-v1
+PR: #1124
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1124
+Branch: feat/unified-inbox-data-layer-v1
 
 # Implementation Summary
 
 ## Mission
-Establish a visually prominent Log In call-to-action on the landing page while preserving the existing signup flow.
+Implement the unified inbox data layer foundation with role-safe tenant and landlord source adapters.
 
 ## Files Changed
-- `rentchain-frontend/src/pages/marketing/LandingPage.tsx`
-- `rentchain-frontend/src/pages/marketing/LandingPage.test.tsx`
+- `rentchain-api/src/services/unifiedInbox/types.ts`
+- `rentchain-api/src/services/unifiedInbox/safeInboxReferences.ts`
+- `rentchain-api/src/services/unifiedInbox/tenantInboxAdapters.ts`
+- `rentchain-api/src/services/unifiedInbox/landlordInboxAdapters.ts`
+- `rentchain-api/src/services/unifiedInbox/deriveUnifiedInbox.ts`
+- `rentchain-api/src/services/unifiedInbox/index.ts`
+- `rentchain-api/src/services/unifiedInbox/__tests__/index.test.ts`
+- `rentchain-api/src/tests/unifiedInbox/safeInboxReferences.test.ts`
+- `rentchain-api/src/tests/unifiedInbox/tenantInboxAdapters.test.ts`
+- `rentchain-api/src/tests/unifiedInbox/landlordInboxAdapters.test.ts`
+- `rentchain-api/src/tests/unifiedInbox/deriveUnifiedInbox.test.ts`
 
 ## What Changed
-- Added co-equal `Sign Up Free` and `Log In` button CTAs in the landing page hero.
-- Added matching `Sign Up Free` and `Log In` CTAs in the closing landing page section.
-- Preserved the existing signup attribution behavior and destination: `/signup?next=/properties&intent=registry_readiness`.
-- Added explicit login CTA routing to `/login`.
-- Updated landing page tests to verify both CTAs render and route correctly.
+- Added canonical unified inbox event types with explicit tenant, landlord, and contractor role surfaces.
+- Added deterministic safe inbox ID, source reference, and scope key helpers using stable hash output.
+- Added pure tenant adapters for notifications, messages, maintenance, and screening source records.
+- Added pure landlord adapters for application, screening, lease, maintenance, and message source records.
+- Added derivation helpers that accept already-loaded source arrays, filter unsafe records, sort deterministically, and return cursor-paginated inbox pages.
+- Added projection tests for role scope filtering, sensitive-field rejection, safe identifier generation, source immutability, ordering, and pagination.
 
 ## Governance
-- Scope limited to the landing page component and its direct test.
-- No auth logic, signup logic, login logic, role-specific onboarding, backend routes, Firestore rules, billing, screening, pricing, deployment, or dependency changes.
-- No tenant, contractor, or landlord account creation behavior changed.
-- Future role-specific onboarding experience remains out of scope for a separate audit.
+- Scope limited to backend service-layer data shaping and tests.
+- No routes, UI, persistence writes, realtime subscriptions, background workers, Firestore rules, auth logic, billing, screening adapters, pricing, deployment, or dependency changes.
+- Tenant and landlord projections use explicit adapters and safe references.
+- Contractor implementation remains out of scope for this mission.
+- Source records are never mutated by adapters or derivation helpers.
 
 ## Validation
-- `npm --prefix rentchain-frontend run test -- src/pages/marketing/LandingPage.test.tsx`: PASS, 4 tests.
-- `npm --prefix rentchain-frontend run build`: PASS.
+- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/`: PASS, 4 files, 12 tests.
+- `npm --prefix rentchain-api test -- src/services/unifiedInbox/`: PASS, 1 file, 1 test.
+- `npm --prefix rentchain-api run build`: PASS.
 - `git diff --check`: PASS.
+- `npm --prefix rentchain-api run lint -- src/services/unifiedInbox/ src/tests/unifiedInbox/`: NOT RUN, package has no `lint` script.
 
 ## Manual QA
-- Local browser QA completed with the dev gate unlocked in browser storage.
-- Desktop 1440x900: both CTAs visible, 48px minimum height, click targets route correctly.
-- Tablet 768x1024: both CTAs visible, stacked cleanly, 48px minimum height, click targets route correctly.
-- Mobile 375x812: both CTAs visible, stacked cleanly, 48px minimum height, click targets route correctly.
-- `Log In` routed to `/login`.
-- `Sign Up Free` routed to `/signup?next=/properties&intent=registry_readiness`.
+- N/A. This is a backend data-layer foundation with no routes, UI, or user-visible runtime behavior.
+- Role separation, projection safety, append safety, and no-mutation behavior are covered by automated tests and code inspection.
 
 ## Known Limitations
-- Screen reader testing with NVDA, JAWS, or VoiceOver was not completed in this environment.
-- Color contrast was reviewed through existing design tokens and button variants, not an external contrast tool.
-- Broader login/signup onboarding audit is intentionally deferred.
+- Derivation helpers accept already-loaded source records and do not perform Firestore reads in this mission.
+- Contractor inbox adapters are intentionally deferred.
+- Route integration, unread state persistence, realtime delivery, admin/support tooling, and UI rendering are intentionally deferred.
+- Backend lint could not run because the package has no lint script.
 
 ## Recommended Follow-Up
-- Run preview QA on the deployed Vercel URL after PR checks complete.
-- Schedule `audit/auth-onboarding-experience-v1` to review role-specific login and signup entry points.
+- Add route-level unified inbox retrieval after this data layer is reviewed and approved.
+- Add contractor adapters in a separate scoped mission after tenant and landlord projections are accepted.

--- a/rentchain-api/src/services/unifiedInbox/__tests__/index.test.ts
+++ b/rentchain-api/src/services/unifiedInbox/__tests__/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { deriveTenantUnifiedInbox, generateSafeInboxId } from "../index";
+
+describe("unified inbox service exports", () => {
+  it("exports safe reference helpers and derivation entry points", async () => {
+    expect(generateSafeInboxId("tenant.message", "message_raw_123", "scope_raw_123")).toMatch(/^inbox_v1_/);
+    await expect(deriveTenantUnifiedInbox({ tenantWorkspaceId: "" })).resolves.toEqual({ items: [] });
+  });
+});

--- a/rentchain-api/src/services/unifiedInbox/deriveUnifiedInbox.ts
+++ b/rentchain-api/src/services/unifiedInbox/deriveUnifiedInbox.ts
@@ -1,0 +1,138 @@
+import {
+  adaptLandlordApplicationInboxToInboxEvent,
+  adaptLandlordLeaseInboxToInboxEvent,
+  adaptLandlordMaintenanceInboxToInboxEvent,
+  adaptLandlordMessageInboxToInboxEvent,
+  adaptLandlordScreeningInboxToInboxEvent,
+} from "./landlordInboxAdapters";
+import {
+  adaptTenantMaintenanceToInboxEvent,
+  adaptTenantMessageToInboxEvent,
+  adaptTenantNotificationToInboxEvent,
+  adaptTenantScreeningToInboxEvent,
+} from "./tenantInboxAdapters";
+import type {
+  LandlordScopeContext,
+  TenantScopeContext,
+  UnifiedInboxEvent,
+  UnifiedInboxPage,
+  UnifiedInboxPaginationOptions,
+  UnifiedInboxPriority,
+} from "./types";
+
+type TenantDerivationOptions = UnifiedInboxPaginationOptions & {
+  notifications?: any[];
+  messages?: any[];
+  maintenanceRequests?: any[];
+  screeningRequests?: any[];
+};
+
+type LandlordDerivationOptions = UnifiedInboxPaginationOptions & {
+  applicationItems?: any[];
+  screeningItems?: any[];
+  leaseItems?: any[];
+  maintenanceRequests?: any[];
+  messages?: any[];
+};
+
+const PRIORITY_RANK: Record<UnifiedInboxPriority, number> = {
+  critical: 0,
+  high: 1,
+  normal: 2,
+  low: 3,
+};
+
+function parseLimit(limit: unknown): number {
+  const parsed = Number(limit);
+  if (!Number.isFinite(parsed)) return 50;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+export function encodeUnifiedInboxCursor(item: UnifiedInboxEvent): string {
+  return Buffer.from(
+    JSON.stringify({
+      occurredAt: item.occurredAt,
+      id: item.id,
+    }),
+    "utf8"
+  ).toString("base64url");
+}
+
+function decodeCursor(value: unknown): { occurredAt: string; id: string } | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const occurredAt = String(parsed?.occurredAt || "").trim();
+    const id = String(parsed?.id || "").trim();
+    if (!occurredAt || !id) return null;
+    return { occurredAt, id };
+  } catch {
+    return null;
+  }
+}
+
+export function sortUnifiedInboxEvents(items: UnifiedInboxEvent[]): UnifiedInboxEvent[] {
+  return [...items].sort((left, right) => {
+    const readDiff = Number(left.status === "read" || left.readAt) - Number(right.status === "read" || right.readAt);
+    if (readDiff !== 0) return readDiff;
+
+    const priorityDiff = PRIORITY_RANK[left.priority] - PRIORITY_RANK[right.priority];
+    if (priorityDiff !== 0) return priorityDiff;
+
+    const timeDiff = Date.parse(right.occurredAt) - Date.parse(left.occurredAt);
+    if (timeDiff !== 0) return timeDiff;
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function paginate(items: UnifiedInboxEvent[], options?: UnifiedInboxPaginationOptions): UnifiedInboxPage {
+  const sorted = sortUnifiedInboxEvents(items);
+  const cursor = decodeCursor(options?.cursor);
+  const cursorIndex = cursor
+    ? sorted.findIndex((item) => item.id === cursor.id && item.occurredAt === cursor.occurredAt)
+    : -1;
+  const cursorFiltered = cursorIndex >= 0 ? sorted.slice(cursorIndex + 1) : sorted;
+  const limit = parseLimit(options?.limit);
+  const page = cursorFiltered.slice(0, limit);
+  const hasMore = cursorFiltered.length > limit;
+  return {
+    items: page,
+    nextCursor: hasMore && page.length ? encodeUnifiedInboxCursor(page[page.length - 1]) : undefined,
+  };
+}
+
+export async function deriveTenantUnifiedInbox(
+  tenantWorkspaceContext: TenantScopeContext,
+  options: TenantDerivationOptions = {}
+): Promise<UnifiedInboxPage> {
+  if (!tenantWorkspaceContext?.tenantWorkspaceId) return { items: [] };
+
+  const items = [
+    ...(options.notifications || []).map((item) => adaptTenantNotificationToInboxEvent(item, tenantWorkspaceContext)),
+    ...(options.messages || []).map((item) => adaptTenantMessageToInboxEvent(item, tenantWorkspaceContext)),
+    ...(options.maintenanceRequests || []).map((item) => adaptTenantMaintenanceToInboxEvent(item, tenantWorkspaceContext)),
+    ...(options.screeningRequests || []).map((item) => adaptTenantScreeningToInboxEvent(item, tenantWorkspaceContext)),
+  ].filter((item): item is UnifiedInboxEvent => Boolean(item));
+
+  return paginate(items, options);
+}
+
+export async function deriveLandlordUnifiedInbox(
+  landlordId: string,
+  options: LandlordDerivationOptions = {}
+): Promise<UnifiedInboxPage> {
+  const context: LandlordScopeContext = { landlordId: String(landlordId || "").trim() };
+  if (!context.landlordId) return { items: [] };
+
+  const items = [
+    ...(options.applicationItems || []).map((item) => adaptLandlordApplicationInboxToInboxEvent(item, context)),
+    ...(options.screeningItems || []).map((item) => adaptLandlordScreeningInboxToInboxEvent(item, context)),
+    ...(options.leaseItems || []).map((item) => adaptLandlordLeaseInboxToInboxEvent(item, context)),
+    ...(options.maintenanceRequests || []).map((item) => adaptLandlordMaintenanceInboxToInboxEvent(item, context)),
+    ...(options.messages || []).map((item) => adaptLandlordMessageInboxToInboxEvent(item, context)),
+  ].filter((item): item is UnifiedInboxEvent => Boolean(item));
+
+  return paginate(items, options);
+}

--- a/rentchain-api/src/services/unifiedInbox/index.ts
+++ b/rentchain-api/src/services/unifiedInbox/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Unified inbox data layer.
+ *
+ * Pure role-safe adapters for existing source records. No routes,
+ * persistence, realtime delivery, or source mutations live here.
+ * See docs/architecture/unified-inbox-implementation-guardrails.md.
+ */
+export * from "./types";
+export * from "./safeInboxReferences";
+export * from "./tenantInboxAdapters";
+export * from "./landlordInboxAdapters";
+export * from "./deriveUnifiedInbox";

--- a/rentchain-api/src/services/unifiedInbox/landlordInboxAdapters.ts
+++ b/rentchain-api/src/services/unifiedInbox/landlordInboxAdapters.ts
@@ -1,0 +1,231 @@
+import {
+  buildSafeSourceRef,
+  generateSafeInboxId,
+  generateSafeScopeKey,
+  safeSourceId,
+} from "./safeInboxReferences";
+import type {
+  LandlordScopeContext,
+  SourceKind,
+  UnifiedInboxEvent,
+  UnifiedInboxPriority,
+  UnifiedInboxStatus,
+} from "./types";
+
+const SAFETY_FLAGS = {
+  rawIdsIncluded: false,
+  tokensIncluded: false,
+  secretsIncluded: false,
+  providerPayloadIncluded: false,
+  storagePathIncluded: false,
+  privateNotesIncluded: false,
+} as const;
+
+const SENSITIVE_KEYS = [
+  "adminMetadata",
+  "adminNotes",
+  "providerPayload",
+  "providerResponse",
+  "screeningReport",
+  "tenantPrivateDocuments",
+  "privateDocuments",
+  "storagePath",
+  "token",
+  "secret",
+  "rawId",
+  "unrelatedContractorThread",
+];
+
+// LANDLORD PROJECTION: landlord events must exclude cross-landlord records, admin-only metadata, tenant private documents, and unrelated contractor threads.
+function asString(value: unknown, fallback = "", max = 500): string {
+  const next = String(value || "").trim().slice(0, max);
+  return next || fallback;
+}
+
+function toIso(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  if (value && typeof (value as any).toMillis === "function") return new Date((value as any).toMillis()).toISOString();
+  if (value && typeof (value as any).seconds === "number") return new Date((value as any).seconds * 1000).toISOString();
+  return new Date(0).toISOString();
+}
+
+function normalizePriority(value: unknown): UnifiedInboxPriority {
+  const next = asString(value, "normal", 40).toLowerCase();
+  if (next === "critical" || next === "high" || next === "low") return next;
+  if (next === "medium") return "normal";
+  return "normal";
+}
+
+function normalizeStatus(value: unknown, readAt: string | null): UnifiedInboxStatus {
+  const next = asString(value, "", 40).toLowerCase();
+  if (next === "archived" || next === "muted" || next === "resolved") return next;
+  if (next === "completed") return "resolved";
+  return readAt ? "read" : "unread";
+}
+
+function hasLandlordScope(record: any, context: LandlordScopeContext): boolean {
+  const landlordId = asString(context.landlordId, "", 160);
+  if (!landlordId) return false;
+  const candidates = [record?.landlordId, record?.ownerId, record?.userId, record?.audienceScopeKey].map((value) =>
+    asString(value, "", 160)
+  );
+  return candidates.some((value) => value === landlordId);
+}
+
+function hasSensitiveValues(record: any): boolean {
+  return SENSITIVE_KEYS.some((key) => record?.[key] != null);
+}
+
+function hasUnsafeText(...values: unknown[]): boolean {
+  return values.some((value) =>
+    /(gs:\/\/|storage\/|firestore|providerPayload|token|secret|-----BEGIN|rawId|adminNotes|privateDocuments)/i.test(
+      String(value || "")
+    )
+  );
+}
+
+function makeLandlordEvent(params: {
+  sourceKind: SourceKind;
+  sourceStableKey: string;
+  context: LandlordScopeContext;
+  title: string;
+  body: string;
+  priority?: UnifiedInboxPriority;
+  status?: UnifiedInboxStatus;
+  occurredAt: string;
+  readAt?: string | null;
+}): UnifiedInboxEvent {
+  const audienceScopeKey = generateSafeScopeKey("landlord", asString(params.context.landlordId, "", 160));
+  const id = generateSafeInboxId(params.sourceKind, params.sourceStableKey, audienceScopeKey);
+  return {
+    ...SAFETY_FLAGS,
+    id,
+    sourceKind: params.sourceKind,
+    sourceId: safeSourceId(params.sourceKind, params.sourceStableKey, audienceScopeKey),
+    audienceRole: "landlord",
+    audienceScopeKey,
+    title: params.title,
+    body: params.body,
+    priority: params.priority || "normal",
+    status: params.status || normalizeStatus(null, params.readAt || null),
+    occurredAt: params.occurredAt,
+    readAt: params.readAt || null,
+    sourceRef: buildSafeSourceRef(params.sourceKind, params.sourceStableKey, audienceScopeKey),
+  };
+}
+
+export function adaptLandlordApplicationInboxToInboxEvent(
+  inboxItem: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(inboxItem, landlordScopeContext) || hasSensitiveValues(inboxItem)) return null;
+  const stableKey = asString(inboxItem?.id || inboxItem?.applicationId || inboxItem?.subjectId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(inboxItem?.title, inboxItem?.description, inboxItem?.summary)) return null;
+  const readAt = inboxItem?.readAt ? toIso(inboxItem.readAt) : null;
+  return makeLandlordEvent({
+    sourceKind: "landlord.application",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title: asString(inboxItem?.title, "Application ready for review", 180),
+    body: asString(inboxItem?.description || inboxItem?.summary, "Application update is available.", 1000),
+    priority: normalizePriority(inboxItem?.priority),
+    status: normalizeStatus(inboxItem?.status, readAt),
+    occurredAt: toIso(inboxItem?.occurredAt || inboxItem?.createdAt || inboxItem?.updatedAt),
+    readAt,
+  });
+}
+
+export function adaptLandlordScreeningInboxToInboxEvent(
+  inboxItem: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(inboxItem, landlordScopeContext) || hasSensitiveValues(inboxItem)) return null;
+  const stableKey = asString(inboxItem?.id || inboxItem?.screeningRequestId || inboxItem?.applicationId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(inboxItem?.title, inboxItem?.description, inboxItem?.nextAction, inboxItem?.summary)) return null;
+  const readAt = inboxItem?.readAt ? toIso(inboxItem.readAt) : null;
+  return makeLandlordEvent({
+    sourceKind: "landlord.screening",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title: asString(inboxItem?.title, "Screening needs review", 180),
+    body: asString(inboxItem?.description || inboxItem?.nextAction || inboxItem?.summary, "Screening update is available.", 1000),
+    priority: normalizePriority(inboxItem?.priority || "high"),
+    status: normalizeStatus(inboxItem?.status, readAt),
+    occurredAt: toIso(inboxItem?.occurredAt || inboxItem?.createdAt || inboxItem?.updatedAt),
+    readAt,
+  });
+}
+
+export function adaptLandlordLeaseInboxToInboxEvent(
+  decisionItem: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(decisionItem, landlordScopeContext) || hasSensitiveValues(decisionItem)) return null;
+  const stableKey = asString(decisionItem?.id || decisionItem?.leaseId || decisionItem?.subjectId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(decisionItem?.title, decisionItem?.actionLabel, decisionItem?.description, decisionItem?.explanation, decisionItem?.summary)) return null;
+  const readAt = decisionItem?.readAt ? toIso(decisionItem.readAt) : null;
+  return makeLandlordEvent({
+    sourceKind: "landlord.lease",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title: asString(decisionItem?.title || decisionItem?.actionLabel, "Lease action available", 180),
+    body: asString(decisionItem?.description || decisionItem?.explanation || decisionItem?.summary, "Lease lifecycle update is available.", 1000),
+    priority: normalizePriority(decisionItem?.priority),
+    status: normalizeStatus(decisionItem?.status || decisionItem?.state, readAt),
+    occurredAt: toIso(decisionItem?.occurredAt || decisionItem?.createdAt || decisionItem?.updatedAt),
+    readAt,
+  });
+}
+
+export function adaptLandlordMaintenanceInboxToInboxEvent(
+  maintenanceRequest: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(maintenanceRequest, landlordScopeContext) || hasSensitiveValues(maintenanceRequest)) return null;
+  const stableKey = asString(maintenanceRequest?.id || maintenanceRequest?.requestId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(maintenanceRequest?.title, maintenanceRequest?.status)) return null;
+  const status = asString(maintenanceRequest?.status, "submitted", 80);
+  const readAt = maintenanceRequest?.readAt ? toIso(maintenanceRequest.readAt) : null;
+  return makeLandlordEvent({
+    sourceKind: "landlord.maintenance",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title: asString(maintenanceRequest?.title, "Maintenance request", 180),
+    body: `Status: ${status}`,
+    priority: normalizePriority(maintenanceRequest?.priority || (/(urgent|blocked|cancelled)/i.test(status) ? "high" : "normal")),
+    status: normalizeStatus(maintenanceRequest?.inboxStatus, readAt),
+    occurredAt: toIso(maintenanceRequest?.updatedAt || maintenanceRequest?.createdAt || maintenanceRequest?.occurredAt),
+    readAt,
+  });
+}
+
+export function adaptLandlordMessageInboxToInboxEvent(
+  message: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(message, landlordScopeContext) || hasSensitiveValues(message)) return null;
+  const stableKey = asString(message?.id || message?.messageId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(message?.body, message?.text, message?.summary)) return null;
+  const readAt = message?.readAt ? toIso(message.readAt) : null;
+  const senderRole = asString(message?.senderRole, "tenant", 40).toLowerCase();
+  return makeLandlordEvent({
+    sourceKind: "landlord.message",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title: senderRole === "contractor" ? "Contractor message" : "Tenant message",
+    body: asString(message?.body || message?.text || message?.summary, "You have a message update.", 1000),
+    priority: normalizePriority(message?.priority),
+    status: normalizeStatus(message?.status, readAt),
+    occurredAt: toIso(message?.createdAt || message?.createdAtMs || message?.occurredAt),
+    readAt,
+  });
+}

--- a/rentchain-api/src/services/unifiedInbox/safeInboxReferences.ts
+++ b/rentchain-api/src/services/unifiedInbox/safeInboxReferences.ts
@@ -1,0 +1,51 @@
+import crypto from "crypto";
+import type { SourceKind, UnifiedInboxAudienceRole, UnifiedInboxSourceRef } from "./types";
+
+function asSafePart(value: string): string {
+  return String(value || "").trim();
+}
+
+export function generateSafeInboxId(
+  sourceKind: SourceKind,
+  sourceStableKey: string,
+  audienceScopeKey: string
+): string {
+  const input = [sourceKind, sourceStableKey, audienceScopeKey].map(asSafePart).join("|");
+  const digest = crypto.createHash("sha256").update(input).digest("base64url").slice(0, 32);
+  return `inbox_v1_${digest}`;
+}
+
+export function buildSafeSourceRef(
+  sourceKind: SourceKind,
+  sourceStableKey: string,
+  audienceScopeKey: string
+): UnifiedInboxSourceRef {
+  return {
+    kind: sourceKind,
+    ref: generateSafeInboxId(sourceKind, sourceStableKey, audienceScopeKey),
+  };
+}
+
+export function safeSourceId(
+  sourceKind: SourceKind,
+  sourceStableKey: string,
+  audienceScopeKey: string
+): string {
+  return buildSafeSourceRef(sourceKind, sourceStableKey, audienceScopeKey).ref;
+}
+
+export function generateSafeScopeKey(role: UnifiedInboxAudienceRole, rawScopeKey: string): string {
+  const input = [role, rawScopeKey].map(asSafePart).join("|");
+  const digest = crypto.createHash("sha256").update(input).digest("base64url").slice(0, 32);
+  return `scope_v1_${digest}`;
+}
+
+export function safeIdContainsRawValue(safeId: string, rawValue: string): boolean {
+  const raw = String(rawValue || "").trim();
+  if (!raw) return false;
+  return safeId.includes(raw);
+}
+
+export function isBase64UrlSafeInboxId(value: string): boolean {
+  return /^inbox_v1_[A-Za-z0-9_-]+$/.test(String(value || ""));
+}

--- a/rentchain-api/src/services/unifiedInbox/tenantInboxAdapters.ts
+++ b/rentchain-api/src/services/unifiedInbox/tenantInboxAdapters.ts
@@ -1,0 +1,236 @@
+import {
+  buildSafeSourceRef,
+  generateSafeInboxId,
+  generateSafeScopeKey,
+  safeSourceId,
+} from "./safeInboxReferences";
+import type {
+  SourceKind,
+  TenantScopeContext,
+  UnifiedInboxEvent,
+  UnifiedInboxPriority,
+  UnifiedInboxStatus,
+} from "./types";
+
+const SAFETY_FLAGS = {
+  rawIdsIncluded: false,
+  tokensIncluded: false,
+  secretsIncluded: false,
+  providerPayloadIncluded: false,
+  storagePathIncluded: false,
+  privateNotesIncluded: false,
+} as const;
+
+const SENSITIVE_KEYS = [
+  "landlordNote",
+  "landlordNotes",
+  "adminMetadata",
+  "adminNotes",
+  "providerPayload",
+  "providerResponse",
+  "screeningReport",
+  "reportContents",
+  "storagePath",
+  "token",
+  "secret",
+  "rawId",
+  "firestoreId",
+  "contractorInternalNotes",
+];
+
+const TENANT_NOTIFICATION_SOURCE_KINDS: SourceKind[] = [
+  "tenant.application",
+  "tenant.lease",
+  "tenant.maintenance",
+  "tenant.message",
+  "tenant.notice",
+  "tenant.screening",
+];
+
+// TENANT PROJECTION: tenant events must exclude landlord notes, provider payloads, raw IDs, admin decisions, and private operational notes.
+function asString(value: unknown, fallback = "", max = 500): string {
+  const next = String(value || "").trim().slice(0, max);
+  return next || fallback;
+}
+
+function toIso(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  if (value && typeof (value as any).toMillis === "function") {
+    return new Date((value as any).toMillis()).toISOString();
+  }
+  if (value && typeof (value as any).seconds === "number") {
+    return new Date((value as any).seconds * 1000).toISOString();
+  }
+  return new Date(0).toISOString();
+}
+
+function normalizePriority(value: unknown): UnifiedInboxPriority {
+  const next = asString(value, "normal", 40).toLowerCase();
+  if (next === "critical" || next === "high" || next === "low") return next;
+  return "normal";
+}
+
+function normalizeStatus(value: unknown, readAt: string | null): UnifiedInboxStatus {
+  const next = asString(value, "", 40).toLowerCase();
+  if (next === "archived" || next === "muted" || next === "resolved") return next;
+  return readAt ? "read" : "unread";
+}
+
+function hasTenantScope(record: any, context: TenantScopeContext): boolean {
+  const tenantWorkspaceId = asString(context.tenantWorkspaceId, "", 160);
+  const tenantId = asString(context.tenantId, "", 160);
+  if (!tenantWorkspaceId) return false;
+
+  const candidates = [
+    record?.tenantWorkspaceId,
+    record?.audienceScopeKey,
+    record?.tenantScopeKey,
+    record?.workspaceId,
+  ].map((value) => asString(value, "", 160));
+  if (candidates.some((value) => value === tenantWorkspaceId)) return true;
+
+  const recordTenantId = asString(record?.tenantId || record?.applicantTenantId, "", 160);
+  return Boolean(tenantId && recordTenantId === tenantId);
+}
+
+function hasSensitiveValues(record: any): boolean {
+  return SENSITIVE_KEYS.some((key) => record?.[key] != null);
+}
+
+function hasUnsafeText(...values: unknown[]): boolean {
+  return values.some((value) =>
+    /(gs:\/\/|storage\/|firestore|providerPayload|token|secret|-----BEGIN|rawId|landlordNotes|adminNotes)/i.test(
+      String(value || "")
+    )
+  );
+}
+
+function normalizeTenantSourceKind(value: unknown): SourceKind {
+  const next = asString(value, "tenant.application", 80);
+  return TENANT_NOTIFICATION_SOURCE_KINDS.includes(next as SourceKind) ? (next as SourceKind) : "tenant.application";
+}
+
+function makeTenantEvent(params: {
+  sourceKind: SourceKind;
+  sourceStableKey: string;
+  context: TenantScopeContext;
+  title: string;
+  body: string;
+  priority?: UnifiedInboxPriority;
+  status?: UnifiedInboxStatus;
+  occurredAt: string;
+  readAt?: string | null;
+}): UnifiedInboxEvent {
+  const audienceScopeKey = generateSafeScopeKey("tenant", asString(params.context.tenantWorkspaceId, "", 160));
+  const id = generateSafeInboxId(params.sourceKind, params.sourceStableKey, audienceScopeKey);
+  return {
+    ...SAFETY_FLAGS,
+    id,
+    sourceKind: params.sourceKind,
+    sourceId: safeSourceId(params.sourceKind, params.sourceStableKey, audienceScopeKey),
+    audienceRole: "tenant",
+    audienceScopeKey,
+    title: params.title,
+    body: params.body,
+    priority: params.priority || "normal",
+    status: params.status || normalizeStatus(null, params.readAt || null),
+    occurredAt: params.occurredAt,
+    readAt: params.readAt || null,
+    sourceRef: buildSafeSourceRef(params.sourceKind, params.sourceStableKey, audienceScopeKey),
+  };
+}
+
+export function adaptTenantNotificationToInboxEvent(
+  notification: any,
+  tenantScopeContext: TenantScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasTenantScope(notification, tenantScopeContext) || hasSensitiveValues(notification)) return null;
+  const stableKey = asString(notification?.id || notification?.notificationId || notification?.sourceKey, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(notification?.title, notification?.summary, notification?.body, notification?.message)) return null;
+  const readAt = notification?.readAt ? toIso(notification.readAt) : null;
+  return makeTenantEvent({
+    sourceKind: normalizeTenantSourceKind(notification?.sourceKind),
+    sourceStableKey: stableKey,
+    context: tenantScopeContext,
+    title: asString(notification?.title, "Tenant notification", 160),
+    body: asString(notification?.summary || notification?.body || notification?.message, "Tenant workspace update", 1000),
+    priority: normalizePriority(notification?.priority || notification?.status),
+    status: normalizeStatus(notification?.status, readAt),
+    occurredAt: toIso(notification?.createdAt || notification?.occurredAt || notification?.updatedAt),
+    readAt,
+  });
+}
+
+export function adaptTenantMessageToInboxEvent(
+  message: any,
+  tenantScopeContext: TenantScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasTenantScope(message, tenantScopeContext) || hasSensitiveValues(message)) return null;
+  const stableKey = asString(message?.id || message?.messageId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(message?.body, message?.text, message?.summary)) return null;
+  const readAt = message?.readAt ? toIso(message.readAt) : null;
+  const senderRole = asString(message?.senderRole, "landlord", 40).toLowerCase();
+  return makeTenantEvent({
+    sourceKind: "tenant.message",
+    sourceStableKey: stableKey,
+    context: tenantScopeContext,
+    title: senderRole === "landlord" ? "Message from landlord" : "Message update",
+    body: asString(message?.body || message?.text || message?.summary, "You have a message update.", 1000),
+    priority: normalizePriority(message?.priority),
+    status: normalizeStatus(message?.status, readAt),
+    occurredAt: toIso(message?.createdAt || message?.createdAtMs || message?.occurredAt),
+    readAt,
+  });
+}
+
+export function adaptTenantMaintenanceToInboxEvent(
+  maintenanceRequest: any,
+  tenantScopeContext: TenantScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasTenantScope(maintenanceRequest, tenantScopeContext) || hasSensitiveValues(maintenanceRequest)) return null;
+  const stableKey = asString(maintenanceRequest?.id || maintenanceRequest?.requestId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(maintenanceRequest?.title, maintenanceRequest?.status)) return null;
+  const status = asString(maintenanceRequest?.status, "submitted", 80);
+  const readAt = maintenanceRequest?.readAt ? toIso(maintenanceRequest.readAt) : null;
+  return makeTenantEvent({
+    sourceKind: "tenant.maintenance",
+    sourceStableKey: stableKey,
+    context: tenantScopeContext,
+    title: asString(maintenanceRequest?.title, "Maintenance request", 160),
+    body: `Status: ${status}`,
+    priority: normalizePriority(maintenanceRequest?.priority || (/(urgent|blocked|cancelled)/i.test(status) ? "high" : "normal")),
+    status: normalizeStatus(maintenanceRequest?.inboxStatus, readAt),
+    occurredAt: toIso(maintenanceRequest?.updatedAt || maintenanceRequest?.createdAt || maintenanceRequest?.occurredAt),
+    readAt,
+  });
+}
+
+export function adaptTenantScreeningToInboxEvent(
+  screeningRequest: any,
+  tenantScopeContext: TenantScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasTenantScope(screeningRequest, tenantScopeContext) || hasSensitiveValues(screeningRequest)) return null;
+  const stableKey = asString(screeningRequest?.id || screeningRequest?.requestId, "", 240);
+  if (!stableKey) return null;
+  if (hasUnsafeText(screeningRequest?.status, screeningRequest?.nextAction)) return null;
+  const screeningStatus = asString(screeningRequest?.status, "pending", 80);
+  const readAt = screeningRequest?.readAt ? toIso(screeningRequest.readAt) : null;
+  return makeTenantEvent({
+    sourceKind: "tenant.screening",
+    sourceStableKey: stableKey,
+    context: tenantScopeContext,
+    title: screeningStatus === "consent_pending" ? "Screening consent required" : "Screening update",
+    body: asString(screeningRequest?.nextAction || `Screening status: ${screeningStatus}`, `Screening status: ${screeningStatus}`, 1000),
+    priority: normalizePriority(screeningRequest?.priority || (screeningStatus === "consent_pending" ? "high" : "normal")),
+    status: normalizeStatus(screeningRequest?.inboxStatus, readAt),
+    occurredAt: toIso(screeningRequest?.requestedAt || screeningRequest?.createdAt || screeningRequest?.updatedAt),
+    readAt,
+  });
+}

--- a/rentchain-api/src/services/unifiedInbox/types.ts
+++ b/rentchain-api/src/services/unifiedInbox/types.ts
@@ -1,0 +1,70 @@
+export type UnifiedInboxAudienceRole = "tenant" | "landlord" | "contractor";
+
+export type UnifiedInboxPriority = "critical" | "high" | "normal" | "low";
+
+export type UnifiedInboxStatus = "unread" | "read" | "archived" | "muted" | "resolved";
+
+export type SourceKind =
+  | "tenant.message"
+  | "tenant.maintenance"
+  | "tenant.screening"
+  | "tenant.lease"
+  | "tenant.application"
+  | "tenant.notice"
+  | "landlord.application"
+  | "landlord.screening"
+  | "landlord.lease"
+  | "landlord.maintenance"
+  | "landlord.message";
+
+export type TenantScopeContext = {
+  tenantWorkspaceId: string;
+  tenantId?: string | null;
+};
+
+export type LandlordScopeContext = {
+  landlordId: string;
+};
+
+export type ContractorScopeContext = {
+  contractorId: string;
+};
+
+export type UnifiedInboxSafetyFlags = {
+  rawIdsIncluded: false;
+  tokensIncluded: false;
+  secretsIncluded: false;
+  providerPayloadIncluded: false;
+  storagePathIncluded: false;
+  privateNotesIncluded: false;
+};
+
+export type UnifiedInboxSourceRef = {
+  kind: SourceKind;
+  ref: string;
+};
+
+export type UnifiedInboxEvent = UnifiedInboxSafetyFlags & {
+  id: string;
+  sourceKind: SourceKind;
+  sourceId: string;
+  audienceRole: UnifiedInboxAudienceRole;
+  audienceScopeKey: string;
+  title: string;
+  body: string;
+  priority: UnifiedInboxPriority;
+  status: UnifiedInboxStatus;
+  occurredAt: string;
+  readAt: string | null;
+  sourceRef: UnifiedInboxSourceRef;
+};
+
+export type UnifiedInboxPage = {
+  items: UnifiedInboxEvent[];
+  nextCursor?: string;
+};
+
+export type UnifiedInboxPaginationOptions = {
+  limit?: number;
+  cursor?: string;
+};

--- a/rentchain-api/src/tests/unifiedInbox/deriveUnifiedInbox.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/deriveUnifiedInbox.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveLandlordUnifiedInbox,
+  deriveTenantUnifiedInbox,
+  encodeUnifiedInboxCursor,
+  sortUnifiedInboxEvents,
+} from "../../services/unifiedInbox";
+import type { UnifiedInboxEvent } from "../../services/unifiedInbox";
+
+function event(overrides: Partial<UnifiedInboxEvent>): UnifiedInboxEvent {
+  return {
+    id: "inbox_v1_default",
+    sourceKind: "tenant.message",
+    sourceId: "inbox_v1_source",
+    audienceRole: "tenant",
+    audienceScopeKey: "scope_v1_default",
+    title: "Title",
+    body: "Body",
+    priority: "normal",
+    status: "unread",
+    occurredAt: "2026-06-09T10:00:00.000Z",
+    readAt: null,
+    sourceRef: { kind: "tenant.message", ref: "inbox_v1_source" },
+    rawIdsIncluded: false,
+    tokensIncluded: false,
+    secretsIncluded: false,
+    providerPayloadIncluded: false,
+    storagePathIncluded: false,
+    privateNotesIncluded: false,
+    ...overrides,
+  };
+}
+
+describe("derive unified inbox", () => {
+  it("sorts unread events before read events, then priority and recency", () => {
+    const sorted = sortUnifiedInboxEvents([
+      event({ id: "inbox_v1_read_critical", priority: "critical", status: "read", readAt: "2026-06-09T14:00:00.000Z" }),
+      event({ id: "inbox_v1_unread_normal_new", priority: "normal", occurredAt: "2026-06-09T15:00:00.000Z" }),
+      event({ id: "inbox_v1_unread_high_old", priority: "high", occurredAt: "2026-06-09T09:00:00.000Z" }),
+    ]);
+
+    expect(sorted.map((item) => item.id)).toEqual([
+      "inbox_v1_unread_high_old",
+      "inbox_v1_unread_normal_new",
+      "inbox_v1_read_critical",
+    ]);
+  });
+
+  it("derives tenant events from scoped sources only and paginates by safe cursor", async () => {
+    const context = {
+      tenantWorkspaceId: "tenant_workspace_raw_abc",
+      tenantId: "tenant_raw_abc",
+    };
+    const notifications = [
+      {
+        id: "notification_raw_1",
+        tenantWorkspaceId: "tenant_workspace_raw_abc",
+        title: "Normal update",
+        summary: "Ready",
+        priority: "normal",
+        createdAt: "2026-06-09T10:00:00.000Z",
+      },
+      {
+        id: "notification_raw_2",
+        tenantWorkspaceId: "tenant_workspace_raw_abc",
+        title: "High update",
+        summary: "Ready",
+        priority: "high",
+        createdAt: "2026-06-09T09:00:00.000Z",
+      },
+      {
+        id: "notification_raw_3",
+        tenantWorkspaceId: "other_workspace",
+        title: "Other update",
+      },
+    ];
+
+    const firstPage = await deriveTenantUnifiedInbox(context, { notifications, limit: 1 });
+    expect(firstPage.items).toHaveLength(1);
+    expect(firstPage.items[0].title).toBe("High update");
+    expect(firstPage.nextCursor).toBeTruthy();
+    expect(firstPage.nextCursor).not.toContain("notification_raw_2");
+
+    const secondPage = await deriveTenantUnifiedInbox(context, {
+      notifications,
+      limit: 5,
+      cursor: firstPage.nextCursor,
+    });
+
+    expect(secondPage.items).toHaveLength(1);
+    expect(secondPage.items[0].title).toBe("Normal update");
+    expect(JSON.stringify([...firstPage.items, ...secondPage.items])).not.toContain("tenant_workspace_raw_abc");
+    expect(JSON.stringify([...firstPage.items, ...secondPage.items])).not.toContain("notification_raw_");
+  });
+
+  it("derives landlord events from scoped sources only", async () => {
+    const page = await deriveLandlordUnifiedInbox("landlord_raw_abc", {
+      applicationItems: [
+        {
+          id: "application_raw_1",
+          landlordId: "landlord_raw_abc",
+          title: "Application ready",
+          summary: "Review needed",
+          priority: "high",
+          occurredAt: "2026-06-09T10:00:00.000Z",
+        },
+        {
+          id: "application_raw_2",
+          landlordId: "landlord_other",
+          title: "Other application",
+          summary: "Should not project",
+        },
+      ],
+      leaseItems: [
+        {
+          id: "lease_raw_1",
+          landlordId: "landlord_raw_abc",
+          title: "Lease ready",
+          state: "pending",
+          occurredAt: "2026-06-09T11:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(page.items.map((item) => item.title)).toEqual(["Application ready", "Lease ready"]);
+    expect(JSON.stringify(page.items)).not.toContain("landlord_raw_abc");
+    expect(JSON.stringify(page.items)).not.toContain("application_raw_");
+    expect(JSON.stringify(page.items)).not.toContain("lease_raw_");
+  });
+
+  it("returns empty pages for missing scope and ignores invalid cursors", async () => {
+    await expect(deriveTenantUnifiedInbox({ tenantWorkspaceId: "" })).resolves.toEqual({ items: [] });
+    await expect(deriveLandlordUnifiedInbox("")).resolves.toEqual({ items: [] });
+
+    const page = await deriveTenantUnifiedInbox(
+      { tenantWorkspaceId: "tenant_workspace_raw_abc" },
+      {
+        notifications: [
+          {
+            id: "notification_raw_1",
+            tenantWorkspaceId: "tenant_workspace_raw_abc",
+            title: "Update",
+          },
+        ],
+        cursor: encodeUnifiedInboxCursor(event({ id: "inbox_v1_missing" })),
+      }
+    );
+
+    expect(page.items).toHaveLength(1);
+  });
+});

--- a/rentchain-api/src/tests/unifiedInbox/landlordInboxAdapters.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/landlordInboxAdapters.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  adaptLandlordApplicationInboxToInboxEvent,
+  adaptLandlordLeaseInboxToInboxEvent,
+  adaptLandlordMaintenanceInboxToInboxEvent,
+  adaptLandlordMessageInboxToInboxEvent,
+  adaptLandlordScreeningInboxToInboxEvent,
+} from "../../services/unifiedInbox";
+
+const landlordContext = {
+  landlordId: "landlord_raw_abc",
+};
+
+function expectLandlordSafe(event: NonNullable<ReturnType<typeof adaptLandlordApplicationInboxToInboxEvent>>) {
+  expect(event.audienceRole).toBe("landlord");
+  expect(event.rawIdsIncluded).toBe(false);
+  expect(event.tokensIncluded).toBe(false);
+  expect(event.secretsIncluded).toBe(false);
+  expect(event.providerPayloadIncluded).toBe(false);
+  expect(event.storagePathIncluded).toBe(false);
+  expect(event.privateNotesIncluded).toBe(false);
+  expect(event.id).toMatch(/^inbox_v1_/);
+  expect(event.sourceId).toMatch(/^inbox_v1_/);
+  expect(event.audienceScopeKey).toMatch(/^scope_v1_/);
+  expect(JSON.stringify(event)).not.toContain("landlord_raw_abc");
+}
+
+describe("landlord inbox adapters", () => {
+  it("projects landlord inbox items into safe events", () => {
+    const event = adaptLandlordApplicationInboxToInboxEvent(
+      {
+        id: "application_raw_123",
+        landlordId: "landlord_raw_abc",
+        title: "Application ready",
+        summary: "Applicant package is ready.",
+        priority: "critical",
+        occurredAt: "2026-06-09T10:00:00.000Z",
+      },
+      landlordContext
+    );
+
+    expect(event).toMatchObject({
+      sourceKind: "landlord.application",
+      title: "Application ready",
+      body: "Applicant package is ready.",
+      priority: "critical",
+      status: "unread",
+      occurredAt: "2026-06-09T10:00:00.000Z",
+    });
+    expectLandlordSafe(event!);
+    expect(JSON.stringify(event)).not.toContain("application_raw_123");
+  });
+
+  it("rejects cross-landlord and sensitive landlord records", () => {
+    expect(
+      adaptLandlordApplicationInboxToInboxEvent(
+        {
+          id: "application_raw_123",
+          landlordId: "landlord_other",
+          title: "Other landlord application",
+        },
+        landlordContext
+      )
+    ).toBeNull();
+
+    expect(
+      adaptLandlordScreeningInboxToInboxEvent(
+        {
+          id: "screening_raw_123",
+          landlordId: "landlord_raw_abc",
+          title: "Screening ready",
+          providerPayload: { raw: true },
+        },
+        landlordContext
+      )
+    ).toBeNull();
+
+    expect(
+      adaptLandlordLeaseInboxToInboxEvent(
+        {
+          id: "lease_raw_123",
+          landlordId: "landlord_raw_abc",
+          title: "Secret token exposed",
+        },
+        landlordContext
+      )
+    ).toBeNull();
+  });
+
+  it("adapts lease, maintenance, and message sources without source mutation", () => {
+    const lease = {
+      id: "lease_raw_123",
+      landlordId: "landlord_raw_abc",
+      title: "Lease ready",
+      state: "pending",
+      updatedAt: "2026-06-09T11:00:00.000Z",
+    };
+    const maintenance = {
+      id: "maintenance_raw_123",
+      ownerId: "landlord_raw_abc",
+      title: "Bathroom fan",
+      status: "submitted",
+      updatedAt: "2026-06-09T12:00:00.000Z",
+    };
+    const message = {
+      id: "message_raw_123",
+      userId: "landlord_raw_abc",
+      senderRole: "tenant",
+      body: "Can we schedule a viewing?",
+      createdAt: "2026-06-09T13:00:00.000Z",
+    };
+    const before = JSON.stringify({ lease, maintenance, message });
+
+    const leaseEvent = adaptLandlordLeaseInboxToInboxEvent(lease, landlordContext);
+    const maintenanceEvent = adaptLandlordMaintenanceInboxToInboxEvent(maintenance, landlordContext);
+    const messageEvent = adaptLandlordMessageInboxToInboxEvent(message, landlordContext);
+
+    expect(leaseEvent).toMatchObject({ sourceKind: "landlord.lease", title: "Lease ready" });
+    expect(maintenanceEvent).toMatchObject({ sourceKind: "landlord.maintenance", body: "Status: submitted" });
+    expect(messageEvent).toMatchObject({ sourceKind: "landlord.message", title: "Tenant message" });
+    expectLandlordSafe(leaseEvent!);
+    expectLandlordSafe(maintenanceEvent!);
+    expectLandlordSafe(messageEvent!);
+    expect(JSON.stringify({ lease, maintenance, message })).toBe(before);
+  });
+});

--- a/rentchain-api/src/tests/unifiedInbox/safeInboxReferences.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/safeInboxReferences.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSafeSourceRef,
+  generateSafeInboxId,
+  generateSafeScopeKey,
+  isBase64UrlSafeInboxId,
+  safeIdContainsRawValue,
+  safeSourceId,
+} from "../../services/unifiedInbox";
+
+describe("safe inbox references", () => {
+  it("generates deterministic safe inbox IDs without raw source values", () => {
+    const id = generateSafeInboxId("tenant.message", "message_raw_123", "scope_raw_456");
+    const repeated = generateSafeInboxId("tenant.message", "message_raw_123", "scope_raw_456");
+
+    expect(id).toBe(repeated);
+    expect(isBase64UrlSafeInboxId(id)).toBe(true);
+    expect(safeIdContainsRawValue(id, "message_raw_123")).toBe(false);
+    expect(safeIdContainsRawValue(id, "scope_raw_456")).toBe(false);
+  });
+
+  it("builds source refs and scope keys with stable safe prefixes", () => {
+    const scopeKey = generateSafeScopeKey("landlord", "landlord_raw_abc");
+    const sourceId = safeSourceId("landlord.application", "application_raw_abc", scopeKey);
+    const sourceRef = buildSafeSourceRef("landlord.application", "application_raw_abc", scopeKey);
+
+    expect(scopeKey).toMatch(/^scope_v1_[A-Za-z0-9_-]+$/);
+    expect(sourceId).toMatch(/^inbox_v1_[A-Za-z0-9_-]+$/);
+    expect(sourceRef).toEqual({
+      kind: "landlord.application",
+      ref: sourceId,
+    });
+    expect(JSON.stringify({ scopeKey, sourceId, sourceRef })).not.toContain("landlord_raw_abc");
+    expect(JSON.stringify({ scopeKey, sourceId, sourceRef })).not.toContain("application_raw_abc");
+  });
+});

--- a/rentchain-api/src/tests/unifiedInbox/tenantInboxAdapters.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/tenantInboxAdapters.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  adaptTenantMaintenanceToInboxEvent,
+  adaptTenantMessageToInboxEvent,
+  adaptTenantNotificationToInboxEvent,
+  adaptTenantScreeningToInboxEvent,
+} from "../../services/unifiedInbox";
+
+const tenantContext = {
+  tenantWorkspaceId: "tenant_workspace_raw_abc",
+  tenantId: "tenant_raw_abc",
+};
+
+function expectTenantSafe(event: NonNullable<ReturnType<typeof adaptTenantNotificationToInboxEvent>>) {
+  expect(event.audienceRole).toBe("tenant");
+  expect(event.rawIdsIncluded).toBe(false);
+  expect(event.tokensIncluded).toBe(false);
+  expect(event.secretsIncluded).toBe(false);
+  expect(event.providerPayloadIncluded).toBe(false);
+  expect(event.storagePathIncluded).toBe(false);
+  expect(event.privateNotesIncluded).toBe(false);
+  expect(event.id).toMatch(/^inbox_v1_/);
+  expect(event.sourceId).toMatch(/^inbox_v1_/);
+  expect(event.audienceScopeKey).toMatch(/^scope_v1_/);
+  expect(JSON.stringify(event)).not.toContain("tenant_workspace_raw_abc");
+  expect(JSON.stringify(event)).not.toContain("tenant_raw_abc");
+}
+
+describe("tenant inbox adapters", () => {
+  it("projects tenant notifications into safe inbox events", () => {
+    const event = adaptTenantNotificationToInboxEvent(
+      {
+        id: "notification_raw_123",
+        tenantWorkspaceId: "tenant_workspace_raw_abc",
+        sourceKind: "tenant.notice",
+        title: "Notice available",
+        summary: "A notice is ready to review.",
+        priority: "high",
+        createdAt: "2026-06-09T10:00:00.000Z",
+      },
+      tenantContext
+    );
+
+    expect(event).toMatchObject({
+      sourceKind: "tenant.notice",
+      title: "Notice available",
+      body: "A notice is ready to review.",
+      priority: "high",
+      status: "unread",
+      occurredAt: "2026-06-09T10:00:00.000Z",
+    });
+    expectTenantSafe(event!);
+    expect(JSON.stringify(event)).not.toContain("notification_raw_123");
+  });
+
+  it("rejects cross-tenant and sensitive tenant records", () => {
+    expect(
+      adaptTenantNotificationToInboxEvent(
+        {
+          id: "notification_raw_123",
+          tenantWorkspaceId: "tenant_workspace_other",
+          title: "Other tenant notification",
+        },
+        tenantContext
+      )
+    ).toBeNull();
+
+    expect(
+      adaptTenantMessageToInboxEvent(
+        {
+          id: "message_raw_123",
+          tenantWorkspaceId: "tenant_workspace_raw_abc",
+          body: "Tenant-safe body",
+          landlordNotes: "internal landlord note",
+        },
+        tenantContext
+      )
+    ).toBeNull();
+
+    expect(
+      adaptTenantMessageToInboxEvent(
+        {
+          id: "message_raw_124",
+          tenantWorkspaceId: "tenant_workspace_raw_abc",
+          body: "File at gs://bucket/private.pdf",
+        },
+        tenantContext
+      )
+    ).toBeNull();
+  });
+
+  it("adapts tenant maintenance and screening sources without source mutation", () => {
+    const maintenance = {
+      id: "maintenance_raw_123",
+      tenantWorkspaceId: "tenant_workspace_raw_abc",
+      title: "Kitchen sink",
+      status: "urgent",
+      updatedAt: "2026-06-09T11:00:00.000Z",
+    };
+    const screening = {
+      id: "screening_raw_123",
+      applicantTenantId: "tenant_raw_abc",
+      status: "consent_pending",
+      requestedAt: "2026-06-09T12:00:00.000Z",
+    };
+    const before = JSON.stringify({ maintenance, screening });
+
+    const maintenanceEvent = adaptTenantMaintenanceToInboxEvent(maintenance, tenantContext);
+    const screeningEvent = adaptTenantScreeningToInboxEvent(screening, tenantContext);
+
+    expect(maintenanceEvent).toMatchObject({
+      sourceKind: "tenant.maintenance",
+      priority: "high",
+      body: "Status: urgent",
+    });
+    expect(screeningEvent).toMatchObject({
+      sourceKind: "tenant.screening",
+      priority: "high",
+      title: "Screening consent required",
+    });
+    expectTenantSafe(maintenanceEvent!);
+    expectTenantSafe(screeningEvent!);
+    expect(JSON.stringify({ maintenance, screening })).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unified inbox event types, safe reference helpers, and pure tenant/landlord source adapters.
- Add derivation helpers for already-loaded tenant and landlord source records with deterministic sorting and cursor pagination.
- Add projection tests for safe IDs, role scope filtering, sensitive-field rejection, and source immutability.

## Validation
- npm --prefix rentchain-api test -- src/tests/unifiedInbox/ passed
- npm --prefix rentchain-api test -- src/services/unifiedInbox/ passed
- npm --prefix rentchain-api run build passed
- git diff --check passed

## Known limitation
- npm --prefix rentchain-api run lint -- src/services/unifiedInbox/ src/tests/unifiedInbox/ could not run because rentchain-api has no lint script.