### PR TITLE
docs: audit unified messaging inbox IA

### DIFF
--- a/docs/audit/decision-queue-source-of-truth-v1.md
+++ b/docs/audit/decision-queue-source-of-truth-v1.md
@@ -1,0 +1,222 @@
+# Decision Queue Source Of Truth V1
+
+## Scope
+
+This audit establishes a single authoritative decision model for Dashboard 2.0 and Operations planning.
+
+Reviewed source areas:
+
+- Dashboard summary and action prompts.
+- Operations command center.
+- Decision inbox.
+- Tenant profiles and move-in readiness.
+- Lease profiles, state coherence, payment readiness, Form P readiness, delivery readiness, signing, documents, workflow pages.
+- Maintenance workspace labels and approval readiness.
+- Payments and delinquency signals.
+- Notices and lease expiry workflows.
+- Property action requests.
+- Tenant portal as a downstream state source.
+
+This is a documentation-only audit. It does not change code, routes, UI, database records, Cloud Run, Vercel, or tests.
+
+## Current Generators
+
+| Generator | Representative source | Emits today | Current destination | Source-of-truth status |
+| --- | --- | --- | --- | --- |
+| Dashboard summary actions | `rentchain-api/src/routes/dashboardRoutes.ts`, `ActionRequiredPanel` | Add property, add unit, track/add applicant, run first screening, invite tenant. | `/dashboard` and direct route links. | Activation prompts, not canonical decisions. |
+| Dashboard decision/analytics panels | Dashboard frontend analytics components and dashboard summary API | Portfolio insights, decision summaries, KPI context. | `/dashboard`. | Summary/preview only. |
+| Decision inbox engine | `deriveDecisionInbox`, `decisionEngine`, `landlordDecisionInboxRoutes` | Lease/payment lifecycle decisions plus analytics decisions. | `/decision-inbox`, Operations. | Closest existing canonical decision engine. |
+| Operations command center | `OperationalCommandCenterPage.tsx` | Derived operational signals from decision inbox, leases, properties. | `/operations`. | Best landlord-facing queue shell, but currently frontend-derived. |
+| Payment delinquency | `delinquencySignals`, `decisionEngine`, payment obligation ledger | Rent due, overdue, failed, missing, underpaid, manual review. | Decision inbox and Operations. | Strong candidate for canonical queue source. |
+| Lease lifecycle | `leaseLifecycle`, `deriveLeaseLifecycleSummary`, notice workflow service | Expiring lease, notice period, renewal/no-response, move-out. | Leases, Dashboard lease notice summary, Operations. | Partly canonical; needs normalized queue promotion. |
+| Lease state coherence | `deriveLeaseOccupancyCoherence` | Active-before-execution, active-on-vacant, occupied-without-executed-lease, payment activity without provider setup. | Leases, Tenants, Operations. | Should become canonical queue generator. |
+| Lease execution/signing | Lease signing service, `LeaseSigningDashboard`, active leases projection | Draft, pending signature, signed, blocked, document availability. | `/leases`. | Source-workspace readiness; queue only when blocking or inconsistent. |
+| Payment readiness | `derivePaymentReadiness` | Ready/not-ready/blocked rent term and payment setup readiness. | `/leases`, Operations. | Warning/readiness generator, not always a decision. |
+| Form P readiness | Lease document/readiness projections | Missing/provided/pending/not applicable lease readiness fields. | `/leases`, generated PDF metadata. | Source readiness; queue only when blocking lease use/signing. |
+| Delivery readiness | Signed lease copy and Act copy/link delivery readiness. | Delivery pending/provided/not recorded. | `/leases`. | Source readiness; queue only after generation/signing context. |
+| Tenant move-in readiness | `moveInRequirements`, `moveInReadiness`, `TenantDetailPanel` | Lease signed, portal invited/activated, deposit, inspection, keys, utilities, insurance. | `/tenants` tenant profile. | Tenant-owned readiness; queue only for move-in blockers. |
+| Tenant state coherence | `tenantDetailsService` plus state coherence projection | Current lease/occupancy/lifecycle agreement or conflict. | `/tenants`, Operations indirectly. | Should feed queue only when conflict is real. |
+| Maintenance lifecycle | `maintenanceWorkspaceState`, `workOrderOperationalLabels` | Submitted, acknowledged, in progress, completed, needs attention. | Maintenance workspace. | Missing canonical queue integration. |
+| Maintenance approval readiness | `maintenanceApprovalReadiness` | Cost/evidence/review readiness for deterministic execution. | Maintenance/cost review surfaces. | Missing canonical queue integration. |
+| Notices | `leaseNoticeWorkflowService`, tenant/landlord notice routes | Notice due, sent, viewed, pending response, no response, renew/quit. | Lease workflow pages, Dashboard summary. | Should feed Upcoming/Warning queue lanes. |
+| Property action requests | `actionRequestsService`, `PropertiesPage` | Open property action requests. | `/properties?panel=actionRequests`. | Missing canonical queue integration. |
+| Tenant portal | Tenant portal services and frontend tenant pages | Tenant-facing documents/payments/maintenance/profile status. | Tenant portal. | State source only; landlord queue should consume only landlord-actionable items. |
+
+## Duplicates
+
+| Duplicate area | Current duplication | Recommended source of truth |
+| --- | --- | --- |
+| "Action Required" versus Decision Queue | Dashboard action prompts look like decisions but are mostly onboarding/activation next steps. | Keep Dashboard actions as Activation/Upcoming Actions, not Decision Queue items. |
+| Operations versus Decision Inbox | Operations consumes decision inbox and adds its own lease/property signals. Decision Inbox remains separately reachable. | Operations should become landlord-facing canonical queue; Decision Inbox should be the engine/detail source. |
+| Lease profile versus tenant profile state coherence | Both surfaces can display draft/pending/review labels for the same lease/tenant relationship. | Lease execution belongs to Leases; move-in/tenant linkage belongs to Tenants. Conflicts should route by owning source. |
+| Lease payment readiness versus payment delinquency | Payment readiness warns about missing setup; delinquency decisions warn about missed/failed payment obligations. | Payment readiness is setup warning; delinquency is decision/critical issue. |
+| Lease lifecycle summary versus notice workflow | Expiry, renewal, no-response, and notice deadlines can appear in dashboard summary, lease profile, and workflow pages. | Notice workflow owns notice action. Lease lifecycle owns status. Operations owns prioritization. |
+| Maintenance labels versus operational decisions | Maintenance uses "needs attention" and "needs review" labels outside Decision Inbox. | Maintenance should emit queue items for submitted, blocked, cancelled, stalled, or cost-review cases. |
+| Property action requests versus operations | Properties has action requests that are not clearly represented in Operations. | Property action requests should feed property-owned Needs Review queue items. |
+
+## Conflicts
+
+| Conflict | Cause | Recommendation |
+| --- | --- | --- |
+| "Needs Review" is used as both state and severity | State coherence, maintenance, screening, and command center all use review wording differently. | Treat Needs Review as review state. Pair with Critical/Warning/Informational severity. |
+| Critical and warning thresholds vary by generator | Decision inbox has `critical/high/medium`; decision engine has `critical/warning/info`; operations has `critical/warning/info`. | Normalize into the severity model before display. |
+| Upcoming items can be mixed with warnings | Lease expiry and notice timing appear as guidance, summary, or review depending on surface. | Use Upcoming until near/missed deadlines; then promote to Warning or Critical. |
+| Onboarding actions can inflate open action counts | Dashboard actions count empty-state setup steps as open actions. | Separate Activation Actions from Decision Queue count. |
+| Readiness gaps can look like legal/compliance failure | Form P and delivery readiness are operational readiness, not legal certification. | Label as operational readiness and keep legal disclaimers out of the decision severity model. |
+| Tenant portal state may be interpreted as landlord action | Tenant-facing pending items can look like landlord blockers. | Only route to landlord queue when landlord has a concrete action or source conflict. |
+
+## Missing Generators
+
+| Missing generator | Why it matters | Recommended queue treatment |
+| --- | --- | --- |
+| Maintenance submitted/unreviewed | Landlords need to triage new requests. | Warning or Needs Review item owned by Maintenance. |
+| Maintenance blocked/cancelled/stalled | Service workflow can stop without entering the canonical queue. | Critical/Warning item owned by Maintenance. |
+| Maintenance cost approval readiness | Cost review can block expense/payment decisions. | Needs Review item owned by Maintenance/Expenses. |
+| Property action requests | Property/unit data issues are operational work. | Needs Review item owned by Properties. |
+| Form P readiness blockers | Lease readiness gaps are visible but not centrally prioritized. | Warning item owned by Leases when generation/signing/use is blocked. |
+| Signed lease delivery/Act link delivery | Post-signing delivery readiness is operationally important. | Warning item owned by Leases after signing/generation context. |
+| Tenant portal invite dispatch/activation mismatch | Move-in readiness can show stale invite state. | Needs Review item owned by Tenants only when move-in is blocked. |
+| Notice response deadline/no response | Renewal/no-response risk should not be only a lease-page detail. | Upcoming before deadline; Warning/Critical after deadline depending business rule. |
+| Lease document source/download failures | Document access can block signing, evidence, and landlord confidence. | Critical if signed lease access fails; Warning if draft preview unavailable. |
+
+## Recommended Hierarchy
+
+The authoritative queue hierarchy should be:
+
+1. Critical Issues
+   - Blocked, failed, overdue, or materially conflicting items.
+   - Examples: overdue rent, failed payment, active-before-execution, signed document inaccessible after signing.
+
+2. Decisions
+   - Items requiring an explicit landlord choice or workflow action.
+   - Examples: approve/manual-review screening, resolve delinquency, choose renewal/no-response path, assign maintenance.
+
+3. Warnings / Needs Review
+   - Incomplete, ambiguous, or inconsistent states that need review but are not yet critical.
+   - Examples: missing due day, Form P email service consent missing, payment setup not ready, tenant portal invite pending.
+
+4. Upcoming Actions
+   - Time-bound, sequence-bound, or planning items.
+   - Examples: lease expiry, notice timing, move-out prep, renewal review.
+
+5. Informational Context
+   - Completed or passive status.
+   - Examples: signed lease available, delivered evidence package, completed maintenance, recent screening completed.
+
+## Recommended Decision Object
+
+Future consolidation should adapt all generators to a common object. The existing Decision Inbox model can be the base, but the canonical model should distinguish intent and display class more explicitly.
+
+```ts
+type LandlordDecisionQueueItem = {
+  id: string;
+  severity: "critical" | "warning" | "needs_review" | "upcoming" | "informational";
+  intent: "decide" | "review" | "complete_setup" | "resolve_conflict" | "plan_deadline" | "observe";
+  status: "open" | "pending" | "blocked" | "resolved" | "dismissed";
+  domain: "lease" | "tenant" | "property" | "payment" | "maintenance" | "screening" | "notice" | "compliance" | "portfolio";
+  ownerWorkspace: string;
+  destination: string;
+  title: string;
+  summary: string;
+  sourceGenerator: string;
+  relatedResource: {
+    type: "lease" | "tenant" | "property" | "unit" | "payment" | "maintenance_request" | "application" | "notice" | "portfolio";
+    id: string;
+    safeLabel: string;
+  } | null;
+  dueAt?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+};
+```
+
+## Recommended Dashboard 2.0 Consumption
+
+Dashboard should consume the queue only as a summary:
+
+- Portfolio Status: aggregate health and critical count.
+- Decision Queue Preview: top critical and decision items only.
+- Upcoming Actions: date-based items only.
+- Financial Snapshot: rent/payment metrics, with delinquency count as a link into Operations/Payments.
+- Activation Actions: onboarding and conversion prompts, separate from the decision queue.
+
+Dashboard should not duplicate:
+
+- Full Operations filters.
+- Lease/tenant readiness panels.
+- Long guidance text.
+- Source-workspace workflow pages.
+
+## Recommended Operations Consumption
+
+Operations should become the landlord-facing full queue:
+
+- All open critical, warning, needs-review, and upcoming items.
+- Filters by severity, domain, owner, timing, assignment, and source.
+- Saved views: Critical, Needs Review, Upcoming, Delinquency, Maintenance, Lease Readiness, Unassigned.
+- Each item routes to its owning workspace, not a generic summary page unless no safer destination exists.
+
+## Source Hierarchy
+
+When surfaces disagree, resolve in this order:
+
+1. Canonical source record and append event state.
+2. Domain projection service.
+3. Decision queue normalization layer.
+4. Dashboard/Operations display adaptation.
+5. Frontend local labels.
+
+Display labels should never override the source record or projection service.
+
+## Priority A: Data Integrity / Workflow Integrity
+
+1. Promote lease state coherence conflicts into canonical queue items.
+2. Promote maintenance submitted/blocked/cost-review states into queue items.
+3. Promote property action requests into queue items.
+4. Promote notice/no-response deadlines into Upcoming/Warning queue lanes.
+5. Normalize payment readiness versus delinquency to avoid false critical states.
+6. Ensure tenant move-in readiness only creates landlord queue items when landlord action is required.
+
+## Priority B: Navigation / Workspace Improvements
+
+1. Make Operations the canonical full Decision Queue route.
+2. Decide whether `/decision-inbox` remains hidden engine/detail or redirects into Operations.
+3. Separate Dashboard Activation Actions from Decision Queue count.
+4. Route each queue item to a focused owning workspace.
+5. Add source generator labels internally for debugging without showing raw IDs.
+
+## Priority C: Visual Polish
+
+1. Dashboard 2.0 should show fewer queue items with stronger hierarchy.
+2. Operations should support dense scanning without long copy.
+3. Lease and tenant profiles should display local readiness without competing with global queue severity.
+4. Mobile should prioritize Critical, Today, and Upcoming before full filters.
+
+## Recommended Next Implementation Sprint
+
+Recommended next sprint:
+
+`feat/landlord-decision-queue-normalization-v1`
+
+Mission objective:
+
+Create a backend normalization layer that adapts existing decision inbox items, lease state coherence, payment readiness, lease lifecycle/notice timing, maintenance readiness, and property action requests into one landlord decision queue response for Operations and Dashboard 2.0.
+
+Suggested first implementation boundaries:
+
+1. Backend read-only route/service only.
+2. No UI redesign.
+3. No new collection.
+4. No mutation workflow.
+5. Preserve existing Decision Inbox route while adding normalized response.
+6. Add tests for severity normalization, duplicate suppression, source routing, and no raw ID labels.
+
+## Non-Goals
+
+- No code changes in this audit.
+- No dashboard redesign.
+- No UI implementation.
+- No queue persistence decision.
+- No autonomous workflow execution.
+- No legal/compliance certification language.
+

