### PR TITLE
Fix guided modal unit save ID persistence

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,62 +1,22 @@
-PR: #1141
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1141
-Branch: fix/free-tier-gated-feature-ux-v1
+PR: #1142
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1142
+Branch: fix/unit-guided-modal-save-v1
 
-# Implementation Summary
+Mission: Fix Unit Guided Modal Save
 
-Mission: Fix free tier gated feature UX
+Implemented:
+- Manual unit creation now returns created unit records with stable Firestore IDs.
+- Placeholder unit IDs are rejected before occupancy updates with UNIT_ID_UNRESOLVED.
+- The property units flow stores only persisted unit records after save responses include stable IDs.
+- Unit edit modal stays open and shows a retryable message if a save response omits a stable ID.
+- Property detail state replaces edited units when the save response returns a different persisted ID.
 
-## Summary
+Validation:
+- rentchain-api: npm run test:single -- src/routes/__tests__/unitsRoutes.patch.test.ts
+- rentchain-api: npm run build
+- rentchain-frontend: npm run test:single -- src/components/properties/UnitEditModal.test.tsx src/components/properties/PropertyDetailPanel.test.tsx src/pages/PropertiesPage.test.tsx
+- rentchain-frontend: npm run build
+- git diff --check
 
-- Implemented locked feature states for free-tier users on lease operations, ledger, ledger v2, and messages.
-- Split operational command center loading so free-safe dashboard, decision inbox, and property signals still load while lease-driven lanes show locked guidance.
-- Normalized backend capability-denial payloads for leases, ledger, ledger v2, and messages.
-- Centralized operations-signal upgrade copy in `upgradeCopy.ts`.
-- Documented the Pilot 1 maintenance decision in the capability catalog without changing maintenance enforcement.
-
-## Backend Changes
-
-- Added `buildUpgradeRequiredResponse()` in `rentchain-api/src/services/capabilityGuard.ts`.
-- Updated ad hoc upgrade-required responses in:
-  - `rentchain-api/src/routes/leaseRoutes.ts`
-  - `rentchain-api/src/routes/ledgerRoutes.ts`
-  - `rentchain-api/src/routes/ledgerV2Routes.ts`
-  - `rentchain-api/src/routes/messagesRoutes.ts`
-- Preserved existing capability decisions and route structure.
-- Did not modify auth middleware, billing flows, pricing tables, Firestore rules, deployment configuration, or entitlement allow lists.
-
-## Frontend Changes
-
-- Updated `LandlordActiveLeasesPage.tsx` to show `LockedFeature` for free-tier users before calling paid lease APIs.
-- Updated `OperationalCommandCenterPage.tsx` to keep free-safe content visible and render locked operations lanes for lease-driven signals.
-- Updated `LedgerPage.tsx`, `LedgerV2Page.tsx`, and `MessagesPage.tsx` to use the shared locked-state component.
-- Added `gatedFeatureErrors.ts` so stale backend denials do not surface raw upgrade errors.
-- Updated `LockedFeature` so feature title and description can default to centralized upgrade copy.
-
-## Tests Added Or Updated
-
-- `rentchain-api/src/services/__tests__/capabilityGuard.test.ts`
-- `rentchain-api/src/services/__tests__/planCapabilities.test.ts`
-- `rentchain-frontend/src/lib/gatedFeatureErrors.test.ts`
-- `rentchain-frontend/src/billing/upgradeCopy.test.ts`
-- `rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx`
-- `rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx`
-- `rentchain-frontend/src/pages/MessagesPage.test.tsx`
-
-## Validation
-
-- Passed: `source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run test:single -- src/services/__tests__/capabilityGuard.test.ts src/services/__tests__/planCapabilities.test.ts` in `rentchain-api`.
-- Passed: `npm run test:single -- src/lib/gatedFeatureErrors.test.ts src/billing/upgradeCopy.test.ts src/pages/LandlordActiveLeasesPage.test.tsx src/pages/OperationalCommandCenterPage.test.tsx src/pages/MessagesPage.test.tsx` in `rentchain-frontend`.
-- Passed: `source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run build` in `rentchain-api`.
-- Passed: `source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run build` in `rentchain-frontend`.
-- Passed: `git diff --check`.
-
-## Manual QA
-
-- Not run locally. This mission changes frontend rendering and should receive preview QA for free-tier, Starter, and Pro landlord accounts before merge.
-
-## Known Limitations
-
-- Frontend build completed with the existing large chunk warning.
-- Full browser preview QA was not run in this workspace.
-- `.handoff/merge-log.md` had pre-existing local edits and was intentionally left unstaged.
+Known limitations:
+- Frontend focused tests still emit an existing duplicate-key warning in the property creation test harness for prop-created; tests pass.

