### PR TITLE
feat: add primary lease document source

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -4,6 +4,9 @@ import { leaseService } from "../../services/leaseService";
 const getSignedDownloadUrlMock = vi.fn(async () => "https://signed.example.com/lease.pdf");
 const sendEmailMock = vi.fn(async () => undefined);
 const writeCanonicalEventMock = vi.fn(async () => undefined);
+const getPrimaryLeaseDocumentSummaryMock = vi.fn(async () => null);
+const generatePrimaryLeaseDocumentMock = vi.fn();
+const lockPrimaryLeaseDocumentForSigningMock = vi.fn();
 
 const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
@@ -124,6 +127,12 @@ vi.mock("../../lib/events/buildEvent", () => ({
   writeCanonicalEvent: writeCanonicalEventMock,
 }));
 
+vi.mock("../../services/leaseDocuments/leaseDocumentService", () => ({
+  getPrimaryLeaseDocumentSummary: getPrimaryLeaseDocumentSummaryMock,
+  generatePrimaryLeaseDocument: generatePrimaryLeaseDocumentMock,
+  lockPrimaryLeaseDocumentForSigning: lockPrimaryLeaseDocumentForSigningMock,
+}));
+
 vi.mock("../../services/stripeService", () => ({
   isStripeConfigured: () => true,
 }));
@@ -176,6 +185,11 @@ describe("leaseRoutes GET /active", () => {
     getSignedDownloadUrlMock.mockClear();
     sendEmailMock.mockClear();
     writeCanonicalEventMock.mockClear();
+    getPrimaryLeaseDocumentSummaryMock.mockReset();
+    getPrimaryLeaseDocumentSummaryMock.mockResolvedValue(null);
+    generatePrimaryLeaseDocumentMock.mockReset();
+    lockPrimaryLeaseDocumentForSigningMock.mockReset();
+    lockPrimaryLeaseDocumentForSigningMock.mockRejectedValue(Object.assign(new Error("signing_document_url_required"), { status: 400 }));
     sendEmailMock.mockResolvedValue(undefined);
     process.env.EMAIL_FROM = "noreply@example.com";
     process.env.SIGNING_PROVIDER = "mock";
@@ -384,6 +398,218 @@ describe("leaseRoutes GET /active", () => {
           }),
         }),
       })
+    );
+  });
+
+  it("projects generated primary lease document availability from leaseDocuments metadata", async () => {
+    getPrimaryLeaseDocumentSummaryMock.mockResolvedValueOnce({
+      id: "ldoc_generated",
+      leaseId: "lease-primary-doc",
+      landlordId: "landlord-1",
+      documentType: "primary_lease",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-primary-lease-draft-v1",
+      counselReviewStatus: "draft",
+      status: "generated",
+      documentHash: "doc_hash_generated",
+      manifestHash: "manifest_hash_generated",
+      storageRef: null,
+      previewUrl: "https://signed.example.com/primary-generated-preview.pdf",
+    });
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leases", "lease-primary-doc", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      dueDay: 1,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/active" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        documentUrl: "https://signed.example.com/primary-generated-preview.pdf",
+        leasePdfStatus: "available",
+        leasePdfLabel: "Lease document available",
+        signatureStatus: "not_started",
+        leaseExecution: expect.objectContaining({
+          executionStatus: "draft",
+          pdfStatus: "generated",
+        }),
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("lease-documents/");
+  });
+
+  it("projects pending signature state from the current signing request", async () => {
+    getPrimaryLeaseDocumentSummaryMock.mockResolvedValueOnce({
+      id: "ldoc_pending",
+      leaseId: "lease-pending-signature",
+      landlordId: "landlord-1",
+      documentType: "primary_lease",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-primary-lease-draft-v1",
+      counselReviewStatus: "draft",
+      status: "locked",
+      documentHash: "doc_hash_pending",
+      manifestHash: "manifest_hash_pending",
+      storageRef: null,
+      previewUrl: "https://signed.example.com/primary-pending-preview.pdf",
+    });
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leases", "lease-pending-signature", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      dueDay: 1,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+    });
+    seedDoc("leaseSigningRequests", "request-pending", {
+      leaseId: "lease-pending-signature",
+      landlordId: "landlord-1",
+      currentSigningStatus: "pending_signature",
+      currentStatusAt: "2026-01-02T12:00:00.000Z",
+      sentAt: "2026-01-02T12:00:00.000Z",
+      documentId: "ldoc_pending",
+      documentHash: "doc_hash_pending",
+      manifestHash: "manifest_hash_pending",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-primary-lease-draft-v1",
+      providerDispatchMode: "sandbox",
+      providerDispatchStatus: "accepted",
+      providerTestMode: true,
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/active" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        signatureStatus: "awaiting_tenant_signature",
+        signatureReadinessLabel: "Awaiting tenant signature",
+        leaseExecution: expect.objectContaining({
+          executionStatus: "ready_for_tenant_signature",
+          executionLabel: "Waiting for tenant signature",
+          requiredNextAction: "tenant_signature",
+        }),
+        stateCoherence: expect.objectContaining({
+          leaseOperationalState: "pending_execution",
+          flags: expect.objectContaining({
+            leaseMarkedActiveBeforeExecution: true,
+          }),
+        }),
+      })
+    );
+  });
+
+  it("projects signed provider lifecycle as executed while preserving payment setup warnings", async () => {
+    getPrimaryLeaseDocumentSummaryMock.mockResolvedValueOnce({
+      id: "ldoc_signed",
+      leaseId: "lease-signed-provider",
+      landlordId: "landlord-1",
+      documentType: "primary_lease",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-primary-lease-draft-v1",
+      counselReviewStatus: "draft",
+      status: "locked",
+      documentHash: "doc_hash_signed",
+      manifestHash: "manifest_hash_signed",
+      storageRef: null,
+      previewUrl: "https://signed.example.com/primary-signed-preview.pdf",
+    });
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leases", "lease-signed-provider", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+    });
+    seedDoc("leaseSigningRequests", "request-signed", {
+      leaseId: "lease-signed-provider",
+      landlordId: "landlord-1",
+      currentSigningStatus: "signed",
+      currentStatusAt: "2026-01-03T12:00:00.000Z",
+      sentAt: "2026-01-02T12:00:00.000Z",
+      documentId: "ldoc_signed",
+      documentHash: "doc_hash_signed",
+      manifestHash: "manifest_hash_signed",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-primary-lease-draft-v1",
+      providerAccessUrlExpiresAt: "2026-01-02T16:00:00.000Z",
+      providerDispatchMode: "sandbox",
+      providerDispatchStatus: "accepted",
+      providerTestMode: true,
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/active" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        signatureStatus: "signed",
+        signatureReadinessLabel: "Lease signing complete",
+        leaseExecution: expect.objectContaining({
+          executionStatus: "fully_executed",
+          executionLabel: "Lease fully executed",
+          requiredNextAction: "none",
+          completedAt: "2026-01-03T12:00:00.000Z",
+        }),
+        stateCoherence: expect.objectContaining({
+          coherenceStatus: "coherent",
+          leaseExecutionState: "executed",
+          leaseOperationalState: "active",
+          flags: expect.objectContaining({
+            leaseMarkedActiveBeforeExecution: false,
+            requiresReview: false,
+          }),
+        }),
+        paymentReadiness: expect.objectContaining({
+          readinessStatus: "not_ready",
+          rentTerms: expect.objectContaining({
+            dueDateAvailable: false,
+            leaseExecuted: true,
+          }),
+        }),
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("providerRequestId");
+    expect(JSON.stringify(res.body)).not.toContain("X-Goog-Signature");
+    expect(JSON.stringify(res.body)).not.toContain("lease-documents/");
+    expect(res.body?.leases?.[0]?.jurisdictionPolicies).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          policyKey: "lease_execution_readiness",
+        }),
+      ])
     );
   });
 
@@ -650,6 +876,84 @@ describe("leaseRoutes GET /active", () => {
     expect(scheduleRes.body?.error).toBe("schedule_a_document_not_found");
   });
 
