### PR TITLE
Simplify free tier landlord journey

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,5 +1,5 @@
-PR: #TBD
-PR URL: TBD
+PR: #1147
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1147
 Branch: fix/free-tier-landlord-experience-v1
 
 WHAT WAS DONE:
@@ -22,7 +22,7 @@ KEY DECISIONS:
 
 CURRENT STATE:
 - Branch: fix/free-tier-landlord-experience-v1
-- PR: pending
+- PR: #1147
 - Source changes are frontend-only.
 - Handoff-only local files outside this mission were not staged.
 

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,105 +1,47 @@
-PR: #1146
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1146
-Branch: audit/free-tier-journey-v1
+PR: #TBD
+PR URL: TBD
+Branch: fix/free-tier-landlord-experience-v1
 
-WHAT WAS AUDITED:
-Comprehensive code inspection audit of the complete free tier user journey covering route entitlements, frontend navigation visibility, onboarding workflows, upgrade decision points, narrative consistency, and locked-state UX patterns. Inspected 25+ backend and frontend files to identify why the platform "feels broken rather than limited" to free tier users.
+WHAT WAS DONE:
+Implemented the first free-tier landlord journey simplification pass focused on clarity, action order, and navigation prominence.
 
-**Backend Route and Entitlement Analysis:**
-- Inspected capability gating middleware in `rentchain-api/src/middleware/entitlements.ts` - returns structured 402 responses with `upgrade_required` error, capability key, current plan, required plan, and `/billing` upgrade path
-- Audited lease route entitlements in `rentchain-api/src/routes/leaseRoutes.ts` - all lease operations (`/active`, `/archived`, creation, editing) protected by `enforceLeaseCapability` function requiring "leases" capability
-- Verified landlord inbox routes in `rentchain-api/src/routes/landlordInboxRoutes.ts` - free tier accessible with full unified inbox aggregating applications, screenings, leases, maintenance, messages, notices
-- Confirmed messaging routes in `rentchain-api/src/routes/messagesRoutes.ts` - protected by messaging capability enforcement at lines 675-688, returns upgrade-required 403 for locked plans
+- Added a dashboard journey card that puts the primary setup order first: Add property -> Add unit -> Add applicant -> Run screening.
+- Reordered dashboard fallback actions so free landlords see property, unit, applicant, and screening steps in the intended sequence.
+- Moved the dashboard Decision Inbox summary into a collapsed lower-priority section instead of placing it beside the main KPI strip.
+- Reordered quick actions to favor Add property, Add unit, and Add applicant before secondary actions.
+- Updated landlord mobile tabs to prioritize Dashboard, Properties, Applicants, and Inbox, with More for secondary pages.
+- De-emphasized Operations and Decisions from the primary landlord drawer while keeping their routes available for deep links and future workflows.
+- Updated nav configuration tests and dashboard regression tests for the new action-order narrative.
 
