### PR TITLE
fix: consolidate inbox routes to unified-inbox entry point

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,27 +1,45 @@
 # Implementation Summary
 
-Mission: fix/occupancy-guide-unit-resolution-v1
-Branch: fix/occupancy-guide-unit-resolution-v1
-PR: #1136
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1136
+PR: #[NUMBER once opened]
+PR URL: [URL once opened]
+Branch: fix/inbox-route-consolidation-v1
+
+Mission: Consolidate Landlord Inbox Routes
+Branch: fix/inbox-route-consolidation-v1
 
 ## Summary
 
-- Blocked occupancy edit entry points from opening the unit edit modal when a unit only has a placeholder reference such as `placeholder-0`.
-- Added a modal-level guard so unresolved unit IDs cannot submit to the unit update API.
-- Preserved persisted unit updates for occupancy status, tenant/occupant name, and lease end date.
-- Mapped missing-unit failures to a clear refresh/save-units message.
-- Added regression coverage for placeholder rejection and persisted occupancy fields.
+- Redirected the legacy landlord UI route `/landlord/inbox` to `/landlord/unified-inbox`.
+- Preserved query string and hash fragments during the redirect.
+- Removed the duplicate landlord drawer Inbox entry so the drawer exposes one Inbox destination.
+- Preserved the landlord mobile Inbox tab at `/landlord/unified-inbox`.
+- Left the unified inbox API helper unchanged so landlord data still uses `GET /api/landlord/inbox`.
+
+## Files Changed
+
+- `rentchain-frontend/src/App.tsx`
+- `rentchain-frontend/src/App.routes.test.tsx`
+- `rentchain-frontend/src/components/layout/navConfig.ts`
+- `rentchain-frontend/src/components/layout/LandlordNav.test.tsx`
+- `.handoff/impl-summary.md`
 
 ## Validation
 
-- `npm --prefix rentchain-api run test:single -- src/routes/__tests__/unitsRoutes.patch.test.ts`
-- `npm --prefix rentchain-frontend run test:single -- src/components/properties/PropertyDetailPanel.test.tsx src/components/properties/UnitEditModal.test.tsx`
-- `npm --prefix rentchain-api run build`
-- `npm --prefix rentchain-frontend run build`
+- `npm run test -- src/App.routes.test.tsx src/components/layout/LandlordNav.test.tsx src/api/unifiedInboxApi.test.ts`
+- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
 - `git diff --check`
 
-## Notes
+## Manual QA
 
-- Manual QA was not run locally.
-- No auth, Firestore rules, dependency, route, or schema changes were made.
+- Not run locally. The required preview/manual QA remains:
+  - Open `/landlord/unified-inbox` as a landlord and confirm the unified inbox renders.
+  - Open `/landlord/inbox` directly and confirm it redirects to `/landlord/unified-inbox`.
+  - Confirm the landlord drawer has one Inbox entry.
+  - Confirm the mobile bottom nav Inbox tab opens `/landlord/unified-inbox`.
+  - Confirm Network responses remain allowlisted and do not expose internal metadata, tokens, storage paths, provider payloads, or private notes.
+
+## Known Limitations
+
+- The legacy `LandlordInboxPage` file remains in the repository but is no longer used by the active landlord route.
+- The frontend build still reports the existing large chunk warning for the app bundle; the build completed successfully.
+- Pre-existing local workflow-rule edits were not touched or staged for this mission.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,7 +1,7 @@
 # Implementation Summary
 
-PR: #[NUMBER once opened]
-PR URL: [URL once opened]
+PR: #1137
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1137
 Branch: fix/inbox-route-consolidation-v1
 
 Mission: Consolidate Landlord Inbox Routes

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -125,6 +125,13 @@ vi.mock("./pages/landlord/LandlordAnalyticsPage", () => ({
   default: () => <h1>Landlord Analytics Dashboard</h1>,
 }));
 