+  it("returns primary lease document summaries without projecting raw storage refs", async () => {
+    getPrimaryLeaseDocumentSummaryMock.mockResolvedValueOnce({
+      id: "ldoc_1",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      documentType: "primary_lease",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-primary-lease-draft-v1",
+      counselReviewStatus: "draft",
+      status: "generated",
+      documentHash: "doc_hash",
+      manifestHash: "manifest_hash",
+      storageRef: null,
+      previewUrl: "https://signed.example.com/primary-preview.pdf",
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/lease-1/primary-document" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.document).toEqual(expect.objectContaining({ id: "ldoc_1", storageRef: null }));
+    expect(getPrimaryLeaseDocumentSummaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ leaseId: "lease-1", landlordId: "landlord-1", includePreviewUrl: false })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("lease-documents/");
+  });
+
+  it("generates primary lease document metadata through the lease route", async () => {
+    generatePrimaryLeaseDocumentMock.mockResolvedValueOnce({
+      id: "ldoc_2",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      documentType: "primary_lease",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-primary-lease-draft-v1",
+      counselReviewStatus: "draft",
+      status: "generated",
+      documentHash: "doc_hash",
+      manifestHash: "manifest_hash",
+      storageRef: null,
+    });
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Coburg Rd", province: "NS" });
+    seedDoc("units", "unit-6", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "6" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Chip Milo", email: "hello+cob6tenant@rentchain.ai" });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-6",
+      unitNumber: "6",
+      province: "NS",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-1/primary-document/generate" });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.document).toEqual(expect.objectContaining({ id: "ldoc_2", storageRef: null }));
+    expect(generatePrimaryLeaseDocumentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        lease: expect.objectContaining({ id: "lease-1", landlordId: "landlord-1" }),
+        property: expect.objectContaining({ id: "prop-1", name: "Coburg Rd" }),
+        unit: expect.objectContaining({ id: "unit-6", unitNumber: "6" }),
+        tenants: [expect.objectContaining({ id: "tenant-1", email: "hello+cob6tenant@rentchain.ai" })],
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("lease-documents/");
+  });
+
   it("does not use app-domain lease PDF paths as document URL fallback", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Coburg Rd" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Chip Milo", email: "hello+cob6tenant@rentchain.ai" });
@@ -804,6 +1108,17 @@ describe("leaseRoutes GET /active", () => {
   });
 
   it("sends a lease signing request for a landlord-scoped lease and records governed signing events", async () => {
+    lockPrimaryLeaseDocumentForSigningMock.mockResolvedValueOnce({
+      providerDocumentUrl: "https://signed.example.com/provider-lease.pdf",
+      document: {
+        id: "ldoc_1",
+        documentHash: "doc_hash",
+        manifestHash: "manifest_hash",
+        templateVersion: "ca-ns-primary-lease-draft-v1",
+        jurisdictionCode: "CA_NS",
+        providerAccessUrlExpiresAt: "2026-01-01T04:00:00.000Z",
+      },
+    });
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",
       propertyId: "prop-1",
@@ -843,13 +1158,18 @@ describe("leaseRoutes GET /active", () => {
         leaseId: "lease-1",
         landlordId: "landlord-1",
         providerId: "mock",
-        documentUrl: "https://files.example.com/lease-1.pdf",
+        documentId: "ldoc_1",
+        documentHash: "doc_hash",
+        manifestHash: "manifest_hash",
+        providerAccessUrlExpiresAt: "2026-01-01T04:00:00.000Z",
         providerDispatchMode: "mock",
         providerDispatchStatus: "mocked_no_email",
         rawIdsIncluded: false,
         payloadIncluded: false,
       })
     );
+    expect(requests[0].data.documentUrl).toBeUndefined();
+    expect(JSON.stringify(requests)).not.toContain("https://signed.example.com/provider-lease.pdf");
     expect(requests[0].data.tenantEmailHashes).toHaveLength(1);
     expect(requests[0].data.providerRequestRef).toMatch(/^mock_ref_/);
     expect(requests[0].data.providerRequestRef).not.toContain("lease-1");
@@ -883,7 +1203,17 @@ describe("leaseRoutes GET /active", () => {
   });
 
   it("resolves storage-backed primary lease documents before sending for signature", async () => {
-    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/provider-readable-lease.pdf");
+    lockPrimaryLeaseDocumentForSigningMock.mockResolvedValueOnce({
+      providerDocumentUrl: "https://signed.example.com/provider-readable-lease.pdf",
+      document: {
+        id: "ldoc_storage",
+        documentHash: "doc_hash",
+        manifestHash: "manifest_hash",
+        templateVersion: "ca-ns-primary-lease-draft-v1",
+        jurisdictionCode: "CA_NS",
+        providerAccessUrlExpiresAt: "2026-01-01T04:00:00.000Z",
+      },
+    });
     seedDoc("leases", "lease-storage-doc", {
       landlordId: "landlord-1",
       propertyId: "prop-1",
@@ -908,22 +1238,51 @@ describe("leaseRoutes GET /active", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
-      bucket: "lease-documents",
-      path: "leases/landlord-1/lease-storage-doc/lease-v1.pdf",
-      expiresMinutes: 30,
-    });
+    expect(lockPrimaryLeaseDocumentForSigningMock).toHaveBeenCalledWith(
+      expect.objectContaining({ leaseId: "lease-storage-doc", landlordId: "landlord-1" })
+    );
     const requests = listDocs("leaseSigningRequests");
     expect(requests).toHaveLength(1);
     expect(requests[0].data).toEqual(
       expect.objectContaining({
         leaseId: "lease-storage-doc",
         providerId: "mock",
-        documentUrl: "https://signed.example.com/provider-readable-lease.pdf",
+        documentId: "ldoc_storage",
+        providerAccessUrlExpiresAt: "2026-01-01T04:00:00.000Z",
       })
     );
+    expect(requests[0].data.documentUrl).toBeUndefined();
+    expect(JSON.stringify(requests)).not.toContain("https://signed.example.com/provider-readable-lease.pdf");
     expect(JSON.stringify(requests)).not.toContain("X-Goog-Expires=1");
     expect(writeCanonicalEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not use Schedule A alone as the primary signing document", async () => {
+    seedDoc("leases", "lease-schedule-only", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      status: "active",
+      scheduleADocument: {
+        bucket: "lease-documents",
+        path: "leases/landlord-1/lease-schedule-only/schedule-a-v1.pdf",
+      },
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-schedule-only/send-for-signature",
+      body: { tenantEmails: ["tenant@example.com"] },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: "signing_document_url_required" });
+    expect(lockPrimaryLeaseDocumentForSigningMock).toHaveBeenCalledWith(
+      expect.objectContaining({ leaseId: "lease-schedule-only", landlordId: "landlord-1" })
+    );
+    expect(listDocs("leaseSigningRequests")).toHaveLength(0);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
   });
 
   it("rejects invalid lease signing recipients without dispatching or writing events", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -85,6 +85,11 @@ import {
   signingErrorCode,
   signingErrorStatus,
 } from "../services/signing/leaseSigningService";
+import {
+  generatePrimaryLeaseDocument,
+  getPrimaryLeaseDocumentSummary,
+  lockPrimaryLeaseDocumentForSigning,
+} from "../services/leaseDocuments/leaseDocumentService";
 
 const router = Router();
 const LEASE_SIGNING_ROUTE_VERSION = "lease-signing-dispatch-metadata-v1";
@@ -1302,6 +1307,84 @@ async function countLeaseLedgerPaymentActivity(leaseId: string, landlordId: stri
   }
 }
 
+function normalizeProjectionStatus(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function latestTimestampMillis(data: any, keys: string[]) {
+  return Math.max(...keys.map((key) => toMillis(data?.[key])).filter((value) => Number.isFinite(value)), 0);
+}
+
+async function loadLatestLeaseSigningRequestForProjection(leaseId: string, landlordId: string | null) {
+  const normalizedLeaseId = String(leaseId || "").trim();
+  const normalizedLandlordId = String(landlordId || "").trim();
+  if (!normalizedLeaseId || !normalizedLandlordId) return null;
+  try {
+    const snap = await db
+      .collection("leaseSigningRequests")
+      .where("leaseId", "==", normalizedLeaseId)
+      .where("landlordId", "==", normalizedLandlordId)
+      .get();
+    return (snap.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+      .sort(
+        (a: any, b: any) =>
+          latestTimestampMillis(b, ["currentStatusAt", "signedAt", "sentAt", "updatedAt", "createdAt"]) -
+          latestTimestampMillis(a, ["currentStatusAt", "signedAt", "sentAt", "updatedAt", "createdAt"])
+      )[0] || null;
+  } catch (err) {
+    console.error("[leaseRoutes] loadLatestLeaseSigningRequestForProjection error", err);
+    return null;
+  }
+}
+
+async function loadLatestSigningSignedEventForProjection(leaseId: string) {
+  const normalizedLeaseId = String(leaseId || "").trim();
+  if (!normalizedLeaseId) return null;
+  try {
+    const snap = await db.collection("canonicalEvents").where("action", "==", "signing_signed").limit(100).get();
+    return (snap.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+      .filter((event: any) => String(event?.resource?.type || "") === "lease")
+      .filter((event: any) => String(event?.resource?.id || "") === normalizedLeaseId)
+      .sort((a: any, b: any) => latestTimestampMillis(b, ["occurredAt", "recordedAt"]) - latestTimestampMillis(a, ["occurredAt", "recordedAt"]))[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function buildLeaseProjectionRaw(input: {
+  raw: any;
+  signingRequest: any | null;
+  signingSignedEvent: any | null;
+  primaryDocument: any | null;
+}) {
+  const signingStatus = normalizeProjectionStatus(input.signingRequest?.currentSigningStatus);
+  const signedByRequest = ["signed", "completed", "complete"].includes(signingStatus);
+  const signedByEvent = Boolean(input.signingSignedEvent);
+  const currentStatusAt =
+    String(input.signingRequest?.currentStatusAt || input.signingSignedEvent?.occurredAt || input.signingSignedEvent?.recordedAt || "").trim() || null;
+  const documentStatus = String(input.primaryDocument?.status || input.signingRequest?.documentStatus || "").trim() || null;
+  return {
+    ...input.raw,
+    currentSigningStatus: signedByRequest || signedByEvent ? "signed" : signingStatus || input.raw?.currentSigningStatus,
+    currentStatusAt: currentStatusAt || input.raw?.currentStatusAt || null,
+    signingStatus: signedByRequest || signedByEvent ? "signed" : signingStatus || input.raw?.signingStatus,
+    sentAt: input.signingRequest?.sentAt || input.raw?.sentAt || null,
+    documentStatus: documentStatus || input.raw?.documentStatus || null,
+    leaseDocumentStatus: documentStatus || input.raw?.leaseDocumentStatus || null,
+    documentGeneratedAt: input.primaryDocument?.generatedAt || input.raw?.documentGeneratedAt || null,
+    documentId: input.signingRequest?.documentId || input.primaryDocument?.id || input.raw?.documentId || null,
+    documentHash: input.signingRequest?.documentHash || input.primaryDocument?.documentHash || input.raw?.documentHash || null,
+    manifestHash: input.signingRequest?.manifestHash || input.primaryDocument?.manifestHash || input.raw?.manifestHash || null,
+    jurisdictionCode: input.signingRequest?.jurisdictionCode || input.primaryDocument?.jurisdictionCode || input.raw?.jurisdictionCode || null,
+    templateVersion: input.signingRequest?.templateVersion || input.primaryDocument?.templateVersion || input.raw?.templateVersion || null,
+  };
+}
+
 function hydrateLeaseUnitDisplayFieldsFromUnits<T extends Record<string, any>>(
   lease: T,
   units: any[]
@@ -1324,15 +1407,23 @@ function hydrateLeaseUnitDisplayFieldsFromUnits<T extends Record<string, any>>(
 async function enrichLeaseRow(raw: any) {
   const lease = normalizeLeaseRow(raw.id, raw);
   const propertyId = String(lease.propertyId || "").trim();
+  const landlordId = String(lease.landlordId || "").trim() || null;
   const tenantId =
     String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim() || null;
 
-  const [propertySnap, tenantSnap, documentUrl, scheduleAUrl] = await Promise.all([
+  const [propertySnap, tenantSnap, legacyDocumentUrl, scheduleAUrl, primaryDocument, signingRequest, signingSignedEvent] = await Promise.all([
     propertyId ? db.collection("properties").doc(propertyId).get().catch(() => null) : Promise.resolve(null),
     tenantId ? db.collection("tenants").doc(tenantId).get().catch(() => null) : Promise.resolve(null),
     loadLeaseDocumentUrlForLease(raw),
     loadScheduleAUrlForLease(raw),
+    landlordId
+      ? getPrimaryLeaseDocumentSummary({ leaseId: lease.id, landlordId, includePreviewUrl: true }).catch(() => null)
+      : Promise.resolve(null),
+    loadLatestLeaseSigningRequestForProjection(lease.id, landlordId),
+    loadLatestSigningSignedEventForProjection(lease.id),
   ]);
+  const documentUrl = legacyDocumentUrl || String(primaryDocument?.previewUrl || "").trim() || null;
+  const projectionRaw = buildLeaseProjectionRaw({ raw, signingRequest, signingSignedEvent, primaryDocument });
 
   const propertyData = propertySnap?.exists ? propertySnap.data() : null;
   const propertyName =
@@ -1357,7 +1448,7 @@ async function enrichLeaseRow(raw: any) {
   const tenantEmail =
     tenantSnap?.exists ? String(tenantSnap.data()?.email || "").trim() || null : null;
   const leasePaymentProjection = await buildLeasePaymentProjection({
-    rawLease: raw,
+    rawLease: projectionRaw,
     lease: {
       id: lease.id,
       landlordId: String(lease.landlordId || "").trim() || null,
@@ -1378,7 +1469,6 @@ async function enrichLeaseRow(raw: any) {
   const leaseReadiness = leasePaymentProjection.leaseReadiness;
   const paymentReadiness = leasePaymentProjection.paymentReadiness;
   const rentPaymentSummary = leasePaymentProjection.rentPaymentSummary;
-  const landlordId = String(lease.landlordId || "").trim() || null;
   const [unitOccupancy, ledgerPaymentCount] = await Promise.all([
     loadLeaseUnitOccupancySnapshot(lease, landlordId),
     countLeaseLedgerPaymentActivity(lease.id, landlordId),
@@ -3060,6 +3150,77 @@ export async function handleLeaseDocumentUrl(req: any, res: Response) {
 
 router.get("/:leaseId/document-url", requireLandlord, handleLeaseDocumentUrl);
 
+async function buildPrimaryLeaseDocumentContext(leaseId: string, lease: any, req: any) {
+  const landlordId = String(lease?.landlordId || req.user?.landlordId || req.user?.id || "").trim();
+  const propertyId = String(lease?.propertyId || "").trim();
+  const unitId = String(lease?.unitId || "").trim();
+  const tenantIds = Array.isArray(lease?.tenantIds)
+    ? lease.tenantIds.map((value: any) => String(value || "").trim()).filter(Boolean)
+    : [lease?.primaryTenantId, lease?.tenantId].map((value) => String(value || "").trim()).filter(Boolean);
+  const [propertySnap, unitSnap, landlordSnap, ...tenantSnaps] = await Promise.all([
+    propertyId ? db.collection("properties").doc(propertyId).get().catch(() => null) : Promise.resolve(null),
+    unitId ? db.collection("units").doc(unitId).get().catch(() => null) : Promise.resolve(null),
+    landlordId ? db.collection("users").doc(landlordId).get().catch(() => null) : Promise.resolve(null),
+    ...tenantIds.map((tenantId: string) => db.collection("tenants").doc(tenantId).get().catch(() => null)),
+  ]);
+  return {
+    leaseId,
+    lease: { id: leaseId, ...lease },
+    landlord:
+      (landlordSnap as any)?.exists
+        ? { id: landlordId, ...(landlordSnap as any).data() }
+        : { id: landlordId, displayName: req.user?.displayName || req.user?.name || req.user?.email || "Landlord" },
+    property: (propertySnap as any)?.exists ? { id: propertyId, ...(propertySnap as any).data() } : null,
+    unit: (unitSnap as any)?.exists ? { id: unitId, ...(unitSnap as any).data() } : null,
+    tenants: tenantSnaps
+      .filter((snap: any) => snap?.exists)
+      .map((snap: any) => ({ id: snap.id, ...snap.data() })),
+    actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
+  };
+}
+
+function leaseDocumentErrorStatus(error: any) {
+  return Number(error?.status || 500);
+}
+
+function leaseDocumentErrorCode(error: any) {
+  const code = String(error?.message || "lease_document_generation_unavailable");
+  return code.includes(" ") ? "lease_document_generation_unavailable" : code;
+}
+
+router.get("/:leaseId/primary-document", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.params?.leaseId || "").trim();
+    const result = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!result.ok) return res.status(result.status).json({ ok: false, error: result.error === "Forbidden" ? "forbidden" : "lease_not_found" });
+    const document = await getPrimaryLeaseDocumentSummary({
+      leaseId,
+      landlordId,
+      includePreviewUrl: String(req.query?.includePreviewUrl || "") === "1",
+    });
+    return res.status(200).json({ ok: true, document });
+  } catch (error: any) {
+    return res.status(leaseDocumentErrorStatus(error)).json({ ok: false, error: leaseDocumentErrorCode(error) });
+  }
+});
+
+router.post("/:leaseId/primary-document/generate", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.params?.leaseId || "").trim();
+    const result = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!result.ok) return res.status(result.status).json({ ok: false, error: result.error === "Forbidden" ? "forbidden" : "lease_not_found" });
+    const context = await buildPrimaryLeaseDocumentContext(leaseId, result.lease as any, req);
+    const document = await generatePrimaryLeaseDocument(context);
+    return res.status(201).json({ ok: true, document });
+  } catch (error: any) {
+    return res.status(leaseDocumentErrorStatus(error)).json({ ok: false, error: leaseDocumentErrorCode(error) });
+  }
+});
+
 router.post("/:leaseId/send-for-signature", requireLandlord, async (req: any, res: Response) => {
   try {
     res.setHeader("x-lease-signing-route-version", LEASE_SIGNING_ROUTE_VERSION);
@@ -3069,16 +3230,35 @@ router.post("/:leaseId/send-for-signature", requireLandlord, async (req: any, re
     if (!leaseId) return res.status(400).json({ ok: false, error: "lease_not_found" });
     const result = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!result.ok) return res.status(result.status).json({ ok: false, error: result.error === "Forbidden" ? "forbidden" : "lease_not_found" });
-    const signingDocumentUrl = await loadLeaseDocumentUrlForLease(result.lease as any);
     const tenantEmails = Array.isArray(req.body?.tenantEmails)
       ? req.body.tenantEmails.map((value: unknown) => String(value || "").trim())
       : [req.body?.tenantEmail].map((value) => String(value || "").trim()).filter(Boolean);
+    const validTenantEmails = tenantEmails.filter(Boolean);
+    if (!validTenantEmails.length || validTenantEmails.some((email: string) => !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))) {
+      return res.status(400).json({ ok: false, error: "invalid_tenant_email" });
+    }
+    const requestIdHint = `${landlordId}:${leaseId}:signing`;
+    const lockedDocument = await lockPrimaryLeaseDocumentForSigning({
+      leaseId,
+      landlordId,
+      actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
+      signingRequestId: requestIdHint,
+    });
     const snapshot = await sendLeaseForSignature({
       leaseId,
-      lease: signingDocumentUrl ? { ...(result.lease as any), documentUrl: signingDocumentUrl } : (result.lease as any),
+      lease: result.lease as any,
       landlordId,
-      tenantEmails,
+      tenantEmails: validTenantEmails,
       message: String(req.body?.message || "").trim() || null,
+      providerDocumentUrl: lockedDocument.providerDocumentUrl,
+      documentMetadata: {
+        documentId: lockedDocument.document.id,
+        documentHash: lockedDocument.document.documentHash,
+        manifestHash: lockedDocument.document.manifestHash,
+        templateVersion: lockedDocument.document.templateVersion,
+        jurisdictionCode: lockedDocument.document.jurisdictionCode,
+        providerAccessUrlExpiresAt: lockedDocument.document.providerAccessUrlExpiresAt,
+      },
     });
     return res.status(200).json({
       ok: true,

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -119,6 +119,15 @@ describe("leaseSigningService", () => {
       leaseId: "lease-1",
       landlordId: "landlord-1",
       lease: { startDate: "2026-01-01" },
+      providerDocumentUrl: "https://signed.example.com/provider-fetch.pdf?X-Goog-Signature=secret",
+      documentMetadata: {
+        documentId: "ldoc_signed",
+        documentHash: "doc_hash_signed",
+        manifestHash: "manifest_hash_signed",
+        jurisdictionCode: "CA_NS",
+        templateVersion: "ca-ns-primary-lease-draft-v1",
+        providerAccessUrlExpiresAt: "2026-01-01T04:00:00.000Z",
+      },
       tenantEmails: ["tenant@example.com"],
     });
     const storedRequest = Array.from(ensureCollection("leaseSigningRequests").values())[0];
@@ -144,6 +153,25 @@ describe("leaseSigningService", () => {
     expect(snapshot.signingStatus).toBe("signed");
     expect(snapshot.derivedLeaseState).toBe("active");
     expect(snapshot.events.map((event) => event.type)).toContain("signed");
+    expect(writeCanonicalEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "signing_signed",
+        metadata: expect.objectContaining({
+          documentId: "ldoc_signed",
+          documentHash: "doc_hash_signed",
+          manifestHash: "manifest_hash_signed",
+          jurisdictionCode: "CA_NS",
+          templateVersion: "ca-ns-primary-lease-draft-v1",
+          providerRef: expect.stringMatching(/^mock_ref_/),
+          providerDispatchMode: "mock",
+          providerDispatchStatus: "mocked_no_email",
+        }),
+      })
+    );
+    const canonicalPayload = JSON.stringify(writeCanonicalEventMock.mock.calls);
+    expect(canonicalPayload).not.toContain("https://signed.example.com");
+    expect(canonicalPayload).not.toContain("X-Goog-Signature");
+    expect(canonicalPayload).not.toContain(storedRequest.providerRequestId);
   });
 
   it("fails closed for explicitly configured Dropbox Sign when config is missing", async () => {
@@ -190,14 +218,30 @@ describe("leaseSigningService", () => {
     const snapshot = await sendLeaseForSignature({
       leaseId: "lease-1",
       landlordId: "landlord-1",
-      lease: { startDate: "2026-01-01", documentUrl: "https://example.com/lease.pdf" },
+      lease: { startDate: "2026-01-01" },
+      providerDocumentUrl: "https://signed.example.com/provider-fetch.pdf?X-Goog-Signature=secret",
+      documentMetadata: {
+        documentId: "ldoc_1",
+        documentHash: "doc_hash",
+        manifestHash: "manifest_hash",
+        jurisdictionCode: "CA_NS",
+        templateVersion: "ca-ns-primary-lease-draft-v1",
+        providerAccessUrlExpiresAt: "2026-01-01T04:00:00.000Z",
+      },
       tenantEmails: ["tenant@example.com"],
     });
 
     const storedRequest = Array.from(ensureCollection("leaseSigningRequests").values())[0];
     expect(storedRequest.providerRequestId).toBe("raw-provider-request-123");
+    expect(storedRequest.documentUrl).toBeUndefined();
+    expect(storedRequest.providerAccessUrlExpiresAt).toBe("2026-01-01T04:00:00.000Z");
+    expect(storedRequest.documentId).toBe("ldoc_1");
+    expect(storedRequest.documentHash).toBe("doc_hash");
+    expect(storedRequest.manifestHash).toBe("manifest_hash");
     expect(snapshot.providerRequestRef).toMatch(/^boldsign_ref_/);
     expect(JSON.stringify(snapshot)).not.toContain("raw-provider-request-123");
+    expect(JSON.stringify(storedRequest)).not.toContain("https://signed.example.com");
+    expect(JSON.stringify(storedRequest)).not.toContain("X-Goog-Signature");
     expect(writeCanonicalEventMock).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "signing_sent",
@@ -205,10 +249,16 @@ describe("leaseSigningService", () => {
           providerDispatchMode: "sandbox",
           providerDispatchStatus: "accepted",
           providerTestMode: true,
+          documentId: "ldoc_1",
+          documentHash: "doc_hash",
+          manifestHash: "manifest_hash",
+          jurisdictionCode: "CA_NS",
+          templateVersion: "ca-ns-primary-lease-draft-v1",
         }),
       })
     );
     expect(JSON.stringify(writeCanonicalEventMock.mock.calls)).not.toContain("raw-provider-request-123");
+    expect(JSON.stringify(writeCanonicalEventMock.mock.calls)).not.toContain("https://signed.example.com");
   });
 
   it("rejects webhook signature failures without writing events", async () => {

--- a/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
@@ -1,0 +1,357 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeCanonicalEventMock = vi.fn(async () => undefined);
+const putPdfObjectMock = vi.fn(async ({ objectKey }: { objectKey: string }) => ({
+  bucket: "lease-documents",
+  path: objectKey,
+}));
+const getSignedDownloadUrlMock = vi.fn(async () => "https://signed.example.com/provider-access.pdf");
+
+const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let idSeq = 0;
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; value: any }>) {
+    return filters.every(({ field, value }) => doc.data?.[field] === value);
+  }
+
+  function makeDoc(name: string, id?: string) {
+    const actualId = id || `doc_${++idSeq}`;
+    const col = ensureCollection(name);
+    return {
+      id: actualId,
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = col.get(actualId)?.data || {};
+        col.set(actualId, { id: actualId, data: options?.merge ? { ...current, ...value } : value });
+      },
+      get: async () => {
+        const entry = col.get(actualId);
+        return { id: actualId, exists: Boolean(entry), data: () => entry?.data };
+      },
+    };
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; value: any }> = []) {
+    return {
+      where: (field: string, _op: string, value: any) => makeQuery(name, [...filters, { field, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id?: string) => makeDoc(name, id),
+    };
+  }
+
+  return {
+    resetFakeDb: () => {
+      store.clear();
+      idSeq = 0;
+    },
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
+    listDocs: (name: string) => Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, data: doc.data })),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, _op: string, value: any) => makeQuery(name, [{ field, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id?: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+vi.mock("../../../firebase", () => ({
+  db: fakeDb,
+  FieldValue: { serverTimestamp: () => "SERVER_TIMESTAMP" },
+}));
+
+vi.mock("../../../storage/pdfStore", () => ({
+  putPdfObject: putPdfObjectMock,
+}));
+
+vi.mock("../../../lib/gcsSignedUrl", () => ({
+  getSignedDownloadUrl: getSignedDownloadUrlMock,
+}));
+
+vi.mock("../../../lib/events/buildEvent", () => ({
+  writeCanonicalEvent: writeCanonicalEventMock,
+}));
+
+function lease(overrides: Record<string, any> = {}) {
+  return {
+    id: "lease-1",
+    landlordId: "landlord-1",
+    tenantIds: ["tenant-1"],
+    province: "NS",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    unitNumber: "101",
+    startDate: "2026-01-01",
+    endDate: "2026-12-31",
+    termType: "fixed",
+    baseRentCents: 180000,
+    dueDay: 1,
+    paymentMethod: "etransfer",
+    ...overrides,
+  };
+}
+
+describe("leaseDocumentService", () => {
+  beforeEach(() => {
+    resetFakeDb();
+    writeCanonicalEventMock.mockClear();
+    putPdfObjectMock.mockClear();
+    getSignedDownloadUrlMock.mockClear();
+    process.env.NODE_ENV = "test";
+    process.env.SIGNING_DOCUMENT_SOURCE_TEST_MODE = "true";
+    delete process.env.LEASE_DOCUMENT_GENERATION_TEST_MODE;
+    delete process.env.SIGNING_PROVIDER_TEST_MODE;
+    process.env.GCS_UPLOAD_BUCKET = "lease-documents";
+  });
+
+  it("generates CA_NS primary lease documents in explicit test mode with safe metadata", async () => {
+    const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
+    const document = await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease(),
+      landlord: { name: "Landlord" },
+      property: { name: "Harbour View" },
+      unit: { unitNumber: "101" },
+      tenants: [{ fullName: "Tenant One" }],
+      actorId: "actor-1",
+    });
+
+    expect(document.documentType).toBe("primary_lease");
+    expect(document.jurisdictionCode).toBe("CA_NS");
+    expect(document.templateEffectiveDate).toBe("2026-06-15");
+    expect(document.counselReviewStatus).toBe("draft");
+    expect(document.sourceReferences).toEqual(["Nova Scotia Form P Standard Lease Form reference upload"]);
+    expect(document.documentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(document.manifestHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(document.storageRef).toBeNull();
+    expect(JSON.stringify(document)).not.toContain("lease-documents/");
+    expect(listDocs("leaseDocuments")).toHaveLength(1);
+    expect(writeCanonicalEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "lease_document_generated",
+        metadata: expect.objectContaining({
+          templateEffectiveDate: "2026-06-15",
+          sourceReferences: ["Nova Scotia Form P Standard Lease Form reference upload"],
+        }),
+      })
+    );
+  });
+
+  it("fails closed for missing jurisdiction adapters without success events", async () => {
+    const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
+    await expect(
+      generatePrimaryLeaseDocument({
+        leaseId: "lease-1",
+        lease: lease({ province: "ON" }),
+        landlord: null,
+        property: null,
+        unit: null,
+        tenants: [],
+        actorId: "actor-1",
+      })
+    ).rejects.toThrow("jurisdiction_template_unavailable");
+    expect(listDocs("leaseDocuments")).toHaveLength(0);
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for draft adapters outside allowed test mode", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.SIGNING_DOCUMENT_SOURCE_TEST_MODE = "false";
+    const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
+    await expect(
+      generatePrimaryLeaseDocument({
+        leaseId: "lease-1",
+        lease: lease(),
+        landlord: null,
+        property: null,
+        unit: null,
+        tenants: [],
+        actorId: "actor-1",
+      })
+    ).rejects.toThrow("jurisdiction_template_unavailable");
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("allows draft CA_NS generation in explicit lease document generation test mode", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.SIGNING_DOCUMENT_SOURCE_TEST_MODE;
+    process.env.LEASE_DOCUMENT_GENERATION_TEST_MODE = "true";
+    const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
+    const document = await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease(),
+      landlord: null,
+      property: null,
+      unit: null,
+      tenants: [],
+      actorId: "actor-1",
+    });
+
+    expect(document.jurisdictionCode).toBe("CA_NS");
+    expect(document.counselReviewStatus).toBe("draft");
+    expect(document.sourceSummary).toEqual(
+      expect.objectContaining({
+        productionApproved: false,
+        signingEnabled: false,
+      })
+    );
+  });
+
+  it("allows preview generation when signing provider test mode is explicitly enabled", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.SIGNING_DOCUMENT_SOURCE_TEST_MODE;
+    delete process.env.LEASE_DOCUMENT_GENERATION_TEST_MODE;
+    process.env.SIGNING_PROVIDER_TEST_MODE = "true";
+    const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
+    const document = await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease(),
+      landlord: null,
+      property: null,
+      unit: null,
+      tenants: [],
+      actorId: "actor-1",
+    });
+
+    expect(document.counselReviewStatus).toBe("draft");
+    expect(document.sourceSummary?.productionApproved).toBe(false);
+    expect(document.sourceSummary?.signingEnabled).toBe(false);
+  });
+
+  it("locks generated primary documents for signing and returns provider-readable URL", async () => {
+    const { generatePrimaryLeaseDocument, lockPrimaryLeaseDocumentForSigning } = await import("../leaseDocumentService");
+    const generated = await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease(),
+      landlord: null,
+      property: null,
+      unit: null,
+      tenants: [],
+      actorId: "actor-1",
+    });
+
+    const locked = await lockPrimaryLeaseDocumentForSigning({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      actorId: "actor-1",
+      signingRequestId: "request-1",
+    });
+
+    expect(locked.document.id).toBe(generated.id);
+    expect(locked.document.status).toBe("locked");
+    expect(locked.providerDocumentUrl).toBe("https://signed.example.com/provider-access.pdf");
+    expect(getSignedDownloadUrlMock).toHaveBeenCalledWith(expect.objectContaining({ expiresMinutes: 240 }));
+    expect(writeCanonicalEventMock).toHaveBeenCalledWith(expect.objectContaining({ action: "lease_document_locked" }));
+  });
+
+  it("does not mutate a locked document during signing", async () => {
+    const { generatePrimaryLeaseDocument, lockPrimaryLeaseDocumentForSigning } = await import("../leaseDocumentService");
+    await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease(),
+      landlord: null,
+      property: null,
+      unit: null,
+      tenants: [],
+      actorId: "actor-1",
+    });
+    await lockPrimaryLeaseDocumentForSigning({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      actorId: "actor-1",
+      signingRequestId: "request-1",
+    });
+
+    await expect(
+      generatePrimaryLeaseDocument({
+        leaseId: "lease-1",
+        lease: lease(),
+        landlord: null,
+        property: null,
+        unit: null,
+        tenants: [],
+        actorId: "actor-1",
+      })
+    ).rejects.toThrow("lease_document_locked");
+
+    const documents = listDocs("leaseDocuments");
+    expect(documents).toHaveLength(1);
+    expect(documents[0].data.status).toBe("locked");
+  });
+
+  it("supersedes generated primary documents and writes a safe canonical event", async () => {
+    const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
+    await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease(),
+      landlord: null,
+      property: null,
+      unit: null,
+      tenants: [],
+      actorId: "actor-1",
+    });
+    await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease({ baseRentCents: 190000 }),
+      landlord: null,
+      property: null,
+      unit: null,
+      tenants: [],
+      actorId: "actor-1",
+    });
+
+    const documents = listDocs("leaseDocuments");
+    expect(documents).toHaveLength(2);
+    expect(documents.map((doc) => doc.data.status).sort()).toEqual(["generated", "superseded"]);
+    expect(writeCanonicalEventMock).toHaveBeenCalledWith(expect.objectContaining({ action: "lease_document_superseded" }));
+    expect(JSON.stringify(writeCanonicalEventMock.mock.calls)).not.toContain("lease-documents/");
+  });
+
+  it("does not sign superseded documents", async () => {
+    seedDoc("leaseDocuments", "old-doc", {
+      id: "old-doc",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      documentType: "primary_lease",
+      status: "superseded",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      storageRef: { bucket: "lease-documents", path: "lease-documents/raw.pdf" },
+    });
+    const { lockPrimaryLeaseDocumentForSigning } = await import("../leaseDocumentService");
+    await expect(
+      lockPrimaryLeaseDocumentForSigning({ leaseId: "lease-1", landlordId: "landlord-1" })
+    ).rejects.toThrow("signing_document_url_required");
+  });
+
+  it("allows future US adapters through the registry without changing the core pipeline", async () => {
+    const { registerLeaseDocumentAdapter, getLeaseDocumentAdapter } = await import("../jurisdictionAdapterRegistry");
+    registerLeaseDocumentAdapter({
+      jurisdictionCode: "US_ME",
+      templateVersion: "us-me-test-v1",
+      effectiveDate: "2026-06-15",
+      counselReviewStatus: "draft",
+      signingEnabled: false,
+      productionApproved: false,
+      requiredSections: [],
+      requiredDisclosures: [],
+      requiredNotices: [],
+      prohibitedClauseChecks: [],
+      languageRequirements: ["en-US"],
+      statutoryReferences: [],
+      sourceReferences: [],
+      renderPrimaryLeasePdf: async () => Buffer.from("pdf"),
+    });
+    expect(getLeaseDocumentAdapter("US_ME")).toEqual(expect.objectContaining({ jurisdictionCode: "US_ME" }));
+  });
+});

--- a/rentchain-api/src/services/leaseDocuments/jurisdictionAdapterRegistry.ts
+++ b/rentchain-api/src/services/leaseDocuments/jurisdictionAdapterRegistry.ts
@@ -1,0 +1,74 @@
+import { caNsLeaseDocumentAdapter } from "./jurisdictions/caNsAdapter";
+import type { JurisdictionAdapterCode, JurisdictionLeaseDocumentAdapter } from "./leaseDocumentTypes";
+
+const adapters = new Map<JurisdictionAdapterCode, JurisdictionLeaseDocumentAdapter>([
+  ["CA_NS", caNsLeaseDocumentAdapter],
+]);
+
+export function jurisdictionCodeFromLease(input: Record<string, any>): JurisdictionAdapterCode | null {
+  const raw = String(
+    input?.jurisdictionCode ||
+      input?.jurisdictionProvince ||
+      input?.province ||
+      input?.provinceState ||
+      ""
+  )
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z_]/g, "");
+  if (!raw) return null;
+  if (raw === "NS" || raw === "CA_NS") return "CA_NS";
+  if (raw === "ON" || raw === "CA_ON") return "CA_ON";
+  if (raw === "BC" || raw === "CA_BC") return "CA_BC";
+  if (raw === "AB" || raw === "CA_AB") return "CA_AB";
+  if (raw === "QC" || raw === "CA_QC") return "CA_QC";
+  if (raw.startsWith("US_")) return raw as JurisdictionAdapterCode;
+  return null;
+}
+
+export function getLeaseDocumentAdapter(code: JurisdictionAdapterCode | null): JurisdictionLeaseDocumentAdapter | null {
+  if (!code) return null;
+  return adapters.get(code) || null;
+}
+
+export function registerLeaseDocumentAdapter(adapter: JurisdictionLeaseDocumentAdapter) {
+  adapters.set(adapter.jurisdictionCode, adapter);
+}
+
+function configuredBoolean(name: string): boolean | null {
+  const explicit = String(process.env[name] || "").trim().toLowerCase();
+  if (explicit === "true" || explicit === "1") return true;
+  if (explicit === "false" || explicit === "0") return false;
+  return null;
+}
+
+export function isLeaseDocumentTestMode() {
+  const documentGenerationMode = configuredBoolean("LEASE_DOCUMENT_GENERATION_TEST_MODE");
+  if (documentGenerationMode !== null) return documentGenerationMode;
+  const legacyDocumentSourceMode = configuredBoolean("SIGNING_DOCUMENT_SOURCE_TEST_MODE");
+  if (legacyDocumentSourceMode !== null) return legacyDocumentSourceMode;
+  const signingProviderTestMode = configuredBoolean("SIGNING_PROVIDER_TEST_MODE");
+  if (signingProviderTestMode !== null) return signingProviderTestMode;
+  return String(process.env.NODE_ENV || "").trim().toLowerCase() !== "production";
+}
+
+export function assertAdapterAllowedForGeneration(adapter: JurisdictionLeaseDocumentAdapter) {
+  if (adapter.productionApproved && adapter.signingEnabled) return;
+  if (isLeaseDocumentTestMode() && adapter.counselReviewStatus === "draft") return;
+  const error = new Error("jurisdiction_template_unavailable") as Error & { status: number };
+  error.status = 400;
+  throw error;
+}
+
+export function assertAdapterAllowedForSigning(adapterStatus: {
+  counselReviewStatus?: string | null;
+  signingEnabled?: boolean | null;
+  productionApproved?: boolean | null;
+}) {
+  if (adapterStatus.productionApproved && adapterStatus.signingEnabled) return;
+  const reviewStatus = String(adapterStatus.counselReviewStatus || (adapterStatus as any).adapterStatus || "");
+  if (isLeaseDocumentTestMode() && reviewStatus === "draft") return;
+  const error = new Error("jurisdiction_template_unavailable") as Error & { status: number };
+  error.status = 400;
+  throw error;
+}

--- a/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
+++ b/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
@@ -1,0 +1,172 @@
+import PDFDocument from "pdfkit";
+import type { JurisdictionLeaseDocumentAdapter, PrimaryLeaseDocumentInput } from "../leaseDocumentTypes";
+
+function text(value: unknown, fallback = "Not provided") {
+  const next = String(value ?? "").trim();
+  return next || fallback;
+}
+
+function money(centsOrDollars: unknown) {
+  const value = Number(centsOrDollars || 0);
+  const dollars = value > 10000 ? value / 100 : value;
+  return dollars.toLocaleString("en-CA", { style: "currency", currency: "CAD" });
+}
+
+function collectPdf(write: (doc: PDFKit.PDFDocument) => void): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 54, size: "LETTER" });
+    const chunks: Buffer[] = [];
+    doc.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    doc.on("error", reject);
+    doc.on("end", () => resolve(Buffer.concat(chunks)));
+    write(doc);
+    doc.end();
+  });
+}
+
+export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
+  jurisdictionCode: "CA_NS",
+  templateVersion: "ca-ns-primary-lease-draft-v1",
+  effectiveDate: "2026-06-15",
+  counselReviewStatus: "draft",
+  signingEnabled: false,
+  productionApproved: false,
+  requiredSections: [
+    "parties",
+    "occupants",
+    "premises",
+    "emergency_contact",
+    "agent",
+    "property_manager",
+    "building_superintendent",
+    "email_service_of_documents",
+    "service_of_notices_documents",
+    "lease_type",
+    "public_housing",
+    "rent",
+    "rent_increases",
+    "rental_incentive",
+    "rent_includes",
+    "tenant_responsibilities",
+    "additional_obligations",
+    "security_deposit",
+    "inspection",
+    "statutory_conditions_reasonable_rules",
+    "assignment_sublet",
+    "rental_arrears",
+    "tenant_notice_to_quit",
+    "landlord_notice_to_quit",
+    "general_binding_clause",
+    "tenant_terms_responsibility",
+    "attachments_initials",
+    "sign_and_date",
+    "schedule_a_statutory_conditions",
+  ],
+  requiredDisclosures: [
+    "Form P is the Nova Scotia Standard Form of Lease under the Residential Tenancies Act.",
+    "A landlord's lease may look different, but must contain all Form P items; missing items may apply anyway.",
+    "Residential lease terms must be reviewed against Nova Scotia requirements before production use.",
+  ],
+  requiredNotices: [
+    "Schedule A statutory conditions are required as an attachment/section and remain distinct from the primary document source.",
+    "This draft/test adapter is not legal advice and is not counsel-approved for production signing.",
+  ],
+  prohibitedClauseChecks: ["unsafe_additional_clauses_unreviewed"],
+  languageRequirements: ["en-CA"],
+  statutoryReferences: [
+    "Nova Scotia Residential Tenancies Act",
+    "Form P Standard Form of Lease",
+    "Schedule A statutory conditions",
+  ],
+  sourceReferences: ["Nova Scotia Form P Standard Lease Form reference upload"],
+  async renderPrimaryLeasePdf(input: PrimaryLeaseDocumentInput) {
+    return collectPdf((doc) => {
+      const lease = input.lease || {};
+      const property = input.property || {};
+      const unit = input.unit || {};
+      const tenants = input.tenants || [];
+      const landlordName = text(input.landlord?.displayName || input.landlord?.name || input.landlord?.email || lease.landlordId, "Landlord");
+      const tenantNames = tenants
+        .map((tenant) => text(tenant.fullName || tenant.name || tenant.email || tenant.id, "Tenant"))
+        .join(", ");
+      const unitLabel = text(unit.unitNumber || unit.label || lease.unitNumber || lease.unitId, "Unit");
+      const propertyLabel = text(property.addressLine1 || property.name || lease.propertyId, "Property");
+
+      doc.fontSize(18).text("Primary Residential Lease Document", { align: "center" });
+      doc.moveDown(0.35);
+      doc.fontSize(9).fillColor("#555").text("Template status: draft/test. Not legal advice. Counsel review required before production signing.", {
+        align: "center",
+      });
+      doc.fillColor("#111").moveDown();
+
+      const section = (title: string) => {
+        doc.moveDown(0.7);
+        doc.fontSize(13).text(title, { underline: true });
+        doc.moveDown(0.3);
+        doc.fontSize(10);
+      };
+      const row = (label: string, value: string) => {
+        doc.font("Helvetica-Bold").text(`${label}: `, { continued: true });
+        doc.font("Helvetica").text(value);
+      };
+
+      section("Parties");
+      row("Landlord", landlordName);
+      row("Tenant(s)", tenantNames || "Tenant details on file");
+      row("Occupants", "Occupants must be listed before production use.");
+
+      section("Premises");
+      row("Property", propertyLabel);
+      row("Unit", unitLabel);
+      row("Jurisdiction", "Nova Scotia, Canada");
+      row("Emergency contact", "Required before production use.");
+      row("Agent", "Required if applicable.");
+      row("Property manager", "Required if applicable.");
+      row("Building superintendent", "Required if applicable.");
+
+      section("Term");
+      row("Start date", text(lease.startDate));
+      row("End date", text(lease.endDate, "Month-to-month or not provided"));
+      row("Term type", text(lease.termType));
+      row("Public housing", "Required if applicable.");
+
+      section("Rent and Payments");
+      row("Monthly rent", money(lease.baseRentCents ?? lease.monthlyRent));
+      row("Due day", text(lease.dueDay));
+      row("Payment method", text(lease.paymentMethod));
+      row("Deposit", lease.depositCents == null ? "Not provided" : money(lease.depositCents));
+      row("Rent increases", "Governed by Nova Scotia requirements.");
+      row("Rental incentive", "Required if applicable.");
+      row("Rent includes", Array.isArray(lease.utilitiesIncluded) && lease.utilitiesIncluded.length ? lease.utilitiesIncluded.join(", ") : "Not provided");
+
+      section("Tenant Responsibilities and Notices");
+      row("Tenant responsibilities", "Required Form P terms and reasonable rules must be included.");
+      row("Additional obligations", "Required if applicable and subject to review.");
+      row("Assignment/sublet", "Required Form P terms apply.");
+      row("Rental arrears", "Required Form P terms apply.");
+      row("Tenant notice to quit", "Required Form P terms apply.");
+      row("Landlord notice to quit", "Required Form P terms apply.");
+      row("Email service of documents", "Landlord and tenant consent details required before production use.");
+      row("How to serve notices/documents", "Required Form P service terms apply.");
+
+      section("Inspection, Rules, and General Terms");
+      row("Inspection", "Required Form P terms apply.");
+      row("Statutory conditions and reasonable rules", "Schedule A statutory conditions must be attached/sectioned.");
+      row("General/binding clause", "Required Form P terms apply.");
+      row("Tenants responsible for terms", "Required Form P terms apply.");
+      doc.moveDown(0.2);
+      doc.text(text(lease.additionalClauses, "No additional clauses provided."));
+
+      section("Attachments");
+      doc.text("Schedule A statutory conditions and addenda must be attached/initialed where required and do not replace this primary lease document.");
+
+      section("Signature Acknowledgement");
+      doc.text("Tenant signature: _______________________________   Date: ______________");
+      doc.moveDown(0.5);
+      doc.text("Landlord signature: _____________________________   Date: ______________");
+
+      doc.moveDown();
+      doc.fontSize(8).fillColor("#555").text("This generated draft is provided for workflow testing. It is not legal advice, certification, notarization, or an enforceability guarantee.");
+    });
+  },
+};

