### PR TITLE
fix: remove debug metadata from unified inbox responses

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,81 +1,66 @@
-PR: #1130
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1130
-Branch: feat/unified-inbox-navigation-v1
+PR: #1131
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1131
+Branch: fix/unified-inbox-debug-metadata-removal-v1
 
 # Implementation Summary
 
 ## Mission
-Implemented unified inbox navigation and read-only list UI for tenant, landlord, and contractor workspaces.
+Removed debug metadata and internal source references from unified inbox API response bodies while preserving existing auth, route behavior, role separation, and adapter projection logic.
 
-## Scope
-- Added read-only shared backend endpoint `GET /api/inbox`.
-- Added backend orchestration service for tenant, landlord, and contractor unified inbox projections.
-- Added frontend unified inbox API helper.
-- Added shared unified inbox page and list/detail component.
-- Added landlord navigation link at `/landlord/unified-inbox`.
-- Added tenant navigation link at `/tenant/inbox`.
-- Added contractor navigation link at `/contractor/inbox`.
-- Added focused backend service/route tests and frontend component/page tests.
+## Audit Findings
+- Tenant, landlord, and contractor unified inbox responses were built from internal `UnifiedInboxEvent` objects.
+- Public `items` and `records` previously exposed `sourceId`, `sourceRef`, `audienceScopeKey`, and six diagnostic safety flags.
+- The raw source record IDs were already hashed before adapter output, but the exposed source/scope reference fields were still internal implementation details.
+- Adapter outputs still carry internal safety flags for projection validation, but those fields no longer cross the service response boundary.
+- Frontend rendering previously depended on diagnostic flags to filter records; that dependency was removed.
 
-## Confirmed Findings
-- Existing role-specific endpoints remain intact: `/api/tenant/inbox`, `/api/landlord/inbox`, and `/api/contractor/inbox`.
-- New `/api/inbox` dispatches by authenticated role and fails closed for unsupported roles or missing role context.
-- Tenant, landlord, and contractor records are filtered by raw scope before unified inbox derivation.
-- Frontend renders only projected records matching the current role and safety flags.
-- UI does not display raw `sourceId`, `sourceRef`, audience scope keys, tokens, storage paths, provider payloads, or private notes.
-- No writes, mutations, real-time listeners, external integrations, Firestore rules, billing, pricing, screening, deployment, or dependency changes were added.
-- Existing data-layer adapters and derivation functions were consumed without mutation.
+## Fields Removed From Public Responses
+- `sourceId`
+- `sourceRef`
+- `audienceScopeKey`
+- `rawIdsIncluded`
+- `tokensIncluded`
+- `secretsIncluded`
+- `providerPayloadIncluded`
+- `storagePathIncluded`
+- `privateNotesIncluded`
+
+## Public Record Fields Kept
+- `id`
+- `sourceKind`
+- `audienceRole`
+- `title`
+- `body`
+- `priority`
+- `status`
+- `occurredAt`
+- `readAt`
 
 ## Files Changed
-- `rentchain-api/src/app.build.ts`
-- `rentchain-api/src/routes/unifiedInboxRoutes.ts`
-- `rentchain-api/src/services/unifiedInbox/index.ts`
+- `rentchain-api/src/services/unifiedInbox/types.ts`
 - `rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts`
 - `rentchain-api/src/tests/unifiedInbox/unifiedInboxRoute.test.ts`
 - `rentchain-api/src/tests/unifiedInbox/unifiedInboxService.test.ts`
-- `rentchain-frontend/src/App.tsx`
 - `rentchain-frontend/src/api/unifiedInboxApi.ts`
 - `rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx`
-- `rentchain-frontend/src/components/layout/ContractorNav.tsx`
-- `rentchain-frontend/src/components/layout/TenantNav.tsx`
-- `rentchain-frontend/src/components/layout/navConfig.ts`
-- `rentchain-frontend/src/pages/UnifiedInboxPage.tsx`
 - `rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx`
 
 ## Validation
-- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/unifiedInboxService.test.ts`: PASS, 3 tests.
-- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/unifiedInboxRoute.test.ts`: PASS, 4 tests.
-- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/unifiedInboxService.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts`: PASS, 7 tests.
-- `npm --prefix rentchain-api test -- src/tests/unifiedInbox/`: PASS, 7 files, 34 tests.
+- `npm --prefix rentchain-api run test:single -- src/tests/unifiedInbox/unifiedInboxService.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts src/tests/unifiedInbox/tenantInboxAdapters.test.ts src/tests/unifiedInbox/landlordInboxAdapters.test.ts src/tests/unifiedInbox/contractorInboxAdapters.test.ts src/tests/unifiedInbox/deriveUnifiedInbox.test.ts src/tests/unifiedInbox/safeInboxReferences.test.ts`: PASS, 7 files, 34 tests.
+- `npm --prefix rentchain-frontend run test:single -- src/api/unifiedInboxApi.test.ts src/pages/UnifiedInboxPage.test.tsx`: PASS, 2 files, 6 tests.
 - `npm --prefix rentchain-api run build`: PASS.
-- `npm --prefix rentchain-frontend test -- src/pages/UnifiedInboxPage.test.tsx`: PASS, 3 tests.
-- `npm --prefix rentchain-frontend test`: PASS, 299 files, 1175 tests.
 - `npm --prefix rentchain-frontend run build`: PASS.
 - `git diff --check`: PASS.
 
-## Manual QA
-- Manual browser QA required because this mission adds user-visible navigation and UI routes.
-- Local dev server started successfully at `http://127.0.0.1:5174/`.
-- In-session browser smoke check could not complete because the browser surface was unavailable.
-- Local dev server was stopped after the failed browser connection attempt.
-- Manual preview QA remains required on the PR preview.
+## Acceptance Criteria Status
+- Raw source references removed from API response bodies: PASS.
+- Debug metadata flags removed from API response bodies: PASS.
+- Tenant, landlord, and contractor public responses constrained to allowlisted fields: PASS.
+- Existing route signatures, auth checks, status codes, and source data remain unchanged: PASS.
+- Frontend unified inbox rendering remains compatible with the public response shape: PASS.
+- Manual browser/network QA: NOT RUN locally because seeded authenticated tenant, landlord, and contractor sessions were not available in this environment.
 
 ## Known Limitations
-- The backend reads representative existing collections and relies on existing document shape conventions from prior route/service patterns.
-- Records with missing role scope identifiers are rejected by pre-derivation filtering or ignored by adapters.
-- No pagination UI, search, archive/read mutations, real-time subscriptions, or bulk workflows were added.
-- The existing landlord application inbox remains separate from the new unified inbox route.
-
-## Acceptance Criteria Status
-- Unified inbox backend route added: PASS.
-- Unified inbox service added: PASS.
-- Tenant, landlord, and contractor UI routes added: PASS.
-- Navigation links added: PASS.
-- Role-safe frontend rendering added: PASS.
-- Backend tests added and passing: PASS.
-- Frontend tests added and passing: PASS.
-- Build validation passing: PASS.
-- Manual browser QA: PENDING on preview due local browser surface unavailability.
-
-## Recommended Next Step
-Complete manual preview QA for `/tenant/inbox`, `/landlord/unified-inbox`, and `/contractor/inbox` with seeded role accounts before Gate 2.
+- The implemented shared router remains mounted as it was before this mission; route mounts and auth middleware were not changed.
+- Internal adapter objects still include safety flags and safe hashed references for derivation tests. These are intentionally stripped before public response serialization.
+- Full authenticated browser Network-tab inspection should still be completed against preview or a seeded local environment before Pilot 1 authorization.

--- a/rentchain-api/src/services/unifiedInbox/types.ts
+++ b/rentchain-api/src/services/unifiedInbox/types.ts
@@ -65,6 +65,11 @@ export type UnifiedInboxEvent = UnifiedInboxSafetyFlags & {
   sourceRef: UnifiedInboxSourceRef;
 };
 
