### PR TITLE
fix: resolve occupancy unit saves

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,98 +1,27 @@
-PR: #1134
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1134
-Branch: fix/unit-csv-import-v1
-
 # Implementation Summary
 
-## Mission
-Unified CSV unit parsing across property creation and property unit table upload flows by routing both upload paths through the backend PapaParser-based unit parser and removing the property creation form's custom string-splitting parser.
+Mission: fix/occupancy-guide-unit-resolution-v1
+Branch: fix/occupancy-guide-unit-resolution-v1
+PR: #1136
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1136
 
-## Files Modified
-- `rentchain-api/src/imports/unitCsv.schema.ts`
-- `rentchain-api/src/imports/unitCsvImport.service.ts`
-- `rentchain-api/src/imports/unitCsvImport.service.test.ts`
-- `rentchain-api/src/routes/propertiesRoutes.ts`
-- `rentchain-api/src/routes/unitImportRoutes.ts`
-- `rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts`
-- `rentchain-frontend/src/api/propertiesApi.ts`
-- `rentchain-frontend/src/api/unitsImportApi.ts`
-- `rentchain-frontend/src/components/properties/AddPropertyForm.tsx`
-- `rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx`
-- `rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx`
-- `rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx`
-- `rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx`
-- `rentchain-frontend/src/components/properties/UnitsCsvPreviewModal.tsx`
-- `rentchain-frontend/src/utils/csvTemplates.ts`
+## Summary
 
-## Backend Changes
-- Added shared CSV field mapping constants for supported unit CSV headers and aliases.
-- Added BOM-safe header normalization.
-- Added explicit header validation for required, missing, and unknown headers.
-- Added row-level preview output with row number, field name, validation status, and issue list.
-- Preserved existing `parseUnitsCsv` candidate output for current import write logic.
-- Added `status` support for `vacant` and `occupied` unit rows.
-- Added non-mutating property creation preview endpoint:
-  - `POST /api/properties/units/csv-preview`
-- Added property-scoped unit table preview endpoint:
-  - `POST /api/properties/:propertyId/units/csv-parse`
-- Updated existing unit import dry-run response to return the same backend preview shape.
-- Updated write modes to fail closed when headers are invalid.
-- Preserved the existing save endpoint:
-  - `POST /api/properties/:propertyId/units/import`
-
-## Frontend Changes
-- Removed custom CSV parsing from `AddPropertyForm.tsx`.
-- Property creation CSV upload now calls backend preview before the property is created.
-- Property creation displays a mandatory preview panel with row status and validation issues.
-- Property creation disables submit while previewing or when CSV preview has errors.
-- Manual unit edits clear stale CSV preview state so users can still proceed manually.
-- Property unit table CSV upload now calls backend preview before opening the confirmation modal.
-- `UnitsCsvPreviewModal` now renders backend row validation status and disables confirm when issues exist.
-- Updated the downloadable unit CSV template to match supported parser headers:
-  - `unitNumber,marketRent,beds,baths,sqft,status`
-
-## Error Message Examples
-- `Required header 'unitNumber' is missing. Expected headers: unitNumber, marketRent, beds, baths, sqft, status`
-- `Unknown header 'privateColumn'. Expected headers: unitNumber, marketRent, beds, baths, sqft, status`
-- `Row 2: rent - Invalid input: expected number, received NaN`
-- `Row 3: entire row is empty, skipping.`
-- `Duplicate unitNumber in CSV: 101`
-
-## Test Coverage
-- Added backend parser tests for:
-  - BOM-prefixed CSVs
-  - public template aliases
-  - missing and unknown headers
-  - row-level field errors
-  - duplicate rows
-  - empty rows
-- Added backend route tests for:
-  - property creation CSV preview
-  - property-scoped unit table CSV preview
-- Added frontend coverage for:
-  - property creation CSV preview through backend parser
-  - previewed unit data flowing into create property payload
-- Updated existing component mocks for the new preview API export.
+- Blocked occupancy edit entry points from opening the unit edit modal when a unit only has a placeholder reference such as `placeholder-0`.
+- Added a modal-level guard so unresolved unit IDs cannot submit to the unit update API.
+- Preserved persisted unit updates for occupancy status, tenant/occupant name, and lease end date.
+- Mapped missing-unit failures to a clear refresh/save-units message.
+- Added regression coverage for placeholder rejection and persisted occupancy fields.
 
 ## Validation
