### PR TITLE
feat: dashboard 2.0 operational home

### DIFF
--- a/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
+++ b/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
@@ -1,0 +1,82 @@
+import { apiFetch } from "./apiFetch";
+
+export type LandlordDecisionQueueSeverity =
+  | "critical"
+  | "warning"
+  | "needs_review"
+  | "upcoming"
+  | "informational";
+
+export type LandlordDecisionQueueWorkspace =
+  | "dashboard"
+  | "operations"
+  | "tenant"
+  | "lease"
+  | "property"
+  | "maintenance"
+  | "payments"
+  | "notices"
+  | "evidence_compliance";
+
+export type LandlordDecisionQueueStatus = "open" | "pending" | "blocked" | "resolved" | "dismissed";
+
+export type LandlordDecisionQueueItem = {
+  id: string;
+  sourceType: string;
+  sourceId: string;
+  workspace: LandlordDecisionQueueWorkspace;
+  severity: LandlordDecisionQueueSeverity;
+  title: string;
+  description: string;
+  recommendedActionLabel: string;
+  recommendedActionHref: string;
+  dueAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  status: LandlordDecisionQueueStatus;
+  dedupeKey: string;
+  sortKey: string;
+  priorityRank: number;
+};
+
+export type LandlordDecisionQueueSummary = {
+  total: number;
+  critical: number;
+  warning: number;
+  needsReview: number;
+  upcoming: number;
+  informational: number;
+  open: number;
+  blocked: number;
+};
+
+export type LandlordDecisionQueueResponse = {
+  ok: true;
+  version: "landlord_decision_queue_v1";
+  landlordId: string;
+  generatedAt: string;
+  items: LandlordDecisionQueueItem[];
+  summary: LandlordDecisionQueueSummary;
+  total: number;
+  limit: number;
+  filters: {
+    severity: LandlordDecisionQueueSeverity | null;
+    workspace: LandlordDecisionQueueWorkspace | null;
+    status: LandlordDecisionQueueStatus | "open_state" | null;
+  };
+};
+
+export async function fetchLandlordDecisionQueue(params?: {
+  limit?: number;
+  status?: LandlordDecisionQueueStatus | "open_state";
+  workspace?: LandlordDecisionQueueWorkspace;
+  severity?: LandlordDecisionQueueSeverity;
+}): Promise<LandlordDecisionQueueResponse> {
+  const search = new URLSearchParams();
+  if (params?.limit) search.set("limit", String(params.limit));
+  if (params?.status) search.set("status", params.status);
+  if (params?.workspace) search.set("workspace", params.workspace);
+  if (params?.severity) search.set("severity", params.severity);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  return apiFetch<LandlordDecisionQueueResponse>(`/landlord/decision-queue${suffix}`);
+}

--- a/rentchain-frontend/src/api/landlordPortfolioStatusFinancialApi.ts
+++ b/rentchain-frontend/src/api/landlordPortfolioStatusFinancialApi.ts
@@ -1,0 +1,79 @@
+import { apiFetch } from "./apiFetch";
+
+export type PortfolioMetricConfidence = "high" | "medium" | "low" | "unavailable";
+
+export type PortfolioDataQualityFlag =
+  | "dashboard_rent_fields_zeroed"
+  | "payment_sources_split"
+  | "payment_source_unavailable"
+  | "ledger_source_unavailable"
+  | "unit_sources_split"
+  | "unit_lease_occupancy_conflict"
+  | "tenant_lease_link_conflict"
+  | "missing_rent_terms"
+  | "stale_lifecycle_projection"
+  | "vacancy_value_unavailable"
+  | "no_scoped_properties"
+  | "no_scoped_units"
+  | "no_scoped_leases";
+
+export type PortfolioOccupancySummary = {
+  totalProperties: number;
+  totalUnits: number;
+  occupiedUnits: number;
+  vacantUnits: number;
+  upcomingUnits: number;
+  noticePeriodUnits: number;
+  reviewRequiredUnits: number;
+  occupancyRate: number | null;
+  activeLeaseCount: number;
+  currentLeaseCount: number;
+  signedFutureLeaseCount: number;
+  leasesRequiringReview: number;
+  criticalOpenIssues: number | null;
+  openOperationalIssues: number | null;
+  confidence: PortfolioMetricConfidence;
+  dataQualityFlags: PortfolioDataQualityFlag[];
+};
+
+export type PortfolioFinancialSnapshot = {
+  period: {
+    month: string;
+    startsAt: string;
+    endsAt: string;
+  };
+  expectedMonthlyRentCents: number | null;
+  collectedCurrentMonthCents: number | null;
+  outstandingCurrentMonthCents: number | null;
+  rentCollectionRate: number | null;
+  rentRollCents: number | null;
+  vacancyImpactCents: number | null;
+  activeLeaseRentTermsCount: number;
+  leasesMissingRentTermsCount: number;
+  paymentSourcesIncluded: Array<"ledgerEvents" | "ledgerEntries" | "rentPayments" | "payments">;
+  confidence: PortfolioMetricConfidence;
+  dataQualityFlags: PortfolioDataQualityFlag[];
+};
+
+export type LandlordPortfolioStatusFinancialResponse = {
+  ok: true;
+  version: "landlord_portfolio_status_financial_v1";
+  landlordId: string;
+  generatedAt: string;
+  portfolioStatus: PortfolioOccupancySummary;
+  financialSnapshot: PortfolioFinancialSnapshot;
+  confidence: {
+    occupancy: PortfolioMetricConfidence;
+    financial: PortfolioMetricConfidence;
+  };
+  dataQualityFlags: PortfolioDataQualityFlag[];
+};
+
+export async function fetchLandlordPortfolioStatusFinancial(params?: {
+  periodMonth?: string;
+}): Promise<LandlordPortfolioStatusFinancialResponse> {
+  const search = new URLSearchParams();
+  if (params?.periodMonth) search.set("periodMonth", params.periodMonth);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  return apiFetch<LandlordPortfolioStatusFinancialResponse>(`/landlord/portfolio-status-financial${suffix}`);
+}

