### PR TITLE
fix: apply projection safety to landlord inbox route response

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,11 +1,10 @@
-# Implementation Summary
-
 PR: #1138
 PR URL: https://github.com/rentchaincanada/rentchain/pull/1138
 Branch: fix/unified-inbox-projection-regression-v1
 
+# Implementation Summary
+
 Mission: Apply Projection Safety to Legacy landlordInboxRoutes Endpoint
-Branch: fix/unified-inbox-projection-regression-v1
 
 ## Summary
 

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,45 +1,46 @@
 # Implementation Summary
 
-PR: #1137
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1137
-Branch: fix/inbox-route-consolidation-v1
+PR: #[NUMBER once opened]
+PR URL: [URL once opened]
+Branch: fix/unified-inbox-projection-regression-v1
 
-Mission: Consolidate Landlord Inbox Routes
-Branch: fix/inbox-route-consolidation-v1
+Mission: Apply Projection Safety to Legacy landlordInboxRoutes Endpoint
+Branch: fix/unified-inbox-projection-regression-v1
 
 ## Summary
 
-- Redirected the legacy landlord UI route `/landlord/inbox` to `/landlord/unified-inbox`.
-- Preserved query string and hash fragments during the redirect.
-- Removed the duplicate landlord drawer Inbox entry so the drawer exposes one Inbox destination.
-- Preserved the landlord mobile Inbox tab at `/landlord/unified-inbox`.
-- Left the unified inbox API helper unchanged so landlord data still uses `GET /api/landlord/inbox`.
+- Exported and reused the unified inbox public projection helper.
+- Applied `toPublicInboxRecord()` to the legacy landlord inbox response before returning items.
+- Applied the same public projection to tenant and contractor legacy inbox routes after audit found they also returned raw inbox events.
+- Updated landlord and tenant response types to use `UnifiedInboxPublicRecord`.
+- Updated landlord, tenant, contractor, and shared unified inbox route tests to assert the allowlisted public record shape and absence of internal fields.
 
 ## Files Changed
 
-- `rentchain-frontend/src/App.tsx`
-- `rentchain-frontend/src/App.routes.test.tsx`
-- `rentchain-frontend/src/components/layout/navConfig.ts`
-- `rentchain-frontend/src/components/layout/LandlordNav.test.tsx`
+- `rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts`
+- `rentchain-api/src/routes/landlordInboxRoutes.ts`
+- `rentchain-api/src/routes/tenantInboxRoutes.ts`
+- `rentchain-api/src/routes/contractorPortalRoutes.ts`
+- `rentchain-api/src/routes/landlord.test.ts`
+- `rentchain-api/src/routes/tenant.test.ts`
+- `rentchain-api/src/routes/contractor.test.ts`
 - `.handoff/impl-summary.md`
 
 ## Validation
 
-- `npm run test -- src/App.routes.test.tsx src/components/layout/LandlordNav.test.tsx src/api/unifiedInboxApi.test.ts`
-- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
+- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/routes/landlord.test.ts src/routes/tenant.test.ts src/routes/contractor.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts`
+- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/tests/unifiedInbox/unifiedInboxService.test.ts`
+- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
+- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
 - `git diff --check`
 
 ## Manual QA
 
-- Not run locally. The required preview/manual QA remains:
-  - Open `/landlord/unified-inbox` as a landlord and confirm the unified inbox renders.
-  - Open `/landlord/inbox` directly and confirm it redirects to `/landlord/unified-inbox`.
-  - Confirm the landlord drawer has one Inbox entry.
-  - Confirm the mobile bottom nav Inbox tab opens `/landlord/unified-inbox`.
-  - Confirm Network responses remain allowlisted and do not expose internal metadata, tokens, storage paths, provider payloads, or private notes.
+- Not run locally. Preview/manual QA should verify `GET /api/landlord/inbox`, `GET /api/tenant/inbox`, and `GET /api/contractor/inbox` responses contain only the public inbox fields: `id`, `sourceKind`, `audienceRole`, `title`, `body`, `priority`, `status`, `occurredAt`, and `readAt`.
+- Network responses should not include `sourceId`, `sourceRef`, `audienceScopeKey`, safety flags, tokens, storage paths, provider payloads, or private notes.
 
 ## Known Limitations
 