-- `npm --prefix rentchain-api run test:single -- src/imports/unitCsvImport.service.test.ts`: PASS, 4 tests.
-- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/unitCsvPreviewRoutes.test.ts`: PASS, 2 tests. Required running outside sandbox because local Supertest binding hit `listen EPERM` inside the sandbox.
-- `npm --prefix rentchain-frontend run test:single -- src/components/properties/AddPropertyForm.test.tsx src/components/properties/PropertyDetailPanel.test.tsx src/components/properties/PropertyOccupancyRegression.test.tsx`: PASS, 20 tests.
-- `npm --prefix rentchain-api run build`: PASS.
-- `npm --prefix rentchain-frontend run build`: PASS.
-- `git diff --check`: PASS.
 
-## Acceptance Criteria Status
-- Same backend parser used by property creation and unit table CSV preview: PASS.
-- Header validation happens before write modes and blocks save on invalid headers: PASS.
-- Row-level errors include row and field context: PASS.
-- Property creation preview is shown before property save: PASS.
-- Unit table preview is shown before unit import confirmation: PASS.
-- No placeholder unit generation added: PASS.
-- Tenant-facing routes or UI were not modified: PASS.
-- No new dependencies added: PASS.
+- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/unitsRoutes.patch.test.ts`
+- `npm --prefix rentchain-frontend run test:single -- src/components/properties/PropertyDetailPanel.test.tsx src/components/properties/UnitEditModal.test.tsx`
+- `npm --prefix rentchain-api run build`
+- `npm --prefix rentchain-frontend run build`
+- `git diff --check`
 
-## Known Limitations
-- The mission requested new `/api/property/:propertyId/units/csv-save` endpoints, but the repo already mounts `/api/properties/:propertyId/units/import`. To avoid duplicate route surfaces, this implementation keeps the existing save route and adds preview endpoints around it.
-- The save route re-runs the same backend parser instead of using a persisted `previewId`; this preserves no-write preview semantics without adding storage state.
-- Manual browser QA with authenticated landlord sessions was not run in this environment.
+## Notes
+
+- Manual QA was not run locally.
+- No auth, Firestore rules, dependency, route, or schema changes were made.

--- a/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
@@ -107,5 +107,45 @@ describe("unitsRoutes PATCH aliases", () => {
     expect(res.body?.unit?.rent).toBe(1800);
     expect(res.body?.unit?.marketRent).toBe(1800);
   });
-});
 
+  it("persists occupancy status, occupant name, and lease end date", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "vacant",
+    });
+    const app = await createApp();
+
+    const res = await request(app).patch("/api/units/unit-1").send({
+      status: "occupied",
+      occupantName: "Jane Tenant",
+      leaseEndDate: "2027-06-10",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.unit).toMatchObject({
+      id: "unit-1",
+      status: "occupied",
+      occupantName: "Jane Tenant",
+      leaseEndDate: "2027-06-10",
+    });
+  });
+
+  it("returns UNIT_NOT_FOUND when updating a non-existent unit", async () => {
+    const app = await createApp();
+
+    const res = await request(app).patch("/api/units/placeholder-0").send({
+      status: "occupied",
+      occupantName: "Jane Tenant",
+      leaseEndDate: "2027-06-10",
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "UNIT_NOT_FOUND",
+    });
+  });
+});

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PropertyDetailPanel } from "./PropertyDetailPanel";
 
 const mocks = vi.hoisted(() => ({
@@ -107,6 +107,10 @@ vi.mock("@/components/properties/PropertyCredibilitySummaryCard", () => ({
 }));
 
 describe("PropertyDetailPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     mocks.updateProperty.mockResolvedValue({
       property: { id: "prop-1" },
@@ -693,6 +697,44 @@ describe("PropertyDetailPanel", () => {
 
     expect(screen.getByText("modal tenant: John Smith")).toBeInTheDocument();
     expect(screen.getByText("modal lease end: 2027-05-29")).toBeInTheDocument();
+  });
+
+  it("blocks occupancy setup when units only have placeholder references", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            unitCount: 1,
+            totalUnits: 1,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const setupButtons = await screen.findAllByRole("button", { name: "Set up current occupancy" });
+    fireEvent.click(setupButtons[0]);
+
+    expect(await screen.findByText(/not ready for occupancy updates/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("unit-edit-modal")).not.toBeInTheDocument();
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Unit not ready",
+        variant: "error",
+      })
+    );
   });
 
   it("uses the updated archive confirmation copy before archiving", async () => {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -234,6 +234,11 @@ function safeStorageSet(key: string, value: string) {
   }
 }
 
+function isPersistedUnitId(unit: any) {
+  const id = String(unit?.id || unit?.unitId || unit?.uid || "").trim();
+  return Boolean(id) && !/^placeholder-/i.test(id);
+}
+
 export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   property,
   onRefresh,
@@ -305,6 +310,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   const [highlightedUnitKey, setHighlightedUnitKey] = useState<string | null>(null);
   const [blockedApplicationUpgradeUnitKey, setBlockedApplicationUpgradeUnitKey] = useState<string | null>(null);
   const [occupancyPromptDismissed, setOccupancyPromptDismissed] = useState(false);
+  const [unitResolutionError, setUnitResolutionError] = useState<string | null>(null);
   const [editComplianceExpanded, setEditComplianceExpanded] = useState(false);
   const [submissionAssistantOpen, setSubmissionAssistantOpen] = useState(false);
   const unitRowRefs = useRef<Record<string, HTMLTableRowElement | null>>({});
@@ -765,6 +771,23 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
       };
     },
     [getUnitOccupancyView]
