### PR TITLE
feat: add trust compliance center

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,94 +1,60 @@
-PR: #1149
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1149
-Branch: fix/upgrade-driver-clarification-v1
+PR: #1161
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1161
+Branch: feat/trust-and-compliance-center-v1
 
 WHAT WAS DONE:
-- Standardized backend upgrade-required payloads from the shared capability guard.
-- Added `userMessage`, `requiredTier`, `upgradeDrivers`, and tier-specific `upgradePath` to capability-denial responses while preserving legacy fields such as `requiredPlan`, `currentPlan`, `capability`, and `message`.
-- Updated the Pro-only expense import/export guard to use the shared upgrade response shape.
-- Added canonical frontend upgrade driver constants for Analytics, Payments, Work Orders, Expenses, and Screening.
-- Extended the locked-state component to show the feature name, required tier, upgrade drivers, driver descriptions, and a styled upgrade CTA.
-- Replaced the Expenses page plain-text import/export lock with the canonical locked-state component.
-- Added expense import/export upgrade copy and required-plan mappings so the Pro expense gate does not fall back to generic copy.
+- Added a read-only landlord Trust & Compliance Center backend endpoint:
+  `GET /api/landlord/trust-compliance/summary`.
+- Aggregated landlord-scoped governance visibility across evidence/export, consent, privacy, retention, screening, audit trail, and incident readiness sections.
+- Added safe route/version header support:
+  `x-route-source: landlordTrustComplianceRoutes.ts`
+  `x-trust-compliance-route-version: trust-compliance-center-v1`
+- Added a minimal read-only frontend page at `/trust-compliance`.
+- Added frontend API types and focused route/page tests.
 
 KEY DECISIONS:
-- Entitlement checks were not changed. The mission explicitly required messaging standardization without widening or weakening auth, billing, or plan enforcement.
-- Existing locked pages for leases, ledger, messages, and operations already use the canonical locked-state component or the shared capability guard, so the patch extends those shared pieces rather than duplicating page-level logic.
-- Maintenance/work-order entitlement behavior was left unchanged because the current capability map documents maintenance as reachable on Free during Pilot 1 measurement.
-- Expenses remain manually usable on Free; only import/export surfaces show the Pro locked state.
-- Operations remains a derived frontend coordination page in the current codebase; there is no separate browser-used `/api/landlord/operations` route to patch in this mission.
+- `canonicalEvents` is the primary source. Existing consent and screening collections are used only as safe supplemental posture sources.
+- Dashboard access does not write canonical events.
+- No new audit collection or compliance workflow collection was added.
+- Event metadata is allowlisted; raw event metadata is not returned wholesale.
+- The frontend also defensively redacts unsafe display values.
 
 CURRENT STATE:
-- Branch: fix/upgrade-driver-clarification-v1
-- PR: pending
-- Backend upgrade response shape is standardized for shared capability-guarded routes and expense import/export gates.
-- Frontend locked-state UI now exposes consistent upgrade-driver messaging.
-- Manual preview QA has not been run in this environment.
+- Branch: feat/trust-and-compliance-center-v1
+- PR: #1161
+- PR URL: https://github.com/rentchaincanada/rentchain/pull/1161
+- Draft PR opened for review.
+- Branch pushed to origin.
 
 VALIDATION:
-- Frontend targeted tests passed:
-  - `npm run test:single -- src/components/billing/LockedFeature.test.tsx src/constants/tiers.test.ts src/pages/ExpensesPage.test.tsx`
-  - `npm run test:single -- src/components/billing/FeatureGate.test.tsx` (after fixing message expectation and committing fix)
 - Backend targeted tests passed:
