### PR TITLE
Fix Numbers CSV compatibility for unit import

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,22 +1,24 @@
-PR: #1142
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1142
-Branch: fix/unit-guided-modal-save-v1
+PR: #1143
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1143
+Branch: fix/numbers-csv-compatibility-v1
 
-Mission: Fix Unit Guided Modal Save
+Mission: Fix Numbers CSV compatibility for property unit import
 
 Implemented:
-- Manual unit creation now returns created unit records with stable Firestore IDs.
-- Placeholder unit IDs are rejected before occupancy updates with UNIT_ID_UNRESOLVED.
-- The property units flow stores only persisted unit records after save responses include stable IDs.
-- Unit edit modal stays open and shows a retryable message if a save response omits a stable ID.
-- Property detail state replaces edited units when the save response returns a different persisted ID.
+- Added canonical unit CSV text normalization before backend parsing.
+- Handled BOM, replacement-character, null-byte, zero-width, no-break space, and CR-only line-ending cases.
+- Normalized formatted numeric cells for rent, beds, baths, and square feet while preserving validation for invalid values.
+- Kept existing CSV template structure, unit schema, API routes, and response contracts unchanged.
+- Aligned the frontend CSV preview utility with the same text normalization.
+- Added Numbers-style regression coverage for backend parsing, both backend preview entry points, frontend preview parsing, and property creation CSV preview acceptance.
 
 Validation:
-- rentchain-api: npm run test:single -- src/routes/__tests__/unitsRoutes.patch.test.ts
+- rentchain-api: npm run test:single -- src/imports/unitCsvImport.service.test.ts src/routes/__tests__/unitCsvPreviewRoutes.test.ts
 - rentchain-api: npm run build
-- rentchain-frontend: npm run test:single -- src/components/properties/UnitEditModal.test.tsx src/components/properties/PropertyDetailPanel.test.tsx src/pages/PropertiesPage.test.tsx
+- rentchain-frontend: npm run test:single -- src/utils/csvPreview.test.ts src/components/properties/AddPropertyForm.test.tsx
 - rentchain-frontend: npm run build
 - git diff --check
 
 Known limitations:
-- Frontend focused tests still emit an existing duplicate-key warning in the property creation test harness for prop-created; tests pass.
+- Supertest route coverage required elevated local execution because the sandbox blocks binding a local test server port.
+- Frontend build still reports the existing large chunk warning.