+  );
+  const openUnitEdit = useCallback(
+    (unit: any) => {
+      if (!isPersistedUnitId(unit)) {
+        const message = "This unit is not ready for occupancy updates yet. Refresh the property after saving units, then try again.";
+        setUnitResolutionError(message);
+        showToast({
+          message: "Unit not ready",
+          description: message,
+          variant: "error",
+        });
+        return;
+      }
+      setUnitResolutionError(null);
+      setEditingUnit(getUnitForEdit(unit));
+    },
+    [getUnitForEdit, showToast]
   );
 
   const unitsNeedingOccupancySetup = useMemo(
@@ -1382,6 +1405,22 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         </div>
       )}
 
+      {unitResolutionError ? (
+        <div
+          role="alert"
+          style={{
+            padding: 10,
+            borderRadius: 10,
+            border: "1px solid #fecdd3",
+            background: "#fef2f2",
+            color: "#991b1b",
+            fontSize: "0.9rem",
+          }}
+        >
+          {unitResolutionError}
+        </div>
+      ) : null}
+
       <PropertyCredibilitySummaryCard
         summary={credibilitySummary}
         leaseHref={property?.id ? `/leases?propertyId=${encodeURIComponent(String(property.id))}` : "/leases"}
@@ -1514,7 +1553,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                   type="button"
                   onClick={() => {
                     const targetUnit = unitsNeedingOccupancySetup[0] || displayedUnits[0] || null;
-                    setEditingUnit(targetUnit ? getUnitForEdit(targetUnit) : null);
+                    if (targetUnit) openUnitEdit(targetUnit);
                     dismissOccupancyPrompt();
                   }}
                   style={{
@@ -1762,7 +1801,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                         <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
                           <button
                             type="button"
-                            onClick={() => setEditingUnit(getUnitForEdit(u))}
+                            onClick={() => openUnitEdit(u)}
                             style={{
                               padding: "6px 10px",
                               borderRadius: 8,
@@ -1936,7 +1975,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                 <div className="rc-unit-actions">
                   <button
                     type="button"
-                    onClick={() => setEditingUnit(getUnitForEdit(u))}
+                    onClick={() => openUnitEdit(u)}
                     style={{
                       padding: "6px 10px",
                       borderRadius: 8,

--- a/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UnitEditModal } from "./UnitEditModal";
+
+const mocks = vi.hoisted(() => ({
+  updateUnit: vi.fn(),
+  uploadUnitLeaseDocument: vi.fn(),
+}));
+
+vi.mock("../../api/unitsApi", () => ({
+  updateUnit: mocks.updateUnit,
+  uploadUnitLeaseDocument: mocks.uploadUnitLeaseDocument,
+}));
+
+describe("UnitEditModal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mocks.updateUnit.mockReset();
+    mocks.uploadUnitLeaseDocument.mockReset();
+  });
+
+  it("blocks placeholder unit IDs before submitting occupancy updates", async () => {
+    render(
+      <UnitEditModal
+        open
+        unit={{ id: "placeholder-0", unitNumber: "1", status: "vacant" }}
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "occupied" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText(/not ready for occupancy updates/i)).toBeInTheDocument();
+    expect(mocks.updateUnit).not.toHaveBeenCalled();
+  });
+
+  it("submits persisted unit IDs with occupancy details", async () => {
+    const onSaved = vi.fn();
+    mocks.updateUnit.mockResolvedValue({
+      unit: {
+        id: "unit-1",
+        status: "occupied",
+        occupantName: "Jane Tenant",
+        leaseEndDate: "2027-06-10",
+      },
+    });
+
+    render(
+      <UnitEditModal
+        open
+        unit={{ id: "unit-1", unitNumber: "101", status: "vacant" }}
+        onClose={vi.fn()}
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "occupied" },
+    });
+    fireEvent.change(await screen.findByLabelText("Current tenant name"), {
+      target: { value: "Jane Tenant" },
+    });
+    fireEvent.change(screen.getByLabelText("Lease end date (optional)"), {
+      target: { value: "2027-06-10" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.updateUnit).toHaveBeenCalledWith(
+        "unit-1",
+        expect.objectContaining({
+          status: "occupied",
+          occupantName: "Jane Tenant",
+          leaseEndDate: "2027-06-10",
+        })
+      );
+    });
+    expect(onSaved).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "unit-1",
+        status: "occupied",
+        occupantName: "Jane Tenant",
+        leaseEndDate: "2027-06-10",
+      })
+    );
+  });
+});

