### PR TITLE
feat: normalize landlord portfolio status metrics

### DIFF
--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts
@@ -170,7 +170,7 @@ describe("landlordPortfolioStatusFinancialService", () => {
 
     expect(summary.portfolioStatus).toEqual(
       expect.objectContaining({
-        occupiedUnits: 0,
+        occupiedUnits: 1,
         vacantUnits: 1,
         reviewRequiredUnits: 2,
       })
@@ -232,10 +232,70 @@ describe("landlordPortfolioStatusFinancialService", () => {
       ledgerEntries: [],
     });
 
-    expect(summary.portfolioStatus.occupiedUnits).toBe(0);
+    expect(summary.portfolioStatus.occupiedUnits).toBe(1);
     expect(summary.portfolioStatus.reviewRequiredUnits).toBe(1);
     expect(summary.portfolioStatus.leasesRequiringReview).toBe(0);
     expect(summary.portfolioStatus.dataQualityFlags).toContain("unit_lease_occupancy_conflict");
+  });
+
+  it("fails closed on explicit landlord mismatches before related-entity fallback", () => {
+    const summary = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: [
+        {
+          id: "property-1",
+          landlordId: "landlord-1",
+          units: [
+            { id: "unit-1", status: "occupied" },
+            { id: "unit-2", status: "occupied" },
+          ],
+        },
+      ],
+      units: [
+        { id: "unit-3", landlordId: "landlord-2", propertyId: "property-1", status: "vacant" },
+      ],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 1000,
+        },
+        {
+          id: "lease-2",
+          landlordId: "landlord-2",
+          propertyId: "property-1",
+          unitId: "unit-2",
+          tenantId: "tenant-2",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 2000,
+        },
+      ],
+      tenants: [
+        { id: "tenant-1", landlordId: "landlord-1", currentLeaseId: "lease-1", status: "active" },
+        { id: "tenant-2", landlordId: "landlord-2", propertyId: "property-1", currentLeaseId: "lease-1", status: "active" },
+      ],
+      ledgerEntries: [
+        { id: "payment-1", landlordId: "landlord-2", leaseId: "lease-1", tenantId: "tenant-1", amountCents: 100000, effectiveDate: "2026-06-02" },
+        { id: "payment-2", leaseId: "lease-1", tenantId: "tenant-1", amountCents: 25000, effectiveDate: "2026-06-03" },
+      ],
+    });
+
+    expect(summary.portfolioStatus.totalUnits).toBe(2);
+    expect(summary.portfolioStatus.activeLeaseCount).toBe(1);
+    expect(summary.financialSnapshot.expectedMonthlyRentCents).toBe(100000);
+    expect(summary.financialSnapshot.collectedCurrentMonthCents).toBe(25000);
+    expect(summary.portfolioStatus.dataQualityFlags).not.toContain("tenant_lease_link_conflict");
   });
 
   it("filters cross-landlord properties, leases, tenants, and payments", () => {

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+import { deriveLandlordPortfolioStatusFinancialSummary } from "../landlordPortfolioStatusFinancialService";
+
+const generatedAt = "2026-06-19T12:00:00.000Z";
+
+function baseProperties() {
+  return [
+    {
+      id: "property-1",
+      landlordId: "landlord-1",
+      units: [
+        { id: "unit-1", unitNumber: "1", status: "occupied" },
+        { id: "unit-2", unitNumber: "2", status: "vacant" },
+      ],
+    },
+  ];
+}
+
+describe("landlordPortfolioStatusFinancialService", () => {
+  it("normalizes portfolio status and financial snapshot from active leases and current month payments", () => {
+    const summary = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: baseProperties(),
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 1800,
+        },
+      ],
+      tenants: [{ id: "tenant-1", landlordId: "landlord-1", propertyId: "property-1", currentLeaseId: "lease-1", status: "active" }],
+      ledgerEntries: [
+        {
+          id: "ledger-payment-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          amountCents: 120000,
+          effectiveDate: "2026-06-02T10:00:00.000Z",
+        },
+      ],
+      rentPayments: [
+        {
+          id: "rent-payment-duplicate",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          amountCents: 120000,
+          paidAt: "2026-06-02T10:00:00.000Z",
+        },
+      ],
+      operationalIssues: { critical: 2, open: 4 },
+    });
+
+    expect(summary.version).toBe("landlord_portfolio_status_financial_v1");
+    expect(summary.portfolioStatus).toEqual(
+      expect.objectContaining({
+        totalProperties: 1,
+        totalUnits: 2,
+        occupiedUnits: 1,
+        vacantUnits: 1,
+        occupancyRate: 0.5,
+        activeLeaseCount: 1,
+        criticalOpenIssues: 2,
+        openOperationalIssues: 4,
+      })
+    );
+    expect(summary.financialSnapshot).toEqual(
+      expect.objectContaining({
+        expectedMonthlyRentCents: 180000,
+        rentRollCents: 180000,
+        collectedCurrentMonthCents: 120000,
+        outstandingCurrentMonthCents: 60000,
+        rentCollectionRate: 0.6667,
+        activeLeaseRentTermsCount: 1,
+        leasesMissingRentTermsCount: 0,
+      })
+    );
+    expect(summary.financialSnapshot.paymentSourcesIncluded).toEqual(["ledgerEntries", "rentPayments"]);
+    expect(summary.dataQualityFlags).toEqual(["payment_sources_split", "vacancy_value_unavailable"]);
+  });
+
+  it("flags missing rent terms and avoids false zeroes when expected rent is unavailable", () => {
+    const summary = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: baseProperties(),
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+        },
+      ],
+      ledgerEntries: [
+        {
+          id: "ledger-payment-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          amountCents: 50000,
+          effectiveDate: "2026-06-02T10:00:00.000Z",
+        },
+      ],
+      dashboardRentSnapshot: {
+        collectedCents: 0,
+        expectedCents: 0,
+        delinquentCents: 0,
+      },
+    });
+
+    expect(summary.financialSnapshot.expectedMonthlyRentCents).toBeNull();
+    expect(summary.financialSnapshot.outstandingCurrentMonthCents).toBeNull();
+    expect(summary.financialSnapshot.collectedCurrentMonthCents).toBe(50000);
+    expect(summary.financialSnapshot.dataQualityFlags).toEqual([
+      "dashboard_rent_fields_zeroed",
+      "missing_rent_terms",
+      "vacancy_value_unavailable",
+    ]);
+    expect(summary.financialSnapshot.confidence).toBe("medium");
+  });
+
+  it("detects vacancy and occupancy conflicts without trusting stale unit status alone", () => {
+    const summary = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: [
+        {
+          id: "property-1",
+          landlordId: "landlord-1",
+          units: [
+            { id: "unit-1", status: "vacant" },
+            { id: "unit-2", status: "occupied" },
+            { id: "unit-3", status: "vacant" },
+          ],
+        },
+      ],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 1200,
+        },
+      ],
+      ledgerEntries: [],
+    });
+
+    expect(summary.portfolioStatus).toEqual(
+      expect.objectContaining({
+        occupiedUnits: 0,
+        vacantUnits: 1,
+        reviewRequiredUnits: 2,
+      })
+    );
+    expect(summary.portfolioStatus.dataQualityFlags).toContain("unit_lease_occupancy_conflict");
+    expect(summary.portfolioStatus.confidence).toBe("medium");
+  });
+
+  it("keeps signed future leases out of occupied unit counts", () => {
+    const summary = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: [{ id: "property-1", landlordId: "landlord-1", units: [{ id: "unit-1", status: "vacant" }] }],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          status: "signed",
+          signedAt: "2026-06-19T10:00:00.000Z",
+          startDate: "2026-07-01",
+          endDate: "2027-06-30",
+          monthlyRent: 1500,
+        },
+      ],
+      ledgerEntries: [],
+    });
+
+    expect(summary.portfolioStatus.occupiedUnits).toBe(0);
+    expect(summary.portfolioStatus.upcomingUnits).toBe(1);
+    expect(summary.portfolioStatus.signedFutureLeaseCount).toBe(1);
+  });
+
+  it("filters cross-landlord properties, leases, tenants, and payments", () => {
+    const summary = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: [
+        { id: "property-1", landlordId: "landlord-1", units: [{ id: "unit-1", status: "occupied" }] },
+        { id: "property-2", landlordId: "landlord-2", units: [{ id: "unit-2", status: "occupied" }] },
+      ],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 1800,
+        },
+        {
+          id: "lease-2",
+          landlordId: "landlord-2",
+          propertyId: "property-2",
+          unitId: "unit-2",
+          tenantId: "tenant-2",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 2200,
+        },
+      ],
+      tenants: [
+        { id: "tenant-1", landlordId: "landlord-1", currentLeaseId: "lease-1", status: "active" },
+        { id: "tenant-2", landlordId: "landlord-2", currentLeaseId: "lease-2", status: "active" },
+      ],
+      ledgerEntries: [
+        { id: "payment-1", landlordId: "landlord-1", leaseId: "lease-1", tenantId: "tenant-1", amountCents: 180000, effectiveDate: "2026-06-02" },
+        { id: "payment-2", landlordId: "landlord-2", leaseId: "lease-2", tenantId: "tenant-2", amountCents: 220000, effectiveDate: "2026-06-02" },
+      ],
+    });
+
+    expect(summary.portfolioStatus.totalProperties).toBe(1);
+    expect(summary.portfolioStatus.totalUnits).toBe(1);
+    expect(summary.portfolioStatus.activeLeaseCount).toBe(1);
+    expect(summary.financialSnapshot.expectedMonthlyRentCents).toBe(180000);
+    expect(summary.financialSnapshot.collectedCurrentMonthCents).toBe(180000);
+  });
+
+  it("returns deterministic output independent of input order", () => {
+    const first = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: [
+        { id: "property-2", landlordId: "landlord-1", units: [{ id: "unit-2", status: "vacant" }] },
+        { id: "property-1", landlordId: "landlord-1", units: [{ id: "unit-1", status: "occupied" }] },
+      ],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 1000,
+        },
+      ],
+      ledgerEntries: [
+        { id: "payment-b", landlordId: "landlord-1", leaseId: "lease-1", amountCents: 30000, effectiveDate: "2026-06-05" },
+        { id: "payment-a", landlordId: "landlord-1", leaseId: "lease-1", amountCents: 20000, effectiveDate: "2026-06-03" },
+      ],
+    });
+    const second = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: [
+        { id: "property-1", landlordId: "landlord-1", units: [{ id: "unit-1", status: "occupied" }] },
+        { id: "property-2", landlordId: "landlord-1", units: [{ id: "unit-2", status: "vacant" }] },
+      ],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 1000,
+        },
+      ],
+      ledgerEntries: [
+        { id: "payment-a", landlordId: "landlord-1", leaseId: "lease-1", amountCents: 20000, effectiveDate: "2026-06-03" },
+        { id: "payment-b", landlordId: "landlord-1", leaseId: "lease-1", amountCents: 30000, effectiveDate: "2026-06-05" },
+      ],
+    });
+
+    expect(second).toEqual(first);
+  });
+});

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts
@@ -205,6 +205,39 @@ describe("landlordPortfolioStatusFinancialService", () => {
     expect(summary.portfolioStatus.signedFutureLeaseCount).toBe(1);
   });
 