-**Frontend Navigation and Visibility Analysis:**
-- Analyzed navigation config in `rentchain-frontend/src/components/layout/navConfig.ts` - Messages requires "messaging" feature, Analytics requires "portfolio_health_summary" feature, filtering applied via `getVisibleNavItems` function
-- Inspected mobile navigation in `rentchain-frontend/src/components/layout/LandlordNav.tsx` - landlord mobile tabs include Dashboard, Documents, Leases, Inbox, Messages (with messaging filter), creating 5 primary command surfaces
-- Found navigation inconsistency: desktop drawer prioritizes Operations and Decisions as primary command entries, but mobile bottom tabs elevate Inbox and Messages while relegating Operations/Decisions to "More" menu
-- Verified free tier navigation visibility: Messages hidden when `features.messaging === false`, other surfaces remain visible but show locked content
-
-**Onboarding and Property Creation Workflow Analysis:**
-- Examined property creation form in `rentchain-frontend/src/components/properties/AddPropertyForm.tsx` - includes structured free tier guidance via `FREE_TIER_UPGRADE_GUIDANCE.propertyCreate` with title "Free tier keeps setup manual", explanation of manual vs Starter tier differences, and "Learn more" CTA linking to `/pricing`
-- Verified property overview guidance in `rentchain-frontend/src/pages/PropertiesPage.tsx` - displays free tier guidance card with `FREE_TIER_UPGRADE_GUIDANCE.propertyOverview` content and `UpgradeCTA` component using "applications" feature key and "properties_free_tier_overview" source tracking
-- Confirmed tier guidance constants in `rentchain-frontend/src/constants/tiers.ts` - defines structured guidance for property creation, applications, and property overview with consistent messaging about manual intake on Free vs batch invitations on Starter
-
-**Upgrade Decision Points and Locked State UX Analysis:**
-- Inspected lease page locked state in `rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx` - uses `isUpgradeRequiredError` detection and `LockedFeature` component presentation, silently handles upgrade errors without showing broken state
-- Analyzed messaging locked state in `rentchain-frontend/src/pages/MessagesPage.tsx` - clean capability check via `features?.messaging !== false`, shows full `LockedFeature` component when disabled with "Upgrade to Starter" CTA
-- Examined operations page tier gating in `rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx` - uses `entitlements.hasCapability("leases")` check, locks lease_lifecycle, payments, and documents lanes when `leaseSignalsLocked` is true, displays locked cards instead of errors
-- Verified LockedFeature component structure in `rentchain-frontend/src/components/billing/LockedFeature.tsx` - professional presentation with "Locked feature" label, clear feature description, required plan indication, upgrade CTA, and reassuring copy about checkout process
-
-**Narrative Consistency and Messaging Analysis:**
-- Found consistent tier labeling: "Free tier" and "Starter" used throughout guidance constants
-- Verified upgrade messaging consistency: all upgrade CTAs link to `/pricing` or `/billing` paths
-- Confirmed locked state language: "Available on Starter" messaging with professional upgrade prompts rather than error language
-- Identified clear upgrade driver messaging: manual intake vs batch invitations, basic property management vs tenant portals, manual applicant handling vs screening workflow tools
-
-KEY FINDINGS:
-
-**1. Navigation Complexity Creates Decision Overload**
-Current free tier users face 8+ primary command surfaces (Dashboard, Operations, Properties, Tenants, Applications, Leases, Inbox, Messages) with unclear prioritization. Mobile navigation prioritizes Inbox/Messages while desktop prioritizes Operations/Decisions, creating inconsistent mental models across devices.
-
-**2. Mixed Locked State Quality - Some Professional, Some Confusing**
-GOOD: Messages, Properties, and Lease creation show professional LockedFeature components with clear upgrade CTAs and plan requirements.
-CONCERNING: Operations page mixes free-accessible content with locked lanes in single interface, potentially creating "partially broken" perception rather than clear limitation messaging.
-
-**3. Strong Upgrade Driver Clarity in Property Creation**
-Property creation workflow includes excellent free tier guidance explaining manual intake vs Starter tier batch invitations. Clear value prop communication about when to upgrade.
-
-**4. Excellent Backend Capability Architecture**
-Backend entitlement system returns structured, API-consistent upgrade responses. Frontend properly detects `upgrade_required` errors and transforms them into professional locked states rather than displaying raw errors.
-
-**5. Mobile vs Desktop Navigation Priority Misalignment**
-Desktop users see Operations/Decisions as primary command entries, mobile users see Inbox/Messages as primary. This creates different free tier experiences based on device, potentially contributing to confusion about platform priorities.
-
-**6. Messaging Capability Inconsistency Risk**
-Messages workspace enforces messaging capability strictly, but unified inbox can include message summaries without equivalent capability gates. Free tier users might see message activity in inbox while blocked from conversation workspace.
-
-**NARRATIVE GAPS IDENTIFIED:**
-
-**Gap 1: Operations Page Overwhelming Rather Than Limited**
-Operations page combines 6 coordination categories (lease lifecycle, payments, occupancy, screening, documents, operational review) into single interface with mixed locked/unlocked lanes. Users experience confusion rather than clear "this feature requires upgrade" messaging.
-
-**Gap 2: Command Surface Decision Overload**
-Free tier users must navigate between Inbox, Messages, Operations, Decisions, Properties, Applications without clear guidance on which surfaces are primary vs secondary for their use case.
-
-**Gap 3: Device-Dependent Navigation Priorities**
-Mobile users experience different command surface hierarchy than desktop users, creating inconsistent onboarding experiences and mental models.
-
-**Gap 4: Partial Access Confusion**
-Operations page and unified inbox show mixed accessible/locked content within same interfaces, creating "partially broken" rather than "intentionally limited" perception.
+KEY DECISIONS:
+- Kept entitlement enforcement, route signatures, billing logic, backend gates, Firestore rules, and API contracts unchanged.
+- Kept Decision Inbox available but reduced its prominence for the free-tier journey.
+- Kept Messages as a gated route and removed it from the mobile primary tab sequence to avoid duplicate Inbox/Messages mental models.
+- Preserved the existing Properties page guidance and Add Units modal path because it already carries the property -> unit flow and recent persistence fixes.
+- Used existing navigation and dashboard components instead of adding a new app shell or dependency.
 
 CURRENT STATE:
