### PR TITLE
feat: add Nova Scotia Form P readiness capture

### DIFF
--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -3195,6 +3195,10 @@ async function buildPrimaryLeaseDocumentContext(leaseId: string, lease: any, req
     tenants: tenantSnaps
       .filter((snap: any) => snap?.exists)
       .map((snap: any) => ({ id: snap.id, ...snap.data() })),
+    formPFields:
+      req.body?.formPFields && typeof req.body.formPFields === "object" && !Array.isArray(req.body.formPFields)
+        ? req.body.formPFields
+        : null,
     actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
   };
 }

--- a/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts
@@ -135,6 +135,20 @@ describe("leaseDocumentService", () => {
     expect(document.documentHash).toMatch(/^[a-f0-9]{64}$/);
     expect(document.manifestHash).toMatch(/^[a-f0-9]{64}$/);
     expect(document.storageRef).toBeNull();
+    expect(document.leaseReadiness).toEqual(
+      expect.objectContaining({
+        version: "ns_form_p_readiness_v1",
+        jurisdictionCode: "CA_NS",
+        overallStatus: expect.any(String),
+        completionPercent: expect.any(Number),
+      })
+    );
+    expect(document.formPFields?.parties?.landlord_legal_name).toEqual(
+      expect.objectContaining({ status: "provided", value: "Landlord" })
+    );
+    expect(document.formPFields?.premises?.unit_number).toEqual(
+      expect.objectContaining({ status: "provided", value: "101" })
+    );
     expect((document as any).signingFieldPlacement).toBeUndefined();
     expect(JSON.stringify(document)).not.toContain("lease-documents/");
     expect(listDocs("leaseDocuments")).toHaveLength(1);
@@ -165,8 +179,45 @@ describe("leaseDocumentService", () => {
         metadata: expect.objectContaining({
           templateEffectiveDate: "2026-06-15",
           sourceReferences: ["Nova Scotia Form P Standard Lease Form reference upload"],
+          leaseReadiness: expect.objectContaining({
+            version: "ns_form_p_readiness_v1",
+            completionPercent: expect.any(Number),
+            sectionStatuses: expect.arrayContaining([
+              expect.objectContaining({ key: "parties", status: expect.any(String) }),
+            ]),
+          }),
         }),
       })
+    );
+  });
+
+  it("persists explicit Form P not applicable states on generated primary lease documents", async () => {
+    const { generatePrimaryLeaseDocument } = await import("../leaseDocumentService");
+    const document = await generatePrimaryLeaseDocument({
+      leaseId: "lease-1",
+      lease: lease(),
+      landlord: { name: "Landlord" },
+      property: { name: "Harbour View" },
+      unit: { unitNumber: "101" },
+      tenants: [{ fullName: "Tenant One" }],
+      actorId: "actor-1",
+      formPFields: {
+        term: {
+          public_housing: { status: "not_applicable" },
+        },
+        premises: {
+          agent: { status: "not_applicable" },
+        },
+      },
+    });
+
+    expect(document.formPFields?.term?.public_housing.status).toBe("not_applicable");
+    expect(document.formPFields?.premises?.agent.status).toBe("not_applicable");
+    expect(document.leaseReadiness?.nonBlockingItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldKey: "public_housing", status: "not_applicable" }),
+        expect.objectContaining({ fieldKey: "agent", status: "not_applicable" }),
+      ])
     );
   });
 