-- The legacy `LandlordInboxPage` file remains in the repository but is no longer used by the active landlord route.
-- The frontend build still reports the existing large chunk warning for the app bundle; the build completed successfully.
-- Pre-existing local workflow-rule edits were not touched or staged for this mission.
+- No auth, Firestore rules, source derivation, or route registration logic was changed.
+- Frontend build still reports the existing large chunk warning; the build completed successfully.
+- Pre-existing unrelated local handoff/workflow-rule edits were preserved in a local stash before final validation.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,7 +1,7 @@
 # Implementation Summary
 
-PR: #[NUMBER once opened]
-PR URL: [URL once opened]
+PR: #1138
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1138
 Branch: fix/unified-inbox-projection-regression-v1
 
 Mission: Apply Projection Safety to Legacy landlordInboxRoutes Endpoint

--- a/rentchain-api/src/routes/contractor.test.ts
+++ b/rentchain-api/src/routes/contractor.test.ts
@@ -96,6 +96,19 @@ function contractorHeader(overrides: Record<string, unknown> = {}) {
   };
 }
 
+const PUBLIC_INBOX_KEYS = ["audienceRole", "body", "id", "occurredAt", "priority", "readAt", "sourceKind", "status", "title"];
+const EXCLUDED_INBOX_FIELDS = [
+  "sourceId",
+  "sourceRef",
+  "audienceScopeKey",
+  "rawIdsIncluded",
+  "tokensIncluded",
+  "secretsIncluded",
+  "providerPayloadIncluded",
+  "storagePathIncluded",
+  "privateNotesIncluded",
+];
+
 function seedInboxData() {
   ensureCollection("workOrders").set("work_order_raw_1", {
     assignedContractorId: "contractor_raw_1",
@@ -204,7 +217,12 @@ describe("contractor inbox route", () => {
       "Contractor message",
     ]);
     expect(res.body.items.every((item: any) => item.audienceRole === "contractor")).toBe(true);
-    expect(res.body.items.every((item: any) => item.rawIdsIncluded === false)).toBe(true);
+    expect(res.body.items.map((item: any) => Object.keys(item).sort())).toEqual([
+      PUBLIC_INBOX_KEYS,
+      PUBLIC_INBOX_KEYS,
+      PUBLIC_INBOX_KEYS,
+      PUBLIC_INBOX_KEYS,
+    ]);
     const payload = JSON.stringify(res.body);
     expect(payload).not.toContain("contractor_raw_1");
     expect(payload).not.toContain("landlord_raw_1");
@@ -215,6 +233,9 @@ describe("contractor inbox route", () => {
     expect(payload).not.toContain("message_raw_");
     expect(payload).not.toContain('"providerPayload":');
     expect(payload).not.toContain("secret token");
+    for (const field of EXCLUDED_INBOX_FIELDS) {
+      expect(payload).not.toContain(field);
+    }
   });
 
   it("supports limit and offset pagination", async () => {

--- a/rentchain-api/src/routes/contractorPortalRoutes.ts
+++ b/rentchain-api/src/routes/contractorPortalRoutes.ts
@@ -1,7 +1,12 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
 import { db } from "../firebase";
 import { requireContractor } from "../middleware/requireContractor";
-import { deriveContractorUnifiedInbox, type SourceKind, type UnifiedInboxEvent } from "../services/unifiedInbox";
+import {
+  deriveContractorUnifiedInbox,
+  toPublicInboxRecord,
+  type SourceKind,
+  type UnifiedInboxEvent,
+} from "../services/unifiedInbox";
 import {
   createContractorPortalMessage,
   getContractorPortalProfile,
@@ -188,7 +193,7 @@ router.get("/contractor/inbox", requireContractor, requireContractorInboxIdentit
       limit: MAX_LIMIT,
     });
     const filteredItems = applyInboxFilters(safePage.items, request);
-    const items = filteredItems.slice(request.offset, request.offset + request.limit);
+    const items = filteredItems.slice(request.offset, request.offset + request.limit).map(toPublicInboxRecord);
 
     return res.json({
       ok: true,

--- a/rentchain-api/src/routes/landlord.test.ts
+++ b/rentchain-api/src/routes/landlord.test.ts
@@ -47,6 +47,18 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
 
 const loadLandlordAnalyticsSnapshot = vi.fn();
 let mockUser: any = null;
+const PUBLIC_INBOX_KEYS = ["audienceRole", "body", "id", "occurredAt", "priority", "readAt", "sourceKind", "status", "title"];
+const EXCLUDED_INBOX_FIELDS = [
+  "sourceId",
+  "sourceRef",
+  "audienceScopeKey",
+  "rawIdsIncluded",
+  "tokensIncluded",
+  "secretsIncluded",
+  "providerPayloadIncluded",
+  "storagePathIncluded",
+  "privateNotesIncluded",
+];
 
 vi.mock("../firebase", () => ({
   db: fakeDb,
@@ -151,11 +163,11 @@ function expectSafeResponse(body: any) {
   expect(serialized).not.toContain("screeningReport");
   for (const item of body.items) {
     expect(item.id).toMatch(/^inbox_v1_/);
-    expect(item.sourceId).toMatch(/^inbox_v1_/);
-    expect(item.audienceScopeKey).toMatch(/^scope_v1_/);
-    expect(item.rawIdsIncluded).toBe(false);
-    expect(item.providerPayloadIncluded).toBe(false);
-    expect(item.storagePathIncluded).toBe(false);
+    expect(Object.keys(item).sort()).toEqual(PUBLIC_INBOX_KEYS);
+    expect(item.audienceRole).toBe("landlord");
+  }
+  for (const field of EXCLUDED_INBOX_FIELDS) {
+    expect(serialized).not.toContain(field);
   }
 }
 

--- a/rentchain-api/src/routes/landlordInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordInboxRoutes.ts
@@ -3,7 +3,13 @@ import { db } from "../firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
-import { deriveLandlordUnifiedInbox, type SourceKind, type UnifiedInboxEvent } from "../services/unifiedInbox";
+import {
+  deriveLandlordUnifiedInbox,
+  toPublicInboxRecord,
+  type SourceKind,
+  type UnifiedInboxEvent,
+  type UnifiedInboxPublicRecord,
+} from "../services/unifiedInbox";
 
 const router = Router();
 
@@ -19,7 +25,7 @@ export type LandlordInboxRequest = {
   dateTo: string | null;
 };
 
-export type LandlordInboxItem = UnifiedInboxEvent;
+export type LandlordInboxItem = UnifiedInboxPublicRecord;
 
 export type LandlordInboxResponse = {
   ok: true;
@@ -230,7 +236,7 @@ router.get("/inbox", requireAuth, requireLandlord, async (req: Request, res: Res
     });
 
     const filteredItems = applySafeFilters(safePage.items, request);
-    const items = filteredItems.slice(request.offset, request.offset + request.limit);
+    const items = filteredItems.slice(request.offset, request.offset + request.limit).map(toPublicInboxRecord);
 
     return res.json({
       ok: true,

--- a/rentchain-api/src/routes/tenant.test.ts
+++ b/rentchain-api/src/routes/tenant.test.ts
@@ -33,6 +33,18 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
 });
 
 let mockUser: any = null;
+const PUBLIC_INBOX_KEYS = ["audienceRole", "body", "id", "occurredAt", "priority", "readAt", "sourceKind", "status", "title"];
+const EXCLUDED_INBOX_FIELDS = [
+  "sourceId",
+  "sourceRef",
+  "audienceScopeKey",
+  "rawIdsIncluded",
+  "tokensIncluded",
+  "secretsIncluded",
+  "providerPayloadIncluded",
+  "storagePathIncluded",
+  "privateNotesIncluded",
+];
 
 vi.mock("../firebase", () => ({
   db: fakeDb,
@@ -174,15 +186,11 @@ function expectSafeResponse(body: any) {
   expect(serialized).not.toContain("screeningReport");
   for (const item of body.items) {
     expect(item.id).toMatch(/^inbox_v1_/);
-    expect(item.sourceId).toMatch(/^inbox_v1_/);
-    expect(item.audienceScopeKey).toMatch(/^scope_v1_/);
+    expect(Object.keys(item).sort()).toEqual(PUBLIC_INBOX_KEYS);
     expect(item.audienceRole).toBe("tenant");
-    expect(item.rawIdsIncluded).toBe(false);
-    expect(item.tokensIncluded).toBe(false);
-    expect(item.secretsIncluded).toBe(false);
-    expect(item.providerPayloadIncluded).toBe(false);
-    expect(item.storagePathIncluded).toBe(false);
-    expect(item.privateNotesIncluded).toBe(false);
+  }
+  for (const field of EXCLUDED_INBOX_FIELDS) {
+    expect(serialized).not.toContain(field);
   }
 }
 

--- a/rentchain-api/src/routes/tenantInboxRoutes.ts
+++ b/rentchain-api/src/routes/tenantInboxRoutes.ts
@@ -1,7 +1,13 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
 import { db } from "../firebase";
 import { requireAuth } from "../middleware/requireAuth";
-import { deriveTenantUnifiedInbox, type SourceKind, type UnifiedInboxEvent } from "../services/unifiedInbox";
+import {
+  deriveTenantUnifiedInbox,
+  toPublicInboxRecord,
+  type SourceKind,
+  type UnifiedInboxEvent,
+  type UnifiedInboxPublicRecord,
+} from "../services/unifiedInbox";
 
 const router = Router();
 
@@ -16,7 +22,7 @@ type TenantInboxRequest = {
   dateTo: string | null;
 };
 
-export type TenantInboxItem = UnifiedInboxEvent;
+export type TenantInboxItem = UnifiedInboxPublicRecord;
 
 export type TenantInboxResponse = {
   ok: true;
@@ -261,7 +267,7 @@ router.get("/inbox", requireAuth, requireTenantInboxIdentity, async (req: Reques
     });
 
     const filteredItems = applySafeFilters(safePage.items, request);
-    const items = filteredItems.slice(request.offset, request.offset + request.limit);
+    const items = filteredItems.slice(request.offset, request.offset + request.limit).map(toPublicInboxRecord);
 
     return res.json({
       ok: true,

--- a/rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts
+++ b/rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts
@@ -203,7 +203,7 @@ function applySafeFilters(items: UnifiedInboxEvent[], request: UnifiedInboxReque
   });
 }
 
-function toPublicInboxRecord(item: UnifiedInboxEvent): UnifiedInboxPublicRecord {
+export function toPublicInboxRecord(item: UnifiedInboxEvent): UnifiedInboxPublicRecord {
   return {
     id: item.id,
     sourceKind: item.sourceKind,


### PR DESCRIPTION
## Summary
- Apply `toPublicInboxRecord()` to legacy landlord, tenant, and contractor inbox route responses.
- Update route response types and tests to assert the allowlisted public inbox shape.
- Preserve auth, derivation, filters, route registration, and Firestore behavior.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/routes/landlord.test.ts src/routes/tenant.test.ts src/routes/contractor.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/tests/unifiedInbox/unifiedInboxService.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
- `git diff --check`

## Manual QA
- Not run locally. Preview QA should verify role-specific inbox responses contain only the public inbox fields and no internal metadata.