### PR TITLE
feat/unified-inbox-tabs-and-filters-v1

### DIFF
--- a/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
+++ b/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ChevronRight, Inbox } from "lucide-react";
+import { ArrowUpRight, ChevronRight, Inbox } from "lucide-react";
 import type { UnifiedInboxRecord, UnifiedInboxRole, UnifiedInboxSourceKind } from "../../api/unifiedInboxApi";
 import { Card } from "../ui/Ui";
 import { colors, radius, spacing, text } from "../../styles/tokens";
@@ -48,6 +48,27 @@ function priorityTone(priority: UnifiedInboxRecord["priority"]) {
   return { color: "#075985", background: "#e0f2fe" };
 }
 
+function workspaceForRecord(record: UnifiedInboxRecord, role: UnifiedInboxRole) {
+  if (role === "tenant") return null;
+  if (role === "contractor") return null;
+  if (record.sourceKind.includes("maintenance") || record.sourceKind.includes("work_order")) {
+    return { href: "/work-orders", label: "Open work orders" };
+  }
+  if (record.sourceKind.includes("lease")) {
+    return { href: "/leases", label: "Open leases" };
+  }
+  if (record.sourceKind.includes("application") || record.sourceKind.includes("screening") || record.sourceKind.includes("viewing")) {
+    return { href: "/applications", label: "Open applications" };
+  }
+  if (/\b(payment|payments|rent|invoice|charge|balance|outstanding|collection)\b/i.test(record.title + " " + record.body)) {
+    return { href: "/payments", label: "Open payments" };
+  }
+  if (record.sourceKind.includes("message")) {
+    return { href: "/landlord/unified-inbox", label: "Stay in inbox" };
+  }
+  return null;
+}
+
 function formatDate(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Date unavailable";
@@ -71,6 +92,7 @@ export function UnifiedInboxList({ records, role }: Props) {
   const safeRecords = records.filter((record) => isSafeRecordForRole(record, role));
   const [selectedId, setSelectedId] = React.useState<string | null>(safeRecords[0]?.id || null);
   const selected = safeRecords.find((record) => record.id === selectedId) || safeRecords[0] || null;
+  const selectedWorkspace = selected ? workspaceForRecord(selected, role) : null;
 
   React.useEffect(() => {
     if (!safeRecords.length) {
@@ -172,11 +194,30 @@ export function UnifiedInboxList({ records, role }: Props) {
                 <span style={{ color: text.muted }}>Updated</span>
                 <strong>{formatDate(selected.occurredAt)}</strong>
               </div>
-              <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
-                <span style={{ color: text.muted }}>Visibility</span>
-                <strong>{formatStatus(selected.audienceRole)}</strong>
-              </div>
             </div>
+            {selectedWorkspace ? (
+              <a
+                href={selectedWorkspace.href}
+                style={{
+                  alignItems: "center",
+                  background: colors.accent,
+                  borderRadius: 999,
+                  color: "#fff",
+                  display: "inline-flex",
+                  fontSize: "0.95rem",
+                  fontWeight: 800,
+                  gap: 8,
+                  justifySelf: "start",
+                  padding: "10px 14px",
+                  textDecoration: "none",
+                }}
+              >
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                  {selectedWorkspace.label}
+                  <ArrowUpRight size={16} aria-hidden="true" />
+                </span>
+              </a>
+            ) : null}
           </>
         ) : null}
       </Card>

--- a/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
+++ b/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
@@ -166,7 +166,21 @@ export function UnifiedInboxList({ records, role, onOpenRecord }: Props) {
               </div>
             </button>
             {active ? (
-              <Card elevated style={{ display: "grid", gap: spacing.md, marginTop: `-${spacing.xs}` }}>
+              <Card
+                data-testid="unified-inbox-detail-panel"
+                style={{
+                  background: "#f8fafc",
+                  borderColor: "rgba(37, 99, 235, 0.16)",
+                  borderLeft: `3px solid ${colors.accent}`,
+                  boxShadow: "none",
+                  display: "grid",
+                  gap: spacing.md,
+                  marginLeft: spacing.md,
+                  marginTop: `-${spacing.xs}`,
+                  maxWidth: `calc(100% - ${spacing.md})`,
+                  padding: spacing.md,
+                }}
+              >
                 <div style={{ display: "grid", gap: 6 }}>
                   <div style={{ color: text.muted, fontSize: "0.86rem", fontWeight: 700 }}>
                     {SOURCE_LABELS[record.sourceKind]}

--- a/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
+++ b/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
@@ -7,6 +7,7 @@ import { colors, radius, spacing, text } from "../../styles/tokens";
 type Props = {
   records: UnifiedInboxRecord[];
   role: UnifiedInboxRole;
+  onOpenRecord?: (record: UnifiedInboxRecord) => void;
 };
 
 const SOURCE_LABELS: Record<UnifiedInboxSourceKind, string> = {
@@ -88,19 +89,18 @@ function isSafeRecordForRole(record: UnifiedInboxRecord, role: UnifiedInboxRole)
   return record.audienceRole === role;
 }
 
-export function UnifiedInboxList({ records, role }: Props) {
+export function UnifiedInboxList({ records, role, onOpenRecord }: Props) {
   const safeRecords = records.filter((record) => isSafeRecordForRole(record, role));
-  const [selectedId, setSelectedId] = React.useState<string | null>(safeRecords[0]?.id || null);
-  const selected = safeRecords.find((record) => record.id === selectedId) || safeRecords[0] || null;
-  const selectedWorkspace = selected ? workspaceForRecord(selected, role) : null;
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const selected = safeRecords.find((record) => record.id === selectedId) || null;
 
   React.useEffect(() => {
     if (!safeRecords.length) {
       setSelectedId(null);
       return;
     }
-    if (!safeRecords.some((record) => record.id === selectedId)) {
-      setSelectedId(safeRecords[0].id);
+    if (selectedId && !safeRecords.some((record) => record.id === selectedId)) {
+      setSelectedId(null);
     }
   }, [safeRecords, selectedId]);
 
@@ -119,24 +119,22 @@ export function UnifiedInboxList({ records, role }: Props) {
   }
 
   return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
-        gap: spacing.md,
-      }}
-    >
-      <div style={{ display: "grid", gap: spacing.sm }}>
-        {safeRecords.map((record) => {
-          const active = record.id === selected?.id;
-          const priority = priorityTone(record.priority);
-          const status = statusTone(record.status);
-          return (
+    <div style={{ display: "grid", gap: spacing.sm }}>
+      {safeRecords.map((record) => {
+        const active = record.id === selected?.id;
+        const priority = priorityTone(record.priority);
+        const status = statusTone(record.status);
+        const selectedWorkspace = active ? workspaceForRecord(record, role) : null;
+        return (
+          <React.Fragment key={record.id}>
             <button
-              key={record.id}
               type="button"
-              onClick={() => setSelectedId(record.id)}
+              onClick={() => {
+                setSelectedId(record.id);
+                onOpenRecord?.(record);
+              }}
               aria-current={active ? "true" : undefined}
+              aria-expanded={active}
               style={{
                 textAlign: "left",
                 border: active ? `1px solid ${colors.accent}` : `1px solid ${colors.border}`,
@@ -167,60 +165,57 @@ export function UnifiedInboxList({ records, role }: Props) {
                 <span style={{ color: text.subtle, fontSize: 12 }}>{formatDate(record.occurredAt)}</span>
               </div>
             </button>
-          );
-        })}
-      </div>
-
-      <Card elevated style={{ alignSelf: "start", display: "grid", gap: spacing.md }}>
-        {selected ? (
-          <>
-            <div style={{ display: "grid", gap: 6 }}>
-              <div style={{ color: text.muted, fontSize: "0.86rem", fontWeight: 700 }}>
-                {SOURCE_LABELS[selected.sourceKind]}
-              </div>
-              <div style={{ color: text.primary, fontSize: "1.2rem", fontWeight: 850 }}>{selected.title}</div>
-              <div style={{ color: text.secondary, lineHeight: 1.6 }}>{selected.body}</div>
-            </div>
-            <div style={{ display: "grid", gap: 10 }}>
-              <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
-                <span style={{ color: text.muted }}>Status</span>
-                <strong>{formatStatus(selected.status)}</strong>
-              </div>
-              <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
-                <span style={{ color: text.muted }}>Priority</span>
-                <strong>{formatStatus(selected.priority)}</strong>
-              </div>
-              <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
-                <span style={{ color: text.muted }}>Updated</span>
-                <strong>{formatDate(selected.occurredAt)}</strong>
-              </div>
-            </div>
-            {selectedWorkspace ? (
-              <a
-                href={selectedWorkspace.href}
-                style={{
-                  alignItems: "center",
-                  background: colors.accent,
-                  borderRadius: 999,
-                  color: "#fff",
-                  display: "inline-flex",
-                  fontSize: "0.95rem",
-                  fontWeight: 800,
-                  gap: 8,
-                  justifySelf: "start",
-                  padding: "10px 14px",
-                  textDecoration: "none",
-                }}
-              >
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-                  {selectedWorkspace.label}
-                  <ArrowUpRight size={16} aria-hidden="true" />
-                </span>
-              </a>
+            {active ? (
+              <Card elevated style={{ display: "grid", gap: spacing.md, marginTop: `-${spacing.xs}` }}>
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ color: text.muted, fontSize: "0.86rem", fontWeight: 700 }}>
+                    {SOURCE_LABELS[record.sourceKind]}
+                  </div>
+                  <div style={{ color: text.primary, fontSize: "1.2rem", fontWeight: 850 }}>{record.title}</div>
+                  <div style={{ color: text.secondary, lineHeight: 1.6 }}>{record.body}</div>
+                </div>
+                <div style={{ display: "grid", gap: 10 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
+                    <span style={{ color: text.muted }}>Status</span>
+                    <strong>{formatStatus(record.status)}</strong>
+                  </div>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
+                    <span style={{ color: text.muted }}>Priority</span>
+                    <strong>{formatStatus(record.priority)}</strong>
+                  </div>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
+                    <span style={{ color: text.muted }}>Updated</span>
+                    <strong>{formatDate(record.occurredAt)}</strong>
+                  </div>
+                </div>
+                {selectedWorkspace ? (
+                  <a
+                    href={selectedWorkspace.href}
+                    style={{
+                      alignItems: "center",
+                      background: colors.accent,
+                      borderRadius: 999,
+                      color: "#fff",
+                      display: "inline-flex",
+                      fontSize: "0.95rem",
+                      fontWeight: 800,
+                      gap: 8,
+                      justifySelf: "start",
+                      padding: "10px 14px",
+                      textDecoration: "none",
+                    }}
+                  >
+                    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                      {selectedWorkspace.label}
+                      <ArrowUpRight size={16} aria-hidden="true" />
+                    </span>
+                  </a>
+                ) : null}
+              </Card>
             ) : null}
-          </>
-        ) : null}
-      </Card>
+          </React.Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -258,6 +258,7 @@ describe("LandlordNav mobile drawer", () => {
     const drawer = screen.getByRole("dialog", { name: "Navigation menu" });
     const inboxButtons = within(drawer).getAllByRole("button", { name: "Inbox" });
     expect(inboxButtons).toHaveLength(1);
+    expect(within(drawer).queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
 
     fireEvent.click(inboxButtons[0]);
 

--- a/rentchain-frontend/src/components/layout/TopNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.test.tsx
@@ -56,13 +56,13 @@ describe("TopNav", () => {
     });
   });
 
-  it("renders a landlord messages shortcut and routes to /messages", async () => {
+  it("renders a landlord inbox shortcut and routes to the unified inbox", async () => {
     render(<TopNav />);
 
-    const messagesButton = await screen.findByRole("button", { name: "Messages" });
+    const messagesButton = await screen.findByRole("button", { name: "Inbox" });
     fireEvent.click(messagesButton);
 
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/messages");
+    expect(mocks.navigateMock).toHaveBeenCalledWith("/landlord/inbox");
   });
 
   it("shows unread indicator from existing conversation unread data", async () => {
@@ -71,7 +71,7 @@ describe("TopNav", () => {
     render(<TopNav />);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Messages (unread)" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Inbox (unread)" })).toBeInTheDocument();
     });
   });
 });

--- a/rentchain-frontend/src/components/layout/TopNav.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.tsx
@@ -111,8 +111,8 @@ const TopNav: React.FC = () => {
               <Button
                 className="rc-top-nav-optional-action"
                 variant="secondary"
-                onClick={() => navigate("/messages")}
-                aria-label={hasUnreadMessages ? "Messages (unread)" : "Messages"}
+                onClick={() => navigate("/landlord/inbox")}
+                aria-label={hasUnreadMessages ? "Inbox (unread)" : "Inbox"}
                 style={{
                   position: "relative",
                   borderRadius: radius.pill,
@@ -124,7 +124,7 @@ const TopNav: React.FC = () => {
                   paddingRight: hasUnreadMessages ? "16px" : undefined,
                 }}
               >
-                Messages
+                Inbox
                 {hasUnreadMessages ? (
                   <span
                     aria-hidden="true"

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -118,7 +118,7 @@ export const NAV_ITEMS: NavItem[] = [
     label: "Messages",
     to: "/messages",
     icon: MessagesSquare,
-    showInDrawer: true,
+    showInDrawer: false,
     showInTabs: false,
     requiresFeature: "messaging",
   },

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -210,7 +210,19 @@ describe("UnifiedInboxPage", () => {
     expect(screen.getByRole("tab", { name: /Unread 1/i })).toBeInTheDocument();
     expect(pipeButton.nextElementSibling).toHaveTextContent("Pipe leak reported");
     expect(pipeButton.nextElementSibling).toHaveTextContent("Status");
+    expect(screen.getByTestId("unified-inbox-detail-panel")).toHaveStyle({
+      background: "#f8fafc",
+      boxShadow: "none",
+    });
     expect(screen.getByRole("link", { name: /Open work orders/i })).toHaveAttribute("href", "/work-orders");
+
+    fireEvent.click(screen.getByRole("tab", { name: /Unread 1/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Outstanding rent balance/i }));
+    const paymentButton = screen.getByRole("button", { name: /Outstanding rent balance/i });
+    expect(paymentButton).toHaveAttribute("aria-expanded", "true");
+    expect(paymentButton).toHaveTextContent("Read");
+    expect(screen.getByRole("tab", { name: /Unread 0/i })).toBeInTheDocument();
+    expect(screen.getByTestId("unified-inbox-detail-panel")).toHaveTextContent("Outstanding rent balance");
 
     fireEvent.click(screen.getByRole("tab", { name: /All 4/i }));
     fireEvent.change(screen.getByLabelText("Search inbox"), { target: { value: "balance" } });
@@ -219,8 +231,9 @@ describe("UnifiedInboxPage", () => {
 
     fireEvent.change(screen.getByLabelText("Search inbox"), { target: { value: "" } });
     fireEvent.change(screen.getByLabelText("Filter inbox status"), { target: { value: "read" } });
-    expect(screen.getAllByText("Lease renewal ready").length).toBeGreaterThan(0);
+    fireEvent.change(screen.getByLabelText("Filter inbox priority"), { target: { value: "low" } });
     expect(screen.getAllByText("System notice").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Lease renewal ready")).not.toBeInTheDocument();
     expect(screen.queryByText("Outstanding rent balance")).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import UnifiedInboxPage from "./UnifiedInboxPage";
 import type { UnifiedInboxRecord } from "../api/unifiedInboxApi";
@@ -106,6 +106,115 @@ describe("UnifiedInboxPage", () => {
     expect(await screen.findByRole("heading", { name: "Unified inbox" })).toBeInTheDocument();
     expect(screen.getAllByText("Work order update").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Work order").length).toBeGreaterThan(0);
+  });
+
+  it("filters landlord inbox records with operational tabs, status, and search", async () => {
+    mocks.fetchUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [
+        record({
+          id: "maintenance-priority",
+          audienceRole: "landlord",
+          sourceKind: "landlord.maintenance",
+          title: "Pipe leak reported",
+          body: "Maintenance priority at Unit 204",
+          priority: "high",
+          status: "unread",
+        }),
+        record({
+          id: "lease-ready",
+          audienceRole: "landlord",
+          sourceKind: "landlord.lease",
+          title: "Lease renewal ready",
+          body: "Renewal waiting for review",
+          priority: "normal",
+          status: "read",
+        }),
+        record({
+          id: "payment-balance",
+          audienceRole: "landlord",
+          sourceKind: "landlord.message",
+          title: "Outstanding rent balance",
+          body: "Payment follow-up needed",
+          priority: "normal",
+          status: "unread",
+        }),
+        record({
+          id: "notice-system",
+          audienceRole: "landlord",
+          sourceKind: "landlord.notice",
+          title: "System notice",
+          body: "Notice delivery update",
+          priority: "low",
+          status: "read",
+        }),
+      ],
+      records: [
+        record({
+          id: "maintenance-priority",
+          audienceRole: "landlord",
+          sourceKind: "landlord.maintenance",
+          title: "Pipe leak reported",
+          body: "Maintenance priority at Unit 204",
+          priority: "high",
+          status: "unread",
+        }),
+        record({
+          id: "lease-ready",
+          audienceRole: "landlord",
+          sourceKind: "landlord.lease",
+          title: "Lease renewal ready",
+          body: "Renewal waiting for review",
+          priority: "normal",
+          status: "read",
+        }),
+        record({
+          id: "payment-balance",
+          audienceRole: "landlord",
+          sourceKind: "landlord.message",
+          title: "Outstanding rent balance",
+          body: "Payment follow-up needed",
+          priority: "normal",
+          status: "unread",
+        }),
+        record({
+          id: "notice-system",
+          audienceRole: "landlord",
+          sourceKind: "landlord.notice",
+          title: "System notice",
+          body: "Notice delivery update",
+          priority: "low",
+          status: "read",
+        }),
+      ],
+      total: 4,
+      limit: 20,
+      offset: 0,
+    });
+
+    render(<UnifiedInboxPage role="landlord" />);
+
+    expect(await screen.findByRole("heading", { name: "Unified inbox" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Maintenance 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Payments 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /System 1/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Maintenance 1/i }));
+    expect(screen.getAllByText("Pipe leak reported").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Lease renewal ready")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open work orders/i })).toHaveAttribute("href", "/work-orders");
+
+    fireEvent.click(screen.getByRole("tab", { name: /All 4/i }));
+    fireEvent.change(screen.getByLabelText("Search inbox"), { target: { value: "balance" } });
+    expect(screen.getAllByText("Outstanding rent balance").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Pipe leak reported")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search inbox"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Filter inbox status"), { target: { value: "read" } });
+    expect(screen.getAllByText("Lease renewal ready").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("System notice").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Outstanding rent balance")).not.toBeInTheDocument();
   });
 
   it("shows a safe error state when the inbox cannot load", async () => {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -203,6 +203,13 @@ describe("UnifiedInboxPage", () => {
     fireEvent.click(screen.getByRole("tab", { name: /Maintenance 1/i }));
     expect(screen.getAllByText("Pipe leak reported").length).toBeGreaterThan(0);
     expect(screen.queryByText("Lease renewal ready")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Pipe leak reported/i }));
+    const pipeButton = screen.getByRole("button", { name: /Pipe leak reported/i });
+    expect(pipeButton).toHaveAttribute("aria-expanded", "true");
+    expect(pipeButton).toHaveTextContent("Read");
+    expect(screen.getByRole("tab", { name: /Unread 1/i })).toBeInTheDocument();
+    expect(pipeButton.nextElementSibling).toHaveTextContent("Pipe leak reported");
+    expect(pipeButton.nextElementSibling).toHaveTextContent("Status");
     expect(screen.getByRole("link", { name: /Open work orders/i })).toHaveAttribute("href", "/work-orders");
 
     fireEvent.click(screen.getByRole("tab", { name: /All 4/i }));

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
@@ -93,6 +93,7 @@ export default function UnifiedInboxPage({ role }: Props) {
   const [priorityFilter, setPriorityFilter] = React.useState<PriorityFilter>("all");
   const [search, setSearch] = React.useState("");
   const [localReadAtById, setLocalReadAtById] = React.useState<Record<string, string>>({});
+  const [openedRecordId, setOpenedRecordId] = React.useState<string | null>(null);
 
   const load = React.useCallback(async () => {
     setLoading(true);
@@ -114,6 +115,7 @@ export default function UnifiedInboxPage({ role }: Props) {
 
   React.useEffect(() => {
     setLocalReadAtById({});
+    setOpenedRecordId(null);
   }, [role]);
 
   const records = data?.records || data?.items || [];
@@ -140,14 +142,26 @@ export default function UnifiedInboxPage({ role }: Props) {
       }),
     [activeTab, normalizedSearch, priorityFilter, safeRecords, statusFilter]
   );
+  const displayedRecords = React.useMemo(() => {
+    if (!openedRecordId || filteredRecords.some((record) => record.id === openedRecordId)) {
+      return filteredRecords;
+    }
+    const openedRecord = safeRecords.find((record) => record.id === openedRecordId);
+    if (!openedRecord) return filteredRecords;
+    return [openedRecord, ...filteredRecords];
+  }, [filteredRecords, openedRecordId, safeRecords]);
   const unreadCount = safeRecords.filter((record) => record.status === "unread").length;
   const priorityCount = safeRecords.filter((record) => record.priority === "critical" || record.priority === "high").length;
   const markRecordRead = React.useCallback((record: UnifiedInboxRecord) => {
+    setOpenedRecordId(record.id);
     if (record.status !== "unread" && record.readAt) return;
     setLocalReadAtById((current) => {
       if (current[record.id]) return current;
       return { ...current, [record.id]: new Date().toISOString() };
     });
+  }, []);
+  const resetFilterContext = React.useCallback(() => {
+    setOpenedRecordId(null);
   }, []);
 
   return (
@@ -195,7 +209,10 @@ export default function UnifiedInboxPage({ role }: Props) {
                     role="tab"
                     aria-selected={selected}
                     aria-label={`${tab.label} ${count}`}
-                    onClick={() => setActiveTab(tab.id)}
+                    onClick={() => {
+                      resetFilterContext();
+                      setActiveTab(tab.id);
+                    }}
                     style={{
                       border: selected ? `1px solid ${colors.accent}` : `1px solid ${colors.border}`,
                       borderRadius: 999,
@@ -235,7 +252,10 @@ export default function UnifiedInboxPage({ role }: Props) {
                   <input
                     type="search"
                     value={search}
-                    onChange={(event) => setSearch(event.target.value)}
+                    onChange={(event) => {
+                      resetFilterContext();
+                      setSearch(event.target.value);
+                    }}
                     placeholder="Search messages"
                     aria-label="Search inbox"
                     style={{
@@ -254,7 +274,10 @@ export default function UnifiedInboxPage({ role }: Props) {
                 Status
                 <select
                   value={statusFilter}
-                  onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
+                  onChange={(event) => {
+                    resetFilterContext();
+                    setStatusFilter(event.target.value as StatusFilter);
+                  }}
                   aria-label="Filter inbox status"
                   style={{
                     border: `1px solid ${colors.border}`,
@@ -277,7 +300,10 @@ export default function UnifiedInboxPage({ role }: Props) {
                 Priority
                 <select
                   value={priorityFilter}
-                  onChange={(event) => setPriorityFilter(event.target.value as PriorityFilter)}
+                  onChange={(event) => {
+                    resetFilterContext();
+                    setPriorityFilter(event.target.value as PriorityFilter);
+                  }}
                   aria-label="Filter inbox priority"
                   style={{
                     border: `1px solid ${colors.border}`,
@@ -309,7 +335,7 @@ export default function UnifiedInboxPage({ role }: Props) {
               </span>
             </div>
           </Card>
-          <UnifiedInboxList records={filteredRecords} role={role} onOpenRecord={markRecordRead} />
+          <UnifiedInboxList records={displayedRecords} role={role} onOpenRecord={markRecordRead} />
         </>
       ) : null}
     </div>

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
@@ -92,6 +92,7 @@ export default function UnifiedInboxPage({ role }: Props) {
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("all");
   const [priorityFilter, setPriorityFilter] = React.useState<PriorityFilter>("all");
   const [search, setSearch] = React.useState("");
+  const [localReadAtById, setLocalReadAtById] = React.useState<Record<string, string>>({});
 
   const load = React.useCallback(async () => {
     setLoading(true);
@@ -111,10 +112,21 @@ export default function UnifiedInboxPage({ role }: Props) {
     void load();
   }, [load]);
 
+  React.useEffect(() => {
+    setLocalReadAtById({});
+  }, [role]);
+
   const records = data?.records || data?.items || [];
   const safeRecords = React.useMemo(
-    () => records.filter((record) => record.audienceRole === role),
-    [records, role]
+    () =>
+      records
+        .filter((record) => record.audienceRole === role)
+        .map((record) => {
+          const localReadAt = localReadAtById[record.id];
+          if (!localReadAt) return record;
+          return { ...record, status: "read" as const, readAt: localReadAt };
+        }),
+    [localReadAtById, records, role]
   );
   const normalizedSearch = normalize(search);
   const filteredRecords = React.useMemo(
@@ -130,6 +142,13 @@ export default function UnifiedInboxPage({ role }: Props) {
   );
   const unreadCount = safeRecords.filter((record) => record.status === "unread").length;
   const priorityCount = safeRecords.filter((record) => record.priority === "critical" || record.priority === "high").length;
+  const markRecordRead = React.useCallback((record: UnifiedInboxRecord) => {
+    if (record.status !== "unread" && record.readAt) return;
+    setLocalReadAtById((current) => {
+      if (current[record.id]) return current;
+      return { ...current, [record.id]: new Date().toISOString() };
+    });
+  }, []);
 
   return (
     <div style={{ display: "grid", gap: spacing.md }}>
@@ -290,7 +309,7 @@ export default function UnifiedInboxPage({ role }: Props) {
               </span>
             </div>
           </Card>
-          <UnifiedInboxList records={filteredRecords} role={role} />
+          <UnifiedInboxList records={filteredRecords} role={role} onOpenRecord={markRecordRead} />
         </>
       ) : null}
     </div>

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
@@ -1,9 +1,16 @@
 import React from "react";
-import { RefreshCcw } from "lucide-react";
-import { fetchUnifiedInbox, type UnifiedInboxResponse, type UnifiedInboxRole } from "../api/unifiedInboxApi";
+import { RefreshCcw, Search } from "lucide-react";
+import {
+  fetchUnifiedInbox,
+  type UnifiedInboxPriority,
+  type UnifiedInboxRecord,
+  type UnifiedInboxResponse,
+  type UnifiedInboxRole,
+  type UnifiedInboxStatus,
+} from "../api/unifiedInboxApi";
 import { UnifiedInboxList } from "../components/UnifiedInbox/UnifiedInboxList";
 import { Button, Card } from "../components/ui/Ui";
-import { colors, spacing, text } from "../styles/tokens";
+import { colors, radius, spacing, text } from "../styles/tokens";
 
 type Props = {
   role: UnifiedInboxRole;
@@ -17,12 +24,12 @@ function titleForRole(role: UnifiedInboxRole) {
 
 function subtitleForRole(role: UnifiedInboxRole) {
   if (role === "tenant") {
-    return "Viewing updates, notices, applications, maintenance, screening, lease, and message activity for your tenant workspace.";
+    return "Tenant updates organized by priority, status, and workflow area.";
   }
   if (role === "contractor") {
-    return "Assigned work orders and property manager messages for your contractor workspace.";
+    return "Work orders and messages organized for quick follow-up.";
   }
-  return "Applications, screenings, leases, maintenance, messages, notices, viewings, and work orders for your landlord workspace.";
+  return "Operational messages organized by priority, status, and workspace.";
 }
 
 function errorMessage(error: unknown) {
@@ -30,10 +37,61 @@ function errorMessage(error: unknown) {
   return "Unable to load the unified inbox.";
 }
 
+type InboxTab = "all" | "unread" | "priority" | "maintenance" | "lease" | "payments" | "system";
+type StatusFilter = "all" | UnifiedInboxStatus;
+type PriorityFilter = "all" | UnifiedInboxPriority;
+
+const TABS: Array<{ id: InboxTab; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "unread", label: "Unread" },
+  { id: "priority", label: "Priority" },
+  { id: "maintenance", label: "Maintenance" },
+  { id: "lease", label: "Lease" },
+  { id: "payments", label: "Payments" },
+  { id: "system", label: "System" },
+];
+
+function normalize(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function recordText(record: UnifiedInboxRecord) {
+  return `${record.title} ${record.body} ${record.sourceKind} ${record.priority} ${record.status}`;
+}
+
+function isPaymentRecord(record: UnifiedInboxRecord) {
+  return /\b(payment|payments|rent|invoice|charge|balance|outstanding|collection)\b/i.test(recordText(record));
+}
+
+function isRecordInTab(record: UnifiedInboxRecord, tab: InboxTab) {
+  if (tab === "all") return true;
+  if (tab === "unread") return record.status === "unread";
+  if (tab === "priority") return record.priority === "critical" || record.priority === "high";
+  if (tab === "maintenance") return record.sourceKind.includes("maintenance") || record.sourceKind.includes("work_order");
+  if (tab === "lease") return record.sourceKind.includes("lease");
+  if (tab === "payments") return isPaymentRecord(record);
+  if (tab === "system") return record.sourceKind.includes("notice");
+  return true;
+}
+
+function statusLabel(value: StatusFilter) {
+  if (value === "all") return "All statuses";
+  return value.replace(/_/g, " ").replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function priorityLabel(value: PriorityFilter) {
+  if (value === "all") return "All priorities";
+  return value.replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
 export default function UnifiedInboxPage({ role }: Props) {
   const [data, setData] = React.useState<UnifiedInboxResponse | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [activeTab, setActiveTab] = React.useState<InboxTab>("all");
+  const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("all");
+  const [priorityFilter, setPriorityFilter] = React.useState<PriorityFilter>("all");
+  const [search, setSearch] = React.useState("");
 
   const load = React.useCallback(async () => {
     setLoading(true);
@@ -54,6 +112,24 @@ export default function UnifiedInboxPage({ role }: Props) {
   }, [load]);
 
   const records = data?.records || data?.items || [];
+  const safeRecords = React.useMemo(
+    () => records.filter((record) => record.audienceRole === role),
+    [records, role]
+  );
+  const normalizedSearch = normalize(search);
+  const filteredRecords = React.useMemo(
+    () =>
+      safeRecords.filter((record) => {
+        const matchesTab = isRecordInTab(record, activeTab);
+        const matchesStatus = statusFilter === "all" || record.status === statusFilter;
+        const matchesPriority = priorityFilter === "all" || record.priority === priorityFilter;
+        const matchesSearch = !normalizedSearch || normalize(recordText(record)).includes(normalizedSearch);
+        return matchesTab && matchesStatus && matchesPriority && matchesSearch;
+      }),
+    [activeTab, normalizedSearch, priorityFilter, safeRecords, statusFilter]
+  );
+  const unreadCount = safeRecords.filter((record) => record.status === "unread").length;
+  const priorityCount = safeRecords.filter((record) => record.priority === "critical" || record.priority === "high").length;
 
   return (
     <div style={{ display: "grid", gap: spacing.md }}>
@@ -88,12 +164,133 @@ export default function UnifiedInboxPage({ role }: Props) {
 
       {!loading && !error ? (
         <>
-          <Card style={{ display: "flex", gap: spacing.md, flexWrap: "wrap", color: text.muted }}>
-            <span>Total visible records: {data?.total || records.length}</span>
-            <span>Returned: {records.length}</span>
-            <span>Role: {role}</span>
+          <Card style={{ display: "grid", gap: spacing.md }}>
+            <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }} role="tablist" aria-label="Inbox views">
+              {TABS.map((tab) => {
+                const selected = activeTab === tab.id;
+                const count = safeRecords.filter((record) => isRecordInTab(record, tab.id)).length;
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={selected}
+                    aria-label={`${tab.label} ${count}`}
+                    onClick={() => setActiveTab(tab.id)}
+                    style={{
+                      border: selected ? `1px solid ${colors.accent}` : `1px solid ${colors.border}`,
+                      borderRadius: 999,
+                      background: selected ? "#eff6ff" : colors.card,
+                      color: selected ? colors.accent : text.secondary,
+                      cursor: "pointer",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 8,
+                      fontWeight: 800,
+                      minHeight: 38,
+                      padding: "8px 12px",
+                    }}
+                  >
+                    <span>{tab.label}</span>
+                    <span style={{ color: selected ? colors.accent : text.subtle, fontSize: 12 }}>{count}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div
+              style={{
+                display: "grid",
+                gap: spacing.sm,
+                gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 180px), 1fr))",
+              }}
+            >
+              <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.86rem", fontWeight: 800 }}>
+                Search
+                <span style={{ position: "relative", display: "block" }}>
+                  <Search
+                    size={16}
+                    aria-hidden="true"
+                    style={{ color: text.subtle, left: 12, position: "absolute", top: "50%", transform: "translateY(-50%)" }}
+                  />
+                  <input
+                    type="search"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search messages"
+                    aria-label="Search inbox"
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      color: text.primary,
+                      minHeight: 42,
+                      padding: "9px 12px 9px 36px",
+                      width: "100%",
+                    }}
+                  />
+                </span>
+              </label>
+
+              <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.86rem", fontWeight: 800 }}>
+                Status
+                <select
+                  value={statusFilter}
+                  onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
+                  aria-label="Filter inbox status"
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    color: text.primary,
+                    minHeight: 42,
+                    padding: "9px 12px",
+                    width: "100%",
+                  }}
+                >
+                  {(["all", "unread", "read", "resolved", "muted", "archived"] as StatusFilter[]).map((value) => (
+                    <option key={value} value={value}>
+                      {statusLabel(value)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.86rem", fontWeight: 800 }}>
+                Priority
+                <select
+                  value={priorityFilter}
+                  onChange={(event) => setPriorityFilter(event.target.value as PriorityFilter)}
+                  aria-label="Filter inbox priority"
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    color: text.primary,
+                    minHeight: 42,
+                    padding: "9px 12px",
+                    width: "100%",
+                  }}
+                >
+                  {(["all", "critical", "high", "normal", "low"] as PriorityFilter[]).map((value) => (
+                    <option key={value} value={value}>
+                      {priorityLabel(value)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <div style={{ display: "flex", gap: spacing.md, flexWrap: "wrap", color: text.muted, fontSize: "0.92rem" }}>
+              <span>
+                Showing <strong style={{ color: text.primary }}>{filteredRecords.length}</strong> of {safeRecords.length}
+              </span>
+              <span>
+                Unread <strong style={{ color: text.primary }}>{unreadCount}</strong>
+              </span>
+              <span>
+                Priority <strong style={{ color: text.primary }}>{priorityCount}</strong>
+              </span>
+            </div>
           </Card>
-          <UnifiedInboxList records={records} role={role} />
+          <UnifiedInboxList records={filteredRecords} role={role} />
         </>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- Add Unified Inbox tabs for All, Unread, Priority, Maintenance, Lease, Payments, and System.
- Add client-side search plus status and priority filters over the existing projected inbox response.
- Clean up the inbox presentation by removing raw role/visibility-style metadata from the visible detail panel and adding landlord workspace-oriented actions where existing routes are clear.

## Scope
- Frontend-only presentation update.
- Preserves existing routes and backend contracts, including the landlord API helper contract at `GET /api/landlord/inbox`.
- No Dashboard, payments workflow, backend, API, auth, or data-model changes.

## Validation
- `npm --prefix rentchain-frontend run test -- UnifiedInboxPage.test.tsx` with Node `20.20.2`
- `npm --prefix rentchain-frontend run build` with Node `20.20.2`
- `git diff --check`

## QA Notes
Manual preview QA is required before merge because this changes a user-facing landlord workspace.