### PR TITLE
fix: improve lease template readiness messaging

### DIFF
--- a/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
@@ -148,6 +148,17 @@ describe("leaseDocumentService", () => {
     );
   });
 
+  it("keeps CA_NS legal gate metadata while using production-ready required notices", async () => {
+    const { caNsLeaseDocumentAdapter } = await import("../jurisdictions/caNsAdapter");
+
+    const requiredNotices = caNsLeaseDocumentAdapter.requiredNotices.join(" ");
+    expect(requiredNotices).toContain("Nova Scotia requirements");
+    expect(requiredNotices).not.toMatch(/draft\/test|production signing|counsel-approved/i);
+    expect(caNsLeaseDocumentAdapter.counselReviewStatus).toBe("draft");
+    expect(caNsLeaseDocumentAdapter.productionApproved).toBe(false);
+    expect(caNsLeaseDocumentAdapter.signingEnabled).toBe(false);
+  });
+
   it("fails closed for missing jurisdiction adapters without success events", async () => {
     const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
     await expect(

--- a/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
+++ b/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
@@ -24,6 +24,35 @@ function collectPdf(write: (doc: PDFKit.PDFDocument) => void): Promise<Buffer> {
   });
 }
 
+function configuredBoolean(name: string): boolean | null {
+  const explicit = String(process.env[name] || "").trim().toLowerCase();
+  if (explicit === "true" || explicit === "1") return true;
+  if (explicit === "false" || explicit === "0") return false;
+  return null;
+}
+
+function isTestDocumentMode() {
+  const documentGenerationMode = configuredBoolean("LEASE_DOCUMENT_GENERATION_TEST_MODE");
+  if (documentGenerationMode !== null) return documentGenerationMode;
+  const legacyDocumentSourceMode = configuredBoolean("SIGNING_DOCUMENT_SOURCE_TEST_MODE");
+  if (legacyDocumentSourceMode !== null) return legacyDocumentSourceMode;
+  const signingProviderTestMode = configuredBoolean("SIGNING_PROVIDER_TEST_MODE");
+  if (signingProviderTestMode !== null) return signingProviderTestMode;
+  return String(process.env.NODE_ENV || "").trim().toLowerCase() !== "production";
+}
+
+function productionReadinessNotice() {
+  const base =
+    "Generated lease package. Review all details and applicable Nova Scotia requirements before signing. RentChain does not provide legal advice or guarantee enforceability.";
+  return isTestDocumentMode() ? `Preview/test environment: ${base}` : base;
+}
+
+function closingReadinessNotice() {
+  const base =
+    "Generated from RentChain lease workflow using provincial workflow inputs. Review all lease details and applicable Nova Scotia requirements before use. RentChain does not provide legal advice, certification, notarization, or an enforceability guarantee.";
+  return isTestDocumentMode() ? `Preview/test environment: ${base}` : base;
+}
+
 export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
   jurisdictionCode: "CA_NS",
   templateVersion: "ca-ns-primary-lease-draft-v1",
@@ -69,7 +98,7 @@ export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
   ],
   requiredNotices: [
     "Schedule A statutory conditions are required as an attachment/section and remain distinct from the primary document source.",
-    "This draft/test adapter is not legal advice and is not counsel-approved for production signing.",
+    "Generated lease packages must be reviewed against applicable Nova Scotia requirements before use.",
   ],
   prohibitedClauseChecks: ["unsafe_additional_clauses_unreviewed"],
   languageRequirements: ["en-CA"],
@@ -94,9 +123,10 @@ export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
 
       doc.fontSize(18).text("Primary Residential Lease Document", { align: "center" });
       doc.moveDown(0.35);
-      doc.fontSize(9).fillColor("#555").text("Template status: draft/test. Not legal advice. Counsel review required before production signing.", {
-        align: "center",
-      });
+      doc
+        .fontSize(9)
+        .fillColor("#555")
+        .text(productionReadinessNotice(), { align: "center" });
       doc.fillColor("#111").moveDown();
 
       const section = (title: string) => {
@@ -166,7 +196,10 @@ export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
       doc.text("Landlord signature: _____________________________   Date: ______________");
 
       doc.moveDown();
-      doc.fontSize(8).fillColor("#555").text("This generated draft is provided for workflow testing. It is not legal advice, certification, notarization, or an enforceability guarantee.");
+      doc
+        .fontSize(8)
+        .fillColor("#555")
+        .text(closingReadinessNotice());
     });
   },
 };

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
@@ -131,6 +131,19 @@ describe("LeaseSigningDashboard", () => {
     expect(screen.queryByText(/lease-documents/i)).not.toBeInTheDocument();
   });
 
+  it("shows calm legal boundary copy without draft/test production-signing language", async () => {
+    render(<LeaseSigningDashboard leaseId="lease-1" tenantEmail="tenant@example.com" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/review all lease details and applicable provincial requirements before signing/i)
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByText(/rentchain does not provide legal advice or guarantee enforceability/i)).toBeInTheDocument();
+    expect(screen.queryByText(/draft\/test/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/production signing/i)).not.toBeInTheDocument();
+  });
+
   it("renders jurisdiction unavailable state safely", async () => {
     vi.mocked(getPrimaryLeaseDocument).mockResolvedValueOnce(null);
     vi.mocked(generatePrimaryLeaseDocument).mockRejectedValueOnce({ body: { error: "jurisdiction_template_unavailable" } });

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
@@ -171,7 +171,7 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
             </div>
             {primaryDocument?.sourceSummary?.productionApproved === false ? (
               <div style={{ color: "#92400e", fontSize: 13 }}>
-                Jurisdiction template is draft/test and requires counsel review before production signing.
+                Review all lease details and applicable provincial requirements before signing. RentChain does not provide legal advice or guarantee enforceability.
               </div>
             ) : null}
             {documentError ? <div style={{ color: "#b91c1c", fontSize: 13 }}>{documentError}</div> : null}


### PR DESCRIPTION
## Summary
- Replace draft/test-facing CA_NS lease PDF wording with calmer production-readiness copy.
- Preserve explicit preview/test marking when document generation runs in test-mode environments.
- Update the lease signing dashboard warning to keep legal boundaries without trust-breaking production-signing language.
- Preserve CA_NS draft/unapproved/signing-disabled metadata and existing fail-closed gating.

## Validation
- `rentchain-api`: `npm run test:single -- src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts`
- `rentchain-frontend`: `npm run test:single -- src/components/LeaseSigningDashboard.test.tsx`
- `rentchain-api`: `npm run build`
- `rentchain-frontend`: `npm run build`
- `git diff --check`

## Scope Notes
- Does not perform the full Nova Scotia lease compliance audit.
- Does not change signing flow, Dropbox return flow, document URL behavior, or signing field placement.
- Source documents outside the workspace were not readable from this sandbox, so this PR does not add new compliance claims; it keeps the wording at a general Nova Scotia requirements review boundary.