--- a/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
@@ -6,6 +6,7 @@ type StoredDoc = { id: string; data: any };
 
 const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
+  let autoCounter = 0;
 
   function ensureCollection(name: string) {
     if (!collections.has(name)) collections.set(name, new Map());
@@ -16,11 +17,22 @@ const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
     return { ...(existing || {}), ...(payload || {}) };
   }
 
-  const dbMock = {
-    collection: (name: string) => ({
+  function snapshotFor(name: string, filters: Array<{ field: string; value: any }>) {
+    const docs = Array.from(ensureCollection(name).values())
+      .filter((doc) => filters.every((filter) => doc.data?.[filter.field] === filter.value))
+      .map((doc) => ({
+        id: doc.id,
+        exists: true,
+        data: () => doc.data,
+      }));
+    return { docs, size: docs.length };
+  }
+
+  function collectionApi(name: string, filters: Array<{ field: string; value: any }> = []): any {
+    return {
       doc: (id?: string) => {
         const col = ensureCollection(name);
-        const docId = id || "auto";
+        const docId = id || `${name}-auto-${++autoCounter}`;
         return {
           id: docId,
           get: async () => {
@@ -41,12 +53,35 @@ const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
           },
         };
       },
-    }),
+      where: (field: string, op: string, value: any) => {
+        if (op !== "==") throw new Error(`Unsupported where op: ${op}`);
+        return collectionApi(name, [...filters, { field, value }]);
+      },
+      get: async () => snapshotFor(name, filters),
+    };
+  }
+
+  const dbMock = {
+    collection: (name: string) => collectionApi(name),
+    batch: () => {
+      const writes: Array<() => Promise<void>> = [];
+      return {
+        set: (ref: any, payload: any, options?: { merge?: boolean }) => {
+          writes.push(() => ref.set(payload, options));
+        },
+        commit: async () => {
+          for (const write of writes) await write();
+        },
+      };
+    },
   };
 
   return {
     dbMock,
-    resetDb: () => collections.clear(),
+    resetDb: () => {
+      collections.clear();
+      autoCounter = 0;
+    },
     seedDoc: (collection: string, id: string, data: any) => {
       ensureCollection(collection).set(id, { id, data });
     },
@@ -133,7 +168,7 @@ describe("unitsRoutes PATCH aliases", () => {
     });
   });
 
