### PR TITLE
fix: route lease workflow buttons to focused reviews

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -184,6 +184,7 @@ const MaintenanceRequestsPage = lazy(() => import("./pages/MaintenanceRequestsPa
 const LeaseLedgerPage = lazy(() => import("./pages/LeaseLedgerPage"));
 const LandlordActiveLeasesPage = lazy(() => import("./pages/LandlordActiveLeasesPage"));
 const LandlordLeaseSummaryPage = lazy(() => import("./pages/LandlordLeaseSummaryPage"));
+const LandlordLeaseWorkflowPage = lazy(() => import("./pages/LandlordLeaseWorkflowPage"));
 const ApplicationReviewSummaryPage = lazy(() => import("./pages/ApplicationReviewSummaryPage"));
 const ReferralsPage = lazy(() => import("./pages/ReferralsPage"));
 const AccountPage = lazy(() => import("./pages/AccountPage"));
@@ -1650,6 +1651,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <LandlordLeaseSummaryPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/leases/:leaseId/workflows/:workflowKey"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <LandlordLeaseWorkflowPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -295,19 +295,19 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getByText("NS Workflow Guidance:")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Renewal Review" })).toHaveAttribute(
       "href",
-      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
+      "/leases/lease-1/workflows/renewal"
     );
     expect(screen.getByRole("link", { name: "Rent Increase Workflow" })).toHaveAttribute(
       "href",
-      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
+      "/leases/lease-1/workflows/rent-increase"
     );
     expect(screen.getByRole("link", { name: "Notice Workflow" })).toHaveAttribute(
       "href",
-      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
+      "/leases/lease-1/workflows/notice"
     );
     expect(screen.getByRole("link", { name: "Deposit Workflow" })).toHaveAttribute(
       "href",
-      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
+      "/leases/lease-1/workflows/deposit"
     );
     expect(screen.getByText("Verify local requirements.")).toBeInTheDocument();
     expect(screen.queryByText("Lease renewal review recommended")).not.toBeInTheDocument();
