### PR TITLE
fix: resolve signed lease document access

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -670,6 +670,83 @@ describe("leaseRoutes GET /active", () => {
     expect(JSON.stringify(refreshRes.body)).not.toContain("signed-expired.pdf");
   });
 
+  it("refreshes signed lease document URLs from signing request storage metadata without exposing storage refs", async () => {
+    getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-signed-lease.pdf");
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leases", "lease-signed", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      primaryTenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      leaseDocument: {
+        bucket: "lease-documents",
+        path: "leases/landlord-1/lease-signed/primary.pdf",
+      },
+    });
+    seedDoc("leaseSigningRequests", "request-signed", {
+      leaseId: "lease-signed",
+      landlordId: "landlord-1",
+      providerId: "dropbox_sign",
+      providerRequestId: "raw-provider-request-id",
+      providerRequestRef: "dropbox_sign_ref_safe",
+      currentSigningStatus: "signed",
+      signedDocument: {
+        bucket: "signed-lease-documents",
+        path: "lease-signing/landlord-1/request-signed/signed.pdf",
+        internalReferenceOnly: true,
+      },
+      signedDocumentHash: "signed_doc_hash",
+      signedDocumentStoredAt: "2026-01-02T00:10:00.000Z",
+      signedDocumentUrl: "https://storage.googleapis.com/signed-lease-documents/lease-signing/landlord-1/request-signed/signed.pdf?X-Goog-Signature=stale",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    seedDoc("leaseSigningEvents", "event-signed", {
+      requestId: "request-signed",
+      leaseId: "lease-signed",
+      landlordId: "landlord-1",
+      type: "signed",
+      occurredAt: "2026-01-02T00:05:00.000Z",
+      actorRole: "provider",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const refreshRes = await invokeRouter(router, { method: "GET", url: "/lease-signed/document-url" });
+
+    expect(refreshRes.status).toBe(200);
+    expect(refreshRes.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        documentUrl: "https://signed.example.com/fresh-signed-lease.pdf",
+        refreshMode: "signed_url",
+        expiresInSeconds: 1800,
+        documentKind: "signed-lease",
+        documentHash: "signed_doc_hash",
+        signedDocumentStoredAt: "2026-01-02T00:10:00.000Z",
+      })
+    );
+    expect(refreshRes.body?.documentRef).toEqual({
+      source: "signedDocument",
+      internalReferenceOnly: true,
+    });
+    expect(getSignedDownloadUrlMock).toHaveBeenCalledWith({
+      bucket: "signed-lease-documents",
+      path: "lease-signing/landlord-1/request-signed/signed.pdf",
+      expiresMinutes: 30,
+    });
+    expect(JSON.stringify(refreshRes.body)).not.toContain("signed-lease-documents");
+    expect(JSON.stringify(refreshRes.body)).not.toContain("lease-signing/landlord-1");
+    expect(JSON.stringify(refreshRes.body)).not.toContain("raw-provider-request-id");
+    expect(JSON.stringify(refreshRes.body)).not.toContain("X-Goog-Signature");
+  });
+
   it("refreshes legacy persisted GCS signed URLs instead of returning stale URLs", async () => {
     getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-legacy-list.pdf");
     getSignedDownloadUrlMock.mockResolvedValueOnce("https://signed.example.com/fresh-legacy-click.pdf");

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -80,6 +80,7 @@ import type { LeaseEvent, LeaseLifecycleState } from "../services/stateMachines/
 import {
   cancelLeaseSigning,
   downloadSignedLease,
+  getSignedLeaseDocumentDownload,
   loadLeaseSigningSnapshot,
   sendLeaseForSignature,
   signingErrorCode,
@@ -3105,6 +3106,25 @@ export async function handleLeaseDocumentUrl(req: any, res: Response) {
 
     const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
+
+    if (!wantsScheduleA) {
+      const signedDocument = await getSignedLeaseDocumentDownload({ leaseId, landlordId });
+      if (signedDocument.documentUrl) {
+        return res.status(200).json({
+          ok: true,
+          documentUrl: signedDocument.documentUrl,
+          refreshMode: "signed_url",
+          expiresInSeconds: signedDocument.expiresInSeconds,
+          documentKind: "signed-lease",
+          documentHash: signedDocument.documentHash,
+          signedDocumentStoredAt: signedDocument.signedDocumentStoredAt,
+          documentRef: {
+            source: signedDocument.source,
+            internalReferenceOnly: true,
+          },
+        });
+      }
+    }
 
     const storageRef = wantsScheduleA
       ? await loadScheduleAStorageRefForLease(leaseCheck.lease as any)

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -447,6 +447,166 @@ describe("leaseSigningService", () => {
     expect(snapshot.derivedLeaseState).toBe("failed");
   });
 
+  it("stores signed document storage metadata and returns a fresh signed URL without persisting it", async () => {
+    const { signingProviderRegistry } = await import("../signing/providers");
+    signingProviderRegistry.register("boldsign", {
+      getProviderId: () => "boldsign",
+      getName: () => "Boldsign download provider",
+      isConfigured: () => true,
+      sendForSignature: async () => ({
+        providerRequestId: "raw-provider-request-download",
+        dispatchMode: "sandbox",
+        dispatchStatus: "accepted",
+        providerTestMode: true,
+      }),
+      getSigningUrl: async () => null,
+      cancelRequest: async () => true,
+      downloadSignedDocument: async () => ({
+        fileName: "signed lease.pdf",
+        contentType: "application/pdf",
+        buffer: Buffer.from("signed-pdf"),
+      }),
+      verifyWebhookSignature: async () => true,
+      parseWebhookPayload: async () => ({
+        providerRequestId: "raw-provider-request-download",
+        providerEventId: "evt_signed_download",
+        type: "signed",
+        occurredAt: "2026-01-02T00:00:00.000Z",
+      }),
+    });
+    process.env.SIGNING_PROVIDER = "boldsign";
+    const { downloadSignedLease, sendLeaseForSignature } = await import("../signing/leaseSigningService");
+    await sendLeaseForSignature({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      lease: { startDate: "2026-01-01" },
+      providerDocumentUrl: "https://example.com/primary.pdf",
+      tenantEmails: ["tenant@example.com"],
+    });
+    const [[requestId]] = Array.from(ensureCollection("leaseSigningRequests").entries());
+    ensureCollection("leaseSigningRequests").get(requestId).currentSigningStatus = "signed";
+    ensureCollection("leaseSigningEvents").set("event-signed-download", {
+      requestId,
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      providerId: "boldsign",
+      providerRequestRef: "boldsign_ref_safe",
+      type: "signed",
+      actorRole: "provider",
+      occurredAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    const snapshot = await downloadSignedLease({ leaseId: "lease-1", landlordId: "landlord-1", lease: { startDate: "2026-01-01" } });
+    const storedRequest = Array.from(ensureCollection("leaseSigningRequests").values())[0];
+
+    expect(snapshot.documentUrl).toContain("https://signed.example/lease-signing/");
+    expect(storedRequest.signedDocument).toEqual(
+      expect.objectContaining({
+        bucket: "bucket",
+        path: expect.stringContaining("signed-lease.pdf"),
+        contentType: "application/pdf",
+        internalReferenceOnly: true,
+      })
+    );
+    expect(storedRequest.signedDocumentUrl).toBeNull();
+    expect(storedRequest.signedDocumentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(storedRequest)).not.toContain("https://signed.example/");
+    expect(JSON.stringify(storedRequest)).not.toContain("X-Goog");
+    expect(JSON.stringify(snapshot)).not.toContain("raw-provider-request-download");
+  });
+
+  it("returns fresh signed document URLs from stored metadata and collapses duplicate signed events in projections", async () => {
+    const { loadLeaseSigningSnapshot } = await import("../signing/leaseSigningService");
+    ensureCollection("leaseSigningRequests").set("request-1", {
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      providerId: "mock",
+      providerRequestId: "raw-provider-request-duplicate",
+      providerRequestRef: "mock_ref_safe",
+      currentSigningStatus: "signed",
+      signedDocument: {
+        bucket: "bucket",
+        path: "lease-signing/landlord/request-1/signed.pdf",
+        internalReferenceOnly: true,
+      },
+      signedDocumentUrl: "https://storage.googleapis.com/bucket/lease-signing/landlord/request-1/signed.pdf?X-Goog-Signature=stale",
+      signedDocumentHash: "signed_hash",
+      signedDocumentStoredAt: "2026-01-02T00:10:00.000Z",
+      sentAt: "2026-01-01T00:00:00.000Z",
+    });
+    ensureCollection("leaseSigningEvents").set("event-sent", {
+      requestId: "request-1",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      type: "sent",
+      actorRole: "landlord",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+    });
+    ensureCollection("leaseSigningEvents").set("event-signed-1", {
+      requestId: "request-1",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      type: "signed",
+      actorRole: "provider",
+      occurredAt: "2026-01-02T00:00:00.000Z",
+    });
+    ensureCollection("leaseSigningEvents").set("event-signed-2", {
+      requestId: "request-1",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      type: "signed",
+      actorRole: "provider",
+      occurredAt: "2026-01-02T00:05:00.000Z",
+    });
+
+    const snapshot = await loadLeaseSigningSnapshot({ leaseId: "lease-1", landlordId: "landlord-1", lease: { startDate: "2026-01-01" } });
+
+    expect(snapshot.documentUrl).toBe("https://signed.example/lease-signing/landlord/request-1/signed.pdf");
+    expect(snapshot.signedAt).toBe("2026-01-02T00:05:00.000Z");
+    expect(snapshot.events.map((event) => event.type)).toEqual(["sent", "signed"]);
+    expect(snapshot.events.find((event) => event.type === "signed")?.occurredAt).toBe("2026-01-02T00:05:00.000Z");
+    expect(JSON.stringify(snapshot)).not.toContain("X-Goog-Signature");
+    expect(JSON.stringify(snapshot)).not.toContain("raw-provider-request-duplicate");
+  });
+
+  it("converts legacy persisted signed URLs into internal signed document metadata on download", async () => {
+    const { downloadSignedLease } = await import("../signing/leaseSigningService");
+    ensureCollection("leaseSigningRequests").set("request-legacy", {
+      leaseId: "lease-legacy",
+      landlordId: "landlord-1",
+      providerId: "mock",
+      providerRequestId: "raw-provider-request-legacy",
+      providerRequestRef: "mock_ref_safe",
+      currentSigningStatus: "signed",
+      signedDocumentUrl:
+        "https://storage.googleapis.com/signed-lease-documents/lease-signing/landlord/request-legacy/signed.pdf?X-Goog-Signature=expired",
+      signedDocumentHash: "legacy_hash",
+      signedDocumentStoredAt: "2026-01-02T00:10:00.000Z",
+      sentAt: "2026-01-01T00:00:00.000Z",
+    });
+    ensureCollection("leaseSigningEvents").set("event-signed-legacy", {
+      requestId: "request-legacy",
+      leaseId: "lease-legacy",
+      landlordId: "landlord-1",
+      type: "signed",
+      actorRole: "provider",
+      occurredAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    const snapshot = await downloadSignedLease({ leaseId: "lease-legacy", landlordId: "landlord-1", lease: { startDate: "2026-01-01" } });
+    const storedRequest = ensureCollection("leaseSigningRequests").get("request-legacy");
+
+    expect(snapshot.documentUrl).toBe("https://signed.example/lease-signing/landlord/request-legacy/signed.pdf");
+    expect(storedRequest.signedDocument).toEqual({
+      bucket: "signed-lease-documents",
+      path: "lease-signing/landlord/request-legacy/signed.pdf",
+      internalReferenceOnly: true,
+    });
+    expect(storedRequest.signedDocumentUrl).toBeNull();
+    expect(JSON.stringify(snapshot)).not.toContain("X-Goog-Signature=expired");
+    expect(JSON.stringify(storedRequest)).not.toContain("X-Goog-Signature=expired");
+  });
+
   it("resolves current state to pending after resending a cancelled signing request", async () => {
     const { cancelLeaseSigning, loadLeaseSigningSnapshot, sendLeaseForSignature } = await import("../signing/leaseSigningService");
     const lease = { startDate: "2026-01-01", documentUrl: "https://example.com/lease.pdf" };

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -43,6 +43,14 @@ export type LeaseSigningSnapshot = {
   events: LeaseSigningEvent[];
 };
 
+export type SignedLeaseDocumentDownload = {
+  documentUrl: string | null;
+  expiresInSeconds: number | null;
+  documentHash: string | null;
+  signedDocumentStoredAt: string | null;
+  source: "signedDocument" | "legacySignedDocumentUrl" | null;
+};
+
 const REQUESTS = "leaseSigningRequests";
 const EVENTS = "leaseSigningEvents";
 const DEAD_LETTERS = "leaseSigningWebhookDeadLetters";
@@ -112,6 +120,65 @@ function asDateMillis(value: any): number {
   if (typeof value?.toMillis === "function") return value.toMillis();
   const parsed = Date.parse(String(value));
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parseGcsUrlStorageRef(value: unknown): { bucket: string; path: string; source: "legacySignedDocumentUrl" } | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.hostname === "storage.googleapis.com") {
+      const [bucket, ...pathParts] = parsed.pathname.replace(/^\/+/, "").split("/");
+      const path = pathParts.join("/");
+      if (bucket && path) return { bucket, path: decodeURIComponent(path), source: "legacySignedDocumentUrl" };
+    }
+    if (parsed.hostname.endsWith(".storage.googleapis.com")) {
+      const bucket = parsed.hostname.replace(/\.storage\.googleapis\.com$/, "");
+      const path = parsed.pathname.replace(/^\/+/, "");
+      if (bucket && path) return { bucket, path: decodeURIComponent(path), source: "legacySignedDocumentUrl" };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function signedDocumentStorageRefFromRequest(data: any): { bucket: string; path: string; source: "signedDocument" | "legacySignedDocumentUrl" } | null {
+  const signedDocument = data?.signedDocument || {};
+  const bucket = String(signedDocument.bucket || signedDocument.storageBucket || "").trim();
+  const path = String(signedDocument.path || signedDocument.storagePath || signedDocument.objectKey || "").trim();
+  if (bucket && path) return { bucket, path, source: "signedDocument" };
+  return parseGcsUrlStorageRef(data?.signedDocumentUrl);
+}
+
+function collapseEventsForProjection(events: LeaseSigningEvent[]) {
+  let latestSigned: LeaseSigningEvent | null = null;
+  for (const event of events) {
+    if (event.type === "signed") latestSigned = event;
+  }
+  return events.filter((event) => event.type !== "signed").concat(latestSigned ? [latestSigned] : []).sort((a, b) => asDateMillis(a.occurredAt) - asDateMillis(b.occurredAt));
+}
+
+async function signedDocumentDownloadFromRequest(data: any): Promise<SignedLeaseDocumentDownload> {
+  const ref = signedDocumentStorageRefFromRequest(data);
+  if (!ref) {
+    return {
+      documentUrl: null,
+      expiresInSeconds: null,
+      documentHash: String(data?.signedDocumentHash || "") || null,
+      signedDocumentStoredAt: String(data?.signedDocumentStoredAt || "") || null,
+      source: null,
+    };
+  }
+  const expiresMinutes = 30;
+  const documentUrl = await getSignedDownloadUrl({ bucket: ref.bucket, path: ref.path, expiresMinutes });
+  return {
+    documentUrl,
+    expiresInSeconds: expiresMinutes * 60,
+    documentHash: String(data?.signedDocumentHash || "") || null,
+    signedDocumentStoredAt: String(data?.signedDocumentStoredAt || "") || null,
+    source: ref.source,
+  };
 }
 
 function statusFromEvents(events: LeaseSigningEvent[]): LeaseSigningStatus {
@@ -302,11 +369,12 @@ export async function loadLeaseSigningSnapshot(input: {
   }
   const events = await loadEvents(request.id);
   const signingStatus = normalizeStoredStatus(request.data?.currentSigningStatus) || statusFromEvents(events);
-  const signedAt = events.find((event) => event.type === "signed")?.occurredAt || null;
+  const signedAt = [...events].reverse().find((event) => event.type === "signed")?.occurredAt || null;
   const sentAt = [...events].reverse().find((event) => event.type === "sent")?.occurredAt || String(request.data?.sentAt || "") || null;
   const providerId = String(request.data?.providerId || "");
   const providerDispatchMode = String(request.data?.providerDispatchMode || (providerId === "mock" ? "mock" : "")).trim() || null;
   const providerDispatchStatus = String(request.data?.providerDispatchStatus || (providerId === "mock" ? "mocked_no_email" : "")).trim() || null;
+  const signedDocument = signingStatus === "signed" ? await signedDocumentDownloadFromRequest(request.data) : null;
   return {
     signingStatus,
     derivedLeaseState: deriveLeaseSigningState({ lease: input.lease || {}, signingStatus }),
@@ -318,9 +386,37 @@ export async function loadLeaseSigningSnapshot(input: {
     providerDispatchMessage: String(request.data?.providerDispatchMessage || (providerId === "mock" ? "Mock signing provider recorded the request without sending email." : "")).trim() || null,
     sentAt,
     signedAt,
-    documentUrl: String(request.data?.signedDocumentUrl || "") || null,
-    events,
+    documentUrl: signedDocument?.documentUrl || null,
+    events: collapseEventsForProjection(events),
   };
+}
+
+export async function getSignedLeaseDocumentDownload(input: {
+  leaseId: string;
+  landlordId: string;
+}): Promise<SignedLeaseDocumentDownload> {
+  const request = await loadLatestRequest(input.leaseId, input.landlordId);
+  if (!request) {
+    return {
+      documentUrl: null,
+      expiresInSeconds: null,
+      documentHash: null,
+      signedDocumentStoredAt: null,
+      source: null,
+    };
+  }
+  const events = await loadEvents(request.id);
+  const signingStatus = normalizeStoredStatus(request.data?.currentSigningStatus) || statusFromEvents(events);
+  if (signingStatus !== "signed") {
+    return {
+      documentUrl: null,
+      expiresInSeconds: null,
+      documentHash: String(request.data?.signedDocumentHash || "") || null,
+      signedDocumentStoredAt: String(request.data?.signedDocumentStoredAt || "") || null,
+      source: null,
+    };
+  }
+  return signedDocumentDownloadFromRequest(request.data);
 }
 
 export async function sendLeaseForSignature(input: {
@@ -475,8 +571,25 @@ export async function downloadSignedLease(input: { leaseId: string; lease: Recor
   const request = await loadLatestRequest(input.leaseId, input.landlordId);
   if (!request) throw Object.assign(new Error("lease_not_found"), { status: 404 });
   const events = await loadEvents(request.id);
-  if (statusFromEvents(events) !== "signed") throw Object.assign(new Error("signed_document_not_found"), { status: 404 });
-  if (request.data?.signedDocumentUrl) return loadLeaseSigningSnapshot({ leaseId: input.leaseId, landlordId: input.landlordId, lease: input.lease });
+  const signingStatus = normalizeStoredStatus(request.data?.currentSigningStatus) || statusFromEvents(events);
+  if (signingStatus !== "signed") throw Object.assign(new Error("signed_document_not_found"), { status: 404 });
+  const existingSignedDocumentRef = signedDocumentStorageRefFromRequest(request.data);
+  if (existingSignedDocumentRef) {
+    if (existingSignedDocumentRef.source === "legacySignedDocumentUrl") {
+      await db.collection(REQUESTS).doc(request.id).set(
+        {
+          signedDocument: {
+            bucket: existingSignedDocumentRef.bucket,
+            path: existingSignedDocumentRef.path,
+            internalReferenceOnly: true,
+          },
+          signedDocumentUrl: null,
+        },
+        { merge: true }
+      );
+    }
+    return loadLeaseSigningSnapshot({ leaseId: input.leaseId, landlordId: input.landlordId, lease: input.lease });
+  }
   const provider = signingProviderRegistry.getProvider(String(request.data?.providerId || ""));
   if (!provider?.isConfigured()) throw Object.assign(new Error("provider_unavailable"), { status: 503 });
   const doc = await provider.downloadSignedDocument(String(request.data?.providerRequestId || ""));
@@ -488,10 +601,16 @@ export async function downloadSignedLease(input: { leaseId: string; lease: Recor
     buffer: doc.buffer,
     metadata: { leaseSigningRequestId: request.id },
   });
-  const documentUrl = await getSignedDownloadUrl({ bucket: uploaded.bucket, path: uploaded.path, expiresMinutes: 30 });
   await db.collection(REQUESTS).doc(request.id).set(
     {
-      signedDocumentUrl: documentUrl,
+      signedDocument: {
+        bucket: uploaded.bucket,
+        path: uploaded.path,
+        contentType: doc.contentType,
+        fileName: doc.fileName,
+        internalReferenceOnly: true,
+      },
+      signedDocumentUrl: null,
       signedDocumentHash: createHash("sha256").update(doc.buffer).digest("hex"),
       signedDocumentStoredAt: nowIso(),
     },

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   getArchivedLeasesForLandlord: vi.fn(),
   enableLeasePaymentRail: vi.fn(),
   getLeaseReconciliationCandidates: vi.fn(),
+  downloadSignedLease: vi.fn(),
   refreshLeaseDocumentUrl: vi.fn(),
   convertUnitReferenceToLease: vi.fn(),
   archiveLeaseRecord: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("@/api/leasesApi", () => ({
   getArchivedLeasesForLandlord: mocks.getArchivedLeasesForLandlord,
   enableLeasePaymentRail: mocks.enableLeasePaymentRail,
   getLeaseReconciliationCandidates: mocks.getLeaseReconciliationCandidates,
+  downloadSignedLease: mocks.downloadSignedLease,
   refreshLeaseDocumentUrl: mocks.refreshLeaseDocumentUrl,
   convertUnitReferenceToLease: mocks.convertUnitReferenceToLease,
   archiveLeaseRecord: mocks.archiveLeaseRecord,
@@ -182,6 +184,12 @@ describe("LandlordActiveLeasesPage", () => {
       refreshMode: "signed_url",
       expiresInSeconds: 1800,
     });
+    mocks.downloadSignedLease.mockReset();
+    mocks.downloadSignedLease.mockResolvedValue({
+      documentUrl: "https://example.com/signed-lease-fresh.pdf",
+      signingStatus: "signed",
+      signedAt: "2026-01-02T00:00:00.000Z",
+    });
     mocks.convertUnitReferenceToLease.mockResolvedValue({
       ok: true,
       lease: { id: "lease-9" },
@@ -295,6 +303,62 @@ describe("LandlordActiveLeasesPage", () => {
     await waitFor(() => expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-stale", { document: "schedule-a" }));
     expect(window.open).not.toHaveBeenCalled();
     expect(await screen.findByText("refresh failed")).toBeInTheDocument();
+  });
+
+  it("opens a fresh signed document when a signed lease primary document refresh is unavailable", async () => {
+    mocks.refreshLeaseDocumentUrl.mockReset();
+    mocks.refreshLeaseDocumentUrl.mockRejectedValueOnce(new Error("lease_document_not_found"));
+    mocks.downloadSignedLease.mockResolvedValueOnce({
+      documentUrl: "https://example.com/fresh-signed-download.pdf",
+      signingStatus: "signed",
+      signedAt: "2026-01-02T00:00:00.000Z",
+    });
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-signed",
+          propertyId: "prop-1",
+          propertyName: "Coburg Rd",
+          unitNumber: "6",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          tenantName: "Chip Milo",
+          tenantEmail: "hello+cob6tenant@rentchain.ai",
+          documentUrl: "https://storage.googleapis.com/signed-lease-documents/stale.pdf?X-Goog-Signature=expired",
+          signingStatus: "signed",
+          leaseExecution: {
+            executionStatus: "fully_executed",
+            executionLabel: "Lease fully executed",
+            executionDescription: "The signing workflow is complete.",
+            requiredNextAction: "none",
+            tenantSignatureStatus: "completed",
+            landlordSignatureStatus: "completed",
+            pdfStatus: "generated",
+            completedAt: "2026-01-02T00:00:00.000Z",
+          },
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.open).mockClear();
+    fireEvent.click(await screen.findByRole("button", { name: "View lease" }));
+
+    await waitFor(() => expect(mocks.refreshLeaseDocumentUrl).toHaveBeenCalledWith("lease-signed"));
+    await waitFor(() => expect(mocks.downloadSignedLease).toHaveBeenCalledWith("lease-signed"));
+    expect(window.open).toHaveBeenCalledWith("https://example.com/fresh-signed-download.pdf", "_blank", "noreferrer");
+    expect(window.open).not.toHaveBeenCalledWith(
+      expect.stringContaining("X-Goog-Signature=expired"),
+      expect.anything(),
+      expect.anything()
+    );
   });
 
   it("shows Schedule A as a separate action without replacing the lease summary action", async () => {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -7,6 +7,7 @@ import {
   getActiveLeasesForLandlord,
   getArchivedLeasesForLandlord,
   getLeaseReconciliationCandidates,
+  downloadSignedLease,
   refreshLeaseDocumentUrl,
   restoreLeaseRecord,
   type LandlordActiveLease,
@@ -109,6 +110,12 @@ function scheduleADocumentUrl(lease: LandlordActiveLease) {
   if (explicit) return explicit;
   const legacy = String(lease.documentUrl || "").trim();
   return isScheduleADocumentUrl(legacy) ? legacy : "";
+}
+
+function isSignedLeaseRecord(lease: LandlordActiveLease) {
+  const signingStatus = String((lease as any).currentSigningStatus || (lease as any).signingStatus || "").trim().toLowerCase();
+  const executionStatus = String(lease.leaseExecution?.executionStatus || "").trim().toLowerCase();
+  return signingStatus === "signed" || executionStatus === "fully_executed" || lease.signatureStatus === "signed";
 }
 
 function normalizePhoneInput(value: string) {
@@ -467,6 +474,18 @@ export default function LandlordActiveLeasesPage() {
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
     } catch (err: unknown) {
+      if (documentKind === "lease" && !primaryRefreshReturnedScheduleA && isSignedLeaseRecord(lease)) {
+        try {
+          const signedDocument = await downloadSignedLease(lease.id);
+          const signedUrl = String(signedDocument?.documentUrl || "").trim();
+          if (signedUrl) {
+            window.open(signedUrl, "_blank", "noreferrer");
+            return;
+          }
+        } catch {
+          // Keep the original document-refresh error visible below.
+        }
+      }
       if (!primaryRefreshReturnedScheduleA && canUseLegacyDocumentFallback(fallbackUrl)) {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;


### PR DESCRIPTION
## Summary
- Resolve signed lease document downloads from signing request storage metadata before falling back to primary lease documents.
- Stop persisting temporary signed GCS URLs as normal signing request metadata after provider document download.
- Convert legacy persisted signed GCS URLs into internal signed-document metadata before returning a fresh URL.
- Collapse duplicate `signed` events in the lease signing snapshot projection while preserving append-safe stored events.
- Make landlord View Lease fall back to the signed-document download path for already signed leases when primary document refresh is unavailable.
- Keep signed document responses access-controlled and time-limited without exposing storage refs, provider request IDs, signed URLs, or raw payloads.

## Root Cause
After provider completion, the signed Dropbox document could exist but `/api/leases/:id/document-url` only knew how to resolve primary lease/Schedule A document sources. The signing service also stored or projected temporary signed download URLs in some paths, and duplicate provider signed/completed lifecycle events could project as duplicate Signed timeline rows.

## Validation
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/services/__tests__/leaseSigningService.test.ts src/routes/__tests__/leaseRoutes.active.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`

## Preview QA
1. Generate/sign a sandbox lease through Dropbox Sign.
2. Confirm View Lease no longer fails with `lease_document_not_found` for a signed lease.
3. Confirm Download signed document works from `/leases` and opens a non-expired document.
4. Confirm repeated download clicks and page refreshes still mint fresh URLs.
5. Confirm the signing timeline shows a single Signed state and remains readable.
6. Confirm no raw storage paths, signed URL query params, provider request IDs, or provider payloads appear in UI/API projections.