### PR TITLE
fix: reorder free landlord onboarding flow

### DIFF
--- a/rentchain-api/src/routes/__tests__/applicationsRoutes.applyWithRentChain.test.ts
+++ b/rentchain-api/src/routes/__tests__/applicationsRoutes.applyWithRentChain.test.ts
@@ -3,8 +3,60 @@ import { APPLICATIONS } from "../../services/applicationsService";
 
 const writeCanonicalEvent = vi.fn().mockResolvedValue(undefined);
 
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function docsFor(name: string, filters: Array<{ field: string; value: any }>) {
+    return Array.from(ensureCollection(name).entries())
+      .filter(([, data]) => filters.every((filter) => data?.[filter.field] === filter.value))
+      .map(([id, data]) => ({ id, data: () => data }));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; value: any }> = []) {
+    return {
+      where: (field: string, _op: string, value: any) => makeQuery(name, [...filters, { field, value }]),
+      limit: () => makeQuery(name, filters),
+      get: async () => {
+        const docs = docsFor(name, filters);
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+    };
+  }
+  return {
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, value }]),
+        limit: () => makeQuery(name),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => ({
+          get: async () => ({
+            exists: ensureCollection(name).has(id),
+            id,
+            data: () => ensureCollection(name).get(id),
+          }),
+        }),
+      }),
+    },
+    resetFakeDb: () => store.clear(),
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, data),
+  };
+});
+
 vi.mock("../../lib/events/buildEvent", () => ({
   writeCanonicalEvent,
+}));
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
 }));
 
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
@@ -103,6 +155,7 @@ function buildPayload(overrides: Record<string, any> = {}) {
 describe("applicationsRoutes apply with RentChain metadata", () => {
   beforeEach(() => {
     APPLICATIONS.splice(0, APPLICATIONS.length);
+    resetFakeDb();
     vi.clearAllMocks();
   });
 
@@ -148,5 +201,23 @@ describe("applicationsRoutes apply with RentChain metadata", () => {
         }),
       })
     );
+  });
+
+  it("does not leak legacy in-memory applications into landlord-scoped list responses", async () => {
+    APPLICATIONS.push(buildPayload({ id: "legacy-demo", landlordId: "other-landlord" }) as any);
+    seedDoc("applications", "other-firestore", {
+      landlordId: "other-landlord",
+      applicant: { firstName: "Other", lastName: "Landlord" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    const router = (await import("../applicationsRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/applications",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
   });
 });

--- a/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
@@ -283,4 +283,25 @@ describe("dashboardRoutes GET /summary", () => {
       })
     );
   });
+
+  it("routes free applicant intake to manual Applications guidance instead of the link modal", async () => {
+    resolveLandlordAndTierMock.mockResolvedValue({ tier: "free" });
+    seedDoc("properties", "prop-active", {
+      landlordId: "landlord-1",
+      portfolioStatus: "active",
+      units: [{ id: "unit-1" }],
+    });
+
+    const app = await makeApp();
+    const response = await invokeSummary(app);
+
+    expect(response.status).toBe(200);
+    expect(response.body?.data?.actions).toEqual([
+      expect.objectContaining({
+        id: "add-applicant",
+        title: "Track an applicant",
+        href: "/applications",
+      }),
+    ]);
+  });
 });

--- a/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
@@ -208,6 +208,11 @@ describe("dashboardRoutes GET /summary", () => {
       propertyId: "prop-active",
       hiddenFromActiveLists: false,
     });
+    seedDoc("applications", "application-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      unitId: "unit-1",
+    });
 
     const app = await makeApp();
     const response = await invokeSummary(app);
@@ -221,6 +226,25 @@ describe("dashboardRoutes GET /summary", () => {
         }),
       ])
     );