--- a/rentchain-api/src/services/leaseDocuments/leaseDocumentService.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseDocumentService.ts
@@ -1,0 +1,301 @@
+import crypto from "crypto";
+import { db, FieldValue } from "../../firebase";
+import { getSignedDownloadUrl } from "../../lib/gcsSignedUrl";
+import { writeCanonicalEvent } from "../../lib/events/buildEvent";
+import { putPdfObject } from "../../storage/pdfStore";
+import {
+  assertAdapterAllowedForGeneration,
+  assertAdapterAllowedForSigning,
+  getLeaseDocumentAdapter,
+  jurisdictionCodeFromLease,
+} from "./jurisdictionAdapterRegistry";
+import type {
+  LeaseDocumentMetadata,
+  LeaseDocumentProjection,
+  PrimaryLeaseDocumentInput,
+} from "./leaseDocumentTypes";
+
+export const LEASE_DOCUMENTS_COLLECTION = "leaseDocuments";
+const PROVIDER_ACCESS_MINUTES = 240;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function digest(input: string | Buffer, length?: number) {
+  const hash = crypto.createHash("sha256").update(input).digest("hex");
+  return length ? hash.slice(0, length) : hash;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function tenantIdsFromLease(lease: Record<string, any>) {
+  const ids = Array.isArray(lease?.tenantIds)
+    ? lease.tenantIds
+    : [lease?.primaryTenantId, lease?.tenantId];
+  return ids.map((value) => String(value || "").trim()).filter(Boolean);
+}
+
+function safeProjection(doc: LeaseDocumentMetadata, previewUrl?: string | null): LeaseDocumentProjection {
+  return {
+    ...doc,
+    storageRef: null,
+    previewUrl: previewUrl || null,
+  };
+}
+
+function manifestFor(input: {
+  leaseId: string;
+  landlordId: string;
+  tenantIds: string[];
+  jurisdictionCode: string;
+  templateVersion: string;
+  documentHash: string;
+  generatedAt: string;
+}) {
+  return {
+    manifestVersion: "primary_lease_document_manifest_v1",
+    documentType: "primary_lease",
+    leaseId: input.leaseId,
+    landlordId: input.landlordId,
+    tenantIds: [...input.tenantIds].sort(),
+    jurisdictionCode: input.jurisdictionCode,
+    templateVersion: input.templateVersion,
+    documentHash: input.documentHash,
+    generatedAt: input.generatedAt,
+  };
+}
+
+async function writeLeaseDocumentEvent(params: {
+  action: "lease_document_generated" | "lease_document_locked" | "lease_document_superseded";
+  status: string;
+  leaseId: string;
+  landlordId: string;
+  actorId?: string | null;
+  document: LeaseDocumentMetadata;
+}) {
+  await writeCanonicalEvent({
+    domain: "lease",
+    action: params.action,
+    status: params.status,
+    actor: { type: "landlord", role: "landlord", id: params.actorId || params.landlordId },
+    resource: { type: "lease", id: params.leaseId },
+    visibility: "internal",
+    summary: "Primary lease document state updated",
+    metadata: {
+      documentId: params.document.id,
+      documentType: params.document.documentType,
+      jurisdictionCode: params.document.jurisdictionCode,
+      templateVersion: params.document.templateVersion,
+      templateEffectiveDate: params.document.templateEffectiveDate,
+      counselReviewStatus: params.document.counselReviewStatus,
+      sourceReferences: params.document.sourceReferences,
+      documentHash: params.document.documentHash,
+      manifestHash: params.document.manifestHash,
+      status: params.document.status,
+    },
+  });
+}
+
+export async function loadCurrentPrimaryLeaseDocument(input: {
+  leaseId: string;
+  landlordId: string;
+  includeSuperseded?: boolean;
+}): Promise<LeaseDocumentMetadata | null> {
+  const snap = await db
+    .collection(LEASE_DOCUMENTS_COLLECTION)
+    .where("leaseId", "==", input.leaseId)
+    .where("landlordId", "==", input.landlordId)
+    .where("documentType", "==", "primary_lease")
+    .get();
+  const docs = snap.docs
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as LeaseDocumentMetadata)
+    .filter((doc) => input.includeSuperseded || doc.status === "generated" || doc.status === "locked")
+    .sort((a, b) => String(b.generatedAt || "").localeCompare(String(a.generatedAt || "")));
+  return docs[0] || null;
+}
+
+export async function getPrimaryLeaseDocumentSummary(input: {
+  leaseId: string;
+  landlordId: string;
+  includePreviewUrl?: boolean;
+}): Promise<LeaseDocumentProjection | null> {
+  const doc = await loadCurrentPrimaryLeaseDocument(input);
+  if (!doc) return null;
+  const previewUrl = input.includePreviewUrl
+    ? await getSignedDownloadUrl({ bucket: doc.storageRef.bucket, path: doc.storageRef.path, expiresMinutes: 30 })
+    : null;
+  return safeProjection(doc, previewUrl);
+}
+
+export async function generatePrimaryLeaseDocument(input: PrimaryLeaseDocumentInput): Promise<LeaseDocumentProjection> {
+  const leaseId = String(input.leaseId || "").trim();
+  const lease = input.lease || {};
+  const landlordId = String(lease.landlordId || "").trim();
+  if (!leaseId || !landlordId) {
+    const error = new Error("lease_document_generation_unavailable") as Error & { status: number };
+    error.status = 400;
+    throw error;
+  }
+  const jurisdictionCode = jurisdictionCodeFromLease({ ...input.property, ...lease });
+  const adapter = getLeaseDocumentAdapter(jurisdictionCode);
+  if (!adapter) {
+    const error = new Error("jurisdiction_template_unavailable") as Error & { status: number };
+    error.status = 400;
+    throw error;
+  }
+  assertAdapterAllowedForGeneration(adapter);
+
+  const previous = await loadCurrentPrimaryLeaseDocument({ leaseId, landlordId });
+  if (previous?.status === "locked") {
+    const error = new Error("lease_document_locked") as Error & { status: number };
+    error.status = 409;
+    throw error;
+  }
+
+  const pdfBuffer = await adapter.renderPrimaryLeasePdf(input);
+  const documentHash = digest(pdfBuffer);
+  const generatedAt = nowIso();
+  const tenantIds = tenantIdsFromLease(lease);
+  const manifest = manifestFor({
+    leaseId,
+    landlordId,
+    tenantIds,
+    jurisdictionCode: adapter.jurisdictionCode,
+    templateVersion: adapter.templateVersion,
+    documentHash,
+    generatedAt,
+  });
+  const manifestHash = digest(stableJson(manifest));
+  const documentId = `ldoc_${digest(`${leaseId}:${documentHash}:${generatedAt}`, 24)}`;
+  const objectKey = `lease-documents/${digest(landlordId, 12)}/${digest(leaseId, 12)}/${documentId}.pdf`;
+  const uploaded = await putPdfObject({ objectKey, pdfBuffer });
+  const storageRef = {
+    bucket: uploaded.bucket || process.env.GCS_UPLOAD_BUCKET || "",
+    path: uploaded.path || objectKey,
+  };
+  if (!storageRef.bucket || !storageRef.path) {
+    const error = new Error("lease_document_generation_unavailable") as Error & { status: number };
+    error.status = 500;
+    throw error;
+  }
+
+  if (previous) {
+    const superseded = { ...previous, status: "superseded" as const, supersededAt: generatedAt, supersededByDocumentId: documentId };
+    await db.collection(LEASE_DOCUMENTS_COLLECTION).doc(previous.id).set(superseded, { merge: true });
+    await writeLeaseDocumentEvent({
+      action: "lease_document_superseded",
+      status: "superseded",
+      leaseId,
+      landlordId,
+      actorId: input.actorId || null,
+      document: superseded,
+    });
+  }
+
+  const document: LeaseDocumentMetadata = {
+    id: documentId,
+    leaseId,
+    landlordId,
+    tenantIds,
+    documentType: "primary_lease",
+    jurisdictionCode: adapter.jurisdictionCode,
+    templateVersion: adapter.templateVersion,
+    templateEffectiveDate: adapter.effectiveDate,
+    counselReviewStatus: adapter.counselReviewStatus,
+    sourceReferences: adapter.sourceReferences,
+    generatedAt,
+    generatedBy: input.actorId || null,
+    documentHash,
+    manifestHash,
+    storageRef,
+    providerAccessUrlExpiresAt: null,
+    status: "generated",
+    lockedAt: null,
+    lockedBy: null,
+    signingRequestId: null,
+    sourceSummary: {
+      adapterStatus: adapter.counselReviewStatus,
+      signingEnabled: adapter.signingEnabled,
+      productionApproved: adapter.productionApproved,
+      templateEffectiveDate: adapter.effectiveDate,
+      sourceReferences: adapter.sourceReferences,
+    },
+  };
+  await db.collection(LEASE_DOCUMENTS_COLLECTION).doc(documentId).set({
+    ...document,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  await writeLeaseDocumentEvent({
+    action: "lease_document_generated",
+    status: "generated",
+    leaseId,
+    landlordId,
+    actorId: input.actorId || null,
+    document,
+  });
+  return safeProjection(document);
+}
+
+export async function lockPrimaryLeaseDocumentForSigning(input: {
+  leaseId: string;
+  landlordId: string;
+  actorId?: string | null;
+  signingRequestId?: string | null;
+}): Promise<{ document: LeaseDocumentMetadata; providerDocumentUrl: string }> {
+  const document = await loadCurrentPrimaryLeaseDocument({ leaseId: input.leaseId, landlordId: input.landlordId });
+  if (!document || document.status === "superseded" || document.status === "expired") {
+    const error = new Error("signing_document_url_required") as Error & { status: number };
+    error.status = 400;
+    throw error;
+  }
+  assertAdapterAllowedForSigning(document.sourceSummary || {});
+
+  const providerDocumentUrl = await getSignedDownloadUrl({
+    bucket: document.storageRef.bucket,
+    path: document.storageRef.path,
+    expiresMinutes: PROVIDER_ACCESS_MINUTES,
+  });
+  const lockedAt = nowIso();
+  const providerAccessUrlExpiresAt = new Date(Date.now() + PROVIDER_ACCESS_MINUTES * 60 * 1000).toISOString();
+  const next: LeaseDocumentMetadata = {
+    ...document,
+    status: "locked",
+    lockedAt: document.lockedAt || lockedAt,
+    lockedBy: document.lockedBy || input.actorId || input.landlordId,
+    signingRequestId: input.signingRequestId || document.signingRequestId || null,
+    providerAccessUrlExpiresAt,
+  };
+  await db.collection(LEASE_DOCUMENTS_COLLECTION).doc(document.id).set(
+    {
+      status: next.status,
+      lockedAt: next.lockedAt,
+      lockedBy: next.lockedBy,
+      signingRequestId: next.signingRequestId,
+      providerAccessUrlExpiresAt,
+      updatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+  if (document.status !== "locked") {
+    await writeLeaseDocumentEvent({
+      action: "lease_document_locked",
+      status: "locked",
+      leaseId: input.leaseId,
+      landlordId: input.landlordId,
+      actorId: input.actorId || null,
+      document: next,
+    });
+  }
+  return { document: next, providerDocumentUrl };
+}

--- a/rentchain-api/src/services/leaseDocuments/leaseDocumentTypes.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseDocumentTypes.ts
@@ -1,0 +1,80 @@
+export type LeaseDocumentStatus = "generated" | "locked" | "expired" | "superseded";
+
+export type CounselReviewStatus = "draft" | "reviewed" | "approved" | "deprecated";
+
+export type JurisdictionAdapterCode =
+  | "CA_NS"
+  | "CA_ON"
+  | "CA_BC"
+  | "CA_AB"
+  | "CA_QC"
+  | `US_${string}`;
+
+export type LeaseDocumentStorageRef = {
+  bucket: string;
+  path: string;
+};
+
+export type LeaseDocumentMetadata = {
+  id: string;
+  leaseId: string;
+  landlordId: string;
+  tenantIds: string[];
+  documentType: "primary_lease";
+  jurisdictionCode: JurisdictionAdapterCode;
+  templateVersion: string;
+  templateEffectiveDate: string;
+  counselReviewStatus: CounselReviewStatus;
+  sourceReferences: string[];
+  generatedAt: string;
+  generatedBy: string | null;
+  documentHash: string;
+  manifestHash: string;
+  storageRef: LeaseDocumentStorageRef;
+  providerAccessUrlExpiresAt: string | null;
+  status: LeaseDocumentStatus;
+  lockedAt: string | null;
+  lockedBy: string | null;
+  signingRequestId: string | null;
+  supersededAt?: string | null;
+  supersededByDocumentId?: string | null;
+  sourceSummary: {
+    adapterStatus: CounselReviewStatus;
+    signingEnabled: boolean;
+    productionApproved: boolean;
+    templateEffectiveDate: string;
+    sourceReferences: string[];
+  };
+};
+
+export type LeaseDocumentProjection = Omit<LeaseDocumentMetadata, "storageRef"> & {
+  storageRef: null;
+  previewUrl?: string | null;
+};
+
+export type PrimaryLeaseDocumentInput = {
+  leaseId: string;
+  lease: Record<string, any>;
+  landlord: Record<string, any> | null;
+  property: Record<string, any> | null;
+  unit: Record<string, any> | null;
+  tenants: Array<Record<string, any>>;
+  actorId?: string | null;
+};
+
+export type JurisdictionLeaseDocumentAdapter = {
+  jurisdictionCode: JurisdictionAdapterCode;
+  templateVersion: string;
+  effectiveDate: string;
+  counselReviewStatus: CounselReviewStatus;
+  signingEnabled: boolean;
+  productionApproved: boolean;
+  requiredSections: string[];
+  requiredDisclosures: string[];
+  requiredNotices: string[];
+  prohibitedClauseChecks: string[];
+  languageRequirements: string[];
+  statutoryReferences: string[];
+  sourceReferences: string[];
+  renderPrimaryLeasePdf(input: PrimaryLeaseDocumentInput): Promise<Buffer>;
+};

--- a/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
+++ b/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
@@ -122,4 +122,43 @@ describe("deriveLeaseExecution", () => {
     expect(result.landlordSignatureStatus).toBe("blocked");
     expect(result.completedAt).toBeNull();
   });
+
+  it("derives fully_executed from provider signing completion state", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "active",
+      raw: {
+        currentSigningStatus: "signed",
+        currentStatusAt: "2026-05-09T12:00:00.000Z",
+      },
+    });
+
+    expect(result.executionStatus).toBe("fully_executed");
+    expect(result.executionLabel).toBe("Lease fully executed");
+    expect(result.requiredNextAction).toBe("none");
+    expect(result.tenantSignatureStatus).toBe("completed");
+    expect(result.landlordSignatureStatus).toBe("completed");
+    expect(result.completedAt).toBe("2026-05-09T12:00:00.000Z");
+  });
+
+  it("derives ready_for_tenant_signature from provider pending signature state", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "active",
+      raw: {
+        currentSigningStatus: "pending_signature",
+        currentStatusAt: "2026-05-09T12:00:00.000Z",
+      },
+    });
+
+    expect(result.executionStatus).toBe("ready_for_tenant_signature");
+    expect(result.executionLabel).toBe("Waiting for tenant signature");
+    expect(result.requiredNextAction).toBe("tenant_signature");
+  });
 });

