### PR TITLE
fix: route tenant profile lease links to signed document source

### DIFF
--- a/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
@@ -6,6 +6,7 @@ const unitDocs = new Map<string, any>();
 const leaseDocs = new Map<string, any>();
 const signingRequestDocs = new Map<string, any>();
 const canonicalEventDocs = new Map<string, any>();
+const getSignedLeaseDocumentDownloadMock = vi.hoisted(() => vi.fn());
 
 function collectionFor(name: string) {
   if (name === "tenants") return tenantDocs;
@@ -114,6 +115,10 @@ vi.mock("../tenantMoveInReadinessService", () => ({
 vi.mock("../tenanciesService", () => ({
   buildDerivedTenancyFromTenant: vi.fn(() => null),
   listTenanciesByTenantId: vi.fn(async () => []),
+}));
+
+vi.mock("../signing/leaseSigningService", () => ({
+  getSignedLeaseDocumentDownload: getSignedLeaseDocumentDownloadMock,
 }));
 
 describe("getTenantsList", () => {
@@ -279,6 +284,14 @@ describe("getTenantDetailBundle", () => {
     leaseDocs.clear();
     signingRequestDocs.clear();
     canonicalEventDocs.clear();
+    getSignedLeaseDocumentDownloadMock.mockReset();
+    getSignedLeaseDocumentDownloadMock.mockResolvedValue({
+      documentUrl: null,
+      expiresInSeconds: null,
+      documentHash: null,
+      signedDocumentStoredAt: null,
+      source: null,
+    });
   });
 
   it("projects signed lease signing request state into tenant profile readiness and coherence", async () => {
@@ -328,6 +341,13 @@ describe("getTenantDetailBundle", () => {
       jurisdictionCode: "CA_NS",
       templateVersion: "ca-ns-form-p-draft-v1",
     });
+    getSignedLeaseDocumentDownloadMock.mockResolvedValue({
+      documentUrl: "https://storage.googleapis.com/rentchain-documents-prod/lease-signing/1?X-Goog-Signature=safe",
+      expiresInSeconds: 1800,
+      documentHash: "hash-1",
+      signedDocumentStoredAt: "2026-06-10T12:05:00.000Z",
+      source: "signedDocument",
+    });
     canonicalEventDocs.set("event-1", {
       action: "signing_signed",
       resource: { type: "lease", id: "lease-1" },
@@ -342,8 +362,16 @@ describe("getTenantDetailBundle", () => {
         id: "lease-1",
         status: "active",
         unit: "6",
+        signedDocumentUrl:
+          "https://storage.googleapis.com/rentchain-documents-prod/lease-signing/1?X-Goog-Signature=safe",
+        signedDocumentExpiresInSeconds: 1800,
+        signedDocumentSource: "signedDocument",
       })
     );
+    expect(getSignedLeaseDocumentDownloadMock).toHaveBeenCalledWith({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+    });
     expect(bundle.lifecycle).toEqual(
       expect.objectContaining({
         lifecycleState: "active",
@@ -365,5 +393,50 @@ describe("getTenantDetailBundle", () => {
         note: null,
       })
     );
+  });
+
+  it("falls back to internal lease summary when no signed document source is available", async () => {
+    tenantDocs.set("tenant-1", {
+      landlordId: "landlord-1",
+      fullName: "Unsigned Tenant",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      currentLeaseId: "lease-1",
+      status: "Current",
+    });
+    propertyDocs.set("property-1", { landlordId: "landlord-1", name: "Oxford Suites" });
+    unitDocs.set("unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "6",
+      status: "occupied",
+      occupancyStatus: "occupied",
+    });
+    leaseDocs.set("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      status: "pending_signature",
+      startDate: "2026-07-01",
+      endDate: "2027-06-30",
+      monthlyRent: 1800,
+    });
+
+    const { getTenantDetailBundle } = await import("../tenantDetailsService");
+    const bundle = await getTenantDetailBundle("tenant-1", { landlordId: "landlord-1" });
+
+    expect(bundle.currentLease).toEqual(
+      expect.objectContaining({
+        id: "lease-1",
+        signedDocumentUrl: null,
+        signedDocumentExpiresInSeconds: null,
+        signedDocumentSource: null,
+      })
+    );
+    expect(getSignedLeaseDocumentDownloadMock).toHaveBeenCalledWith({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+    });
   });
 });

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -33,6 +33,7 @@ import {
   type TenantLifecycleResult,
 } from "../lib/tenants/deriveTenantLifecycle";
 import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupancyCoherence";
+import { getSignedLeaseDocumentDownload } from "./signing/leaseSigningService";
 
 export interface TenantRecord {
   id: string;
@@ -77,6 +78,9 @@ export interface TenantLease {
   leaseEnd: string | null;
   monthlyRent: number;
   status?: string | null;
+  signedDocumentUrl?: string | null;
+  signedDocumentExpiresInSeconds?: number | null;
+  signedDocumentSource?: "signedDocument" | "legacySignedDocumentUrl" | null;
 }
 
 export interface TenantPaymentDto {
@@ -617,6 +621,28 @@ async function loadLatestTenantInviteState(tenant: TenantRecord | null, landlord
   }
 }
 
+async function loadSignedLeaseDocumentLink(leaseId: string | null | undefined, landlordId?: string | null) {
+  const normalizedLeaseId = String(leaseId || "").trim();
+  const normalizedLandlordId = String(landlordId || "").trim();
+  if (!normalizedLeaseId || !normalizedLandlordId) return null;
+  try {
+    const signedDocument = await getSignedLeaseDocumentDownload({
+      leaseId: normalizedLeaseId,
+      landlordId: normalizedLandlordId,
+    });
+    const documentUrl = String(signedDocument?.documentUrl || "").trim();
+    if (!documentUrl) return null;
+    return {
+      signedDocumentUrl: documentUrl,
+      signedDocumentExpiresInSeconds: signedDocument.expiresInSeconds ?? null,
+      signedDocumentSource: signedDocument.source ?? null,
+    };
+  } catch (err) {
+    console.error("[tenantDetailsService] loadSignedLeaseDocumentLink error", err);
+    return null;
+  }
+}
+
 export async function getTenantsList(opts: TenantQueryOptions = {}): Promise<TenantRecord[]> {
   const landlordId = opts.landlordId?.trim?.() ? String(opts.landlordId).trim() : null;
   const excludeHiddenFromActiveLists = opts.excludeHiddenFromActiveLists === true;
@@ -741,6 +767,7 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
     landlordId
   );
   const latestLeaseNoticeSummary = await loadLatestLeaseNoticeSummary(currentLeaseRecord?.id || null, currentLeaseRecord?.status || null);
+  const signedDocumentLink = await loadSignedLeaseDocumentLink(currentLeaseRecord?.id || null, landlordId);
 
   const lease: TenantLease | null = currentLeaseRecord
     ? {
@@ -757,6 +784,9 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
         leaseEnd: currentLeaseRecord.leaseEndDate,
         monthlyRent: Number(currentLeaseRecord.currentRent || 0),
         status: currentLeaseRecord.status,
+        signedDocumentUrl: signedDocumentLink?.signedDocumentUrl || null,
+        signedDocumentExpiresInSeconds: signedDocumentLink?.signedDocumentExpiresInSeconds ?? null,
+        signedDocumentSource: signedDocumentLink?.signedDocumentSource || null,
       }
     : tenant
     ? {

--- a/rentchain-frontend/src/api/tenantDetail.ts
+++ b/rentchain-frontend/src/api/tenantDetail.ts
@@ -26,6 +26,9 @@ export interface TenantLeaseSummary {
   leaseEnd: string | null;
   monthlyRent: string | number;
   status?: string | null;
+  signedDocumentUrl?: string | null;
+  signedDocumentExpiresInSeconds?: number | null;
+  signedDocumentSource?: "signedDocument" | "legacySignedDocumentUrl" | null;
 }
 
 export interface TenantPropertySummary {

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -260,6 +260,64 @@ describe("TenantsPage", () => {
     expect(screen.queryByText("No current lease linked")).not.toBeInTheDocument();
   });
 
+  it("prefers the signed lease document URL for tenant profile lease links when available", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyName: "Main Street",
+        propertyId: "property-1",
+        unit: "Unit 4",
+        unitId: "unit-4",
+        currentLeaseId: "lease-signed-1",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([
+      { id: "tenancy-1", tenantId: "tenant-1", status: "active", unitLabel: "Unit 4" },
+    ]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      bundle: {
+        tenant: { id: "tenant-1", fullName: "Taylor Tenant" },
+        currentLease: {
+          id: "lease-signed-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          propertyName: "Main Street",
+          unitId: "unit-4",
+          unit: "Unit 4",
+          leaseStart: "2026-01-01",
+          leaseEnd: null,
+          monthlyRent: 1850,
+          status: "active",
+          signedDocumentUrl: "https://storage.googleapis.com/rentchain-documents-prod/lease-signing/1?X-Goog-Signature=safe",
+          signedDocumentExpiresInSeconds: 1800,
+          signedDocumentSource: "signedDocument",
+        },
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    const leaseLinks = screen.getAllByRole("link", { name: "Main Street · Unit 4 · Lease" });
+    expect(leaseLinks.length).toBeGreaterThan(0);
+    expect(leaseLinks[0]).toHaveAttribute(
+      "href",
+      "https://storage.googleapis.com/rentchain-documents-prod/lease-signing/1?X-Goog-Signature=safe"
+    );
+    expect(leaseLinks[0]).toHaveAttribute("target", "_blank");
+  });
+
   it("uses the current lease as the active unit link when tenancy registration is stale", async () => {
     mocks.useCapabilitiesMock.mockReturnValue({
       features: { tenant_invites: true },

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -184,6 +184,48 @@ function getTenantCurrentLeaseId(
   return String(currentLease?.id || tenant?.currentLeaseId || "").trim();
 }
 
+function buildTenantLeaseLink(
+  tenant?: TenantApiModel | null,
+  currentLease?: TenantLeaseSummary | null
+) {
+  const signedDocumentUrl = String(currentLease?.signedDocumentUrl || "").trim();
+  if (signedDocumentUrl) {
+    return {
+      href: signedDocumentUrl,
+      external: true,
+    };
+  }
+  const currentLeaseId = getTenantCurrentLeaseId(tenant, currentLease);
+  return currentLeaseId
+    ? {
+        href: `/leases/${encodeURIComponent(currentLeaseId)}/summary`,
+        external: false,
+      }
+    : null;
+}
+
+function TenantLeaseLink({
+  link,
+  children,
+}: {
+  link: ReturnType<typeof buildTenantLeaseLink>;
+  children: React.ReactNode;
+}) {
+  if (!link) return <>{children}</>;
+  if (link.external) {
+    return (
+      <a href={link.href} target="_blank" rel="noreferrer" style={{ fontWeight: 700, color: "#2563eb" }}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link to={link.href} style={{ fontWeight: 700, color: "#2563eb" }}>
+      {children}
+    </Link>
+  );
+}
+
 type TenantsErrorBoundaryState = {
   hasError: boolean;
   debugId: string;
@@ -480,9 +522,7 @@ const loadTenants = useCallback(async () => {
   const selectedLeaseLedgerPath = selectedCurrentLeaseId
     ? `/leases/${encodeURIComponent(selectedCurrentLeaseId)}/ledger`
     : null;
-  const selectedLeaseSummaryPath = selectedCurrentLeaseId
-    ? `/leases/${encodeURIComponent(selectedCurrentLeaseId)}/summary`
-    : null;
+  const selectedLeaseLink = buildTenantLeaseLink(selectedTenant, selectedCurrentLease);
 
   const filteredTenants = useMemo(() => {
     const base = tenants || [];
@@ -961,13 +1001,7 @@ const loadTenants = useCallback(async () => {
                       <Card>
                         <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Current lease link</div>
                         <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
-                          {selectedLeaseSummaryPath ? (
-                            <Link to={selectedLeaseSummaryPath} style={{ fontWeight: 700, color: "#2563eb" }}>
-                              {selectedTenantLinkage.leaseLabel}
-                            </Link>
-                          ) : (
-                            selectedTenantLinkage.leaseLabel
-                          )}
+                          <TenantLeaseLink link={selectedLeaseLink}>{selectedTenantLinkage.leaseLabel}</TenantLeaseLink>
                         </div>
                       </Card>
                       <Card>
@@ -1051,13 +1085,7 @@ const loadTenants = useCallback(async () => {
                         <div>
                           <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Current lease</div>
                           <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
-                            {selectedLeaseSummaryPath ? (
-                              <Link to={selectedLeaseSummaryPath} style={{ fontWeight: 700, color: "#2563eb" }}>
-                                {selectedTenantLinkage.leaseLabel}
-                              </Link>
-                            ) : (
-                              selectedTenantLinkage.leaseLabel
-                            )}
+                            <TenantLeaseLink link={selectedLeaseLink}>{selectedTenantLinkage.leaseLabel}</TenantLeaseLink>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- Extend the landlord-scoped tenant detail payload with a safe, time-limited signed lease document URL when the canonical signed document source exists.
- Update `/tenants` current lease links to prefer the signed document URL and fall back to `/leases/:leaseId/summary` when no signed document is available.
- Add backend/frontend regression coverage for signed-document preference and summary fallback.

## Tests
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- --run src/services/__tests__/tenantDetailsService.test.ts` from `rentchain-api`
- `npm test -- --run src/pages/TenantsPage.test.tsx` from `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- --run src/services/__tests__/leaseSigningService.test.ts` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` from `rentchain-frontend`
- `git diff --check`

## Preview QA Plan
- Open `/tenants` for a tenant with a signed lease document and confirm the current lease link opens the signed document URL.
- Open `/tenants` for a tenant without a signed document and confirm the current lease link still routes to `/leases/:leaseId/summary`.
- Confirm `/leases`, lease summary, ledger, signed document download, and tenant profile rendering still behave normally.

## Notes
- No raw storage refs, provider IDs, or provider payloads are exposed. The frontend receives only the existing backend-generated signed document URL and expiry/source metadata.
- This does not change lease signing lifecycle, webhook handling, document generation, or Form P readiness behavior.