--- a/rentchain-frontend/src/components/layout/MacShell.tsx
+++ b/rentchain-frontend/src/components/layout/MacShell.tsx
@@ -8,12 +8,14 @@ interface MacShellProps {
   title?: string;
   children: React.ReactNode;
   showTopNav?: boolean;
+  maxWidth?: number | string;
 }
 
 export const MacShell: React.FC<MacShellProps> = ({
   title = "RentChain",
   children,
   showTopNav = true,
+  maxWidth = layout.maxWidth,
 }) => {
   const renderTopNav = showTopNav;
 
@@ -41,7 +43,7 @@ export const MacShell: React.FC<MacShellProps> = ({
       <main
         className="rc-mac-shell-main"
         style={{
-          maxWidth: layout.maxWidth,
+          maxWidth,
           margin: "0 auto",
           padding: `${spacing.lg} ${layout.pagePadding} ${spacing.xxl}`,
         }}

--- a/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthDimensionList.tsx
+++ b/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthDimensionList.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
 import type { PortfolioHealthDimensionV1 } from "../../api/landlordPortfolioHealthApi";
 import { Card, Pill } from "../ui/Ui";
 
@@ -6,31 +8,56 @@ type Props = {
   dimensions: PortfolioHealthDimensionV1[];
 };
 
+const dimensionActions: Record<PortfolioHealthDimensionV1["key"], { href: string; label: string }> = {
+  screening_health: { href: "/applications", label: "Review applications" },
+  maintenance_health: { href: "/work-orders", label: "Review work orders" },
+  workflow_health: { href: "/operations", label: "Open operations" },
+  response_health: { href: "/landlord/inbox", label: "Open inbox" },
+};
+
 export default function PortfolioHealthDimensionList({ dimensions }: Props) {
   return (
     <Card style={{ display: "grid", gap: 12 }}>
-      <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Health dimensions</h2>
-      <div style={{ display: "grid", gap: 10 }}>
-        {dimensions.map((dimension) => (
-          <div
-            key={dimension.key}
-            style={{
-              display: "grid",
-              gap: 6,
-              padding: 12,
-              borderRadius: 12,
-              border: "1px solid #e2e8f0",
-              background: "#f8fafc",
-            }}
-          >
-            <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
-              <div style={{ fontWeight: 700 }}>{dimension.label}</div>
-              <Pill>{dimension.status.replace(/_/g, " ")}</Pill>
-            </div>
-            <div style={{ color: "#475569" }}>{dimension.summary}</div>
-          </div>
-        ))}
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+        <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Health actions</h2>
+        <div style={{ color: "#475569", fontSize: 13 }}>Each area opens the workspace that owns follow-through.</div>
       </div>
+      {dimensions.length === 0 ? (
+        <div style={{ color: "#475569" }}>No health actions are currently available.</div>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 240px), 1fr))", gap: 10 }}>
+          {dimensions.map((dimension) => {
+            const action = dimensionActions[dimension.key];
+            return (
+              <Link
+                key={dimension.key}
+                to={action.href}
+                style={{
+                  display: "grid",
+                  gap: 10,
+                  minHeight: 132,
+                  padding: 14,
+                  borderRadius: 8,
+                  border: "1px solid #e2e8f0",
+                  background: "#fff",
+                  color: "#0f172a",
+                  textDecoration: "none",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+                  <div style={{ fontWeight: 800 }}>{dimension.label}</div>
+                  <Pill>{dimension.status.replace(/_/g, " ")}</Pill>
+                </div>
+                <div style={{ color: "#475569", lineHeight: 1.4 }}>{dimension.summary}</div>
+                <div style={{ marginTop: "auto", display: "inline-flex", gap: 8, alignItems: "center", color: "#1d4ed8", fontWeight: 800 }}>
+                  {action.label}
+                  <ArrowRight size={16} />
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
     </Card>
   );
 }

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -1,958 +1,291 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import { ToastProvider } from "../components/ui/ToastProvider";
 import DashboardPage from "./DashboardPage";
+import type { LandlordDecisionQueueResponse } from "@/api/landlordDecisionQueueApi";
+import type { LandlordPortfolioStatusFinancialResponse } from "@/api/landlordPortfolioStatusFinancialApi";
 
 const mocks = vi.hoisted(() => ({
-  useAuthMock: vi.fn(),
-  useCapabilitiesMock: vi.fn(),
-  fetchDashboardSummaryMock: vi.fn(),
-  useApplicationsMock: vi.fn(),
-  useTenantsMock: vi.fn(),
-  fetchPropertiesMock: vi.fn(),
-  listTenantInvitesMock: vi.fn(),
-  listReferralsMock: vi.fn(),
-  getLandlordActivationMock: vi.fn(),
-  fetchLandlordTransUnionOnboardingAnalyticsMock: vi.fn(),
-  useOnboardingStateMock: vi.fn(),
-  useUpgradeMock: vi.fn(),
-  navigateMock: vi.fn(),
-  patchDecisionActionMock: vi.fn(),
+  fetchLandlordDecisionQueueMock: vi.fn(),
+  fetchLandlordPortfolioStatusFinancialMock: vi.fn(),
 }));
 
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<any>("react-router-dom");
-  return {
-    ...actual,
-    useNavigate: () => mocks.navigateMock,
+vi.mock("@/api/landlordDecisionQueueApi", () => ({
+  fetchLandlordDecisionQueue: mocks.fetchLandlordDecisionQueueMock,
+}));
+
+vi.mock("@/api/landlordPortfolioStatusFinancialApi", () => ({
+  fetchLandlordPortfolioStatusFinancial: mocks.fetchLandlordPortfolioStatusFinancialMock,
+}));
+
+function installMatchMedia(matches = false) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function portfolioResponse(
+  overrides: Partial<LandlordPortfolioStatusFinancialResponse> = {}
+): LandlordPortfolioStatusFinancialResponse {
+  const base: LandlordPortfolioStatusFinancialResponse = {
+    ok: true,
+    version: "landlord_portfolio_status_financial_v1",
+    landlordId: "landlord-1",
+    generatedAt: "2026-06-19T12:00:00.000Z",
+    confidence: {
+      occupancy: "high",
+      financial: "medium",
+    },
+    dataQualityFlags: ["missing_rent_terms"],
+    portfolioStatus: {
+      totalProperties: 2,
+      totalUnits: 10,
+      occupiedUnits: 8,
+      vacantUnits: 2,
+      upcomingUnits: 1,
+      noticePeriodUnits: 1,
+      reviewRequiredUnits: 1,
+      occupancyRate: 0.8,
+      activeLeaseCount: 8,
+      currentLeaseCount: 8,
+      signedFutureLeaseCount: 1,
+      leasesRequiringReview: 1,
+      criticalOpenIssues: null,
+      openOperationalIssues: null,
+      confidence: "high",
+      dataQualityFlags: ["unit_lease_occupancy_conflict"],
+    },
+    financialSnapshot: {
+      period: {
+        month: "2026-06",
+        startsAt: "2026-06-01T00:00:00.000Z",
+        endsAt: "2026-06-30T23:59:59.999Z",
+      },
+      expectedMonthlyRentCents: 1200000,
+      collectedCurrentMonthCents: 900000,
+      outstandingCurrentMonthCents: 300000,
+      rentCollectionRate: 0.75,
+      rentRollCents: 1200000,
+      vacancyImpactCents: null,
+      activeLeaseRentTermsCount: 7,
+      leasesMissingRentTermsCount: 1,
+      paymentSourcesIncluded: ["ledgerEvents"],
+      confidence: "medium",
+      dataQualityFlags: ["missing_rent_terms"],
+    },
   };
-});
+  return {
+    ...base,
+    ...overrides,
+    confidence: {
+      ...base.confidence,
+      ...overrides.confidence,
+    },
+    portfolioStatus: {
+      ...base.portfolioStatus,
+      ...overrides.portfolioStatus,
+    },
+    financialSnapshot: {
+      ...base.financialSnapshot,
+      ...overrides.financialSnapshot,
+      period: {
+        ...base.financialSnapshot.period,
+        ...overrides.financialSnapshot?.period,
+      },
+    },
+  };
+}
 
-vi.mock("../context/useAuth", () => ({
-  useAuth: mocks.useAuthMock,
-}));
+function queueResponse(overrides: Partial<LandlordDecisionQueueResponse> = {}): LandlordDecisionQueueResponse {
+  const base: LandlordDecisionQueueResponse = {
+    ok: true,
+    version: "landlord_decision_queue_v1",
+    landlordId: "landlord-1",
+    generatedAt: "2026-06-19T12:01:00.000Z",
+    total: 2,
+    limit: 6,
+    filters: {
+      severity: null,
+      workspace: null,
+      status: "open_state",
+    },
+    summary: {
+      total: 2,
+      critical: 0,
+      warning: 1,
+      needsReview: 1,
+      upcoming: 1,
+      informational: 0,
+      open: 2,
+      blocked: 0,
+    },
+    items: [
+      {
+        id: "decision-1",
+        sourceType: "lease",
+        sourceId: "lease-1",
+        workspace: "lease",
+        severity: "needs_review",
+        title: "Resolve lease renewal",
+        description: "A lease needs a renewal decision before the notice window closes.",
+        recommendedActionLabel: "Open lease workspace",
+        recommendedActionHref: "/leases",
+        dueAt: "2026-06-25T12:00:00.000Z",
+        createdAt: "2026-06-18T12:00:00.000Z",
+        updatedAt: "2026-06-19T12:00:00.000Z",
+        status: "open",
+        dedupeKey: "lease-renewal",
+        sortKey: "1",
+        priorityRank: 10,
+      },
+      {
+        id: "decision-2",
+        sourceType: "payment",
+        sourceId: "payment-1",
+        workspace: "payments",
+        severity: "upcoming",
+        title: "Review outstanding rent",
+        description: "A rent collection item is coming due.",
+        recommendedActionLabel: "Open payments",
+        recommendedActionHref: "/payments",
+        dueAt: null,
+        createdAt: "2026-06-18T12:00:00.000Z",
+        updatedAt: "2026-06-19T12:00:00.000Z",
+        status: "pending",
+        dedupeKey: "payment-review",
+        sortKey: "2",
+        priorityRank: 20,
+      },
+    ],
+  };
+  return {
+    ...base,
+    ...overrides,
+    summary: {
+      ...base.summary,
+      ...overrides.summary,
+    },
+    filters: {
+      ...base.filters,
+      ...overrides.filters,
+    },
+    items: overrides.items ?? base.items,
+  };
+}
 
-vi.mock("@/hooks/useCapabilities", () => ({
-  useCapabilities: mocks.useCapabilitiesMock,
-}));
-
-vi.mock("../api/dashboard", () => ({
-  fetchDashboardSummary: mocks.fetchDashboardSummaryMock,
-}));
-
-vi.mock("../hooks/useApplications", () => ({
-  useApplications: mocks.useApplicationsMock,
-}));
-
-vi.mock("../hooks/useTenants", () => ({
-  useTenants: mocks.useTenantsMock,
-}));
-
-vi.mock("../api/propertiesApi", () => ({
-  fetchProperties: mocks.fetchPropertiesMock,
-}));
-
-vi.mock("../api/tenantInvites", () => ({
-  listTenantInvites: mocks.listTenantInvitesMock,
-}));
-
-vi.mock("../api/referralsApi", () => ({
-  listReferrals: mocks.listReferralsMock,
-}));
-
-vi.mock("@/api/activationApi", () => ({
-  getLandlordActivation: mocks.getLandlordActivationMock,
-}));
-
-vi.mock("@/api/landlordAnalyticsApi", () => ({
-  fetchLandlordTransUnionOnboardingAnalytics: mocks.fetchLandlordTransUnionOnboardingAnalyticsMock,
-}));
-
-vi.mock("../hooks/useOnboardingState", () => ({
-  useOnboardingState: mocks.useOnboardingStateMock,
-}));
-
-vi.mock("../context/UpgradeContext", () => ({
-  useUpgrade: mocks.useUpgradeMock,
-}));
-
-vi.mock("../config/screening", () => ({
-  SCREENING_ENABLED: true,
-  getUiLocale: () => "en",
-  screeningComingSoonLabel: () => "Credit screening - coming soon.",
-}));
-
-vi.mock("@/api/decisionApi", () => ({
-  patchDecisionAction: mocks.patchDecisionActionMock,
-}));
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <DashboardPage />
+    </MemoryRouter>
+  );
+}
 
 afterEach(() => {
   cleanup();
 });
 
 describe("DashboardPage", () => {
-  const assignMock = vi.fn();
-
   beforeEach(() => {
-    window.localStorage.removeItem("rentchain.landlordWelcome.pending.landlord-1");
-    window.localStorage.removeItem("rentchain.landlordWelcome.seen.landlord-1");
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    });
-    mocks.useAuthMock.mockReturnValue({
-      user: { id: "landlord-1", role: "", actorRole: "landlord", plan: "elite" },
-      ready: true,
-      isLoading: false,
-      authStatus: "authed",
-    });
-    mocks.useCapabilitiesMock.mockReturnValue({
-      caps: { plan: "elite" },
-      features: {},
-      loading: false,
-    });
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({});
-    mocks.patchDecisionActionMock.mockImplementation(async (_decisionId: string, payload: any) => ({
-      ok: true,
-      decision: {
-        ...payload.decision,
-        status: payload.actionType === "reviewed" ? "reviewed" : payload.actionType,
-        latestAction: {
-          actionId: "action-1",
-          decisionId: payload.decision.decisionId,
-          actionType: payload.actionType,
-          nextStatus: payload.actionType === "reviewed" ? "reviewed" : payload.actionType,
-          createdAt: "2026-05-05T12:00:00.000Z",
-        },
-      },
-    }));
-    mocks.useApplicationsMock.mockReturnValue({
-      applications: [],
-      loading: false,
-    });
-    mocks.useTenantsMock.mockReturnValue({
-      tenants: [],
-      loading: false,
-    });
-    mocks.fetchPropertiesMock.mockResolvedValue({ properties: [] });
-    mocks.listTenantInvitesMock.mockResolvedValue({ items: [] });
-    mocks.listReferralsMock.mockResolvedValue([]);
-    mocks.getLandlordActivationMock.mockResolvedValue({
-      completedCount: 0,
-      totalCount: 7,
-      nextStepKey: "property",
-      steps: [
-        {
-          key: "property",
-          title: "Add Property",
-          status: "in_progress",
-          description: "Add your first rental property to begin onboarding applicants.",
-          actionLabel: "Add Property",
-          actionPath: "/properties",
-        },
-      ],
-    });
-    mocks.fetchLandlordTransUnionOnboardingAnalyticsMock.mockResolvedValue({
-      totals: {
-        viewed: 3,
-        started: 2,
-        emailClicked: 1,
-        phoneClicked: 0,
-        alreadyCredentialedClicked: 0,
-        connected: 1,
-      },
-      conversionRate: 0.5,
-    });
-    mocks.useOnboardingStateMock.mockReturnValue({
-      loading: false,
-      dismissed: false,
-      steps: {
-        propertyAdded: false,
-        unitAdded: false,
-        tenantInvited: false,
-        applicationCreated: false,
-        exportPreviewed: false,
-      },
-      lastSeenAt: null,
-      allComplete: false,
-      refresh: vi.fn(),
-      markStepComplete: vi.fn(),
-      dismissOnboarding: vi.fn(),
-      showOnboarding: vi.fn(),
-    });
-    mocks.useUpgradeMock.mockReturnValue({
-      openUpgrade: vi.fn(),
-    });
-    mocks.navigateMock.mockReset();
-    assignMock.mockReset();
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: {
-        ...window.location,
-        assign: assignMock,
-      },
-    });
+    installMatchMedia(false);
+    mocks.fetchLandlordPortfolioStatusFinancialMock.mockResolvedValue(portfolioResponse());
+    mocks.fetchLandlordDecisionQueueMock.mockResolvedValue(queueResponse());
   });
 
-  it("loads landlord activation when actorRole is landlord even if role is blank", async () => {
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
+  it("renders Dashboard 2.0 sections from the portfolio and decision queue contracts", async () => {
+    renderDashboard();
+
+    expect(await screen.findByText("Operational Home")).toBeInTheDocument();
+    expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Portfolio Status");
+    expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("80%");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Decision Queue Preview");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Resolve lease renewal");
+    expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Upcoming Actions");
+    expect(screen.getByTestId("financial-snapshot-section")).toHaveTextContent("Financial Snapshot");
+    expect(screen.getByTestId("workspace-routing-section")).toHaveTextContent("Operations full queue");
+
+    expect(mocks.fetchLandlordPortfolioStatusFinancialMock).toHaveBeenCalledWith({ periodMonth: expect.stringMatching(/^\d{4}-\d{2}$/) });
+    expect(mocks.fetchLandlordDecisionQueueMock).toHaveBeenCalledWith({ status: "open_state", limit: 6 });
+    expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("payment-1")).not.toBeInTheDocument();
+  });
+
+  it("keeps decision queue content visible when portfolio data fails", async () => {
+    mocks.fetchLandlordPortfolioStatusFinancialMock.mockRejectedValue(new Error("Portfolio API unavailable"));
+
+    renderDashboard();
+
+    expect((await screen.findAllByText("Portfolio API unavailable")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Resolve lease renewal")).length).toBeGreaterThan(0);
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Full queue");
+  });
+
+  it("shows degraded and unavailable metric states with data-quality flags", async () => {
+    mocks.fetchLandlordPortfolioStatusFinancialMock.mockResolvedValue(
+      portfolioResponse({
+        confidence: {
+          occupancy: "low",
+          financial: "unavailable",
+        },
+        portfolioStatus: {
+          occupancyRate: null,
+          dataQualityFlags: ["unit_lease_occupancy_conflict"],
+        },
+        financialSnapshot: {
+          expectedMonthlyRentCents: null,
+          collectedCurrentMonthCents: null,
+          outstandingCurrentMonthCents: null,
+          rentCollectionRate: null,
+          dataQualityFlags: ["payment_source_unavailable"],
+        },
+      })
     );
+
+    renderDashboard();
+
+    expect((await screen.findAllByText("Unavailable")).length).toBeGreaterThan(0);
+    expect(screen.getByText(/unit lease occupancy conflict/)).toBeInTheDocument();
+    expect(screen.getByText(/payment source unavailable/)).toBeInTheDocument();
+    expect(screen.getAllByText("Degraded").length).toBeGreaterThan(0);
+  });
+
+  it("uses intentional empty states when no decision items are returned", async () => {
+    mocks.fetchLandlordDecisionQueueMock.mockResolvedValue(
+      queueResponse({
+        total: 0,
+        summary: {
+          total: 0,
+          open: 0,
+          needsReview: 0,
+          blocked: 0,
+        },
+        items: [],
+      })
+    );
+
+    renderDashboard();
+
+    expect(await screen.findByText("No open decisions. New operational decisions will appear here before routing to their owning workspace.")).toBeInTheDocument();
+    expect(screen.getByText("No dated actions are due right now. When lease, payment, notice, or maintenance decisions have dates, they appear here.")).toBeInTheDocument();
+  });
+
+  it("collapses the primary dashboard grid on narrow viewports", async () => {
+    installMatchMedia(true);
+
+    renderDashboard();
 
     await waitFor(() => {
-      expect(mocks.getLandlordActivationMock).toHaveBeenCalled();
+      expect(screen.getByTestId("dashboard-operational-grid")).toHaveStyle({ gridTemplateColumns: "1fr" });
     });
-
-    expect(screen.getByText("Get your first tenant screened")).toBeInTheDocument();
-  });
-
-  it("shows the landlord welcome modal when a fresh signup marker exists", async () => {
-    window.localStorage.setItem("rentchain.landlordWelcome.pending.landlord-1", "1");
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByText("Welcome to RentChain")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Start setup" })).toBeInTheDocument();
-  });
-
-  it("links open actions and review items to the approved destinations", async () => {
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 2,
-        tenantsCount: 1,
-        openActionsCount: 3,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [{ id: "a-1", title: "Invite a tenant", severity: "info", href: "/tenants" }],
-      events: [],
-      leaseNoticeSummary: {
-        expiringSoon: 0,
-        pendingResponse: 0,
-        renewed: 0,
-        quitting: 0,
-        noResponse: 0,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 5,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 2,
-        missingCredibilityCount: 1,
-        healthStatus: "watch",
-      },
-      decisions: [
-        {
-          decisionId: "decision:review_overdue_rent:lease-1",
-          leaseId: "lease-1",
-          propertyId: "property-1",
-          unitId: "unit-1",
-          decisionType: "review_overdue_rent",
-          severity: "critical",
-          status: "detected",
-          reason: "Rent past due date",
-          metadata: {},
-        },
-        {
-          decisionId: "decision:review_underpaid_rent:lease-2",
-          leaseId: "lease-2",
-          propertyId: "property-2",
-          unitId: "unit-2",
-          decisionType: "review_underpaid_rent",
-          severity: "warning",
-          status: "detected",
-          reason: "Partial payment received",
-          metadata: {},
-        },
-        {
-          decisionId: "decision:review_manual_payment_issue:lease-3",
-          leaseId: "lease-3",
-          propertyId: "property-3",
-          unitId: "unit-3",
-          decisionType: "review_manual_payment_issue",
-          severity: "warning",
-          status: "detected",
-          reason: "Payment mismatch detected",
-          metadata: {},
-        },
-      ],
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByRole("link", { name: "Open Actions" })).toHaveAttribute("href", "/dashboard#open-actions");
-    expect(screen.getByRole("link", { name: "Properties" })).toHaveAttribute("href", "/properties");
-    expect(screen.getByRole("link", { name: "Tenants" })).toHaveAttribute("href", "/tenants");
-    expect(screen.getByRole("link", { name: "Delinquencies" })).toHaveAttribute("href", "/payments?filter=delinquent");
-    expect(screen.getAllByRole("link", { name: "2" }).some((link) => link.getAttribute("href") === "/applications?status=review")).toBe(true);
-    expect(screen.getByText("Decision summary")).toBeInTheDocument();
-    expect(screen.getByText("Read-only decisions from detected rent and lease signals.")).toBeInTheDocument();
-    expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
-    expect(screen.getAllByText("Rent past due date").length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("link", { name: "Lease ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-1/ledger")).toBe(true);
-    expect(screen.getAllByRole("link", { name: "Property / unit" }).some((link) => link.getAttribute("href") === "/properties?propertyId=property-1&unitId=unit-1")).toBe(true);
-    expect(screen.getByText("Underpaid Rent")).toBeInTheDocument();
-    expect(screen.getAllByText("Partial payment received").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Payment mismatch detected").length).toBeGreaterThan(0);
-    expect(screen.getByTestId("dashboard-kpi-decision-stack")).toHaveStyle({
-      display: "grid",
-      gap: "2rem",
-      width: "100%",
-      boxSizing: "border-box",
-    });
-  });
-
-  it("updates dashboard decision status from human actions", async () => {
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      decisions: [
-        {
-          decisionId: "decision:review_overdue_rent:lease-1",
-          leaseId: "lease-1",
-          propertyId: "property-1",
-          unitId: "unit-1",
-          decisionType: "review_overdue_rent",
-          severity: "critical",
-          status: "detected",
-          reason: "Rent past due date",
-          metadata: {},
-        },
-      ],
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByText("Overdue Rent")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
-
-    await waitFor(() =>
-      expect(mocks.patchDecisionActionMock).toHaveBeenCalledWith(
-        "decision:review_overdue_rent:lease-1",
-        expect.objectContaining({ actionType: "reviewed", leaseId: "lease-1" })
-      )
-    );
-    expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
-  });
-
-  it("renders an empty dashboard decision state without adding actions", async () => {
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByText("Decision summary")).toBeInTheDocument();
-    expect(screen.getByText("No issues detected. Everything is up to date.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /accept/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
-  });
-
-  it("starts new landlords with Add Property and hides tenant invite and screening CTAs", async () => {
-    mocks.useAuthMock.mockReturnValue({
-      user: { id: "landlord-1", role: "", actorRole: "landlord", plan: "free" },
-      ready: true,
-      isLoading: false,
-      authStatus: "authed",
-    });
-    mocks.useCapabilitiesMock.mockReturnValue({
-      caps: { plan: "free" },
-      features: {},
-      loading: false,
-    });
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 0,
-        unitsCount: 0,
-        tenantsCount: 0,
-        openActionsCount: 0,
-        delinquentCount: 0,
-        screeningsCount: 0,
-        applicationsCount: 0,
-      },
-      actions: [
-        {
-          id: "run-first-screening",
-          title: "Run your first screening",
-          severity: "info",
-          href: "/applications?openTransUnionAccess=1",
-        },
-        {
-          id: "invite-tenant",
-          title: "Invite a tenant",
-          severity: "info",
-          href: "/tenants",
-        },
-      ],
-      events: [],
-    });
-    mocks.fetchPropertiesMock.mockResolvedValue({ properties: [] });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByTestId("free-tier-journey-card")).toBeInTheDocument();
-    expect(screen.getByText("Start in order")).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Add property" }).length).toBeGreaterThan(0);
-    expect(screen.getByText("Add a property before unit setup.")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Invite tenant" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Run screening" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Set up screening workflow" })).not.toBeInTheDocument();
-  });
-
-  it("uses scoped dashboard application counts and routes Free Step 3 to manual intake", async () => {
-    mocks.useAuthMock.mockReturnValue({
-      user: { id: "landlord-1", role: "", actorRole: "landlord", plan: "free" },
-      ready: true,
-      isLoading: false,
-      authStatus: "authed",
-    });
-    mocks.useCapabilitiesMock.mockReturnValue({
-      caps: { plan: "free" },
-      features: {},
-      loading: false,
-    });
-    mocks.useApplicationsMock.mockReturnValue({
-      applications: [{ id: "demo-1" }, { id: "demo-2" }],
-      loading: false,
-    });
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 1,
-        tenantsCount: 0,
-        openActionsCount: 1,
-        delinquentCount: 0,
-        screeningsCount: 0,
-        applicationsCount: 0,
-      },
-      actions: [],
-      events: [],
-    });
-    mocks.fetchPropertiesMock.mockResolvedValue({
-      properties: [{ id: "property-1", name: "Main Street", units: [{ id: "unit-1" }] }],
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByTestId("free-tier-journey-card")).toBeInTheDocument();
-    expect(screen.queryByText("2 applicants started")).not.toBeInTheDocument();
-    expect(screen.getByText("Track applicant intake after a unit exists.")).toBeInTheDocument();
-    screen.getAllByRole("button", { name: "Track applicant" })[0].click();
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/applications");
-    expect(mocks.navigateMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ search: expect.stringContaining("openSendApplication") }),
-      expect.anything()
-    );
-  });
-
-  it("prioritizes the free-tier setup journey before review-heavy dashboard work", async () => {
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 0,
-        tenantsCount: 0,
-        openActionsCount: 0,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [],
-      events: [],
-      decisions: [
-        {
-          decisionId: "decision:review_overdue_rent:lease-1",
-          leaseId: "lease-1",
-          propertyId: "property-1",
-          unitId: "unit-1",
-          decisionType: "review_overdue_rent",
-          severity: "critical",
-          status: "detected",
-          reason: "Rent past due date",
-          metadata: {},
-        },
-      ],
-    });
-    mocks.fetchPropertiesMock.mockResolvedValue({
-      properties: [{ id: "property-1", name: "Main Street", units: [] }],
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByTestId("free-tier-journey-card")).toBeInTheDocument();
-    expect(screen.getByText("Start in order")).toBeInTheDocument();
-    expect(screen.getByText("Step 1")).toBeInTheDocument();
-    expect(screen.getByText("Step 2")).toBeInTheDocument();
-    expect(screen.getAllByText("Add unit").length).toBeGreaterThan(0);
-    expect(screen.getByText("Decision inbox summary")).toBeInTheDocument();
-
-    const actionRequired = screen.getByText("Action required").closest("div");
-    expect(actionRequired).not.toBeNull();
-    expect(screen.getAllByText("Add a unit").length).toBeGreaterThan(0);
-    expect(screen.queryByText("Set up screening workflow")).not.toBeInTheDocument();
-  });
-
-  it("keeps dashboard recent activity ledger CTA label consistent when lease context is missing", async () => {
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 1,
-        tenantsCount: 1,
-        openActionsCount: 0,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [],
-      events: [{ id: "event-1", title: "Rent charge posted", createdAt: "2026-04-01T00:00:00.000Z" }],
-      leaseNoticeSummary: {
-        expiringSoon: 0,
-        pendingResponse: 0,
-        renewed: 0,
-        quitting: 0,
-        noResponse: 0,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 1,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 0,
-        missingCredibilityCount: 0,
-        healthStatus: "watch",
-      },
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByText("Rent charge posted")).toBeInTheDocument();
-    screen.getByRole("button", { name: "View leases" }).click();
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/leases");
-    expect(mocks.navigateMock).not.toHaveBeenCalledWith("/ledger");
-    expect(screen.queryByRole("button", { name: "View ledger" })).not.toBeInTheDocument();
-  });
-
-  it("routes dashboard recent activity ledger CTA to a lease ledger when lease context exists", async () => {
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 1,
-        tenantsCount: 1,
-        openActionsCount: 0,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [],
-      events: [{ id: "event-1", title: "Rent charge posted", leaseId: "lease-42", createdAt: "2026-04-01T00:00:00.000Z" }],
-      leaseNoticeSummary: {
-        expiringSoon: 0,
-        pendingResponse: 0,
-        renewed: 0,
-        quitting: 0,
-        noResponse: 0,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 1,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 0,
-        missingCredibilityCount: 0,
-        healthStatus: "watch",
-      },
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByText("Rent charge posted")).toBeInTheDocument();
-    screen.getByRole("button", { name: "View ledger" }).click();
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/leases/lease-42/ledger");
-  });
-
-  it("opens an explanation from the action required Info button", async () => {
-    mocks.useApplicationsMock.mockReturnValue({
-      applications: [{ id: "application-1" }],
-      loading: false,
-    });
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 1,
-        tenantsCount: 1,
-        openActionsCount: 1,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [
-        {
-          id: "run-first-screening",
-          title: "Run your first screening",
-          severity: "info",
-          href: "/applications?openTransUnionAccess=1",
-        },
-      ],
-      events: [],
-      leaseNoticeSummary: {
-        expiringSoon: 0,
-        pendingResponse: 0,
-        renewed: 0,
-        quitting: 0,
-        noResponse: 0,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 1,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 0,
-        missingCredibilityCount: 0,
-        healthStatus: "watch",
-      },
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByText("Run your first screening")).toBeInTheDocument();
-    expect(screen.getAllByText("Info")).toHaveLength(1);
-    screen.getByRole("button", { name: "Info about Run your first screening" }).click();
-    await waitFor(() => expect(screen.getByRole("dialog", { name: "Action information" })).toBeInTheDocument());
-    expect(screen.getByText(/Open the screening workflow from Applications/i)).toBeInTheDocument();
-    screen.getByRole("button", { name: "Open" }).click();
-    expect(assignMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
-  });
-
-  it("routes the provider funnel CTA to applications once TransUnion is connected", async () => {
-    mocks.useApplicationsMock.mockReturnValue({
-      applications: [{ id: "application-1" }],
-      loading: false,
-    });
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 1,
-        tenantsCount: 1,
-        openActionsCount: 0,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [],
-      events: [],
-      leaseNoticeSummary: {
-        expiringSoon: 0,
-        pendingResponse: 0,
-        renewed: 0,
-        quitting: 0,
-        noResponse: 0,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 0,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 0,
-        missingCredibilityCount: 0,
-        healthStatus: "watch",
-      },
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByText("Provider setup funnel")).toBeInTheDocument();
-    screen.getAllByRole("button", { name: "Run screening" })[0].click();
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/applications");
-    expect(screen.getByText("Started → Connected 50%")).toBeInTheDocument();
-    expect(screen.getByText("1 onboarding start still need credential connection.")).toBeInTheDocument();
-  });
-
-  it("routes the quick screening CTA to setup until TransUnion is connected, then to applications", async () => {
-    mocks.useApplicationsMock.mockReturnValue({
-      applications: [{ id: "application-1" }],
-      loading: false,
-    });
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 1,
-        tenantsCount: 1,
-        openActionsCount: 0,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [],
-      events: [],
-      leaseNoticeSummary: {
-        expiringSoon: 0,
-        pendingResponse: 0,
-        renewed: 0,
-        quitting: 0,
-        noResponse: 0,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 0,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 0,
-        missingCredibilityCount: 0,
-        healthStatus: "watch",
-      },
-    });
-    mocks.fetchLandlordTransUnionOnboardingAnalyticsMock.mockResolvedValueOnce({
-      totals: {
-        viewed: 3,
-        started: 2,
-        emailClicked: 1,
-        phoneClicked: 0,
-        alreadyCredentialedClicked: 0,
-        connected: 0,
-      },
-      conversionRate: 0,
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findAllByRole("button", { name: "Set up screening workflow" })).not.toHaveLength(0);
-    screen.getAllByRole("button", { name: "Set up screening workflow" })[0].click();
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
-
-    mocks.navigateMock.mockReset();
-    cleanup();
-    mocks.useApplicationsMock.mockReturnValue({
-      applications: [{ id: "application-1" }],
-      loading: false,
-    });
-    mocks.fetchLandlordTransUnionOnboardingAnalyticsMock.mockResolvedValue({
-      totals: {
-        viewed: 3,
-        started: 2,
-        emailClicked: 1,
-        phoneClicked: 0,
-        alreadyCredentialedClicked: 0,
-        connected: 1,
-      },
-      conversionRate: 0.5,
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findAllByRole("button", { name: "Run screening" })).not.toHaveLength(0);
-    screen.getAllByRole("button", { name: "Run screening" })[0].click();
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/applications");
-  });
-
-  it("links lease notice status tiles to the approved follow-through destinations", async () => {
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 2,
-        tenantsCount: 1,
-        openActionsCount: 0,
-        delinquentCount: 0,
-        screeningsCount: 1,
-      },
-      actions: [],
-      events: [],
-      leaseNoticeSummary: {
-        expiringSoon: 2,
-        pendingResponse: 1,
-        renewed: 3,
-        quitting: 4,
-        noResponse: 5,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 5,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 0,
-        missingCredibilityCount: 0,
-        healthStatus: "watch",
-      },
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    expect(await screen.findByRole("link", { name: /Expiring soon/i })).toHaveAttribute(
-      "href",
-      "/portfolio-health?entry=lease-renewals&status=expiring"
-    );
-    expect(screen.getByRole("link", { name: /Pending response/i })).toHaveAttribute(
-      "href",
-      "/portfolio-health?entry=lease-renewals&status=pending-response"
-    );
-    expect(screen.getByRole("link", { name: /No response/i })).toHaveAttribute(
-      "href",
-      "/portfolio-health?entry=lease-renewals&status=no-response"
-    );
-    expect(screen.getByRole("link", { name: /Renewed/i })).toHaveAttribute("href", "/leases?view=active");
-    expect(screen.getByRole("link", { name: /Quitting/i })).toHaveAttribute("href", "/leases?view=active");
-  });
-
-  it("renders a stable open actions hash target when the dashboard hash is present", async () => {
-    mocks.fetchDashboardSummaryMock.mockResolvedValue({
-      kpis: {
-        propertiesCount: 1,
-        unitsCount: 2,
-        tenantsCount: 1,
-        openActionsCount: 1,
-        delinquentCount: 0,
-        screeningsCount: 0,
-      },
-      actions: [{ id: "a-1", title: "Invite a tenant", severity: "info", href: "/tenants" }],
-      events: [],
-      leaseNoticeSummary: {
-        expiringSoon: 0,
-        pendingResponse: 0,
-        renewed: 0,
-        quitting: 0,
-        noResponse: 0,
-      },
-      portfolioCredibilitySummary: {
-        propertyCount: 1,
-        activeLeaseCount: 1,
-        tenantScoreAverage: null,
-        tenantScoreGradeAverage: null,
-        leaseRiskAverage: null,
-        leaseRiskGradeAverage: null,
-        tenantsWithScoreCount: 0,
-        leasesWithRiskCount: 0,
-        lowConfidenceCount: 0,
-        missingCredibilityCount: 0,
-        healthStatus: "watch",
-      },
-    });
-
-    render(
-      <ToastProvider>
-        <MemoryRouter initialEntries={[{ pathname: "/dashboard", hash: "#open-actions" }]}>
-          <DashboardPage />
-        </MemoryRouter>
-      </ToastProvider>
-    );
-
-    await screen.findByText("Action required");
-    const target = document.getElementById("open-actions");
-    expect(target).not.toBeNull();
-    expect(target).toHaveAttribute("tabindex", "-1");
   });
 });

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   fetchTenantsMock: vi.fn(),
   fetchUnifiedInboxMock: vi.fn(),
   listWorkOrdersMock: vi.fn(),