--- a/docs/audit/decision-queue-source-of-truth-v1.md
+++ b/docs/audit/decision-queue-source-of-truth-v1.md
@@ -16,6 +16,7 @@ Reviewed source areas:
 - Notices and lease expiry workflows.
 - Property action requests.
 - Tenant portal as a downstream state source.
+- Unified inbox, landlord/tenant messages, tenant portal communications, contractor messages, and communication-derived follow-up.
 
 This is a documentation-only audit. It does not change code, routes, UI, database records, Cloud Run, Vercel, or tests.
 
@@ -41,6 +42,9 @@ This is a documentation-only audit. It does not change code, routes, UI, databas
 | Notices | `leaseNoticeWorkflowService`, tenant/landlord notice routes | Notice due, sent, viewed, pending response, no response, renew/quit. | Lease workflow pages, Dashboard summary. | Should feed Upcoming/Warning queue lanes. |
 | Property action requests | `actionRequestsService`, `PropertiesPage` | Open property action requests. | `/properties?panel=actionRequests`. | Missing canonical queue integration. |
 | Tenant portal | Tenant portal services and frontend tenant pages | Tenant-facing documents/payments/maintenance/profile status. | Tenant portal. | State source only; landlord queue should consume only landlord-actionable items. |
+| Unified inbox events | `unifiedInboxService`, unified inbox adapters | Role-scoped activity stream across messages, maintenance, lease, application, notice, viewing, work orders. | `/landlord/unified-inbox`, tenant/contractor inboxes. | Activity source, not canonical decision queue. |
+| Landlord/tenant messages | `messagesRoutes.ts`, `MessagesPage.tsx`, tenant communications services | Conversations, unread/read state, tenant reply context. | `/messages`, tenant portal communications. | Message workspace source; queue only when actionable. |
+| Contractor messages/work-order communication | contractor inbox adapters, work order communications | Contractor work-order messages, schedule/access/cost communication. | Contractor inbox and maintenance/work-order contexts. | Missing canonical queue integration for landlord-response-required items. |
 
 ## Duplicates
 
