### PR TITLE
feat: global workspace shell sticky navigation

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -3,6 +3,11 @@
   --rc-mobile-drawer-bottom-offset: calc(
     var(--rc-mobile-bottom-nav-height) + env(safe-area-inset-bottom, 0px)
   );
+  --rc-landlord-desktop-topnav-height: 60px;
+  --rc-landlord-workspace-bar-height: 48px;
+  --rc-landlord-sticky-shell-height: calc(
+    var(--rc-landlord-desktop-topnav-height) + var(--rc-landlord-workspace-bar-height) + env(safe-area-inset-top, 0px)
+  );
 }
 
 .rc-landlord-shell {
@@ -16,22 +21,39 @@
 
 .rc-landlord-topnav {
   display: block;
-  position: sticky;
+  position: fixed;
   top: 0;
+  right: 0;
+  left: 0;
   z-index: 95;
+  box-sizing: border-box;
   background: rgba(255, 255, 255, 0.97);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
   backdrop-filter: blur(12px);
+}
+
+.rc-landlord-topnav .rc-top-nav {
+  box-sizing: border-box;
+  position: relative !important;
+  top: auto !important;
+  z-index: auto !important;
+  min-height: calc(var(--rc-landlord-desktop-topnav-height) + env(safe-area-inset-top, 0px));
+}
+
+.rc-landlord-topnav .rc-top-nav-inner {
+  min-height: var(--rc-landlord-desktop-topnav-height);
 }
 
 .rc-landlord-workspace-bar {
   display: flex;
   align-items: center;
   gap: 16px;
-  min-height: 48px;
+  min-height: var(--rc-landlord-workspace-bar-height);
+  height: var(--rc-landlord-workspace-bar-height);
   padding: 6px max(20px, env(safe-area-inset-right, 0px)) 8px max(20px, env(safe-area-inset-left, 0px));
   border-bottom: 1px solid rgba(15, 23, 42, 0.08);
   background: rgba(248, 250, 252, 0.96);
+  box-sizing: border-box;
   max-width: 100%;
   overflow: hidden;
 }
@@ -88,12 +110,16 @@
 }
 
 .rc-landlord-content {
-  padding: 12px 0 24px;
+  padding: 0 0 24px;
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
   min-width: 0;
   overflow-x: hidden;
+}
+
+.rc-landlord-content--sticky-offset {
+  padding-top: calc(var(--rc-landlord-sticky-shell-height) + 12px);
 }
 
 .rc-landlord-mobile-topbar {

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -3,11 +3,12 @@
   --rc-mobile-drawer-bottom-offset: calc(
     var(--rc-mobile-bottom-nav-height) + env(safe-area-inset-bottom, 0px)
   );
-  --rc-landlord-desktop-topnav-height: 60px;
+  --rc-landlord-desktop-topnav-height: 72px;
   --rc-landlord-workspace-bar-height: 48px;
   --rc-landlord-sticky-shell-height: calc(
     var(--rc-landlord-desktop-topnav-height) + var(--rc-landlord-workspace-bar-height) + env(safe-area-inset-top, 0px)
   );
+  --rc-landlord-sticky-shell-gap: 20px;
 }
 
 .rc-landlord-shell {
@@ -119,7 +120,10 @@
 }
 
 .rc-landlord-content--sticky-offset {
-  padding-top: calc(var(--rc-landlord-sticky-shell-height) + 12px);
+  padding-top: calc(
+    var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height)) +
+    var(--rc-landlord-sticky-shell-gap)
+  );
 }
 
 .rc-landlord-mobile-topbar {

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -26,11 +26,12 @@
   top: 0;
   right: 0;
   left: 0;
-  z-index: 95;
+  z-index: 2400;
   box-sizing: border-box;
-  background: rgba(255, 255, 255, 0.97);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
-  backdrop-filter: blur(12px);
+  isolation: isolate;
+  background: #ffffff;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.16);
 }
 
 .rc-landlord-topnav .rc-top-nav {
@@ -46,14 +47,18 @@
 }
 
 .rc-landlord-workspace-bar {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 16px;
   min-height: var(--rc-landlord-workspace-bar-height);
   height: var(--rc-landlord-workspace-bar-height);
   padding: 6px max(20px, env(safe-area-inset-right, 0px)) 8px max(20px, env(safe-area-inset-left, 0px));
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(248, 250, 252, 0.96);
+  border-top: 1px solid rgba(15, 23, 42, 0.06);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.14);
+  background: #f8fafc;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
   box-sizing: border-box;
   max-width: 100%;
   overflow: hidden;

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -16,6 +16,75 @@
 
 .rc-landlord-topnav {
   display: block;
+  position: sticky;
+  top: 0;
+  z-index: 95;
+  background: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(12px);
+}
+
+.rc-landlord-workspace-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-height: 48px;
+  padding: 6px max(20px, env(safe-area-inset-right, 0px)) 8px max(20px, env(safe-area-inset-left, 0px));
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.96);
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.rc-landlord-workspace-context {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-width: 0;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.rc-landlord-workspace-context strong {
+  color: #0f172a;
+  font-size: 14px;
+}
+
+.rc-landlord-workspace-links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rc-landlord-workspace-links::-webkit-scrollbar {
+  display: none;
+}
+
+.rc-landlord-workspace-links a {
+  flex: 0 0 auto;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 999px;
+  padding: 7px 10px;
+  background: #ffffff;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.rc-landlord-workspace-links a.active {
+  border-color: rgba(37, 99, 235, 0.32);
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
 }
 
 .rc-landlord-content {

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -97,6 +97,36 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(drawer).getByRole("button", { name: "Work Orders" })).toBeInTheDocument();
   });
 
