### PR TITLE
docs: design dashboard 2.0 wire ia

### DIFF
--- a/docs/design/dashboard-2.0-to-operations-boundaries-v1.md
+++ b/docs/design/dashboard-2.0-to-operations-boundaries-v1.md
@@ -274,7 +274,7 @@ Dashboard should not require the user to understand the source generator. Operat
 
 ## Recommended Implementation Sequence
 
-1. Expose the read-only normalized landlord decision queue API.
+1. Use the merged read-only normalized landlord decision queue API.
 2. Add Dashboard 2.0 data adapter using the queue for preview sections.
 3. Implement Decision Queue Preview on Dashboard with strict caps.
 4. Implement Operations full queue consumption with filters.

--- a/docs/design/dashboard-2.0-to-operations-boundaries-v1.md
+++ b/docs/design/dashboard-2.0-to-operations-boundaries-v1.md
@@ -1,0 +1,294 @@
+# Dashboard 2.0 To Operations Boundaries V1
+
+## Scope
+
+This document defines the boundary between Dashboard 2.0 and Operations.
+
+It is a design-only document. It does not implement dashboard UI, Operations UI, routing, backend APIs, CSS, or navigation shell changes.
+
+## Boundary Summary
+
+Dashboard is the operational home.
+
+Operations is the operational triage workspace.
+
+Dashboard should answer:
+
+- Is my portfolio healthy?
+- What matters today?
+- What requires a decision?
+- What is coming up?
+- How is the business performing?
+
+Operations should answer:
+
+- Show me every open decision.
+- Filter by severity, workspace, due date, and source.
+- Let me triage cross-domain work.
+- Help me route into the correct workspace.
+
+## Dashboard Responsibilities
+
+Dashboard owns:
+
+- Portfolio health summary.
+- Top critical and warning decisions.
+- Upcoming action preview.
+- Financial pulse.
+- Portfolio detail routing.
+- Calm empty states and activation guidance.
+
+Dashboard does not own:
+
+- Full queue filtering.
+- Detailed workflow review.
+- Full inbox.
+- Full ledger.
+- Full audit trail.
+- Full maintenance workbench.
+- Full compliance/trust center.
+
+## Operations Responsibilities
+
+Operations owns:
+
+- Full normalized decision queue.
+- Filters by severity, workspace, status, source type, due date, and related domain.
+- Saved operational views, if later implemented.
+- Dense triage and cross-domain scanning.
+- Routing to source workspaces.
+
+Operations does not own:
+
+- Source-specific edit forms.
+- Legal guidance pages.
+- Full tenant portal views.
+- Full document viewers.
+- Full evidence exports.
+
+## Dashboard Inclusion Rules
+
+Dashboard should show a decision when at least one is true:
+
+- Severity is critical.
+- It is a warning with direct landlord action.
+- It blocks signing, rent collection, move-in, maintenance, notice, payment, or tenant response.
+- It is upcoming and inside the defined action window.
+- It is a message-derived item requiring landlord response or escalation.
+
+Dashboard should not show a decision when:
+
+- It is informational.
+- It is resolved or dismissed.
+- It is an ordinary unread message.
+- It is a low-urgency readiness detail better handled in a source workspace.
+- It is duplicate context already represented by a higher severity item.
+- It lacks a safe action destination.
+
+## Operations-Only Items
+
+These should usually stay out of Dashboard and live in Operations or a source workspace:
+
+- Informational queue items.
+- Full needs-review backlog.
+- Low-priority setup/readiness details.
+- Ordinary unread messages.
+- Full maintenance request list.
+- Full property action request list.
+- Evidence/export activity history.
+- Trust/compliance audit trails.
+- Debug/source generator items.
+- Resolved, dismissed, or historical decisions.
+
+## Severity Boundary
+
+| Severity | Dashboard treatment | Operations treatment |
+| --- | --- | --- |
+| critical | Always show until cap is reached. | Full item with filters and route. |
+| warning | Show if action-required or materially time-sensitive. | Full item. |
+| needs_review | Show only if blocking or among top few decisions. | Full item. |
+| upcoming | Show in Upcoming Actions window. | Full item in upcoming/date views. |
+| informational | Hide by default. | Available only if Operations later supports informational filters. |
+
+Dashboard should avoid overusing red. Red is for critical state, material overdue state, or real operational failure. Missing setup, draft readiness, and early upcoming work should use calmer treatment.
+
+## Workspace Routing Boundary
+
+| Workspace | Dashboard role | Operations role | Source workspace role |
+| --- | --- | --- | --- |
+| Leases | Show blocking lease execution/readiness items. | Filter and prioritize lease decisions. | Resolve signing, documents, Form P readiness, delivery readiness. |
+| Tenants | Show move-in or tenant-response blockers only. | Filter and prioritize tenant decisions. | Resolve tenant lifecycle, current lease, portal, move-in state. |
+| Payments | Show financial pulse and payment criticals. | Triage delinquency/setup/payment review. | Resolve ledger and payment setup. |
+| Maintenance | Show urgent maintenance count/top item. | Triage submitted, blocked, cost-review, contractor-response work. | Resolve request/work order details. |
+| Properties | Show property/unit health and material action requests. | Triage property action requests. | Resolve property/unit readiness and occupancy context. |
+| Notices | Show imminent or overdue notice deadlines. | Triage notice/response/deadline work. | Resolve notice workflow. |
+| Messaging | Show urgent/awaiting-response communication only. | Triage communication decisions. | Read and reply to threads. |
+| Evidence/Compliance | Show material trust/evidence blocker only. | Triage if queue-supported. | Resolve in Trust/Compliance or evidence workspace. |
+
+## Messaging Boundary
+
+Dashboard should treat messaging as an operational signal, not an inbox.
+
+Dashboard may show:
+
+- Urgent message count.
+- Tenant awaiting reply count.
+- One top urgent communication decision.
+- Support escalation requiring landlord action.
+
+Dashboard should not show:
+
+- Full thread list.
+- Message bodies.
+- Ordinary unread count as a warning.
+- Contractor chatter.
+- Notice/legal excerpts.
+
+Operations should show message-derived decisions when they are normalized as:
+
+- `message_thread`
+- `message_unread_priority`
+- `message_notice_relevance`
+- `message_maintenance_follow_up`
+- `message_support_escalation`
+- `unified_inbox_event`
+
+The Messaging workspace should own reading, replying, resolving, and thread history.
+
+## Lease, Tenant, Payment, Maintenance, And Property Boundaries
+
+### Lease Issues
+
+Dashboard:
+
+- Show only blocking execution/readiness, active conflict, signing failure, or imminent lifecycle issue.
+
+Operations:
+
+- Show all open lease decisions and warnings.
+
+Leases:
+
+- Own document generation, signing state, Form P readiness, delivery readiness, workflow pages, and lease summary.
+
+### Tenant Issues
+
+Dashboard:
+
+- Show move-in blockers and tenant response blockers only when timely or high value.
+
+Operations:
+
+- Show tenant lifecycle and state-coherence items.
+
+Tenants:
+
+- Own tenant profile, current lease linkage, unit relationship, portal readiness, and move-in readiness.
+
+### Payment Issues
+
+Dashboard:
+
+- Show financial snapshot, overdue/failed count, and top delinquency item.
+
+Operations:
+
+- Show full payment readiness/delinquency queue.
+
+Payments/Ledger:
+
+- Own ledger, payment evidence, setup, failed/underpaid/manual review actions.
+
+### Maintenance Issues
+
+Dashboard:
+
+- Show urgent, blocked, or unreviewed maintenance counts and top item.
+
+Operations:
+
+- Show full maintenance triage lane.
+
+Maintenance:
+
+- Own request detail, assignment, contractor communication, cost approval, completion.
+
+### Property Issues
+
+Dashboard:
+
+- Show material property/unit readiness or occupancy conflicts.
+
+Operations:
+
+- Show property action requests and property-owned needs-review items.
+
+Properties:
+
+- Own property/unit records, occupancy source context, and action requests.
+
+## Preventing Dashboard From Becoming A Filing Cabinet
+
+Dashboard must not absorb source-workspace tables. Use these rules:
+
+1. If a user needs filters, it belongs in Operations or a source workspace.
+2. If a user needs to edit, approve, sign, assign, or send, route to the source workspace.
+3. If content has more than five rows, summarize it and link out.
+4. If content is history, show only recent signal or route to the owning history/audit surface.
+5. If content is a document, show status and a safe action, not the document library.
+6. If content is a message thread, route to Messaging or the source workspace.
+
+## Peace Of Mind Hierarchy
+
+Dashboard should feel calm by default:
+
+- Healthy status should be visible when nothing is urgent.
+- Critical items should be rare and specific.
+- Warnings should be grouped by user action, not source generator.
+- Upcoming items should not look like failures.
+- Empty states should explain absence of data without implying broken setup.
+- Legal/compliance readiness should be operational, not alarmist.
+
+## Sticky Workspace Navigation Implications
+
+Future sticky navigation should support this model:
+
+- Dashboard remains the default landing page.
+- Operations is adjacent and clearly labelled as the full queue.
+- Workspace tabs remain stable across Dashboard, Operations, Properties, Tenants, Leases, Maintenance, Payments, Messaging, and Trust.
+- Breadcrumbs appear only after drilling into a specific tenant, lease, property, request, or document.
+- Mobile navigation should expose Dashboard and Operations without hiding the primary action.
+
+Dashboard cards should use stable action paths so sticky navigation can preserve context after the user routes into a workspace.
+
+## Dashboard To Operations Handoff
+
+Each dashboard decision item should support:
+
+- A direct source workspace action.
+- A secondary "View in Operations" action or context when the item is part of a broader queue.
+- A clear workspace label.
+- A stable status and severity.
+
+Dashboard should not require the user to understand the source generator. Operations may expose source filters for power users later, but not raw implementation details.
+
+## Recommended Implementation Sequence
+
+1. Expose the read-only normalized landlord decision queue API.
+2. Add Dashboard 2.0 data adapter using the queue for preview sections.
+3. Implement Decision Queue Preview on Dashboard with strict caps.
+4. Implement Operations full queue consumption with filters.
+5. Move legacy dashboard action prompts into Activation/Upcoming Actions where appropriate.
+6. Add message-derived decision treatment once messaging source items are available.
+7. Add sticky workspace shell/navigation after route behavior is stable.
+8. Apply visual polish and charts after hierarchy and routing are working.
+
+## Non-Goals
+
+- No Dashboard 2.0 UI build.
+- No Operations redesign implementation.
+- No route changes.
+- No API changes.
+- No CSS or mockups.
+- No message inbox implementation.
+- No notification delivery changes.

