### PR TITLE
Expand unified inbox data layer adapters

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,55 +1,55 @@
-PR: #1128
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1128
-Branch: fix/viewing-cancellation-notification-v1
+PR: #PR_NUMBER_PENDING
+PR URL: PR_URL_PENDING
+Branch: feat/unified-inbox-data-layer-expansion-v1
 
 # Implementation Summary
 
 ## Mission
-Fix viewing cancellation and reschedule notifications for applicant-facing viewing workflows.
+Expand the unified inbox data layer with viewing request, notice, application status, work order, and work order communication adapters.
 
 ## Files Changed
-- `rentchain-api/src/routes/viewingRoutes.ts`
-- `rentchain-api/src/routes/__tests__/viewingRoutes.test.ts`
-- `rentchain-api/src/services/viewings/viewingController.ts`
-- `rentchain-api/src/services/viewings/viewingRepository.ts`
-- `rentchain-api/src/services/viewings/viewingService.ts`
-- `rentchain-api/src/services/viewings/viewingTypes.ts`
 - `rentchain-api/src/services/unifiedInbox/types.ts`
 - `rentchain-api/src/services/unifiedInbox/tenantInboxAdapters.ts`
+- `rentchain-api/src/services/unifiedInbox/landlordInboxAdapters.ts`
+- `rentchain-api/src/services/unifiedInbox/contractorInboxAdapters.ts`
+- `rentchain-api/src/services/unifiedInbox/deriveUnifiedInbox.ts`
 - `rentchain-api/src/tests/unifiedInbox/tenantInboxAdapters.test.ts`
+- `rentchain-api/src/tests/unifiedInbox/landlordInboxAdapters.test.ts`
+- `rentchain-api/src/tests/unifiedInbox/contractorInboxAdapters.test.ts`
+- `rentchain-api/src/tests/unifiedInbox/deriveUnifiedInbox.test.ts`
 
 ## What Changed
-- Added applicant notifications for landlord viewing cancellations.
-- Added viewing reschedule service flow and route handler.
-- Added landlord-prefixed route aliases for cancellation and reschedule.
-- Added deterministic safe viewing references for applicant notifications.
-- Added idempotent notification creation for cancellation and unchanged reschedule retries.
-- Added transaction-aware persistence for viewing request update, tenant notification creation, and viewing audit event creation.
-- Added `tenant.viewing` source support for safe tenant inbox projection.
-- Added tests for cancellation notifications, reschedule notifications, retry idempotency, landlord authorization, rollback behavior, and tenant viewing projection.
+- Added tenant adapters for viewing requests, lease notices, and application status records.
+- Added landlord adapters for viewing requests, work orders, lease notices, and application status records.
+- Added contractor adapter for work order communications.
+- Added landlord source kinds for viewing, notice, and work order events.
+- Extended tenant, landlord, and contractor derivation options to aggregate the new source arrays.
+- Added tests for scope validation, sensitive-field rejection, lifecycle status mapping, safe references, and mixed-source aggregation.
 
 ## Governance
-- Scope limited to backend viewing notification behavior, tenant inbox source typing, and tests.
-- No frontend UI, Firestore rules, billing, screening, pricing, deployment, dependency, or auth core changes.
-- Landlord ownership remains enforced server-side before cancellation or reschedule changes.
-- Applicant notifications use safe deterministic viewing references and do not expose raw viewing request IDs in projected fields.
-- Viewing state changes for cancellation and reschedule write an audit event in the same transaction path.
+- Scope limited to unified inbox data-layer adapters and tests.
+- No routes, UI, persistence writes, Firestore rules, billing, screening, pricing, deployment, dependency, or auth core changes.
+- Adapters are pure transformations and do not mutate source records.
+- Tenant, landlord, and contractor adapters validate audience scope before projection.
+- Sensitive fields, unsafe text, provider payloads, storage paths, raw IDs, internal notes, screening reports, and private evidence are rejected.
+- Output events use existing safe inbox identifiers and safe source references.
 
 ## Validation
-- `npm --prefix rentchain-api test -- src/routes/__tests__/viewingRoutes.test.ts`: PASS, 1 file, 19 tests.
-- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/`: PASS, 5 files, 17 tests.
+- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/tenantInboxAdapters.test.ts`: PASS, 1 file, 8 tests.
+- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/landlordInboxAdapters.test.ts`: PASS, 1 file, 5 tests.
+- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/contractorInboxAdapters.test.ts`: PASS, 1 file, 5 tests.
+- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/deriveUnifiedInbox.test.ts`: PASS, 1 file, 7 tests.
+- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/`: PASS, 5 files, 27 tests.
 - `npm --prefix rentchain-api run build`: PASS.
 - `git diff --check`: PASS.
-- `npm --prefix rentchain-api run lint`: NOT RUN, script missing in `rentchain-api`.
 
 ## Manual QA
-- Not completed locally. This mission changes authenticated backend route behavior and requires manual QA before merge.
+- Not required for this mission because it adds pure backend data-layer adapters only and does not change routes, UI, auth flow, or user-visible runtime behavior.
 
 ## Known Limitations
-- Transaction rollback is covered by the route test mock and production Firestore transaction path; local fallback without `runTransaction` remains best-effort for non-production adapters.
-- Applicant notification routing is based on existing viewing request applicant email or tenant fields when present.
-- No cancellation or reschedule UI was added.
+- The new adapters are available for route/UI consumers but no new route or UI integration was added in this mission.
+- Source records with missing scope identifiers are rejected fail-closed.
+- Adapter tests use representative document shapes from existing route and service patterns; live Firestore shape variation should be validated when inbox UI consumes these arrays.
 
 ## Recommended Follow-Up
-- Manual QA against deployed backend for no-auth 401, wrong-landlord 403, cancellation notification creation, reschedule notification creation, retry idempotency, and safe response fields.
-- Continue to unified inbox data-layer expansion after viewing notification QA passes.
+- Build unified inbox UI and route integration only after Gate 2 approval confirms these adapter projections are safe.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,5 +1,5 @@
-PR: #PR_NUMBER_PENDING
-PR URL: PR_URL_PENDING
+PR: #1129
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1129
 Branch: feat/unified-inbox-data-layer-expansion-v1
 
 # Implementation Summary

