### PR TITLE
fix: acknowledge dropbox sign webhooks as plain text

### DIFF
--- a/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/signingWebhookRoutes.test.ts
@@ -81,6 +81,25 @@ describe("signingWebhookHandler", () => {
     expect(res.json).not.toHaveBeenCalled();
   });
 
+  it("returns exact Dropbox Sign acknowledgement for successful lifecycle callbacks", async () => {
+    processSigningWebhookMock.mockResolvedValueOnce({});
+    const req: any = {
+      params: { providerId: "dropbox_sign" },
+      query: {},
+      headers: { "content-type": "application/json" },
+      body: { event: { event_type: "signature_request_signed" } },
+    };
+    const res = makeRes();
+
+    await signingWebhookHandler(req, res);
+
+    expect(processSigningWebhookMock).toHaveBeenCalledWith(expect.objectContaining({ providerId: "dropbox_sign" }));
+    expect(res.statusCode).toBe(200);
+    expect(res.type).toHaveBeenCalledWith("text/plain");
+    expect(res.body).toBe("Hello API Event Received");
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
   it("preserves JSON acknowledgement for normal webhook processing", async () => {
     processSigningWebhookMock.mockResolvedValueOnce({});
     const req: any = { params: { providerId: "mock" }, query: {}, headers: {}, body: { ok: true } };

--- a/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
+++ b/rentchain-api/src/routes/webhooks/signingWebhookRoutes.ts
@@ -20,6 +20,10 @@ export function signingWebhookBrowserReturnHandler(_req: Request, res: Response)
     .send("Lease signing completed. You may close this page or return to RentChain.");
 }
 
+function requiresDropboxSignPlainTextAck(providerId: string) {
+  return providerId === "dropbox_sign" || providerId === "hellosign";
+}
+
 export async function signingWebhookHandler(req: Request & { rawBody?: Buffer }, res: Response) {
   const providerId = String(req.params?.providerId || req.query?.provider || process.env.SIGNING_PROVIDER || "mock")
     .trim()
@@ -31,6 +35,9 @@ export async function signingWebhookHandler(req: Request & { rawBody?: Buffer },
       body: req.body,
       rawBody: Buffer.isBuffer(req.body) ? req.body : req.rawBody,
     });
+    if (requiresDropboxSignPlainTextAck(providerId)) {
+      return res.status(200).type("text/plain").send("Hello API Event Received");
+    }
     if (result.providerResponseText) {
       return res.status(200).type("text/plain").send(result.providerResponseText);
     }


### PR DESCRIPTION
## Summary
- Ensure every successfully processed Dropbox Sign/HelloSign POST webhook returns HTTP 200 with exact plain-text body `Hello API Event Received`.
- Preserve webhook event processing before acknowledgement.
- Preserve existing JSON acknowledgement for non-Dropbox providers.
- Preserve GET browser return behavior from the signing completion route.

## Validation
- `rentchain-api`: `npm run test:single -- src/routes/__tests__/signingWebhookRoutes.test.ts`
- `rentchain-api`: `npm run test:single -- src/services/__tests__/leaseSigningService.test.ts`
- `rentchain-api`: `npm run build`
- `git diff --check`

## Manual/Preview QA Required
- Deploy Cloud Run for this PR head and confirm image parity.
- POST a verified Dropbox Sign callback fixture or run Dropbox Sign callback test against `/api/webhooks/signing/dropbox_sign`.
- Confirm response is `200`, `Content-Type: text/plain`, body exactly `Hello API Event Received`.
- Confirm signing lifecycle still updates from verified POST webhook.
- Confirm GET signing return route remains non-mutating.