### PR TITLE
docs: plan dashboard 2.0 operational home

### DIFF
--- a/docs/design/dashboard-2.0-implementation-plan-v1.md
+++ b/docs/design/dashboard-2.0-implementation-plan-v1.md
@@ -1,0 +1,281 @@
+# Dashboard 2.0 Implementation Plan V1
+
+## Scope
+
+This document plans the future implementation sprint for `feat/dashboard-2.0-operational-home-v1`.
+
+It is planning only. It does not implement UI, API routes, backend services, CSS, navigation, or data model changes.
+
+This plan assumes:
+
+- The normalized landlord decision queue service from PR #1184 exists.
+- The read-only decision queue API from PR #1185 is the intended decision source once reviewed and merged.
+- Dashboard 2.0 IA from PR #1186 and the Dashboard versus Operations entrypoint model from PR #1187 are the design baseline.
+
+## Product Objective
+
+Dashboard 2.0 should become the landlord operational home.
+
+It should answer:
+
+1. Is my portfolio healthy?
+2. What requires attention today?
+3. What decisions must I make?
+4. What actions should I take next?
+5. How is my business performing?
+
+Dashboard should summarize and route. Operations should own the full queue. Source workspaces should resolve the work.
+
+## Implementation Phases
+
+### Phase 0: Preconditions
+
+Goal: ensure prerequisites are merged and stable before UI work begins.
+
+Required before implementation:
+
+- PR #1185 reviewed and merged.
+- Dashboard IA docs reviewed and merged.
+- Entrypoint architecture reviewed and merged.
+- Current Dashboard behavior documented enough to avoid losing existing onboarding and free-tier states.
+
+Validation:
+
+- Confirm `GET /api/landlord/decision-queue` contract.
+- Confirm route-version header and filter semantics.
+- Confirm no Dashboard 2.0 UI work starts before the API contract is available.
+
+### Phase 1: Data Adapter And Page Boundary
+
+Goal: introduce a frontend adapter layer for Dashboard 2.0 data without changing the visual experience yet.
+
+Work:
+
+- Add a Dashboard 2.0 data adapter that consumes existing dashboard summary data and the decision queue API.
+- Normalize dashboard widget inputs into stable view models.
+- Preserve existing dashboard route and auth behavior.
+- Keep existing onboarding/free-tier prompts available.
+
+Outputs:
+
+- Portfolio status view model.
+- Decision queue preview view model.
+- Upcoming actions view model.
+- Financial snapshot view model.
+- Portfolio detail view model.
+
+Non-goals:
+
+- No visual redesign in this phase.
+- No Operations queue implementation.
+- No new backend aggregation endpoint unless later justified.
+
+### Phase 2: Portfolio Status And Decision Preview
+
+Goal: replace the top dashboard experience with the new operational home hierarchy.
+
+Work:
+
+- Implement Portfolio Status as the first section.
+- Implement Decision Queue Preview using the normalized queue.
+- Cap visible queue items.
+- Use clear empty and degraded states.
+- Link "View all decisions" to Operations or the existing full queue route until Operations 2.0 exists.
+
+Critical details:
+
+- Do not show all queue items on Dashboard.
+- Do not treat ordinary unread messages as warnings.
+- Do not turn onboarding setup into critical issues.
+
+### Phase 3: Upcoming Actions And Financial Snapshot
+
+Goal: separate planned work from warnings and restore financial business context.
+
+Work:
+
+- Implement Upcoming Actions from upcoming queue items and safe lifecycle dates.
+- Implement Financial Snapshot from existing payment/ledger summaries and payment queue items.
+- Keep overdue/failed/underpaid states distinct from missing setup.
+
+Decision rules:
+
+- Upcoming items should not look broken until thresholds are crossed.
+- Missing rent terms are warnings only when they block a real workflow.
+- Financial totals must show freshness or degrade safely.
+
+### Phase 4: Portfolio Detail And Workspace Routing
+
+Goal: provide compact workspace routing without recreating source tables.
+
+Work:
+
+- Add compact Portfolio Detail for Properties, Tenants, Leases, Maintenance, Payments, Messaging, and Trust/Compliance as applicable.
+- Annotate detail rows with queue counts by workspace where available.
+- Route to source workspaces for detail and resolution.
+
+Avoid:
+
+- Full tenant table.
+- Full lease table.
+- Full maintenance list.
+- Full message inbox.
+- Full ledger.
+
+### Phase 5: Operations Handoff And Navigation Prep
+
+Goal: make Dashboard handoffs ready for Operations and future sticky navigation.
+
+Work:
+
+- Ensure Dashboard item actions route directly to owning workspace when possible.
+- Ensure secondary "View all" routes to Operations or the current queue surface.
+- Preserve route labels that can survive a future sticky workspace shell.
+- Confirm mobile route targets remain usable.
+
+Non-goals:
+
+- No full Operations redesign unless separately scoped.
+- No sticky shell build unless separately approved.
+
+### Phase 6: QA, Preview, And Iteration
+
+Goal: verify the operational home behavior before merge.
+
+Work:
+
+- Run focused frontend tests.
+- Run frontend build.
+- Run backend checks only if Dashboard touches backend code.
+- Run manual preview QA for first-login, active portfolio, empty portfolio, mobile, degraded queue, and routing.
+
+## Component Ownership
+
+| Component or adapter | Responsibility | Data source | Owning surface |
+| --- | --- | --- | --- |
+| Dashboard page shell | Maintains Dashboard as post-login operational home. | Existing frontend route/auth state. | Dashboard |
+| Portfolio Status section | Shows portfolio health and critical count. | Dashboard summary, decision queue aggregates, domain summaries. | Dashboard |
+| Decision Queue Preview | Shows top actionable items only. | Decision queue API. | Dashboard preview; Operations owns full queue. |
+| Upcoming Actions | Shows near-term planned work. | Decision queue upcoming items, lease/notice lifecycle summaries. | Dashboard preview; source workspaces resolve. |
+| Financial Snapshot | Shows rent/payment pulse. | Payment/ledger summaries and payment queue items. | Dashboard preview; Ledger/Payments resolve. |
+| Portfolio Detail | Routes to domain workspaces. | Property/unit/tenant/lease/maintenance summaries. | Dashboard navigation |
+| Messaging Signal Preview | Shows only urgent/awaiting-response communication signals. | Message-derived queue items and safe inbox aggregates. | Dashboard preview; Messaging resolves. |
+| Dashboard data adapter | Converts API/domain data into widget-ready view models. | API clients and existing hooks. | Frontend data boundary |
+| Dashboard empty/degraded state helpers | Prevent false urgency and stale critical states. | Adapter-level status. | Dashboard |
+
+## Data Dependencies
+
+Primary:
+
+- Decision queue API for critical/warning/needs-review/upcoming decision preview.
+- Existing dashboard summary for activation and portfolio baseline.
+- Payment/ledger summaries for financial snapshot.
+- Lease lifecycle and notice timing data for upcoming actions where already available.
+- Property/unit/tenant/maintenance summaries for portfolio detail.
+
+Secondary:
+
+- Unified inbox or message-derived queue items for communication signals.
+- Trust/compliance summaries only when material and already available.
+
+Do not add new backend dependencies unless implementation proves the existing APIs cannot support safe Dashboard view models.
+
+## API Dependencies
+
+Required:
+
+- `GET /api/landlord/decision-queue` after PR #1185 is merged.
+
+Expected filters:
+
+- `severity`
+- `workspace`
+- `status` or `open`
+- `limit`
+
+Expected queue behavior:
+
+- Landlord-authenticated.
+- Read-only.
+- Deterministically sorted.
+- Deduped.
+- Safe normalized item shape.
+- No source record mutation.
+- No audit event creation.
+
+Fallback behavior if queue API is unavailable:
+
+- Dashboard should show portfolio summaries that can load independently.
+- Decision Queue Preview should show unavailable/degraded state.
+- Dashboard should not synthesize critical queue items from stale local state.
+
+## Migration Strategy
+
+Dashboard 2.0 should be migrated incrementally.
+
+Step 1:
+
+- Add adapter and view models while keeping existing visual structure mostly intact.
+
+Step 2:
+
+- Replace existing decision/action areas with Decision Queue Preview and Portfolio Status.
+
+Step 3:
+
+- Move legacy setup/onboarding prompts into Activation or Upcoming Actions, separate from critical decisions.
+
+Step 4:
+
+- Add Upcoming Actions and Financial Snapshot refinements.
+
+Step 5:
+
+- Add Portfolio Detail routing and messaging signal treatment.
+
+Step 6:
+
+- Remove redundant legacy dashboard panels only after the new equivalents are validated.
+
+Do not remove current onboarding/free-tier guidance until the new Dashboard path has equivalent or better behavior.
+
+## Routing Strategy
+
+Dashboard should route in this order:
+
+1. Direct workspace action when an item has one clear resolution path.
+2. Operations filtered queue when the item belongs to a larger group.
+3. Source workspace fallback when no specific target exists.
+
+Examples:
+
+- Overdue rent -> Ledger or Payments.
+- Lease signing blocked -> Leases.
+- Tenant awaiting reply -> Tenant profile or Messaging.
+- Maintenance blocker -> Maintenance request.
+- Notice deadline -> Notice or lease workflow.
+- Property action request -> Property workspace.
+
+## Out Of Scope For First Implementation
+
+- Full Operations redesign.
+- Sticky workspace shell.
+- Visual chart system.
+- New backend summary endpoint.
+- New queue persistence.
+- AI assistant or chatbot.
+- Notification delivery.
+- Tenant portal simplification.
+- Evidence/compliance feature expansion.
+
+## Merge Readiness Criteria For Future Implementation
+
+Future Dashboard implementation should not be merge-ready until:
+
+- Queue-driven decision preview works.
+- Dashboard still supports empty/new landlord state.
+- Existing onboarding/free-tier paths are not regressed.
+- Dashboard routes correctly into Operations and source workspaces.
+- Mobile layout is usable.
+- Degraded queue behavior is safe.
+- Manual preview QA passes.