--- a/rentchain-api/src/services/unifiedInbox/contractorInboxAdapters.ts
+++ b/rentchain-api/src/services/unifiedInbox/contractorInboxAdapters.ts
@@ -168,3 +168,27 @@ export function adaptContractorMessageToInboxEvent(
     readAt,
   });
 }
+
+export function adaptContractorWorkOrderCommunicationToInboxEvent(
+  workOrderMessage: any,
+  contractorScopeContext: ContractorScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasContractorScope(workOrderMessage, contractorScopeContext) || hasSensitiveValues(workOrderMessage)) return null;
+  const stableKey = asString(workOrderMessage?.id || workOrderMessage?.messageId || workOrderMessage?.workOrderUpdateId, "", 240);
+  if (!stableKey) return null;
+  const messageText = asString(workOrderMessage?.body || workOrderMessage?.text || workOrderMessage?.message || workOrderMessage?.summary, "", 1000);
+  const status = asString(workOrderMessage?.status || workOrderMessage?.workOrderStatus, "", 80);
+  if (hasUnsafeText(messageText, status, workOrderMessage?.landlordInternalNotes, workOrderMessage?.tenantNotes)) return null;
+  const readAt = workOrderMessage?.readAt ? toIso(workOrderMessage.readAt) : null;
+  return makeContractorEvent({
+    sourceKind: "contractor.message",
+    sourceStableKey: stableKey,
+    context: contractorScopeContext,
+    title: "Work order message from property manager",
+    body: messageText || (status ? `Work order status: ${status}` : "You have a work order update."),
+    priority: normalizePriority(workOrderMessage?.priority || (/deadline|urgent|overdue/i.test(messageText) ? "high" : "normal")),
+    status: normalizeStatus(workOrderMessage?.inboxStatus || workOrderMessage?.status, readAt),
+    occurredAt: toIso(workOrderMessage?.createdAt || workOrderMessage?.createdAtMs || workOrderMessage?.updatedAt),
+    readAt,
+  });
+}

