### PR TITLE
feat: expose landlord portfolio status financial api

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -150,6 +150,7 @@ import adminPdfExportObservabilityRoutes from "./routes/adminPdfExportObservabil
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
+import landlordPortfolioStatusFinancialRoutes from "./routes/landlordPortfolioStatusFinancialRoutes";
 import landlordAnalyticsRoutes from "./routes/landlordAnalyticsRoutes";
 import landlordAnalyticsAlertsRoutes from "./routes/landlordAnalyticsAlertsRoutes";
 import landlordAnalyticsBenchmarkingRoutes from "./routes/landlordAnalyticsBenchmarkingRoutes";
@@ -496,6 +497,8 @@ app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioSc
 console.log("[route-mount] portfolioScoreHistoryRoutes mounted at /api/admin");
 app.use("/api", routeSource("landlordPortfolioHealthRoutes.ts"), landlordPortfolioHealthRoutes);
 console.log("[route-mount] landlordPortfolioHealthRoutes mounted at /api");
+app.use("/api", routeSource("landlordPortfolioStatusFinancialRoutes.ts"), landlordPortfolioStatusFinancialRoutes);
+console.log("[route-mount] landlordPortfolioStatusFinancialRoutes mounted at /api");
 app.use("/api", routeSource("landlordAnalyticsRoutes.ts"), landlordAnalyticsRoutes);
 console.log("[route-mount] landlordAnalyticsRoutes mounted at /api");
 app.use("/api", routeSource("landlordAnalyticsAlertsRoutes.ts"), landlordAnalyticsAlertsRoutes);

