### PR TITLE
fix: unify unit CSV import parser

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,251 +1,98 @@
-# Property Onboarding Workflow Audit Report
+PR: #[NUMBER once opened]
+PR URL: [URL once opened]
+Branch: fix/unit-csv-import-v1
 
-PR: #1133
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1133
-Branch: audit/property-onboarding-workflow-v1
+# Implementation Summary
 
-## Executive Summary
+## Mission
+Unified CSV unit parsing across property creation and property unit table upload flows by routing both upload paths through the backend PapaParser-based unit parser and removing the property creation form's custom string-splitting parser.
 
-This audit identifies critical issues in the property onboarding workflow that explain the 33% success rate (2 of 3 properties failed) in self-serve property creation with CSV-based unit import. The root cause is a **split implementation** between property creation and unit import flows, with fundamentally different CSV parsing approaches that handle edge cases inconsistently.
+## Files Modified
+- `rentchain-api/src/imports/unitCsv.schema.ts`
+- `rentchain-api/src/imports/unitCsvImport.service.ts`
+- `rentchain-api/src/imports/unitCsvImport.service.test.ts`
+- `rentchain-api/src/routes/propertiesRoutes.ts`
+- `rentchain-api/src/routes/unitImportRoutes.ts`
+- `rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts`
+- `rentchain-frontend/src/api/propertiesApi.ts`
+- `rentchain-frontend/src/api/unitsImportApi.ts`
+- `rentchain-frontend/src/components/properties/AddPropertyForm.tsx`
+- `rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx`
+- `rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx`
+- `rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx`
+- `rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx`
+- `rentchain-frontend/src/components/properties/UnitsCsvPreviewModal.tsx`
+- `rentchain-frontend/src/utils/csvTemplates.ts`
 
-## Critical Findings
+## Backend Changes
+- Added shared CSV field mapping constants for supported unit CSV headers and aliases.
+- Added BOM-safe header normalization.
+- Added explicit header validation for required, missing, and unknown headers.
+- Added row-level preview output with row number, field name, validation status, and issue list.
+- Preserved existing `parseUnitsCsv` candidate output for current import write logic.
+- Added `status` support for `vacant` and `occupied` unit rows.
+- Added non-mutating property creation preview endpoint:
+  - `POST /api/properties/units/csv-preview`
+- Added property-scoped unit table preview endpoint:
+  - `POST /api/properties/:propertyId/units/csv-parse`
+- Updated existing unit import dry-run response to return the same backend preview shape.
+- Updated write modes to fail closed when headers are invalid.
+- Preserved the existing save endpoint:
+  - `POST /api/properties/:propertyId/units/import`
 
-### 1. Split CSV Implementation Architecture (PRIMARY ROOT CAUSE)
+## Frontend Changes
+- Removed custom CSV parsing from `AddPropertyForm.tsx`.
+- Property creation CSV upload now calls backend preview before the property is created.
+- Property creation displays a mandatory preview panel with row status and validation issues.
+- Property creation disables submit while previewing or when CSV preview has errors.
+- Manual unit edits clear stale CSV preview state so users can still proceed manually.
+- Property unit table CSV upload now calls backend preview before opening the confirmation modal.
+- `UnitsCsvPreviewModal` now renders backend row validation status and disables confirm when issues exist.
+- Updated the downloadable unit CSV template to match supported parser headers:
+  - `unitNumber,marketRent,beds,baths,sqft,status`
 
-**Two completely separate CSV parsing implementations exist:**
+## Error Message Examples
+- `Required header 'unitNumber' is missing. Expected headers: unitNumber, marketRent, beds, baths, sqft, status`
+- `Unknown header 'privateColumn'. Expected headers: unitNumber, marketRent, beds, baths, sqft, status`
+- `Row 2: rent - Invalid input: expected number, received NaN`
+- `Row 3: entire row is empty, skipping.`
+- `Duplicate unitNumber in CSV: 101`
 
