### PR TITLE
fix: restore manual unit save validation

### DIFF
--- a/rentchain-api/src/imports/unitCsv.schema.ts
+++ b/rentchain-api/src/imports/unitCsv.schema.ts
@@ -11,6 +11,26 @@ export const UnitCsvRowSchema = z.object({
 
 export type UnitCsvRow = z.infer<typeof UnitCsvRowSchema>;
 
+export type ManualUnitValidationIssue = {
+  index: number;
+  position: number;
+  field: "unitNumber" | "marketRent" | "beds" | "baths" | "sqft" | "status";
+  message: string;
+};
+
+export type ManualUnitValidationResult = {
+  valid: boolean;
+  units: Array<{
+    unitNumber: string;
+    rent: number | null;
+    bedrooms: number | null;
+    bathrooms: number | null;
+    sqft: number | null;
+    status: "vacant" | "occupied" | null;
+  }>;
+  issues: ManualUnitValidationIssue[];
+};
+
 export const UNIT_CSV_FIELD_MAP = [
   {
     field: "unitNumber",
@@ -74,6 +94,71 @@ function normalizeStatus(value: any) {
   return text;
 }
 
+function hasManualUnitValue(unit: any) {
+  if (!unit || typeof unit !== "object") return false;
+  const values = [
+    unit.unitNumber,
+    unit.unit,
+    unit.label,
+    unit.rent,
+    unit.marketRent,
+    unit.monthlyRent,
+    unit.bedrooms,
+    unit.beds,
+    unit.bathrooms,
+    unit.baths,
+    unit.sqft,
+    unit.squareFeet,
+    unit.status,
+  ];
+  return values.some((value) => {
+    if (value === undefined || value === null) return false;
+    return String(value).trim() !== "";
+  });
+}
+
+function coerceOptionalNumber(value: any) {
+  if (value === undefined || value === null || String(value).trim() === "") return undefined;
+  return value;
+}
+
+function publicFieldName(field: string): ManualUnitValidationIssue["field"] {
+  if (field === "rent") return "marketRent";
+  if (field === "bedrooms") return "beds";
+  if (field === "bathrooms") return "baths";
+  if (field === "sqft") return "sqft";
+  if (field === "status") return "status";
+  return "unitNumber";
+}
+
+function fieldLabel(field: ManualUnitValidationIssue["field"]) {
+  switch (field) {
+    case "unitNumber":
+      return "Unit number";
+    case "marketRent":
+      return "Rent";
+    case "beds":
+      return "Beds";
+    case "baths":
+      return "Baths";
+    case "sqft":
+      return "Square feet";
+    case "status":
+      return "Status";
+  }
+}
+
+function manualMessage(field: ManualUnitValidationIssue["field"], zodMessage: string) {
+  const label = fieldLabel(field);
+  if (zodMessage.includes("Required")) return `${label} is required.`;
+  if (field === "marketRent") return "Rent must be a number greater than or equal to 0.";
+  if (field === "beds") return "Beds must be a whole number from 0 to 10.";
+  if (field === "baths") return "Baths must be a number from 0 to 10.";
+  if (field === "sqft") return "Square feet must be a whole number greater than or equal to 0.";
+  if (field === "status") return "Status must be vacant or occupied.";
+  return `${label} is invalid.`;
+}
+
 export function resolveUnitCsvField(header: string): (typeof UNIT_CSV_FIELD_MAP)[number] | undefined {
   const normalized = normalizeHeader(header);
   return UNIT_CSV_FIELD_MAP.find((entry) =>
@@ -91,4 +176,73 @@ export function mapRow(raw: Record<string, any>) {
     out[entry.field] = value;
   }
   return out;
+}
+
+export function validateManualUnitInputs(units: any[]): ManualUnitValidationResult {
+  const normalized: ManualUnitValidationResult["units"] = [];
+  const issues: ManualUnitValidationIssue[] = [];
+
+  (Array.isArray(units) ? units : []).forEach((unit, index) => {
+    if (!hasManualUnitValue(unit)) return;
+
+    const mapped = {
+      unitNumber: cleanCell(unit?.unitNumber ?? unit?.unit ?? unit?.label),
+      rent: coerceOptionalNumber(unit?.marketRent ?? unit?.rent ?? unit?.monthlyRent),
+      bedrooms: coerceOptionalNumber(unit?.beds ?? unit?.bedrooms),
+      bathrooms: coerceOptionalNumber(unit?.baths ?? unit?.bathrooms),
+      sqft: coerceOptionalNumber(unit?.sqft ?? unit?.squareFeet),
+      status: normalizeStatus(unit?.status),
+    };
+
+    const unitNumberMissing = mapped.unitNumber === undefined;
+    const rentMissing = mapped.rent === undefined;
+    const parsed = UnitCsvRowSchema.safeParse(mapped);
+    if (!parsed.success || unitNumberMissing || rentMissing) {
+      if (unitNumberMissing) {
+        issues.push({
+          index,
+          position: index + 1,
+          field: "unitNumber",
+          message: "Unit number is required.",
+        });
+      }
+      if (rentMissing) {
+        issues.push({
+          index,
+          position: index + 1,
+          field: "marketRent",
+          message: "Rent is required.",
+        });
+      }
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          const field = publicFieldName(String(issue.path[0] || "unitNumber"));
+          if (field === "unitNumber" && unitNumberMissing) continue;
+          if (field === "marketRent" && rentMissing) continue;
+          issues.push({
+            index,
+            position: index + 1,
+            field,
+            message: manualMessage(field, issue.message),
+          });
+        }
+      }
+      return;
+    }
+
+    normalized.push({
+      unitNumber: parsed.data.unitNumber.trim(),
+      rent: parsed.data.rent ?? null,
+      bedrooms: parsed.data.bedrooms ?? null,
+      bathrooms: parsed.data.bathrooms ?? null,
+      sqft: parsed.data.sqft ?? null,
+      status: parsed.data.status ?? null,
+    });
+  });
+
+  return {
+    valid: issues.length === 0,
+    units: normalized,
+    issues,
+  };
 }

--- a/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
@@ -6,7 +6,7 @@ import { resolveRegistrySchemaForProperty } from "../../services/registry/schema
 
 type StoredDoc = { id: string; data: any };
 
-const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+const { dbMock, resetDb, seedDoc, listDocs } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
   let autoId = 0;
 
@@ -131,6 +131,7 @@ const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
     seedDoc: (collection: string, id: string, data: any) => {
       ensureCollection(collection).set(id, { id, data });
     },
+    listDocs: (collection: string) => Array.from(ensureCollection(collection).values()),
   };
 });
 