--- a/rentchain-api/src/services/unifiedInbox/deriveUnifiedInbox.ts
+++ b/rentchain-api/src/services/unifiedInbox/deriveUnifiedInbox.ts
@@ -1,19 +1,27 @@
 import {
   adaptContractorMessageToInboxEvent,
+  adaptContractorWorkOrderCommunicationToInboxEvent,
   adaptContractorWorkOrderToInboxEvent,
 } from "./contractorInboxAdapters";
 import {
   adaptLandlordApplicationInboxToInboxEvent,
+  adaptLandlordApplicationStatusToInboxEvent,
   adaptLandlordLeaseInboxToInboxEvent,
+  adaptLandlordLeaseNoticeToInboxEvent,
   adaptLandlordMaintenanceInboxToInboxEvent,
   adaptLandlordMessageInboxToInboxEvent,
   adaptLandlordScreeningInboxToInboxEvent,
+  adaptLandlordViewingRequestToInboxEvent,
+  adaptLandlordWorkOrderToInboxEvent,
 } from "./landlordInboxAdapters";
 import {
+  adaptTenantApplicationStatusToInboxEvent,
+  adaptTenantLeaseNoticeToInboxEvent,
   adaptTenantMaintenanceToInboxEvent,
   adaptTenantMessageToInboxEvent,
   adaptTenantNotificationToInboxEvent,
   adaptTenantScreeningToInboxEvent,
+  adaptTenantViewingRequestToInboxEvent,
 } from "./tenantInboxAdapters";
 import type {
   ContractorScopeContext,
@@ -30,6 +38,9 @@ type TenantDerivationOptions = UnifiedInboxPaginationOptions & {
   messages?: any[];
   maintenanceRequests?: any[];
   screeningRequests?: any[];
+  viewingRequests?: any[];
+  notices?: any[];
+  applicationStatusItems?: any[];
 };
 
 type LandlordDerivationOptions = UnifiedInboxPaginationOptions & {
@@ -38,11 +49,16 @@ type LandlordDerivationOptions = UnifiedInboxPaginationOptions & {
   leaseItems?: any[];
   maintenanceRequests?: any[];
   messages?: any[];
+  viewingRequests?: any[];
+  workOrders?: any[];
+  notices?: any[];
+  applicationStatusItems?: any[];
 };
 
 type ContractorDerivationOptions = UnifiedInboxPaginationOptions & {
   workOrders?: any[];
   messages?: any[];
+  workOrderCommunications?: any[];
 };
 
 const PRIORITY_RANK: Record<UnifiedInboxPriority, number> = {
@@ -124,6 +140,9 @@ export async function deriveTenantUnifiedInbox(
     ...(options.messages || []).map((item) => adaptTenantMessageToInboxEvent(item, tenantWorkspaceContext)),
     ...(options.maintenanceRequests || []).map((item) => adaptTenantMaintenanceToInboxEvent(item, tenantWorkspaceContext)),
     ...(options.screeningRequests || []).map((item) => adaptTenantScreeningToInboxEvent(item, tenantWorkspaceContext)),
+    ...(options.viewingRequests || []).map((item) => adaptTenantViewingRequestToInboxEvent(item, tenantWorkspaceContext)),
+    ...(options.notices || []).map((item) => adaptTenantLeaseNoticeToInboxEvent(item, tenantWorkspaceContext)),
+    ...(options.applicationStatusItems || []).map((item) => adaptTenantApplicationStatusToInboxEvent(item, tenantWorkspaceContext)),
   ].filter((item): item is UnifiedInboxEvent => Boolean(item));
 
   return paginate(items, options);
@@ -142,6 +161,10 @@ export async function deriveLandlordUnifiedInbox(
     ...(options.leaseItems || []).map((item) => adaptLandlordLeaseInboxToInboxEvent(item, context)),
     ...(options.maintenanceRequests || []).map((item) => adaptLandlordMaintenanceInboxToInboxEvent(item, context)),
     ...(options.messages || []).map((item) => adaptLandlordMessageInboxToInboxEvent(item, context)),
+    ...(options.viewingRequests || []).map((item) => adaptLandlordViewingRequestToInboxEvent(item, context)),
+    ...(options.workOrders || []).map((item) => adaptLandlordWorkOrderToInboxEvent(item, context)),
+    ...(options.notices || []).map((item) => adaptLandlordLeaseNoticeToInboxEvent(item, context)),
+    ...(options.applicationStatusItems || []).map((item) => adaptLandlordApplicationStatusToInboxEvent(item, context)),
   ].filter((item): item is UnifiedInboxEvent => Boolean(item));
 
   return paginate(items, options);
@@ -157,6 +180,7 @@ export async function deriveContractorUnifiedInbox(
   const items = [
     ...(options.workOrders || []).map((item) => adaptContractorWorkOrderToInboxEvent(item, context)),
     ...(options.messages || []).map((item) => adaptContractorMessageToInboxEvent(item, context)),
+    ...(options.workOrderCommunications || []).map((item) => adaptContractorWorkOrderCommunicationToInboxEvent(item, context)),
   ].filter((item): item is UnifiedInboxEvent => Boolean(item));
 
   return paginate(items, options);

--- a/rentchain-api/src/services/unifiedInbox/landlordInboxAdapters.ts
+++ b/rentchain-api/src/services/unifiedInbox/landlordInboxAdapters.ts
@@ -34,6 +34,15 @@ const SENSITIVE_KEYS = [
   "secret",
   "rawId",
   "unrelatedContractorThread",
+  "contractorInternalNotes",
+  "pendingCostEstimate",
+  "pendingCostEstimates",
+  "costEstimatePendingApproval",
+  "evidence",
+  "privateEvidence",
+  "vendorIntegrationFields",
+  "internalSchedulingConflicts",
+  "riskAssessment",
 ];
 
 // LANDLORD PROJECTION: landlord events must exclude cross-landlord records, admin-only metadata, tenant private documents, and unrelated contractor threads.
@@ -65,6 +74,28 @@ function normalizeStatus(value: unknown, readAt: string | null): UnifiedInboxSta
   if (next === "archived" || next === "muted" || next === "resolved") return next;
   if (next === "completed") return "resolved";
   return readAt ? "read" : "unread";
+}
+
+function normalizeLifecycleStatus(value: unknown, readAt: string | null): UnifiedInboxStatus {
+  const next = asString(value, "", 80).toLowerCase();
+  if (next === "completed" || next === "approved" || next === "acknowledged") return "resolved";
+  if (next === "cancelled" || next === "canceled" || next === "rejected" || next === "expired") return "archived";
+  return normalizeStatus(next, readAt);
+}
+
+function normalizeLifecyclePriority(value: unknown, fallback: UnifiedInboxPriority = "normal"): UnifiedInboxPriority {
+  const next = asString(value, "", 80).toLowerCase();
+  if (
+    next === "requested" ||
+    next === "slots_proposed" ||
+    next === "requires_decision" ||
+    next === "screening_complete" ||
+    next === "deadline_approaching" ||
+    next === "overdue"
+  ) {
+    return "high";
+  }
+  return normalizePriority(next || fallback);
 }
 
 function hasLandlordScope(record: any, context: LandlordScopeContext): boolean {
@@ -226,6 +257,127 @@ export function adaptLandlordMessageInboxToInboxEvent(
     priority: normalizePriority(message?.priority),
     status: normalizeStatus(message?.status, readAt),
     occurredAt: toIso(message?.createdAt || message?.createdAtMs || message?.occurredAt),
+    readAt,
+  });
+}
+
+export function adaptLandlordViewingRequestToInboxEvent(
+  viewingRequest: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(viewingRequest, landlordScopeContext) || hasSensitiveValues(viewingRequest)) return null;
+  const stableKey = asString(viewingRequest?.id || viewingRequest?.viewingRequestId, "", 240);
+  if (!stableKey) return null;
+  const status = asString(viewingRequest?.status, "requested", 80).toLowerCase();
+  const applicantName = asString(viewingRequest?.applicantName, "Applicant", 180);
+  const selectedStart = asString(viewingRequest?.selectedSlot?.startAt || viewingRequest?.scheduledFor, "", 120);
+  if (hasUnsafeText(applicantName, viewingRequest?.applicantEmail, status, selectedStart, viewingRequest?.cancelledReason)) return null;
+  const readAt = viewingRequest?.readAt ? toIso(viewingRequest.readAt) : null;
+  const title =
+    status === "scheduled"
+      ? "Applicant scheduled viewing"
+      : status === "cancelled" || status === "canceled"
+      ? "Viewing cancelled"
+      : status === "slots_proposed"
+      ? "Viewing needs confirmation"
+      : "Viewing request received";
+  const body = selectedStart ? `${applicantName} - ${status} at ${toIso(selectedStart)}` : `${applicantName} - ${status}`;
+  return makeLandlordEvent({
+    sourceKind: "landlord.viewing",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title,
+    body,
+    priority: normalizeLifecyclePriority(status),
+    status: normalizeLifecycleStatus(status, readAt),
+    occurredAt: toIso(
+      viewingRequest?.updatedAt ||
+        viewingRequest?.scheduledAt ||
+        viewingRequest?.cancelledAt ||
+        viewingRequest?.requestedAt ||
+        viewingRequest?.createdAt
+    ),
+    readAt,
+  });
+}
+
+export function adaptLandlordWorkOrderToInboxEvent(
+  workOrder: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(workOrder, landlordScopeContext) || hasSensitiveValues(workOrder)) return null;
+  const stableKey = asString(workOrder?.id || workOrder?.workOrderId || workOrder?.maintenanceRequestId, "", 240);
+  if (!stableKey) return null;
+  const status = asString(workOrder?.status || workOrder?.contractorStatus, "assigned", 80).toLowerCase();
+  const category = asString(workOrder?.category || workOrder?.title, "Work order", 160);
+  const dueDate = asString(workOrder?.dueDate || workOrder?.scheduledFor || workOrder?.serviceWindowStartAt, "", 120);
+  if (hasUnsafeText(category, status, dueDate, workOrder?.contractorInternalNotes)) return null;
+  const readAt = workOrder?.readAt ? toIso(workOrder.readAt) : null;
+  return makeLandlordEvent({
+    sourceKind: "landlord.work_order",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title: status === "completed" ? "Work order completed" : "Work order update",
+    body: dueDate ? `${category} status: ${status}. Due: ${toIso(dueDate)}` : `${category} status: ${status}`,
+    priority: normalizeLifecyclePriority(status),
+    status: normalizeLifecycleStatus(status, readAt),
+    occurredAt: toIso(workOrder?.updatedAt || workOrder?.createdAt || workOrder?.assignedAt || workOrder?.dueDate),
+    readAt,
+  });
+}
+
+export function adaptLandlordLeaseNoticeToInboxEvent(
+  notice: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(notice, landlordScopeContext) || hasSensitiveValues(notice)) return null;
+  const stableKey = asString(notice?.id || notice?.noticeId || notice?.sourceKey, "", 240);
+  if (!stableKey) return null;
+  const noticeType = asString(notice?.noticeType || notice?.type, "lease_notice", 120);
+  const tenantName = asString(notice?.tenantName, "Tenant", 180);
+  const status = asString(notice?.status || notice?.noticeStatus, "served", 80).toLowerCase();
+  if (hasUnsafeText(noticeType, tenantName, status, notice?.summary)) return null;
+  const readAt = notice?.readAt ? toIso(notice.readAt) : null;
+  return makeLandlordEvent({
+    sourceKind: "landlord.notice",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title: status === "acknowledged" ? "Tenant acknowledged notice" : "Notice sent to tenant",
+    body: `${tenantName} - ${noticeType} status: ${status}`,
+    priority: normalizeLifecyclePriority(status),
+    status: normalizeLifecycleStatus(status, readAt),
+    occurredAt: toIso(notice?.servedAt || notice?.createdAt || notice?.updatedAt),
+    readAt,
+  });
+}
+
+export function adaptLandlordApplicationStatusToInboxEvent(
+  application: any,
+  landlordScopeContext: LandlordScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasLandlordScope(application, landlordScopeContext) || hasSensitiveValues(application)) return null;
+  const stableKey = asString(application?.id || application?.applicationId || application?.sourceKey, "", 240);
+  if (!stableKey) return null;
+  const status = asString(application?.status || application?.applicationStatus, "submitted", 80).toLowerCase();
+  const applicantName = asString(application?.applicantName, "Applicant", 180);
+  const nextAction = asString(application?.nextAction || application?.landlordNextAction, "", 240);
+  if (hasUnsafeText(status, applicantName, nextAction, application?.screeningReport)) return null;
+  const readAt = application?.readAt ? toIso(application.readAt) : null;
+  const title =
+    status === "requires_decision"
+      ? "Your decision needed"
+      : status === "screening_complete"
+      ? "Application screening complete"
+      : "Application status updated";
+  return makeLandlordEvent({
+    sourceKind: "landlord.application",
+    sourceStableKey: stableKey,
+    context: landlordScopeContext,
+    title,
+    body: nextAction || `${applicantName} application status: ${status}`,
+    priority: normalizeLifecyclePriority(status),
+    status: normalizeLifecycleStatus(status, readAt),
+    occurredAt: toIso(application?.submittedAt || application?.updatedAt || application?.createdAt),
     readAt,
   });
 }

