### PR TITLE
feat: add real lease signing dispatch

### DIFF
--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -1,60 +1,72 @@
-PR: #1161
-PR URL: https://github.com/rentchaincanada/rentchain/pull/1161
-Branch: feat/trust-and-compliance-center-v1
+PR: #1162
+PR URL: https://github.com/rentchaincanada/rentchain/pull/1162
+Branch: feat/signing-provider-real-dispatch-v1
 
 WHAT WAS DONE:
-- Added a read-only landlord Trust & Compliance Center backend endpoint:
-  `GET /api/landlord/trust-compliance/summary`.
-- Aggregated landlord-scoped governance visibility across evidence/export, consent, privacy, retention, screening, audit trail, and incident readiness sections.
-- Added safe route/version header support:
-  `x-route-source: landlordTrustComplianceRoutes.ts`
-  `x-trust-compliance-route-version: trust-compliance-center-v1`
-- Added a minimal read-only frontend page at `/trust-compliance`.
-- Added frontend API types and focused route/page tests.
+- Converted the Dropbox Sign provider from stub-only behavior to a real SDK-backed dispatch path.
+- Kept the provider-agnostic signing adapter and preserved mock signing as the default local/dev/test provider.
+- Added Dropbox Sign test-mode dispatch metadata and safe real/sandbox UI messaging.
+- Added a `failed` signing state so provider failures can be visible and retryable without claiming a request is pending or signed.
+- Repaired signing webhook raw-body handling for provider callbacks and widened signing webhook raw parsing to support non-JSON callback payloads.
+- Preserved existing signing collections:
+  - `leaseSigningRequests`
+  - `leaseSigningEvents`
+  - `leaseSigningWebhookDeadLetters`
+  - `canonicalEvents`
 
 KEY DECISIONS:
-- `canonicalEvents` is the primary source. Existing consent and screening collections are used only as safe supplemental posture sources.
-- Dashboard access does not write canonical events.
-- No new audit collection or compliance workflow collection was added.
-- Event metadata is allowlisted; raw event metadata is not returned wholesale.
-- The frontend also defensively redacts unsafe display values.
+- Dropbox Sign is the first real provider because `@dropbox/sign` is already a backend dependency and the existing registry already supports `dropbox_sign`.
+- V1 uses provider-readable HTTP(S) lease document URLs through Dropbox Sign `fileUrls`.
+- Raw provider request IDs are stored internally only and are not projected to UI/API or canonical event metadata.
+- Webhook payloads and provider payloads are not stored.
+- No provider selection UI, DocuSign work, public verification portal, legal certificate generation, blockchain anchoring, or broad document-management work was added.
 
 CURRENT STATE:
-- Branch: feat/trust-and-compliance-center-v1
-- PR: #1161
-- PR URL: https://github.com/rentchaincanada/rentchain/pull/1161
+- Branch: feat/signing-provider-real-dispatch-v1
+- PR: #1162
+- PR URL: https://github.com/rentchaincanada/rentchain/pull/1162
 - Draft PR opened for review.
 - Branch pushed to origin.
 
 VALIDATION:
 - Backend targeted tests passed:
-  - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/trustCompliance/__tests__/trustComplianceSummaryService.test.ts src/routes/__tests__/landlordTrustComplianceRoutes.test.ts src/routes/__tests__/routeMountSmoke.test.ts`
+  - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/signing/providers/__tests__/dropboxSignProvider.test.ts src/services/signing/providers/__tests__/mockSigningProvider.test.ts src/services/__tests__/leaseSigningService.test.ts src/routes/__tests__/leaseRoutes.active.test.ts`
+- Backend route smoke test passed with local bind permission:
+  - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/routes/__tests__/routeMountSmoke.test.ts`
 - Backend build passed:
   - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
-- Frontend targeted tests passed under ambient Node v25.8.1:
-  - `npm run test:single -- TrustComplianceCenterPage.test.tsx App.routes.test.tsx`
-- Frontend build passed under repo-required Node 20.11.1:
+- Frontend targeted test passed:
+  - `npm run test:single -- LeaseSigningDashboard.test.tsx`
+- Frontend build passed:
   - `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
-- `git diff --cached --check` passed.
+- `git diff --check` passed.
 
 FILES CHANGED:
 - `rentchain-api/src/app.build.ts`
-- `rentchain-api/src/routes/landlordTrustComplianceRoutes.ts`
-- `rentchain-api/src/routes/__tests__/landlordTrustComplianceRoutes.test.ts`
-- `rentchain-api/src/services/trustCompliance/trustComplianceSummaryService.ts`
-- `rentchain-api/src/services/trustCompliance/trustComplianceTypes.ts`
-- `rentchain-api/src/services/trustCompliance/__tests__/trustComplianceSummaryService.test.ts`
-- `rentchain-frontend/src/App.tsx`
-- `rentchain-frontend/src/App.routes.test.tsx`
-- `rentchain-frontend/src/api/trustComplianceApi.ts`
-- `rentchain-frontend/src/pages/TrustComplianceCenterPage.tsx`
-- `rentchain-frontend/src/pages/TrustComplianceCenterPage.test.tsx`
+- `rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts`
+- `rentchain-api/src/services/__tests__/leaseSigningService.test.ts`
+- `rentchain-api/src/services/leaseStateHelper.ts`
+- `rentchain-api/src/services/signing/leaseSigningService.ts`
+- `rentchain-api/src/services/signing/providers/dropboxSignProvider.ts`
+- `rentchain-api/src/services/signing/providers/mockSigningProvider.ts`
+- `rentchain-api/src/services/signing/providers/types.ts`
+- `rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts`
+- `rentchain-frontend/src/api/leasesApi.ts`
+- `rentchain-frontend/src/api/tenantPortal.ts`
+- `rentchain-frontend/src/components/LeaseSigningDashboard.tsx`
+- `rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx`
 
 KNOWN LIMITATIONS:
-- Frontend Vitest under local Node 20.11.1 fails before importing tests because of a jsdom/html-encoding-sniffer ESM dependency issue. The same targeted frontend tests pass under ambient Node v25.8.1, and the frontend build passes under Node 20.11.1.
-- No preview deployment or manual browser QA has been run yet.
+- Provider-readable URL support is implemented through Dropbox Sign `fileUrls`, but preview must confirm Dropbox Sign can fetch the current lease document URL. If Dropbox Sign rejects the URL, file upload support should be a follow-up and not bundled into this PR.
+- Real Dropbox Sign dispatch requires preview/runtime config:
+  - `SIGNING_PROVIDER=dropbox_sign`
+  - `SIGNING_PROVIDER_API_KEY`
+  - `SIGNING_PROVIDER_WEBHOOK_SECRET`
+  - `SIGNING_PROVIDER_CALLBACK_URL`
+  - `SIGNING_PROVIDER_TEST_MODE=true`
+- `npm ci` was run for `rentchain-api` to restore the declared `@dropbox/sign` dependency locally; no manifest changes were made.
 
 NEXT STEP:
 - Wait for PR checks.
-- Deploy the PR backend for preview if checks pass.
-- Verify route headers, landlord-scoped summary contents, and that dashboard access writes no canonical event.
+- Deploy PR backend after checks are green.
+- Preview QA mock mode unchanged, then Dropbox Sign test mode dispatch, webhook lifecycle, safe UI projection, and canonical event metadata.

--- a/.handoff/impl-summary.md
+++ b/.handoff/impl-summary.md
@@ -61,7 +61,7 @@ KNOWN LIMITATIONS:
 - Real Dropbox Sign dispatch requires preview/runtime config:
   - `SIGNING_PROVIDER=dropbox_sign`
   - `SIGNING_PROVIDER_API_KEY`