+  });
+
+  it("recommends applicant intake before screening when property and unit context exist", async () => {
+    seedDoc("properties", "prop-active", {
+      landlordId: "landlord-1",
+      portfolioStatus: "active",
+      units: [{ id: "unit-1" }],
+    });
+
+    const app = await makeApp();
+    const response = await invokeSummary(app);
+
+    expect(response.status).toBe(200);
+    expect(response.body?.data?.actions).toEqual([
+      expect.objectContaining({
+        id: "add-applicant",
+        href: "/applications?openSendApplication=1",
+      }),
+    ]);
   });
 
   it("derives expiring, pending, and no-response counts from the shared renewal dataset", async () => {

--- a/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
@@ -228,6 +228,93 @@ describe("dashboardRoutes GET /summary", () => {
     );
   });
 
+  it("counts only applications scoped to active visible landlord properties", async () => {
+    seedDoc("properties", "prop-active", {
+      landlordId: "landlord-1",
+      portfolioStatus: "active",
+      units: [{ id: "unit-1" }],
+    });
+    seedDoc("properties", "prop-archived", {
+      landlordId: "landlord-1",
+      portfolioStatus: "archived",
+      units: [{ id: "unit-2" }],
+    });
+    seedDoc("properties", "prop-hidden", {
+      landlordId: "landlord-1",
+      portfolioStatus: "active",
+      hiddenFromActiveLists: true,
+      units: [{ id: "unit-3" }],
+    });
+    seedDoc("applications", "application-active", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      unitId: "unit-1",
+    });
+    seedDoc("applications", "application-archived", {
+      landlordId: "landlord-1",
+      propertyId: "prop-archived",
+      unitId: "unit-2",
+    });
+    seedDoc("applications", "application-hidden", {
+      landlordId: "landlord-1",
+      propertyId: "prop-hidden",
+      unitId: "unit-3",
+    });
+    seedDoc("applications", "application-missing-property", {
+      landlordId: "landlord-1",
+      propertyId: "missing-property",
+      unitId: "unit-4",
+    });
+    seedDoc("applications", "application-other-landlord", {
+      landlordId: "other-landlord",
+      propertyId: "prop-active",
+      unitId: "unit-1",
+    });
+
+    const app = await makeApp();
+    const response = await invokeSummary(app);
+
+    expect(response.status).toBe(200);
+    expect(response.body?.data?.kpis?.applicationsCount).toBe(1);
+    expect(response.body?.data?.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "run-first-screening",
+          href: "/applications?openTransUnionAccess=1",
+        }),
+      ])
+    );
+  });
+
+  it("does not let stale landlordId-only applications satisfy applicant setup", async () => {
+    seedDoc("properties", "prop-active", {
+      landlordId: "landlord-1",
+      portfolioStatus: "active",
+      units: [{ id: "unit-1" }],
+    });
+    seedDoc("applications", "application-missing-property", {
+      landlordId: "landlord-1",
+      propertyId: "missing-property",
+      unitId: "unit-2",
+    });
+    seedDoc("applications", "application-no-property", {
+      landlordId: "landlord-1",
+      unitId: "unit-3",
+    });
+
+    const app = await makeApp();
+    const response = await invokeSummary(app);
+
+    expect(response.status).toBe(200);
+    expect(response.body?.data?.kpis?.applicationsCount).toBe(0);
+    expect(response.body?.data?.actions).toEqual([
+      expect.objectContaining({
+        id: "add-applicant",
+        href: "/applications?openSendApplication=1",
+      }),
+    ]);
+  });
+
   it("recommends applicant intake before screening when property and unit context exist", async () => {
     seedDoc("properties", "prop-active", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/applicationsRoutes.ts
+++ b/rentchain-api/src/routes/applicationsRoutes.ts
@@ -526,9 +526,7 @@ router.get("/applications", async (req: any, res) => {
     const toMillis = (v: any) => (v?.toMillis?.() ?? Date.parse(v || "") ?? 0);
     items.sort((a, b) => (toMillis(b.createdAt) || 0) - (toMillis(a.createdAt) || 0));
 
-    // Fallback to in-memory if Firestore empty (legacy/demo)
-    const result = items.length ? items : getApplications().map(normalizeApplicantFields);
-    return res.status(200).json(result);
+    return res.status(200).json(items);
   } catch (err: any) {
     console.error("[applications] list failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "Failed to load applications" });

--- a/rentchain-api/src/routes/dashboardRoutes.ts
+++ b/rentchain-api/src/routes/dashboardRoutes.ts
@@ -149,6 +149,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
     invitesSnap,
     referralsSnap,
     screeningSnap,
+    applicationsSnap,
     ledgerEventsSnap,
     leasesSnap,
     leaseNoticesSnap,
@@ -158,6 +159,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
     db.collection("tenantInvites").where("landlordId", "==", landlordId).limit(20).get(),
     db.collection("referrals").where("referrerLandlordId", "==", landlordId).limit(20).get(),
     db.collection("screeningOrders").where("landlordId", "==", landlordId).limit(30).get(),
+    db.collection("applications").where("landlordId", "==", landlordId).limit(30).get(),
     db.collection("ledgerEvents").where("landlordId", "==", landlordId).limit(20).get(),
     db.collection("leases").where("landlordId", "==", landlordId).limit(400).get(),
     db.collection("leaseNotices").where("landlordId", "==", landlordId).limit(400).get(),
@@ -177,6 +179,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
 
   const screeningOrders = screeningSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
   const screeningsCount = screeningOrders.length;
+  const applicationsCount = applicationsSnap.size;
   const tenantCredibilityRecords = tenantsSnap.docs.map((doc) => {
     const raw = doc.data() as any;
     return {
@@ -352,28 +355,40 @@ router.get("/summary", requireAuth, async (req: any, res) => {
       href: "/billing",
     });
   } else {
-    if (screeningsCount === 0) {
-      actions.push({
-        id: "run-first-screening",
-        title: "Run your first screening",
-        severity: "info",
-        href: "/applications?openTransUnionAccess=1",
-      });
-    }
-    if (activeTenantsCount === 0) {
-      actions.push({
-        id: "invite-tenant",
-        title: "Invite a tenant",
-        severity: "info",
-        href: "/tenants",
-      });
-    }
     if (propertiesSnap.empty) {
       actions.push({
         id: "add-property",
         title: "Add a property",
         severity: "info",
         href: "/properties",
+      });
+    } else if (unitsCount === 0) {
+      actions.push({
+        id: "add-unit",
+        title: "Add a unit",
+        severity: "info",
+        href: "/properties?openAddUnit=1",
+      });
+    } else if (applicationsCount === 0) {
+      actions.push({
+        id: "add-applicant",
+        title: "Add an applicant",
+        severity: "info",
+        href: "/applications?openSendApplication=1",
+      });
+    } else if (screeningsCount === 0) {
+      actions.push({
+        id: "run-first-screening",
+        title: "Run your first screening",
+        severity: "info",
+        href: "/applications?openTransUnionAccess=1",
+      });
+    } else if (activeTenantsCount === 0) {
+      actions.push({
+        id: "invite-tenant",
+        title: "Invite a tenant",
+        severity: "info",
+        href: "/tenants",
       });
     }
   }
@@ -386,6 +401,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
       openActionsCount: actions.length,
       delinquentCount: 0,
       screeningsCount,
+      applicationsCount,
     },
     rent: {
       month,

--- a/rentchain-api/src/routes/dashboardRoutes.ts
+++ b/rentchain-api/src/routes/dashboardRoutes.ts
@@ -345,6 +345,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   const tierResolved = await resolveLandlordAndTier(req.user);
   const tier = tierResolved.tier;
   const isStarter = tier === "starter";
+  const isFree = tier === "free";
 
   const actions: Array<{ id: string; title: string; severity: "info"; href: string }> = [];
   if (isStarter) {
@@ -372,9 +373,9 @@ router.get("/summary", requireAuth, async (req: any, res) => {
     } else if (applicationsCount === 0) {
       actions.push({
         id: "add-applicant",
-        title: "Add an applicant",
+        title: isFree ? "Track an applicant" : "Add an applicant",
         severity: "info",
-        href: "/applications?openSendApplication=1",
+        href: isFree ? "/applications" : "/applications?openSendApplication=1",
       });
     } else if (screeningsCount === 0) {
       actions.push({

--- a/rentchain-api/src/routes/dashboardRoutes.ts
+++ b/rentchain-api/src/routes/dashboardRoutes.ts
@@ -28,6 +28,15 @@ function isVisibleActiveTenant(raw: any) {
   return raw?.hiddenFromActiveLists !== true && !isTargetedHiddenTenantId(raw?.id);
 }
 
+function isVisibleActiveProperty(raw: any) {
+  return raw?.hiddenFromActiveLists !== true && normalizePortfolioStatus(raw?.portfolioStatus) === "active";
+}
+
+function isApplicationScopedToActiveProperty(raw: any, activePropertyIds: Set<string>) {
+  const propertyId = String(raw?.propertyId || "").trim();
+  return Boolean(propertyId && activePropertyIds.has(propertyId));
+}
+
 // Set route source header for debugging
 router.use((req, res, next) => {
   res.setHeader("x-route-source", "dashboardRoutes");
@@ -168,7 +177,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   const properties = propertiesSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
   const activePropertyIds = new Set(
     properties
-      .filter((property) => normalizePortfolioStatus(property?.portfolioStatus) === "active")
+      .filter(isVisibleActiveProperty)
       .map((property) => String(property?.id || "").trim())
       .filter(Boolean)
   );
@@ -179,7 +188,10 @@ router.get("/summary", requireAuth, async (req: any, res) => {
 
   const screeningOrders = screeningSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
   const screeningsCount = screeningOrders.length;
-  const applicationsCount = applicationsSnap.size;
+  const scopedApplications = applicationsSnap.docs
+    .map((doc) => ({ id: doc.id, ...(doc.data() as any) }))
+    .filter((application) => isApplicationScopedToActiveProperty(application, activePropertyIds));
+  const applicationsCount = scopedApplications.length;
   const tenantCredibilityRecords = tenantsSnap.docs.map((doc) => {
     const raw = doc.data() as any;
     return {

--- a/rentchain-frontend/src/api/dashboard.ts
+++ b/rentchain-frontend/src/api/dashboard.ts
@@ -8,6 +8,7 @@ export type DashboardKpis = {
   openActionsCount: number;
   delinquentCount: number;
   screeningsCount?: number;
+  applicationsCount?: number;
 };
 
 export type DashboardRent = {

--- a/rentchain-frontend/src/components/onboarding/GettingStartedCard.tsx
+++ b/rentchain-frontend/src/components/onboarding/GettingStartedCard.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import { Card, Button } from "../ui/Ui";
 import { colors, radius, spacing, text } from "../../styles/tokens";
 
 type GettingStartedCardProps = {
   propertiesCount: number;
   unitsCount: number;
-  tenantsCount: number;
-  inviteTenantHref?: string;
+  applicationsCount?: number;
+  screeningsCount?: number;
   onAddProperty: () => void;
+  onAddApplicant?: () => void;
 };
 
 type StepRowProps = {
@@ -52,20 +52,21 @@ function StepRow({ done, title, description, action }: StepRowProps) {
 export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
   propertiesCount,
   unitsCount,
-  tenantsCount,
-  inviteTenantHref,
+  applicationsCount = 0,
+  screeningsCount = 0,
   onAddProperty,
+  onAddApplicant,
 }) => {
   const propertyDone = propertiesCount > 0;
   const unitDone = unitsCount > 0;
-  const tenantDone = tenantsCount > 0;
-  const canInviteTenant = propertyDone && unitDone && Boolean(inviteTenantHref);
+  const applicantDone = applicationsCount > 0;
+  const screeningDone = screeningsCount > 0;
 
   return (
     <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
       <div style={{ fontWeight: 700, marginBottom: spacing.xs }}>Getting started</div>
       <div style={{ color: text.muted, marginBottom: spacing.md }}>
-        Start your portfolio setup with these three steps.
+        Start your portfolio setup in the order landlords validated during onboarding.
       </div>
 
       <div style={{ display: "grid", gap: spacing.sm }}>
@@ -91,33 +92,43 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
         />
 
         <StepRow
-          done={tenantDone}
-          title="3. Invite first tenant"
+          done={applicantDone}
+          title="3. Add first applicant"
           description={
             !propertyDone
-              ? "Add a property first so tenant records have a home."
+              ? "Add a property first so applicant records have a home."
               : !unitDone
-              ? "Add at least one unit before inviting a tenant."
-              : "Invite a tenant to start collecting applications and screening consent."
+              ? "Add at least one unit before starting applicant intake."
+              : "Send an application link or start the applicant record for the unit."
           }
           action={
-            canInviteTenant ? (
-              <Link
-                to={inviteTenantHref}
-                style={{
-                  display: "inline-block",
-                  color: colors.accent,
-                  fontWeight: 600,
-                  textDecoration: "none",
-                }}
-              >
-                Invite first tenant
-              </Link>
+            propertyDone && unitDone && onAddApplicant ? (
+              <Button onClick={onAddApplicant} aria-label="Add first applicant">
+                Add first applicant
+              </Button>
             ) : (
-              <span style={{ color: text.muted, fontSize: 13 }}>
-                Complete this step to continue.
-              </span>
+              <span style={{ color: text.muted, fontSize: 13 }}>Complete the prior step to continue.</span>
             )
+          }
+        />
+
+        <StepRow
+          done={screeningDone}
+          title="4. Run screening"
+          description={
+            applicantDone
+              ? "Open the screening workflow once applicant context exists."
+              : "Add an applicant before screening becomes the next step."
+          }
+        />
+
+        <StepRow
+          done={false}
+          title="5. Create lease"
+          description={
+            applicantDone
+              ? "Prepare lease documents after applicant and screening context exists."
+              : "Applicant context comes before lease preparation."
           }
         />
       </div>

--- a/rentchain-frontend/src/components/onboarding/GettingStartedCard.tsx
+++ b/rentchain-frontend/src/components/onboarding/GettingStartedCard.tsx
@@ -9,6 +9,7 @@ type GettingStartedCardProps = {
   screeningsCount?: number;
   onAddProperty: () => void;
   onAddApplicant?: () => void;
+  applicantActionLabel?: string;
 };
 
 type StepRowProps = {
@@ -56,6 +57,7 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
   screeningsCount = 0,
   onAddProperty,
   onAddApplicant,
+  applicantActionLabel = "Add first applicant",
 }) => {
   const propertyDone = propertiesCount > 0;
   const unitDone = unitsCount > 0;
@@ -103,8 +105,8 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
           }
           action={
             propertyDone && unitDone && onAddApplicant ? (
-              <Button onClick={onAddApplicant} aria-label="Add first applicant">
-                Add first applicant
+              <Button onClick={onAddApplicant} aria-label={applicantActionLabel}>
+                {applicantActionLabel}
               </Button>
             ) : (
               <span style={{ color: text.muted, fontSize: 13 }}>Complete the prior step to continue.</span>

--- a/rentchain-frontend/src/lib/onboardingSteps.test.ts
+++ b/rentchain-frontend/src/lib/onboardingSteps.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildOnboardingSteps } from "./onboardingSteps";
+
+describe("buildOnboardingSteps", () => {
+  it("orders landlord onboarding as property, unit, applicant, screening, lease", () => {
+    const steps = buildOnboardingSteps({
+      onboarding: {
+        steps: {
+          propertyAdded: false,
+          unitAdded: false,
+          applicationCreated: false,
+          exportPreviewed: false,
+          leasePackGenerated: false,
+        },
+      },
+      navigate: vi.fn(),
+      track: vi.fn(),
+      propertiesCount: 0,
+      unitsCount: 0,
+    });
+
+    expect(steps.map((step) => step.title)).toEqual([
+      "Add your first property",
+      "Add units",
+      "Add an applicant",
+      "Run screening",
+      "Create lease",
+    ]);
+    expect(steps.find((step) => step.title === "Run screening")?.actionLabel).toBe("Add applicant");
+  });
+
+  it("routes screening and lease actions through applicant setup until an application exists", () => {
+    const navigate = vi.fn();
+    const track = vi.fn();
+    const steps = buildOnboardingSteps({
+      onboarding: {
+        steps: {
+          propertyAdded: true,
+          unitAdded: true,
+          applicationCreated: false,
+          exportPreviewed: false,
+          leasePackGenerated: false,
+        },
+      },
+      navigate,
+      track,
+      propertiesCount: 1,
+      unitsCount: 1,
+    });
+
+    steps.find((step) => step.title === "Run screening")?.onAction();
+    steps.find((step) => step.title === "Create lease")?.onAction();
+
+    expect(navigate).toHaveBeenCalledTimes(2);
+    expect(navigate).toHaveBeenNthCalledWith(1, "/applications?autoSelectProperty=1&openSendApplication=1");
+    expect(navigate).toHaveBeenNthCalledWith(2, "/applications?autoSelectProperty=1&openSendApplication=1");
+    expect(track).toHaveBeenCalledWith("onboarding_step_clicked", { stepKey: "applicationCreated" });
+  });
+});

--- a/rentchain-frontend/src/lib/onboardingSteps.test.ts
+++ b/rentchain-frontend/src/lib/onboardingSteps.test.ts
@@ -26,10 +26,10 @@ describe("buildOnboardingSteps", () => {
       "Run screening",
       "Create lease",
     ]);
-    expect(steps.find((step) => step.title === "Run screening")?.actionLabel).toBe("Add applicant");
+    expect(steps.find((step) => step.title === "Run screening")?.actionLabel).toBe("Track applicant");
   });
 
-  it("routes screening and lease actions through applicant setup until an application exists", () => {
+  it("routes free screening and lease actions through manual applicant intake until an application exists", () => {
     const navigate = vi.fn();
     const track = vi.fn();
     const steps = buildOnboardingSteps({
@@ -46,14 +46,39 @@ describe("buildOnboardingSteps", () => {
       track,
       propertiesCount: 1,
       unitsCount: 1,
+      plan: "free",
     });
 
     steps.find((step) => step.title === "Run screening")?.onAction();
     steps.find((step) => step.title === "Create lease")?.onAction();
 
     expect(navigate).toHaveBeenCalledTimes(2);
-    expect(navigate).toHaveBeenNthCalledWith(1, "/applications?autoSelectProperty=1&openSendApplication=1");
-    expect(navigate).toHaveBeenNthCalledWith(2, "/applications?autoSelectProperty=1&openSendApplication=1");
+    expect(navigate).toHaveBeenNthCalledWith(1, "/applications");
+    expect(navigate).toHaveBeenNthCalledWith(2, "/applications");
     expect(track).toHaveBeenCalledWith("onboarding_step_clicked", { stepKey: "applicationCreated" });
+  });
+
+  it("routes paid applicant setup to the application link workflow", () => {
+    const navigate = vi.fn();
+    const steps = buildOnboardingSteps({
+      onboarding: {
+        steps: {
+          propertyAdded: true,
+          unitAdded: true,
+          applicationCreated: false,
+          exportPreviewed: false,
+          leasePackGenerated: false,
+        },
+      },
+      navigate,
+      track: vi.fn(),
+      propertiesCount: 1,
+      unitsCount: 1,
+      plan: "starter",
+    });
+
+    steps.find((step) => step.title === "Add an applicant")?.onAction();
+
+    expect(navigate).toHaveBeenCalledWith("/applications?autoSelectProperty=1&openSendApplication=1");
   });
 });

--- a/rentchain-frontend/src/lib/onboardingSteps.ts
+++ b/rentchain-frontend/src/lib/onboardingSteps.ts
@@ -30,20 +30,6 @@ export function buildOnboardingSteps({
   unitsCount = 0,
 }: BuildArgs): OnboardingStep[] {
   const prereq = getApplicationPrereqState({ propertiesCount, unitsCount });
-  const routeToInviteTenant = () => {
-    if (prereq.missingProperty) {
-      track("onboarding_step_clicked", { stepKey: "tenantInvited", blockedBy: "no_property" });
-      navigate("/properties?focus=addProperty");
-      return;
-    }
-    if (prereq.missingUnit) {
-      track("onboarding_step_clicked", { stepKey: "tenantInvited", blockedBy: "no_units" });
-      navigate("/properties?openAddUnit=1");
-      return;
-    }
-    track("onboarding_step_clicked", { stepKey: "tenantInvited" });
-    navigate("/tenants?invite=1");
-  };
   const routeToCreateApplication = () => {
     if (prereq.missingProperty) {
       track("onboarding_step_clicked", { stepKey: "applicationCreated", blockedBy: "no_property" });
@@ -74,7 +60,7 @@ export function buildOnboardingSteps({
     {
       key: "unitAdded",
       title: "Add units",
-      description: "Add units so you can invite tenants and track rent.",
+      description: "Add units so applicants and lease records have property context.",
       isComplete: !!onboarding.steps.unitAdded,
       actionLabel: "Add units",
       onAction: () => {
@@ -83,54 +69,49 @@ export function buildOnboardingSteps({
       },
     },
     {
-      key: "tenantInvited",
-      title: "Invite a tenant",
-      description: prereq.missingProperty
-        ? "Add your first property to unlock tenant invites."
-        : prereq.missingUnit
-        ? "Add a unit before inviting tenants so each invite is tied to the right rental."
-        : "Send your first tenant invite.",
-      isComplete: !!onboarding.steps.tenantInvited,
-      actionLabel: prereq.missingProperty
-        ? "Add property"
-        : prereq.missingUnit
-        ? "Add unit"
-        : "Invite tenant",
-      onAction: routeToInviteTenant,
-    },
-    {
       key: "applicationCreated",
-      title: "Create an application",
-      description: "Invite an applicant or start an application record.",
+      title: "Add an applicant",
+      description: prereq.missingProperty
+        ? "Add your first property before starting applicant intake."
+        : prereq.missingUnit
+        ? "Add a unit before starting applicant intake."
+        : "Send an application link or start an applicant record.",
       isComplete: !!onboarding.steps.applicationCreated,
-      actionLabel: "Send application link",
+      actionLabel: prereq.missingProperty ? "Add property" : prereq.missingUnit ? "Add unit" : "Add applicant",
       onAction: routeToCreateApplication,
       isPrimary: true,
     },
     {
       key: "exportPreviewed",
-      title: "Preview export (Pro)",
-      description: "See the export preview and unlock Pro when you're ready.",
+      title: "Run screening",
+      description: onboarding.steps.applicationCreated
+        ? "Review screening setup from Applications when the applicant is ready."
+        : "Add an applicant before screening appears.",
       isComplete: !!onboarding.steps.exportPreviewed,
-      actionLabel: "Preview export",
+      actionLabel: onboarding.steps.applicationCreated ? "Review screening" : "Add applicant",
       onAction: () => {
         track("onboarding_step_clicked", { stepKey: "exportPreviewed" });
-        const url = "/sample/screening_report_sample.pdf";
-        if (typeof window !== "undefined") {
-          window.location.assign(url);
+        if (!onboarding.steps.applicationCreated) {
+          routeToCreateApplication();
           return;
         }
-        navigate(url);
+        navigate("/applications?openTransUnionAccess=1");
       },
     },
     {
       key: "leasePackGenerated",
-      title: "Generate lease pack",
-      description: "Choose a property and download a province lease pack bundle or individual docs.",
+      title: "Create lease",
+      description: onboarding.steps.applicationCreated
+        ? "Create the lease after applicant and screening context exists."
+        : "Add an applicant before preparing lease documents.",
       isComplete: !!onboarding.steps.leasePackGenerated,
-      actionLabel: "Generate Lease Pack",
+      actionLabel: onboarding.steps.applicationCreated ? "Create lease" : "Add applicant",
       onAction: () => {
         track("onboarding_step_clicked", { stepKey: "leasePackGenerated" });
+        if (!onboarding.steps.applicationCreated) {
+          routeToCreateApplication();
+          return;
+        }
         navigate("/properties?openLeasePack=1");
       },
     },

--- a/rentchain-frontend/src/lib/onboardingSteps.ts
+++ b/rentchain-frontend/src/lib/onboardingSteps.ts
@@ -1,4 +1,5 @@
 import { getApplicationPrereqState } from "./applicationPrereqs";
+import { normalizePlan, type Plan } from "./plan";
 
 export type OnboardingStep = {
   key: string;
@@ -20,6 +21,7 @@ type BuildArgs = {
   track: (eventName: string, props?: Record<string, unknown>) => void;
   propertiesCount?: number;
   unitsCount?: number;
+  plan?: Plan | string;
 };
 
 export function buildOnboardingSteps({
@@ -28,8 +30,11 @@ export function buildOnboardingSteps({
   track,
   propertiesCount = 0,
   unitsCount = 0,
+  plan = "free",
 }: BuildArgs): OnboardingStep[] {
   const prereq = getApplicationPrereqState({ propertiesCount, unitsCount });
+  const currentPlan = normalizePlan(plan);
+  const isFreePlan = currentPlan === "free";
   const routeToCreateApplication = () => {
     if (prereq.missingProperty) {
       track("onboarding_step_clicked", { stepKey: "applicationCreated", blockedBy: "no_property" });
@@ -42,7 +47,7 @@ export function buildOnboardingSteps({
       return;
     }
     track("onboarding_step_clicked", { stepKey: "applicationCreated" });
-    navigate("/applications?autoSelectProperty=1&openSendApplication=1");
+    navigate(isFreePlan ? "/applications" : "/applications?autoSelectProperty=1&openSendApplication=1");
   };
 
   return [
@@ -75,9 +80,17 @@ export function buildOnboardingSteps({
         ? "Add your first property before starting applicant intake."
         : prereq.missingUnit
         ? "Add a unit before starting applicant intake."
+        : isFreePlan
+        ? "Track applicant intake manually on Free. Starter adds secure application links."
         : "Send an application link or start an applicant record.",
       isComplete: !!onboarding.steps.applicationCreated,
-      actionLabel: prereq.missingProperty ? "Add property" : prereq.missingUnit ? "Add unit" : "Add applicant",
+      actionLabel: prereq.missingProperty
+        ? "Add property"
+        : prereq.missingUnit
+        ? "Add unit"
+        : isFreePlan
+        ? "Track applicant"
+        : "Add applicant",
       onAction: routeToCreateApplication,
       isPrimary: true,
     },
@@ -88,7 +101,7 @@ export function buildOnboardingSteps({
         ? "Review screening setup from Applications when the applicant is ready."
         : "Add an applicant before screening appears.",
       isComplete: !!onboarding.steps.exportPreviewed,
-      actionLabel: onboarding.steps.applicationCreated ? "Review screening" : "Add applicant",
+      actionLabel: onboarding.steps.applicationCreated ? "Review screening" : isFreePlan ? "Track applicant" : "Add applicant",
       onAction: () => {
         track("onboarding_step_clicked", { stepKey: "exportPreviewed" });
         if (!onboarding.steps.applicationCreated) {
@@ -105,7 +118,7 @@ export function buildOnboardingSteps({
         ? "Create the lease after applicant and screening context exists."
         : "Add an applicant before preparing lease documents.",
       isComplete: !!onboarding.steps.leasePackGenerated,
-      actionLabel: onboarding.steps.applicationCreated ? "Create lease" : "Add applicant",
+      actionLabel: onboarding.steps.applicationCreated ? "Create lease" : isFreePlan ? "Track applicant" : "Add applicant",
       onAction: () => {
         track("onboarding_step_clicked", { stepKey: "leasePackGenerated" });
         if (!onboarding.steps.applicationCreated) {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -394,6 +394,11 @@ describe("DashboardPage", () => {
       isLoading: false,
       authStatus: "authed",
     });
+    mocks.useCapabilitiesMock.mockReturnValue({
+      caps: { plan: "free" },
+      features: {},
+      loading: false,
+    });
     mocks.fetchDashboardSummaryMock.mockResolvedValue({
       kpis: {
         propertiesCount: 0,
@@ -402,6 +407,7 @@ describe("DashboardPage", () => {
         openActionsCount: 0,
         delinquentCount: 0,
         screeningsCount: 0,
+        applicationsCount: 0,
       },
       actions: [
         {
@@ -436,6 +442,58 @@ describe("DashboardPage", () => {
     expect(screen.queryByRole("button", { name: "Invite tenant" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Run screening" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Set up screening workflow" })).not.toBeInTheDocument();
+  });
+
+  it("uses scoped dashboard application counts and routes Free Step 3 to manual intake", async () => {
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "landlord-1", role: "", actorRole: "landlord", plan: "free" },
+      ready: true,
+      isLoading: false,
+      authStatus: "authed",
+    });
+    mocks.useCapabilitiesMock.mockReturnValue({
+      caps: { plan: "free" },
+      features: {},
+      loading: false,
+    });
+    mocks.useApplicationsMock.mockReturnValue({
+      applications: [{ id: "demo-1" }, { id: "demo-2" }],
+      loading: false,
+    });
+    mocks.fetchDashboardSummaryMock.mockResolvedValue({
+      kpis: {
+        propertiesCount: 1,
+        unitsCount: 1,
+        tenantsCount: 0,
+        openActionsCount: 1,
+        delinquentCount: 0,
+        screeningsCount: 0,
+        applicationsCount: 0,
+      },
+      actions: [],
+      events: [],
+    });
+    mocks.fetchPropertiesMock.mockResolvedValue({
+      properties: [{ id: "property-1", name: "Main Street", units: [{ id: "unit-1" }] }],
+    });
+
+    render(
+      <ToastProvider>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByTestId("free-tier-journey-card")).toBeInTheDocument();
+    expect(screen.queryByText("2 applicants started")).not.toBeInTheDocument();
+    expect(screen.getByText("Track applicant intake after a unit exists.")).toBeInTheDocument();
+    screen.getAllByRole("button", { name: "Track applicant" })[0].click();
+    expect(mocks.navigateMock).toHaveBeenCalledWith("/applications");
+    expect(mocks.navigateMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ search: expect.stringContaining("openSendApplication") }),
+      expect.anything()
+    );
   });
 
   it("prioritizes the free-tier setup journey before review-heavy dashboard work", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -387,6 +387,57 @@ describe("DashboardPage", () => {
     expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
   });
 
+  it("starts new landlords with Add Property and hides tenant invite and screening CTAs", async () => {
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "landlord-1", role: "", actorRole: "landlord", plan: "free" },
+      ready: true,
+      isLoading: false,
+      authStatus: "authed",
+    });
+    mocks.fetchDashboardSummaryMock.mockResolvedValue({
+      kpis: {
+        propertiesCount: 0,
+        unitsCount: 0,
+        tenantsCount: 0,
+        openActionsCount: 0,
+        delinquentCount: 0,
+        screeningsCount: 0,
+      },
+      actions: [
+        {
+          id: "run-first-screening",
+          title: "Run your first screening",
+          severity: "info",
+          href: "/applications?openTransUnionAccess=1",
+        },
+        {
+          id: "invite-tenant",
+          title: "Invite a tenant",
+          severity: "info",
+          href: "/tenants",
+        },
+      ],
+      events: [],
+    });
+    mocks.fetchPropertiesMock.mockResolvedValue({ properties: [] });
+
+    render(
+      <ToastProvider>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByTestId("free-tier-journey-card")).toBeInTheDocument();
+    expect(screen.getByText("Start in order")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Add property" }).length).toBeGreaterThan(0);
+    expect(screen.getByText("Add a property before unit setup.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Invite tenant" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run screening" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Set up screening workflow" })).not.toBeInTheDocument();
+  });
+
   it("prioritizes the free-tier setup journey before review-heavy dashboard work", async () => {
     mocks.fetchDashboardSummaryMock.mockResolvedValue({
       kpis: {
@@ -535,6 +586,10 @@ describe("DashboardPage", () => {
   });
 
   it("opens an explanation from the action required Info button", async () => {
+    mocks.useApplicationsMock.mockReturnValue({
+      applications: [{ id: "application-1" }],
+      loading: false,
+    });
     mocks.fetchDashboardSummaryMock.mockResolvedValue({
       kpis: {
         propertiesCount: 1,
@@ -593,6 +648,10 @@ describe("DashboardPage", () => {
   });
 
   it("routes the provider funnel CTA to applications once TransUnion is connected", async () => {
+    mocks.useApplicationsMock.mockReturnValue({
+      applications: [{ id: "application-1" }],
+      loading: false,
+    });
     mocks.fetchDashboardSummaryMock.mockResolvedValue({
       kpis: {
         propertiesCount: 1,
@@ -642,6 +701,10 @@ describe("DashboardPage", () => {
   });
 
   it("routes the quick screening CTA to setup until TransUnion is connected, then to applications", async () => {
+    mocks.useApplicationsMock.mockReturnValue({
+      applications: [{ id: "application-1" }],
+      loading: false,
+    });
     mocks.fetchDashboardSummaryMock.mockResolvedValue({
       kpis: {
         propertiesCount: 1,
@@ -700,6 +763,10 @@ describe("DashboardPage", () => {
 
     mocks.navigateMock.mockReset();
     cleanup();
+    mocks.useApplicationsMock.mockReturnValue({
+      applications: [{ id: "application-1" }],
+      loading: false,
+    });
     mocks.fetchLandlordTransUnionOnboardingAnalyticsMock.mockResolvedValue({
       totals: {
         viewed: 3,

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -273,52 +273,87 @@ function FreeTierJourneyCard({
   unitsCount,
   applicantsCount,
   screeningReady,
+  leaseReady,
   onAddProperty,
   onAddUnit,
   onAddApplicant,
   onScreening,
+  onCreateLease,
 }: {
   propertiesCount: number;
   unitsCount: number;
   applicantsCount: number;
   screeningReady: boolean;
+  leaseReady: boolean;
   onAddProperty: () => void;
   onAddUnit: () => void;
   onAddApplicant: () => void;
   onScreening: () => void;
+  onCreateLease: () => void;
 }) {
+  const hasProperty = propertiesCount > 0;
+  const hasUnit = unitsCount > 0;
+  const hasApplicant = applicantsCount > 0;
   const steps = [
     {
       id: "property",
       label: "Add property",
-      done: propertiesCount > 0,
-      helper: propertiesCount > 0 ? `${propertiesCount} propert${propertiesCount === 1 ? "y" : "ies"} added` : "Start with the rental address.",
+      done: hasProperty,
+      helper: hasProperty ? `${propertiesCount} propert${propertiesCount === 1 ? "y" : "ies"} added` : "Start with the rental address.",
       action: onAddProperty,
-      actionLabel: propertiesCount > 0 ? "View properties" : "Add property",
+      actionLabel: hasProperty ? "View properties" : "Add property",
     },
     {
       id: "unit",
       label: "Add unit",
-      done: unitsCount > 0,
-      helper: unitsCount > 0 ? `${unitsCount} unit${unitsCount === 1 ? "" : "s"} added` : "Add rent, beds, baths, and occupancy.",
-      action: onAddUnit,
-      actionLabel: unitsCount > 0 ? "View units" : "Add unit",
+      done: hasUnit,
+      helper: hasUnit
+        ? `${unitsCount} unit${unitsCount === 1 ? "" : "s"} added`
+        : hasProperty
+        ? "Add rent, beds, baths, and occupancy."
+        : "Add a property before unit setup.",
+      action: hasProperty ? onAddUnit : onAddProperty,
+      actionLabel: hasProperty ? (hasUnit ? "View units" : "Add unit") : "Add property",
     },
     {
       id: "applicant",
       label: "Add applicant",
-      done: applicantsCount > 0,
-      helper: applicantsCount > 0 ? `${applicantsCount} applicant${applicantsCount === 1 ? "" : "s"} started` : "Send an application after a unit exists.",
-      action: onAddApplicant,
-      actionLabel: applicantsCount > 0 ? "View applicants" : "Add applicant",
+      done: hasApplicant,
+      helper: hasApplicant
+        ? `${applicantsCount} applicant${applicantsCount === 1 ? "" : "s"} started`
+        : hasUnit
+        ? "Send an application after a unit exists."
+        : "Add a unit before applicant intake.",
+      action: hasUnit ? onAddApplicant : hasProperty ? onAddUnit : onAddProperty,
+      actionLabel: hasUnit ? (hasApplicant ? "View applicants" : "Add applicant") : hasProperty ? "Add unit" : "Add property",
     },
     {
       id: "screening",
       label: "Run screening",
-      done: screeningReady,
-      helper: screeningReady ? "Screening setup is connected." : "Screening is the upgrade-ready next step.",
-      action: onScreening,
-      actionLabel: screeningReady ? "Run screening" : "Review screening",
+      done: hasApplicant && screeningReady,
+      helper: hasApplicant
+        ? screeningReady
+          ? "Screening setup is connected."
+          : "Screening is the upgrade-ready next step."
+        : "Add an applicant before screening appears.",
+      action: hasApplicant ? onScreening : hasUnit ? onAddApplicant : hasProperty ? onAddUnit : onAddProperty,
+      actionLabel: hasApplicant
+        ? screeningReady
+          ? "Run screening"
+          : "Review screening"
+        : hasUnit
+        ? "Add applicant"
+        : hasProperty
+        ? "Add unit"
+        : "Add property",
+    },
+    {
+      id: "lease",
+      label: "Create lease",
+      done: hasApplicant && leaseReady,
+      helper: hasApplicant ? "Prepare lease documents after applicant and screening context." : "Add an applicant before lease setup.",
+      action: hasApplicant ? onCreateLease : hasUnit ? onAddApplicant : hasProperty ? onAddUnit : onAddProperty,
+      actionLabel: hasApplicant ? "Create lease" : hasUnit ? "Add applicant" : hasProperty ? "Add unit" : "Add property",
     },
   ];
   const nextStep = steps.find((step) => !step.done) || steps[steps.length - 1];
@@ -774,7 +809,16 @@ const DashboardPage: React.FC = () => {
     }
     return items;
   }, [applicationsCount, canManualScreen, derivedPropertiesCount, derivedUnitsCount, kpis.screeningsCount]);
-  const actions = Array.isArray(data?.actions) && data.actions.length > 0 ? data.actions : fallbackActions;
+  const rawActions = Array.isArray(data?.actions) && data.actions.length > 0 ? data.actions : fallbackActions;
+  const visibleActions = rawActions.filter((item: any) => {
+    const id = String(item?.id || "");
+    if (id === "add-unit") return derivedPropertiesCount > 0;
+    if (id === "add-applicant") return derivedUnitsCount > 0;
+    if (id === "run-first-screening") return applicationsCount > 0;
+    if (id === "invite-tenant") return derivedPropertiesCount > 0 && derivedUnitsCount > 0;
+    return true;
+  });
+  const actions = visibleActions.length > 0 ? visibleActions : fallbackActions;
   const leaseNoticeSummary = data?.leaseNoticeSummary || {
     expiringSoon: 0,
     pendingResponse: 0,
@@ -788,8 +832,12 @@ const DashboardPage: React.FC = () => {
   const countsReady = !propsLoading && !applicationsLoading && !tenantsLoading && !invitesLoading;
   const hasNoProperties = dataReady && (kpis?.propertiesCount ?? 0) === 0;
   const hasNoApplications = dataReady && applicationsCount === 0;
+  const hasPortfolioContext = derivedPropertiesCount > 0;
+  const hasUnitContext = derivedUnitsCount > 0;
+  const hasApplicantContext = applicationsCount > 0;
   const showEmptyCTA = hasNoProperties;
   const showGettingStartedCard = isLandlord && showEmptyCTA;
+  const showScreeningWorkflowCard = dataReady && hasApplicantContext;
   const progressLoading = !dataReady || onboarding.loading;
   const showOnboardingSkeleton = onboarding.loading && !isAdmin;
   const showStarterOnboarding =
@@ -858,11 +906,11 @@ const DashboardPage: React.FC = () => {
     if (!prev.propertyAdded && derivedSteps.propertyAdded) {
       showToast({ message: "Nice — add units next.", variant: "success" });
     } else if (!prev.unitAdded && derivedSteps.unitAdded) {
-      showToast({ message: "Great — invite a tenant next.", variant: "success" });
+      showToast({ message: "Great — add an applicant next.", variant: "success" });
     } else if (!prev.tenantInvited && derivedSteps.tenantInvited) {
       showToast({ message: "Invite sent — create an application next.", variant: "success" });
     } else if (!prev.applicationCreated && derivedSteps.applicationCreated) {
-      showToast({ message: "Application started — preview export next.", variant: "success" });
+      showToast({ message: "Application started — screening is next.", variant: "success" });
     }
     prevDerivedRef.current = {
       propertyAdded: derivedSteps.propertyAdded,
@@ -955,10 +1003,12 @@ const DashboardPage: React.FC = () => {
             unitsCount={derivedUnitsCount}
             applicantsCount={applicationsCount}
             screeningReady={screeningSetupComplete}
+            leaseReady={false}
             onAddProperty={() => navigate("/properties?focus=addProperty")}
             onAddUnit={() => navigate("/properties?openAddUnit=1")}
             onAddApplicant={handleCreateApplicationClick}
             onScreening={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}
+            onCreateLease={() => navigate("/properties?openLeasePack=1")}
           />
         ) : null}
 
@@ -1133,7 +1183,7 @@ const DashboardPage: React.FC = () => {
                 loading={loading}
                 viewAllEnabled={false}
                 title="Action required"
-                emptyLabel="No pending actions. Add a property or invite a tenant to begin."
+                emptyLabel="No pending actions. Add a property to begin setup."
               />
             </div>
             <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
@@ -1147,38 +1197,36 @@ const DashboardPage: React.FC = () => {
                 >
                   Add property
                 </Button>
-                <Button
-                  variant="secondary"
-                  onClick={() => navigate("/properties?openAddUnit=1")}
-                  aria-label="Add unit"
-                  disabled={progressLoading}
-                >
-                  Add unit
-                </Button>
-                <Button
-                  variant="secondary"
-                  onClick={handleCreateApplicationClick}
-                  aria-label="Add applicant"
-                  disabled={progressLoading}
-                >
-                  Add applicant
-                </Button>
-                <Button
-                  variant="secondary"
-                  onClick={() => navigate("/tenants?invite=1")}
-                  aria-label="Invite tenant"
-                  disabled={progressLoading}
-                >
-                  Invite tenant
-                </Button>
-                <Button
-                  variant="secondary"
-                  onClick={() => navigate("/properties?openLeasePack=1")}
-                  aria-label="Generate lease pack"
-                  disabled={progressLoading}
-                >
-                  Generate Lease Pack
-                </Button>
+                {hasPortfolioContext ? (
+                  <Button
+                    variant="secondary"
+                    onClick={() => navigate("/properties?openAddUnit=1")}
+                    aria-label="Add unit"
+                    disabled={progressLoading}
+                  >
+                    Add unit
+                  </Button>
+                ) : null}
+                {hasUnitContext ? (
+                  <Button
+                    variant="secondary"
+                    onClick={handleCreateApplicationClick}
+                    aria-label="Add applicant"
+                    disabled={progressLoading}
+                  >
+                    Add applicant
+                  </Button>
+                ) : null}
+                {hasApplicantContext ? (
+                  <Button
+                    variant="secondary"
+                    onClick={() => navigate("/properties?openLeasePack=1")}
+                    aria-label="Create lease"
+                    disabled={progressLoading}
+                  >
+                    Create lease
+                  </Button>
+                ) : null}
                 <Button
                   variant="secondary"
                   onClick={() => setAddExpenseOpen(true)}
@@ -1187,19 +1235,21 @@ const DashboardPage: React.FC = () => {
                 >
                   Add Expense
                 </Button>
-                {!SCREENING_ENABLED ? (
-                  <Button variant="primary" onClick={() => navigate("/applications")}>
-                    {screeningWorkflowLabel}
-                  </Button>
-                ) : screeningSetupComplete ? (
-                  <Button variant="primary" onClick={() => navigate("/applications")}>
-                    Run screening
-                  </Button>
-                ) : (
-                  <Button variant="primary" onClick={() => navigate("/applications?openTransUnionAccess=1")}>
-                    Set up screening workflow
-                  </Button>
-                )}
+                {hasApplicantContext ? (
+                  !SCREENING_ENABLED ? (
+                    <Button variant="primary" onClick={() => navigate("/applications")}>
+                      {screeningWorkflowLabel}
+                    </Button>
+                  ) : screeningSetupComplete ? (
+                    <Button variant="primary" onClick={() => navigate("/applications")}>
+                      Run screening
+                    </Button>
+                  ) : (
+                    <Button variant="primary" onClick={() => navigate("/applications?openTransUnionAccess=1")}>
+                      Set up screening workflow
+                    </Button>
+                  )
+                ) : null}
               </div>
             </Card>
           </div>
@@ -1272,9 +1322,10 @@ const DashboardPage: React.FC = () => {
           <GettingStartedCard
             propertiesCount={derivedPropertiesCount}
             unitsCount={derivedUnitsCount}
-            tenantsCount={tenantCount}
-            inviteTenantHref="/tenants?invite=1"
+            applicationsCount={applicationsCount}
+            screeningsCount={kpis.screeningsCount ?? 0}
             onAddProperty={() => navigate("/properties")}
+            onAddApplicant={handleCreateApplicationClick}
           />
         ) : null}
 
@@ -1282,31 +1333,31 @@ const DashboardPage: React.FC = () => {
         !showStarterOnboarding &&
         derivedSteps.propertyAdded &&
         derivedSteps.unitAdded &&
-        derivedSteps.tenantInvited ? (
+        derivedSteps.applicationCreated ? (
           <Card style={{ padding: spacing.md }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Your portfolio is set up 🎉</div>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>Your applicant workflow is set up</div>
             <div style={{ color: text.muted, marginBottom: 12 }}>
-              Next up: create your first application.
+              Next up: review screening workflow setup.
             </div>
-            <Button onClick={handleCreateApplicationClick}>
-              Send application link
+            <Button onClick={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}>
+              {screeningSetupComplete ? "Run screening" : "Set up screening workflow"}
             </Button>
           </Card>
         ) : null}
 
-        {dataReady && !showEmptyCTA && hasNoApplications ? (
+        {dataReady && !showEmptyCTA && hasNoApplications && hasUnitContext ? (
           <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Next: create an application</div>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>Next: add an applicant</div>
             <div style={{ color: text.muted, marginBottom: 12 }}>
-              Invite a tenant or send an application link to keep your pipeline moving.
+              Send an application link once the property and unit are ready.
             </div>
             <Button onClick={handleCreateApplicationClick}>
-              Send application link
+              Add applicant
             </Button>
           </Card>
         ) : null}
 
-        {dataReady ? (
+        {showScreeningWorkflowCard ? (
           <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
             <div style={{ fontWeight: 700, marginBottom: 6 }}>Screening workflow</div>
             <div style={{ color: text.muted, marginBottom: 12 }}>
@@ -1322,7 +1373,7 @@ const DashboardPage: React.FC = () => {
           </Card>
         ) : null}
 
-        {dataReady && SCREENING_ENABLED ? (
+        {showScreeningWorkflowCard && SCREENING_ENABLED ? (
           <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
             <div style={{ fontWeight: 700, marginBottom: 6 }}>Provider setup funnel</div>
             <div style={{ color: text.muted, marginBottom: 12 }}>

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -34,6 +34,7 @@ import { SCREENING_ENABLED } from "../config/screening";
 import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import { UpgradeNudgeInlineCard } from "@/features/upgradeNudges/UpgradeNudgeInlineCard";
 import { canUseTimeline, normalizeTimelinePlan } from "@/features/automation/timeline/timelineEntitlements";
+import { normalizePlan } from "@/lib/plan";
 import { getLandlordActivation, type LandlordActivationSummary } from "@/api/activationApi";
 import {
   fetchLandlordTransUnionOnboardingAnalytics,
@@ -274,6 +275,7 @@ function FreeTierJourneyCard({
   applicantsCount,
   screeningReady,
   leaseReady,
+  applicantActionLabel,
   onAddProperty,
   onAddUnit,
   onAddApplicant,
@@ -285,6 +287,7 @@ function FreeTierJourneyCard({
   applicantsCount: number;
   screeningReady: boolean;
   leaseReady: boolean;
+  applicantActionLabel: string;
   onAddProperty: () => void;
   onAddUnit: () => void;
   onAddApplicant: () => void;
@@ -322,10 +325,10 @@ function FreeTierJourneyCard({
       helper: hasApplicant
         ? `${applicantsCount} applicant${applicantsCount === 1 ? "" : "s"} started`
         : hasUnit
-        ? "Send an application after a unit exists."
+        ? "Track applicant intake after a unit exists."
         : "Add a unit before applicant intake.",
       action: hasUnit ? onAddApplicant : hasProperty ? onAddUnit : onAddProperty,
-      actionLabel: hasUnit ? (hasApplicant ? "View applicants" : "Add applicant") : hasProperty ? "Add unit" : "Add property",
+      actionLabel: hasUnit ? (hasApplicant ? "View applicants" : applicantActionLabel) : hasProperty ? "Add unit" : "Add property",
     },
     {
       id: "screening",
@@ -424,7 +427,7 @@ const DashboardPage: React.FC = () => {
   const { applications, loading: applicationsLoading } = useApplications();
   const { tenants, loading: tenantsLoading } = useTenants();
   const { user, ready: authReady, isLoading: authLoading } = useAuth();
-  const { features } = useCapabilities();
+  const { caps, features } = useCapabilities();
   const { showToast } = useToast();
   const location = useLocation();
   const navigate = useNavigate();
@@ -439,6 +442,8 @@ const DashboardPage: React.FC = () => {
   const isLandlord = roleLower === "landlord";
   const timelineEnabled = canUseTimeline(user?.plan || "");
   const planNormalized = normalizeTimelinePlan(user?.plan || "");
+  const currentPlan = normalizePlan(caps?.plan || user?.plan || "free");
+  const isFreePlan = currentPlan === "free";
   const shouldConsiderTimelineNudge = meLoaded && !isAdmin && !timelineEnabled;
   const [showTimelineNudge, setShowTimelineNudge] = React.useState(false);
   const timelineNudgeViewedRef = React.useRef(false);
@@ -717,7 +722,8 @@ const DashboardPage: React.FC = () => {
 
   const derivedPropertiesCount = properties.length;
   const derivedUnitsCount = properties.reduce((sum, p) => sum + unitsForProperty(p), 0);
-  const applicationsCount = applications.length;
+  const applicationsCount =
+    typeof data?.kpis?.applicationsCount === "number" ? data.kpis.applicationsCount : applications.length;
   const tenantCount = tenants.length;
   const kpis = {
     propertiesCount: derivedPropertiesCount,
@@ -794,9 +800,9 @@ const DashboardPage: React.FC = () => {
     if (derivedUnitsCount > 0 && applicationsCount === 0) {
       items.push({
         id: "add-applicant",
-        title: "Add an applicant",
+        title: isFreePlan ? "Track an applicant" : "Add an applicant",
         severity: "info",
-        href: "/applications?openSendApplication=1",
+        href: isFreePlan ? "/applications" : "/applications?openSendApplication=1",
       });
     }
     if (SCREENING_ENABLED && canManualScreen && applicationsCount > 0 && (kpis.screeningsCount ?? 0) === 0) {
@@ -808,7 +814,7 @@ const DashboardPage: React.FC = () => {
       });
     }
     return items;
-  }, [applicationsCount, canManualScreen, derivedPropertiesCount, derivedUnitsCount, kpis.screeningsCount]);
+  }, [applicationsCount, canManualScreen, derivedPropertiesCount, derivedUnitsCount, isFreePlan, kpis.screeningsCount]);
   const rawActions = Array.isArray(data?.actions) && data.actions.length > 0 ? data.actions : fallbackActions;
   const visibleActions = rawActions.filter((item: any) => {
     const id = String(item?.id || "");
@@ -860,6 +866,24 @@ const DashboardPage: React.FC = () => {
       });
       setPendingPropertyAction("create_application");
       setPropertyGateOpen(true);
+      return;
+    }
+    if (prereq.missingUnit) {
+      track("onboarding_step_clicked", {
+        stepKey: "applicationCreated",
+        blockedBy: "no_units",
+        source: "dashboard",
+      });
+      navigate("/properties?openAddUnit=1");
+      return;
+    }
+    if (isFreePlan) {
+      track("onboarding_step_clicked", {
+        stepKey: "applicationCreated",
+        source: "dashboard",
+        mode: "manual_intake",
+      });
+      navigate("/applications");
       return;
     }
     track("onboarding_step_clicked", {
@@ -1004,6 +1028,7 @@ const DashboardPage: React.FC = () => {
             applicantsCount={applicationsCount}
             screeningReady={screeningSetupComplete}
             leaseReady={false}
+            applicantActionLabel={isFreePlan ? "Track applicant" : "Add applicant"}
             onAddProperty={() => navigate("/properties?focus=addProperty")}
             onAddUnit={() => navigate("/properties?openAddUnit=1")}
             onAddApplicant={handleCreateApplicationClick}
@@ -1211,10 +1236,10 @@ const DashboardPage: React.FC = () => {
                   <Button
                     variant="secondary"
                     onClick={handleCreateApplicationClick}
-                    aria-label="Add applicant"
+                    aria-label={isFreePlan ? "Track applicant" : "Add applicant"}
                     disabled={progressLoading}
                   >
-                    Add applicant
+                    {isFreePlan ? "Track applicant" : "Add applicant"}
                   </Button>
                 ) : null}
                 {hasApplicantContext ? (
@@ -1287,9 +1312,10 @@ const DashboardPage: React.FC = () => {
                     onboarding,
                     navigate,
                     track,
-                    propertiesCount: derivedPropertiesCount,
-                    unitsCount: derivedUnitsCount,
-                  })}
+                  propertiesCount: derivedPropertiesCount,
+                  unitsCount: derivedUnitsCount,
+                  plan: currentPlan,
+                })}
                   loading={progressLoading}
                   onDismiss={() => onboarding.dismissOnboarding()}
                 />
@@ -1326,6 +1352,7 @@ const DashboardPage: React.FC = () => {
             screeningsCount={kpis.screeningsCount ?? 0}
             onAddProperty={() => navigate("/properties")}
             onAddApplicant={handleCreateApplicationClick}
+            applicantActionLabel={isFreePlan ? "Track applicant manually" : "Add first applicant"}
           />
         ) : null}
 


### PR DESCRIPTION
## Summary
- Reorders Free landlord onboarding surfaces to property, unit, applicant, screening, lease.
- Gates dashboard quick actions, Action Required items, screening cards, and setup copy so screening and tenant invite CTAs do not appear before required context exists.
- Updates dashboard API recommendations to emit the same prerequisite order and adds focused regression coverage.

## Validation
- npm test -- DashboardPage.test.tsx onboardingSteps.test.ts (rentchain-frontend)
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- dashboardRoutes.test.ts (rentchain-api)
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build (rentchain-frontend)
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build (rentchain-api)
- git diff --check

Note: frontend build passes, with existing Vite warnings that Node 20.11.1 is below Vite's recommended 20.19+ and some chunks exceed 700 kB.