### PR TITLE
fix: use readable unit labels in evidence PDFs

### DIFF
--- a/rentchain-api/src/services/evidencePackages/__tests__/leaseEvidencePackageService.test.ts
+++ b/rentchain-api/src/services/evidencePackages/__tests__/leaseEvidencePackageService.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { generateLeaseEvidencePackage } from "../leaseEvidencePackageService";
+import { renderLeaseEvidencePackagePdf } from "../leaseEvidencePackagePdf";
 
 function createStore() {
   const store = new Map<string, Map<string, any>>();
@@ -56,6 +57,15 @@ function seedLease(store: ReturnType<typeof createStore>, overrides: Record<stri
     ],
     ...overrides,
   });
+}
+
+function decodedPdfText(pdf: Buffer): string {
+  const raw = pdf.toString("latin1");
+  const chunks: string[] = [];
+  for (const match of raw.matchAll(/<([0-9a-fA-F]+)>/g)) {
+    chunks.push(Buffer.from(match[1], "hex").toString("latin1"));
+  }
+  return chunks.join("");
 }
 
 describe("lease evidence package service", () => {
@@ -168,6 +178,40 @@ describe("lease evidence package service", () => {
     expect(serialized).not.toContain("storagePath");
   });
 
+  it("uses human-readable property and unit labels in the generated PDF instead of unit document IDs", async () => {
+    const store = createStore();
+    const rawUnitDocumentId = "a1O2tQcdEZ7t6y3GHT5G";
+    seedLease(store, {
+      propertyId: "property-coburg",
+      unitId: rawUnitDocumentId,
+      propertyName: null,
+      unitNumber: null,
+      unitLabel: null,
+      tenantName: null,
+    });
+    store.seed("properties", "property-coburg", {
+      name: "Coburg Rd",
+    });
+    store.seed("units", rawUnitDocumentId, {
+      unitNumber: "6",
+    });
+
+    const pkg = await generateLeaseEvidencePackage({
+      leaseId: "lease-raw-firestore-id-123456789",
+      landlordId: "landlord-1",
+      generatedBy: "landlord-1",
+      generatedAt: "2026-06-14T12:00:00.000Z",
+      firestore: store.firestore as any,
+    });
+    const pdf = await renderLeaseEvidencePackagePdf(pkg);
+    const text = decodedPdfText(pdf);
+
+    expect(pkg.subtitle).toContain("Coburg Rd · Unit 6");
+    expect(text).toContain("Coburg Rd");
+    expect(text).toContain("Unit 6");
+    expect(text).not.toContain(rawUnitDocumentId);
+  });
+
   it("rejects cross-landlord lease access", async () => {
     const store = createStore();
     seedLease(store);
@@ -182,4 +226,3 @@ describe("lease evidence package service", () => {
     ).rejects.toMatchObject({ message: "forbidden", status: 403 });
   });
 });
-

--- a/rentchain-api/src/services/evidencePackages/leaseEvidencePackageService.ts
+++ b/rentchain-api/src/services/evidencePackages/leaseEvidencePackageService.ts
@@ -184,11 +184,39 @@ function item(input: {
   };
 }
 
-function leaseTitle(lease: any): string {
+function propertyDisplayLabel(lease: any, property?: RecordWithId | null): string {
+  return cleanText(
+    property?.data?.name ||
+      property?.data?.propertyName ||
+      property?.data?.address ||
+      property?.data?.propertyAddress ||
+      lease?.propertyName ||
+      lease?.propertyLabel ||
+      lease?.propertyAddress,
+    140
+  );
+}
+
+function unitDisplayLabel(lease: any, unit?: RecordWithId | null): string {
+  const value = cleanText(
+    unit?.data?.unitNumber ||
+      unit?.data?.unitLabel ||
+      unit?.data?.label ||
+      unit?.data?.name ||
+      unit?.data?.unit ||
+      lease?.unitNumber ||
+      lease?.unitLabel,
+    80
+  );
+  if (!value) return "";
+  return /^unit\b/i.test(value) ? value : `Unit ${value}`;
+}
+
+function leaseTitle(lease: any, property?: RecordWithId | null, unit?: RecordWithId | null): string {
   return cleanText(
     [
-      lease?.propertyName || lease?.propertyLabel || lease?.propertyAddress,
-      lease?.unitNumber || lease?.unitLabel || lease?.unitId ? `Unit ${lease?.unitNumber || lease?.unitLabel || lease?.unitId}` : "",
+      propertyDisplayLabel(lease, property),
+      unitDisplayLabel(lease, unit),
       lease?.tenantName || lease?.primaryTenantName,
     ].filter(Boolean).join(" · "),
     220
@@ -262,8 +290,8 @@ function partiesItems(lease: RecordWithId, tenant: RecordWithId | null, property
       label: "Property and unit",
       description: cleanText(
         [
-          property?.data?.name || property?.data?.propertyName || raw.propertyName || raw.propertyLabel || "Property",
-          unit?.data?.unitNumber || raw.unitNumber || raw.unitLabel ? `Unit ${unit?.data?.unitNumber || raw.unitNumber || raw.unitLabel}` : "",
+          propertyDisplayLabel(raw, property) || "Property",
+          unitDisplayLabel(raw, unit),
         ].filter(Boolean).join(" · "),
         220
       ),
@@ -498,7 +526,7 @@ export async function generateLeaseEvidencePackage(input: GenerateLeaseEvidenceP
     section("cover_summary", [
       item({
         label: "Evidence package generated",
-        description: `${leaseTitle(lease.data)} evidence package generated for manual review.`,
+        description: `${leaseTitle(lease.data, sources.property, sources.unit)} evidence package generated for manual review.`,
         timestamp: generatedAt,
         sourceCollection: "leases",
         sourceId: lease.id,
@@ -524,7 +552,7 @@ export async function generateLeaseEvidencePackage(input: GenerateLeaseEvidenceP
 
   return {
     title: "Lease Evidence Package",
-    subtitle: leaseTitle(lease.data),
+    subtitle: leaseTitle(lease.data, sources.property, sources.unit),
     governance: {
       evidencePackageId: `lep_${stableHash([landlordId, leaseId, generatedAt], 24)}`,
       generatedBy: cleanText(input.generatedBy, 240) || "unknown",


### PR DESCRIPTION
## Summary

Fixes evidence package PDF display when a lease has only a Firestore unit document id on the lease record.

- Builds the evidence package title/header from loaded property and unit records when available.
- Prefers readable labels such as `Coburg Rd · Unit 6`.
- Falls back to readable lease-level unit labels where present.
- Avoids rendering the raw unit document id in the human-facing PDF.
- Keeps internal ids available in service metadata/source references.

## Validation

- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- leaseEvidencePackage`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- landlordEvidencePackageGenerationRoutes`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `git diff --check`

## QA

- Generate an evidence package for a lease whose `unitId` is a unit document id and whose unit record has `unitNumber: 6`.
- Confirm the PDF header/subtitle shows `Coburg Rd · Unit 6` or at minimum `Unit 6`.
- Confirm the raw unit document id is not visible in the PDF.
- Confirm route ownership/version headers and successful audit behavior remain unchanged.