-  - `SIGNING_PROVIDER_WEBHOOK_SECRET`
+  - `SIGNING_PROVIDER_WEBHOOK_SECRET` set to the Dropbox Sign API key/callback verification key used to validate callback `event_hash`
   - `SIGNING_PROVIDER_CALLBACK_URL`
   - `SIGNING_PROVIDER_TEST_MODE=true`
 - `npm ci` was run for `rentchain-api` to restore the declared `@dropbox/sign` dependency locally; no manifest changes were made.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -238,13 +238,13 @@ app.post(
 );
 app.post(
   "/webhooks/signing/:providerId?",
-  express.raw({ type: "application/json" }),
+  express.raw({ type: "*/*" }),
   routeSource("signingWebhookRoutes.ts"),
   signingWebhookHandler
 );
 app.post(
   "/api/webhooks/signing/:providerId?",
-  express.raw({ type: "application/json" }),
+  express.raw({ type: "*/*" }),
   routeSource("signingWebhookRoutes.ts"),
   signingWebhookHandler
 );

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -882,6 +882,50 @@ describe("leaseRoutes GET /active", () => {
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
+  it("resolves storage-backed primary lease documents before sending for signature", async () => {
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/provider-readable-lease.pdf");
+    seedDoc("leases", "lease-storage-doc", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+      documentUrl: "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-storage-doc/lease-v1.pdf?X-Goog-Expires=1",
+      leaseDocument: {
+        bucket: "lease-documents",
+        path: "leases/landlord-1/lease-storage-doc/lease-v1.pdf",
+      },
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-storage-doc/send-for-signature",
+      body: { tenantEmails: ["tenant@example.com"], message: "Please sign." },
+    });
+
+    expect(res.status).toBe(200);
+    expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
+      bucket: "lease-documents",
+      path: "leases/landlord-1/lease-storage-doc/lease-v1.pdf",
+      expiresMinutes: 30,
+    });
+    const requests = listDocs("leaseSigningRequests");
+    expect(requests).toHaveLength(1);
+    expect(requests[0].data).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-storage-doc",
+        providerId: "mock",
+        documentUrl: "https://signed.example.com/provider-readable-lease.pdf",
+      })
+    );
+    expect(JSON.stringify(requests)).not.toContain("X-Goog-Expires=1");
+    expect(writeCanonicalEventMock).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects invalid lease signing recipients without dispatching or writing events", async () => {
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { signingWebhookHandler } from "../webhooks/signingWebhookRoutes";
+
+const { processSigningWebhookMock } = vi.hoisted(() => ({
+  processSigningWebhookMock: vi.fn(),
+}));
+
+vi.mock("../../services/signing/leaseSigningService", () => ({
+  processSigningWebhook: processSigningWebhookMock,
+  signingErrorCode: (error: any) => String(error?.message || "lease_signing_failed"),
+  signingErrorStatus: (error: any) => Number(error?.status || 500),
+}));
+
+function makeRes() {
+  const res: any = {
+    statusCode: 200,
+    headers: new Map<string, string>(),
+    body: undefined as any,
+    status: vi.fn((code: number) => {
+      res.statusCode = code;
+      return res;
+    }),
+    type: vi.fn((value: string) => {
+      res.headers.set("content-type", value);
+      return res;
+    }),
+    send: vi.fn((value: any) => {
+      res.body = value;
+      return res;
+    }),
+    json: vi.fn((value: any) => {
+      res.body = value;
+      res.headers.set("content-type", "application/json");
+      return res;
+    }),
+  };
+  return res;
+}
+
+describe("signingWebhookHandler", () => {
+  beforeEach(() => {
+    processSigningWebhookMock.mockReset();
+    delete process.env.SIGNING_PROVIDER;
+  });
+
+  it("returns Dropbox Sign account callback acknowledgement as exact plain text", async () => {
+    processSigningWebhookMock.mockResolvedValueOnce({ providerResponseText: "Hello API Event Received" });
+    const req: any = {
+      params: { providerId: "dropbox_sign" },
+      query: {},
+      headers: { "content-type": "multipart/form-data; boundary=test" },
+      body: Buffer.from("redacted"),
+    };
+    const res = makeRes();
+
+    await signingWebhookHandler(req, res);
+
+    expect(processSigningWebhookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "dropbox_sign",
+        rawBody: req.body,
+      })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.type).toHaveBeenCalledWith("text/plain");
+    expect(res.body).toBe("Hello API Event Received");
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("preserves JSON acknowledgement for normal webhook processing", async () => {
+    processSigningWebhookMock.mockResolvedValueOnce({});
+    const req: any = { params: { providerId: "mock" }, query: {}, headers: {}, body: { ok: true } };
+    const res = makeRes();
+
+    await signingWebhookHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+});

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -3069,12 +3069,13 @@ router.post("/:leaseId/send-for-signature", requireLandlord, async (req: any, re
     if (!leaseId) return res.status(400).json({ ok: false, error: "lease_not_found" });
     const result = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!result.ok) return res.status(result.status).json({ ok: false, error: result.error === "Forbidden" ? "forbidden" : "lease_not_found" });
+    const signingDocumentUrl = await loadLeaseDocumentUrlForLease(result.lease as any);
     const tenantEmails = Array.isArray(req.body?.tenantEmails)
       ? req.body.tenantEmails.map((value: unknown) => String(value || "").trim())
       : [req.body?.tenantEmail].map((value) => String(value || "").trim()).filter(Boolean);
     const snapshot = await sendLeaseForSignature({
       leaseId,
-      lease: result.lease as any,
+      lease: signingDocumentUrl ? { ...(result.lease as any), documentUrl: signingDocumentUrl } : (result.lease as any),
       landlordId,
       tenantEmails,
       message: String(req.body?.message || "").trim() || null,

--- a/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
+++ b/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
@@ -6,12 +6,15 @@ export async function signingWebhookHandler(req: Request & { rawBody?: Buffer },
     .trim()
     .toLowerCase();
   try {
-    await processSigningWebhook({
+    const result = await processSigningWebhook({
       providerId,
       headers: req.headers,
       body: req.body,
       rawBody: Buffer.isBuffer(req.body) ? req.body : req.rawBody,
     });
+    if (result.providerResponseText) {
+      return res.status(200).type("text/plain").send(result.providerResponseText);
+    }
     return res.status(200).json({ ok: true });
   } catch (error: any) {
     const status = signingErrorStatus(error);

--- a/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
+++ b/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
@@ -10,7 +10,7 @@ export async function signingWebhookHandler(req: Request & { rawBody?: Buffer },
       providerId,
       headers: req.headers,
       body: req.body,
-      rawBody: req.rawBody,
+      rawBody: Buffer.isBuffer(req.body) ? req.body : req.rawBody,
     });
     return res.status(200).json({ ok: true });
   } catch (error: any) {

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -72,6 +72,9 @@ describe("leaseSigningService", () => {
     writeCanonicalEventMock.mockClear();
     process.env.SIGNING_PROVIDER = "mock";
     process.env.PUBLIC_APP_URL = "http://localhost:5173";
+    delete process.env.SIGNING_PROVIDER_API_KEY;
+    delete process.env.SIGNING_PROVIDER_WEBHOOK_SECRET;
+    delete process.env.SIGNING_PROVIDER_TEST_MODE;
   });
 
   it("creates a pending signing request without exposing raw provider references in projected snapshot", async () => {
@@ -141,6 +144,136 @@ describe("leaseSigningService", () => {
     expect(snapshot.signingStatus).toBe("signed");
     expect(snapshot.derivedLeaseState).toBe("active");
     expect(snapshot.events.map((event) => event.type)).toContain("signed");
+  });
+
+  it("fails closed for explicitly configured Dropbox Sign when config is missing", async () => {
+    process.env.SIGNING_PROVIDER = "dropbox_sign";
+    const { sendLeaseForSignature } = await import("../signing/leaseSigningService");
+
+    await expect(
+      sendLeaseForSignature({
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        lease: { startDate: "2026-01-01", documentUrl: "https://example.com/lease.pdf" },
+        tenantEmails: ["tenant@example.com"],
+      })
+    ).rejects.toMatchObject({ message: "provider_unavailable", status: 503 });
+    expect(ensureCollection("leaseSigningRequests").size).toBe(0);
+    expect(ensureCollection("leaseSigningEvents").size).toBe(0);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("stores raw provider request id internally while projecting and auditing safe refs only", async () => {
+    const { signingProviderRegistry } = await import("../signing/providers");
+    signingProviderRegistry.register("boldsign", {
+      getProviderId: () => "boldsign",
+      getName: () => "Real test provider",
+      isConfigured: () => true,
+      sendForSignature: async () => ({
+        providerRequestId: "raw-provider-request-123",
+        dispatchMode: "sandbox",
+        dispatchStatus: "accepted",
+        dispatchMessage: "Provider accepted the request in test mode.",
+        providerTestMode: true,
+      }),
+      getSigningUrl: async () => null,
+      cancelRequest: async () => true,
+      downloadSignedDocument: async () => null,
+      verifyWebhookSignature: async () => true,
+      parseWebhookPayload: async () => {
+        throw new Error("not_used");
+      },
+    });
+    process.env.SIGNING_PROVIDER = "boldsign";
+    const { sendLeaseForSignature } = await import("../signing/leaseSigningService");
+
+    const snapshot = await sendLeaseForSignature({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      lease: { startDate: "2026-01-01", documentUrl: "https://example.com/lease.pdf" },
+      tenantEmails: ["tenant@example.com"],
+    });
+
+    const storedRequest = Array.from(ensureCollection("leaseSigningRequests").values())[0];
+    expect(storedRequest.providerRequestId).toBe("raw-provider-request-123");
+    expect(snapshot.providerRequestRef).toMatch(/^boldsign_ref_/);
+    expect(JSON.stringify(snapshot)).not.toContain("raw-provider-request-123");
+    expect(writeCanonicalEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "signing_sent",
+        metadata: expect.objectContaining({
+          providerDispatchMode: "sandbox",
+          providerDispatchStatus: "accepted",
+          providerTestMode: true,
+        }),
+      })
+    );
+    expect(JSON.stringify(writeCanonicalEventMock.mock.calls)).not.toContain("raw-provider-request-123");
+  });
+
+  it("rejects webhook signature failures without writing events", async () => {
+    process.env.SIGNING_PROVIDER_WEBHOOK_SECRET = "expected";
+    const { processSigningWebhook, sendLeaseForSignature } = await import("../signing/leaseSigningService");
+    await sendLeaseForSignature({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      lease: { startDate: "2026-01-01" },
+      tenantEmails: ["tenant@example.com"],
+    });
+    writeCanonicalEventMock.mockClear();
+
+    await expect(
+      processSigningWebhook({
+        providerId: "mock",
+        headers: { "x-mock-signing-secret": "wrong" },
+        body: { providerRequestId: "mock_request", eventId: "evt_signed", type: "signed" },
+      })
+    ).rejects.toMatchObject({ message: "webhook_validation_failed", status: 400 });
+
+    expect(ensureCollection("leaseSigningEvents").size).toBe(1);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("handles duplicate webhooks idempotently and maps declined expired cancelled and failed events", async () => {
+    const { processSigningWebhook, sendLeaseForSignature, loadLeaseSigningSnapshot } = await import("../signing/leaseSigningService");
+    await sendLeaseForSignature({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      lease: { startDate: "2026-01-01" },
+      tenantEmails: ["tenant@example.com"],
+    });
+    const storedRequest = Array.from(ensureCollection("leaseSigningRequests").values())[0];
+
+    for (const type of ["rejected", "expired", "cancelled", "failed"] as const) {
+      await processSigningWebhook({
+        providerId: "mock",
+        headers: {},
+        body: {
+          providerRequestId: storedRequest.providerRequestId,
+          eventId: `evt_${type}`,
+          type,
+          signerEmail: "tenant@example.com",
+          occurredAt: `2026-01-02T00:00:0${["rejected", "expired", "cancelled", "failed"].indexOf(type)}.000Z`,
+        },
+      });
+      await processSigningWebhook({
+        providerId: "mock",
+        headers: {},
+        body: {
+          providerRequestId: storedRequest.providerRequestId,
+          eventId: `evt_${type}`,
+          type,
+          signerEmail: "tenant@example.com",
+          occurredAt: `2026-01-02T00:00:0${["rejected", "expired", "cancelled", "failed"].indexOf(type)}.000Z`,
+        },
+      });
+    }
+
+    const snapshot = await loadLeaseSigningSnapshot({ leaseId: "lease-1", landlordId: "landlord-1", lease: { startDate: "2026-01-01" } });
+    expect(snapshot.events.map((event) => event.type).sort()).toEqual(["cancelled", "expired", "failed", "rejected", "sent"]);
+    expect(snapshot.events).toHaveLength(5);
+    expect(snapshot.signingStatus).toBe("failed");
+    expect(snapshot.derivedLeaseState).toBe("failed");
   });
 
   it("resolves current state to pending after resending a cancelled signing request", async () => {

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -258,7 +258,7 @@ describe("leaseSigningService", () => {
     });
     const { processSigningWebhook } = await import("../signing/leaseSigningService");
 
-    await expect(processSigningWebhook({ providerId: "boldsign", headers: {}, body: { event: { event_type: "callback_test" } } })).resolves.toBeUndefined();
+    await expect(processSigningWebhook({ providerId: "boldsign", headers: {}, body: { event: { event_type: "callback_test" } } })).resolves.toEqual({});
 
     const deadLetters = Array.from(ensureCollection("leaseSigningWebhookDeadLetters").values());
     expect(deadLetters).toHaveLength(1);
@@ -272,6 +272,41 @@ describe("leaseSigningService", () => {
       })
     );
     expect(JSON.stringify(deadLetters)).not.toContain("evt_callback_test_raw");
+    expect(ensureCollection("leaseSigningEvents").size).toBe(0);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Dropbox Sign account callback acknowledgement text without writing success events", async () => {
+    const { signingProviderRegistry } = await import("../signing/providers");
+    signingProviderRegistry.register("dropbox_sign", {
+      getProviderId: () => "dropbox_sign",
+      getName: () => "Dropbox Sign test provider",
+      isConfigured: () => true,
+      sendForSignature: async () => {
+        throw new Error("not_used");
+      },
+      getSigningUrl: async () => null,
+      cancelRequest: async () => true,
+      downloadSignedDocument: async () => null,
+      verifyWebhookSignature: async () => true,
+      parseWebhookPayload: async () => ({
+        providerRequestId: null,
+        providerEventId: "evt_callback_test_raw",
+        providerEventType: "callback_test",
+        type: "sent",
+        occurredAt: "2026-01-02T00:00:00.000Z",
+        accountCallback: true,
+      }),
+    });
+    const { processSigningWebhook } = await import("../signing/leaseSigningService");
+
+    await expect(processSigningWebhook({ providerId: "dropbox_sign", headers: {}, body: { event: { event_type: "callback_test" } } })).resolves.toEqual({
+      providerResponseText: "Hello API Event Received",
+    });
+
+    const deadLetters = Array.from(ensureCollection("leaseSigningWebhookDeadLetters").values());
+    expect(deadLetters).toHaveLength(1);
+    expect(deadLetters[0]).toEqual(expect.objectContaining({ status: "account_callback_acknowledged", payloadIncluded: false }));
     expect(ensureCollection("leaseSigningEvents").size).toBe(0);
     expect(writeCanonicalEventMock).not.toHaveBeenCalled();
   });
@@ -299,7 +334,7 @@ describe("leaseSigningService", () => {
     });
     const { processSigningWebhook } = await import("../signing/leaseSigningService");
 
-    await expect(processSigningWebhook({ providerId: "boldsign", headers: {}, body: { signature_request: {} } })).resolves.toBeUndefined();
+    await expect(processSigningWebhook({ providerId: "boldsign", headers: {}, body: { signature_request: {} } })).resolves.toEqual({});
 
     const deadLetters = Array.from(ensureCollection("leaseSigningWebhookDeadLetters").values());
     expect(deadLetters).toHaveLength(1);

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -234,6 +234,92 @@ describe("leaseSigningService", () => {
     expect(writeCanonicalEventMock).not.toHaveBeenCalled();
   });
 
+  it("acknowledges verified provider account callback tests without signing events", async () => {
+    const { signingProviderRegistry } = await import("../signing/providers");
+    signingProviderRegistry.register("boldsign", {
+      getProviderId: () => "boldsign",
+      getName: () => "Account callback test provider",
+      isConfigured: () => true,
+      sendForSignature: async () => {
+        throw new Error("not_used");
+      },
+      getSigningUrl: async () => null,
+      cancelRequest: async () => true,
+      downloadSignedDocument: async () => null,
+      verifyWebhookSignature: async () => true,
+      parseWebhookPayload: async () => ({
+        providerRequestId: null,
+        providerEventId: "evt_callback_test_raw",
+        providerEventType: "callback_test",
+        type: "sent",
+        occurredAt: "2026-01-02T00:00:00.000Z",
+        accountCallback: true,
+      }),
+    });
+    const { processSigningWebhook } = await import("../signing/leaseSigningService");
+
+    await expect(processSigningWebhook({ providerId: "boldsign", headers: {}, body: { event: { event_type: "callback_test" } } })).resolves.toBeUndefined();
+
+    const deadLetters = Array.from(ensureCollection("leaseSigningWebhookDeadLetters").values());
+    expect(deadLetters).toHaveLength(1);
+    expect(deadLetters[0]).toEqual(
+      expect.objectContaining({
+        providerId: "boldsign",
+        status: "account_callback_acknowledged",
+        providerEventType: "callback_test",
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      })
+    );
+    expect(JSON.stringify(deadLetters)).not.toContain("evt_callback_test_raw");
+    expect(ensureCollection("leaseSigningEvents").size).toBe(0);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges verified provider callbacks that do not correlate to a local request", async () => {
+    const { signingProviderRegistry } = await import("../signing/providers");
+    signingProviderRegistry.register("boldsign", {
+      getProviderId: () => "boldsign",
+      getName: () => "Unknown request provider",
+      isConfigured: () => true,
+      sendForSignature: async () => {
+        throw new Error("not_used");
+      },
+      getSigningUrl: async () => null,
+      cancelRequest: async () => true,
+      downloadSignedDocument: async () => null,
+      verifyWebhookSignature: async () => true,
+      parseWebhookPayload: async () => ({
+        providerRequestId: "raw-provider-request-missing",
+        providerEventId: "evt_missing_request_raw",
+        providerEventType: "signature_request_sent",
+        type: "sent",
+        occurredAt: "2026-01-02T00:00:00.000Z",
+      }),
+    });
+    const { processSigningWebhook } = await import("../signing/leaseSigningService");
+
+    await expect(processSigningWebhook({ providerId: "boldsign", headers: {}, body: { signature_request: {} } })).resolves.toBeUndefined();
+
+    const deadLetters = Array.from(ensureCollection("leaseSigningWebhookDeadLetters").values());
+    expect(deadLetters).toHaveLength(1);
+    expect(deadLetters[0]).toEqual(
+      expect.objectContaining({
+        providerId: "boldsign",
+        status: "request_not_found",
+        providerRequestRef: expect.stringMatching(/^boldsign_ref_/),
+        providerEventRef: expect.stringMatching(/^boldsign_ref_/),
+        providerEventType: "signature_request_sent",
+        rawIdsIncluded: false,
+        payloadIncluded: false,
+      })
+    );
+    expect(JSON.stringify(deadLetters)).not.toContain("raw-provider-request-missing");
+    expect(JSON.stringify(deadLetters)).not.toContain("evt_missing_request_raw");
+    expect(ensureCollection("leaseSigningEvents").size).toBe(0);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
   it("handles duplicate webhooks idempotently and maps declined expired cancelled and failed events", async () => {
     const { processSigningWebhook, sendLeaseForSignature, loadLeaseSigningSnapshot } = await import("../signing/leaseSigningService");
     await sendLeaseForSignature({

--- a/rentchain-api/src/services/leaseStateHelper.ts
+++ b/rentchain-api/src/services/leaseStateHelper.ts
@@ -8,7 +8,7 @@ function asIsoDate(value: unknown): string | null {
   return new Date(parsed).toISOString().slice(0, 10);
 }
 
-export type DerivedLeaseSigningState = "not_started" | "pending_signature" | "signed_future" | "active" | "rejected" | "expired" | "cancelled";
+export type DerivedLeaseSigningState = "not_started" | "pending_signature" | "signed_future" | "active" | "rejected" | "expired" | "cancelled" | "failed";
 
 export function deriveLeaseSigningState(input: {
   lease: Record<string, unknown>;
@@ -16,7 +16,7 @@ export function deriveLeaseSigningState(input: {
   now?: Date;
 }): DerivedLeaseSigningState {
   const status = String(input.signingStatus || "").trim();
-  if (status === "rejected" || status === "expired" || status === "cancelled") return status as DerivedLeaseSigningState;
+  if (status === "rejected" || status === "expired" || status === "cancelled" || status === "failed") return status as DerivedLeaseSigningState;
   if (status !== "signed") return status === "pending_signature" ? "pending_signature" : "not_started";
 
   const startDate = asIsoDate(input.lease?.startDate || input.lease?.leaseStart || input.lease?.leaseStartDate);

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -467,16 +467,41 @@ export async function processSigningWebhook(input: { providerId: string; headers
     });
     throw error;
   }
-  const requestSnap = await db.collection(REQUESTS).where("providerRequestRef", "==", safeProviderRef(provider.getProviderId(), parsed.providerRequestId)).limit(1).get();
+  if (!parsed.providerRequestId && parsed.accountCallback) {
+    await db.collection(DEAD_LETTERS).doc(`dl_${digest(`${input.providerId}:${parsed.providerEventId || Date.now()}`, 24)}`).set({
+      providerId: input.providerId,
+      status: "account_callback_acknowledged",
+      providerEventRef: safeProviderRef(provider.getProviderId(), parsed.providerEventId || ""),
+      providerEventType: parsed.providerEventType || null,
+      createdAt: FieldValue.serverTimestamp(),
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    });
+    return;
+  }
+  const providerRequestId = String(parsed.providerRequestId || "");
+  const requestSnap = await db.collection(REQUESTS).where("providerRequestRef", "==", safeProviderRef(provider.getProviderId(), providerRequestId)).limit(1).get();
   const requestDoc = requestSnap.docs?.[0];
-  if (!requestDoc) throw Object.assign(new Error("lease_not_found"), { status: 404 });
+  if (!requestDoc) {
+    await db.collection(DEAD_LETTERS).doc(`dl_${digest(`${input.providerId}:${parsed.providerEventId || Date.now()}`, 24)}`).set({
+      providerId: input.providerId,
+      status: "request_not_found",
+      providerRequestRef: safeProviderRef(provider.getProviderId(), providerRequestId),
+      providerEventRef: safeProviderRef(provider.getProviderId(), parsed.providerEventId || ""),
+      providerEventType: parsed.providerEventType || null,
+      createdAt: FieldValue.serverTimestamp(),
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    });
+    return;
+  }
   const data = requestDoc.data() as any;
   await appendSigningEvent({
     requestId: requestDoc.id,
     leaseId: String(data?.leaseId || ""),
     landlordId: String(data?.landlordId || ""),
     providerId: provider.getProviderId(),
-    providerRequestId: parsed.providerRequestId,
+    providerRequestId,
     providerEventId: parsed.providerEventId,
     type: parsed.type,
     actorRole: "provider",

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -439,7 +439,11 @@ export async function downloadSignedLease(input: { leaseId: string; lease: Recor
   return loadLeaseSigningSnapshot({ leaseId: input.leaseId, landlordId: input.landlordId, lease: input.lease });
 }
 
-export async function processSigningWebhook(input: { providerId: string; headers: any; body: any; rawBody?: Buffer }) {
+export type SigningWebhookProcessResult = {
+  providerResponseText?: string;
+};
+
+export async function processSigningWebhook(input: { providerId: string; headers: any; body: any; rawBody?: Buffer }): Promise<SigningWebhookProcessResult> {
   const provider = signingProviderRegistry.getProvider(input.providerId);
   if (!provider?.isConfigured()) {
     await db.collection(DEAD_LETTERS).doc(`dl_${digest(`${input.providerId}:${Date.now()}`, 24)}`).set({
@@ -477,7 +481,7 @@ export async function processSigningWebhook(input: { providerId: string; headers
       rawIdsIncluded: false,
       payloadIncluded: false,
     });
-    return;
+    return provider.getProviderId() === "dropbox_sign" ? { providerResponseText: "Hello API Event Received" } : {};
   }
   const providerRequestId = String(parsed.providerRequestId || "");
   const requestSnap = await db.collection(REQUESTS).where("providerRequestRef", "==", safeProviderRef(provider.getProviderId(), providerRequestId)).limit(1).get();
@@ -493,7 +497,7 @@ export async function processSigningWebhook(input: { providerId: string; headers
       rawIdsIncluded: false,
       payloadIncluded: false,
     });
-    return;
+    return {};
   }
   const data = requestDoc.data() as any;
   await appendSigningEvent({
@@ -508,6 +512,7 @@ export async function processSigningWebhook(input: { providerId: string; headers
     signerEmail: parsed.signerEmail || null,
     occurredAt: parsed.occurredAt,
   });
+  return {};
 }
 
 export function signingErrorStatus(error: any) {

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -13,7 +13,8 @@ export type LeaseSigningStatus =
   | "signed"
   | "rejected"
   | "expired"
-  | "cancelled";
+  | "cancelled"
+  | "failed";
 
 export type LeaseSigningEvent = {
   id: string;
@@ -24,6 +25,7 @@ export type LeaseSigningEvent = {
   providerDispatchMode?: string | null;
   providerDispatchStatus?: string | null;
   providerDispatchMessage?: string | null;
+  providerTestMode?: boolean | null;
 };
 
 export type LeaseSigningSnapshot = {
@@ -91,6 +93,7 @@ function statusFromEvents(events: LeaseSigningEvent[]): LeaseSigningStatus {
     const type = events[index]?.type;
     if (type === "signed") return "signed";
     if (type === "cancelled") return "cancelled";
+    if (type === "failed") return "failed";
     if (type === "rejected") return "rejected";
     if (type === "expired") return "expired";
     if (type === "sent" || type === "viewed") return "pending_signature";
@@ -101,6 +104,7 @@ function statusFromEvents(events: LeaseSigningEvent[]): LeaseSigningStatus {
 function statusFromEventType(type: SigningProviderEventType): LeaseSigningStatus | null {
   if (type === "signed") return "signed";
   if (type === "cancelled") return "cancelled";
+  if (type === "failed") return "failed";
   if (type === "rejected") return "rejected";
   if (type === "expired") return "expired";
   if (type === "sent" || type === "viewed") return "pending_signature";
@@ -115,7 +119,8 @@ function normalizeStoredStatus(value: unknown): LeaseSigningStatus | null {
     status === "signed" ||
     status === "rejected" ||
     status === "expired" ||
-    status === "cancelled"
+    status === "cancelled" ||
+    status === "failed"
   ) {
     return status;
   }
@@ -133,6 +138,7 @@ function projectEvent(doc: any): LeaseSigningEvent {
     providerDispatchMode: data?.providerDispatchMode || null,
     providerDispatchStatus: data?.providerDispatchStatus || null,
     providerDispatchMessage: data?.providerDispatchMessage || null,
+    providerTestMode: data?.providerTestMode === true ? true : data?.providerTestMode === false ? false : null,
   };
 }
 
@@ -158,6 +164,7 @@ async function appendSigningEvent(input: {
   providerDispatchMode?: string | null;
   providerDispatchStatus?: string | null;
   providerDispatchMessage?: string | null;
+  providerTestMode?: boolean | null;
 }) {
   const occurredAt = input.occurredAt || nowIso();
   const id = eventIdFor(input.requestId, input.type, occurredAt, input.providerEventId || "");
@@ -177,6 +184,7 @@ async function appendSigningEvent(input: {
     providerDispatchMode: input.providerDispatchMode || null,
     providerDispatchStatus: input.providerDispatchStatus || null,
     providerDispatchMessage: input.providerDispatchMessage || null,
+    providerTestMode: input.providerTestMode ?? null,
     occurredAt,
     createdAt: FieldValue.serverTimestamp(),
     rawIdsIncluded: false,
@@ -211,6 +219,7 @@ async function appendSigningEvent(input: {
       providerRef: safeProviderRef(input.providerId, input.providerRequestId),
       providerDispatchMode: input.providerDispatchMode || null,
       providerDispatchStatus: input.providerDispatchStatus || null,
+      providerTestMode: input.providerTestMode ?? null,
     },
   }).catch(() => undefined);
   return id;
@@ -295,7 +304,7 @@ export async function sendLeaseForSignature(input: {
     title: "Lease signature request",
     message: input.message || null,
     signers: emails.map((email) => ({ email, role: "tenant" as const })),
-    callbackUrl: process.env.SIGNING_CALLBACK_URL || null,
+    callbackUrl: process.env.SIGNING_PROVIDER_CALLBACK_URL || process.env.SIGNING_CALLBACK_URL || null,
   });
   const providerId = provider.getProviderId();
   const requestId = requestIdFor(input.landlordId, input.leaseId, providerId);
@@ -315,6 +324,7 @@ export async function sendLeaseForSignature(input: {
       providerDispatchMode: sent.dispatchMode || null,
       providerDispatchStatus: sent.dispatchStatus || null,
       providerDispatchMessage: sent.dispatchMessage || null,
+      providerTestMode: sent.providerTestMode ?? null,
       sentAt: now,
       updatedAt: FieldValue.serverTimestamp(),
       createdAt: existing.exists ? existing.data()?.createdAt || FieldValue.serverTimestamp() : FieldValue.serverTimestamp(),
@@ -335,6 +345,7 @@ export async function sendLeaseForSignature(input: {
     providerDispatchMode: sent.dispatchMode || null,
     providerDispatchStatus: sent.dispatchStatus || null,
     providerDispatchMessage: sent.dispatchMessage || null,
+    providerTestMode: sent.providerTestMode ?? null,
   });
   return loadLeaseSigningSnapshot({ leaseId: input.leaseId, landlordId: input.landlordId, lease: input.lease });
 }
@@ -440,9 +451,22 @@ export async function processSigningWebhook(input: { providerId: string; headers
     });
     throw Object.assign(new Error("provider_unavailable"), { status: 503 });
   }
-  const verified = await provider.verifyWebhookSignature(input);
+  const rawBody = input.rawBody || (Buffer.isBuffer(input.body) ? input.body : undefined);
+  const verified = await provider.verifyWebhookSignature({ ...input, rawBody });
   if (!verified) throw Object.assign(new Error("webhook_validation_failed"), { status: 400 });
-  const parsed = await provider.parseWebhookPayload(input.body);
+  let parsed;
+  try {
+    parsed = await provider.parseWebhookPayload(input.body);
+  } catch (error) {
+    await db.collection(DEAD_LETTERS).doc(`dl_${digest(`${input.providerId}:${Date.now()}`, 24)}`).set({
+      providerId: input.providerId,
+      status: "payload_parse_failed",
+      createdAt: FieldValue.serverTimestamp(),
+      rawIdsIncluded: false,
+      payloadIncluded: false,
+    });
+    throw error;
+  }
   const requestSnap = await db.collection(REQUESTS).where("providerRequestRef", "==", safeProviderRef(provider.getProviderId(), parsed.providerRequestId)).limit(1).get();
   const requestDoc = requestSnap.docs?.[0];
   if (!requestDoc) throw Object.assign(new Error("lease_not_found"), { status: 404 });

--- a/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
+++ b/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
@@ -174,4 +174,41 @@ describe("DropboxSignProvider", () => {
       providerEventType: "callback_test",
     });
   });
+
+  it("verifies multipart Dropbox Sign account callback tests with a json field", async () => {
+    const provider = new DropboxSignProvider();
+    const eventHash = createHmac("sha256", "dropbox-key").update("1780000000callback_test").digest("hex");
+    const json = JSON.stringify({
+      event: {
+        event_type: "callback_test",
+        event_hash: eventHash,
+        event_time: 1780000000,
+      },
+      account: { account_id: "acct_redacted" },
+    });
+    const boundary = "----RentChainDropboxSignCallbackTest";
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="json"',
+      "",
+      json,
+      `--${boundary}--`,
+      "",
+    ].join("\r\n");
+
+    await expect(
+      provider.verifyWebhookSignature({
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+        body: Buffer.from(body),
+      })
+    ).resolves.toBe(true);
+    await expect(provider.parseWebhookPayload(Buffer.from(body))).resolves.toEqual({
+      providerRequestId: null,
+      providerEventId: eventHash,
+      type: "sent",
+      occurredAt: "2026-05-28T20:26:40.000Z",
+      accountCallback: true,
+      providerEventType: "callback_test",
+    });
+  });
 });

--- a/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
+++ b/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
@@ -12,11 +12,39 @@ vi.mock("@dropbox/sign", () => ({
       signatureRequestSend = signatureRequestSendMock;
       signatureRequestFiles = signatureRequestFilesMock;
     },
+    EventCallbackRequest: {
+      init: (data: any) => ({
+        event: {
+          eventTime: data?.event?.event_time,
+          eventType: data?.event?.event_type,
+          eventHash: data?.event?.event_hash,
+        },
+      }),
+    },
+    EventCallbackHelper: {
+      isValid: (apiKey: string, eventCallback: any) =>
+        eventCallback?.event?.eventHash ===
+        createHmac("sha256", apiKey).update(`${eventCallback?.event?.eventTime}${eventCallback?.event?.eventType}`).digest("hex"),
+    },
   },
   SignatureRequestApi: class {
     username = "";
     signatureRequestSend = signatureRequestSendMock;
     signatureRequestFiles = signatureRequestFilesMock;
+  },
+  EventCallbackRequest: {
+    init: (data: any) => ({
+      event: {
+        eventTime: data?.event?.event_time,
+        eventType: data?.event?.event_type,
+        eventHash: data?.event?.event_hash,
+      },
+    }),
+  },
+  EventCallbackHelper: {
+    isValid: (apiKey: string, eventCallback: any) =>
+      eventCallback?.event?.eventHash ===
+      createHmac("sha256", apiKey).update(`${eventCallback?.event?.eventTime}${eventCallback?.event?.eventType}`).digest("hex"),
   },
 }));
 
@@ -25,7 +53,7 @@ describe("DropboxSignProvider", () => {
     signatureRequestSendMock.mockReset();
     signatureRequestFilesMock.mockReset();
     process.env.SIGNING_PROVIDER_API_KEY = "dropbox-key";
-    process.env.SIGNING_PROVIDER_WEBHOOK_SECRET = "webhook-secret";
+    process.env.SIGNING_PROVIDER_WEBHOOK_SECRET = "dropbox-key";
     process.env.SIGNING_PROVIDER_TEST_MODE = "true";
     delete process.env.SIGNING_PROVIDER_CALLBACK_URL;
   });
@@ -103,17 +131,20 @@ describe("DropboxSignProvider", () => {
   it("verifies webhook signatures and parses Dropbox Sign lifecycle events", async () => {
     const provider = new DropboxSignProvider();
     const body = JSON.stringify({
-      event: { event_type: "signature_request_all_signed", event_hash: "evt_1", event_time: 1780000000 },
+      event: {
+        event_type: "signature_request_all_signed",
+        event_hash: createHmac("sha256", "dropbox-key").update("1780000000signature_request_all_signed").digest("hex"),
+        event_time: 1780000000,
+      },
       signature_request: { signature_request_id: "raw_provider_request_123" },
       signature: { signer_email_address: "Tenant@Example.com" },
     });
-    const signature = createHmac("sha256", "webhook-secret").update(body).digest("hex");
-
-    await expect(provider.verifyWebhookSignature({ headers: { "x-dropbox-signature": signature }, body: Buffer.from(body) })).resolves.toBe(true);
-    await expect(provider.verifyWebhookSignature({ headers: { "x-dropbox-signature": "bad" }, body: Buffer.from(body) })).resolves.toBe(false);
+    await expect(provider.verifyWebhookSignature({ headers: {}, body: Buffer.from(body) })).resolves.toBe(true);
+    process.env.SIGNING_PROVIDER_WEBHOOK_SECRET = "wrong-key";
+    await expect(provider.verifyWebhookSignature({ headers: {}, body: Buffer.from(body) })).resolves.toBe(false);
     await expect(provider.parseWebhookPayload(Buffer.from(body))).resolves.toEqual({
       providerRequestId: "raw_provider_request_123",
-      providerEventId: "evt_1",
+      providerEventId: createHmac("sha256", "dropbox-key").update("1780000000signature_request_all_signed").digest("hex"),
       type: "signed",
       signerEmail: "tenant@example.com",
       occurredAt: "2026-05-28T20:26:40.000Z",

--- a/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
+++ b/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
@@ -1,0 +1,122 @@
+import { createHmac } from "crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DropboxSignProvider } from "../dropboxSignProvider";
+
+const signatureRequestSendMock = vi.fn();
+const signatureRequestFilesMock = vi.fn();
+
+vi.mock("@dropbox/sign", () => ({
+  default: {
+    SignatureRequestApi: class {
+      username = "";
+      signatureRequestSend = signatureRequestSendMock;
+      signatureRequestFiles = signatureRequestFilesMock;
+    },
+  },
+  SignatureRequestApi: class {
+    username = "";
+    signatureRequestSend = signatureRequestSendMock;
+    signatureRequestFiles = signatureRequestFilesMock;
+  },
+}));
+
+describe("DropboxSignProvider", () => {
+  beforeEach(() => {
+    signatureRequestSendMock.mockReset();
+    signatureRequestFilesMock.mockReset();
+    process.env.SIGNING_PROVIDER_API_KEY = "dropbox-key";
+    process.env.SIGNING_PROVIDER_WEBHOOK_SECRET = "webhook-secret";
+    process.env.SIGNING_PROVIDER_TEST_MODE = "true";
+    delete process.env.SIGNING_PROVIDER_CALLBACK_URL;
+  });
+
+  it("sends a Dropbox Sign request in test mode and maps safe dispatch metadata", async () => {
+    signatureRequestSendMock.mockResolvedValueOnce({
+      body: {
+        signature_request: {
+          signature_request_id: "raw_provider_request_123",
+          signing_url: "https://app.hellosign.com/sign/raw_provider_request_123",
+        },
+      },
+    });
+
+    const provider = new DropboxSignProvider();
+    const result = await provider.sendForSignature({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      documentUrl: "https://files.example.com/lease.pdf",
+      title: "Lease signature request",
+      signers: [{ email: "tenant@example.com", role: "tenant" }],
+      message: "Please sign.",
+    });
+
+    expect(signatureRequestSendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileUrls: ["https://files.example.com/lease.pdf"],
+        testMode: true,
+        metadata: { leaseId: "lease-1", landlordId: "landlord-1" },
+      })
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        providerRequestId: "raw_provider_request_123",
+        dispatchMode: "sandbox",
+        dispatchStatus: "accepted",
+        providerTestMode: true,
+      })
+    );
+  });
+
+  it("fails closed when config or provider-readable document URL is missing", async () => {
+    const provider = new DropboxSignProvider();
+    process.env.SIGNING_PROVIDER_API_KEY = "";
+    expect(provider.isConfigured()).toBe(false);
+
+    process.env.SIGNING_PROVIDER_API_KEY = "dropbox-key";
+    await expect(
+      provider.sendForSignature({
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        documentUrl: "gs://private/lease.pdf",
+        title: "Lease",
+        signers: [{ email: "tenant@example.com" }],
+      })
+    ).rejects.toThrow("signing_document_url_required");
+    expect(signatureRequestSendMock).not.toHaveBeenCalled();
+  });
+
+  it("maps provider API failures to a safe dispatch error", async () => {
+    signatureRequestSendMock.mockRejectedValueOnce({ status: 400, body: { error: { errorMsg: "Bad file URL" } } });
+    const provider = new DropboxSignProvider();
+
+    await expect(
+      provider.sendForSignature({
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        documentUrl: "https://files.example.com/lease.pdf",
+        title: "Lease",
+        signers: [{ email: "tenant@example.com" }],
+      })
+    ).rejects.toMatchObject({ message: "provider_dispatch_failed", status: 400, safeMessage: "Bad file URL" });
+  });
+
+  it("verifies webhook signatures and parses Dropbox Sign lifecycle events", async () => {
+    const provider = new DropboxSignProvider();
+    const body = JSON.stringify({
+      event: { event_type: "signature_request_all_signed", event_hash: "evt_1", event_time: 1780000000 },
+      signature_request: { signature_request_id: "raw_provider_request_123" },
+      signature: { signer_email_address: "Tenant@Example.com" },
+    });
+    const signature = createHmac("sha256", "webhook-secret").update(body).digest("hex");
+
+    await expect(provider.verifyWebhookSignature({ headers: { "x-dropbox-signature": signature }, body: Buffer.from(body) })).resolves.toBe(true);
+    await expect(provider.verifyWebhookSignature({ headers: { "x-dropbox-signature": "bad" }, body: Buffer.from(body) })).resolves.toBe(false);
+    await expect(provider.parseWebhookPayload(Buffer.from(body))).resolves.toEqual({
+      providerRequestId: "raw_provider_request_123",
+      providerEventId: "evt_1",
+      type: "signed",
+      signerEmail: "tenant@example.com",
+      occurredAt: "2026-05-28T20:26:40.000Z",
+    });
+  });
+});

--- a/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
+++ b/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
@@ -148,6 +148,30 @@ describe("DropboxSignProvider", () => {
       type: "signed",
       signerEmail: "tenant@example.com",
       occurredAt: "2026-05-28T20:26:40.000Z",
+      providerEventType: "signature_request_all_signed",
+    });
+  });
+
+  it("acknowledges verified Dropbox Sign account callback tests without a signature request", async () => {
+    const provider = new DropboxSignProvider();
+    const eventHash = createHmac("sha256", "dropbox-key").update("1780000000callback_test").digest("hex");
+    const body = JSON.stringify({
+      event: {
+        event_type: "callback_test",
+        event_hash: eventHash,
+        event_time: 1780000000,
+      },
+      account: { account_id: "acct_redacted" },
+    });
+
+    await expect(provider.verifyWebhookSignature({ headers: {}, body: Buffer.from(body) })).resolves.toBe(true);
+    await expect(provider.parseWebhookPayload(Buffer.from(body))).resolves.toEqual({
+      providerRequestId: null,
+      providerEventId: eventHash,
+      type: "sent",
+      occurredAt: "2026-05-28T20:26:40.000Z",
+      accountCallback: true,
+      providerEventType: "callback_test",
     });
   });
 });

--- a/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
+++ b/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
@@ -55,8 +55,34 @@ function parseMaybeJsonBuffer(body: unknown) {
     const params = new URLSearchParams(raw);
     const json = params.get("json");
     if (json) return JSON.parse(json);
+    const multipartJson = extractMultipartJsonField(raw);
+    if (multipartJson) return JSON.parse(multipartJson);
     throw new Error("signing_webhook_payload_invalid");
   }
+}
+
+function extractMultipartJsonField(raw: string) {
+  const nameMatch = /name="json"|name=json/i.exec(raw);
+  if (!nameMatch) return "";
+  const headerEnd = raw.indexOf("\r\n\r\n", nameMatch.index);
+  if (headerEnd < 0) return "";
+  const valueStart = headerEnd + 4;
+  const boundaryStart = raw.indexOf("\r\n--", valueStart);
+  const value = raw.slice(valueStart, boundaryStart >= 0 ? boundaryStart : undefined).trim();
+  return value || "";
+}
+
+function safeWebhookBodyShape(input: SigningProviderWebhookInput) {
+  const raw = input.rawBody || (Buffer.isBuffer(input.body) ? input.body : undefined);
+  const text = raw?.toString("utf8") || "";
+  return {
+    contentType: String((input.headers as any)?.["content-type"] || "").split(";")[0].slice(0, 80),
+    bodyKind: raw ? "buffer" : typeof input.body,
+    bodyLength: raw?.length || 0,
+    hasUrlEncodedJson: text.includes("json="),
+    hasMultipartJson: /name="json"|name=json/i.test(text),
+    looksJson: text.trim().startsWith("{"),
+  };
 }
 
 async function loadDropboxSignSdk() {
@@ -165,8 +191,21 @@ export class DropboxSignProvider implements ISigningProvider {
       const sdk = await loadDropboxSignSdk();
       const parsed = parseMaybeJsonBuffer(input.rawBody || input.body);
       const eventCallback = sdk.EventCallbackRequest?.init ? sdk.EventCallbackRequest.init(parsed) : parsed;
-      return sdk.EventCallbackHelper.isValid(callbackKey, eventCallback);
-    } catch {
+      const valid = sdk.EventCallbackHelper.isValid(callbackKey, eventCallback);
+      if (!valid) {
+        console.warn("[dropbox-sign-webhook] verification failed", {
+          ...safeWebhookBodyShape(input),
+          hasEventTime: Boolean(eventCallback?.event?.eventTime),
+          hasEventType: Boolean(eventCallback?.event?.eventType),
+          hasEventHash: Boolean(eventCallback?.event?.eventHash),
+        });
+      }
+      return valid;
+    } catch (error: any) {
+      console.warn("[dropbox-sign-webhook] verification parse failed", {
+        ...safeWebhookBodyShape(input),
+        reason: safeMessage(error?.message || "parse_failed"),
+      });
       return false;
     }
   }

--- a/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
+++ b/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
@@ -19,6 +19,57 @@ function safeCompare(a: string, b: string) {
   return left.length === right.length && timingSafeEqual(left, right);
 }
 
+function boolEnv(value: unknown) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+function safeMessage(value: unknown) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 240);
+}
+
+function validProviderReadableUrl(value: unknown) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "https:" || parsed.protocol === "http:" ? raw : "";
+  } catch {
+    return "";
+  }
+}
+
+function eventTimeToIso(value: unknown) {
+  const raw = String(value || "").trim();
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return new Date(numeric * (raw.length <= 10 ? 1000 : 1)).toISOString();
+  }
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function parseMaybeJsonBuffer(body: unknown) {
+  if (!Buffer.isBuffer(body)) return body;
+  const raw = body.toString("utf8");
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const params = new URLSearchParams(raw);
+    const json = params.get("json");
+    if (json) return JSON.parse(json);
+    throw new Error("signing_webhook_payload_invalid");
+  }
+}
+
+async function loadDropboxSignSdk() {
+  const mod = (await import("@dropbox/sign")) as any;
+  return mod.default || mod;
+}
+
 export class DropboxSignProvider implements ISigningProvider {
   getProviderId() {
     return "dropbox_sign" as const;
@@ -34,14 +85,62 @@ export class DropboxSignProvider implements ISigningProvider {
 
   async sendForSignature(input: SigningProviderSendInput): Promise<SigningProviderSendResult> {
     if (!this.isConfigured()) throw new Error("provider_unavailable");
-    return {
-      providerRequestId: `dropbox_${sha(`${input.landlordId}:${input.leaseId}:${Date.now()}`)}`,
-      signingUrl: null,
-      expiresAt: null,
-      dispatchMode: "stub",
-      dispatchStatus: "stubbed_no_email",
-      dispatchMessage: "Dropbox Sign provider is configured as a local stub and did not send email.",
-    };
+    const documentUrl = validProviderReadableUrl(input.documentUrl);
+    if (!documentUrl) throw Object.assign(new Error("signing_document_url_required"), { status: 400 });
+    try {
+      const sdk = await loadDropboxSignSdk();
+      const apiCaller = new sdk.SignatureRequestApi();
+      apiCaller.username = String(process.env.SIGNING_PROVIDER_API_KEY || "").trim();
+      const testMode = boolEnv(process.env.SIGNING_PROVIDER_TEST_MODE);
+      const callbackUrl = String(process.env.SIGNING_PROVIDER_CALLBACK_URL || input.callbackUrl || "").trim() || undefined;
+      const request = {
+        title: input.title.slice(0, 255),
+        subject: input.title.slice(0, 255),
+        message: input.message || undefined,
+        testMode,
+        fileUrls: [documentUrl],
+        signers: input.signers.map((signer, index) => ({
+          emailAddress: signer.email,
+          name: signer.name || signer.email,
+          order: index,
+        })),
+        metadata: {
+          leaseId: input.leaseId,
+          landlordId: input.landlordId,
+        },
+        signingOptions: {
+          draw: true,
+          type: true,
+          upload: false,
+          phone: false,
+          defaultType: "type",
+        },
+        ...(callbackUrl ? { signingRedirectUrl: callbackUrl } : {}),
+      };
+      const response = await apiCaller.signatureRequestSend(request as any);
+      const body = response?.body || response || {};
+      const signatureRequest = body.signatureRequest || body.signature_request || {};
+      const providerRequestId = String(signatureRequest.signatureRequestId || signatureRequest.signature_request_id || "").trim();
+      if (!providerRequestId) throw Object.assign(new Error("provider_response_invalid"), { status: 502 });
+      return {
+        providerRequestId,
+        signingUrl: String(signatureRequest.signingUrl || signatureRequest.signing_url || "") || null,
+        expiresAt: signatureRequest.expiresAt || signatureRequest.expires_at ? eventTimeToIso(signatureRequest.expiresAt || signatureRequest.expires_at) : null,
+        dispatchMode: testMode ? "sandbox" : "real",
+        dispatchStatus: "accepted",
+        dispatchMessage: testMode
+          ? "Dropbox Sign accepted the request in test mode."
+          : "Dropbox Sign accepted the request and will dispatch signature email.",
+        providerTestMode: testMode,
+      };
+    } catch (error: any) {
+      const status = Number(error?.status || error?.statusCode || error?.code || 502);
+      const message = safeMessage(error?.body?.error?.errorMsg || error?.body?.message || error?.message || "provider_dispatch_failed");
+      throw Object.assign(new Error("provider_dispatch_failed"), {
+        status: status >= 400 && status < 600 ? status : 502,
+        safeMessage: message,
+      });
+    }
   }
 
   async getSigningUrl(input: SigningProviderSigningUrlInput) {
@@ -56,17 +155,19 @@ export class DropboxSignProvider implements ISigningProvider {
 
   async downloadSignedDocument(providerRequestId: string): Promise<SigningProviderDocumentResult | null> {
     if (!this.isConfigured()) throw new Error("provider_unavailable");
-    return {
-      buffer: Buffer.from(`Dropbox Sign document placeholder\nrequest=${providerRequestId}\n`, "utf8"),
-      contentType: "application/pdf",
-      fileName: `${providerRequestId}.pdf`,
-    };
+    const sdk = await loadDropboxSignSdk();
+    const apiCaller = new sdk.SignatureRequestApi();
+    apiCaller.username = String(process.env.SIGNING_PROVIDER_API_KEY || "").trim();
+    const response = await apiCaller.signatureRequestFiles(providerRequestId, "pdf");
+    const buffer = Buffer.isBuffer(response?.body) ? response.body : Buffer.from(response?.body || []);
+    if (!buffer.length) return null;
+    return { buffer, contentType: "application/pdf", fileName: `${providerRequestId}.pdf` };
   }
 
   async verifyWebhookSignature(input: SigningProviderWebhookInput) {
     const secret = String(process.env.SIGNING_PROVIDER_WEBHOOK_SECRET || "").trim();
     if (!secret) return false;
-    const raw = input.rawBody?.toString("utf8") || JSON.stringify(input.body || {});
+    const raw = input.rawBody?.toString("utf8") || (Buffer.isBuffer(input.body) ? input.body.toString("utf8") : JSON.stringify(input.body || {}));
     const supplied = String((input.headers as any)?.["x-dropbox-signature"] || (input.headers as any)?.["x-hellosign-signature"] || "").trim();
     if (!supplied) return false;
     const expected = createHmac("sha256", secret).update(raw).digest("hex");
@@ -74,15 +175,17 @@ export class DropboxSignProvider implements ISigningProvider {
   }
 
   async parseWebhookPayload(body: any): Promise<SigningProviderParsedWebhook> {
+    body = parseMaybeJsonBuffer(body);
     const event = body?.event || body?.event_data || body || {};
     const request = body?.signature_request || body?.signatureRequest || {};
     const eventType = String(event?.event_type || event?.type || "").toLowerCase();
     const mapped =
+      eventType.includes("fail") || eventType.includes("error") ? "failed" :
       eventType.includes("view") ? "viewed" :
       eventType.includes("decline") || eventType.includes("reject") ? "rejected" :
       eventType.includes("expire") ? "expired" :
       eventType.includes("cancel") ? "cancelled" :
-      eventType.includes("sign") ? "signed" :
+      eventType.includes("complete") || eventType.includes("all_signed") || eventType.includes("sign") ? "signed" :
       "sent";
     const providerRequestId = String(request?.signature_request_id || body?.signature_request_id || body?.providerRequestId || "").trim();
     if (!providerRequestId) throw new Error("signing_webhook_request_missing");
@@ -91,7 +194,7 @@ export class DropboxSignProvider implements ISigningProvider {
       providerEventId: String(event?.event_hash || event?.event_id || sha(JSON.stringify(body))).trim(),
       type: mapped as any,
       signerEmail: String(body?.signature?.signer_email_address || body?.signerEmail || "").trim().toLowerCase() || null,
-      occurredAt: new Date(Number(event?.event_time || Date.now()) * (String(event?.event_time || "").length <= 10 ? 1000 : 1)).toISOString(),
+      occurredAt: eventTimeToIso(event?.event_time || event?.time || event?.created_at),
     };
   }
 }

--- a/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
+++ b/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac, timingSafeEqual } from "crypto";
+import { createHash } from "crypto";
 import type {
   ISigningProvider,
   SigningProviderDocumentResult,
@@ -11,12 +11,6 @@ import type {
 
 function sha(value: string) {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);
-}
-
-function safeCompare(a: string, b: string) {
-  const left = Buffer.from(a);
-  const right = Buffer.from(b);
-  return left.length === right.length && timingSafeEqual(left, right);
 }
 
 function boolEnv(value: unknown) {
@@ -165,13 +159,16 @@ export class DropboxSignProvider implements ISigningProvider {
   }
 
   async verifyWebhookSignature(input: SigningProviderWebhookInput) {
-    const secret = String(process.env.SIGNING_PROVIDER_WEBHOOK_SECRET || "").trim();
-    if (!secret) return false;
-    const raw = input.rawBody?.toString("utf8") || (Buffer.isBuffer(input.body) ? input.body.toString("utf8") : JSON.stringify(input.body || {}));
-    const supplied = String((input.headers as any)?.["x-dropbox-signature"] || (input.headers as any)?.["x-hellosign-signature"] || "").trim();
-    if (!supplied) return false;
-    const expected = createHmac("sha256", secret).update(raw).digest("hex");
-    return safeCompare(supplied, expected);
+    const callbackKey = String(process.env.SIGNING_PROVIDER_WEBHOOK_SECRET || process.env.SIGNING_PROVIDER_API_KEY || "").trim();
+    if (!callbackKey) return false;
+    try {
+      const sdk = await loadDropboxSignSdk();
+      const parsed = parseMaybeJsonBuffer(input.rawBody || input.body);
+      const eventCallback = sdk.EventCallbackRequest?.init ? sdk.EventCallbackRequest.init(parsed) : parsed;
+      return sdk.EventCallbackHelper.isValid(callbackKey, eventCallback);
+    } catch {
+      return false;
+    }
   }
 
   async parseWebhookPayload(body: any): Promise<SigningProviderParsedWebhook> {

--- a/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
+++ b/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
@@ -185,13 +185,27 @@ export class DropboxSignProvider implements ISigningProvider {
       eventType.includes("complete") || eventType.includes("all_signed") || eventType.includes("sign") ? "signed" :
       "sent";
     const providerRequestId = String(request?.signature_request_id || body?.signature_request_id || body?.providerRequestId || "").trim();
-    if (!providerRequestId) throw new Error("signing_webhook_request_missing");
+    const providerEventId = String(event?.event_hash || event?.event_id || sha(JSON.stringify(body))).trim();
+    if (!providerRequestId) {
+      if (eventType === "callback_test" || Boolean(body?.account) || Boolean(body?.template)) {
+        return {
+          providerRequestId: null,
+          providerEventId,
+          type: "sent",
+          occurredAt: eventTimeToIso(event?.event_time || event?.time || event?.created_at),
+          accountCallback: true,
+          providerEventType: eventType || null,
+        };
+      }
+      throw new Error("signing_webhook_request_missing");
+    }
     return {
       providerRequestId,
-      providerEventId: String(event?.event_hash || event?.event_id || sha(JSON.stringify(body))).trim(),
+      providerEventId,
       type: mapped as any,
       signerEmail: String(body?.signature?.signer_email_address || body?.signerEmail || "").trim().toLowerCase() || null,
       occurredAt: eventTimeToIso(event?.event_time || event?.time || event?.created_at),
+      providerEventType: eventType || null,
     };
   }
 }

--- a/rentchain-api/src/services/signing/providers/mockSigningProvider.ts
+++ b/rentchain-api/src/services/signing/providers/mockSigningProvider.ts
@@ -69,7 +69,7 @@ export class MockSigningProvider implements ISigningProvider {
     const providerRequestId = String(body?.providerRequestId || body?.signingRequestId || "").trim();
     if (!providerRequestId) throw new Error("signing_webhook_request_missing");
     const type = String(body?.type || body?.eventType || "signed").trim().toLowerCase();
-    const allowed = new Set(["sent", "viewed", "signed", "rejected", "expired", "cancelled", "downloaded"]);
+    const allowed = new Set(["sent", "viewed", "signed", "rejected", "expired", "cancelled", "failed", "downloaded"]);
     if (!allowed.has(type)) throw new Error("signing_webhook_type_invalid");
     return {
       providerRequestId,

--- a/rentchain-api/src/services/signing/providers/types.ts
+++ b/rentchain-api/src/services/signing/providers/types.ts
@@ -55,11 +55,13 @@ export type SigningProviderWebhookInput = {
 };
 
 export type SigningProviderParsedWebhook = {
-  providerRequestId: string;
+  providerRequestId?: string | null;
   providerEventId: string;
   type: SigningProviderEventType;
   signerEmail?: string | null;
   occurredAt: string;
+  accountCallback?: boolean;
+  providerEventType?: string | null;
 };
 
 export interface ISigningProvider {

--- a/rentchain-api/src/services/signing/providers/types.ts
+++ b/rentchain-api/src/services/signing/providers/types.ts
@@ -7,6 +7,7 @@ export type SigningProviderEventType =
   | "rejected"
   | "expired"
   | "cancelled"
+  | "failed"
   | "downloaded";
 
 export type SigningProviderSigner = {
@@ -30,8 +31,9 @@ export type SigningProviderSendResult = {
   signingUrl?: string | null;
   expiresAt?: string | null;
   dispatchMode?: "real" | "sandbox" | "mock" | "stub";
-  dispatchStatus?: "accepted" | "mocked_no_email" | "stubbed_no_email";
+  dispatchStatus?: "accepted" | "sent" | "failed" | "mocked_no_email" | "stubbed_no_email";
   dispatchMessage?: string | null;
+  providerTestMode?: boolean;
 };
 
 export type SigningProviderSigningUrlInput = {

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -207,7 +207,7 @@ export interface LandlordActiveLease extends Lease {
 }
 
 export type LeaseSigningStatusResponse = {
-  signingStatus: "not_started" | "pending_signature" | "signed" | "rejected" | "expired" | "cancelled";
+  signingStatus: "not_started" | "pending_signature" | "signed" | "rejected" | "expired" | "cancelled" | "failed";
   derivedLeaseState: string;
   signingProviderId: string | null;
   signingRequestId: string | null;

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -137,7 +137,7 @@ export type TenantWorkspaceLease = TenantSafeProjectionMetadata & {
     } | null;
     paymentExperience: PaymentExperience;
   } | null;
-  providerSigningStatus?: "not_started" | "pending_signature" | "signed" | "rejected" | "expired" | "cancelled";
+  providerSigningStatus?: "not_started" | "pending_signature" | "signed" | "rejected" | "expired" | "cancelled" | "failed";
   providerSignedAt?: string | null;
   providerDerivedLeaseState?: "not_started" | "pending_signature" | "signed_future" | "active" | "rejected" | "expired" | "cancelled";
   providerSigningAvailable?: boolean;

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
@@ -78,4 +78,39 @@ describe("LeaseSigningDashboard", () => {
     await waitFor(() => expect(screen.getByText("invalid_tenant_email")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /send for signature/i })).toBeEnabled();
   });
+
+  it("shows real provider dispatch without mock no-email warning", async () => {
+    vi.mocked(getLeaseSigningStatus).mockResolvedValueOnce({
+      ...pendingStatus,
+      signingProviderId: "dropbox_sign",
+      providerDispatchMode: "sandbox",
+      providerDispatchStatus: "accepted",
+      providerDispatchMessage: "Dropbox Sign accepted the request in test mode.",
+    });
+
+    render(<LeaseSigningDashboard leaseId="lease-1" tenantEmail="tenant@example.com" />);
+
+    await waitFor(() => expect(screen.getByText(/dropbox sign accepted the request in test mode/i)).toBeInTheDocument());
+    expect(screen.queryByText(/no signature email was sent/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/raw-provider-request/i)).not.toBeInTheDocument();
+  });
+
+  it("renders failed signing state safely and allows retry", async () => {
+    vi.mocked(getLeaseSigningStatus).mockResolvedValueOnce({
+      ...notStartedStatus,
+      signingStatus: "failed",
+      derivedLeaseState: "failed",
+      signingProviderId: "dropbox_sign",
+      signingRequestId: "lsr_safe_ref",
+      providerDispatchMode: "real",
+      providerDispatchStatus: "failed",
+      providerDispatchMessage: "Signing provider could not accept the request.",
+    });
+
+    render(<LeaseSigningDashboard leaseId="lease-1" tenantEmail="tenant@example.com" />);
+
+    await waitFor(() => expect(screen.getByText(/status: failed/i)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /send for signature/i })).toBeEnabled();
+    expect(screen.queryByText(/raw-provider-request/i)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
@@ -28,6 +28,12 @@ function dispatchNotice(status: LeaseSigningStatusResponse | null) {
   if (dispatchMode === "stub" || dispatchStatus === "stubbed_no_email") {
     return "Sandbox signing request recorded. No signature email was sent by the configured signing stub.";
   }
+  if (dispatchMode === "sandbox") {
+    return status.providerDispatchMessage || "Dropbox Sign accepted the request in test mode.";
+  }
+  if (dispatchMode === "real" || dispatchStatus === "accepted" || dispatchStatus === "sent") {
+    return status.providerDispatchMessage || "Signature request sent by the signing provider.";
+  }
   return null;
 }
 
@@ -98,7 +104,7 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
   }
 
   const signingStatus = status?.signingStatus || "not_started";
-  const canSend = signingStatus === "not_started" || signingStatus === "cancelled" || signingStatus === "expired" || signingStatus === "rejected";
+  const canSend = signingStatus === "not_started" || signingStatus === "cancelled" || signingStatus === "expired" || signingStatus === "rejected" || signingStatus === "failed";
   const canCancel = signingStatus === "pending_signature";
   const canDownload = signingStatus === "signed";
   const noEmailNotice = dispatchNotice(status);


### PR DESCRIPTION
## Summary
- Convert the Dropbox Sign provider from stub-only behavior to a real SDK-backed provider infrastructure path.
- Preserve mock provider behavior for local/dev/test and keep safe dispatch metadata projected to the lease signing UI.
- Add provider test-mode metadata, safe failed signing state handling, webhook raw-body handling, Dropbox webhook parsing, idempotent webhook coverage, and no raw provider ID projection.
- Align webhook verification with the Dropbox Sign SDK callback verifier: `event_hash` is validated from `event_time + event_type` using the Dropbox Sign API key/callback verification key.
- Acknowledge verified Dropbox Sign account callback tests and unknown-request callbacks safely without writing signing success events or storing raw provider payloads.
- Resolve storage-backed primary lease document URLs before signing dispatch when a primary lease document source already exists.

## Safety and Governance
- Keeps existing `leaseSigningRequests`, `leaseSigningEvents`, `leaseSigningWebhookDeadLetters`, and `canonicalEvents` collections.
- Does not add provider selection UI or a new audit system.
- Stores raw provider request IDs internally only; API/UI/canonical metadata use safe provider refs/status.
- Does not store raw webhook payloads, secret-bearing headers, or raw provider payloads.
- Mock/stub no-email notices remain unchanged; real/sandbox accepted requests show pending signature without no-email copy.
- Verified account/test callbacks are acknowledged without creating signing success events or canonical signing events.
- Missing provider config fails closed.
- Missing primary signing document fails safely before provider dispatch.

## Document Source Limitation
- PR #1162 delivers Dropbox Sign provider infrastructure only.
- Full Dropbox Send QA is blocked until a primary provider-readable lease document source exists.
- Schedule A is intentionally not used as the primary lease document.
- This PR does not add document generation, document upload, file-source architecture, or broad document management.
- Follow-up required: `feat/signing-provider-document-source-v1`.

## Tests
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/routes/__tests__/leaseRoutes.active.test.ts` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/__tests__/leaseSigningService.test.ts src/services/signing/providers/__tests__/dropboxSignProvider.test.ts src/services/signing/providers/__tests__/mockSigningProvider.test.ts src/routes/__tests__/signingWebhookRoutes.test.ts` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` from `rentchain-api`
- `git diff --check`

## Preview QA
- Confirm Cloud Run image tag matches PR head before retesting.
- Confirm mock mode remains unchanged and still shows the no-email notice.
- Configure `SIGNING_PROVIDER=dropbox_sign`, `SIGNING_PROVIDER_API_KEY`, `SIGNING_PROVIDER_WEBHOOK_SECRET`, `SIGNING_PROVIDER_CALLBACK_URL`, and `SIGNING_PROVIDER_TEST_MODE=true` for preview.
- `SIGNING_PROVIDER_WEBHOOK_SECRET` must contain the Dropbox Sign API key/callback verification key used by `EventCallbackHelper.isValid` to validate callback `event_hash`; it may be stored as a separate secret alias, but the value must match the Dropbox Sign API key used for callback verification.
- Run the Dropbox Sign Account Callback Test and confirm the endpoint returns exactly `Hello API Event Received` without creating signing/canonical success events.
- Confirm `POST /api/leases/ZD2VvH7cCZ7Q8YfVGR55/send-for-signature` returns `400 signing_document_url_required`, with no provider API call, no signing success event, and no canonical `signing_sent` success event.
- Do not perform full Dropbox Send QA until `feat/signing-provider-document-source-v1` provides a primary provider-readable lease document source.