--- a/docs/design/dashboard-2.0-widget-contracts-v1.md
+++ b/docs/design/dashboard-2.0-widget-contracts-v1.md
@@ -6,7 +6,7 @@ This document defines stable information contracts for Dashboard 2.0 widgets.
 
 It is a design-only contract. It does not add TypeScript types, API routes, UI components, CSS, backend services, or runtime behavior.
 
-The contracts assume a future read-only normalized landlord decision queue API and existing domain summaries. They are written to help Dashboard 2.0 implementation avoid drifting into a filing cabinet or duplicate Operations page.
+The contracts assume the merged read-only normalized landlord decision queue API and existing domain summaries. They are written to help Dashboard 2.0 implementation avoid drifting into a filing cabinet or duplicate Operations page.
 
 ## Shared Contract Principles
 
@@ -235,7 +235,7 @@ Rules:
 
 ## Dashboard Queue Query Recommendations
 
-Future Dashboard 2.0 can use a queue request equivalent to:
+Dashboard 2.0 can use a queue request equivalent to:
 
 ```txt
 GET /api/landlord/decision-queue?status=open&limit=10

--- a/docs/design/dashboard-2.0-widget-contracts-v1.md
+++ b/docs/design/dashboard-2.0-widget-contracts-v1.md
@@ -39,8 +39,7 @@ type DashboardDecisionQueueItem = {
     | "maintenance"
     | "payments"
     | "notices"
-    | "evidence"
-    | "compliance";
+    | "evidence_compliance";
   severity: "critical" | "warning" | "needs_review" | "upcoming" | "informational";
   title: string;
   description: string;
@@ -243,9 +242,20 @@ GET /api/landlord/decision-queue?status=open&limit=10
 
 Optional dashboard-oriented filters:
 
-- `severity=critical,warning,needs_review,upcoming`
-- `workspace=lease,tenant,payments,maintenance,property,notices`
+- `severity=critical`
+- `severity=warning`
+- `severity=needs_review`
+- `severity=upcoming`
+- `workspace=lease`
+- `workspace=tenant`
+- `workspace=payments`
+- `workspace=maintenance`
+- `workspace=property`
+- `workspace=notices`
+- `workspace=evidence_compliance`
 - `limit=5` for preview widgets.
+
+The merged queue API accepts one severity and one workspace filter value per request. Dashboard implementations that need a mixed preview should either request an unfiltered open queue with a small limit and apply display rules client-side, or issue separate focused requests where that is justified.
 
 Dashboard should not require a new route if the queue API can provide stable sorting and filtering. A later summary endpoint can be considered only if performance or layout needs justify it.
 

--- a/docs/design/dashboard-2.0-widget-contracts-v1.md
+++ b/docs/design/dashboard-2.0-widget-contracts-v1.md
@@ -1,0 +1,299 @@
+# Dashboard 2.0 Widget Contracts V1
+
+## Scope
+
+This document defines stable information contracts for Dashboard 2.0 widgets.
+
+It is a design-only contract. It does not add TypeScript types, API routes, UI components, CSS, backend services, or runtime behavior.
+
+The contracts assume a future read-only normalized landlord decision queue API and existing domain summaries. They are written to help Dashboard 2.0 implementation avoid drifting into a filing cabinet or duplicate Operations page.
+
+## Shared Contract Principles
+
+All dashboard widgets should follow these rules:
+
+1. Summarize first, route second, never replace the source workspace.
+2. Use normalized decision queue items for decision-oriented content.
+3. Never expose raw IDs, storage paths, provider payloads, tokens, or private message bodies.
+4. Distinguish no data, loading, degraded, and healthy states.
+5. Avoid red unless severity is `critical` or a material deadline is missed.
+6. Keep mobile content shorter than desktop content.
+7. Prefer one clear primary action per widget.
+
+## Normalized Decision Queue Assumptions
+
+Dashboard decision widgets should consume queue items with fields equivalent to:
+
+```ts
+type DashboardDecisionQueueItem = {
+  id: string;
+  landlordId: string;
+  sourceType: string;
+  sourceId: string;
+  workspace:
+    | "dashboard"
+    | "operations"
+    | "tenant"
+    | "lease"
+    | "property"
+    | "maintenance"
+    | "payments"
+    | "notices"
+    | "evidence"
+    | "compliance";
+  severity: "critical" | "warning" | "needs_review" | "upcoming" | "informational";
+  title: string;
+  description: string;
+  recommendedActionLabel: string;
+  recommendedActionHref: string;
+  dueAt?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  status: "open" | "pending" | "blocked" | "resolved" | "dismissed";
+  dedupeKey: string;
+  sortKey: string;
+  priorityRank: number;
+  relatedEntityRefs?: {
+    propertyId?: string;
+    unitId?: string;
+    tenantId?: string;
+    leaseId?: string;
+    maintenanceRequestId?: string;
+    noticeId?: string;
+  };
+};
+```
+
+Dashboard should display only safe labels and route labels derived from this model. It should not display `sourceId`, `dedupeKey`, or raw related IDs as user-facing text.
+
+## Widget: Portfolio Status
+
+| Field | Contract |
+| --- | --- |
+| Purpose | High-level business health. |
+| Primary question | "Is my portfolio healthy?" |
+| Inputs | Portfolio counts, occupancy summary, rent/payment summary, maintenance summary, decision severity counts. |
+| Decision queue dependency | Severity aggregate counts and top critical presence. |
+| Output | Health label, critical count, occupancy status, rent status, maintenance status, lease/document readiness status. |
+| Primary action | Open Operations filtered to critical or needs-attention items. |
+| Empty state | Setup prompt for first property/unit. |
+| Degraded state | Show unavailable metric labels per source; do not create synthetic warnings. |
+| Mobile | One health card, one primary action, two supporting facts. |
+
+Recommended display fields:
+
+- `overallStatus`: stable, needs_attention, critical_review.
+- `criticalCount`.
+- `warningCount`.
+- `occupancySummary`.
+- `rentCollectionSummary`.
+- `maintenanceSummary`.
+- `leaseReadinessSummary`.
+
+## Widget: Decision Queue Preview
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Show top actionable decisions. |
+| Primary question | "What do I need to handle first?" |
+| Inputs | Normalized decision queue items. |
+| Decision queue dependency | Primary source. |
+| Output | Top critical/warning/needs-review items. |
+| Primary action | Item action opens `recommendedActionHref`; secondary action opens Operations. |
+| Empty state | "No open decisions." |
+| Degraded state | "Decision queue unavailable" without stale red state. |
+| Mobile | Top three items max. |
+
+Dashboard filters:
+
+- Include `status` open, pending, or blocked.
+- Exclude resolved and dismissed.
+- Include severity critical, warning, needs_review, and near-term upcoming.
+- Exclude informational by default.
+- Limit to 3 to 5 items.
+
+Message-derived source types allowed:
+
+- `message_thread`
+- `message_unread_priority`
+- `message_notice_relevance`
+- `message_maintenance_follow_up`
+- `message_support_escalation`
+- `unified_inbox_event` only when action-required.
+
+## Widget: Upcoming Actions
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Preview time-bound work. |
+| Primary question | "What is coming up?" |
+| Inputs | Queue items with `upcoming` severity, due dates, lease lifecycle, notice timing, maintenance scheduling. |
+| Decision queue dependency | Upcoming queue items and due date ordering. |
+| Output | Date-ordered upcoming action rows. |
+| Primary action | Route to owning lease, notice, tenant, or maintenance workspace. |
+| Empty state | "No upcoming actions in this window." |
+| Degraded state | Show schedule unavailable without warnings. |
+| Mobile | Timeline list, max three rows. |
+
+Upcoming rows should include:
+
+- Title.
+- Due date or timeframe.
+- Workspace label.
+- Short action label.
+
+Rows should not include long legal, notice, or lease guidance.
+
+## Widget: Financial Snapshot
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Show rent collection and payment health. |
+| Primary question | "How is my business performing financially?" |
+| Inputs | Rent obligations, ledger/payment summary, payment readiness, delinquency decision items. |
+| Decision queue dependency | Payment critical/warning/needs-review items. |
+| Output | Rent expected, rent collected, overdue/failed/underpaid count, setup blockers. |
+| Primary action | Open Ledger or Payments workspace. |
+| Empty state | "No rent collection data yet." |
+| Degraded state | Show snapshot unavailable; do not show stale financial totals without freshness. |
+| Mobile | Primary total plus compact status row. |
+
+Decision item source families:
+
+- Payment delinquency.
+- Failed payment.
+- Underpaid payment.
+- Payment setup readiness.
+- Missing rent terms only when it blocks collection.
+
+## Widget: Portfolio Detail
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Provide a compact route map to domain workspaces. |
+| Primary question | "Where should I go for details?" |
+| Inputs | Property, unit, tenant, lease, maintenance, document, and trust/compliance summary counts. |
+| Decision queue dependency | Workspace-level open decision counts. |
+| Output | Domain cards or rows with safe counts and action routes. |
+| Primary action | Open the relevant workspace. |
+| Empty state | Domain-specific setup prompt. |
+| Degraded state | Domain unavailable row; other domains remain usable. |
+| Mobile | Collapsible domain list. |
+
+Portfolio Detail rows should include:
+
+- Domain label.
+- Healthy/needs attention status.
+- Count or short summary.
+- Workspace route.
+
+They should not include full lists of tenants, leases, messages, maintenance requests, documents, or audit events.
+
+## Widget: Messaging Signal Preview
+
+Messaging should usually be represented inside Decision Queue Preview, but a compact signal may be shown when communication volume is operationally important.
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Show actionable communication state without becoming an inbox. |
+| Primary question | "Is someone waiting on me?" |
+| Inputs | Message-derived queue items and safe unified inbox aggregates. |
+| Decision queue dependency | Only action-required message items. |
+| Output | Awaiting reply count, urgent message count, one top communication decision. |
+| Primary action | Open Messaging, Operations filtered to communication, or the owning workspace. |
+| Empty state | "No messages need action." |
+| Degraded state | "Messaging status unavailable." |
+| Mobile | Count and one action route only. |
+
+Do not show:
+
+- Full message list.
+- Ordinary unread count as a warning.
+- Raw message content.
+- Contractor chatter.
+- Notice excerpts.
+
+## Widget State Contract
+
+Each widget should support:
+
+```ts
+type WidgetState = {
+  status: "ready" | "empty" | "loading" | "degraded" | "error";
+  generatedAt?: string;
+  dataFreshness?: "fresh" | "stale" | "unknown";
+  message?: string;
+};
+```
+
+Rules:
+
+- Loading should not reserve large empty regions on mobile.
+- Degraded should identify the affected source only.
+- Error should route to a safe retry or workspace, not display raw API errors.
+- Stale data must be labelled if shown.
+
+## Dashboard Queue Query Recommendations
+
+Future Dashboard 2.0 can use a queue request equivalent to:
+
+```txt
+GET /api/landlord/decision-queue?status=open&limit=10
+```
+
+Optional dashboard-oriented filters:
+
+- `severity=critical,warning,needs_review,upcoming`
+- `workspace=lease,tenant,payments,maintenance,property,notices`
+- `limit=5` for preview widgets.
+
+Dashboard should not require a new route if the queue API can provide stable sorting and filtering. A later summary endpoint can be considered only if performance or layout needs justify it.
+
+## Safety Contract
+
+Widgets must not display:
+
+- Raw Firestore IDs as labels.
+- Raw provider request IDs.
+- Storage paths or signed URL internals.
+- Payment processor IDs.
+- Full message bodies.
+- Screening report payloads.
+- Private notes.
+- Audit debug payloads.
+- Legal approval or enforceability claims.
+
+Widgets may display:
+
+- Safe role labels.
+- Safe property/unit/tenant labels.
+- Count summaries.
+- Readiness labels.
+- Bounded message/action summaries already safe for landlord projection.
+
+## Mobile Contract
+
+Mobile ordering:
+
+1. Portfolio health.
+2. Critical decision preview.
+3. Today/upcoming.
+4. Financial pulse.
+5. Portfolio detail links.
+
+Mobile limits:
+
+- Three decision items max.
+- Three upcoming items max.
+- One primary action per card.
+- Avoid side-by-side dense metrics.
+- Avoid hidden-only critical information.
+
+## Non-Goals
+
+- No UI implementation.
+- No API implementation.
+- No backend normalization changes.
+- No chart specification.
+- No visual styling.
+- No component props committed to code.

--- a/docs/design/dashboard-2.0-wire-ia-v1.md
+++ b/docs/design/dashboard-2.0-wire-ia-v1.md
@@ -287,7 +287,7 @@ Dashboard content should not rely on page-level context that disappears when the
 
 ## Implementation Sequence Recommendation
 
-1. Merge or finalize read-only decision queue API.
+1. Use the merged read-only decision queue API as the decision-oriented source.
 2. Add a Dashboard 2.0 adapter contract that consumes queue summaries without changing visual layout.
 3. Replace dashboard decision/action panels with queue-driven preview widgets.
 4. Add Operations full-queue consumption.

--- a/docs/design/dashboard-2.0-wire-ia-v1.md
+++ b/docs/design/dashboard-2.0-wire-ia-v1.md
@@ -1,0 +1,306 @@
+# Dashboard 2.0 Wire IA V1
+
+## Scope
+
+This document defines the Dashboard 2.0 information architecture for the landlord operational home.
+
+It assumes the normalized landlord decision queue will become the source for decision-oriented widgets after the read-only queue API is available. It does not require that API to be merged before this design is useful.
+
+This is a design-only document. It does not implement UI, routes, API changes, backend services, CSS, or visual mockups.
+
+## Product Intent
+
+Dashboard 2.0 should answer five landlord questions in order:
+
+1. Is my portfolio healthy?
+2. What requires my attention today?
+3. What decisions must I make?
+4. What actions should I take next?
+5. How is my business performing?
+
+The dashboard should be an operational home, not a filing cabinet. It should summarize, prioritize, and route. Source workspaces should hold the detail.
+
+## Global Hierarchy
+
+Dashboard 2.0 should use this hierarchy:
+
+1. Portfolio Status
+2. Decision Queue
+3. Upcoming Actions
+4. Financial Snapshot
+5. Portfolio Detail
+
+This order is intentional. A landlord should see health first, urgent decisions second, planned work third, financial performance fourth, and entity-level detail last.
+
+## Section 1: Portfolio Status
+
+| Field | Definition |
+| --- | --- |
+| Purpose | Provide a calm top-level answer to whether the rental business is healthy. |
+| Primary user question | "Is anything materially wrong right now?" |
+| Data source | Portfolio summary data, normalized decision queue aggregates, lease/payment/maintenance/property summaries. |
+| Decision queue dependency | Uses aggregate counts by severity and workspace, not full queue rows. |
+| Action path | Critical count links to Operations filtered to critical; portfolio entities link to Properties, Tenants, Leases, or Maintenance. |
+| Owning workspace | Dashboard owns the summary; Operations and domain workspaces own resolution. |
+| Empty state | "No active portfolio records yet" with a setup path to add property/unit. |
+| Degraded/loading state | Show last known stable portfolio counts only if freshness is explicit; otherwise show neutral loading without false warnings. |
+| Mobile behavior | First card only: health label, critical count, next best action. Secondary stats stack below. |
+
+Recommended content:
+
+- Overall health label: Stable, Needs Attention, Critical Review.
+- Critical issue count.
+- Rent collection status.
+- Occupancy signal.
+- Maintenance signal.
+- Lease/document readiness signal.
+
+Avoid:
+
+- Long explanations.
+- Every warning.
+- Red health labels for incomplete onboarding unless something is actually risky.
+
+## Section 2: Decision Queue
+
+| Field | Definition |
+| --- | --- |
+| Purpose | Show the highest priority landlord decisions requiring review or action. |
+| Primary user question | "What do I need to decide or fix first?" |
+| Data source | Normalized landlord decision queue. |
+| Decision queue dependency | Primary dependency. Items must come from normalized source types and severity model. |
+| Action path | Each item routes to `recommendedActionHref` in its owning workspace. "View all" routes to Operations. |
+| Owning workspace | Operations owns the full queue. Dashboard owns a preview. |
+| Empty state | "No open decisions" with a neutral explanation that informational activity remains in workspaces. |
+| Degraded/loading state | If queue is unavailable, show "Decision queue unavailable" and do not synthesize critical items from stale local data. |
+| Mobile behavior | Show at most three items: first critical, then warning, then needs-review/upcoming. Keep item copy one or two lines. |
+
+Dashboard inclusion rules:
+
+- Include all critical items up to a small cap.
+- Include high-value warning and needs-review items with direct landlord action.
+- Include time-sensitive upcoming items only when they are due soon.
+- Exclude informational items.
+- Exclude ordinary unread messages unless they are normalized as urgent or awaiting-response decisions.
+
+Recommended display fields:
+
+- Severity label.
+- Title.
+- Short description.
+- Recommended action label.
+- Workspace tag.
+- Due date only when relevant.
+
+Do not show:
+
+- Raw internal IDs.
+- Dedupe keys.
+- Source debug metadata.
+- Full message bodies.
+- Legal/compliance claims.
+
+## Section 3: Upcoming Actions
+
+| Field | Definition |
+| --- | --- |
+| Purpose | Make planned operational work visible without turning it into warnings too early. |
+| Primary user question | "What is coming up soon?" |
+| Data source | Normalized decision queue items with `upcoming` severity, lease lifecycle/notice timing, maintenance schedule, renewal/move-out timing. |
+| Decision queue dependency | Uses upcoming items and due dates from the normalized queue. |
+| Action path | Routes to lease workflow pages, notice workflow, maintenance request, or tenant/lease profile. |
+| Owning workspace | Operations owns full action list; domain workspaces own completion. |
+| Empty state | "No upcoming actions in the selected window." |
+| Degraded/loading state | Show date-window unavailable state; avoid converting missing calendar data into warnings. |
+| Mobile behavior | Timeline-style list with next two or three actions and a link to Operations. |
+
+Recommended content:
+
+- Lease expiry and renewal review.
+- Notice deadlines and response dates.
+- Move-out preparation.
+- Maintenance scheduling.
+- Tenant move-in blockers only when time-sensitive.
+
+Upcoming actions should become warnings only when a defined threshold is crossed, such as a missed date, response overdue, or workflow blocked.
+
+## Section 4: Financial Snapshot
+
+| Field | Definition |
+| --- | --- |
+| Purpose | Show whether the rental business is collecting and tracking money as expected. |
+| Primary user question | "How is my rental income performing?" |
+| Data source | Payment/ledger summaries, rent obligations, payment readiness, delinquency decisions. |
+| Decision queue dependency | Uses payment-related queue items for overdue, failed, underpaid, and setup blockers. |
+| Action path | Routes to Ledger, Payments, or lease payment readiness context. |
+| Owning workspace | Payments/Ledger owns detail; Dashboard owns snapshot. |
+| Empty state | "No rent collection data yet" with setup path if eligible. |
+| Degraded/loading state | Show financial snapshot unavailable; do not display stale rent collected values without freshness. |
+| Mobile behavior | One primary number plus two supporting stats; detailed breakdown collapses. |
+
+Recommended content:
+
+- Rent expected this period.
+- Rent collected.
+- Overdue/failed/underpaid count.
+- Payment setup readiness when it blocks collection.
+
+Avoid:
+
+- Dense ledger tables.
+- Payment processor internals.
+- Overdue warnings when rent terms are simply not configured unless the landlord is actively using rent collection.
+
+## Section 5: Portfolio Detail
+
+| Field | Definition |
+| --- | --- |
+| Purpose | Provide a compact map of the landlord's properties, units, leases, tenants, and maintenance state. |
+| Primary user question | "Where do I go for the details?" |
+| Data source | Properties, units, tenants, leases, maintenance summaries, occupancy projections. |
+| Decision queue dependency | Uses queue counts by workspace to annotate detail rows, not to replace workspace detail. |
+| Action path | Routes to Properties, Tenants, Leases, Maintenance, Ledger, or Trust/Compliance as applicable. |
+| Owning workspace | Domain workspaces own detail and edits. |
+| Empty state | "Add your first property" or "No active records in this area." |
+| Degraded/loading state | Show affected domain unavailable, not whole dashboard failure if one domain is down. |
+| Mobile behavior | Collapsible sections; show counts first, detail links second. |
+
+Recommended content:
+
+- Property/unit occupancy summary.
+- Active lease count.
+- Tenant move-in/readiness status count.
+- Open maintenance count.
+- Evidence/export/trust status only when material.
+
+Portfolio Detail should not become the full property table, tenant table, maintenance list, or lease list.
+
+## Dashboard Versus Operations Boundary
+
+Dashboard owns:
+
+- Health summary.
+- Top few decisions.
+- Today's or soonest actions.
+- Financial pulse.
+- Entity navigation.
+
+Operations owns:
+
+- Full normalized queue.
+- Filters by severity, workspace, due date, source type, and status.
+- Dense triage.
+- Cross-domain review.
+- Saved views and operational lanes.
+
+Dashboard must avoid becoming a duplicate Operations page. It should answer "what matters now?" and route to Operations for "show me everything."
+
+## Decision Inclusion Rules
+
+Show on Dashboard:
+
+- Critical items.
+- Warnings with immediate landlord action.
+- Needs-review items that block signing, rent collection, move-in, maintenance, notices, or tenant response.
+- Upcoming items inside the selected action window.
+- Message-derived decisions only when urgent, awaiting landlord response, notice relevant, maintenance blocking, or support escalation.
+
+Keep Operations-only:
+
+- Informational items.
+- Resolved/dismissed items.
+- Ordinary unread messages.
+- Low-priority readiness checks.
+- Long guidance text.
+- Duplicate source-specific readiness panels.
+- Debug/source-generator data.
+
+## Messaging-Derived Decisions
+
+Messaging should appear on Dashboard only as decision-quality signals:
+
+- Urgent tenant message.
+- Tenant awaiting landlord reply.
+- Maintenance message requiring landlord response.
+- Contractor quote or schedule issue.
+- Notice-relevant message.
+- Support escalation requiring landlord action.
+
+Dashboard should not show:
+
+- Full inbox.
+- Ordinary unread count as a warning.
+- Message body previews beyond safe short summaries.
+- Contractor chatter.
+- System notifications with no action.
+
+## Domain Signal Placement
+
+| Signal family | Dashboard treatment | Operations treatment | Owning workspace |
+| --- | --- | --- | --- |
+| Lease execution/signing | Top warning only if blocking or inconsistent. | Full queue item with route to lease workspace. | Leases |
+| Tenant move-in readiness | Summary count or top blocker only. | Tenant-scoped needs-review item. | Tenants |
+| Payment delinquency | Critical/warning preview. | Payment queue lane. | Payments/Ledger |
+| Payment setup readiness | Show only when it blocks collection. | Needs-review item. | Payments or Leases |
+| Maintenance submitted/blocked | Show urgent count/top item. | Maintenance lane. | Maintenance |
+| Property action requests | Show only material unresolved count. | Property lane. | Properties |
+| Notices/lease expiry | Upcoming or warning based on timing. | Notice/lease lifecycle lane. | Notices or Leases |
+| Evidence/compliance | Show only material export/evidence/trust posture issues. | Evidence/compliance lane when implemented. | Trust/Compliance |
+| Messaging | Urgent/awaiting response only. | Communication-filtered queue. | Messaging or owning source workspace |
+
+## Calm Hierarchy Rules
+
+Dashboard 2.0 should preserve peace of mind by:
+
+- Using red only for critical or materially overdue items.
+- Treating missing setup separately from operational failure.
+- Showing counts and routes before long explanations.
+- Grouping related warnings under one item.
+- Keeping compliance/readiness language operational, not legal.
+- Avoiding duplicate labels across Dashboard, Operations, Leases, and Tenants.
+
+## Filing Cabinet Prevention
+
+Do not place these on the dashboard:
+
+- Full tenant list.
+- Full lease list.
+- Full maintenance list.
+- Full inbox.
+- Full document library.
+- Full audit trail.
+- Full compliance center.
+- Full ledger.
+
+Instead, show summary counts, health, top blockers, and routes into owned workspaces.
+
+## Sticky Workspace Shell Support
+
+Dashboard 2.0 should be compatible with a future sticky workspace shell:
+
+- Sticky global title: "Dashboard" or "Operational Home".
+- Sticky workspace navigation: Dashboard, Operations, Properties, Tenants, Leases, Maintenance, Payments, Trust.
+- Breadcrumbs for drill-down pages, not dashboard cards.
+- Mobile sticky bottom or top navigation should prioritize Dashboard, Operations, Properties/Tenants, and Messages.
+
+Dashboard content should not rely on page-level context that disappears when the title bar is sticky.
+
+## Implementation Sequence Recommendation
+
+1. Merge or finalize read-only decision queue API.
+2. Add a Dashboard 2.0 adapter contract that consumes queue summaries without changing visual layout.
+3. Replace dashboard decision/action panels with queue-driven preview widgets.
+4. Add Operations full-queue consumption.
+5. Add financial snapshot and upcoming actions refinements.
+6. Add sticky workspace shell/navigation improvements.
+7. Apply visual polish only after IA behavior is stable.
+
+## Non-Goals
+
+- No visual mockups.
+- No component implementation.
+- No CSS.
+- No route changes.
+- No API changes.
+- No backend changes.
+- No dashboard build.


### PR DESCRIPTION
## Summary

- Adds Dashboard 2.0 wire IA around the landlord operational home hierarchy.
- Defines dashboard widget contracts for portfolio status, decision preview, upcoming actions, financial snapshot, portfolio detail, and messaging signals.
- Documents Dashboard versus Operations boundaries for future implementation.

## Scope

Docs only. No UI, route, API, backend service, CSS, or deployment changes.

## Validation

- `git diff --check`
- `git diff --cached --check` before commit

## Notes

This now assumes the merged normalized landlord decision queue API from PR #1185 as the source for decision-oriented widgets.