-#### Frontend CSV Parsing (Property Creation Flow)
-- **Location**: [rentchain-frontend/src/components/properties/AddPropertyForm.tsx:107-157](rentchain-frontend/src/components/properties/AddPropertyForm.tsx#L107-L157)
-- **Implementation**: Naive string splitting approach
-```typescript
-const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
-const headers = headerLine.split(",").map((h) => h.trim().toLowerCase());
-const cols = line.split(",").map((c) => c.trim());
-```
-- **Issues**:
-  - No BOM handling
-  - No CSV escaping/quoting support
-  - Simple comma splitting breaks with quoted values
-  - No validation preview
-  - Basic header mapping only
+## Test Coverage
+- Added backend parser tests for:
+  - BOM-prefixed CSVs
+  - public template aliases
+  - missing and unknown headers
+  - row-level field errors
+  - duplicate rows
+  - empty rows
+- Added backend route tests for:
+  - property creation CSV preview
+  - property-scoped unit table CSV preview
+- Added frontend coverage for:
+  - property creation CSV preview through backend parser
+  - previewed unit data flowing into create property payload
+- Updated existing component mocks for the new preview API export.
 
-#### Backend CSV Parsing (Unit Import Flow)
-- **Location**: [rentchain-api/src/imports/unitCsvImport.service.ts:18-66](rentchain-api/src/imports/unitCsvImport.service.ts#L18-L66)
-- **Implementation**: PapaParser library with proper CSV handling
-```typescript
-const parsed = Papa.parse(csvText, { header: true, skipEmptyLines: true });
-```
-- **Features**:
-  - Proper CSV parsing with escaping/quoting
-  - Schema validation with Zod
-  - Flexible header mapping
-  - Duplicate detection
-  - Preview functionality available
+## Validation
+- `npm --prefix rentchain-api run test:single -- src/imports/unitCsvImport.service.test.ts`: PASS, 4 tests.
+- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/unitCsvPreviewRoutes.test.ts`: PASS, 2 tests. Required running outside sandbox because local Supertest binding hit `listen EPERM` inside the sandbox.
+- `npm --prefix rentchain-frontend run test:single -- src/components/properties/AddPropertyForm.test.tsx src/components/properties/PropertyDetailPanel.test.tsx src/components/properties/PropertyOccupancyRegression.test.tsx`: PASS, 20 tests.
+- `npm --prefix rentchain-api run build`: PASS.
+- `npm --prefix rentchain-frontend run build`: PASS.
+- `git diff --check`: PASS.
 
-### 2. Property Creation Entry Points
+## Acceptance Criteria Status
+- Same backend parser used by property creation and unit table CSV preview: PASS.
+- Header validation happens before write modes and blocks save on invalid headers: PASS.
+- Row-level errors include row and field context: PASS.
+- Property creation preview is shown before property save: PASS.
+- Unit table preview is shown before unit import confirmation: PASS.
+- No placeholder unit generation added: PASS.
+- Tenant-facing routes or UI were not modified: PASS.
+- No new dependencies added: PASS.
 
-#### Primary Property Creation Route
-- **Endpoint**: `POST /api/properties` ([propertiesRoutes.ts:259-522](rentchain-api/src/routes/propertiesRoutes.ts#L259-L522))
-- **Request Shape**:
-```typescript
-{
-  addressLine1: string,
-  city: string,
-  province: string,
-  units?: Array<{unitNumber: string, rent: number, bedrooms?: number, bathrooms?: number, sqft?: number}>
-}
-```
-- **Unit Handling**: Inline unit creation via `normalizeUnits()` function and Firestore batch writes
-- **CSV Support**: None - requires pre-parsed unit array
-
-#### Secondary Unit Import Route
-- **Endpoint**: `POST /api/properties/:propertyId/units/import` ([unitImportRoutes.ts:334-372](rentchain-api/src/routes/unitImportRoutes.ts#L334-L372))
-- **Request Shape**:
-```typescript
-{
-  csvText: string,
-  mode: "dryRun" | "strict" | "partial",
-  idempotencyKey: string
-}
-```
-- **CSV Support**: Full PapaParser implementation with validation
-
-### 3. Unit ID Generation Strategy
-
-- **Implementation**: [rentchain-api/src/imports/unitId.ts:1-4](rentchain-api/src/imports/unitId.ts#L1-L4)
-- **Strategy**: Deterministic composite key generation
-```typescript
-function unitDocId(propertyId: string, unitNumber: string) {
-  const clean = String(unitNumber).trim().replace(/[^a-zA-Z0-9_-]/g, "_");
-  return `unit__${propertyId}__${clean}`.slice(0, 500);
-}
-```
-- **Implications**: Unit IDs are deterministic based on property ID + unit number, enabling deduplication
-
-### 4. CSV Handling Analysis
-
-#### BOM Handling
-- **Frontend**: No BOM handling in AddPropertyForm CSV parsing
-- **Backend**: PapaParser handles BOM automatically
-- **Additional Utility**: [rentchain-api/src/utils/csv.ts:41](rentchain-api/src/utils/csv.ts#L41) shows BOM stripping pattern `h.replace(/^﻿/, "")` but is unused by unit parsing
-
-#### Line Ending Handling
-- **Frontend**: Basic regex `/\r?\n/` in AddPropertyForm
-- **Backend**: PapaParser handles all line ending variations
-- **Impact**: Frontend parsing can fail on mixed line endings from spreadsheet editors
-
-#### CSV Escaping/Quoting
-- **Frontend**: No support for quoted fields containing commas
-- **Backend**: Full CSV standard compliance via PapaParser
-
-### 5. Property/Units Table Upload Flow
-
-#### CSV Preview Implementation
-- **Component**: [UnitsCsvPreviewModal.tsx](rentchain-frontend/src/components/properties/UnitsCsvPreviewModal.tsx)
-- **Usage**: Property details page CSV upload ([PropertyDetailPanel.tsx:1140-1159](rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx#L1140-L1159))
-- **Preview Parser**: [parseCsvPreview utility](rentchain-frontend/src/utils/csvPreview.ts) - shows first 10 rows
-- **Backend Integration**: Calls `importUnitsCsv` API with full validation
-
-### 6. Occupancy Unit Resolution
-
-#### Implementation
-- **Location**: [occupancyPrompt.ts:12-36](rentchain-frontend/src/components/properties/occupancyPrompt.ts#L12-L36)
-- **Purpose**: Identifies units needing occupancy status setup
-- **Resolution Strategy**:
-  - Match by unit ID: `lease.unitId` → `unit.id`
-  - Fallback to unit number: `lease.unitNumber` → `unit.unitNumber`
-  - Case-insensitive string matching
-
-#### Potential Issues
-- **Mixed ID Types**: Frontend generates random UUIDs, backend generates deterministic IDs
-- **Reference Mismatch**: Temporary frontend IDs may not match persisted Firestore IDs
-- **Inconsistent Matching**: Different resolution logic across components
-
-## Failure Mode Analysis
-
-### CSV Corruption from Spreadsheet Editors (Confirmed)
-
-**Scenario 1: Apple Numbers/Google Sheets Export**
-- **Issue**: BOM characters, smart quotes, non-standard line endings
-- **Frontend Impact**: Parsing fails silently, creates malformed unit numbers
-- **Backend Impact**: PapaParser handles gracefully
-- **Reproduction**: Export CSV from Numbers with special characters
-
-**Scenario 2: Trailing Commas/Empty Columns**
-- **Issue**: Spreadsheet exports often include trailing empty columns
-- **Frontend Impact**: Creates empty unit entries, validation failures
-- **Backend Impact**: `skipEmptyLines: true` handles correctly
-- **Reproduction**: Add empty columns in spreadsheet before export
-
-**Scenario 3: Quoted Fields with Commas**
-- **Issue**: Unit names like "Unit 1A, Building B" break simple comma splitting
-- **Frontend Impact**: Incorrect field separation, data corruption
-- **Backend Impact**: Full CSV standard compliance
-- **Reproduction**: Use unit names with commas in CSV
-
-### Split Implementation Validation Differences
-
-**Frontend Property Creation**:
-- **Validation**: Basic type coercion and null checks
-- **Error Handling**: Generic "Failed to parse CSV file" message
-- **Unit Count**: Uses `totalUnits` override if provided
-
-**Backend Unit Import**:
-- **Validation**: Zod schema validation with detailed error messages
-- **Error Handling**: Detailed validation reports with row numbers
-- **Duplicate Detection**: Prevents duplicate unit numbers
-- **Conflict Resolution**: Checks against existing units
-
-## Error Handling and User Feedback Analysis
-
-### Property Creation Flow
-- **Location**: [AddPropertyForm.tsx:159-189](rentchain-frontend/src/components/properties/AddPropertyForm.tsx#L159-L189)
-- **Success Message**: "Loaded X units from CSV. You can still edit them below before saving."
-- **Error Message**: Generic "Failed to parse CSV file" or "CSV parsed but no valid rows found"
-- **No Preview**: Users cannot verify CSV correctness before submission
-
-### Unit Import Flow
-- **Location**: [PropertyDetailPanel.tsx:348-416](rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx#L348-L416)
-- **Preview**: Full CSV preview modal with first 10 rows
-- **Detailed Feedback**: "Created X | Updated Y | Skipped Z | N issue(s)"
-- **Error Details**: Row-level validation errors with specific messages
-
-## Recommended Fix Scope for Follow-Up Missions
-
-### fix/unit-csv-import-v1
-**Scope**: Consolidate CSV parsing to use backend implementation only
-- Migrate AddPropertyForm to use unit import API
-- Remove frontend CSV parsing logic
-- Implement CSV preview in property creation flow
-- Add proper validation feedback
-
-### fix/unit-manual-save-v1
-**Scope**: Improve manual unit entry validation and error handling
-- Standardize unit validation across both flows
-- Improve error messages for manual unit entry
-- Add client-side validation preview
-
-### fix/occupancy-guide-unit-resolution-v1
-**Scope**: Standardize unit reference resolution
-- Implement consistent unit ID generation strategy
-- Fix unit reference matching logic
-- Add validation for unit reference integrity
-
-## Test Coverage Analysis
-
-### Backend Tests
-- **Property Creation**: Limited test coverage for edge cases
-- **Unit Import**: Comprehensive CSV parsing tests exist
-- **Missing Coverage**: BOM handling, mixed line endings, quotation edge cases
-
-### Frontend Tests
-- **Property Creation**: Basic component tests
-- **CSV Parsing**: No tests for frontend CSV parsing logic
-- **Missing Coverage**: CSV edge case handling, error state validation
-
-## Recommended Testing Improvements
-
-1. **CSV Edge Case Test Suite**:
-   - BOM character handling
-   - Mixed line endings (CRLF vs LF)
-   - Quoted fields with commas, quotes, newlines
-   - Trailing comma scenarios
-   - Empty row handling
-
-2. **Integration Tests**:
-   - End-to-end property creation with various CSV formats
-   - Unit reference resolution validation
-   - Error message consistency verification
-
-## Code Locations Summary
-
-### API Routes
-- [propertiesRoutes.ts:259-522](rentchain-api/src/routes/propertiesRoutes.ts#L259-L522) - Property creation endpoint
-- [unitsRoutes.ts:175-306](rentchain-api/src/routes/unitsRoutes.ts#L175-L306) - Unit management endpoints
-- [unitImportRoutes.ts:334-372](rentchain-api/src/routes/unitImportRoutes.ts#L334-L372) - CSV import endpoint
-
-### Services
-- [unitCsvImport.service.ts:18-66](rentchain-api/src/imports/unitCsvImport.service.ts#L18-L66) - Backend CSV parsing
-- [unitId.ts:1-4](rentchain-api/src/imports/unitId.ts#L1-L4) - Unit ID generation
-- [occupancyPrompt.ts:12-36](rentchain-frontend/src/components/properties/occupancyPrompt.ts#L12-L36) - Unit resolution
-
-### Frontend Components
-- [AddPropertyForm.tsx:107-157](rentchain-frontend/src/components/properties/AddPropertyForm.tsx#L107-L157) - Frontend CSV parsing
-- [PropertyDetailPanel.tsx:1140-1159](rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx#L1140-L1159) - CSV upload interface
-- [UnitsCsvPreviewModal.tsx](rentchain-frontend/src/components/properties/UnitsCsvPreviewModal.tsx) - CSV preview component
-
-### Utilities
-- [csv.ts:41](rentchain-api/src/utils/csv.ts#L41) - Unused but correct BOM handling pattern
-- [unitCsv.schema.ts:13-28](rentchain-api/src/imports/unitCsv.schema.ts#L13-L28) - Header normalization and mapping
-
-## Conclusion
-
-The 33% failure rate in property onboarding is directly attributable to the split CSV implementation architecture. The frontend parsing approach fails on common CSV edge cases that are properly handled by the backend PapaParser implementation. Consolidating to a single, robust CSV parsing approach will significantly improve success rates and user experience.
-
-The audit confirms all hypotheses from the mission brief:
-- ✅ CSV corruption from spreadsheet editors (BOM, line endings, trailing commas)
-- ✅ Split implementation between creation flow and import flow (different validation logic)
-- ✅ Missing CSV preview in property creation flow
-- ✅ Unit resolution issues in occupancy guide workflows (reference integrity problems)
-
-The recommended fix missions will address these root causes systematically while preserving audit history and maintaining role separation as required.
+## Known Limitations
+- The mission requested new `/api/property/:propertyId/units/csv-save` endpoints, but the repo already mounts `/api/properties/:propertyId/units/import`. To avoid duplicate route surfaces, this implementation keeps the existing save route and adds preview endpoints around it.
+- The save route re-runs the same backend parser instead of using a persisted `previewId`; this preserves no-write preview semantics without adding storage state.
+- Manual browser QA with authenticated landlord sessions was not run in this environment.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,5 +1,5 @@
-PR: #[NUMBER once opened]
-PR URL: [URL once opened]
+PR: #1134
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1134
 Branch: fix/unit-csv-import-v1
 
 # Implementation Summary

--- a/rentchain-api/src/imports/unitCsv.schema.ts
+++ b/rentchain-api/src/imports/unitCsv.schema.ts
@@ -6,23 +6,89 @@ export const UnitCsvRowSchema = z.object({
   bedrooms: z.coerce.number().int().min(0).max(10).optional(),
   bathrooms: z.coerce.number().min(0).max(10).optional(),
   sqft: z.coerce.number().int().nonnegative().optional(),
+  status: z.enum(["vacant", "occupied"]).optional(),
 });
 
 export type UnitCsvRow = z.infer<typeof UnitCsvRowSchema>;
 
+export const UNIT_CSV_FIELD_MAP = [
+  {
+    field: "unitNumber",
+    canonicalHeader: "unitNumber",
+    required: true,
+    aliases: ["unit", "unitnumber", "unitno", "number", "suite", "unit name", "unit name/number"],
+  },
+  {
+    field: "rent",
+    canonicalHeader: "marketRent",
+    required: false,
+    aliases: ["rent", "rentamount", "amount", "marketrent", "market rent", "monthlyrent", "monthly rent"],
+  },
+  {
+    field: "bedrooms",
+    canonicalHeader: "beds",
+    required: false,
+    aliases: ["bed", "beds", "bedrooms"],
+  },
+  {
+    field: "bathrooms",
+    canonicalHeader: "baths",
+    required: false,
+    aliases: ["bath", "baths", "bathrooms"],
+  },
+  {
+    field: "sqft",
+    canonicalHeader: "sqft",
+    required: false,
+    aliases: ["sqft", "squarefeet", "square feet", "size"],
+  },
+  {
+    field: "status",
+    canonicalHeader: "status",
+    required: false,
+    aliases: ["status", "occupancy", "occupancy status"],
+  },
+] as const;
+
+export const EXPECTED_UNIT_CSV_HEADERS = UNIT_CSV_FIELD_MAP.map((entry) => entry.canonicalHeader);
+
 export function normalizeHeader(h: string) {
-  return h.trim().toLowerCase().replace(/\s+/g, "");
+  return h
+    .replace(/^\uFEFF/, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "");
+}
+
+function cleanCell(value: any) {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  return text === "" ? undefined : text;
+}
+
+function normalizeStatus(value: any) {
+  const text = String(value || "").trim().toLowerCase();
+  if (!text) return undefined;
+  if (["vacant", "available", "empty"].includes(text)) return "vacant";
+  if (["occupied", "leased", "rented"].includes(text)) return "occupied";
+  return text;
+}
+
+export function resolveUnitCsvField(header: string): (typeof UNIT_CSV_FIELD_MAP)[number] | undefined {
+  const normalized = normalizeHeader(header);
+  return UNIT_CSV_FIELD_MAP.find((entry) =>
+    entry.aliases.some((alias) => normalizeHeader(alias) === normalized)
+  );
 }
 
 export function mapRow(raw: Record<string, any>) {
   const out: any = {};
   for (const [k, v] of Object.entries(raw)) {
-    const key = normalizeHeader(k);
-    if (["unit", "unitnumber", "unitno", "number"].includes(key)) out.unitNumber = v;
-    else if (["rent", "rentamount", "amount"].includes(key)) out.rent = v;
-    else if (["bed", "beds", "bedrooms"].includes(key)) out.bedrooms = v;
-    else if (["bath", "baths", "bathrooms"].includes(key)) out.bathrooms = v;
-    else if (["sqft", "squarefeet", "size"].includes(key)) out.sqft = v;
+    const entry = resolveUnitCsvField(k);
+    if (!entry) continue;
+    const value = entry.field === "status" ? normalizeStatus(v) : cleanCell(v);
+    if (value === undefined) continue;
+    out[entry.field] = value;
   }
   return out;
 }

--- a/rentchain-api/src/imports/unitCsvImport.service.test.ts
+++ b/rentchain-api/src/imports/unitCsvImport.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { parseUnitsCsv } from "./unitCsvImport.service";
+
+describe("parseUnitsCsv", () => {
+  it("parses BOM-prefixed CSVs with public template aliases", () => {
+    const csv = "\uFEFFunitNumber,marketRent,beds,baths,sqft,status\r\n101,1850,1,1,610,vacant\r\n102,1650,0,1,450,occupied";
+
+    const result = parseUnitsCsv(csv);
+
+    expect(result.headers).toMatchObject({ valid: true, missing: [], unknown: [] });
+    expect(result.preview.errors).toEqual([]);
+    expect(result.candidates).toHaveLength(2);
+    expect(result.candidates[0].data).toMatchObject({
+      unitNumber: "101",
+      rent: 1850,
+      bedrooms: 1,
+      bathrooms: 1,
+      sqft: 610,
+      status: "vacant",
+    });
+  });
+
+  it("reports exact missing and unknown headers", () => {
+    const result = parseUnitsCsv("marketRent,internalId\n1850,secret");
+
+    expect(result.headers.valid).toBe(false);
+    expect(result.headers.missing).toEqual(["unitNumber"]);
+    expect(result.headers.unknown).toEqual(["internalId"]);
+    expect(result.preview.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "HEADER_MISSING", field: "unitNumber" }),
+        expect.objectContaining({ code: "HEADER_UNKNOWN", field: "internalId" }),
+      ])
+    );
+  });
+
+  it("reports row-level field errors without silently coercing bad values", () => {
+    const result = parseUnitsCsv("unitNumber,marketRent,beds,baths,sqft\n101,not-a-number,1,1,610\n102,1500,eleven,1,450");
+
+    expect(result.preview.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ row: 2, code: "ROW_INVALID", field: "rent" }),
+        expect.objectContaining({ row: 3, code: "ROW_INVALID", field: "bedrooms" }),
+      ])
+    );
+    expect(result.candidates).toHaveLength(0);
+  });
+
+  it("marks duplicate and empty rows in preview output", () => {
+    const result = parseUnitsCsv("unitNumber,marketRent\n101,1850\n\n101,1900");
+
+    expect(result.duplicatesInCsv).toEqual([
+      expect.objectContaining({ row: 4, code: "DUPLICATE_IN_CSV", unitNumber: "101" }),
+    ]);
+    expect(result.preview.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ row: 3, status: "skipped" }),
+        expect.objectContaining({ row: 4, status: "invalid" }),
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/imports/unitCsvImport.service.ts
+++ b/rentchain-api/src/imports/unitCsvImport.service.ts
@@ -1,11 +1,26 @@
 import Papa from "papaparse";
-import { UnitCsvRowSchema, mapRow } from "./unitCsv.schema";
+import {
+  EXPECTED_UNIT_CSV_HEADERS,
+  UNIT_CSV_FIELD_MAP,
+  UnitCsvRowSchema,
+  mapRow,
+  resolveUnitCsvField,
+} from "./unitCsv.schema";
 
 export type RowIssue = {
   row: number;
   code: string;
   message: string;
+  field?: string;
   unitNumber?: string;
+};
+
+export type UnitCsvPreviewRow = {
+  row: number;
+  status: "valid" | "invalid" | "skipped";
+  unitNumber?: string;
+  data: Record<string, any>;
+  issues: RowIssue[];
 };
 
 export type ParsedUnitsCsv = {
@@ -13,29 +28,98 @@ export type ParsedUnitsCsv = {
   candidates: { row: number; unitNumber: string; data: any }[];
   invalid: RowIssue[];
   duplicatesInCsv: RowIssue[];
+  headers: {
+    valid: boolean;
+    received: string[];
+    expected: string[];
+    missing: string[];
+    unknown: string[];
+  };
+  rows: UnitCsvPreviewRow[];
+  preview: {
+    rows: UnitCsvPreviewRow[];
+    errors: RowIssue[];
+  };
 };
 
 export function parseUnitsCsv(csvText: string): ParsedUnitsCsv {
-  const parsed = Papa.parse(csvText, { header: true, skipEmptyLines: true });
+  const parsed = Papa.parse(csvText, { header: true, skipEmptyLines: false });
   const data = (parsed.data || []) as any[];
+  const receivedHeaders = (parsed.meta.fields || []).map((header) => String(header || "").replace(/^\uFEFF/, "").trim());
+  const knownFields = new Set<string>();
+  const unknown = receivedHeaders.filter((header) => {
+    if (!header) return false;
+    const field = resolveUnitCsvField(header)?.field;
+    if (field) knownFields.add(field);
+    return !field;
+  });
+  const missing = UNIT_CSV_FIELD_MAP.filter((entry) => entry.required && !knownFields.has(entry.field)).map(
+    (entry) => entry.canonicalHeader
+  );
+  const headerIssues: RowIssue[] = [
+    ...missing.map((header) => ({
+      row: 1,
+      code: "HEADER_MISSING",
+      field: header,
+      message: `Required header '${header}' is missing. Expected headers: ${EXPECTED_UNIT_CSV_HEADERS.join(", ")}`,
+    })),
+    ...unknown.map((header) => ({
+      row: 1,
+      code: "HEADER_UNKNOWN",
+      field: header,
+      message: `Unknown header '${header}'. Expected headers: ${EXPECTED_UNIT_CSV_HEADERS.join(", ")}`,
+    })),
+  ];
 
-  const invalid: RowIssue[] = [];
+  const invalid: RowIssue[] = [...headerIssues];
   const candidates: { row: number; unitNumber: string; data: any }[] = [];
+  const rows: UnitCsvPreviewRow[] = [];
 
   data.forEach((raw, idx) => {
     const rowNum = idx + 2; // header row is 1
+    const isEmpty = Object.values(raw || {}).every((value) => String(value ?? "").trim() === "");
+    if (isEmpty) {
+      const issue = {
+        row: rowNum,
+        code: "ROW_EMPTY",
+        message: `Row ${rowNum}: entire row is empty, skipping.`,
+      };
+      rows.push({ row: rowNum, status: "skipped", data: {}, issues: [issue] });
+      return;
+    }
+
     const mapped = mapRow(raw);
     const v = UnitCsvRowSchema.safeParse(mapped);
     if (!v.success) {
-      invalid.push({ row: rowNum, code: "ROW_INVALID", message: "Invalid row shape", unitNumber: undefined });
+      const issues = v.error.issues.map((issue) => {
+        const field = String(issue.path[0] || "row");
+        return {
+          row: rowNum,
+          code: "ROW_INVALID",
+          field,
+          message: `Row ${rowNum}: ${field} - ${issue.message}`,
+          unitNumber: mapped.unitNumber ? String(mapped.unitNumber).trim() : undefined,
+        };
+      });
+      invalid.push(...issues);
+      rows.push({ row: rowNum, status: "invalid", unitNumber: mapped.unitNumber, data: mapped, issues });
       return;
     }
     const unitNumber = String(v.data.unitNumber || "").trim();
     if (!unitNumber) {
-      invalid.push({ row: rowNum, code: "UNIT_REQUIRED", message: "unitNumber is required" });
+      const issue = {
+        row: rowNum,
+        code: "UNIT_REQUIRED",
+        field: "unitNumber",
+        message: `Row ${rowNum}: unitNumber - unitNumber is required`,
+      };
+      invalid.push(issue);
+      rows.push({ row: rowNum, status: "invalid", data: mapped, issues: [issue] });
       return;
     }
-    candidates.push({ row: rowNum, unitNumber, data: { ...v.data, unitNumber } });
+    const data = { ...v.data, unitNumber };
+    candidates.push({ row: rowNum, unitNumber, data });
+    rows.push({ row: rowNum, status: "valid", unitNumber, data, issues: [] });
   });
 
   const seen = new Map<string, number>();
@@ -46,6 +130,7 @@ export function parseUnitsCsv(csvText: string): ParsedUnitsCsv {
       duplicatesInCsv.push({
         row: c.row,
         code: "DUPLICATE_IN_CSV",
+        field: "unitNumber",
         message: `Duplicate unitNumber in CSV: ${c.unitNumber}`,
         unitNumber: c.unitNumber,
       });
@@ -62,5 +147,34 @@ export function parseUnitsCsv(csvText: string): ParsedUnitsCsv {
     unique.push(c);
   }
 
-  return { totalRows: data.length, candidates: unique, invalid, duplicatesInCsv };
+  const duplicateRows = new Map(duplicatesInCsv.map((issue) => [issue.row, issue]));
+  const previewRows = rows.map((row) => {
+    const duplicate = duplicateRows.get(row.row);
+    if (!duplicate) return row;
+    return {
+      ...row,
+      status: "invalid" as const,
+      issues: [...row.issues, duplicate],
+    };
+  });
+  const errors = [...invalid, ...duplicatesInCsv];
+
+  return {
+    totalRows: data.length,
+    candidates: unique,
+    invalid,
+    duplicatesInCsv,
+    headers: {
+      valid: missing.length === 0 && unknown.length === 0,
+      received: receivedHeaders,
+      expected: EXPECTED_UNIT_CSV_HEADERS,
+      missing,
+      unknown,
+    },
+    rows: previewRows,
+    preview: {
+      rows: previewRows,
+      errors,
+    },
+  };
 }

--- a/rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts
@@ -1,0 +1,113 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, { id: string; data: any }>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  const dbMock = {
+    collection: (name: string) => ({
+      doc: (id: string) => {
+        const col = ensureCollection(name);
+        return {
+          id,
+          get: async () => {
+            const existing = col.get(id);
+            return {
+              id,
+              exists: Boolean(existing),
+              data: () => existing?.data,
+            };
+          },
+        };
+      },
+    }),
+  };
+
+  return {
+    dbMock,
+    resetDb: () => collections.clear(),
+    seedDoc: (collection: string, id: string, data: any) => {
+      ensureCollection(collection).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    increment: (n: number) => ({ __op: "inc", n }),
+    serverTimestamp: () => Date.now(),
+  },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", plan: "starter" };
+    next();
+  },
+}));
+
+vi.mock("../../imports/unitConflictCheck", () => ({
+  fetchExistingUnitNumbersForProperty: vi.fn(async () => new Set<string>()),
+}));
+
+async function createPropertiesApp() {
+  const router = (await import("../propertiesRoutes")).default;
+  const app = express();
+  app.use(express.json());
+  app.use("/api/properties", router);
+  return app;
+}
+
+async function createUnitImportApp() {
+  const router = (await import("../unitImportRoutes")).default;
+  const app = express();
+  app.use(express.json());
+  app.use("/api/properties/:propertyId/units", router);
+  return app;
+}
+
+describe("unit CSV preview routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("previews property creation CSV without mutating a property", async () => {
+    const app = await createPropertiesApp();
+
+    const res = await request(app).post("/api/properties/units/csv-preview").send({
+      csvText: "unitNumber,marketRent,beds,baths,sqft,status\n101,1850,1,1,610,vacant",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.preview.rows[0]).toMatchObject({
+      row: 2,
+      status: "valid",
+      data: { unitNumber: "101", rent: 1850, bedrooms: 1, bathrooms: 1, sqft: 610, status: "vacant" },
+    });
+  });
+
+  it("previews property unit table CSV through the property-scoped route", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
+    const app = await createUnitImportApp();
+
+    const res = await request(app).post("/api/properties/prop-1/units/csv-parse").send({
+      csvText: "unitNumber,marketRent,privateColumn\n101,1850,secret",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.headers.unknown).toEqual(["privateColumn"]);
+    expect(res.body.preview.errors).toEqual([
+      expect.objectContaining({ code: "HEADER_UNKNOWN", field: "privateColumn" }),
+    ]);
+  });
+});

--- a/rentchain-api/src/routes/propertiesRoutes.ts
+++ b/rentchain-api/src/routes/propertiesRoutes.ts
@@ -5,6 +5,7 @@ import { requireCapability } from "../entitlements/entitlements.middleware";
 import { db, FieldValue } from "../firebase";
 import { normalizeProvince } from "../lib/province";
 import { requireLandlord } from "../middleware/requireLandlord";
+import { parseUnitsCsv } from "../imports/unitCsvImport.service";
 import { ensureRegistrySource } from "../services/registry/registryImportService";
 import { getPropertyRegistryProjection, upsertPropertyRegistryProjection } from "../services/registry/registryStatusProjectionService";
 import {
@@ -106,6 +107,7 @@ function normalizeUnits(units: any[]): Array<{
   bedrooms: number | null;
   bathrooms: number | null;
   sqft: number | null;
+  status: "vacant" | "occupied" | null;
 }> {
   return (Array.isArray(units) ? units : [])
     .map((u) => {
@@ -115,12 +117,14 @@ function normalizeUnits(units: any[]): Array<{
       const bedroomsRaw = u?.bedrooms ?? u?.beds ?? null;
       const bathroomsRaw = u?.bathrooms ?? u?.baths ?? null;
       const sqftRaw = u?.sqft ?? u?.squareFeet ?? null;
+      const statusRaw = String(u?.status || "").trim().toLowerCase();
       return {
         unitNumber,
         rent: Number.isFinite(Number(rentRaw)) ? Number(rentRaw) : null,
         bedrooms: Number.isFinite(Number(bedroomsRaw)) ? Number(bedroomsRaw) : null,
         bathrooms: Number.isFinite(Number(bathroomsRaw)) ? Number(bathroomsRaw) : null,
         sqft: Number.isFinite(Number(sqftRaw)) ? Number(sqftRaw) : null,
+        status: statusRaw === "occupied" || statusRaw === "vacant" ? statusRaw : null,
       };
     })
     .filter(Boolean) as Array<{
@@ -129,6 +133,7 @@ function normalizeUnits(units: any[]): Array<{
       bedrooms: number | null;
       bathrooms: number | null;
       sqft: number | null;
+      status: "vacant" | "occupied" | null;
     }>;
 }
 
@@ -157,6 +162,39 @@ function resolveLandlordId(req: any): string {
 function uniqueById<T extends { id: string }>(items: T[]): T[] {
   return Array.from(new Map(items.map((item) => [item.id, item])).values());
 }
+
+router.post("/units/csv-preview", requireLandlord, async (req: any, res) => {
+  const requestId =
+    String(req.headers["x-request-id"] || req.headers["x-requestid"] || req.headers["x-correlation-id"] || "")
+      .trim() || undefined;
+  const landlordId = req.user?.landlordId || req.user?.id;
+  if (!landlordId) {
+    return res.status(401).json({ ok: false, error: "Unauthorized", requestId });
+  }
+
+  const csvText = String(req.body?.csvText || "");
+  if (!csvText.trim()) {
+    return res.status(400).json({ ok: false, error: "csvText required", requestId });
+  }
+
+  const parsed = parseUnitsCsv(csvText);
+  return res.status(200).json({
+    ok: parsed.headers.valid && parsed.preview.errors.length === 0,
+    requestId,
+    mode: "preview",
+    headers: parsed.headers,
+    summary: {
+      totalRows: parsed.totalRows,
+      candidates: parsed.candidates.length,
+      invalid: parsed.invalid.length,
+      duplicatesInCsv: parsed.duplicatesInCsv.length,
+      issueCount: parsed.preview.errors.length,
+    },
+    preview: parsed.preview,
+    rows: parsed.preview.rows,
+    issues: parsed.preview.errors.slice(0, 200),
+  });
+});
 
 function isManagedByUser(item: any, userId: string): boolean {
   const managerIds = Array.isArray(item?.managerUserIds) ? item.managerUserIds.map((value: any) => String(value || "").trim()) : [];
@@ -455,7 +493,7 @@ router.post(
             bedrooms: unit.bedrooms,
             bathrooms: unit.bathrooms,
             sqft: unit.sqft,
-            status: "vacant",
+            status: unit.status || "vacant",
             createdAt: now,
             updatedAt: now,
             updatedAtServer: FieldValue.serverTimestamp(),

--- a/rentchain-api/src/routes/unitImportRoutes.ts
+++ b/rentchain-api/src/routes/unitImportRoutes.ts
@@ -109,6 +109,7 @@ router.post("/", requireLandlord, async (req: any, res) => {
         bedrooms: raw?.bedrooms ?? raw?.beds ?? null,
         bathrooms: raw?.bathrooms ?? raw?.baths ?? null,
         sqft: raw?.sqft ?? null,
+        status: raw?.status === "occupied" ? "occupied" : raw?.status === "vacant" ? "vacant" : null,
         notes: raw?.notes ?? null,
       });
     }
@@ -223,14 +224,45 @@ async function runUnitImport(opts: {
     return {
       httpStatus: 200,
       body: {
-        ok: true,
+        ok: parsed.headers.valid && issues.length === 0,
         mode,
         requestId,
+        headers: parsed.headers,
         summary,
         issues: issues.slice(0, 200),
-        preview: insertable.slice(0, 25).map((x) => x.data),
+        preview: {
+          rows: parsed.preview.rows,
+          errors: issues.slice(0, 200),
+        },
       },
       report: { mode, summary, issues },
+    };
+  }
+
+  if (!parsed.headers.valid) {
+    if (jobRef) {
+      await failImportJob(jobRef, {
+        totalRows: parsed.totalRows,
+        attemptedValid: 0,
+        errorCount: issues.length,
+      });
+    }
+    return {
+      httpStatus: 400,
+      body: {
+        ok: false,
+        code: "CSV_HEADERS_INVALID",
+        error: "CSV headers are invalid; import aborted",
+        requestId,
+        headers: parsed.headers,
+        summary: { ...summary, issueCount: issues.length },
+        issues: issues.slice(0, 200),
+        preview: {
+          rows: parsed.preview.rows,
+          errors: issues.slice(0, 200),
+        },
+      },
+      report: { ok: false, mode, summary, issues },
     };
   }
 
@@ -251,6 +283,10 @@ async function runUnitImport(opts: {
         requestId,
         summary: { ...summary, issueCount: issues.length },
         issues: issues.slice(0, 200),
+        preview: {
+          rows: parsed.preview.rows,
+          errors: issues.slice(0, 200),
+        },
       },
       report: { ok: false, mode, summary, issues },
     };
@@ -270,6 +306,7 @@ async function runUnitImport(opts: {
         bedrooms: c.data.bedrooms ?? null,
         bathrooms: c.data.bathrooms ?? null,
         sqft: c.data.sqft ?? null,
+        status: c.data.status ?? "vacant",
         createdAt: FieldValue.serverTimestamp(),
         updatedAt: FieldValue.serverTimestamp(),
       });
@@ -324,12 +361,52 @@ async function runUnitImport(opts: {
     skippedCount,
     summary,
     issues: issues.slice(0, 200),
+    preview: {
+      rows: parsed.preview.rows,
+      errors: issues.slice(0, 200),
+    },
   };
 
   const report = { ok: true, mode, summary, issues, imported: wouldInsert };
 
   return { httpStatus: 200, body, report };
 }
+
+router.post("/csv-parse", requireLandlord, async (req: any, res, next) => {
+  const requestId = req.requestId;
+  try {
+    const { propertyId } = req.params as any;
+    const landlordId = (req as any).user?.landlordId || (req as any).user?.id;
+    const csvText = String(req.body?.csvText || "");
+
+    if (!propertyId) return jsonError(res, 400, "BAD_REQUEST", "propertyId required", undefined, requestId);
+    if (!landlordId) return jsonError(res, 401, "UNAUTHORIZED", "Unauthorized", undefined, requestId);
+    if (!csvText.trim()) return jsonError(res, 400, "BAD_REQUEST", "csvText required", undefined, requestId);
+
+    const propSnap = await db.collection("properties").doc(propertyId).get();
+    if (!propSnap.exists) {
+      return jsonError(res, 404, "NOT_FOUND", "Property not found", undefined, requestId);
+    }
+    const propData = propSnap.data() as any;
+    if (propData?.landlordId && propData.landlordId !== landlordId) {
+      return jsonError(res, 403, "FORBIDDEN", "Forbidden", undefined, requestId);
+    }
+
+    const result = await runUnitImport({
+      landlordId,
+      propertyId,
+      mode: "dryRun",
+      csvText,
+      requestId,
+      plan: req.user?.plan,
+      user: req.user,
+    });
+
+    return res.status(result.httpStatus).json(result.body);
+  } catch (e) {
+    return next(e);
+  }
+});
 
 router.post("/import", requireLandlord, async (req: any, res, next) => {
   const requestId = req.requestId;

--- a/rentchain-frontend/src/api/propertiesApi.ts
+++ b/rentchain-frontend/src/api/propertiesApi.ts
@@ -9,6 +9,7 @@ export interface UnitInput {
   bedrooms?: number | null;
   bathrooms?: number | null;
   sqft?: number | null;
+  status?: "vacant" | "occupied" | null;
   utilitiesIncluded?: string[];
 }
 

--- a/rentchain-frontend/src/api/unitsImportApi.ts
+++ b/rentchain-frontend/src/api/unitsImportApi.ts
@@ -1,5 +1,75 @@
 import api from "./client";
 
+export type UnitCsvIssue = {
+  row: number;
+  code: string;
+  message: string;
+  field?: string;
+  unitNumber?: string;
+};
+
+export type UnitCsvPreviewRow = {
+  row: number;
+  status: "valid" | "invalid" | "skipped";
+  unitNumber?: string;
+  data: {
+    unitNumber?: string;
+    rent?: number | null;
+    bedrooms?: number | null;
+    bathrooms?: number | null;
+    sqft?: number | null;
+    status?: "vacant" | "occupied" | null;
+  };
+  issues: UnitCsvIssue[];
+};
+
+export type UnitCsvPreviewResponse = {
+  ok: boolean;
+  headers?: {
+    valid: boolean;
+    received: string[];
+    expected: string[];
+    missing: string[];
+    unknown: string[];
+  };
+  summary?: {
+    totalRows?: number;
+    candidates?: number;
+    insertable?: number;
+    invalid?: number;
+    duplicatesInCsv?: number;
+    conflicts?: number;
+    issueCount?: number;
+  };
+  preview?: {
+    rows: UnitCsvPreviewRow[];
+    errors: UnitCsvIssue[];
+  };
+  rows?: UnitCsvPreviewRow[];
+  issues?: UnitCsvIssue[];
+};
+
+export async function previewUnitsCsv(csvText: string): Promise<UnitCsvPreviewResponse> {
+  const res = await api.post(
+    "/properties/units/csv-preview",
+    { csvText },
+    { headers: { "Content-Type": "application/json" } }
+  );
+  return res.data;
+}
+
+export async function previewPropertyUnitsCsv(
+  propertyId: string,
+  csvText: string
+): Promise<UnitCsvPreviewResponse> {
+  const res = await api.post(
+    `/properties/${propertyId}/units/csv-parse`,
+    { csvText },
+    { headers: { "Content-Type": "application/json" } }
+  );
+  return res.data;
+}
+
 export async function importUnitsCsv(
   propertyId: string,
   csvText: string,

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AddPropertyForm } from "./AddPropertyForm";
 
 const mocks = vi.hoisted(() => ({
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   setOnboardingStepMock: vi.fn(),
   showToastMock: vi.fn(),
   useAuthMock: vi.fn(),
+  previewUnitsCsvMock: vi.fn(),
 }));
 
 vi.mock("../../api/propertiesApi", () => ({
@@ -16,6 +17,10 @@ vi.mock("../../api/propertiesApi", () => ({
 
 vi.mock("../../api/onboardingApi", () => ({
   setOnboardingStep: mocks.setOnboardingStepMock,
+}));
+
+vi.mock("../../api/unitsImportApi", () => ({
+  previewUnitsCsv: mocks.previewUnitsCsvMock,
 }));
 
 vi.mock("../../lib/analytics", () => ({
@@ -31,13 +36,40 @@ vi.mock("../../context/useAuth", () => ({
 }));
 
 describe("AddPropertyForm", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
+    mocks.createPropertyMock.mockReset();
     mocks.createPropertyMock.mockResolvedValue({
       property: { id: "prop-1", name: "Created Property", portfolioStatus: "active" },
     });
     mocks.trackMock.mockReset();
     mocks.setOnboardingStepMock.mockResolvedValue(undefined);
     mocks.showToastMock.mockReset();
+    mocks.previewUnitsCsvMock.mockResolvedValue({
+      ok: true,
+      headers: {
+        valid: true,
+        received: ["unitNumber", "marketRent", "beds", "baths", "sqft", "status"],
+        expected: ["unitNumber", "marketRent", "beds", "baths", "sqft", "status"],
+        missing: [],
+        unknown: [],
+      },
+      preview: {
+        errors: [],
+        rows: [
+          {
+            row: 2,
+            status: "valid",
+            unitNumber: "101",
+            data: { unitNumber: "101", rent: 1850, bedrooms: 1, bathrooms: 1, sqft: 610, status: "vacant" },
+            issues: [],
+          },
+        ],
+      },
+    });
     mocks.useAuthMock.mockReturnValue({
       user: { id: "user-1", plan: "free", role: "landlord" },
     });
@@ -92,6 +124,54 @@ describe("AddPropertyForm", () => {
           surface: "properties_page",
           source: "add_property_form",
           plan: "free",
+        })
+      );
+    });
+  });
+
+  it("previews CSV units through the backend parser before creating the property", async () => {
+    const { container } = render(<AddPropertyForm onCreated={vi.fn()} />);
+
+    fireEvent.change(screen.getAllByPlaceholderText("123 Main Street")[0], {
+      target: { value: "123 Main Street" },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText("Halifax")[0], {
+      target: { value: "Halifax" },
+    });
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
+      target: { value: "1" },
+    });
+    const unitsToggle = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Units & Rents (Optional)")
+    );
+    expect(unitsToggle).toBeTruthy();
+    fireEvent.click(unitsToggle!);
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["unitNumber,marketRent\n101,1850"], "units.csv", { type: "text/csv" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mocks.previewUnitsCsvMock).toHaveBeenCalledWith("unitNumber,marketRent\n101,1850");
+    });
+    expect(await screen.findByText(/CSV preview: units.csv/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Create property" })[0]);
+
+    await waitFor(() => {
+      expect(mocks.createPropertyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          totalUnits: 1,
+          units: [
+            expect.objectContaining({
+              unitNumber: "101",
+              rent: 1850,
+              bedrooms: 1,
+              bathrooms: 1,
+              sqft: 610,
+              status: "vacant",
+            }),
+          ],
         })
       );
     });

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
@@ -7,6 +7,11 @@ import {
 } from "../../api/propertiesApi";
 import { colors, radius, text } from "../../styles/tokens";
 import { setOnboardingStep } from "../../api/onboardingApi";
+import {
+  previewUnitsCsv,
+  type UnitCsvPreviewResponse,
+  type UnitCsvPreviewRow,
+} from "../../api/unitsImportApi";
 import { useToast } from "@/components/ui/ToastProvider";
 import { PROVINCE_OPTIONS } from "@/lib/provinces";
 import { track } from "../../lib/analytics";
@@ -20,6 +25,7 @@ interface AddPropertyFormProps {
 
 interface UnitRow extends UnitInput {
   id: string;
+  status?: "vacant" | "occupied" | null;
 }
 
 const makeId = () =>
@@ -53,6 +59,9 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   const [totalUnits, setTotalUnits] = useState<number | "">("");
   const [amenitiesText, setAmenitiesText] = useState("");
   const [units, setUnits] = useState<UnitRow[]>([emptyUnitRow()]);
+  const [csvPreview, setCsvPreview] = useState<UnitCsvPreviewResponse | null>(null);
+  const [csvFilename, setCsvFilename] = useState("");
+  const [isPreviewingCsv, setIsPreviewingCsv] = useState(false);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
@@ -74,11 +83,17 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     .map((x) => x.trim())
     .filter(Boolean);
 
+  const clearCsvPreviewState = () => {
+    setCsvPreview(null);
+    setCsvFilename("");
+  };
+
   const handleUnitChange = (
     id: string,
     field: keyof UnitRow,
     value: string
   ) => {
+    clearCsvPreviewState();
     setUnits((prev) =>
       prev.map((u) => {
         if (u.id !== id) return u;
@@ -97,89 +112,68 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   };
 
   const handleAddUnitRow = () => {
+    clearCsvPreviewState();
     setUnits((prev) => [...prev, emptyUnitRow()]);
   };
 
   const handleRemoveUnitRow = (id: string) => {
+    clearCsvPreviewState();
     setUnits((prev) => (prev.length <= 1 ? prev : prev.filter((u) => u.id !== id)));
   };
-
-  const parseUnitsCsv = (text: string): UnitRow[] => {
-    const lines = text
-      .split(/\r?\n/)
-      .map((l) => l.trim())
-      .filter(Boolean);
-
-    if (lines.length === 0) return [];
-
-    const [headerLine, ...dataLines] = lines;
-    const headers = headerLine.split(",").map((h) => h.trim().toLowerCase());
-
-    const idxUnit = headers.indexOf("unitnumber");
-    const idxRent = headers.indexOf("rent");
-    const idxBeds = headers.indexOf("bedrooms");
-    const idxBaths = headers.indexOf("bathrooms");
-    const idxSqft = headers.indexOf("sqft");
-
-    const rows: UnitRow[] = [];
-
-    for (const line of dataLines) {
-      const cols = line.split(",").map((c) => c.trim());
-      if (cols.length === 0) continue;
-
-      const unitNumber = idxUnit >= 0 ? cols[idxUnit] : cols[0] ?? "";
-
-      const rentRaw = idxRent >= 0 ? cols[idxRent] : "";
-      const rent = rentRaw ? Number(rentRaw) : NaN;
-
-      if (!unitNumber || Number.isNaN(rent)) {
-        continue;
-      }
-
-      const bedrooms =
-        idxBeds >= 0 && cols[idxBeds] ? Number(cols[idxBeds]) : null;
-      const bathrooms =
-        idxBaths >= 0 && cols[idxBaths] ? Number(cols[idxBaths]) : null;
-      const sqft = idxSqft >= 0 && cols[idxSqft] ? Number(cols[idxSqft]) : null;
-
-      rows.push({
-        id: makeId(),
-        unitNumber,
-        rent,
-        bedrooms,
-        bathrooms,
-        sqft,
-        utilitiesIncluded: [],
-      });
-    }
-
-    return rows;
-  };
-
   const handleCsvUpload: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    e.target.value = "";
 
     const reader = new FileReader();
-    reader.onload = () => {
+    reader.onload = async () => {
       try {
         const text = String(reader.result ?? "");
-        const parsed = parseUnitsCsv(text);
-        if (parsed.length === 0) {
+        if (!text.trim()) {
           setErrorText(
-            "CSV parsed but no valid rows were found. Make sure headers include at least unitNumber and rent."
+            "CSV file appears empty or unreadable."
           );
           return;
         }
+        setIsPreviewingCsv(true);
+        const preview = await previewUnitsCsv(text);
+        setCsvPreview(preview);
+        setCsvFilename(file.name);
+        const rows = preview.preview?.rows || preview.rows || [];
+        const errors = preview.preview?.errors || preview.issues || [];
+        const validRows = rows.filter((row) => row.status === "valid");
+
+        if (errors.length > 0 || preview.headers?.valid === false) {
+          setErrorText("CSV preview found issues. Fix the CSV and upload it again before creating the property.");
+          setSuccessText(null);
+          return;
+        }
+
+        if (validRows.length === 0) {
+          setErrorText("CSV preview found no valid unit rows.");
+          setSuccessText(null);
+          return;
+        }
+
+        const parsed = validRows.map((row: UnitCsvPreviewRow) => ({
+          id: makeId(),
+          unitNumber: String(row.data.unitNumber || row.unitNumber || "").trim(),
+          rent: typeof row.data.rent === "number" ? row.data.rent : 0,
+          bedrooms: row.data.bedrooms ?? null,
+          bathrooms: row.data.bathrooms ?? null,
+          sqft: row.data.sqft ?? null,
+          status: row.data.status ?? null,
+          utilitiesIncluded: [],
+        }));
         setUnits(parsed);
         setTotalUnits(parsed.length);
         setErrorText(null);
-        setSuccessText(
-          `Loaded ${parsed.length} units from CSV. You can still edit them below before saving.`
-        );
+        setSuccessText(`Previewed ${parsed.length} units from CSV. Review the rows below before creating the property.`);
       } catch (err) {
-        console.error("Error parsing CSV", err);
-        setErrorText("Failed to parse CSV file");
+        console.error("Error previewing CSV", err);
+        setErrorText("Failed to preview CSV file");
+      } finally {
+        setIsPreviewingCsv(false);
       }
     };
     reader.onerror = () => {
@@ -211,6 +205,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
         bedrooms: u.bedrooms ?? null,
         bathrooms: u.bathrooms ?? null,
         sqft: u.sqft ?? null,
+        status: u.status ?? null,
         utilitiesIncluded: u.utilitiesIncluded ?? [],
       }));
 
@@ -221,6 +216,12 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
 
     if (!totalUnitCount || Number.isNaN(totalUnitCount)) {
       setErrorText("Total units is required (we auto-create units).");
+      return;
+    }
+
+    const csvErrors = csvPreview?.preview?.errors || csvPreview?.issues || [];
+    if (csvErrors.length > 0 || csvPreview?.headers?.valid === false) {
+      setErrorText("Resolve CSV preview issues before creating the property.");
       return;
     }
 
@@ -308,6 +309,9 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
       setIsSubmitting(false);
     }
   };
+
+  const csvPreviewIssues = csvPreview?.preview?.errors || csvPreview?.issues || [];
+  const isCreateDisabled = isSubmitting || isPreviewingCsv || csvPreviewIssues.length > 0 || csvPreview?.headers?.valid === false;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -619,10 +623,83 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                   CSV template
                 </a>
                 <span style={{ color: "#9ca3af" }}>
-                  Expected headers: unitNumber, rent, bedrooms, bathrooms, sqft
+                  Expected headers: unitNumber, marketRent, beds, baths, sqft, status
                 </span>
               </div>
             </div>
+
+            {isPreviewingCsv ? (
+              <div style={{ fontSize: "0.82rem", color: "#475569" }}>Previewing CSV...</div>
+            ) : null}
+
+            {csvPreview ? (
+              <div
+                style={{
+                  border: "1px solid #dbe4f0",
+                  borderRadius: 10,
+                  background: "#ffffff",
+                  padding: 10,
+                  display: "grid",
+                  gap: 8,
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                  <div style={{ fontWeight: 700, fontSize: "0.86rem", color: "#0f172a" }}>
+                    CSV preview{csvFilename ? `: ${csvFilename}` : ""}
+                  </div>
+                  <div style={{ fontSize: "0.78rem", color: "#475569" }}>
+                    {(csvPreview.preview?.rows || csvPreview.rows || []).filter((row) => row.status === "valid").length} ready
+                    {" | "}
+                    {(csvPreview.preview?.errors || csvPreview.issues || []).length} issue(s)
+                  </div>
+                </div>
+                {(csvPreview.headers?.missing?.length || csvPreview.headers?.unknown?.length) ? (
+                  <div style={{ color: "#b91c1c", fontSize: "0.8rem", lineHeight: 1.45 }}>
+                    {csvPreview.headers.missing.length ? `Missing: ${csvPreview.headers.missing.join(", ")}. ` : ""}
+                    {csvPreview.headers.unknown.length ? `Unknown: ${csvPreview.headers.unknown.join(", ")}.` : ""}
+                  </div>
+                ) : null}
+                {(csvPreview.preview?.errors || csvPreview.issues || []).length ? (
+                  <div style={{ display: "grid", gap: 4 }}>
+                    {(csvPreview.preview?.errors || csvPreview.issues || []).slice(0, 5).map((issue, idx) => (
+                      <div key={`${issue.row}-${issue.code}-${idx}`} style={{ color: "#b91c1c", fontSize: "0.8rem" }}>
+                        {issue.message}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+                <div style={{ overflowX: "auto" }}>
+                  <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.78rem" }}>
+                    <thead>
+                      <tr style={{ textAlign: "left", color: "#475569" }}>
+                        <th style={{ padding: "6px" }}>Row</th>
+                        <th style={{ padding: "6px" }}>Status</th>
+                        <th style={{ padding: "6px" }}>Unit</th>
+                        <th style={{ padding: "6px" }}>Rent</th>
+                        <th style={{ padding: "6px" }}>Beds</th>
+                        <th style={{ padding: "6px" }}>Baths</th>
+                        <th style={{ padding: "6px" }}>Sqft</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(csvPreview.preview?.rows || csvPreview.rows || []).slice(0, 12).map((row) => (
+                        <tr key={row.row} style={{ borderTop: "1px solid #e5e7eb" }}>
+                          <td style={{ padding: "6px" }}>{row.row}</td>
+                          <td style={{ padding: "6px", color: row.status === "valid" ? "#166534" : "#b91c1c" }}>
+                            {row.status}
+                          </td>
+                          <td style={{ padding: "6px" }}>{row.data.unitNumber || row.unitNumber || ""}</td>
+                          <td style={{ padding: "6px" }}>{row.data.rent ?? ""}</td>
+                          <td style={{ padding: "6px" }}>{row.data.bedrooms ?? ""}</td>
+                          <td style={{ padding: "6px" }}>{row.data.bathrooms ?? ""}</td>
+                          <td style={{ padding: "6px" }}>{row.data.sqft ?? ""}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : null}
 
             <div
               style={{
@@ -805,7 +882,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
 
       <button
         type="submit"
-        disabled={isSubmitting}
+        disabled={isCreateDisabled}
         style={{
           alignSelf: "flex-start",
           padding: "8px 20px",
@@ -815,11 +892,11 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
           color: "#f9fafb",
           fontSize: "0.85rem",
           fontWeight: 500,
-          cursor: isSubmitting ? "default" : "pointer",
-          opacity: isSubmitting ? 0.7 : 1,
+          cursor: isCreateDisabled ? "default" : "pointer",
+          opacity: isCreateDisabled ? 0.7 : 1,
         }}
       >
-        {isSubmitting ? "Saving..." : "Create property"}
+        {isSubmitting ? "Saving..." : isPreviewingCsv ? "Previewing CSV..." : "Create property"}
       </button>
     </form>
       )}

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/api/paymentsApi", () => ({
 
 vi.mock("../../api/unitsImportApi", () => ({
   importUnitsCsv: vi.fn(),
+  previewPropertyUnitsCsv: vi.fn(),
 }));
 
 vi.mock("../../api/unitsApi", () => ({

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -15,13 +15,17 @@ import {
   getPropertyMonthlyPayments,
   Payment,
 } from "@/api/paymentsApi";
-import { importUnitsCsv } from "../../api/unitsImportApi";
+import {
+  importUnitsCsv,
+  previewPropertyUnitsCsv,
+  type UnitCsvIssue,
+  type UnitCsvPreviewRow,
+} from "../../api/unitsImportApi";
 import { fetchUnitsForProperty } from "../../api/unitsApi";
 import { buildUnitsCsvTemplate, downloadTextFile } from "../../utils/csvTemplates";
 import { UnitsCsvPreviewModal } from "./UnitsCsvPreviewModal";
 import { UnitEditModal } from "./UnitEditModal";
 import { SendApplicationModal } from "./SendApplicationModal";
-import { parseCsvPreview } from "../../utils/csvPreview";
 import { useToast } from "../ui/ToastProvider";
 import { setOnboardingStep } from "../../api/onboardingApi";
 import { track } from "../../lib/analytics";
@@ -272,6 +276,8 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewHeaders, setPreviewHeaders] = useState<string[]>([]);
   const [previewRows, setPreviewRows] = useState<string[][]>([]);
+  const [unitCsvPreviewRows, setUnitCsvPreviewRows] = useState<UnitCsvPreviewRow[]>([]);
+  const [unitCsvIssues, setUnitCsvIssues] = useState<UnitCsvIssue[]>([]);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [pendingFilename, setPendingFilename] = useState<string>("");
   const [units, setUnits] = useState<any[]>([]);
@@ -373,7 +379,11 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
           (result?.summary?.duplicatesInCsv ?? 0) +
           (result?.summary?.conflicts ?? 0)) ??
         0;
-      const errCount = Array.isArray(result?.errors) ? result.errors.length : 0;
+      const errCount = Array.isArray(result?.issues)
+        ? result.issues.length
+        : Array.isArray(result?.errors)
+        ? result.errors.length
+        : 0;
       showToast({
         message: "Units imported",
         description: `Created ${created} | Updated ${updated} | Skipped ${skipped}${
@@ -384,6 +394,8 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
       setPreviewOpen(false);
       setPendingFile(null);
       setPendingFilename("");
+      setUnitCsvPreviewRows([]);
+      setUnitCsvIssues([]);
       setImportMessage(
         result?.message ||
           `Created ${created} | Updated ${updated} | Skipped ${skipped}${
@@ -1143,16 +1155,18 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                     if (!file || !property) return;
                     try {
                       const text = await readFileText(file);
-                      const { headers, rows } = parseCsvPreview(text, 10);
+                      const preview = await previewPropertyUnitsCsv(property.id, text);
                       setPendingFile(file);
                       setPendingFilename(file.name);
-                      setPreviewHeaders(headers);
-                      setPreviewRows(rows);
+                      setPreviewHeaders(preview.headers?.expected || []);
+                      setPreviewRows([]);
+                      setUnitCsvPreviewRows(preview.preview?.rows || preview.rows || []);
+                      setUnitCsvIssues(preview.preview?.errors || preview.issues || []);
                       setPreviewOpen(true);
                     } catch (err: any) {
                       showToast({
-                        message: "Failed to read CSV file",
-                        description: err?.message,
+                        message: "Failed to preview CSV file",
+                        description: err?.response?.data?.error || err?.message,
                         variant: "error",
                       });
                     }
@@ -2239,11 +2253,19 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
       ) : null}
       <UnitsCsvPreviewModal
         open={previewOpen}
-        onClose={() => setPreviewOpen(false)}
+        onClose={() => {
+          setPreviewOpen(false);
+          setPendingFile(null);
+          setPendingFilename("");
+          setUnitCsvPreviewRows([]);
+          setUnitCsvIssues([]);
+        }}
         onConfirm={confirmImport}
         filename={pendingFilename}
         headers={previewHeaders}
         rows={previewRows}
+        previewRows={unitCsvPreviewRows}
+        issues={unitCsvIssues}
         isImporting={isImporting}
       />
     </>

--- a/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
@@ -55,6 +55,7 @@ vi.mock("@/api/paymentsApi", () => ({
 
 vi.mock("../../api/unitsImportApi", () => ({
   importUnitsCsv: vi.fn(),
+  previewPropertyUnitsCsv: vi.fn(),
 }));
 
 vi.mock("../../api/unitsApi", () => ({

--- a/rentchain-frontend/src/components/properties/UnitsCsvPreviewModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitsCsvPreviewModal.tsx
@@ -1,24 +1,32 @@
 import React from "react";
 import { Card, Button } from "../ui/Ui";
+import type { UnitCsvIssue, UnitCsvPreviewRow } from "../../api/unitsImportApi";
 
 export function UnitsCsvPreviewModal({
   open,
   onClose,
   onConfirm,
   filename,
-  headers,
-  rows,
+  headers = [],
+  rows = [],
+  previewRows = [],
+  issues = [],
   isImporting,
 }: {
   open: boolean;
   onClose: () => void;
   onConfirm: () => void;
   filename: string;
-  headers: string[];
-  rows: string[][];
+  headers?: string[];
+  rows?: string[][];
+  previewRows?: UnitCsvPreviewRow[];
+  issues?: UnitCsvIssue[];
   isImporting: boolean;
 }) {
   if (!open) return null;
+  const hasBackendPreview = previewRows.length > 0 || issues.length > 0;
+  const validCount = previewRows.filter((row) => row.status === "valid").length;
+  const hasBlockingIssues = issues.length > 0 || previewRows.some((row) => row.status === "invalid");
 
   return (
     <div
@@ -38,8 +46,17 @@ export function UnitsCsvPreviewModal({
           <div style={{ padding: 18 }}>
             <div style={{ fontWeight: 900, fontSize: 16 }}>Preview import</div>
             <div style={{ marginTop: 6, opacity: 0.75, fontSize: 13 }}>
-              {filename} • showing first {rows.length} rows
+              {filename} - {hasBackendPreview ? `${validCount} row(s) ready, ${issues.length} issue(s)` : `showing first ${rows.length} rows`}
             </div>
+            {issues.length > 0 ? (
+              <div style={{ marginTop: 10, display: "grid", gap: 4 }}>
+                {issues.slice(0, 8).map((issue, idx) => (
+                  <div key={`${issue.row}-${issue.code}-${idx}`} style={{ color: "#b91c1c", fontSize: 13 }}>
+                    {issue.message}
+                  </div>
+                ))}
+              </div>
+            ) : null}
 
             <div
               style={{
@@ -58,44 +75,104 @@ export function UnitsCsvPreviewModal({
                   fontSize: 13,
                 }}
               >
-                <thead>
-                  <tr>
-                    {headers.map((h, idx) => (
-                      <th
-                        key={idx}
-                        style={{
-                          textAlign: "left",
-                          padding: "10px 12px",
-                          borderBottom: "1px solid rgba(15,23,42,0.10)",
-                          position: "sticky",
-                          top: 0,
-                          background: "white",
-                          fontWeight: 800,
-                        }}
-                      >
-                        {h}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((r, i) => (
-                    <tr key={i}>
-                      {headers.map((_, j) => (
-                        <td
-                          key={j}
-                          style={{
-                            padding: "8px 12px",
-                            borderBottom: "1px solid rgba(15,23,42,0.06)",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {r[j] ?? ""}
-                        </td>
+                {hasBackendPreview ? (
+                  <>
+                    <thead>
+                      <tr>
+                        {["Row", "Status", "Unit", "Rent", "Beds", "Baths", "Sqft"].map((h) => (
+                          <th
+                            key={h}
+                            style={{
+                              textAlign: "left",
+                              padding: "10px 12px",
+                              borderBottom: "1px solid rgba(15,23,42,0.10)",
+                              position: "sticky",
+                              top: 0,
+                              background: "white",
+                              fontWeight: 800,
+                            }}
+                          >
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {previewRows.map((row) => (
+                        <tr key={row.row}>
+                          <td style={{ padding: "8px 12px", borderBottom: "1px solid rgba(15,23,42,0.06)" }}>
+                            {row.row}
+                          </td>
+                          <td
+                            style={{
+                              padding: "8px 12px",
+                              borderBottom: "1px solid rgba(15,23,42,0.06)",
+                              color: row.status === "valid" ? "#166534" : "#b91c1c",
+                            }}
+                          >
+                            {row.status}
+                          </td>
+                          <td style={{ padding: "8px 12px", borderBottom: "1px solid rgba(15,23,42,0.06)" }}>
+                            {row.data.unitNumber || row.unitNumber || ""}
+                          </td>
+                          <td style={{ padding: "8px 12px", borderBottom: "1px solid rgba(15,23,42,0.06)" }}>
+                            {row.data.rent ?? ""}
+                          </td>
+                          <td style={{ padding: "8px 12px", borderBottom: "1px solid rgba(15,23,42,0.06)" }}>
+                            {row.data.bedrooms ?? ""}
+                          </td>
+                          <td style={{ padding: "8px 12px", borderBottom: "1px solid rgba(15,23,42,0.06)" }}>
+                            {row.data.bathrooms ?? ""}
+                          </td>
+                          <td style={{ padding: "8px 12px", borderBottom: "1px solid rgba(15,23,42,0.06)" }}>
+                            {row.data.sqft ?? ""}
+                          </td>
+                        </tr>
                       ))}
-                    </tr>
-                  ))}
-                </tbody>
+                    </tbody>
+                  </>
+                ) : (
+                  <>
+                    <thead>
+                      <tr>
+                        {headers.map((h, idx) => (
+                          <th
+                            key={idx}
+                            style={{
+                              textAlign: "left",
+                              padding: "10px 12px",
+                              borderBottom: "1px solid rgba(15,23,42,0.10)",
+                              position: "sticky",
+                              top: 0,
+                              background: "white",
+                              fontWeight: 800,
+                            }}
+                          >
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((r, i) => (
+                        <tr key={i}>
+                          {headers.map((_, j) => (
+                            <td
+                              key={j}
+                              style={{
+                                padding: "8px 12px",
+                                borderBottom: "1px solid rgba(15,23,42,0.06)",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {r[j] ?? ""}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </>
+                )}
               </table>
             </div>
 
@@ -110,7 +187,7 @@ export function UnitsCsvPreviewModal({
               <Button onClick={onClose} disabled={isImporting}>
                 Cancel
               </Button>
-              <Button onClick={onConfirm} disabled={isImporting}>
+              <Button onClick={onConfirm} disabled={isImporting || hasBlockingIssues}>
                 {isImporting ? "Importing…" : "Confirm import"}
               </Button>
             </div>

--- a/rentchain-frontend/src/utils/csvTemplates.ts
+++ b/rentchain-frontend/src/utils/csvTemplates.ts
@@ -1,48 +1,16 @@
 export function buildUnitsCsvTemplate() {
   const headers = [
     "unitNumber",
-    "floor",
-    "unitType",
-    "status",
+    "marketRent",
     "beds",
     "baths",
     "sqft",
-    "marketRent",
-    "deposit",
-    "utilitiesIncluded",
-    "amenities",
-    "notes",
+    "status",
   ];
 
   const exampleRows = [
-    [
-      "101",
-      "1",
-      "1br",
-      "vacant",
-      "1",
-      "1",
-      "610",
-      "1850",
-      "1850",
-      "heat;water",
-      "balcony;parking",
-      "Near elevator",
-    ],
-    [
-      "102",
-      "1",
-      "studio",
-      "occupied",
-      "0",
-      "1",
-      "450",
-      "1650",
-      "1650",
-      "heat",
-      "parking",
-      "",
-    ],
+    ["101", "1850", "1", "1", "610", "vacant"],
+    ["102", "1650", "0", "1", "450", "occupied"],
   ];
 
   const lines = [


### PR DESCRIPTION
## Summary
- route property creation and property unit table CSV previews through the shared backend unit CSV parser
- add header validation, row-level preview errors, status preservation, and fail-closed write behavior for invalid headers
- remove property creation CSV string-splitting and update the unit CSV template to supported headers

## Validation
- npm --prefix rentchain-api run test:single -- src/imports/unitCsvImport.service.test.ts
- npm --prefix rentchain-api run test:single -- src/routes/__tests__/unitCsvPreviewRoutes.test.ts
- npm --prefix rentchain-frontend run test:single -- src/components/properties/AddPropertyForm.test.tsx src/components/properties/PropertyDetailPanel.test.tsx src/components/properties/PropertyOccupancyRegression.test.tsx
- npm --prefix rentchain-api run build
- npm --prefix rentchain-frontend run build
- git diff --check

## Notes
- Keeps the existing save route /api/properties/:propertyId/units/import to avoid duplicate write surfaces.
- Adds non-mutating preview routes for property creation and property-scoped unit table uploads.
- Manual authenticated browser QA was not run locally.