### PR TITLE
fix: simplify lease status workflow guidance

### DIFF
--- a/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
@@ -44,7 +44,9 @@ function Section({
   return (
     <section
       id={anchorIds ? id : undefined}
+      tabIndex={anchorIds ? -1 : undefined}
       aria-labelledby={titleId}
+      data-workflow-target={highlighted ? "true" : undefined}
       style={{
         display: "grid",
         gap: 10,

--- a/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
@@ -33,10 +33,29 @@ function prettyLeaseStatus(value: string | null | undefined) {
   return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-function Section({ id, title, children }: React.PropsWithChildren<{ id: string; title: string }>) {
+function Section({
+  id,
+  title,
+  anchorIds = true,
+  highlighted = false,
+  children,
+}: React.PropsWithChildren<{ id: string; title: string; anchorIds?: boolean; highlighted?: boolean }>) {
   const titleId = `${id}-heading`;
   return (
-    <section aria-labelledby={titleId} style={{ display: "grid", gap: 10, paddingTop: 18, borderTop: "1px solid #e2e8f0" }}>
+    <section
+      id={anchorIds ? id : undefined}
+      aria-labelledby={titleId}
+      style={{
+        display: "grid",
+        gap: 10,
+        padding: highlighted ? "18px 14px 14px" : "18px 0 0",
+        borderTop: highlighted ? "2px solid #2563eb" : "1px solid #e2e8f0",
+        borderRadius: highlighted ? 8 : 0,
+        background: highlighted ? "#eff6ff" : "transparent",
+        scrollMarginTop: 96,
+        transition: "background-color 160ms ease, border-color 160ms ease",
+      }}
+    >
       <h2 id={titleId} style={{ margin: 0, fontSize: 16, letterSpacing: 0, color: "#0f172a" }}>{title}</h2>
       <div style={{ display: "grid", gap: 8 }}>{children}</div>
     </section>
@@ -54,7 +73,15 @@ function Field({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
-export function LeaseDocumentView({ lease }: { lease: LandlordActiveLease }) {
+export function LeaseDocumentView({
+  lease,
+  activeSectionId = null,
+  anchorIds = true,
+}: {
+  lease: LandlordActiveLease;
+  activeSectionId?: string | null;
+  anchorIds?: boolean;
+}) {
   const documentDefinition = composeLeaseSummaryLegalDocument(lease, {
     currency: formatCurrency,
     date: formatDate,
@@ -94,7 +121,13 @@ export function LeaseDocumentView({ lease }: { lease: LandlordActiveLease }) {
       </header>
 
       {documentDefinition.sections.map((section) => (
-        <Section key={section.id} id={`lease-section-${section.id}`} title={section.title}>
+        <Section
+          key={section.id}
+          id={`lease-section-${section.id}`}
+          title={section.title}
+          anchorIds={anchorIds}
+          highlighted={activeSectionId === `lease-section-${section.id}`}
+        >
           {section.fields.length ? (
             <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14, margin: 0 }}>
               {section.fields.map((field) => (

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -288,10 +288,22 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);
     expect(screen.getByText(/Prepare renewal notice/i)).toBeInTheDocument();
     expect(screen.getByText("NS Workflow Guidance:")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Renewal Review" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-audit-events");
-    expect(screen.getByRole("link", { name: "Rent Increase Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-rent-payment");
-    expect(screen.getByRole("link", { name: "Notice Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-audit-events");
-    expect(screen.getByRole("link", { name: "Deposit Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-rent-payment");
+    expect(screen.getByRole("link", { name: "Renewal Review" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
+    );
+    expect(screen.getByRole("link", { name: "Rent Increase Workflow" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
+    );
+    expect(screen.getByRole("link", { name: "Notice Workflow" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
+    );
+    expect(screen.getByRole("link", { name: "Deposit Workflow" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
+    );
     expect(screen.getByText("Verify local requirements.")).toBeInTheDocument();
     expect(screen.queryByText("Lease renewal review recommended")).not.toBeInTheDocument();
     expect(screen.queryByText("Rent increase workflow metadata available")).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -288,10 +288,10 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);
     expect(screen.getByText(/Prepare renewal notice/i)).toBeInTheDocument();
     expect(screen.getByText("NS Workflow Guidance:")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Renewal Review" })).toHaveAttribute("href", "/leases/lease-1/summary");
-    expect(screen.getByRole("link", { name: "Rent Increase Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary");
-    expect(screen.getByRole("link", { name: "Notice Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary");
-    expect(screen.getByRole("link", { name: "Deposit Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByRole("link", { name: "Renewal Review" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-audit-events");
+    expect(screen.getByRole("link", { name: "Rent Increase Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-rent-payment");
+    expect(screen.getByRole("link", { name: "Notice Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-audit-events");
+    expect(screen.getByRole("link", { name: "Deposit Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary#lease-section-rent-payment");
     expect(screen.getByText("Verify local requirements.")).toBeInTheDocument();
     expect(screen.queryByText("Lease renewal review recommended")).not.toBeInTheDocument();
     expect(screen.queryByText("Rent increase workflow metadata available")).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LandlordActiveLeasesPage from "./LandlordActiveLeasesPage";
 
@@ -40,6 +40,11 @@ vi.mock("@/hooks/useEntitlements", () => ({
 vi.mock("@/components/billing/LockedFeature", () => ({
   LockedFeature: ({ featureKey }: { featureKey: string }) => <div>Locked feature: {featureKey}</div>,
 }));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="current-location">{`${location.pathname}${location.search}${location.hash}`}</div>;
+}
 
 describe("LandlordActiveLeasesPage", () => {
   afterEach(() => {
@@ -328,6 +333,37 @@ describe("LandlordActiveLeasesPage", () => {
     await waitFor(() => expect(mocks.archiveLeaseRecord).toHaveBeenCalledWith("lease-1"));
     fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
+  });
+
+  it("navigates compact workflow buttons to distinct summary section URLs", async () => {
+    render(
+      <MemoryRouter>
+        <LocationProbe />
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("NS Workflow Guidance:");
+
+    fireEvent.click(screen.getByRole("link", { name: "Rent Increase Workflow" }));
+    expect(screen.getByTestId("current-location")).toHaveTextContent(
+      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Deposit Workflow" }));
+    expect(screen.getByTestId("current-location")).toHaveTextContent(
+      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Notice Workflow" }));
+    expect(screen.getByTestId("current-location")).toHaveTextContent(
+      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Renewal Review" }));
+    expect(screen.getByTestId("current-location")).toHaveTextContent(
+      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
+    );
   });
 
   it("does not open stale GCS or app-domain lease document fallbacks when refresh fails", async () => {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -154,6 +154,48 @@ describe("LandlordActiveLeasesPage", () => {
               disclaimer:
                 "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.",
             },
+            {
+              jurisdiction: "NS",
+              policyKey: "rent_increase_workflow_availability",
+              status: "ok",
+              severity: "info",
+              label: "Rent increase workflow metadata available",
+              reason: "This jurisdiction has rent increase workflow metadata configured for operational review.",
+              recommendation: "Use the guided workflow as a review aid and verify current local requirements before sending notices.",
+              sourceRuleKey: "NS.rent_increase_workflow",
+              confidence: "medium",
+              legalAdvice: false,
+              disclaimer:
+                "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.",
+            },
+            {
+              jurisdiction: "NS",
+              policyKey: "notice_workflow_readiness",
+              status: "ok",
+              severity: "info",
+              label: "Notice workflow guidance available",
+              reason: "Province-aware notice workflow metadata is available for landlord review.",
+              recommendation: "Prepare notice workflow steps manually and verify local legal requirements before delivery.",
+              sourceRuleKey: "NS.notice_workflow_readiness",
+              confidence: "medium",
+              legalAdvice: false,
+              disclaimer:
+                "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.",
+            },
+            {
+              jurisdiction: "NS",
+              policyKey: "deposit_workflow_review",
+              status: "review",
+              severity: "info",
+              label: "Deposit workflow review available",
+              reason: "This jurisdiction has deposit workflow metadata flagged for operational review.",
+              recommendation: "Review deposit handling as part of the lease workflow without treating this as a compliance determination.",
+              sourceRuleKey: "NS.deposit_workflow_review",
+              confidence: "medium",
+              legalAdvice: false,
+              disclaimer:
+                "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.",
+            },
           ],
         },
       ],
@@ -245,9 +287,17 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.queryByText("Lease execution review recommended")).not.toBeInTheDocument();
     expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);
     expect(screen.getByText(/Prepare renewal notice/i)).toBeInTheDocument();
-    expect(screen.getByText("NS workflow guidance")).toBeInTheDocument();
-    expect(screen.getByText("Lease renewal review recommended")).toBeInTheDocument();
-    expect(screen.getByText("Workflow guidance only — verify local legal requirements.")).toBeInTheDocument();
+    expect(screen.getByText("NS Workflow Guidance:")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Renewal Review" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByRole("link", { name: "Rent Increase Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByRole("link", { name: "Notice Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByRole("link", { name: "Deposit Workflow" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByText("Verify local requirements.")).toBeInTheDocument();
+    expect(screen.queryByText("Lease renewal review recommended")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rent increase workflow metadata available")).not.toBeInTheDocument();
+    expect(screen.queryByText("Notice workflow guidance available")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deposit workflow review available")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Prepare notice workflow steps manually/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View lease" })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -304,15 +304,44 @@ function renderLifecycleSummary(lease: LandlordActiveLease) {
   );
 }
 
+function jurisdictionWorkflowTitle(lease: LandlordActiveLease) {
+  const policies = Array.isArray(lease.jurisdictionPolicies) ? lease.jurisdictionPolicies : [];
+  const jurisdiction = policies[0]?.jurisdiction;
+  if (jurisdiction === "NS") return "NS Workflow Guidance";
+  if (jurisdiction === "ON") return "ON Workflow Guidance";
+  return "Jurisdiction Workflow Guidance";
+}
+
+function compactPolicyActionLabel(policyKey: string, fallback: string) {
+  switch (policyKey) {
+    case "rent_increase_workflow_availability":
+      return "Rent Increase Workflow";
+    case "notice_workflow_readiness":
+      return "Notice Workflow";
+    case "deposit_workflow_review":
+      return "Deposit Workflow";
+    case "lease_renewal_review":
+      return "Renewal Review";
+    case "move_out_preparation":
+      return "Move-Out Prep";
+    case "lease_execution_readiness":
+      return "Execution Review";
+    default:
+      return fallback.replace(/\s+(available|recommended)$/i, "");
+  }
+}
+
 function renderJurisdictionPolicyGuidance(lease: LandlordActiveLease) {
   const policies = Array.isArray(lease.jurisdictionPolicies) ? lease.jurisdictionPolicies : [];
   if (policies.length === 0) return null;
-  const visiblePolicies = policies.slice(0, 3);
+  const visiblePolicies = policies.slice(0, 6);
   return (
     <div
       style={{
-        display: "grid",
-        gap: 6,
+        display: "flex",
+        gap: 8,
+        flexWrap: "wrap",
+        alignItems: "center",
         marginTop: 8,
         padding: "8px 10px",
         border: "1px solid #bfdbfe",
@@ -322,22 +351,29 @@ function renderJurisdictionPolicyGuidance(lease: LandlordActiveLease) {
         fontSize: 12,
       }}
     >
-      <div style={{ fontWeight: 800 }}>
-        {policies[0]?.jurisdiction === "NS"
-          ? "NS workflow guidance"
-          : policies[0]?.jurisdiction === "ON"
-          ? "ON workflow guidance"
-          : "Jurisdiction workflow guidance"}
-      </div>
+      <div style={{ fontWeight: 800, marginRight: 2 }}>{jurisdictionWorkflowTitle(lease)}:</div>
       {visiblePolicies.map((policy) => (
-        <div key={`${policy.policyKey}:${policy.sourceRuleKey}`} style={{ display: "grid", gap: 2 }}>
-          <div style={{ fontWeight: policy.severity === "warning" || policy.severity === "critical" ? 800 : 700 }}>
-            {policy.label}
-          </div>
-          <div>{policy.recommendation}</div>
-        </div>
+        <Link
+          key={`${policy.policyKey}:${policy.sourceRuleKey}`}
+          to={`/leases/${encodeURIComponent(lease.id)}/summary`}
+          title={`${policy.label}: ${policy.recommendation}`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            minHeight: 24,
+            padding: "3px 8px",
+            borderRadius: 999,
+            border: "1px solid #bfdbfe",
+            background: "#fff",
+            color: policy.severity === "warning" || policy.severity === "critical" ? "#92400e" : "#1d4ed8",
+            fontWeight: 800,
+            textDecoration: "none",
+          }}
+        >
+          {compactPolicyActionLabel(policy.policyKey, policy.label)}
+        </Link>
       ))}
-      <div style={{ color: "#475569" }}>Workflow guidance only — verify local legal requirements.</div>
+      <div style={{ color: "#475569" }}>Verify local requirements.</div>
     </div>
   );
 }

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -336,12 +336,12 @@ function policySummaryHref(leaseId: string, policyKey: string) {
   switch (policyKey) {
     case "rent_increase_workflow_availability":
     case "deposit_workflow_review":
-      return `${base}#lease-section-rent-payment`;
+      return `${base}?section=rent-payment#lease-section-rent-payment`;
     case "lease_execution_readiness":
     case "lease_renewal_review":
     case "move_out_preparation":
     case "notice_workflow_readiness":
-      return `${base}#lease-section-audit-events`;
+      return `${base}?section=audit-events#lease-section-audit-events`;
     default:
       return base;
   }

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -331,6 +331,22 @@ function compactPolicyActionLabel(policyKey: string, fallback: string) {
   }
 }
 
+function policySummaryHref(leaseId: string, policyKey: string) {
+  const base = `/leases/${encodeURIComponent(leaseId)}/summary`;
+  switch (policyKey) {
+    case "rent_increase_workflow_availability":
+    case "deposit_workflow_review":
+      return `${base}#lease-section-rent-payment`;
+    case "lease_execution_readiness":
+    case "lease_renewal_review":
+    case "move_out_preparation":
+    case "notice_workflow_readiness":
+      return `${base}#lease-section-audit-events`;
+    default:
+      return base;
+  }
+}
+
 function renderJurisdictionPolicyGuidance(lease: LandlordActiveLease) {
   const policies = Array.isArray(lease.jurisdictionPolicies) ? lease.jurisdictionPolicies : [];
   if (policies.length === 0) return null;
@@ -355,7 +371,7 @@ function renderJurisdictionPolicyGuidance(lease: LandlordActiveLease) {
       {visiblePolicies.map((policy) => (
         <Link
           key={`${policy.policyKey}:${policy.sourceRuleKey}`}
-          to={`/leases/${encodeURIComponent(lease.id)}/summary`}
+          to={policySummaryHref(lease.id, policy.policyKey)}
           title={`${policy.label}: ${policy.recommendation}`}
           style={{
             display: "inline-flex",

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -82,6 +82,21 @@ describe("LandlordLeaseSummaryPage", () => {
       configurable: true,
       value: vi.fn(),
     });
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
     HTMLAnchorElement.prototype.click = vi.fn();
   });
 
@@ -115,6 +130,10 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getAllByText("Rent and Payment Terms").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Clauses and Additional Terms").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Audit and Events").length).toBeGreaterThan(0);
+    expect(document.getElementById("lease-section-rent-payment")).toBeTruthy();
+    expect(document.getElementById("lease-section-audit-events")).toBeTruthy();
+    expect(document.querySelectorAll("#lease-section-rent-payment")).toHaveLength(1);
+    expect(document.querySelectorAll("#lease-section-audit-events")).toHaveLength(1);
     expect(mocks.getLeaseById).toHaveBeenCalledWith("lease-1");
     expect(screen.getAllByText("Coburg Rd").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Tony Wenpeng").length).toBeGreaterThan(0);
@@ -123,6 +142,27 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download evidence package" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
+  });
+
+  it("scrolls to and highlights requested lease summary workflow sections after data loads", async () => {
+    const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Lease summary")).toBeInTheDocument();
+    const target = document.getElementById("lease-section-rent-payment");
+
+    expect(target).toBeTruthy();
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    });
+    expect(target).toHaveStyle({ background: "#eff6ff" });
   });
 
   it("renders a non-empty printable lease summary source for browser print preview", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -146,6 +146,7 @@ describe("LandlordLeaseSummaryPage", () => {
 
   it("scrolls to and highlights requested lease summary workflow sections after data loads", async () => {
     const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => undefined);
+    const focus = vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => undefined);
 
     render(
       <MemoryRouter initialEntries={["/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"]}>
@@ -158,8 +159,13 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(await screen.findByText("Lease summary")).toBeInTheDocument();
     const target = document.getElementById("lease-section-rent-payment");
 
+    expect(screen.getByRole("status")).toHaveTextContent("Rent and Payment workflow focus");
+    expect(screen.getByRole("status")).toHaveTextContent("Review rent terms, deposit handling, rent collection readiness");
     expect(target).toBeTruthy();
+    expect(target).toHaveAttribute("data-workflow-target", "true");
+    expect(target).toHaveAttribute("tabindex", "-1");
     await waitFor(() => {
+      expect(focus).toHaveBeenCalledWith({ preventScroll: true });
       expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
     });
     expect(target).toHaveStyle({ background: "#eff6ff" });

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router-dom";
 import { downloadAuthenticatedExport } from "@/api/exportDownload";
 import { getLeaseById, type LandlordActiveLease } from "@/api/leasesApi";
 import { LeaseDocumentView } from "@/components/leases/LeaseDocumentView";
@@ -27,11 +27,23 @@ function prettyLeaseStatus(value: string | null | undefined) {
   return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function sectionTargetFromLocation(location: { hash: string; search: string }) {
+  const hashTarget = location.hash.replace(/^#/, "").trim();
+  if (hashTarget) return hashTarget;
+  const section = new URLSearchParams(location.search).get("section");
+  if (!section) return null;
+  if (section === "rent-payment") return "lease-section-rent-payment";
+  if (section === "audit-events") return "lease-section-audit-events";
+  return null;
+}
+
 export default function LandlordLeaseSummaryPage() {
   const { leaseId = "" } = useParams();
+  const location = useLocation();
   const [lease, setLease] = React.useState<LandlordActiveLease | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const activeSectionId = sectionTargetFromLocation(location);
 
   React.useEffect(() => {
     let active = true;
@@ -63,6 +75,15 @@ export default function LandlordLeaseSummaryPage() {
       active = false;
     };
   }, [leaseId]);
+
+  React.useEffect(() => {
+    if (!lease || loading || !activeSectionId) return;
+    const frame = window.requestAnimationFrame(() => {
+      const target = document.getElementById(activeSectionId);
+      target?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [activeSectionId, lease, loading]);
 
   const ledgerPath = lease ? `/leases/${encodeURIComponent(lease.id)}/ledger` : `/leases/${encodeURIComponent(leaseId)}/ledger`;
   async function handlePrintOrSavePdf() {
@@ -137,9 +158,9 @@ export default function LandlordLeaseSummaryPage() {
 
       {lease ? (
         <>
-          <LeaseDocumentView lease={lease} />
+          <LeaseDocumentView lease={lease} activeSectionId={activeSectionId} />
           <div className="print-only print-only-summary" aria-hidden="true">
-            <LeaseDocumentView lease={lease} />
+            <LeaseDocumentView lease={lease} anchorIds={false} />
           </div>
         </>
       ) : null}

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -37,6 +37,22 @@ function sectionTargetFromLocation(location: { hash: string; search: string }) {
   return null;
 }
 
+function workflowFocusForSection(sectionId: string | null) {
+  if (sectionId === "lease-section-rent-payment") {
+    return {
+      title: "Rent and Payment workflow focus",
+      description: "Review rent terms, deposit handling, rent collection readiness, and payment setup context in this section.",
+    };
+  }
+  if (sectionId === "lease-section-audit-events") {
+    return {
+      title: "Audit and Events workflow focus",
+      description: "Review execution, notice, renewal, move-out, and lifecycle context in this section.",
+    };
+  }
+  return null;
+}
+
 export default function LandlordLeaseSummaryPage() {
   const { leaseId = "" } = useParams();
   const location = useLocation();
@@ -44,6 +60,7 @@ export default function LandlordLeaseSummaryPage() {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const activeSectionId = sectionTargetFromLocation(location);
+  const workflowFocus = workflowFocusForSection(activeSectionId);
 
   React.useEffect(() => {
     let active = true;
@@ -80,6 +97,7 @@ export default function LandlordLeaseSummaryPage() {
     if (!lease || loading || !activeSectionId) return;
     const frame = window.requestAnimationFrame(() => {
       const target = document.getElementById(activeSectionId);
+      target?.focus({ preventScroll: true });
       target?.scrollIntoView({ behavior: "smooth", block: "start" });
     });
     return () => window.cancelAnimationFrame(frame);
@@ -155,6 +173,25 @@ export default function LandlordLeaseSummaryPage() {
 
       {loading ? <div>Loading lease summary…</div> : null}
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      {workflowFocus ? (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            border: "1px solid #bfdbfe",
+            borderRadius: 10,
+            background: "#eff6ff",
+            color: "#1e3a8a",
+            padding: "10px 12px",
+            display: "grid",
+            gap: 3,
+          }}
+        >
+          <div style={{ fontWeight: 800 }}>{workflowFocus.title}</div>
+          <div style={{ fontSize: 13, color: "#334155" }}>{workflowFocus.description}</div>
+        </div>
+      ) : null}
 
       {lease ? (
         <>


### PR DESCRIPTION
## Summary
- Replace long jurisdiction workflow guidance paragraphs in the landlord lease status panel with compact workflow links.
- Keep signed/occupied/payment/readiness states and lease actions unchanged.
- Preserve backend jurisdiction policy records; this is a presentation cleanup only.

## Validation
- `rentchain-frontend`: `npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx`
- `rentchain-frontend`: `npm run build`
- `git diff --check`

## Manual QA
- Visit `/leases` with a Nova Scotia lease that has policy guidance.
- Confirm the status panel shows compact items such as `Rent Increase Workflow`, `Notice Workflow`, and `Deposit Workflow` instead of recommendation paragraphs.
- Confirm signed/occupied/rent collection state remains clear.
- Confirm existing links/actions still work: View lease, Lease summary, Ledger, Email, Save, Archive, Enable rent collection.