@@ -406,6 +407,95 @@ describe("properties routes publish + defaults", () => {
 
     expect(res.status).toBe(201);
     expect(res.body?.pid).toBe("AB-123_CD");
+  });
+
+  it("creates properties with valid manually entered units", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/properties")
+      .send({
+        addressLine1: "100 Unit St",
+        city: "Halifax",
+        province: "NS",
+        totalUnits: 1,
+        units: [
+          {
+            unitNumber: "101",
+            rent: 1850,
+            bedrooms: 1,
+            bathrooms: 1,
+            sqft: 650,
+            status: "vacant",
+          },
+        ],
+      });
+
+    expect(res.status).toBe(201);
+    const units = listDocs("units");
+    expect(units).toHaveLength(1);
+    expect(units[0].data).toMatchObject({
+      landlordId: "landlord-1",
+      propertyId: res.body.id,
+      unitNumber: "101",
+      rent: 1850,
+      bedrooms: 1,
+      bathrooms: 1,
+      sqft: 650,
+      status: "vacant",
+    });
+  });
+
+  it("rejects invalid manually entered units before creating records", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post("/api/properties")
+      .send({
+        addressLine1: "101 Unit St",
+        city: "Halifax",
+        province: "NS",
+        totalUnits: 2,
+        units: [
+          {
+            unitNumber: "101",
+            rent: 1850,
+          },
+          {
+            unitNumber: "",
+            rent: null,
+            bedrooms: 12,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      error: "manual_unit_validation_failed",
+      message: "Some unit details need to be corrected before creating the property.",
+    });
+    expect(res.body.unitErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          index: 1,
+          position: 2,
+          field: "unitNumber",
+          message: "Unit number is required.",
+        }),
+        expect.objectContaining({
+          index: 1,
+          position: 2,
+          field: "marketRent",
+          message: "Rent is required.",
+        }),
+        expect.objectContaining({
+          index: 1,
+          position: 2,
+          field: "beds",
+          message: "Beds must be a whole number from 0 to 10.",
+        }),
+      ])
+    );
+    expect(listDocs("properties")).toHaveLength(0);
+    expect(listDocs("units")).toHaveLength(0);
   });
 
   it("rejects malformed pid values during create", async () => {

--- a/rentchain-api/src/routes/propertiesRoutes.ts
+++ b/rentchain-api/src/routes/propertiesRoutes.ts
@@ -6,6 +6,7 @@ import { db, FieldValue } from "../firebase";
 import { normalizeProvince } from "../lib/province";
 import { requireLandlord } from "../middleware/requireLandlord";
 import { parseUnitsCsv } from "../imports/unitCsvImport.service";
+import { validateManualUnitInputs } from "../imports/unitCsv.schema";
 import { ensureRegistrySource } from "../services/registry/registryImportService";
 import { getPropertyRegistryProjection, upsertPropertyRegistryProjection } from "../services/registry/registryStatusProjectionService";
 import {
@@ -99,42 +100,6 @@ function makeAddressKeyFromParts(street: string, city: string, province: string,
   const provinceKey = normalize(province);
   const postalKey = normalize(postal);
   return [streetKey, cityKey, provinceKey, postalKey].filter(Boolean).join("|");
-}
-
-function normalizeUnits(units: any[]): Array<{
-  unitNumber: string;
-  rent: number | null;
-  bedrooms: number | null;
-  bathrooms: number | null;
-  sqft: number | null;
-  status: "vacant" | "occupied" | null;
-}> {
-  return (Array.isArray(units) ? units : [])
-    .map((u) => {
-      const unitNumber = String(u?.unitNumber ?? u?.unit ?? u?.label ?? "").trim();
-      if (!unitNumber) return null;
-      const rentRaw = u?.rent ?? u?.marketRent ?? u?.monthlyRent ?? null;
-      const bedroomsRaw = u?.bedrooms ?? u?.beds ?? null;
-      const bathroomsRaw = u?.bathrooms ?? u?.baths ?? null;
-      const sqftRaw = u?.sqft ?? u?.squareFeet ?? null;
-      const statusRaw = String(u?.status || "").trim().toLowerCase();
-      return {
-        unitNumber,
-        rent: Number.isFinite(Number(rentRaw)) ? Number(rentRaw) : null,
-        bedrooms: Number.isFinite(Number(bedroomsRaw)) ? Number(bedroomsRaw) : null,
-        bathrooms: Number.isFinite(Number(bathroomsRaw)) ? Number(bathroomsRaw) : null,
-        sqft: Number.isFinite(Number(sqftRaw)) ? Number(sqftRaw) : null,
-        status: statusRaw === "occupied" || statusRaw === "vacant" ? statusRaw : null,
-      };
-    })
-    .filter(Boolean) as Array<{
-      unitNumber: string;
-      rent: number | null;
-      bedrooms: number | null;
-      bathrooms: number | null;
-      sqft: number | null;
-      status: "vacant" | "occupied" | null;
-    }>;
 }
 
 function parseScreeningRequiredBeforeApproval(input: any, fallback = true): boolean {
@@ -379,8 +344,16 @@ router.post(
       });
     }
 
-    const normalizedUnits = normalizeUnits(units);
-    const submittedUnitsCount = Array.isArray(units) ? units.length : 0;
+    const manualUnitValidation = validateManualUnitInputs(units);
+    if (!manualUnitValidation.valid) {
+      return res.status(400).json({
+        error: "manual_unit_validation_failed",
+        message: "Some unit details need to be corrected before creating the property.",
+        unitErrors: manualUnitValidation.issues,
+      });
+    }
+    const normalizedUnits = manualUnitValidation.units;
+    const submittedUnitsCount = normalizedUnits.length;
     const resolvedUnitCount =
       normalizedUnits.length > 0
         ? normalizedUnits.length

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
@@ -176,4 +176,99 @@ describe("AddPropertyForm", () => {
       );
     });
   });
