### PR TITLE
fix: align tenant lease profile state

### DIFF
--- a/rentchain-api/src/services/__tests__/moveInRequirements.test.ts
+++ b/rentchain-api/src/services/__tests__/moveInRequirements.test.ts
@@ -65,6 +65,23 @@ describe("buildMoveInRequirements", () => {
     expect(leaseSigned?.source).toBe("lease_status");
   });
 
+  it("marks lease signed from provider signing status without relying on generic signedAt", () => {
+    const requirements = buildMoveInRequirements({
+      lease: { status: "signed_future" },
+      leaseRaw: {
+        status: "signed_future",
+        currentSigningStatus: "signed",
+        currentStatusAt: "2026-05-09T12:00:00.000Z",
+      },
+    });
+
+    const leaseSigned = requirements.items.find((item) => item.key === "lease_signed");
+    expect(leaseSigned?.state).toBe("complete");
+    expect(leaseSigned?.updatedAt).toBe("2026-05-09T12:00:00.000Z");
+    expect(leaseSigned?.source).toBe("signing_request");
+    expect(leaseSigned?.note).toBeNull();
+  });
+
   it("returns unknown when there is no move-in context", () => {
     const requirements = buildMoveInRequirements({ tenant: { id: "tenant-1" } });
 

--- a/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
@@ -3,109 +3,107 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const tenantDocs = new Map<string, any>();
 const propertyDocs = new Map<string, any>();
 const unitDocs = new Map<string, any>();
+const leaseDocs = new Map<string, any>();
+const signingRequestDocs = new Map<string, any>();
+const canonicalEventDocs = new Map<string, any>();
+
+function collectionFor(name: string) {
+  if (name === "tenants") return tenantDocs;
+  if (name === "properties") return propertyDocs;
+  if (name === "units") return unitDocs;
+  if (name === "leases") return leaseDocs;
+  if (name === "leaseSigningRequests") return signingRequestDocs;
+  if (name === "canonicalEvents") return canonicalEventDocs;
+  return new Map<string, any>();
+}
+
+function makeCollection(name: string) {
+  const docs = collectionFor(name);
+  const makeDoc = (id: string) => ({
+    id,
+    get: async () => ({
+      id,
+      exists: docs.has(id),
+      data: () => docs.get(id),
+    }),
+  });
+  const makeQuery = (filters: Array<{ field: string; value: any }> = []) => ({
+    where: (field: string, _op: string, value: any) => makeQuery([...filters, { field, value }]),
+    limit: () => makeQuery(filters),
+    orderBy: () => makeQuery(filters),
+    doc: makeDoc,
+    get: async () => {
+      const matched = Array.from(docs.entries()).filter(([, data]) =>
+        filters.every(({ field, value }) => data?.[field] === value)
+      );
+      return {
+        docs: matched.map(([id, data]) => ({ id, exists: true, data: () => data })),
+        forEach: (callback: (doc: any) => void) => {
+          for (const [id, data] of matched) callback({ id, exists: true, data: () => data });
+        },
+      };
+    },
+  });
+  return {
+    doc: makeDoc,
+    where: (field: string, _op: string, value: any) => makeQuery([{ field, value }]),
+    limit: () => makeQuery(),
+    orderBy: () => makeQuery(),
+    get: () => makeQuery().get(),
+  };
+}
 
 vi.mock("../../firebase", () => ({
   db: {
-    collection: (name: string) => {
-      if (name === "properties") {
-        return {
-          doc: (id: string) => ({
-            get: async () => ({
-              id,
-              exists: propertyDocs.has(id),
-              data: () => propertyDocs.get(id),
-            }),
-          }),
-          where: () => ({
-            get: async () => ({ docs: [] }),
-          }),
-          get: async () => ({ docs: [] }),
-        };
-      }
-      if (name !== "tenants") {
-        return {
-          doc: () => ({
-            get: async () => ({ exists: false, data: () => null }),
-          }),
-          where: (field: string, _op: string, value: string) => ({
-            get: async () => ({
-              docs: Array.from(unitDocs.entries())
-                .filter(([, data]) => data?.[field] === value)
-                .map(([id, data]) => ({ id, data: () => data })),
-            }),
-          }),
-          get: async () => ({ docs: [] }),
-        };
-      }
-      return {
-        where: (field: string, _op: string, value: string) => ({
-          get: async () => ({
-            forEach: (callback: (doc: any) => void) => {
-              for (const [id, data] of tenantDocs.entries()) {
-                if (data?.[field] === value) {
-                  callback({ id, data: () => data });
-                }
-              }
-            },
-          }),
-        }),
-        get: async () => ({
-          forEach: (callback: (doc: any) => void) => {
-            for (const [id, data] of tenantDocs.entries()) {
-              callback({ id, data: () => data });
-            }
-          },
-        }),
-      };
-    },
+    collection: makeCollection,
   },
 }));
 
-vi.mock("../leaseNoticeWorkflowService", () => ({
-  computeNoResponseState: vi.fn(),
-  getLeaseNoticeByLeaseId: vi.fn(),
-}));
+vi.mock("../leaseNoticeWorkflowService", async () => {
+  const actual = await vi.importActual<any>("../leaseNoticeWorkflowService");
+  return {
+    ...actual,
+    computeNoResponseState: vi.fn(),
+    getLeaseNoticeByLeaseId: vi.fn(async () => []),
+  };
+});
 
-vi.mock("../leaseCanonicalizationService", () => ({
-  loadUnitsForProperty: vi.fn(async (_db: any, propertyId: string, landlordId?: string | null) =>
-    Array.from(unitDocs.entries())
-      .filter(([, data]) => data?.propertyId === propertyId && (!landlordId || data?.landlordId === landlordId))
-      .map(([id, raw]) => ({
-        id,
-        landlordId: raw.landlordId ?? null,
-        propertyId: raw.propertyId ?? null,
-        unitNumber: raw.unitNumber ?? null,
-        label: raw.label ?? raw.unitLabel ?? raw.unitNumber ?? null,
-        rent: raw.rent ?? null,
-        raw,
-      }))
-  ),
-  resolveUnitReference: vi.fn((units: any[], reference: any) => {
-    const target = String(reference || "").trim().toLowerCase();
-    const unit = units.find((candidate) =>
-      [candidate.id, candidate.unitNumber, candidate.label]
-        .map((value) => String(value || "").trim().toLowerCase())
-        .includes(target)
-    );
-    return { unit: unit || null, matchedBy: unit ? "test" : null, ambiguous: false, candidateIds: unit ? [unit.id] : [] };
-  }),
-  toCanonicalLeaseRecord: vi.fn(() => null),
-  isCurrentLeaseStatus: vi.fn(() => false),
-}));
+vi.mock("../leaseCanonicalizationService", async () => {
+  const actual = await vi.importActual<any>("../leaseCanonicalizationService");
+  return {
+    ...actual,
+    loadUnitsForProperty: vi.fn(async (_db: any, propertyId: string, landlordId?: string | null) =>
+      Array.from(unitDocs.entries())
+        .filter(([, data]) => data?.propertyId === propertyId && (!landlordId || data?.landlordId === landlordId))
+        .map(([id, raw]) => ({
+          id,
+          landlordId: raw.landlordId ?? null,
+          propertyId: raw.propertyId ?? null,
+          unitNumber: raw.unitNumber ?? null,
+          label: raw.label ?? raw.unitLabel ?? raw.unitNumber ?? null,
+          rent: raw.rent ?? null,
+          raw,
+        }))
+    ),
+    resolveUnitReference: vi.fn((units: any[], reference: any) => {
+      const target = String(reference || "").trim().toLowerCase();
+      const unit = units.find((candidate) =>
+        [candidate.id, candidate.unitNumber, candidate.label]
+          .map((value) => String(value || "").trim().toLowerCase())
+          .includes(target)
+      );
+      return { unit: unit || null, matchedBy: unit ? "test" : null, ambiguous: false, candidateIds: unit ? [unit.id] : [] };
+    }),
+  };
+});
 
-vi.mock("../leasePartyConsolidationService", () => ({
-  groupLeaseAgreementCandidates: vi.fn(() => []),
-  pickAgreementWinner: vi.fn(() => null),
-  pickTenantWinningAgreement: vi.fn(() => null),
-}));
+vi.mock("../leasePartyConsolidationService", async () => vi.importActual("../leasePartyConsolidationService"));
 
 vi.mock("../risk/credibilityInsights", () => ({
   buildCredibilityInsights: vi.fn(() => null),
 }));
 
-vi.mock("../moveInRequirements", () => ({
-  buildMoveInRequirements: vi.fn(() => null),
-}));
+vi.mock("../moveInRequirements", async () => vi.importActual("../moveInRequirements"));
 
 vi.mock("../tenantMoveInReadinessService", () => ({
   buildMoveInReadinessRecord: vi.fn(() => null),
@@ -123,6 +121,9 @@ describe("getTenantsList", () => {
     tenantDocs.clear();
     propertyDocs.clear();
     unitDocs.clear();
+    leaseDocs.clear();
+    signingRequestDocs.clear();
+    canonicalEventDocs.clear();
     tenantDocs.set("tenant-visible", {
       landlordId: "landlord-1",
       fullName: "Visible Tenant",
@@ -267,5 +268,102 @@ describe("getTenantsList", () => {
     const tenants = await getTenantsList();
 
     expect(tenants.map((tenant) => tenant.id)).toEqual(["t1", "t2", "t3"]);
+  });
+});
+
+describe("getTenantDetailBundle", () => {
+  beforeEach(() => {
+    tenantDocs.clear();
+    propertyDocs.clear();
+    unitDocs.clear();
+    leaseDocs.clear();
+    signingRequestDocs.clear();
+    canonicalEventDocs.clear();
+  });
+
+  it("projects signed lease signing request state into tenant profile readiness and coherence", async () => {
+    propertyDocs.set("property-1", {
+      landlordId: "landlord-1",
+      name: "Oxford Suites",
+    });
+    unitDocs.set("unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "6",
+      label: "Unit 6",
+      status: "occupied",
+      occupancyStatus: "occupied",
+    });
+    tenantDocs.set("tenant-1", {
+      landlordId: "landlord-1",
+      fullName: "Signed Tenant",
+      email: "tenant@example.com",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      currentLeaseId: "lease-1",
+      status: "Current",
+      createdAt: "2026-01-05T00:00:00.000Z",
+    });
+    leaseDocs.set("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2026-07-01",
+      endDate: "2027-06-30",
+      monthlyRent: 1800,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    signingRequestDocs.set("request-1", {
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      currentSigningStatus: "signed",
+      currentStatusAt: "2026-06-10T12:00:00.000Z",
+      providerDispatchStatus: "accepted",
+      documentId: "doc-1",
+      documentHash: "hash-1",
+      manifestHash: "manifest-1",
+      jurisdictionCode: "CA_NS",
+      templateVersion: "ca-ns-form-p-draft-v1",
+    });
+    canonicalEventDocs.set("event-1", {
+      action: "signing_signed",
+      resource: { type: "lease", id: "lease-1" },
+      occurredAt: "2026-06-10T12:00:00.000Z",
+    });
+
+    const { getTenantDetailBundle } = await import("../tenantDetailsService");
+    const bundle = await getTenantDetailBundle("tenant-1", { landlordId: "landlord-1" });
+
+    expect(bundle.currentLease).toEqual(
+      expect.objectContaining({
+        id: "lease-1",
+        status: "active",
+        unit: "6",
+      })
+    );
+    expect(bundle.lifecycle).toEqual(
+      expect.objectContaining({
+        lifecycleState: "active",
+        flags: expect.objectContaining({ hasStateConflict: false }),
+      })
+    );
+    expect(bundle.stateCoherence).toEqual(
+      expect.objectContaining({
+        coherenceStatus: "coherent",
+        leaseExecutionState: "executed",
+        leaseOperationalState: "active",
+        occupancyState: "occupied",
+      })
+    );
+    expect(bundle.moveInRequirements?.items.find((item) => item.key === "lease_signed")).toEqual(
+      expect.objectContaining({
+        state: "complete",
+        source: "signing_request",
+        note: null,
+      })
+    );
   });
 });

--- a/rentchain-api/src/services/moveInRequirements.ts
+++ b/rentchain-api/src/services/moveInRequirements.ts
@@ -102,6 +102,10 @@ function includesKeyword(value: unknown, keywords: string[]) {
   return keywords.some((keyword) => text.includes(keyword));
 }
 
+function normalizeStatus(value: unknown): string {
+  return String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
 function hasDepositReceiptEvidence(payments: Array<{ notes?: unknown; method?: unknown }>, ledger: Array<{ notes?: unknown; type?: unknown }>) {
   const keywords = ["deposit", "security deposit"];
   return payments.some((payment) =>
@@ -164,8 +168,19 @@ export function buildMoveInRequirements(params: MoveInRequirementsParams): MoveI
   const leaseSignedAt =
     firstIso((leaseRaw as any)?.tenantSignature, ["signedAt"]) ||
     firstIso(leaseRaw, ["tenantSignedAt", "tenantSignatureCompletedAt", "fullySignedAt", "signatureCompletedAt"]);
+  const providerSigningStatus = normalizeStatus(
+    (leaseRaw as any)?.currentSigningStatus ||
+      (leaseRaw as any)?.signingStatus ||
+      (leaseRaw as any)?.leaseSigningStatus ||
+      (leaseRaw as any)?.providerSigningStatus
+  );
+  const providerSigned = ["signed", "completed", "complete"].includes(providerSigningStatus);
+  const providerSignedAt = providerSigned
+    ? firstIso(leaseRaw, ["currentStatusAt", "signingCompletedAt", "providerSignedAt", "fullyExecutedAt"])
+    : null;
   const leaseSigned = Boolean(
     leaseSignedAt ||
+      providerSigned ||
       firstBoolean(leaseRaw, ["leaseSigned", "isSigned", "signed"])
   );
 
@@ -254,8 +269,8 @@ export function buildMoveInRequirements(params: MoveInRequirementsParams): MoveI
       label: "Lease signed",
       required: hasLeaseContext,
       complete: hasLeaseContext ? leaseSigned : null,
-      source: leaseSignedAt ? "lease" : hasLeaseContext ? "lease_status" : null,
-      updatedAt: leaseSignedAt,
+      source: leaseSignedAt ? "lease" : providerSigned ? "signing_request" : hasLeaseContext ? "lease_status" : null,
+      updatedAt: leaseSignedAt || providerSignedAt,
       note: leaseSigned ? null : "Lease signature pending",
       unknownWhenOptional: true,
     }),

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -200,6 +200,118 @@ function normalizeTenantEmail(value: any): string | null {
   return next && next.includes("@") ? next : null;
 }
 
+const TENANT_PROFILE_LEASE_STATUSES = new Set([
+  "active",
+  "current",
+  "notice_pending",
+  "renewal_pending",
+  "renewal_accepted",
+  "move_out_pending",
+  "signed",
+  "signed_future",
+  "fully_executed",
+  "pending_signature",
+  "sent",
+  "ready_for_tenant_signature",
+  "tenant_signed",
+  "ready_for_landlord_signature",
+  "landlord_signed",
+]);
+
+function isTenantProfileLeaseCandidate(raw: Record<string, unknown>): boolean {
+  const status = normalizeIdentityString((raw as any)?.status);
+  const signingStatus = normalizeIdentityString(
+    (raw as any)?.currentSigningStatus ||
+      (raw as any)?.signingStatus ||
+      (raw as any)?.leaseSigningStatus ||
+      (raw as any)?.providerSigningStatus
+  );
+  return isCurrentLeaseStatus(status) || TENANT_PROFILE_LEASE_STATUSES.has(status) || TENANT_PROFILE_LEASE_STATUSES.has(signingStatus);
+}
+
+function latestTimestampMillis(record: Record<string, unknown> | null | undefined, keys: string[]): number {
+  if (!record) return 0;
+  return Math.max(0, ...keys.map((key) => toMillis((record as any)?.[key]) || 0));
+}
+
+async function loadLatestLeaseSigningRequest(leaseId: string | null | undefined, landlordId?: string | null) {
+  const normalizedLeaseId = String(leaseId || "").trim();
+  const normalizedLandlordId = String(landlordId || "").trim();
+  if (!normalizedLeaseId) return null;
+  try {
+    let query: FirebaseFirestore.Query = db.collection("leaseSigningRequests").where("leaseId", "==", normalizedLeaseId);
+    if (normalizedLandlordId) query = query.where("landlordId", "==", normalizedLandlordId);
+    const snap = await query.get();
+    return (
+      (snap.docs || [])
+        .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+        .sort(
+          (a: any, b: any) =>
+            latestTimestampMillis(b, ["currentStatusAt", "signedAt", "sentAt", "updatedAt", "createdAt"]) -
+            latestTimestampMillis(a, ["currentStatusAt", "signedAt", "sentAt", "updatedAt", "createdAt"])
+        )[0] || null
+    );
+  } catch (err) {
+    console.error("[tenantDetailsService] loadLatestLeaseSigningRequest error", err);
+    return null;
+  }
+}
+
+async function loadLatestSigningSignedEvent(leaseId: string | null | undefined) {
+  const normalizedLeaseId = String(leaseId || "").trim();
+  if (!normalizedLeaseId) return null;
+  try {
+    const snap = await db.collection("canonicalEvents").where("action", "==", "signing_signed").limit(100).get();
+    return (
+      (snap.docs || [])
+        .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+        .filter((event: any) => String(event?.resource?.type || "") === "lease")
+        .filter((event: any) => String(event?.resource?.id || "") === normalizedLeaseId)
+        .sort(
+          (a: any, b: any) =>
+            latestTimestampMillis(b, ["occurredAt", "recordedAt", "createdAt"]) -
+            latestTimestampMillis(a, ["occurredAt", "recordedAt", "createdAt"])
+        )[0] || null
+    );
+  } catch (err) {
+    console.error("[tenantDetailsService] loadLatestSigningSignedEvent error", err);
+    return null;
+  }
+}
+
+function buildTenantProfileLeaseRawProjection(params: {
+  raw: Record<string, unknown> | null;
+  signingRequest: any | null;
+  signingSignedEvent: any | null;
+}): Record<string, unknown> | null {
+  if (!params.raw) return null;
+  const signingStatus = normalizeIdentityString(params.signingRequest?.currentSigningStatus);
+  const signedByRequest = ["signed", "completed", "complete"].includes(signingStatus);
+  const signedByEvent = Boolean(params.signingSignedEvent);
+  const currentStatusAt =
+    pickString(params.signingRequest?.currentStatusAt, params.signingSignedEvent?.occurredAt, params.signingSignedEvent?.recordedAt) ||
+    null;
+
+  return {
+    ...params.raw,
+    currentSigningStatus:
+      signedByRequest || signedByEvent
+        ? "signed"
+        : signingStatus || (params.raw as any)?.currentSigningStatus || null,
+    signingStatus:
+      signedByRequest || signedByEvent
+        ? "signed"
+        : signingStatus || (params.raw as any)?.signingStatus || null,
+    currentStatusAt: currentStatusAt || (params.raw as any)?.currentStatusAt || null,
+    sentAt: params.signingRequest?.sentAt || (params.raw as any)?.sentAt || null,
+    documentId: params.signingRequest?.documentId || (params.raw as any)?.documentId || null,
+    documentHash: params.signingRequest?.documentHash || (params.raw as any)?.documentHash || null,
+    manifestHash: params.signingRequest?.manifestHash || (params.raw as any)?.manifestHash || null,
+    jurisdictionCode: params.signingRequest?.jurisdictionCode || (params.raw as any)?.jurisdictionCode || null,
+    templateVersion: params.signingRequest?.templateVersion || (params.raw as any)?.templateVersion || null,
+  };
+}
+
 function isHiddenFromActiveLists(tenant: Pick<TenantRecord, "id" | "hiddenFromActiveLists">) {
   return tenant.hiddenFromActiveLists === true || isTargetedHiddenTenantId(tenant.id);
 }
@@ -345,7 +457,7 @@ async function loadCurrentLeaseSnapshot(tenant: TenantRecord | null, landlordId?
 
     const currentEntries = Array.from(candidates.entries()).filter(([, raw]) => {
       const landlordMatch = !landlordId || String((raw as any)?.landlordId || "").trim() === String(landlordId);
-      return landlordMatch && isCurrentLeaseStatus((raw as any)?.status);
+      return landlordMatch && isTenantProfileLeaseCandidate(raw);
     });
     if (!currentEntries.length) return null;
 
@@ -604,15 +716,22 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
   }
 
   const currentLeaseRecord = await loadCurrentLeaseSnapshot(tenant, landlordId);
-  const currentLeaseRaw = await loadLeaseRawById(currentLeaseRecord?.id || null);
-  const [tenantInviteState, tenantTenancies, applicationRaw] = await Promise.all([
+  const baseCurrentLeaseRaw = await loadLeaseRawById(currentLeaseRecord?.id || null);
+  const [tenantInviteState, tenantTenancies, applicationRaw, latestSigningRequest, latestSigningSignedEvent] = await Promise.all([
     loadLatestTenantInviteState(tenant, landlordId),
     tenant ? listTenanciesByTenantId(tenant.id, { landlordId }).catch((err) => {
       console.error("[tenantDetailsService] listTenanciesByTenantId error", err);
       return [];
     }) : Promise.resolve([]),
     loadApplicationRawById(tenant?.applicationId || null),
+    loadLatestLeaseSigningRequest(currentLeaseRecord?.id || null, landlordId),
+    loadLatestSigningSignedEvent(currentLeaseRecord?.id || null),
   ]);
+  const currentLeaseRaw = buildTenantProfileLeaseRawProjection({
+    raw: baseCurrentLeaseRaw,
+    signingRequest: latestSigningRequest,
+    signingSignedEvent: latestSigningSignedEvent,
+  });
   const currentTenancy = tenantTenancies[0] || buildDerivedTenancyFromTenant(tenant);
   const property = await loadPropertyRecord(currentLeaseRecord?.propertyId || tenant?.propertyId || null);
   const unit = await loadUnitRecord(

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -258,6 +258,63 @@ describe("TenantsPage", () => {
     expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-active-1/summary");
     expect(screen.queryByText("lease-active-1")).not.toBeInTheDocument();
     expect(screen.queryByText("No current lease linked")).not.toBeInTheDocument();
+  });
+
+  it("uses the current lease as the active unit link when tenancy registration is stale", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyName: "Main Street",
+        propertyId: "property-1",
+        unit: "Unit 4",
+        unitId: "unit-4",
+        currentLeaseId: "lease-signed-1",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      bundle: {
+        tenant: { id: "tenant-1", fullName: "Taylor Tenant" },
+        currentLease: {
+          id: "lease-signed-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          propertyName: "Main Street",
+          unitId: "unit-4",
+          unit: "Unit 4",
+          leaseStart: "2026-01-01",
+          leaseEnd: null,
+          monthlyRent: 1850,
+          status: "active",
+        },
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Current lease links this tenant to the active lease and unit; no separate active tenancy registration is recorded yet."
+      )
+    ).toBeInTheDocument();
+    const registeredUnitsCard =
+      screen.getByText("Active registered units").closest("section") ||
+      screen.getByText("Active registered units").parentElement;
+    expect(registeredUnitsCard).not.toBeNull();
+    expect(within(registeredUnitsCard as HTMLElement).getByText("1")).toBeInTheDocument();
+    expect(screen.queryByText("No active tenancy registrations are linked to this tenant.")).not.toBeInTheDocument();
   });
 
   it("shows no current lease linked when neither list nor detail has a current lease", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -152,23 +152,27 @@ function describeTenantLinkage(
   const primaryProperty = tenant.propertyName || tenant.propertyId || "No property linked";
   const primaryUnit = tenant.unit || tenant.unitLabel || tenant.unitId || "No unit linked";
   const currentLeaseId = String(currentLease?.id || tenant.currentLeaseId || "").trim();
+  const hasCurrentLeaseLink = Boolean(currentLeaseId);
   const leaseLabel = currentLeaseId
     ? [primaryProperty !== "No property linked" ? primaryProperty : null, primaryUnit !== "No unit linked" ? primaryUnit : null, "Lease"]
         .filter(Boolean)
         .join(" · ")
     : "No current lease linked";
+  const activeTenancyCount = activeTenancies.length || (hasCurrentLeaseLink ? 1 : 0);
 
   return {
     propertyLabel: primaryProperty,
     unitLabel: primaryUnit,
     leaseLabel,
     leaseId: currentLeaseId || null,
-    activeTenancyCount: activeTenancies.length,
+    activeTenancyCount,
     linkageNote:
       !tenant.propertyId && !tenant.unitId && !currentLeaseId
         ? "This tenant record has no canonical property, unit, or current lease linkage yet."
         : activeTenancies.length === 0
-        ? "No active tenancy registrations are linked to this tenant."
+        ? hasCurrentLeaseLink
+          ? "Current lease links this tenant to the active lease and unit; no separate active tenancy registration is recorded yet."
+          : "No active tenancy registrations are linked to this tenant."
         : "Tenant profile links remain separate from tenancy and lease lifecycle state.",
   };
 }


### PR DESCRIPTION
## Summary
- Project the latest lease signing request and canonical signing event into the tenant profile lease read model.
- Treat provider-signed leases as signed for move-in readiness so tenant profiles stop showing stale "Lease signature pending" blockers.
- Use the selected current lease as the active unit link in `/tenants` when a separate tenancy registration row has not caught up.

## Root Cause
`/tenants` was deriving profile readiness from older lease and tenancy registration projections. It did not consume the same signing request/canonical signed-event evidence now used by `/leases`, so a signed lease could still look like draft or pending in tenant profile surfaces.

## Validation
- `rentchain-api`: `npm run test:emulator -- src/services/__tests__/moveInRequirements.test.ts src/services/__tests__/tenantDetailsService.test.ts src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts src/lib/leases/__tests__/deriveLeaseOccupancyCoherence.test.ts src/lib/tenants/__tests__/deriveTenantLifecycle.test.ts`
- `rentchain-frontend`: `npm run test -- src/pages/TenantsPage.test.tsx`
- `rentchain-api`: `npm run build`
- `rentchain-frontend`: `npm run build`
- `git diff --check`

## QA Notes
Manual preview QA should verify a signed/executed lease shows consistently across `/leases` and `/tenants`: signed state, no lease signature pending blocker, coherent occupancy/unit link, and the current lease link to the lease workspace.