--- a/rentchain-api/src/services/unifiedInbox/tenantInboxAdapters.ts
+++ b/rentchain-api/src/services/unifiedInbox/tenantInboxAdapters.ts
@@ -36,6 +36,15 @@ const SENSITIVE_KEYS = [
   "rawId",
   "firestoreId",
   "contractorInternalNotes",
+  "schedulingMetadata",
+  "vendorIntegrationFields",
+  "adminEnforcementFlags",
+  "enforcementMetadata",
+  "internalProceduralNotes",
+  "paymentProcessingMetadata",
+  "landlordDecisionReasoning",
+  "riskAssessment",
+  "internalFlags",
 ];
 
 const TENANT_NOTIFICATION_SOURCE_KINDS: SourceKind[] = [
@@ -113,6 +122,28 @@ function hasUnsafeText(...values: unknown[]): boolean {
 function normalizeTenantSourceKind(value: unknown): SourceKind {
   const next = asString(value, "tenant.application", 80);
   return TENANT_NOTIFICATION_SOURCE_KINDS.includes(next as SourceKind) ? (next as SourceKind) : "tenant.application";
+}
+
+function tenantStatusForLifecycle(value: unknown, readAt: string | null): UnifiedInboxStatus {
+  const next = asString(value, "", 80).toLowerCase();
+  if (next === "completed" || next === "approved" || next === "acknowledged") return readAt ? "read" : "resolved";
+  if (next === "cancelled" || next === "canceled" || next === "rejected" || next === "expired") return "archived";
+  return normalizeStatus(next, readAt);
+}
+
+function tenantPriorityForStatus(value: unknown, fallback: UnifiedInboxPriority = "normal"): UnifiedInboxPriority {
+  const next = asString(value, "", 80).toLowerCase();
+  if (
+    next === "requested" ||
+    next === "pending_documents" ||
+    next === "resubmit_needed" ||
+    next === "deadline_approaching" ||
+    next === "requires_acknowledgment" ||
+    next === "served"
+  ) {
+    return "high";
+  }
+  return normalizePriority(next || fallback);
 }
 
 function makeTenantEvent(params: {
@@ -232,6 +263,106 @@ export function adaptTenantScreeningToInboxEvent(
     priority: normalizePriority(screeningRequest?.priority || (screeningStatus === "consent_pending" ? "high" : "normal")),
     status: normalizeStatus(screeningRequest?.inboxStatus, readAt),
     occurredAt: toIso(screeningRequest?.requestedAt || screeningRequest?.createdAt || screeningRequest?.updatedAt),
+    readAt,
+  });
+}
+
+export function adaptTenantViewingRequestToInboxEvent(
+  viewingRequest: any,
+  tenantScopeContext: TenantScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasTenantScope(viewingRequest, tenantScopeContext) || hasSensitiveValues(viewingRequest)) return null;
+  const stableKey = asString(viewingRequest?.id || viewingRequest?.viewingRequestId, "", 240);
+  if (!stableKey) return null;
+  const status = asString(viewingRequest?.status, "requested", 80).toLowerCase();
+  const selectedStart = asString(viewingRequest?.selectedSlot?.startAt || viewingRequest?.scheduledFor || viewingRequest?.newTime, "", 120);
+  if (hasUnsafeText(viewingRequest?.requestedMessage, viewingRequest?.status, selectedStart)) return null;
+  const readAt = viewingRequest?.readAt ? toIso(viewingRequest.readAt) : null;
+  const title =
+    status === "scheduled"
+      ? "Viewing scheduled"
+      : status === "cancelled" || status === "canceled"
+      ? "Viewing cancelled"
+      : status === "slots_proposed"
+      ? "Viewing times proposed"
+      : status === "completed"
+      ? "Viewing completed"
+      : "Viewing request submitted";
+  const body = selectedStart
+    ? `Viewing status: ${status}. Scheduled time: ${toIso(selectedStart)}`
+    : `Viewing status: ${status}`;
+  return makeTenantEvent({
+    sourceKind: "tenant.viewing",
+    sourceStableKey: stableKey,
+    context: tenantScopeContext,
+    title,
+    body,
+    priority: tenantPriorityForStatus(status),
+    status: tenantStatusForLifecycle(status, readAt),
+    occurredAt: toIso(
+      viewingRequest?.updatedAt ||
+        viewingRequest?.scheduledAt ||
+        viewingRequest?.cancelledAt ||
+        viewingRequest?.requestedAt ||
+        viewingRequest?.createdAt
+    ),
+    readAt,
+  });
+}
+
+export function adaptTenantLeaseNoticeToInboxEvent(
+  notice: any,
+  tenantScopeContext: TenantScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasTenantScope(notice, tenantScopeContext) || hasSensitiveValues(notice)) return null;
+  const stableKey = asString(notice?.id || notice?.noticeId || notice?.sourceKey, "", 240);
+  if (!stableKey) return null;
+  const noticeType = asString(notice?.noticeType || notice?.type, "lease_notice", 120);
+  const status = asString(notice?.status || notice?.noticeStatus, "served", 80).toLowerCase();
+  const deadline = asString(notice?.deadline || notice?.responseDeadline || notice?.expiresAt, "", 120);
+  if (hasUnsafeText(notice?.title, notice?.summary, noticeType, status, deadline)) return null;
+  const readAt = notice?.readAt || status === "acknowledged" ? toIso(notice?.readAt || notice?.acknowledgedAt || notice?.updatedAt) : null;
+  return makeTenantEvent({
+    sourceKind: "tenant.notice",
+    sourceStableKey: stableKey,
+    context: tenantScopeContext,
+    title: status === "acknowledged" ? "Lease notice acknowledged" : "Lease notice served",
+    body: deadline ? `Notice type: ${noticeType}. Deadline: ${toIso(deadline)}` : `Notice type: ${noticeType}`,
+    priority: tenantPriorityForStatus(status),
+    status: tenantStatusForLifecycle(status, readAt),
+    occurredAt: toIso(notice?.servedAt || notice?.createdAt || notice?.updatedAt),
+    readAt,
+  });
+}
+
+export function adaptTenantApplicationStatusToInboxEvent(
+  application: any,
+  tenantScopeContext: TenantScopeContext
+): UnifiedInboxEvent | null {
+  if (!hasTenantScope(application, tenantScopeContext) || hasSensitiveValues(application)) return null;
+  const stableKey = asString(application?.id || application?.applicationId || application?.sourceKey, "", 240);
+  if (!stableKey) return null;
+  const status = asString(application?.status || application?.applicationStatus, "started", 80).toLowerCase();
+  const nextAction = asString(application?.nextAction || application?.nextRequiredAction, "", 240);
+  if (hasUnsafeText(application?.title, application?.summary, status, nextAction)) return null;
+  const readAt = application?.readAt ? toIso(application.readAt) : null;
+  const title =
+    status === "approved"
+      ? "Application approved"
+      : status === "rejected"
+      ? "Application update"
+      : status === "pending_documents" || status === "resubmit_needed"
+      ? "Application action needed"
+      : "Application status updated";
+  return makeTenantEvent({
+    sourceKind: "tenant.application",
+    sourceStableKey: stableKey,
+    context: tenantScopeContext,
+    title,
+    body: nextAction || `Application status: ${status}`,
+    priority: tenantPriorityForStatus(status),
+    status: tenantStatusForLifecycle(status, readAt),
+    occurredAt: toIso(application?.submittedAt || application?.updatedAt || application?.createdAt),
     readAt,
   });
 }