+  listLandlordMaintenanceMock: vi.fn(),
 }));
 
 vi.mock("@/api/landlordDecisionQueueApi", () => ({
@@ -37,6 +38,10 @@ vi.mock("@/api/unifiedInboxApi", () => ({
 
 vi.mock("@/api/workOrdersApi", () => ({
   listWorkOrders: mocks.listWorkOrdersMock,
+}));
+
+vi.mock("@/api/maintenanceWorkflowApi", () => ({
+  listLandlordMaintenance: mocks.listLandlordMaintenanceMock,
 }));
 
 const macShellProps = vi.hoisted(() => ({
@@ -236,6 +241,14 @@ describe("DashboardPage", () => {
     mocks.fetchApplicationsMock.mockResolvedValue([{ id: "app-1", status: "SUBMITTED" }, { id: "app-2", status: "APPROVED" }]);
     mocks.fetchTenantsMock.mockResolvedValue([{ id: "tenant-1" }, { id: "tenant-2" }, { id: "tenant-3" }]);
     mocks.listWorkOrdersMock.mockResolvedValue([{ id: "wo-1", status: "open" }, { id: "wo-2", status: "completed" }]);
+    mocks.listLandlordMaintenanceMock.mockResolvedValue({
+      ok: true,
+      items: [
+        { id: "maint-1", status: "submitted" },
+        { id: "maint-2", status: "completed" },
+        { id: "maint-3", status: "in_progress" },
+      ],
+    });
     mocks.fetchUnifiedInboxMock.mockResolvedValue({ ok: true, role: "landlord", items: [], records: [], total: 4, limit: 50, offset: 0 });
   });
 
@@ -252,6 +265,8 @@ describe("DashboardPage", () => {
     expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("80%");
     expect(screen.getByTestId("portfolio-counts-row")).toHaveTextContent("Applications Pending");
     expect(screen.getByTestId("portfolio-counts-row")).toHaveTextContent("Tenants");
+    expect(screen.getByRole("link", { name: /Maintenance Requests/i })).toHaveAttribute("href", "/maintenance");
+    expect(screen.getByRole("link", { name: /Work Orders/i })).toHaveAttribute("href", "/work-orders");
     expect(screen.getByRole("link", { name: /Unified Messages/i })).toHaveAttribute("href", "/landlord/inbox");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Decision Queue Preview");
     expect(screen.getByText("Highest-priority decisions needing attention.")).toBeInTheDocument();
@@ -266,6 +281,7 @@ describe("DashboardPage", () => {
     expect(mocks.fetchApplicationsMock).toHaveBeenCalled();
     expect(mocks.fetchTenantsMock).toHaveBeenCalled();
     expect(mocks.listWorkOrdersMock).toHaveBeenCalled();
+    expect(mocks.listLandlordMaintenanceMock).toHaveBeenCalled();
     expect(mocks.fetchUnifiedInboxMock).toHaveBeenCalledWith("landlord");
     expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.queryByText("payment-1")).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import DashboardPage from "./DashboardPage";
@@ -177,7 +177,7 @@ function queueResponse(overrides: Partial<LandlordDecisionQueueResponse> = {}): 
         description: "A lease needs a renewal decision before the notice window closes.",
         recommendedActionLabel: "Open lease workspace",
         recommendedActionHref: "/leases",
-        dueAt: "2026-06-25T12:00:00.000Z",
+        dueAt: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
         createdAt: "2026-06-18T12:00:00.000Z",
         updatedAt: "2026-06-19T12:00:00.000Z",
         status: "open",
@@ -272,6 +272,11 @@ describe("DashboardPage", () => {
     expect(screen.getByText("Highest-priority decisions needing attention.")).toBeInTheDocument();
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Resolve lease renewal");
     expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Upcoming Actions");
+    expect(screen.getByTestId("calendar-preview-section")).toHaveTextContent("Calendar Preview");
+    expect(screen.getByTestId("calendar-preview-section")).toHaveTextContent("Resolve lease renewal");
+    expect(screen.getByRole("link", { name: /Open Full Schedule/i })).toHaveAttribute("href", "/scheduling");
+    fireEvent.click(screen.getByRole("button", { name: "Month view" }));
+    expect(screen.getByRole("button", { name: "7-day view" })).toBeInTheDocument();
     expect(screen.getByTestId("financial-snapshot-section")).toHaveTextContent("Financial Snapshot");
     expect(screen.getByText(/Current rent collection and outstanding balance overview/i)).toBeInTheDocument();
     expect(screen.getByTestId("workspace-routing-section")).toHaveTextContent("Operations full queue");
@@ -345,6 +350,7 @@ describe("DashboardPage", () => {
 
     expect(await screen.findByText("No open decisions. New operational decisions will appear here before routing to their owning workspace.")).toBeInTheDocument();
     expect(screen.getByText("No dated actions are due right now. When lease, payment, notice, or maintenance decisions have dates, they appear here.")).toBeInTheDocument();
+    expect(screen.getByText("No dated schedule items are visible for this week. Upcoming dated decisions will appear here.")).toBeInTheDocument();
   });
 
   it("collapses the primary dashboard grid on narrow viewports", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -8,6 +8,10 @@ import type { LandlordPortfolioStatusFinancialResponse } from "@/api/landlordPor
 const mocks = vi.hoisted(() => ({
   fetchLandlordDecisionQueueMock: vi.fn(),
   fetchLandlordPortfolioStatusFinancialMock: vi.fn(),
+  fetchApplicationsMock: vi.fn(),
+  fetchTenantsMock: vi.fn(),
+  fetchUnifiedInboxMock: vi.fn(),
+  listWorkOrdersMock: vi.fn(),
 }));
 
 vi.mock("@/api/landlordDecisionQueueApi", () => ({
@@ -16,6 +20,22 @@ vi.mock("@/api/landlordDecisionQueueApi", () => ({
 
 vi.mock("@/api/landlordPortfolioStatusFinancialApi", () => ({
   fetchLandlordPortfolioStatusFinancial: mocks.fetchLandlordPortfolioStatusFinancialMock,
+}));
+
+vi.mock("@/api/applicationsApi", () => ({
+  fetchApplications: mocks.fetchApplicationsMock,
+}));
+
+vi.mock("@/api/tenantsApi", () => ({
+  fetchTenants: mocks.fetchTenantsMock,
+}));
+
+vi.mock("@/api/unifiedInboxApi", () => ({
+  fetchUnifiedInbox: mocks.fetchUnifiedInboxMock,
+}));
+
+vi.mock("@/api/workOrdersApi", () => ({
+  listWorkOrders: mocks.listWorkOrdersMock,
 }));
 
 function installMatchMedia(matches = false) {
@@ -200,14 +220,24 @@ describe("DashboardPage", () => {
     installMatchMedia(false);
     mocks.fetchLandlordPortfolioStatusFinancialMock.mockResolvedValue(portfolioResponse());
     mocks.fetchLandlordDecisionQueueMock.mockResolvedValue(queueResponse());
+    mocks.fetchApplicationsMock.mockResolvedValue([{ id: "app-1", status: "SUBMITTED" }, { id: "app-2", status: "APPROVED" }]);
+    mocks.fetchTenantsMock.mockResolvedValue([{ id: "tenant-1" }, { id: "tenant-2" }, { id: "tenant-3" }]);
+    mocks.listWorkOrdersMock.mockResolvedValue([{ id: "wo-1", status: "open" }, { id: "wo-2", status: "completed" }]);
+    mocks.fetchUnifiedInboxMock.mockResolvedValue({ ok: true, role: "landlord", items: [], records: [], total: 4, limit: 50, offset: 0 });
   });
 
   it("renders Dashboard 2.0 sections from the portfolio and decision queue contracts", async () => {
     renderDashboard();
 
-    expect(await screen.findByText("Operational Home")).toBeInTheDocument();
-    expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Portfolio Status");
+    expect(await screen.findByTestId("portfolio-status-section")).toHaveTextContent("Portfolio Health");
+    expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Properties");
+    expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Units");
+    expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Occupied");
+    expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Vacant");
     expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("80%");
+    expect(screen.getByTestId("portfolio-counts-row")).toHaveTextContent("Applications Pending");
+    expect(screen.getByTestId("portfolio-counts-row")).toHaveTextContent("Tenants");
+    expect(screen.getByRole("link", { name: /Unified Messages/i })).toHaveAttribute("href", "/landlord/inbox");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Decision Queue Preview");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Resolve lease renewal");
     expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Upcoming Actions");
@@ -216,8 +246,13 @@ describe("DashboardPage", () => {
 
     expect(mocks.fetchLandlordPortfolioStatusFinancialMock).toHaveBeenCalledWith({ periodMonth: expect.stringMatching(/^\d{4}-\d{2}$/) });
     expect(mocks.fetchLandlordDecisionQueueMock).toHaveBeenCalledWith({ status: "open_state", limit: 6 });
+    expect(mocks.fetchApplicationsMock).toHaveBeenCalled();
+    expect(mocks.fetchTenantsMock).toHaveBeenCalled();
+    expect(mocks.listWorkOrdersMock).toHaveBeenCalled();
+    expect(mocks.fetchUnifiedInboxMock).toHaveBeenCalledWith("landlord");
     expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.queryByText("payment-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("A lease needs a renewal decision before the notice window closes.")).not.toBeInTheDocument();
   });
 
   it("keeps decision queue content visible when portfolio data fails", async () => {
@@ -227,7 +262,7 @@ describe("DashboardPage", () => {
 
     expect((await screen.findAllByText("Portfolio API unavailable")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Resolve lease renewal")).length).toBeGreaterThan(0);
-    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Full queue");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("View Full Queue");
   });
 
   it("shows degraded and unavailable metric states with data-quality flags", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
@@ -36,6 +37,17 @@ vi.mock("@/api/unifiedInboxApi", () => ({
 
 vi.mock("@/api/workOrdersApi", () => ({
   listWorkOrders: mocks.listWorkOrdersMock,
+}));
+
+const macShellProps = vi.hoisted(() => ({
+  latest: vi.fn(),
+}));
+
+vi.mock("../components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+    macShellProps.latest(props);
+    return <div>{children}</div>;
+  },
 }));
 
 function installMatchMedia(matches = false) {
@@ -217,6 +229,7 @@ afterEach(() => {
 
 describe("DashboardPage", () => {
   beforeEach(() => {
+    macShellProps.latest.mockReset();
     installMatchMedia(false);
     mocks.fetchLandlordPortfolioStatusFinancialMock.mockResolvedValue(portfolioResponse());
     mocks.fetchLandlordDecisionQueueMock.mockResolvedValue(queueResponse());
@@ -230,7 +243,9 @@ describe("DashboardPage", () => {
     renderDashboard();
 
     expect(await screen.findByTestId("portfolio-status-section")).toHaveTextContent("Portfolio Health");
+    expect(macShellProps.latest).toHaveBeenCalledWith(expect.objectContaining({ maxWidth: 1320, showTopNav: false }));
     expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Properties");
+    expect(screen.getByText("Quick view of portfolio occupancy and health.")).toBeInTheDocument();
     expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Units");
     expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Occupied");
     expect(screen.getByTestId("portfolio-status-section")).toHaveTextContent("Vacant");
@@ -239,9 +254,11 @@ describe("DashboardPage", () => {
     expect(screen.getByTestId("portfolio-counts-row")).toHaveTextContent("Tenants");
     expect(screen.getByRole("link", { name: /Unified Messages/i })).toHaveAttribute("href", "/landlord/inbox");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Decision Queue Preview");
+    expect(screen.getByText("Highest-priority decisions needing attention.")).toBeInTheDocument();
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Resolve lease renewal");
     expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Upcoming Actions");
     expect(screen.getByTestId("financial-snapshot-section")).toHaveTextContent("Financial Snapshot");
+    expect(screen.getByText(/Current rent collection and outstanding balance overview/i)).toBeInTheDocument();
     expect(screen.getByTestId("workspace-routing-section")).toHaveTextContent("Operations full queue");
 
     expect(mocks.fetchLandlordPortfolioStatusFinancialMock).toHaveBeenCalledWith({ periodMonth: expect.stringMatching(/^\d{4}-\d{2}$/) });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -36,6 +36,7 @@ import { fetchApplications } from "@/api/applicationsApi";
 import { fetchTenants } from "@/api/tenantsApi";
 import { fetchUnifiedInbox } from "@/api/unifiedInboxApi";
 import { listWorkOrders } from "@/api/workOrdersApi";
+import { listLandlordMaintenance } from "@/api/maintenanceWorkflowApi";
 
 type Loadable<T> = {
   data: T | null;
@@ -48,6 +49,7 @@ type MetricState = "trusted" | "degraded" | "unavailable";
 type PortfolioCounts = {
   applicationsPending: number | null;
   tenants: number | null;
+  maintenanceRequests: number | null;
   workOrders: number | null;
   unifiedMessages: number | null;
 };
@@ -168,6 +170,12 @@ function isOpenWorkOrder(workOrder: { status?: unknown }): boolean {
   const status = String(workOrder.status || "").trim().toLowerCase();
   if (!status) return true;
   return !["done", "closed", "completed", "cancelled", "canceled", "resolved"].includes(status);
+}
+
+function isOpenMaintenanceRequest(request: { status?: unknown }): boolean {
+  const status = String(request.status || "").trim().toLowerCase();
+  if (!status) return true;
+  return !["completed", "cancelled", "canceled", "resolved", "closed"].includes(status);
 }
 
 function useNarrowDashboardLayout(): boolean {
@@ -309,8 +317,8 @@ function PortfolioHealthSection({ portfolio }: { portfolio: LandlordPortfolioSta
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 145px), 1fr))",
-          gap: spacing.sm,
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 132px), 1fr))",
+          gap: 10,
           alignItems: "stretch",
         }}
       >
@@ -367,6 +375,7 @@ function PortfolioCountsRow({
     { label: "Units", value: status?.totalUnits ?? null, href: "/properties", icon: <Route size={18} /> },
     { label: "Applications Pending", value: counts.data?.applicationsPending ?? null, href: "/applications", icon: <FileText size={18} /> },
     { label: "Tenants", value: counts.data?.tenants ?? null, href: "/tenants", icon: <Users size={18} /> },
+    { label: "Maintenance Requests", value: counts.data?.maintenanceRequests ?? null, href: "/maintenance", icon: <Wrench size={18} /> },
     { label: "Work Orders", value: counts.data?.workOrders ?? null, href: "/work-orders", icon: <Wrench size={18} /> },
     { label: "Unified Messages", value: counts.data?.unifiedMessages ?? null, href: "/landlord/inbox", icon: <Mail size={18} /> },
     { label: "Leases", value: status?.currentLeaseCount ?? null, href: "/leases", icon: <ClipboardList size={18} /> },
@@ -377,8 +386,8 @@ function PortfolioCountsRow({
       data-testid="portfolio-counts-row"
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 150px), 1fr))",
-        gap: spacing.sm,
+        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 136px), 1fr))",
+        gap: 10,
       }}
     >
       {cards.map((card) => {
@@ -389,9 +398,9 @@ function PortfolioCountsRow({
             to={card.href}
             style={{
               display: "grid",
-              gap: 9,
-              minHeight: 96,
-              padding: 14,
+              gap: 8,
+              minHeight: 90,
+              padding: 12,
               borderRadius: 8,
               border: `1px solid ${colors.border}`,
               background: "#fff",
@@ -698,19 +707,27 @@ export default function DashboardPage() {
       fetchApplications(),
       fetchTenants(),
       listWorkOrders(),
+      listLandlordMaintenance(),
       fetchUnifiedInbox("landlord"),
     ])
-      .then(([applicationsResult, tenantsResult, workOrdersResult, inboxResult]) => {
+      .then(([applicationsResult, tenantsResult, workOrdersResult, maintenanceResult, inboxResult]) => {
         if (!alive) return;
         const applications = applicationsResult.status === "fulfilled" && Array.isArray(applicationsResult.value) ? applicationsResult.value : null;
         const tenants = tenantsResult.status === "fulfilled" && Array.isArray(tenantsResult.value) ? tenantsResult.value : null;
         const workOrders = workOrdersResult.status === "fulfilled" && Array.isArray(workOrdersResult.value) ? workOrdersResult.value : null;
+        const maintenanceRequests =
+          maintenanceResult.status === "fulfilled" && Array.isArray(maintenanceResult.value?.items)
+            ? maintenanceResult.value.items
+            : maintenanceResult.status === "fulfilled" && Array.isArray(maintenanceResult.value?.data)
+              ? maintenanceResult.value.data
+              : null;
         const inbox = inboxResult.status === "fulfilled" ? inboxResult.value : null;
 
         setCounts({
           data: {
             applicationsPending: applications ? applications.filter(isPendingApplication).length : null,
             tenants: tenants ? tenants.length : null,
+            maintenanceRequests: maintenanceRequests ? maintenanceRequests.filter(isOpenMaintenanceRequest).length : null,
             workOrders: workOrders ? workOrders.filter(isOpenWorkOrder).length : null,
             unifiedMessages: typeof inbox?.total === "number" ? inbox.total : Array.isArray(inbox?.items) ? inbox.items.length : null,
           },
@@ -719,6 +736,7 @@ export default function DashboardPage() {
             applicationsResult.status === "rejected" ||
             tenantsResult.status === "rejected" ||
             workOrdersResult.status === "rejected" ||
+            maintenanceResult.status === "rejected" ||
             inboxResult.status === "rejected"
               ? "Some portfolio counts could not load."
               : null,

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRight,
   Banknote,
   Building2,
+  CalendarDays,
   CheckCircle2,
   ClipboardList,
   Clock3,
@@ -154,6 +155,32 @@ function formatDate(value: string | null | undefined): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "No due date";
   return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
+}
+
+function formatShortWeekday(value: Date): string {
+  return new Intl.DateTimeFormat(undefined, { weekday: "short" }).format(value);
+}
+
+function formatShortMonthDay(value: Date): string {
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(value);
+}
+
+function startOfDay(value: Date): Date {
+  return new Date(value.getFullYear(), value.getMonth(), value.getDate());
+}
+
+function addDays(value: Date, days: number): Date {
+  const next = new Date(value);
+  next.setDate(value.getDate() + days);
+  return next;
+}
+
+function isSameCalendarDay(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth() && left.getDate() === right.getDate();
+}
+
+function isSameCalendarMonth(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
 }
 
 function cleanFlags(flags: PortfolioDataQualityFlag[] | null | undefined): string[] {
@@ -614,6 +641,130 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
   );
 }
 
+function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse | null }) {
+  const [view, setView] = React.useState<"week" | "month">("week");
+  const today = React.useMemo(() => startOfDay(new Date()), []);
+  const weekDays = React.useMemo(() => Array.from({ length: 7 }, (_, index) => addDays(today, index)), [today]);
+  const monthDays = React.useMemo(() => {
+    const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+    return Array.from({ length: new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate() }, (_, index) => addDays(monthStart, index));
+  }, [today]);
+  const datedItems = React.useMemo(
+    () =>
+      (queue?.items || [])
+        .map((item) => {
+          const date = item.dueAt ? new Date(item.dueAt) : null;
+          return date && !Number.isNaN(date.getTime()) ? { item, date } : null;
+        })
+        .filter((entry): entry is { item: LandlordDecisionQueueItem; date: Date } => Boolean(entry))
+        .sort((left, right) => left.date.getTime() - right.date.getTime()),
+    [queue]
+  );
+  const days = view === "week" ? weekDays : monthDays;
+  const visibleItems = datedItems.filter(({ date }) =>
+    view === "week"
+      ? date >= today && date < addDays(today, 7)
+      : isSameCalendarMonth(date, today)
+  );
+
+  return (
+    <Card style={sectionCard} data-testid="calendar-preview-section">
+      <SectionHeader
+        icon={<CalendarDays size={18} />}
+        title="Calendar Preview"
+        subtitle="Quick weekly view of dated operational follow-up."
+        action={
+          <Link to="/scheduling" style={compactButton}>
+            Open Full Schedule <ArrowRight size={16} />
+          </Link>
+        }
+      />
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }} aria-label="Calendar view">
+        {(["week", "month"] as const).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => setView(option)}
+            style={{
+              ...compactButton,
+              minHeight: 34,
+              padding: "6px 10px",
+              background: view === option ? "#eff6ff" : "#fff",
+              borderColor: view === option ? "#bfdbfe" : colors.borderStrong,
+              color: view === option ? "#1d4ed8" : text.primary,
+            }}
+          >
+            {option === "week" ? "7-day view" : "Month view"}
+          </button>
+        ))}
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: view === "week" ? "repeat(7, minmax(78px, 1fr))" : "repeat(auto-fit, minmax(46px, 1fr))",
+          gap: 8,
+          overflowX: view === "week" ? "auto" : "visible",
+          paddingBottom: view === "week" ? 4 : 0,
+        }}
+      >
+        {days.map((day) => {
+          const dayItems = datedItems.filter(({ date }) => isSameCalendarDay(date, day)).slice(0, view === "week" ? 2 : 1);
+          return (
+            <div
+              key={day.toISOString()}
+              style={{
+                display: "grid",
+                gap: 6,
+                alignContent: "start",
+                minHeight: view === "week" ? 96 : 58,
+                minWidth: view === "week" ? 78 : 0,
+                padding: view === "week" ? 10 : 8,
+                borderRadius: 8,
+                border: `1px solid ${isSameCalendarDay(day, today) ? "#bfdbfe" : colors.border}`,
+                background: isSameCalendarDay(day, today) ? "#eff6ff" : "#fff",
+              }}
+            >
+              <div style={{ display: "grid", gap: 2 }}>
+                <div style={{ color: text.muted, fontSize: 11, fontWeight: 800, whiteSpace: "nowrap" }}>{formatShortWeekday(day)}</div>
+                <div style={{ color: text.primary, fontSize: view === "week" ? 16 : 13, fontWeight: 900, whiteSpace: "nowrap" }}>
+                  {view === "week" ? formatShortMonthDay(day) : day.getDate()}
+                </div>
+              </div>
+              {dayItems.map(({ item }) => (
+                <Link
+                  key={item.id}
+                  to={operationalHref(item)}
+                  style={{
+                    color: "#1d4ed8",
+                    fontSize: 12,
+                    fontWeight: 800,
+                    lineHeight: 1.25,
+                    textDecoration: "none",
+                    overflow: "hidden",
+                    display: "-webkit-box",
+                    WebkitLineClamp: view === "week" ? 2 : 1,
+                    WebkitBoxOrient: "vertical",
+                  }}
+                >
+                  {item.title || "Review item"}
+                </Link>
+              ))}
+              {view === "month" && dayItems.length > 0 ? (
+                <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: 99, background: "#2563eb" }} />
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      {visibleItems.length === 0 ? (
+        <div style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: 12, color: text.muted }}>
+          No dated schedule items are visible for this {view === "week" ? "week" : "month"}. Upcoming dated decisions will appear here.
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
 function WorkspaceRoutingSection() {
   const routes = [
     { label: "Operations full queue", href: "/operations", icon: <ClipboardList size={17} />, helper: "Execution workspace" },
@@ -810,6 +961,8 @@ export default function DashboardPage() {
               {queue.loading ? <LoadingSection title="Upcoming Actions" /> : <UpcomingActions queue={queue.data} />}
             </aside>
           </div>
+
+          {queue.loading ? <LoadingSection title="Calendar Preview" /> : <CalendarPreviewPanel queue={queue.data} />}
 
           {portfolio.loading ? (
             <LoadingSection title="Financial Snapshot" />

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -8,10 +8,13 @@ import {
   CheckCircle2,
   ClipboardList,
   Clock3,
-  ExternalLink,
+  FileText,
   ListChecks,
+  Mail,
   Route,
+  Users,
   WalletCards,
+  Wrench,
 } from "lucide-react";
 import { MacShell } from "../components/layout/MacShell";
 import { Card, SkeletonBlock } from "../components/ui/Ui";
@@ -29,6 +32,10 @@ import {
   type PortfolioDataQualityFlag,
   type PortfolioMetricConfidence,
 } from "@/api/landlordPortfolioStatusFinancialApi";
+import { fetchApplications } from "@/api/applicationsApi";
+import { fetchTenants } from "@/api/tenantsApi";
+import { fetchUnifiedInbox } from "@/api/unifiedInboxApi";
+import { listWorkOrders } from "@/api/workOrdersApi";
 
 type Loadable<T> = {
   data: T | null;
@@ -37,6 +44,13 @@ type Loadable<T> = {
 };
 
 type MetricState = "trusted" | "degraded" | "unavailable";
+
+type PortfolioCounts = {
+  applicationsPending: number | null;
+  tenants: number | null;
+  workOrders: number | null;
+  unifiedMessages: number | null;
+};
 
 const sectionCard: React.CSSProperties = {
   display: "grid",
@@ -119,6 +133,11 @@ function formatPercent(value: number | null | undefined): string {
   return `${Math.round(value * 100)}%`;
 }
 
+function formatCount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "Unavailable";
+  return new Intl.NumberFormat().format(value);
+}
+
 function formatMoney(cents: number | null | undefined): string {
   if (cents == null || !Number.isFinite(cents)) return "Unavailable";
   return new Intl.NumberFormat(undefined, {
@@ -137,6 +156,18 @@ function formatDate(value: string | null | undefined): string {
 
 function cleanFlags(flags: PortfolioDataQualityFlag[] | null | undefined): string[] {
   return (flags || []).slice(0, 3).map((flag) => flag.replace(/_/g, " "));
+}
+
+function isPendingApplication(application: { status?: unknown; applicationStatus?: unknown }): boolean {
+  const status = String(application.status || application.applicationStatus || "").trim().toLowerCase();
+  if (!status) return true;
+  return !["approved", "accepted", "rejected", "declined", "converted", "withdrawn", "cancelled", "canceled"].includes(status);
+}
+
+function isOpenWorkOrder(workOrder: { status?: unknown }): boolean {
+  const status = String(workOrder.status || "").trim().toLowerCase();
+  if (!status) return true;
+  return !["done", "closed", "completed", "cancelled", "canceled", "resolved"].includes(status);
 }
 
 function useNarrowDashboardLayout(): boolean {
@@ -179,36 +210,23 @@ function StatusPill({ state }: { state: MetricState }) {
   );
 }
 
-function MetricTile({
-  label,
-  value,
-  state,
-  helper,
-}: {
-  label: string;
-  value: string;
-  state: MetricState;
-  helper?: string;
-}) {
+function MiniStateLabel({ state }: { state: MetricState }) {
   return (
-    <div
+    <span
       style={{
-        display: "grid",
-        gap: 8,
-        padding: 14,
-        minWidth: 0,
-        border: `1px solid ${colors.border}`,
+        ...stateStyle(state),
+        display: "inline-flex",
+        alignItems: "center",
+        width: "fit-content",
         borderRadius: 8,
-        background: "#fff",
+        padding: "3px 7px",
+        fontSize: 11,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
       }}
     >
-      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center" }}>
-        <div style={{ color: text.muted, fontSize: 13, fontWeight: 750 }}>{label}</div>
-        <StatusPill state={state} />
-      </div>
-      <div style={{ color: text.primary, fontSize: 26, fontWeight: 850, lineHeight: 1 }}>{value}</div>
-      {helper ? <div style={{ color: text.subtle, fontSize: 13, lineHeight: 1.45 }}>{helper}</div> : null}
-    </div>
+      {stateLabel(state)}
+    </span>
   );
 }
 
@@ -243,7 +261,7 @@ function SectionHeader({
         </div>
         <div style={{ display: "grid", gap: 3, minWidth: 0 }}>
           <h2 style={{ margin: 0, fontSize: 18, letterSpacing: 0 }}>{title}</h2>
-          <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.45 }}>{subtitle}</div>
+          {subtitle ? <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.45 }}>{subtitle}</div> : null}
         </div>
       </div>
       {action}
@@ -272,7 +290,7 @@ function ErrorSection({ title, message, onRetry }: { title: string; message: str
   );
 }
 
-function PortfolioStatusSection({ portfolio }: { portfolio: LandlordPortfolioStatusFinancialResponse }) {
+function PortfolioHealthSection({ portfolio }: { portfolio: LandlordPortfolioStatusFinancialResponse }) {
   const status = portfolio.portfolioStatus;
   const state = metricState(portfolio.confidence.occupancy);
   const flags = cleanFlags(status.dataQualityFlags);
@@ -280,25 +298,120 @@ function PortfolioStatusSection({ portfolio }: { portfolio: LandlordPortfolioSta
     <Card style={sectionCard} data-testid="portfolio-status-section">
       <SectionHeader
         icon={<Building2 size={18} />}
-        title="Portfolio Status"
-        subtitle="The current operating position across properties, units, and leases."
+        title="Portfolio Health"
+        subtitle=""
         action={
           <Link to="/portfolio-health" style={compactButton}>
             Portfolio detail <ArrowRight size={16} />
           </Link>
         }
       />
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 170px), 1fr))", gap: spacing.sm }}>
-        <MetricTile label="Occupancy" value={formatPercent(status.occupancyRate)} state={state} helper={`${status.occupiedUnits} occupied, ${status.vacantUnits} vacant`} />
-        <MetricTile label="Current leases" value={String(status.currentLeaseCount)} state={state} helper={`${status.noticePeriodUnits} in notice, ${status.signedFutureLeaseCount} upcoming`} />
-        <MetricTile label="Review units" value={String(status.reviewRequiredUnits)} state={state} helper="Conflicts stay visible instead of changing counts silently." />
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 145px), 1fr))",
+          gap: spacing.sm,
+          alignItems: "stretch",
+        }}
+      >
+        <HeroKpi label="Properties" value={formatCount(status.totalProperties)} />
+        <HeroKpi label="Units" value={formatCount(status.totalUnits)} />
+        <HeroKpi label="Occupied" value={formatCount(status.occupiedUnits)} emphasis />
+        <HeroKpi label="Vacant" value={formatCount(status.vacantUnits)} />
+        <HeroKpi label="Occupancy" value={formatPercent(status.occupancyRate)} emphasis />
       </div>
       {flags.length > 0 ? (
-        <div style={{ color: text.muted, fontSize: 13 }}>Data quality: {flags.join(", ")}</div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", color: text.muted, fontSize: 13 }}>
+          <MiniStateLabel state={state} />
+          <span>Data quality: {flags.join(", ")}</span>
+        </div>
       ) : (
-        <div style={{ color: "#047857", fontSize: 13 }}>No portfolio data-quality flags reported.</div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", color: "#047857", fontSize: 13 }}>
+          <MiniStateLabel state={state} />
+          <span>Occupied / total units: {formatCount(status.occupiedUnits)} / {formatCount(status.totalUnits)}</span>
+        </div>
       )}
     </Card>
+  );
+}
+
+function HeroKpi({ label, value, emphasis = false }: { label: string; value: string; emphasis?: boolean }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 6,
+        padding: "12px 14px",
+        borderRadius: 8,
+        border: `1px solid ${emphasis ? "rgba(37,99,235,0.32)" : colors.border}`,
+        background: emphasis ? "#eff6ff" : "#fff",
+        minWidth: 0,
+      }}
+    >
+      <div style={{ color: text.muted, fontSize: 13, fontWeight: 800, whiteSpace: "nowrap" }}>{label}</div>
+      <div style={{ color: text.primary, fontSize: 30, lineHeight: 1, fontWeight: 900, whiteSpace: "nowrap" }}>{value}</div>
+    </div>
+  );
+}
+
+function PortfolioCountsRow({
+  portfolio,
+  counts,
+}: {
+  portfolio: LandlordPortfolioStatusFinancialResponse | null;
+  counts: Loadable<PortfolioCounts>;
+}) {
+  const status = portfolio?.portfolioStatus;
+  const cards = [
+    { label: "Properties", value: status?.totalProperties ?? null, href: "/properties", icon: <Building2 size={18} /> },
+    { label: "Units", value: status?.totalUnits ?? null, href: "/properties", icon: <Route size={18} /> },
+    { label: "Applications Pending", value: counts.data?.applicationsPending ?? null, href: "/applications", icon: <FileText size={18} /> },
+    { label: "Tenants", value: counts.data?.tenants ?? null, href: "/tenants", icon: <Users size={18} /> },
+    { label: "Work Orders", value: counts.data?.workOrders ?? null, href: "/work-orders", icon: <Wrench size={18} /> },
+    { label: "Unified Messages", value: counts.data?.unifiedMessages ?? null, href: "/landlord/inbox", icon: <Mail size={18} /> },
+    { label: "Leases", value: status?.currentLeaseCount ?? null, href: "/leases", icon: <ClipboardList size={18} /> },
+  ];
+
+  return (
+    <div
+      data-testid="portfolio-counts-row"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 150px), 1fr))",
+        gap: spacing.sm,
+      }}
+    >
+      {cards.map((card) => {
+        const isUnavailable = card.value == null || counts.loading;
+        return (
+          <Link
+            key={card.label}
+            to={card.href}
+            style={{
+              display: "grid",
+              gap: 9,
+              minHeight: 96,
+              padding: 14,
+              borderRadius: 8,
+              border: `1px solid ${colors.border}`,
+              background: "#fff",
+              color: text.primary,
+              textDecoration: "none",
+              minWidth: 0,
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+              <span style={{ color: "#1d4ed8", lineHeight: 0 }}>{card.icon}</span>
+              <ArrowRight size={15} color={text.subtle} />
+            </div>
+            <div style={{ display: "grid", gap: 3, minWidth: 0 }}>
+              <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{card.label}</div>
+              <div style={{ fontSize: 26, lineHeight: 1, fontWeight: 900, whiteSpace: "nowrap" }}>{isUnavailable ? "—" : formatCount(card.value)}</div>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
   );
 }
 
@@ -306,29 +419,90 @@ function FinancialSnapshotSection({ portfolio }: { portfolio: LandlordPortfolioS
   const financial = portfolio.financialSnapshot;
   const state = metricState(portfolio.confidence.financial);
   const flags = cleanFlags(financial.dataQualityFlags);
+  const collected = Math.max(0, financial.collectedCurrentMonthCents || 0);
+  const outstanding = Math.max(0, financial.outstandingCurrentMonthCents || 0);
+  const vacancy = Math.max(0, financial.vacancyImpactCents || 0);
+  const total = collected + outstanding + vacancy;
+  const collectedDegrees = total > 0 ? (collected / total) * 360 : 0;
+  const outstandingDegrees = total > 0 ? (outstanding / total) * 360 : 0;
   return (
     <Card style={sectionCard} data-testid="financial-snapshot-section">
       <SectionHeader
         icon={<Banknote size={18} />}
         title="Financial Snapshot"
-        subtitle={`Rent collection view for ${financial.period.month}. Missing sources degrade individual metrics, not the whole dashboard.`}
+        subtitle={`Rent collection view for ${financial.period.month}.`}
         action={
           <Link to="/payments" style={compactButton}>
-            Payments workspace <ArrowRight size={16} />
+            Payments Workspace <ArrowRight size={16} />
           </Link>
         }
       />
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 170px), 1fr))", gap: spacing.sm }}>
-        <MetricTile label="Expected rent" value={formatMoney(financial.expectedMonthlyRentCents)} state={state} helper={`${financial.activeLeaseRentTermsCount} leases with rent terms`} />
-        <MetricTile label="Collected" value={formatMoney(financial.collectedCurrentMonthCents)} state={state} helper={`Collection rate ${formatPercent(financial.rentCollectionRate)}`} />
-        <MetricTile label="Outstanding" value={formatMoney(financial.outstandingCurrentMonthCents)} state={state} helper={`${financial.leasesMissingRentTermsCount} leases missing terms`} />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 220px), 1fr))", gap: spacing.md, alignItems: "center" }}>
+        <div style={{ display: "grid", placeItems: "center", gap: 10 }}>
+          <div
+            aria-label="Collection mix"
+            style={{
+              width: 150,
+              height: 150,
+              borderRadius: "50%",
+              background:
+                total > 0
+                  ? `conic-gradient(#2563eb 0 ${collectedDegrees}deg, #f59e0b ${collectedDegrees}deg ${collectedDegrees + outstandingDegrees}deg, #cbd5e1 ${collectedDegrees + outstandingDegrees}deg 360deg)`
+                  : "#e2e8f0",
+              display: "grid",
+              placeItems: "center",
+            }}
+          >
+            <div style={{ width: 92, height: 92, borderRadius: "50%", background: "#fff", display: "grid", placeItems: "center", textAlign: "center", padding: 8 }}>
+              <div>
+                <div style={{ fontSize: 22, fontWeight: 900, lineHeight: 1 }}>{formatPercent(financial.rentCollectionRate)}</div>
+                <div style={{ color: text.muted, fontSize: 12, fontWeight: 800 }}>Collected</div>
+              </div>
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap", justifyContent: "center", color: text.muted, fontSize: 12 }}>
+            <LegendDot color="#2563eb" label="Collected" />
+            <LegendDot color="#f59e0b" label="Outstanding" />
+            <LegendDot color="#cbd5e1" label="Vacancy" />
+          </div>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 145px), 1fr))", gap: spacing.sm }}>
+          <FinancialValue label="Expected" value={formatMoney(financial.expectedMonthlyRentCents)} />
+          <FinancialValue label="Collected" value={formatMoney(financial.collectedCurrentMonthCents)} />
+          <FinancialValue label="Outstanding" value={formatMoney(financial.outstandingCurrentMonthCents)} />
+          <FinancialValue label="Vacancy Impact" value={formatMoney(financial.vacancyImpactCents)} />
+        </div>
       </div>
       {flags.length > 0 ? (
-        <div style={{ color: text.muted, fontSize: 13 }}>Data quality: {flags.join(", ")}</div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", color: text.muted, fontSize: 13 }}>
+          <MiniStateLabel state={state} />
+          <span>Data quality: {flags.join(", ")}</span>
+        </div>
       ) : (
-        <div style={{ color: "#047857", fontSize: 13 }}>No financial data-quality flags reported.</div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", color: "#047857", fontSize: 13 }}>
+          <MiniStateLabel state={state} />
+          <span>Financial source is available.</span>
+        </div>
       )}
     </Card>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span style={{ display: "inline-flex", gap: 5, alignItems: "center", whiteSpace: "nowrap" }}>
+      <span aria-hidden="true" style={{ width: 8, height: 8, borderRadius: 99, background: color }} />
+      {label}
+    </span>
+  );
+}
+
+function FinancialValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: "grid", gap: 6, padding: 12, borderRadius: 8, border: `1px solid ${colors.border}`, background: "#fff", minWidth: 0 }}>
+      <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, whiteSpace: "nowrap" }}>{label}</div>
+      <div style={{ color: text.primary, fontSize: 20, fontWeight: 900, lineHeight: 1.1, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{value}</div>
+    </div>
   );
 }
 
@@ -339,18 +513,13 @@ function DecisionQueuePreview({ queue }: { queue: LandlordDecisionQueueResponse 
       <SectionHeader
         icon={<ClipboardList size={18} />}
         title="Decision Queue Preview"
-        subtitle="The most important open decisions. Full triage and execution stay in Operations."
+        subtitle="Decision and action only. Operations has the full queue."
         action={
           <Link to="/operations" style={compactButton}>
-            Full queue <ArrowRight size={16} />
+            View Full Queue <ArrowRight size={16} />
           </Link>
         }
       />
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 150px), 1fr))", gap: spacing.sm }}>
-        <MetricTile label="Open" value={String(queue.summary.open)} state="trusted" />
-        <MetricTile label="Needs review" value={String(queue.summary.needsReview)} state={queue.summary.needsReview > 0 ? "degraded" : "trusted"} />
-        <MetricTile label="Blocked" value={String(queue.summary.blocked)} state={queue.summary.blocked > 0 ? "degraded" : "trusted"} />
-      </div>
       {items.length === 0 ? (
         <div style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: 14, color: text.muted }}>
           No open decisions. New operational decisions will appear here before routing to their owning workspace.
@@ -370,29 +539,28 @@ function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
   return (
     <div
       style={{
-        display: "grid",
-        gap: 8,
+        display: "flex",
+        justifyContent: "space-between",
+        gap: 12,
+        alignItems: "center",
+        flexWrap: "wrap",
         padding: 12,
         border: `1px solid ${colors.border}`,
         borderRadius: 8,
         background: "#fff",
       }}
     >
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-        <span style={{ ...severityStyle(item.severity), borderRadius: 8, padding: "3px 8px", fontSize: 12, fontWeight: 850 }}>
+      <div style={{ display: "grid", gap: 5, minWidth: 0, flex: "1 1 240px" }}>
+        <div style={{ fontWeight: 850, color: text.primary, overflowWrap: "anywhere" }}>{item.title || "Review required"}</div>
+        <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.35, overflowWrap: "anywhere" }}>
+          {workspaceLabel(item.workspace)} workspace · {formatDate(item.dueAt)}
+        </div>
+        <span style={{ ...severityStyle(item.severity), borderRadius: 8, padding: "3px 8px", fontSize: 12, fontWeight: 850, width: "fit-content", whiteSpace: "nowrap" }}>
           {item.severity.replace(/_/g, " ")}
         </span>
-        <span style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: "3px 8px", color: text.muted, fontSize: 12, fontWeight: 800 }}>
-          {workspaceLabel(item.workspace)}
-        </span>
-        <span style={{ color: text.subtle, fontSize: 12 }}>{formatDate(item.dueAt)}</span>
-      </div>
-      <div style={{ display: "grid", gap: 4 }}>
-        <div style={{ fontWeight: 850, color: text.primary, overflowWrap: "anywhere" }}>{item.title || "Review required"}</div>
-        <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.45, overflowWrap: "anywhere" }}>{item.description || "Open the workspace to review the next step."}</div>
       </div>
       <Link to={operationalHref(item)} style={{ ...compactButton, width: "fit-content" }}>
-        {item.recommendedActionLabel || "Open workspace"} <ExternalLink size={15} />
+        Open
       </Link>
     </div>
   );
@@ -407,10 +575,10 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
       <SectionHeader
         icon={<ListChecks size={18} />}
         title="Upcoming Actions"
-        subtitle="Time-bound work derived from normalized decision items."
+        subtitle="Next dated items from the normalized queue."
         action={
           <Link to="/operations?status=open_state" style={compactButton}>
-            Operations <ArrowRight size={16} />
+            Open Operations <ArrowRight size={16} />
           </Link>
         }
       />
@@ -421,7 +589,7 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
       ) : (
         <div style={{ display: "grid", gap: 10 }}>
           {actions.map((item) => (
-            <div key={item.id} style={{ display: "flex", justifyContent: "space-between", gap: 12, borderBottom: `1px solid ${colors.border}`, paddingBottom: 10 }}>
+            <div key={item.id} style={{ display: "flex", justifyContent: "space-between", gap: 12, borderBottom: `1px solid ${colors.border}`, paddingBottom: 10, alignItems: "center" }}>
               <div style={{ minWidth: 0 }}>
                 <div style={{ fontWeight: 800, overflowWrap: "anywhere" }}>{item.title}</div>
                 <div style={{ color: text.muted, fontSize: 13 }}>{workspaceLabel(item.workspace)} · {formatDate(item.dueAt)}</div>
@@ -495,6 +663,11 @@ export default function DashboardPage() {
     loading: true,
     error: null,
   });
+  const [counts, setCounts] = React.useState<Loadable<PortfolioCounts>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
   const [refreshKey, setRefreshKey] = React.useState(0);
 
   React.useEffect(() => {
@@ -503,6 +676,7 @@ export default function DashboardPage() {
 
     setPortfolio((current) => ({ ...current, loading: true, error: null }));
     setQueue((current) => ({ ...current, loading: true, error: null }));
+    setCounts((current) => ({ ...current, loading: true, error: null }));
 
     void fetchLandlordPortfolioStatusFinancial({ periodMonth })
       .then((data) => {
@@ -520,6 +694,40 @@ export default function DashboardPage() {
         if (alive) setQueue({ data: null, loading: false, error: errorMessage(error, "Decision queue could not load.") });
       });
 
+    void Promise.allSettled([
+      fetchApplications(),
+      fetchTenants(),
+      listWorkOrders(),
+      fetchUnifiedInbox("landlord"),
+    ])
+      .then(([applicationsResult, tenantsResult, workOrdersResult, inboxResult]) => {
+        if (!alive) return;
+        const applications = applicationsResult.status === "fulfilled" && Array.isArray(applicationsResult.value) ? applicationsResult.value : null;
+        const tenants = tenantsResult.status === "fulfilled" && Array.isArray(tenantsResult.value) ? tenantsResult.value : null;
+        const workOrders = workOrdersResult.status === "fulfilled" && Array.isArray(workOrdersResult.value) ? workOrdersResult.value : null;
+        const inbox = inboxResult.status === "fulfilled" ? inboxResult.value : null;
+
+        setCounts({
+          data: {
+            applicationsPending: applications ? applications.filter(isPendingApplication).length : null,
+            tenants: tenants ? tenants.length : null,
+            workOrders: workOrders ? workOrders.filter(isOpenWorkOrder).length : null,
+            unifiedMessages: typeof inbox?.total === "number" ? inbox.total : Array.isArray(inbox?.items) ? inbox.items.length : null,
+          },
+          loading: false,
+          error:
+            applicationsResult.status === "rejected" ||
+            tenantsResult.status === "rejected" ||
+            workOrdersResult.status === "rejected" ||
+            inboxResult.status === "rejected"
+              ? "Some portfolio counts could not load."
+              : null,
+        });
+      })
+      .catch((error) => {
+        if (alive) setCounts({ data: null, loading: false, error: errorMessage(error, "Portfolio counts could not load.") });
+      });
+
     return () => {
       alive = false;
     };
@@ -532,67 +740,68 @@ export default function DashboardPage() {
   return (
     <MacShell title="RentChain · Dashboard 2.0" showTopNav={false}>
       <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
-        <header style={{ display: "grid", gap: spacing.sm }}>
-          <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, alignItems: "flex-start", flexWrap: "wrap" }}>
-            <div style={{ display: "grid", gap: 6, minWidth: 0 }}>
-              <h1 style={{ margin: 0, fontSize: "clamp(1.6rem, 3vw, 2.15rem)", letterSpacing: 0, color: text.primary }}>
-                Operational Home
-              </h1>
-              <div style={{ color: text.muted, lineHeight: 1.55, maxWidth: 760 }}>
-                Portfolio health, decisions, upcoming work, and financial state in one place. Execution stays in Operations and owning workspaces.
-              </div>
+        <div
+          data-testid="dashboard-operational-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            gap: spacing.lg,
+          }}
+        >
+          {portfolio.loading ? (
+            <LoadingSection title="Portfolio Health" />
+          ) : portfolio.error ? (
+            <ErrorSection title="Portfolio Health" message={portfolio.error} onRetry={() => setRefreshKey((key) => key + 1)} />
+          ) : portfolio.data ? (
+            <PortfolioHealthSection portfolio={portfolio.data} />
+          ) : null}
+
+          <PortfolioCountsRow portfolio={portfolio.data} counts={counts} />
+
+          <div style={{ display: "flex", justifyContent: "space-between", flexWrap: "wrap", gap: 10, alignItems: "center" }}>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+              <StatusPill state={portfolioState} />
+              <StatusPill state={financialState} />
+              <span style={{ color: text.subtle, fontSize: 13, alignSelf: "center" }}>
+                {generatedAt ? `Generated ${new Date(generatedAt).toLocaleString()}` : "Generating current state"}
+              </span>
             </div>
             <button type="button" onClick={() => setRefreshKey((key) => key + 1)} style={compactButton}>
               Refresh
             </button>
           </div>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-            <StatusPill state={portfolioState} />
-            <StatusPill state={financialState} />
-            <span style={{ color: text.subtle, fontSize: 13, alignSelf: "center" }}>
-              {generatedAt ? `Generated ${new Date(generatedAt).toLocaleString()}` : "Generating current state"}
-            </span>
-          </div>
-        </header>
 
-        <div
-          data-testid="dashboard-operational-grid"
-          style={{
-            display: "grid",
-            gridTemplateColumns: isNarrow ? "1fr" : "minmax(0, 1.25fr) minmax(280px, 0.75fr)",
-            gap: spacing.lg,
-          }}
-        >
-          <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
-            {portfolio.loading ? (
-              <LoadingSection title="Portfolio Status" />
-            ) : portfolio.error ? (
-              <ErrorSection title="Portfolio Status" message={portfolio.error} onRetry={() => setRefreshKey((key) => key + 1)} />
-            ) : portfolio.data ? (
-              <PortfolioStatusSection portfolio={portfolio.data} />
-            ) : null}
-
-            {queue.loading ? (
-              <LoadingSection title="Decision Queue Preview" />
-            ) : queue.error ? (
-              <ErrorSection title="Decision Queue Preview" message={queue.error} onRetry={() => setRefreshKey((key) => key + 1)} />
-            ) : queue.data ? (
-              <DecisionQueuePreview queue={queue.data} />
-            ) : null}
-
-            <WorkspaceRoutingSection />
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: isNarrow ? "1fr" : "minmax(0, 1.15fr) minmax(300px, 0.85fr)",
+              gap: spacing.lg,
+              minWidth: 0,
+            }}
+          >
+            <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
+              {queue.loading ? (
+                <LoadingSection title="Decision Queue Preview" />
+              ) : queue.error ? (
+                <ErrorSection title="Decision Queue Preview" message={queue.error} onRetry={() => setRefreshKey((key) => key + 1)} />
+              ) : queue.data ? (
+                <DecisionQueuePreview queue={queue.data} />
+              ) : null}
+            </div>
+            <aside style={{ display: "grid", gap: spacing.lg, alignContent: "start", minWidth: 0 }}>
+              {queue.loading ? <LoadingSection title="Upcoming Actions" /> : <UpcomingActions queue={queue.data} />}
+            </aside>
           </div>
 
-          <aside style={{ display: "grid", gap: spacing.lg, alignContent: "start", minWidth: 0 }}>
-            {queue.loading ? <LoadingSection title="Upcoming Actions" /> : <UpcomingActions queue={queue.data} />}
-            {portfolio.loading ? (
-              <LoadingSection title="Financial Snapshot" />
-            ) : portfolio.error ? (
-              <ErrorSection title="Financial Snapshot" message={portfolio.error} onRetry={() => setRefreshKey((key) => key + 1)} />
-            ) : portfolio.data ? (
-              <FinancialSnapshotSection portfolio={portfolio.data} />
-            ) : null}
-          </aside>
+          {portfolio.loading ? (
+            <LoadingSection title="Financial Snapshot" />
+          ) : portfolio.error ? (
+            <ErrorSection title="Financial Snapshot" message={portfolio.error} onRetry={() => setRefreshKey((key) => key + 1)} />
+          ) : portfolio.data ? (
+            <FinancialSnapshotSection portfolio={portfolio.data} />
+          ) : null}
+
+          <WorkspaceRoutingSection />
         </div>
       </div>
     </MacShell>

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -299,7 +299,7 @@ function PortfolioHealthSection({ portfolio }: { portfolio: LandlordPortfolioSta
       <SectionHeader
         icon={<Building2 size={18} />}
         title="Portfolio Health"
-        subtitle=""
+        subtitle="Quick view of portfolio occupancy and health."
         action={
           <Link to="/portfolio-health" style={compactButton}>
             Portfolio detail <ArrowRight size={16} />
@@ -430,7 +430,7 @@ function FinancialSnapshotSection({ portfolio }: { portfolio: LandlordPortfolioS
       <SectionHeader
         icon={<Banknote size={18} />}
         title="Financial Snapshot"
-        subtitle={`Rent collection view for ${financial.period.month}.`}
+        subtitle={`Current rent collection and outstanding balance overview for ${financial.period.month}.`}
         action={
           <Link to="/payments" style={compactButton}>
             Payments Workspace <ArrowRight size={16} />
@@ -513,7 +513,7 @@ function DecisionQueuePreview({ queue }: { queue: LandlordDecisionQueueResponse 
       <SectionHeader
         icon={<ClipboardList size={18} />}
         title="Decision Queue Preview"
-        subtitle="Decision and action only. Operations has the full queue."
+        subtitle="Highest-priority decisions needing attention."
         action={
           <Link to="/operations" style={compactButton}>
             View Full Queue <ArrowRight size={16} />
@@ -575,7 +575,7 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
       <SectionHeader
         icon={<ListChecks size={18} />}
         title="Upcoming Actions"
-        subtitle="Next dated items from the normalized queue."
+        subtitle="Time-sensitive next steps from the operations queue."
         action={
           <Link to="/operations?status=open_state" style={compactButton}>
             Open Operations <ArrowRight size={16} />
@@ -617,7 +617,7 @@ function WorkspaceRoutingSection() {
       <SectionHeader
         icon={<Route size={18} />}
         title="Portfolio Detail / Workspace Routing"
-        subtitle="Dashboard summarizes. Operations and owning workspaces handle execution."
+        subtitle="Open the workspace that owns the next action."
       />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 190px), 1fr))", gap: spacing.sm }}>
         {routes.map((route) => (
@@ -738,7 +738,7 @@ export default function DashboardPage() {
   const financialState = metricState(portfolio.data?.confidence.financial);
 
   return (
-    <MacShell title="RentChain · Dashboard 2.0" showTopNav={false}>
+    <MacShell title="RentChain · Dashboard 2.0" showTopNav={false} maxWidth={1320}>
       <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
         <div
           data-testid="dashboard-operational-grid"

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -1,1550 +1,600 @@
 import React from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
+import {
+  AlertCircle,
+  ArrowRight,
+  Banknote,
+  Building2,
+  CheckCircle2,
+  ClipboardList,
+  Clock3,
+  ExternalLink,
+  ListChecks,
+  Route,
+  WalletCards,
+} from "lucide-react";
 import { MacShell } from "../components/layout/MacShell";
-import { Card, Section, Button } from "../components/ui/Ui";
-import { spacing, text, colors } from "../styles/tokens";
-import { KpiStrip } from "../components/dashboard/KpiStrip";
-import { ActionRequiredPanel } from "../components/dashboard/ActionRequiredPanel";
-import { RecentEventsCard } from "../components/dashboard/RecentEventsCard";
-import { PortfolioCredibilitySummaryCard } from "../components/dashboard/PortfolioCredibilitySummaryCard";
-import { debugApiBase } from "@/api/baseUrl";
-import { fetchDashboardSummary } from "../api/dashboard";
-import { fetchProperties } from "../api/propertiesApi";
-import { unitsForProperty } from "../lib/propertyCounts";
-import { useApplications } from "../hooks/useApplications";
-import { useOnboardingState } from "../hooks/useOnboardingState";
-import { useTenants } from "../hooks/useTenants";
-import { listTenantInvites } from "../api/tenantInvites";
-import { track } from "../lib/analytics";
-import { useAuth } from "../context/useAuth";
-import { useToast } from "../components/ui/ToastProvider";
-import { useCapabilities } from "../hooks/useCapabilities";
-import { buildOnboardingSteps } from "../lib/onboardingSteps";
-import { getApplicationPrereqState } from "../lib/applicationPrereqs";
-import { CreatePropertyFirstModal } from "../components/properties/CreatePropertyFirstModal";
-import { buildCreatePropertyUrl, buildReturnTo } from "../lib/propertyGate";
-import { SendApplicationModal } from "../components/properties/SendApplicationModal";
-import { AddExpenseModal } from "../components/expenses/AddExpenseModal";
-import { useUnitsForProperty } from "../hooks/useUnitsForProperty";
-import { listReferrals } from "../api/referralsApi";
-import { markDashboardVisit } from "@/features/upgradeNudges/nudgeStore";
-import { GettingStartedCard } from "../components/onboarding/GettingStartedCard";
-import { LandlordWelcomeModal } from "../components/onboarding/LandlordWelcomeModal";
-import { SCREENING_ENABLED } from "../config/screening";
-import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
-import { UpgradeNudgeInlineCard } from "@/features/upgradeNudges/UpgradeNudgeInlineCard";
-import { canUseTimeline, normalizeTimelinePlan } from "@/features/automation/timeline/timelineEntitlements";
-import { normalizePlan } from "@/lib/plan";
-import { getLandlordActivation, type LandlordActivationSummary } from "@/api/activationApi";
+import { Card, SkeletonBlock } from "../components/ui/Ui";
+import { colors, spacing, text } from "../styles/tokens";
 import {
-  fetchLandlordTransUnionOnboardingAnalytics,
-  type LandlordTransUnionOnboardingAnalytics,
-} from "@/api/landlordAnalyticsApi";
-import { LandlordActivationFlowCard } from "@/components/activation/LandlordActivationFlowCard";
-import { clearPostUpgradeState, getPostUpgradeContent, getPostUpgradeState } from "@/lib/postUpgrade";
+  fetchLandlordDecisionQueue,
+  type LandlordDecisionQueueItem,
+  type LandlordDecisionQueueResponse,
+  type LandlordDecisionQueueSeverity,
+  type LandlordDecisionQueueWorkspace,
+} from "@/api/landlordDecisionQueueApi";
 import {
-  decisionDisplayCopy,
-  decisionSeverityStyle,
-  decisionStatusCopy,
-  normalizeDecisionItems,
-  summarizeDecisionItems,
-  type DecisionActionType,
-  type DecisionItem,
-} from "@/lib/decisions/decisionDisplay";
-import { patchDecisionAction } from "@/api/decisionApi";
-import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
+  fetchLandlordPortfolioStatusFinancial,
+  type LandlordPortfolioStatusFinancialResponse,
+  type PortfolioDataQualityFlag,
+  type PortfolioMetricConfidence,
+} from "@/api/landlordPortfolioStatusFinancialApi";
 
-const StarterOnboardingPanel = React.lazy(
-  () => import("../components/dashboard/StarterOnboardingPanel")
-);
-const TIMELINE_NUDGE_DISMISSED_AT_KEY = "nudge.timeline.dismissedAt";
-const TIMELINE_NUDGE_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
-const LANDLORD_WELCOME_PENDING_KEY = "rentchain.landlordWelcome.pending";
-const LANDLORD_WELCOME_SEEN_KEY = "rentchain.landlordWelcome.seen";
+type Loadable<T> = {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+};
 
-class OnboardingErrorBoundary extends React.Component<
-  { onError: () => void; children: React.ReactNode },
-  { hasError: boolean }
-> {
-  private didLog = false;
-  constructor(props: { onError: () => void; children: React.ReactNode }) {
-    super(props);
-    this.state = { hasError: false };
-  }
+type MetricState = "trusted" | "degraded" | "unavailable";
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
+const sectionCard: React.CSSProperties = {
+  display: "grid",
+  gap: spacing.md,
+  minWidth: 0,
+};
 
-  componentDidCatch() {
-    if (!this.didLog) {
-      this.didLog = true;
-      console.error("[onboarding] render crashed");
-    }
-    this.props.onError();
-  }
+const compactButton: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 8,
+  minHeight: 38,
+  padding: "8px 12px",
+  borderRadius: 8,
+  border: `1px solid ${colors.borderStrong}`,
+  background: "#fff",
+  color: text.primary,
+  fontWeight: 750,
+  textDecoration: "none",
+  fontSize: 14,
+};
 
-  render() {
-    if (this.state.hasError) {
-      return (
-        <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-          <div style={{ fontWeight: 700, marginBottom: 10 }}>Get started</div>
-          <div style={{ color: text.muted, marginBottom: 12 }}>
-            Something went wrong while loading onboarding.
-          </div>
-          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-            <Button onClick={() => window.location.reload()}>Reload</Button>
-            <Button variant="ghost" onClick={() => window.location.assign("/dashboard")}>
-              Go to Dashboard
-            </Button>
-          </div>
-        </Card>
-      );
-    }
-    return this.props.children;
-  }
+function getCurrentMonth(): string {
+  return new Date().toISOString().slice(0, 7);
 }
 
-function formatDate(ts: number | null): string {
-  if (!ts) return "—";
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(ts));
-  } catch {
-    return new Date(ts).toISOString();
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+function metricState(confidence: PortfolioMetricConfidence | null | undefined): MetricState {
+  if (confidence === "high") return "trusted";
+  if (confidence === "medium" || confidence === "low") return "degraded";
+  return "unavailable";
+}
+
+function stateLabel(state: MetricState) {
+  if (state === "trusted") return "Trusted";
+  if (state === "degraded") return "Degraded";
+  return "Unavailable";
+}
+
+function stateStyle(state: MetricState): React.CSSProperties {
+  if (state === "trusted") {
+    return { background: "#ecfdf5", color: "#047857", border: "1px solid #a7f3d0" };
   }
+  if (state === "degraded") {
+    return { background: "#fffbeb", color: "#92400e", border: "1px solid #fde68a" };
+  }
+  return { background: "#f8fafc", color: "#64748b", border: "1px solid #cbd5e1" };
 }
 
-function localDecisionStatus(decision: DecisionItem, actionType: DecisionActionType): DecisionItem {
-  const status =
-    actionType === "reviewed"
-      ? "reviewed"
-      : actionType === "snoozed"
-      ? "snoozed"
-      : actionType === "assigned"
-      ? "assigned"
-      : actionType === "dismissed"
-      ? "dismissed"
-      : "resolved";
-  return { ...decision, status };
+function severityStyle(severity: LandlordDecisionQueueSeverity): React.CSSProperties {
+  if (severity === "critical") return { background: "#fef2f2", color: "#991b1b", border: "1px solid #fecaca" };
+  if (severity === "warning" || severity === "needs_review") {
+    return { background: "#fff7ed", color: "#9a3412", border: "1px solid #fed7aa" };
+  }
+  if (severity === "upcoming") return { background: "#eff6ff", color: "#1d4ed8", border: "1px solid #bfdbfe" };
+  return { background: "#f8fafc", color: "#475569", border: "1px solid #cbd5e1" };
 }
 
-function DashboardDecisionSummaryPanel({
-  decisions,
-  pendingId,
-  onAction,
-}: {
-  decisions: DecisionItem[];
-  pendingId: string | null;
-  onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
-}) {
-  const summary = summarizeDecisionItems(decisions);
-  const cells = [
-    { label: "Overdue", value: summary.overdue, severity: "critical" as const },
-    { label: "Underpaid", value: summary.underpaid, severity: "warning" as const },
-    { label: "Missing", value: summary.missing, severity: "critical" as const },
-    { label: "Failed", value: summary.failed, severity: "critical" as const },
-    { label: "Manual Review", value: summary.manualReview, severity: "warning" as const },
-  ];
+function workspaceLabel(workspace: LandlordDecisionQueueWorkspace): string {
+  const labels: Record<LandlordDecisionQueueWorkspace, string> = {
+    dashboard: "Dashboard",
+    operations: "Operations",
+    tenant: "Tenant",
+    lease: "Lease",
+    property: "Property",
+    maintenance: "Maintenance",
+    payments: "Payments",
+    notices: "Notices",
+    evidence_compliance: "Evidence",
+  };
+  return labels[workspace] || "Operations";
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "Unavailable";
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatMoney(cents: number | null | undefined): string {
+  if (cents == null || !Number.isFinite(cents)) return "Unavailable";
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "CAD",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "No due date";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "No due date";
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
+}
+
+function cleanFlags(flags: PortfolioDataQualityFlag[] | null | undefined): string[] {
+  return (flags || []).slice(0, 3).map((flag) => flag.replace(/_/g, " "));
+}
+
+function useNarrowDashboardLayout(): boolean {
+  const [isNarrow, setIsNarrow] = React.useState(false);
+
+  React.useEffect(() => {
+    const media = window.matchMedia("(max-width: 900px)");
+    const update = () => setIsNarrow(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return isNarrow;
+}
+
+function operationalHref(item: LandlordDecisionQueueItem): string {
+  const href = String(item.recommendedActionHref || "").trim();
+  return href.startsWith("/") ? href : "/operations";
+}
+
+function StatusPill({ state }: { state: MetricState }) {
   return (
-    <Card
+    <span
       style={{
-        padding: spacing.md,
-        border: `1px solid ${colors.border}`,
-        display: "grid",
-        gap: spacing.sm,
-        minWidth: 0,
-        width: "100%",
-        boxSizing: "border-box",
-        overflow: "hidden",
+        ...stateStyle(state),
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        width: "fit-content",
+        borderRadius: 8,
+        padding: "4px 8px",
+        fontSize: 12,
+        fontWeight: 800,
       }}
     >
-      <div>
-        <div style={{ fontWeight: 800 }}>Decision summary</div>
-        <div style={{ color: text.muted, fontSize: 13, marginTop: 3 }}>
-          Read-only decisions from detected rent and lease signals.
-        </div>
-        <Link to="/decision-inbox" style={{ display: "inline-block", marginTop: 6, color: "#2563eb", fontWeight: 800 }}>
-          Open decision inbox
-        </Link>
+      {state === "trusted" ? <CheckCircle2 size={14} /> : state === "degraded" ? <AlertCircle size={14} /> : <Clock3 size={14} />}
+      {stateLabel(state)}
+    </span>
+  );
+}
+
+function MetricTile({
+  label,
+  value,
+  state,
+  helper,
+}: {
+  label: string;
+  value: string;
+  state: MetricState;
+  helper?: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 8,
+        padding: 14,
+        minWidth: 0,
+        border: `1px solid ${colors.border}`,
+        borderRadius: 8,
+        background: "#fff",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center" }}>
+        <div style={{ color: text.muted, fontSize: 13, fontWeight: 750 }}>{label}</div>
+        <StatusPill state={state} />
       </div>
-      {summary.allTotal === 0 ? (
-        <div style={{ color: "#166534", background: "#f0fdf4", border: "1px solid #bbf7d0", borderRadius: 10, padding: 10 }}>
-          No issues detected. Everything is up to date.
+      <div style={{ color: text.primary, fontSize: 26, fontWeight: 850, lineHeight: 1 }}>{value}</div>
+      {helper ? <div style={{ color: text.subtle, fontSize: 13, lineHeight: 1.45 }}>{helper}</div> : null}
+    </div>
+  );
+}
+
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+  action,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, alignItems: "flex-start", flexWrap: "wrap" }}>
+      <div style={{ display: "flex", gap: 10, minWidth: 0 }}>
+        <div
+          aria-hidden="true"
+          style={{
+            width: 36,
+            height: 36,
+            flex: "0 0 auto",
+            borderRadius: 8,
+            display: "grid",
+            placeItems: "center",
+            background: "#eef2ff",
+            color: "#1d4ed8",
+          }}
+        >
+          {icon}
         </div>
+        <div style={{ display: "grid", gap: 3, minWidth: 0 }}>
+          <h2 style={{ margin: 0, fontSize: 18, letterSpacing: 0 }}>{title}</h2>
+          <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.45 }}>{subtitle}</div>
+        </div>
+      </div>
+      {action}
+    </div>
+  );
+}
+
+function LoadingSection({ title }: { title: string }) {
+  return (
+    <Card style={sectionCard}>
+      <SectionHeader icon={<Clock3 size={18} />} title={title} subtitle="Loading current operational state." />
+      <SkeletonBlock lines={4} label={`Loading ${title}`} />
+    </Card>
+  );
+}
+
+function ErrorSection({ title, message, onRetry }: { title: string; message: string; onRetry: () => void }) {
+  return (
+    <Card style={sectionCard}>
+      <SectionHeader icon={<AlertCircle size={18} />} title={title} subtitle="This section could not load. Other dashboard sections remain available." />
+      <div style={{ color: text.muted, lineHeight: 1.5 }}>{message}</div>
+      <button type="button" onClick={onRetry} style={{ ...compactButton, width: "fit-content" }}>
+        Retry section
+      </button>
+    </Card>
+  );
+}
+
+function PortfolioStatusSection({ portfolio }: { portfolio: LandlordPortfolioStatusFinancialResponse }) {
+  const status = portfolio.portfolioStatus;
+  const state = metricState(portfolio.confidence.occupancy);
+  const flags = cleanFlags(status.dataQualityFlags);
+  return (
+    <Card style={sectionCard} data-testid="portfolio-status-section">
+      <SectionHeader
+        icon={<Building2 size={18} />}
+        title="Portfolio Status"
+        subtitle="The current operating position across properties, units, and leases."
+        action={
+          <Link to="/portfolio-health" style={compactButton}>
+            Portfolio detail <ArrowRight size={16} />
+          </Link>
+        }
+      />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 170px), 1fr))", gap: spacing.sm }}>
+        <MetricTile label="Occupancy" value={formatPercent(status.occupancyRate)} state={state} helper={`${status.occupiedUnits} occupied, ${status.vacantUnits} vacant`} />
+        <MetricTile label="Current leases" value={String(status.currentLeaseCount)} state={state} helper={`${status.noticePeriodUnits} in notice, ${status.signedFutureLeaseCount} upcoming`} />
+        <MetricTile label="Review units" value={String(status.reviewRequiredUnits)} state={state} helper="Conflicts stay visible instead of changing counts silently." />
+      </div>
+      {flags.length > 0 ? (
+        <div style={{ color: text.muted, fontSize: 13 }}>Data quality: {flags.join(", ")}</div>
       ) : (
-        <>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 130px), 1fr))",
-              gap: spacing.sm,
-              minWidth: 0,
-              boxSizing: "border-box",
-            }}
-          >
-            {cells.map((cell) => {
-              const tone = decisionSeverityStyle[cell.severity];
-              return (
-                <div
-                  key={cell.label}
-                  style={{
-                    border: `1px solid ${tone.border}`,
-                    background: tone.bg,
-                    borderRadius: 10,
-                    padding: 10,
-                    minWidth: 0,
-                    boxSizing: "border-box",
-                  }}
-                >
-                  <div style={{ color: tone.color, fontSize: 12, fontWeight: 700 }}>{cell.label}</div>
-                  <strong style={{ color: tone.color, fontSize: 20 }}>{cell.value}</strong>
-                </div>
-              );
-            })}
-          </div>
-          <div style={{ display: "grid", gap: 6 }}>
-            {decisions.slice(0, 3).map((decision) => {
-              const copy = decisionDisplayCopy[decision.decisionType];
-              const tone = decisionSeverityStyle[decision.severity];
-              return (
-                <div
-                  key={decision.decisionId}
-                  style={{
-                    display: "grid",
-                    gap: 6,
-                    color: text.primary,
-                    borderTop: `1px solid ${colors.border}`,
-                    paddingTop: 8,
-                    minWidth: 0,
-                    boxSizing: "border-box",
-                  }}
-                >
-                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-                  <span style={{ border: `1px solid ${tone.border}`, background: tone.bg, color: tone.color, borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
-                    {copy.badge}
-                  </span>
-                    <span style={{ border: "1px solid #cbd5e1", borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
-                      {decisionStatusCopy[decision.status || "detected"]}
-                    </span>
-                  <span>{copy.label}</span>
-                  <span style={{ color: text.muted, overflowWrap: "anywhere" }}>{decision.reason}</span>
-                  </div>
-                  <DecisionContextPanel decision={decision} compact />
-                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                    {(["reviewed", "snoozed", "assigned", "dismissed", "resolved"] as DecisionActionType[]).map((actionType) => (
-                      <button
-                        key={actionType}
-                        type="button"
-                        disabled={pendingId === decision.decisionId || !decision.leaseId}
-                        onClick={() => onAction(decision, actionType)}
-                        style={{ border: "1px solid #cbd5e1", background: "#fff", borderRadius: 8, padding: "5px 8px", fontWeight: 700 }}
-                      >
-                        {pendingId === decision.decisionId
-                          ? "Saving..."
-                          : actionType === "reviewed"
-                          ? "Mark reviewed"
-                          : actionType === "snoozed"
-                          ? "Snooze"
-                          : actionType === "assigned"
-                          ? "Assign"
-                          : actionType === "dismissed"
-                          ? "Dismiss"
-                          : "Resolve"}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </>
+        <div style={{ color: "#047857", fontSize: 13 }}>No portfolio data-quality flags reported.</div>
       )}
     </Card>
   );
 }
 
-function FreeTierJourneyCard({
-  propertiesCount,
-  unitsCount,
-  applicantsCount,
-  screeningReady,
-  leaseReady,
-  applicantActionLabel,
-  onAddProperty,
-  onAddUnit,
-  onAddApplicant,
-  onScreening,
-  onCreateLease,
-}: {
-  propertiesCount: number;
-  unitsCount: number;
-  applicantsCount: number;
-  screeningReady: boolean;
-  leaseReady: boolean;
-  applicantActionLabel: string;
-  onAddProperty: () => void;
-  onAddUnit: () => void;
-  onAddApplicant: () => void;
-  onScreening: () => void;
-  onCreateLease: () => void;
-}) {
-  const hasProperty = propertiesCount > 0;
-  const hasUnit = unitsCount > 0;
-  const hasApplicant = applicantsCount > 0;
-  const steps = [
-    {
-      id: "property",
-      label: "Add property",
-      done: hasProperty,
-      helper: hasProperty ? `${propertiesCount} propert${propertiesCount === 1 ? "y" : "ies"} added` : "Start with the rental address.",
-      action: onAddProperty,
-      actionLabel: hasProperty ? "View properties" : "Add property",
-    },
-    {
-      id: "unit",
-      label: "Add unit",
-      done: hasUnit,
-      helper: hasUnit
-        ? `${unitsCount} unit${unitsCount === 1 ? "" : "s"} added`
-        : hasProperty
-        ? "Add rent, beds, baths, and occupancy."
-        : "Add a property before unit setup.",
-      action: hasProperty ? onAddUnit : onAddProperty,
-      actionLabel: hasProperty ? (hasUnit ? "View units" : "Add unit") : "Add property",
-    },
-    {
-      id: "applicant",
-      label: "Add applicant",
-      done: hasApplicant,
-      helper: hasApplicant
-        ? `${applicantsCount} applicant${applicantsCount === 1 ? "" : "s"} started`
-        : hasUnit
-        ? "Track applicant intake after a unit exists."
-        : "Add a unit before applicant intake.",
-      action: hasUnit ? onAddApplicant : hasProperty ? onAddUnit : onAddProperty,
-      actionLabel: hasUnit ? (hasApplicant ? "View applicants" : applicantActionLabel) : hasProperty ? "Add unit" : "Add property",
-    },
-    {
-      id: "screening",
-      label: "Run screening",
-      done: hasApplicant && screeningReady,
-      helper: hasApplicant
-        ? screeningReady
-          ? "Screening setup is connected."
-          : "Screening is the upgrade-ready next step."
-        : "Add an applicant before screening appears.",
-      action: hasApplicant ? onScreening : hasUnit ? onAddApplicant : hasProperty ? onAddUnit : onAddProperty,
-      actionLabel: hasApplicant
-        ? screeningReady
-          ? "Run screening"
-          : "Review screening"
-        : hasUnit
-        ? "Add applicant"
-        : hasProperty
-        ? "Add unit"
-        : "Add property",
-    },
-    {
-      id: "lease",
-      label: "Create lease",
-      done: hasApplicant && leaseReady,
-      helper: hasApplicant ? "Prepare lease documents after applicant and screening context." : "Add an applicant before lease setup.",
-      action: hasApplicant ? onCreateLease : hasUnit ? onAddApplicant : hasProperty ? onAddUnit : onAddProperty,
-      actionLabel: hasApplicant ? "Create lease" : hasUnit ? "Add applicant" : hasProperty ? "Add unit" : "Add property",
-    },
-  ];
-  const nextStep = steps.find((step) => !step.done) || steps[steps.length - 1];
-
+function FinancialSnapshotSection({ portfolio }: { portfolio: LandlordPortfolioStatusFinancialResponse }) {
+  const financial = portfolio.financialSnapshot;
+  const state = metricState(portfolio.confidence.financial);
+  const flags = cleanFlags(financial.dataQualityFlags);
   return (
-    <Card
-      data-testid="free-tier-journey-card"
+    <Card style={sectionCard} data-testid="financial-snapshot-section">
+      <SectionHeader
+        icon={<Banknote size={18} />}
+        title="Financial Snapshot"
+        subtitle={`Rent collection view for ${financial.period.month}. Missing sources degrade individual metrics, not the whole dashboard.`}
+        action={
+          <Link to="/payments" style={compactButton}>
+            Payments workspace <ArrowRight size={16} />
+          </Link>
+        }
+      />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 170px), 1fr))", gap: spacing.sm }}>
+        <MetricTile label="Expected rent" value={formatMoney(financial.expectedMonthlyRentCents)} state={state} helper={`${financial.activeLeaseRentTermsCount} leases with rent terms`} />
+        <MetricTile label="Collected" value={formatMoney(financial.collectedCurrentMonthCents)} state={state} helper={`Collection rate ${formatPercent(financial.rentCollectionRate)}`} />
+        <MetricTile label="Outstanding" value={formatMoney(financial.outstandingCurrentMonthCents)} state={state} helper={`${financial.leasesMissingRentTermsCount} leases missing terms`} />
+      </div>
+      {flags.length > 0 ? (
+        <div style={{ color: text.muted, fontSize: 13 }}>Data quality: {flags.join(", ")}</div>
+      ) : (
+        <div style={{ color: "#047857", fontSize: 13 }}>No financial data-quality flags reported.</div>
+      )}
+    </Card>
+  );
+}
+
+function DecisionQueuePreview({ queue }: { queue: LandlordDecisionQueueResponse }) {
+  const items = queue.items.slice(0, 4);
+  return (
+    <Card style={sectionCard} data-testid="decision-queue-section">
+      <SectionHeader
+        icon={<ClipboardList size={18} />}
+        title="Decision Queue Preview"
+        subtitle="The most important open decisions. Full triage and execution stay in Operations."
+        action={
+          <Link to="/operations" style={compactButton}>
+            Full queue <ArrowRight size={16} />
+          </Link>
+        }
+      />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 150px), 1fr))", gap: spacing.sm }}>
+        <MetricTile label="Open" value={String(queue.summary.open)} state="trusted" />
+        <MetricTile label="Needs review" value={String(queue.summary.needsReview)} state={queue.summary.needsReview > 0 ? "degraded" : "trusted"} />
+        <MetricTile label="Blocked" value={String(queue.summary.blocked)} state={queue.summary.blocked > 0 ? "degraded" : "trusted"} />
+      </div>
+      {items.length === 0 ? (
+        <div style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: 14, color: text.muted }}>
+          No open decisions. New operational decisions will appear here before routing to their owning workspace.
+        </div>
+      ) : (
+        <div style={{ display: "grid", gap: 10 }}>
+          {items.map((item) => (
+            <DecisionRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
+  return (
+    <div
       style={{
-        padding: spacing.md,
-        border: `1px solid ${colors.border}`,
         display: "grid",
-        gap: spacing.md,
+        gap: 8,
+        padding: 12,
+        border: `1px solid ${colors.border}`,
+        borderRadius: 8,
+        background: "#fff",
       }}
     >
-      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
-        <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
-          <div style={{ fontWeight: 800, fontSize: 18 }}>Start in order</div>
-          <div style={{ color: text.muted, lineHeight: 1.55 }}>
-            Free tier works best when setup follows property, unit, applicant, screening, then lease.
-          </div>
-        </div>
-        <Button onClick={nextStep.action}>{nextStep.actionLabel}</Button>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <span style={{ ...severityStyle(item.severity), borderRadius: 8, padding: "3px 8px", fontSize: 12, fontWeight: 850 }}>
+          {item.severity.replace(/_/g, " ")}
+        </span>
+        <span style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: "3px 8px", color: text.muted, fontSize: 12, fontWeight: 800 }}>
+          {workspaceLabel(item.workspace)}
+        </span>
+        <span style={{ color: text.subtle, fontSize: 12 }}>{formatDate(item.dueAt)}</span>
       </div>
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 160px), 1fr))",
-          gap: spacing.sm,
-        }}
-      >
-        {steps.map((step, index) => (
-          <button
-            key={step.id}
-            type="button"
-            onClick={step.action}
+      <div style={{ display: "grid", gap: 4 }}>
+        <div style={{ fontWeight: 850, color: text.primary, overflowWrap: "anywhere" }}>{item.title || "Review required"}</div>
+        <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.45, overflowWrap: "anywhere" }}>{item.description || "Open the workspace to review the next step."}</div>
+      </div>
+      <Link to={operationalHref(item)} style={{ ...compactButton, width: "fit-content" }}>
+        {item.recommendedActionLabel || "Open workspace"} <ExternalLink size={15} />
+      </Link>
+    </div>
+  );
+}
+
+function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | null }) {
+  const actions = (queue?.items || [])
+    .filter((item) => item.dueAt || item.severity === "upcoming")
+    .slice(0, 4);
+  return (
+    <Card style={sectionCard} data-testid="upcoming-actions-section">
+      <SectionHeader
+        icon={<ListChecks size={18} />}
+        title="Upcoming Actions"
+        subtitle="Time-bound work derived from normalized decision items."
+        action={
+          <Link to="/operations?status=open_state" style={compactButton}>
+            Operations <ArrowRight size={16} />
+          </Link>
+        }
+      />
+      {actions.length === 0 ? (
+        <div style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: 14, color: text.muted }}>
+          No dated actions are due right now. When lease, payment, notice, or maintenance decisions have dates, they appear here.
+        </div>
+      ) : (
+        <div style={{ display: "grid", gap: 10 }}>
+          {actions.map((item) => (
+            <div key={item.id} style={{ display: "flex", justifyContent: "space-between", gap: 12, borderBottom: `1px solid ${colors.border}`, paddingBottom: 10 }}>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontWeight: 800, overflowWrap: "anywhere" }}>{item.title}</div>
+                <div style={{ color: text.muted, fontSize: 13 }}>{workspaceLabel(item.workspace)} · {formatDate(item.dueAt)}</div>
+              </div>
+              <Link to={operationalHref(item)} aria-label={`Open ${item.title}`} style={{ ...compactButton, flex: "0 0 auto" }}>
+                <ArrowRight size={16} />
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function WorkspaceRoutingSection() {
+  const routes = [
+    { label: "Operations full queue", href: "/operations", icon: <ClipboardList size={17} />, helper: "Execution workspace" },
+    { label: "Properties", href: "/properties", icon: <Building2 size={17} />, helper: "Portfolio records" },
+    { label: "Leases", href: "/leases", icon: <Route size={17} />, helper: "Lease workspace" },
+    { label: "Payments", href: "/payments", icon: <WalletCards size={17} />, helper: "Financial workspace" },
+  ];
+  return (
+    <Card style={sectionCard} data-testid="workspace-routing-section">
+      <SectionHeader
+        icon={<Route size={18} />}
+        title="Portfolio Detail / Workspace Routing"
+        subtitle="Dashboard summarizes. Operations and owning workspaces handle execution."
+      />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 190px), 1fr))", gap: spacing.sm }}>
+        {routes.map((route) => (
+          <Link
+            key={route.href}
+            to={route.href}
             style={{
-              textAlign: "left",
-              border: `1px solid ${step.done ? "rgba(16,185,129,0.35)" : colors.border}`,
-              background: step.done ? "rgba(236,253,245,0.88)" : colors.panel,
-              borderRadius: 8,
-              padding: 12,
               display: "grid",
-              gap: 6,
-              cursor: "pointer",
-              minWidth: 0,
+              gap: 8,
+              minHeight: 88,
+              padding: 14,
+              borderRadius: 8,
+              border: `1px solid ${colors.border}`,
+              background: "#fff",
+              color: text.primary,
+              textDecoration: "none",
             }}
           >
-            <div style={{ color: step.done ? "#047857" : text.muted, fontSize: 12, fontWeight: 900 }}>
-              Step {index + 1}
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center" }}>
+              <span style={{ color: "#1d4ed8" }}>{route.icon}</span>
+              <ArrowRight size={16} color={text.subtle} />
             </div>
-            <div style={{ color: text.primary, fontWeight: 800 }}>{step.label}</div>
-            <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }}>{step.helper}</div>
-          </button>
+            <div>
+              <div style={{ fontWeight: 850 }}>{route.label}</div>
+              <div style={{ color: text.muted, fontSize: 13, marginTop: 3 }}>{route.helper}</div>
+            </div>
+          </Link>
         ))}
       </div>
     </Card>
   );
 }
 
-const DashboardPage: React.FC = () => {
-  // Guardrail: declare derived values used in hook deps above the hooks that depend on them.
-  const [data, setData] = React.useState<any | null>(null);
-  const [decisionRows, setDecisionRows] = React.useState<DecisionItem[]>([]);
-  const [decisionActionPendingId, setDecisionActionPendingId] = React.useState<string | null>(null);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState<string | null>(null);
-  const [lastUpdatedAt, setLastUpdatedAt] = React.useState<number | null>(null);
-  const { applications, loading: applicationsLoading } = useApplications();
-  const { tenants, loading: tenantsLoading } = useTenants();
-  const { user, ready: authReady, isLoading: authLoading } = useAuth();
-  const { caps, features } = useCapabilities();
-  const { showToast } = useToast();
-  const location = useLocation();
-  const navigate = useNavigate();
-  const apiBase = debugApiBase();
-  const showDebug =
-    typeof window !== "undefined" && new URLSearchParams(window.location.search).get("debug") === "1";
-  const isMobile =
-    typeof window !== "undefined" ? window.matchMedia("(max-width: 768px)").matches : false;
-  const meLoaded = authReady && !authLoading && Boolean(user?.id);
-  const roleLower = String(user?.actorRole || user?.role || "").toLowerCase();
-  const isAdmin = roleLower === "admin";
-  const isLandlord = roleLower === "landlord";
-  const timelineEnabled = canUseTimeline(user?.plan || "");
-  const planNormalized = normalizeTimelinePlan(user?.plan || "");
-  const currentPlan = normalizePlan(caps?.plan || user?.plan || "free");
-  const isFreePlan = currentPlan === "free";
-  const shouldConsiderTimelineNudge = meLoaded && !isAdmin && !timelineEnabled;
-  const [showTimelineNudge, setShowTimelineNudge] = React.useState(false);
-  const timelineNudgeViewedRef = React.useRef(false);
-  const canManualScreen = isAdmin || features?.screening_pay_per_use !== false;
-  const screeningWorkflowLabel = "Screening workflow setup";
-  const openActionsRef = React.useRef<HTMLDivElement | null>(null);
-  const canUseReferrals = isLandlord || isAdmin;
-  const [properties, setProperties] = React.useState<any[]>([]);
-  const [propsLoading, setPropsLoading] = React.useState(false);
-  const [invitesCount, setInvitesCount] = React.useState(0);
-  const [invitesLoading, setInvitesLoading] = React.useState(false);
-  const [propertyGateOpen, setPropertyGateOpen] = React.useState(false);
-  const [pendingPropertyAction, setPendingPropertyAction] = React.useState<"create_application" | null>(null);
-  const [sendApplicationOpen, setSendApplicationOpen] = React.useState(false);
-  const [addExpenseOpen, setAddExpenseOpen] = React.useState(false);
-  const [modalPropertyId, setModalPropertyId] = React.useState<string | null>(null);
-  const [modalUnitId, setModalUnitId] = React.useState<string | null>(null);
-  const [onboardingChunkError, setOnboardingChunkError] = React.useState(false);
-  const [referralsCount, setReferralsCount] = React.useState(0);
-  const [activationSummary, setActivationSummary] = React.useState<LandlordActivationSummary | null>(null);
-  const [activationLoading, setActivationLoading] = React.useState(false);
-  const [activationError, setActivationError] = React.useState<string | null>(null);
-  const [transUnionFunnel, setTransUnionFunnel] = React.useState<LandlordTransUnionOnboardingAnalytics | null>(null);
-  const [transUnionFunnelLoading, setTransUnionFunnelLoading] = React.useState(false);
-  const [showWelcomeModal, setShowWelcomeModal] = React.useState(false);
-  const [postUpgradePlan, setPostUpgradePlan] = React.useState<"starter" | "pro" | "elite" | null>(null);
-  const onboarding = useOnboardingState();
-  const prevDerivedRef = React.useRef({
-    propertyAdded: false,
-    unitAdded: false,
-    tenantInvited: false,
-    applicationCreated: false,
+export default function DashboardPage() {
+  const isNarrow = useNarrowDashboardLayout();
+  const [portfolio, setPortfolio] = React.useState<Loadable<LandlordPortfolioStatusFinancialResponse>>({
+    data: null,
+    loading: true,
+    error: null,
   });
-  const nudgeReadyRef = React.useRef(false);
-  const dashboardVisitMarkedRef = React.useRef(false);
-  const loadDashboard = React.useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const summary = await fetchDashboardSummary();
-      setData(summary);
-      setDecisionRows(normalizeDecisionItems((summary as any)?.decisions));
-      setLastUpdatedAt(Date.now());
-    } catch (err: any) {
-      setError(err?.message || "Failed to load dashboard");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-  const refetch = React.useCallback(() => {
-    void loadDashboard();
-  }, [loadDashboard]);
-
-  const dismissWelcomeModal = React.useCallback(() => {
-    if (typeof window !== "undefined" && user?.id) {
-      window.localStorage.setItem(`${LANDLORD_WELCOME_SEEN_KEY}.${user.id}`, "1");
-      window.localStorage.removeItem(`${LANDLORD_WELCOME_PENDING_KEY}.${user.id}`);
-    }
-    setShowWelcomeModal(false);
-  }, [user?.id]);
-
-  const handleStartSetupWelcome = React.useCallback(() => {
-    dismissWelcomeModal();
-    window.setTimeout(() => {
-      const target = document.querySelector('[data-testid="landlord-activation-card"]');
-      if (target instanceof HTMLElement) {
-        target.scrollIntoView({ behavior: "smooth", block: "start" });
-      }
-    }, 0);
-  }, [dismissWelcomeModal]);
-
-  React.useEffect(() => {
-    void loadDashboard();
-  }, [loadDashboard]);
-
-  React.useEffect(() => {
-    if (!SCREENING_ENABLED || (!isLandlord && !isAdmin)) {
-      setTransUnionFunnel(null);
-      setTransUnionFunnelLoading(false);
-      return;
-    }
-
-    let alive = true;
-    (async () => {
-      try {
-        setTransUnionFunnelLoading(true);
-        const data = await fetchLandlordTransUnionOnboardingAnalytics();
-        if (alive) setTransUnionFunnel(data);
-      } catch {
-        if (alive) setTransUnionFunnel(null);
-      } finally {
-        if (alive) setTransUnionFunnelLoading(false);
-      }
-    })();
-
-    return () => {
-      alive = false;
-    };
-  }, [isAdmin, isLandlord]);
-
-  React.useEffect(() => {
-    let alive = true;
-    const loadProps = async () => {
-      try {
-        setPropsLoading(true);
-        const res: any = await fetchProperties();
-        const list = Array.isArray(res?.items)
-          ? res.items
-          : Array.isArray(res?.properties)
-          ? res.properties
-          : Array.isArray(res)
-          ? res
-          : [];
-        if (alive) setProperties(list);
-      } catch {
-        if (alive) setProperties([]);
-      } finally {
-        if (alive) setPropsLoading(false);
-      }
-    };
-    void loadProps();
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  React.useEffect(() => {
-    let active = true;
-    const loadReferrals = async () => {
-      if (!meLoaded || !canUseReferrals) return;
-      try {
-        const rows = await listReferrals();
-        if (active) setReferralsCount(rows.length);
-      } catch {
-        if (active) setReferralsCount(0);
-      }
-    };
-    void loadReferrals();
-    return () => {
-      active = false;
-    };
-  }, [meLoaded, canUseReferrals]);
-
-  const loadActivation = React.useCallback(async () => {
-    if (!isLandlord) return;
-    try {
-      setActivationLoading(true);
-      setActivationError(null);
-      const next = await getLandlordActivation();
-      setActivationSummary(next);
-    } catch (err: any) {
-      setActivationError(err?.message || "Failed to load activation steps.");
-    } finally {
-      setActivationLoading(false);
-    }
-  }, [isLandlord]);
-
-  React.useEffect(() => {
-    if (!meLoaded || !isLandlord) return;
-    void loadActivation();
-  }, [isLandlord, loadActivation, meLoaded]);
-
-  React.useEffect(() => {
-    const state = getPostUpgradeState();
-    if (!state?.plan) return;
-    setPostUpgradePlan(state.plan);
-  }, []);
-
-  const dismissPostUpgradeBanner = React.useCallback(() => {
-    clearPostUpgradeState();
-    setPostUpgradePlan(null);
-  }, []);
-
-  const postUpgradeContent = postUpgradePlan ? getPostUpgradeContent(postUpgradePlan) : null;
-
-  React.useEffect(() => {
-    if (typeof window === "undefined" || !meLoaded || !isLandlord || !user?.id) return;
-    const pending = window.localStorage.getItem(`${LANDLORD_WELCOME_PENDING_KEY}.${user.id}`) === "1";
-    const seen = window.localStorage.getItem(`${LANDLORD_WELCOME_SEEN_KEY}.${user.id}`) === "1";
-    setShowWelcomeModal(pending && !seen);
-  }, [isLandlord, meLoaded, user?.id]);
-
-  React.useEffect(() => {
-    let alive = true;
-    const loadInvites = async () => {
-      try {
-        setInvitesLoading(true);
-        const res = await listTenantInvites();
-        if (alive) {
-          setInvitesCount(Array.isArray(res?.items) ? res.items.length : 0);
-        }
-      } catch {
-        if (alive) setInvitesCount(0);
-      } finally {
-        if (alive) setInvitesLoading(false);
-      }
-    };
-    void loadInvites();
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  React.useEffect(() => {
-    if (showDebug) {
-      console.log("[debug] apiBase", apiBase);
-    }
-  }, [showDebug, apiBase]);
-
-  React.useEffect(() => {
-    if (import.meta.env.DEV) {
-      console.debug("[onboarding]", {
-        authReady,
-        meLoaded,
-        planLoaded: Boolean(user?.plan),
-        isMobile,
-      });
-    }
-  }, [authReady, meLoaded, user?.plan, isMobile]);
-
-  React.useEffect(() => {
-    if (!meLoaded || !user?.id || dashboardVisitMarkedRef.current) return;
-    dashboardVisitMarkedRef.current = true;
-    markDashboardVisit(String(user.id));
-  }, [meLoaded, user?.id]);
-
-  React.useEffect(() => {
-    if (!shouldConsiderTimelineNudge) {
-      setShowTimelineNudge(false);
-      return;
-    }
-    try {
-      const dismissedAt = Number(localStorage.getItem(TIMELINE_NUDGE_DISMISSED_AT_KEY) || "0");
-      if (!dismissedAt || Date.now() - dismissedAt > TIMELINE_NUDGE_COOLDOWN_MS) {
-        setShowTimelineNudge(true);
-      } else {
-        setShowTimelineNudge(false);
-      }
-    } catch {
-      setShowTimelineNudge(true);
-    }
-  }, [shouldConsiderTimelineNudge]);
-
-  React.useEffect(() => {
-    const dataReadyForNudge =
-      !loading && !propsLoading && !applicationsLoading && !tenantsLoading && !invitesLoading && !error;
-    if (!dataReadyForNudge || !showTimelineNudge || timelineNudgeViewedRef.current) return;
-    timelineNudgeViewedRef.current = true;
-    try {
-      track("dashboard_timeline_nudge_viewed", { planNormalized });
-    } catch {
-      // telemetry must never interrupt UX
-    }
-  }, [
-    loading,
-    propsLoading,
-    applicationsLoading,
-    tenantsLoading,
-    invitesLoading,
-    error,
-    showTimelineNudge,
-    planNormalized,
-  ]);
-
-  React.useEffect(() => {
-    if (import.meta.env.DEV) {
-      console.debug("[dashboard gates]", {
-        loadingSummary: loading,
-        applicationsLoading,
-        propsLoading,
-        propertiesCount: properties?.length ?? null,
-        applicationsCount: applications?.length ?? null,
-      });
-    }
-  }, [loading, applicationsLoading, propsLoading, properties, applications]);
-
-  const derivedPropertiesCount = properties.length;
-  const derivedUnitsCount = properties.reduce((sum, p) => sum + unitsForProperty(p), 0);
-  const applicationsCount =
-    typeof data?.kpis?.applicationsCount === "number" ? data.kpis.applicationsCount : applications.length;
-  const tenantCount = tenants.length;
-  const kpis = {
-    propertiesCount: derivedPropertiesCount,
-    unitsCount: derivedUnitsCount,
-    tenantsCount: data?.kpis?.tenantsCount ?? 0,
-    openActionsCount: data?.kpis?.openActionsCount ?? 0,
-    delinquentCount: data?.kpis?.delinquentCount ?? 0,
-    screeningsCount: data?.kpis?.screeningsCount ?? 0,
-  };
-  const transUnionStarted = transUnionFunnel?.totals.started ?? 0;
-  const transUnionConnected = transUnionFunnel?.totals.connected ?? 0;
-  const screeningSetupComplete = SCREENING_ENABLED && transUnionConnected > 0;
-  const transUnionConversionLabel =
-    transUnionFunnel?.conversionRate == null ? "—" : `${Math.round(transUnionFunnel.conversionRate * 100)}%`;
-  const transUnionDropOffInsight =
-    transUnionStarted > transUnionConnected
-      ? `${transUnionStarted - transUnionConnected} onboarding start${
-          transUnionStarted - transUnionConnected === 1 ? "" : "s"
-        } still need credential connection.`
-      : transUnionStarted > 0
-        ? "No onboarding drop-off right now."
-        : "No onboarding starts recorded yet.";
-  const events = Array.isArray(data?.events) ? data.events : [];
-  const dashboardDecisions = decisionRows;
-
-  const handleDashboardDecisionAction = async (decision: DecisionItem, actionType: DecisionActionType) => {
-    if (!decision.leaseId) return;
-    setDecisionActionPendingId(decision.decisionId);
-    try {
-      const result = await patchDecisionAction(decision.decisionId, {
-        leaseId: decision.leaseId,
-        actionType,
-        decision,
-        assignedTo: actionType === "assigned" ? "operations" : undefined,
-        snoozedUntil: actionType === "snoozed" ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() : undefined,
-      });
-      const nextDecision = result?.decision || localDecisionStatus(decision, actionType);
-      setDecisionRows((current) => current.map((item) => (item.decisionId === decision.decisionId ? nextDecision : item)));
-    } catch (err) {
-      showToast("Unable to update decision right now.", "error");
-    } finally {
-      setDecisionActionPendingId(null);
-    }
-  };
-
-  React.useEffect(() => {
-    if (location.hash !== "#open-actions") return;
-    const node = openActionsRef.current;
-    if (!node) return;
-    window.setTimeout(() => {
-      node.scrollIntoView({ behavior: "smooth", block: "start" });
-      node.focus();
-    }, 0);
-  }, [location.hash]);
-
-  const fallbackActions = React.useMemo(() => {
-    const items: Array<{ id: string; title: string; severity: "info"; href: string }> = [];
-    if (derivedPropertiesCount === 0) {
-      items.push({
-        id: "add-property",
-        title: "Add a property",
-        severity: "info",
-        href: "/properties",
-      });
-    }
-    if (derivedPropertiesCount > 0 && derivedUnitsCount === 0) {
-      items.push({
-        id: "add-unit",
-        title: "Add a unit",
-        severity: "info",
-        href: "/properties?openAddUnit=1",
-      });
-    }
-    if (derivedUnitsCount > 0 && applicationsCount === 0) {
-      items.push({
-        id: "add-applicant",
-        title: isFreePlan ? "Track an applicant" : "Add an applicant",
-        severity: "info",
-        href: isFreePlan ? "/applications" : "/applications?openSendApplication=1",
-      });
-    }
-    if (SCREENING_ENABLED && canManualScreen && applicationsCount > 0 && (kpis.screeningsCount ?? 0) === 0) {
-      items.push({
-        id: "run-first-screening",
-        title: "Set up screening workflow",
-        severity: "info",
-        href: "/applications?openTransUnionAccess=1",
-      });
-    }
-    return items;
-  }, [applicationsCount, canManualScreen, derivedPropertiesCount, derivedUnitsCount, isFreePlan, kpis.screeningsCount]);
-  const rawActions = Array.isArray(data?.actions) && data.actions.length > 0 ? data.actions : fallbackActions;
-  const visibleActions = rawActions.filter((item: any) => {
-    const id = String(item?.id || "");
-    if (id === "add-unit") return derivedPropertiesCount > 0;
-    if (id === "add-applicant") return derivedUnitsCount > 0;
-    if (id === "run-first-screening") return applicationsCount > 0;
-    if (id === "invite-tenant") return derivedPropertiesCount > 0 && derivedUnitsCount > 0;
-    return true;
+  const [queue, setQueue] = React.useState<Loadable<LandlordDecisionQueueResponse>>({
+    data: null,
+    loading: true,
+    error: null,
   });
-  const actions = visibleActions.length > 0 ? visibleActions : fallbackActions;
-  const leaseNoticeSummary = data?.leaseNoticeSummary || {
-    expiringSoon: 0,
-    pendingResponse: 0,
-    renewed: 0,
-    quitting: 0,
-    noResponse: 0,
-  };
-
-  const dataReady =
-    !loading && !propsLoading && !applicationsLoading && !tenantsLoading && !invitesLoading && !error;
-  const countsReady = !propsLoading && !applicationsLoading && !tenantsLoading && !invitesLoading;
-  const hasNoProperties = dataReady && (kpis?.propertiesCount ?? 0) === 0;
-  const hasNoApplications = dataReady && applicationsCount === 0;
-  const hasPortfolioContext = derivedPropertiesCount > 0;
-  const hasUnitContext = derivedUnitsCount > 0;
-  const hasApplicantContext = applicationsCount > 0;
-  const showEmptyCTA = hasNoProperties;
-  const showGettingStartedCard = isLandlord && showEmptyCTA;
-  const showScreeningWorkflowCard = dataReady && hasApplicantContext;
-  const progressLoading = !dataReady || onboarding.loading;
-  const showOnboardingSkeleton = onboarding.loading && !isAdmin;
-  const showStarterOnboarding =
-    meLoaded &&
-    !onboarding.loading &&
-    !onboarding.dismissed &&
-    !onboardingChunkError;
-  const showAdvancedCollapsed = showStarterOnboarding;
-
-  const handleCreateApplicationClick = () => {
-    const prereq = getApplicationPrereqState({
-      propertiesCount: derivedPropertiesCount,
-      unitsCount: derivedUnitsCount,
-    });
-    if (prereq.missingProperty) {
-      track("onboarding_step_clicked", {
-        stepKey: "applicationCreated",
-        blockedBy: "no_property",
-        source: "dashboard",
-      });
-      setPendingPropertyAction("create_application");
-      setPropertyGateOpen(true);
-      return;
-    }
-    if (prereq.missingUnit) {
-      track("onboarding_step_clicked", {
-        stepKey: "applicationCreated",
-        blockedBy: "no_units",
-        source: "dashboard",
-      });
-      navigate("/properties?openAddUnit=1");
-      return;
-    }
-    if (isFreePlan) {
-      track("onboarding_step_clicked", {
-        stepKey: "applicationCreated",
-        source: "dashboard",
-        mode: "manual_intake",
-      });
-      navigate("/applications");
-      return;
-    }
-    track("onboarding_step_clicked", {
-      stepKey: "applicationCreated",
-      source: "dashboard",
-    });
-    setModalPropertyId(propertyOptions[0]?.id || null);
-    setModalUnitId(null);
-    setSendApplicationOpen(true);
-  };
-
-  const derivedSteps = React.useMemo(
-    () => ({
-      propertyAdded: derivedPropertiesCount > 0,
-      unitAdded: derivedUnitsCount > 0,
-      tenantInvited: tenantCount > 0 || invitesCount > 0,
-      applicationCreated: applicationsCount > 0,
-    }),
-    [derivedPropertiesCount, derivedUnitsCount, tenantCount, invitesCount, applicationsCount]
-  );
+  const [refreshKey, setRefreshKey] = React.useState(0);
 
   React.useEffect(() => {
-    if (progressLoading || !countsReady) return;
-    (Object.keys(derivedSteps) as Array<keyof typeof derivedSteps>).forEach((key) => {
-      if (derivedSteps[key] && !onboarding.steps[key]) {
-        onboarding.markStepComplete(key, "derived");
-      }
-    });
-  }, [derivedSteps, onboarding, progressLoading, countsReady]);
+    let alive = true;
+    const periodMonth = getCurrentMonth();
 
-  React.useEffect(() => {
-    if (progressLoading || !countsReady) return;
-    if (!nudgeReadyRef.current) {
-      nudgeReadyRef.current = true;
-      prevDerivedRef.current = {
-        propertyAdded: derivedSteps.propertyAdded,
-        unitAdded: derivedSteps.unitAdded,
-        tenantInvited: derivedSteps.tenantInvited,
-        applicationCreated: derivedSteps.applicationCreated,
-      };
-      return;
-    }
-    const prev = prevDerivedRef.current;
-    if (!prev.propertyAdded && derivedSteps.propertyAdded) {
-      showToast({ message: "Nice — add units next.", variant: "success" });
-    } else if (!prev.unitAdded && derivedSteps.unitAdded) {
-      showToast({ message: "Great — add an applicant next.", variant: "success" });
-    } else if (!prev.tenantInvited && derivedSteps.tenantInvited) {
-      showToast({ message: "Invite sent — create an application next.", variant: "success" });
-    } else if (!prev.applicationCreated && derivedSteps.applicationCreated) {
-      showToast({ message: "Application started — screening is next.", variant: "success" });
-    }
-    prevDerivedRef.current = {
-      propertyAdded: derivedSteps.propertyAdded,
-      unitAdded: derivedSteps.unitAdded,
-      tenantInvited: derivedSteps.tenantInvited,
-      applicationCreated: derivedSteps.applicationCreated,
+    setPortfolio((current) => ({ ...current, loading: true, error: null }));
+    setQueue((current) => ({ ...current, loading: true, error: null }));
+
+    void fetchLandlordPortfolioStatusFinancial({ periodMonth })
+      .then((data) => {
+        if (alive) setPortfolio({ data, loading: false, error: null });
+      })
+      .catch((error) => {
+        if (alive) setPortfolio({ data: null, loading: false, error: errorMessage(error, "Portfolio status could not load.") });
+      });
+
+    void fetchLandlordDecisionQueue({ status: "open_state", limit: 6 })
+      .then((data) => {
+        if (alive) setQueue({ data, loading: false, error: null });
+      })
+      .catch((error) => {
+        if (alive) setQueue({ data: null, loading: false, error: errorMessage(error, "Decision queue could not load.") });
+      });
+
+    return () => {
+      alive = false;
     };
-  }, [derivedSteps, progressLoading, showToast, countsReady]);
+  }, [refreshKey]);
 
-  React.useEffect(() => {
-    if (!showStarterOnboarding || onboarding.loading) return;
-    track("onboarding_viewed");
-  }, [showStarterOnboarding, onboarding.loading]);
-
-  const propertyOptions = React.useMemo(
-    () =>
-      properties.map((p) => ({
-        id: String(p?.id || p?.propertyId || ""),
-        name: p?.name || p?.address || "Property",
-      })).filter((p) => p.id),
-    [properties]
-  );
-
-  const {
-    units: modalUnits,
-    loading: modalUnitsLoading,
-    error: modalUnitsError,
-    refetch: refetchModalUnits,
-  } = useUnitsForProperty(modalPropertyId, sendApplicationOpen);
+  const generatedAt = portfolio.data?.generatedAt || queue.data?.generatedAt || null;
+  const portfolioState = metricState(portfolio.data?.confidence.occupancy);
+  const financialState = metricState(portfolio.data?.confidence.financial);
 
   return (
-    <MacShell title="RentChain · Dashboard" showTopNav={false}>
-      <LandlordWelcomeModal
-        open={showWelcomeModal}
-        onStartSetup={handleStartSetupWelcome}
-        onExploreDashboard={dismissWelcomeModal}
-      />
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: spacing.lg,
-          padding: isMobile
-            ? `${spacing.sm}px 0 ${spacing.md}px`
-            : `${spacing.md}px ${spacing.lg}px`,
-          minWidth: 0,
-        }}
-      >
-        {error ? (
-          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 800, color: colors.danger, marginBottom: 8 }}>Couldn't load dashboard</div>
-            <div style={{ marginBottom: 12 }}>{error}</div>
-            <Button onClick={refetch}>Retry</Button>
-          </Card>
-        ) : null}
-
-        {!dataReady && !error ? (
-          <Card
-            style={{
-              padding: spacing.md,
-              border: `1px solid ${colors.border}`,
-              background: colors.card,
-            }}
-          >
-            <div style={{ fontWeight: 700, marginBottom: 10 }}>Loading your dashboard...</div>
-            <div style={{ display: "grid", gap: 10 }}>
-              <div style={{ height: 12, borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-              <div style={{ height: 12, width: "80%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-              <div style={{ height: 12, width: "60%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-              <div style={{ height: 180, borderRadius: 12, background: "rgba(15,23,42,0.05)" }} />
+    <MacShell title="RentChain · Dashboard 2.0" showTopNav={false}>
+      <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
+        <header style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6, minWidth: 0 }}>
+              <h1 style={{ margin: 0, fontSize: "clamp(1.6rem, 3vw, 2.15rem)", letterSpacing: 0, color: text.primary }}>
+                Operational Home
+              </h1>
+              <div style={{ color: text.muted, lineHeight: 1.55, maxWidth: 760 }}>
+                Portfolio health, decisions, upcoming work, and financial state in one place. Execution stays in Operations and owning workspaces.
+              </div>
             </div>
-          </Card>
-        ) : null}
-
-        {showOnboardingSkeleton ? (
-          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 10 }}>Get started</div>
-            <div style={{ display: "grid", gap: 8 }}>
-              <div style={{ height: 12, borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-              <div style={{ height: 12, width: "70%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-              <div style={{ height: 12, width: "85%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-              <div style={{ height: 12, width: "55%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-            </div>
-          </Card>
-        ) : null}
-
-        {dataReady ? (
-          <FreeTierJourneyCard
-            propertiesCount={derivedPropertiesCount}
-            unitsCount={derivedUnitsCount}
-            applicantsCount={applicationsCount}
-            screeningReady={screeningSetupComplete}
-            leaseReady={false}
-            applicantActionLabel={isFreePlan ? "Track applicant" : "Add applicant"}
-            onAddProperty={() => navigate("/properties?focus=addProperty")}
-            onAddUnit={() => navigate("/properties?openAddUnit=1")}
-            onAddApplicant={handleCreateApplicationClick}
-            onScreening={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}
-            onCreateLease={() => navigate("/properties?openLeasePack=1")}
-          />
-        ) : null}
-
-        {dataReady ? (
-          <div
-            data-testid="dashboard-kpi-decision-stack"
-            style={{
-              display: "grid",
-              gap: spacing.xl,
-              minWidth: 0,
-              width: "100%",
-              boxSizing: "border-box",
-              clear: "both",
-              alignItems: "start",
-            }}
-          >
-            <KpiStrip
-              kpis={kpis}
-              loading={loading}
-              links={{
-                propertiesCount: "/properties",
-                unitsCount: "/properties",
-                tenantsCount: "/tenants",
-                openActionsCount: "/dashboard#open-actions",
-                delinquentCount: "/payments?filter=delinquent",
-              }}
-            />
-          </div>
-        ) : null}
-        {dataReady ? (
-          <div style={{ marginTop: spacing.md }}>
-            <PortfolioCredibilitySummaryCard
-              summary={data?.portfolioCredibilitySummary ?? null}
-              activeLeasesHref="/leases"
-              reviewItemsHref="/applications?status=review"
-            />
-          </div>
-        ) : null}
-        {dataReady &&
-        (leaseNoticeSummary.expiringSoon > 0 ||
-          leaseNoticeSummary.pendingResponse > 0 ||
-          leaseNoticeSummary.renewed > 0 ||
-          leaseNoticeSummary.quitting > 0 ||
-          leaseNoticeSummary.noResponse > 0) ? (
-          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: spacing.sm }}>Lease notice status</div>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
-                gap: spacing.sm,
-              }}
-            >
-              {[
-                { label: "Expiring soon", value: leaseNoticeSummary.expiringSoon, href: "/portfolio-health?entry=lease-renewals&status=expiring" },
-                { label: "Pending response", value: leaseNoticeSummary.pendingResponse, href: "/portfolio-health?entry=lease-renewals&status=pending-response" },
-                { label: "Renewed", value: leaseNoticeSummary.renewed, href: "/leases?view=active" },
-                { label: "Quitting", value: leaseNoticeSummary.quitting, href: "/leases?view=active" },
-                { label: "No response", value: leaseNoticeSummary.noResponse, href: "/portfolio-health?entry=lease-renewals&status=no-response" },
-              ].map((item) => (
-                <Link
-                  key={item.label}
-                  to={item.href}
-                  style={{
-                    display: "block",
-                    padding: spacing.sm,
-                    borderRadius: 12,
-                    border: `1px solid ${colors.border}`,
-                    background: colors.panel,
-                    textDecoration: "none",
-                    color: "inherit",
-                  }}
-                >
-                  <div style={{ color: text.muted, fontSize: 12, marginBottom: 6 }}>{item.label}</div>
-                  <div style={{ fontSize: 24, fontWeight: 800 }}>{item.value}</div>
-                </Link>
-              ))}
-            </div>
-          </Card>
-        ) : null}
-        {dataReady && showTimelineNudge ? (
-          <UpgradeNudgeInlineCard
-            type="GENERIC_UPGRADE"
-            title="New: Automation Timeline (Pro)"
-            body="Track applications -> screening -> leases -> payments in one unified event ledger. Includes Integrity Verified + Insights + Filters."
-            primaryCtaLabel="Unlock with Pro"
-            secondaryCtaLabel="Dismiss"
-            onUpgrade={() => {
-              try {
-                track("dashboard_timeline_nudge_clicked", {
-                  planNormalized,
-                  source: "dashboard_nudge",
-                });
-              } catch {
-                // telemetry must never interrupt UX
-              }
-              void openUpgradeFlow({
-                navigate,
-                fallbackPath: "/pricing",
-                currentPlan: planNormalized,
-              });
-            }}
-            onDismiss={() => {
-              try {
-                localStorage.setItem(TIMELINE_NUDGE_DISMISSED_AT_KEY, String(Date.now()));
-              } catch {
-                // no-op
-              }
-              setShowTimelineNudge(false);
-            }}
-          />
-        ) : null}
-        {dataReady && showTimelineNudge ? (
-          <div style={{ marginTop: -8 }}>
-            <button
-              type="button"
-              onClick={() => navigate("/pricing")}
-              style={{
-                border: "none",
-                background: "transparent",
-                color: colors.accent,
-                cursor: "pointer",
-                padding: 0,
-                fontSize: 13,
-                fontWeight: 600,
-              }}
-            >
-              Learn more
+            <button type="button" onClick={() => setRefreshKey((key) => key + 1)} style={compactButton}>
+              Refresh
             </button>
           </div>
-        ) : null}
-        {dataReady && postUpgradeContent ? (
-          <Card
-            style={{
-              border: "1px solid rgba(16,185,129,0.28)",
-              background: "linear-gradient(135deg, rgba(16,185,129,0.08), rgba(59,130,246,0.06))",
-              display: "grid",
-              gap: spacing.sm,
-            }}
-          >
-            <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
-              <div style={{ display: "grid", gap: 6 }}>
-                <div style={{ fontWeight: 800, fontSize: 16 }}>{postUpgradeContent.title}</div>
-                <div style={{ color: text.muted, fontSize: 14 }}>{postUpgradeContent.dashboardBanner}</div>
-              </div>
-              <Button variant="ghost" onClick={dismissPostUpgradeBanner}>
-                Dismiss
-              </Button>
-            </div>
-            <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-              <Button onClick={() => navigate(postUpgradeContent.primaryAction.to)}>
-                {postUpgradeContent.primaryAction.label}
-              </Button>
-              <Button variant="secondary" onClick={() => navigate(postUpgradeContent.secondaryAction.to)}>
-                {postUpgradeContent.secondaryAction.label}
-              </Button>
-            </div>
-          </Card>
-        ) : null}
-
-        {dataReady ? (
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
-              gap: spacing.md,
-            }}
-          >
-            <div id="open-actions" ref={openActionsRef} tabIndex={-1}>
-              <ActionRequiredPanel
-                items={actions}
-                loading={loading}
-                viewAllEnabled={false}
-                title="Action required"
-                emptyLabel="No pending actions. Add a property to begin setup."
-              />
-            </div>
-            <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-              <div style={{ fontWeight: 700, marginBottom: spacing.sm }}>Quick actions</div>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: spacing.sm }}>
-                <Button
-                  variant="secondary"
-                  onClick={() => navigate("/properties")}
-                  aria-label="Add property"
-                  disabled={progressLoading}
-                >
-                  Add property
-                </Button>
-                {hasPortfolioContext ? (
-                  <Button
-                    variant="secondary"
-                    onClick={() => navigate("/properties?openAddUnit=1")}
-                    aria-label="Add unit"
-                    disabled={progressLoading}
-                  >
-                    Add unit
-                  </Button>
-                ) : null}
-                {hasUnitContext ? (
-                  <Button
-                    variant="secondary"
-                    onClick={handleCreateApplicationClick}
-                    aria-label={isFreePlan ? "Track applicant" : "Add applicant"}
-                    disabled={progressLoading}
-                  >
-                    {isFreePlan ? "Track applicant" : "Add applicant"}
-                  </Button>
-                ) : null}
-                {hasApplicantContext ? (
-                  <Button
-                    variant="secondary"
-                    onClick={() => navigate("/properties?openLeasePack=1")}
-                    aria-label="Create lease"
-                    disabled={progressLoading}
-                  >
-                    Create lease
-                  </Button>
-                ) : null}
-                <Button
-                  variant="secondary"
-                  onClick={() => setAddExpenseOpen(true)}
-                  aria-label="Add expense"
-                  disabled={progressLoading}
-                >
-                  Add Expense
-                </Button>
-                {hasApplicantContext ? (
-                  !SCREENING_ENABLED ? (
-                    <Button variant="primary" onClick={() => navigate("/applications")}>
-                      {screeningWorkflowLabel}
-                    </Button>
-                  ) : screeningSetupComplete ? (
-                    <Button variant="primary" onClick={() => navigate("/applications")}>
-                      Run screening
-                    </Button>
-                  ) : (
-                    <Button variant="primary" onClick={() => navigate("/applications?openTransUnionAccess=1")}>
-                      Set up screening workflow
-                    </Button>
-                  )
-                ) : null}
-              </div>
-            </Card>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            <StatusPill state={portfolioState} />
+            <StatusPill state={financialState} />
+            <span style={{ color: text.subtle, fontSize: 13, alignSelf: "center" }}>
+              {generatedAt ? `Generated ${new Date(generatedAt).toLocaleString()}` : "Generating current state"}
+            </span>
           </div>
-        ) : null}
+        </header>
 
-        {isLandlord ? (
-          <LandlordActivationFlowCard
-            summary={activationSummary}
-            loading={activationLoading}
-            error={activationError}
-            onRetry={() => {
-              void loadActivation();
-            }}
-          />
-        ) : null}
-
-        {showStarterOnboarding && !isAdmin ? (
-          <>
-            <React.Suspense
-              fallback={
-                <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-                  <div style={{ fontWeight: 700, marginBottom: 10 }}>Get started</div>
-                  <div style={{ display: "grid", gap: 8 }}>
-                    <div style={{ height: 12, borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-                    <div style={{ height: 12, width: "70%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-                    <div style={{ height: 12, width: "85%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-                    <div style={{ height: 12, width: "55%", borderRadius: 999, background: "rgba(15,23,42,0.08)" }} />
-                  </div>
-                </Card>
-              }
-            >
-              <OnboardingErrorBoundary onError={() => setOnboardingChunkError(true)}>
-                <StarterOnboardingPanel
-                  steps={buildOnboardingSteps({
-                    onboarding,
-                    navigate,
-                    track,
-                  propertiesCount: derivedPropertiesCount,
-                  unitsCount: derivedUnitsCount,
-                  plan: currentPlan,
-                })}
-                  loading={progressLoading}
-                  onDismiss={() => onboarding.dismissOnboarding()}
-                />
-              </OnboardingErrorBoundary>
-            </React.Suspense>
-          </>
-        ) : null}
-
-        {!progressLoading && onboarding.dismissed && !isAdmin ? (
-          <div style={{ display: "flex", alignItems: "center", gap: 10, color: text.muted }}>
-            <span>Onboarding hidden.</span>
-            <button
-              type="button"
-              onClick={() => onboarding.showOnboarding()}
-              style={{
-                border: "none",
-                background: "transparent",
-                padding: 0,
-                color: colors.accent,
-                cursor: "pointer",
-                fontWeight: 600,
-              }}
-            >
-              Show onboarding
-            </button>
-          </div>
-        ) : null}
-
-        {dataReady && showGettingStartedCard ? (
-          <GettingStartedCard
-            propertiesCount={derivedPropertiesCount}
-            unitsCount={derivedUnitsCount}
-            applicationsCount={applicationsCount}
-            screeningsCount={kpis.screeningsCount ?? 0}
-            onAddProperty={() => navigate("/properties")}
-            onAddApplicant={handleCreateApplicationClick}
-            applicantActionLabel={isFreePlan ? "Track applicant manually" : "Add first applicant"}
-          />
-        ) : null}
-
-        {dataReady &&
-        !showStarterOnboarding &&
-        derivedSteps.propertyAdded &&
-        derivedSteps.unitAdded &&
-        derivedSteps.applicationCreated ? (
-          <Card style={{ padding: spacing.md }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Your applicant workflow is set up</div>
-            <div style={{ color: text.muted, marginBottom: 12 }}>
-              Next up: review screening workflow setup.
-            </div>
-            <Button onClick={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}>
-              {screeningSetupComplete ? "Run screening" : "Set up screening workflow"}
-            </Button>
-          </Card>
-        ) : null}
-
-        {dataReady && !showEmptyCTA && hasNoApplications && hasUnitContext ? (
-          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Next: add an applicant</div>
-            <div style={{ color: text.muted, marginBottom: 12 }}>
-              Send an application link once the property and unit are ready.
-            </div>
-            <Button onClick={handleCreateApplicationClick}>
-              Add applicant
-            </Button>
-          </Card>
-        ) : null}
-
-        {showScreeningWorkflowCard ? (
-          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Screening workflow</div>
-            <div style={{ color: text.muted, marginBottom: 12 }}>
-              {SCREENING_ENABLED
-                ? screeningSetupComplete
-                  ? "Your configured screening provider is connected. Go to Applications to start screening."
-                  : "Open the screening workflow to review provider setup, consent requirements, and manual/offline options."
-                : "Open the screening workflow to review provider paths, consent requirements, and manual/offline options."}
-            </div>
-            <Button onClick={() => navigate(screeningSetupComplete ? "/applications" : "/applications?openTransUnionAccess=1")}>
-              {screeningSetupComplete ? "Run screening" : "Set up screening workflow"}
-            </Button>
-          </Card>
-        ) : null}
-
-        {showScreeningWorkflowCard && SCREENING_ENABLED ? (
-          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Provider setup funnel</div>
-            <div style={{ color: text.muted, marginBottom: 12 }}>
-              {transUnionFunnelLoading
-                ? "Loading onboarding funnel..."
-                : `Started → Connected ${transUnionConversionLabel}`}
-            </div>
-            {!transUnionFunnelLoading ? (
-              <div style={{ display: "grid", gap: 6, color: text.primary, fontSize: 14 }}>
-                <div>Viewed: {transUnionFunnel?.totals.viewed ?? 0}</div>
-                <div>Started: {transUnionStarted}</div>
-                <div>Email clicked: {transUnionFunnel?.totals.emailClicked ?? 0}</div>
-                <div>Connected: {transUnionConnected}</div>
-                <div style={{ color: text.muted }}>{transUnionDropOffInsight}</div>
-              </div>
+        <div
+          data-testid="dashboard-operational-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: isNarrow ? "1fr" : "minmax(0, 1.25fr) minmax(280px, 0.75fr)",
+            gap: spacing.lg,
+          }}
+        >
+          <div style={{ display: "grid", gap: spacing.lg, minWidth: 0 }}>
+            {portfolio.loading ? (
+              <LoadingSection title="Portfolio Status" />
+            ) : portfolio.error ? (
+              <ErrorSection title="Portfolio Status" message={portfolio.error} onRetry={() => setRefreshKey((key) => key + 1)} />
+            ) : portfolio.data ? (
+              <PortfolioStatusSection portfolio={portfolio.data} />
             ) : null}
-          </Card>
-        ) : null}
 
-        {dataReady ? (
-          <details
-            style={{
-              border: `1px solid ${colors.border}`,
-              borderRadius: 8,
-              padding: spacing.md,
-              background: colors.card,
-            }}
-          >
-            <summary style={{ cursor: "pointer", fontWeight: 800 }}>Decision inbox summary</summary>
-            <div style={{ marginTop: spacing.md }}>
-              <DashboardDecisionSummaryPanel
-                decisions={dashboardDecisions}
-                pendingId={decisionActionPendingId}
-                onAction={handleDashboardDecisionAction}
-              />
-            </div>
-          </details>
-        ) : null}
+            {queue.loading ? (
+              <LoadingSection title="Decision Queue Preview" />
+            ) : queue.error ? (
+              <ErrorSection title="Decision Queue Preview" message={queue.error} onRetry={() => setRefreshKey((key) => key + 1)} />
+            ) : queue.data ? (
+              <DecisionQueuePreview queue={queue.data} />
+            ) : null}
 
-        {dataReady && canUseReferrals ? (
-          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
-            <div style={{ fontWeight: 700, marginBottom: 6 }}>Invite another landlord</div>
-            <div style={{ color: text.muted, marginBottom: 12 }}>
-              Referrals sent: {referralsCount}
-            </div>
-            <Button onClick={() => navigate("/referrals")}>Refer a landlord</Button>
-          </Card>
-        ) : null}
-
-        {dataReady && showAdvancedCollapsed ? (
-          <details
-            style={{
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: spacing.md,
-              background: colors.card,
-            }}
-          >
-            <summary style={{ cursor: "pointer", fontWeight: 700 }}>More insights</summary>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))",
-                gap: spacing.md,
-                marginTop: spacing.md,
-              }}
-            >
-              <RecentEventsCard
-                events={events}
-                loading={loading}
-                onOpenLedger={(leaseId) => navigate(leaseId ? `/leases/${leaseId}/ledger` : "/leases")}
-                title="Recent activity"
-                emptyLabel="No recent activity yet. Add a property to start activity tracking."
-              />
-            </div>
-          </details>
-        ) : dataReady ? (
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "1fr",
-              gap: spacing.md,
-            }}
-          >
-            <RecentEventsCard
-              events={events}
-              loading={loading}
-              onOpenLedger={(leaseId) => navigate(leaseId ? `/leases/${leaseId}/ledger` : "/leases")}
-              title="Recent activity"
-              emptyLabel="No recent activity yet. Add a property to start activity tracking."
-            />
+            <WorkspaceRoutingSection />
           </div>
-        ) : null}
 
-        <Section>
-          <div style={{ color: text.muted, fontSize: 12, textAlign: "right" }}>
-            Last updated: {formatDate(lastUpdatedAt)}
-          </div>
-        </Section>
-
-        {showDebug ? (
-          <Section>
-            <div style={{ color: text.muted, fontSize: 12 }}>
-              API Base: {apiBase.normalized || "(relative)"}
-            </div>
-            <div style={{ color: text.muted, fontSize: 12 }}>
-              API Base Raw: {apiBase.raw ?? "(unset)"}
-            </div>
-          </Section>
-        ) : null}
+          <aside style={{ display: "grid", gap: spacing.lg, alignContent: "start", minWidth: 0 }}>
+            {queue.loading ? <LoadingSection title="Upcoming Actions" /> : <UpcomingActions queue={queue.data} />}
+            {portfolio.loading ? (
+              <LoadingSection title="Financial Snapshot" />
+            ) : portfolio.error ? (
+              <ErrorSection title="Financial Snapshot" message={portfolio.error} onRetry={() => setRefreshKey((key) => key + 1)} />
+            ) : portfolio.data ? (
+              <FinancialSnapshotSection portfolio={portfolio.data} />
+            ) : null}
+          </aside>
+        </div>
       </div>
-      <CreatePropertyFirstModal
-        open={propertyGateOpen}
-        onClose={() => setPropertyGateOpen(false)}
-        onCreate={() => {
-          const returnTo = buildReturnTo(pendingPropertyAction || "create_application");
-          navigate(buildCreatePropertyUrl(returnTo));
-          setPropertyGateOpen(false);
-        }}
-      />
-      <SendApplicationModal
-        open={sendApplicationOpen}
-        onClose={() => setSendApplicationOpen(false)}
-        properties={propertyOptions}
-        propertyId={modalPropertyId}
-        units={modalUnits}
-        unitsLoading={modalUnitsLoading}
-        unitsError={modalUnitsError}
-        onUnitsRetry={refetchModalUnits}
-        initialUnitId={modalUnitId}
-        onPropertyChange={(nextId) => {
-          setModalPropertyId(nextId);
-          setModalUnitId(null);
-        }}
-        onUnitChange={(nextId) => setModalUnitId(nextId)}
-      />
-      <AddExpenseModal
-        open={addExpenseOpen}
-        properties={propertyOptions}
-        defaultPropertyId={propertyOptions[0]?.id || null}
-        onClose={() => setAddExpenseOpen(false)}
-      />
     </MacShell>
   );
-};
-
-export default DashboardPage;
+}

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -105,6 +105,24 @@ describe("PortfolioHealthSummaryPage", () => {
             status: "watch",
             summary: "Application and screening follow-through may need closer attention.",
           },
+          {
+            key: "maintenance_health",
+            label: "Maintenance health",
+            status: "healthy",
+            summary: "Work order follow-through is steady.",
+          },
+          {
+            key: "workflow_health",
+            label: "Workflow health",
+            status: "watch",
+            summary: "Operational queue follow-through needs review.",
+          },
+          {
+            key: "response_health",
+            label: "Response health",
+            status: "healthy",
+            summary: "Inbox response patterns are steady.",
+          },
         ],
         nextFocus: [
           {
@@ -133,6 +151,10 @@ describe("PortfolioHealthSummaryPage", () => {
     expect((await screen.findAllByText(/stable overall, with a few areas to monitor/i)).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getAllByText(/Screening health/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Screening health.*Review applications/i })).toHaveAttribute("href", "/applications");
+    expect(screen.getByRole("link", { name: /Maintenance health.*Review work orders/i })).toHaveAttribute("href", "/work-orders");
+    expect(screen.getByRole("link", { name: /Workflow health.*Open operations/i })).toHaveAttribute("href", "/operations");
+    expect(screen.getByRole("link", { name: /Response health.*Open inbox/i })).toHaveAttribute("href", "/landlord/inbox");
     expect(screen.getByText(/Resident feedback patterns/i)).toBeInTheDocument();
     expect(screen.getByText(/Workflow follow-through/i)).toBeInTheDocument();
     expect(macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -400,7 +400,7 @@ export default function PortfolioHealthSummaryPage() {
             <div style={{ display: "grid", gap: 6 }}>
               <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Portfolio health</h1>
               <div style={{ color: "#475569", maxWidth: 820 }}>
-                A high-level view of overall portfolio health, recent direction, and where follow-through may help most.
+                Review portfolio health and open the workspace that owns each follow-through area.
               </div>
             </div>
             <button


### PR DESCRIPTION
## Summary
- Replaces the landlord dashboard with the Dashboard 2.0 Operational Home using the merged Decision Queue and Portfolio Status / Financial Snapshot APIs.
- Adds frontend API helpers for `/landlord/decision-queue` and `/landlord/portfolio-status-financial` without client-selected landlord scope.
- Adds focused Dashboard 2.0 tests for contract rendering, partial degradation, unavailable/degraded metrics, empty states, raw ID absence, and narrow viewport layout.

## Scope controls
- No backend changes.
- No source mutations, payment workflow changes, audit events, notifications, delegated access, contractor organization, or workspace shell work.
- Dashboard preview links route execution to Operations and owning workspaces.

## Validation
- `npm run test:single -- src/pages/DashboardPage.test.tsx` passed.
- `npm run build` passed. Existing large chunk warning remains.
- `git diff --check` passed.

## QA
- Manual QA is required after preview deployment before merge.