### PR TITLE
feat: place signing fields on lease signature lines

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1194,6 +1194,25 @@ describe("leaseRoutes GET /active", () => {
         templateVersion: "ca-ns-primary-lease-draft-v1",
         jurisdictionCode: "CA_NS",
         providerAccessUrlExpiresAt: "2026-01-01T04:00:00.000Z",
+        signingFieldPlacement: {
+          provider: "dropbox_sign",
+          placementVersion: "dropbox_sign_form_fields_v1",
+          fields: [
+            {
+              apiId: "tenant_signature",
+              type: "signature",
+              signerRole: "tenant",
+              signerIndex: 0,
+              documentIndex: 0,
+              page: 2,
+              x: 170,
+              y: 165,
+              width: 270,
+              height: 52,
+              required: true,
+            },
+          ],
+        },
       },
     });
     seedDoc("leases", "lease-1", {
@@ -1329,6 +1348,7 @@ describe("leaseRoutes GET /active", () => {
       })
     );
     expect(requests[0].data.documentUrl).toBeUndefined();
+    expect(requests[0].data.signingFieldPlacement).toBeUndefined();
     expect(JSON.stringify(requests)).not.toContain("https://signed.example.com/provider-readable-lease.pdf");
     expect(JSON.stringify(requests)).not.toContain("X-Goog-Expires=1");
     expect(writeCanonicalEventMock).toHaveBeenCalledTimes(1);

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -3278,6 +3278,7 @@ router.post("/:leaseId/send-for-signature", requireLandlord, async (req: any, re
         templateVersion: lockedDocument.document.templateVersion,
         jurisdictionCode: lockedDocument.document.jurisdictionCode,
         providerAccessUrlExpiresAt: lockedDocument.document.providerAccessUrlExpiresAt,
+        signingFieldPlacement: lockedDocument.document.signingFieldPlacement || null,
       },
     });
     return res.status(200).json({

--- a/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
@@ -135,8 +135,30 @@ describe("leaseDocumentService", () => {
     expect(document.documentHash).toMatch(/^[a-f0-9]{64}$/);
     expect(document.manifestHash).toMatch(/^[a-f0-9]{64}$/);
     expect(document.storageRef).toBeNull();
+    expect((document as any).signingFieldPlacement).toBeUndefined();
     expect(JSON.stringify(document)).not.toContain("lease-documents/");
     expect(listDocs("leaseDocuments")).toHaveLength(1);
+    expect(listDocs("leaseDocuments")[0].data.signingFieldPlacement).toEqual(
+      expect.objectContaining({
+        provider: "dropbox_sign",
+        placementVersion: "dropbox_sign_form_fields_v1",
+        landlordPlacementPrepared: true,
+        fields: expect.arrayContaining([
+          expect.objectContaining({
+            apiId: "tenant_signature",
+            type: "signature",
+            signerRole: "tenant",
+            signerIndex: 0,
+          }),
+          expect.objectContaining({
+            apiId: "tenant_date_signed",
+            type: "date_signed",
+            signerRole: "tenant",
+            signerIndex: 0,
+          }),
+        ]),
+      })
+    );
     expect(writeCanonicalEventMock).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "lease_document_generated",

--- a/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
+++ b/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
@@ -1,5 +1,9 @@
 import PDFDocument from "pdfkit";
-import type { JurisdictionLeaseDocumentAdapter, PrimaryLeaseDocumentInput } from "../leaseDocumentTypes";
+import type {
+  JurisdictionLeaseDocumentAdapter,
+  LeaseDocumentSigningFieldPlacement,
+  PrimaryLeaseDocumentInput,
+} from "../leaseDocumentTypes";
 
 function text(value: unknown, fallback = "Not provided") {
   const next = String(value ?? "").trim();
@@ -22,6 +26,44 @@ function collectPdf(write: (doc: PDFKit.PDFDocument) => void): Promise<Buffer> {
     write(doc);
     doc.end();
   });
+}
+
+function buildDropboxSignPlacement(signaturePage: number): LeaseDocumentSigningFieldPlacement {
+  return {
+    provider: "dropbox_sign",
+    placementVersion: "dropbox_sign_form_fields_v1",
+    landlordPlacementPrepared: true,
+    fields: [
+      {
+        apiId: "tenant_signature",
+        type: "signature",
+        signerRole: "tenant",
+        signerIndex: 0,
+        documentIndex: 0,
+        page: signaturePage,
+        x: 170,
+        y: 165,
+        width: 270,
+        height: 52,
+        required: true,
+        name: "Tenant signature",
+      },
+      {
+        apiId: "tenant_date_signed",
+        type: "date_signed",
+        signerRole: "tenant",
+        signerIndex: 0,
+        documentIndex: 0,
+        page: signaturePage,
+        x: 455,
+        y: 175,
+        width: 92,
+        height: 28,
+        required: true,
+        name: "Tenant date signed",
+      },
+    ],
+  };
 }
 
 export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
@@ -80,7 +122,12 @@ export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
   ],
   sourceReferences: ["Nova Scotia Form P Standard Lease Form reference upload"],
   async renderPrimaryLeasePdf(input: PrimaryLeaseDocumentInput) {
-    return collectPdf((doc) => {
+    let pageNumber = 1;
+    let signaturePage = 1;
+    const pdfBuffer = await collectPdf((doc) => {
+      doc.on("pageAdded", () => {
+        pageNumber += 1;
+      });
       const lease = input.lease || {};
       const property = input.property || {};
       const unit = input.unit || {};
@@ -160,13 +207,35 @@ export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
       section("Attachments");
       doc.text("Schedule A statutory conditions and addenda must be attached/initialed where required and do not replace this primary lease document.");
 
-      section("Signature Acknowledgement");
-      doc.text("Tenant signature: _______________________________   Date: ______________");
-      doc.moveDown(0.5);
-      doc.text("Landlord signature: _____________________________   Date: ______________");
+      doc.addPage();
+      signaturePage = pageNumber;
+      doc.fontSize(16).fillColor("#111").text("Sign and Date", { align: "center" });
+      doc.moveDown(0.7);
+      doc.fontSize(10).text("Review the lease details and applicable provincial requirements before signing. RentChain does not provide legal advice or guarantee enforceability.");
+
+      doc.moveDown(2);
+      doc.font("Helvetica-Bold").fontSize(10).text("Tenant signature", 72, 150);
+      doc.font("Helvetica").moveTo(170, 207).lineTo(440, 207).stroke("#111");
+      doc.text("Date", 455, 150);
+      doc.moveTo(455, 207).lineTo(547, 207).stroke("#111");
+
+      doc.font("Helvetica-Bold").text("Landlord signature", 72, 245);
+      doc.font("Helvetica").moveTo(170, 302).lineTo(440, 302).stroke("#111");
+      doc.text("Date", 455, 245);
+      doc.moveTo(455, 302).lineTo(547, 302).stroke("#111");
+      doc.fontSize(8).fillColor("#555").text(
+        "Landlord signature placement is prepared for a future countersignature flow. The current Dropbox Sign request places the tenant signature and signing date.",
+        72,
+        330,
+        { width: 476 }
+      );
 
       doc.moveDown();
       doc.fontSize(8).fillColor("#555").text("This generated draft is provided for workflow testing. It is not legal advice, certification, notarization, or an enforceability guarantee.");
     });
+    return {
+      pdfBuffer,
+      signingFieldPlacement: buildDropboxSignPlacement(signaturePage),
+    };
   },
 };

--- a/rentchain-api/src/services/leaseDocuments/leaseDocumentService.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseDocumentService.ts
@@ -46,8 +46,9 @@ function tenantIdsFromLease(lease: Record<string, any>) {
 }
 
 function safeProjection(doc: LeaseDocumentMetadata, previewUrl?: string | null): LeaseDocumentProjection {
+  const { signingFieldPlacement: _signingFieldPlacement, ...projected } = doc;
   return {
-    ...doc,
+    ...projected,
     storageRef: null,
     previewUrl: previewUrl || null,
   };
@@ -162,7 +163,9 @@ export async function generatePrimaryLeaseDocument(input: PrimaryLeaseDocumentIn
     throw error;
   }
 
-  const pdfBuffer = await adapter.renderPrimaryLeasePdf(input);
+  const rendered = await adapter.renderPrimaryLeasePdf(input);
+  const pdfBuffer = Buffer.isBuffer(rendered) ? rendered : rendered.pdfBuffer;
+  const signingFieldPlacement = Buffer.isBuffer(rendered) ? null : rendered.signingFieldPlacement || null;
   const documentHash = digest(pdfBuffer);
   const generatedAt = nowIso();
   const tenantIds = tenantIdsFromLease(lease);
@@ -223,6 +226,7 @@ export async function generatePrimaryLeaseDocument(input: PrimaryLeaseDocumentIn
     lockedAt: null,
     lockedBy: null,
     signingRequestId: null,
+    signingFieldPlacement,
     sourceSummary: {
       adapterStatus: adapter.counselReviewStatus,
       signingEnabled: adapter.signingEnabled,

--- a/rentchain-api/src/services/leaseDocuments/leaseDocumentTypes.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseDocumentTypes.ts
@@ -15,6 +15,28 @@ export type LeaseDocumentStorageRef = {
   path: string;
 };
 
+export type LeaseDocumentSigningPlacementField = {
+  apiId: string;
+  type: "signature" | "date_signed";
+  signerRole: "tenant" | "landlord";
+  signerIndex: number;
+  documentIndex: number;
+  page: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  required: boolean;
+  name?: string;
+};
+
+export type LeaseDocumentSigningFieldPlacement = {
+  provider: "dropbox_sign";
+  placementVersion: "dropbox_sign_form_fields_v1";
+  fields: LeaseDocumentSigningPlacementField[];
+  landlordPlacementPrepared: boolean;
+};
+
 export type LeaseDocumentMetadata = {
   id: string;
   leaseId: string;
@@ -36,6 +58,7 @@ export type LeaseDocumentMetadata = {
   lockedAt: string | null;
   lockedBy: string | null;
   signingRequestId: string | null;
+  signingFieldPlacement?: LeaseDocumentSigningFieldPlacement | null;
   supersededAt?: string | null;
   supersededByDocumentId?: string | null;
   sourceSummary: {
@@ -47,7 +70,7 @@ export type LeaseDocumentMetadata = {
   };
 };
 
-export type LeaseDocumentProjection = Omit<LeaseDocumentMetadata, "storageRef"> & {
+export type LeaseDocumentProjection = Omit<LeaseDocumentMetadata, "storageRef" | "signingFieldPlacement"> & {
   storageRef: null;
   previewUrl?: string | null;
 };
@@ -76,5 +99,11 @@ export type JurisdictionLeaseDocumentAdapter = {
   languageRequirements: string[];
   statutoryReferences: string[];
   sourceReferences: string[];
-  renderPrimaryLeasePdf(input: PrimaryLeaseDocumentInput): Promise<Buffer>;
+  renderPrimaryLeasePdf(input: PrimaryLeaseDocumentInput): Promise<
+    | Buffer
+    | {
+        pdfBuffer: Buffer;
+        signingFieldPlacement?: LeaseDocumentSigningFieldPlacement | null;
+      }
+  >;
 };

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -5,7 +5,7 @@ import { uploadBufferToGcs } from "../../lib/gcs";
 import { writeCanonicalEvent } from "../../lib/events/buildEvent";
 import { deriveLeaseSigningState, type DerivedLeaseSigningState } from "../leaseStateHelper";
 import { getConfiguredSigningProvider, signingProviderRegistry } from "./providers";
-import type { ISigningProvider, SigningProviderEventType } from "./providers/types";
+import type { ISigningProvider, SigningProviderEventType, SigningProviderFieldPlacement } from "./providers/types";
 
 export type LeaseSigningStatus =
   | "not_started"
@@ -265,6 +265,7 @@ async function appendSigningEvent(input: {
     templateVersion?: string | null;
     jurisdictionCode?: string | null;
     providerAccessUrlExpiresAt?: string | null;
+    signingFieldPlacement?: SigningProviderFieldPlacement | null;
   } | null;
 }) {
   const occurredAt = input.occurredAt || nowIso();
@@ -433,6 +434,7 @@ export async function sendLeaseForSignature(input: {
     templateVersion?: string | null;
     jurisdictionCode?: string | null;
     providerAccessUrlExpiresAt?: string | null;
+    signingFieldPlacement?: SigningProviderFieldPlacement | null;
   } | null;
 }) {
   const provider = getConfiguredSigningProvider();
@@ -461,6 +463,7 @@ export async function sendLeaseForSignature(input: {
     signers: emails.map((email) => ({ email, role: "tenant" as const })),
     callbackUrl: process.env.SIGNING_PROVIDER_CALLBACK_URL || process.env.SIGNING_CALLBACK_URL || null,
     returnUrl: signingReturnUrl(),
+    fieldPlacement: input.documentMetadata?.signingFieldPlacement || null,
   });
   const providerId = provider.getProviderId();
   const requestId = requestIdFor(input.landlordId, input.leaseId, providerId);

--- a/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
+++ b/rentchain-api/src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
@@ -78,6 +78,54 @@ describe("DropboxSignProvider", () => {
       message: "Please sign.",
       callbackUrl: "https://api.example.com/api/webhooks/signing/dropbox_sign",
       returnUrl: "https://app.example.com/signing/complete",
+      fieldPlacement: {
+        provider: "dropbox_sign",
+        placementVersion: "dropbox_sign_form_fields_v1",
+        fields: [
+          {
+            apiId: "tenant_signature",
+            type: "signature",
+            signerRole: "tenant",
+            signerIndex: 0,
+            documentIndex: 0,
+            page: 2,
+            x: 170,
+            y: 165,
+            width: 270,
+            height: 52,
+            required: true,
+            name: "Tenant signature",
+          },
+          {
+            apiId: "tenant_date_signed",
+            type: "date_signed",
+            signerRole: "tenant",
+            signerIndex: 0,
+            documentIndex: 0,
+            page: 2,
+            x: 455,
+            y: 175,
+            width: 92,
+            height: 28,
+            required: true,
+            name: "Tenant date signed",
+          },
+          {
+            apiId: "landlord_signature",
+            type: "signature",
+            signerRole: "landlord",
+            signerIndex: 1,
+            documentIndex: 0,
+            page: 2,
+            x: 170,
+            y: 260,
+            width: 270,
+            height: 52,
+            required: false,
+            name: "Landlord signature",
+          },
+        ],
+      },
     });
 
     expect(signatureRequestSendMock).toHaveBeenCalledWith(
@@ -86,8 +134,28 @@ describe("DropboxSignProvider", () => {
         testMode: true,
         signingRedirectUrl: "https://app.example.com/signing/complete",
         metadata: { leaseId: "lease-1", landlordId: "landlord-1" },
+        formFieldsPerDocument: [
+          expect.objectContaining({
+            apiId: "tenant_signature",
+            type: "signature",
+            signer: 0,
+            page: 2,
+            x: 170,
+            y: 165,
+          }),
+          expect.objectContaining({
+            apiId: "tenant_date_signed",
+            type: "date_signed",
+            signer: 0,
+            page: 2,
+            x: 455,
+            y: 175,
+          }),
+        ],
       })
     );
+    expect(signatureRequestSendMock.mock.calls[0]?.[0]?.formFieldsPerDocument).toHaveLength(2);
+    expect(JSON.stringify(signatureRequestSendMock.mock.calls[0]?.[0]?.formFieldsPerDocument)).not.toContain("landlord_signature");
     expect(signatureRequestSendMock.mock.calls[0]?.[0]?.signingRedirectUrl).not.toContain("/api/webhooks/signing");
     expect(result).toEqual(
       expect.objectContaining({

--- a/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
+++ b/rentchain-api/src/services/signing/providers/dropboxSignProvider.ts
@@ -36,6 +36,27 @@ function validProviderReadableUrl(value: unknown) {
   }
 }
 
+function buildFormFieldsPerDocument(input: SigningProviderSendInput) {
+  if (input.fieldPlacement?.provider !== "dropbox_sign") return undefined;
+  const maxSignerIndex = input.signers.length - 1;
+  const fields = (input.fieldPlacement.fields || [])
+    .filter((field) => field.signerIndex >= 0 && field.signerIndex <= maxSignerIndex)
+    .map((field) => ({
+      documentIndex: field.documentIndex,
+      apiId: field.apiId,
+      type: field.type,
+      signer: field.signerIndex,
+      page: field.page,
+      x: field.x,
+      y: field.y,
+      width: field.width,
+      height: field.height,
+      required: field.required,
+      name: field.name,
+    }));
+  return fields.length ? fields : undefined;
+}
+
 function eventTimeToIso(value: unknown) {
   const raw = String(value || "").trim();
   const numeric = Number(raw);
@@ -113,6 +134,7 @@ export class DropboxSignProvider implements ISigningProvider {
       apiCaller.username = String(process.env.SIGNING_PROVIDER_API_KEY || "").trim();
       const testMode = boolEnv(process.env.SIGNING_PROVIDER_TEST_MODE);
       const returnUrl = String(input.returnUrl || "").trim() || undefined;
+      const formFieldsPerDocument = buildFormFieldsPerDocument(input);
       const request = {
         title: input.title.slice(0, 255),
         subject: input.title.slice(0, 255),
@@ -135,6 +157,7 @@ export class DropboxSignProvider implements ISigningProvider {
           phone: false,
           defaultType: "type",
         },
+        ...(formFieldsPerDocument ? { formFieldsPerDocument } : {}),
         ...(returnUrl ? { signingRedirectUrl: returnUrl } : {}),
       };
       const response = await apiCaller.signatureRequestSend(request as any);

--- a/rentchain-api/src/services/signing/providers/types.ts
+++ b/rentchain-api/src/services/signing/providers/types.ts
@@ -16,6 +16,25 @@ export type SigningProviderSigner = {
   role?: "tenant" | "landlord";
 };
 
+export type SigningProviderFieldPlacement = {
+  provider: "dropbox_sign";
+  placementVersion: "dropbox_sign_form_fields_v1";
+  fields: Array<{
+    apiId: string;
+    type: "signature" | "date_signed";
+    signerRole: "tenant" | "landlord";
+    signerIndex: number;
+    documentIndex: number;
+    page: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    required: boolean;
+    name?: string;
+  }>;
+};
+
 export type SigningProviderSendInput = {
   leaseId: string;
   landlordId: string;
@@ -25,6 +44,7 @@ export type SigningProviderSendInput = {
   signers: SigningProviderSigner[];
   callbackUrl?: string | null;
   returnUrl?: string | null;
+  fieldPlacement?: SigningProviderFieldPlacement | null;
 };
 
 export type SigningProviderSendResult = {


### PR DESCRIPTION
## Summary
- add internal primary lease signing field placement metadata for Dropbox Sign
- place tenant signature/date fields on the generated CA_NS lease signature page instead of relying on Dropbox Sign's appended signature page
- prepare landlord signature line visually for a future countersignature flow without changing current signer lifecycle

## Validation
- npm run test -- --run src/services/signing/providers/__tests__/dropboxSignProvider.test.ts
- npm run test -- --run src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
- npm run test -- --run src/routes/__tests__/leaseRoutes.active.test.ts
- npm run build
- git diff --check

## QA Required
- deploy backend preview/Cloud Run for this PR head
- generate a primary lease PDF
- send Dropbox Sign sandbox request
- confirm tenant signature lands on the tenant signature line and no extra Dropbox-only signature page is used
- confirm webhook lifecycle, return route, and signed document download still work

## Scope Notes
- landlord countersignature placement is prepared visually but not sent until a landlord signer exists
- no changes to webhook ack, return route, signed document URL handling, workflow review routes, or CA_NS legal gating