@@ -53,6 +57,8 @@ This is a documentation-only audit. It does not change code, routes, UI, databas
 | Lease lifecycle summary versus notice workflow | Expiry, renewal, no-response, and notice deadlines can appear in dashboard summary, lease profile, and workflow pages. | Notice workflow owns notice action. Lease lifecycle owns status. Operations owns prioritization. |
 | Maintenance labels versus operational decisions | Maintenance uses "needs attention" and "needs review" labels outside Decision Inbox. | Maintenance should emit queue items for submitted, blocked, cancelled, stalled, or cost-review cases. |
 | Property action requests versus operations | Properties has action requests that are not clearly represented in Operations. | Property action requests should feed property-owned Needs Review queue items. |
+| Unified Inbox versus Decision Queue | Unified Inbox contains activity records that can look like decisions. | Unified Inbox should remain activity; queue should promote only actionable message-derived items. |
+| Messages versus Dashboard | Unread messages can inflate attention surfaces if all unread state is treated as action. | Dashboard should show only urgent/awaiting-response communication counts and top critical message decisions. |
 
 ## Conflicts
 
@@ -78,6 +84,11 @@ This is a documentation-only audit. It does not change code, routes, UI, databas
 | Tenant portal invite dispatch/activation mismatch | Move-in readiness can show stale invite state. | Needs Review item owned by Tenants only when move-in is blocked. |
 | Notice response deadline/no response | Renewal/no-response risk should not be only a lease-page detail. | Upcoming before deadline; Warning/Critical after deadline depending business rule. |
 | Lease document source/download failures | Document access can block signing, evidence, and landlord confidence. | Critical if signed lease access fails; Warning if draft preview unavailable. |
+| Tenant awaiting landlord reply | Reply responsibility is operational work but currently lives mainly in messaging surfaces. | Needs Review or Warning item owned by Tenant/Messaging depending urgency. |
+| Urgent high-priority tenant message | Unread urgent communication can require same-day landlord action. | Warning or Critical item owned by Tenant or Operations. |
+| Contractor quote/schedule response | Contractor workflow can stall until landlord approves or responds. | Needs Review or Warning item owned by Maintenance. |
+| Notice-relevant message | Communication can affect lease/notice timing or evidence context. | Upcoming/Warning item owned by Notices or Lease workflow. |
+| Support escalation message | Support/admin escalation may require landlord action. | Warning/Critical item owned by Operations, with support-safe projection only. |
 
 ## Recommended Hierarchy
 