--- a/rentchain-api/src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { deriveNovaScotiaFormPReadiness } from "../leaseFormPReadiness";
+
+function baseInput(overrides: Record<string, any> = {}) {
+  return {
+    leaseId: "lease-1",
+    lease: {
+      landlordId: "landlord-1",
+      tenantIds: ["tenant-1"],
+      province: "NS",
+      unitNumber: "6",
+      startDate: "2026-07-01",
+      endDate: "2027-06-30",
+      termType: "fixed",
+      baseRentCents: 180000,
+      dueDay: 1,
+      paymentMethod: "etransfer",
+      utilitiesIncluded: ["water"],
+      depositCents: 90000,
+      ...overrides.lease,
+    },
+    landlord: {
+      displayName: "Oxford Landlord",
+      email: "landlord@example.com",
+      ...overrides.landlord,
+    },
+    property: {
+      addressLine1: "10 Coburg Rd",
+      city: "Halifax",
+      province: "NS",
+      postalCode: "B3H 1Y9",
+      propertyType: "apartment",
+      ...overrides.property,
+    },
+    unit: {
+      unitNumber: "6",
+      ...overrides.unit,
+    },
+    tenants: Object.prototype.hasOwnProperty.call(overrides, "tenants")
+      ? overrides.tenants
+      : [
+          {
+            fullName: "Tenant One",
+            email: "tenant@example.com",
+            phone: "902-555-0100",
+          },
+        ],
+    formPFields: overrides.formPFields || null,
+  } as any;
+}
+
+describe("deriveNovaScotiaFormPReadiness", () => {
+  it("derives provided core Form P fields from lease, landlord, property, unit, and tenant data", () => {
+    const result = deriveNovaScotiaFormPReadiness(baseInput());
+
+    expect(result.formPFields.parties.landlord_legal_name.status).toBe("provided");
+    expect(result.formPFields.parties.tenant_names.value).toEqual(["Tenant One"]);
+    expect(result.formPFields.premises.full_civic_address.value).toContain("10 Coburg Rd");
+    expect(result.formPFields.term.start_date.status).toBe("provided");
+    expect(result.formPFields.rent_payments.rent_amount.status).toBe("provided");
+    expect(result.leaseReadiness.version).toBe("ns_form_p_readiness_v1");
+    expect(result.leaseReadiness.completionPercent).toBeGreaterThan(30);
+  });
+
+  it("supports explicit not applicable and pending states for conditional fields", () => {
+    const result = deriveNovaScotiaFormPReadiness(
+      baseInput({
+        formPFields: {
+          premises: {
+            agent: { status: "not_applicable", note: "No agent for this lease." },
+            building_superintendent: { status: "pending" },
+          },
+          term: {
+            public_housing: { status: "not_applicable" },
+          },
+        },
+      })
+    );
+
+    expect(result.formPFields.premises.agent.status).toBe("not_applicable");
+    expect(result.formPFields.premises.building_superintendent.status).toBe("pending");
+    expect(result.formPFields.term.public_housing.status).toBe("not_applicable");
+    expect(result.leaseReadiness.nonBlockingItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldKey: "agent", status: "not_applicable" }),
+        expect.objectContaining({ fieldKey: "building_superintendent", status: "pending" }),
+      ])
+    );
+  });
+
+  it("marks missing required fields as blocking readiness items", () => {
+    const result = deriveNovaScotiaFormPReadiness(
+      baseInput({
+        lease: {
+          startDate: "",
+          baseRentCents: null,
+          dueDay: null,
+          paymentMethod: "",
+        },
+        tenants: [],
+      })
+    );
+
+    expect(result.leaseReadiness.overallStatus).toBe("incomplete");
+    expect(result.leaseReadiness.blockingItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldKey: "tenant_names" }),
+        expect.objectContaining({ fieldKey: "start_date" }),
+        expect.objectContaining({ fieldKey: "rent_amount" }),
+        expect.objectContaining({ fieldKey: "due_day" }),
+        expect.objectContaining({ fieldKey: "payment_method" }),
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/services/leaseDocuments/leaseDocumentService.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseDocumentService.ts
@@ -3,6 +3,7 @@ import { db, FieldValue } from "../../firebase";
 import { getSignedDownloadUrl } from "../../lib/gcsSignedUrl";
 import { writeCanonicalEvent } from "../../lib/events/buildEvent";
 import { putPdfObject } from "../../storage/pdfStore";
+import { deriveNovaScotiaFormPReadiness } from "./leaseFormPReadiness";
 import {
   assertAdapterAllowedForGeneration,
   assertAdapterAllowedForSigning,
@@ -103,6 +104,20 @@ async function writeLeaseDocumentEvent(params: {
       documentHash: params.document.documentHash,
       manifestHash: params.document.manifestHash,
       status: params.document.status,
+      leaseReadiness: params.document.leaseReadiness
+        ? {
+            version: params.document.leaseReadiness.version,
+            overallStatus: params.document.leaseReadiness.overallStatus,
+            completionPercent: params.document.leaseReadiness.completionPercent,
+            missingFieldCount: params.document.leaseReadiness.missingFields.length,
+            blockingItemCount: params.document.leaseReadiness.blockingItems.length,
+            sectionStatuses: params.document.leaseReadiness.sectionStatuses.map((section) => ({
+              key: section.key,
+              status: section.status,
+              completionPercent: section.completionPercent,
+            })),
+          }
+        : null,
     },
   });
 }
