### PR TITLE
fix: make add property form collapsible

### DIFF
--- a/rentchain-frontend/src/components/action-center/ActionCenterDrawer.css
+++ b/rentchain-frontend/src/components/action-center/ActionCenterDrawer.css
@@ -1,0 +1,26 @@
+.rc-action-center-backdrop {
+  top: var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px));
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2300;
+}
+
+.rc-action-center-drawer {
+  top: var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px));
+  height: calc(100dvh - var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px)));
+  z-index: 2301;
+}
+
+@media (max-width: 820px) {
+  .rc-action-center-backdrop {
+    top: 0;
+    z-index: 3000;
+  }
+
+  .rc-action-center-drawer {
+    top: 0;
+    height: 100dvh;
+    z-index: 3001;
+  }
+}

--- a/rentchain-frontend/src/components/action-center/ActionCenterDrawer.test.tsx
+++ b/rentchain-frontend/src/components/action-center/ActionCenterDrawer.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { ActionCenterDrawer } from "./ActionCenterDrawer";
+
+const mocks = vi.hoisted(() => ({
+  fetchActionCenterMock: vi.fn(),
+}));
+
+vi.mock("../../api/actionCenterApi", () => ({
+  fetchActionCenter: mocks.fetchActionCenterMock,
+}));
+
+describe("ActionCenterDrawer", () => {
+  it("uses shell-aware overlay classes so the drawer does not sit under the workspace bar", async () => {
+    mocks.fetchActionCenterMock.mockResolvedValue({ actionRequests: [] });
+
+    render(
+      <MemoryRouter>
+        <ActionCenterDrawer open onClose={vi.fn()} propertyLabelById={{}} />
+      </MemoryRouter>
+    );
+
+    const drawer = await screen.findByText("Action Center");
+    const drawerShell = drawer.closest(".rc-action-center-drawer");
+    const backdrop = document.querySelector(".rc-action-center-backdrop");
+
+    expect(drawerShell).toBeInTheDocument();
+    expect(drawerShell).toHaveClass("rc-safe-drawer");
+    expect(backdrop).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/action-center/ActionCenterDrawer.tsx
+++ b/rentchain-frontend/src/components/action-center/ActionCenterDrawer.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { fetchActionCenter } from "../../api/actionCenterApi";
 import type { ActionRequest } from "../../api/actionRequestsApi";
 import { fixActionForRequest } from "../../services/actionRequestFixRouter";
+import "./ActionCenterDrawer.css";
 
 function shortId(v: any, n = 8) {
   const s = typeof v === "string" ? v : "";
@@ -202,25 +203,21 @@ export function ActionCenterDrawer({
   return (
     <>
       <div
+        className="rc-action-center-backdrop"
         onClick={onClose}
         style={{
           position: "fixed",
-          inset: 0,
           background: "rgba(2,6,23,0.35)",
-          zIndex: 50,
         }}
       />
 
       <div
-        className="rc-safe-drawer"
+        className="rc-safe-drawer rc-action-center-drawer"
         style={{
           position: "fixed",
-          top: 0,
           right: 0,
-          height: "100dvh",
           width: "min(480px, 92vw)",
           background: "white",
-          zIndex: 51,
           boxShadow: "0 25px 60px rgba(2,6,23,0.25)",
           borderLeft: "1px solid rgba(148,163,184,0.25)",
           display: "flex",

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
@@ -99,6 +99,14 @@ describe("AddPropertyForm", () => {
     expect(screen.queryByPlaceholderText("1800")).not.toBeInTheDocument();
   });
 
+  it("can hide its internal show-hide control when a parent owns collapse state", () => {
+    render(<AddPropertyForm showInternalToggle={false} />);
+
+    expect(screen.queryByRole("button", { name: "Hide form" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show form" })).not.toBeInTheDocument();
+    expect(screen.getByText("Only three details are required to get started")).toBeInTheDocument();
+  });
+
   it("submits the first-property path with only the required fields", async () => {
     render(<AddPropertyForm onCreated={vi.fn()} />);
 

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.test.tsx
@@ -99,14 +99,6 @@ describe("AddPropertyForm", () => {
     expect(screen.queryByPlaceholderText("1800")).not.toBeInTheDocument();
   });
 
-  it("can hide its internal show-hide control when a parent owns collapse state", () => {
-    render(<AddPropertyForm showInternalToggle={false} />);
-
-    expect(screen.queryByRole("button", { name: "Hide form" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Show form" })).not.toBeInTheDocument();
-    expect(screen.getByText("Only three details are required to get started")).toBeInTheDocument();
-  });
-
   it("submits the first-property path with only the required fields", async () => {
     render(<AddPropertyForm onCreated={vi.fn()} />);
 

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
@@ -22,7 +22,6 @@ import "../../styles/propertiesMobile.css";
 interface AddPropertyFormProps {
   onCreated?: (property: Property) => void;
   onExistingPropertyId?: (id: string) => void;
-  showInternalToggle?: boolean;
 }
 
 interface UnitRow extends UnitInput {
@@ -51,7 +50,6 @@ const emptyUnitRow = (): UnitRow => ({
 export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   onCreated,
   onExistingPropertyId,
-  showInternalToggle = true,
 }) => {
   const { user } = useAuth();
   const isFreePlan = String(user?.plan || "free").toLowerCase() === "free";
@@ -74,7 +72,6 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
   const [successText, setSuccessText] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState(true);
   const [complianceExpanded, setComplianceExpanded] = useState(false);
   const [unitsExpanded, setUnitsExpanded] = useState(false);
   const { showToast } = useToast();
@@ -377,34 +374,15 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      {showInternalToggle ? (
-        <button
-          type="button"
-          onClick={() => setExpanded((prev) => !prev)}
-          style={{
-            alignSelf: "flex-start",
-            padding: "6px 12px",
-            borderRadius: radius.pill,
-            border: `1px solid ${colors.border}`,
-            background: colors.card,
-            color: text.primary,
-            cursor: "pointer",
-          }}
-        >
-          {expanded ? "Hide form" : "Show form"}
-        </button>
-      ) : null}
-
-      {!expanded ? null : (
-        <form
-          className="rc-add-property-form"
-          onSubmit={handleSubmit}
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 16,
-          }}
-        >
+      <form
+        className="rc-add-property-form"
+        onSubmit={handleSubmit}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        }}
+      >
           <div
             style={{
               borderRadius: 12,
@@ -1008,8 +986,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
       >
         {isSubmitting ? "Saving..." : isPreviewingCsv ? "Previewing CSV..." : "Create property"}
       </button>
-    </form>
-      )}
+      </form>
     </div>
   );
 };

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
@@ -22,6 +22,7 @@ import "../../styles/propertiesMobile.css";
 interface AddPropertyFormProps {
   onCreated?: (property: Property) => void;
   onExistingPropertyId?: (id: string) => void;
+  showInternalToggle?: boolean;
 }
 
 interface UnitRow extends UnitInput {
@@ -50,6 +51,7 @@ const emptyUnitRow = (): UnitRow => ({
 export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   onCreated,
   onExistingPropertyId,
+  showInternalToggle = true,
 }) => {
   const { user } = useAuth();
   const isFreePlan = String(user?.plan || "free").toLowerCase() === "free";
@@ -375,21 +377,23 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      <button
-        type="button"
-        onClick={() => setExpanded((prev) => !prev)}
-        style={{
-          alignSelf: "flex-start",
-          padding: "6px 12px",
-          borderRadius: radius.pill,
-          border: `1px solid ${colors.border}`,
-          background: colors.card,
-          color: text.primary,
-          cursor: "pointer",
-        }}
-      >
-        {expanded ? "Hide form" : "Show form"}
-      </button>
+      {showInternalToggle ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          style={{
+            alignSelf: "flex-start",
+            padding: "6px 12px",
+            borderRadius: radius.pill,
+            border: `1px solid ${colors.border}`,
+            background: colors.card,
+            color: text.primary,
+            cursor: "pointer",
+          }}
+        >
+          {expanded ? "Hide form" : "Show form"}
+        </button>
+      ) : null}
 
       {!expanded ? null : (
         <form

--- a/rentchain-frontend/src/components/properties/PropertyCredibilitySummaryCard.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyCredibilitySummaryCard.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { PropertyCredibilitySummaryCard } from "./PropertyCredibilitySummaryCard";
 
@@ -28,6 +28,8 @@ describe("PropertyCredibilitySummaryCard", () => {
 
     expect(screen.getByText("Property credibility summary")).toBeInTheDocument();
     expect(screen.getByText("Watch")).toBeInTheDocument();
+    expect(screen.queryByText("Active leases")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "View details" }));
     expect(screen.getByText("Active leases")).toBeInTheDocument();
     expect(screen.getByText("Missing credibility")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
@@ -36,6 +38,10 @@ describe("PropertyCredibilitySummaryCard", () => {
   it("renders the empty state when no summary data is available", () => {
     render(<PropertyCredibilitySummaryCard summary={null} />);
 
+    expect(
+      screen.queryByText("Credibility summary will appear as lease and tenant history becomes available.")
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "View details" }));
     expect(
       screen.getByText("Credibility summary will appear as lease and tenant history becomes available.")
     ).toBeInTheDocument();
@@ -60,6 +66,10 @@ describe("PropertyCredibilitySummaryCard", () => {
       />
     );
 
+    expect(
+      screen.queryByText("Credibility summary will appear as lease and tenant history becomes available.")
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "View details" }));
     expect(
       screen.getByText("Credibility summary will appear as lease and tenant history becomes available.")
     ).toBeInTheDocument();

--- a/rentchain-frontend/src/components/properties/PropertyCredibilitySummaryCard.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyCredibilitySummaryCard.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { RiskScoreBadge } from "@/components/leases/RiskScoreBadge";
 import type { PropertyCredibilitySummary } from "@/types/credibilitySummary";
-import { colors, radius, shadows, spacing, text } from "@/styles/tokens";
+import { colors, radius, spacing, text } from "@/styles/tokens";
 
 interface PropertyCredibilitySummaryCardProps {
   summary?: PropertyCredibilitySummary | null;
@@ -50,41 +50,65 @@ const MetricTile: React.FC<{ label: string; value: React.ReactNode; caption?: Re
 );
 
 export const PropertyCredibilitySummaryCard: React.FC<PropertyCredibilitySummaryCardProps> = ({ summary, leaseHref = "/leases" }) => {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
   if (!summary || summary.healthStatus === "unknown") {
     return (
       <section
         style={{
-          borderRadius: radius.xl,
-          border: `1px solid ${colors.borderStrong}`,
-          background: "linear-gradient(180deg, rgba(255,255,255,0.98), rgba(248,250,252,0.96))",
-          boxShadow: shadows.soft,
-          padding: spacing.lg,
+          borderRadius: radius.lg,
+          border: `1px solid ${colors.border}`,
+          background: "rgba(255,255,255,0.96)",
+          padding: spacing.md,
           display: "grid",
-          gap: spacing.md,
+          gap: detailsOpen ? spacing.md : 0,
         }}
       >
-        <div style={{ display: "grid", gap: 6 }}>
-          <div style={{ color: text.primary, fontSize: "1rem", fontWeight: 800 }}>Property credibility summary</div>
-          <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.6 }}>
-            This summary reflects current lease and tenant credibility signals for this property. Decision support only.
+        <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, alignItems: "center", flexWrap: "wrap" }}>
+          <div style={{ display: "grid", gap: 4 }}>
+            <div style={{ color: text.primary, fontSize: "0.95rem", fontWeight: 800 }}>Property credibility summary</div>
+            <div style={{ color: text.muted, fontSize: 12 }}>Limited data</div>
           </div>
-          <a href={leaseHref} style={{ color: "#2563eb", fontSize: 13, fontWeight: 700 }}>
-            View related leases
-          </a>
+          <button
+            type="button"
+            onClick={() => setDetailsOpen((value) => !value)}
+            style={{
+              border: `1px solid ${colors.borderStrong}`,
+              background: "#fff",
+              borderRadius: radius.md,
+              color: text.primary,
+              cursor: "pointer",
+              fontSize: 12,
+              fontWeight: 750,
+              padding: "6px 10px",
+            }}
+          >
+            {detailsOpen ? "Hide details" : "View details"}
+          </button>
         </div>
-        <div
-          style={{
-            borderRadius: radius.lg,
-            border: `1px dashed ${colors.borderStrong}`,
-            background: "rgba(248,250,252,0.92)",
-            padding: spacing.md,
-            color: text.muted,
-            fontSize: 13,
-            lineHeight: 1.6,
-          }}
-        >
-          Credibility summary will appear as lease and tenant history becomes available.
-        </div>
+        {detailsOpen ? (
+          <>
+            <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.5 }}>
+              This summary reflects current lease and tenant credibility signals for this property. Decision support only.
+            </div>
+            <a href={leaseHref} style={{ color: "#2563eb", fontSize: 13, fontWeight: 700 }}>
+              View related leases
+            </a>
+            <div
+              style={{
+                borderRadius: radius.lg,
+                border: `1px dashed ${colors.borderStrong}`,
+                background: "rgba(248,250,252,0.92)",
+                padding: spacing.md,
+                color: text.muted,
+                fontSize: 13,
+                lineHeight: 1.5,
+              }}
+            >
+              Credibility summary will appear as lease and tenant history becomes available.
+            </div>
+          </>
+        ) : null}
       </section>
     );
   }
@@ -94,70 +118,94 @@ export const PropertyCredibilitySummaryCard: React.FC<PropertyCredibilitySummary
   return (
     <section
       style={{
-        borderRadius: radius.xl,
-        border: `1px solid ${colors.borderStrong}`,
-        background: "linear-gradient(180deg, rgba(255,255,255,0.98), rgba(248,250,252,0.96))",
-        boxShadow: shadows.soft,
-        padding: spacing.lg,
+        borderRadius: radius.lg,
+        border: `1px solid ${colors.border}`,
+        background: "rgba(255,255,255,0.96)",
+        padding: spacing.md,
         display: "grid",
-        gap: spacing.md,
+        gap: detailsOpen ? spacing.md : 0,
       }}
     >
-      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, alignItems: "flex-start", flexWrap: "wrap" }}>
-        <div style={{ display: "grid", gap: 6 }}>
-          <div style={{ color: text.primary, fontSize: "1rem", fontWeight: 800 }}>Property credibility summary</div>
-          <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.6 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, alignItems: "center", flexWrap: "wrap" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <div style={{ color: text.primary, fontSize: "0.95rem", fontWeight: 800 }}>Property credibility summary</div>
+          <div style={{ color: text.muted, fontSize: 12 }}>
+            {summary.activeLeaseCount} active leases · {summary.lowConfidenceCount} review items
+          </div>
+        </div>
+        <div style={{ display: "inline-flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              padding: "5px 9px",
+              borderRadius: radius.pill,
+              border: `1px solid ${tone.border}`,
+              background: tone.background,
+              color: tone.color,
+              fontSize: 12,
+              fontWeight: 800,
+            }}
+          >
+            {tone.label}
+          </span>
+          <button
+            type="button"
+            onClick={() => setDetailsOpen((value) => !value)}
+            style={{
+              border: `1px solid ${colors.borderStrong}`,
+              background: "#fff",
+              borderRadius: radius.md,
+              color: text.primary,
+              cursor: "pointer",
+              fontSize: 12,
+              fontWeight: 750,
+              padding: "6px 10px",
+            }}
+          >
+            {detailsOpen ? "Hide details" : "View details"}
+          </button>
+        </div>
+      </div>
+
+      {detailsOpen ? (
+        <>
+          <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.5 }}>
             This summary reflects current lease and tenant credibility signals for this property. Decision support only.
           </div>
           <a href={leaseHref} style={{ color: "#2563eb", fontSize: 13, fontWeight: 700 }}>
             View related leases
           </a>
-        </div>
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            padding: "6px 10px",
-            borderRadius: radius.pill,
-            border: `1px solid ${tone.border}`,
-            background: tone.background,
-            color: tone.color,
-            fontSize: 12,
-            fontWeight: 800,
-          }}
-        >
-          {tone.label}
-        </span>
-      </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: spacing.md }}>
+            <MetricTile
+              label="Tenant score average"
+              value={<RiskScoreBadge grade={summary.tenantScoreGradeAverage} score={summary.tenantScoreAverage} />}
+              caption={`${summary.tenantsWithScoreCount} tenants with score`}
+            />
+            <MetricTile
+              label="Lease risk average"
+              value={<RiskScoreBadge grade={summary.leaseRiskGradeAverage} score={summary.leaseRiskAverage} />}
+              caption={`${summary.leasesWithRiskCount} leases with risk`}
+            />
+            <MetricTile
+              label="Active leases"
+              value={summary.activeLeaseCount}
+              caption="Current lease agreements in this rollup"
+            />
+            <MetricTile
+              label="Review items"
+              value={summary.lowConfidenceCount}
+              caption="Low-confidence records to review"
+            />
+          </div>
 
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: spacing.md }}>
-        <MetricTile
-          label="Tenant score average"
-          value={<RiskScoreBadge grade={summary.tenantScoreGradeAverage} score={summary.tenantScoreAverage} />}
-          caption={`${summary.tenantsWithScoreCount} tenants with score`}
-        />
-        <MetricTile
-          label="Lease risk average"
-          value={<RiskScoreBadge grade={summary.leaseRiskGradeAverage} score={summary.leaseRiskAverage} />}
-          caption={`${summary.leasesWithRiskCount} leases with risk`}
-        />
-        <MetricTile
-          label="Active leases"
-          value={summary.activeLeaseCount}
-          caption="Current lease agreements in this rollup"
-        />
-        <MetricTile
-          label="Review items"
-          value={summary.lowConfidenceCount}
-          caption="Low-confidence records to review"
-        />
-      </div>
-
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: spacing.md }}>
-        <MetricTile label="Missing credibility" value={summary.missingCredibilityCount} caption="Records without current score or risk data" />
-        <MetricTile label="Tenant score avg" value={formatAverage(summary.tenantScoreAverage)} caption={summary.tenantScoreAverage != null ? `Grade ${summary.tenantScoreGradeAverage}` : "No tenant scores yet"} />
-        <MetricTile label="Lease risk avg" value={formatAverage(summary.leaseRiskAverage)} caption={summary.leaseRiskAverage != null ? `Grade ${summary.leaseRiskGradeAverage}` : "No lease risk yet"} />
-      </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: spacing.md }}>
+            <MetricTile label="Missing credibility" value={summary.missingCredibilityCount} caption="Records without current score or risk data" />
+            <MetricTile label="Tenant score avg" value={formatAverage(summary.tenantScoreAverage)} caption={summary.tenantScoreAverage != null ? `Grade ${summary.tenantScoreGradeAverage}` : "No tenant scores yet"} />
+            <MetricTile label="Lease risk avg" value={formatAverage(summary.leaseRiskAverage)} caption={summary.leaseRiskAverage != null ? `Grade ${summary.leaseRiskGradeAverage}` : "No lease risk yet"} />
+          </div>
+        </>
+      ) : null}
     </section>
   );
 };

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -855,6 +855,79 @@ describe("PropertyDetailPanel", () => {
     );
   });
 
+  it("opens occupancy setup from persisted property units while the unit API catches up", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            unitCount: 1,
+            totalUnits: 1,
+            amenities: [],
+            units: [{ id: "unit-created-101", unitNumber: "101" }],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const setupButtons = await screen.findAllByRole("button", { name: "Set up current occupancy" });
+    fireEvent.click(setupButtons[0]);
+
+    expect(await screen.findByTestId("unit-edit-modal")).toBeInTheDocument();
+    expect(screen.queryByText(/not ready for occupancy updates/i)).not.toBeInTheDocument();
+    expect(mocks.showToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Unit not ready",
+      })
+    );
+  });
+
+  it("opens unit edit without occupancy readiness toast when persisted property units are available", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            unitCount: 1,
+            totalUnits: 1,
+            amenities: [],
+            units: [{ id: "unit-created-101", unitNumber: "101", status: "vacant" }],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "Edit" }).length).toBeGreaterThan(1));
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
+
+    expect(await screen.findByTestId("unit-edit-modal")).toBeInTheDocument();
+    expect(mocks.showToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Unit not ready",
+      })
+    );
+  });
+
   it("replaces the edited unit when the save response returns a persisted ID", async () => {
     mocks.fetchUnitsForProperty.mockResolvedValue([
       { id: "unit-persisted-1", unitNumber: "101", status: "vacant" },

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -1067,8 +1067,9 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             <div style={{ color: "#475569", fontSize: "0.8rem" }}>
               PID: {property.pid || "--"}
             </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div className="rc-property-status-row" style={{ display: "flex", alignItems: "center", gap: 8 }}>
               <span
+                className="rc-property-status-badge"
                 style={{
                   padding: "2px 8px",
                   borderRadius: 999,
@@ -1085,6 +1086,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                 {propertyStatus}
               </span>
               <span
+                className="rc-property-status-badge"
                 style={{
                   padding: "2px 8px",
                   borderRadius: 999,

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -644,7 +644,8 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
 
   useEffect(() => {
     let cancelled = false;
-    setUnits(property?.units || []);
+    const propertyUnits = Array.isArray(property?.units) ? property.units : [];
+    setUnits(propertyUnits);
 
     const loadUnits = async () => {
       const pid = property?.id;
@@ -664,6 +665,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
           setUnits(res);
           return;
         }
+        if (propertyUnits.length > 0) {
+          setUnits(propertyUnits);
+          return;
+        }
         const count = (property as any)?.unitCount ?? 0;
         if (count > 0) {
           setUnits(
@@ -675,6 +680,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         }
       } catch (e) {
         if (cancelled) return;
+        if (propertyUnits.length > 0) {
+          setUnits(propertyUnits);
+          return;
+        }
         const count = (property as any)?.unitCount ?? 0;
         if (count > 0) {
           setUnits(
@@ -1618,21 +1627,27 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
           </div>
           {showOccupancyPrompt ? (
             <div
+              className="rc-occupancy-setup-panel"
               style={{
                 marginBottom: 12,
-                padding: "14px 16px",
+                padding: "12px 14px",
                 borderRadius: 14,
                 border: "1px solid rgba(37,99,235,0.18)",
                 background: "rgba(37,99,235,0.06)",
-                display: "grid",
-                gap: 8,
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 12,
+                flexWrap: "wrap",
               }}
             >
-              <div style={{ fontWeight: 700, color: "#0f172a" }}>
-                Do any of these units already have active tenants?
-              </div>
-              <div style={{ color: "#475569", fontSize: "0.92rem", lineHeight: 1.6 }}>
-                Set current occupancy now to keep your occupancy and rent views accurate. You can still upgrade later to create full lease records, tenant history, and verified reporting.
+              <div style={{ display: "grid", gap: 3, minWidth: 0 }}>
+                <div style={{ fontWeight: 750, color: "#0f172a" }}>
+                  Current occupancy
+                </div>
+                <div style={{ color: "#475569", fontSize: "0.85rem", lineHeight: 1.35 }}>
+                  Mark active tenants now; full lease setup can come later.
+                </div>
               </div>
               <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                 <button

--- a/rentchain-frontend/src/components/properties/PropertyRegistryStatusCard.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyRegistryStatusCard.test.tsx
@@ -530,12 +530,11 @@ describe("PropertyRegistryStatusCard", () => {
       />
     );
 
-    expect(await screen.findByText("Compliance / Registry Readiness")).toBeInTheDocument();
-expect(await screen.findByText("Compliance / Registry Readiness")).toBeInTheDocument();
-expect(screen.getByText("Ready to file")).toBeInTheDocument();
-expect(screen.getByText("Halifax Rental Registry")).toBeInTheDocument();
-expect(screen.queryByText("Filing timeline")).not.toBeInTheDocument();
-expect(screen.getByRole("button", { name: "View details" })).toBeInTheDocument();
+    expect(await screen.findByText("Registry readiness")).toBeInTheDocument();
+    expect(screen.getByText("Ready to file")).toBeInTheDocument();
+    expect(screen.getByText(/Halifax Rental Registry/)).toBeInTheDocument();
+    expect(screen.queryByText("Filing timeline")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View details" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "View details" }));
     expect(await screen.findByText("Filing timeline")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/properties/PropertyRegistryStatusCard.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyRegistryStatusCard.tsx
@@ -694,43 +694,43 @@ export const PropertyRegistryStatusCard: React.FC<Props> = ({ property, onOpenSu
   );
 
   return (
-    <Card style={{ display: "grid", gap: 12 }}>
+    <Card style={{ display: "grid", gap: 10, padding: 14 }}>
       <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-        <div>
+        <div style={{ display: "grid", gap: 4 }}>
           <div style={{ fontSize: 12, color: "#64748b", textTransform: "uppercase", letterSpacing: 0.6 }}>
             Compliance / Registry
           </div>
-          <div style={{ fontSize: 18, fontWeight: 700 }}>Compliance / Registry Readiness</div>
+          <div style={{ fontSize: 15, fontWeight: 800 }}>Registry readiness</div>
+          {!loading && data?.readiness ? (
+            <div style={{ color: "#64748b", fontSize: 12 }}>
+              {data.readiness.schemaLabel}
+              {data.readiness.readinessStatus !== "verified" ? ` · ${data.readiness.completionPercent}% complete` : ""}
+            </div>
+          ) : null}
         </div>
-        {data?.readiness ? <Pill tone={readinessTone(data.readiness.readinessStatus)}>{readinessLabel(data.readiness.readinessStatus)}</Pill> : null}
+        <div style={{ display: "inline-flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          {data?.readiness ? <Pill tone={readinessTone(data.readiness.readinessStatus)}>{readinessLabel(data.readiness.readinessStatus)}</Pill> : null}
+          {!loading && data ? (
+            <Button type="button" variant="secondary" onClick={() => setDetailsOpen(true)} style={{ padding: "6px 10px", fontSize: 12 }}>
+              View details
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       {loading ? <div style={{ color: "#475569" }}>Checking registry and readiness…</div> : null}
       {!loading && error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
 
       {!loading && data?.readiness ? (
-        <div style={{ display: "grid", gap: 10 }}>
-          <div style={{ color: "#475569", lineHeight: 1.5 }}>{compactSupportingLine(data.readiness)}</div>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-            <Pill tone="muted">{data.readiness.schemaLabel}</Pill>
-            {data.readiness.readinessStatus !== "verified" ? (
-              <Pill tone="muted">{data.readiness.completionPercent}% complete</Pill>
-            ) : null}
-{filingStatusLabel(workflowStatus) ? (
-  <Pill tone={filingStatusTone(workflowStatus)}>{filingStatusLabel(workflowStatus)}</Pill>
-) : null}
-          
-          </div>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            <Button type="button" variant="secondary" onClick={() => setDetailsOpen(true)}>
-              View details
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          {filingStatusLabel(workflowStatus) ? (
+            <Pill tone={filingStatusTone(workflowStatus)}>{filingStatusLabel(workflowStatus)}</Pill>
+          ) : null}
+          {onOpenSubmissionAssistant && shouldShowCompactAssistantCta(data.readiness) ? (
+            <Button type="button" onClick={onOpenSubmissionAssistant} style={{ padding: "6px 10px", fontSize: 12 }}>
+              {data.readiness.assistant.ctaLabel}
             </Button>
-            {onOpenSubmissionAssistant && shouldShowCompactAssistantCta(data.readiness) ? (
-              <Button type="button" onClick={onOpenSubmissionAssistant}>
-                {data.readiness.assistant.ctaLabel}
-              </Button>
-            ) : null}
-          </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/rentchain-frontend/src/components/properties/UnitEditModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.tsx
@@ -118,6 +118,7 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
 
   return (
     <div
+      className="rc-unit-edit-overlay"
       style={{
         position: "fixed",
         inset: 0,
@@ -133,10 +134,13 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
       }}
     >
       <div
+        className="rc-unit-edit-panel"
         onMouseDown={(e) => e.stopPropagation()}
         style={{
           width: "100%",
           maxWidth: 520,
+          maxHeight: "calc(100vh - 32px)",
+          overflowY: "auto",
           background: "#fff",
           borderRadius: 12,
           border: "1px solid #e5e7eb",
@@ -180,7 +184,7 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
           />
         </label>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <div className="rc-unit-edit-two-col" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
           <label style={{ display: "grid", gap: 6, fontSize: 13 }}>
             Beds
             <input
@@ -312,7 +316,7 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
           </div>
         ) : null}
 
-        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <div className="rc-unit-edit-actions" style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
           <Button onClick={onClose} disabled={saving} style={{ padding: "8px 12px" }}>
             Cancel
           </Button>

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.test.tsx
@@ -81,4 +81,18 @@ describe("InviteTenantModal", () => {
     expect(screen.queryByLabelText("Tenant email")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Send invite" })).not.toBeInTheDocument();
   });
+
+  it("honors an explicit locked invite state without loading property or unit selectors", () => {
+    mocks.useCapabilities.mockReturnValue({ features: { tenant_invites: true } });
+    mocks.useAuth.mockReturnValue({ user: { id: "user-1", role: "admin", plan: "free" } });
+
+    render(<InviteTenantModal open onClose={vi.fn()} canInviteOverride={false} />);
+
+    expect(screen.getByText("Upgrade required")).toBeInTheDocument();
+    expect(screen.queryByText("Property")).not.toBeInTheDocument();
+    expect(screen.queryByText("Unit")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Tenant email")).not.toBeInTheDocument();
+    expect(mocks.fetchProperties).not.toHaveBeenCalled();
+    expect(mocks.fetchUnitsForProperty).not.toHaveBeenCalled();
+  });
 });

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InviteTenantModal } from "./InviteTenantModal";
+
+const mocks = vi.hoisted(() => ({
+  fetchProperties: vi.fn(),
+  fetchUnitsForProperty: vi.fn(),
+  createTenantInvite: vi.fn(),
+  setOnboardingStep: vi.fn(),
+  useCapabilities: vi.fn(),
+  useAuth: vi.fn(),
+  showToast: vi.fn(),
+  dispatchUpgradePrompt: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("../../api/tenantInvites", () => ({
+  createTenantInvite: mocks.createTenantInvite,
+}));
+
+vi.mock("../../api/onboardingApi", () => ({
+  setOnboardingStep: mocks.setOnboardingStep,
+}));
+
+vi.mock("../../api/propertiesApi", () => ({
+  fetchProperties: mocks.fetchProperties,
+}));
+
+vi.mock("../../api/unitsApi", () => ({
+  fetchUnitsForProperty: mocks.fetchUnitsForProperty,
+}));
+
+vi.mock("../../hooks/useCapabilities", () => ({
+  useCapabilities: () => mocks.useCapabilities(),
+}));
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => mocks.useAuth(),
+}));
+
+vi.mock("../../context/LanguageContext", () => ({
+  useLanguage: () => ({ locale: "en" }),
+}));
+
+vi.mock("../ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+vi.mock("../../lib/upgradePrompt", () => ({
+  dispatchUpgradePrompt: (...args: any[]) => mocks.dispatchUpgradePrompt(...args),
+  resolveRequiredPlanLabel: () => "Starter",
+}));
+
+vi.mock("../../lib/analytics", () => ({
+  track: (...args: any[]) => mocks.track(...args),
+}));
+
+describe("InviteTenantModal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mocks.fetchProperties.mockResolvedValue({ items: [{ id: "prop-1", name: "Harbour View" }] });
+    mocks.fetchUnitsForProperty.mockResolvedValue([{ id: "unit-1", unitNumber: "101" }]);
+    mocks.createTenantInvite.mockResolvedValue({ ok: true });
+    mocks.setOnboardingStep.mockResolvedValue(undefined);
+    mocks.useCapabilities.mockReturnValue({ features: { tenant_invites: false } });
+    mocks.useAuth.mockReturnValue({ user: { id: "user-1", role: "landlord", plan: "free" } });
+    mocks.showToast.mockReset();
+    mocks.dispatchUpgradePrompt.mockReset();
+    mocks.track.mockReset();
+  });
+
+  it("shows upgrade requirements immediately instead of the invite form when tenant invites are locked", () => {
+    render(<InviteTenantModal open onClose={vi.fn()} />);
+
+    expect(screen.getByText("Upgrade required")).toBeInTheDocument();
+    expect(screen.getByText("Upgrade to Starter to send tenant invites.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Unlock tenant invites" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Tenant email")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send invite" })).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.test.tsx
@@ -95,4 +95,19 @@ describe("InviteTenantModal", () => {
     expect(mocks.fetchProperties).not.toHaveBeenCalled();
     expect(mocks.fetchUnitsForProperty).not.toHaveBeenCalled();
   });
+
+  it("fails closed when the invite feature is cached true but the plan is free", () => {
+    mocks.useCapabilities.mockReturnValue({ caps: { plan: "free" }, features: { tenant_invites: true } });
+    mocks.useAuth.mockReturnValue({ user: { id: "user-1", role: "landlord", plan: "free" } });
+
+    render(<InviteTenantModal open onClose={vi.fn()} />);
+
+    expect(screen.getByText("Upgrade required")).toBeInTheDocument();
+    expect(screen.queryByText("Property")).not.toBeInTheDocument();
+    expect(screen.queryByText("Unit")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Tenant email")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send invite" })).not.toBeInTheDocument();
+    expect(mocks.fetchProperties).not.toHaveBeenCalled();
+    expect(mocks.fetchUnitsForProperty).not.toHaveBeenCalled();
+  });
 });

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
@@ -5,6 +5,7 @@ import { fetchProperties } from "../../api/propertiesApi";
 import { fetchUnitsForProperty } from "../../api/unitsApi";
 import { useCapabilities } from "../../hooks/useCapabilities";
 import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "../../lib/upgradePrompt";
+import { isPlanAtLeast, normalizePlan } from "../../lib/plan";
 import { track } from "../../lib/analytics";
 import { useAuth } from "../../context/useAuth";
 import { useLanguage } from "../../context/LanguageContext";
@@ -73,15 +74,17 @@ export const InviteTenantModal: React.FC<Props> = ({
   const [unitId, setUnitId] = useState(defaultUnitId || "");
   const [loadingProperties, setLoadingProperties] = useState(false);
   const [loadingUnits, setLoadingUnits] = useState(false);
-  const { features } = useCapabilities();
+  const { caps, features } = useCapabilities();
   const { user } = useAuth();
   const { locale } = useLanguage();
   const { showToast } = useToast();
   const role = String(user?.role || "").toLowerCase();
+  const currentPlan = normalizePlan(caps?.plan || user?.plan || "free");
+  const inviteFeatureEnabled = Boolean(features?.tenant_invites || features?.tenantInvites);
   const canInvite =
     typeof canInviteOverride === "boolean"
       ? canInviteOverride
-      : role === "admin" || Boolean(features?.tenant_invites || features?.tenantInvites);
+      : role === "admin" || (inviteFeatureEnabled && isPlanAtLeast(currentPlan, "starter"));
   const inviteRequiredPlanLabel = resolveRequiredPlanLabel("tenant_invites", user?.plan) || "Starter";
   const inviteUpgradeMessage = `Upgrade to ${inviteRequiredPlanLabel} to send tenant invites.`;
   const inviteUpgradeRedirect =

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
@@ -20,6 +20,7 @@ interface Props {
   defaultLeaseId?: string;
   defaultTenantEmail?: string;
   defaultTenantName?: string;
+  canInviteOverride?: boolean;
 }
 
 type PropertyOption = { id: string; name: string };
@@ -57,6 +58,7 @@ export const InviteTenantModal: React.FC<Props> = ({
   defaultUnitId,
   defaultTenantEmail,
   defaultTenantName,
+  canInviteOverride,
 }) => {
   const [tenantEmail, setTenantEmail] = useState("");
   const [tenantName, setTenantName] = useState("");
@@ -76,7 +78,10 @@ export const InviteTenantModal: React.FC<Props> = ({
   const { locale } = useLanguage();
   const { showToast } = useToast();
   const role = String(user?.role || "").toLowerCase();
-  const canInvite = role === "admin" || Boolean(features?.tenant_invites || features?.tenantInvites);
+  const canInvite =
+    typeof canInviteOverride === "boolean"
+      ? canInviteOverride
+      : role === "admin" || Boolean(features?.tenant_invites || features?.tenantInvites);
   const inviteRequiredPlanLabel = resolveRequiredPlanLabel("tenant_invites", user?.plan) || "Starter";
   const inviteUpgradeMessage = `Upgrade to ${inviteRequiredPlanLabel} to send tenant invites.`;
   const inviteUpgradeRedirect =
@@ -125,6 +130,13 @@ export const InviteTenantModal: React.FC<Props> = ({
 
   React.useEffect(() => {
     if (!open) return;
+    if (!canInvite) {
+      setProperties([]);
+      setUnits([]);
+      setPropertyId("");
+      setUnitId("");
+      return;
+    }
     let mounted = true;
     (async () => {
       setLoadingProperties(true);
@@ -161,10 +173,10 @@ export const InviteTenantModal: React.FC<Props> = ({
     return () => {
       mounted = false;
     };
-  }, [open, defaultPropertyId, propertyId]);
+  }, [open, canInvite, defaultPropertyId, propertyId]);
 
   React.useEffect(() => {
-    if (!open || !propertyId) {
+    if (!open || !canInvite || !propertyId) {
       setUnits([]);
       setUnitId("");
       return;
@@ -202,7 +214,7 @@ export const InviteTenantModal: React.FC<Props> = ({
     return () => {
       mounted = false;
     };
-  }, [open, propertyId, defaultUnitId]);
+  }, [open, canInvite, propertyId, defaultUnitId]);
 
   if (!open) return null;
   const selectedUnitRequiresLease = unitId ? units.find((u) => u.id === unitId)?.inviteEligible === false : false;

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
@@ -76,7 +76,7 @@ export const InviteTenantModal: React.FC<Props> = ({
   const { locale } = useLanguage();
   const { showToast } = useToast();
   const role = String(user?.role || "").toLowerCase();
-  const canInvite = role === "admin" || features?.tenant_invites !== false;
+  const canInvite = role === "admin" || Boolean(features?.tenant_invites || features?.tenantInvites);
   const inviteRequiredPlanLabel = resolveRequiredPlanLabel("tenant_invites", user?.plan) || "Starter";
   const inviteUpgradeMessage = `Upgrade to ${inviteRequiredPlanLabel} to send tenant invites.`;
   const inviteUpgradeRedirect =
@@ -213,6 +213,15 @@ export const InviteTenantModal: React.FC<Props> = ({
       currentPlan: currentPlan || undefined,
       source,
       redirectTo: inviteUpgradeRedirect,
+    });
+  };
+
+  const handleUpgradeRequired = () => {
+    promptInviteUpgrade("tenants_invite_modal_open");
+    showToast({
+      message: "Tenant invites require an upgrade",
+      description: inviteUpgradeMessage,
+      variant: "warning",
     });
   };
 
@@ -362,6 +371,28 @@ export const InviteTenantModal: React.FC<Props> = ({
             Close
           </Button>
         </div>
+
+        {!canInvite ? (
+          <div
+            role="status"
+            style={{
+              display: "grid",
+              gap: 10,
+              padding: 12,
+              borderRadius: 12,
+              border: "1px solid #f5d0fe",
+              background: "#faf5ff",
+              color: "#581c87",
+            }}
+          >
+            <div style={{ fontWeight: 750 }}>Upgrade required</div>
+            <div style={{ fontSize: 13, lineHeight: 1.45 }}>{inviteUpgradeMessage}</div>
+            <Button type="button" onClick={handleUpgradeRequired} style={{ justifySelf: "start" }}>
+              Unlock tenant invites
+            </Button>
+          </div>
+        ) : (
+          <>
 
         <div style={{ display: "grid", gap: 6 }}>
           <label style={{ fontSize: 13 }}>Property</label>
@@ -556,6 +587,8 @@ export const InviteTenantModal: React.FC<Props> = ({
             {loading ? "Sending..." : "Send invite"}
           </Button>
         </div>
+          </>
+        )}
         </div>
       </div>
     </div>

--- a/rentchain-frontend/src/pages/PropertiesPage.css
+++ b/rentchain-frontend/src/pages/PropertiesPage.css
@@ -13,10 +13,114 @@
   min-width: 0;
 }
 
+.rc-units-edit-table-wrap {
+  overflow-x: auto;
+}
+
+.rc-units-edit-mobile-list {
+  display: none;
+}
+
 @media (max-width: 768px) {
+  .rc-modal-shell {
+    width: calc(100vw - 16px) !important;
+    max-height: calc(100vh - 16px) !important;
+    border-radius: 12px !important;
+  }
+
+  .rc-modal-body {
+    padding: 12px !important;
+  }
+
+  .rc-modal-footer {
+    position: sticky;
+    bottom: 0;
+    background: #ffffff;
+    padding: 12px !important;
+    align-items: stretch;
+  }
+
+  .rc-modal-footer > button,
+  .rc-modal-footer .rc-wrap-row,
+  .rc-modal-footer .rc-wrap-row button {
+    width: 100%;
+  }
+
+  .rc-modal-footer .rc-wrap-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+
+  .rc-units-edit-table-wrap {
+    display: none;
+  }
+
+  .rc-units-edit-mobile-list {
+    display: grid;
+    gap: 12px;
+  }
+
+  .rc-units-edit-mobile-card {
+    display: grid;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    border-radius: 12px;
+    background: #ffffff;
+  }
+
+  .rc-units-edit-mobile-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    color: #0f172a;
+    font-size: 0.92rem;
+    font-weight: 800;
+  }
+
+  .rc-units-edit-remove-button {
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: transparent;
+    border-radius: 8px;
+    color: #475569;
+    cursor: pointer;
+    font-size: 0.8rem;
+    padding: 5px 8px;
+  }
+
+  .rc-units-edit-mobile-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .rc-units-edit-field {
+    display: grid;
+    gap: 5px;
+    color: #334155;
+    font-size: 0.78rem;
+    font-weight: 650;
+    min-width: 0;
+  }
+
+  .rc-units-edit-field input,
+  .rc-units-edit-field select {
+    font-size: 0.92rem;
+    min-height: 38px;
+  }
+
   .rc-units-edit-table th,
   .rc-units-edit-table td {
     padding: 6px 4px;
     font-size: 12px;
+  }
+}
+
+@media (max-width: 380px) {
+  .rc-units-edit-mobile-grid,
+  .rc-modal-footer .rc-wrap-row {
+    grid-template-columns: 1fr;
   }
 }

--- a/rentchain-frontend/src/pages/PropertiesPage.guidedUnitsPayload.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.guidedUnitsPayload.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import PropertiesPage from "./PropertiesPage";
@@ -121,6 +121,7 @@ vi.mock("../lib/analytics", () => ({
 
 describe("PropertiesPage guided unit payload", () => {
   beforeEach(() => {
+    cleanup();
     mocks.apiFetchMock.mockReset();
     mocks.fetchPropertiesMock.mockReset();
     mocks.fetchCountsMock.mockReset();
@@ -158,6 +159,7 @@ describe("PropertiesPage guided unit payload", () => {
       </MemoryRouter>
     );
 
+    fireEvent.click(await screen.findByRole("button", { name: "Add Property" }));
     const setupButtons = await screen.findAllByRole("button", {
       name: "Complete property setup",
     });

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -1,11 +1,12 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import PropertiesPage from "./PropertiesPage";
+import PropertiesPage, { buildMonthlyOpsSnapshotRows } from "./PropertiesPage";
 
 const mocks = vi.hoisted(() => ({
   fetchPropertiesMock: vi.fn(),
   fetchCountsMock: vi.fn(),
+  fetchMonthlyOpsSnapshotMock: vi.fn(),
   addUnitsManualMock: vi.fn(),
   patchCreatedUnitOccupancyMetadataMock: vi.fn(),
   showToastMock: vi.fn(),
@@ -96,7 +97,7 @@ vi.mock("../api/actionRequestsApi", () => ({
 }));
 
 vi.mock("../api/actionSnapshotApi", () => ({
-  fetchMonthlyOpsSnapshot: vi.fn().mockResolvedValue({ properties: {} }),
+  fetchMonthlyOpsSnapshot: mocks.fetchMonthlyOpsSnapshotMock,
 }));
 
 vi.mock("../api/onboardingApi", () => ({
@@ -138,6 +139,7 @@ describe("PropertiesPage", () => {
     cleanup();
     mocks.fetchPropertiesMock.mockReset();
     mocks.fetchCountsMock.mockReset();
+    mocks.fetchMonthlyOpsSnapshotMock.mockReset();
     mocks.addUnitsManualMock.mockReset();
     mocks.patchCreatedUnitOccupancyMetadataMock.mockReset();
     mocks.showToastMock.mockReset();
@@ -152,6 +154,7 @@ describe("PropertiesPage", () => {
           : [{ id: "prop-1", name: "Active Property", portfolioStatus: "active" }],
     }));
     mocks.fetchCountsMock.mockResolvedValue({ counts: {} });
+    mocks.fetchMonthlyOpsSnapshotMock.mockResolvedValue({ properties: {} });
     mocks.addUnitsManualMock.mockResolvedValue({
       ok: true,
       created: 1,
@@ -248,6 +251,58 @@ describe("PropertiesPage", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "Print / Save PDF" })[0]);
 
     expect(mocks.printSummaryDocumentMock).toHaveBeenCalledWith("summary");
+  });
+
+  it("downloads a zero-activity monthly ops snapshot when property details are omitted", async () => {
+    mocks.fetchMonthlyOpsSnapshotMock.mockResolvedValue({
+      ok: true,
+      data: {
+        openCount: 0,
+        overdueCount: 0,
+        highSeverityCount: 0,
+      },
+    });
+    const createObjectUrl = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:monthly-ops");
+    const revokeObjectUrl = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Monthly Ops Snapshot" }));
+
+    await waitFor(() => {
+      expect(mocks.fetchMonthlyOpsSnapshotMock).toHaveBeenCalled();
+    });
+    expect(createObjectUrl).toHaveBeenCalledWith(expect.any(Blob));
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:monthly-ops");
+
+    createObjectUrl.mockRestore();
+    revokeObjectUrl.mockRestore();
+  });
+
+  it("builds a safe monthly ops CSV row for aggregate-only empty snapshots", () => {
+    expect(
+      buildMonthlyOpsSnapshotRows({
+        ok: true,
+        data: {
+          openCount: 0,
+          overdueCount: 0,
+          highSeverityCount: 0,
+        },
+      })
+    ).toEqual([
+      {
+        propertyName: "Portfolio total",
+        propertyAddress: "No property-level action requests",
+        openRequests: 0,
+        overdueRequests: 0,
+        highSeverity: 0,
+        oldestOpenDays: "",
+      },
+    ]);
   });
 
   it("shows a guided first-property empty state for new users", async () => {

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -177,6 +177,7 @@ describe("PropertiesPage", () => {
       </MemoryRouter>
     );
 
+    fireEvent.click(await screen.findByRole("button", { name: "Add Property" }));
     const setupButtons = await screen.findAllByRole("button", {
       name: "Complete property setup",
     });
@@ -263,7 +264,34 @@ describe("PropertiesPage", () => {
       screen.getByText("Add your first property to begin managing tenants, leases, and maintenance in one place.")
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add your first property" })).toBeInTheDocument();
+    expect(screen.queryByText("Start here: add your first property")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add your first property" }));
+
     expect(screen.getByText("Start here: add your first property")).toBeInTheDocument();
+  });
+
+  it("keeps the add property form collapsed until requested and supports hiding it", async () => {
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mocks.fetchPropertiesMock).toHaveBeenCalledWith({ status: "active" });
+    });
+
+    expect(screen.queryByText("Add form")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Property" }));
+
+    expect(screen.getByText("Add a new property")).toBeInTheDocument();
+    expect(screen.getByText("Add form")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide form" }));
+
+    expect(screen.queryByText("Add form")).not.toBeInTheDocument();
   });
 
   it("shows a free-safe next step after property creation", async () => {
@@ -275,12 +303,14 @@ describe("PropertiesPage", () => {
       </MemoryRouter>
     );
 
+    fireEvent.click(await screen.findByRole("button", { name: "Add Property" }));
     const setupButtons = await screen.findAllByRole("button", {
       name: "Complete property setup",
     });
     fireEvent.click(setupButtons[0]);
 
     expect(await screen.findByText("Your first property is set up")).toBeInTheDocument();
+    expect(screen.queryByText("Add form")).not.toBeInTheDocument();
     expect(screen.getByText("Step 1 complete")).toBeInTheDocument();
     expect(screen.getByText("Step 2 next")).toBeInTheDocument();
     expect(screen.getByText("Add your first unit")).toBeInTheDocument();
@@ -305,6 +335,7 @@ describe("PropertiesPage", () => {
       </MemoryRouter>
     );
 
+    fireEvent.click(await screen.findByRole("button", { name: "Add Property" }));
     const setupButtons = await screen.findAllByRole("button", {
       name: "Complete property setup",
     });
@@ -429,6 +460,7 @@ describe("PropertiesPage", () => {
       </MemoryRouter>
     );
 
+    fireEvent.click(await screen.findByRole("button", { name: "Add Property" }));
     const setupButtons = await screen.findAllByRole("button", {
       name: "Complete property setup",
     });

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -288,6 +288,8 @@ describe("PropertiesPage", () => {
 
     expect(screen.getByText("Add a new property")).toBeInTheDocument();
     expect(screen.getByText("Add form")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Hide form" })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "Show form" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Hide form" }));
 

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -503,6 +503,7 @@ describe("PropertiesPage", () => {
 
     fireEvent.click(await screen.findByTestId("property-table-add-units-prop-1"));
     expect(await screen.findByText("Add Units")).toBeInTheDocument();
+    expect(screen.getByLabelText("Add units mobile form")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Unit number 1"), { target: { value: "301" } });
     fireEvent.change(screen.getByLabelText("Beds 1"), { target: { value: "2" } });

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -115,6 +115,45 @@ function mergePersistedUnits(existingUnits: any[] | undefined, persistedUnits: U
   return ordered;
 }
 
+function numericSnapshotValue(value: any) {
+  const next = Number(value);
+  return Number.isFinite(next) ? next : 0;
+}
+
+function safeSnapshotRecord(value: any) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+export function buildMonthlyOpsSnapshotRows(snapshot: any, propertyLabelById: Record<string, any> = {}) {
+  const properties = safeSnapshotRecord(snapshot?.properties);
+  const aggregate = safeSnapshotRecord(snapshot?.data || snapshot?.totals || snapshot);
+  const rows = Object.entries(properties).map(([propertyId, rawData]) => {
+    const data = safeSnapshotRecord(rawData);
+    const label = propertyLabelById?.[propertyId];
+    return {
+      propertyName: label?.name || propertyId,
+      propertyAddress: label?.subtitle || "",
+      openRequests: numericSnapshotValue(data.openCount ?? data.open ?? data.openRequests),
+      overdueRequests: numericSnapshotValue(data.overdueCount ?? data.overdue ?? data.overdueRequests),
+      highSeverity: numericSnapshotValue(data.highSeverity ?? data.highSeverityCount),
+      oldestOpenDays: data.oldestDays ?? data.oldestOpenDays ?? "",
+    };
+  });
+
+  if (rows.length) return rows;
+
+  return [
+    {
+      propertyName: "Portfolio total",
+      propertyAddress: "No property-level action requests",
+      openRequests: numericSnapshotValue(aggregate.openCount ?? aggregate.open ?? aggregate.openRequests),
+      overdueRequests: numericSnapshotValue(aggregate.overdueCount ?? aggregate.overdue ?? aggregate.overdueRequests),
+      highSeverity: numericSnapshotValue(aggregate.highSeverity ?? aggregate.highSeverityCount),
+      oldestOpenDays: aggregate.oldestDays ?? aggregate.oldestOpenDays ?? "",
+    },
+  ];
+}
+
 function unitSaveErrorMessage(error: any) {
   const code = String(error?.code || error?.error || error?.message || "");
   if (code === "UNIT_ID_UNRESOLVED" || code === "UNIT_PERSISTENCE_FAILED") {
@@ -684,22 +723,13 @@ const PropertiesPage: React.FC = () => {
               type="button"
               onClick={async () => {
                 const snap = await fetchMonthlyOpsSnapshot();
-
-                const rows = Object.entries(snap.properties).map(([propertyId, data]) => {
-                  const label = propertyLabelById?.[propertyId];
-                  return {
-                    propertyName: label?.name || propertyId,
-                    propertyAddress: label?.subtitle || "",
-                    openRequests: data.openCount,
-                    highSeverity: data.highSeverity,
-                    oldestOpenDays: data.oldestDays ?? "",
-                  };
-                });
+                const rows = buildMonthlyOpsSnapshotRows(snap, propertyLabelById);
 
                 const header = [
                   "propertyName",
                   "propertyAddress",
                   "openRequests",
+                  "overdueRequests",
                   "highSeverity",
                   "oldestOpenDays",
                 ];

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -766,6 +766,7 @@ const PropertiesPage: React.FC = () => {
                 </Button>
               </div>
               <AddPropertyForm
+                showInternalToggle={false}
                 onCreated={handlePropertyCreated}
                 onExistingPropertyId={(existingId) => {
                   setIsAddPropertyOpen(false);

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -766,7 +766,6 @@ const PropertiesPage: React.FC = () => {
                 </Button>
               </div>
               <AddPropertyForm
-                showInternalToggle={false}
                 onCreated={handlePropertyCreated}
                 onExistingPropertyId={(existingId) => {
                   setIsAddPropertyOpen(false);

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -183,6 +183,7 @@ const PropertiesPage: React.FC = () => {
   const [actionRequests, setActionRequests] = useState<PropertyActionRequest[]>([]);
   const [actionRequestsLoading, setActionRequestsLoading] = useState(false);
   const addPropertyRef = useRef<HTMLDivElement | null>(null);
+  const [isAddPropertyOpen, setIsAddPropertyOpen] = useState(false);
   const [actionRequestsError, setActionRequestsError] = useState<string | null>(null);
   const [actionFilter, setActionFilter] = useState<ActionRequestStatus | "all">("all");
   const [activeRequest, setActiveRequest] = useState<PropertyActionRequest | null>(null);
@@ -222,6 +223,16 @@ const PropertiesPage: React.FC = () => {
   const totalOpenAcrossPortfolio = useMemo(() => Object.values(actionCounts || {}).reduce((a, b) => a + (b || 0), 0), [
     actionCounts,
   ]);
+
+  const openAddPropertyForm = useCallback(() => {
+    setIsAddPropertyOpen(true);
+    window.requestAnimationFrame(() => {
+      const scrollIntoView = addPropertyRef.current?.scrollIntoView;
+      if (typeof scrollIntoView === "function") {
+        scrollIntoView.call(addPropertyRef.current, { behavior: "smooth", block: "start" });
+      }
+    });
+  }, []);
 
   const propertyLabelById = useMemo(() => {
     const out: Record<string, { name: string; subtitle?: string }> = {};
@@ -419,6 +430,7 @@ const PropertiesPage: React.FC = () => {
 
   const handlePropertyCreated = (property: Property) => {
     if (property?.id) {
+      setIsAddPropertyOpen(false);
       setProperties((prev) => [...prev, property]);
       setSelectedPropertyId(property.id);
       setRecentlyCreatedPropertyId(property.id);
@@ -561,6 +573,17 @@ const PropertiesPage: React.FC = () => {
         <div className="rc-properties-header" style={{ display: "flex", alignItems: "center", gap: 10 }}>
           <div className="rc-properties-title-row" style={{ display: "flex", alignItems: "center", gap: 10 }}>
             <div style={{ fontWeight: 800, fontSize: "1.2rem" }}>Properties</div>
+            <Button
+              type="button"
+              onClick={openAddPropertyForm}
+              style={{
+                padding: "7px 12px",
+                fontSize: 13,
+                whiteSpace: "nowrap",
+              }}
+            >
+              Add Property
+            </Button>
             <div
               className="rc-properties-counts"
               style={{
@@ -730,32 +753,49 @@ const PropertiesPage: React.FC = () => {
           </div>
         </div>
 
-        <Card elevated ref={addPropertyRef}>
-          <h1 style={{ margin: 0, fontSize: "1.4rem", fontWeight: 700 }}>
-            {properties.length === 0 ? "Start here: add your first property" : "Add a new property"}
-          </h1>
-          <p
-            style={{
-              marginTop: 6,
-              marginBottom: 14,
-              color: text.muted,
-              fontSize: "0.95rem",
-            }}
-          >
-            {properties.length === 0
-              ? "Start your rental workflow by adding one property. You only need the address, city, and total units to get moving."
-              : "Capture units, rents, and amenities. Newly added properties will show up in your list and rent roll below."}
-          </p>
-          <AddPropertyForm
-            onCreated={handlePropertyCreated}
-            onExistingPropertyId={(existingId) => {
-              setSelectedPropertyId(existingId);
-              const next = new URLSearchParams(location.search);
-              next.set("propertyId", existingId);
-              navigate({ pathname: location.pathname, search: next.toString() }, { replace: true });
-            }}
-          />
-        </Card>
+        <div ref={addPropertyRef}>
+          {isAddPropertyOpen ? (
+            <Card elevated>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start", flexWrap: "wrap" }}>
+                <div>
+                  <h1 style={{ margin: 0, fontSize: "1.4rem", fontWeight: 700 }}>
+                    {properties.length === 0 ? "Start here: add your first property" : "Add a new property"}
+                  </h1>
+                  <p
+                    style={{
+                      marginTop: 6,
+                      marginBottom: 14,
+                      color: text.muted,
+                      fontSize: "0.95rem",
+                    }}
+                  >
+                    {properties.length === 0
+                      ? "Start your rental workflow by adding one property. You only need the address, city, and total units to get moving."
+                      : "Capture units, rents, and amenities. Newly added properties will show up in your list and rent roll below."}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setIsAddPropertyOpen(false)}
+                  style={{ whiteSpace: "nowrap" }}
+                >
+                  Hide form
+                </Button>
+              </div>
+              <AddPropertyForm
+                onCreated={handlePropertyCreated}
+                onExistingPropertyId={(existingId) => {
+                  setIsAddPropertyOpen(false);
+                  setSelectedPropertyId(existingId);
+                  const next = new URLSearchParams(location.search);
+                  next.set("propertyId", existingId);
+                  navigate({ pathname: location.pathname, search: next.toString() }, { replace: true });
+                }}
+              />
+            </Card>
+          ) : null}
+        </div>
 
         <Card
           elevated
@@ -883,7 +923,7 @@ const PropertiesPage: React.FC = () => {
                   <Button
                     onClick={() => {
                       track("empty_state_cta_clicked", { pageKey: "properties", ctaKey: "add_property" });
-                      addPropertyRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                      openAddPropertyForm();
                     }}
                     style={{ width: "fit-content" }}
                   >

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -570,47 +570,29 @@ const PropertiesPage: React.FC = () => {
         className="page-content"
         style={{ display: "flex", flexDirection: "column", gap: spacing.lg }}
       >
-        <div className="rc-properties-header" style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <div className="rc-properties-title-row" style={{ display: "flex", alignItems: "center", gap: 10 }}>
-            <div style={{ fontWeight: 800, fontSize: "1.2rem" }}>Properties</div>
+        <div className="rc-properties-header">
+          <div className="rc-properties-title-stack">
+            <div className="rc-properties-title-row">
+              <div className="rc-properties-page-title">Properties</div>
+              <div
+                className="rc-properties-counts"
+                title={`Properties ${currentProperties} - Units ${unitsUsed}`}
+              >
+                <span>{currentProperties} props</span>
+                <span aria-hidden="true">·</span>
+                <span>{unitsUsed} units</span>
+              </div>
+            </div>
+            <div className="rc-properties-helper">{archiveHelpCopy}</div>
+          </div>
+          <div className="rc-properties-header-actions">
             <Button
               type="button"
               onClick={openAddPropertyForm}
-              style={{
-                padding: "7px 12px",
-                fontSize: 13,
-                whiteSpace: "nowrap",
-              }}
+              className="rc-properties-add-button"
             >
               Add Property
             </Button>
-            <div
-              className="rc-properties-counts"
-              style={{
-                padding: "6px 10px",
-                borderRadius: 12,
-                border: "1px solid rgba(148,163,184,0.35)",
-                fontSize: 12,
-                fontWeight: 700,
-                color: text.muted,
-                display: "inline-flex",
-                gap: 8,
-                alignItems: "center",
-              }}
-              title={`Properties ${currentProperties} - Units ${unitsUsed}`}
-            >
-            <span>
-              Props: {currentProperties}
-            </span>
-            <span aria-hidden="true">·</span>
-            <span>
-              Units: {unitsUsed}
-            </span>
-            </div>
-          </div>
-          <div style={{ color: text.muted, fontSize: 13 }}>{archiveHelpCopy}</div>
-
-          <div className="rc-properties-header-actions" style={{ display: "flex", gap: 8 }}>
             {selectedPropertyId ? (
               <button
                 type="button"
@@ -1607,7 +1589,7 @@ const UnitsModal = ({
         </div>
 
         <div className="rc-modal-body" style={{ padding: 16, overflow: "auto", minHeight: 0 }}>
-          <div style={{ overflowX: "auto" }}>
+          <div className="rc-units-edit-table-wrap">
             <table className="rc-units-edit-table" style={{ width: "100%", minWidth: 980, tableLayout: "fixed", borderCollapse: "collapse" }}>
               <colgroup>
                 <col style={{ width: "13%" }} />
@@ -1744,6 +1726,117 @@ const UnitsModal = ({
                 ))}
               </tbody>
             </table>
+          </div>
+          <div className="rc-units-edit-mobile-list" aria-label="Add units mobile form">
+            {units.map((u, idx) => {
+              const occupied = (u.status ?? "vacant") === "occupied";
+              return (
+                <div className="rc-units-edit-mobile-card" key={idx}>
+                  <div className="rc-units-edit-mobile-card-header">
+                    <div>Unit {idx + 1}</div>
+                    <button
+                      type="button"
+                      onClick={() => removeRow(idx)}
+                      className="rc-units-edit-remove-button"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <label className="rc-units-edit-field">
+                    Unit number
+                    <input
+                      aria-label={`Mobile unit number ${idx + 1}`}
+                      value={u.unitNumber}
+                      onChange={(e) => updateUnit(idx, "unitNumber", e.target.value)}
+                      style={baseFieldStyle}
+                    />
+                  </label>
+                  <div className="rc-units-edit-mobile-grid">
+                    <label className="rc-units-edit-field">
+                      Beds
+                      <input
+                        aria-label={`Mobile beds ${idx + 1}`}
+                        type="number"
+                        value={u.beds}
+                        onChange={(e) => updateUnit(idx, "beds", e.target.value)}
+                        style={baseFieldStyle}
+                      />
+                    </label>
+                    <label className="rc-units-edit-field">
+                      Baths
+                      <input
+                        aria-label={`Mobile baths ${idx + 1}`}
+                        type="number"
+                        value={u.baths}
+                        onChange={(e) => updateUnit(idx, "baths", e.target.value)}
+                        style={baseFieldStyle}
+                      />
+                    </label>
+                  </div>
+                  <div className="rc-units-edit-mobile-grid">
+                    <label className="rc-units-edit-field">
+                      Sqft
+                      <input
+                        aria-label={`Mobile square footage ${idx + 1}`}
+                        type="number"
+                        value={u.sqft}
+                        onChange={(e) => updateUnit(idx, "sqft", e.target.value)}
+                        style={baseFieldStyle}
+                      />
+                    </label>
+                    <label className="rc-units-edit-field">
+                      Market rent
+                      <input
+                        aria-label={`Mobile market rent ${idx + 1}`}
+                        type="number"
+                        value={u.marketRent}
+                        onChange={(e) => updateUnit(idx, "marketRent", e.target.value)}
+                        onFocus={() => {
+                          if (String(u.marketRent ?? "") === "0") {
+                            updateUnit(idx, "marketRent", "");
+                          }
+                        }}
+                        style={baseFieldStyle}
+                      />
+                    </label>
+                  </div>
+                  <label className="rc-units-edit-field">
+                    Status
+                    <select
+                      aria-label={`Mobile status ${idx + 1}`}
+                      value={u.status ?? "vacant"}
+                      onChange={(e) => updateUnit(idx, "status", e.target.value)}
+                      style={baseFieldStyle}
+                    >
+                      <option value="vacant">Vacant</option>
+                      <option value="occupied">Occupied</option>
+                    </select>
+                  </label>
+                  <label className="rc-units-edit-field">
+                    Occupant
+                    <input
+                      aria-label={`Mobile occupant name ${idx + 1}`}
+                      value={u.occupantName ?? ""}
+                      onChange={(e) => updateUnit(idx, "occupantName", e.target.value)}
+                      disabled={!occupied}
+                      placeholder={occupied ? "Tenant name" : "Vacant"}
+                      style={occupied ? activeOccupancyFieldStyle : inactiveOccupancyFieldStyle}
+                    />
+                  </label>
+                  <label className="rc-units-edit-field">
+                    Lease end
+                    <input
+                      aria-label={`Mobile lease end date ${idx + 1}`}
+                      type="date"
+                      value={u.leaseEndDate ?? ""}
+                      onChange={(e) => updateUnit(idx, "leaseEndDate", e.target.value)}
+                      disabled={!occupied}
+                      style={occupied ? activeOccupancyFieldStyle : inactiveOccupancyFieldStyle}
+                    />
+                  </label>
+                </div>
+              );
+            })}
           </div>
           {error ? (
             <div

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -4,7 +4,20 @@
 }
 
 .rc-tenants-page {
+  position: relative;
+  z-index: 0;
+  padding-top: 8px;
   scroll-margin-top: calc(var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px)) + 24px);
+}
+
+.rc-tenants-header {
+  position: relative;
+  z-index: 0;
+}
+
+.rc-tenants-header > div:first-child {
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .rc-tenants-list {
@@ -16,7 +29,7 @@
 
 .rc-tenants-search {
   position: sticky;
-  top: 0;
+  top: calc(var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px)) + 8px);
   z-index: 5;
   background: #ffffff;
   padding: 8px 0 10px;

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -20,6 +20,18 @@
   gap: 12px;
 }
 
+.rc-tenants-upgrade-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #f5d0fe;
+  border-radius: 14px;
+  background: #faf5ff;
+}
+
 .rc-tenants-list {
   display: flex;
   flex-direction: column;
@@ -73,5 +85,10 @@
 
   .rc-tenants-header {
     position: static;
+  }
+
+  .rc-tenants-upgrade-card {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -3,6 +3,10 @@
   min-height: 0;
 }
 
+.rc-tenants-page {
+  scroll-margin-top: calc(var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px)) + 24px);
+}
+
 .rc-tenants-list {
   display: flex;
   flex-direction: column;
@@ -49,14 +53,12 @@
   }
 
   .rc-tenants-search {
-    top: 0;
+    position: static;
     padding-top: 6px;
     padding-bottom: 8px;
   }
 
   .rc-tenants-header {
-    position: sticky;
-    top: 0;
-    z-index: 6;
+    position: static;
   }
 }

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -149,6 +149,7 @@ describe("TenantsPage", () => {
     expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
       expect.objectContaining({ fallbackPath: "/pricing" })
     );
+    expect(mocks.inviteTenantModalMock).not.toHaveBeenCalled();
   });
 
   it("does not open the invite modal from a deep link when tenant invites are locked", async () => {
@@ -167,6 +168,7 @@ describe("TenantsPage", () => {
     expect(
       screen.queryByText("Upgrade confirmed. Tenant invites are now unlocked for this workspace.")
     ).not.toBeInTheDocument();
+    expect(mocks.inviteTenantModalMock).not.toHaveBeenCalled();
   });
 
   it("shows a tenant action hub with edit, note, and invite actions", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -16,6 +16,7 @@ type InviteTenantModalProps = {
   defaultTenantName?: string;
   defaultPropertyId?: string;
   defaultUnitId?: string;
+  canInviteOverride?: boolean;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -150,6 +151,33 @@ describe("TenantsPage", () => {
       expect.objectContaining({ fallbackPath: "/pricing" })
     );
     expect(mocks.inviteTenantModalMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks locked selected-tenant invite actions before rendering the invite modal", async () => {
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyId: "property-1",
+        unitId: "unit-4",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Unlock Tenant Invites" }));
+
+    expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackPath: "/pricing" })
+    );
+    expect(mocks.inviteTenantModalMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("Invite modal open")).not.toBeInTheDocument();
   });
 
   it("does not open the invite modal from a deep link when tenant invites are locked", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -151,6 +151,24 @@ describe("TenantsPage", () => {
     );
   });
 
+  it("does not open the invite modal from a deep link when tenant invites are locked", async () => {
+    render(
+      <MemoryRouter initialEntries={["/tenants?invite=1&upgradeConfirmed=1&highlight=tenants"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByRole("button", { name: "Unlock Tenant Invites" });
+
+    expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackPath: "/pricing" })
+    );
+    expect(screen.queryByText("Invite modal open")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Upgrade confirmed. Tenant invites are now unlocked for this workspace.")
+    ).not.toBeInTheDocument();
+  });
+
   it("shows a tenant action hub with edit, note, and invite actions", async () => {
     mocks.useCapabilitiesMock.mockReturnValue({
       features: { tenant_invites: true },

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -116,7 +116,7 @@ describe("TenantsPage", () => {
 
   beforeEach(() => {
     mocks.useAuthMock.mockReturnValue({
-      user: { id: "user-1", role: "landlord" },
+      user: { id: "user-1", role: "landlord", plan: "starter" },
       ready: true,
       isLoading: false,
       authStatus: "ready",
@@ -145,12 +145,41 @@ describe("TenantsPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole("button", { name: "Unlock Tenant Invites" }));
+    expect(await screen.findByText("Tenant invites require Starter")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Unlock Tenant Invites" })[0]);
 
     expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
       expect.objectContaining({ fallbackPath: "/pricing" })
     );
     expect(mocks.inviteTenantModalMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when cached invite capability is true but the authenticated plan is free", async () => {
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "user-1", role: "landlord", plan: "free" },
+      ready: true,
+      isLoading: false,
+      authStatus: "ready",
+    });
+    mocks.useCapabilitiesMock.mockReturnValue({
+      caps: { plan: "free" },
+      features: { tenant_invites: true },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant invites require Starter")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Unlock Tenant Invites" })[0]);
+
+    expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackPath: "/pricing" })
+    );
+    expect(mocks.inviteTenantModalMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("Invite modal open")).not.toBeInTheDocument();
   });
 
   it("blocks locked selected-tenant invite actions before rendering the invite modal", async () => {
@@ -171,7 +200,8 @@ describe("TenantsPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole("button", { name: "Unlock Tenant Invites" }));
+    expect(await screen.findByText("Tenant invites require Starter")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Unlock Tenant Invites" })[0]);
 
     expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
       expect.objectContaining({ fallbackPath: "/pricing" })
@@ -187,7 +217,7 @@ describe("TenantsPage", () => {
       </MemoryRouter>
     );
 
-    await screen.findByRole("button", { name: "Unlock Tenant Invites" });
+    expect(await screen.findByText("Tenant invites require Starter")).toBeInTheDocument();
 
     expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
       expect.objectContaining({ fallbackPath: "/pricing" })

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -349,6 +349,7 @@ export const TenantsPage: React.FC = () => {
   const handleInviteAction = useCallback(() => {
     if (!inviteEnabled) {
       void openUpgradeFlow({ navigate, fallbackPath: "/pricing" });
+      setInviteOpen(false);
       return;
     }
     setInviteOpen(true);
@@ -653,7 +654,7 @@ const loadTenants = useCallback(async () => {
 
   return (
     <TenantsErrorBoundary>
-      <div className="page-content" style={{ display: "flex", flexDirection: "column", gap: spacing.lg }}>
+      <div className="page-content rc-tenants-page" style={{ display: "flex", flexDirection: "column", gap: spacing.lg }}>
       <Card elevated className="rc-tenants-header">
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
           <div>

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -355,6 +355,12 @@ export const TenantsPage: React.FC = () => {
     setInviteOpen(true);
   }, [inviteEnabled, navigate]);
 
+  useEffect(() => {
+    if (!inviteEnabled && inviteOpen) {
+      setInviteOpen(false);
+    }
+  }, [inviteEnabled, inviteOpen]);
+
   const refreshTenantTenancies = useCallback(async (tenantId: string) => {
     const nextTenancies = await fetchTenantTenancies(tenantId);
     setTenants((prev) =>
@@ -1163,17 +1169,19 @@ const loadTenants = useCallback(async () => {
         />
       </Card>
 
-      <InviteTenantModal
-        open={inviteOpen}
-        onClose={() => setInviteOpen(false)}
-        defaultPropertyId={selectedTenant?.propertyId || undefined}
-        defaultUnitId={selectedTenant?.unitId || undefined}
-        defaultTenantEmail={selectedTenant?.email || undefined}
-        defaultTenantName={selectedTenant?.fullName || selectedTenant?.name || undefined}
-        onInviteCreated={() => {
-          void loadTenants();
-        }}
-      />
+      {inviteEnabled ? (
+        <InviteTenantModal
+          open={inviteOpen}
+          onClose={() => setInviteOpen(false)}
+          defaultPropertyId={selectedTenant?.propertyId || undefined}
+          defaultUnitId={selectedTenant?.unitId || undefined}
+          defaultTenantEmail={selectedTenant?.email || undefined}
+          defaultTenantName={selectedTenant?.fullName || selectedTenant?.name || undefined}
+          onInviteCreated={() => {
+            void loadTenants();
+          }}
+        />
+      ) : null}
 
       {tenantEdit.open ? (
         <div

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -25,6 +25,7 @@ import { useCapabilities } from "@/hooks/useCapabilities";
 import { useTenantDetail } from "@/hooks/useTenantDetail";
 import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import { isTargetedHiddenTenantId } from "@/lib/testDataVisibilityTargets";
+import { isPlanAtLeast, normalizePlan } from "@/lib/plan";
 import type { TenantLeaseSummary } from "@/api/tenantDetail";
 import "./TenantsPage.css";
 
@@ -338,12 +339,14 @@ export const TenantsPage: React.FC = () => {
 
   const selectedTenantIdFromUrl = searchParams.get("tenantId");
   const [selectedTenantId, setSelectedTenantId] = useState<string | null>(selectedTenantIdFromUrl);
-  const { features } = useCapabilities();
-  const inviteEnabled = Boolean(features?.tenant_invites || features?.tenantInvites);
+  const { caps, features } = useCapabilities();
+  const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
+  const currentPlan = normalizePlan(caps?.plan || user?.plan || "free");
+  const inviteFeatureEnabled = Boolean(features?.tenant_invites || features?.tenantInvites);
+  const inviteEnabled = role === "admin" || (inviteFeatureEnabled && isPlanAtLeast(currentPlan, "starter"));
   const upgradeConfirmed = searchParams.get("upgradeConfirmed") === "1";
   const upgradeHighlight = searchParams.get("highlight");
 
-  const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
   const canViewTenants = role === "landlord" || role === "admin";
 
   const handleInviteAction = useCallback(() => {
@@ -701,6 +704,19 @@ const loadTenants = useCallback(async () => {
             }}
           >
             Upgrade confirmed. Tenant invites are now unlocked for this workspace.
+          </div>
+        ) : null}
+        {!inviteEnabled ? (
+          <div className="rc-tenants-upgrade-card" role="status">
+            <div>
+              <div style={{ fontWeight: 850, color: "#581c87" }}>Tenant invites require Starter</div>
+              <div style={{ marginTop: 3, fontSize: 13, color: "#6b21a8", lineHeight: 1.4 }}>
+                Upgrade before creating invite links. The invite form stays locked on this plan.
+              </div>
+            </div>
+            <Button type="button" variant="secondary" onClick={handleInviteAction}>
+              Unlock Tenant Invites
+            </Button>
           </div>
         ) : null}
       </Card>

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -1177,6 +1177,7 @@ const loadTenants = useCallback(async () => {
           defaultUnitId={selectedTenant?.unitId || undefined}
           defaultTenantEmail={selectedTenant?.email || undefined}
           defaultTenantName={selectedTenant?.fullName || selectedTenant?.name || undefined}
+          canInviteOverride={inviteEnabled}
           onInviteCreated={() => {
             void loadTenants();
           }}

--- a/rentchain-frontend/src/styles/propertiesMobile.css
+++ b/rentchain-frontend/src/styles/propertiesMobile.css
@@ -72,6 +72,70 @@
   display: none;
 }
 
+.rc-properties-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+}
+
+.rc-properties-title-stack {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.rc-properties-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.rc-properties-page-title {
+  color: #0f172a;
+  font-size: 1.25rem;
+  font-weight: 850;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.rc-properties-counts {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 6px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 750;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.rc-properties-helper {
+  color: #64748b;
+  font-size: 13px;
+  line-height: 1.35;
+  max-width: 680px;
+}
+
+.rc-properties-header-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.rc-properties-add-button {
+  padding: 7px 12px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
 @media (max-width: 768px) {
   .rc-property-selector-row {
     grid-template-columns: 1fr;
@@ -150,20 +214,34 @@
   }
 
   .rc-properties-header {
-    flex-direction: column;
+    grid-template-columns: 1fr;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .rc-properties-title-row {
+    flex-wrap: wrap;
     align-items: flex-start;
     gap: 8px;
   }
 
-  .rc-properties-title-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
+  .rc-properties-page-title {
+    font-size: 1.15rem;
+  }
+
+  .rc-properties-helper {
+    font-size: 12px;
+    line-height: 1.35;
   }
 
   .rc-properties-header-actions {
     flex-wrap: wrap;
     width: 100%;
+    justify-content: flex-start;
+  }
+
+  .rc-properties-add-button {
+    min-height: 40px;
   }
 
   .rc-properties-pill {
@@ -256,6 +334,63 @@
 
   .rc-add-property-form label {
     color: #0f172a;
+  }
+
+  .rc-unit-edit-overlay {
+    align-items: stretch !important;
+    justify-content: center !important;
+    padding: 8px !important;
+  }
+
+  .rc-unit-edit-panel {
+    align-self: center;
+    width: min(100%, calc(100vw - 16px)) !important;
+    max-width: none !important;
+    max-height: calc(100vh - 16px) !important;
+    padding: 12px !important;
+    gap: 10px !important;
+    overflow-x: hidden !important;
+  }
+
+  .rc-unit-edit-panel input,
+  .rc-unit-edit-panel select,
+  .rc-unit-edit-panel textarea {
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 0;
+    font-size: 0.92rem;
+  }
+
+  .rc-unit-edit-two-col {
+    grid-template-columns: 1fr !important;
+    gap: 10px !important;
+  }
+
+  .rc-unit-edit-actions {
+    position: sticky;
+    bottom: -12px;
+    margin: 0 -12px -12px;
+    padding: 10px 12px;
+    background: #ffffff;
+    border-top: 1px solid rgba(148, 163, 184, 0.22);
+  }
+
+  .rc-unit-edit-actions button {
+    flex: 1 1 0;
+    min-height: 40px;
+  }
+
+  .rc-occupancy-setup-panel {
+    align-items: stretch !important;
+  }
+
+  .rc-occupancy-setup-panel > div:last-child {
+    width: 100%;
+  }
+
+  .rc-occupancy-setup-panel button {
+    flex: 1 1 140px;
+    min-height: 38px;
   }
 
   .rc-add-property-units-table input {

--- a/rentchain-frontend/src/styles/propertiesMobile.css
+++ b/rentchain-frontend/src/styles/propertiesMobile.css
@@ -136,6 +136,19 @@
   white-space: nowrap;
 }
 
+.rc-property-status-row {
+  flex-wrap: wrap;
+}
+
+.rc-property-status-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  white-space: nowrap;
+  word-break: keep-all;
+  overflow-wrap: normal;
+}
+
 @media (max-width: 768px) {
   .rc-property-selector-row {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Add an Add Property action beside the Properties page title.
- Keep the add-property form collapsed by default until requested.
- Add a Hide form control and collapse the form after successful property creation or existing-property selection.
- Preserve the existing AddPropertyForm behavior, validation, and backend contract.

## Validation
- npm --prefix rentchain-frontend run test -- PropertiesPage.test.tsx PropertiesPage.guidedUnitsPayload.test.tsx
- npm --prefix rentchain-frontend run build
- git diff --check

## Scope
- Frontend-only Properties page UX change.
- No backend/API changes.
- No Dashboard, Inbox, Payments, or Scheduling changes.