+  it("renders a sticky workspace context bar with primary landlord workspace links", () => {
+    renderLandlordNav("/payments");
+
+    const context = screen.getByLabelText("Workspace context");
+    const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
+
+    expect(document.querySelector(".rc-landlord-topnav")).toBeInTheDocument();
+    expect(context).toHaveTextContent("Current workspace");
+    expect(context).toHaveTextContent("Payments");
+    expect(within(workspaceNav).getByRole("link", { name: "Dashboard" })).toHaveAttribute("href", "/dashboard");
+    expect(within(workspaceNav).getByRole("link", { name: "Operations" })).toHaveAttribute("href", "/operations");
+    expect(within(workspaceNav).getByRole("link", { name: "Properties" })).toHaveAttribute("href", "/properties");
+    expect(within(workspaceNav).getByRole("link", { name: "Tenants" })).toHaveAttribute("href", "/tenants");
+    expect(within(workspaceNav).getByRole("link", { name: "Leases" })).toHaveAttribute("href", "/leases");
+    expect(within(workspaceNav).getByRole("link", { name: "Payments" })).toHaveClass("active");
+    expect(within(workspaceNav).getByRole("link", { name: "Inbox" })).toHaveAttribute("href", "/landlord/unified-inbox");
+    expect(within(workspaceNav).getByRole("link", { name: "Work Orders" })).toHaveAttribute("href", "/work-orders");
+  });
+
+  it("keeps canonical inbox context visible for legacy landlord inbox paths", () => {
+    renderLandlordNav("/landlord/inbox");
+
+    const context = screen.getByLabelText("Workspace context");
+    const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
+
+    expect(context).toHaveTextContent("Inbox");
+    expect(within(workspaceNav).getByRole("link", { name: "Inbox" })).toHaveClass("active");
+    expect(screen.getByText("Inbox", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
+  });
+
   it("keeps the mobile tab bar and close control available while the drawer is open", () => {
     renderLandlordNav();
 

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -131,6 +131,31 @@ describe("LandlordNav mobile drawer", () => {
     expect(content).toContainElement(screen.getByTestId("page-content"));
   });
 
+  it("stores the measured fixed shell height for the content offset", async () => {
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect() {
+      const height = this.classList.contains("rc-landlord-topnav") ? 148 : 0;
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        right: 0,
+        bottom: height,
+        left: 0,
+        width: 0,
+        height,
+        toJSON: () => ({}),
+      };
+    });
+
+    renderLandlordNav("/dashboard");
+
+    await waitFor(() => {
+      expect((document.querySelector(".rc-landlord-shell") as HTMLElement).style.getPropertyValue("--rc-landlord-sticky-shell-measured-height")).toBe("148px");
+    });
+
+    rectSpy.mockRestore();
+  });
+
   it("keeps canonical inbox context visible for legacy landlord inbox paths", () => {
     renderLandlordNav("/landlord/inbox");
 

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -102,8 +102,12 @@ describe("LandlordNav mobile drawer", () => {
 
     const context = screen.getByLabelText("Workspace context");
     const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
+    const shell = document.querySelector(".rc-landlord-topnav");
+    const content = document.querySelector(".rc-landlord-content");
 
-    expect(document.querySelector(".rc-landlord-topnav")).toBeInTheDocument();
+    expect(shell).toBeInTheDocument();
+    expect(content).toHaveClass("rc-landlord-content--sticky-offset");
+    expect(shell?.nextElementSibling).toBe(document.querySelector(".rc-landlord-mobile-topbar"));
     expect(context).toHaveTextContent("Current workspace");
     expect(context).toHaveTextContent("Payments");
     expect(within(workspaceNav).getByRole("link", { name: "Dashboard" })).toHaveAttribute("href", "/dashboard");
@@ -114,6 +118,17 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(workspaceNav).getByRole("link", { name: "Payments" })).toHaveClass("active");
     expect(within(workspaceNav).getByRole("link", { name: "Inbox" })).toHaveAttribute("href", "/landlord/unified-inbox");
     expect(within(workspaceNav).getByRole("link", { name: "Work Orders" })).toHaveAttribute("href", "/work-orders");
+  });
+
+  it("renders page content in the offset shell region below sticky navigation", () => {
+    renderLandlordNav("/operations");
+
+    const topNav = document.querySelector(".rc-landlord-topnav");
+    const content = document.querySelector(".rc-landlord-content");
+
+    expect(topNav).toBeInTheDocument();
+    expect(content).toHaveClass("rc-landlord-content--sticky-offset");
+    expect(content).toContainElement(screen.getByTestId("page-content"));
   });
 
   it("keeps canonical inbox context visible for legacy landlord inbox paths", () => {

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -85,6 +85,8 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   const [hasUnread, setHasUnread] = useState<boolean>(false);
   const unreadFlag = typeof unreadMessages === "boolean" ? unreadMessages : hasUnread;
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const stickyShellRef = useRef<HTMLDivElement | null>(null);
   const lastFocusedRef = useRef<HTMLElement | null>(null);
   const navLoading = !ready || isLoading || authStatus === "restoring" || !user || capsLoading;
   const isAdminLikeContext = React.useMemo(() => isAdminContext(user), [user]);
@@ -198,6 +200,33 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
     };
   }, [drawerOpen]);
 
+  React.useLayoutEffect(() => {
+    const shell = shellRef.current;
+    const stickyShell = stickyShellRef.current;
+    if (!shell || !stickyShell) return undefined;
+
+    const syncStickyOffset = () => {
+      const height = Math.ceil(stickyShell.getBoundingClientRect().height);
+      if (height > 0) {
+        shell.style.setProperty("--rc-landlord-sticky-shell-measured-height", `${height}px`);
+      }
+    };
+
+    syncStickyOffset();
+    window.addEventListener("resize", syncStickyOffset);
+
+    const observer =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => syncStickyOffset())
+        : null;
+    observer?.observe(stickyShell);
+
+    return () => {
+      window.removeEventListener("resize", syncStickyOffset);
+      observer?.disconnect();
+    };
+  }, [workspaceItems.length, workspaceLabel]);
+
   if (navLoading) {
     return (
       <div
@@ -237,8 +266,8 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   }
 
   return (
-    <div className={shellClassName}>
-      <div className="rc-landlord-topnav">
+    <div className={shellClassName} ref={shellRef}>
+      <div className="rc-landlord-topnav" ref={stickyShellRef}>
         <TopNav />
         <div className="rc-landlord-workspace-bar" aria-label="Workspace context">
           <div className="rc-landlord-workspace-context">

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -129,6 +129,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   ].filter(Boolean).join(" ");
   const contentClassName = [
     "rc-landlord-content",
+    "rc-landlord-content--sticky-offset",
     loc.pathname.startsWith("/messages") ? "rc-landlord-content--mobile-flush" : "",
   ].filter(Boolean).join(" ");
 

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Building2, Inbox, LayoutDashboard, Menu, ScrollText, X } from "lucide-react";
-import { Navigate, useLocation, useNavigate } from "react-router-dom";
+import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
 import { fetchLandlordConversations } from "../../api/messagesApi";
@@ -22,6 +22,37 @@ const landlordMobileTabs = [
   { to: "/applications", label: "Applicants", icon: ScrollText },
   { to: "/landlord/unified-inbox", label: "Inbox", icon: Inbox },
 ];
+
+const stickyWorkspaceIds = new Set([
+  "dashboard",
+  "operations",
+  "properties",
+  "tenants",
+  "leases",
+  "payments",
+  "unified-inbox",
+  "work-orders",
+]);
+
+const workspaceAliases: Array<{ prefix: string; label: string }> = [
+  { prefix: "/landlord/inbox", label: "Inbox" },
+  { prefix: "/landlord/unified-inbox", label: "Inbox" },
+  { prefix: "/work-orders", label: "Work Orders" },
+  { prefix: "/maintenance", label: "Maintenance" },
+];
+
+function isRouteActive(pathname: string, target: string): boolean {
+  return pathname === target || pathname.startsWith(`${target}/`);
+}
+
+function resolveWorkspaceLabel(pathname: string, items: Array<{ to: string; label: string }>): string {
+  const alias = workspaceAliases.find((entry) => isRouteActive(pathname, entry.prefix));
+  if (alias) return alias.label;
+  const match = [...items]
+    .sort((left, right) => right.to.length - left.to.length)
+    .find((item) => isRouteActive(pathname, item.to));
+  return match?.label || "Workspace";
+}
 
 function includesAdminAuthority(value: unknown): boolean {
   if (Array.isArray(value)) {
@@ -74,6 +105,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   }
   const visibleItems = navLoading || !isLandlordWorkspace ? [] : getVisibleNavItems(effectiveRole, features);
   const drawerItems = visibleItems.filter((item) => item.showInDrawer !== false);
+  const workspaceItems = visibleItems.filter((item) => stickyWorkspaceIds.has(item.id));
   const primaryDrawerItems = drawerItems.filter((item) => !item.requiresAdmin);
   const adminDrawerItems = drawerItems.filter((item) => item.requiresAdmin);
   const orderedPrimaryDrawerItems = React.useMemo(
@@ -90,6 +122,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       ? landlordMobileTabs.filter((item) => !item.requiresMessaging || features?.messaging !== false)
       : [];
   const showMobileBottomNav = effectiveRole === "landlord" && !isAdminLikeContext;
+  const workspaceLabel = resolveWorkspaceLabel(loc.pathname, visibleItems);
   const shellClassName = [
     "rc-landlord-shell",
     showMobileBottomNav ? "rc-landlord-shell--mobile-tabs" : "",
@@ -206,11 +239,28 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
     <div className={shellClassName}>
       <div className="rc-landlord-topnav">
         <TopNav />
+        <div className="rc-landlord-workspace-bar" aria-label="Workspace context">
+          <div className="rc-landlord-workspace-context">
+            <span>Current workspace</span>
+            <strong>{workspaceLabel}</strong>
+          </div>
+          <nav className="rc-landlord-workspace-links" aria-label="Workspace navigation">
+            {workspaceItems.map(({ id, to, label }) => (
+              <Link
+                key={id}
+                to={to}
+                className={isRouteActive(loc.pathname, to) || (id === "unified-inbox" && isRouteActive(loc.pathname, "/landlord/inbox")) ? "active" : ""}
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
       </div>
 
       <div className="rc-landlord-mobile-topbar">
         <RentChainLogo href="/dashboard" size="sm" />
-        <span className="rc-landlord-mobile-role">{effectiveRole === "admin" ? "Admin" : "Landlord"}</span>
+        <span className="rc-landlord-mobile-role">{workspaceLabel}</span>
         <button
           type="button"
           className="rc-landlord-mobile-menu"


### PR DESCRIPTION
## Summary
- Adds a sticky landlord workspace shell above primary landlord workspaces so the title/navigation context stays visible while scrolling.
- Adds a compact workspace context row with quick links for Dashboard, Operations, Properties, Tenants, Leases, Payments, Inbox, and Work Orders.
- Keeps mobile behavior compact by preserving the sticky mobile top bar and showing the current workspace context there.

## Scope Controls
- No Dashboard redesign.
- No workspace redesign.
- No API/backend changes.
- No routing model changes beyond using existing workspace links.

## Validation
- `npm run test:single -- src/components/layout/LandlordNav.test.tsx`
- `npm run build`
- `git diff --check`

## Manual QA Required
- Verify sticky title/navigation behavior in the Vercel preview across Dashboard, Properties, Tenants, Leases, Payments, Unified Inbox, Operations, and Work Orders.
- Verify mobile/narrow viewport behavior has no overlap or horizontal page scrolling.

Closes #1197