@@ -164,6 +179,10 @@ export async function generatePrimaryLeaseDocument(input: PrimaryLeaseDocumentIn
   }
 
   const rendered = await adapter.renderPrimaryLeasePdf(input);
+  const { formPFields, leaseReadiness } =
+    adapter.jurisdictionCode === "CA_NS"
+      ? deriveNovaScotiaFormPReadiness(input)
+      : { formPFields: null, leaseReadiness: null };
   const pdfBuffer = Buffer.isBuffer(rendered) ? rendered : rendered.pdfBuffer;
   const signingFieldPlacement = Buffer.isBuffer(rendered) ? null : rendered.signingFieldPlacement || null;
   const documentHash = digest(pdfBuffer);
@@ -227,6 +246,8 @@ export async function generatePrimaryLeaseDocument(input: PrimaryLeaseDocumentIn
     lockedBy: null,
     signingRequestId: null,
     signingFieldPlacement,
+    formPFields,
+    leaseReadiness,
     sourceSummary: {
       adapterStatus: adapter.counselReviewStatus,
       signingEnabled: adapter.signingEnabled,

--- a/rentchain-api/src/services/leaseDocuments/leaseDocumentTypes.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseDocumentTypes.ts
@@ -37,6 +37,53 @@ export type LeaseDocumentSigningFieldPlacement = {
   landlordPlacementPrepared: boolean;
 };
 
+export type FormPFieldStatus = "provided" | "not_applicable" | "pending" | "missing";
+
+export type FormPSectionKey =
+  | "parties"
+  | "premises"
+  | "term"
+  | "rent_payments"
+  | "security_deposit"
+  | "service_notices"
+  | "rules_addenda"
+  | "attachments_condition_report"
+  | "signatures_delivery";
+
+export type FormPFieldEntry = {
+  key: string;
+  label: string;
+  status: FormPFieldStatus;
+  value?: string | number | boolean | string[] | null;
+  note?: string | null;
+};
+
+export type FormPSectionReadiness = {
+  key: FormPSectionKey;
+  label: string;
+  status: "complete" | "incomplete" | "not_applicable" | "pending";
+  completionPercent: number;
+  fields: FormPFieldEntry[];
+};
+
+export type FormPLeaseReadiness = {
+  version: "ns_form_p_readiness_v1";
+  jurisdictionCode: "CA_NS";
+  overallStatus: "complete" | "incomplete" | "pending";
+  completionPercent: number;
+  missingFields: Array<{ sectionKey: FormPSectionKey; fieldKey: string; label: string }>;
+  blockingItems: Array<{ sectionKey: FormPSectionKey; fieldKey: string; label: string }>;
+  nonBlockingItems: Array<{
+    sectionKey: FormPSectionKey;
+    fieldKey: string;
+    label: string;
+    status: Extract<FormPFieldStatus, "pending" | "not_applicable">;
+  }>;
+  sectionStatuses: FormPSectionReadiness[];
+};
+
+export type FormPStructuredFields = Record<FormPSectionKey, Record<string, FormPFieldEntry>>;
+
 export type LeaseDocumentMetadata = {
   id: string;
   leaseId: string;
@@ -59,6 +106,8 @@ export type LeaseDocumentMetadata = {
   lockedBy: string | null;
   signingRequestId: string | null;
   signingFieldPlacement?: LeaseDocumentSigningFieldPlacement | null;
+  formPFields?: FormPStructuredFields | null;
+  leaseReadiness?: FormPLeaseReadiness | null;
   supersededAt?: string | null;
   supersededByDocumentId?: string | null;
   sourceSummary: {
@@ -82,6 +131,7 @@ export type PrimaryLeaseDocumentInput = {
   property: Record<string, any> | null;
   unit: Record<string, any> | null;
   tenants: Array<Record<string, any>>;
+  formPFields?: Record<string, any> | null;
   actorId?: string | null;
 };
 

--- a/rentchain-api/src/services/leaseDocuments/leaseFormPReadiness.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseFormPReadiness.ts
@@ -1,0 +1,229 @@
+import type {
+  FormPFieldEntry,
+  FormPFieldStatus,
+  FormPLeaseReadiness,
+  FormPSectionKey,
+  FormPSectionReadiness,
+  FormPStructuredFields,
+  PrimaryLeaseDocumentInput,
+} from "./leaseDocumentTypes";
+
+type FieldSpec = {
+  sectionKey: FormPSectionKey;
+  fieldKey: string;
+  label: string;
+  value?: unknown;
+  required?: boolean;
+  conditional?: boolean;
+  note?: string | null;
+};
+
+const SECTION_LABELS: Record<FormPSectionKey, string> = {
+  parties: "Parties",
+  premises: "Premises",
+  term: "Term",
+  rent_payments: "Rent & Payments",
+  security_deposit: "Security Deposit",
+  service_notices: "Service & Notices",
+  rules_addenda: "Rules & Addenda",
+  attachments_condition_report: "Attachments / Condition Report",
+  signatures_delivery: "Signatures / Delivery",
+};
+
+const SECTION_ORDER = Object.keys(SECTION_LABELS) as FormPSectionKey[];
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function firstNonEmpty(...values: unknown[]) {
+  for (const value of values) {
+    const cleaned = cleanString(value);
+    if (cleaned) return cleaned;
+  }
+  return "";
+}
+
+function asList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => cleanString(item, 240)).filter(Boolean);
+}
+
+function hasValue(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some((item) => hasValue(item));
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "boolean") return true;
+  return cleanString(value).length > 0;
+}
+
+function overrideFor(overrides: Record<string, any> | null | undefined, sectionKey: FormPSectionKey, fieldKey: string) {
+  const section = overrides?.[sectionKey];
+  if (!section || typeof section !== "object") return null;
+  const value = section[fieldKey];
+  if (value == null) return null;
+  if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, any>;
+  return { value };
+}
+
+function fieldFromSpec(spec: FieldSpec, overrides?: Record<string, any> | null): FormPFieldEntry {
+  const override = overrideFor(overrides, spec.sectionKey, spec.fieldKey);
+  const overrideStatus = cleanString(override?.status, 40) as FormPFieldStatus;
+  const allowed = new Set<FormPFieldStatus>(["provided", "not_applicable", "pending", "missing"]);
+  if (allowed.has(overrideStatus)) {
+    return {
+      key: spec.fieldKey,
+      label: spec.label,
+      status: overrideStatus,
+      value: overrideStatus === "not_applicable" ? null : override?.value ?? spec.value ?? null,
+      note: cleanString(override?.note || spec.note || "") || null,
+    };
+  }
+
+  const value = override?.value ?? spec.value;
+  const status: FormPFieldStatus = hasValue(value) ? "provided" : spec.conditional ? "pending" : "missing";
+  return {
+    key: spec.fieldKey,
+    label: spec.label,
+    status,
+    value: hasValue(value) ? (Array.isArray(value) ? asList(value) : (value as any)) : null,
+    note: cleanString(override?.note || spec.note || "") || null,
+  };
+}
+
+function sectionStatus(fields: FormPFieldEntry[]): FormPSectionReadiness["status"] {
+  if (fields.length && fields.every((field) => field.status === "not_applicable")) return "not_applicable";
+  if (fields.some((field) => field.status === "missing")) return "incomplete";
+  if (fields.some((field) => field.status === "pending")) return "pending";
+  return "complete";
+}
+
+function completionPercent(fields: FormPFieldEntry[]): number {
+  if (!fields.length) return 100;
+  const complete = fields.filter((field) => field.status === "provided" || field.status === "not_applicable").length;
+  return Math.round((complete / fields.length) * 100);
+}
+
+export function deriveNovaScotiaFormPReadiness(input: PrimaryLeaseDocumentInput): {
+  formPFields: FormPStructuredFields;
+  leaseReadiness: FormPLeaseReadiness;
+} {
+  const lease = input.lease || {};
+  const landlord = input.landlord || {};
+  const property = input.property || {};
+  const unit = input.unit || {};
+  const tenants = input.tenants || [];
+  const overrides = input.formPFields || null;
+  const tenantNames = tenants
+    .map((tenant) => firstNonEmpty(tenant.fullName, tenant.name, tenant.displayName, tenant.email))
+    .filter(Boolean);
+  const tenantEmails = tenants.map((tenant) => firstNonEmpty(tenant.email, tenant.serviceEmail)).filter(Boolean);
+  const tenantPhones = tenants.map((tenant) => firstNonEmpty(tenant.phone, tenant.phoneNumber)).filter(Boolean);
+  const unitNumber = firstNonEmpty(unit.unitNumber, unit.label, lease.unitNumber);
+  const fullAddress = [
+    firstNonEmpty(property.addressLine1, property.address, property.name),
+    firstNonEmpty(property.addressLine2, unitNumber ? `Unit ${unitNumber}` : ""),
+    firstNonEmpty(property.city),
+    firstNonEmpty(property.province || lease.province),
+    firstNonEmpty(property.postalCode),
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  const specs: FieldSpec[] = [
+    { sectionKey: "parties", fieldKey: "landlord_legal_name", label: "Landlord legal/display name", value: firstNonEmpty(landlord.legalName, landlord.displayName, landlord.name, landlord.email, lease.landlordName), required: true },
+    { sectionKey: "parties", fieldKey: "landlord_service_email", label: "Landlord contact/service email", value: firstNonEmpty(landlord.serviceEmail, landlord.email), conditional: true },
+    { sectionKey: "parties", fieldKey: "landlord_phone", label: "Landlord phone", value: firstNonEmpty(landlord.phone, landlord.phoneNumber), conditional: true },
+    { sectionKey: "parties", fieldKey: "tenant_names", label: "Tenant names", value: tenantNames, required: true },
+    { sectionKey: "parties", fieldKey: "tenant_emails", label: "Tenant email addresses", value: tenantEmails, conditional: true },
+    { sectionKey: "parties", fieldKey: "tenant_phones", label: "Tenant phone numbers", value: tenantPhones, conditional: true },
+    { sectionKey: "parties", fieldKey: "occupants", label: "Occupants/adult occupants/children", value: asList(lease.occupants || unit.occupants), conditional: true },
+
+    { sectionKey: "premises", fieldKey: "full_civic_address", label: "Full civic address", value: fullAddress, required: true },
+    { sectionKey: "premises", fieldKey: "unit_number", label: "Unit number", value: unitNumber, required: true },
+    { sectionKey: "premises", fieldKey: "property_type", label: "Property type", value: firstNonEmpty(property.propertyType, property.type, lease.propertyType), conditional: true },
+    { sectionKey: "premises", fieldKey: "mailing_or_po_box", label: "Mailing/PO box", value: firstNonEmpty(property.mailingAddress, property.poBox), conditional: true },
+    { sectionKey: "premises", fieldKey: "emergency_contact", label: "Emergency contact", value: firstNonEmpty(lease.emergencyContact, property.emergencyContact), conditional: true },
+    { sectionKey: "premises", fieldKey: "agent", label: "Agent", value: firstNonEmpty(property.agentName, lease.agentName), conditional: true },
+    { sectionKey: "premises", fieldKey: "property_manager", label: "Property manager", value: firstNonEmpty(property.managerName, property.propertyManagerName, lease.propertyManagerName), conditional: true },
+    { sectionKey: "premises", fieldKey: "building_superintendent", label: "Building superintendent", value: firstNonEmpty(property.superintendentName, lease.superintendentName), conditional: true },
+
+    { sectionKey: "term", fieldKey: "start_date", label: "Start date", value: firstNonEmpty(lease.startDate), required: true },
+    { sectionKey: "term", fieldKey: "end_date", label: "End date", value: firstNonEmpty(lease.endDate), conditional: true },
+    { sectionKey: "term", fieldKey: "term_type", label: "Term type", value: firstNonEmpty(lease.termType), required: true },
+    { sectionKey: "term", fieldKey: "periodic_details", label: "Fixed-term / periodic details", value: firstNonEmpty(lease.periodicDetails), conditional: true },
+    { sectionKey: "term", fieldKey: "public_housing", label: "Public housing", value: firstNonEmpty(lease.publicHousing), conditional: true },
+
+    { sectionKey: "rent_payments", fieldKey: "rent_amount", label: "Rent amount", value: lease.baseRentCents ?? lease.monthlyRent, required: true },
+    { sectionKey: "rent_payments", fieldKey: "rent_frequency", label: "Rent frequency", value: firstNonEmpty(lease.rentFrequency, "monthly"), required: true },
+    { sectionKey: "rent_payments", fieldKey: "due_day", label: "Due day", value: lease.dueDay, required: true },
+    { sectionKey: "rent_payments", fieldKey: "payment_method", label: "Payment method", value: firstNonEmpty(lease.paymentMethod), required: true },
+    { sectionKey: "rent_payments", fieldKey: "payee_destination", label: "Payee / payment destination", value: firstNonEmpty(lease.paymentDestination, lease.payeeName), conditional: true },
+    { sectionKey: "rent_payments", fieldKey: "parking", label: "Parking", value: lease.parkingCents, conditional: true },
+    { sectionKey: "rent_payments", fieldKey: "utilities_services_included", label: "Utilities/services included", value: asList(lease.utilitiesIncluded), conditional: true },
+    { sectionKey: "rent_payments", fieldKey: "appliances_services_included", label: "Appliances/services included", value: asList(lease.appliancesIncluded || lease.servicesIncluded), conditional: true },
+    { sectionKey: "rent_payments", fieldKey: "rental_incentives", label: "Rental incentives", value: firstNonEmpty(lease.rentalIncentives), conditional: true },
+    { sectionKey: "rent_payments", fieldKey: "rent_increase_reference", label: "Rent increase reference fields", value: firstNonEmpty(lease.rentIncreaseReference), conditional: true },
+
+    { sectionKey: "security_deposit", fieldKey: "deposit_amount", label: "Deposit amount", value: lease.depositCents, conditional: true },
+    { sectionKey: "security_deposit", fieldKey: "deposit_paid_date", label: "Deposit paid date", value: firstNonEmpty(lease.depositPaidDate), conditional: true },
+    { sectionKey: "security_deposit", fieldKey: "deposit_status", label: "Deposit status", value: firstNonEmpty(lease.depositStatus), conditional: true },
+    { sectionKey: "security_deposit", fieldKey: "deposit_accounting_placeholder", label: "Deposit accounting / Form R placeholder", value: firstNonEmpty(lease.depositAccountingStatus), conditional: true },
+
+    { sectionKey: "service_notices", fieldKey: "email_service_consent", label: "Email service consent", value: firstNonEmpty(lease.emailServiceConsent), conditional: true },
+    { sectionKey: "service_notices", fieldKey: "landlord_service_email", label: "Landlord service email", value: firstNonEmpty(landlord.serviceEmail, landlord.email), conditional: true },
+    { sectionKey: "service_notices", fieldKey: "tenant_service_email", label: "Tenant service email", value: tenantEmails, conditional: true },
+    { sectionKey: "service_notices", fieldKey: "notice_method_acknowledgement", label: "Notice/service method acknowledgement", value: firstNonEmpty(lease.noticeMethodAcknowledgement), conditional: true },
+
+    { sectionKey: "rules_addenda", fieldKey: "additional_clauses", label: "Additional clauses", value: firstNonEmpty(lease.additionalClauses), conditional: true },
+    { sectionKey: "rules_addenda", fieldKey: "rules_addenda_references", label: "Rules/addenda attachment references", value: asList(lease.rulesAddendaReferences), conditional: true },
+    { sectionKey: "rules_addenda", fieldKey: "rules_acknowledgement", label: "Reasonableness/equal-application acknowledgement", value: firstNonEmpty(lease.rulesAcknowledgement), conditional: true },
+
+    { sectionKey: "attachments_condition_report", fieldKey: "condition_report_reference", label: "Condition report reference", value: firstNonEmpty(lease.conditionReportReference), conditional: true },
+    { sectionKey: "attachments_condition_report", fieldKey: "schedule_a_reference", label: "Schedule A reference", value: firstNonEmpty(lease.scheduleAUrl, lease.scheduleAReference, "Schedule A attached/sectioned separately"), required: true },
+    { sectionKey: "attachments_condition_report", fieldKey: "addenda_list", label: "Addenda list", value: asList(lease.addendaList), conditional: true },
+
+    { sectionKey: "signatures_delivery", fieldKey: "signed_lease_copy_delivery", label: "Signed lease copy delivery readiness", value: firstNonEmpty(lease.signedLeaseCopyDeliveryStatus), conditional: true },
+    { sectionKey: "signatures_delivery", fieldKey: "act_copy_delivery", label: "Act copy/link delivery readiness", value: firstNonEmpty(lease.actCopyDeliveryStatus), conditional: true },
+  ];
+
+  const grouped = SECTION_ORDER.reduce((acc, key) => ({ ...acc, [key]: {} }), {} as FormPStructuredFields);
+  for (const spec of specs) {
+    grouped[spec.sectionKey][spec.fieldKey] = fieldFromSpec(spec, overrides);
+  }
+
+  const sectionStatuses = SECTION_ORDER.map((key) => {
+    const fields = Object.values(grouped[key]);
+    return {
+      key,
+      label: SECTION_LABELS[key],
+      status: sectionStatus(fields),
+      completionPercent: completionPercent(fields),
+      fields,
+    };
+  });
+  const missingFields = sectionStatuses.flatMap((section) =>
+    section.fields
+      .filter((field) => field.status === "missing")
+      .map((field) => ({ sectionKey: section.key, fieldKey: field.key, label: field.label }))
+  );
+  const nonBlockingItems = sectionStatuses.flatMap((section) =>
+    section.fields
+      .filter((field) => field.status === "pending" || field.status === "not_applicable")
+      .map((field) => ({ sectionKey: section.key, fieldKey: field.key, label: field.label, status: field.status as "pending" | "not_applicable" }))
+  );
+  const allFields = sectionStatuses.flatMap((section) => section.fields);
+  const completion = completionPercent(allFields);
+  return {
+    formPFields: grouped,
+    leaseReadiness: {
+      version: "ns_form_p_readiness_v1",
+      jurisdictionCode: "CA_NS",
+      overallStatus: missingFields.length ? "incomplete" : nonBlockingItems.some((item) => item.status === "pending") ? "pending" : "complete",
+      completionPercent: completion,
+      missingFields,
+      blockingItems: missingFields,
+      nonBlockingItems,
+      sectionStatuses,
+    },
+  };
+}

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -248,6 +248,28 @@ export type PrimaryLeaseDocument = {
   signingRequestId: string | null;
   storageRef: null;
   previewUrl?: string | null;
+  formPFields?: Record<string, Record<string, {
+    key: string;
+    label: string;
+    status: "provided" | "not_applicable" | "pending" | "missing";
+    value?: string | number | boolean | string[] | null;
+    note?: string | null;
+  }>> | null;
+  leaseReadiness?: {
+    version: "ns_form_p_readiness_v1";
+    jurisdictionCode: "CA_NS";
+    overallStatus: "complete" | "incomplete" | "pending";
+    completionPercent: number;
+    missingFields: Array<{ sectionKey: string; fieldKey: string; label: string }>;
+    blockingItems: Array<{ sectionKey: string; fieldKey: string; label: string }>;
+    nonBlockingItems: Array<{ sectionKey: string; fieldKey: string; label: string; status: "pending" | "not_applicable" }>;
+    sectionStatuses: Array<{
+      key: string;
+      label: string;
+      status: "complete" | "incomplete" | "not_applicable" | "pending";
+      completionPercent: number;
+    }>;
+  } | null;
   sourceSummary?: {
     adapterStatus: string;
     signingEnabled: boolean;
@@ -282,10 +304,13 @@ export async function getPrimaryLeaseDocument(
   return res.document;
 }
 
-export async function generatePrimaryLeaseDocument(leaseId: string): Promise<PrimaryLeaseDocument> {
+export async function generatePrimaryLeaseDocument(
+  leaseId: string,
+  payload?: { formPFields?: Record<string, Record<string, unknown>> }
+): Promise<PrimaryLeaseDocument> {
   const res = await apiJson<{ ok: boolean; document: PrimaryLeaseDocument }>(
     `/leases/${encodeURIComponent(leaseId)}/primary-document/generate`,
-    { method: "POST", body: "{}" }
+    { method: "POST", body: JSON.stringify(payload || {}) }
   );
   return res.document;
 }

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
@@ -62,6 +62,23 @@ const primaryDocument: PrimaryLeaseDocument = {
   lockedBy: null,
   signingRequestId: null,
   storageRef: null,
+  leaseReadiness: {
+    version: "ns_form_p_readiness_v1",
+    jurisdictionCode: "CA_NS",
+    overallStatus: "incomplete",
+    completionPercent: 58,
+    missingFields: [{ sectionKey: "parties", fieldKey: "occupants", label: "Occupants/adult occupants/children" }],
+    blockingItems: [{ sectionKey: "parties", fieldKey: "occupants", label: "Occupants/adult occupants/children" }],
+    nonBlockingItems: [{ sectionKey: "term", fieldKey: "public_housing", label: "Public housing", status: "pending" }],
+    sectionStatuses: [
+      {
+        key: "parties",
+        label: "Parties",
+        status: "incomplete",
+        completionPercent: 80,
+      },
+    ],
+  },
   sourceSummary: {
     adapterStatus: "draft",
     signingEnabled: false,
@@ -128,6 +145,15 @@ describe("LeaseSigningDashboard", () => {
 
     await waitFor(() => expect(generatePrimaryLeaseDocument).toHaveBeenCalledWith("lease-1"));
     await waitFor(() => expect(screen.getByRole("button", { name: /send for signature/i })).toBeEnabled());
+    expect(screen.queryByText(/lease-documents/i)).not.toBeInTheDocument();
+  });
+
+  it("renders Form P readiness status without exposing internal document storage", async () => {
+    render(<LeaseSigningDashboard leaseId="lease-1" tenantEmail="tenant@example.com" />);
+
+    await waitFor(() => expect(screen.getByText(/form p readiness: incomplete/i)).toBeInTheDocument());
+    expect(screen.getByText(/58% complete/i)).toBeInTheDocument();
+    expect(screen.getByText(/missing required fields: occupants/i)).toBeInTheDocument();
     expect(screen.queryByText(/lease-documents/i)).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
@@ -174,6 +174,24 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
                 Jurisdiction template is draft/test and requires counsel review before production signing.
               </div>
             ) : null}
+            {primaryDocument?.leaseReadiness ? (
+              <div style={{ display: "grid", gap: 4, color: "#475569", fontSize: 13 }}>
+                <div>
+                  Form P readiness: {pretty(primaryDocument.leaseReadiness.overallStatus)} ·{" "}
+                  {primaryDocument.leaseReadiness.completionPercent}% complete
+                </div>
+                {primaryDocument.leaseReadiness.blockingItems.length ? (
+                  <div>
+                    Missing required fields:{" "}
+                    {primaryDocument.leaseReadiness.blockingItems
+                      .slice(0, 3)
+                      .map((item) => item.label)
+                      .join(", ")}
+                    {primaryDocument.leaseReadiness.blockingItems.length > 3 ? "…" : ""}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
             {documentError ? <div style={{ color: "#b91c1c", fontSize: 13 }}>{documentError}</div> : null}
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <button type="button" onClick={() => void generateDocument()} disabled={documentBusy || busy}>


### PR DESCRIPTION
## Summary
- Add a structured Nova Scotia Form P field/readiness model for primary lease documents.
- Derive section-level readiness from existing lease, landlord, property, unit, and tenant data, with explicit `provided`, `missing`, `pending`, and `not_applicable` field states.
- Store safe Form P field/readiness metadata on generated primary lease documents and include aggregate readiness metadata on canonical lease document events.
- Surface a compact Form P readiness summary in the existing lease signing document panel without changing signing behavior.

## Scope boundaries
- No Dropbox Sign provider changes.
- No signed document download changes.
- No full email-service consent workflow.
- No Act-copy delivery workflow.
- No Form R/security deposit accounting workflow.
- No Form P renderer completeness pass.
- CA_NS counsel/legal gating remains draft/unapproved.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:emulator -- src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- LeaseSigningDashboard.test.tsx` in `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
- `git diff --check`

## Preview QA recommendation
- Generate a Nova Scotia primary lease PDF for a lease with partial Form P data.
- Confirm the signing panel shows Form P readiness status and missing required fields.
- Confirm primary document generation, preview, send-for-signature, return route, webhook lifecycle, and signed document download still work.