### PR TITLE
feat: expose landlord decision queue api

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -157,6 +157,7 @@ import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes"
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
 import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
+import landlordDecisionQueueRoutes from "./routes/landlordDecisionQueueRoutes";
 import landlordInstitutionalExportGenerationRoutes from "./routes/landlordInstitutionalExportGenerationRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
@@ -509,6 +510,8 @@ app.use("/api/landlord", routeSource("landlordInboxRoutes.ts"), landlordInboxRou
 console.log("[route-mount] landlordInboxRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlordDecisionInboxRoutes);
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordDecisionQueueRoutes.ts"), landlordDecisionQueueRoutes);
+console.log("[route-mount] landlordDecisionQueueRoutes mounted at /api/landlord");
 app.use("/api/landlord/institutional-exports", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordInstitutionalExportGenerationRoutes.ts"), landlordInstitutionalExportGenerationRoutes);
 console.log("[route-mount] landlordInstitutionalExportGenerationRoutes mounted at /api/landlord");

--- a/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadLandlordAnalyticsSnapshot = vi.hoisted(() => vi.fn());
+const deriveLeaseDecisionsForInbox = vi.hoisted(() => vi.fn());
+const getUnifiedInbox = vi.hoisted(() => vi.fn());
+const writeCanonicalEventMock = vi.hoisted(() => vi.fn());
+let mockUser: any;
+
+vi.mock("../../services/landlord/landlordAnalyticsSnapshot", () => ({
+  loadLandlordAnalyticsSnapshot,
+}));
+
+vi.mock("../landlordDecisionInboxRoutes", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../landlordDecisionInboxRoutes")>();
+  return {
+    ...original,
+    deriveLeaseDecisionsForInbox,
+  };
+});
+
+vi.mock("../../services/unifiedInbox", () => ({
+  getUnifiedInbox,
+}));
+
+vi.mock("../../lib/events/buildEvent", () => ({
+  writeCanonicalEvent: writeCanonicalEventMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+        return this;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers: this.headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function analyticsDecision(overrides: Record<string, any> = {}) {
+  return {
+    id: "payment-decision-1",
+    decisionType: "review_revenue_pressure",
+    priority: "high",
+    explanation: "Payment review is required.",
+    supportingSignals: [],
+    recommendedAction: "Review ledger",
+    actionLabel: "Review ledger",
+    destination: "/leases/lease-1/ledger",
+    state: "pending",
+    executionState: "blocked",
+    executionMapping: {
+      resourceType: "lease",
+      resourceId: "lease-1",
+    },
+    ...overrides,
+  };
+}
+
+function unifiedInboxRecord(overrides: Record<string, any> = {}) {
+  return {
+    id: "tenant-message-1",
+    sourceKind: "landlord.message",
+    audienceRole: "landlord",
+    title: "Tenant awaiting reply",
+    body: "Tenant asked for a response.",
+    priority: "high",
+    status: "unread",
+    occurredAt: "2026-06-18T10:00:00.000Z",
+    readAt: null,
+    ...overrides,
+  };
+}
+
+describe("landlordDecisionQueueRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [analyticsDecision()] } });
+    deriveLeaseDecisionsForInbox.mockResolvedValue([]);
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [unifiedInboxRecord()],
+      records: [unifiedInboxRecord()],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+  });
+
+  it("returns 401 for unauthenticated requests with route version header", async () => {
+    mockUser = null;
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue", user: null });
+
+    expect(res.status).toBe(401);
+    expect(res.headers["x-landlord-decision-queue-route-version"]).toBe("landlord-decision-queue-api-v1");
+    expect(loadLandlordAnalyticsSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-landlord users", async () => {
+    mockUser = { id: "tenant-1", role: "tenant" };
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue" });
+
+    expect(res.status).toBe(403);
+    expect(getUnifiedInbox).not.toHaveBeenCalled();
+  });
+
+  it("returns a landlord-scoped normalized decision queue", async () => {
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.version).toBe("landlord_decision_queue_v1");
+    expect(res.body.landlordId).toBe("landlord-1");
+    expect(loadLandlordAnalyticsSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+      })
+    );
+    expect(getUnifiedInbox).toHaveBeenCalledWith({ role: "landlord", landlordId: "landlord-1" }, { limit: 100 });
+    expect(res.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          landlordId: "landlord-1",
+          sourceType: "decision_inbox",
+          workspace: "payments",
+          severity: "warning",
+        }),
+        expect.objectContaining({
+          landlordId: "landlord-1",
+          sourceType: "message_unread_priority",
+          workspace: "tenant",
+          severity: "warning",
+        }),
+      ])
+    );
+    expect(JSON.stringify(res.body)).not.toContain("providerRequestId");
+    expect(JSON.stringify(res.body)).not.toContain("gs://");
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
+  it("supports safe filters and preserves stable sorting from the normalized service", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "critical-payment",
+            priority: "high",
+            executionState: "blocked",
+            destination: "/leases/lease-1/ledger",
+          }),
+          analyticsDecision({
+            id: "lease-info",
+            decisionType: "review_lease_renewals",
+            priority: "low",
+            destination: "/leases/lease-2/summary",
+          }),
+        ],
+      },
+    });
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [
+        unifiedInboxRecord({ id: "message-1", priority: "high", occurredAt: "2026-06-18T10:00:00.000Z" }),
+        unifiedInboxRecord({ id: "notice-1", sourceKind: "landlord.notice", priority: "normal", status: "unread" }),
+      ],
+      records: [],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue?severity=warning&workspace=tenant&limit=1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.filters).toEqual({
+      severity: "warning",
+      workspace: "tenant",
+      status: null,
+    });
+    expect(res.body.total).toBe(1);
+    expect(res.body.limit).toBe(1);
+    expect(res.body.items).toEqual([
+      expect.objectContaining({
+        sourceId: "message-1",
+        sourceType: "message_unread_priority",
+        sortKey: expect.any(String),
+      }),
+    ]);
+  });
+
+  it("ignores invalid filters safely and applies default limit", async () => {
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/decision-queue?severity=severe&workspace=../../admin&status=destroyed&limit=-5",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.filters).toEqual({
+      severity: null,
+      workspace: null,
+      status: null,
+    });
+    expect(res.body.limit).toBe(50);
+    expect(res.body.items.length).toBeGreaterThan(0);
+  });
+
+  it("returns a clean empty queue response", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    deriveLeaseDecisionsForInbox.mockResolvedValue([]);
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [],
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        version: "landlord_decision_queue_v1",
+        landlordId: "landlord-1",
+        items: [],
+        total: 0,
+        limit: 50,
+        summary: {
+          total: 0,
+          critical: 0,
+          warning: 0,
+          needsReview: 0,
+          upcoming: 0,
+          informational: 0,
+          open: 0,
+          blocked: 0,
+        },
+      })
+    );
+  });
+
+  it("keeps messaging source types and excludes non-landlord inbox records", async () => {
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [
+        unifiedInboxRecord({ id: "tenant-message", sourceKind: "landlord.message", priority: "high" }),
+        unifiedInboxRecord({ id: "notice-message", sourceKind: "landlord.notice", priority: "normal", status: "unread" }),
+        unifiedInboxRecord({ id: "maintenance-message", sourceKind: "landlord.maintenance", priority: "high" }),
+        unifiedInboxRecord({ id: "tenant-scope-message", sourceKind: "tenant.message", audienceRole: "tenant", priority: "high" }),
+      ],
+      records: [],
+      total: 4,
+      limit: 100,
+      offset: 0,
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue?open=true" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items.map((item: any) => item.sourceType)).toEqual(
+      expect.arrayContaining([
+        "decision_inbox",
+        "message_unread_priority",
+        "message_notice_relevance",
+        "message_maintenance_follow_up",
+      ])
+    );
+    expect(JSON.stringify(res.body)).not.toContain("tenant-scope-message");
+  });
+});

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -106,7 +106,7 @@ async function loadDecisionActionsForLease(leaseId: string) {
   return (snap?.docs || []).map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
 }
 
