### PR TITLE
feat: add evidence package chain-of-custody manifest

### DIFF
--- a/rentchain-api/src/routes/__tests__/landlordEvidencePackageGenerationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordEvidencePackageGenerationRoutes.test.ts
@@ -187,6 +187,7 @@ describe("landlordEvidencePackageGenerationRoutes", () => {
     expect(res.headers["x-rentchain-governance"]).toBe("metadata-only");
     expect(res.headers["x-evidence-package-route-version"]).toBe("lease-evidence-package-pdf-v1");
     expect(res.buffer.toString("latin1", 0, 5)).toBe("%PDF-");
+    expect(writeCanonicalEventMock).toHaveBeenCalledTimes(1);
     expect(writeCanonicalEventMock).toHaveBeenCalledWith(
       expect.objectContaining({
         domain: "lease",
@@ -198,10 +199,32 @@ describe("landlordEvidencePackageGenerationRoutes", () => {
           generatedBy: "landlord-1",
           packageType: "lease_evidence_pdf",
           sectionsIncluded: expect.arrayContaining(["cover_summary", "audit_trail"]),
+          manifestVersion: "lease_evidence_manifest_v1",
+          hashAlgorithm: "sha256",
+          manifestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          packageVersion: "lease-evidence-package-pdf-v1",
+          sourceReferenceCount: expect.any(Number),
+          sourceCollections: expect.arrayContaining(["leases", "payments", "canonicalEvents"]),
+          sectionSourceCounts: expect.arrayContaining([
+            expect.objectContaining({
+              sectionKey: "cover_summary",
+              itemCount: 1,
+              sourceCollections: expect.arrayContaining(["leases"]),
+            }),
+            expect.objectContaining({
+              sectionKey: "audit_trail",
+              itemCount: 1,
+              sourceCollections: expect.arrayContaining(["canonicalEvents"]),
+            }),
+          ]),
         }),
       })
     );
-    expect(JSON.stringify(writeCanonicalEventMock.mock.calls[0][0].metadata)).not.toContain("pi_secret_123");
+    const metadataJson = JSON.stringify(writeCanonicalEventMock.mock.calls[0][0].metadata);
+    expect(metadataJson).not.toContain("pi_secret_123");
+    expect(metadataJson).not.toContain("sourceReference\":\"");
+    expect(metadataJson).not.toContain("payments:");
+    expect(metadataJson).not.toContain("processorPaymentIntentId");
   });
 
   it("returns 403 for another landlord and does not write an audit event", async () => {

--- a/rentchain-api/src/routes/landlordEvidencePackageGenerationRoutes.ts
+++ b/rentchain-api/src/routes/landlordEvidencePackageGenerationRoutes.ts
@@ -8,10 +8,14 @@ import {
   auditMetadataForLeaseEvidencePackage,
   generateLeaseEvidencePackage,
 } from "../services/evidencePackages/leaseEvidencePackageService";
+import {
+  buildLeaseEvidencePackageVerificationMetadata,
+  LEASE_EVIDENCE_PACKAGE_VERSION,
+} from "../services/evidencePackages/leaseEvidencePackageManifest";
 import { renderLeaseEvidencePackagePdf } from "../services/evidencePackages/leaseEvidencePackagePdf";
 
 const router = Router();
-const EVIDENCE_PACKAGE_ROUTE_VERSION = "lease-evidence-package-pdf-v1";
+const EVIDENCE_PACKAGE_ROUTE_VERSION = LEASE_EVIDENCE_PACKAGE_VERSION;
 
 function asString(value: unknown, max = 500): string {
   return String(value ?? "").trim().slice(0, max);
@@ -42,6 +46,7 @@ router.get("/evidence-packages/leases/:leaseId.pdf", evidencePackageRouteVersion
     const leaseId = asString(req.params?.leaseId, 240);
     const generatedBy = asString(req.user?.id || req.user?.uid || req.user?.email || landlordId, 240);
     const pkg = await generateLeaseEvidencePackage({ leaseId, landlordId, generatedBy });
+    pkg.governance.verification = buildLeaseEvidencePackageVerificationMetadata(pkg);
     const pdf = await renderLeaseEvidencePackagePdf(pkg);
 
     await writeCanonicalEvent({

--- a/rentchain-api/src/services/evidencePackages/__tests__/leaseEvidencePackageManifest.test.ts
+++ b/rentchain-api/src/services/evidencePackages/__tests__/leaseEvidencePackageManifest.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLeaseEvidencePackageManifest,
+  buildLeaseEvidencePackageVerificationMetadata,
+  canonicalizeJson,
+  hashLeaseEvidencePackageManifest,
+} from "../leaseEvidencePackageManifest";
+import type { LeaseEvidencePackage } from "../leaseEvidencePackageTypes";
+
+function packageFixture(overrides: Partial<LeaseEvidencePackage> = {}): LeaseEvidencePackage {
+  const base: LeaseEvidencePackage = {
+    title: "Lease Evidence Package",
+    subtitle: "Coburg Rd · Unit 6",
+    governance: {
+      evidencePackageId: "lep_test_package",
+      generatedBy: "landlord-actor-1",
+      generatedAt: "2026-06-14T12:00:00.000Z",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      packageType: "lease_evidence_pdf",
+      sourceReferences: [
+        { sourceCollection: "leases", sourceReference: "leases:internal-lease-token" },
+        { sourceCollection: "messages", sourceReference: "messages:internal-message-token" },
+        { sourceCollection: "canonicalEvents", sourceReference: "canonicalEvents:internal-event-token" },
+      ],
+      auditReferences: [
+        { sourceCollection: "canonicalEvents", sourceReference: "canonicalEvents:internal-event-token" },
+      ],
+      sectionsIncluded: ["cover_summary", "messages", "audit_trail"],
+    },
+    sections: [
+      {
+        key: "cover_summary",
+        title: "Cover Summary",
+        emptyState: "No cover summary details were available.",
+        items: [
+          {
+            label: "Evidence package generated",
+            description: "Internal note must not affect the manifest.",
+            timestamp: "2026-06-14T12:00:00.000Z",
+            sourceCollection: "leases",
+            sourceReference: "leases:internal-lease-token",
+          },
+        ],
+      },
+      {
+        key: "messages",
+        title: "Messages",
+        emptyState: "No landlord-visible messages were available.",
+        items: [
+          {
+            label: "Message from tenant",
+            description: "Private message body excerpt with gs://private/path and pi_secret_123.",
+            timestamp: "2026-06-14T12:01:00.000Z",
+            sourceCollection: "messages",
+            sourceReference: "messages:internal-message-token",
+          },
+        ],
+      },
+      {
+        key: "audit_trail",
+        title: "Audit Trail",
+        emptyState: "No canonical audit events were available.",
+        items: [
+          {
+            label: "lease.created",
+            description: "Audit event metadata.",
+            timestamp: "2026-06-14T12:02:00.000Z",
+            sourceCollection: "canonicalEvents",
+            sourceReference: "canonicalEvents:internal-event-token",
+          },
+        ],
+      },
+    ],
+  };
+  return {
+    ...base,
+    ...overrides,
+    governance: { ...base.governance, ...overrides.governance },
+    sections: overrides.sections || base.sections,
+  };
+}
+
+describe("lease evidence package manifest", () => {
+  it("hashes the same manifest input deterministically", () => {
+    const manifest = buildLeaseEvidencePackageManifest(packageFixture());
+    const first = hashLeaseEvidencePackageManifest(manifest);
+    const second = hashLeaseEvidencePackageManifest(buildLeaseEvidencePackageManifest(packageFixture()));
+
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(second).toBe(first);
+  });
+
+  it("keeps source ordering from changing the manifest hash", () => {
+    const first = packageFixture();
+    const second = packageFixture({
+      governance: {
+        ...first.governance,
+        sourceReferences: [...first.governance.sourceReferences].reverse(),
+        sectionsIncluded: [...first.governance.sectionsIncluded].reverse(),
+      },
+      sections: [...first.sections].reverse().map((section) => ({
+        ...section,
+        items: [...section.items].reverse(),
+      })),
+    });
+
+    expect(hashLeaseEvidencePackageManifest(buildLeaseEvidencePackageManifest(second))).toBe(
+      hashLeaseEvidencePackageManifest(buildLeaseEvidencePackageManifest(first))
+    );
+  });
+
+  it("changes the hash when the safe source summary changes", () => {
+    const first = packageFixture();
+    const second = packageFixture({
+      governance: {
+        ...first.governance,
+        sourceReferences: [
+          ...first.governance.sourceReferences,
+          { sourceCollection: "payments", sourceReference: "payments:internal-payment-token" },
+        ],
+      },
+      sections: [
+        ...first.sections,
+        {
+          key: "payments",
+          title: "Payments",
+          emptyState: "No lease payment records were available.",
+          items: [
+            {
+              label: "Payment recorded",
+              description: "Payment summary.",
+              timestamp: "2026-06-14T12:03:00.000Z",
+              sourceCollection: "payments",
+              sourceReference: "payments:internal-payment-token",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(hashLeaseEvidencePackageManifest(buildLeaseEvidencePackageManifest(second))).not.toBe(
+      hashLeaseEvidencePackageManifest(buildLeaseEvidencePackageManifest(first))
+    );
+  });
+
+  it("excludes unsafe fields from manifest JSON and verification metadata", () => {
+    const pkg = packageFixture();
+    const manifestJson = canonicalizeJson(buildLeaseEvidencePackageManifest(pkg));
+    const verificationJson = JSON.stringify(buildLeaseEvidencePackageVerificationMetadata(pkg));
+
+    for (const unsafe of [
+      "Private message body",
+      "gs://private/path",
+      "pi_secret_123",
+      "leases:internal-lease-token",
+      "messages:internal-message-token",
+      "canonicalEvents:internal-event-token",
+      "provider_secret_request",
+      "dropbox_sign",
+      "storagePath",
+    ]) {
+      expect(manifestJson).not.toContain(unsafe);
+      expect(verificationJson).not.toContain(unsafe);
+    }
+
+    expect(manifestJson).toContain("sourceCountsByCollection");
+    expect(verificationJson).toContain("manifestHash");
+  });
+});

--- a/rentchain-api/src/services/evidencePackages/__tests__/leaseEvidencePackagePdf.test.ts
+++ b/rentchain-api/src/services/evidencePackages/__tests__/leaseEvidencePackagePdf.test.ts
@@ -26,6 +26,23 @@ function packageFixture(): LeaseEvidencePackage {
         "signature_events",
         "audit_trail",
       ],
+      verification: {
+        manifestVersion: "lease_evidence_manifest_v1",
+        hashAlgorithm: "sha256",
+        manifestHash: "a".repeat(64),
+        packageVersion: "lease-evidence-package-pdf-v1",
+        evidencePackageId: "lep_test_package",
+        generatedAt: "2026-06-14T12:00:00.000Z",
+        sourceReferenceCount: 4,
+        sourceCollections: ["canonicalEvents", "leaseSigningRequests", "leases", "messages"],
+        sectionSourceCounts: [
+          { sectionKey: "cover_summary", itemCount: 1, sourceCollections: ["leases"] },
+          { sectionKey: "messages", itemCount: 1, sourceCollections: ["messages"] },
+          { sectionKey: "payments", itemCount: 1, sourceCollections: ["ledgerEntries"] },
+          { sectionKey: "signature_events", itemCount: 1, sourceCollections: ["leaseSigningRequests"] },
+          { sectionKey: "audit_trail", itemCount: 1, sourceCollections: ["canonicalEvents"] },
+        ],
+      },
       sourceReferences: [
         { sourceCollection: "leases", sourceReference: "leases:c46d6f2b5e6a8d17d240" },
         { sourceCollection: "messages", sourceReference: "messages:097bc6c0f4e698e3fb27" },
@@ -133,6 +150,14 @@ describe("lease evidence package PDF renderer", () => {
     expect(text).toContain("Generated At");
     expect(text).toContain("Package Type");
     expect(text).toContain("Sections Included");
+    expect(text).toContain("Verification Summary");
+    expect(text).toContain("Manifest Version");
+    expect(text).toContain("Hash Algorithm");
+    expect(text).toContain("Manifest Hash");
+    expect(text).toContain("Package Version");
+    expect(text).toContain("lease_evidence_manifest_v1");
+    expect(text).toContain("sha256");
+    expect(text).toContain("lease-evidence-package-pdf-v1");
     expect(text).toContain("Lease record");
     expect(text).toContain("Message record");
     expect(text).toContain("Payment ledger entry");

--- a/rentchain-api/src/services/evidencePackages/leaseEvidencePackageManifest.ts
+++ b/rentchain-api/src/services/evidencePackages/leaseEvidencePackageManifest.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto";
+import type {
+  LeaseEvidencePackage,
+  LeaseEvidencePackageManifest,
+  LeaseEvidencePackageSectionSourceCount,
+  LeaseEvidencePackageSourceManifest,
+  LeaseEvidencePackageVerificationMetadata,
+} from "./leaseEvidencePackageTypes";
+
+export const LEASE_EVIDENCE_PACKAGE_MANIFEST_VERSION = "lease_evidence_manifest_v1";
+export const LEASE_EVIDENCE_PACKAGE_VERSION = "lease-evidence-package-pdf-v1";
+export const LEASE_EVIDENCE_PACKAGE_HASH_ALGORITHM = "sha256";
+
+function sortedUnique(values: unknown[]): string[] {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => String(value ?? "").trim())
+        .filter(Boolean)
+    )
+  ).sort((a, b) => a.localeCompare(b));
+}
+
+function sortedRecord(record: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(Object.entries(record).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+export function canonicalizeJson(value: unknown): string {
+  if (value == null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => canonicalizeJson(entry)).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalizeJson(entry)}`).join(",")}}`;
+}
+
+function sourceManifestForPackage(pkg: LeaseEvidencePackage): LeaseEvidencePackageSourceManifest {
+  const sourceCollections = sortedUnique(pkg.governance.sourceReferences.map((ref) => ref.sourceCollection));
+  const sourceCountsByCollection: Record<string, number> = {};
+  for (const ref of pkg.governance.sourceReferences) {
+    const collection = String(ref.sourceCollection || "").trim();
+    if (!collection) continue;
+    sourceCountsByCollection[collection] = (sourceCountsByCollection[collection] || 0) + 1;
+  }
+  const sectionSourceCounts: LeaseEvidencePackageSectionSourceCount[] = pkg.sections
+    .map((section) => ({
+      sectionKey: section.key,
+      itemCount: section.items.length,
+      sourceCollections: sortedUnique(section.items.map((item) => item.sourceCollection)),
+    }))
+    .sort((left, right) => left.sectionKey.localeCompare(right.sectionKey));
+
+  return {
+    totalSourceReferences: pkg.governance.sourceReferences.length,
+    sourceCollections,
+    sourceCountsByCollection: sortedRecord(sourceCountsByCollection),
+    sectionSourceCounts,
+  };
+}
+
+export function buildLeaseEvidencePackageManifest(pkg: LeaseEvidencePackage): LeaseEvidencePackageManifest {
+  return {
+    manifestVersion: LEASE_EVIDENCE_PACKAGE_MANIFEST_VERSION,
+    packageVersion: LEASE_EVIDENCE_PACKAGE_VERSION,
+    evidencePackageId: pkg.governance.evidencePackageId,
+    leaseId: pkg.governance.leaseId,
+    landlordId: pkg.governance.landlordId,
+    packageType: pkg.governance.packageType,
+    generatedAt: pkg.governance.generatedAt,
+    generatedBy: {
+      actorType: "landlord",
+      actorId: pkg.governance.generatedBy,
+    },
+    sectionsIncluded: [...pkg.governance.sectionsIncluded].sort((left, right) => left.localeCompare(right)),
+    sourceManifest: sourceManifestForPackage(pkg),
+  };
+}
+
+export function hashLeaseEvidencePackageManifest(manifest: LeaseEvidencePackageManifest): string {
+  return crypto.createHash(LEASE_EVIDENCE_PACKAGE_HASH_ALGORITHM).update(canonicalizeJson(manifest)).digest("hex");
+}
+
+export function buildLeaseEvidencePackageVerificationMetadata(pkg: LeaseEvidencePackage): LeaseEvidencePackageVerificationMetadata {
+  const manifest = buildLeaseEvidencePackageManifest(pkg);
+  return {
+    manifestVersion: manifest.manifestVersion,
+    hashAlgorithm: LEASE_EVIDENCE_PACKAGE_HASH_ALGORITHM,
+    manifestHash: hashLeaseEvidencePackageManifest(manifest),
+    packageVersion: manifest.packageVersion,
+    evidencePackageId: manifest.evidencePackageId,
+    generatedAt: manifest.generatedAt,
+    sourceReferenceCount: manifest.sourceManifest.totalSourceReferences,
+    sourceCollections: manifest.sourceManifest.sourceCollections,
+    sectionSourceCounts: manifest.sourceManifest.sectionSourceCounts,
+  };
+}

--- a/rentchain-api/src/services/evidencePackages/leaseEvidencePackagePdf.ts
+++ b/rentchain-api/src/services/evidencePackages/leaseEvidencePackagePdf.ts
@@ -63,6 +63,18 @@ export async function renderLeaseEvidencePackagePdf(pkg: LeaseEvidencePackage): 
     line(doc, "Sections Included", pkg.governance.sectionsIncluded.join(", "));
     doc.moveDown();
 
+    if (pkg.governance.verification) {
+      doc.font("Helvetica-Bold").fontSize(12).text("Verification Summary");
+      doc.moveDown(0.25);
+      doc.fontSize(9);
+      line(doc, "Evidence Package ID", pkg.governance.verification.evidencePackageId);
+      line(doc, "Manifest Version", pkg.governance.verification.manifestVersion);
+      line(doc, "Hash Algorithm", pkg.governance.verification.hashAlgorithm);
+      line(doc, "Manifest Hash", pkg.governance.verification.manifestHash);
+      line(doc, "Package Version", pkg.governance.verification.packageVersion);
+      doc.moveDown();
+    }
+
     for (const section of pkg.sections) {
       if (doc.y > 700) doc.addPage();
       doc.font("Helvetica-Bold").fontSize(13).text(section.title);

--- a/rentchain-api/src/services/evidencePackages/leaseEvidencePackageService.ts
+++ b/rentchain-api/src/services/evidencePackages/leaseEvidencePackageService.ts
@@ -576,5 +576,6 @@ export function auditMetadataForLeaseEvidencePackage(pkg: LeaseEvidencePackage) 
     generatedAt: pkg.governance.generatedAt,
     packageType: pkg.governance.packageType,
     sectionsIncluded: pkg.governance.sectionsIncluded,
+    ...(pkg.governance.verification || {}),
   };
 }

--- a/rentchain-api/src/services/evidencePackages/leaseEvidencePackageTypes.ts
+++ b/rentchain-api/src/services/evidencePackages/leaseEvidencePackageTypes.ts
@@ -42,6 +42,7 @@ export type LeaseEvidencePackageGovernance = {
     sourceReference: string;
   }>;
   sectionsIncluded: LeaseEvidencePackageSectionKey[];
+  verification?: LeaseEvidencePackageVerificationMetadata;
 };
 
 export type LeaseEvidencePackage = {
@@ -51,3 +52,43 @@ export type LeaseEvidencePackage = {
   sections: LeaseEvidencePackageSection[];
 };
 
+export type LeaseEvidencePackageSectionSourceCount = {
+  sectionKey: LeaseEvidencePackageSectionKey;
+  itemCount: number;
+  sourceCollections: string[];
+};
+
+export type LeaseEvidencePackageSourceManifest = {
+  totalSourceReferences: number;
+  sourceCollections: string[];
+  sourceCountsByCollection: Record<string, number>;
+  sectionSourceCounts: LeaseEvidencePackageSectionSourceCount[];
+};
+
+export type LeaseEvidencePackageManifest = {
+  manifestVersion: "lease_evidence_manifest_v1";
+  packageVersion: "lease-evidence-package-pdf-v1";
+  evidencePackageId: string;
+  leaseId: string;
+  landlordId: string;
+  packageType: "lease_evidence_pdf";
+  generatedAt: string;
+  generatedBy: {
+    actorType: "landlord";
+    actorId: string;
+  };
+  sectionsIncluded: LeaseEvidencePackageSectionKey[];
+  sourceManifest: LeaseEvidencePackageSourceManifest;
+};
+
+export type LeaseEvidencePackageVerificationMetadata = {
+  manifestVersion: LeaseEvidencePackageManifest["manifestVersion"];
+  hashAlgorithm: "sha256";
+  manifestHash: string;
+  packageVersion: LeaseEvidencePackageManifest["packageVersion"];
+  evidencePackageId: string;
+  generatedAt: string;
+  sourceReferenceCount: number;
+  sourceCollections: string[];
+  sectionSourceCounts: LeaseEvidencePackageSectionSourceCount[];
+};


### PR DESCRIPTION
## Summary
- Add metadata-only lease evidence package manifest generation with deterministic canonical JSON and SHA-256 hashing.
- Attach verification metadata to the existing `lease.evidence_package_generated` canonical event without creating a new collection or duplicate audit event.
- Render a human-safe PDF verification summary with Evidence Package ID, manifest version, hash algorithm, manifest hash, and package version.

## Safety
- Hashes the manifest, not PDF bytes.
- Does not store PDF contents, message bodies, raw storage paths, payment processor IDs, signing provider request IDs, or raw source references in verification metadata.
- Keeps chain-of-custody language to manifest/hash metadata only; no certification, notarization, blockchain anchoring, or legal verification claims.

## Tests
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/evidencePackages/__tests__/leaseEvidencePackageManifest.test.ts src/services/evidencePackages/__tests__/leaseEvidencePackagePdf.test.ts src/routes/__tests__/landlordEvidencePackageGenerationRoutes.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/evidencePackages/__tests__/leaseEvidencePackageService.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/evidencePackages src/routes/__tests__/landlordEvidencePackageGenerationRoutes.test.ts`
- `git diff --check`

## Preview QA
- Generate a lease evidence package PDF from `/api/landlord/evidence-packages/leases/:leaseId.pdf`.
- Confirm response headers still include `x-route-source: landlordEvidencePackageGenerationRoutes.ts` and `x-evidence-package-route-version: lease-evidence-package-pdf-v1`.
- Confirm the PDF contains the verification summary fields and a 64-character SHA-256 manifest hash.
- Confirm the PDF does not expose raw source reference tokens, storage paths, payment processor IDs, signing provider request IDs, or message bodies beyond existing bounded excerpts.
- Confirm the `lease.evidence_package_generated` canonical event has manifest/version/hash/source summary metadata and denied or missing requests write no event.