@@ -120,7 +131,7 @@ type LandlordDecisionQueueItem = {
   summary: string;
   sourceGenerator: string;
   relatedResource: {
-    type: "lease" | "tenant" | "property" | "unit" | "payment" | "maintenance_request" | "application" | "notice" | "portfolio";
+    type: "lease" | "tenant" | "property" | "unit" | "payment" | "maintenance_request" | "application" | "notice" | "message_thread" | "portfolio";
     id: string;
     safeLabel: string;
   } | null;
@@ -200,7 +211,7 @@ Recommended next sprint:
 
 Mission objective:
 
-Create a backend normalization layer that adapts existing decision inbox items, lease state coherence, payment readiness, lease lifecycle/notice timing, maintenance readiness, and property action requests into one landlord decision queue response for Operations and Dashboard 2.0.
+Create a backend normalization layer that adapts existing decision inbox items, lease state coherence, payment readiness, lease lifecycle/notice timing, maintenance readiness, property action requests, and actionable messaging/unified-inbox signals into one landlord decision queue response for Operations and Dashboard 2.0.
 
 Suggested first implementation boundaries:
 
@@ -209,7 +220,8 @@ Suggested first implementation boundaries:
 3. No new collection.
 4. No mutation workflow.
 5. Preserve existing Decision Inbox route while adding normalized response.
-6. Add tests for severity normalization, duplicate suppression, source routing, and no raw ID labels.
+6. Include messaging source types such as `message_thread`, `message_unread_priority`, `message_notice_relevance`, `message_maintenance_follow_up`, `message_support_escalation`, and `unified_inbox_event`.
+7. Add tests for severity normalization, duplicate suppression, source routing, messaging noise suppression, and no raw ID labels.
 
 ## Non-Goals
 
@@ -219,4 +231,3 @@ Suggested first implementation boundaries:
 - No queue persistence decision.
 - No autonomous workflow execution.
 - No legal/compliance certification language.
-

--- a/docs/audit/decision-routing-model-v1.md
+++ b/docs/audit/decision-routing-model-v1.md
@@ -1,0 +1,129 @@
+# Decision Routing Model V1
+
+## Scope
+
+This document defines which workspace owns each landlord-facing decision, warning, review state, upcoming action, and critical issue.
+
+It is a documentation-only routing model for future Dashboard 2.0 and Operations work. It does not change routes or UI behavior.
+
+## Routing Principles
+
+1. The decision queue owns prioritization, not all content.
+2. The source workspace owns resolution.
+3. Dashboard owns summarization and preview only.
+4. Operations owns full triage and cross-domain filtering.
+5. Detail workspaces own domain-specific context, evidence, and final action.
+6. Tenant portal state can inform landlord decisions but should not become a landlord decision destination unless landlord action is required.
+
+## Workspace Ownership
+
+| Workspace | Owns | Should not own |
+| --- | --- | --- |
+| Dashboard | Portfolio health, top critical items, today's next actions, financial snapshot, upcoming preview. | Full review workflow, detailed lease/payment/tenant troubleshooting. |
+| Operations | Canonical Decision Queue, cross-domain triage, filters, saved operational views, unassigned/escalated lanes. | Source-specific editing forms or long domain guidance. |
+| Decision Inbox | Lower-level derived decision list and workflow routing engine. | User-facing operational home if Operations becomes the canonical queue. |
+| Properties | Property/unit readiness, occupancy source context, action requests, unit-level conflicts. | Lease execution detail, tenant move-in checklist, payments. |
+| Tenants | Tenant lifecycle, current lease linkage, move-in readiness, tenant portal readiness, tenant-specific state coherence. | Portfolio-wide decisions or unrelated lease/payment queues. |
+| Tenant Profile | One tenant's current blockers, linked lease/unit, move-in progress, tenant communications/readiness. | Global decision prioritization. |
+| Leases | Lease execution, document generation/signing, Form P readiness, payment readiness, delivery readiness, lease lifecycle. | Tenant portal activation except as linked readiness context. |
+| Lease Workflow Pages | Focused execution, rent increase, notice, deposit, renewal, and move-out reviews. | General lease summary replacement or legal advice. |
+| Payments/Ledger | Delinquency, payment evidence, failed or missing payments, payment setup readiness. | Lease document execution or tenant move-in readiness. |
+| Maintenance | Submitted requests, assignment, scheduling, in-progress work, completion, cost review. | Lease lifecycle or payment obligation decisions. |
+| Notices | Notice preparation, response deadlines, renewal/move-out responses, no-response review. | Full lease status or tenant profile state. |
+| Tenant Portal | Tenant-facing status, tasks, documents, payments, maintenance, communication, and trust views. | Landlord's authoritative decision queue. |
+
+## Canonical Route Ownership By Decision Type
+
+| Decision or signal | Canonical owner | Preferred destination | Dashboard treatment | Operations treatment |
+| --- | --- | --- | --- | --- |
+| Overdue rent | Payments/Ledger | `/leases/:leaseId/ledger` or payment workspace | Critical preview | Critical queue item |
+| Failed payment | Payments/Ledger | `/leases/:leaseId/ledger` or payment workspace | Critical preview | Critical queue item |
+| Underpaid or partial payment | Payments/Ledger | `/leases/:leaseId/ledger` | Warning preview if material | Warning queue item |
+| Manual payment review | Payments/Ledger | `/leases/:leaseId/ledger` | Needs review count | Needs Review queue item |
+| Missing rent terms | Leases | `/leases` or `/leases/:leaseId/summary` | Warning only when blocking next action | Lease readiness item |
+| Payment setup not enabled | Leases/Payments | `/leases/:leaseId/ledger` | Warning only if landlord is trying to collect rent | Payment readiness item |
+| Lease active before execution | Leases | `/leases/:leaseId/summary` | Critical preview | Critical queue item |
+| Occupied unit without active executed lease | Properties/Leases | `/leases/:leaseId/summary` if lease exists; otherwise property/unit workspace | Critical preview | Critical queue item |
+| Active lease on vacant unit | Properties/Leases | `/leases/:leaseId/summary` or `/properties` | Critical or Warning preview | Queue item |
+| State coherence needs review | Owning source workspace | Source workspace based on conflict | Needs review preview | Needs Review queue item |
+| Lease signature pending | Leases | `/leases` or lease signing panel | Warning only if blocking move-in | Documents/lease item |
+| Primary lease document unavailable | Leases | `/leases` | Warning only if signing is expected | Documents/lease item |
+| Signed lease available | Leases | governed document action | Informational/activity | Not queued |
+| Form P readiness incomplete | Leases | `/leases` signing/document panel | Warning if signing/use is blocked | Lease readiness item |
+| Email service consent missing | Leases | `/leases` Form P readiness | Warning if lease generation/signing context | Lease readiness item |
+| Signed lease delivery pending | Leases | `/leases` delivery readiness | Warning if post-signing delivery needed | Lease readiness item |
+| Act copy/link delivery pending | Leases | `/leases` delivery readiness | Warning if lease package generated/signed | Lease readiness item |
+| Lease expiring soon | Leases/Notices | `/leases/:leaseId/workflows/renewal` or notice workflow | Upcoming | Upcoming item |
+| Notice due or response deadline | Notices/Leases | `/leases/:leaseId/workflows/notice` | Upcoming or Warning when close | Upcoming/Warning queue item |
+| No renewal response | Notices/Leases | `/leases/:leaseId/workflows/notice` | Warning preview | Needs Review queue item |
+| Tenant move-in lease signature pending | Tenants/Leases | tenant profile or lease signing panel | Warning only if move-in window active | Needs Review item scoped to tenant |
+| Tenant portal invite pending | Tenants | tenant profile | Informational or Warning if required for move-in | Tenant readiness item |
+| Tenant portal activation pending | Tenants | tenant profile | Informational unless blocking workflow | Tenant readiness item |
+| Submitted maintenance request | Maintenance | maintenance workspace | Warning if unreviewed | Needs Review queue item |
+| Maintenance blocked/cancelled needs attention | Maintenance | maintenance request detail | Critical or Warning | Queue item |
+| Maintenance in progress | Maintenance | maintenance workspace | Informational | Not queued unless late/stalled |
+| Maintenance cost approval incomplete | Maintenance/Expenses | work order cost review | Warning | Needs Review queue item |
+| Screening provider/setup blocked | Applications/Screening | `/applications` | Critical if screening is primary next step | Screening review item |
+| Screening review needed | Applications/Screening | application/screening workflow | Warning | Screening review item |
+| Applicant funnel empty | Applications | `/applications` | Upcoming/action prompt | Not a critical queue item |
+| Add property/unit onboarding | Properties | `/properties` | Upcoming/action prompt | Not decision queue |
+
+## Routing Fallbacks
+
+| Condition | Fallback |
+| --- | --- |
+| Lease-scoped item lacks a safe lease workspace destination | Route to `/leases` with contextual copy. |
+| Tenant-scoped item lacks a current lease | Route to tenant profile. |
+| Property/unit conflict lacks lease context | Route to `/properties`. |
+| Payment item lacks ledger context | Route to payment workspace or `/leases` only if no payment route is available. |
+| Source is derived analytics without a safe entity destination | Route to Operations detail/decision inbox, not a raw ID label. |
+
+## Dashboard Versus Operations Routing
+
+Dashboard should display:
+
+- Top 3 Critical Issues.
+- Today's Upcoming Actions.
+- Portfolio status summary.
+- Financial snapshot.
+- Link to full Operations queue.
+
+Dashboard should not display:
+
+- Every warning.
+- Full decision filters.
+- Long explanations.
+- Duplicate lease/tenant readiness panels.
+
+Operations should display:
+
+- Full normalized queue.
+- Severity filters.
+- Domain filters.
+- Owner/unassigned/escalated views.
+- Links into the owning workspace for resolution.
+
+Operations should not display:
+
+- Source-specific edit forms.
+- Long legal/workflow guidance better handled by lease workflow pages.
+- Duplicate dashboard KPI cards.
+
+## Missing Routing Decisions
+
+| Gap | Recommendation |
+| --- | --- |
+| Decision Inbox and Operations overlap | Treat Operations as landlord-facing canonical queue. Treat Decision Inbox as engine/detail surface or consolidate behind Operations. |
+| Dashboard actions and decisions overlap | Keep onboarding/activation actions separate from the Decision Queue. |
+| Lease and tenant profiles both emit readiness warnings | Choose the source workspace by resource ownership: lease execution belongs to Leases; move-in readiness belongs to Tenants. |
+| Maintenance does not appear fully integrated into decision inbox | Add maintenance submitted/blocked/cost-review generators to canonical queue in a future implementation mission. |
+| Notices and lease expiry appear in dashboard/lease views but not consistently in decision inbox | Promote near-deadline and missed-response notice items into Upcoming/Warning queue lanes. |
+| Property action requests are separate from Operations | Map open property action requests into Operations as property-owned Needs Review items. |
+
+## Non-Goals
+
+- This model does not create new routes.
+- This model does not remove `/decision-inbox`.
+- This model does not implement Dashboard 2.0.
+- This model does not alter auth, projection, or queue persistence.
+

--- a/docs/audit/decision-severity-model-v1.md
+++ b/docs/audit/decision-severity-model-v1.md
@@ -1,0 +1,110 @@
+# Decision Severity Model V1
+
+## Scope
+
+This document defines the canonical landlord-facing severity model for decision queue, dashboard, operations, tenant, lease, maintenance, payment, notice, and readiness surfaces.
+
+It is a documentation-only model. It does not change code, routes, UI, database records, or queue behavior.
+
+## Canonical Terms
+
+| Term | Definition | User question answered | Canonical queue treatment |
+| --- | --- | --- | --- |
+| Critical Issue | A current condition that blocks a core workflow, indicates material risk, or requires prompt landlord review before the source workflow should progress. | What must I deal with now? | Queue item, top priority, owner required. |
+| Warning | A non-blocking risk, inconsistency, or incomplete setup that may become material if ignored. | What should I review soon? | Queue item or source-workspace warning, depending on actionability. |
+| Needs Review | A state where RentChain cannot safely classify the source as ready, complete, or coherent without landlord review. | What needs human judgment? | Queue item when actionable; source-workspace badge when contextual. |
+| Upcoming Action | A time-based or sequence-based item that is not currently broken but has a future deadline or expected next step. | What is coming up? | Upcoming queue lane and dashboard preview. |
+| Informational | Context that improves understanding but does not require action or review. | What should I know? | Workspace context, not primary decision queue. |
+
+## Canonical Severity Levels
+
+The platform should normalize all landlord-facing attention items into these levels before Dashboard 2.0 and Operations consume them.
+
+| Severity | Meaning | Examples | Default treatment |
+| --- | --- | --- | --- |
+| Critical | Blocking, risky, overdue, failed, escalated, or materially conflicting. | Overdue rent, failed payment, blocked signing, active lease on vacant unit, occupied unit without executed active lease, invalid source-state conflict. | Show in portfolio status, decision queue, and owning workspace. |
+| Warning | Important but not immediately blocking. | Missing rent terms, partial payment, pending signature, maintenance submitted but not reviewed, lease ending within a near window. | Show in decision queue if actionable; otherwise show in owning workspace. |
+| Needs Review | Ambiguous or incomplete state requiring landlord judgment before treating it as ready. | State coherence review required, payment readiness not ready, move-in readiness pending, manual payment review required. | Route to owning workspace and optionally aggregate in operations. |
+| Upcoming | Time-bound item that should be planned but is not broken. | Lease expiry window, notice timing, renewal follow-up, move-out prep. | Show in upcoming lane, not mixed with urgent critical items. |
+| Informational | Visibility only. | Recent screening completed, generated evidence package, completed maintenance, signed lease already downloaded. | Show as activity/history or detail context. |
+
+## Mapping From Current Code Vocabulary
+
+| Current vocabulary | Observed source | Canonical mapping | Notes |
+| --- | --- | --- | --- |
+| `critical` | Decision inbox, delinquency signals, operations command center | Critical | Already close to canonical. |
+| `high` | Analytics decision priority, decision inbox | Critical or Warning | Use Critical when blocked/escalated/financially material; Warning otherwise. |
+| `medium` | Decision inbox mapped from `warning` | Warning | Should remain non-critical unless blocked. |
+| `warning` | Decision engine, operations, maintenance, payments | Warning | Current use is broad; normalize by blocking/actionability. |
+| `needs_review` | Operations filters, screening/app statuses, readiness surfaces | Needs Review | Should not automatically mean Critical. |
+| `review_required` | State coherence, maintenance, compliance | Needs Review or Critical | Critical only when workflow is blocked or state conflict is material. |
+| `blocked` | Decision inbox, payment readiness, lease execution | Critical | Blocked items should surface above ordinary review states. |
+| `upcoming` | Operations priority group, lease expiry/notice timing | Upcoming | Should not be presented as a warning unless the deadline is near or missed. |
+| `info` / `informational` | Dashboard, operations, decision inbox | Informational | Keep out of the primary decision queue unless there is a clear next action. |
+
+## Decision Versus Warning Versus Action
+
+| Concept | Canonical definition | Examples that qualify | Examples that do not qualify |
+| --- | --- | --- | --- |
+| Decision | A landlord must choose, approve, dismiss, assign, resolve, or take an explicit workflow step. | Approve screening outcome, review overdue rent, resolve occupancy conflict, choose renewal/move-out path. | Passive KPI, completed signing event, general portfolio summary. |
+| Warning | The system detects risk or incompleteness but the next step may simply be review. | Due day missing, tenant email missing, payment setup not enabled. | Completed lease signing, signed document available. |
+| Needs Review | The system lacks enough confidence to treat the source as coherent or complete. | State coherence conflict, manual payment issue, unresolved source projection mismatch. | Low-priority upcoming lease expiry with known dates. |
+| Upcoming Action | A known future date or workflow sequence requires planning. | Lease expiring in 90 days, notice due, renewal response deadline. | Already overdue payment or failed dispatch. |
+| Critical Issue | The system is blocked, overdue, failed, materially inconsistent, or at risk of landlord harm if ignored. | Overdue rent, failed provider payment, lease active before execution, invalid authorization/source mismatch. | Generic informational guidance. |
+
+## Severity Rules
+
+1. Blocked beats incomplete.
+   If a workflow cannot proceed safely, map to Critical unless it is an intentional empty state.
+
+2. Overdue beats upcoming.
+   A missed due date or expired deadline is Critical or Warning, not Upcoming.
+
+3. Needs Review is not a severity by itself.
+   It is a review state. It must be paired with Critical, Warning, or Informational based on risk and blocking status.
+
+4. Onboarding prompts are not decisions.
+   Add property, add unit, track applicant, invite tenant, and run first screening are Upcoming Actions or Activation Actions, not Critical Issues.
+
+5. Readiness gaps are warnings until they block a workflow.
+   Missing Form P fields, missing payment setup, or missing delivery tracking are Warnings unless signing, rent collection, delivery, or export is blocked.
+
+6. Source-state conflicts should be queueable.
+   State coherence conflicts should become Decision Queue items because they represent conflicting source records, not simple page copy.
+
+7. Completed states should leave the queue.
+   Signed leases, completed maintenance, delivered documents, resolved decisions, and dismissed items should move to history/activity.
+
+## Recommended Normalization Contract
+
+Future generators should emit or adapt into this shape before display:
+
+```ts
+type DecisionSeverity = "critical" | "warning" | "needs_review" | "upcoming" | "informational";
+
+type DecisionIntent =
+  | "decide"
+  | "review"
+  | "complete_setup"
+  | "resolve_conflict"
+  | "plan_deadline"
+  | "observe";
+```
+
+Recommended user-facing labels:
+
+| Canonical severity | Label |
+| --- | --- |
+| `critical` | Critical |
+| `warning` | Warning |
+| `needs_review` | Needs review |
+| `upcoming` | Upcoming |
+| `informational` | Informational |
+
+## Non-Goals
+
+- This model does not add queue persistence.
+- This model does not change the existing `DecisionInboxSeverity` TypeScript types.
+- This model does not remove source-workspace readiness panels.
+- This model does not redesign Dashboard or Operations UI.
+

--- a/docs/audit/messaging-to-decision-routing-model-v1.md
+++ b/docs/audit/messaging-to-decision-routing-model-v1.md
@@ -1,0 +1,175 @@
+# Messaging To Decision Routing Model V1
+
+## Scope
+
+This document defines when communication signals become landlord decision queue items and which workspace should own resolution.
+
+It is a documentation-only routing model. It does not implement message parsing, inbox UI, notification delivery, AI classification, or decision queue code.
+
+## Routing Principle
+
+Messages are not decisions by default.
+
+A message becomes a decision only when it creates one of these conditions:
+
+1. A landlord must reply.
+2. A landlord must approve, reject, assign, schedule, or resolve something.
+3. A deadline, notice, complaint, or dispute makes the message operationally urgent.
+4. A maintenance, contractor, lease, payment, or support workflow is blocked.
+5. A high-priority unread message creates material risk.
+
+Ordinary unread messages should stay in Messaging or Unified Inbox.
+
+## Message-Derived Decision Conditions
+
+| Condition | Source type | Severity | Workspace | Recommended destination |
+| --- | --- | --- | --- | --- |
+| Tenant awaiting landlord reply | `message_thread` | needs_review | tenant | Tenant profile or message thread. |
+| Unread high-priority tenant message | `message_unread_priority` | warning | tenant | Message thread with tenant context. |
+| Urgent tenant complaint/dispute | `message_thread` | warning or critical | tenant or lease | Tenant profile or lease workspace based on resource. |
+| Maintenance message requires landlord response | `message_maintenance_follow_up` | warning | maintenance | Maintenance request detail. |
+| Contractor quote requires approval | `message_maintenance_follow_up` | needs_review | maintenance | Work order cost/approval context. |
+| Contractor schedule/access issue | `message_maintenance_follow_up` | warning | maintenance | Work order schedule/access context. |
+| Message is notice relevant | `message_notice_relevance` | upcoming or warning | notices | Notice workflow or lease workflow page. |
+| Message affects lease signing/document readiness | `message_thread` | warning | lease | Lease signing/document panel. |
+| Support escalation requiring landlord response | `message_support_escalation` | warning or critical | operations | Operations item or support thread. |
+| System notification with no action | `unified_inbox_event` | informational | dashboard or operations summary | No queue item unless action is required. |
+
+## Severity Mapping
+
+| Communication state | Canonical severity |
+| --- | --- |
+| Verified emergency, urgent maintenance access issue, material support escalation | critical |
+| Urgent unread tenant message, notice-relevant message near deadline, blocked maintenance communication | warning |
+| Tenant awaiting reply, contractor approval needed, unresolved non-urgent thread | needs_review |
+| Notice response deadline or planned follow-up date not yet near | upcoming |
+| General read/unread informational update | informational |
+
+Severity must be derived from source context and actionability, not from unread state alone.
+
+## Recommended Normalized Item Mapping
+
+Future decision queue items from messaging should include:
+
+```ts
+{
+  sourceType:
+    | "message_thread"
+    | "message_unread_priority"
+    | "message_notice_relevance"
+    | "message_maintenance_follow_up"
+    | "message_support_escalation"
+    | "unified_inbox_event";
+  workspace: "tenant" | "lease" | "maintenance" | "notices" | "operations" | "dashboard";
+  severity: "critical" | "warning" | "needs_review" | "upcoming" | "informational";
+  title: string;
+  description: string;
+  recommendedActionLabel: string;
+  recommendedActionHref: string;
+  relatedEntityRefs: {
+    tenantId?: string;
+    leaseId?: string;
+    propertyId?: string;
+    unitId?: string;
+    maintenanceRequestId?: string;
+    noticeId?: string;
+  };
+  dedupeKey: string;
+}
+```
+
+The item should not expose raw message IDs as user-facing labels.
+
+## Workspace Routing
+
+| Workspace | Owns message-derived decisions when |
+| --- | --- |
+| Tenant | The thread concerns tenant reply, move-in readiness, tenant lifecycle, or tenant-specific issue resolution. |
+| Lease | The thread concerns lease execution, signing, documents, Form P readiness, delivery readiness, or lease lifecycle. |
+| Maintenance | The thread concerns maintenance request triage, contractor communication, quote approval, access, schedule, completion, or rework. |
+| Notices | The thread has notice/legal-relevance classification or relates to notice deadlines/responses. |
+| Operations | The thread is cross-cutting, escalated, support-driven, or lacks a more specific safe owner. |
+| Dashboard | Summary preview only; dashboard should not own resolution. |
+
+## Dedupe Rules
+
+Message-derived decisions should dedupe against source workflow decisions.
+
+| Duplicate pattern | Dedupe rule |
+| --- | --- |
+| Maintenance request already emits "needs review" and tenant sends message on same request | Keep one maintenance decision, attach message context. |
+| Notice deadline item and notice-relevant message for same notice | Keep notice deadline item, add message context or raise severity if needed. |
+| Tenant awaiting reply and unread high-priority message in same thread | Keep higher severity item with one thread destination. |
+| Support escalation and system notification for same support case | Keep support escalation item only. |
+| Lease signing failure and message about signing failure | Keep lease signing failure item, attach message context. |
+
+Recommended dedupe key pattern:
+
+```txt
+message:<sourceType>:<workspace>:<resourceType>:<resourceId>:<threadOrCaseRef>
+```
+
+The displayed item should use safe labels and not expose this raw key.
+
+## Evidence Rules
+
+Message-derived decisions may reference evidence context, but the decision queue should not become an evidence export surface.
+
+Allowed decision metadata:
+
+- Safe thread label.
+- Sender/recipient role labels.
+- Last activity timestamp.
+- Message count.
+- Short safe summary or approved excerpt if already landlord-visible.
+- Notice/maintenance/lease relationship.
+
+Excluded decision metadata:
+
+- Raw message body dumps.
+- Private notes.
+- Raw provider payloads.
+- Storage paths.
+- Tokens or secrets.
+- Unrelated tenant metadata.
+- Raw internal IDs as labels.
+
+## Dashboard Treatment
+
+Dashboard should consume message decisions as:
+
+- Critical communication count.
+- Top urgent communication item.
+- Awaiting reply count if non-zero.
+- Link to Messaging or Operations.
+
+Dashboard should not display:
+
+- Full threads.
+- Ordinary unread message lists.
+- Contractor chatter.
+- Notice/legal excerpts.
+- Support/admin raw details.
+
+## Operations Treatment
+
+Operations should consume message decisions as first-class queue items with filters:
+
+- Communication.
+- Tenant.
+- Maintenance.
+- Notice.
+- Support escalation.
+- Awaiting response.
+- Urgent.
+
+Operations should route users to the owning workspace or message thread for resolution.
+
+## Non-Goals
+
+- No code changes.
+- No AI classification implementation.
+- No messaging UI changes.
+- No new notification delivery.
+- No new evidence export behavior.
+- No legal advice or notice automation.

--- a/docs/audit/messaging-workspace-boundaries-v1.md
+++ b/docs/audit/messaging-workspace-boundaries-v1.md
@@ -1,0 +1,209 @@
+# Messaging Workspace Boundaries V1
+
+## Scope
+
+This document defines boundaries between the messaging workspace, unified inbox, dashboard, operations, tenant workspace, maintenance workspace, notice workflows, lease workflows, contractor communication, and support/admin communication.
+
+It is a documentation-only model. It does not change routes, navigation, inbox UI, notification delivery, or backend services.
+
+## Boundary Summary
+
+| Surface | Primary job | Communication role | Should not do |
+| --- | --- | --- | --- |
+| Messaging | Conversation management. | Read, reply, search, filter, and manage threads. | Prioritize all landlord operations. |
+| Unified Inbox | Cross-role activity stream. | Show safe role-scoped activity from multiple sources. | Become the decision queue. |
+| Dashboard | Portfolio operational home. | Show only top communication risks and counts. | Show full inbox or long threads. |
+| Operations | Full landlord decision queue. | Triage actionable message-derived decisions. | Replace message reply workspace. |
+| Tenant workspace | Tenant lifecycle context. | Show tenant-specific messages and reply blockers. | Show global communication queue. |
+| Lease workspace | Lease execution and lifecycle context. | Show signing, notice, document, and lease-related communication context. | Become general messaging. |
+| Maintenance workspace | Maintenance execution context. | Show tenant/contractor maintenance messages. | Route unrelated tenant chat. |
+| Notices | Formal notice workflow context. | Show notice-relevant messages and response deadlines. | Treat ordinary chat as formal notice. |
+| Contractor workspace | Work-order communication context. | Show contractor messages linked to assigned work. | Expose landlord/tenant private context outside scope. |
+| Support/admin | Escalation and internal support context. | Surface safe landlord-facing support escalations. | Expose internal admin notes or payloads. |
+
+## Standalone Messaging Boundary
+
+Standalone Messaging should own:
+
+- Thread list.
+- Conversation detail.
+- Reply composer.
+- Read/unread state.
+- Resolved/archived/muted state.
+- Sender/recipient context.
+- Safe tenant/property/lease labels.
+- Thread search and filters.
+
+Standalone Messaging should not own:
+
+- Portfolio health.
+- Full operations prioritization.
+- Lease document readiness.
+- Maintenance approval workflows.
+- Notice deadline logic.
+- Payment delinquency resolution.
+
+## Unified Inbox Boundary
+
+Unified Inbox should remain a safe role-scoped activity aggregation layer.
+
+It should own:
+
+- Role-based inbox records.
+- Safe cross-source projections.
+- Activity status and priority labels.
+- Source kind labels.
+
+It should not own:
+
+- Long-term queue prioritization.
+- Landlord decision source of truth.
+- Message reply workflow if a dedicated Messaging workspace exists.
+- Tenant or contractor data outside explicit projections.
+
+## Operations Boundary
+
+Operations should own:
+
+- Prioritized landlord decision queue.
+- Cross-domain filters.
+- Severity sorting.
+- Message-derived action items.
+- Routing to source workspaces.
+
+Operations should not own:
+
+- Full message threads.
+- Message composition.
+- General unread inbox browsing.
+- Legal or notice drafting automation.
+
+## Dashboard Boundary
+
+Dashboard should own:
+
+- Portfolio status summary.
+- Top critical communication indicator.
+- Awaiting reply count.
+- Link into Messaging or Operations.
+
+Dashboard should exclude:
+
+- Full message previews.
+- Ordinary unread counts without actionability.
+- System notification streams.
+- Contractor chatter.
+- Support/admin internal context.
+
+## Tenant Workspace Boundary
+
+Tenant workspace should own:
+
+- Tenant-specific conversations.
+- Tenant awaiting reply state.
+- Move-in or lease-context messages.
+- Tenant portal readiness messaging.
+
+Tenant workspace should not own:
+
+- Portfolio-wide communication triage.
+- Other tenants' message context.
+- Contractor operational details unrelated to tenant-facing maintenance.
+
+## Maintenance Boundary
+
+Maintenance workspace should own:
+
+- Maintenance request thread context.
+- Contractor quote messages.
+- Schedule/access coordination.
+- Completion, rework, signoff, and cost-review communication.
+
+Maintenance-derived message decisions should route to Maintenance, not generic lease summary pages.
+
+## Notice Boundary
+
+Notice workflows should own:
+
+- Notice-relevant message classification.
+- Notice response timing.
+- Renewal/no-response context.
+- Notice follow-up.
+
+Ordinary tenant chat should not be treated as notice-relevant unless an explicit source or workflow classification exists.
+
+## Lease Signing Boundary
+
+Lease signing communications should own:
+
+- Signing request sent/failed context.
+- Provider lifecycle communication status.
+- Return route and completion guidance.
+- Signed document availability context.
+
+Signing completion events should be audit/evidence context. They should produce queue items only when failed, blocked, or awaiting landlord action.
+
+## Contractor Boundary
+
+Contractor messaging should be tied to work orders.
+
+Recommended future path:
+
+1. Contractor messages live inside work-order context.
+2. Landlord sees contractor-derived decisions in Operations only when action is required.
+3. Contractor portal sees a contractor-safe view of assigned work messages.
+4. Dashboard shows only critical contractor-related blockers.
+
+## Support/Admin Boundary
+
+Support/admin communications should surface to landlords only as safe support escalation items when landlord action is required.
+
+Do not expose:
+
+- Internal support notes.
+- Admin investigation context.
+- Raw system logs.
+- Provider payloads.
+- Sensitive tenant or screening metadata.
+
+## Message Noise Controls
+
+To avoid dashboard and operations overload:
+
+1. Do not promote every unread message.
+2. Promote only actionable, urgent, blocked, notice-relevant, support-escalated, or workflow-linked messages.
+3. Deduplicate message items against source workflow decisions.
+4. Use safe short summaries only.
+5. Route to the source workspace where the work is resolved.
+
+## Recommended Navigation Model
+
+Recommended landlord navigation:
+
+- Dashboard: operational home with communication summary.
+- Operations: full decision queue, including message-derived decisions.
+- Messages: standalone conversation workspace.
+- Maintenance: work-order communication and execution.
+- Tenants: tenant-specific messages and readiness.
+- Leases: lease-specific signing, notice, document, and delivery communication.
+
+The visible primary nav should avoid presenting both Unified Inbox and Messages as equivalent destinations unless their purposes are clearly named.
+
+## Future Implementation Sequence
+
+1. Add messaging source types to the read-only landlord decision queue normalization service.
+2. Normalize only actionable message-derived conditions first.
+3. Preserve Unified Inbox as an activity source.
+4. Keep Message workspace as the reply/composition surface.
+5. Add Operations filters for Communication, Awaiting response, Urgent, Maintenance, Notice, and Support.
+6. Revisit landlord navigation labels after Dashboard 2.0 and Operations boundaries are implemented.
+
+## Non-Goals
+
+- No code changes.
+- No UI redesign.
+- No inbox implementation.
+- No notification delivery changes.
+- No contractor portal implementation.
+- No AI message classification.
+- No legal notice automation.

--- a/docs/audit/unified-messaging-inbox-ia-v1.md
+++ b/docs/audit/unified-messaging-inbox-ia-v1.md
@@ -1,0 +1,203 @@
+# Unified Messaging Inbox IA V1
+
+## Scope
+
+This audit defines how RentChain communications should flow into a unified messaging model and how message-derived decisions should surface in Dashboard 2.0 and Operations.
+
+Reviewed communication areas:
+
+- Landlord and tenant direct messages.
+- Tenant portal communications.
+- Maintenance-related messages.
+- Contractor work-order messages and future contractor portal messaging.
+- Notice-related communications.
+- Lease signing communications and provider lifecycle notifications.
+- System notifications.
+- Support/admin messages and escalation-style notifications where present.
+- Existing unified inbox architecture.
+
+This is a documentation-only audit. It does not change messaging code, inbox UI, notification delivery, routes, database records, Cloud Run, Vercel, or tests.
+
+## Current Communication Surfaces
+
+| Surface | Representative source | Current role | IA finding |
+| --- | --- | --- | --- |
+| Unified Inbox | `rentchain-api/src/services/unifiedInbox/*`, `UnifiedInboxPage.tsx` | Role-based activity aggregator for tenant, landlord, contractor audiences. | Useful as a safe activity stream, but not yet a canonical decision queue. |
+| Landlord Messages | `messagesRoutes.ts`, `MessagesPage.tsx` | Dedicated conversation workspace for landlord replies and thread management. | Should remain the primary reply/composition workspace. |
+| Tenant Communications | `tenantCommunicationsService.ts`, tenant communications workspace state | Tenant-safe conversation projection and tenant-side response state. | Should be simplified around "needs reply", "active", and "informational" states. |
+| Maintenance communications | Maintenance requests, work order updates, contractor communications | Operational discussion attached to a maintenance request or work order. | Should be embedded in Maintenance and generate decisions only when blocked, urgent, or awaiting landlord response. |
+| Contractor communications | Contractor work orders, contractor messages, work order communications | Future contractor portal communication stream. | Should connect through work-order context, not become a standalone landlord dashboard feed. |
+| Notices | Tenant notices and lease notice workflows | Formal or semi-formal tenancy communication. | Notice relevance should be explicitly classified and routed to Notices/Lease workflow, not ordinary chat. |
+| Lease signing communications | Signing request events, signing emails, webhook lifecycle | Provider-driven lifecycle and email delivery state. | Signing lifecycle is audit/evidence context; only failures or required actions should become decisions. |
+| System notifications | Derived notifications and service emails | Product/system status and task nudges. | Should remain informational unless tied to a concrete landlord action. |
+| Support/admin messages | Admin/support notification derivation where available | Internal or support escalation signals. | Should enter landlord decision flow only as safe support escalation metadata. |
+
+## Implemented Unified Inbox Shape
+
+The current unified inbox already has strong projection and safety foundations:
+
+- Audiences: tenant, landlord, contractor.
+- Source kinds: message, maintenance, screening, lease, application, notice, viewing, work order, contractor message.
+- Statuses: unread, read, archived, muted, resolved.
+- Priorities: critical, high, normal, low.
+- Public records expose a safe subset: id, source kind, audience role, title, body, priority, status, timestamps, and read metadata.
+- Adapters exclude raw IDs, tokens, secrets, provider payloads, storage paths, private notes, and risk metadata.
+
+IA conclusion: keep the unified inbox as a cross-source activity layer, but do not treat every inbox event as a landlord decision.
+
+## Primary Inbox Recommendation
+
+RentChain should use a dual model:
+
+1. Messaging workspace
+   - Primary place to read and reply to conversations.
+   - Supports landlord, tenant, maintenance, contractor, and support-style threads.
+   - Owns composition, reply, thread history, read state, and message context.
+
+2. Decision queue
+   - Primary place to prioritize actionable message-derived work.
+   - Receives only normalized message decisions.
+   - Does not replace the messaging workspace.
+
+The landlord dashboard should not become the primary inbox. It should display only top critical communication decisions and count summaries.
+
+## Standalone Versus Embedded Messaging
+
+Messaging should be both standalone and embedded, but with different responsibilities.
+
+| Placement | Responsibility | Examples |
+| --- | --- | --- |
+| Standalone Messaging workspace | Conversation list, reply workflow, unread management, thread search/filtering. | Tenant asking a question, landlord reply, support escalation. |
+| Tenant workspace embedded thread | Tenant-specific conversation context and move-in/readiness questions. | Tenant asks about move-in, lease, documents, portal activation. |
+| Lease workspace embedded thread/history | Lease-signing and notice-related communication context. | Signing issue, lease question, notice response. |
+| Maintenance workspace embedded thread | Work-order and contractor/tenant maintenance communication. | Tenant access issue, contractor quote, completion question. |
+| Operations queue | Actionable messages only, normalized by severity. | Tenant awaiting reply, urgent maintenance message, contractor quote requires response. |
+| Dashboard | Summary only. | "2 urgent messages" or one critical communication item. |
+
+## Message State Semantics
+
+| State | Definition | Queue treatment |
+| --- | --- | --- |
+| Unread | A message has not been read by the current audience. | Informational unless high priority, urgent, or from an active workflow. |
+| Urgent | Message is marked critical/high or belongs to an urgent source workflow. | Warning or Critical decision item. |
+| Awaiting response | Latest actionable message is from another party and requires landlord reply. | Needs Review or Warning decision item. |
+| Unresolved | Thread is open with unresolved operational context. | Needs Review only if landlord has next action. |
+| Resolved | Thread no longer requires action. | Remove from decision queue; keep in messaging history. |
+| Notice relevant | Message is tied to a formal notice, dispute, complaint, or legal-relevance classification. | Route to Notices or Lease workflow; do not treat as ordinary chat. |
+| Evidence relevant | Message should be available to evidence packages as safe metadata/excerpt. | Evidence context, not automatically a decision. |
+
+## What Messages Generate Decisions
+
+Message-derived decisions should be generated only when there is a clear landlord action or material risk.
+
+| Condition | Decision item? | Severity | Owning workspace |
+| --- | --- | --- | --- |
+| Tenant awaiting landlord reply on an active lease or move-in workflow | Yes | needs_review or warning | tenant |
+| Urgent unread tenant message | Yes | warning or critical | tenant |
+| Urgent maintenance message | Yes | warning or critical | maintenance |
+| Contractor quote requires landlord approval | Yes | needs_review | maintenance |
+| Contractor schedule/access issue requires landlord response | Yes | warning | maintenance |
+| Tenant dispute or complaint requires review | Yes | warning or critical | tenant or lease |
+| Message contains notice/legal relevance | Yes | warning or upcoming depending deadline | notices |
+| Support escalation requiring landlord action | Yes | warning or critical | operations |
+| General unread message | Usually no | informational | messaging |
+| System notification with no action | No | informational | unified inbox |
+| Completed signing email/provider notice | No | informational | lease |
+
+## Message Evidence Model
+
+Messaging should support evidence without flooding the decision queue.
+
+Evidence packages and institutional exports should be able to reference:
+
+- Safe message metadata.
+- Sender/recipient role labels.
+- Sent/received timestamps.
+- Thread context.
+- Short bounded excerpts when landlord-visible and already allowed by evidence package policy.
+- Notice-relevance classification where available.
+
+They should not expose:
+
+- Raw message payloads beyond approved excerpts.
+- Private/internal notes.
+- Provider IDs.
+- Storage paths.
+- Tokens.
+- Unrelated tenant or support metadata.
+
+## Tenant Portal Simplification
+
+Tenant messaging should be simplified around user intent:
+
+1. Messages needing tenant reply.
+2. Active conversations.
+3. Documents/notices requiring review.
+4. Informational updates.
+
+Tenant portal should avoid exposing landlord operational categories such as Decision Queue, Operations, state coherence, or compliance posture.
+
+## Contractor Messaging Connection
+
+Contractor messaging should eventually connect through work orders:
+
+- Contractor messages belong to a work order or maintenance request.
+- Landlords should see contractor communication in Maintenance context.
+- Operations should show contractor-derived decisions only when a landlord action is required.
+- Contractor portal should receive a narrowed contractor-safe view.
+
+Contractor messages should not become a separate dashboard inbox unless contractor volume justifies a dedicated filter inside Messaging or Operations.
+
+## Dashboard Treatment
+
+Dashboard should display only communication summary signals:
+
+- Critical communication count.
+- Top one or two urgent communication decisions.
+- "Awaiting reply" count when material.
+- Link to Messaging or Operations.
+
+Dashboard should exclude:
+
+- Full message list.
+- Ordinary unread counts without actionability.
+- Long conversation previews.
+- Maintenance thread details.
+- Contractor chatter.
+- Support/system informational notifications.
+
+## Operations Treatment
+
+Operations should own normalized message-derived decisions:
+
+- Tenant awaiting reply.
+- Urgent unread message.
+- Maintenance communication blocker.
+- Contractor quote or schedule response required.
+- Notice-relevant message.
+- Support escalation.
+
+Each item should route to the workspace where the landlord can resolve it.
+
+## Recommended Source Types For Future Decision Queue
+
+Add messaging source types to the future landlord decision queue normalization mission:
+
+- `message_thread`
+- `message_unread_priority`
+- `message_notice_relevance`
+- `message_maintenance_follow_up`
+- `message_support_escalation`
+- `unified_inbox_event`
+
+These should be normalized, deduped, and routed like other operational signals. They should not import the entire unified inbox into the decision queue.
+
+## Non-Goals
+
+- No messaging implementation.
+- No inbox UI build.
+- No notification delivery changes.
+- No code changes.
+- No unrestricted AI assistant behavior.
+- No new evidence export behavior.
+- No tenant visibility expansion.


### PR DESCRIPTION
## Summary
- Adds the decision queue source-of-truth, severity, and routing audits for Dashboard 2.0 and Operations.
- Adds unified messaging inbox IA for landlord, tenant, contractor, notice, lease, maintenance, system, and support communication boundaries.
- Adds message-to-decision routing guidance for actionable messaging signals.
- Adds messaging workspace boundary guidance to keep Messaging, Unified Inbox, Dashboard, Operations, Tenant, Lease, Maintenance, Notices, Contractor, and Support roles distinct.
- Updates the decision queue source-of-truth audit so the next normalization sprint includes actionable messaging/unified-inbox source types.

## Stack State
The prior decision queue audit commit was not merged to main. This PR is intentionally treated as a combined docs PR containing both audit sets:
- decision queue source-of-truth/severity/routing docs
- unified messaging inbox addendum docs

## Scope
- Documentation only.
- No code changes.
- No UI implementation.
- No notification delivery changes.

## Validation
- git diff --check
- docs link scan: no markdown links/TODO/FIXME references found in the changed audit docs