### PR TITLE
fix: align lease readiness projection

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -522,7 +522,7 @@ describe("leaseRoutes GET /active", () => {
     );
   });
 
-  it("projects signed provider lifecycle as executed while preserving payment setup warnings", async () => {
+  it("projects signed provider lifecycle and Form P rent terms from the primary document", async () => {
     getPrimaryLeaseDocumentSummaryMock.mockResolvedValueOnce({
       id: "ldoc_signed",
       leaseId: "lease-signed-provider",
@@ -536,6 +536,15 @@ describe("leaseRoutes GET /active", () => {
       manifestHash: "manifest_hash_signed",
       storageRef: null,
       previewUrl: "https://signed.example.com/primary-signed-preview.pdf",
+      formPFields: {
+        rent_payments: {
+          due_day: {
+            label: "Due day",
+            status: "provided",
+            value: 1,
+          },
+        },
+      },
     });
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
@@ -593,9 +602,9 @@ describe("leaseRoutes GET /active", () => {
           }),
         }),
         paymentReadiness: expect.objectContaining({
-          readinessStatus: "not_ready",
+          readinessStatus: "ready_to_configure",
           rentTerms: expect.objectContaining({
-            dueDateAvailable: false,
+            dueDateAvailable: true,
             leaseExecuted: true,
           }),
         }),

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -1383,6 +1383,8 @@ function buildLeaseProjectionRaw(input: {
     manifestHash: input.signingRequest?.manifestHash || input.primaryDocument?.manifestHash || input.raw?.manifestHash || null,
     jurisdictionCode: input.signingRequest?.jurisdictionCode || input.primaryDocument?.jurisdictionCode || input.raw?.jurisdictionCode || null,
     templateVersion: input.signingRequest?.templateVersion || input.primaryDocument?.templateVersion || input.raw?.templateVersion || null,
+    formPFields: input.raw?.formPFields || input.primaryDocument?.formPFields || null,
+    leaseReadiness: input.raw?.leaseReadiness || input.primaryDocument?.leaseReadiness || null,
   };
 }
 

--- a/rentchain-api/src/services/projections/__tests__/buildLeasePaymentProjection.test.ts
+++ b/rentchain-api/src/services/projections/__tests__/buildLeasePaymentProjection.test.ts
@@ -100,4 +100,45 @@ describe("buildLeasePaymentProjection", () => {
     expect(result.blockedReason).toBe("payment_readiness_not_ready");
     expect(result.rentPaymentSummary.paymentRail.blockedReason).toBe("payment_readiness_not_ready");
   });
+
+  it("uses provided Form P due day metadata when the lease row is stale", async () => {
+    const { buildLeasePaymentProjection } = await import("../buildLeasePaymentProjection");
+    const result = await buildLeasePaymentProjection({
+      rawLease: {
+        status: "active",
+        dueDay: null,
+        tenantSignedAt: "2026-04-20T12:00:00.000Z",
+        landlordSignedAt: "2026-04-21T12:00:00.000Z",
+        formPFields: {
+          rent_payments: {
+            due_day: {
+              label: "Due day",
+              status: "provided",
+              value: 1,
+            },
+          },
+        },
+      },
+      lease: {
+        id: "lease-3",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        primaryTenantId: "tenant-1",
+        tenantIds: ["tenant-1"],
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        unitNumber: "1A",
+        monthlyRent: 1800,
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        status: "active",
+      },
+      leaseId: "lease-3",
+      documentUrl: "safe-document-ref",
+    });
+
+    expect(result.paymentReadiness.rentTerms.dueDateAvailable).toBe(true);
+    expect(result.paymentReadiness.readinessStatus).toBe("ready_to_configure");
+    expect(result.blockedReason).toBeNull();
+  });
 });

--- a/rentchain-api/src/services/projections/buildLeasePaymentProjection.ts
+++ b/rentchain-api/src/services/projections/buildLeasePaymentProjection.ts
@@ -47,6 +47,13 @@ export type LeasePaymentProjection = {
   rentPaymentSummary: RentPaymentSummary;
 };
 
+function numberFromFormPField(raw: any, sectionKey: string, fieldKey: string): number | null {
+  const field = raw?.formPFields?.[sectionKey]?.[fieldKey];
+  if (!field || String(field.status || "").trim() !== "provided") return null;
+  const value = Number(field.value);
+  return Number.isFinite(value) ? value : null;
+}
+
 export async function buildLeasePaymentProjection(
   input: BuildLeasePaymentProjectionInput
 ): Promise<LeasePaymentProjection> {
@@ -57,12 +64,16 @@ export async function buildLeasePaymentProjection(
     leaseId,
     documentUrl: input.documentUrl ?? null,
   });
+  const dueDay =
+    typeof raw?.dueDay === "number"
+      ? raw.dueDay
+      : numberFromFormPField(raw, "rent_payments", "due_day");
   const paymentReadiness = derivePaymentReadiness({
     leaseId,
     monthlyRent: lease.monthlyRent,
     startDate: lease.startDate,
     endDate: lease.endDate,
-    dueDay: typeof raw?.dueDay === "number" ? raw.dueDay : null,
+    dueDay,
     tenantId:
       asProjectionString(lease.tenantId) ||
       asProjectionString(lease.primaryTenantId) ||


### PR DESCRIPTION
## Summary
- Carries sanitized primary lease document readiness metadata into the active lease projection.
- Lets payment readiness use a provided Form P `rent_payments.due_day` value when the underlying lease row is stale or missing `dueDay`.
- Adds regression coverage for the observed contradiction where the generated lease contains `Due day: 1` but the lease card still reports `Due day missing`.

## Scope
Backend projection only. No lease generation, signing, Dropbox, document download, Form R/deposit, or frontend UI behavior changes.

## Validation
- `rentchain-api`: `npm run test:emulator -- src/services/projections/__tests__/buildLeasePaymentProjection.test.ts src/routes/__tests__/leaseRoutes.active.test.ts src/services/paymentReadiness/__tests__/derivePaymentReadiness.test.ts`
- `rentchain-api`: `npm run build`
- `git diff --check`

## Preview QA Notes
After Cloud Run parity, verify a lease whose generated PDF shows `Due day: 1` no longer shows `Due day missing` in `/leases` readiness/payment cards. Confirm genuinely missing due-day leases still surface the missing state.