@@ -346,24 +346,16 @@ describe("LandlordActiveLeasesPage", () => {
     await screen.findByText("NS Workflow Guidance:");
 
     fireEvent.click(screen.getByRole("link", { name: "Rent Increase Workflow" }));
-    expect(screen.getByTestId("current-location")).toHaveTextContent(
-      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
-    );
+    expect(screen.getByTestId("current-location")).toHaveTextContent("/leases/lease-1/workflows/rent-increase");
 
     fireEvent.click(screen.getByRole("link", { name: "Deposit Workflow" }));
-    expect(screen.getByTestId("current-location")).toHaveTextContent(
-      "/leases/lease-1/summary?section=rent-payment#lease-section-rent-payment"
-    );
+    expect(screen.getByTestId("current-location")).toHaveTextContent("/leases/lease-1/workflows/deposit");
 
     fireEvent.click(screen.getByRole("link", { name: "Notice Workflow" }));
-    expect(screen.getByTestId("current-location")).toHaveTextContent(
-      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
-    );
+    expect(screen.getByTestId("current-location")).toHaveTextContent("/leases/lease-1/workflows/notice");
 
     fireEvent.click(screen.getByRole("link", { name: "Renewal Review" }));
-    expect(screen.getByTestId("current-location")).toHaveTextContent(
-      "/leases/lease-1/summary?section=audit-events#lease-section-audit-events"
-    );
+    expect(screen.getByTestId("current-location")).toHaveTextContent("/leases/lease-1/workflows/renewal");
   });
 
   it("does not open stale GCS or app-domain lease document fallbacks when refresh fails", async () => {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -331,19 +331,23 @@ function compactPolicyActionLabel(policyKey: string, fallback: string) {
   }
 }
 
-function policySummaryHref(leaseId: string, policyKey: string) {
-  const base = `/leases/${encodeURIComponent(leaseId)}/summary`;
+function policyWorkflowHref(leaseId: string, policyKey: string) {
+  const base = `/leases/${encodeURIComponent(leaseId)}/workflows`;
   switch (policyKey) {
     case "rent_increase_workflow_availability":
+      return `${base}/rent-increase`;
     case "deposit_workflow_review":
-      return `${base}?section=rent-payment#lease-section-rent-payment`;
+      return `${base}/deposit`;
     case "lease_execution_readiness":
+      return `${base}/execution`;
     case "lease_renewal_review":
+      return `${base}/renewal`;
     case "move_out_preparation":
+      return `${base}/move-out`;
     case "notice_workflow_readiness":
-      return `${base}?section=audit-events#lease-section-audit-events`;
+      return `${base}/notice`;
     default:
-      return base;
+      return `/leases/${encodeURIComponent(leaseId)}/summary`;
   }
 }
 
@@ -371,7 +375,7 @@ function renderJurisdictionPolicyGuidance(lease: LandlordActiveLease) {
       {visiblePolicies.map((policy) => (
         <Link
           key={`${policy.policyKey}:${policy.sourceRuleKey}`}
-          to={policySummaryHref(lease.id, policy.policyKey)}
+          to={policyWorkflowHref(lease.id, policy.policyKey)}
           title={`${policy.label}: ${policy.recommendation}`}
           style={{
             display: "inline-flex",

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import LandlordLeaseWorkflowPage from "./LandlordLeaseWorkflowPage";
+
+const mocks = vi.hoisted(() => ({
+  getLeaseById: vi.fn(),
+}));
+
+vi.mock("@/api/leasesApi", () => ({
+  getLeaseById: mocks.getLeaseById,
+}));
+
+function renderWorkflow(path: string) {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/leases/:leaseId/workflows/:workflowKey" element={<LandlordLeaseWorkflowPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("LandlordLeaseWorkflowPage", () => {
+  beforeEach(() => {
+    mocks.getLeaseById.mockReset();
+    mocks.getLeaseById.mockResolvedValue({
+      lease: {
+        id: "lease-1",
+        propertyId: "prop-1",
+        propertyName: "Harbour View",
+        unitNumber: "101",
+        monthlyRent: 1850,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        status: "active",
+        tenantName: "Jane Tenant",
+        tenantEmail: "jane@example.com",
+        leaseExecution: {
+          executionStatus: "fully_executed",
+          executionLabel: "Lease fully executed",
+          executionDescription: "The visible lease record indicates the current execution flow is complete.",
+          requiredNextAction: "none",
+          tenantSignatureStatus: "completed",
+          landlordSignatureStatus: "completed",
+          pdfStatus: "generated",
+          completedAt: "2026-01-01T00:00:00.000Z",
+        },
+        paymentReadiness: {
+          readinessStatus: "ready_to_configure",
+          readinessLabel: "Rent terms ready for future setup",
+          readinessDescription: "The current lease shows the rent terms needed for a future setup workflow.",
+          requiredNextAction: "confirm_payment_setup_later",
+          rentTerms: {
+            rentAmountAvailable: true,
+            dueDateAvailable: true,
+            leaseDatesAvailable: true,
+            tenantLinked: true,
+            leaseExecuted: true,
+          },
+          paymentSetup: {
+            processorConnected: false,
+            moneyMovementEnabled: false,
+            storedPaymentMethod: false,
+          },
+        },
+        leaseLifecycleSummary: {
+          lifecycleStatus: "expiring_soon",
+          lifecycleLabel: "Expiring soon",
+          lifecycleDescription: "This lease is approaching notice timing.",
+          requiredNextAction: "prepare_renewal_notice",
+          renewalOutcome: "not_started",
+          daysUntilExpiry: 30,
+          history: [],
+        },
+        jurisdictionPolicies: [
+          {
+            jurisdiction: "NS",
+            policyKey: "rent_increase_workflow_availability",
+            status: "ok",
+            severity: "info",
+            label: "Rent increase workflow metadata available",
+            reason: "This jurisdiction has rent increase workflow metadata configured for operational review.",
+            recommendation: "Use the guided workflow as a review aid and verify current local requirements before sending notices.",
+            sourceRuleKey: "NS.rent_increase_workflow",
+            confidence: "medium",
+            legalAdvice: false,
+            disclaimer:
+              "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.",
+          },
+          {
+            jurisdiction: "NS",
+            policyKey: "deposit_workflow_review",
+            status: "review",
+            severity: "info",
+            label: "Deposit workflow review available",
+            reason: "This jurisdiction has deposit workflow metadata flagged for operational review.",
+            recommendation: "Review deposit handling as part of the lease workflow without treating this as a compliance determination.",
+            sourceRuleKey: "NS.deposit_workflow_review",
+            confidence: "medium",
+            legalAdvice: false,
+            disclaimer:
+              "RentChain provides operational workflow guidance only. It does not provide legal advice, create legal conclusions, or replace review of current provincial forms and rules.",
+          },
+        ],
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a focused rent increase workflow review", async () => {
+    renderWorkflow("/leases/lease-1/workflows/rent-increase");
+
+    expect(await screen.findByRole("heading", { name: "Rent Increase Workflow" })).toBeInTheDocument();
+    expect(screen.getByText("Review rent terms and jurisdiction-aware rent increase readiness before preparing any notice.")).toBeInTheDocument();
+    expect(screen.getByText("CA$1,850.00")).toBeInTheDocument();
+    expect(screen.getByText("Use the guided workflow as a review aid and verify current local requirements before sending notices.")).toBeInTheDocument();
+    expect(screen.getByText(/RentChain does not provide legal advice or guarantee enforceability/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Lease summary" })).toHaveAttribute("href", "/leases/lease-1/summary");
+  });
+
+  it("renders deposit as a distinct review destination", async () => {
+    renderWorkflow("/leases/lease-1/workflows/deposit");
+
+    expect(await screen.findByRole("heading", { name: "Deposit Workflow" })).toBeInTheDocument();
+    expect(screen.getByText("Review deposit handling context separately from rent collection and general lease summary details.")).toBeInTheDocument();
+    expect(screen.getByText("Review deposit handling as part of the lease workflow without treating this as a compliance determination.")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Rent Increase Workflow" })).not.toBeInTheDocument();
+  });
+
+  it("renders notice and execution workflow pages with separate purposes", async () => {
+    renderWorkflow("/leases/lease-1/workflows/notice");
+    expect(await screen.findByRole("heading", { name: "Notice Workflow" })).toBeInTheDocument();
+    expect(screen.getByText("Review notice-related lease status, lifecycle timing, and audit context before preparing a notice.")).toBeInTheDocument();
+
+    cleanup();
+    renderWorkflow("/leases/lease-1/workflows/execution");
+    expect(await screen.findByRole("heading", { name: "Execution Review" })).toBeInTheDocument();
+    expect(screen.getByText("Review the lease package, signature state, and document readiness before treating execution as complete.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1,0 +1,319 @@
+import React from "react";
+import { Link, useParams } from "react-router-dom";
+import { getLeaseById, type JurisdictionPolicyGuidance, type LandlordActiveLease } from "@/api/leasesApi";
+
+type WorkflowKey = "execution" | "rent-increase" | "notice" | "deposit" | "renewal" | "move-out";
+
+type WorkflowConfig = {
+  key: WorkflowKey;
+  title: string;
+  eyebrow: string;
+  purpose: string;
+  reviewItems: string[];
+  policyKeys: string[];
+  facts: Array<{
+    label: string;
+    value(lease: LandlordActiveLease): string;
+  }>;
+};
+
+const WORKFLOWS: Record<WorkflowKey, WorkflowConfig> = {
+  execution: {
+    key: "execution",
+    title: "Execution Review",
+    eyebrow: "Lease execution workflow",
+    purpose: "Review the lease package, signature state, and document readiness before treating execution as complete.",
+    policyKeys: ["lease_execution_readiness"],
+    facts: [
+      { label: "Execution status", value: (lease) => lease.leaseExecution?.executionLabel || "Execution status unavailable" },
+      { label: "Tenant signature", value: (lease) => lease.leaseExecution?.tenantSignatureStatus || lease.signatureStatus || "Unknown" },
+      { label: "Lease document", value: (lease) => lease.leasePdfLabel || lease.leaseExecution?.pdfStatus || "Document status unavailable" },
+    ],
+    reviewItems: [
+      "Confirm the current lease document is the intended signing package.",
+      "Confirm tenant and landlord signature state before relying on execution status.",
+      "Use the signing timeline and signed document download when available.",
+    ],
+  },
+  "rent-increase": {
+    key: "rent-increase",
+    title: "Rent Increase Workflow",
+    eyebrow: "Rent review workflow",
+    purpose: "Review rent terms and jurisdiction-aware rent increase readiness before preparing any notice.",
+    policyKeys: ["rent_increase_workflow_availability"],
+    facts: [
+      { label: "Monthly rent", value: (lease) => formatCurrency(lease.monthlyRent) },
+      { label: "Lease end", value: (lease) => formatDate(lease.endDate) },
+      { label: "Payment readiness", value: (lease) => lease.paymentReadiness?.readinessLabel || "Payment readiness unavailable" },
+    ],
+    reviewItems: [
+      "Confirm the current rent amount, lease dates, and tenancy context.",
+      "Verify current provincial notice timing and form requirements before sending anything.",
+      "Keep rent collection setup separate from rent increase notice review.",
+    ],
+  },
+  notice: {
+    key: "notice",
+    title: "Notice Workflow",
+    eyebrow: "Notice readiness workflow",
+    purpose: "Review notice-related lease status, lifecycle timing, and audit context before preparing a notice.",
+    policyKeys: ["notice_workflow_readiness"],
+    facts: [
+      { label: "Lease status", value: (lease) => prettyValue(lease.status) },
+      { label: "Lifecycle", value: (lease) => lease.leaseLifecycleSummary?.lifecycleLabel || "Lifecycle status unavailable" },
+      { label: "Next action", value: (lease) => prettyValue(lease.leaseLifecycleSummary?.requiredNextAction || "review lease context") },
+    ],
+    reviewItems: [
+      "Confirm which notice type applies before preparing a document.",
+      "Review lifecycle timing and recent lease events.",
+      "Verify delivery requirements against current provincial rules.",
+    ],
+  },
+  deposit: {
+    key: "deposit",
+    title: "Deposit Workflow",
+    eyebrow: "Deposit review workflow",
+    purpose: "Review deposit handling context separately from rent collection and general lease summary details.",
+    policyKeys: ["deposit_workflow_review"],
+    facts: [
+      { label: "Property", value: (lease) => propertyLabel(lease) },
+      { label: "Tenant", value: (lease) => lease.tenantName || "Tenant not linked" },
+      { label: "Lease dates", value: (lease) => `${formatDate(lease.startDate)} to ${formatDate(lease.endDate)}` },
+    ],
+    reviewItems: [
+      "Confirm any deposit terms against the signed lease package and current provincial requirements.",
+      "Keep deposit review distinct from monthly rent collection setup.",
+      "Use official provincial resources before making deposit deductions or claims.",
+    ],
+  },
+  renewal: {
+    key: "renewal",
+    title: "Renewal Review",
+    eyebrow: "Renewal workflow",
+    purpose: "Review lease end timing and renewal context before deciding on renewal, continuation, or move-out next steps.",
+    policyKeys: ["lease_renewal_review"],
+    facts: [
+      { label: "Lease end", value: (lease) => formatDate(lease.endDate) },
+      { label: "Lifecycle", value: (lease) => lease.leaseLifecycleSummary?.lifecycleLabel || "Lifecycle status unavailable" },
+      { label: "Days until end", value: (lease) => daysUntilEndLabel(lease) },
+    ],
+    reviewItems: [
+      "Confirm the lease end date and current occupancy context.",
+      "Review whether renewal, continuation, or move-out planning is appropriate.",
+      "Verify local requirements before preparing renewal or notice documents.",
+    ],
+  },
+  "move-out": {
+    key: "move-out",
+    title: "Move-Out Prep",
+    eyebrow: "Move-out workflow",
+    purpose: "Review lease end, notice, inspection, and deposit context before move-out follow-through.",
+    policyKeys: ["move_out_preparation"],
+    facts: [
+      { label: "Lease end", value: (lease) => formatDate(lease.endDate) },
+      { label: "Tenant", value: (lease) => lease.tenantName || "Tenant not linked" },
+      { label: "Lifecycle", value: (lease) => lease.leaseLifecycleSummary?.lifecycleLabel || "Lifecycle status unavailable" },
+    ],
+    reviewItems: [
+      "Confirm move-out timing and any required notice context.",
+      "Review inspection and deposit follow-up separately from rent collection.",
+      "Verify current provincial forms and timelines before taking action.",
+    ],
+  },
+};
+
+function workflowFromParam(value: string | undefined): WorkflowConfig {
+  if (value && Object.prototype.hasOwnProperty.call(WORKFLOWS, value)) {
+    return WORKFLOWS[value as WorkflowKey];
+  }
+  return WORKFLOWS.execution;
+}
+
+function errorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+function formatCurrency(value: number | null | undefined) {
+  const amount = typeof value === "number" ? value : 0;
+  return amount.toLocaleString(undefined, { style: "currency", currency: "CAD" });
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "Not set";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-CA", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString("en-CA", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function prettyValue(value: string | null | undefined) {
+  const normalized = String(value || "").trim();
+  if (!normalized) return "Not available";
+  return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function propertyLabel(lease: LandlordActiveLease) {
+  const property = lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property";
+  return lease.unitNumber ? `${property} · Unit ${lease.unitNumber}` : property;
+}
+
+function daysUntilEndLabel(lease: LandlordActiveLease) {
+  const days = lease.leaseLifecycleSummary?.daysUntilExpiry;
+  if (typeof days !== "number") return "Not available";
+  if (days < 0) return "Lease end has passed";
+  if (days === 0) return "Lease ends today";
+  return `${days} days`;
+}
+
+function matchingPolicy(lease: LandlordActiveLease, config: WorkflowConfig): JurisdictionPolicyGuidance | null {
+  const policies = Array.isArray(lease.jurisdictionPolicies) ? lease.jurisdictionPolicies : [];
+  return policies.find((policy) => config.policyKeys.includes(policy.policyKey)) || null;
+}
+
+export default function LandlordLeaseWorkflowPage() {
+  const { leaseId = "", workflowKey } = useParams();
+  const workflow = workflowFromParam(workflowKey);
+  const [lease, setLease] = React.useState<LandlordActiveLease | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let active = true;
+
+    async function load() {
+      if (!leaseId) {
+        setError("Missing lease id.");
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await getLeaseById(leaseId);
+        if (!active) return;
+        setLease(response.lease || null);
+      } catch (err: unknown) {
+        if (!active) return;
+        setError(errorMessage(err, "Failed to load workflow review."));
+        setLease(null);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [leaseId]);
+
+  const policy = lease ? matchingPolicy(lease, workflow) : null;
+  const summaryPath = lease ? `/leases/${encodeURIComponent(lease.id)}/summary` : `/leases/${encodeURIComponent(leaseId)}/summary`;
+  const ledgerPath = lease ? `/leases/${encodeURIComponent(lease.id)}/ledger` : `/leases/${encodeURIComponent(leaseId)}/ledger`;
+
+  return (
+    <div style={{ display: "grid", gap: 16, maxWidth: 920 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <div style={{ fontSize: 12, color: "#2563eb", fontWeight: 800, textTransform: "uppercase", letterSpacing: 0 }}>
+          {workflow.eyebrow}
+        </div>
+        <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{workflow.title}</h1>
+        <div style={{ color: "#475569", lineHeight: 1.6 }}>{workflow.purpose}</div>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <Link to="/leases" style={buttonLinkStyle}>
+          Back to leases
+        </Link>
+        <Link to={summaryPath} style={buttonLinkStyle}>
+          Lease summary
+        </Link>
+        <Link to={ledgerPath} style={buttonLinkStyle}>
+          Ledger
+        </Link>
+      </div>
+
+      {loading ? <div>Loading workflow review…</div> : null}
+      {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      {lease ? (
+        <>
+          <section style={panelStyle} aria-label="Lease facts">
+            <h2 style={sectionHeadingStyle}>{propertyLabel(lease)}</h2>
+            <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14, margin: 0 }}>
+              {workflow.facts.map((fact) => (
+                <div key={fact.label} style={{ display: "grid", gap: 4 }}>
+                  <dt style={termStyle}>{fact.label}</dt>
+                  <dd style={{ margin: 0, color: "#0f172a" }}>{fact.value(lease)}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section style={panelStyle} aria-label="Workflow review checklist">
+            <h2 style={sectionHeadingStyle}>Review before action</h2>
+            <ul style={{ margin: 0, paddingLeft: 20, display: "grid", gap: 8, color: "#334155", lineHeight: 1.55 }}>
+              {workflow.reviewItems.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section style={panelStyle} aria-label="Jurisdiction context">
+            <h2 style={sectionHeadingStyle}>Jurisdiction context</h2>
+            <div style={{ color: "#334155", lineHeight: 1.6 }}>
+              {policy ? policy.recommendation : "No specific jurisdiction policy is available for this workflow yet."}
+            </div>
+            <div style={{ marginTop: 10, color: "#475569", lineHeight: 1.6 }}>
+              Workflow guidance is operational only. Verify current provincial requirements and official forms before acting.
+              RentChain does not provide legal advice or guarantee enforceability.
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+const buttonLinkStyle: React.CSSProperties = {
+  padding: "8px 10px",
+  borderRadius: 8,
+  border: "1px solid #cbd5e1",
+  textDecoration: "none",
+  color: "#0f172a",
+  background: "#fff",
+  fontWeight: 700,
+};
+
+const panelStyle: React.CSSProperties = {
+  border: "1px solid #dbe4ee",
+  borderRadius: 8,
+  background: "#fff",
+  padding: 16,
+  display: "grid",
+  gap: 12,
+};
+
+const sectionHeadingStyle: React.CSSProperties = {
+  margin: 0,
+  color: "#0f172a",
+  fontSize: 18,
+  letterSpacing: 0,
+};
+
+const termStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 800,
+  color: "#64748b",
+  textTransform: "uppercase",
+  letterSpacing: 0,
+};


### PR DESCRIPTION
## Summary
- Adds focused landlord lease workflow review pages for execution, rent increase, notice, deposit, renewal, and move-out review.
- Routes compact `/leases` workflow buttons to those dedicated destinations instead of the generic lease summary.
- Keeps the lease panel compact and preserves operational/legal boundary copy without adding workflow automation.

## Validation
- `npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx`
- `npm run test:single -- src/pages/LandlordLeaseWorkflowPage.test.tsx`
- `npm run test:single -- src/pages/LandlordLeaseSummaryPage.test.tsx`
- `npm run build`
- `git diff --check`

## Preview QA
Required before merge: authenticated preview QA should confirm each compact workflow button lands on a distinct focused review page and existing lease actions still work.