-  - `npm run test:single -- src/services/__tests__/capabilityGuard.test.ts`
-  - `npm run test:single -- src/routes/__tests__/expensesRoutes.test.ts`
+  - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/trustCompliance/__tests__/trustComplianceSummaryService.test.ts src/routes/__tests__/landlordTrustComplianceRoutes.test.ts src/routes/__tests__/routeMountSmoke.test.ts`
 - Backend build passed:
-  - `npm run build`
-- Frontend build passed:
-  - `npm run build`
-- `git diff --check` passed (after fixing trailing whitespace).
-- Test fix committed: d779cf20 "fix: update FeatureGate test expectation for new upgrade messaging"
-- Note: the first sandboxed backend route test run failed with `listen EPERM: operation not permitted 0.0.0.0`; rerunning the same route suite outside the sandbox passed.
-- Frontend build retained an existing large chunk warning; build completed successfully.
+  - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
+- Frontend targeted tests passed under ambient Node v25.8.1:
+  - `npm run test:single -- TrustComplianceCenterPage.test.tsx App.routes.test.tsx`
+- Frontend build passed under repo-required Node 20.11.1:
+  - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
+- `git diff --cached --check` passed.
 
 FILES CHANGED:
-- `rentchain-api/src/services/capabilityGuard.ts`
-- `rentchain-api/src/services/__tests__/capabilityGuard.test.ts`
-- `rentchain-api/src/routes/expensesRoutes.ts`
-- `rentchain-api/src/routes/__tests__/expensesRoutes.test.ts`
-- `rentchain-frontend/src/constants/tiers.ts`
-- `rentchain-frontend/src/constants/tiers.test.ts`
-- `rentchain-frontend/src/components/billing/LockedFeature.tsx`
-- `rentchain-frontend/src/components/billing/LockedFeature.test.tsx`
-- `rentchain-frontend/src/components/billing/FeatureGate.test.tsx`
-- `rentchain-frontend/src/billing/upgradeCopy.ts`
-- `rentchain-frontend/src/lib/upgradePrompt.ts`
-- `rentchain-frontend/src/pages/ExpensesPage.tsx`
-- `rentchain-frontend/src/pages/ExpensesPage.test.tsx`
-- `.handoff/impl-summary.md`
+- `rentchain-api/src/app.build.ts`
+- `rentchain-api/src/routes/landlordTrustComplianceRoutes.ts`
+- `rentchain-api/src/routes/__tests__/landlordTrustComplianceRoutes.test.ts`
+- `rentchain-api/src/services/trustCompliance/trustComplianceSummaryService.ts`
+- `rentchain-api/src/services/trustCompliance/trustComplianceTypes.ts`
+- `rentchain-api/src/services/trustCompliance/__tests__/trustComplianceSummaryService.test.ts`
+- `rentchain-frontend/src/App.tsx`
+- `rentchain-frontend/src/App.routes.test.tsx`
+- `rentchain-frontend/src/api/trustComplianceApi.ts`
+- `rentchain-frontend/src/pages/TrustComplianceCenterPage.tsx`
+- `rentchain-frontend/src/pages/TrustComplianceCenterPage.test.tsx`
 
 KNOWN LIMITATIONS:
-- No live browser preview QA was run.
-- No Cloud Run deployment verification was performed because this mission only changes response copy/shape and frontend locked-state rendering, not deployment configuration.
-- Existing non-mission local handoff edits remain unstaged in `.handoff/merge-log.md` and `.handoff/mission-current.md`.
+- Frontend Vitest under local Node 20.11.1 fails before importing tests because of a jsdom/html-encoding-sniffer ESM dependency issue. The same targeted frontend tests pass under ambient Node v25.8.1, and the frontend build passes under Node 20.11.1.
+- No preview deployment or manual browser QA has been run yet.
 
 NEXT STEP:
-- Review PR, run preview QA for Free-tier locked surfaces, and then proceed to the next adoption-flow mission only after this upgrade messaging pass is accepted.
-
-## Manual QA Results — Vercel Preview
-
-Step 1: PARTIAL — /expenses canonical LockedFeature renders on first load but reverts
-to plain text "Import expenses / Upgrade to Pro..." after page refresh.
-State persistence issue — component may have conditional fallback to old text implementation.
-Step 2: PASS — Other locked surfaces consistent with canonical component
-Step 3: N/A — Could not test CTA link after LockedFeature reverted on refresh
-Step 4: PASS — Mobile layout 375px confirmed, no overflow
-
-FINDING 1 (medium): /expenses LockedFeature reverts to plain text after refresh —
-conditional render or hydration issue. Blocks full acceptance criteria.
-
-FINDING 2 (low): /payments missing single payment add — CSV upload only.
-Log as follow-up mission fix/payments-manual-entry-v1.
-
-## Manual QA Results — Final (after navigation-back fix)
-
-Step 1: PASS — /expenses LockedFeature displays correctly on Free tier
-Step 2: PASS — CTA → /pricing → browser back → /expenses: LockedFeature persists
-Step 3: PASS — Hard refresh: LockedFeature persists
-
-Root cause resolved: useRef stable state prevents LockedFeature from reverting
-during navigation transitions when useCapabilities briefly shows loading: true.
-
-FINDING 2 (low): /payments missing single payment add — log as follow-up mission.
-
-Manual QA: PASS — all three checks confirmed on Vercel preview.
+- Wait for PR checks.
+- Deploy the PR backend for preview if checks pass.
+- Verify route headers, landlord-scoped summary contents, and that dashboard access writes no canonical event.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -160,6 +160,7 @@ import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordInstitutionalExportGenerationRoutes from "./routes/landlordInstitutionalExportGenerationRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
+import landlordTrustComplianceRoutes from "./routes/landlordTrustComplianceRoutes";
 import landlordOperatorReviewRoutes from "./routes/landlordOperatorReviewRoutes";
 import landlordEvidencePackRoutes from "./routes/landlordEvidencePackRoutes";
 import landlordEvidencePackageGenerationRoutes from "./routes/landlordEvidencePackageGenerationRoutes";
@@ -506,6 +507,8 @@ app.use("/api/landlord", routeSource("landlordInstitutionExportsRoutes.ts"), lan
 console.log("[route-mount] landlordInstitutionExportsRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordAuditComplianceRoutes.ts"), landlordAuditComplianceRoutes);
 console.log("[route-mount] landlordAuditComplianceRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordTrustComplianceRoutes.ts"), landlordTrustComplianceRoutes);
+console.log("[route-mount] landlordTrustComplianceRoutes mounted at /api/landlord");
 app.use("/api/landlord/operator-reviews", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordOperatorReviewRoutes.ts"), landlordOperatorReviewRoutes);
 console.log("[route-mount] landlordOperatorReviewRoutes mounted at /api/landlord");

--- a/rentchain-api/src/routes/__tests__/landlordTrustComplianceRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordTrustComplianceRoutes.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeCanonicalEventMock = vi.hoisted(() => vi.fn(async () => ({ id: "event-1" })));
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  const clone = (value: any) => JSON.parse(JSON.stringify(value));
+  const getPath = (value: any, path: string) =>
+    path.split(".").reduce((current, key) => (current == null ? undefined : current[key]), value);
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = getPath(doc?.data, field);
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = [], cap = Infinity): any {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }], cap),
+      limit: (limit: number) => makeQuery(name, filters, limit),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .slice(0, cap)
+          .map((doc) => ({ id: doc.id, exists: true, data: () => clone(doc.data) }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data: clone(data) }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        limit: (limit: number) => makeQuery(name, [], limit),
+        get: async () => makeQuery(name).get(),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../lib/events/buildEvent", () => ({
+  CANONICAL_EVENTS_COLLECTION: "canonicalEvents",
+  writeCanonicalEvent: writeCanonicalEventMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+        return this;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordTrustComplianceRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetFakeDb();
+    writeCanonicalEventMock.mockClear();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockUser = null;
+    const router = (await import("../landlordTrustComplianceRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/trust-compliance/summary", user: null });
+
+    expect(res.status).toBe(401);
+    expect(res.headers["x-trust-compliance-route-version"]).toBe("trust-compliance-center-v1");
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-landlord users", async () => {
+    mockUser = { id: "tenant-1", role: "tenant" };
+    const router = (await import("../landlordTrustComplianceRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/trust-compliance/summary" });
+
+    expect(res.status).toBe(403);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a landlord-scoped read-only trust compliance summary", async () => {
+    seedDoc("canonicalEvents", "evidence-1", {
+      type: "lease.evidence_package_generated",
+      action: "evidence_package_generated",
+      actor: { id: "landlord-1", role: "landlord" },
+      occurredAt: "2026-06-14T10:00:00.000Z",
+      summary: "Lease evidence package PDF generated",
+      metadata: {
+        landlordId: "landlord-1",
+        evidencePackageId: "lep_safe",
+        manifestHash: "a".repeat(64),
+        manifestVersion: "lease_evidence_manifest_v1",
+        packageVersion: "lease-evidence-package-pdf-v1",
+        documentUrl: "gs://private/raw.pdf",
+      },
+    });
+    seedDoc("canonicalEvents", "export-1", {
+      type: "lease.institutional_export_generated",
+      action: "institutional_export_generated",
+      actor: { id: "landlord-1", role: "landlord" },
+      occurredAt: "2026-06-14T11:00:00.000Z",
+      summary: "Lease institutional evidence export generated",
+      metadata: {
+        exportReason: "tribunal",
+        exportScope: "lease_evidence_package",
+        exportFormat: "pdf",
+        retentionCategory: "export_metadata",
+        sensitivity: "confidential",
+        paymentProcessorId: "pi_secret_123",
+      },
+    });
+    seedDoc("canonicalEvents", "other-1", {
+      type: "lease.institutional_export_generated",
+      action: "institutional_export_generated",
+      actor: { id: "landlord-2", role: "landlord" },
+      occurredAt: "2026-06-14T12:00:00.000Z",
+      summary: "Other landlord export",
+      metadata: { landlordId: "landlord-2" },
+    });
+    seedDoc("consents", "consent-1", {
+      landlordId: "landlord-1",
+      status: "active",
+      consentType: "screening_consent",
+      signedDocumentStoragePath: "gs://private/consent.pdf",
+      createdAt: "2026-06-13T09:00:00.000Z",
+    });
+    seedDoc("screeningOrders", "screening-1", {
+      landlordId: "landlord-1",
+      status: "paid",
+      rawBureauPayload: "secret bureau data",
+      createdAt: "2026-06-12T09:00:00.000Z",
+    });
+
+    const router = (await import("../landlordTrustComplianceRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/trust-compliance/summary" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-trust-compliance-route-version"]).toBe("trust-compliance-center-v1");
+    expect(res.body.summary).toEqual(
+      expect.objectContaining({
+        version: "trust_compliance_center_v1",
+        landlordId: "landlord-1",
+        overallStatus: expect.any(String),
+      })
+    );
+    const evidence = res.body.summary.sections.find((section: any) => section.key === "evidence_exports");
+    expect(evidence.count).toBe(2);
+    expect(evidence.lastActivityAt).toBe("2026-06-14T11:00:00.000Z");
+    expect(evidence.items[0].safeMetadata).toEqual(
+      expect.objectContaining({
+        exportReason: "tribunal",
+        exportScope: "lease_evidence_package",
+        exportFormat: "pdf",
+        retentionCategory: "export_metadata",
+      })
+    );
+    expect(res.body.summary.sections.map((section: any) => section.key)).toEqual([
+      "evidence_exports",
+      "consent",
+      "privacy",
+      "retention",
+      "screening",
+      "audit_trail",
+      "incident_readiness",
+    ]);
+    expect(res.body.summary.recentAuditTrail.length).toBeLessThanOrEqual(12);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+
+    const serialized = JSON.stringify(res.body.summary);
+    expect(serialized).not.toContain("other-1");
+    expect(serialized).not.toContain("landlord-2");
+    expect(serialized).not.toContain("gs://private");
+    expect(serialized).not.toContain("pi_secret_123");
+    expect(serialized).not.toContain("secret bureau data");
+    expect(serialized).not.toContain("rawBureauPayload");
+    expect(serialized).not.toContain("documentUrl");
+  });
+});

--- a/rentchain-api/src/routes/landlordTrustComplianceRoutes.ts
+++ b/rentchain-api/src/routes/landlordTrustComplianceRoutes.ts
@@ -1,0 +1,44 @@
+import { Router } from "express";
+import { getEffectiveLandlordId } from "../auth/requestAuthority";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { buildTrustComplianceSummary } from "../services/trustCompliance/trustComplianceSummaryService";
+import { TRUST_COMPLIANCE_ROUTE_VERSION } from "../services/trustCompliance/trustComplianceTypes";
+
+const router = Router();
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function statusFor(error: any): number {
+  const status = Number(error?.status);
+  return Number.isInteger(status) && status >= 400 && status < 600 ? status : 500;
+}
+
+function codeFor(error: any): string {
+  const code = asString(error?.message, 120);
+  if (code === "landlord_id_required") return "UNAUTHORIZED";
+  return "TRUST_COMPLIANCE_SUMMARY_FAILED";
+}
+
+function trustComplianceRouteVersion(_req: any, res: any, next: any) {
+  res.setHeader("x-trust-compliance-route-version", TRUST_COMPLIANCE_ROUTE_VERSION);
+  return next();
+}
+
+router.get("/trust-compliance/summary", trustComplianceRouteVersion, requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(getEffectiveLandlordId(req), 240);
+    const summary = await buildTrustComplianceSummary({ landlordId });
+    return res.json({ ok: true, summary });
+  } catch (error: any) {
+    const status = statusFor(error);
+    if (status >= 500) {
+      console.error("[landlord-trust-compliance] summary failed", { message: error?.message || "failed" });
+    }
+    return res.status(status).json({ ok: false, error: codeFor(error) });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/trustCompliance/__tests__/trustComplianceSummaryService.test.ts
+++ b/rentchain-api/src/services/trustCompliance/__tests__/trustComplianceSummaryService.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildTrustComplianceSummary } from "../trustComplianceSummaryService";
+
+const { fakeDb, resetFakeDb, seedDoc } = (() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  const clone = (value: any) => JSON.parse(JSON.stringify(value));
+  const getPath = (value: any, path: string) =>
+    path.split(".").reduce((current, key) => (current == null ? undefined : current[key]), value);
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = getPath(doc?.data, field);
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = [], cap = Infinity): any {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }], cap),
+      limit: (limit: number) => makeQuery(name, filters, limit),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .slice(0, cap)
+          .map((doc) => ({ id: doc.id, exists: true, data: () => clone(doc.data) }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data: clone(data) }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        limit: (limit: number) => makeQuery(name, [], limit),
+        get: async () => makeQuery(name).get(),
+      }),
+    },
+  };
+})();
+
+function section(summary: any, key: string) {
+  return summary.sections.find((item: any) => item.key === key);
+}
+
+describe("trustComplianceSummaryService", () => {
+  beforeEach(() => {
+    resetFakeDb();
+  });
+
+  it("aggregates landlord-scoped evidence and export events with safe manifest metadata", async () => {
+    seedDoc("canonicalEvents", "event-own-evidence", {
+      type: "lease.evidence_package_generated",
+      action: "evidence_package_generated",
+      status: "generated",
+      actor: { id: "landlord-1", role: "landlord" },
+      occurredAt: "2026-06-14T10:00:00.000Z",
+      summary: "Lease evidence package PDF generated",
+      metadata: {
+        landlordId: "landlord-1",
+        evidencePackageId: "lep_safe123",
+        manifestHash: "a".repeat(64),
+        manifestVersion: "lease_evidence_manifest_v1",
+        packageVersion: "lease-evidence-package-pdf-v1",
+        storagePath: "gs://private/raw.pdf",
+        providerRequestId: "provider-secret",
+      },
+    });
+    seedDoc("canonicalEvents", "event-own-export", {
+      type: "lease.institutional_export_generated",
+      action: "institutional_export_generated",
+      status: "generated",
+      actor: { id: "landlord-1", role: "landlord" },
+      occurredAt: "2026-06-14T11:00:00.000Z",
+      summary: "Lease institutional evidence export generated",
+      metadata: {
+        exportReason: "tribunal",
+        exportScope: "lease_evidence_package",
+        exportFormat: "pdf",
+        retentionCategory: "export_metadata",
+        sensitivity: "confidential",
+        manifestHash: "b".repeat(64),
+        paymentProcessorId: "pi_secret_123",
+      },
+    });
+    seedDoc("canonicalEvents", "event-other", {
+      type: "lease.institutional_export_generated",
+      action: "institutional_export_generated",
+      actor: { id: "landlord-2", role: "landlord" },
+      occurredAt: "2026-06-14T12:00:00.000Z",
+      summary: "Other landlord export",
+      metadata: { landlordId: "landlord-2", manifestHash: "c".repeat(64) },
+    });
+
+    const summary = await buildTrustComplianceSummary({
+      landlordId: "landlord-1",
+      firestore: fakeDb,
+      generatedAt: "2026-06-15T00:00:00.000Z",
+    });
+
+    expect(summary.version).toBe("trust_compliance_center_v1");
+    expect(summary.landlordId).toBe("landlord-1");
+    expect(section(summary, "evidence_exports")).toEqual(
+      expect.objectContaining({
+        count: 2,
+        sourceAvailability: "available",
+        lastActivityAt: "2026-06-14T11:00:00.000Z",
+      })
+    );
+    expect(section(summary, "evidence_exports").items[0].safeMetadata).toEqual(
+      expect.objectContaining({
+        exportReason: "tribunal",
+        exportScope: "lease_evidence_package",
+        exportFormat: "pdf",
+        retentionCategory: "export_metadata",
+        sensitivity: "confidential",
+        manifestHash: "b".repeat(64),
+      })
+    );
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain("event-own-evidence");
+    expect(serialized).not.toContain("event-other");
+    expect(serialized).not.toContain("landlord-2");
+    expect(serialized).not.toContain("gs://private/raw.pdf");
+    expect(serialized).not.toContain("provider-secret");
+    expect(serialized).not.toContain("pi_secret_123");
+    expect(serialized).not.toContain("storagePath");
+    expect(serialized).not.toContain("providerRequestId");
+  });
+
+  it("renders empty consent and screening sections safely when sources have no records", async () => {
+    const summary = await buildTrustComplianceSummary({ landlordId: "landlord-1", firestore: fakeDb });
+
+    expect(section(summary, "consent")).toEqual(
+      expect.objectContaining({
+        count: 0,
+        sourceAvailability: "empty",
+        emptyState: "No landlord-scoped consent records are available yet.",
+      })
+    );
+    expect(section(summary, "screening")).toEqual(
+      expect.objectContaining({
+        count: 0,
+        sourceAvailability: "empty",
+        emptyState: "No landlord-scoped screening status records are available yet.",
+      })
+    );
+  });
+
+  it("bounds the recent audit trail and sorts newest first", async () => {
+    for (let i = 0; i < 20; i += 1) {
+      seedDoc("canonicalEvents", `event-${i}`, {
+        type: "lease.updated",
+        action: "updated",
+        actor: { id: "landlord-1", role: "landlord" },
+        occurredAt: `2026-06-14T${String(i).padStart(2, "0")}:00:00.000Z`,
+        summary: `Governance event ${i}`,
+        metadata: { landlordId: "landlord-1" },
+      });
+    }
+
+    const summary = await buildTrustComplianceSummary({ landlordId: "landlord-1", firestore: fakeDb });
+
+    expect(summary.recentAuditTrail).toHaveLength(12);
+    expect(summary.recentAuditTrail[0].occurredAt).toBe("2026-06-14T19:00:00.000Z");
+    expect(summary.recentAuditTrail[11].occurredAt).toBe("2026-06-14T08:00:00.000Z");
+  });
+});

--- a/rentchain-api/src/services/trustCompliance/trustComplianceSummaryService.ts
+++ b/rentchain-api/src/services/trustCompliance/trustComplianceSummaryService.ts
@@ -1,0 +1,360 @@
+import { db } from "../../firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
+import {
+  TRUST_COMPLIANCE_CENTER_VERSION,
+  type TrustComplianceCenterSummary,
+  type TrustComplianceSafeMetadata,
+  type TrustComplianceSectionKey,
+  type TrustComplianceSectionSummary,
+  type TrustComplianceSourceAvailability,
+  type TrustComplianceStatus,
+  type TrustComplianceSummaryItem,
+} from "./trustComplianceTypes";
+
+type DocSnapshotLike = {
+  id: string;
+  data: () => any;
+};
+
+type QuerySnapshotLike = {
+  docs?: DocSnapshotLike[];
+};
+
+type QueryLike = {
+  where?: (field: string, op: string, value: unknown) => QueryLike;
+  limit?: (value: number) => QueryLike;
+  get: () => Promise<QuerySnapshotLike>;
+};
+
+type CollectionLike = QueryLike;
+
+export type TrustComplianceFirestoreLike = {
+  collection: (name: string) => CollectionLike;
+};
+
+type RecordWithId = {
+  id: string;
+  data: any;
+  collectionName: string;
+};
+
+type SourceLoad = {
+  records: RecordWithId[];
+  available: boolean;
+};
+
+const MAX_SECTION_ITEMS = 6;
+const MAX_RECENT_AUDIT_ITEMS = 12;
+const MAX_SOURCE_RECORDS = 100;
+
+const SECTION_LABELS: Record<TrustComplianceSectionKey, string> = {
+  evidence_exports: "Evidence & Exports",
+  consent: "Consent",
+  privacy: "Privacy",
+  retention: "Retention",
+  screening: "Screening",
+  audit_trail: "Audit Trail",
+  incident_readiness: "Breach / Incident Readiness",
+};
+
+const SECTION_EMPTY: Record<TrustComplianceSectionKey, string> = {
+  evidence_exports: "No evidence package or institutional export events are available yet.",
+  consent: "No landlord-scoped consent records are available yet.",
+  privacy: "No privacy governance events are available yet.",
+  retention: "No retention metadata is available yet.",
+  screening: "No landlord-scoped screening status records are available yet.",
+  audit_trail: "No landlord-scoped governance audit events are available yet.",
+  incident_readiness: "No incident readiness signals are available yet.",
+};
+
+const REDACTIONS = [
+  "Raw Firestore document IDs are not used as human-facing labels.",
+  "Raw event metadata, storage paths, provider request IDs, payment processor IDs, private documents, message bodies, and screening reports are excluded.",
+  "Section summaries are bounded and metadata-only.",
+];
+
+const UNSAFE_PATTERN =
+  /gs:\/\/|storage\.googleapis\.com|providerRequestId|providerRequestRef|processor|paymentIntent|checkoutSession|stripe|secret|token|credential|privateKey|rawPayload|messageBody|documentUrl|storagePath|screeningReport|bureau/i;
+
+function trustDb(firestore?: TrustComplianceFirestoreLike): TrustComplianceFirestoreLike {
+  return firestore || (db as unknown as TrustComplianceFirestoreLike);
+}
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function safeText(value: unknown, fallback: string, max = 240): string {
+  const text = asString(value, max).replace(/\s+/g, " ");
+  if (!text || UNSAFE_PATTERN.test(text)) return fallback;
+  return text;
+}
+
+function normalizeKey(value: unknown): string {
+  return asString(value, 120).toLowerCase().replace(/[\s.-]+/g, "_");
+}
+
+function timestamp(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  if (typeof (value as any)?.toDate === "function") {
+    const date = (value as any).toDate();
+    return Number.isFinite(date?.getTime?.()) ? date.toISOString() : null;
+  }
+  if (typeof (value as any)?.toMillis === "function") {
+    const millis = Number((value as any).toMillis());
+    return Number.isFinite(millis) ? new Date(millis).toISOString() : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function occurredAt(record: any): string | null {
+  return timestamp(record?.occurredAt || record?.createdAt || record?.updatedAt || record?.generatedAt || record?.acceptedAt);
+}
+
+function sortByActivity<T extends { occurredAt: string | null; label?: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const left = a.occurredAt ? Date.parse(a.occurredAt) : 0;
+    const right = b.occurredAt ? Date.parse(b.occurredAt) : 0;
+    if (left !== right) return right - left;
+    return asString(a.label).localeCompare(asString(b.label));
+  });
+}
+
+function sourceAvailability(records: RecordWithId[], available: boolean): TrustComplianceSourceAvailability {
+  if (!available) return "unavailable";
+  return records.length ? "available" : "empty";
+}
+
+function uniqueRecords(records: RecordWithId[]): RecordWithId[] {
+  const byKey = new Map<string, RecordWithId>();
+  for (const record of records) byKey.set(`${record.collectionName}:${record.id}`, record);
+  return Array.from(byKey.values());
+}
+
+async function loadByLandlordFields(
+  firestore: TrustComplianceFirestoreLike,
+  collectionName: string,
+  landlordId: string,
+  fields: string[] = ["landlordId", "ownerId", "userId", "createdByLandlordId", "metadata.landlordId", "actor.id"]
+): Promise<SourceLoad> {
+  const records: RecordWithId[] = [];
+  let available = true;
+  await Promise.all(
+    fields.map(async (field) => {
+      const query = firestore.collection(collectionName).where?.(field, "==", landlordId);
+      const limited = query?.limit?.(MAX_SOURCE_RECORDS) || query;
+      const snap = await limited?.get().catch(() => {
+        available = false;
+        return null;
+      });
+      for (const doc of snap?.docs || []) {
+        records.push({ id: doc.id, data: doc.data() || {}, collectionName });
+      }
+    })
+  );
+  return { records: uniqueRecords(records), available };
+}
+
+function belongsToLandlord(record: any, landlordId: string): boolean {
+  const candidates = [
+    record?.landlordId,
+    record?.ownerId,
+    record?.userId,
+    record?.createdByLandlordId,
+    record?.metadata?.landlordId,
+    record?.actor?.id,
+  ];
+  return candidates.some((value) => asString(value, 240) === landlordId);
+}
+
+function pickSafeMetadata(metadata: any): TrustComplianceSafeMetadata | undefined {
+  const safe: TrustComplianceSafeMetadata = {};
+  for (const key of [
+    "evidencePackageId",
+    "manifestHash",
+    "manifestVersion",
+    "packageVersion",
+    "exportFormat",
+    "exportReason",
+    "exportScope",
+    "sensitivity",
+    "retentionCategory",
+    "consentState",
+    "consentType",
+    "screeningStatus",
+  ] as const) {
+    const value = asString(metadata?.[key], key === "manifestHash" ? 128 : 120);
+    if (value && !UNSAFE_PATTERN.test(value)) safe[key] = value;
+  }
+  return Object.keys(safe).length ? safe : undefined;
+}
+
+function eventItem(event: any, fallbackLabel: string): TrustComplianceSummaryItem {
+  const action = asString(event?.action, 120);
+  const type = asString(event?.type, 160);
+  return {
+    label: safeText(event?.summary, fallbackLabel, 180),
+    description: safeText(type || action, "Governance event metadata available.", 180),
+    eventType: type || null,
+    action: action || null,
+    status: asString(event?.status, 80) || null,
+    occurredAt: occurredAt(event),
+    safeMetadata: pickSafeMetadata(event?.metadata || {}),
+  };
+}
+
+function sourceItem(record: RecordWithId, params: { label: string; description: string; safeMetadata?: TrustComplianceSafeMetadata }): TrustComplianceSummaryItem {
+  return {
+    label: params.label,
+    description: params.description,
+    status: asString(record.data?.status || record.data?.state || record.data?.lifecycle, 80) || null,
+    occurredAt: occurredAt(record.data),
+    safeMetadata: params.safeMetadata,
+  };
+}
+
+function buildSection(input: {
+  key: TrustComplianceSectionKey;
+  items: TrustComplianceSummaryItem[];
+  availability: TrustComplianceSourceAvailability;
+  forceStatus?: TrustComplianceStatus;
+}): TrustComplianceSectionSummary {
+  const items = sortByActivity(input.items).slice(0, MAX_SECTION_ITEMS);
+  const lastActivityAt = sortByActivity(input.items)[0]?.occurredAt || null;
+  const status = input.forceStatus || (input.availability === "unavailable" ? "unavailable" : input.items.length ? "ready" : "needs_attention");
+  return {
+    key: input.key,
+    label: SECTION_LABELS[input.key],
+    status,
+    count: input.items.length,
+    lastActivityAt,
+    sourceAvailability: input.availability,
+    items,
+    emptyState: SECTION_EMPTY[input.key],
+  };
+}
+
+function aggregateStatus(sections: TrustComplianceSectionSummary[]): TrustComplianceStatus {
+  if (sections.every((section) => section.sourceAvailability === "unavailable")) return "unavailable";
+  if (sections.some((section) => section.status === "needs_attention" || section.status === "unavailable")) return "needs_attention";
+  return "ready";
+}
+
+export async function buildTrustComplianceSummary(input: {
+  landlordId: string;
+  firestore?: TrustComplianceFirestoreLike;
+  generatedAt?: string | Date | null;
+}): Promise<TrustComplianceCenterSummary> {
+  const landlordId = asString(input.landlordId, 240);
+  if (!landlordId) throw Object.assign(new Error("landlord_id_required"), { status: 401 });
+  const firestore = trustDb(input.firestore);
+  const generatedAt = timestamp(input.generatedAt) || new Date().toISOString();
+
+  const [eventLoad, consentLoad, reportingConsentLoad, screeningOrderLoad, screeningEventLoad] = await Promise.all([
+    loadByLandlordFields(firestore, CANONICAL_EVENTS_COLLECTION, landlordId),
+    loadByLandlordFields(firestore, "consents", landlordId),
+    loadByLandlordFields(firestore, "reportingConsents", landlordId, ["landlordId", "ownerId", "userId"]),
+    loadByLandlordFields(firestore, "screeningOrders", landlordId),
+    loadByLandlordFields(firestore, "screeningEvents", landlordId),
+  ]);
+
+  const canonicalEvents = eventLoad.records.map((record) => record.data).filter((event) => belongsToLandlord(event, landlordId));
+  const evidenceEvents = canonicalEvents.filter((event) =>
+    ["lease.evidence_package_generated", "lease.institutional_export_generated"].includes(asString(event?.type, 160)) ||
+    ["evidence_package_generated", "institutional_export_generated"].includes(asString(event?.action, 160))
+  );
+  const consentRecords = uniqueRecords([...consentLoad.records, ...reportingConsentLoad.records]);
+  const screeningRecords = uniqueRecords([...screeningOrderLoad.records, ...screeningEventLoad.records]);
+
+  const privacyEvents = canonicalEvents.filter((event) => {
+    const haystack = `${event?.domain || ""} ${event?.type || ""} ${event?.action || ""} ${event?.summary || ""}`.toLowerCase();
+    return haystack.includes("privacy") || haystack.includes("consent") || haystack.includes("projection") || haystack.includes("access");
+  });
+
+  const retentionEvents = canonicalEvents.filter((event) => {
+    const metadata = event?.metadata || {};
+    return Boolean(metadata.retentionCategory || metadata.retentionClass || metadata.sensitivity);
+  });
+
+  const screeningEvents = canonicalEvents.filter((event) => {
+    const domain = normalizeKey(event?.domain);
+    const type = normalizeKey(event?.type);
+    const action = normalizeKey(event?.action);
+    return domain === "screening" || type.includes("screening") || action.includes("screening");
+  });
+
+  const incidentEvents = canonicalEvents.filter((event) => {
+    const haystack = `${event?.domain || ""} ${event?.type || ""} ${event?.action || ""} ${event?.summary || ""}`.toLowerCase();
+    return haystack.includes("incident") || haystack.includes("breach") || haystack.includes("security");
+  });
+
+  const sections = [
+    buildSection({
+      key: "evidence_exports",
+      availability: sourceAvailability(evidenceEvents.map((data, index) => ({ id: String(index), data, collectionName: CANONICAL_EVENTS_COLLECTION })), eventLoad.available),
+      items: evidenceEvents.map((event) => eventItem(event, "Evidence/export governance event")),
+    }),
+    buildSection({
+      key: "consent",
+      availability: sourceAvailability(consentRecords, consentLoad.available || reportingConsentLoad.available),
+      items: consentRecords.map((record) =>
+        sourceItem(record, {
+          label: "Consent record",
+          description: "Consent lifecycle metadata is available.",
+          safeMetadata: {
+            consentState: asString(record.data?.status || record.data?.state || record.data?.consentState, 80) || undefined,
+            consentType: asString(record.data?.type || record.data?.consentType || record.data?.scope, 100) || undefined,
+          },
+        })
+      ),
+    }),
+    buildSection({
+      key: "privacy",
+      availability: sourceAvailability(privacyEvents.map((data, index) => ({ id: String(index), data, collectionName: CANONICAL_EVENTS_COLLECTION })), eventLoad.available),
+      items: privacyEvents.map((event) => eventItem(event, "Privacy governance event")),
+    }),
+    buildSection({
+      key: "retention",
+      availability: sourceAvailability(retentionEvents.map((data, index) => ({ id: String(index), data, collectionName: CANONICAL_EVENTS_COLLECTION })), eventLoad.available),
+      items: retentionEvents.map((event) => eventItem(event, "Retention governance metadata")),
+    }),
+    buildSection({
+      key: "screening",
+      availability: sourceAvailability([...screeningRecords, ...screeningEvents.map((data, index) => ({ id: `event-${index}`, data, collectionName: CANONICAL_EVENTS_COLLECTION }))], screeningOrderLoad.available || screeningEventLoad.available || eventLoad.available),
+      items: [
+        ...screeningRecords.map((record) =>
+          sourceItem(record, {
+            label: "Screening status record",
+            description: "Screening posture metadata is available.",
+            safeMetadata: { screeningStatus: asString(record.data?.status || record.data?.state, 80) || undefined },
+          })
+        ),
+        ...screeningEvents.map((event) => eventItem(event, "Screening governance event")),
+      ],
+    }),
+    buildSection({
+      key: "audit_trail",
+      availability: sourceAvailability(canonicalEvents.map((data, index) => ({ id: String(index), data, collectionName: CANONICAL_EVENTS_COLLECTION })), eventLoad.available),
+      items: canonicalEvents.map((event) => eventItem(event, "Governance audit event")),
+    }),
+    buildSection({
+      key: "incident_readiness",
+      availability: eventLoad.available ? (incidentEvents.length ? "available" : "empty") : "unavailable",
+      items: incidentEvents.map((event) => eventItem(event, "Incident readiness signal")),
+    }),
+  ] satisfies TrustComplianceSectionSummary[];
+
+  const recentAuditTrail = sortByActivity(canonicalEvents.map((event) => eventItem(event, "Governance audit event"))).slice(0, MAX_RECENT_AUDIT_ITEMS);
+
+  return {
+    version: TRUST_COMPLIANCE_CENTER_VERSION,
+    generatedAt,
+    landlordId,
+    overallStatus: aggregateStatus(sections),
+    sections,
+    recentAuditTrail,
+    redactions: REDACTIONS,
+  };
+}

--- a/rentchain-api/src/services/trustCompliance/trustComplianceTypes.ts
+++ b/rentchain-api/src/services/trustCompliance/trustComplianceTypes.ts
@@ -1,0 +1,60 @@
+export const TRUST_COMPLIANCE_CENTER_VERSION = "trust_compliance_center_v1";
+export const TRUST_COMPLIANCE_ROUTE_VERSION = "trust-compliance-center-v1";
+
+export type TrustComplianceSectionKey =
+  | "evidence_exports"
+  | "consent"
+  | "privacy"
+  | "retention"
+  | "screening"
+  | "audit_trail"
+  | "incident_readiness";
+
+export type TrustComplianceStatus = "ready" | "needs_attention" | "unavailable";
+export type TrustComplianceSourceAvailability = "available" | "empty" | "unavailable" | "access_unavailable";
+
+export type TrustComplianceSafeMetadata = {
+  evidencePackageId?: string;
+  manifestHash?: string;
+  manifestVersion?: string;
+  packageVersion?: string;
+  exportFormat?: string;
+  exportReason?: string;
+  exportScope?: string;
+  sensitivity?: string;
+  retentionCategory?: string;
+  consentState?: string;
+  consentType?: string;
+  screeningStatus?: string;
+};
+
+export type TrustComplianceSummaryItem = {
+  label: string;
+  description: string;
+  eventType?: string | null;
+  action?: string | null;
+  status?: string | null;
+  occurredAt: string | null;
+  safeMetadata?: TrustComplianceSafeMetadata;
+};
+
+export type TrustComplianceSectionSummary = {
+  key: TrustComplianceSectionKey;
+  label: string;
+  status: TrustComplianceStatus;
+  count: number;
+  lastActivityAt: string | null;
+  sourceAvailability: TrustComplianceSourceAvailability;
+  items: TrustComplianceSummaryItem[];
+  emptyState: string;
+};
+
+export type TrustComplianceCenterSummary = {
+  version: typeof TRUST_COMPLIANCE_CENTER_VERSION;
+  generatedAt: string;
+  landlordId: string;
+  overallStatus: TrustComplianceStatus;
+  sections: TrustComplianceSectionSummary[];
+  recentAuditTrail: TrustComplianceSummaryItem[];
+  redactions: string[];
+};

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -148,6 +148,10 @@ vi.mock("./pages/AuditCompliancePage", () => ({
   default: () => <h1>Audit Compliance Readiness Page</h1>,
 }));
 
+vi.mock("./pages/TrustComplianceCenterPage", () => ({
+  default: () => <h1>Trust Compliance Center Page</h1>,
+}));
+
 vi.mock("./pages/EvidencePackPage", () => ({
   default: () => <h1>Evidence Pack Preview Page</h1>,
 }));
@@ -397,6 +401,20 @@ describe("Routes: /audit-compliance", () => {
     );
 
     expect(await screen.findByText(/Audit Compliance Readiness Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /trust-compliance", () => {
+  it("renders the read-only trust compliance center route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/trust-compliance"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Trust Compliance Center Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -152,6 +152,7 @@ const AgentSupervisionPage = lazy(() => import("./pages/AgentSupervisionPage"));
 const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage"));
 const RecipientTrustReviewPage = lazy(() => import("./pages/RecipientTrustReviewPage"));
 const AuditCompliancePage = lazy(() => import("./pages/AuditCompliancePage"));
+const TrustComplianceCenterPage = lazy(() => import("./pages/TrustComplianceCenterPage"));
 const EvidencePackPage = lazy(() => import("./pages/EvidencePackPage"));
 const ReviewTimelinePage = lazy(() => import("./pages/ReviewTimelinePage"));
 const IdentityLayerPage = lazy(() => import("./pages/IdentityLayerPage"));
@@ -650,6 +651,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <AuditCompliancePage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/trust-compliance"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <TrustComplianceCenterPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/trustComplianceApi.ts
+++ b/rentchain-frontend/src/api/trustComplianceApi.ts
@@ -1,0 +1,64 @@
+import { apiFetch } from "./apiFetch";
+
+export type TrustComplianceSectionKey =
+  | "evidence_exports"
+  | "consent"
+  | "privacy"
+  | "retention"
+  | "screening"
+  | "audit_trail"
+  | "incident_readiness";
+
+export type TrustComplianceStatus = "ready" | "needs_attention" | "unavailable";
+export type TrustComplianceSourceAvailability = "available" | "empty" | "unavailable" | "access_unavailable";
+
+export type TrustComplianceSafeMetadata = {
+  evidencePackageId?: string;
+  manifestHash?: string;
+  manifestVersion?: string;
+  packageVersion?: string;
+  exportFormat?: string;
+  exportReason?: string;
+  exportScope?: string;
+  sensitivity?: string;
+  retentionCategory?: string;
+  consentState?: string;
+  consentType?: string;
+  screeningStatus?: string;
+};
+
+export type TrustComplianceSummaryItem = {
+  label: string;
+  description: string;
+  eventType?: string | null;
+  action?: string | null;
+  status?: string | null;
+  occurredAt: string | null;
+  safeMetadata?: TrustComplianceSafeMetadata;
+};
+
+export type TrustComplianceSectionSummary = {
+  key: TrustComplianceSectionKey;
+  label: string;
+  status: TrustComplianceStatus;
+  count: number;
+  lastActivityAt: string | null;
+  sourceAvailability: TrustComplianceSourceAvailability;
+  items: TrustComplianceSummaryItem[];
+  emptyState: string;
+};
+
+export type TrustComplianceCenterSummary = {
+  version: "trust_compliance_center_v1";
+  generatedAt: string;
+  landlordId: string;
+  overallStatus: TrustComplianceStatus;
+  sections: TrustComplianceSectionSummary[];
+  recentAuditTrail: TrustComplianceSummaryItem[];
+  redactions: string[];
+};
+
+export async function fetchTrustComplianceSummary(): Promise<TrustComplianceCenterSummary> {
+  const response = await apiFetch<{ ok: true; summary: TrustComplianceCenterSummary }>("/landlord/trust-compliance/summary");
+  return response.summary;
+}

--- a/rentchain-frontend/src/pages/TrustComplianceCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/TrustComplianceCenterPage.test.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TrustComplianceCenterPage from "./TrustComplianceCenterPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchTrustComplianceSummary: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/trustComplianceApi", async () => {
+  const actual = await vi.importActual<any>("@/api/trustComplianceApi");
+  return {
+    ...actual,
+    fetchTrustComplianceSummary: apiMocks.fetchTrustComplianceSummary,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: apiMocks.showToast,
+  }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function section(key: string, label: string, overrides: Record<string, unknown> = {}) {
+  return {
+    key,
+    label,
+    status: "needs_attention",
+    count: 0,
+    lastActivityAt: null,
+    sourceAvailability: "empty",
+    items: [],
+    emptyState: `No ${label.toLowerCase()} records yet.`,
+    ...overrides,
+  };
+}
+
+function summary(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "trust_compliance_center_v1",
+    generatedAt: "2026-06-15T00:00:00.000Z",
+    landlordId: "landlord-1",
+    overallStatus: "needs_attention",
+    sections: [
+      section("evidence_exports", "Evidence & Exports", {
+        status: "ready",
+        count: 2,
+        lastActivityAt: "2026-06-14T11:00:00.000Z",
+        sourceAvailability: "available",
+        items: [
+          {
+            label: "Lease institutional evidence export generated",
+            description: "lease.institutional_export_generated",
+            eventType: "lease.institutional_export_generated",
+            action: "institutional_export_generated",
+            status: "generated",
+            occurredAt: "2026-06-14T11:00:00.000Z",
+            safeMetadata: {
+              exportReason: "tribunal",
+              exportScope: "lease_evidence_package",
+              exportFormat: "pdf",
+              manifestHash: "a".repeat(64),
+              storagePath: "gs://private/raw.pdf",
+            },
+          },
+        ],
+      }),
+      section("consent", "Consent"),
+      section("privacy", "Privacy"),
+      section("retention", "Retention"),
+      section("screening", "Screening"),
+      section("audit_trail", "Audit Trail"),
+      section("incident_readiness", "Breach / Incident Readiness"),
+    ],
+    recentAuditTrail: [
+      {
+        label: "rawFirestoreDocId123456",
+        description: "gs://private/raw.pdf",
+        occurredAt: "2026-06-14T11:00:00.000Z",
+      },
+    ],
+    redactions: ["Raw Firestore document IDs are not used as human-facing labels."],
+    ...overrides,
+  };
+}
+
+describe("TrustComplianceCenterPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    apiMocks.fetchTrustComplianceSummary.mockResolvedValue(summary());
+  });
+
+  it("renders all read-only sections, counts, safe metadata, and empty states", async () => {
+    render(<TrustComplianceCenterPage />);
+
+    expect(await screen.findByRole("heading", { name: "Trust & Compliance Center" })).toBeInTheDocument();
+    expect(screen.getByText("Evidence & Exports")).toBeInTheDocument();
+    expect(screen.getByText(/2 records/i)).toBeInTheDocument();
+    expect(screen.getByText("Consent")).toBeInTheDocument();
+    expect(screen.getByText("No consent records yet.")).toBeInTheDocument();
+    expect(screen.getByText("Privacy")).toBeInTheDocument();
+    expect(screen.getByText("Retention")).toBeInTheDocument();
+    expect(screen.getByText("Screening")).toBeInTheDocument();
+    expect(screen.getByText("Audit Trail")).toBeInTheDocument();
+    expect(screen.getByText("Breach / Incident Readiness")).toBeInTheDocument();
+    expect(screen.getByText(/Export Reason: tribunal/i)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`Manifest Hash: ${"a".repeat(64)}`))).toBeInTheDocument();
+    expect(screen.getByText("Recent Audit Trail")).toBeInTheDocument();
+    expect(screen.getAllByText("Governance summary").length).toBeGreaterThan(0);
+    expect(screen.getByText("Metadata-only summary")).toBeInTheDocument();
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+
+    expect(screen.queryByText(/rawFirestoreDocId123456/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/gs:\/\/private/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/storagePath/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("form")).not.toBeInTheDocument();
+  });
+
+  it("renders loading and error states", async () => {
+    apiMocks.fetchTrustComplianceSummary.mockRejectedValueOnce(new Error("network failed"));
+    render(<TrustComplianceCenterPage />);
+
+    expect(screen.getByText("Loading trust and compliance summary...")).toBeInTheDocument();
+    expect(await screen.findByText("We couldn't load trust and compliance summary right now.")).toBeInTheDocument();
+    expect(apiMocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Failed to load trust and compliance summary",
+        description: "network failed",
+        variant: "error",
+      })
+    );
+  });
+});

--- a/rentchain-frontend/src/pages/TrustComplianceCenterPage.tsx
+++ b/rentchain-frontend/src/pages/TrustComplianceCenterPage.tsx
@@ -1,0 +1,232 @@
+import React from "react";
+import {
+  fetchTrustComplianceSummary,
+  type TrustComplianceCenterSummary,
+  type TrustComplianceSectionSummary,
+  type TrustComplianceStatus,
+  type TrustComplianceSummaryItem,
+} from "@/api/trustComplianceApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+function label(value: string) {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+const UNSAFE_DISPLAY_PATTERN =
+  /gs:\/\/|storage\.googleapis\.com|providerRequestId|providerRequestRef|processor|paymentIntent|checkoutSession|stripe|secret|token|credential|rawPayload|messageBody|documentUrl|storagePath|screeningReport|bureau/i;
+
+function safeDisplay(value: unknown, fallback: string) {
+  const text = String(value ?? "").trim().replace(/\s+/g, " ");
+  if (!text || UNSAFE_DISPLAY_PATTERN.test(text)) return fallback;
+  if (/^[A-Za-z0-9_-]{18,}$/.test(text)) return fallback;
+  return text;
+}
+
+function dateOrEmpty(value: string | null | undefined) {
+  if (!value) return "No activity yet";
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toLocaleString() : value;
+}
+
+function statusTone(status: TrustComplianceStatus) {
+  if (status === "ready") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  if (status === "needs_attention") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ status, children }: { status: TrustComplianceStatus; children: React.ReactNode }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function sourceLabel(value: string) {
+  if (value === "available") return "Source available";
+  if (value === "empty") return "No records yet";
+  if (value === "access_unavailable") return "Access unavailable";
+  return "Source unavailable";
+}
+
+function metadataRows(item: TrustComplianceSummaryItem) {
+  const metadata = item.safeMetadata || {};
+  return Object.entries(metadata).filter(([, value]) => value);
+}
+
+function SummaryItemCard({ item }: { item: TrustComplianceSummaryItem }) {
+  const rows = metadataRows(item);
+  return (
+    <Card style={{ borderRadius: 8, padding: 12, display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 10 }}>
+        <div>
+          <strong style={{ color: "#0f172a" }}>{safeDisplay(item.label, "Governance summary")}</strong>
+          <div style={{ color: "#64748b", fontSize: 13 }}>{safeDisplay(item.description, "Metadata-only summary")}</div>
+        </div>
+        {item.status ? (
+          <span style={{ color: "#475569", fontSize: 12, fontWeight: 800, whiteSpace: "nowrap" }}>{label(item.status)}</span>
+        ) : null}
+      </div>
+      <div style={{ color: "#64748b", fontSize: 12 }}>{dateOrEmpty(item.occurredAt)}</div>
+      {rows.length ? (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {rows.slice(0, 6).map(([key, value]) => (
+            <span
+              key={key}
+              style={{
+                border: "1px solid #e2e8f0",
+                borderRadius: 999,
+                padding: "3px 8px",
+                color: "#334155",
+                fontSize: 12,
+                background: "#fff",
+              }}
+            >
+              {label(key)}: {key === "manifestHash" ? String(value) : safeDisplay(value, "Redacted")}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function SectionCard({ section }: { section: TrustComplianceSectionSummary }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: "1.05rem" }}>{section.label}</h2>
+          <div style={{ color: "#64748b", fontSize: 13 }}>
+            {sourceLabel(section.sourceAvailability)} · {section.count} records · Last activity {dateOrEmpty(section.lastActivityAt)}
+          </div>
+        </div>
+        <Badge status={section.status}>{label(section.status)}</Badge>
+      </div>
+      {section.items.length ? (
+        <div style={{ display: "grid", gap: 10 }}>
+          {section.items.map((item, index) => (
+            <SummaryItemCard key={`${section.key}-${index}-${item.occurredAt || "none"}`} item={item} />
+          ))}
+        </div>
+      ) : (
+        <Card style={{ color: "#64748b", borderRadius: 8 }}>{section.emptyState}</Card>
+      )}
+    </Section>
+  );
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load trust and compliance summary";
+}
+
+export default function TrustComplianceCenterPage() {
+  const { showToast } = useToast();
+  const [summary, setSummary] = React.useState<TrustComplianceCenterSummary | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const result = await fetchTrustComplianceSummary();
+        if (mounted) setSummary(result);
+      } catch (err) {
+        const message = errorMessage(err);
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load trust and compliance summary", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  return (
+    <MacShell title="Trust & Compliance Center" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Trust & Compliance Center</h1>
+            <div style={{ color: "#475569", maxWidth: 920 }}>
+              Read-only governance visibility across evidence, export, consent, privacy, retention, screening, audit, and incident readiness signals.
+            </div>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading trust and compliance summary...</Card> : null}
+        {!loading && error ? (
+          <Card style={{ color: "#b91c1c" }}>We couldn't load trust and compliance summary right now.</Card>
+        ) : null}
+
+        {!loading && !error && summary ? (
+          <>
+            <Section style={{ display: "grid", gap: 12 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Overall governance posture</div>
+                  <div style={{ color: "#0f172a", fontSize: "1.1rem", fontWeight: 900 }}>{label(summary.overallStatus)}</div>
+                  <div style={{ color: "#64748b", fontSize: 13 }}>Generated {dateOrEmpty(summary.generatedAt)}</div>
+                </div>
+                <Badge status={summary.overallStatus}>{label(summary.overallStatus)}</Badge>
+              </div>
+            </Section>
+
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 12 }}>
+              {summary.sections.map((section) => (
+                <SectionCard key={section.key} section={section} />
+              ))}
+            </div>
+
+            <Section style={{ display: "grid", gap: 10 }}>
+              <div style={{ fontWeight: 900 }}>Recent Audit Trail</div>
+              {summary.recentAuditTrail.length ? (
+                <div style={{ display: "grid", gap: 10 }}>
+                  {summary.recentAuditTrail.map((item, index) => (
+                    <SummaryItemCard key={`audit-${index}-${item.occurredAt || "none"}`} item={item} />
+                  ))}
+                </div>
+              ) : (
+                <Card style={{ color: "#64748b", borderRadius: 8 }}>No recent governance audit events are available yet.</Card>
+              )}
+            </Section>
+
+            <Section style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 900 }}>Redactions</div>
+              {summary.redactions.map((redaction) => (
+                <div key={redaction} style={{ color: "#475569", lineHeight: 1.55 }}>
+                  {redaction}
+                </div>
+              ))}
+            </Section>
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a read-only landlord Trust & Compliance Center summary endpoint at `GET /api/landlord/trust-compliance/summary`.
- Aggregate landlord-scoped governance visibility across evidence/export, consent, privacy, retention, screening, audit trail, and incident readiness sections.
- Add a minimal read-only frontend page at `/trust-compliance` with safe section cards, empty states, loading/error states, and no forms or mutation actions.

## Governance and Safety
- Uses `canonicalEvents` as the primary source and existing consent/screening collections only as safe supplemental posture sources.
- Does not create a new audit collection and does not write an audit event for dashboard access.
- Uses explicit metadata allowlists; raw event metadata is not returned wholesale.
- Excludes storage paths, provider request IDs, payment processor IDs, private documents, message bodies, and raw screening payloads/reports from the response and UI.
- Adds route/version headers: `x-route-source: landlordTrustComplianceRoutes.ts` and `x-trust-compliance-route-version: trust-compliance-center-v1`.

## Tests
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/trustCompliance/__tests__/trustComplianceSummaryService.test.ts src/routes/__tests__/landlordTrustComplianceRoutes.test.ts src/routes/__tests__/routeMountSmoke.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` from `rentchain-api`
- `npm run test:single -- TrustComplianceCenterPage.test.tsx App.routes.test.tsx` from `rentchain-frontend` using ambient Node v25.8.1
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` from `rentchain-frontend`
- `git diff --cached --check`

## Notes
- Frontend Vitest under local Node 20.11.1 fails before importing tests due a jsdom/html-encoding-sniffer ESM dependency issue; the same targeted tests pass under ambient Node v25.8.1. Frontend build passes under Node 20.11.1.

## Preview QA
- Deploy the PR backend and confirm Cloud Run image parity for this branch head.
- Authenticated landlord: `GET /api/landlord/trust-compliance/summary` returns 200 with both route/version headers.
- Confirm response includes all seven sections, bounded recent audit trail, and no raw storage paths/provider IDs/processor IDs/message bodies/screening payloads.
- Confirm no new `canonicalEvents` record is written by opening the dashboard.
- Open `/trust-compliance` in preview and confirm cards, empty states, counts, and loading/error handling render read-only with no forms or actions.