### PR TITLE
feat: add signing completion return route

### DIFF
--- a/docs/architecture/lease-execution-provider-integration-v1.md
+++ b/docs/architecture/lease-execution-provider-integration-v1.md
@@ -46,6 +46,19 @@ Webhook:
 1. `POST /webhooks/signing/:providerId?`
 2. `POST /api/webhooks/signing/:providerId?`
 
+Signer browser return:
+1. `GET /signing/complete`
+
+Provider configuration must keep the signer browser return URL separate from the
+webhook callback URL:
+- `SIGNING_PROVIDER_RETURN_URL` should point to the frontend completion route,
+  for example `https://<frontend-host>/signing/complete`.
+- `SIGNING_PROVIDER_CALLBACK_URL` remains the backend webhook endpoint,
+  for example `https://<api-host>/api/webhooks/signing/dropbox_sign`.
+
+These URLs must not be the same. Browser GET returns are safe acknowledgements
+only and must not drive signing lifecycle state.
+
 ## Security Boundaries
 
 - Landlord endpoints require landlord authentication and lease ownership.
@@ -53,6 +66,9 @@ Webhook:
 - Tenant projections never include provider request IDs, webhook metadata, landlord-only fields, or provider payloads.
 - Audit records use hashes and safe provider references.
 - Webhook payloads are not stored.
+- Verified POST webhooks remain the authoritative source for provider lifecycle
+  mutations. Browser GET returns must not write signing events or canonical
+  events.
 
 ## Recovery
 

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -98,7 +98,7 @@ import stripeScreeningOrdersWebhookRoutes, {
   stripeWebhookHandler,
 } from "./routes/stripeScreeningOrdersWebhookRoutes";
 import { transunionWebhookHandler } from "./routes/transunionWebhookRoutes";
-import { signingWebhookHandler } from "./routes/webhooks/signingWebhookRoutes";
+import { signingWebhookBrowserReturnHandler, signingWebhookHandler } from "./routes/webhooks/signingWebhookRoutes";
 import { requireAuth } from "./middleware/requireAuth";
 import { requirePermission } from "./middleware/requireAuthz";
 import screeningJobsAdminRoutes from "./routes/screeningJobsAdminRoutes";