--- a/rentchain-api/src/imports/unitCsv.schema.ts
+++ b/rentchain-api/src/imports/unitCsv.schema.ts
@@ -73,17 +73,32 @@ export const UNIT_CSV_FIELD_MAP = [
 export const EXPECTED_UNIT_CSV_HEADERS = UNIT_CSV_FIELD_MAP.map((entry) => entry.canonicalHeader);
 
 export function normalizeHeader(h: string) {
-  return h
-    .replace(/^\uFEFF/, "")
+  return cleanText(h)
     .trim()
     .toLowerCase()
     .replace(/\s+/g, "");
 }
 
+export function cleanText(value: any) {
+  return String(value ?? "")
+    .replace(/^\uFEFF/, "")
+    .replace(/^[\uFFFD]+/, "")
+    .replace(/\u0000/g, "")
+    .replace(/[\u200B-\u200D\u2060]/g, "")
+    .replace(/\u00A0/g, " ");
+}
+
 function cleanCell(value: any) {
   if (value === undefined || value === null) return undefined;
-  const text = String(value).trim();
+  const text = cleanText(value).trim();
   return text === "" ? undefined : text;
+}
+
+function cleanNumericCell(value: any) {
+  const text = cleanCell(value);
+  if (text === undefined) return undefined;
+  const normalized = text.replace(/[$£€]/g, "").replace(/(?<=\d)[,\s](?=\d{3}(\D|$))/g, "");
+  return normalized.trim();
 }
 
 function normalizeStatus(value: any) {
@@ -171,7 +186,12 @@ export function mapRow(raw: Record<string, any>) {
   for (const [k, v] of Object.entries(raw)) {
     const entry = resolveUnitCsvField(k);
     if (!entry) continue;
-    const value = entry.field === "status" ? normalizeStatus(v) : cleanCell(v);
+    const value =
+      entry.field === "status"
+        ? normalizeStatus(v)
+        : ["rent", "bedrooms", "bathrooms", "sqft"].includes(entry.field)
+          ? cleanNumericCell(v)
+          : cleanCell(v);
     if (value === undefined) continue;
     out[entry.field] = value;
   }

--- a/rentchain-api/src/imports/unitCsvImport.service.test.ts
+++ b/rentchain-api/src/imports/unitCsvImport.service.test.ts
@@ -20,6 +20,51 @@ describe("parseUnitsCsv", () => {
     });
   });
 
+  it("parses Numbers-style CSVs with CR line endings and formatted numeric cells", () => {
+    const csv = [
+      "\uFEFFunitNumber,marketRent,beds,baths,sqft,status",
+      '101,"$1,850",1,1,610,vacant',
+      "102,1\u00A0650,0,1,450,leased",
+      ",,,,,",
+    ].join("\r");
+
+    const result = parseUnitsCsv(csv);
+
+    expect(result.headers).toMatchObject({ valid: true, missing: [], unknown: [] });
+    expect(result.preview.errors).toEqual([]);
+    expect(result.candidates).toHaveLength(2);
+    expect(result.candidates[0].data).toMatchObject({
+      unitNumber: "101",
+      rent: 1850,
+      bedrooms: 1,
+      bathrooms: 1,
+      sqft: 610,
+      status: "vacant",
+    });
+    expect(result.candidates[1].data).toMatchObject({
+      unitNumber: "102",
+      rent: 1650,
+      bedrooms: 0,
+      bathrooms: 1,
+      sqft: 450,
+      status: "occupied",
+    });
+  });
+
+  it("recovers UTF-16 BOM text when upload decoding leaves null bytes", () => {
+    const csv = Buffer.from("\uFEFFunitNumber,marketRent,beds\r101,1850,1", "utf16le").toString("utf8");
+
+    const result = parseUnitsCsv(csv);
+
+    expect(result.headers).toMatchObject({ valid: true, missing: [], unknown: [] });
+    expect(result.preview.errors).toEqual([]);
+    expect(result.candidates[0].data).toMatchObject({
+      unitNumber: "101",
+      rent: 1850,
+      bedrooms: 1,
+    });
+  });
+
   it("reports exact missing and unknown headers", () => {
     const result = parseUnitsCsv("marketRent,internalId\n1850,secret");
 

--- a/rentchain-api/src/imports/unitCsvImport.service.ts
+++ b/rentchain-api/src/imports/unitCsvImport.service.ts
@@ -3,6 +3,7 @@ import {
   EXPECTED_UNIT_CSV_HEADERS,
   UNIT_CSV_FIELD_MAP,
   UnitCsvRowSchema,
+  cleanText,
   mapRow,
   resolveUnitCsvField,
 } from "./unitCsv.schema";
@@ -42,10 +43,16 @@ export type ParsedUnitsCsv = {
   };
 };
 
+export function normalizeUnitCsvText(csvText: string): string {
+  return cleanText(csvText)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
 export function parseUnitsCsv(csvText: string): ParsedUnitsCsv {
-  const parsed = Papa.parse(csvText, { header: true, skipEmptyLines: false });
+  const parsed = Papa.parse(normalizeUnitCsvText(csvText), { header: true, skipEmptyLines: false });
   const data = (parsed.data || []) as any[];
-  const receivedHeaders = (parsed.meta.fields || []).map((header) => String(header || "").replace(/^\uFEFF/, "").trim());
+  const receivedHeaders = (parsed.meta.fields || []).map((header) => cleanText(header).trim());
   const knownFields = new Set<string>();
   const unknown = receivedHeaders.filter((header) => {
     if (!header) return false;

--- a/rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts
@@ -95,6 +95,29 @@ describe("unit CSV preview routes", () => {
     });
   });
 
+  it("previews Numbers-style CSV through the property creation route", async () => {
+    const app = await createPropertiesApp();
+
+    const res = await request(app).post("/api/properties/units/csv-preview").send({
+      csvText: '\uFEFFunitNumber,marketRent,beds,baths,sqft,status\r101,"$1,850",1,1,610,vacant\r102,1\u00A0650,0,1,450,leased',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.preview.rows).toEqual([
+      expect.objectContaining({
+        row: 2,
+        status: "valid",
+        data: expect.objectContaining({ unitNumber: "101", rent: 1850, status: "vacant" }),
+      }),
+      expect.objectContaining({
+        row: 3,
+        status: "valid",
+        data: expect.objectContaining({ unitNumber: "102", rent: 1650, status: "occupied" }),
+      }),
+    ]);
+  });
+
   it("previews property unit table CSV through the property-scoped route", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
     const app = await createUnitImportApp();
@@ -109,5 +132,21 @@ describe("unit CSV preview routes", () => {
     expect(res.body.preview.errors).toEqual([
       expect.objectContaining({ code: "HEADER_UNKNOWN", field: "privateColumn" }),
     ]);
+  });
+
+  it("previews Numbers-style CSV through the property-scoped route", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
+    const app = await createUnitImportApp();
+
+    const csvText = Buffer.from("\uFEFFunitNumber,marketRent,beds\r101,1850,1", "utf16le").toString("utf8");
+    const res = await request(app).post("/api/properties/prop-1/units/csv-parse").send({ csvText });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.preview.rows[0]).toMatchObject({
+      row: 2,
+      status: "valid",
+      data: { unitNumber: "101", rent: 1850, bedrooms: 1 },
+    });
   });
 });

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
@@ -48,6 +48,7 @@ describe("AddPropertyForm", () => {
     mocks.trackMock.mockReset();
     mocks.setOnboardingStepMock.mockResolvedValue(undefined);
     mocks.showToastMock.mockReset();
+    mocks.previewUnitsCsvMock.mockReset();
     mocks.previewUnitsCsvMock.mockResolvedValue({
       ok: true,
       headers: {
@@ -178,6 +179,78 @@ describe("AddPropertyForm", () => {
               sqft: 610,
               status: "vacant",
             }),
+          ],
+        })
+      );
+    });
+  });
+
+  it("accepts Numbers-style CSV preview output before creating the property", async () => {
+    mocks.previewUnitsCsvMock.mockResolvedValueOnce({
+      ok: true,
+      headers: {
+        valid: true,
+        received: ["unitNumber", "marketRent", "beds", "baths", "sqft", "status"],
+        expected: ["unitNumber", "marketRent", "beds", "baths", "sqft", "status"],
+        missing: [],
+        unknown: [],
+      },
+      preview: {
+        errors: [],
+        rows: [
+          {
+            row: 2,
+            status: "valid",
+            unitNumber: "101",
+            data: { unitNumber: "101", rent: 1850, bedrooms: 1, bathrooms: 1, sqft: 610, status: "vacant" },
+            issues: [],
+          },
+          {
+            row: 3,
+            status: "valid",
+            unitNumber: "102",
+            data: { unitNumber: "102", rent: 1650, bedrooms: 0, bathrooms: 1, sqft: 450, status: "occupied" },
+            issues: [],
+          },
+        ],
+      },
+    });
+    const { container } = render(<AddPropertyForm onCreated={vi.fn()} />);
+
+    fireEvent.change(screen.getAllByPlaceholderText("123 Main Street")[0], {
+      target: { value: "123 Main Street" },
+    });
+    fireEvent.change(screen.getAllByPlaceholderText("Halifax")[0], {
+      target: { value: "Halifax" },
+    });
+    const unitsToggle = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Units & Rents (Optional)")
+    );
+    expect(unitsToggle).toBeTruthy();
+    fireEvent.click(unitsToggle!);
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['\uFEFFunitNumber,marketRent,beds,baths,sqft,status\r101,"$1,850",1,1,610,vacant\r102,1\u00A0650,0,1,450,leased'], "numbers-units.csv", {
+      type: "text/csv",
+    });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mocks.previewUnitsCsvMock).toHaveBeenLastCalledWith(
+        'unitNumber,marketRent,beds,baths,sqft,status\r101,"$1,850",1,1,610,vacant\r102,1\u00A0650,0,1,450,leased'
+      );
+    });
+    expect(await screen.findByText(/CSV preview: numbers-units.csv/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Create property" })[0]);
+
+    await waitFor(() => {
+      expect(mocks.createPropertyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          totalUnits: 2,
+          units: [
+            expect.objectContaining({ unitNumber: "101", rent: 1850, status: "vacant" }),
+            expect.objectContaining({ unitNumber: "102", rent: 1650, status: "occupied" }),
           ],
         })
       );

--- a/rentchain-frontend/src/utils/csvPreview.test.ts
+++ b/rentchain-frontend/src/utils/csvPreview.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCsvPreviewText, parseCsvPreview } from "./csvPreview";
+
+describe("csvPreview", () => {
+  it("normalizes Numbers-style BOM, null bytes, CR rows, and no-break spaces", () => {
+    const text = "\uFFFD\uFFFDU\u0000n\u0000i\u0000t\u0000,\u0000R\u0000e\u0000n\u0000t\u0000\r101,1\u00A0850\r";
+
+    expect(normalizeCsvPreviewText(text)).toBe("Unit,Rent\n101,1 850\n");
+  });
+
+  it("parses normalized Numbers-style preview rows", () => {
+    const result = parseCsvPreview("\uFEFFunitNumber,marketRent\r101,\"1,850\"\r102,1\u00A0650\r");
+
+    expect(result.headers).toEqual(["unitNumber", "marketRent"]);
+    expect(result.rows).toEqual([
+      ["101", "1,850"],
+      ["102", "1 650"],
+    ]);
+  });
+});

--- a/rentchain-frontend/src/utils/csvPreview.ts
+++ b/rentchain-frontend/src/utils/csvPreview.ts
@@ -1,6 +1,17 @@
+export function normalizeCsvPreviewText(text: string) {
+  return String(text ?? "")
+    .replace(/^\uFEFF/, "")
+    .replace(/^[\uFFFD]+/, "")
+    .replace(/\u0000/g, "")
+    .replace(/[\u200B-\u200D\u2060]/g, "")
+    .replace(/\u00A0/g, " ")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
 export function parseCsvPreview(text: string, maxRows = 10) {
-  const lines = text
-    .split(/\r?\n/)
+  const lines = normalizeCsvPreviewText(text)
+    .split("\n")
     .map((l) => l.trim())
     .filter(Boolean);
 
@@ -23,13 +34,13 @@ export function parseCsvPreview(text: string, maxRows = 10) {
         continue;
       }
       if (ch === "," && !inQuotes) {
-        out.push(cur.trim());
+        out.push(cur.replace(/^\uFEFF/, "").trim());
         cur = "";
         continue;
       }
       cur += ch;
     }
-    out.push(cur.trim());
+    out.push(cur.replace(/^\uFEFF/, "").trim());
     return out;
   };
 


### PR DESCRIPTION
## Summary
- Normalize unit CSV text before parsing to handle BOM, null-byte, replacement-character, zero-width, no-break space, and CR-only line-ending cases
- Normalize formatted numeric CSV cells for rent, beds, baths, and square feet without changing the template or route contracts
- Align the frontend CSV preview utility with the same text normalization and add regression coverage for property creation and property-scoped previews

## Validation
- rentchain-api: npm run test:single -- src/imports/unitCsvImport.service.test.ts src/routes/__tests__/unitCsvPreviewRoutes.test.ts
- rentchain-api: npm run build
- rentchain-frontend: npm run test:single -- src/utils/csvPreview.test.ts src/components/properties/AddPropertyForm.test.tsx
- rentchain-frontend: npm run build
- git diff --check

## Notes
- The Supertest route suite required elevated local execution because the sandbox blocks binding a local test server port.
- Frontend build still reports the existing large chunk warning.