--- a/rentchain-api/src/services/unifiedInbox/types.ts
+++ b/rentchain-api/src/services/unifiedInbox/types.ts
@@ -17,6 +17,9 @@ export type SourceKind =
   | "landlord.lease"
   | "landlord.maintenance"
   | "landlord.message"
+  | "landlord.notice"
+  | "landlord.viewing"
+  | "landlord.work_order"
   | "contractor.work_order"
   | "contractor.message";
 

--- a/rentchain-api/src/tests/unifiedInbox/contractorInboxAdapters.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/contractorInboxAdapters.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   adaptContractorMessageToInboxEvent,
+  adaptContractorWorkOrderCommunicationToInboxEvent,
   adaptContractorWorkOrderToInboxEvent,
   deriveContractorUnifiedInbox,
   safeIdContainsRawValue,
@@ -72,7 +73,40 @@ describe("contractor inbox adapters", () => {
     expect(JSON.stringify(event)).not.toContain("landlord_raw_abc");
   });
 
+  it("projects work order communications with contractor scope", () => {
+    const event = adaptContractorWorkOrderCommunicationToInboxEvent(
+      {
+        id: "work_order_message_raw_1",
+        contractorId: "contractor_raw_abc",
+        workOrderId: "work_order_raw_1",
+        text: "Deadline approaching. Please confirm availability.",
+        createdAt: "2026-06-09T13:00:00.000Z",
+      },
+      context
+    );
+
+    expect(event).toMatchObject({
+      sourceKind: "contractor.message",
+      audienceRole: "contractor",
+      title: "Work order message from property manager",
+      priority: "high",
+    });
+    expect(JSON.stringify(event)).not.toContain("work_order_message_raw_1");
+    expect(JSON.stringify(event)).not.toContain("work_order_raw_1");
+    expect(JSON.stringify(event)).not.toContain("contractor_raw_abc");
+  });
+
   it("rejects cross-contractor and sensitive source records", () => {
+    expect(
+      adaptContractorWorkOrderCommunicationToInboxEvent(
+        {
+          id: "message_raw_2",
+          contractorId: "contractor_raw_abc",
+          text: "landlordId leaked in body",
+        },
+        context
+      )
+    ).toBeNull();
     expect(
       adaptContractorWorkOrderToInboxEvent(
         {

--- a/rentchain-api/src/tests/unifiedInbox/deriveUnifiedInbox.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/deriveUnifiedInbox.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  deriveContractorUnifiedInbox,
   deriveLandlordUnifiedInbox,
   deriveTenantUnifiedInbox,
   encodeUnifiedInboxCursor,
@@ -147,5 +148,161 @@ describe("derive unified inbox", () => {
     );
 
     expect(page.items).toHaveLength(1);
+  });
+
+  it("derives tenant mixed source events for viewing, notices, and application status", async () => {
+    const context = {
+      tenantWorkspaceId: "tenant_workspace_raw_abc",
+      tenantId: "tenant_raw_abc",
+    };
+    const page = await deriveTenantUnifiedInbox(context, {
+      viewingRequests: [
+        {
+          id: "viewing_raw_1",
+          tenantWorkspaceId: "tenant_workspace_raw_abc",
+          status: "scheduled",
+          selectedSlot: { startAt: "2026-06-09T15:00:00.000Z" },
+          updatedAt: "2026-06-09T15:00:00.000Z",
+        },
+      ],
+      notices: [
+        {
+          id: "notice_raw_1",
+          tenantId: "tenant_raw_abc",
+          noticeType: "renewal_offer",
+          status: "served",
+          servedAt: "2026-06-09T14:00:00.000Z",
+        },
+      ],
+      applicationStatusItems: [
+        {
+          id: "application_raw_1",
+          applicantTenantId: "tenant_raw_abc",
+          status: "pending_documents",
+          nextAction: "Upload documents.",
+          updatedAt: "2026-06-09T13:00:00.000Z",
+        },
+      ],
+      limit: 2,
+    });
+
+    expect(page.items.map((item) => item.sourceKind)).toEqual(["tenant.notice", "tenant.application"]);
+    expect(page.nextCursor).toBeTruthy();
+    expect(JSON.stringify(page.items)).not.toContain("tenant_raw_abc");
+    expect(JSON.stringify(page.items)).not.toContain("_raw_");
+
+    const secondPage = await deriveTenantUnifiedInbox(context, {
+      viewingRequests: [
+        {
+          id: "viewing_raw_1",
+          tenantWorkspaceId: "tenant_workspace_raw_abc",
+          status: "scheduled",
+          selectedSlot: { startAt: "2026-06-09T15:00:00.000Z" },
+          updatedAt: "2026-06-09T15:00:00.000Z",
+        },
+      ],
+      notices: [
+        {
+          id: "notice_raw_1",
+          tenantId: "tenant_raw_abc",
+          noticeType: "renewal_offer",
+          status: "served",
+          servedAt: "2026-06-09T14:00:00.000Z",
+        },
+      ],
+      applicationStatusItems: [
+        {
+          id: "application_raw_1",
+          applicantTenantId: "tenant_raw_abc",
+          status: "pending_documents",
+          nextAction: "Upload documents.",
+          updatedAt: "2026-06-09T13:00:00.000Z",
+        },
+      ],
+      limit: 2,
+      cursor: page.nextCursor,
+    });
+
+    expect(secondPage.items.map((item) => item.sourceKind)).toEqual(["tenant.viewing"]);
+  });
+
+  it("derives landlord mixed source events for viewing, work order, notice, and application status", async () => {
+    const page = await deriveLandlordUnifiedInbox("landlord_raw_abc", {
+      viewingRequests: [
+        {
+          id: "viewing_raw_1",
+          landlordId: "landlord_raw_abc",
+          applicantName: "Jordan Lee",
+          status: "slots_proposed",
+          updatedAt: "2026-06-09T14:00:00.000Z",
+        },
+      ],
+      workOrders: [
+        {
+          id: "work_order_raw_1",
+          landlordId: "landlord_raw_abc",
+          category: "plumbing",
+          status: "overdue",
+          updatedAt: "2026-06-09T13:00:00.000Z",
+        },
+      ],
+      notices: [
+        {
+          id: "notice_raw_1",
+          landlordId: "landlord_raw_abc",
+          tenantName: "Jordan Lee",
+          noticeType: "renewal_offer",
+          status: "served",
+          servedAt: "2026-06-09T12:00:00.000Z",
+        },
+      ],
+      applicationStatusItems: [
+        {
+          id: "application_raw_1",
+          landlordId: "landlord_raw_abc",
+          applicantName: "Jordan Lee",
+          status: "requires_decision",
+          updatedAt: "2026-06-09T11:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(page.items.map((item) => item.sourceKind)).toEqual([
+      "landlord.viewing",
+      "landlord.work_order",
+      "landlord.application",
+      "landlord.notice",
+    ]);
+    expect(JSON.stringify(page.items)).not.toContain("landlord_raw_abc");
+    expect(JSON.stringify(page.items)).not.toContain("_raw_");
+  });
+
+  it("derives contractor work order communications separately from work orders", async () => {
+    const page = await deriveContractorUnifiedInbox("contractor_raw_abc", {
+      workOrders: [
+        {
+          id: "work_order_raw_1",
+          assignedContractorId: "contractor_raw_abc",
+          title: "Repair sink",
+          status: "assigned",
+          updatedAt: "2026-06-09T13:00:00.000Z",
+        },
+      ],
+      workOrderCommunications: [
+        {
+          id: "communication_raw_1",
+          contractorId: "contractor_raw_abc",
+          text: "Deadline approaching.",
+          createdAt: "2026-06-09T14:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(page.items.map((item) => item.title)).toEqual([
+      "Work order message from property manager",
+      "Repair sink",
+    ]);
+    expect(JSON.stringify(page.items)).not.toContain("contractor_raw_abc");
+    expect(JSON.stringify(page.items)).not.toContain("_raw_");
   });
 });

--- a/rentchain-api/src/tests/unifiedInbox/landlordInboxAdapters.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/landlordInboxAdapters.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   adaptLandlordApplicationInboxToInboxEvent,
+  adaptLandlordApplicationStatusToInboxEvent,
   adaptLandlordLeaseInboxToInboxEvent,
+  adaptLandlordLeaseNoticeToInboxEvent,
   adaptLandlordMaintenanceInboxToInboxEvent,
   adaptLandlordMessageInboxToInboxEvent,
   adaptLandlordScreeningInboxToInboxEvent,
+  adaptLandlordViewingRequestToInboxEvent,
+  adaptLandlordWorkOrderToInboxEvent,
 } from "../../services/unifiedInbox";
 
 const landlordContext = {
@@ -122,5 +126,104 @@ describe("landlord inbox adapters", () => {
     expectLandlordSafe(maintenanceEvent!);
     expectLandlordSafe(messageEvent!);
     expect(JSON.stringify({ lease, maintenance, message })).toBe(before);
+  });
+
+  it("adapts landlord viewing requests, work orders, notices, and application statuses", () => {
+    const viewing = adaptLandlordViewingRequestToInboxEvent(
+      {
+        id: "viewing_raw_123",
+        landlordId: "landlord_raw_abc",
+        applicantName: "Jordan Lee",
+        applicantEmail: "jordan@example.com",
+        status: "slots_proposed",
+        updatedAt: "2026-06-09T10:00:00.000Z",
+      },
+      landlordContext
+    );
+    const workOrder = adaptLandlordWorkOrderToInboxEvent(
+      {
+        id: "work_order_raw_123",
+        landlordId: "landlord_raw_abc",
+        category: "plumbing",
+        status: "overdue",
+        dueDate: "2026-06-10T12:00:00.000Z",
+      },
+      landlordContext
+    );
+    const notice = adaptLandlordLeaseNoticeToInboxEvent(
+      {
+        id: "notice_raw_123",
+        landlordId: "landlord_raw_abc",
+        tenantName: "Jordan Lee",
+        noticeType: "renewal_offer",
+        status: "served",
+        servedAt: "2026-06-09T11:00:00.000Z",
+      },
+      landlordContext
+    );
+    const application = adaptLandlordApplicationStatusToInboxEvent(
+      {
+        id: "application_raw_456",
+        landlordId: "landlord_raw_abc",
+        applicantName: "Jordan Lee",
+        status: "requires_decision",
+        updatedAt: "2026-06-09T12:00:00.000Z",
+      },
+      landlordContext
+    );
+
+    expect(viewing).toMatchObject({ sourceKind: "landlord.viewing", title: "Viewing needs confirmation", priority: "high" });
+    expect(workOrder).toMatchObject({ sourceKind: "landlord.work_order", title: "Work order update", priority: "high" });
+    expect(notice).toMatchObject({ sourceKind: "landlord.notice", title: "Notice sent to tenant" });
+    expect(application).toMatchObject({ sourceKind: "landlord.application", title: "Your decision needed", priority: "high" });
+    [viewing, workOrder, notice, application].forEach((event) => expectLandlordSafe(event!));
+    expect(JSON.stringify([viewing, workOrder, notice, application])).not.toContain("landlord_raw_abc");
+    expect(JSON.stringify([viewing, workOrder, notice, application])).not.toContain("work_order_raw_");
+  });
+
+  it("rejects new landlord source records outside scope or with sensitive fields", () => {
+    expect(
+      adaptLandlordViewingRequestToInboxEvent(
+        {
+          id: "viewing_raw_123",
+          landlordId: "landlord_other",
+          status: "requested",
+        },
+        landlordContext
+      )
+    ).toBeNull();
+    expect(
+      adaptLandlordWorkOrderToInboxEvent(
+        {
+          id: "work_order_raw_123",
+          landlordId: "landlord_raw_abc",
+          status: "assigned",
+          contractorInternalNotes: "private",
+        },
+        landlordContext
+      )
+    ).toBeNull();
+    expect(
+      adaptLandlordLeaseNoticeToInboxEvent(
+        {
+          id: "notice_raw_123",
+          landlordId: "landlord_raw_abc",
+          status: "served",
+          adminMetadata: { internal: true },
+        },
+        landlordContext
+      )
+    ).toBeNull();
+    expect(
+      adaptLandlordApplicationStatusToInboxEvent(
+        {
+          id: "application_raw_123",
+          landlordId: "landlord_raw_abc",
+          status: "requires_decision",
+          screeningReport: { raw: true },
+        },
+        landlordContext
+      )
+    ).toBeNull();
   });
 });

--- a/rentchain-api/src/tests/unifiedInbox/tenantInboxAdapters.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/tenantInboxAdapters.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  adaptTenantApplicationStatusToInboxEvent,
+  adaptTenantLeaseNoticeToInboxEvent,
   adaptTenantMaintenanceToInboxEvent,
   adaptTenantMessageToInboxEvent,
   adaptTenantNotificationToInboxEvent,
   adaptTenantScreeningToInboxEvent,
+  adaptTenantViewingRequestToInboxEvent,
 } from "../../services/unifiedInbox";
 
 const tenantContext = {
@@ -145,5 +148,133 @@ describe("tenant inbox adapters", () => {
     expectTenantSafe(maintenanceEvent!);
     expectTenantSafe(screeningEvent!);
     expect(JSON.stringify({ maintenance, screening })).toBe(before);
+  });
+
+  it("adapts tenant viewing requests with lifecycle status mapping", () => {
+    const scheduled = adaptTenantViewingRequestToInboxEvent(
+      {
+        id: "viewing_raw_123",
+        tenantWorkspaceId: "tenant_workspace_raw_abc",
+        status: "scheduled",
+        selectedSlot: { startAt: "2026-06-10T18:00:00.000Z" },
+        updatedAt: "2026-06-09T13:00:00.000Z",
+      },
+      tenantContext
+    );
+    const cancelled = adaptTenantViewingRequestToInboxEvent(
+      {
+        id: "viewing_raw_124",
+        tenantWorkspaceId: "tenant_workspace_raw_abc",
+        status: "cancelled",
+        cancelledAt: "2026-06-09T14:00:00.000Z",
+      },
+      tenantContext
+    );
+
+    expect(scheduled).toMatchObject({
+      sourceKind: "tenant.viewing",
+      title: "Viewing scheduled",
+      priority: "normal",
+      status: "unread",
+    });
+    expect(cancelled).toMatchObject({
+      sourceKind: "tenant.viewing",
+      title: "Viewing cancelled",
+      priority: "normal",
+      status: "archived",
+    });
+    expectTenantSafe(scheduled!);
+    expectTenantSafe(cancelled!);
+    expect(JSON.stringify([scheduled, cancelled])).not.toContain("viewing_raw_");
+  });
+
+  it("rejects tenant viewing requests outside scope or with sensitive fields", () => {
+    expect(
+      adaptTenantViewingRequestToInboxEvent(
+        {
+          id: "viewing_raw_123",
+          tenantWorkspaceId: "other_workspace",
+          status: "scheduled",
+        },
+        tenantContext
+      )
+    ).toBeNull();
+    expect(
+      adaptTenantViewingRequestToInboxEvent(
+        {
+          id: "viewing_raw_124",
+          tenantWorkspaceId: "tenant_workspace_raw_abc",
+          status: "scheduled",
+          landlordNotes: "internal",
+        },
+        tenantContext
+      )
+    ).toBeNull();
+  });
+
+  it("adapts tenant lease notices and application statuses safely", () => {
+    const notice = adaptTenantLeaseNoticeToInboxEvent(
+      {
+        id: "notice_raw_123",
+        tenantId: "tenant_raw_abc",
+        noticeType: "renewal_offer",
+        status: "served",
+        deadline: "2026-06-30T12:00:00.000Z",
+        servedAt: "2026-06-09T12:00:00.000Z",
+      },
+      tenantContext
+    );
+    const application = adaptTenantApplicationStatusToInboxEvent(
+      {
+        id: "application_raw_123",
+        applicantTenantId: "tenant_raw_abc",
+        status: "pending_documents",
+        nextAction: "Upload requested documents.",
+        updatedAt: "2026-06-09T13:00:00.000Z",
+      },
+      tenantContext
+    );
+
+    expect(notice).toMatchObject({
+      sourceKind: "tenant.notice",
+      title: "Lease notice served",
+      priority: "high",
+      status: "unread",
+    });
+    expect(application).toMatchObject({
+      sourceKind: "tenant.application",
+      title: "Application action needed",
+      priority: "high",
+      status: "unread",
+    });
+    expectTenantSafe(notice!);
+    expectTenantSafe(application!);
+    expect(JSON.stringify([notice, application])).not.toContain("notice_raw_");
+    expect(JSON.stringify([notice, application])).not.toContain("application_raw_");
+  });
+
+  it("rejects tenant notice and application records with unsafe internals", () => {
+    expect(
+      adaptTenantLeaseNoticeToInboxEvent(
+        {
+          id: "notice_raw_123",
+          tenantId: "tenant_raw_abc",
+          status: "served",
+          adminEnforcementFlags: ["internal"],
+        },
+        tenantContext
+      )
+    ).toBeNull();
+    expect(
+      adaptTenantApplicationStatusToInboxEvent(
+        {
+          id: "application_raw_123",
+          applicantTenantId: "tenant_raw_abc",
+          status: "under_review",
+          screeningReport: { raw: true },
+        },
+        tenantContext
+      )
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Added tenant adapters for viewing requests, lease notices, and application status records.
- Added landlord adapters for viewing requests, work orders, lease notices, and application status records.
- Added contractor work order communication adapter.
- Extended unified inbox derivation to aggregate the new source arrays.
- Added adapter and mixed-source derivation tests for scope, sensitivity, status mapping, and safe references.

## Validation
- npm --prefix rentchain-api test -- src/tests/unifiedInbox/tenantInboxAdapters.test.ts
- npm --prefix rentchain-api test -- src/tests/unifiedInbox/landlordInboxAdapters.test.ts
- npm --prefix rentchain-api test -- src/tests/unifiedInbox/contractorInboxAdapters.test.ts
- npm --prefix rentchain-api test -- src/tests/unifiedInbox/deriveUnifiedInbox.test.ts
- npm --prefix rentchain-api test -- src/tests/unifiedInbox/
- npm --prefix rentchain-api run build
- git diff --check

## Notes
- Data-layer only: no routes, UI, persistence writes, Firestore rules, billing, screening, pricing, deployment, dependency, or auth core changes.
- Manual QA is not required before review because this does not alter user-visible runtime behavior.