+vi.mock("./pages/UnifiedInboxPage", () => ({
+  default: ({ role }: { role: string }) => {
+    const location = useLocation();
+    return <h1>{`Unified Inbox Page ${role} ${location.pathname}${location.search}${location.hash}`}</h1>;
+  },
+}));
+
 vi.mock("./pages/DecisionInboxPage", () => ({
   default: () => <h1>Decision Inbox Page</h1>,
 }));
@@ -332,6 +339,22 @@ describe("Routes: /decision-inbox", () => {
     );
 
     expect(await screen.findByText(/Decision Inbox Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /landlord/inbox", () => {
+  it("redirects the legacy landlord inbox route to the unified inbox route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/landlord/inbox?status=unread#updates"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByText("Unified Inbox Page landlord /landlord/unified-inbox?status=unread#updates")
+    ).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -62,6 +62,20 @@ import { getTenantToken } from "./lib/tenantAuth";
 const TENANT_PORTAL_ENABLED = import.meta.env.VITE_TENANT_PORTAL_ENABLED === "true";
 const CONTRACTOR_PORTAL_ENABLED = import.meta.env.VITE_CONTRACTOR_PORTAL_ENABLED !== "false";
 
+function LandlordInboxRedirect() {
+  const location = useLocation();
+  return (
+    <Navigate
+      to={{
+        pathname: "/landlord/unified-inbox",
+        search: location.search,
+        hash: location.hash,
+      }}
+      replace
+    />
+  );
+}
+
 function lazyWithRetry<T extends React.ComponentType<any>>(
   importer: () => Promise<{ default: T }>,
   retries = 1
@@ -131,7 +145,6 @@ const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage")
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
 const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
-const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"));
 const UnifiedInboxPage = lazy(() => import("./pages/UnifiedInboxPage"));
 const OperationalCommandCenterPage = lazy(() => import("./pages/OperationalCommandCenterPage"));
 const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
@@ -578,11 +591,7 @@ function App() {
           path="/landlord/inbox"
           element={
             <RequireAuth>
-              <LandlordNav>
-                <Suspense fallback={null}>
-                  <LandlordInboxPage />
-                </Suspense>
-              </LandlordNav>
+              <LandlordInboxRedirect />
             </RequireAuth>
           }
         />

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -182,6 +182,22 @@ describe("LandlordNav mobile drawer", () => {
     ]);
   });
 
+  it("shows one landlord drawer inbox entry pointing to the unified inbox", async () => {
+    renderLandlordNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
+
+    const drawer = screen.getByRole("dialog", { name: "Navigation menu" });
+    const inboxButtons = within(drawer).getAllByRole("button", { name: "Inbox" });
+    expect(inboxButtons).toHaveLength(1);
+
+    fireEvent.click(inboxButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
+    });
+  });
+
   it("navigates landlord mobile tabs to canonical routes", () => {
     renderLandlordNav();
 

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -86,16 +86,8 @@ export const NAV_ITEMS: NavItem[] = [
     requiresLandlordOrAdmin: true,
   },
   {
-    id: "landlord-inbox",
-    label: "Inbox",
-    to: "/landlord/inbox",
-    icon: Inbox,
-    showInDrawer: true,
-    requiresLandlordOrAdmin: true,
-  },
-  {
     id: "unified-inbox",
-    label: "Unified Inbox",
+    label: "Inbox",
     to: "/landlord/unified-inbox",
     icon: Inbox,
     showInDrawer: true,


### PR DESCRIPTION
## Summary
- Redirect legacy `/landlord/inbox` UI visits to `/landlord/unified-inbox`, preserving search and hash fragments.
- Collapse landlord drawer navigation to one Inbox destination.
- Preserve the landlord unified inbox API helper contract at `/landlord/inbox`.

## Validation
- `npm run test -- src/App.routes.test.tsx src/components/layout/LandlordNav.test.tsx src/api/unifiedInboxApi.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`

## Manual QA
- Not run locally. Preview QA should verify direct `/landlord/inbox` navigation redirects to `/landlord/unified-inbox`, drawer/mobile navigation expose one Inbox path, and Network responses remain allowlisted.