@@ -247,6 +247,16 @@ app.post(
   express.raw({ type: "*/*" }),
   routeSource("signingWebhookRoutes.ts"),
   signingWebhookHandler
+);
+app.get(
+  "/webhooks/signing/:providerId?",
+  routeSource("signingWebhookRoutes.ts"),
+  signingWebhookBrowserReturnHandler
+);
+app.get(
+  "/api/webhooks/signing/:providerId?",
+  routeSource("signingWebhookRoutes.ts"),
+  signingWebhookBrowserReturnHandler
 );
 const jsonParser = express.json({
   limit: "10mb",

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -293,6 +293,7 @@ describe("API route ownership regression", () => {
     const leaseDocumentUrlRoute = source.indexOf(
       'app.get("/api/leases/:leaseId/document-url", routeSource("leaseRoutes.ts"), requireLandlord, handleLeaseDocumentUrl)'
     );
+    const signingWebhookBrowserReturnRoute = source.indexOf('app.get(\n  "/api/webhooks/signing/:providerId?"');
     const leasesMount = source.indexOf('app.use("/api/leases", routeSource("leaseRoutes.ts"), leaseRoutes)');
     const tenantsMount = source.indexOf('app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes)');
     const telemetryMount = source.indexOf('app.use("/api", routeSource("telemetryRoutes.ts"), telemetryRoutes)');
@@ -315,6 +316,7 @@ describe("API route ownership regression", () => {
     expect(ledgerMount).toBeGreaterThan(-1);
     expect(decisionsMount).toBeGreaterThan(-1);
     expect(leaseDocumentUrlRoute).toBeGreaterThan(-1);
+    expect(signingWebhookBrowserReturnRoute).toBeGreaterThan(-1);
     expect(leasesMount).toBeGreaterThan(-1);
     expect(tenantsMount).toBeGreaterThan(-1);
     expect(telemetryMount).toBeGreaterThan(-1);
@@ -334,6 +336,8 @@ describe("API route ownership regression", () => {
     expect(ledgerMount).toBeLessThan(screeningJobsMount);
     expect(decisionsMount).toBeLessThan(screeningJobsMount);
     expect(leaseDocumentUrlRoute).toBeLessThan(screeningJobsMount);
+    expect(signingWebhookBrowserReturnRoute).toBeLessThan(riskAgentMount);
+    expect(signingWebhookBrowserReturnRoute).toBeLessThan(apiCatchall);
     expect(leasesMount).toBeLessThan(screeningJobsMount);
     expect(tenantsMount).toBeLessThan(screeningJobsMount);
     expect(statusMount).toBeLessThan(paymentsBroadMount);

--- a/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
@@ -111,4 +111,24 @@ describe("signingWebhookHandler", () => {
     expect(res.body).toBe("https://preview.rentchain.ai/signing/complete");
     expect(JSON.stringify(res.body)).not.toContain("raw-provider-id");
   });
+
+  it("acknowledges browser GET returns safely when no frontend return URL is configured", async () => {
+    const req: any = {
+      params: { providerId: "dropbox_sign" },
+      query: { event: "signature_request_signed", signature_request_id: "raw-provider-id" },
+      headers: {},
+      body: undefined,
+    };
+    const res = makeRes();
+
+    signingWebhookBrowserReturnHandler(req, res);
+
+    expect(processSigningWebhookMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("content-type")).toBe("text/plain");
+    expect(res.headers.get("location")).toBeUndefined();
+    expect(res.body).toBe("Lease signing completed. You may close this page or return to RentChain.");
+    expect(JSON.stringify(res.body)).not.toContain("raw-provider-id");
+  });
 });

--- a/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { signingWebhookHandler } from "../webhooks/signingWebhookRoutes";
+import { signingWebhookBrowserReturnHandler, signingWebhookHandler } from "../webhooks/signingWebhookRoutes";
 
 const { processSigningWebhookMock } = vi.hoisted(() => ({
   processSigningWebhookMock: vi.fn(),
@@ -33,6 +33,16 @@ function makeRes() {
       res.headers.set("content-type", "application/json");
       return res;
     }),
+    redirect: vi.fn((code: number, value: string) => {
+      res.statusCode = code;
+      res.body = value;
+      res.headers.set("location", value);
+      return res;
+    }),
+    setHeader: vi.fn((key: string, value: string) => {
+      res.headers.set(key.toLowerCase(), value);
+      return res;
+    }),
   };
   return res;
 }
@@ -41,6 +51,10 @@ describe("signingWebhookHandler", () => {
   beforeEach(() => {
     processSigningWebhookMock.mockReset();
     delete process.env.SIGNING_PROVIDER;
+    delete process.env.PUBLIC_APP_URL;
+    delete process.env.APP_BASE_URL;
+    delete process.env.SIGNING_PROVIDER_RETURN_URL;
+    delete process.env.SIGNING_RETURN_URL;
   });
 
   it("returns Dropbox Sign account callback acknowledgement as exact plain text", async () => {
@@ -76,5 +90,25 @@ describe("signingWebhookHandler", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it("redirects browser GET returns without processing webhook lifecycle", async () => {
+    process.env.PUBLIC_APP_URL = "https://preview.rentchain.ai";
+    const req: any = {
+      params: { providerId: "dropbox_sign" },
+      query: { event: "signature_request_signed", signature_request_id: "raw-provider-id" },
+      headers: {},
+      body: undefined,
+    };
+    const res = makeRes();
+
+    signingWebhookBrowserReturnHandler(req, res);
+
+    expect(processSigningWebhookMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(303);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("location")).toBe("https://preview.rentchain.ai/signing/complete");
+    expect(res.body).toBe("https://preview.rentchain.ai/signing/complete");
+    expect(JSON.stringify(res.body)).not.toContain("raw-provider-id");
   });
 });

--- a/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
+++ b/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
@@ -1,6 +1,18 @@
 import { Request, Response } from "express";
 import { processSigningWebhook, signingErrorCode, signingErrorStatus } from "../../services/signing/leaseSigningService";
 
+function frontendSigningCompleteUrl() {
+  const explicit = String(process.env.SIGNING_PROVIDER_RETURN_URL || process.env.SIGNING_RETURN_URL || "").trim();
+  if (explicit) return explicit;
+  const appBaseUrl = String(process.env.PUBLIC_APP_URL || process.env.APP_BASE_URL || "").trim().replace(/\/+$/, "");
+  return appBaseUrl ? `${appBaseUrl}/signing/complete` : "/signing/complete";
+}
+
+export function signingWebhookBrowserReturnHandler(_req: Request, res: Response) {
+  res.setHeader("Cache-Control", "no-store");
+  return res.redirect(303, frontendSigningCompleteUrl());
+}
+
 export async function signingWebhookHandler(req: Request & { rawBody?: Buffer }, res: Response) {
   const providerId = String(req.params?.providerId || req.query?.provider || process.env.SIGNING_PROVIDER || "mock")
     .trim()

--- a/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
+++ b/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
@@ -5,12 +5,19 @@ function frontendSigningCompleteUrl() {
   const explicit = String(process.env.SIGNING_PROVIDER_RETURN_URL || process.env.SIGNING_RETURN_URL || "").trim();
   if (explicit) return explicit;
   const appBaseUrl = String(process.env.PUBLIC_APP_URL || process.env.APP_BASE_URL || "").trim().replace(/\/+$/, "");
-  return appBaseUrl ? `${appBaseUrl}/signing/complete` : "/signing/complete";
+  return appBaseUrl ? `${appBaseUrl}/signing/complete` : null;
 }
 
 export function signingWebhookBrowserReturnHandler(_req: Request, res: Response) {
   res.setHeader("Cache-Control", "no-store");
-  return res.redirect(303, frontendSigningCompleteUrl());
+  const completeUrl = frontendSigningCompleteUrl();
+  if (completeUrl) {
+    return res.redirect(303, completeUrl);
+  }
+  return res
+    .status(200)
+    .type("text/plain")
+    .send("Lease signing completed. You may close this page or return to RentChain.");
 }
 
 export async function signingWebhookHandler(req: Request & { rawBody?: Buffer }, res: Response) {

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -63,6 +63,13 @@ function normalizeEmail(value: unknown) {
   return String(value || "").trim().toLowerCase();
 }
 
+function signingReturnUrl() {
+  const explicit = String(process.env.SIGNING_PROVIDER_RETURN_URL || process.env.SIGNING_RETURN_URL || "").trim();
+  if (explicit) return explicit;
+  const appBaseUrl = String(process.env.PUBLIC_APP_URL || process.env.APP_BASE_URL || "").trim().replace(/\/+$/, "");
+  return appBaseUrl ? `${appBaseUrl}/signing/complete` : null;
+}
+
 function emailHash(value: unknown) {
   const email = normalizeEmail(value);
   return email ? digest(`email:${email}`, 24) : null;
@@ -357,6 +364,7 @@ export async function sendLeaseForSignature(input: {
     message: input.message || null,
     signers: emails.map((email) => ({ email, role: "tenant" as const })),
     callbackUrl: process.env.SIGNING_PROVIDER_CALLBACK_URL || process.env.SIGNING_CALLBACK_URL || null,
+    returnUrl: signingReturnUrl(),
   });
   const providerId = provider.getProviderId();
   const requestId = requestIdFor(input.landlordId, input.leaseId, providerId);

--- a/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
+++ b/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
@@ -76,15 +76,19 @@ describe("DropboxSignProvider", () => {
       title: "Lease signature request",
       signers: [{ email: "tenant@example.com", role: "tenant" }],
       message: "Please sign.",
+      callbackUrl: "https://api.example.com/api/webhooks/signing/dropbox_sign",
+      returnUrl: "https://app.example.com/signing/complete",
     });
 
     expect(signatureRequestSendMock).toHaveBeenCalledWith(
       expect.objectContaining({
         fileUrls: ["https://files.example.com/lease.pdf"],
         testMode: true,
+        signingRedirectUrl: "https://app.example.com/signing/complete",
         metadata: { leaseId: "lease-1", landlordId: "landlord-1" },
       })
     );
+    expect(signatureRequestSendMock.mock.calls[0]?.[0]?.signingRedirectUrl).not.toContain("/api/webhooks/signing");
     expect(result).toEqual(
       expect.objectContaining({
         providerRequestId: "raw_provider_request_123",

--- a/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
+++ b/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
@@ -112,7 +112,7 @@ export class DropboxSignProvider implements ISigningProvider {
       const apiCaller = new sdk.SignatureRequestApi();
       apiCaller.username = String(process.env.SIGNING_PROVIDER_API_KEY || "").trim();
       const testMode = boolEnv(process.env.SIGNING_PROVIDER_TEST_MODE);
-      const callbackUrl = String(process.env.SIGNING_PROVIDER_CALLBACK_URL || input.callbackUrl || "").trim() || undefined;
+      const returnUrl = String(input.returnUrl || "").trim() || undefined;
       const request = {
         title: input.title.slice(0, 255),
         subject: input.title.slice(0, 255),
@@ -135,7 +135,7 @@ export class DropboxSignProvider implements ISigningProvider {
           phone: false,
           defaultType: "type",
         },
-        ...(callbackUrl ? { signingRedirectUrl: callbackUrl } : {}),
+        ...(returnUrl ? { signingRedirectUrl: returnUrl } : {}),
       };
       const response = await apiCaller.signatureRequestSend(request as any);
       const body = response?.body || response || {};

--- a/rentchain-api/src/services/signing/providers/types.ts
+++ b/rentchain-api/src/services/signing/providers/types.ts
@@ -24,6 +24,7 @@ export type SigningProviderSendInput = {
   message?: string | null;
   signers: SigningProviderSigner[];
   callbackUrl?: string | null;
+  returnUrl?: string | null;
 };
 
 export type SigningProviderSendResult = {

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -15,6 +15,7 @@ import SignupPage from "./pages/SignupPage";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage";
 import AuthActionPage from "./pages/AuthActionPage";
 import AuthOnboardPage from "./pages/AuthOnboardPage";
+import SigningCompletePage from "./pages/SigningCompletePage";
 import TenantLoginPageV2 from "./pages/tenant/TenantLoginPage.v2";
 import InviteRedeemPage from "./pages/InviteRedeemPage";
 import NotFoundPage from "./pages/NotFoundPage";
@@ -404,6 +405,7 @@ function App() {
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/auth/action" element={<AuthActionPage />} />
         <Route path="/auth/onboard" element={<AuthOnboardPage />} />
+        <Route path="/signing/complete" element={<SigningCompletePage />} />
         <Route
           path="/tenant/login"
           element={TENANT_PORTAL_ENABLED ? <TenantLoginPageV2 /> : <TenantPortalComingSoon />}

--- a/rentchain-frontend/src/pages/SigningCompletePage.test.tsx
+++ b/rentchain-frontend/src/pages/SigningCompletePage.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SigningCompletePage from "./SigningCompletePage";
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: () => mocks.useAuth(),
+}));
+
+describe("SigningCompletePage", () => {
+  beforeEach(() => {
+    mocks.useAuth.mockReturnValue({
+      user: null,
+      ready: true,
+      isLoading: false,
+    });
+  });
+
+  it("renders an unauthenticated safe completion state without private data", () => {
+    render(
+      <MemoryRouter initialEntries={["/signing/complete?signature_request_id=raw-secret"]}>
+        <SigningCompletePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Lease signing completed" })).toBeInTheDocument();
+    expect(screen.getByText("You may close this page or return to RentChain.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/login");
+    expect(document.body.textContent).not.toContain("raw-secret");
+    expect(document.body.textContent).not.toContain("signature_request_id");
+  });
+
+  it("renders role-aware navigation when a user session is available", () => {
+    mocks.useAuth.mockReturnValue({
+      user: { id: "tenant-1", email: "tenant@example.com", role: "tenant" },
+      ready: true,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <SigningCompletePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Return to tenant portal" })).toHaveAttribute("href", "/tenant");
+  });
+});

--- a/rentchain-frontend/src/pages/SigningCompletePage.tsx
+++ b/rentchain-frontend/src/pages/SigningCompletePage.tsx
@@ -1,0 +1,88 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "../context/useAuth";
+
+function destinationForRole(role?: string | null) {
+  const normalized = String(role || "").trim().toLowerCase();
+  if (normalized === "tenant") return { to: "/tenant", label: "Return to tenant portal" };
+  if (normalized === "admin" || normalized === "support") return { to: "/admin", label: "Return to admin workspace" };
+  if (normalized === "contractor") return { to: "/contractor", label: "Return to contractor workspace" };
+  return { to: "/dashboard", label: "Return to RentChain" };
+}
+
+export default function SigningCompletePage() {
+  const { user, ready, isLoading } = useAuth();
+  const destination = user ? destinationForRole(user.role || user.actorRole) : null;
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+        background: "#f8fafc",
+      }}
+    >
+      <section
+        aria-labelledby="signing-complete-title"
+        style={{
+          width: "100%",
+          maxWidth: 520,
+          display: "grid",
+          gap: 16,
+          padding: 24,
+          border: "1px solid #e2e8f0",
+          borderRadius: 8,
+          background: "#fff",
+          color: "#0f172a",
+        }}
+      >
+        <div style={{ display: "grid", gap: 8 }}>
+          <p style={{ margin: 0, color: "#166534", fontSize: 13, fontWeight: 800, textTransform: "uppercase" }}>
+            Signing complete
+          </p>
+          <h1 id="signing-complete-title" style={{ margin: 0, fontSize: 28, lineHeight: 1.15 }}>
+            Lease signing completed
+          </h1>
+          <p style={{ margin: 0, color: "#475569", lineHeight: 1.55 }}>
+            You may close this page or return to RentChain.
+          </p>
+        </div>
+
+        {!ready || isLoading ? (
+          <p style={{ margin: 0, color: "#64748b" }}>Checking session...</p>
+        ) : destination ? (
+          <Link
+            to={destination.to}
+            style={{
+              justifySelf: "start",
+              padding: "10px 14px",
+              borderRadius: 8,
+              background: "#0f172a",
+              color: "#fff",
+              textDecoration: "none",
+              fontWeight: 700,
+            }}
+          >
+            {destination.label}
+          </Link>
+        ) : (
+          <Link
+            to="/login"
+            style={{
+              justifySelf: "start",
+              padding: "10px 14px",
+              borderRadius: 8,
+              border: "1px solid #cbd5e1",
+              color: "#0f172a",
+              textDecoration: "none",
+              fontWeight: 700,
+            }}
+          >
+            Sign in
+          </Link>
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- separates Dropbox Sign signer return URL from the verified webhook callback URL
- adds safe GET handling for `/webhooks/signing/:providerId?` and `/api/webhooks/signing/:providerId?` that redirects to `/signing/complete` without mutating signing state
- adds a public `/signing/complete` page with unauthenticated-safe messaging and role-aware navigation when a session exists

## Governance
- POST webhook remains the only authoritative lifecycle mutation path
- GET browser return does not parse provider state, write signing events, or write canonical events
- no raw provider IDs, provider payloads, storage paths, signed URLs, or secrets are rendered

## Validation
- `npm run test:single -- src/routes/__tests__/signingWebhookRoutes.test.ts src/routes/__tests__/apiRouteOwnershipRegression.test.ts src/services/signing/providers/__tests__/dropboxSignProvider.test.ts src/services/__tests__/leaseSigningService.test.ts`
- `npm run test:single -- SigningCompletePage.test.tsx`
- backend build
- frontend build
- `git diff --check`

## Preview QA
- send a Dropbox Sign sandbox request
- complete tenant signing
- confirm browser lands on `/signing/complete` or safe redirect target, not API 401
- confirm `leaseSigningRequest` becomes signed only from verified POST webhook
- confirm canonical `lease.signing_signed` is still written by the webhook path only

## Follow-up
- `feat/signing-field-placement-v1` remains separate for signature anchors/field placement.