--- a/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
+++ b/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
@@ -104,6 +104,12 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
     asNumber(raw?.rentAmount) ??
     (typeof raw?.rentCents === "number" ? Math.round(raw.rentCents) / 100 : null);
   const normalizedStatus = normalizeStatus(input.status || raw?.status);
+  const normalizedSigningStatus = normalizeStatus(
+    raw?.currentSigningStatus || raw?.signingStatus || raw?.leaseSigningStatus || raw?.providerSigningStatus
+  );
+  const providerSignedAt = ["signed", "completed", "complete"].includes(normalizedSigningStatus)
+    ? firstIso(raw, ["currentStatusAt", "signedAt", "signingCompletedAt", "providerSignedAt", "fullyExecutedAt"])
+    : null;
 
   const tenantSignedAt =
     firstIso(raw?.tenantSignature, ["signedAt"]) ||
@@ -113,6 +119,7 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
     firstIso(raw, ["landlordSignedAt", "landlordSignatureCompletedAt"]);
   const fullyExecutedAt = firstIso(raw, ["fullyExecutedAt"]);
   const signatureWorkflowStartedAt = firstIso(raw, [
+    "currentStatusAt",
     "sentAt",
     "sharedAt",
     "leaseSentAt",
@@ -126,11 +133,14 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
   const landlordSignatureCaptured = Boolean(landlordSignedAt);
   const statusImpliesReadyForTenant = [
     "sent",
+    "viewed",
+    "pending",
+    "pending_signature",
     "awaiting_tenant_signature",
     "pending_tenant_signature",
     "ready_for_signature",
     "signature_requested",
-  ].includes(normalizedStatus);
+  ].includes(normalizedStatus) || ["sent", "viewed", "pending", "pending_signature"].includes(normalizedSigningStatus);
   const statusImpliesReadyForLandlord = [
     "awaiting_landlord_signature",
     "pending_landlord_signature",
@@ -140,12 +150,13 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
     signatureWorkflowStartedAt ||
       statusImpliesReadyForTenant ||
       statusImpliesReadyForLandlord ||
+      providerSignedAt ||
       tenantSignatureCaptured ||
       landlordSignatureCaptured ||
       fullyExecutedAt
   );
 
-  const executed = Boolean(tenantSignatureCaptured && landlordSignatureCaptured);
+  const executed = Boolean(providerSignedAt || (tenantSignatureCaptured && landlordSignatureCaptured));
   const landlordSigned = Boolean(!executed && landlordSignatureCaptured);
   const readyForLandlord = Boolean(!executed && !landlordSigned && statusImpliesReadyForLandlord);
   const tenantSigned = Boolean(
@@ -199,7 +210,7 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
 
   const completedAt =
     executionStatus === "fully_executed"
-      ? fullyExecutedAt || landlordSignedAt || tenantSignedAt || null
+      ? providerSignedAt || fullyExecutedAt || landlordSignedAt || tenantSignedAt || null
       : executionStatus === "landlord_signed"
       ? landlordSignedAt || null
       : null;

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -72,6 +72,25 @@ function safeProviderRef(providerId: string, providerRequestId: string) {
   return `${providerId}_ref_${digest(`${providerId}:${providerRequestId}`, 24)}`;
 }
 
+function safeDocumentMetadataFromRequest(data: any) {
+  return {
+    documentId: String(data?.documentId || "") || null,
+    documentHash: String(data?.documentHash || "") || null,
+    manifestHash: String(data?.manifestHash || "") || null,
+    templateVersion: String(data?.templateVersion || "") || null,
+    jurisdictionCode: String(data?.jurisdictionCode || "") || null,
+  };
+}
+
+function safeProviderMetadataFromRequest(data: any) {
+  return {
+    providerDispatchMode: String(data?.providerDispatchMode || "") || null,
+    providerDispatchStatus: String(data?.providerDispatchStatus || "") || null,
+    providerDispatchMessage: String(data?.providerDispatchMessage || "") || null,
+    providerTestMode: data?.providerTestMode === true ? true : data?.providerTestMode === false ? false : null,
+  };
+}
+
 function requestIdFor(landlordId: string, leaseId: string, providerId: string) {
   return `lsr_${digest(`${landlordId}:${leaseId}:${providerId}`, 24)}`;
 }
@@ -165,6 +184,14 @@ async function appendSigningEvent(input: {
   providerDispatchStatus?: string | null;
   providerDispatchMessage?: string | null;
   providerTestMode?: boolean | null;
+  documentMetadata?: {
+    documentId?: string | null;
+    documentHash?: string | null;
+    manifestHash?: string | null;
+    templateVersion?: string | null;
+    jurisdictionCode?: string | null;
+    providerAccessUrlExpiresAt?: string | null;
+  } | null;
 }) {
   const occurredAt = input.occurredAt || nowIso();
   const id = eventIdFor(input.requestId, input.type, occurredAt, input.providerEventId || "");
@@ -185,6 +212,11 @@ async function appendSigningEvent(input: {
     providerDispatchStatus: input.providerDispatchStatus || null,
     providerDispatchMessage: input.providerDispatchMessage || null,
     providerTestMode: input.providerTestMode ?? null,
+    documentId: input.documentMetadata?.documentId || null,
+    documentHash: input.documentMetadata?.documentHash || null,
+    manifestHash: input.documentMetadata?.manifestHash || null,
+    templateVersion: input.documentMetadata?.templateVersion || null,
+    jurisdictionCode: input.documentMetadata?.jurisdictionCode || null,
     occurredAt,
     createdAt: FieldValue.serverTimestamp(),
     rawIdsIncluded: false,
@@ -220,6 +252,11 @@ async function appendSigningEvent(input: {
       providerDispatchMode: input.providerDispatchMode || null,
       providerDispatchStatus: input.providerDispatchStatus || null,
       providerTestMode: input.providerTestMode ?? null,
+      documentId: input.documentMetadata?.documentId || null,
+      documentHash: input.documentMetadata?.documentHash || null,
+      manifestHash: input.documentMetadata?.manifestHash || null,
+      templateVersion: input.documentMetadata?.templateVersion || null,
+      jurisdictionCode: input.documentMetadata?.jurisdictionCode || null,
     },
   }).catch(() => undefined);
   return id;
@@ -274,7 +311,7 @@ export async function loadLeaseSigningSnapshot(input: {
     providerDispatchMessage: String(request.data?.providerDispatchMessage || (providerId === "mock" ? "Mock signing provider recorded the request without sending email." : "")).trim() || null,
     sentAt,
     signedAt,
-    documentUrl: String(request.data?.signedDocumentUrl || request.data?.documentUrl || "") || null,
+    documentUrl: String(request.data?.signedDocumentUrl || "") || null,
     events,
   };
 }
@@ -285,6 +322,15 @@ export async function sendLeaseForSignature(input: {
   landlordId: string;
   tenantEmails: string[];
   message?: string | null;
+  providerDocumentUrl?: string | null;
+  documentMetadata?: {
+    documentId?: string | null;
+    documentHash?: string | null;
+    manifestHash?: string | null;
+    templateVersion?: string | null;
+    jurisdictionCode?: string | null;
+    providerAccessUrlExpiresAt?: string | null;
+  } | null;
 }) {
   const provider = getConfiguredSigningProvider();
   if (!provider?.isConfigured()) throw Object.assign(new Error("provider_unavailable"), { status: 503 });
@@ -296,7 +342,13 @@ export async function sendLeaseForSignature(input: {
     throw Object.assign(new Error("invalid_tenant_email"), { status: 400 });
   }
 
-  const documentUrl = String(input.lease?.documentUrl || input.lease?.approvedDocumentUrl || input.lease?.documentRef || "").trim();
+  const documentUrl = String(
+    input.providerDocumentUrl ||
+      input.lease?.documentUrl ||
+      input.lease?.approvedDocumentUrl ||
+      input.lease?.documentRef ||
+      ""
+  ).trim();
   const sent = await provider.sendForSignature({
     leaseId: input.leaseId,
     landlordId: input.landlordId,
@@ -319,12 +371,17 @@ export async function sendLeaseForSignature(input: {
       providerRequestRef: safeProviderRef(providerId, sent.providerRequestId),
       providerRequestId: sent.providerRequestId,
       tenantEmailHashes: emails.map(emailHash),
-      documentUrl,
       expiresAt: sent.expiresAt || null,
       providerDispatchMode: sent.dispatchMode || null,
       providerDispatchStatus: sent.dispatchStatus || null,
       providerDispatchMessage: sent.dispatchMessage || null,
       providerTestMode: sent.providerTestMode ?? null,
+      documentId: input.documentMetadata?.documentId || null,
+      documentHash: input.documentMetadata?.documentHash || null,
+      manifestHash: input.documentMetadata?.manifestHash || null,
+      templateVersion: input.documentMetadata?.templateVersion || null,
+      jurisdictionCode: input.documentMetadata?.jurisdictionCode || null,
+      providerAccessUrlExpiresAt: input.documentMetadata?.providerAccessUrlExpiresAt || null,
       sentAt: now,
       updatedAt: FieldValue.serverTimestamp(),
       createdAt: existing.exists ? existing.data()?.createdAt || FieldValue.serverTimestamp() : FieldValue.serverTimestamp(),
@@ -346,6 +403,7 @@ export async function sendLeaseForSignature(input: {
     providerDispatchStatus: sent.dispatchStatus || null,
     providerDispatchMessage: sent.dispatchMessage || null,
     providerTestMode: sent.providerTestMode ?? null,
+    documentMetadata: input.documentMetadata || null,
   });
   return loadLeaseSigningSnapshot({ leaseId: input.leaseId, landlordId: input.landlordId, lease: input.lease });
 }
@@ -378,6 +436,8 @@ export async function getTenantSigningUrl(input: {
     type: "viewed",
     actorRole: "tenant",
     signerEmail: input.tenantEmail || null,
+    ...safeProviderMetadataFromRequest(request.data),
+    documentMetadata: safeDocumentMetadataFromRequest(request.data),
   });
   return { signingUrl: url, signingProviderId: provider.getProviderId() };
 }
@@ -397,6 +457,8 @@ export async function cancelLeaseSigning(input: { leaseId: string; lease: Record
     providerRequestId: String(request.data?.providerRequestId || ""),
     type: "cancelled",
     actorRole: "landlord",
+    ...safeProviderMetadataFromRequest(request.data),
+    documentMetadata: safeDocumentMetadataFromRequest(request.data),
   });
   return loadLeaseSigningSnapshot({ leaseId: input.leaseId, landlordId: input.landlordId, lease: input.lease });
 }
@@ -435,6 +497,8 @@ export async function downloadSignedLease(input: { leaseId: string; lease: Recor
     providerRequestId: String(request.data?.providerRequestId || ""),
     type: "downloaded",
     actorRole: "landlord",
+    ...safeProviderMetadataFromRequest(request.data),
+    documentMetadata: safeDocumentMetadataFromRequest(request.data),
   });
   return loadLeaseSigningSnapshot({ leaseId: input.leaseId, landlordId: input.landlordId, lease: input.lease });
 }
@@ -511,6 +575,8 @@ export async function processSigningWebhook(input: { providerId: string; headers
     actorRole: "provider",
     signerEmail: parsed.signerEmail || null,
     occurredAt: parsed.occurredAt,
+    ...safeProviderMetadataFromRequest(data),
+    documentMetadata: safeDocumentMetadataFromRequest(data),
   });
   return {};
 }

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -331,6 +331,9 @@ export function deriveTenantSafeLeaseReadinessMetadata(
   const normalizedDocumentStatus = normalizeStatus(
     data?.documentStatus || data?.leaseDocumentStatus || data?.pdfStatus || data?.generationStatus
   );
+  const normalizedSigningStatus = normalizeStatus(
+    data?.currentSigningStatus || data?.signingStatus || data?.leaseSigningStatus || data?.providerSigningStatus
+  );
   const documentWorkflowPending =
     Boolean(documentWorkflowStartedAt) ||
     ["pending", "preparing", "generating", "generated", "ready_for_review", "review_pending"].includes(
@@ -366,6 +369,12 @@ export function deriveTenantSafeLeaseReadinessMetadata(
       : "No approved lease document link is available in this workspace yet.";
 
   const signatureStatus: TenantLeaseProjection["signatureStatus"] = (() => {
+    if (["signed", "completed", "complete"].includes(normalizedSigningStatus)) {
+      return "signed";
+    }
+    if (["sent", "viewed", "pending", "pending_signature"].includes(normalizedSigningStatus)) {
+      return "awaiting_tenant_signature";
+    }
     if (tenantSignedAt && landlordSignedAt) {
       return "signed";
     }

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -226,6 +226,37 @@ export type LeaseSigningStatusResponse = {
   }>;
 };
 
+export type PrimaryLeaseDocument = {
+  id: string;
+  leaseId: string;
+  landlordId: string;
+  tenantIds: string[];
+  documentType: "primary_lease";
+  jurisdictionCode: string;
+  templateVersion: string;
+  templateEffectiveDate: string;
+  counselReviewStatus: "draft" | "reviewed" | "approved" | "deprecated";
+  sourceReferences: string[];
+  generatedAt: string;
+  generatedBy: string | null;
+  documentHash: string;
+  manifestHash: string;
+  providerAccessUrlExpiresAt: string | null;
+  status: "generated" | "locked" | "expired" | "superseded";
+  lockedAt: string | null;
+  lockedBy: string | null;
+  signingRequestId: string | null;
+  storageRef: null;
+  previewUrl?: string | null;
+  sourceSummary?: {
+    adapterStatus: string;
+    signingEnabled: boolean;
+    productionApproved: boolean;
+    templateEffectiveDate?: string;
+    sourceReferences?: string[];
+  };
+};
+
 export async function sendLeaseForSignature(
   leaseId: string,
   payload: { tenantEmails: string[]; message?: string }
@@ -238,6 +269,25 @@ export async function sendLeaseForSignature(
     }
   );
   return res.data;
+}
+
+export async function getPrimaryLeaseDocument(
+  leaseId: string,
+  options?: { includePreviewUrl?: boolean }
+): Promise<PrimaryLeaseDocument | null> {
+  const query = options?.includePreviewUrl ? "?includePreviewUrl=1" : "";
+  const res = await apiJson<{ ok: boolean; document: PrimaryLeaseDocument | null }>(
+    `/leases/${encodeURIComponent(leaseId)}/primary-document${query}`
+  );
+  return res.document;
+}
+
+export async function generatePrimaryLeaseDocument(leaseId: string): Promise<PrimaryLeaseDocument> {
+  const res = await apiJson<{ ok: boolean; document: PrimaryLeaseDocument }>(
+    `/leases/${encodeURIComponent(leaseId)}/primary-document/generate`,
+    { method: "POST", body: "{}" }
+  );
+  return res.document;
 }
 
 export async function getLeaseSigningStatus(leaseId: string): Promise<LeaseSigningStatusResponse> {

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
@@ -2,14 +2,19 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LeaseSigningDashboard from "./LeaseSigningDashboard";
 import {
+  generatePrimaryLeaseDocument,
+  getPrimaryLeaseDocument,
   getLeaseSigningStatus,
   sendLeaseForSignature,
+  type PrimaryLeaseDocument,
   type LeaseSigningStatusResponse,
 } from "../api/leasesApi";
 
 vi.mock("../api/leasesApi", () => ({
   cancelLeaseSigning: vi.fn(),
   downloadSignedLease: vi.fn(),
+  generatePrimaryLeaseDocument: vi.fn(),
+  getPrimaryLeaseDocument: vi.fn(),
   getLeaseSigningStatus: vi.fn(),
   sendLeaseForSignature: vi.fn(),
 }));
@@ -36,9 +41,41 @@ const pendingStatus: LeaseSigningStatusResponse = {
   sentAt: "2026-06-14T12:00:00.000Z",
 };
 
+const primaryDocument: PrimaryLeaseDocument = {
+  id: "ldoc_safe",
+  leaseId: "lease-1",
+  landlordId: "landlord-1",
+  tenantIds: ["tenant-1"],
+  documentType: "primary_lease",
+  jurisdictionCode: "CA_NS",
+  templateVersion: "ca-ns-primary-lease-draft-v1",
+  templateEffectiveDate: "2026-06-15",
+  counselReviewStatus: "draft",
+  sourceReferences: ["Nova Scotia Form P Standard Lease Form reference upload"],
+  generatedAt: "2026-06-15T12:00:00.000Z",
+  generatedBy: "actor-1",
+  documentHash: "a".repeat(64),
+  manifestHash: "b".repeat(64),
+  providerAccessUrlExpiresAt: null,
+  status: "generated",
+  lockedAt: null,
+  lockedBy: null,
+  signingRequestId: null,
+  storageRef: null,
+  sourceSummary: {
+    adapterStatus: "draft",
+    signingEnabled: false,
+    productionApproved: false,
+    templateEffectiveDate: "2026-06-15",
+    sourceReferences: ["Nova Scotia Form P Standard Lease Form reference upload"],
+  },
+};
+
 describe("LeaseSigningDashboard", () => {
   beforeEach(() => {
     vi.mocked(getLeaseSigningStatus).mockResolvedValue(notStartedStatus);
+    vi.mocked(getPrimaryLeaseDocument).mockResolvedValue(primaryDocument);
+    vi.mocked(generatePrimaryLeaseDocument).mockResolvedValue(primaryDocument);
     vi.mocked(sendLeaseForSignature).mockResolvedValue(pendingStatus);
   });
 
@@ -73,10 +110,37 @@ describe("LeaseSigningDashboard", () => {
     vi.mocked(sendLeaseForSignature).mockRejectedValueOnce({ body: { error: "invalid_tenant_email" } });
     render(<LeaseSigningDashboard leaseId="lease-1" tenantEmail="invalid-email" />);
 
+    await waitFor(() => expect(screen.getByRole("button", { name: /send for signature/i })).toBeEnabled());
     fireEvent.click(screen.getByRole("button", { name: /send for signature/i }));
 
     await waitFor(() => expect(screen.getByText("invalid_tenant_email")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /send for signature/i })).toBeEnabled();
+  });
+
+  it("keeps send disabled until a primary lease document exists", async () => {
+    vi.mocked(getPrimaryLeaseDocument).mockResolvedValueOnce(null);
+    render(<LeaseSigningDashboard leaseId="lease-1" tenantEmail="tenant@example.com" />);
+
+    await waitFor(() => expect(screen.getByText(/no primary lease pdf generated yet/i)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /send for signature/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /generate primary lease pdf/i }));
+
+    await waitFor(() => expect(generatePrimaryLeaseDocument).toHaveBeenCalledWith("lease-1"));
+    await waitFor(() => expect(screen.getByRole("button", { name: /send for signature/i })).toBeEnabled());
+    expect(screen.queryByText(/lease-documents/i)).not.toBeInTheDocument();
+  });
+
+  it("renders jurisdiction unavailable state safely", async () => {
+    vi.mocked(getPrimaryLeaseDocument).mockResolvedValueOnce(null);
+    vi.mocked(generatePrimaryLeaseDocument).mockRejectedValueOnce({ body: { error: "jurisdiction_template_unavailable" } });
+    render(<LeaseSigningDashboard leaseId="lease-1" tenantEmail="tenant@example.com" />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /generate primary lease pdf/i })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /generate primary lease pdf/i }));
+
+    await waitFor(() => expect(screen.getByText("jurisdiction_template_unavailable")).toBeInTheDocument());
+    expect(screen.queryByText(/storage.googleapis.com/i)).not.toBeInTheDocument();
   });
 
   it("shows real provider dispatch without mock no-email warning", async () => {

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import {
   cancelLeaseSigning,
   downloadSignedLease,
+  generatePrimaryLeaseDocument,
+  getPrimaryLeaseDocument,
   getLeaseSigningStatus,
   sendLeaseForSignature,
   type LeaseSigningStatusResponse,
+  type PrimaryLeaseDocument,
 } from "../api/leasesApi";
 
 type Props = {
@@ -42,7 +45,10 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
   const [email, setEmail] = React.useState(String(tenantEmail || ""));
   const [message, setMessage] = React.useState("");
   const [busy, setBusy] = React.useState(false);
+  const [documentBusy, setDocumentBusy] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [documentError, setDocumentError] = React.useState<string | null>(null);
+  const [primaryDocument, setPrimaryDocument] = React.useState<PrimaryLeaseDocument | null>(null);
 
   React.useEffect(() => {
     const nextTenantEmail = String(tenantEmail || "").trim();
@@ -53,7 +59,12 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
   const refresh = React.useCallback(async () => {
     if (!leaseId) return;
     try {
-      setStatus(await getLeaseSigningStatus(leaseId));
+      const [nextStatus, nextDocument] = await Promise.all([
+        getLeaseSigningStatus(leaseId),
+        getPrimaryLeaseDocument(leaseId).catch(() => null),
+      ]);
+      setStatus(nextStatus);
+      setPrimaryDocument(nextDocument);
     } catch {
       setStatus(null);
     }
@@ -64,6 +75,10 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
   }, [refresh]);
 
   async function submit() {
+    if (!primaryDocument || (primaryDocument.status !== "generated" && primaryDocument.status !== "locked")) {
+      setError("Generate a primary lease PDF before sending for signature.");
+      return;
+    }
     const tenantEmails = email.split(",").map((item) => item.trim()).filter(Boolean);
     setBusy(true);
     setError(null);
@@ -73,6 +88,33 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
       setError(err?.body?.error || err?.message || "Unable to send lease for signature.");
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function generateDocument() {
+    setDocumentBusy(true);
+    setDocumentError(null);
+    setError(null);
+    try {
+      setPrimaryDocument(await generatePrimaryLeaseDocument(leaseId));
+    } catch (err: any) {
+      setDocumentError(err?.body?.error || err?.message || "Primary lease document is unavailable for this jurisdiction.");
+    } finally {
+      setDocumentBusy(false);
+    }
+  }
+
+  async function previewDocument() {
+    setDocumentBusy(true);
+    setDocumentError(null);
+    try {
+      const next = await getPrimaryLeaseDocument(leaseId, { includePreviewUrl: true });
+      setPrimaryDocument(next);
+      if (next?.previewUrl) window.open(next.previewUrl, "_blank", "noreferrer");
+    } catch (err: any) {
+      setDocumentError(err?.body?.error || err?.message || "Primary lease document preview is unavailable.");
+    } finally {
+      setDocumentBusy(false);
     }
   }
 
@@ -105,6 +147,7 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
 
   const signingStatus = status?.signingStatus || "not_started";
   const canSend = signingStatus === "not_started" || signingStatus === "cancelled" || signingStatus === "expired" || signingStatus === "rejected" || signingStatus === "failed";
+  const hasPrimaryDocument = Boolean(primaryDocument && (primaryDocument.status === "generated" || primaryDocument.status === "locked"));
   const canCancel = signingStatus === "pending_signature";
   const canDownload = signingStatus === "signed";
   const noEmailNotice = dispatchNotice(status);
@@ -119,6 +162,30 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
       </div>
       {canSend ? (
         <div style={{ display: "grid", gap: 8 }}>
+          <div style={{ display: "grid", gap: 6, padding: 10, border: "1px solid #e5e7eb", borderRadius: 8 }}>
+            <div style={{ fontWeight: 800 }}>Primary lease PDF</div>
+            <div style={{ color: "#64748b", fontSize: 13 }}>
+              {primaryDocument
+                ? `Status: ${pretty(primaryDocument.status)} · ${primaryDocument.jurisdictionCode} · ${primaryDocument.counselReviewStatus}`
+                : "No primary lease PDF generated yet."}
+            </div>
+            {primaryDocument?.sourceSummary?.productionApproved === false ? (
+              <div style={{ color: "#92400e", fontSize: 13 }}>
+                Jurisdiction template is draft/test and requires counsel review before production signing.
+              </div>
+            ) : null}
+            {documentError ? <div style={{ color: "#b91c1c", fontSize: 13 }}>{documentError}</div> : null}
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <button type="button" onClick={() => void generateDocument()} disabled={documentBusy || busy}>
+                {documentBusy ? "Working..." : "Generate Primary Lease PDF"}
+              </button>
+              {primaryDocument ? (
+                <button type="button" onClick={() => void previewDocument()} disabled={documentBusy || busy}>
+                  Preview Lease Document
+                </button>
+              ) : null}
+            </div>
+          </div>
           <label style={{ display: "grid", gap: 4, fontWeight: 700 }}>
             Tenant email
             <input value={email} onChange={(event) => setEmail(event.target.value)} placeholder="tenant@example.com" />
@@ -127,7 +194,7 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
             Message
             <textarea value={message} onChange={(event) => setMessage(event.target.value)} rows={3} />
           </label>
-          <button type="button" onClick={() => void submit()} disabled={busy || !email.trim()}>
+          <button type="button" onClick={() => void submit()} disabled={busy || !email.trim() || !hasPrimaryDocument}>
             {busy ? "Sending..." : "Send for Signature"}
           </button>
         </div>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -233,6 +233,8 @@ describe("LandlordActiveLeasesPage", () => {
     expect(document.querySelector(".rc-leases-page")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getAllByText("Lease fully executed").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Needs review: Draft lease · Review needed occupancy/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Lease execution review recommended")).not.toBeInTheDocument();
     expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);
     expect(screen.getByText(/Prepare renewal notice/i)).toBeInTheDocument();
     expect(screen.getByText("NS workflow guidance")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Adds a landlord-scoped primary lease document source pipeline backed by `leaseDocuments` metadata, document hash, manifest hash, internal storage refs, and provider-readable signed URLs.
- Adds a draft/test CA_NS jurisdiction adapter based on the Form P section inventory, with Schedule A kept as a separate statutory attachment/section rather than a substitute primary document.
- Updates Send for Signature to require a generated/locked primary lease document and pass only safe document metadata to signing/audit paths.
- Adds minimal lease signing UI controls for generating, previewing, and gating Send for Signature on primary document availability.

## Legal/Governance Boundary
- CA_NS is `draft`/test only: `productionApproved=false`, `signingEnabled=false`.
- Production signing fails closed unless a template is counsel-approved and signing-enabled.
- Test/dev generation and signing require test-mode allowance; this PR does not claim legal approval, certification, notarization, or enforceability.
- Schedule A remains separate and cannot satisfy the primary signing document requirement by itself.

## Validation
- `rentchain-api`: `npm run test:single -- src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts src/routes/__tests__/leaseRoutes.active.test.ts src/services/__tests__/leaseSigningService.test.ts`
- `rentchain-api`: `npm run build`
- `rentchain-frontend`: `npm run test:single -- LeaseSigningDashboard.test.tsx`
- `rentchain-frontend`: `npm run build`
- `git diff --check`

## Preview QA
1. In preview/test mode, generate a primary lease PDF for a Nova Scotia lease.
2. Confirm the generated document appears as draft/test with no production legal approval claim.
3. Confirm Preview Lease Document opens a signed preview URL and the UI does not expose storage paths or raw IDs.
4. Confirm Send for Signature is disabled when only Schedule A exists.
5. Confirm Send for Signature uses the generated/locked primary document and does not expose raw storage refs/provider URLs in UI/audit metadata.
6. With `SIGNING_PROVIDER=dropbox_sign`, confirm Dropbox can fetch the GCS signed provider URL; if not, stop and use the planned file-upload follow-up.

## Remaining Risk / Follow-up
- Form P PDF extraction was not available locally; the adapter uses the operator-provided Form P section inventory and references the uploaded Form P file as source material.
- CA_NS remains draft/test until counsel review.
- If Dropbox Sign cannot fetch the signed GCS URL in preview, follow-up is `feat/signing-provider-file-upload-dispatch-v1`.