+
+  it("displays manual unit save-time validation errors and allows retry after correction", async () => {
+    mocks.createPropertyMock
+      .mockRejectedValueOnce({
+        response: {
+          status: 400,
+          data: {
+            error: "manual_unit_validation_failed",
+            unitErrors: [
+              {
+                index: 0,
+                position: 1,
+                field: "marketRent",
+                message: "Rent is required.",
+              },
+            ],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        property: { id: "prop-1", name: "Created Property", portfolioStatus: "active" },
+      });
+
+    const onCreated = vi.fn();
+    const { container } = render(<AddPropertyForm onCreated={onCreated} />);
+
+    fireEvent.change(screen.getAllByPlaceholderText("123 Main Street")[0], {
+      target: { value: "123 Main Street" },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText("Halifax")[0], {
+      target: { value: "Halifax" },
+    });
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
+      target: { value: "1" },
+    });
+
+    const unitsToggle = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Units & Rents (Optional)")
+    );
+    expect(unitsToggle).toBeTruthy();
+    fireEvent.click(unitsToggle!);
+
+    fireEvent.change(screen.getByPlaceholderText("101"), {
+      target: { value: "101" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("1800"), {
+      target: { value: "" },
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Create property" })[0]);
+
+    expect(await screen.findByText("Rent is required.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Some unit details need to be corrected before creating the property.")
+    ).toBeInTheDocument();
+    expect(mocks.createPropertyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        units: [
+          expect.objectContaining({
+            unitNumber: "101",
+            rent: null,
+          }),
+        ],
+      })
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("1800"), {
+      target: { value: "1800" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Rent is required.")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Create property" })[0]);
+
+    await waitFor(() => {
+      expect(mocks.createPropertyMock).toHaveBeenCalledTimes(2);
+    });
+    expect(mocks.createPropertyMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        units: [
+          expect.objectContaining({
+            unitNumber: "101",
+            rent: 1800,
+          }),
+        ],
+      })
+    );
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "prop-1" })
+      );
+    });
+  });
 });

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
@@ -28,6 +28,9 @@ interface UnitRow extends UnitInput {
   status?: "vacant" | "occupied" | null;
 }
 