+  it("matches leases to units by property and unit number when the lease has no unit document id", () => {
+    const summary = deriveLandlordPortfolioStatusFinancialSummary({
+      landlordId: "landlord-1",
+      generatedAt,
+      properties: [
+        {
+          id: "property-1",
+          landlordId: "landlord-1",
+          units: [{ id: "unit-doc-1", unitNumber: "6", status: "vacant" }],
+        },
+      ],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitNumber: "6",
+          status: "active",
+          signedAt: "2026-05-15T12:00:00.000Z",
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          monthlyRent: 1600,
+        },
+      ],
+      ledgerEntries: [],
+    });
+
+    expect(summary.portfolioStatus.occupiedUnits).toBe(0);
+    expect(summary.portfolioStatus.reviewRequiredUnits).toBe(1);
+    expect(summary.portfolioStatus.leasesRequiringReview).toBe(0);
+    expect(summary.portfolioStatus.dataQualityFlags).toContain("unit_lease_occupancy_conflict");
+  });
+
   it("filters cross-landlord properties, leases, tenants, and payments", () => {
     const summary = deriveLandlordPortfolioStatusFinancialSummary({
       landlordId: "landlord-1",

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/index.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/index.ts
@@ -1,0 +1,2 @@
+export * from "./landlordPortfolioStatusFinancialService";
+export * from "./landlordPortfolioStatusFinancialTypes";

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialService.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialService.ts
@@ -155,6 +155,11 @@ function scopedByLandlord(record: Record<string, unknown>, landlordId: string): 
   return asString(record.landlordId, 240) === landlordId;
 }
 
+function hasMismatchedExplicitLandlord(record: Record<string, unknown>, landlordId: string): boolean {
+  const recordLandlordId = asString(record.landlordId, 240);
+  return Boolean(recordLandlordId && recordLandlordId !== landlordId);
+}
+
 function unitKey(input: { id?: unknown; propertyId?: unknown; unitId?: unknown; unitNumber?: unknown }): string {
   const id = asString(input.id || input.unitId, 240);
   if (id) return `id:${id}`;
@@ -216,10 +221,11 @@ function normalizeUnits(
   }
 
   for (const rawUnit of units || []) {
+    if (hasMismatchedExplicitLandlord(rawUnit, landlordId)) continue;
     const propertyId = asString(rawUnit.propertyId, 240);
     const scoped =
       scopedByLandlord(rawUnit, landlordId) ||
-      (propertyId && scopedPropertyIds.has(propertyId));
+      (!asString(rawUnit.landlordId, 240) && propertyId && scopedPropertyIds.has(propertyId));
     if (!scoped || isHiddenOrArchived(rawUnit)) continue;
     const unit = normalizeUnit(rawUnit);
     if (byKey.has(unit.key)) flags.add("unit_sources_split");
@@ -253,7 +259,10 @@ function normalizeLeases(
   generatedAt: string
 ): NormalizedLease[] {
   return (leases || [])
-    .filter((lease) => scopedByLandlord(lease, landlordId) || scopedPropertyIds.has(asString(lease.propertyId, 240)))
+    .filter((lease) => {
+      if (hasMismatchedExplicitLandlord(lease, landlordId)) return false;
+      return scopedByLandlord(lease, landlordId) || (!asString(lease.landlordId, 240) && scopedPropertyIds.has(asString(lease.propertyId, 240)));
+    })
     .filter((lease) => !isHiddenOrArchived(lease))
     .map((lease) => {
       const lifecycle = deriveLeaseLifecycleState(lease as any, generatedAt);
@@ -282,7 +291,10 @@ function normalizeTenants(
   scopedPropertyIds: Set<string>
 ): PortfolioTenantRecord[] {
   return (tenants || [])
-    .filter((tenant) => scopedByLandlord(tenant, landlordId) || scopedPropertyIds.has(asString(tenant.propertyId, 240)))
+    .filter((tenant) => {
+      if (hasMismatchedExplicitLandlord(tenant, landlordId)) return false;
+      return scopedByLandlord(tenant, landlordId) || (!asString(tenant.landlordId, 240) && scopedPropertyIds.has(asString(tenant.propertyId, 240)));
+    })
     .filter((tenant) => !isHiddenOrArchived(tenant));
 }
 
@@ -299,11 +311,13 @@ function normalizePayments(
 ): NormalizedPayment[] {
   return (records || [])
     .filter((record) => {
+      if (hasMismatchedExplicitLandlord(record, landlordId)) return false;
       const scoped =
         scopedByLandlord(record, landlordId) ||
-        context.leaseIds.has(asString(record.leaseId, 240)) ||
-        context.tenantIds.has(asString(record.tenantId, 240)) ||
-        context.propertyIds.has(asString(record.propertyId, 240));
+        (!asString(record.landlordId, 240) &&
+          (context.leaseIds.has(asString(record.leaseId, 240)) ||
+            context.tenantIds.has(asString(record.tenantId, 240)) ||
+            context.propertyIds.has(asString(record.propertyId, 240))));
       if (!scoped) return false;
       const status = normalizeToken(record.status || record.paymentStatus);
       return !["failed", "void", "voided", "cancelled", "canceled", "refunded"].includes(status);
@@ -431,16 +445,19 @@ export function deriveLandlordPortfolioStatusFinancialSummary(
       occupancyFlags.add("unit_lease_occupancy_conflict");
       continue;
     }
-    if ((active.length > 0 || notice.length > 0) && ["vacant", "available"].includes(unitOccupancy)) {
-      reviewRequiredUnits += 1;
-      occupancyFlags.add("unit_lease_occupancy_conflict");
-      continue;
-    }
     if (active.length > 0) {
+      if (["vacant", "available"].includes(unitOccupancy)) {
+        reviewRequiredUnits += 1;
+        occupancyFlags.add("unit_lease_occupancy_conflict");
+      }
       occupiedUnits += 1;
       continue;
     }
     if (notice.length > 0) {
+      if (["vacant", "available"].includes(unitOccupancy)) {
+        reviewRequiredUnits += 1;
+        occupancyFlags.add("unit_lease_occupancy_conflict");
+      }
       noticePeriodUnits += 1;
       continue;
     }

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialService.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialService.ts
@@ -163,6 +163,13 @@ function unitKey(input: { id?: unknown; propertyId?: unknown; unitId?: unknown; 
   return propertyId || unitNumber ? `property:${propertyId}:unit:${unitNumber || "unknown"}` : "unit:unknown";
 }
 
+function unitLookupKeys(unit: NormalizedUnit): string[] {
+  const keys = new Set<string>();
+  keys.add(unitKey(unit));
+  if (unit.propertyId && unit.unitNumber) keys.add(`property:${unit.propertyId}:unit:${unit.unitNumber.toLowerCase()}`);
+  return Array.from(keys);
+}
+
 function leaseUnitKeys(lease: NormalizedLease): string[] {
   const keys = new Set<string>();
   if (lease.unitId) keys.add(`id:${lease.unitId}`);
@@ -407,7 +414,13 @@ export function deriveLandlordPortfolioStatusFinancialSummary(
   let reviewRequiredUnits = 0;
 
   for (const unit of units) {
-    const leasesForUnit = currentLeaseByUnitKey.get(unitKey(unit)) || [];
+    const leasesForUnit = Array.from(
+      new Map(
+        unitLookupKeys(unit)
+          .flatMap((key) => currentLeaseByUnitKey.get(key) || [])
+          .map((lease) => [lease.id, lease])
+      ).values()
+    );
     const active = leasesForUnit.filter((lease) => lease.lifecycleState === "active");
     const notice = leasesForUnit.filter((lease) => lease.lifecycleState === "notice_period");
     const upcoming = leasesForUnit.filter((lease) => lease.lifecycleState === "signed_future");
@@ -539,7 +552,7 @@ export function deriveLandlordPortfolioStatusFinancialSummary(
     activeLeaseCount: currentLeases.length,
     currentLeaseCount: currentLeases.length,
     signedFutureLeaseCount: signedFutureLeases.length,
-    leasesRequiringReview: leases.filter((lease) => lease.isReviewRequired).length + reviewRequiredUnits,
+    leasesRequiringReview: leases.filter((lease) => lease.isReviewRequired).length,
     criticalOpenIssues: input.operationalIssues?.critical == null ? null : Math.max(0, Math.floor(Number(input.operationalIssues.critical) || 0)),
     openOperationalIssues: input.operationalIssues?.open == null ? null : Math.max(0, Math.floor(Number(input.operationalIssues.open) || 0)),
     confidence: occupancyConfidence,

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialService.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialService.ts
@@ -1,0 +1,576 @@
+import { deriveLeaseLifecycleState } from "../../lib/leases/leaseLifecycle";
+import type {
+  LandlordPortfolioStatusFinancialInput,
+  LandlordPortfolioStatusFinancialSummary,
+  PortfolioDataQualityFlag,
+  PortfolioFinancialSnapshot,
+  PortfolioMetricConfidence,
+  PortfolioOccupancySummary,
+  PortfolioPaymentRecord,
+  PortfolioPaymentSource,
+  PortfolioPropertyRecord,
+  PortfolioTenantRecord,
+  PortfolioUnitRecord,
+} from "./landlordPortfolioStatusFinancialTypes";
+
+const VERSION = "landlord_portfolio_status_financial_v1" as const;
+
+type NormalizedUnit = {
+  id: string;
+  propertyId: string | null;
+  unitNumber: string | null;
+  status: string;
+  occupancyStatus: string;
+  currentLeaseId: string | null;
+  currentTenantId: string | null;
+};
+
+type NormalizedLease = {
+  raw: Record<string, unknown>;
+  id: string;
+  propertyId: string | null;
+  unitId: string | null;
+  unitNumber: string | null;
+  tenantId: string | null;
+  tenantIds: string[];
+  rentCents: number | null;
+  lifecycleState: string;
+  isCurrent: boolean;
+  isReviewRequired: boolean;
+};
+
+type NormalizedPayment = {
+  id: string;
+  source: PortfolioPaymentSource;
+  leaseId: string | null;
+  tenantId: string | null;
+  propertyId: string | null;
+  amountCents: number;
+  paidAt: string;
+};
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeToken(value: unknown): string {
+  return asString(value, 160).toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function asNumber(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const next = Number(value);
+  return Number.isFinite(next) ? next : null;
+}
+
+function normalizeDate(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  if (typeof (value as any)?.toDate === "function") {
+    try {
+      const date = (value as any).toDate();
+      return date instanceof Date && !Number.isNaN(date.getTime()) ? date.toISOString() : null;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof (value as any)?.seconds === "number") {
+    const date = new Date((value as any).seconds * 1000);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function resolveGeneratedAt(input: LandlordPortfolioStatusFinancialInput): string {
+  return normalizeDate(input.generatedAt) || new Date().toISOString();
+}
+
+function monthFromGeneratedAt(generatedAt: string): string {
+  return generatedAt.slice(0, 7);
+}
+
+function monthBounds(month: string): { month: string; startsAt: string; endsAt: string } {
+  const normalized = /^\d{4}-\d{2}$/.test(month) ? month : monthFromGeneratedAt(new Date().toISOString());
+  const [year, monthNumber] = normalized.split("-").map((part) => Number(part));
+  const startsAt = new Date(Date.UTC(year, monthNumber - 1, 1, 0, 0, 0, 0));
+  const endsAt = new Date(Date.UTC(year, monthNumber, 0, 23, 59, 59, 999));
+  return {
+    month: normalized,
+    startsAt: startsAt.toISOString(),
+    endsAt: endsAt.toISOString(),
+  };
+}
+
+function monthMatches(value: string, month: string): boolean {
+  return value.slice(0, 7) === month;
+}
+
+function centsFromDollarValue(value: unknown): number | null {
+  const amount = asNumber(value);
+  if (amount == null || amount <= 0) return null;
+  return Math.round(amount * 100);
+}
+
+function centsFromCentValue(value: unknown): number | null {
+  const amount = asNumber(value);
+  if (amount == null || amount <= 0) return null;
+  return Math.round(amount);
+}
+
+function rentCentsFromLease(raw: Record<string, unknown>): number | null {
+  return (
+    centsFromCentValue(raw.monthlyRentCents) ||
+    centsFromCentValue(raw.rentAmountCents) ||
+    centsFromCentValue((raw as any).rent?.amountCents) ||
+    centsFromDollarValue(raw.monthlyRent) ||
+    centsFromDollarValue(raw.rentAmount) ||
+    centsFromDollarValue((raw as any).rent?.amount)
+  );
+}
+
+function amountCentsFromPayment(raw: PortfolioPaymentRecord): number | null {
+  return (
+    centsFromCentValue(raw.amountCents) ||
+    centsFromCentValue((raw as any).paidAmountCents) ||
+    centsFromCentValue((raw as any).amountPaidCents) ||
+    centsFromDollarValue(raw.amount) ||
+    centsFromDollarValue((raw as any).amountPaid)
+  );
+}
+
+function isHiddenOrArchived(record: Record<string, unknown>): boolean {
+  const status = normalizeToken(record.status || record.portfolioStatus || record.lifecycleStatus);
+  return (
+    record.hiddenFromActiveLists === true ||
+    record.isArchived === true ||
+    Boolean(record.archivedAt) ||
+    status === "archived" ||
+    status === "deleted" ||
+    status === "removed"
+  );
+}
+
+function scopedByLandlord(record: Record<string, unknown>, landlordId: string): boolean {
+  return asString(record.landlordId, 240) === landlordId;
+}
+
+function unitKey(input: { id?: unknown; propertyId?: unknown; unitId?: unknown; unitNumber?: unknown }): string {
+  const id = asString(input.id || input.unitId, 240);
+  if (id) return `id:${id}`;
+  const propertyId = asString(input.propertyId, 240);
+  const unitNumber = asString(input.unitNumber, 120).toLowerCase();
+  return propertyId || unitNumber ? `property:${propertyId}:unit:${unitNumber || "unknown"}` : "unit:unknown";
+}
+
+function leaseUnitKeys(lease: NormalizedLease): string[] {
+  const keys = new Set<string>();
+  if (lease.unitId) keys.add(`id:${lease.unitId}`);
+  if (lease.propertyId && lease.unitNumber) keys.add(`property:${lease.propertyId}:unit:${lease.unitNumber.toLowerCase()}`);
+  return Array.from(keys);
+}
+
+function tenantIdsFromLease(raw: Record<string, unknown>): string[] {
+  const ids = new Set<string>();
+  const primary = asString(raw.tenantId || raw.primaryTenantId, 240);
+  if (primary) ids.add(primary);
+  if (Array.isArray(raw.tenantIds)) {
+    for (const id of raw.tenantIds) {
+      const next = asString(id, 240);
+      if (next) ids.add(next);
+    }
+  }
+  return Array.from(ids);
+}
+
+function normalizeProperties(
+  landlordId: string,
+  properties: PortfolioPropertyRecord[] | null | undefined
+): PortfolioPropertyRecord[] {
+  return (properties || []).filter((property) => scopedByLandlord(property, landlordId) && !isHiddenOrArchived(property));
+}
+
+function normalizeUnits(
+  landlordId: string,
+  properties: PortfolioPropertyRecord[],
+  units: PortfolioUnitRecord[] | null | undefined,
+  flags: Set<PortfolioDataQualityFlag>
+): NormalizedUnit[] {
+  const scopedPropertyIds = new Set(properties.map((property) => asString(property.id, 240)).filter(Boolean));
+  const byKey = new Map<string, NormalizedUnit>();
+
+  for (const property of properties) {
+    const propertyId = asString(property.id, 240) || null;
+    for (const embeddedUnit of property.units || []) {
+      if (isHiddenOrArchived(embeddedUnit)) continue;
+      const unit = normalizeUnit({ ...embeddedUnit, propertyId: embeddedUnit.propertyId || propertyId });
+      byKey.set(unit.key, unit.unit);
+    }
+  }
+
+  for (const rawUnit of units || []) {
+    const propertyId = asString(rawUnit.propertyId, 240);
+    const scoped =
+      scopedByLandlord(rawUnit, landlordId) ||
+      (propertyId && scopedPropertyIds.has(propertyId));
+    if (!scoped || isHiddenOrArchived(rawUnit)) continue;
+    const unit = normalizeUnit(rawUnit);
+    if (byKey.has(unit.key)) flags.add("unit_sources_split");
+    byKey.set(unit.key, unit.unit);
+  }
+
+  return Array.from(byKey.values()).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function normalizeUnit(rawUnit: PortfolioUnitRecord): { key: string; unit: NormalizedUnit } {
+  const key = unitKey(rawUnit);
+  const id = asString(rawUnit.id || rawUnit.unitId, 240) || key;
+  return {
+    key,
+    unit: {
+      id,
+      propertyId: asString(rawUnit.propertyId, 240) || null,
+      unitNumber: asString(rawUnit.unitNumber, 120) || null,
+      status: normalizeToken(rawUnit.status),
+      occupancyStatus: normalizeToken(rawUnit.occupancyStatus),
+      currentLeaseId: asString(rawUnit.currentLeaseId, 240) || null,
+      currentTenantId: asString(rawUnit.currentTenantId, 240) || null,
+    },
+  };
+}
+
+function normalizeLeases(
+  landlordId: string,
+  leases: Record<string, unknown>[] | null | undefined,
+  scopedPropertyIds: Set<string>,
+  generatedAt: string
+): NormalizedLease[] {
+  return (leases || [])
+    .filter((lease) => scopedByLandlord(lease, landlordId) || scopedPropertyIds.has(asString(lease.propertyId, 240)))
+    .filter((lease) => !isHiddenOrArchived(lease))
+    .map((lease) => {
+      const lifecycle = deriveLeaseLifecycleState(lease as any, generatedAt);
+      const id = asString(lease.id || lease.leaseId, 240);
+      return {
+        raw: lease,
+        id,
+        propertyId: asString(lease.propertyId, 240) || null,
+        unitId: asString(lease.unitId, 240) || null,
+        unitNumber: asString(lease.unitNumber, 120) || null,
+        tenantId: asString(lease.tenantId || lease.primaryTenantId, 240) || null,
+        tenantIds: tenantIdsFromLease(lease),
+        rentCents: rentCentsFromLease(lease),
+        lifecycleState: lifecycle.state,
+        isCurrent: lifecycle.isCurrent,
+        isReviewRequired: lifecycle.requiresReview,
+      };
+    })
+    .filter((lease) => Boolean(lease.id))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function normalizeTenants(
+  landlordId: string,
+  tenants: PortfolioTenantRecord[] | null | undefined,
+  scopedPropertyIds: Set<string>
+): PortfolioTenantRecord[] {
+  return (tenants || [])
+    .filter((tenant) => scopedByLandlord(tenant, landlordId) || scopedPropertyIds.has(asString(tenant.propertyId, 240)))
+    .filter((tenant) => !isHiddenOrArchived(tenant));
+}
+
+function normalizePayments(
+  landlordId: string,
+  source: PortfolioPaymentSource,
+  records: PortfolioPaymentRecord[] | null | undefined,
+  context: {
+    leaseIds: Set<string>;
+    tenantIds: Set<string>;
+    propertyIds: Set<string>;
+    month: string;
+  }
+): NormalizedPayment[] {
+  return (records || [])
+    .filter((record) => {
+      const scoped =
+        scopedByLandlord(record, landlordId) ||
+        context.leaseIds.has(asString(record.leaseId, 240)) ||
+        context.tenantIds.has(asString(record.tenantId, 240)) ||
+        context.propertyIds.has(asString(record.propertyId, 240));
+      if (!scoped) return false;
+      const status = normalizeToken(record.status || record.paymentStatus);
+      return !["failed", "void", "voided", "cancelled", "canceled", "refunded"].includes(status);
+    })
+    .map((record) => {
+      const paidAt = normalizeDate(record.paidAt || record.effectiveDate || record.paymentDate || record.createdAt);
+      const amountCents = amountCentsFromPayment(record);
+      if (!paidAt || !monthMatches(paidAt, context.month) || amountCents == null) return null;
+      const id = asString(record.id, 240) || [
+        source,
+        asString(record.leaseId, 240),
+        asString(record.tenantId, 240),
+        paidAt.slice(0, 10),
+        String(amountCents),
+      ].join(":");
+      return {
+        id,
+        source,
+        leaseId: asString(record.leaseId, 240) || null,
+        tenantId: asString(record.tenantId, 240) || null,
+        propertyId: asString(record.propertyId, 240) || null,
+        amountCents,
+        paidAt,
+      };
+    })
+    .filter((record): record is NormalizedPayment => Boolean(record))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function dedupePayments(payments: NormalizedPayment[]): NormalizedPayment[] {
+  const byKey = new Map<string, NormalizedPayment>();
+  for (const payment of payments) {
+    const key = [
+      payment.leaseId || "no_lease",
+      payment.tenantId || "no_tenant",
+      payment.propertyId || "no_property",
+      payment.paidAt.slice(0, 10),
+      String(payment.amountCents),
+    ].join("|");
+    const existing = byKey.get(key);
+    if (!existing || payment.source.localeCompare(existing.source) < 0) {
+      byKey.set(key, payment);
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => a.paidAt.localeCompare(b.paidAt) || a.id.localeCompare(b.id));
+}
+
+function confidenceFromFlags(flags: Set<PortfolioDataQualityFlag>, empty: boolean): PortfolioMetricConfidence {
+  if (empty) return "unavailable";
+  if (
+    flags.has("payment_source_unavailable") ||
+    flags.has("ledger_source_unavailable") ||
+    flags.has("no_scoped_units") ||
+    flags.has("no_scoped_properties")
+  ) {
+    return "low";
+  }
+  if (
+    flags.has("payment_sources_split") ||
+    flags.has("unit_sources_split") ||
+    flags.has("unit_lease_occupancy_conflict") ||
+    flags.has("tenant_lease_link_conflict") ||
+    flags.has("missing_rent_terms")
+  ) {
+    return "medium";
+  }
+  return "high";
+}
+
+function sortedFlags(flags: Set<PortfolioDataQualityFlag>): PortfolioDataQualityFlag[] {
+  return Array.from(flags).sort((a, b) => a.localeCompare(b));
+}
+
+export function deriveLandlordPortfolioStatusFinancialSummary(
+  input: LandlordPortfolioStatusFinancialInput
+): LandlordPortfolioStatusFinancialSummary {
+  const landlordId = asString(input.landlordId, 240);
+  const generatedAt = resolveGeneratedAt(input);
+  const period = monthBounds(asString(input.periodMonth, 20) || monthFromGeneratedAt(generatedAt));
+  const globalFlags = new Set<PortfolioDataQualityFlag>();
+  const occupancyFlags = new Set<PortfolioDataQualityFlag>();
+  const financialFlags = new Set<PortfolioDataQualityFlag>();
+
+  const properties = normalizeProperties(landlordId, input.properties);
+  if (properties.length === 0) occupancyFlags.add("no_scoped_properties");
+  const scopedPropertyIds = new Set(properties.map((property) => asString(property.id, 240)).filter(Boolean));
+  const units = normalizeUnits(landlordId, properties, input.units, occupancyFlags);
+  if (units.length === 0) occupancyFlags.add("no_scoped_units");
+  const leases = normalizeLeases(landlordId, input.leases as any, scopedPropertyIds, generatedAt);
+  if (leases.length === 0) occupancyFlags.add("no_scoped_leases");
+  const tenants = normalizeTenants(landlordId, input.tenants, scopedPropertyIds);
+
+  const currentLeases = leases.filter((lease) => lease.lifecycleState === "active" || lease.lifecycleState === "notice_period");
+  const signedFutureLeases = leases.filter((lease) => lease.lifecycleState === "signed_future");
+  const currentLeaseByUnitKey = new Map<string, NormalizedLease[]>();
+  for (const lease of [...currentLeases, ...signedFutureLeases]) {
+    for (const key of leaseUnitKeys(lease)) {
+      const existing = currentLeaseByUnitKey.get(key) || [];
+      existing.push(lease);
+      currentLeaseByUnitKey.set(key, existing);
+    }
+  }
+
+  let occupiedUnits = 0;
+  let vacantUnits = 0;
+  let upcomingUnits = 0;
+  let noticePeriodUnits = 0;
+  let reviewRequiredUnits = 0;
+
+  for (const unit of units) {
+    const leasesForUnit = currentLeaseByUnitKey.get(unitKey(unit)) || [];
+    const active = leasesForUnit.filter((lease) => lease.lifecycleState === "active");
+    const notice = leasesForUnit.filter((lease) => lease.lifecycleState === "notice_period");
+    const upcoming = leasesForUnit.filter((lease) => lease.lifecycleState === "signed_future");
+    const unitOccupancy = unit.occupancyStatus || unit.status;
+
+    if (active.length + notice.length + upcoming.length > 1) {
+      reviewRequiredUnits += 1;
+      occupancyFlags.add("unit_lease_occupancy_conflict");
+      continue;
+    }
+    if ((active.length > 0 || notice.length > 0) && ["vacant", "available"].includes(unitOccupancy)) {
+      reviewRequiredUnits += 1;
+      occupancyFlags.add("unit_lease_occupancy_conflict");
+      continue;
+    }
+    if (active.length > 0) {
+      occupiedUnits += 1;
+      continue;
+    }
+    if (notice.length > 0) {
+      noticePeriodUnits += 1;
+      continue;
+    }
+    if (upcoming.length > 0) {
+      upcomingUnits += 1;
+      continue;
+    }
+    if (["occupied", "active", "current"].includes(unitOccupancy)) {
+      reviewRequiredUnits += 1;
+      occupancyFlags.add("unit_lease_occupancy_conflict");
+      continue;
+    }
+    vacantUnits += 1;
+  }
+
+  const currentLeaseIds = new Set(currentLeases.map((lease) => lease.id));
+  for (const tenant of tenants) {
+    const tenantCurrentLeaseId = asString(tenant.currentLeaseId, 240);
+    const tenantStatus = normalizeToken(tenant.status);
+    if (tenantCurrentLeaseId && !currentLeaseIds.has(tenantCurrentLeaseId) && ["active", "current"].includes(tenantStatus)) {
+      occupancyFlags.add("tenant_lease_link_conflict");
+    }
+  }
+
+  const activeLeaseRentTerms = currentLeases.filter((lease) => lease.rentCents != null);
+  const leasesMissingRentTermsCount = currentLeases.length - activeLeaseRentTerms.length;
+  if (leasesMissingRentTermsCount > 0) financialFlags.add("missing_rent_terms");
+
+  const scopedLeaseIds = new Set(leases.map((lease) => lease.id));
+  const scopedTenantIds = new Set<string>();
+  for (const lease of leases) {
+    for (const tenantId of lease.tenantIds) scopedTenantIds.add(tenantId);
+  }
+  for (const tenant of tenants) {
+    const tenantId = asString(tenant.id || tenant.tenantId, 240);
+    if (tenantId) scopedTenantIds.add(tenantId);
+  }
+
+  const paymentGroups: Array<[PortfolioPaymentSource, PortfolioPaymentRecord[] | null | undefined]> = [
+    ["ledgerEvents", input.ledgerEvents],
+    ["ledgerEntries", input.ledgerEntries],
+    ["rentPayments", input.rentPayments],
+    ["payments", input.payments],
+  ];
+  const paymentSourcesIncluded: PortfolioPaymentSource[] = paymentGroups
+    .filter(([, records]) => (records || []).length > 0)
+    .map(([source]) => source);
+  if (paymentSourcesIncluded.length === 0) financialFlags.add("payment_source_unavailable");
+  if (!input.ledgerEvents && !input.ledgerEntries) financialFlags.add("ledger_source_unavailable");
+  if (paymentSourcesIncluded.length > 1) financialFlags.add("payment_sources_split");
+
+  const payments = dedupePayments(
+    paymentGroups.flatMap(([source, records]) =>
+      normalizePayments(landlordId, source, records, {
+        leaseIds: scopedLeaseIds,
+        tenantIds: scopedTenantIds,
+        propertyIds: scopedPropertyIds,
+        month: period.month,
+      })
+    )
+  );
+
+  const expectedMonthlyRentCents = activeLeaseRentTerms.length > 0
+    ? activeLeaseRentTerms.reduce((sum, lease) => sum + (lease.rentCents || 0), 0)
+    : currentLeases.length > 0
+    ? null
+    : 0;
+  const rentRollCents = expectedMonthlyRentCents;
+  const collectedCurrentMonthCents = payments.length > 0
+    ? payments.reduce((sum, payment) => sum + payment.amountCents, 0)
+    : paymentSourcesIncluded.length > 0
+    ? 0
+    : null;
+  const outstandingCurrentMonthCents =
+    expectedMonthlyRentCents != null && collectedCurrentMonthCents != null
+      ? Math.max(expectedMonthlyRentCents - collectedCurrentMonthCents, 0)
+      : null;
+  const rentCollectionRate =
+    expectedMonthlyRentCents && expectedMonthlyRentCents > 0 && collectedCurrentMonthCents != null
+      ? Number((collectedCurrentMonthCents / expectedMonthlyRentCents).toFixed(4))
+      : null;
+  const vacancyImpactCents = vacantUnits > 0 ? null : 0;
+  if (vacantUnits > 0) financialFlags.add("vacancy_value_unavailable");
+
+  const dashboardRent = input.dashboardRentSnapshot;
+  if (
+    dashboardRent &&
+    Number(dashboardRent.collectedCents || 0) === 0 &&
+    Number(dashboardRent.expectedCents || 0) === 0 &&
+    Number(dashboardRent.delinquentCents || 0) === 0
+  ) {
+    financialFlags.add("dashboard_rent_fields_zeroed");
+  }
+
+  for (const flag of occupancyFlags) globalFlags.add(flag);
+  for (const flag of financialFlags) globalFlags.add(flag);
+
+  const occupancyConfidence = confidenceFromFlags(occupancyFlags, units.length === 0);
+  const financialConfidence = confidenceFromFlags(financialFlags, currentLeases.length === 0 && paymentSourcesIncluded.length === 0);
+  const portfolioStatus: PortfolioOccupancySummary = {
+    totalProperties: properties.length,
+    totalUnits: units.length,
+    occupiedUnits,
+    vacantUnits,
+    upcomingUnits,
+    noticePeriodUnits,
+    reviewRequiredUnits,
+    occupancyRate: units.length > 0 ? Number(((occupiedUnits + noticePeriodUnits) / units.length).toFixed(4)) : null,
+    activeLeaseCount: currentLeases.length,
+    currentLeaseCount: currentLeases.length,
+    signedFutureLeaseCount: signedFutureLeases.length,
+    leasesRequiringReview: leases.filter((lease) => lease.isReviewRequired).length + reviewRequiredUnits,
+    criticalOpenIssues: input.operationalIssues?.critical == null ? null : Math.max(0, Math.floor(Number(input.operationalIssues.critical) || 0)),
+    openOperationalIssues: input.operationalIssues?.open == null ? null : Math.max(0, Math.floor(Number(input.operationalIssues.open) || 0)),
+    confidence: occupancyConfidence,
+    dataQualityFlags: sortedFlags(occupancyFlags),
+  };
+
+  const financialSnapshot: PortfolioFinancialSnapshot = {
+    period,
+    expectedMonthlyRentCents,
+    collectedCurrentMonthCents,
+    outstandingCurrentMonthCents,
+    rentCollectionRate,
+    rentRollCents,
+    vacancyImpactCents,
+    activeLeaseRentTermsCount: activeLeaseRentTerms.length,
+    leasesMissingRentTermsCount,
+    paymentSourcesIncluded: paymentSourcesIncluded.sort((a, b) => a.localeCompare(b)),
+    confidence: financialConfidence,
+    dataQualityFlags: sortedFlags(financialFlags),
+  };
+
+  return {
+    version: VERSION,
+    landlordId,
+    generatedAt,
+    portfolioStatus,
+    financialSnapshot,
+    confidence: {
+      occupancy: occupancyConfidence,
+      financial: financialConfidence,
+    },
+    dataQualityFlags: sortedFlags(globalFlags),
+  };
+}

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialTypes.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/landlordPortfolioStatusFinancialTypes.ts
@@ -1,0 +1,141 @@
+export type PortfolioMetricConfidence = "high" | "medium" | "low" | "unavailable";
+
+export type PortfolioDataQualityFlag =
+  | "dashboard_rent_fields_zeroed"
+  | "payment_sources_split"
+  | "payment_source_unavailable"
+  | "ledger_source_unavailable"
+  | "unit_sources_split"
+  | "unit_lease_occupancy_conflict"
+  | "tenant_lease_link_conflict"
+  | "missing_rent_terms"
+  | "stale_lifecycle_projection"
+  | "vacancy_value_unavailable"
+  | "no_scoped_properties"
+  | "no_scoped_units"
+  | "no_scoped_leases";
+
+export type PortfolioPaymentSource = "ledgerEvents" | "ledgerEntries" | "rentPayments" | "payments";
+
+export type PortfolioRecord = Record<string, unknown> & {
+  id?: string | null;
+  landlordId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  leaseId?: string | null;
+};
+
+export type PortfolioPropertyRecord = PortfolioRecord & {
+  units?: PortfolioUnitRecord[] | null;
+};
+
+export type PortfolioUnitRecord = PortfolioRecord & {
+  unitNumber?: string | number | null;
+  status?: string | null;
+  occupancyStatus?: string | null;
+  currentLeaseId?: string | null;
+  currentTenantId?: string | null;
+};
+
+export type PortfolioLeaseRecord = PortfolioRecord & {
+  status?: string | null;
+  monthlyRent?: number | string | null;
+  monthlyRentCents?: number | string | null;
+  rentAmount?: number | string | null;
+  rentAmountCents?: number | string | null;
+  tenantIds?: string[] | null;
+  primaryTenantId?: string | null;
+};
+
+export type PortfolioTenantRecord = PortfolioRecord & {
+  currentLeaseId?: string | null;
+  status?: string | null;
+};
+
+export type PortfolioPaymentRecord = PortfolioRecord & {
+  amount?: number | string | null;
+  amountCents?: number | string | null;
+  paidAt?: unknown;
+  effectiveDate?: unknown;
+  paymentDate?: unknown;
+  createdAt?: unknown;
+  status?: string | null;
+  paymentStatus?: string | null;
+};
+
+export type PortfolioOperationalIssueSummary = {
+  critical?: number | null;
+  open?: number | null;
+};
+
+export type LandlordPortfolioStatusFinancialInput = {
+  landlordId: string;
+  generatedAt?: string | null;
+  periodMonth?: string | null;
+  properties?: PortfolioPropertyRecord[] | null;
+  units?: PortfolioUnitRecord[] | null;
+  leases?: PortfolioLeaseRecord[] | null;
+  tenants?: PortfolioTenantRecord[] | null;
+  payments?: PortfolioPaymentRecord[] | null;
+  ledgerEntries?: PortfolioPaymentRecord[] | null;
+  ledgerEvents?: PortfolioPaymentRecord[] | null;
+  rentPayments?: PortfolioPaymentRecord[] | null;
+  operationalIssues?: PortfolioOperationalIssueSummary | null;
+  dashboardRentSnapshot?: {
+    collectedCents?: number | null;
+    expectedCents?: number | null;
+    delinquentCents?: number | null;
+  } | null;
+};
+
+export type PortfolioOccupancySummary = {
+  totalProperties: number;
+  totalUnits: number;
+  occupiedUnits: number;
+  vacantUnits: number;
+  upcomingUnits: number;
+  noticePeriodUnits: number;
+  reviewRequiredUnits: number;
+  occupancyRate: number | null;
+  activeLeaseCount: number;
+  currentLeaseCount: number;
+  signedFutureLeaseCount: number;
+  leasesRequiringReview: number;
+  criticalOpenIssues: number | null;
+  openOperationalIssues: number | null;
+  confidence: PortfolioMetricConfidence;
+  dataQualityFlags: PortfolioDataQualityFlag[];
+};
+
+export type PortfolioFinancialSnapshot = {
+  period: {
+    month: string;
+    startsAt: string;
+    endsAt: string;
+  };
+  expectedMonthlyRentCents: number | null;
+  collectedCurrentMonthCents: number | null;
+  outstandingCurrentMonthCents: number | null;
+  rentCollectionRate: number | null;
+  rentRollCents: number | null;
+  vacancyImpactCents: number | null;
+  activeLeaseRentTermsCount: number;
+  leasesMissingRentTermsCount: number;
+  paymentSourcesIncluded: PortfolioPaymentSource[];
+  confidence: PortfolioMetricConfidence;
+  dataQualityFlags: PortfolioDataQualityFlag[];
+};
+
+export type LandlordPortfolioStatusFinancialSummary = {
+  version: "landlord_portfolio_status_financial_v1";
+  landlordId: string;
+  generatedAt: string;
+  portfolioStatus: PortfolioOccupancySummary;
+  financialSnapshot: PortfolioFinancialSnapshot;
+  confidence: {
+    occupancy: PortfolioMetricConfidence;
+    financial: PortfolioMetricConfidence;
+  };
+  dataQualityFlags: PortfolioDataQualityFlag[];
+};


### PR DESCRIPTION
## Summary
- Adds a read-only backend normalization service for landlord portfolio status and financial snapshot metrics.
- Normalizes property/unit/lease/tenant/payment inputs into occupancy, vacancy, rent roll, current-month collection, outstanding rent, confidence, and data-quality flags.
- Stabilizes explicit landlord scoping so mismatched `landlordId` records fail closed before related-entity fallback.
- Treats current/notice lease lifecycle as authoritative for occupancy while surfacing stale unit-status mismatches as data-quality conflicts.
- Keeps the mission backend-service-only: no route, no UI, no writes, no audit events, no notifications.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run test:single -- src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run build`
- `git diff --check`

## Notes
- The first test attempt without `nvm use 20` failed the repo Node preflight because the shell was on Node 25; validation was rerun successfully on Node 20.
- Dashboard 2.0 UI and API exposure remain out of scope for this PR.