-  it("returns UNIT_NOT_FOUND when updating a non-existent unit", async () => {
+  it("returns UNIT_ID_UNRESOLVED when updating a placeholder unit", async () => {
     const app = await createApp();
 
     const res = await request(app).patch("/api/units/placeholder-0").send({
@@ -142,10 +177,32 @@ describe("unitsRoutes PATCH aliases", () => {
       leaseEndDate: "2027-06-10",
     });
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(400);
     expect(res.body).toMatchObject({
       ok: false,
-      error: "UNIT_NOT_FOUND",
+      error: "UNIT_ID_UNRESOLVED",
+      code: "UNIT_ID_UNRESOLVED",
     });
+  });
+
+  it("returns persisted IDs when creating units for a property", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/properties/prop-1/units")
+      .send({
+        units: [
+          { unitNumber: "101", beds: 1, baths: 1, sqft: 500, marketRent: 1500, status: "vacant" },
+          { unitNumber: "102", beds: 2, baths: 1, sqft: 700, marketRent: 1900, status: "vacant" },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, created: 2 });
+    expect(res.body.units).toHaveLength(2);
+    expect(res.body.units[0]).toMatchObject({ id: "units-auto-1", unitNumber: "101", propertyId: "prop-1" });
+    expect(res.body.units[1]).toMatchObject({ id: "units-auto-2", unitNumber: "102", propertyId: "prop-1" });
+    expect(res.body.items).toEqual(res.body.units);
   });
 });

--- a/rentchain-api/src/routes/unitsRoutes.ts
+++ b/rentchain-api/src/routes/unitsRoutes.ts
@@ -103,6 +103,11 @@ function normalizeStatus(value: any): string {
   return String(value || "").trim().toLowerCase();
 }
 
+function isPlaceholderUnitId(value: any): boolean {
+  const id = String(value || "").trim();
+  return Boolean(id) && /^placeholder-/i.test(id);
+}
+
 async function attachSignedLeaseDocument(unit: any) {
   const leaseDocument = unit?.leaseDocument;
   if (!leaseDocument || typeof leaseDocument !== "object") return unit;
@@ -329,13 +334,14 @@ router.post(
     let created = 0;
     const batch = db.batch();
     const now = new Date();
+    const createdUnits: any[] = [];
 
     for (const u of units) {
       const unitNumber = String((u?.unitNumber ?? u?.label ?? u?.unit) || "").trim();
       if (!unitNumber) continue;
 
       const ref = db.collection("units").doc();
-      batch.set(ref, {
+      const unitRecord = {
         landlordId,
         propertyId,
         unitNumber,
@@ -347,6 +353,14 @@ router.post(
         createdAt: now,
         updatedAt: now,
         updatedAtServer: FieldValue.serverTimestamp(),
+      };
+      batch.set(ref, unitRecord);
+      createdUnits.push({
+        id: ref.id,
+        ...unitRecord,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+        updatedAtServer: null,
       });
       created += 1;
     }
@@ -354,8 +368,25 @@ router.post(
     if (created === 0) {
       return res.status(400).json({ ok: false, error: "No valid units to create" });
     }
+    if (createdUnits.some((unit) => !unit.id || isPlaceholderUnitId(unit.id))) {
+      return res.status(500).json({
+        ok: false,
+        error: "UNIT_ID_UNRESOLVED",
+        code: "UNIT_ID_UNRESOLVED",
+        message: "Units could not be saved with stable IDs. Please try again.",
+      });
+    }
 
-    await batch.commit();
+    try {
+      await batch.commit();
+    } catch {
+      return res.status(500).json({
+        ok: false,
+        error: "UNIT_PERSISTENCE_FAILED",
+        code: "UNIT_PERSISTENCE_FAILED",
+        message: "Units could not be saved. Please try again.",
+      });
+    }
 
     try {
       const countSnap = await db
@@ -375,7 +406,7 @@ router.post(
       // ignore count update errors
     }
 
-    return res.json({ ok: true, created });
+    return res.json({ ok: true, created, units: createdUnits, items: createdUnits });
   }
 );
 
@@ -386,6 +417,14 @@ router.patch("/units/:unitId", authenticateJwt, requireLandlord, async (req: any
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   if (!unitId) return res.status(400).json({ ok: false, error: "Missing unitId" });
   if (!(await enforceUnitsCapability(req, res))) return;
+  if (isPlaceholderUnitId(unitId)) {
+    return res.status(400).json({
+      ok: false,
+      error: "UNIT_ID_UNRESOLVED",
+      code: "UNIT_ID_UNRESOLVED",
+      message: "Save the unit before updating occupancy fields.",
+    });
+  }
 
   const ref = db.collection("units").doc(unitId);
   const snap = await ref.get();

--- a/rentchain-frontend/src/api/unitsApi.ts
+++ b/rentchain-frontend/src/api/unitsApi.ts
@@ -11,6 +11,20 @@ export type UnitInput = {
   leaseEndDate?: string | null;
 };
 
+export type UnitRecord = UnitInput & {
+  id: string;
+  propertyId?: string;
+  unitId?: string;
+  uid?: string;
+};
+
+export type AddUnitsManualResponse = {
+  ok?: boolean;
+  created?: number;
+  units?: UnitRecord[];
+  items?: UnitRecord[];
+};
+
 export async function fetchUnitsForProperty(propertyId: string) {
   // Primary endpoint
   const res: any = await apiFetch(`/properties/${propertyId}/units`, {
@@ -27,11 +41,11 @@ export async function fetchUnitsForProperty(propertyId: string) {
   return [];
 }
 
-export async function addUnitsManual(propertyId: string, units: UnitInput[]) {
+export async function addUnitsManual(propertyId: string, units: UnitInput[]): Promise<AddUnitsManualResponse> {
   return apiFetch(`/properties/${propertyId}/units`, {
     method: "POST",
     body: JSON.stringify({ units }),
-  });
+  }) as Promise<AddUnitsManualResponse>;
 }
 
 export async function updateUnit(unitId: string, payload: any) {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -85,11 +85,24 @@ vi.mock("./UnitsCsvPreviewModal", () => ({
 }));
 
 vi.mock("./UnitEditModal", () => ({
-  UnitEditModal: ({ open, unit }: any) =>
+  UnitEditModal: ({ open, unit, onSaved }: any) =>
     open ? (
       <div data-testid="unit-edit-modal">
         <div>modal tenant: {unit?.occupantName || ""}</div>
         <div>modal lease end: {unit?.leaseEndDate || ""}</div>
+        <button
+          type="button"
+          onClick={() =>
+            onSaved?.({
+              id: "unit-persisted-2",
+              unitNumber: unit?.unitNumber || "101",
+              status: "occupied",
+              occupantName: "Pat Tenant",
+            })
+          }
+        >
+          Mock save persisted unit
+        </button>
       </div>
     ) : null,
 }));
@@ -735,6 +748,43 @@ describe("PropertyDetailPanel", () => {
         variant: "error",
       })
     );
+  });
+
+  it("replaces the edited unit when the save response returns a persisted ID", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      { id: "unit-persisted-1", unitNumber: "101", status: "vacant" },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            unitCount: 1,
+            totalUnits: 1,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "Edit" }).length).toBeGreaterThan(1));
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
+    fireEvent.click(screen.getByRole("button", { name: "Mock save persisted unit" }));
+
+    await waitFor(() => expect(screen.queryByTestId("unit-edit-modal")).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
+    expect(await screen.findByText("modal tenant: Pat Tenant")).toBeInTheDocument();
   });
 
   it("uses the updated archive confirmation copy before archiving", async () => {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -2025,7 +2025,23 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         unit={editingUnit}
         onClose={() => setEditingUnit(null)}
         onSaved={(updated) => {
-          setUnits((prev) => prev.map((u) => (u?.id === updated?.id ? { ...u, ...updated } : u)));
+          const editingKey = String(editingUnit?.id || editingUnit?.unitId || editingUnit?.uid || "").trim();
+          const updatedKey = String(updated?.id || updated?.unitId || updated?.uid || "").trim();
+          if (!isPersistedUnitId(updated)) {
+            setUnitResolutionError("This unit is not ready for occupancy updates yet. Refresh the property after saving units, then try again.");
+            showToast({
+              title: "Unit not ready",
+              description: "Refresh the property after saving units, then try again.",
+              variant: "warning",
+            });
+            return;
+          }
+          setUnits((prev) =>
+            prev.map((u) => {
+              const currentKey = String(u?.id || u?.unitId || u?.uid || "").trim();
+              return currentKey === updatedKey || currentKey === editingKey ? { ...u, ...updated } : u;
+            })
+          );
           setEditingUnit(null);
         }}
       />

--- a/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
@@ -91,4 +91,36 @@ describe("UnitEditModal", () => {
       })
     );
   });
+
+  it("keeps the modal open when the update response omits a persisted ID", async () => {
+    const onClose = vi.fn();
+    const onSaved = vi.fn();
+    mocks.updateUnit.mockResolvedValue({
+      unit: {
+        status: "occupied",
+        occupantName: "Jane Tenant",
+      },
+    });
+
+    render(
+      <UnitEditModal
+        open
+        unit={{ id: "unit-1", unitNumber: "101", status: "vacant" }}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "occupied" },
+    });
+    fireEvent.change(await screen.findByLabelText("Current tenant name"), {
+      target: { value: "Jane Tenant" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText(/stable ID was not returned/i)).toBeInTheDocument();
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/rentchain-frontend/src/components/properties/UnitEditModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.tsx
@@ -14,6 +14,15 @@ function isPersistedUnitId(unit: any) {
   return Boolean(id) && !/^placeholder-/i.test(id);
 }
 
+function resolveSavedUnit(response: any, fallbackUnit: any, payload: any) {
+  const updated = response?.unit || { ...fallbackUnit, ...payload };
+  if (!isPersistedUnitId(updated)) {
+    const err = new Error("UNIT_ID_UNRESOLVED");
+    throw err;
+  }
+  return updated;
+}
+
 export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
   const [unitNumber, setUnitNumber] = useState("");
   const [rent, setRent] = useState<string>("");
@@ -82,10 +91,14 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
       payload.leaseEndDate = payload.status === "occupied" ? leaseEndDate || null : null;
       const unitId = String(unit.id || unit.unitId || unit.uid);
       const resp: any = await updateUnit(unitId, payload);
-      let updated = resp?.unit || { ...unit, ...payload };
+      let updated = resolveSavedUnit(resp, unit, payload);
       if (payload.status === "occupied" && leaseDocumentFile) {
         const uploadedResp: any = await uploadUnitLeaseDocument(unitId, leaseDocumentFile);
-        updated = uploadedResp?.unit || { ...updated, leaseDocument: uploadedResp?.leaseDocument || null };
+        updated = resolveSavedUnit(
+          uploadedResp?.unit ? uploadedResp : { unit: { ...updated, leaseDocument: uploadedResp?.leaseDocument || null } },
+          updated,
+          {}
+        );
       }
       onSaved(updated);
       onClose();
@@ -94,6 +107,8 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
       setError(
         message === "UNIT_NOT_FOUND"
           ? "This unit could not be found. Refresh the property after saving units, then try again."
+          : message === "UNIT_ID_UNRESOLVED"
+          ? "The unit was saved, but its stable ID was not returned. Keep this modal open and try again, or refresh the property."
           : message || "Failed to save unit"
       );
     } finally {
@@ -113,7 +128,9 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
         zIndex: 4000,
         padding: 16,
       }}
-      onMouseDown={onClose}
+      onMouseDown={() => {
+        if (!saving) onClose();
+      }}
     >
       <div
         onMouseDown={(e) => e.stopPropagation()}
@@ -130,7 +147,7 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
       >
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
           <div style={{ fontWeight: 700, fontSize: 16 }}>Edit unit</div>
-          <Button onClick={onClose} style={{ padding: "6px 10px" }}>
+          <Button onClick={onClose} disabled={saving} style={{ padding: "6px 10px" }}>
             Close
           </Button>
         </div>
@@ -296,7 +313,7 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
         ) : null}
 
         <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-          <Button onClick={onClose} style={{ padding: "8px 12px" }}>
+          <Button onClick={onClose} disabled={saving} style={{ padding: "8px 12px" }}>
             Cancel
           </Button>
           <Button onClick={save} disabled={saving || !unitNumber} style={{ padding: "8px 12px" }}>

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -6,6 +6,8 @@ import PropertiesPage from "./PropertiesPage";
 const mocks = vi.hoisted(() => ({
   fetchPropertiesMock: vi.fn(),
   fetchCountsMock: vi.fn(),
+  addUnitsManualMock: vi.fn(),
+  showToastMock: vi.fn(),
   useToastMock: vi.fn(),
   useAuthMock: vi.fn(),
   useCapabilitiesMock: vi.fn(),
@@ -47,7 +49,14 @@ vi.mock("../components/property/PropertyActivityPanel", () => ({
 }));
 
 vi.mock("../components/properties/PropertyDetailPanel", () => ({
-  PropertyDetailPanel: () => <div>Detail</div>,
+  PropertyDetailPanel: ({ property }: any) => (
+    <div>
+      <div>Detail</div>
+      {(property?.units || []).map((unit: any) => (
+        <div key={String(unit?.id || unit?.unitNumber)}>{`${unit?.id}:${unit?.unitNumber}`}</div>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock("../components/properties/PropertySelector", () => ({
@@ -89,7 +98,7 @@ vi.mock("../api/onboardingApi", () => ({
 }));
 
 vi.mock("../api/unitsApi", () => ({
-  addUnitsManual: vi.fn(),
+  addUnitsManual: mocks.addUnitsManualMock,
 }));
 
 vi.mock("../components/ui/ToastProvider", () => ({
@@ -114,6 +123,14 @@ vi.mock("../lib/analytics", () => ({
 
 describe("PropertiesPage", () => {
   beforeEach(() => {
+    mocks.fetchPropertiesMock.mockReset();
+    mocks.fetchCountsMock.mockReset();
+    mocks.addUnitsManualMock.mockReset();
+    mocks.showToastMock.mockReset();
+    mocks.useToastMock.mockReset();
+    mocks.useAuthMock.mockReset();
+    mocks.useCapabilitiesMock.mockReset();
+    mocks.printSummaryDocumentMock.mockReset();
     mocks.fetchPropertiesMock.mockImplementation(async (filters?: any) => ({
       items:
         filters?.status === "archived"
@@ -121,7 +138,12 @@ describe("PropertiesPage", () => {
           : [{ id: "prop-1", name: "Active Property", portfolioStatus: "active" }],
     }));
     mocks.fetchCountsMock.mockResolvedValue({ counts: {} });
-    mocks.useToastMock.mockReturnValue({ showToast: vi.fn() });
+    mocks.addUnitsManualMock.mockResolvedValue({
+      ok: true,
+      created: 1,
+      units: [{ id: "unit-created-1", unitNumber: "101", beds: 1, baths: 1, sqft: 500, marketRent: 1500, status: "vacant" }],
+    });
+    mocks.useToastMock.mockReturnValue({ showToast: mocks.showToastMock });
     mocks.useAuthMock.mockReturnValue({
       user: { id: "user-1", plan: "free", role: "landlord" },
     });
@@ -166,7 +188,7 @@ describe("PropertiesPage", () => {
         "Free tier supports manual applicant intake and basic property management. Starter adds batch application invitations, screening workflow tools, and tenant portals."
       ).length
     ).toBeGreaterThan(0);
-    expect(screen.getByText("Active Property")).toBeInTheDocument();
+    expect(screen.getAllByText("Active Property").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Free tier").length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: "Upgrade to Starter" }).length).toBeGreaterThan(0);
   });
@@ -262,5 +284,61 @@ describe("PropertiesPage", () => {
     expect(await screen.findByText("Move into the application workflow")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send application" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Invite a tenant" })).not.toBeInTheDocument();
+  });
+
+  it("stores created units with persisted IDs from the save response", async () => {
+    mocks.fetchPropertiesMock.mockResolvedValue({ items: [] });
+
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    const setupButtons = await screen.findAllByRole("button", {
+      name: "Complete property setup",
+    });
+    fireEvent.click(setupButtons[0]);
+    fireEvent.click(await screen.findByRole("button", { name: "Add a unit" }));
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "101" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save units" }));
+
+    await waitFor(() => {
+      expect(mocks.addUnitsManualMock).toHaveBeenCalledWith(
+        "prop-created",
+        expect.arrayContaining([expect.objectContaining({ unitNumber: "101" })])
+      );
+    });
+    expect(await screen.findByText("unit-created-1:101")).toBeInTheDocument();
+  });
+
+  it("keeps the unit modal open when created unit IDs are unresolved", async () => {
+    mocks.fetchPropertiesMock.mockResolvedValue({ items: [] });
+    mocks.addUnitsManualMock.mockResolvedValue({ ok: true, created: 1 });
+
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    const setupButtons = await screen.findAllByRole("button", {
+      name: "Complete property setup",
+    });
+    fireEvent.click(setupButtons[0]);
+    fireEvent.click(await screen.findByRole("button", { name: "Add a unit" }));
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "101" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save units" }));
+
+    await waitFor(() => {
+      expect(mocks.showToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to save units",
+          description: expect.stringContaining("stable IDs"),
+          variant: "error",
+        })
+      );
+    });
+    expect(screen.getByText("Add Units")).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -23,7 +23,7 @@ import { fetchMonthlyOpsSnapshot } from "../api/actionSnapshotApi";
 import { asArray } from "../lib/asArray";
 import { arr, str } from "@/utils/safe";
 import { setOnboardingStep } from "../api/onboardingApi";
-import { addUnitsManual, type UnitInput } from "../api/unitsApi";
+import { addUnitsManual, type AddUnitsManualResponse, type UnitInput, type UnitRecord } from "../api/unitsApi";
 import { useToast } from "../components/ui/ToastProvider";
 import { unitsForProperty } from "../lib/propertyCounts";
 import { PropertySelector } from "../components/properties/PropertySelector";
@@ -37,6 +37,48 @@ import { deriveUnitOccupancyFromLeases } from "../lib/leases/leaseLifecycle";
 import { printSummaryDocument } from "../utils/printSummary";
 import { UpgradeCTA } from "../components/billing/UpgradeCTA";
 import { FREE_TIER_UPGRADE_GUIDANCE } from "../constants/tiers";
+
+function isPersistedUnitIdValue(value: any) {
+  const id = String(value || "").trim();
+  return Boolean(id) && !/^placeholder-/i.test(id);
+}
+
+function resolveCreatedUnits(response: AddUnitsManualResponse | undefined, requestedUnits: UnitInput[]): UnitRecord[] {
+  const returnedUnits = Array.isArray(response?.units)
+    ? response?.units
+    : Array.isArray(response?.items)
+      ? response?.items
+      : [];
+  if (!returnedUnits || returnedUnits.length < requestedUnits.length) {
+    const err = new Error("Saved units were not returned with stable IDs. Please try again.");
+    (err as any).code = "UNIT_ID_UNRESOLVED";
+    throw err;
+  }
+
+  return requestedUnits.map((requestedUnit, index) => {
+    const returnedUnit = returnedUnits[index] as UnitRecord | undefined;
+    const id = String(returnedUnit?.id || returnedUnit?.unitId || returnedUnit?.uid || "").trim();
+    if (!isPersistedUnitIdValue(id)) {
+      const err = new Error("Saved units were not returned with stable IDs. Please try again.");
+      (err as any).code = "UNIT_ID_UNRESOLVED";
+      throw err;
+    }
+    return {
+      ...requestedUnit,
+      ...returnedUnit,
+      id,
+      unitNumber: String(returnedUnit?.unitNumber || requestedUnit.unitNumber || "").trim(),
+    };
+  });
+}
+
+function unitSaveErrorMessage(error: any) {
+  const code = String(error?.code || error?.error || error?.message || "");
+  if (code === "UNIT_ID_UNRESOLVED" || code === "UNIT_PERSISTENCE_FAILED") {
+    return "Units could not be saved with stable IDs. Keep this form open and try again.";
+  }
+  return error?.message ?? "Could not save units";
+}
 
 const PropertiesPage: React.FC = () => {
   const [properties, setProperties] = useState<Property[]>([]);
@@ -342,7 +384,8 @@ const PropertiesPage: React.FC = () => {
 
     setSavingUnits(true);
     try {
-      await addUnitsManual(activePropertyId, clean);
+      const response = await addUnitsManual(activePropertyId, clean);
+      const persistedUnits = resolveCreatedUnits(response, clean);
       track("activation_unit_created", {
         surface: "properties_page",
         source: "manual_units_modal",
@@ -354,8 +397,9 @@ const PropertiesPage: React.FC = () => {
           String(p.id) === String(activePropertyId)
             ? {
                 ...p,
-                units: clean as any,
-                unitCount: clean.length,
+                units: persistedUnits as any,
+                unitCount: persistedUnits.length,
+                unitsCount: persistedUnits.length,
               }
             : p
         )
@@ -370,7 +414,7 @@ const PropertiesPage: React.FC = () => {
     } catch (e: any) {
       showToast({
         title: "Failed to save units",
-        description: e?.message ?? "Could not save units",
+        description: unitSaveErrorMessage(e),
         variant: "error",
       });
     } finally {


### PR DESCRIPTION
## Summary
- Return created unit records with stable Firestore IDs from manual unit creation
- Keep unit creation and occupancy edit flows open when stable IDs are unresolved
- Add focused backend and frontend coverage for placeholder rejection, persisted create responses, and retry behavior

## Validation
- rentchain-api: npm run test:single -- src/routes/__tests__/unitsRoutes.patch.test.ts
- rentchain-api: npm run build
- rentchain-frontend: npm run test:single -- src/components/properties/UnitEditModal.test.tsx src/components/properties/PropertyDetailPanel.test.tsx src/pages/PropertiesPage.test.tsx
- rentchain-frontend: npm run build
- git diff --check