### PR TITLE
clarify free tier upgrade path in onboarding and property management UX

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,5 +1,5 @@
-PR: #[NUMBER once opened]
-PR URL: [URL once opened]
+PR: #1139
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1139
 Branch: fix/free-tier-upgrade-path-clarity-v1
 
 # Implementation Summary

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,45 +1,48 @@
-PR: #1138
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1138
-Branch: fix/unified-inbox-projection-regression-v1
+PR: #[NUMBER once opened]
+PR URL: [URL once opened]
+Branch: fix/free-tier-upgrade-path-clarity-v1
 
 # Implementation Summary
 
-Mission: Apply Projection Safety to Legacy landlordInboxRoutes Endpoint
+Mission: Free Tier Upgrade Path Clarity
 
 ## Summary
 
-- Exported and reused the unified inbox public projection helper.
-- Applied `toPublicInboxRecord()` to the legacy landlord inbox response before returning items.
-- Applied the same public projection to tenant and contractor legacy inbox routes after audit found they also returned raw inbox events.
-- Updated landlord and tenant response types to use `UnifiedInboxPublicRecord`.
-- Updated landlord, tenant, contractor, and shared unified inbox route tests to assert the allowlisted public record shape and absence of internal fields.
+- Added shared tier guidance copy and upgrade documentation link constants.
+- Added a free-plan property creation callout explaining manual intake and Starter application invitation/tenant portal upgrade path.
+- Added a free-plan applications page banner near the applicant workflow with a contextual Starter CTA.
+- Added a free-plan property overview panel that labels each property as Free tier and provides an Upgrade to Starter CTA.
+- Preserved existing backend-driven entitlement checks and billing flows; no auth, pricing, entitlement, or billing route behavior changed.
+- Added focused frontend regression coverage for the new guidance copy and CTA surfaces.
 
 ## Files Changed
 
-- `rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts`
-- `rentchain-api/src/routes/landlordInboxRoutes.ts`
-- `rentchain-api/src/routes/tenantInboxRoutes.ts`
-- `rentchain-api/src/routes/contractorPortalRoutes.ts`
-- `rentchain-api/src/routes/landlord.test.ts`
-- `rentchain-api/src/routes/tenant.test.ts`
-- `rentchain-api/src/routes/contractor.test.ts`
+- `rentchain-frontend/src/constants/tiers.ts`
+- `rentchain-frontend/src/constants/tiers.test.ts`
+- `rentchain-frontend/src/components/properties/AddPropertyForm.tsx`
+- `rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx`
+- `rentchain-frontend/src/pages/ApplicationsPage.tsx`
+- `rentchain-frontend/src/pages/ApplicationsPage.test.tsx`
+- `rentchain-frontend/src/pages/PropertiesPage.tsx`
+- `rentchain-frontend/src/pages/PropertiesPage.test.tsx`
 - `.handoff/impl-summary.md`
 
 ## Validation
 
-- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/routes/landlord.test.ts src/routes/tenant.test.ts src/routes/contractor.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts`
-- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/tests/unifiedInbox/unifiedInboxService.test.ts`
-- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
+- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/constants/tiers.test.ts src/components/properties/AddPropertyForm.test.tsx src/pages/ApplicationsPage.test.tsx src/pages/PropertiesPage.test.tsx` in `rentchain-frontend`
 - `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
+- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/routes/__tests__/tenantInvitesRoutes.test.ts src/routes/__tests__/rentalApplicationsDecisionActions.test.ts` in `rentchain-api`
 - `git diff --check`
 
 ## Manual QA
 
-- Not run locally. Preview/manual QA should verify `GET /api/landlord/inbox`, `GET /api/tenant/inbox`, and `GET /api/contractor/inbox` responses contain only the public inbox fields: `id`, `sourceKind`, `audienceRole`, `title`, `body`, `priority`, `status`, `occurredAt`, and `readAt`.
-- Network responses should not include `sourceId`, `sourceRef`, `audienceScopeKey`, safety flags, tokens, storage paths, provider payloads, or private notes.
+- Not run locally. Preview/manual QA should verify free-plan landlords see upgrade guidance during property creation, on the applications page, and in the property overview.
+- Preview/manual QA should verify guidance does not block property creation, manual applicant handling, or property selection workflows.
+- Preview/manual QA should verify tenant and contractor views do not show landlord tier guidance.
 
 ## Known Limitations
 
-- No auth, Firestore rules, source derivation, or route registration logic was changed.
+- No upgrade checkout flow, payment modal, pricing change, analytics event, entitlement change, or billing API change was included.
+- Backend route enforcement was verified with focused existing tests, but no backend source changes were made.
 - Frontend build still reports the existing large chunk warning; the build completed successfully.
-- Pre-existing unrelated local handoff/workflow-rule edits were preserved in a local stash before final validation.
+- Focused `PropertiesPage.test.tsx` still emits a pre-existing duplicate mocked property key warning in one test; assertions pass.

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
@@ -79,6 +79,13 @@ describe("AddPropertyForm", () => {
     render(<AddPropertyForm />);
 
     expect(screen.getByText("Only three details are required to get started")).toBeInTheDocument();
+    expect(screen.getByText("Free tier keeps setup manual")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Free tier includes manual applicant intake and basic property management. Upgrade to Starter to send batch application invitations and enable tenant portals."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Learn more" })).toHaveAttribute("href", "/pricing");
     expect(
       screen.getByText(
         "Enter the street address, city, and total units. You can add amenities, unit details, and compliance information after your first property is set up."

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
@@ -16,6 +16,7 @@ import { useToast } from "@/components/ui/ToastProvider";
 import { PROVINCE_OPTIONS } from "@/lib/provinces";
 import { track } from "../../lib/analytics";
 import { useAuth } from "../../context/useAuth";
+import { FREE_TIER_UPGRADE_GUIDANCE, TIER_GUIDANCE_LINKS } from "../../constants/tiers";
 import "../../styles/propertiesMobile.css";
 
 interface AddPropertyFormProps {
@@ -51,6 +52,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   onExistingPropertyId,
 }) => {
   const { user } = useAuth();
+  const isFreePlan = String(user?.plan || "free").toLowerCase() === "free";
   const [name, setName] = useState("");
   const [pid, setPid] = useState("");
   const [addressLine1, setAddressLine1] = useState("");
@@ -417,6 +419,36 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
               and compliance information after your first property is set up.
             </div>
           </div>
+          {isFreePlan ? (
+            <div
+              style={{
+                borderRadius: 12,
+                border: "1px solid rgba(14,165,233,0.26)",
+                background: "rgba(240,249,255,0.94)",
+                padding: 12,
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ fontSize: "0.92rem", fontWeight: 700, color: "#0f172a" }}>
+                {FREE_TIER_UPGRADE_GUIDANCE.propertyCreate.title}
+              </div>
+              <div style={{ fontSize: "0.84rem", color: "#475569", lineHeight: 1.5 }}>
+                {FREE_TIER_UPGRADE_GUIDANCE.propertyCreate.body}
+              </div>
+              <a
+                href={TIER_GUIDANCE_LINKS.upgradeDocsUrl}
+                style={{
+                  color: "#0369a1",
+                  fontSize: "0.84rem",
+                  fontWeight: 700,
+                  width: "fit-content",
+                }}
+              >
+                {FREE_TIER_UPGRADE_GUIDANCE.propertyCreate.ctaLabel}
+              </a>
+            </div>
+          ) : null}
           <div
             style={{
               display: "grid",

--- a/rentchain-frontend/src/constants/tiers.test.ts
+++ b/rentchain-frontend/src/constants/tiers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { FREE_TIER_UPGRADE_GUIDANCE, TIER_GUIDANCE_LINKS } from "./tiers";
+
+describe("tier guidance constants", () => {
+  it("keeps free-to-starter upgrade copy centralized without pricing references", () => {
+    const copy = [
+      FREE_TIER_UPGRADE_GUIDANCE.propertyCreate.body,
+      FREE_TIER_UPGRADE_GUIDANCE.applications.body,
+      FREE_TIER_UPGRADE_GUIDANCE.propertyOverview.body,
+    ].join(" ");
+
+    expect(copy).toContain("Free tier");
+    expect(copy).toContain("Starter");
+    expect(copy).not.toMatch(/\$\d/);
+    expect(TIER_GUIDANCE_LINKS.upgradeDocsUrl).toBe("/pricing");
+  });
+});

--- a/rentchain-frontend/src/constants/tiers.ts
+++ b/rentchain-frontend/src/constants/tiers.ts
@@ -1,0 +1,26 @@
+export const TIER_GUIDANCE_LINKS = {
+  upgradeDocsUrl: "/pricing",
+} as const;
+
+export const FREE_TIER_UPGRADE_GUIDANCE = {
+  freeLabel: "Free tier",
+  starterLabel: "Starter",
+  propertyCreate: {
+    title: "Free tier keeps setup manual",
+    body:
+      "Free tier includes manual applicant intake and basic property management. Upgrade to Starter to send batch application invitations and enable tenant portals.",
+    ctaLabel: "Learn more",
+  },
+  applications: {
+    title: "Manual applicant intake stays available on Free",
+    body:
+      "Starter adds batch application invitations, screening workflow tools, and tenant portals when you are ready to move beyond manual intake.",
+    ctaLabel: "Learn about Starter",
+  },
+  propertyOverview: {
+    title: "Free tier property workflow",
+    body:
+      "Free tier supports manual applicant intake and basic property management. Starter adds batch application invitations, screening workflow tools, and tenant portals.",
+    ctaLabel: "Upgrade to Starter",
+  },
+} as const;

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -381,6 +381,22 @@ describe("ApplicationsPage", () => {
     expect(container.querySelector(".rc-applications-detail")).toBeTruthy();
   });
 
+  it("shows free-tier upgrade guidance near manual applicant intake", async () => {
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Manual applicant intake stays available on Free")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Starter adds batch application invitations, screening workflow tools, and tenant portals when you are ready to move beyond manual intake."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Learn about Starter" })).toBeInTheDocument();
+  });
+
   it("provides a printable application summary action for the selected application", async () => {
     const { container } = render(
       <MemoryRouter>

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -112,6 +112,7 @@ import { FeatureGate } from "@/components/billing/FeatureGate";
 import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
 import { UpgradeCTA } from "@/components/billing/UpgradeCTA";
 import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
+import { FREE_TIER_UPGRADE_GUIDANCE } from "@/constants/tiers";
 const statusOptions: RentalApplicationStatus[] = [
   "SUBMITTED",
   "IN_REVIEW",
@@ -2468,6 +2469,36 @@ const ApplicationsPage: React.FC = () => {
       </Card>
 
       <Card elevated className="rc-applications-grid">
+        {currentPlan === "free" ? (
+          <Card
+            style={{
+              marginBottom: spacing.md,
+              border: "1px solid rgba(14,165,233,0.26)",
+              background: "rgba(240,249,255,0.94)",
+              display: "grid",
+              gap: spacing.sm,
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, alignItems: "center", flexWrap: "wrap" }}>
+              <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+                <div style={{ fontWeight: 800, color: text.primary }}>
+                  {FREE_TIER_UPGRADE_GUIDANCE.applications.title}
+                </div>
+                <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.6 }}>
+                  {FREE_TIER_UPGRADE_GUIDANCE.applications.body}
+                </div>
+              </div>
+              <UpgradeCTA
+                featureKey="applications"
+                label={FREE_TIER_UPGRADE_GUIDANCE.applications.ctaLabel}
+                source="applications_manual_intake_guidance"
+                presentation="inline"
+                variant="secondary"
+                size="sm"
+              />
+            </div>
+          </Card>
+        ) : null}
         <Card
           style={{
             marginBottom: spacing.md,

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -54,6 +54,10 @@ vi.mock("../components/properties/PropertySelector", () => ({
   PropertySelector: () => <div>Selector</div>,
 }));
 
+vi.mock("../components/billing/UpgradeCTA", () => ({
+  UpgradeCTA: ({ label }: { label?: string }) => <button type="button">{label || "Upgrade"}</button>,
+}));
+
 vi.mock("../components/ActionRequestsPanel", () => ({
   ActionRequestsPanel: () => <div>Actions</div>,
 }));
@@ -147,6 +151,24 @@ describe("PropertiesPage", () => {
     });
 
     expect(screen.getByText("Archived properties are hidden from active portfolio views but preserved for records and history.")).toBeInTheDocument();
+  });
+
+  it("shows free tier labels and upgrade guidance in the property overview", async () => {
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Free tier property workflow")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "Free tier supports manual applicant intake and basic property management. Starter adds batch application invitations, screening workflow tools, and tenant portals."
+      ).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Active Property")).toBeInTheDocument();
+    expect(screen.getAllByText("Free tier").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Upgrade to Starter" }).length).toBeGreaterThan(0);
   });
 
   it("shows a print action when a property is selected", async () => {

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -35,6 +35,8 @@ import { resolveReturnToParam } from "../lib/propertyGate";
 import { useCapabilities } from "../hooks/useCapabilities";
 import { deriveUnitOccupancyFromLeases } from "../lib/leases/leaseLifecycle";
 import { printSummaryDocument } from "../utils/printSummary";
+import { UpgradeCTA } from "../components/billing/UpgradeCTA";
+import { FREE_TIER_UPGRADE_GUIDANCE } from "../constants/tiers";
 
 const PropertiesPage: React.FC = () => {
   const [properties, setProperties] = useState<Property[]>([]);
@@ -69,8 +71,9 @@ const PropertiesPage: React.FC = () => {
   const [leasePackOpen, setLeasePackOpen] = useState(false);
   const [leasePackInitialPropertyId, setLeasePackInitialPropertyId] = useState<string | null>(null);
   const { showToast } = useToast();
-  const { features } = useCapabilities();
+  const { caps, features } = useCapabilities();
   const currentProperties = properties?.length ?? 0;
+  const currentPlan = String(caps?.plan || "free").toLowerCase();
   const canInviteTenant = Boolean(features?.tenant_invites || features?.tenantInvites);
   const archiveHelpCopy =
     propertyView === "archived"
@@ -663,6 +666,73 @@ const PropertiesPage: React.FC = () => {
             selectedId={selectedPropertyId}
             onSelect={handleSelectProperty}
           />
+
+          {currentPlan === "free" && safeProperties.length > 0 ? (
+            <div
+              style={{
+                display: "grid",
+                gap: 10,
+                padding: 14,
+                borderRadius: radius.lg,
+                border: "1px solid rgba(14,165,233,0.26)",
+                background: "rgba(240,249,255,0.94)",
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "flex-start", flexWrap: "wrap" }}>
+                <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+                  <div style={{ color: text.primary, fontSize: 16, fontWeight: 800 }}>
+                    {FREE_TIER_UPGRADE_GUIDANCE.propertyOverview.title}
+                  </div>
+                  <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.6 }}>
+                    {FREE_TIER_UPGRADE_GUIDANCE.propertyOverview.body}
+                  </div>
+                </div>
+                <UpgradeCTA
+                  featureKey="applications"
+                  label={FREE_TIER_UPGRADE_GUIDANCE.propertyOverview.ctaLabel}
+                  source="properties_free_tier_overview"
+                  presentation="inline"
+                  variant="secondary"
+                  size="sm"
+                />
+              </div>
+              <div style={{ display: "grid", gap: 6 }}>
+                {safeProperties.map((property) => (
+                  <div
+                    key={property.id}
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      gap: 10,
+                      flexWrap: "wrap",
+                      padding: "8px 10px",
+                      borderRadius: radius.md,
+                      border: `1px solid ${colors.border}`,
+                      background: colors.card,
+                    }}
+                  >
+                    <div style={{ color: text.primary, fontSize: 13, fontWeight: 700, overflowWrap: "anywhere" }}>
+                      {property.name || property.addressLine1 || "Property"}
+                    </div>
+                    <span
+                      style={{
+                        borderRadius: radius.pill,
+                        border: "1px solid rgba(14,165,233,0.28)",
+                        background: "rgba(14,165,233,0.1)",
+                        color: "#0369a1",
+                        fontSize: 12,
+                        fontWeight: 800,
+                        padding: "3px 8px",
+                      }}
+                    >
+                      {FREE_TIER_UPGRADE_GUIDANCE.freeLabel}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
 
           {isLoadingProperties ? (
             <SkeletonBlock lines={4} label="Loading properties" />


### PR DESCRIPTION
## Summary
- Add centralized free-tier upgrade guidance copy and help link constants.
- Surface free-plan guidance in property creation, applications, and property overview workflows.
- Preserve existing entitlement, billing, auth, and backend route behavior while verifying current gates with focused tests.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/constants/tiers.test.ts src/components/properties/AddPropertyForm.test.tsx src/pages/ApplicationsPage.test.tsx src/pages/PropertiesPage.test.tsx` in `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- src/routes/__tests__/tenantInvitesRoutes.test.ts src/routes/__tests__/rentalApplicationsDecisionActions.test.ts` in `rentchain-api`
- `git diff --check`

## Manual QA
- Not run locally. Preview QA should verify free-plan landlords see guidance during property creation, on applications, and in property overview; guidance stays non-blocking; tenant and contractor views are unchanged.