### PR TITLE
feat: add institutional export framework

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -157,6 +157,7 @@ import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes"
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
 import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
+import landlordInstitutionalExportGenerationRoutes from "./routes/landlordInstitutionalExportGenerationRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
 import landlordOperatorReviewRoutes from "./routes/landlordOperatorReviewRoutes";
@@ -497,6 +498,9 @@ app.use("/api/landlord", routeSource("landlordInboxRoutes.ts"), landlordInboxRou
 console.log("[route-mount] landlordInboxRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlordDecisionInboxRoutes);
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
+app.use("/api/landlord/institutional-exports", rateLimitEvidenceExportReview);
+app.use("/api/landlord", routeSource("landlordInstitutionalExportGenerationRoutes.ts"), landlordInstitutionalExportGenerationRoutes);
+console.log("[route-mount] landlordInstitutionalExportGenerationRoutes mounted at /api/landlord");
 app.use("/api/landlord/institution-exports", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordInstitutionExportsRoutes.ts"), landlordInstitutionExportsRoutes);
 console.log("[route-mount] landlordInstitutionExportsRoutes mounted at /api/landlord");

--- a/rentchain-api/src/routes/__tests__/landlordInstitutionalExportGenerationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordInstitutionalExportGenerationRoutes.test.ts
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeCanonicalEventMock = vi.hoisted(() => vi.fn(async () => ({ id: "event-1" })));
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  const clone = (value: any) => JSON.parse(JSON.stringify(value));
+  const getPath = (value: any, path: string) =>
+    path.split(".").reduce((current, key) => (current == null ? undefined : current[key]), value);
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = getPath(doc?.data, field);
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = [], cap = Infinity): any {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }], cap),
+      limit: (limit: number) => makeQuery(name, filters, limit),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .slice(0, cap)
+          .map((doc) => ({ id: doc.id, exists: true, data: () => clone(doc.data) }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => clone(entry?.data) };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data: clone(data) });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data: clone(data) }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        limit: (limit: number) => makeQuery(name, [], limit),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../lib/events/buildEvent", () => ({
+  writeCanonicalEvent: writeCanonicalEventMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; body?: Record<string, unknown>; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string>; text: string; buffer: Buffer }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+        return this;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers, text: JSON.stringify(payload), buffer: Buffer.from("") });
+        return this;
+      },
+      send(payload: any) {
+        const buffer = Buffer.isBuffer(payload) ? payload : Buffer.from(String(payload));
+        resolve({ status: this.statusCode, body: null, headers: this.headers, text: buffer.toString("latin1"), buffer });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedLease(overrides: Record<string, any> = {}) {
+  seedDoc("leases", "lease-1", {
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    tenantName: "Jane Tenant",
+    propertyName: "Oxford Suites",
+    unitNumber: "101",
+    status: "active",
+    startDate: "2026-01-01",
+    endDate: "2026-12-31",
+    monthlyRent: 1800,
+    documentUrl: "gs://private-bucket/raw-lease.pdf",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  });
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    exportFormat: "pdf",
+    exportReason: "tribunal",
+    exportScope: "lease_evidence_package",
+    resourceType: "lease",
+    leaseId: "lease-1",
+    ...overrides,
+  };
+}
+
+function decodedPdfText(pdf: Buffer): string {
+  const raw = pdf.toString("latin1");
+  const chunks: string[] = [];
+  for (const match of raw.matchAll(/<([0-9a-fA-F]+)>/g)) {
+    chunks.push(Buffer.from(match[1], "hex").toString("latin1"));
+  }
+  return chunks.join("");
+}
+
+describe("landlordInstitutionalExportGenerationRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetFakeDb();
+    writeCanonicalEventMock.mockClear();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("lets a landlord generate a PDF institutional export for their own lease", async () => {
+    seedLease();
+    seedDoc("payments", "payment-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      amount: 1800,
+      method: "etransfer",
+      paidAt: "2026-02-01T00:00:00.000Z",
+      processorPaymentIntentId: "pi_secret_123",
+    });
+    seedDoc("leaseSigningRequests", "signing-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      providerRequestId: "provider_secret_request_123",
+      providerDispatchStatus: "sent",
+      sentAt: "2026-02-02T00:00:00.000Z",
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      type: "lease.created",
+      action: "created",
+      resource: { id: "lease-1", type: "lease" },
+      summary: "Lease created.",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const router = (await import("../landlordInstitutionalExportGenerationRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/institutional-exports", body: validBody() });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/pdf");
+    expect(res.headers["content-disposition"]).toMatch(/rentchain-institutional-lease-evidence-export-\d{4}-\d{2}-\d{2}\.pdf/);
+    expect(res.headers["x-rentchain-governance"]).toBe("metadata-only");
+    expect(res.headers["x-rentchain-export-sensitivity"]).toBe("confidential");
+    expect(res.headers["x-rentchain-retention-category"]).toBe("export_metadata");
+    expect(res.headers["x-rentchain-institutional-export-id"]).toMatch(/^instexp_[a-f0-9]{24}$/);
+    expect(res.headers["x-rentchain-institutional-export-version"]).toBe("institutional-export-framework-v1");
+    expect(res.headers["x-rentchain-evidence-package-id"]).toMatch(/^lep_[a-f0-9]{24}$/);
+    expect(res.buffer.toString("latin1", 0, 5)).toBe("%PDF-");
+
+    expect(writeCanonicalEventMock).toHaveBeenCalledTimes(1);
+    expect(writeCanonicalEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: "lease",
+        action: "institutional_export_generated",
+        resource: { type: "lease", id: "lease-1" },
+        metadata: expect.objectContaining({
+          exportId: res.headers["x-rentchain-institutional-export-id"],
+          exportType: "institutional_export",
+          exportFormat: "pdf",
+          exportReason: "tribunal",
+          exportScope: "lease_evidence_package",
+          resourceType: "lease",
+          resourceId: "lease-1",
+          leaseId: "lease-1",
+          generatedBy: "landlord-1",
+          generatedAt: expect.any(String),
+          evidencePackageId: res.headers["x-rentchain-evidence-package-id"],
+          manifestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          manifestVersion: "lease_evidence_manifest_v1",
+          packageVersion: "lease-evidence-package-pdf-v1",
+        }),
+      })
+    );
+
+    const pdfText = decodedPdfText(res.buffer);
+    expect(pdfText).toContain("Generated By");
+    expect(pdfText).toContain("Authorized User");
+    expect(pdfText).toContain("Verification Summary");
+    expect(pdfText).toContain("Manifest Hash");
+    for (const unsafe of [
+      "landlord-1",
+      "gs://private-bucket/raw-lease.pdf",
+      "pi_secret_123",
+      "provider_secret_request_123",
+      "payments:",
+      "leaseSigningRequests:",
+      "canonicalEvents:",
+      "sourceReference",
+    ]) {
+      expect(pdfText).not.toContain(unsafe);
+    }
+    for (const unsafe of [
+      "gs://private-bucket/raw-lease.pdf",
+      "pi_secret_123",
+      "provider_secret_request_123",
+      "payments:",
+      "leaseSigningRequests:",
+      "canonicalEvents:",
+      "sourceReference",
+    ]) {
+      expect(JSON.stringify(writeCanonicalEventMock.mock.calls[0][0].metadata)).not.toContain(unsafe);
+    }
+  });
+
+  it("returns 403 for another landlord and writes no success event", async () => {
+    seedLease();
+    mockUser = { id: "landlord-2", landlordId: "landlord-2", role: "landlord" };
+    const router = (await import("../landlordInstitutionalExportGenerationRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/institutional-exports", body: validBody() });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("FORBIDDEN");
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a missing lease and writes no success event", async () => {
+    const router = (await import("../landlordInstitutionalExportGenerationRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/institutional-exports", body: validBody() });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("LEASE_NOT_FOUND");
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ exportFormat: "csv" }, "UNSUPPORTED_EXPORT_FORMAT"],
+    [{ exportScope: "payments" }, "UNSUPPORTED_EXPORT_SCOPE"],
+    [{ resourceType: "tenant" }, "UNSUPPORTED_EXPORT_RESOURCE"],
+    [{ exportReason: "unsupported" }, "INVALID_EXPORT_REASON"],
+  ])("rejects invalid export request %o and writes no success event", async (patch, errorCode) => {
+    seedLease();
+    const router = (await import("../landlordInstitutionalExportGenerationRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/institutional-exports",
+      body: validBody(patch),
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe(errorCode);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-api/src/routes/__tests__/landlordInstitutionalExportGenerationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordInstitutionalExportGenerationRoutes.test.ts
@@ -215,6 +215,7 @@ describe("landlordInstitutionalExportGenerationRoutes", () => {
     expect(res.headers["x-rentchain-governance"]).toBe("metadata-only");
     expect(res.headers["x-rentchain-export-sensitivity"]).toBe("confidential");
     expect(res.headers["x-rentchain-retention-category"]).toBe("export_metadata");
+    expect(res.headers["x-institutional-export-route-version"]).toBe("institutional-export-framework-v1");
     expect(res.headers["x-rentchain-institutional-export-id"]).toMatch(/^instexp_[a-f0-9]{24}$/);
     expect(res.headers["x-rentchain-institutional-export-version"]).toBe("institutional-export-framework-v1");
     expect(res.headers["x-rentchain-evidence-package-id"]).toMatch(/^lep_[a-f0-9]{24}$/);

--- a/rentchain-api/src/routes/landlordInstitutionalExportGenerationRoutes.ts
+++ b/rentchain-api/src/routes/landlordInstitutionalExportGenerationRoutes.ts
@@ -1,0 +1,87 @@
+import { Router } from "express";
+import { getEffectiveLandlordId } from "../auth/requestAuthority";
+import { buildDatedExportFilename, setAttachmentExportHeaders } from "../lib/exports/exportResponse";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import {
+  generateLeaseEvidenceInstitutionalExport,
+  INSTITUTIONAL_EXPORT_VERSION,
+  parseInstitutionalExportRequest,
+} from "../services/institutionalExports/institutionalExportService";
+
+const router = Router();
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function statusFor(error: any): number {
+  const status = Number(error?.status);
+  return Number.isInteger(status) && status >= 400 && status < 600 ? status : 500;
+}
+
+function codeFor(error: any): string {
+  const code = asString(error?.message, 120);
+  if (code === "lease_not_found") return "LEASE_NOT_FOUND";
+  if (code === "forbidden") return "FORBIDDEN";
+  if (code === "lease_id_required") return "LEASE_ID_REQUIRED";
+  if (code === "landlord_id_required") return "UNAUTHORIZED";
+  if (code === "UNSUPPORTED_EXPORT_FORMAT") return "UNSUPPORTED_EXPORT_FORMAT";
+  if (code === "UNSUPPORTED_EXPORT_SCOPE") return "UNSUPPORTED_EXPORT_SCOPE";
+  if (code === "UNSUPPORTED_EXPORT_RESOURCE") return "UNSUPPORTED_EXPORT_RESOURCE";
+  if (code === "INVALID_EXPORT_REASON") return "INVALID_EXPORT_REASON";
+  if (code === "LEASE_ID_REQUIRED") return "LEASE_ID_REQUIRED";
+  return "INSTITUTIONAL_EXPORT_GENERATION_FAILED";
+}
+
+function institutionalExportRouteVersion(_req: any, res: any, next: any) {
+  res.setHeader("X-RentChain-Institutional-Export-Version", INSTITUTIONAL_EXPORT_VERSION);
+  return next();
+}
+
+router.post("/institutional-exports", institutionalExportRouteVersion, requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(getEffectiveLandlordId(req), 240);
+    const generatedBy = asString(req.user?.id || req.user?.uid || req.user?.email || landlordId, 240);
+    const request = parseInstitutionalExportRequest(req.body);
+    const result = await generateLeaseEvidenceInstitutionalExport({ request, landlordId, generatedBy });
+
+    await writeCanonicalEvent({
+      domain: "lease",
+      action: "institutional_export_generated",
+      status: "generated",
+      actor: {
+        type: "landlord",
+        role: "landlord",
+        id: generatedBy,
+      },
+      resource: {
+        type: "lease",
+        id: request.leaseId,
+      },
+      occurredAt: result.metadata.generatedAt,
+      visibility: "internal",
+      summary: "Lease institutional evidence export generated",
+      metadata: result.metadata,
+    });
+
+    setAttachmentExportHeaders(res, {
+      filename: buildDatedExportFilename({ prefix: result.filenamePrefix, format: "pdf" }),
+      format: "pdf",
+      sensitivity: "confidential",
+    });
+    res.setHeader("X-RentChain-Institutional-Export-Id", result.metadata.exportId);
+    res.setHeader("X-RentChain-Institutional-Export-Version", result.metadata.exportVersion);
+    res.setHeader("X-RentChain-Evidence-Package-Id", result.metadata.evidencePackageId);
+    return res.status(200).send(result.pdf);
+  } catch (error: any) {
+    const status = statusFor(error);
+    if (status >= 500) {
+      console.error("[institutional-export] generation failed", { message: error?.message || "failed" });
+    }
+    return res.status(status).json({ ok: false, error: codeFor(error) });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/landlordInstitutionalExportGenerationRoutes.ts
+++ b/rentchain-api/src/routes/landlordInstitutionalExportGenerationRoutes.ts
@@ -36,6 +36,7 @@ function codeFor(error: any): string {
 }
 
 function institutionalExportRouteVersion(_req: any, res: any, next: any) {
+  res.setHeader("X-Institutional-Export-Route-Version", INSTITUTIONAL_EXPORT_VERSION);
   res.setHeader("X-RentChain-Institutional-Export-Version", INSTITUTIONAL_EXPORT_VERSION);
   return next();
 }

--- a/rentchain-api/src/services/institutionalExports/institutionalExportService.ts
+++ b/rentchain-api/src/services/institutionalExports/institutionalExportService.ts
@@ -1,0 +1,118 @@
+import crypto from "crypto";
+import {
+  buildLeaseEvidencePackageVerificationMetadata,
+  LEASE_EVIDENCE_PACKAGE_VERSION,
+} from "../evidencePackages/leaseEvidencePackageManifest";
+import { renderLeaseEvidencePackagePdf } from "../evidencePackages/leaseEvidencePackagePdf";
+import { generateLeaseEvidencePackage } from "../evidencePackages/leaseEvidencePackageService";
+import type {
+  InstitutionalExportReason,
+  InstitutionalExportRequest,
+  InstitutionalLeaseEvidencePdfExport,
+} from "./institutionalExportTypes";
+
+export const INSTITUTIONAL_EXPORT_VERSION = "institutional-export-framework-v1";
+
+const EXPORT_REASONS = new Set<InstitutionalExportReason>([
+  "tribunal",
+  "court",
+  "insurance",
+  "lender",
+  "internal_review",
+  "other",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function stableHash(parts: unknown[], length = 24): string {
+  return crypto
+    .createHash("sha256")
+    .update(parts.map((part) => String(part ?? "")).join("|"))
+    .digest("hex")
+    .slice(0, length);
+}
+
+export function parseInstitutionalExportRequest(body: any): InstitutionalExportRequest {
+  const exportFormat = asString(body?.exportFormat, 24);
+  if (exportFormat !== "pdf") {
+    throw Object.assign(new Error("UNSUPPORTED_EXPORT_FORMAT"), { status: 400 });
+  }
+
+  const exportScope = asString(body?.exportScope, 80);
+  if (exportScope !== "lease_evidence_package") {
+    throw Object.assign(new Error("UNSUPPORTED_EXPORT_SCOPE"), { status: 400 });
+  }
+
+  const resourceType = asString(body?.resourceType, 80);
+  if (resourceType !== "lease") {
+    throw Object.assign(new Error("UNSUPPORTED_EXPORT_RESOURCE"), { status: 400 });
+  }
+
+  const exportReason = asString(body?.exportReason, 80) as InstitutionalExportReason;
+  if (!EXPORT_REASONS.has(exportReason)) {
+    throw Object.assign(new Error("INVALID_EXPORT_REASON"), { status: 400 });
+  }
+
+  const leaseId = asString(body?.leaseId, 240);
+  if (!leaseId) {
+    throw Object.assign(new Error("LEASE_ID_REQUIRED"), { status: 400 });
+  }
+
+  return {
+    exportFormat,
+    exportReason,
+    exportScope,
+    resourceType,
+    leaseId,
+  };
+}
+
+export async function generateLeaseEvidenceInstitutionalExport(input: {
+  request: InstitutionalExportRequest;
+  landlordId: string;
+  generatedBy: string;
+}): Promise<InstitutionalLeaseEvidencePdfExport> {
+  const generatedAt = new Date().toISOString();
+  const pkg = await generateLeaseEvidencePackage({
+    leaseId: input.request.leaseId,
+    landlordId: input.landlordId,
+    generatedBy: input.generatedBy,
+    generatedAt,
+  });
+  pkg.governance.verification = buildLeaseEvidencePackageVerificationMetadata(pkg);
+  const pdf = await renderLeaseEvidencePackagePdf(pkg);
+  const verification = pkg.governance.verification;
+  const exportId = `instexp_${stableHash([
+    input.landlordId,
+    input.request.leaseId,
+    input.request.exportReason,
+    generatedAt,
+    verification.manifestHash,
+  ])}`;
+
+  return {
+    pdf,
+    filenamePrefix: "rentchain-institutional-lease-evidence-export",
+    metadata: {
+      exportId,
+      exportType: "institutional_export",
+      exportFormat: "pdf",
+      exportReason: input.request.exportReason,
+      exportScope: "lease_evidence_package",
+      generatedBy: input.generatedBy,
+      generatedAt,
+      resourceType: "lease",
+      resourceId: input.request.leaseId,
+      leaseId: input.request.leaseId,
+      sensitivity: "confidential",
+      retentionCategory: "export_metadata",
+      exportVersion: INSTITUTIONAL_EXPORT_VERSION,
+      evidencePackageId: verification.evidencePackageId,
+      manifestHash: verification.manifestHash,
+      manifestVersion: verification.manifestVersion,
+      packageVersion: LEASE_EVIDENCE_PACKAGE_VERSION,
+    },
+  };
+}

--- a/rentchain-api/src/services/institutionalExports/institutionalExportTypes.ts
+++ b/rentchain-api/src/services/institutionalExports/institutionalExportTypes.ts
@@ -1,0 +1,53 @@
+export type InstitutionalExportFormat = "pdf" | "csv" | "json";
+
+export type InstitutionalExportReason =
+  | "tribunal"
+  | "court"
+  | "insurance"
+  | "lender"
+  | "internal_review"
+  | "other";
+
+export type InstitutionalExportScope =
+  | "lease_evidence_package"
+  | "payments"
+  | "maintenance"
+  | "messages"
+  | "notices"
+  | "audit_trail";
+
+export type InstitutionalExportResourceType = "lease";
+
+export type InstitutionalExportRequest = {
+  exportFormat: InstitutionalExportFormat;
+  exportReason: InstitutionalExportReason;
+  exportScope: InstitutionalExportScope;
+  resourceType: InstitutionalExportResourceType;
+  leaseId: string;
+};
+
+export type InstitutionalExportGovernanceMetadata = {
+  exportId: string;
+  exportType: "institutional_export";
+  exportFormat: "pdf";
+  exportReason: InstitutionalExportReason;
+  exportScope: "lease_evidence_package";
+  generatedBy: string;
+  generatedAt: string;
+  resourceType: "lease";
+  resourceId: string;
+  leaseId: string;
+  sensitivity: "confidential";
+  retentionCategory: "export_metadata";
+  exportVersion: "institutional-export-framework-v1";
+  evidencePackageId: string;
+  manifestHash: string;
+  manifestVersion: string;
+  packageVersion: string;
+};
+
+export type InstitutionalLeaseEvidencePdfExport = {
+  pdf: Buffer;
+  filenamePrefix: string;
+  metadata: InstitutionalExportGovernanceMetadata;
+};


### PR DESCRIPTION
## Summary
- Add a governed `POST /api/landlord/institutional-exports` endpoint for V1 PDF institutional exports.
- Back the PDF export with the existing lease evidence package generation and manifest/hash verification flow.
- Stream generated output directly and write one `lease.institutional_export_generated` canonical event on success.

## Scope
- PDF only for V1.
- CSV/JSON and non-lease scopes are validated as unsupported and are not generated.
- No new export/audit collection, no file storage, no blockchain anchoring, no signing-provider work, and no frontend UI.

## Governance and Safety
- Response preserves export governance headers and adds institutional export ID/version plus linked evidence package ID.
- Canonical event metadata includes export reason/scope/format, export ID, generated actor/time, linked evidence package ID, manifest hash/version, and package version.
- Human-facing PDF output continues to exclude raw actor IDs, storage paths, source reference tokens, payment processor IDs, and signing provider request IDs.

## Tests
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/routes/__tests__/landlordInstitutionalExportGenerationRoutes.test.ts src/routes/__tests__/landlordEvidencePackageGenerationRoutes.test.ts src/services/evidencePackages`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/routes/__tests__/routeMountSmoke.test.ts`
- `git diff --check`

## Preview QA
- Deploy backend for this PR head before preview QA.
- Authenticated landlord POSTs `/api/landlord/institutional-exports` with `{ "exportFormat": "pdf", "exportReason": "tribunal", "exportScope": "lease_evidence_package", "resourceType": "lease", "leaseId": "<owned lease id>" }`.
- Confirm `200`, PDF attachment, governance headers, `X-RentChain-Institutional-Export-Id`, `X-RentChain-Institutional-Export-Version`, and `X-RentChain-Evidence-Package-Id`.
- Confirm canonicalEvents has one `lease.institutional_export_generated` event with export metadata and linked manifest hash metadata.
- Confirm unsupported format/scope/reason and denied/missing lease paths do not write a success event.