--- a/rentchain-frontend/src/components/properties/UnitEditModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.tsx
@@ -9,6 +9,11 @@ type Props = {
   onSaved: (unit: any) => void;
 };
 
+function isPersistedUnitId(unit: any) {
+  const id = String(unit?.id || unit?.unitId || unit?.uid || "").trim();
+  return Boolean(id) && !/^placeholder-/i.test(id);
+}
+
 export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
   const [unitNumber, setUnitNumber] = useState("");
   const [rent, setRent] = useState<string>("");
@@ -59,8 +64,8 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
   if (!open || !unit) return null;
 
   async function save() {
-    if (!unit.id) {
-      setError("Missing unit id");
+    if (!isPersistedUnitId(unit)) {
+      setError("This unit is not ready for occupancy updates yet. Refresh the property after saving units, then try again.");
       return;
     }
     setSaving(true);
@@ -75,16 +80,22 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
       payload.status = (status || "vacant").toLowerCase();
       payload.occupantName = payload.status === "occupied" ? occupantName.trim() || null : null;
       payload.leaseEndDate = payload.status === "occupied" ? leaseEndDate || null : null;
-      const resp: any = await updateUnit(String(unit.id), payload);
+      const unitId = String(unit.id || unit.unitId || unit.uid);
+      const resp: any = await updateUnit(unitId, payload);
       let updated = resp?.unit || { ...unit, ...payload };
       if (payload.status === "occupied" && leaseDocumentFile) {
-        const uploadedResp: any = await uploadUnitLeaseDocument(String(unit.id), leaseDocumentFile);
+        const uploadedResp: any = await uploadUnitLeaseDocument(unitId, leaseDocumentFile);
         updated = uploadedResp?.unit || { ...updated, leaseDocument: uploadedResp?.leaseDocument || null };
       }
       onSaved(updated);
       onClose();
     } catch (e: any) {
-      setError(e?.message || "Failed to save unit");
+      const message = String(e?.message || "");
+      setError(
+        message === "UNIT_NOT_FOUND"
+          ? "This unit could not be found. Refresh the property after saving units, then try again."
+          : message || "Failed to save unit"
+      );
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary
- Block occupancy edits for placeholder unit references before the unit update API is called.
- Keep the edit modal guarded against unresolved unit IDs and map UNIT_NOT_FOUND to a clear refresh/save-units message.
- Add frontend and backend regression coverage for placeholder IDs and persisted occupancy fields.

## Validation
- npm --prefix rentchain-api run test:single -- src/routes/__tests__/unitsRoutes.patch.test.ts
- npm --prefix rentchain-frontend run test:single -- src/components/properties/PropertyDetailPanel.test.tsx src/components/properties/UnitEditModal.test.tsx
- npm --prefix rentchain-api run build
- npm --prefix rentchain-frontend run build
- git diff --check

## Manual QA
- Not run locally; covered by focused route/component tests and builds.