-- Branch: audit/free-tier-journey-v1
-- Implementation approach: Code inspection only, zero source code changes
-- Files inspected: 25+ backend routes, frontend pages, components, and configuration files
-- Audit coverage: Complete 6-phase analysis per mission requirements
-- Findings documentation: Comprehensive with specific code locations and line numbers
+- Branch: fix/free-tier-landlord-experience-v1
+- PR: pending
+- Source changes are frontend-only.
+- Handoff-only local files outside this mission were not staged.
 
-RECOMMENDED FIXES (Prioritized by Impact):
-
-**HIGH IMPACT - Immediate Narrative Clarity:**
-1. **Split Operations Page:** Move locked lanes (lease lifecycle, payments, documents) behind clear upgrade prompts. Keep free-safe content (property overview, basic inbox) as simplified operations view.
-2. **Unify Mobile/Desktop Navigation Priorities:** Establish consistent primary command surfaces across devices. Recommend: Dashboard + Properties + Inbox as primary, Operations + Messages + Leases as secondary.
-3. **Consolidate Command Surfaces:** Reduce free tier navigation from 8+ surfaces to 4-5 clear paths with obvious upgrade drivers.
-
-**MEDIUM IMPACT - UX Polish:**
-4. **Standardize Locked State Presentation:** Ensure all locked features use LockedFeature component rather than mixed content interfaces.
-5. **Clarify Messages vs Inbox Relationship:** Document intended separation and ensure capability enforcement consistency.
-6. **Strengthen Property Creation Success Path:** Add clearer "what next?" guidance after property creation completion.
-
-**LOW IMPACT - Consistency:**
-7. **Audit Messaging Capability Consistency:** Ensure unified inbox message inclusion matches messages workspace capability enforcement.
-8. **Standardize Tier Language:** Confirm "Free tier" vs "Starter" language consistency across all surfaces.
-
-NEXT STEPS:
-Based on audit findings, recommend three follow-up implementation missions:
-1. `fix/landlord-command-surface-simplification-v1` - Consolidate navigation surfaces and split operations page locked lanes
-2. `fix/upgrade-driver-clarification-v1` - Strengthen upgrade decision points and locked state consistency
-3. `fix/onboarding-flow-reordering-v1` - Establish device-consistent navigation priorities and success path guidance
+VALIDATION:
+- `npm test -- DashboardPage.test.tsx LandlordNav.test.tsx` passed.
+- `git diff --check` passed.
+- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` passed. Vite emitted its existing Node preference warning for Node 20.19+, but the build completed successfully under the repo-pinned Node 20.11.1.
+- `npm test` passed: 306 files, 1214 tests.
+- `npm run lint` passed.
 
 KNOWN LIMITATIONS:
-- Audit based on code inspection only, no live user testing or account-specific entitlement verification
-- Did not inspect every landlord route in repository, focused on primary user journey surfaces
-- Tier gating behavior validated through code patterns, not runtime API payload samples
-- Mobile responsive breakpoint behavior inferred from CSS/component logic, not device testing
+- Manual preview QA was not run in this local execution.
+- Operations page content was not redesigned; this mission only de-emphasizes it from the primary free-tier navigation.
+- Locked-state copy still relies on the existing `LockedFeature` and upgrade copy system. No entitlement or billing copy source of truth was changed.
+- Messages and Inbox remain separate surfaces; this mission only reduces mobile navigation duplication.
+
+NEXT STEP:
+Run preview QA for the free-tier landlord dashboard and navigation:
+- Dashboard shows setup order before decision/review language.
+- Mobile bottom nav fits cleanly and shows Dashboard, Properties, Applicants, Inbox, More.
+- Drawer no longer promotes Operations or Decisions as primary free-tier choices.
+- Property -> unit -> applicant -> screening path is understandable in the first 30 minutes.

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -148,27 +148,25 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByTestId("current-path")).toHaveTextContent("/payments");
   });
 
-  it("uses the requested landlord mobile app tabs", () => {
+  it("uses the free-tier landlord mobile app tabs in setup order", () => {
     renderLandlordNav();
 
     const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
     expect(within(tabbar).getByText("Dashboard")).toBeInTheDocument();
-    expect(within(tabbar).getByText("Documents")).toBeInTheDocument();
-    expect(within(tabbar).getByText("Leases")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Properties")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Applicants")).toBeInTheDocument();
     expect(within(tabbar).getByText("Inbox")).toBeInTheDocument();
-    expect(within(tabbar).getByText("Messages")).toBeInTheDocument();
     expect(within(tabbar).getByText("More")).toBeInTheDocument();
     expect(within(tabbar).getAllByRole("button").map((button) => button.textContent)).toEqual([
       "Dashboard",
-      "Documents",
-      "Leases",
+      "Properties",
+      "Applicants",
       "Inbox",
-      "Messages",
       "More",
     ]);
-    expect(within(tabbar).queryByText("Applications")).not.toBeInTheDocument();
     expect(within(tabbar).queryByText("Tenants")).not.toBeInTheDocument();
-    expect(within(tabbar).queryByText("Properties")).not.toBeInTheDocument();
+    expect(within(tabbar).queryByText("Leases")).not.toBeInTheDocument();
+    expect(within(tabbar).queryByText("Messages")).not.toBeInTheDocument();
   });
 
   it("keeps the shared nav tab configuration aligned with the landlord mobile app tabs", async () => {
@@ -176,9 +174,9 @@ describe("LandlordNav mobile drawer", () => {
 
     expect(NAV_ITEMS.filter((item) => item.showInTabs).map((item) => item.label)).toEqual([
       "Dashboard",
-      "Documents",
-      "Leases",
-      "Messages",
+      "Properties",
+      "Applications",
+      "Inbox",
     ]);
   });
 
@@ -202,11 +200,11 @@ describe("LandlordNav mobile drawer", () => {
     renderLandlordNav();
 
     const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
-    fireEvent.click(within(tabbar).getByRole("button", { name: "Documents" }));
-    expect(screen.getByTestId("current-path")).toHaveTextContent("/applications");
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Properties" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/properties");
 
-    fireEvent.click(within(tabbar).getByRole("button", { name: "Leases" }));
-    expect(screen.getByTestId("current-path")).toHaveTextContent("/leases");
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Applicants" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/applications");
 
     fireEvent.click(within(tabbar).getByRole("button", { name: "Inbox" }));
     expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { FileText, Inbox, LayoutDashboard, Menu, MessagesSquare, ScrollText, X } from "lucide-react";
+import { Building2, Inbox, LayoutDashboard, Menu, ScrollText, X } from "lucide-react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
@@ -18,10 +18,9 @@ type Props = {
 
 const landlordMobileTabs = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { to: "/applications", label: "Documents", icon: FileText },
-  { to: "/leases", label: "Leases", icon: ScrollText },
+  { to: "/properties", label: "Properties", icon: Building2 },
+  { to: "/applications", label: "Applicants", icon: ScrollText },
   { to: "/landlord/unified-inbox", label: "Inbox", icon: Inbox },
-  { to: "/messages", label: "Messages", icon: MessagesSquare, requiresMessaging: true },
 ];
 
 function includesAdminAuthority(value: unknown): boolean {

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -43,7 +43,7 @@ export const NAV_ITEMS: NavItem[] = [
     label: "Operations",
     to: "/operations",
     icon: ClipboardList,
-    showInDrawer: true,
+    showInDrawer: false,
     requiresLandlordOrAdmin: true,
   },
   {
@@ -52,6 +52,7 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/properties",
     icon: Building2,
     showInDrawer: true,
+    showInTabs: true,
   },
   {
     id: "tenants",
@@ -66,6 +67,7 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/applications",
     icon: ScrollText,
     showInDrawer: true,
+    showInTabs: true,
   },
   {
     id: "documents",
@@ -73,7 +75,7 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/applications",
     icon: FileText,
     showInDrawer: false,
-    showInTabs: true,
+    showInTabs: false,
     requiresLandlordOrAdmin: true,
   },
   {
@@ -82,7 +84,7 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/leases",
     icon: ScrollText,
     showInDrawer: true,
-    showInTabs: true,
+    showInTabs: false,
     requiresLandlordOrAdmin: true,
   },
   {
@@ -91,6 +93,7 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/landlord/unified-inbox",
     icon: Inbox,
     showInDrawer: true,
+    showInTabs: true,
     requiresLandlordOrAdmin: true,
   },
   {
@@ -98,7 +101,7 @@ export const NAV_ITEMS: NavItem[] = [
     label: "Decisions",
     to: "/decision-inbox",
     icon: Inbox,
-    showInDrawer: true,
+    showInDrawer: false,
     requiresLandlordOrAdmin: true,
   },
   {
@@ -116,7 +119,7 @@ export const NAV_ITEMS: NavItem[] = [
     to: "/messages",
     icon: MessagesSquare,
     showInDrawer: true,
-    showInTabs: true,
+    showInTabs: false,
     requiresFeature: "messaging",
   },
   {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -387,6 +387,57 @@ describe("DashboardPage", () => {
     expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
   });
 
+  it("prioritizes the free-tier setup journey before review-heavy dashboard work", async () => {
+    mocks.fetchDashboardSummaryMock.mockResolvedValue({
+      kpis: {
+        propertiesCount: 1,
+        unitsCount: 0,
+        tenantsCount: 0,
+        openActionsCount: 0,
+        delinquentCount: 0,
+        screeningsCount: 0,
+      },
+      actions: [],
+      events: [],
+      decisions: [
+        {
+          decisionId: "decision:review_overdue_rent:lease-1",
+          leaseId: "lease-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          decisionType: "review_overdue_rent",
+          severity: "critical",
+          status: "detected",
+          reason: "Rent past due date",
+          metadata: {},
+        },
+      ],
+    });
+    mocks.fetchPropertiesMock.mockResolvedValue({
+      properties: [{ id: "property-1", name: "Main Street", units: [] }],
+    });
+
+    render(
+      <ToastProvider>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByTestId("free-tier-journey-card")).toBeInTheDocument();
+    expect(screen.getByText("Start in order")).toBeInTheDocument();
+    expect(screen.getByText("Step 1")).toBeInTheDocument();
+    expect(screen.getByText("Step 2")).toBeInTheDocument();
+    expect(screen.getAllByText("Add unit").length).toBeGreaterThan(0);
+    expect(screen.getByText("Decision inbox summary")).toBeInTheDocument();
+
+    const actionRequired = screen.getByText("Action required").closest("div");
+    expect(actionRequired).not.toBeNull();
+    expect(screen.getAllByText("Add a unit").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Set up screening workflow")).not.toBeInTheDocument();
+  });
+
   it("keeps dashboard recent activity ledger CTA label consistent when lease context is missing", async () => {
     mocks.fetchDashboardSummaryMock.mockResolvedValue({
       kpis: {
@@ -541,7 +592,7 @@ describe("DashboardPage", () => {
     expect(assignMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
   });
 
-  it("routes the screening setup CTA to the applications TransUnion onboarding path", async () => {
+  it("routes the provider funnel CTA to applications once TransUnion is connected", async () => {
     mocks.fetchDashboardSummaryMock.mockResolvedValue({
       kpis: {
         propertiesCount: 1,
@@ -584,8 +635,8 @@ describe("DashboardPage", () => {
     );
 
     expect(await screen.findByText("Provider setup funnel")).toBeInTheDocument();
-    screen.getAllByRole("button", { name: "Open" })[0].click();
-    expect(assignMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
+    screen.getAllByRole("button", { name: "Run screening" })[0].click();
+    expect(mocks.navigateMock).toHaveBeenCalledWith("/applications");
     expect(screen.getByText("Started → Connected 50%")).toBeInTheDocument();
     expect(screen.getByText("1 onboarding start still need credential connection.")).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -268,6 +268,116 @@ function DashboardDecisionSummaryPanel({
   );
 }
 
+function FreeTierJourneyCard({
+  propertiesCount,
+  unitsCount,
+  applicantsCount,
+  screeningReady,
+  onAddProperty,
+  onAddUnit,
+  onAddApplicant,
+  onScreening,
+}: {
+  propertiesCount: number;
+  unitsCount: number;
+  applicantsCount: number;
+  screeningReady: boolean;
+  onAddProperty: () => void;
+  onAddUnit: () => void;
+  onAddApplicant: () => void;
+  onScreening: () => void;
+}) {
+  const steps = [
+    {
+      id: "property",
+      label: "Add property",
+      done: propertiesCount > 0,
+      helper: propertiesCount > 0 ? `${propertiesCount} propert${propertiesCount === 1 ? "y" : "ies"} added` : "Start with the rental address.",
+      action: onAddProperty,
+      actionLabel: propertiesCount > 0 ? "View properties" : "Add property",
+    },
+    {
+      id: "unit",
+      label: "Add unit",
+      done: unitsCount > 0,
+      helper: unitsCount > 0 ? `${unitsCount} unit${unitsCount === 1 ? "" : "s"} added` : "Add rent, beds, baths, and occupancy.",
+      action: onAddUnit,
+      actionLabel: unitsCount > 0 ? "View units" : "Add unit",
+    },
+    {
+      id: "applicant",
+      label: "Add applicant",
+      done: applicantsCount > 0,
+      helper: applicantsCount > 0 ? `${applicantsCount} applicant${applicantsCount === 1 ? "" : "s"} started` : "Send an application after a unit exists.",
+      action: onAddApplicant,
+      actionLabel: applicantsCount > 0 ? "View applicants" : "Add applicant",
+    },
+    {
+      id: "screening",
+      label: "Run screening",
+      done: screeningReady,
+      helper: screeningReady ? "Screening setup is connected." : "Screening is the upgrade-ready next step.",
+      action: onScreening,
+      actionLabel: screeningReady ? "Run screening" : "Review screening",
+    },
+  ];
+  const nextStep = steps.find((step) => !step.done) || steps[steps.length - 1];
+
+  return (
+    <Card
+      data-testid="free-tier-journey-card"
+      style={{
+        padding: spacing.md,
+        border: `1px solid ${colors.border}`,
+        display: "grid",
+        gap: spacing.md,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
+        <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+          <div style={{ fontWeight: 800, fontSize: 18 }}>Start in order</div>
+          <div style={{ color: text.muted, lineHeight: 1.55 }}>
+            Free tier works best when setup follows property, unit, applicant, screening, then lease.
+          </div>
+        </div>
+        <Button onClick={nextStep.action}>{nextStep.actionLabel}</Button>
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 160px), 1fr))",
+          gap: spacing.sm,
+        }}
+      >
+        {steps.map((step, index) => (
+          <button
+            key={step.id}
+            type="button"
+            onClick={step.action}
+            style={{
+              textAlign: "left",
+              border: `1px solid ${step.done ? "rgba(16,185,129,0.35)" : colors.border}`,
+              background: step.done ? "rgba(236,253,245,0.88)" : colors.panel,
+              borderRadius: 8,
+              padding: 12,
+              display: "grid",
+              gap: 6,
+              cursor: "pointer",
+              minWidth: 0,
+            }}
+          >
+            <div style={{ color: step.done ? "#047857" : text.muted, fontSize: 12, fontWeight: 900 }}>
+              Step {index + 1}
+            </div>
+            <div style={{ color: text.primary, fontWeight: 800 }}>{step.label}</div>
+            <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }}>{step.helper}</div>
+          </button>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
 const DashboardPage: React.FC = () => {
   // Guardrail: declare derived values used in hook deps above the hooks that depend on them.
   const [data, setData] = React.useState<any | null>(null);
@@ -630,22 +740,6 @@ const DashboardPage: React.FC = () => {
 
   const fallbackActions = React.useMemo(() => {
     const items: Array<{ id: string; title: string; severity: "info"; href: string }> = [];
-    if (SCREENING_ENABLED && canManualScreen && (kpis.screeningsCount ?? 0) === 0) {
-      items.push({
-        id: "run-first-screening",
-        title: "Set up screening workflow",
-        severity: "info",
-        href: "/applications?openTransUnionAccess=1",
-      });
-    }
-    if (tenantCount === 0) {
-      items.push({
-        id: "invite-tenant",
-        title: "Invite a tenant",
-        severity: "info",
-        href: "/tenants",
-      });
-    }
     if (derivedPropertiesCount === 0) {
       items.push({
         id: "add-property",
@@ -654,8 +748,32 @@ const DashboardPage: React.FC = () => {
         href: "/properties",
       });
     }
+    if (derivedPropertiesCount > 0 && derivedUnitsCount === 0) {
+      items.push({
+        id: "add-unit",
+        title: "Add a unit",
+        severity: "info",
+        href: "/properties?openAddUnit=1",
+      });
+    }
+    if (derivedUnitsCount > 0 && applicationsCount === 0) {
+      items.push({
+        id: "add-applicant",
+        title: "Add an applicant",
+        severity: "info",
+        href: "/applications?openSendApplication=1",
+      });
+    }
+    if (SCREENING_ENABLED && canManualScreen && applicationsCount > 0 && (kpis.screeningsCount ?? 0) === 0) {
+      items.push({
+        id: "run-first-screening",
+        title: "Set up screening workflow",
+        severity: "info",
+        href: "/applications?openTransUnionAccess=1",
+      });
+    }
     return items;
-  }, [canManualScreen, derivedPropertiesCount, kpis.screeningsCount, tenantCount]);
+  }, [applicationsCount, canManualScreen, derivedPropertiesCount, derivedUnitsCount, kpis.screeningsCount]);
   const actions = Array.isArray(data?.actions) && data.actions.length > 0 ? data.actions : fallbackActions;
   const leaseNoticeSummary = data?.leaseNoticeSummary || {
     expiringSoon: 0,
@@ -832,6 +950,19 @@ const DashboardPage: React.FC = () => {
         ) : null}
 
         {dataReady ? (
+          <FreeTierJourneyCard
+            propertiesCount={derivedPropertiesCount}
+            unitsCount={derivedUnitsCount}
+            applicantsCount={applicationsCount}
+            screeningReady={screeningSetupComplete}
+            onAddProperty={() => navigate("/properties?focus=addProperty")}
+            onAddUnit={() => navigate("/properties?openAddUnit=1")}
+            onAddApplicant={handleCreateApplicationClick}
+            onScreening={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}
+          />
+        ) : null}
+
+        {dataReady ? (
           <div
             data-testid="dashboard-kpi-decision-stack"
             style={{
@@ -854,11 +985,6 @@ const DashboardPage: React.FC = () => {
                 openActionsCount: "/dashboard#open-actions",
                 delinquentCount: "/payments?filter=delinquent",
               }}
-            />
-            <DashboardDecisionSummaryPanel
-              decisions={dashboardDecisions}
-              pendingId={decisionActionPendingId}
-              onAction={handleDashboardDecisionAction}
             />
           </div>
         ) : null}
@@ -1023,6 +1149,22 @@ const DashboardPage: React.FC = () => {
                 </Button>
                 <Button
                   variant="secondary"
+                  onClick={() => navigate("/properties?openAddUnit=1")}
+                  aria-label="Add unit"
+                  disabled={progressLoading}
+                >
+                  Add unit
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={handleCreateApplicationClick}
+                  aria-label="Add applicant"
+                  disabled={progressLoading}
+                >
+                  Add applicant
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() => navigate("/tenants?invite=1")}
                   aria-label="Invite tenant"
                   disabled={progressLoading}
@@ -1036,14 +1178,6 @@ const DashboardPage: React.FC = () => {
                   disabled={progressLoading}
                 >
                   Generate Lease Pack
-                </Button>
-                <Button
-                  variant="secondary"
-                  onClick={handleCreateApplicationClick}
-                  aria-label="Send application link"
-                  disabled={progressLoading}
-                >
-                  Send application link
                 </Button>
                 <Button
                   variant="secondary"
@@ -1206,6 +1340,26 @@ const DashboardPage: React.FC = () => {
               </div>
             ) : null}
           </Card>
+        ) : null}
+
+        {dataReady ? (
+          <details
+            style={{
+              border: `1px solid ${colors.border}`,
+              borderRadius: 8,
+              padding: spacing.md,
+              background: colors.card,
+            }}
+          >
+            <summary style={{ cursor: "pointer", fontWeight: 800 }}>Decision inbox summary</summary>
+            <div style={{ marginTop: spacing.md }}>
+              <DashboardDecisionSummaryPanel
+                decisions={dashboardDecisions}
+                pendingId={decisionActionPendingId}
+                onAction={handleDashboardDecisionAction}
+              />
+            </div>
+          </details>
         ) : null}
 
         {dataReady && canUseReferrals ? (


### PR DESCRIPTION
## Summary
- Add a dashboard setup-order card for property -> unit -> applicant -> screening
- Reorder dashboard fallback actions and quick actions around the first 30-minute free-tier journey
- De-emphasize Operations and Decisions from primary landlord navigation while keeping routes available
- Update mobile landlord tabs to Dashboard, Properties, Applicants, Inbox, More

## Validation
- npm test -- DashboardPage.test.tsx LandlordNav.test.tsx
- git diff --check
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build
- npm test
- npm run lint

## Notes
- Frontend-only change
- No entitlement, billing, backend route, Firestore rule, or API contract changes
- Manual preview QA still recommended for free-tier dashboard and mobile navigation