--- a/rentchain-api/src/routes/__tests__/landlordPortfolioStatusFinancialRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordPortfolioStatusFinancialRoutes.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadLandlordPortfolioStatusFinancialInput = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    }
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+vi.mock("../../services/landlordPortfolioStatusFinancial/loadLandlordPortfolioStatusFinancialInput", () => ({
+  loadLandlordPortfolioStatusFinancialInput,
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordPortfolioStatusFinancialRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadLandlordPortfolioStatusFinancialInput.mockResolvedValue({
+      landlordId: "landlord-1",
+      generatedAt: "2026-06-19T12:00:00.000Z",
+      periodMonth: "2026-06",
+      properties: [{ id: "property-1", landlordId: "landlord-1" }],
+      units: [{ id: "unit-1", landlordId: "landlord-1", propertyId: "property-1", status: "vacant" }],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          status: "active",
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          monthlyRentCents: 120000,
+        },
+      ],
+      tenants: [],
+      rentPayments: [
+        {
+          id: "payment-1",
+          landlordId: "landlord-1",
+          propertyId: "property-1",
+          leaseId: "lease-1",
+          amountCents: 120000,
+          paidAt: "2026-06-03T12:00:00.000Z",
+          status: "paid",
+        },
+      ],
+      ledgerEntries: null,
+      ledgerEvents: null,
+      payments: null,
+    });
+  });
+
+  it("returns landlord-scoped portfolio status and financial summary", async () => {
+    const router = (await import("../landlordPortfolioStatusFinancialRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-status-financial?periodMonth=2026-06",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.version).toBe("landlord_portfolio_status_financial_v1");
+    expect(response.body.landlordId).toBe("landlord-1");
+    expect(response.body.generatedAt).toBe("2026-06-19T12:00:00.000Z");
+    expect(response.body.portfolioStatus).toEqual(
+      expect.objectContaining({
+        totalProperties: 1,
+        totalUnits: 1,
+        occupiedUnits: 1,
+        reviewRequiredUnits: 1,
+      })
+    );
+    expect(response.body.financialSnapshot).toEqual(
+      expect.objectContaining({
+        expectedMonthlyRentCents: 120000,
+        collectedCurrentMonthCents: 120000,
+        outstandingCurrentMonthCents: 0,
+      })
+    );
+    expect(response.body.confidence).toEqual(
+      expect.objectContaining({
+        occupancy: expect.any(String),
+        financial: expect.any(String),
+      })
+    );
+    expect(response.body.dataQualityFlags).toContain("unit_lease_occupancy_conflict");
+    expect(JSON.stringify(response.body)).not.toContain("providerRequestId");
+    expect(JSON.stringify(response.body)).not.toContain("gs://");
+  });
+
+  it("does not allow arbitrary landlord lookup from query params", async () => {
+    const router = (await import("../landlordPortfolioStatusFinancialRoutes")).default;
+    await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-status-financial?landlordId=other-landlord&periodMonth=2026-06",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(loadLandlordPortfolioStatusFinancialInput).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      periodMonth: "2026-06",
+    });
+  });
+
+  it("returns 200 with degraded metric state when source data is unavailable", async () => {
+    loadLandlordPortfolioStatusFinancialInput.mockResolvedValueOnce({
+      landlordId: "landlord-1",
+      generatedAt: "2026-06-19T12:00:00.000Z",
+      periodMonth: "2026-06",
+      properties: null,
+      units: null,
+      leases: null,
+      tenants: null,
+      rentPayments: null,
+      ledgerEntries: null,
+      ledgerEvents: null,
+      payments: null,
+    });
+    const router = (await import("../landlordPortfolioStatusFinancialRoutes")).default;
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-status-financial?periodMonth=2026-06",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.generatedAt).toBe("2026-06-19T12:00:00.000Z");
+    expect(response.body.confidence).toEqual({ occupancy: "unavailable", financial: "unavailable" });
+    expect(response.body.dataQualityFlags).toEqual(
+      expect.arrayContaining([
+        "ledger_source_unavailable",
+        "no_scoped_leases",
+        "no_scoped_properties",
+        "no_scoped_units",
+        "payment_source_unavailable",
+      ])
+    );
+  });
+
+  it("enforces landlord-authenticated scope", async () => {
+    const router = (await import("../landlordPortfolioStatusFinancialRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-status-financial",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const unauthorized = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-status-financial",
+      user: null,
+    });
+    expect(unauthorized.status).toBe(401);
+    expect(loadLandlordPortfolioStatusFinancialInput).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-api/src/routes/__tests__/landlordPortfolioStatusFinancialRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordPortfolioStatusFinancialRoutes.test.ts
@@ -97,7 +97,7 @@ describe("landlordPortfolioStatusFinancialRoutes", () => {
           monthlyRentCents: 120000,
         },
       ],
-      tenants: [],
+      tenants: [{ id: "tenant-1", landlordId: "landlord-1", propertyId: "property-1", currentLeaseId: "lease-1" }],
       rentPayments: [
         {
           id: "payment-1",
@@ -124,6 +124,16 @@ describe("landlordPortfolioStatusFinancialRoutes", () => {
     });
 
     expect(response.status).toBe(200);
+    expect(Object.keys(response.body).sort()).toEqual([
+      "confidence",
+      "dataQualityFlags",
+      "financialSnapshot",
+      "generatedAt",
+      "landlordId",
+      "ok",
+      "portfolioStatus",
+      "version",
+    ]);
     expect(response.body.ok).toBe(true);
     expect(response.body.version).toBe("landlord_portfolio_status_financial_v1");
     expect(response.body.landlordId).toBe("landlord-1");
@@ -152,6 +162,10 @@ describe("landlordPortfolioStatusFinancialRoutes", () => {
     expect(response.body.dataQualityFlags).toContain("unit_lease_occupancy_conflict");
     expect(JSON.stringify(response.body)).not.toContain("providerRequestId");
     expect(JSON.stringify(response.body)).not.toContain("gs://");
+    expect(JSON.stringify(response.body)).not.toContain("unit-1");
+    expect(JSON.stringify(response.body)).not.toContain("lease-1");
+    expect(JSON.stringify(response.body)).not.toContain("tenant-1");
+    expect(JSON.stringify(response.body)).not.toContain("payment-1");
   });
 
   it("does not allow arbitrary landlord lookup from query params", async () => {

--- a/rentchain-api/src/routes/landlordPortfolioStatusFinancialRoutes.ts
+++ b/rentchain-api/src/routes/landlordPortfolioStatusFinancialRoutes.ts
@@ -1,0 +1,43 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import {
+  deriveLandlordPortfolioStatusFinancialSummary,
+  loadLandlordPortfolioStatusFinancialInput,
+} from "../services/landlordPortfolioStatusFinancial";
+
+const router = Router();
+
+function asString(value: unknown, max = 240): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizePeriodMonth(value: unknown): string | null {
+  const raw = asString(value, 20);
+  return /^\d{4}-\d{2}$/.test(raw) ? raw : null;
+}
+
+router.get("/landlord/portfolio-status-financial", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const input = await loadLandlordPortfolioStatusFinancialInput({
+      landlordId,
+      periodMonth: normalizePeriodMonth(req.query?.periodMonth || req.query?.month),
+    });
+    const summary = deriveLandlordPortfolioStatusFinancialSummary(input);
+
+    return res.status(200).json({
+      ok: true,
+      ...summary,
+    });
+  } catch (err: any) {
+    console.error("[landlord-portfolio-status-financial] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_PORTFOLIO_STATUS_FINANCIAL_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/loadLandlordPortfolioStatusFinancialInput.test.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/__tests__/loadLandlordPortfolioStatusFinancialInput.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type CollectionName =
+  | "properties"
+  | "units"
+  | "leases"
+  | "tenants"
+  | "ledgerEvents"
+  | "ledgerEntries"
+  | "rentPayments"
+  | "payments";
+
+const writes = {
+  add: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+const store: Record<CollectionName, Array<Record<string, unknown> & { id: string }>> = {
+  properties: [],
+  units: [],
+  leases: [],
+  tenants: [],
+  ledgerEvents: [],
+  ledgerEntries: [],
+  rentPayments: [],
+  payments: [],
+};
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function fakeDoc(record: Record<string, unknown> & { id: string }) {
+  return {
+    id: record.id,
+    data: () => record,
+  };
+}
+
+function query(collectionName: CollectionName, filters: Array<{ field: string; op: string; value: unknown }> = []) {
+  return {
+    where(field: string, op: string, value: unknown) {
+      return query(collectionName, [...filters, { field, op, value }]);
+    },
+    limit() {
+      return this;
+    },
+    async get() {
+      const docs = store[collectionName].filter((record) =>
+        filters.every((filter) => {
+          if (filter.op === "==") return record[filter.field] === filter.value;
+          if (filter.op === "in") return asArray(filter.value).includes(record[filter.field]);
+          return false;
+        })
+      );
+      return { docs: docs.map(fakeDoc) };
+    },
+    add: writes.add,
+    doc() {
+      return {
+        set: writes.set,
+        update: writes.update,
+        delete: writes.delete,
+      };
+    },
+  };
+}
+
+vi.mock("../../../firebase", () => ({
+  db: {
+    collection(name: CollectionName) {
+      return query(name);
+    },
+  },
+}));
+
+describe("loadLandlordPortfolioStatusFinancialInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(store) as CollectionName[]) {
+      store[key] = [];
+    }
+  });
+
+  it("loads portfolio inputs through read-only Firestore queries without source mutations", async () => {
+    store.properties = [{ id: "property-1", landlordId: "landlord-1" }];
+    store.units = [{ id: "unit-1", landlordId: "landlord-1", propertyId: "property-1" }];
+    store.leases = [{ id: "lease-1", landlordId: "landlord-1", propertyId: "property-1", tenantId: "tenant-1" }];
+    store.tenants = [{ id: "tenant-1", landlordId: "landlord-1", propertyId: "property-1", currentLeaseId: "lease-1" }];
+    store.rentPayments = [{ id: "payment-1", landlordId: "landlord-1", leaseId: "lease-1", tenantId: "tenant-1" }];
+
+    const { loadLandlordPortfolioStatusFinancialInput } = await import("../loadLandlordPortfolioStatusFinancialInput");
+    const input = await loadLandlordPortfolioStatusFinancialInput({
+      landlordId: "landlord-1",
+      periodMonth: "2026-06",
+      generatedAt: "2026-06-19T12:00:00.000Z",
+    });
+
+    expect(input).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        periodMonth: "2026-06",
+        generatedAt: "2026-06-19T12:00:00.000Z",
+      })
+    );
+    expect(input.properties?.map((record) => record.id)).toEqual(["property-1"]);
+    expect(input.units?.map((record) => record.id)).toEqual(["unit-1"]);
+    expect(input.leases?.map((record) => record.id)).toEqual(["lease-1"]);
+    expect(input.tenants?.map((record) => record.id)).toEqual(["tenant-1"]);
+    expect(input.rentPayments?.map((record) => record.id)).toEqual(["payment-1"]);
+    expect(writes.add).not.toHaveBeenCalled();
+    expect(writes.set).not.toHaveBeenCalled();
+    expect(writes.update).not.toHaveBeenCalled();
+    expect(writes.delete).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/index.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/index.ts
@@ -1,2 +1,3 @@
 export * from "./landlordPortfolioStatusFinancialService";
 export * from "./landlordPortfolioStatusFinancialTypes";
+export * from "./loadLandlordPortfolioStatusFinancialInput";

--- a/rentchain-api/src/services/landlordPortfolioStatusFinancial/loadLandlordPortfolioStatusFinancialInput.ts
+++ b/rentchain-api/src/services/landlordPortfolioStatusFinancial/loadLandlordPortfolioStatusFinancialInput.ts
@@ -1,0 +1,172 @@
+import { db } from "../../firebase";
+import type {
+  LandlordPortfolioStatusFinancialInput,
+  PortfolioPaymentRecord,
+  PortfolioPropertyRecord,
+  PortfolioTenantRecord,
+  PortfolioUnitRecord,
+  PortfolioLeaseRecord,
+  PortfolioRecord,
+} from "./landlordPortfolioStatusFinancialTypes";
+
+const DEFAULT_LIMIT = 500;
+const PAYMENT_LIMIT = 1000;
+const IN_CHUNK_SIZE = 10;
+
+function asString(value: unknown, max = 240): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function unique(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map((value) => asString(value, 240)).filter(Boolean)));
+}
+
+function chunks(values: string[], size = IN_CHUNK_SIZE): string[][] {
+  const out: string[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    out.push(values.slice(index, index + size));
+  }
+  return out;
+}
+
+function withDocId<T extends PortfolioRecord>(doc: any): T {
+  const data = ((typeof doc?.data === "function" ? doc.data() : {}) || {}) as Record<string, unknown>;
+  return {
+    ...data,
+    id: asString(data.id, 240) || asString(doc?.id, 240),
+  } as T;
+}
+
+async function queryByField<T extends PortfolioRecord>(
+  collectionName: string,
+  field: string,
+  value: string,
+  limit = DEFAULT_LIMIT
+): Promise<T[] | null> {
+  try {
+    const snap = await db.collection(collectionName).where(field, "==", value).limit(limit).get();
+    return (snap.docs || []).map((doc: any) => withDocId<T>(doc));
+  } catch (err: any) {
+    console.warn("[landlord-portfolio-status-financial] source query failed", {
+      collectionName,
+      field,
+      message: err?.message || String(err),
+    });
+    return null;
+  }
+}
+
+async function queryByFieldIn<T extends PortfolioRecord>(
+  collectionName: string,
+  field: string,
+  values: string[],
+  limitPerChunk = DEFAULT_LIMIT
+): Promise<T[] | null> {
+  const scopedValues = unique(values);
+  if (scopedValues.length === 0) return [];
+
+  const results: T[] = [];
+  let anySucceeded = false;
+  for (const chunk of chunks(scopedValues)) {
+    try {
+      const snap = await db.collection(collectionName).where(field, "in", chunk).limit(limitPerChunk).get();
+      results.push(...((snap.docs || []).map((doc: any) => withDocId<T>(doc)) as T[]));
+      anySucceeded = true;
+    } catch (err: any) {
+      console.warn("[landlord-portfolio-status-financial] related source query failed", {
+        collectionName,
+        field,
+        message: err?.message || String(err),
+      });
+    }
+  }
+
+  return anySucceeded ? results : null;
+}
+
+function mergeById<T extends PortfolioRecord>(...groups: Array<T[] | null | undefined>): T[] | null {
+  let anyAvailable = false;
+  const byId = new Map<string, T>();
+
+  for (const group of groups) {
+    if (!group) continue;
+    anyAvailable = true;
+    for (const record of group) {
+      const id = asString(record.id, 240) || JSON.stringify(record);
+      byId.set(id, record);
+    }
+  }
+
+  return anyAvailable ? Array.from(byId.values()) : null;
+}
+
+function tenantIdsFromLeases(leases: PortfolioLeaseRecord[] | null): string[] {
+  if (!leases) return [];
+  const ids: string[] = [];
+  for (const lease of leases) {
+    ids.push(asString(lease.tenantId, 240), asString(lease.primaryTenantId, 240));
+    if (Array.isArray(lease.tenantIds)) {
+      for (const id of lease.tenantIds) ids.push(asString(id, 240));
+    }
+  }
+  return unique(ids);
+}
+
+export async function loadLandlordPortfolioStatusFinancialInput(params: {
+  landlordId: string;
+  periodMonth?: string | null;
+  generatedAt?: string | null;
+}): Promise<LandlordPortfolioStatusFinancialInput> {
+  const landlordId = asString(params.landlordId, 240);
+  const generatedAt = params.generatedAt || new Date().toISOString();
+
+  const properties = await queryByField<PortfolioPropertyRecord>("properties", "landlordId", landlordId, DEFAULT_LIMIT);
+  const propertyIds = unique((properties || []).map((property) => asString(property.id || property.propertyId, 240)));
+
+  const [unitsByLandlord, unitsByProperty, leasesByLandlord, leasesByProperty] = await Promise.all([
+    queryByField<PortfolioUnitRecord>("units", "landlordId", landlordId, DEFAULT_LIMIT),
+    queryByFieldIn<PortfolioUnitRecord>("units", "propertyId", propertyIds, DEFAULT_LIMIT),
+    queryByField<PortfolioLeaseRecord>("leases", "landlordId", landlordId, DEFAULT_LIMIT),
+    queryByFieldIn<PortfolioLeaseRecord>("leases", "propertyId", propertyIds, DEFAULT_LIMIT),
+  ]);
+
+  const units = mergeById(unitsByLandlord, unitsByProperty);
+  const leases = mergeById(leasesByLandlord, leasesByProperty);
+  const leaseIds = unique((leases || []).map((lease) => asString(lease.id || lease.leaseId, 240)));
+  const tenantIds = tenantIdsFromLeases(leases);
+
+  const [tenantsByLandlord, tenantsByProperty, tenantsByCurrentLease, ledgerEvents, ledgerEntries, rentPayments, payments] = await Promise.all([
+    queryByField<PortfolioTenantRecord>("tenants", "landlordId", landlordId, DEFAULT_LIMIT),
+    queryByFieldIn<PortfolioTenantRecord>("tenants", "propertyId", propertyIds, DEFAULT_LIMIT),
+    queryByFieldIn<PortfolioTenantRecord>("tenants", "currentLeaseId", leaseIds, DEFAULT_LIMIT),
+    queryByField<PortfolioPaymentRecord>("ledgerEvents", "landlordId", landlordId, PAYMENT_LIMIT),
+    queryByField<PortfolioPaymentRecord>("ledgerEntries", "landlordId", landlordId, PAYMENT_LIMIT),
+    queryByField<PortfolioPaymentRecord>("rentPayments", "landlordId", landlordId, PAYMENT_LIMIT),
+    queryByField<PortfolioPaymentRecord>("payments", "landlordId", landlordId, PAYMENT_LIMIT),
+  ]);
+
+  const tenants = mergeById(tenantsByLandlord, tenantsByProperty, tenantsByCurrentLease);
+  const tenantIdsFromTenants = unique((tenants || []).map((tenant) => asString(tenant.id || tenant.tenantId, 240)));
+  const allTenantIds = unique([...tenantIds, ...tenantIdsFromTenants]);
+
+  const [rentPaymentsByLease, rentPaymentsByTenant, paymentsByLease, paymentsByTenant] = await Promise.all([
+    queryByFieldIn<PortfolioPaymentRecord>("rentPayments", "leaseId", leaseIds, PAYMENT_LIMIT),
+    queryByFieldIn<PortfolioPaymentRecord>("rentPayments", "tenantId", allTenantIds, PAYMENT_LIMIT),
+    queryByFieldIn<PortfolioPaymentRecord>("payments", "leaseId", leaseIds, PAYMENT_LIMIT),
+    queryByFieldIn<PortfolioPaymentRecord>("payments", "tenantId", allTenantIds, PAYMENT_LIMIT),
+  ]);
+
+  return {
+    landlordId,
+    generatedAt,
+    periodMonth: params.periodMonth || null,
+    properties,
+    units,
+    leases,
+    tenants,
+    ledgerEvents,
+    ledgerEntries,
+    rentPayments: mergeById(rentPayments, rentPaymentsByLease, rentPaymentsByTenant),
+    payments: mergeById(payments, paymentsByLease, paymentsByTenant),
+  };
+}


### PR DESCRIPTION
## Summary
- Add authenticated landlord route `GET /api/landlord/portfolio-status-financial`.
- Load landlord-scoped Firestore inputs for properties, units, leases, tenants, payment and ledger sources.
- Return the normalized `landlord_portfolio_status_financial_v1` contract at top level with `generatedAt`, `confidence`, and `dataQualityFlags`.
- Preserve degraded-state behavior: source-unavailable/sparse inputs still return `200 OK` with unavailable/low-confidence metrics instead of failing the whole payload.

## Contract notes
- Auth and landlord authorization remain required.
- Query params cannot select another landlord; scope comes from authenticated landlord context.
- Route is read-only and does not mutate source data.
- Unsupported or missing data is expressed through existing confidence/data-quality fields.

## Validation
- `npm run test:single -- src/routes/__tests__/landlordPortfolioStatusFinancialRoutes.test.ts src/services/landlordPortfolioStatusFinancial/__tests__/landlordPortfolioStatusFinancialService.test.ts`
- `npm run build`
- `git diff --check`

## Out of scope
- No Dashboard 2.0 UI work.
- No payment workflow changes.
- No source-data repair or migration.
- No audit or notification side effects.
- Manual QA not required until Dashboard 2.0 preview deployment.