### PR TITLE
fix: add unified inbox to landlord mobile bottom navigation

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -184,7 +184,7 @@
   border-top: 1px solid rgba(0, 0, 0, 0.08);
   background: #ffffff;
   padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px));
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   z-index: 20;
   box-sizing: border-box;
   max-width: 100%;
@@ -362,7 +362,7 @@
 
   .rc-landlord-mobile-tabbar {
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
     z-index: 100;
     width: 100%;
     max-width: 100%;

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -155,8 +155,17 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(tabbar).getByText("Dashboard")).toBeInTheDocument();
     expect(within(tabbar).getByText("Documents")).toBeInTheDocument();
     expect(within(tabbar).getByText("Leases")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Inbox")).toBeInTheDocument();
     expect(within(tabbar).getByText("Messages")).toBeInTheDocument();
     expect(within(tabbar).getByText("More")).toBeInTheDocument();
+    expect(within(tabbar).getAllByRole("button").map((button) => button.textContent)).toEqual([
+      "Dashboard",
+      "Documents",
+      "Leases",
+      "Inbox",
+      "Messages",
+      "More",
+    ]);
     expect(within(tabbar).queryByText("Applications")).not.toBeInTheDocument();
     expect(within(tabbar).queryByText("Tenants")).not.toBeInTheDocument();
     expect(within(tabbar).queryByText("Properties")).not.toBeInTheDocument();
@@ -182,6 +191,16 @@ describe("LandlordNav mobile drawer", () => {
 
     fireEvent.click(within(tabbar).getByRole("button", { name: "Leases" }));
     expect(screen.getByTestId("current-path")).toHaveTextContent("/leases");
+
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Inbox" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
+  });
+
+  it("marks the unified inbox tab active on the landlord unified inbox route", () => {
+    renderLandlordNav("/landlord/unified-inbox");
+
+    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+    expect(within(tabbar).getByRole("button", { name: "Inbox" })).toHaveClass("active");
   });
 
   it("does not render the landlord bottom nav for admin role contexts", () => {

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { FileText, LayoutDashboard, Menu, MessagesSquare, ScrollText, X } from "lucide-react";
+import { FileText, Inbox, LayoutDashboard, Menu, MessagesSquare, ScrollText, X } from "lucide-react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
@@ -20,6 +20,7 @@ const landlordMobileTabs = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/applications", label: "Documents", icon: FileText },
   { to: "/leases", label: "Leases", icon: ScrollText },
+  { to: "/landlord/unified-inbox", label: "Inbox", icon: Inbox },
   { to: "/messages", label: "Messages", icon: MessagesSquare, requiresMessaging: true },
 ];
 


### PR DESCRIPTION
## Summary
- add the landlord unified inbox as an Inbox entry in the landlord mobile bottom navigation
- keep the existing drawer and mobile More control available
- update LandlordNav tests for Inbox visibility, navigation, and active state

## Validation
- npm --prefix rentchain-frontend run test:single -- src/components/layout/LandlordNav.test.tsx
- npm --prefix rentchain-frontend test -- LandlordNav --watch=false
- npm --prefix rentchain-frontend run build
- git diff --check

## Manual QA
- Browser smoke check was not completed because the in-app browser surface was unavailable in this session. Seeded authenticated landlord preview QA remains required for mobile breakpoints.