### PR TITLE
feat: add Nova Scotia lease email-service consent readiness

### DIFF
--- a/rentchain-api/src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts
@@ -118,6 +118,64 @@ describe("deriveNovaScotiaFormPReadiness", () => {
     );
   });
 
+  it("treats email addresses without explicit email-service consent as blocking readiness gaps", () => {
+    const result = deriveNovaScotiaFormPReadiness(baseInput());
+
+    expect(result.formPFields.service_notices.landlord_service_email).toEqual(
+      expect.objectContaining({ status: "provided", value: "landlord@example.com" })
+    );
+    expect(result.formPFields.service_notices.tenant_service_email).toEqual(
+      expect.objectContaining({ status: "provided", value: "tenant@example.com" })
+    );
+    expect(result.formPFields.service_notices.landlord_email_service_consent.status).toBe("missing");
+    expect(result.formPFields.service_notices.tenant_email_service_consent.status).toBe("missing");
+    expect(result.leaseReadiness.blockingItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldKey: "landlord_email_service_consent" }),
+        expect.objectContaining({ fieldKey: "tenant_email_service_consent" }),
+      ])
+    );
+  });
+
+  it("marks tenant service email missing when the tenant record has no email or service email", () => {
+    const result = deriveNovaScotiaFormPReadiness(
+      baseInput({
+        tenants: [{ fullName: "Tenant One" }],
+      })
+    );
+
+    expect(result.formPFields.service_notices.tenant_service_email.status).toBe("missing");
+    expect(result.leaseReadiness.blockingItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldKey: "tenant_service_email", label: "Tenant service email" }),
+      ])
+    );
+  });
+
+  it("consumes explicit landlord and tenant email-service consent from party records", () => {
+    const result = deriveNovaScotiaFormPReadiness(
+      baseInput({
+        landlord: {
+          emailServiceConsent: true,
+          emailServiceConsentCapturedAt: "2026-06-17T12:00:00.000Z",
+        },
+        tenants: [
+          {
+            fullName: "Tenant One",
+            email: "tenant@example.com",
+            emailServiceConsentStatus: "consented",
+          },
+        ],
+      })
+    );
+
+    expect(result.formPFields.service_notices.landlord_email_service_consent.status).toBe("provided");
+    expect(result.formPFields.service_notices.tenant_email_service_consent.status).toBe("provided");
+    expect(result.formPFields.service_notices.email_service_consent_captured_at).toEqual(
+      expect.objectContaining({ status: "provided", value: "2026-06-17T12:00:00.000Z" })
+    );
+  });
+
   it("supports explicit not applicable state for email-service consent", () => {
     const result = deriveNovaScotiaFormPReadiness(
       baseInput({

--- a/rentchain-api/src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts
@@ -88,6 +88,61 @@ describe("deriveNovaScotiaFormPReadiness", () => {
     );
   });
 
+  it("derives structured email-service consent readiness fields", () => {
+    const result = deriveNovaScotiaFormPReadiness(
+      baseInput({
+        lease: {
+          landlordEmailServiceConsent: true,
+          tenantEmailServiceConsent: "consented",
+          landlordServiceEmail: "service-landlord@example.com",
+          tenantServiceEmail: "service-tenant@example.com",
+          emailServiceConsentCapturedAt: "2026-06-17T10:00:00.000Z",
+        },
+      })
+    );
+
+    expect(result.formPFields.service_notices.landlord_email_service_consent).toEqual(
+      expect.objectContaining({ status: "provided", value: "consented" })
+    );
+    expect(result.formPFields.service_notices.tenant_email_service_consent).toEqual(
+      expect.objectContaining({ status: "provided", value: "consented" })
+    );
+    expect(result.formPFields.service_notices.landlord_service_email).toEqual(
+      expect.objectContaining({ status: "provided", value: "service-landlord@example.com" })
+    );
+    expect(result.formPFields.service_notices.tenant_service_email).toEqual(
+      expect.objectContaining({ status: "provided", value: "service-tenant@example.com" })
+    );
+    expect(result.formPFields.service_notices.email_service_consent_captured_at).toEqual(
+      expect.objectContaining({ status: "provided", value: "2026-06-17T10:00:00.000Z" })
+    );
+  });
+
+  it("supports explicit not applicable state for email-service consent", () => {
+    const result = deriveNovaScotiaFormPReadiness(
+      baseInput({
+        formPFields: {
+          service_notices: {
+            landlord_email_service_consent: { status: "not_applicable", note: "Email service not used." },
+            tenant_email_service_consent: { status: "not_applicable", note: "Email service not used." },
+            landlord_service_email: { status: "not_applicable" },
+            tenant_service_email: { status: "not_applicable" },
+            email_service_consent_captured_at: { status: "not_applicable" },
+          },
+        },
+      })
+    );
+
+    expect(result.formPFields.service_notices.landlord_email_service_consent.status).toBe("not_applicable");
+    expect(result.formPFields.service_notices.tenant_email_service_consent.status).toBe("not_applicable");
+    expect(result.leaseReadiness.nonBlockingItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldKey: "landlord_email_service_consent", status: "not_applicable" }),
+        expect.objectContaining({ fieldKey: "tenant_email_service_consent", status: "not_applicable" }),
+      ])
+    );
+  });
+
   it("marks missing required fields as blocking readiness items", () => {
     const result = deriveNovaScotiaFormPReadiness(
       baseInput({

--- a/rentchain-api/src/services/leaseDocuments/jurisdictions/__tests__/caNsAdapter.test.ts
+++ b/rentchain-api/src/services/leaseDocuments/jurisdictions/__tests__/caNsAdapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { buildEmailServiceConsentDisplay } from "../caNsAdapter";
+
+function input(overrides: Record<string, any> = {}) {
+  return {
+    leaseId: "lease-1",
+    lease: {
+      landlordId: "landlord-1",
+      ...overrides.lease,
+    },
+    landlord: {
+      email: "landlord@example.com",
+      ...overrides.landlord,
+    },
+    property: null,
+    unit: null,
+    tenants: [
+      {
+        email: "tenant@example.com",
+      },
+    ],
+    formPFields: overrides.formPFields || null,
+  } as any;
+}
+
+describe("CA_NS adapter email-service consent display", () => {
+  it("renders clear missing guidance when email-service consent details are unavailable", () => {
+    expect(buildEmailServiceConsentDisplay(input({ landlord: { email: "" }, tenants: [] }))).toBe(
+      "Landlord and tenant consent details required before production use."
+    );
+  });
+
+  it("renders provided email-service consent details without claiming legal validity", () => {
+    const display = buildEmailServiceConsentDisplay(
+      input({
+        lease: {
+          landlordEmailServiceConsent: true,
+          tenantEmailServiceConsent: true,
+          landlordServiceEmail: "service-landlord@example.com",
+          tenantServiceEmail: "service-tenant@example.com",
+          emailServiceConsentCapturedAt: "2026-06-17T10:00:00.000Z",
+        },
+      })
+    );
+
+    expect(display).toContain("Landlord consent: provided");
+    expect(display).toContain("landlord service email: service-landlord@example.com");
+    expect(display).toContain("tenant consent: provided");
+    expect(display).toContain("tenant service email: service-tenant@example.com");
+    expect(display).toContain("captured: 2026-06-17T10:00:00.000Z");
+    expect(display).toContain("Verify applicable provincial requirements");
+    expect(display).not.toMatch(/legal advice|enforceability guarantee|certified/i);
+  });
+
+  it("uses explicit Form P field overrides when provided", () => {
+    const display = buildEmailServiceConsentDisplay(
+      input({
+        formPFields: {
+          service_notices: {
+            landlord_email_service_consent: { status: "provided", value: "consented" },
+            tenant_email_service_consent: { status: "provided", value: "consented" },
+            landlord_service_email: { status: "provided", value: "landlord-service@example.com" },
+            tenant_service_email: { status: "provided", value: "tenant-service@example.com" },
+            email_service_consent_captured_at: { status: "provided", value: "2026-06-17T11:00:00.000Z" },
+          },
+        },
+      })
+    );
+
+    expect(display).toContain("landlord service email: landlord-service@example.com");
+    expect(display).toContain("tenant service email: tenant-service@example.com");
+    expect(display).toContain("captured: 2026-06-17T11:00:00.000Z");
+  });
+});

--- a/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
+++ b/rentchain-api/src/services/leaseDocuments/jurisdictions/caNsAdapter.ts
@@ -16,6 +16,79 @@ function money(centsOrDollars: unknown) {
   return dollars.toLocaleString("en-CA", { style: "currency", currency: "CAD" });
 }
 
+function formPValue(input: PrimaryLeaseDocumentInput, section: string, key: string): unknown {
+  const field = (input.formPFields as any)?.[section]?.[key];
+  if (!field) return null;
+  if (typeof field === "object" && !Array.isArray(field)) {
+    if (String(field.status || "").trim() === "not_applicable") return "Not applicable";
+    return field.value ?? null;
+  }
+  return field;
+}
+
+function consentLabel(value: unknown): string {
+  const raw = String(value ?? "").trim().toLowerCase();
+  if (!raw) return "";
+  if (["true", "yes", "consented", "provided"].includes(raw)) return "provided";
+  if (["false", "no", "declined", "not_consented"].includes(raw)) return "not provided";
+  return String(value ?? "").trim();
+}
+
+export function buildEmailServiceConsentDisplay(input: PrimaryLeaseDocumentInput): string {
+  const lease = input.lease || {};
+  const landlord = input.landlord || {};
+  const tenants = input.tenants || [];
+  const tenantEmails = tenants
+    .map((tenant) => text(tenant.serviceEmail || tenant.email, ""))
+    .filter(Boolean);
+  const landlordServiceEmail = text(
+    formPValue(input, "service_notices", "landlord_service_email") ||
+      lease.landlordServiceEmail ||
+      landlord.serviceEmail ||
+      landlord.email,
+    ""
+  );
+  const tenantServiceEmail = text(
+    formPValue(input, "service_notices", "tenant_service_email") ||
+      lease.tenantServiceEmail ||
+      lease.serviceEmail ||
+      tenantEmails[0],
+    ""
+  );
+  const landlordConsent = consentLabel(
+    formPValue(input, "service_notices", "landlord_email_service_consent") ||
+      lease.landlordEmailServiceConsent ||
+      lease.emailServiceConsent?.landlordConsentStatus ||
+      lease.emailServiceConsent?.landlordConsented
+  );
+  const tenantConsent = consentLabel(
+    formPValue(input, "service_notices", "tenant_email_service_consent") ||
+      lease.tenantEmailServiceConsent ||
+      lease.emailServiceConsent?.tenantConsentStatus ||
+      lease.emailServiceConsent?.tenantConsented
+  );
+  const capturedAt = text(
+    formPValue(input, "service_notices", "email_service_consent_captured_at") ||
+      lease.emailServiceConsentCapturedAt ||
+      lease.emailServiceConsent?.capturedAt,
+    ""
+  );
+  if (!landlordConsent && !tenantConsent) {
+    return "Landlord and tenant consent details required before production use.";
+  }
+  const parts = [
+    landlordConsent ? `Landlord consent: ${landlordConsent}` : "",
+    landlordServiceEmail ? `landlord service email: ${landlordServiceEmail}` : "",
+    tenantConsent ? `tenant consent: ${tenantConsent}` : "",
+    tenantServiceEmail ? `tenant service email: ${tenantServiceEmail}` : "",
+    capturedAt ? `captured: ${capturedAt}` : "",
+  ].filter(Boolean);
+  if (!parts.length) {
+    return "Landlord and tenant consent details required before production use.";
+  }
+  return `${parts.join("; ")}. Verify applicable provincial requirements before relying on electronic service.`;
+}
+
 function collectPdf(write: (doc: PDFKit.PDFDocument) => void): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const doc = new PDFDocument({ margin: 54, size: "LETTER" });
@@ -193,7 +266,7 @@ export const caNsLeaseDocumentAdapter: JurisdictionLeaseDocumentAdapter = {
       row("Rental arrears", "Required Form P terms apply.");
       row("Tenant notice to quit", "Required Form P terms apply.");
       row("Landlord notice to quit", "Required Form P terms apply.");
-      row("Email service of documents", "Landlord and tenant consent details required before production use.");
+      row("Email service of documents", buildEmailServiceConsentDisplay(input));
       row("How to serve notices/documents", "Required Form P service terms apply.");
 
       section("Inspection, Rules, and General Terms");

--- a/rentchain-api/src/services/leaseDocuments/leaseFormPReadiness.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseFormPReadiness.ts
@@ -50,10 +50,10 @@ function asList(value: unknown): string[] {
 }
 
 function consentValue(value: unknown): string {
-  if (typeof value === "boolean") return value ? "consented" : "not_consented";
+  if (typeof value === "boolean") return value ? "consented" : "";
   const cleaned = cleanString(value, 80).toLowerCase();
   if (["yes", "true", "consent", "consented", "provided"].includes(cleaned)) return "consented";
-  if (["no", "false", "declined", "not_consented"].includes(cleaned)) return "not_consented";
+  if (["no", "false", "declined", "not_consented"].includes(cleaned)) return "";
   return cleaned;
 }
 
@@ -120,6 +120,7 @@ export function deriveNovaScotiaFormPReadiness(input: PrimaryLeaseDocumentInput)
   const property = input.property || {};
   const unit = input.unit || {};
   const tenants = input.tenants || [];
+  const firstTenant = tenants[0] || {};
   const overrides = input.formPFields || null;
   const tenantNames = tenants
     .map((tenant) => firstNonEmpty(tenant.fullName, tenant.name, tenant.displayName, tenant.email))
@@ -130,23 +131,36 @@ export function deriveNovaScotiaFormPReadiness(input: PrimaryLeaseDocumentInput)
   const tenantServiceEmail = firstNonEmpty(
     lease.tenantServiceEmail,
     lease.serviceEmail,
+    firstTenant.serviceEmail,
     tenantEmails[0]
   );
   const landlordEmailConsent = consentValue(
     lease.landlordEmailServiceConsent ??
       lease.landlordEmailServiceConsentStatus ??
       lease.emailServiceConsent?.landlordConsentStatus ??
-      lease.emailServiceConsent?.landlordConsented
+      lease.emailServiceConsent?.landlordConsented ??
+      landlord.emailServiceConsent ??
+      landlord.emailServiceConsentStatus ??
+      landlord.emailServiceConsent?.consentStatus ??
+      landlord.emailServiceConsent?.consented
   );
   const tenantEmailConsent = consentValue(
     lease.tenantEmailServiceConsent ??
       lease.tenantEmailServiceConsentStatus ??
       lease.emailServiceConsent?.tenantConsentStatus ??
-      lease.emailServiceConsent?.tenantConsented
+      lease.emailServiceConsent?.tenantConsented ??
+      firstTenant.emailServiceConsent ??
+      firstTenant.emailServiceConsentStatus ??
+      firstTenant.emailServiceConsent?.consentStatus ??
+      firstTenant.emailServiceConsent?.consented
   );
   const emailConsentCapturedAt = firstNonEmpty(
     lease.emailServiceConsentCapturedAt,
-    lease.emailServiceConsent?.capturedAt
+    lease.emailServiceConsent?.capturedAt,
+    firstTenant.emailServiceConsentCapturedAt,
+    firstTenant.emailServiceConsent?.capturedAt,
+    landlord.emailServiceConsentCapturedAt,
+    landlord.emailServiceConsent?.capturedAt
   );
   const unitNumber = firstNonEmpty(unit.unitNumber, unit.label, lease.unitNumber);
   const fullAddress = [
@@ -199,10 +213,10 @@ export function deriveNovaScotiaFormPReadiness(input: PrimaryLeaseDocumentInput)
     { sectionKey: "security_deposit", fieldKey: "deposit_status", label: "Deposit status", value: firstNonEmpty(lease.depositStatus), conditional: true },
     { sectionKey: "security_deposit", fieldKey: "deposit_accounting_placeholder", label: "Deposit accounting / Form R placeholder", value: firstNonEmpty(lease.depositAccountingStatus), conditional: true },
 
-    { sectionKey: "service_notices", fieldKey: "landlord_email_service_consent", label: "Landlord email service consent", value: landlordEmailConsent, conditional: true },
-    { sectionKey: "service_notices", fieldKey: "tenant_email_service_consent", label: "Tenant email service consent", value: tenantEmailConsent, conditional: true },
-    { sectionKey: "service_notices", fieldKey: "landlord_service_email", label: "Landlord service email", value: landlordServiceEmail, conditional: true },
-    { sectionKey: "service_notices", fieldKey: "tenant_service_email", label: "Tenant service email", value: tenantServiceEmail, conditional: true },
+    { sectionKey: "service_notices", fieldKey: "landlord_email_service_consent", label: "Landlord email service consent", value: landlordEmailConsent, required: true },
+    { sectionKey: "service_notices", fieldKey: "tenant_email_service_consent", label: "Tenant email service consent", value: tenantEmailConsent, required: true },
+    { sectionKey: "service_notices", fieldKey: "landlord_service_email", label: "Landlord service email", value: landlordServiceEmail, required: true },
+    { sectionKey: "service_notices", fieldKey: "tenant_service_email", label: "Tenant service email", value: tenantServiceEmail, required: true },
     { sectionKey: "service_notices", fieldKey: "email_service_consent_captured_at", label: "Email service consent captured timestamp", value: emailConsentCapturedAt, conditional: true },
     { sectionKey: "service_notices", fieldKey: "notice_method_acknowledgement", label: "Notice/service method acknowledgement", value: firstNonEmpty(lease.noticeMethodAcknowledgement), conditional: true },
 

--- a/rentchain-api/src/services/leaseDocuments/leaseFormPReadiness.ts
+++ b/rentchain-api/src/services/leaseDocuments/leaseFormPReadiness.ts
@@ -49,6 +49,14 @@ function asList(value: unknown): string[] {
   return value.map((item) => cleanString(item, 240)).filter(Boolean);
 }
 
+function consentValue(value: unknown): string {
+  if (typeof value === "boolean") return value ? "consented" : "not_consented";
+  const cleaned = cleanString(value, 80).toLowerCase();
+  if (["yes", "true", "consent", "consented", "provided"].includes(cleaned)) return "consented";
+  if (["no", "false", "declined", "not_consented"].includes(cleaned)) return "not_consented";
+  return cleaned;
+}
+
 function hasValue(value: unknown): boolean {
   if (Array.isArray(value)) return value.some((item) => hasValue(item));
   if (typeof value === "number") return Number.isFinite(value);
@@ -118,6 +126,28 @@ export function deriveNovaScotiaFormPReadiness(input: PrimaryLeaseDocumentInput)
     .filter(Boolean);
   const tenantEmails = tenants.map((tenant) => firstNonEmpty(tenant.email, tenant.serviceEmail)).filter(Boolean);
   const tenantPhones = tenants.map((tenant) => firstNonEmpty(tenant.phone, tenant.phoneNumber)).filter(Boolean);
+  const landlordServiceEmail = firstNonEmpty(lease.landlordServiceEmail, landlord.serviceEmail, landlord.email);
+  const tenantServiceEmail = firstNonEmpty(
+    lease.tenantServiceEmail,
+    lease.serviceEmail,
+    tenantEmails[0]
+  );
+  const landlordEmailConsent = consentValue(
+    lease.landlordEmailServiceConsent ??
+      lease.landlordEmailServiceConsentStatus ??
+      lease.emailServiceConsent?.landlordConsentStatus ??
+      lease.emailServiceConsent?.landlordConsented
+  );
+  const tenantEmailConsent = consentValue(
+    lease.tenantEmailServiceConsent ??
+      lease.tenantEmailServiceConsentStatus ??
+      lease.emailServiceConsent?.tenantConsentStatus ??
+      lease.emailServiceConsent?.tenantConsented
+  );
+  const emailConsentCapturedAt = firstNonEmpty(
+    lease.emailServiceConsentCapturedAt,
+    lease.emailServiceConsent?.capturedAt
+  );
   const unitNumber = firstNonEmpty(unit.unitNumber, unit.label, lease.unitNumber);
   const fullAddress = [
     firstNonEmpty(property.addressLine1, property.address, property.name),
@@ -169,9 +199,11 @@ export function deriveNovaScotiaFormPReadiness(input: PrimaryLeaseDocumentInput)
     { sectionKey: "security_deposit", fieldKey: "deposit_status", label: "Deposit status", value: firstNonEmpty(lease.depositStatus), conditional: true },
     { sectionKey: "security_deposit", fieldKey: "deposit_accounting_placeholder", label: "Deposit accounting / Form R placeholder", value: firstNonEmpty(lease.depositAccountingStatus), conditional: true },
 
-    { sectionKey: "service_notices", fieldKey: "email_service_consent", label: "Email service consent", value: firstNonEmpty(lease.emailServiceConsent), conditional: true },
-    { sectionKey: "service_notices", fieldKey: "landlord_service_email", label: "Landlord service email", value: firstNonEmpty(landlord.serviceEmail, landlord.email), conditional: true },
-    { sectionKey: "service_notices", fieldKey: "tenant_service_email", label: "Tenant service email", value: tenantEmails, conditional: true },
+    { sectionKey: "service_notices", fieldKey: "landlord_email_service_consent", label: "Landlord email service consent", value: landlordEmailConsent, conditional: true },
+    { sectionKey: "service_notices", fieldKey: "tenant_email_service_consent", label: "Tenant email service consent", value: tenantEmailConsent, conditional: true },
+    { sectionKey: "service_notices", fieldKey: "landlord_service_email", label: "Landlord service email", value: landlordServiceEmail, conditional: true },
+    { sectionKey: "service_notices", fieldKey: "tenant_service_email", label: "Tenant service email", value: tenantServiceEmail, conditional: true },
+    { sectionKey: "service_notices", fieldKey: "email_service_consent_captured_at", label: "Email service consent captured timestamp", value: emailConsentCapturedAt, conditional: true },
     { sectionKey: "service_notices", fieldKey: "notice_method_acknowledgement", label: "Notice/service method acknowledgement", value: firstNonEmpty(lease.noticeMethodAcknowledgement), conditional: true },
 
     { sectionKey: "rules_addenda", fieldKey: "additional_clauses", label: "Additional clauses", value: firstNonEmpty(lease.additionalClauses), conditional: true },

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.test.tsx
@@ -67,8 +67,22 @@ const primaryDocument: PrimaryLeaseDocument = {
     jurisdictionCode: "CA_NS",
     overallStatus: "incomplete",
     completionPercent: 58,
-    missingFields: [{ sectionKey: "parties", fieldKey: "occupants", label: "Occupants/adult occupants/children" }],
-    blockingItems: [{ sectionKey: "parties", fieldKey: "occupants", label: "Occupants/adult occupants/children" }],
+    missingFields: [
+      { sectionKey: "parties", fieldKey: "occupants", label: "Occupants/adult occupants/children" },
+      { sectionKey: "term", fieldKey: "term_type", label: "Term type" },
+      { sectionKey: "rent_payments", fieldKey: "due_day", label: "Due day" },
+      { sectionKey: "service_notices", fieldKey: "tenant_service_email", label: "Tenant service email" },
+      { sectionKey: "service_notices", fieldKey: "tenant_email_service_consent", label: "Tenant email service consent" },
+      { sectionKey: "service_notices", fieldKey: "landlord_email_service_consent", label: "Landlord email service consent" },
+    ],
+    blockingItems: [
+      { sectionKey: "parties", fieldKey: "occupants", label: "Occupants/adult occupants/children" },
+      { sectionKey: "term", fieldKey: "term_type", label: "Term type" },
+      { sectionKey: "rent_payments", fieldKey: "due_day", label: "Due day" },
+      { sectionKey: "service_notices", fieldKey: "tenant_service_email", label: "Tenant service email" },
+      { sectionKey: "service_notices", fieldKey: "tenant_email_service_consent", label: "Tenant email service consent" },
+      { sectionKey: "service_notices", fieldKey: "landlord_email_service_consent", label: "Landlord email service consent" },
+    ],
     nonBlockingItems: [{ sectionKey: "term", fieldKey: "public_housing", label: "Public housing", status: "pending" }],
     sectionStatuses: [
       {
@@ -153,7 +167,11 @@ describe("LeaseSigningDashboard", () => {
 
     await waitFor(() => expect(screen.getByText(/form p readiness: incomplete/i)).toBeInTheDocument());
     expect(screen.getByText(/58% complete/i)).toBeInTheDocument();
-    expect(screen.getByText(/missing required fields: occupants/i)).toBeInTheDocument();
+    expect(screen.getByText(/missing required fields: occupants\/adult occupants\/children, term type, due day, and 3 more/i)).toBeInTheDocument();
+    expect(screen.getByText(/view all missing form p fields/i)).toBeInTheDocument();
+    expect(screen.getByText(/tenant service email/i)).toBeInTheDocument();
+    expect(screen.getByText(/tenant email service consent/i)).toBeInTheDocument();
+    expect(screen.getByText(/landlord email service consent/i)).toBeInTheDocument();
     expect(screen.queryByText(/lease-documents/i)).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
+++ b/rentchain-frontend/src/components/LeaseSigningDashboard.tsx
@@ -187,8 +187,20 @@ export function LeaseSigningDashboard({ leaseId, tenantEmail }: Props) {
                       .slice(0, 3)
                       .map((item) => item.label)
                       .join(", ")}
-                    {primaryDocument.leaseReadiness.blockingItems.length > 3 ? "…" : ""}
+                    {primaryDocument.leaseReadiness.blockingItems.length > 3
+                      ? `, and ${primaryDocument.leaseReadiness.blockingItems.length - 3} more`
+                      : ""}
                   </div>
+                ) : null}
+                {primaryDocument.leaseReadiness.blockingItems.length > 3 ? (
+                  <details>
+                    <summary style={{ cursor: "pointer", fontWeight: 700 }}>View all missing Form P fields</summary>
+                    <ul style={{ margin: "6px 0 0 18px", padding: 0 }}>
+                      {primaryDocument.leaseReadiness.blockingItems.map((item) => (
+                        <li key={`${item.sectionKey}:${item.fieldKey}`}>{item.label}</li>
+                      ))}
+                    </ul>
+                  </details>
                 ) : null}
               </div>
             ) : null}

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -451,6 +451,49 @@ describe("LandlordActiveLeasesPage", () => {
     );
   });
 
+  it("does not expose View lease for generated draft primary-document previews", async () => {
+    mocks.refreshLeaseDocumentUrl.mockReset();
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-draft-generated",
+          propertyId: "prop-1",
+          propertyName: "Coburg Rd",
+          unitNumber: "6",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          tenantName: "Chip Milo",
+          tenantEmail: "hello+cob6tenant@rentchain.ai",
+          documentUrl:
+            "https://storage.googleapis.com/rentchain-lease-documents/lease-documents/hash/lease-draft-generated.pdf?X-Goog-Expires=1800",
+          signingStatus: "not_started",
+          leaseExecution: {
+            executionStatus: "draft",
+            executionLabel: "Draft lease",
+            executionDescription: "The generated lease is available for preview before signing.",
+            requiredNextAction: "tenant_signature",
+            tenantSignatureStatus: "needed",
+            landlordSignatureStatus: "not_required",
+            pdfStatus: "generated",
+            completedAt: null,
+          },
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("button", { name: "Use Preview Lease Document" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "View lease" })).not.toBeInTheDocument();
+    expect(mocks.refreshLeaseDocumentUrl).not.toHaveBeenCalled();
+  });
+
   it("shows Schedule A as a separate action without replacing the lease summary action", async () => {
     mocks.getActiveLeasesForLandlord.mockResolvedValue({
       leases: [

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -118,6 +118,13 @@ function isSignedLeaseRecord(lease: LandlordActiveLease) {
   return signingStatus === "signed" || executionStatus === "fully_executed" || lease.signatureStatus === "signed";
 }
 
+function canOpenPrimaryLeaseDocumentFromList(lease: LandlordActiveLease) {
+  const value = primaryLeaseDocumentUrl(lease);
+  if (!value) return false;
+  if (isSignedLeaseRecord(lease)) return true;
+  return canUseLegacyDocumentFallback(value);
+}
+
 function normalizePhoneInput(value: string) {
   return String(value || "").replace(/\D/g, "").slice(0, 15);
 }
@@ -615,11 +622,12 @@ export default function LandlordActiveLeasesPage() {
   function renderLeaseActions(lease: LandlordActiveLease) {
     const { ledgerPath, summaryPath, emailHref } = buildLeaseActionMeta(lease);
     const primaryDocumentUrl = primaryLeaseDocumentUrl(lease);
+    const canOpenPrimaryDocument = canOpenPrimaryLeaseDocumentFromList(lease);
     const scheduleAUrl = scheduleADocumentUrl(lease);
     return (
       <div style={{ display: "grid", gap: 12 }}>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-          {primaryDocumentUrl ? (
+          {canOpenPrimaryDocument ? (
             <button
               type="button"
               onClick={() => void openLeaseDocument(lease)}
@@ -627,6 +635,15 @@ export default function LandlordActiveLeasesPage() {
               style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
             >
               {documentBusyLeaseId === lease.id ? "Opening..." : "View lease"}
+            </button>
+          ) : primaryDocumentUrl ? (
+            <button
+              type="button"
+              disabled
+              title="Use Preview Lease Document in the lease signing panel for generated draft lease PDFs."
+              style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #e2e8f0", background: "#f8fafc", color: "#64748b" }}
+            >
+              Use Preview Lease Document
             </button>
           ) : (
             <button
@@ -676,7 +693,7 @@ export default function LandlordActiveLeasesPage() {
           <button
             type="button"
             onClick={() => {
-              if (primaryLeaseDocumentUrl(lease)) {
+              if (canOpenPrimaryDocument) {
                 void openLeaseDocument(lease);
                 return;
               }


### PR DESCRIPTION
## Summary
- Add structured Nova Scotia email-service consent readiness fields for Form P metadata.
- Track landlord consent, tenant consent, landlord service email, tenant service email, and captured timestamp as `provided` / `missing` / `pending` / `not_applicable` states.
- Update CA_NS primary lease rendering so provided consent details replace the generic placeholder, while missing consent keeps clear readiness guidance.
- Preserve legal boundaries by requiring consent status before rendering electronic-service details and adding provincial-requirements review language.

## Scope boundaries
- No Dropbox Sign provider changes.
- No signing return/webhook/download changes.
- No Act copy or signed lease delivery tracking.
- No Form R/deposit workflow.
- No full Form P renderer completeness pass.
- No legal advice, certification, or enforceability guarantee.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:emulator -- src/services/leaseDocuments/__tests__/leaseFormPReadiness.test.ts src/services/leaseDocuments/__tests__/leaseDocumentService.test.ts src/services/leaseDocuments/jurisdictions/__tests__/caNsAdapter.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
- `git diff --check`

## Preview QA recommendation
- Generate a CA_NS primary lease with email-service consent metadata.
- Confirm the generated PDF no longer shows the generic email-service placeholder when consent details are provided.
- Generate or inspect a lease without consent metadata and confirm clear readiness guidance remains.
- Confirm lease generation, preview, signing, return route, signed document download, workflow review pages, lease summary, and ledger remain unchanged.