--- a/docs/design/dashboard-2.0-qa-plan-v1.md
+++ b/docs/design/dashboard-2.0-qa-plan-v1.md
@@ -1,0 +1,275 @@
+# Dashboard 2.0 QA Plan V1
+
+## Scope
+
+This document defines the future QA plan for `feat/dashboard-2.0-operational-home-v1`.
+
+It is planning only. It does not implement tests, UI, APIs, backend services, routes, CSS, or deployment changes.
+
+Manual preview QA is not required for this planning mission. It will be required once Dashboard 2.0 UI implementation begins.
+
+## QA Goals
+
+Dashboard 2.0 QA should prove:
+
+1. Dashboard remains the default operational home.
+2. Decision items appear in the right order.
+3. Dashboard routes to Operations and source workspaces correctly.
+4. Mobile remains usable.
+5. Empty and degraded states are calm and accurate.
+6. Sticky navigation assumptions do not break route context.
+7. Existing landlord onboarding/free-tier behavior is not regressed.
+
+## Automated Validation Targets
+
+Future implementation should include focused frontend tests for:
+
+- Dashboard renders Portfolio Status.
+- Dashboard renders Decision Queue Preview from normalized queue data.
+- Critical items sort above warnings, needs-review, upcoming, and informational items.
+- Informational items do not appear in the default dashboard preview.
+- Message-derived items appear only when actionable.
+- Empty queue shows "No open decisions" style state.
+- Queue API failure shows degraded state, not false all-clear.
+- Dashboard "View all" routes to Operations or current full queue route.
+- Decision action buttons use `recommendedActionHref`.
+- Financial snapshot handles empty, loading, and degraded states.
+- Mobile-friendly content caps are enforced where testable.
+
+Backend tests are not expected unless the implementation changes backend code.
+
+## Manual Preview QA Preconditions
+
+Before manual QA:
+
+- PR #1185 or equivalent decision queue API is merged.
+- Dashboard implementation branch is deployed to Vercel preview.
+- Cloud Run parity is confirmed if backend code changes are included.
+- Test landlord accounts or fixtures are available for:
+  - empty/new landlord
+  - active portfolio
+  - landlord with critical/warning queue items
+  - landlord with upcoming actions
+  - landlord with no open decisions
+  - landlord with degraded or simulated queue failure if feasible
+
+## QA Scenario 1: First Login Experience
+
+Goal: confirm the landlord sees calm operational orientation first.
+
+Steps:
+
+1. Log in as a new or low-data landlord.
+2. Confirm Dashboard is default post-login destination.
+3. Confirm first viewport answers portfolio status and next action.
+4. Confirm setup/activation prompts are not styled as critical issues.
+5. Confirm route options to Properties, Applications, or setup flow remain clear.
+
+Pass criteria:
+
+- Dashboard feels like an operational home.
+- No dense Operations queue appears by default.
+- No false red/critical warnings appear for normal empty state.
+
+## QA Scenario 2: Decision Ordering
+
+Goal: confirm decision severity hierarchy is respected.
+
+Steps:
+
+1. Use a landlord with multiple normalized queue items.
+2. Confirm critical items appear before warnings.
+3. Confirm warnings appear before needs-review.
+4. Confirm upcoming items appear in Upcoming Actions rather than mixed as failures.
+5. Confirm informational items are hidden from Dashboard preview.
+
+Pass criteria:
+
+- Queue order matches severity model.
+- Dashboard preview is capped.
+- No duplicate item appears for the same underlying issue.
+
+## QA Scenario 3: Dashboard To Operations Routing
+
+Goal: confirm Dashboard hands off to Operations for full triage.
+
+Steps:
+
+1. Click "View all decisions" or equivalent.
+2. Confirm user lands on Operations or the current full queue route.
+3. Confirm filters/context preserve the expected queue lane when applicable.
+4. Return to Dashboard.
+
+Pass criteria:
+
+- Dashboard preview and Operations full queue feel complementary.
+- Operations provides broader queue context.
+- Dashboard does not become full queue.
+
+## QA Scenario 4: Workspace Routing
+
+Goal: confirm decision actions route to source workspaces.
+
+Test examples:
+
+- Payment issue routes to Ledger or Payments.
+- Lease signing/document issue routes to Leases.
+- Tenant move-in issue routes to tenant profile.
+- Maintenance issue routes to maintenance request/workspace.
+- Notice issue routes to notice or lease workflow.
+- Property action request routes to property workspace.
+- Message awaiting reply routes to Messaging or source workspace.
+
+Pass criteria:
+
+- Each item opens the workspace where the landlord can act.
+- No item routes to a generic summary when a focused destination exists.
+- No raw IDs appear in labels.
+
+## QA Scenario 5: Messaging-Derived Decisions
+
+Goal: confirm communication signals do not flood Dashboard.
+
+Steps:
+
+1. Use queue data with ordinary unread messages.
+2. Confirm ordinary unread messages do not appear as dashboard warnings.
+3. Use urgent/awaiting-response message-derived item.
+4. Confirm it appears as actionable.
+5. Confirm action routes to Messaging, tenant profile, maintenance, notice, or support context as appropriate.
+
+Pass criteria:
+
+- Dashboard shows only actionable communication items.
+- Full inbox remains outside Dashboard.
+- Message bodies are not exposed in dashboard cards.
+
+## QA Scenario 6: Mobile Behavior
+
+Goal: confirm first-screen hierarchy works on mobile.
+
+Viewports:
+
+- Small mobile width.
+- Tablet width.
+
+Steps:
+
+1. Open Dashboard on mobile viewport.
+2. Confirm Portfolio Status appears first.
+3. Confirm top decision or no-decision state appears near top.
+4. Confirm upcoming and financial sections stack cleanly.
+5. Confirm Portfolio Detail collapses or remains compact.
+6. Confirm no text overlaps or buttons overflow.
+
+Pass criteria:
+
+- First viewport is understandable.
+- Critical action is reachable.
+- Dashboard does not become a long dense queue.
+
+## QA Scenario 7: Empty States
+
+Goal: confirm empty states do not feel broken or alarmist.
+
+Cases:
+
+- No properties.
+- Properties but no leases.
+- No open decisions.
+- No upcoming actions.
+- No rent collection data.
+- No actionable messages.
+
+Pass criteria:
+
+- Each empty state is specific.
+- Empty state offers a route or explanation when useful.
+- Empty state does not imply compliance approval, legal certainty, or hidden failure.
+
+## QA Scenario 8: Degraded States
+
+Goal: confirm degraded data does not produce false confidence or false urgency.
+
+Cases:
+
+- Decision queue unavailable.
+- Financial summary unavailable.
+- Portfolio detail partially unavailable.
+- Messaging summary unavailable.
+
+Pass criteria:
+
+- Affected section says unavailable/degraded.
+- Other sections remain usable.
+- Dashboard does not show "no decisions" when queue failed.
+- Raw API errors are not exposed.
+
+## QA Scenario 9: Sticky Navigation Validation
+
+Goal: confirm Dashboard implementation remains compatible with future sticky workspace shell.
+
+Steps:
+
+1. Confirm page title/context remains visible or recoverable.
+2. Confirm Dashboard and Operations are clearly distinct nav destinations.
+3. Confirm route transitions preserve workspace context.
+4. Confirm mobile navigation does not hide the primary action.
+
+Pass criteria:
+
+- Dashboard can support future sticky title/workspace nav.
+- Breadcrumbs are not needed on Dashboard cards.
+- Source workspace routes remain stable.
+
+## QA Scenario 10: Regression Coverage
+
+Confirm existing flows still work:
+
+- Free-tier onboarding dashboard prompts.
+- Add property/unit path.
+- Applications/manual applicant guidance path.
+- Leases page access.
+- Tenants page access.
+- Maintenance workspace access.
+- Payments/Ledger access.
+- Messages or unified inbox access.
+- Trust/Compliance access where available.
+
+Pass criteria:
+
+- Dashboard 2.0 does not break existing workspace access.
+- Existing landlord conversion paths remain discoverable.
+
+## Manual QA Evidence To Capture
+
+For future implementation PRs, capture:
+
+- Preview URL and commit SHA.
+- Backend Cloud Run image/revision if backend changed.
+- Landlord account type used.
+- Screenshots for first viewport desktop and mobile.
+- Screenshots for decision preview and empty/degraded states.
+- Browser URL after Dashboard -> Operations and Dashboard -> workspace clicks.
+- Any failed route, console error, or missing data condition.
+
+## Go / No-Go Criteria
+
+Go:
+
+- Decision ordering is correct.
+- Dashboard routes correctly.
+- Empty/degraded states are safe.
+- Mobile is usable.
+- Existing onboarding and workspace access are preserved.
+- CI is green.
+- Manual preview QA passes.
+
+No-go:
+
+- Dashboard shows full queue or full inbox.
+- Critical/warning states are false or duplicated.
+- Queue failure appears as no open work.
+- Mobile first viewport hides primary action.
+- Source workspace routes are broken.
+- Raw IDs, provider IDs, storage paths, or message bodies appear.