+export type UnifiedInboxPublicRecord = Pick<
+  UnifiedInboxEvent,
+  "id" | "sourceKind" | "audienceRole" | "title" | "body" | "priority" | "status" | "occurredAt" | "readAt"
+>;
+
 export type UnifiedInboxPage = {
   items: UnifiedInboxEvent[];
   nextCursor?: string;

--- a/rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts
+++ b/rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts
@@ -4,7 +4,7 @@ import {
   deriveLandlordUnifiedInbox,
   deriveTenantUnifiedInbox,
 } from "./deriveUnifiedInbox";
-import type { SourceKind, UnifiedInboxEvent } from "./types";
+import type { SourceKind, UnifiedInboxEvent, UnifiedInboxPublicRecord } from "./types";
 
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 20;
@@ -64,8 +64,8 @@ export type UnifiedInboxContext = {
 export type UnifiedInboxResult = {
   ok: true;
   role: UnifiedInboxRole;
-  items: UnifiedInboxEvent[];
-  records: UnifiedInboxEvent[];
+  items: UnifiedInboxPublicRecord[];
+  records: UnifiedInboxPublicRecord[];
   total: number;
   limit: number;
   offset: number;
@@ -203,6 +203,20 @@ function applySafeFilters(items: UnifiedInboxEvent[], request: UnifiedInboxReque
   });
 }
 
+function toPublicInboxRecord(item: UnifiedInboxEvent): UnifiedInboxPublicRecord {
+  return {
+    id: item.id,
+    sourceKind: item.sourceKind,
+    audienceRole: item.audienceRole,
+    title: item.title,
+    body: item.body,
+    priority: item.priority,
+    status: item.status,
+    occurredAt: item.occurredAt,
+    readAt: item.readAt,
+  };
+}
+
 function assertNoCrossScopeAttempt(query: UnifiedInboxQuery, context: UnifiedInboxContext) {
   const tenantId = asString(query.tenantId, 240);
   const tenantWorkspaceId = asString(query.tenantWorkspaceId || query.workspaceId, 240);
@@ -325,7 +339,7 @@ export async function getUnifiedInbox(context: UnifiedInboxContext, query: Unifi
       : await loadContractorInbox(context);
 
   const filteredItems = applySafeFilters(page.items, request, context.role);
-  const items = filteredItems.slice(request.offset, request.offset + request.limit);
+  const items = filteredItems.slice(request.offset, request.offset + request.limit).map(toPublicInboxRecord);
 
   return {
     ok: true,

--- a/rentchain-api/src/tests/unifiedInbox/unifiedInboxRoute.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/unifiedInboxRoute.test.ts
@@ -33,6 +33,19 @@ vi.mock("../../middleware/requireAuth", () => ({
   },
 }));
 
+const PUBLIC_RECORD_KEYS = ["audienceRole", "body", "id", "occurredAt", "priority", "readAt", "sourceKind", "status", "title"];
+const EXCLUDED_RESPONSE_FIELDS = [
+  "sourceId",
+  "sourceRef",
+  "audienceScopeKey",
+  "rawIdsIncluded",
+  "tokensIncluded",
+  "secretsIncluded",
+  "providerPayloadIncluded",
+  "storagePathIncluded",
+  "privateNotesIncluded",
+];
+
 async function invokeRouter(
   router: { handle: (req: Record<string, unknown>, res: Record<string, unknown>, next: (error?: unknown) => void) => void },
   options: {
@@ -128,10 +141,16 @@ describe("unifiedInboxRoutes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ ok: true, role: "tenant", total: 2 });
+    const body = res.body as { items: Array<Record<string, unknown>>; records: Array<Record<string, unknown>> };
+    expect(body.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
+    expect(body.records).toEqual(body.items);
     const json = JSON.stringify(res.body);
     expect(json).toContain("tenant.viewing");
     expect(json).not.toContain("tenant-workspace-1");
     expect(json).not.toContain("landlord-1");
+    for (const field of EXCLUDED_RESPONSE_FIELDS) {
+      expect(json).not.toContain(field);
+    }
   });
 
   it("returns the landlord projection and rejects tenant source filters", async () => {
@@ -148,8 +167,13 @@ describe("unifiedInboxRoutes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ ok: true, role: "landlord", total: 1 });
+    const body = res.body as { items: Array<Record<string, unknown>> };
+    expect(body.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS]);
     expect(JSON.stringify(res.body)).toContain("landlord.work_order");
     expect(JSON.stringify(res.body)).not.toContain("work-order-1");
+    for (const field of EXCLUDED_RESPONSE_FIELDS) {
+      expect(JSON.stringify(res.body)).not.toContain(field);
+    }
 
     const forbiddenSource = await invokeRouter(router, {
       method: "GET",
@@ -175,7 +199,13 @@ describe("unifiedInboxRoutes", () => {
     });
     expect(contractor.status).toBe(200);
     expect(contractor.body).toMatchObject({ ok: true, role: "contractor", total: 1 });
-    expect(JSON.stringify(contractor.body)).not.toContain("contractor-1");
+    const body = contractor.body as { items: Array<Record<string, unknown>> };
+    expect(body.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS]);
+    const json = JSON.stringify(contractor.body);
+    expect(json).not.toContain("contractor-1");
+    for (const field of EXCLUDED_RESPONSE_FIELDS) {
+      expect(json).not.toContain(field);
+    }
 
     const admin = await invokeRouter(router, {
       method: "GET",

--- a/rentchain-api/src/tests/unifiedInbox/unifiedInboxService.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/unifiedInboxService.test.ts
@@ -24,6 +24,19 @@ const dbMock = {
 
 vi.mock("../../firebase", () => ({ db: dbMock }));
 
+const PUBLIC_RECORD_KEYS = ["audienceRole", "body", "id", "occurredAt", "priority", "readAt", "sourceKind", "status", "title"];
+const EXCLUDED_RESPONSE_FIELDS = [
+  "sourceId",
+  "sourceRef",
+  "audienceScopeKey",
+  "rawIdsIncluded",
+  "tokensIncluded",
+  "secretsIncluded",
+  "providerPayloadIncluded",
+  "storagePathIncluded",
+  "privateNotesIncluded",
+];
+
 describe("unified inbox service", () => {
   beforeEach(() => {
     collections.clear();
@@ -80,11 +93,16 @@ describe("unified inbox service", () => {
     expect(result.role).toBe("tenant");
     expect(result.items.map((item) => item.audienceRole)).toEqual(["tenant", "tenant"]);
     expect(result.items.map((item) => item.sourceKind)).toEqual(["tenant.viewing", "tenant.message"]);
+    expect(result.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
+    expect(result.records).toEqual(result.items);
     const json = JSON.stringify(result.items);
     expect(json).not.toContain("tenant-workspace-1");
     expect(json).not.toContain("viewing-1");
     expect(json).not.toContain("tenant-message-1");
     expect(json).not.toContain("secret token");
+    for (const field of EXCLUDED_RESPONSE_FIELDS) {
+      expect(json).not.toContain(field);
+    }
   });
 
   it("returns landlord and contractor projections for their own scopes only", async () => {
@@ -92,13 +110,21 @@ describe("unified inbox service", () => {
 
     const landlordResult = await getUnifiedInbox({ role: "landlord", landlordId: "landlord-1" }, {});
     expect(landlordResult.items.map((item) => item.sourceKind)).toEqual(["landlord.viewing", "landlord.work_order"]);
+    expect(landlordResult.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
     expect(JSON.stringify(landlordResult.items)).not.toContain("landlord-1");
     expect(JSON.stringify(landlordResult.items)).not.toContain("work-order-1");
+    for (const field of EXCLUDED_RESPONSE_FIELDS) {
+      expect(JSON.stringify(landlordResult.items)).not.toContain(field);
+    }
 
     const contractorResult = await getUnifiedInbox({ role: "contractor", contractorId: "contractor-1" }, {});
     expect(contractorResult.items.map((item) => item.sourceKind)).toEqual(["contractor.work_order", "contractor.message"]);
+    expect(contractorResult.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
     expect(JSON.stringify(contractorResult.items)).not.toContain("contractor-1");
     expect(JSON.stringify(contractorResult.items)).not.toContain("landlord-1");
+    for (const field of EXCLUDED_RESPONSE_FIELDS) {
+      expect(JSON.stringify(contractorResult.items)).not.toContain(field);
+    }
   });
 
   it("fails closed on cross-scope query attempts and invalid filters", async () => {

--- a/rentchain-frontend/src/api/unifiedInboxApi.ts
+++ b/rentchain-frontend/src/api/unifiedInboxApi.ts
@@ -29,25 +29,13 @@ export type UnifiedInboxSourceKind =
 export type UnifiedInboxRecord = {
   id: string;
   sourceKind: UnifiedInboxSourceKind;
-  sourceId: string;
   audienceRole: UnifiedInboxRole;
-  audienceScopeKey: string;
   title: string;
   body: string;
   priority: UnifiedInboxPriority;
   status: UnifiedInboxStatus;
   occurredAt: string;
   readAt: string | null;
-  sourceRef: {
-    kind: UnifiedInboxSourceKind;
-    ref: string;
-  };
-  rawIdsIncluded: false;
-  tokensIncluded: false;
-  secretsIncluded: false;
-  providerPayloadIncluded: false;
-  storagePathIncluded: false;
-  privateNotesIncluded: false;
 };
 
 export type UnifiedInboxResponse = {

--- a/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
+++ b/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
@@ -64,15 +64,7 @@ function formatStatus(value: string) {
 }
 
 function isSafeRecordForRole(record: UnifiedInboxRecord, role: UnifiedInboxRole) {
-  return (
-    record.audienceRole === role &&
-    record.rawIdsIncluded === false &&
-    record.tokensIncluded === false &&
-    record.secretsIncluded === false &&
-    record.providerPayloadIncluded === false &&
-    record.storagePathIncluded === false &&
-    record.privateNotesIncluded === false
-  );
+  return record.audienceRole === role;
 }
 
 export function UnifiedInboxList({ records, role }: Props) {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -19,22 +19,13 @@ function record(overrides: Partial<UnifiedInboxRecord>): UnifiedInboxRecord {
   return {
     id: "inbox-v1-safe",
     sourceKind: "tenant.message",
-    sourceId: "safe-source",
     audienceRole: "tenant",
-    audienceScopeKey: "safe-scope",
     title: "Message update",
     body: "Your landlord replied.",
     priority: "normal",
     status: "unread",
     occurredAt: "2026-06-09T12:00:00.000Z",
     readAt: null,
-    sourceRef: { kind: "tenant.message", ref: "safe-source" },
-    rawIdsIncluded: false,
-    tokensIncluded: false,
-    secretsIncluded: false,
-    providerPayloadIncluded: false,
-    storagePathIncluded: false,
-    privateNotesIncluded: false,
     ...overrides,
   };
 }
@@ -48,12 +39,6 @@ describe("UnifiedInboxPage", () => {
       items: [
         record({ title: "Viewing scheduled", body: "Viewing status: scheduled", sourceKind: "tenant.viewing" }),
         record({
-          id: "unsafe",
-          title: "Unsafe record",
-          body: "Should not render",
-          rawIdsIncluded: true as false,
-        }),
-        record({
           id: "landlord-record",
           audienceRole: "landlord",
           sourceKind: "landlord.work_order",
@@ -63,19 +48,13 @@ describe("UnifiedInboxPage", () => {
       records: [
         record({ title: "Viewing scheduled", body: "Viewing status: scheduled", sourceKind: "tenant.viewing" }),
         record({
-          id: "unsafe",
-          title: "Unsafe record",
-          body: "Should not render",
-          rawIdsIncluded: true as false,
-        }),
-        record({
           id: "landlord-record",
           audienceRole: "landlord",
           sourceKind: "landlord.work_order",
           title: "Landlord only",
         }),
       ],
-      total: 3,
+      total: 2,
       limit: 20,
       offset: 0,
     });
@@ -91,7 +70,6 @@ describe("UnifiedInboxPage", () => {
     expect(await screen.findByRole("heading", { name: "Tenant inbox" })).toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchUnifiedInbox).toHaveBeenCalledWith("tenant"));
     expect(screen.getAllByText("Viewing scheduled").length).toBeGreaterThan(0);
-    expect(screen.queryByText("Unsafe record")).not.toBeInTheDocument();
     expect(screen.queryByText("Landlord only")).not.toBeInTheDocument();
     expect(screen.queryByText(/safe-source|safe-scope/i)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- sanitize unified inbox service results to public allowlisted record fields
- remove public response exposure of internal source references and diagnostic safety flags
- update frontend unified inbox types and focused tests for the public response shape

## Validation
- npm --prefix rentchain-api run test:single -- src/tests/unifiedInbox/unifiedInboxService.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts src/tests/unifiedInbox/tenantInboxAdapters.test.ts src/tests/unifiedInbox/landlordInboxAdapters.test.ts src/tests/unifiedInbox/contractorInboxAdapters.test.ts src/tests/unifiedInbox/deriveUnifiedInbox.test.ts src/tests/unifiedInbox/safeInboxReferences.test.ts
- npm --prefix rentchain-frontend run test:single -- src/api/unifiedInboxApi.test.ts src/pages/UnifiedInboxPage.test.tsx
- npm --prefix rentchain-api run build
- npm --prefix rentchain-frontend run build
- git diff --check

## Manual QA
- Not run locally because seeded authenticated tenant, landlord, and contractor sessions were not available in this environment.