-async function deriveLeaseDecisionsForInbox(landlordId: string): Promise<Decision[]> {
+export async function deriveLeaseDecisionsForInbox(landlordId: string): Promise<Decision[]> {
   const leases = await loadLandlordLeases(landlordId);
   const nested = await Promise.all(
     leases.map(async (lease) => {

--- a/rentchain-api/src/routes/landlordDecisionQueueRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionQueueRoutes.ts
@@ -1,0 +1,140 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
+import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
+import { deriveLeaseDecisionsForInbox } from "./landlordDecisionInboxRoutes";
+import { getUnifiedInbox } from "../services/unifiedInbox";
+import {
+  deriveLandlordDecisionQueue,
+  type LandlordDecisionQueueItem,
+  type LandlordDecisionQueueSeverity,
+  type LandlordDecisionQueueStatus,
+  type LandlordDecisionQueueWorkspace,
+} from "../services/landlordDecisionQueue";
+
+const router = Router();
+
+const ROUTE_VERSION = "landlord-decision-queue-api-v1";
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 50;
+
+const SEVERITIES = new Set<LandlordDecisionQueueSeverity>([
+  "critical",
+  "warning",
+  "needs_review",
+  "upcoming",
+  "informational",
+]);
+const WORKSPACES = new Set<LandlordDecisionQueueWorkspace>([
+  "dashboard",
+  "operations",
+  "tenant",
+  "lease",
+  "property",
+  "maintenance",
+  "payments",
+  "notices",
+  "evidence_compliance",
+]);
+const STATUSES = new Set<LandlordDecisionQueueStatus>(["open", "pending", "blocked", "resolved", "dismissed"]);
+
+router.use((_req, res, next) => {
+  res.setHeader("x-landlord-decision-queue-route-version", ROUTE_VERSION);
+  next();
+});
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeFilter<T extends string>(value: unknown, known: Set<T>): T | null {
+  const raw = asString(value, 80).toLowerCase().replace(/-/g, "_");
+  if (!raw || raw === "all") return null;
+  return known.has(raw as T) ? (raw as T) : null;
+}
+
+function parseLimit(value: unknown): number {
+  if (value == null || value === "") return DEFAULT_LIMIT;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+function applyFilters(
+  items: LandlordDecisionQueueItem[],
+  filters: {
+    severity: LandlordDecisionQueueSeverity | null;
+    workspace: LandlordDecisionQueueWorkspace | null;
+    status: LandlordDecisionQueueStatus | "open_state" | null;
+  }
+) {
+  return items.filter((item) => {
+    if (filters.severity && item.severity !== filters.severity) return false;
+    if (filters.workspace && item.workspace !== filters.workspace) return false;
+    if (filters.status === "open_state" && (item.status === "resolved" || item.status === "dismissed")) return false;
+    if (filters.status && filters.status !== "open_state" && item.status !== filters.status) return false;
+    return true;
+  });
+}
+
+router.get("/decision-queue", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const [snapshot, leaseDecisions, unifiedInbox] = await Promise.all([
+      loadLandlordAnalyticsSnapshot({
+        landlordId,
+        period: req.query?.period,
+        propertyId: req.query?.propertyId,
+      }),
+      deriveLeaseDecisionsForInbox(landlordId),
+      getUnifiedInbox({ role: "landlord", landlordId }, { limit: MAX_LIMIT }),
+    ]);
+
+    const decisionInbox = deriveDecisionInbox({
+      analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
+      leaseDecisions,
+    });
+
+    const queue = deriveLandlordDecisionQueue({
+      landlordId,
+      decisionInboxItems: decisionInbox.items,
+      unifiedInboxRecords: unifiedInbox.items,
+    });
+
+    const statusRaw = asString(req.query?.status ?? req.query?.open, 80).toLowerCase();
+    const status =
+      statusRaw === "true" || statusRaw === "open_state"
+        ? "open_state"
+        : normalizeFilter(req.query?.status, STATUSES);
+    const filteredItems = applyFilters(queue.items, {
+      severity: normalizeFilter(req.query?.severity, SEVERITIES),
+      workspace: normalizeFilter(req.query?.workspace, WORKSPACES),
+      status,
+    });
+    const limit = parseLimit(req.query?.limit);
+    const items = filteredItems.slice(0, limit);
+
+    return res.json({
+      ok: true,
+      ...queue,
+      items,
+      total: filteredItems.length,
+      limit,
+      filters: {
+        severity: normalizeFilter(req.query?.severity, SEVERITIES),
+        workspace: normalizeFilter(req.query?.workspace, WORKSPACES),
+        status,
+      },
+    });
+  } catch (err: any) {
+    console.error("[landlord-decision-queue] failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_DECISION_QUEUE_FAILED" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Adds landlord-authenticated read-only endpoint: GET /api/landlord/decision-queue.
- Reuses the merged landlord decision queue normalization service from PR #1184.
- Feeds the service with existing decision inbox derivation and landlord unified inbox records.
- Adds route-version header: x-landlord-decision-queue-route-version: landlord-decision-queue-api-v1.
- Adds safe query filters for severity, workspace, status/open state, and limit.

## Scope
- Backend API only.
- No UI changes.
- No source record mutation.
- No audit event creation.
- No notification/message mutation.
- No new collection.

## API Contract
Request:
- GET /api/landlord/decision-queue
- Optional query params: severity, workspace, status, open=true, limit.
- Invalid filter values are ignored safely and reported as null filters.
- Limit defaults to 50 and caps at 100.

Response:
- ok
- version
- landlordId
- generatedAt
- items
- summary
- total
- limit
- filters

Each item includes:
- id
- landlordId
- sourceType
- sourceId
- workspace
- severity
- title
- description
- recommendedActionLabel
- recommendedActionHref
- dueAt
- createdAt
- updatedAt
- status
- dedupeKey
- sortKey
- priorityRank
- related refs: propertyId, unitId, tenantId, leaseId, maintenanceRequestId, noticeId

## Tests
- npm run test:single -- src/routes/__tests__/landlordDecisionQueueRoutes.test.ts src/services/landlordDecisionQueue/__tests__/landlordDecisionQueueService.test.ts
- npm run build
- git diff --check

## Preview QA
Backend route added, so preview validation should confirm Cloud Run parity before using the endpoint:
- image tag matches this PR head
- GET /api/landlord/decision-queue unauthenticated returns 401 with route-version header
- authenticated landlord response is scoped and contains normalized queue items
- filters work for severity/workspace/status/limit
- empty queue response is clean
- no raw provider/storage payloads exposed