--- a/docs/design/dashboard-2.0-risk-register-v1.md
+++ b/docs/design/dashboard-2.0-risk-register-v1.md
@@ -1,0 +1,113 @@
+# Dashboard 2.0 Risk Register V1
+
+## Scope
+
+This document identifies risks for the future `feat/dashboard-2.0-operational-home-v1` implementation.
+
+It is planning only. It does not implement UI, routes, APIs, backend services, tests, CSS, or deployment changes.
+
+## Risk Summary
+
+Dashboard 2.0 risk is mainly about hierarchy and trust:
+
+- If the decision queue is wrong, the dashboard will feel unreliable.
+- If the dashboard shows too much, it becomes Operations.
+- If the dashboard shows too little, landlords miss work.
+- If mobile is dense, the first-login experience fails.
+- If empty states are alarmist, landlords lose confidence.
+
+## Decision Queue Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Queue API not merged before implementation | Dashboard implementation blocks or reintroduces local derivation. | Medium | Treat PR #1185 merge as Phase 0 precondition. Do not duplicate queue logic in frontend. |
+| Queue items are technically correct but not landlord-actionable | Dashboard feels noisy and unactionable. | Medium | Dashboard preview should include only critical, warning, blocking needs-review, and near-term upcoming items. |
+| Duplicate queue items appear from multiple source generators | Dashboard looks repetitive and untrustworthy. | Medium | Rely on service dedupe and add frontend grouping only if needed. Do not hide source conflicts without review. |
+| Informational items appear as decisions | Dashboard becomes a filing cabinet. | Medium | Exclude informational by default. Route activity/history to source workspaces. |
+| Messaging unread state floods the dashboard | Landlords see noise instead of action. | High | Only show message-derived decisions when urgent, awaiting response, notice relevant, maintenance blocking, or support escalation. |
+| Source workspace links are too generic | Decisions feel like dead-end links. | Medium | Use `recommendedActionHref` where available. Prefer focused workspace destination over generic summaries. |
+| Queue API degraded state looks like no decisions | Landlords may miss work. | Medium | Show explicit "Decision queue unavailable" state and avoid false all-clear messaging. |
+| Severity colors overstate risk | Dashboard becomes stressful. | Medium | Use red only for critical or materially overdue issues. Use calm labels for setup/readiness gaps. |
+
+## Performance Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Dashboard waits on too many domain APIs | First screen loads slowly. | Medium | Load queue and summary sections independently. Degrade per section, not whole page. |
+| Decision queue request is expensive | Dashboard first render slows. | Low to medium | Use safe `limit` for Dashboard preview. Avoid fetching full queue on Dashboard. |
+| Financial and portfolio summaries duplicate expensive fetches | Increased API load and flicker. | Medium | Reuse existing hooks/adapters where stable. Cache at page level if existing pattern allows. |
+| Mobile rendering has too many cards | Slow perceived load. | Medium | Prioritize Portfolio Status, top decision, upcoming action, financial pulse. Collapse details. |
+| Loading states shift layout | Poor perceived polish. | Medium | Reserve stable section structure and use compact skeletons or stable empty rows. |
+
+## Mobile Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Dashboard becomes vertically overwhelming | Mobile landlords miss important work. | High | Limit visible decisions and upcoming actions to three each. Collapse Portfolio Detail. |
+| Primary action is below the fold | Dashboard fails as operational home. | Medium | Place top health and primary action in first viewport. |
+| Charts or dense metrics dominate small screens | Low usability. | Medium | Use concise status rows before visualizations. Do not add charts for decoration. |
+| Operations and Dashboard feel indistinguishable on mobile | Navigation confusion. | Medium | Dashboard shows preview; Operations shows filters and full queue. |
+| Sticky navigation later conflicts with dashboard sections | Layout churn in future shell work. | Medium | Keep Dashboard section labels and route targets stable. |
+
+## Navigation Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Dashboard actions route to generic summary pages | Landlords feel the UI is not guiding them. | Medium | Route to owning workspace and focused workflow pages where available. |
+| Operations becomes a duplicate Dashboard | Users lose clear mental model. | Medium | Dashboard summarizes; Operations filters and triages. |
+| Source workspaces become hidden behind Operations | Users lose context for resolution. | Low to medium | Every queue item should expose a direct source workspace action. |
+| Breadcrumb/sticky shell changes later break context | Future navigation refactor creates regressions. | Medium | Use stable action paths and workspace labels in Dashboard contracts. |
+| Messaging route ownership is unclear | Messages can duplicate tenant/maintenance decisions. | Medium | Route replies to Messaging or source workspace; queue only actionable message decisions. |
+
+## Empty-State Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Empty portfolio looks broken | New landlords lose confidence. | Medium | Provide setup path and calm copy. |
+| No decisions looks like missing data | Users distrust Dashboard. | Medium | Distinguish "No open decisions" from "Decision queue unavailable." |
+| Missing rent/payment setup appears critical | Free/new landlords feel punished. | Medium | Keep setup prompts separate from critical issues. |
+| No messages needing action hides inbox access | Landlords may miss ordinary communication. | Low | Include route to Messages without treating it as a warning. |
+| Empty upcoming actions implies no lease lifecycle data | Confusion when data unavailable. | Medium | Use "No upcoming actions in this window" only when data is loaded. Use degraded state otherwise. |
+
+## Data Integrity Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Dashboard and source workspace disagree | Landlords lose trust. | Medium | Source workspace remains source of resolution. Dashboard should render queue/source labels, not invent states. |
+| Lease and tenant state coherence regressions reappear | Dashboard shows stale blockers. | Medium | Use normalized queue and existing projection fixes; add QA around signed/executed lease state. |
+| Payment readiness and delinquency are conflated | False critical financial states. | Medium | Treat readiness as setup warning; delinquency as financial decision. |
+| Maintenance status lacks queue integration | Dashboard under-reports maintenance work. | Medium | Use normalized maintenance source types as they become available. |
+| Property action requests are omitted | Landlords miss property readiness work. | Low to medium | Include property workspace queue counts and source items when present. |
+
+## Compliance And Trust Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Dashboard uses legal/compliance language too strongly | Overclaims readiness. | Medium | Use operational readiness language only. Avoid certification or enforceability claims. |
+| Evidence/compliance items appear without context | Dashboard feels alarmist. | Low to medium | Show only material trust/evidence blockers; route to Trust/Compliance. |
+| Raw IDs or sensitive metadata leak into widgets | Privacy/security issue. | Low | Display safe labels only. Do not display source IDs, provider IDs, storage paths, message bodies, or processor IDs. |
+
+## Release Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+| --- | --- | --- | --- |
+| Dashboard implementation starts before docs/API merge | Rework and conflict risk. | Medium | Keep Phase 0 precondition explicit. |
+| Large one-shot dashboard rewrite | Hard review and QA. | Medium | Implement in phases and preserve current dashboard behavior until replacements validate. |
+| Manual QA is skipped because change is "just dashboard" | User-facing regressions. | Medium | Require authenticated preview QA for first-login, active landlord, mobile, empty states, and routing. |
+| Feature flags are absent | Rollback may require revert. | Low to medium | Consider scoped adapter-first rollout; keep old sections until new sections are verified. |
+
+## Risk Acceptance
+
+Accepted for first implementation:
+
+- Dashboard may initially use existing Operations route as the "View all" destination.
+- Some domain summary data may remain coarse until source workspaces expose better summaries.
+- Visual polish can lag behind hierarchy as long as the operational home is coherent and usable.
+
+Not accepted:
+
+- Duplicating backend decision queue logic in the frontend.
+- Showing full queue or full inbox on Dashboard.
+- Treating no queue data as no work.
+- Reintroducing raw IDs, storage paths, provider IDs, or message bodies into dashboard widgets.
+- Starting Dashboard implementation before PR #1185 is resolved.


### PR DESCRIPTION
## Summary

- Adds the implementation plan for future `feat/dashboard-2.0-operational-home-v1`.
- Adds a Dashboard 2.0 risk register covering decision queue, performance, mobile, navigation, empty-state, and release risks.
- Adds a future QA plan for first-login behavior, decision ordering, Dashboard to Operations routing, workspace routing, mobile, empty, degraded, and sticky navigation validation.

## Scope

Planning docs only. No code, UI, route, API, backend service, CSS, or Dashboard implementation changes.

## Validation

- `git diff --check`
- `git diff --cached --check`

## Notes

This keeps Dashboard implementation blocked until PR #1185 and the IA docs are resolved, and defines how the future implementation should proceed once approved.