+type ManualUnitErrorField = "unitNumber" | "rent" | "bedrooms" | "bathrooms" | "sqft" | "status";
+type ManualUnitErrorsById = Record<string, Partial<Record<ManualUnitErrorField, string[]>>>;
+
 const makeId = () =>
   typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
     ? crypto.randomUUID()
@@ -62,6 +65,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   const [csvPreview, setCsvPreview] = useState<UnitCsvPreviewResponse | null>(null);
   const [csvFilename, setCsvFilename] = useState("");
   const [isPreviewingCsv, setIsPreviewingCsv] = useState(false);
+  const [manualUnitErrors, setManualUnitErrors] = useState<ManualUnitErrorsById>({});
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
@@ -88,12 +92,30 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     setCsvFilename("");
   };
 
+  const clearManualUnitError = (id: string, field?: ManualUnitErrorField) => {
+    setManualUnitErrors((prev) => {
+      const existing = prev[id];
+      if (!existing) return prev;
+      if (!field) {
+        const { [id]: _removed, ...rest } = prev;
+        return rest;
+      }
+      const { [field]: _fieldRemoved, ...remainingFields } = existing;
+      if (Object.keys(remainingFields).length === 0) {
+        const { [id]: _removed, ...rest } = prev;
+        return rest;
+      }
+      return { ...prev, [id]: remainingFields };
+    });
+  };
+
   const handleUnitChange = (
     id: string,
     field: keyof UnitRow,
     value: string
   ) => {
     clearCsvPreviewState();
+    clearManualUnitError(id, field === "rent" ? "rent" : (field as ManualUnitErrorField));
     setUnits((prev) =>
       prev.map((u) => {
         if (u.id !== id) return u;
@@ -118,6 +140,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
 
   const handleRemoveUnitRow = (id: string) => {
     clearCsvPreviewState();
+    clearManualUnitError(id);
     setUnits((prev) => (prev.length <= 1 ? prev : prev.filter((u) => u.id !== id)));
   };
   const handleCsvUpload: React.ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -186,22 +209,26 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     e.preventDefault();
     setErrorText(null);
     setSuccessText(null);
+    setManualUnitErrors({});
 
     if (!addressLine1.trim() || !city.trim()) {
       setErrorText("Address and City are required.");
       return;
     }
 
-    const validUnits: UnitInput[] = units
-      .filter(
-        (u) =>
-          u.unitNumber.trim() &&
-          typeof u.rent === "number" &&
-          !Number.isNaN(u.rent)
-      )
-      .map((u) => ({
+    const attemptedUnitRows = units.filter((u) => {
+      if (u.unitNumber.trim()) return true;
+      if (u.rent !== null && u.rent !== 0 && !Number.isNaN(Number(u.rent))) return true;
+      if (u.bedrooms !== null && u.bedrooms !== undefined) return true;
+      if (u.bathrooms !== null && u.bathrooms !== undefined) return true;
+      if (u.sqft !== null && u.sqft !== undefined) return true;
+      if (u.status) return true;
+      return false;
+    });
+    const submittedUnitIds = attemptedUnitRows.map((u) => u.id);
+    const attemptedUnits = attemptedUnitRows.map((u) => ({
         unitNumber: u.unitNumber.trim(),
-        rent: Number(u.rent),
+        rent: u.rent,
         bedrooms: u.bedrooms ?? null,
         bathrooms: u.bathrooms ?? null,
         sqft: u.sqft ?? null,
@@ -212,7 +239,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
     const totalUnitCount =
       typeof totalUnits === "number" && totalUnits > 0
         ? totalUnits
-        : validUnits.length;
+        : attemptedUnits.length;
 
     if (!totalUnitCount || Number.isNaN(totalUnitCount)) {
       setErrorText("Total units is required (we auto-create units).");
@@ -236,7 +263,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
       country: country.trim() || undefined,
       totalUnits: totalUnitCount,
       amenities,
-      units: validUnits.length > 0 ? validUnits : undefined,
+      units: attemptedUnits.length > 0 ? (attemptedUnits as UnitInput[]) : undefined,
     };
 
     setIsSubmitting(true);
@@ -295,6 +322,37 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
           return;
         }
         setErrorText("A property with this address already exists.");
+        return;
+      }
+
+      const unitErrors = err?.response?.data?.unitErrors;
+      if (Array.isArray(unitErrors) && unitErrors.length > 0) {
+        const nextErrors: ManualUnitErrorsById = {};
+        for (const issue of unitErrors) {
+          const rowId = submittedUnitIds[Number(issue?.index)];
+          if (!rowId) continue;
+          const field =
+            issue?.field === "marketRent"
+              ? "rent"
+              : issue?.field === "beds"
+              ? "bedrooms"
+              : issue?.field === "baths"
+              ? "bathrooms"
+              : issue?.field;
+          if (!["unitNumber", "rent", "bedrooms", "bathrooms", "sqft", "status"].includes(field)) continue;
+          nextErrors[rowId] = {
+            ...nextErrors[rowId],
+            [field]: [...(nextErrors[rowId]?.[field as ManualUnitErrorField] || []), String(issue?.message || "This field needs correction.")],
+          };
+        }
+        setManualUnitErrors(nextErrors);
+        const msg = "Some unit details need to be corrected before creating the property.";
+        setErrorText(msg);
+        showToast({
+          message: "Unit details need attention",
+          description: msg,
+          variant: "error",
+        });
         return;
       }
 
@@ -725,7 +783,17 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                   </tr>
                 </thead>
                 <tbody>
-                  {units.map((u) => (
+                  {units.map((u) => {
+                    const rowErrors = manualUnitErrors[u.id] || {};
+                    const fieldBorder = (field: ManualUnitErrorField) =>
+                      rowErrors[field]?.length ? "1px solid #dc2626" : "1px solid #374151";
+                    const renderFieldErrors = (field: ManualUnitErrorField) =>
+                      rowErrors[field]?.length ? (
+                        <div style={{ marginTop: 4, color: "#b91c1c", fontSize: "0.72rem", lineHeight: 1.25 }}>
+                          {rowErrors[field]?.join(" ")}
+                        </div>
+                      ) : null;
+                    return (
                     <tr key={u.id}>
                       <td style={{ padding: "4px 6px" }}>
                         <input
@@ -739,10 +807,11 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                             width: "100%",
                             padding: 6,
                             borderRadius: 6,
-                            border: "1px solid #374151",
+                            border: fieldBorder("unitNumber"),
                             fontSize: "0.8rem",
                           }}
                         />
+                        {renderFieldErrors("unitNumber")}
                       </td>
                       <td style={{ padding: "4px 6px" }}>
                         <input
@@ -766,10 +835,11 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                             width: "100%",
                             padding: 6,
                             borderRadius: 6,
-                            border: "1px solid #374151",
+                            border: fieldBorder("rent"),
                             fontSize: "0.8rem",
                           }}
                         />
+                        {renderFieldErrors("rent")}
                       </td>
                       <td style={{ padding: "4px 6px" }}>
                         <input
@@ -784,10 +854,11 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                             width: "100%",
                             padding: 6,
                             borderRadius: 6,
-                            border: "1px solid #374151",
+                            border: fieldBorder("bedrooms"),
                             fontSize: "0.8rem",
                           }}
                         />
+                        {renderFieldErrors("bedrooms")}
                       </td>
                       <td style={{ padding: "4px 6px" }}>
                         <input
@@ -802,10 +873,11 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                             width: "100%",
                             padding: 6,
                             borderRadius: 6,
-                            border: "1px solid #374151",
+                            border: fieldBorder("bathrooms"),
                             fontSize: "0.8rem",
                           }}
                         />
+                        {renderFieldErrors("bathrooms")}
                       </td>
                       <td style={{ padding: "4px 6px" }}>
                         <input
@@ -818,10 +890,11 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                             width: "100%",
                             padding: 6,
                             borderRadius: 6,
-                            border: "1px solid #374151",
+                            border: fieldBorder("sqft"),
                             fontSize: "0.8rem",
                           }}
                         />
+                        {renderFieldErrors("sqft")}
                       </td>
                       <td style={{ padding: "4px 6px", textAlign: "right" }}>
                         <button
@@ -843,7 +916,8 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
                         </button>
                       </td>
                     </tr>
-                  ))}
+                    );
+                  })}
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
## Summary
- validate manually entered units before property creation writes
- return safe unit-indexed field errors for manual unit save failures
- show save-time manual unit errors in the property creation form while preserving CSV preview behavior

## Validation
- npm --prefix rentchain-api run test:single -- src/routes/__tests__/propertiesRoutes.test.ts
- npm --prefix rentchain-api run test:single -- src/imports/unitCsvImport.service.test.ts src/routes/__tests__/unitCsvPreviewRoutes.test.ts
- npm --prefix rentchain-frontend run test:single -- src/components/properties/AddPropertyForm.test.tsx
- npm --prefix rentchain-api run build
- npm --prefix rentchain-frontend run build
- git diff --check

## Notes
- Manual authenticated browser QA was not run locally.