### PR TITLE
feat: add payments dashboard context filter

### DIFF
--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -279,6 +279,10 @@ describe("DashboardPage", () => {
     expect(screen.getByRole("button", { name: "7-day view" })).toBeInTheDocument();
     expect(screen.getByTestId("financial-snapshot-section")).toHaveTextContent("Financial Snapshot");
     expect(screen.getByText(/Current rent collection and outstanding balance overview/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Payments Workspace/i })).toHaveAttribute(
+      "href",
+      "/payments?context=current_month&period=2026-06&source=dashboard"
+    );
     expect(screen.getByTestId("workspace-routing-section")).toHaveTextContent("Operations full queue");
 
     expect(mocks.fetchLandlordPortfolioStatusFinancialMock).toHaveBeenCalledWith({ periodMonth: expect.stringMatching(/^\d{4}-\d{2}$/) });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -453,6 +453,9 @@ function PortfolioCountsRow({
 
 function FinancialSnapshotSection({ portfolio }: { portfolio: LandlordPortfolioStatusFinancialResponse }) {
   const financial = portfolio.financialSnapshot;
+  const paymentsWorkspaceHref = `/payments?context=current_month&period=${encodeURIComponent(
+    financial.period.month
+  )}&source=dashboard`;
   const state = metricState(portfolio.confidence.financial);
   const flags = cleanFlags(financial.dataQualityFlags);
   const collected = Math.max(0, financial.collectedCurrentMonthCents || 0);
@@ -468,7 +471,7 @@ function FinancialSnapshotSection({ portfolio }: { portfolio: LandlordPortfolioS
         title="Financial Snapshot"
         subtitle={`Current rent collection and outstanding balance overview for ${financial.period.month}.`}
         action={
-          <Link to="/payments" style={compactButton}>
+          <Link to={paymentsWorkspaceHref} style={compactButton}>
             Payments Workspace <ArrowRight size={16} />
           </Link>
         }

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -46,7 +46,7 @@ vi.mock("../utils/printSummary", () => ({
 }));
 
 vi.mock("@/components/ledger/PaymentCsvImportPreviewCard", () => ({
-  PaymentCsvImportPreviewCard: () => <div>AI-assisted payment CSV import</div>,
+  PaymentCsvImportPreviewCard: () => <div>Payment CSV import panel</div>,
 }));
 
 function renderPaymentsPage(initialEntry = "/payments") {
@@ -107,6 +107,8 @@ describe("PaymentsPage", () => {
     expect(screen.getByRole("button", { name: "Export Spreadsheet (.xls)" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByText("AI-assisted payment CSV import")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upload CSV" })).toBeInTheDocument();
+    expect(screen.queryByText("Payment CSV import panel")).not.toBeInTheDocument();
     expect((await screen.findAllByText("Taylor Tenant")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("123 Main St / Unit 3A").length).toBeGreaterThan(0);
     expect(screen.getAllByText("e-transfer").length).toBeGreaterThan(0);
@@ -115,6 +117,22 @@ describe("PaymentsPage", () => {
     expect(screen.getByRole("textbox", { name: "Search payments" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Filter payments by status" })).toHaveValue("");
     expect(screen.getByRole("combobox", { name: "Filter payments by method" })).toHaveValue("");
+  });
+
+  it("opens and hides the CSV import panel from a collapsed default state", async () => {
+    renderPaymentsPage();
+
+    expect(screen.queryByText("Payment CSV import panel")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload CSV" }));
+
+    expect(screen.getByText("Payment CSV import panel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide" }));
+
+    expect(screen.queryByText("Payment CSV import panel")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upload CSV" })).toBeInTheDocument();
   });
 
   it("routes PDF export through the shared print helper", async () => {
@@ -426,6 +444,114 @@ describe("PaymentsPage", () => {
     expect((await screen.findAllByText("June Tenant")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("May Tenant")).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: "Clear workspace filters" })).not.toBeInTheDocument();
+  });
+
+  it("deduplicates status filters case-insensitively and displays readable labels", async () => {
+    mocks.usePayments.mockReturnValue({
+      payments: [
+        {
+          id: "payment-checkout",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          amount: 1800,
+          paidAt: "2026-06-03",
+          method: "stripe",
+          notes: "",
+          status: "checkout_created",
+          source: "payments",
+        },
+        {
+          id: "payment-recorded-lower",
+          tenantId: "tenant-2",
+          propertyId: "prop-1",
+          amount: 1700,
+          paidAt: "2026-06-04",
+          method: "cheque",
+          notes: "",
+          status: "recorded",
+          source: "payments",
+        },
+        {
+          id: "payment-recorded-title",
+          tenantId: "tenant-3",
+          propertyId: "prop-1",
+          amount: 1600,
+          paidAt: "2026-06-05",
+          method: "cash",
+          notes: "",
+          status: "Recorded",
+          source: "payments",
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mocks.fetchTenants.mockResolvedValue([
+      { id: "tenant-1", fullName: "Checkout Tenant" },
+      { id: "tenant-2", fullName: "Lower Tenant" },
+      { id: "tenant-3", fullName: "Title Tenant" },
+    ]);
+
+    renderPaymentsPage();
+
+    const statusFilter = screen.getByRole("combobox", { name: "Filter payments by status" });
+    expect(screen.getByRole("option", { name: "Checkout Created" })).toHaveValue("checkout_created");
+    expect(screen.getAllByRole("option", { name: "Recorded" })).toHaveLength(1);
+
+    fireEvent.change(statusFilter, { target: { value: "recorded" } });
+
+    expect((await screen.findAllByText("Lower Tenant")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Title Tenant").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Checkout Tenant")).not.toBeInTheDocument();
+  });
+
+  it("filters payments by custom paid date range and clears the date filter", async () => {
+    mocks.usePayments.mockReturnValue({
+      payments: [
+        {
+          id: "payment-june",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          amount: 1800,
+          paidAt: "2026-06-03",
+          method: "e-transfer",
+          notes: "June rent",
+          status: "Recorded",
+          source: "payments",
+        },
+        {
+          id: "payment-may",
+          tenantId: "tenant-2",
+          propertyId: "prop-1",
+          amount: 1700,
+          paidAt: "2026-05-03",
+          method: "cheque",
+          notes: "May rent",
+          status: "Recorded",
+          source: "payments",
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mocks.fetchTenants.mockResolvedValue([
+      { id: "tenant-1", fullName: "June Tenant" },
+      { id: "tenant-2", fullName: "May Tenant" },
+    ]);
+
+    renderPaymentsPage();
+
+    fireEvent.change(screen.getByLabelText("Filter payments from date"), { target: { value: "2026-06-01" } });
+    fireEvent.change(screen.getByLabelText("Filter payments to date"), { target: { value: "2026-06-30" } });
+
+    expect((await screen.findAllByText("June Tenant")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("May Tenant")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear workspace filters" }));
+
+    expect((await screen.findAllByText("May Tenant")).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Filter payments from date")).toHaveValue("");
+    expect(screen.getByLabelText("Filter payments to date")).toHaveValue("");
   });
 
   it("renders a calm empty state for empty Dashboard context results", async () => {

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 import PaymentsPage from "./PaymentsPage";
 
 const mocks = vi.hoisted(() => ({
@@ -48,6 +49,14 @@ vi.mock("@/components/ledger/PaymentCsvImportPreviewCard", () => ({
   PaymentCsvImportPreviewCard: () => <div>AI-assisted payment CSV import</div>,
 }));
 
+function renderPaymentsPage(initialEntry = "/payments") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <PaymentsPage />
+    </MemoryRouter>
+  );
+}
+
 describe("PaymentsPage", () => {
   afterEach(() => {
     cleanup();
@@ -78,7 +87,7 @@ describe("PaymentsPage", () => {
   });
 
   it("renders the recorded-payments framing, explainer, and export controls", async () => {
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     expect(screen.getByText("Payments (recorded)")).toBeInTheDocument();
     expect(
@@ -101,10 +110,11 @@ describe("PaymentsPage", () => {
     expect((await screen.findAllByText("Taylor Tenant")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("123 Main St / Unit 3A").length).toBeGreaterThan(0);
     expect(screen.getAllByText("e-transfer").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument();
   });
 
   it("routes PDF export through the shared print helper", async () => {
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Print / Save PDF" }))[0]);
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
@@ -123,7 +133,7 @@ describe("PaymentsPage", () => {
       return originalCreateElement(tagName);
     }) as any);
 
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Export CSV" }))[0]);
     await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(1));
@@ -160,7 +170,7 @@ describe("PaymentsPage", () => {
     mocks.fetchTenants.mockResolvedValue([]);
     mocks.fetchProperties.mockResolvedValue({ items: [] });
 
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     expect((await screen.findAllByText("Tenant ref tenant-2")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Property ref prop-2")).length).toBeGreaterThan(0);
@@ -205,7 +215,7 @@ describe("PaymentsPage", () => {
       error: null,
     });
 
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     await screen.findAllByText("Taylor Tenant");
     expect(await screen.findAllByRole("button", { name: "Edit" })).toHaveLength(1);
@@ -244,7 +254,7 @@ describe("PaymentsPage", () => {
       .mockReturnValueOnce("e-transfer")
       .mockReturnValueOnce("April rent adjusted");
 
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Edit" }))[0]);
 
@@ -284,7 +294,7 @@ describe("PaymentsPage", () => {
       error: null,
     });
 
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     await screen.findAllByText("Taylor Tenant");
     expect(await screen.findAllByRole("button", { name: "Edit" })).toHaveLength(1);
@@ -308,9 +318,83 @@ describe("PaymentsPage", () => {
       error: null,
     });
 
-    render(<PaymentsPage />);
+    renderPaymentsPage();
 
     await screen.findAllByText("Taylor Tenant");
     expect(await screen.findAllByRole("button", { name: "Edit" })).toHaveLength(1);
+  });
+
+  it("applies and clears the Dashboard current-month context filter", async () => {
+    mocks.usePayments.mockReturnValue({
+      payments: [
+        {
+          id: "payment-june",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          amount: 1800,
+          paidAt: "2026-06-03",
+          method: "e-transfer",
+          notes: "June rent",
+          status: "Recorded",
+          source: "payments",
+        },
+        {
+          id: "payment-may",
+          tenantId: "tenant-2",
+          propertyId: "prop-1",
+          amount: 1700,
+          paidAt: "2026-05-03",
+          method: "cheque",
+          notes: "May rent",
+          status: "Recorded",
+          source: "payments",
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mocks.fetchTenants.mockResolvedValue([
+      { id: "tenant-1", fullName: "June Tenant" },
+      { id: "tenant-2", fullName: "May Tenant" },
+    ]);
+
+    renderPaymentsPage("/payments?context=current_month&period=2026-06&source=dashboard");
+
+    expect(await screen.findByText("Current month payments (2026-06)")).toBeInTheDocument();
+    expect((await screen.findAllByText("June Tenant")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("May Tenant")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear filter" }));
+
+    expect((await screen.findAllByText("May Tenant")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("Current month payments (2026-06)")).not.toBeInTheDocument();
+  });
+
+  it("renders a calm empty state for empty Dashboard context results", async () => {
+    mocks.usePayments.mockReturnValue({
+      payments: [
+        {
+          id: "payment-may",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          amount: 1700,
+          paidAt: "2026-05-03",
+          method: "cheque",
+          notes: "May rent",
+          status: "Recorded",
+          source: "payments",
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+
+    renderPaymentsPage("/payments?context=current_month&period=2026-06&source=dashboard");
+
+    expect(await screen.findByText("Current month payments (2026-06)")).toBeInTheDocument();
+    expect(
+      screen.getByText("No payments match current month payments (2026-06). Clear the filter to return to all recorded payments.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear filter" })).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -111,6 +111,10 @@ describe("PaymentsPage", () => {
     expect(screen.getAllByText("123 Main St / Unit 3A").length).toBeGreaterThan(0);
     expect(screen.getAllByText("e-transfer").length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument();
+    expect(screen.getByText("Payment Filters")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Search payments" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Filter payments by status" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Filter payments by method" })).toHaveValue("");
   });
 
   it("routes PDF export through the shared print helper", async () => {
@@ -368,6 +372,60 @@ describe("PaymentsPage", () => {
 
     expect((await screen.findAllByText("May Tenant")).length).toBeGreaterThan(0);
     expect(screen.queryByText("Current month payments (2026-06)")).not.toBeInTheDocument();
+    expect(screen.getByText("Payment Filters")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Search payments" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Filter payments by status" })).toHaveValue("");
+    expect(screen.getByRole("combobox", { name: "Filter payments by method" })).toHaveValue("");
+  });
+
+  it("keeps normal workspace filters available after clearing Dashboard context", async () => {
+    mocks.usePayments.mockReturnValue({
+      payments: [
+        {
+          id: "payment-june",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          amount: 1800,
+          paidAt: "2026-06-03",
+          method: "e-transfer",
+          notes: "June rent",
+          status: "Recorded",
+          source: "payments",
+        },
+        {
+          id: "payment-may",
+          tenantId: "tenant-2",
+          propertyId: "prop-1",
+          amount: 1700,
+          paidAt: "2026-05-03",
+          method: "cheque",
+          notes: "May rent",
+          status: "Recorded",
+          source: "payments",
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mocks.fetchTenants.mockResolvedValue([
+      { id: "tenant-1", fullName: "June Tenant" },
+      { id: "tenant-2", fullName: "May Tenant" },
+    ]);
+
+    renderPaymentsPage("/payments?context=current_month&period=2026-06&source=dashboard");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Clear filter" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Search payments" }), { target: { value: "May" } });
+
+    expect(await screen.findByText("Clear workspace filters")).toBeInTheDocument();
+    expect((await screen.findAllByText("May Tenant")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("June Tenant")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear workspace filters" }));
+
+    expect((await screen.findAllByText("June Tenant")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("May Tenant")).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Clear workspace filters" })).not.toBeInTheDocument();
   });
 
   it("renders a calm empty state for empty Dashboard context results", async () => {

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -87,10 +87,35 @@ function normalizeFilterValue(value: string) {
   return value.trim().toLowerCase();
 }
 
-function uniqueSortedValues(values: string[]) {
-  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((a, b) =>
-    a.localeCompare(b)
-  );
+function readableFilterLabel(value: string) {
+  return value
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function uniqueSortedFilterOptions(values: string[]) {
+  const options = new Map<string, string>();
+  for (const value of values) {
+    const normalized = normalizeFilterValue(value);
+    if (!normalized || options.has(normalized)) continue;
+    options.set(normalized, readableFilterLabel(value));
+  }
+  return Array.from(options.entries())
+    .map(([value, label]) => ({ value, label }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function paidDateKey(payment: PaymentRecord) {
+  const raw = String(payment.paidAt || "").trim();
+  if (!raw) return "";
+  const parsed = new Date(raw);
+  if (Number.isFinite(parsed.getTime())) return parsed.toISOString().slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}/.test(raw) ? raw.slice(0, 10) : "";
 }
 
 function applyPaymentsWorkspaceFilters(
@@ -98,18 +123,25 @@ function applyPaymentsWorkspaceFilters(
   searchTerm: string,
   statusFilter: string,
   methodFilter: string,
+  fromDate: string,
+  toDate: string,
   getTenantLabel: (payment: PaymentRecord) => string,
   getPropertyLabel: (payment: PaymentRecord) => string
 ) {
   const normalizedSearch = normalizeFilterValue(searchTerm);
   const normalizedStatus = normalizeFilterValue(statusFilter);
   const normalizedMethod = normalizeFilterValue(methodFilter);
+  const normalizedFromDate = /^\d{4}-\d{2}-\d{2}$/.test(fromDate) ? fromDate : "";
+  const normalizedToDate = /^\d{4}-\d{2}-\d{2}$/.test(toDate) ? toDate : "";
 
   return payments.filter((payment) => {
     const status = normalizeFilterValue(String(payment.status || ""));
     const method = normalizeFilterValue(String(payment.method || ""));
     if (normalizedStatus && status !== normalizedStatus) return false;
     if (normalizedMethod && method !== normalizedMethod) return false;
+    const paidDate = paidDateKey(payment);
+    if (normalizedFromDate && (!paidDate || paidDate < normalizedFromDate)) return false;
+    if (normalizedToDate && (!paidDate || paidDate > normalizedToDate)) return false;
     if (!normalizedSearch) return true;
 
     const searchable = [
@@ -166,6 +198,9 @@ const PaymentsPage: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
   const [methodFilter, setMethodFilter] = useState("");
+  const [fromDateFilter, setFromDateFilter] = useState("");
+  const [toDateFilter, setToDateFilter] = useState("");
+  const [isCsvImportOpen, setIsCsvImportOpen] = useState(false);
   const [exporting, setExporting] = useState<null | "csv" | "xls">(null);
   const [labelMap, setLabelMap] = useState<{ tenants: Map<string, string>; properties: Map<string, string> }>({
     tenants: new Map(),
@@ -225,17 +260,21 @@ const PaymentsPage: React.FC = () => {
     searchTerm,
     statusFilter,
     methodFilter,
+    fromDateFilter,
+    toDateFilter,
     getTenantLabel,
     getPropertyLabel
   );
-  const statusOptions = uniqueSortedValues(rows.map((payment) => String(payment.status || "")));
-  const methodOptions = uniqueSortedValues(rows.map((payment) => String(payment.method || "")));
-  const isWorkspaceFilterActive = Boolean(searchTerm.trim() || statusFilter || methodFilter);
+  const statusOptions = uniqueSortedFilterOptions(rows.map((payment) => String(payment.status || "")));
+  const methodOptions = uniqueSortedFilterOptions(rows.map((payment) => String(payment.method || "")));
+  const isWorkspaceFilterActive = Boolean(searchTerm.trim() || statusFilter || methodFilter || fromDateFilter || toDateFilter);
 
   const clearWorkspaceFilters = () => {
     setSearchTerm("");
     setStatusFilter("");
     setMethodFilter("");
+    setFromDateFilter("");
+    setToDateFilter("");
   };
 
   useEffect(() => {
@@ -391,7 +430,26 @@ const PaymentsPage: React.FC = () => {
         </div>
       </Card>
 
-      <PaymentCsvImportPreviewCard onImportComplete={refresh} />
+      <Card>
+        <div style={{ display: "grid", gap: isCsvImportOpen ? spacing.md : 0 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: spacing.sm, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontSize: "1rem", fontWeight: 800, color: text.primary }}>AI-assisted payment CSV import</div>
+              <div style={{ fontSize: "0.9rem", color: text.muted }}>Upload payment rows when you need assisted matching.</div>
+            </div>
+            {isCsvImportOpen ? (
+              <Button variant="secondary" onClick={() => setIsCsvImportOpen(false)}>
+                Hide
+              </Button>
+            ) : (
+              <Button variant="secondary" onClick={() => setIsCsvImportOpen(true)}>
+                Upload CSV
+              </Button>
+            )}
+          </div>
+          {isCsvImportOpen ? <PaymentCsvImportPreviewCard onImportComplete={refresh} /> : null}
+        </div>
+      </Card>
 
       {isDashboardContextActive ? (
         <Card>
@@ -420,7 +478,7 @@ const PaymentsPage: React.FC = () => {
               </Button>
             ) : null}
           </div>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 180px), 1fr))", gap: spacing.sm }}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 170px), 1fr))", gap: spacing.sm }}>
             <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.84rem", fontWeight: 700 }}>
               Search
               <input
@@ -458,8 +516,8 @@ const PaymentsPage: React.FC = () => {
               >
                 <option value="">All statuses</option>
                 {statusOptions.map((status) => (
-                  <option key={status} value={status}>
-                    {status}
+                  <option key={status.value} value={status.value}>
+                    {status.label}
                   </option>
                 ))}
               </select>
@@ -483,11 +541,47 @@ const PaymentsPage: React.FC = () => {
               >
                 <option value="">All methods</option>
                 {methodOptions.map((method) => (
-                  <option key={method} value={method}>
-                    {method}
+                  <option key={method.value} value={method.value}>
+                    {method.label}
                   </option>
                 ))}
               </select>
+            </label>
+            <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.84rem", fontWeight: 700 }}>
+              From date
+              <input
+                aria-label="Filter payments from date"
+                type="date"
+                value={fromDateFilter}
+                onChange={(event) => setFromDateFilter(event.target.value)}
+                style={{
+                  width: "100%",
+                  boxSizing: "border-box",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 8,
+                  padding: "0.65rem 0.75rem",
+                  color: text.primary,
+                  fontSize: "0.95rem",
+                }}
+              />
+            </label>
+            <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.84rem", fontWeight: 700 }}>
+              To date
+              <input
+                aria-label="Filter payments to date"
+                type="date"
+                value={toDateFilter}
+                onChange={(event) => setToDateFilter(event.target.value)}
+                style={{
+                  width: "100%",
+                  boxSizing: "border-box",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 8,
+                  padding: "0.65rem 0.75rem",
+                  color: text.primary,
+                  fontSize: "0.95rem",
+                }}
+              />
             </label>
           </div>
         </div>

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -83,6 +83,50 @@ export function filterPaymentsByDashboardContext(
   return [];
 }
 
+function normalizeFilterValue(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function uniqueSortedValues(values: string[]) {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort((a, b) =>
+    a.localeCompare(b)
+  );
+}
+
+function applyPaymentsWorkspaceFilters(
+  payments: PaymentRecord[],
+  searchTerm: string,
+  statusFilter: string,
+  methodFilter: string,
+  getTenantLabel: (payment: PaymentRecord) => string,
+  getPropertyLabel: (payment: PaymentRecord) => string
+) {
+  const normalizedSearch = normalizeFilterValue(searchTerm);
+  const normalizedStatus = normalizeFilterValue(statusFilter);
+  const normalizedMethod = normalizeFilterValue(methodFilter);
+
+  return payments.filter((payment) => {
+    const status = normalizeFilterValue(String(payment.status || ""));
+    const method = normalizeFilterValue(String(payment.method || ""));
+    if (normalizedStatus && status !== normalizedStatus) return false;
+    if (normalizedMethod && method !== normalizedMethod) return false;
+    if (!normalizedSearch) return true;
+
+    const searchable = [
+      getTenantLabel(payment),
+      getPropertyLabel(payment),
+      payment.amount != null ? String(payment.amount) : "",
+      payment.paidAt || "",
+      payment.method || "",
+      payment.notes || "",
+      payment.status || "",
+    ]
+      .join(" ")
+      .toLowerCase();
+    return searchable.includes(normalizedSearch);
+  });
+}
+
 function dashboardContextLabel(context: PaymentsDashboardContext | null, periodMonth: string) {
   if (context === "current_month") return `Current month payments (${periodMonth})`;
   if (context === "collected") return "Collected payments";
@@ -119,6 +163,9 @@ const PaymentsPage: React.FC = () => {
   const { payments, loading, error, refresh } = usePayments();
   const [searchParams, setSearchParams] = useSearchParams();
   const [rows, setRows] = useState<PaymentRecord[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [methodFilter, setMethodFilter] = useState("");
   const [exporting, setExporting] = useState<null | "csv" | "xls">(null);
   const [labelMap, setLabelMap] = useState<{ tenants: Map<string, string>; properties: Map<string, string> }>({
     tenants: new Map(),
@@ -131,7 +178,6 @@ const PaymentsPage: React.FC = () => {
 
   const dashboardContext = normalizeDashboardContext(searchParams.get("context"));
   const contextPeriodMonth = normalizePeriodMonth(searchParams.get("period"));
-  const visibleRows = filterPaymentsByDashboardContext(rows, dashboardContext, contextPeriodMonth);
   const isDashboardContextActive = Boolean(dashboardContext);
   const contextLabel = dashboardContextLabel(dashboardContext, contextPeriodMonth);
   const contextDescription = dashboardContextDescription(dashboardContext);
@@ -142,6 +188,54 @@ const PaymentsPage: React.FC = () => {
     next.delete("period");
     next.delete("source");
     setSearchParams(next, { replace: true });
+  };
+
+  const getTenantLabel = (payment: PaymentRecord) => {
+    const record = payment as any;
+    return (
+      tenantLabelFromValue(record.tenant) ||
+      tenantLabelFromValue(record.tenantProfile) ||
+      String(record.tenantName || record.tenantDisplayName || record.applicantName || "").trim() ||
+      labelMap.tenants.get(String(payment.tenantId || "").trim()) ||
+      (payment.tenantId ? formatOperationalReference("tenant", payment.tenantId) : "Tenant")
+    );
+  };
+  const getPropertyLabel = (payment: PaymentRecord) => {
+    const record = payment as any;
+    const propertyLabel =
+      propertyLabelFromValue(record.property) ||
+      String(record.propertyName || record.propertyDisplayName || record.propertyDisplayLabel || "").trim() ||
+      labelMap.properties.get(String(payment.propertyId || "").trim()) ||
+      "";
+    const unitLabel = String(record.unitName || record.unitNumber || record.unitLabel || record.unitDisplayLabel || "").trim();
+    const formattedUnit = unitLabel ? (/^unit\b/i.test(unitLabel) ? unitLabel : `Unit ${unitLabel}`) : "";
+    if (propertyLabel && formattedUnit) return `${propertyLabel} / ${formattedUnit}`;
+    const propertyId = String(payment.propertyId || "").trim();
+    const unitId = String(record.unitId || "").trim();
+    if (propertyLabel || formattedUnit) return propertyLabel || formattedUnit;
+    if (propertyId && unitId) return `${formatOperationalReference("property", propertyId)} / ${formatOperationalReference("unit", unitId)}`;
+    if (propertyId) return formatOperationalReference("property", propertyId);
+    if (unitId) return formatOperationalReference("unit", unitId);
+    return "Property";
+  };
+
+  const contextRows = filterPaymentsByDashboardContext(rows, dashboardContext, contextPeriodMonth);
+  const visibleRows = applyPaymentsWorkspaceFilters(
+    contextRows,
+    searchTerm,
+    statusFilter,
+    methodFilter,
+    getTenantLabel,
+    getPropertyLabel
+  );
+  const statusOptions = uniqueSortedValues(rows.map((payment) => String(payment.status || "")));
+  const methodOptions = uniqueSortedValues(rows.map((payment) => String(payment.method || "")));
+  const isWorkspaceFilterActive = Boolean(searchTerm.trim() || statusFilter || methodFilter);
+
+  const clearWorkspaceFilters = () => {
+    setSearchTerm("");
+    setStatusFilter("");
+    setMethodFilter("");
   };
 
   useEffect(() => {
@@ -184,35 +278,6 @@ const PaymentsPage: React.FC = () => {
       cancelled = true;
     };
   }, []);
-
-  const getTenantLabel = (payment: PaymentRecord) => {
-    const record = payment as any;
-    return (
-      tenantLabelFromValue(record.tenant) ||
-      tenantLabelFromValue(record.tenantProfile) ||
-      String(record.tenantName || record.tenantDisplayName || record.applicantName || "").trim() ||
-      labelMap.tenants.get(String(payment.tenantId || "").trim()) ||
-      (payment.tenantId ? formatOperationalReference("tenant", payment.tenantId) : "Tenant")
-    );
-  };
-  const getPropertyLabel = (payment: PaymentRecord) => {
-    const record = payment as any;
-    const propertyLabel =
-      propertyLabelFromValue(record.property) ||
-      String(record.propertyName || record.propertyDisplayName || record.propertyDisplayLabel || "").trim() ||
-      labelMap.properties.get(String(payment.propertyId || "").trim()) ||
-      "";
-    const unitLabel = String(record.unitName || record.unitNumber || record.unitLabel || record.unitDisplayLabel || "").trim();
-    const formattedUnit = unitLabel ? (/^unit\b/i.test(unitLabel) ? unitLabel : `Unit ${unitLabel}`) : "";
-    if (propertyLabel && formattedUnit) return `${propertyLabel} / ${formattedUnit}`;
-    const propertyId = String(payment.propertyId || "").trim();
-    const unitId = String(record.unitId || "").trim();
-    if (propertyLabel || formattedUnit) return propertyLabel || formattedUnit;
-    if (propertyId && unitId) return `${formatOperationalReference("property", propertyId)} / ${formatOperationalReference("unit", unitId)}`;
-    if (propertyId) return formatOperationalReference("property", propertyId);
-    if (unitId) return formatOperationalReference("unit", unitId);
-    return "Property";
-  };
 
   const triggerExport = async (format: "csv" | "xls") => {
     try {
@@ -343,6 +408,92 @@ const PaymentsPage: React.FC = () => {
       ) : null}
 
       <Card>
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: spacing.sm, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontSize: "1rem", fontWeight: 700, color: text.primary }}>Payment Filters</div>
+              <div style={{ fontSize: "0.9rem", color: text.muted }}>Search and narrow recorded payment rows.</div>
+            </div>
+            {isWorkspaceFilterActive ? (
+              <Button variant="secondary" onClick={clearWorkspaceFilters}>
+                Clear workspace filters
+              </Button>
+            ) : null}
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 180px), 1fr))", gap: spacing.sm }}>
+            <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.84rem", fontWeight: 700 }}>
+              Search
+              <input
+                aria-label="Search payments"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Tenant, property, notes..."
+                style={{
+                  width: "100%",
+                  boxSizing: "border-box",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 8,
+                  padding: "0.65rem 0.75rem",
+                  color: text.primary,
+                  fontSize: "0.95rem",
+                }}
+              />
+            </label>
+            <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.84rem", fontWeight: 700 }}>
+              Status
+              <select
+                aria-label="Filter payments by status"
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+                style={{
+                  width: "100%",
+                  boxSizing: "border-box",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 8,
+                  padding: "0.65rem 0.75rem",
+                  color: text.primary,
+                  fontSize: "0.95rem",
+                  background: "#fff",
+                }}
+              >
+                <option value="">All statuses</option>
+                {statusOptions.map((status) => (
+                  <option key={status} value={status}>
+                    {status}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 6, color: text.muted, fontSize: "0.84rem", fontWeight: 700 }}>
+              Method
+              <select
+                aria-label="Filter payments by method"
+                value={methodFilter}
+                onChange={(event) => setMethodFilter(event.target.value)}
+                style={{
+                  width: "100%",
+                  boxSizing: "border-box",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 8,
+                  padding: "0.65rem 0.75rem",
+                  color: text.primary,
+                  fontSize: "0.95rem",
+                  background: "#fff",
+                }}
+              >
+                <option value="">All methods</option>
+                {methodOptions.map((method) => (
+                  <option key={method} value={method}>
+                    {method}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
         <div style={{ display: "grid", gap: spacing.xs }}>
           <div style={{ fontSize: "1rem", fontWeight: 700, color: text.primary }}>Financial Activity</div>
           <div style={{ fontSize: "0.92rem", color: text.primary }}>
@@ -362,7 +513,9 @@ const PaymentsPage: React.FC = () => {
         {error && <div style={{ color: colors.danger, fontSize: "0.95rem" }}>Failed to load payments: {error}</div>}
         {!loading && !error && visibleRows.length === 0 && (
           <div style={{ fontSize: "0.95rem", color: text.muted }}>
-            {isDashboardContextActive
+            {isWorkspaceFilterActive
+              ? "No payments match these workspace filters. Clear workspace filters to return to the available payment rows."
+              : isDashboardContextActive
               ? `No payments match ${contextLabel.toLowerCase()}. Clear the filter to return to all recorded payments.`
               : "No payments recorded yet."}
           </div>

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -1,5 +1,6 @@
 // rentchain-frontend/src/pages/PaymentsPage.tsx
 import React, { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { usePayments } from "../hooks/usePayments";
 import {
   getCanonicalPaymentEditId,
@@ -16,6 +17,87 @@ import { triggerBlobDownload } from "../utils/downloadBlob";
 import { buildCsvBlob } from "../utils/csvExport";
 import { formatOperationalReference } from "@/lib/identityReferences";
 import { PaymentCsvImportPreviewCard } from "@/components/ledger/PaymentCsvImportPreviewCard";
+
+type PaymentsDashboardContext = "outstanding" | "collected" | "needs_review" | "current_month";
+
+const DASHBOARD_CONTEXTS = new Set<PaymentsDashboardContext>([
+  "outstanding",
+  "collected",
+  "needs_review",
+  "current_month",
+]);
+
+function currentMonthKey() {
+  return new Date().toISOString().slice(0, 7);
+}
+
+function normalizeDashboardContext(value: string | null): PaymentsDashboardContext | null {
+  const context = String(value || "").trim().toLowerCase();
+  return DASHBOARD_CONTEXTS.has(context as PaymentsDashboardContext) ? (context as PaymentsDashboardContext) : null;
+}
+
+function normalizePeriodMonth(value: string | null) {
+  const period = String(value || "").trim();
+  return /^\d{4}-\d{2}$/.test(period) ? period : currentMonthKey();
+}
+
+function paymentMonth(payment: PaymentRecord) {
+  const raw = String(payment.paidAt || "").trim();
+  if (!raw) return "";
+  const parsed = new Date(raw);
+  if (Number.isFinite(parsed.getTime())) return parsed.toISOString().slice(0, 7);
+  return /^\d{4}-\d{2}/.test(raw) ? raw.slice(0, 7) : "";
+}
+
+function paymentNeedsReview(payment: PaymentRecord) {
+  const status = String(payment.status || "").trim().toLowerCase();
+  const method = String(payment.method || "").trim().toLowerCase();
+  const notes = String(payment.notes || "").trim().toLowerCase();
+  return (
+    status.includes("review") ||
+    status.includes("failed") ||
+    status.includes("unmatched") ||
+    method.includes("review") ||
+    notes.includes("review")
+  );
+}
+
+export function filterPaymentsByDashboardContext(
+  payments: PaymentRecord[],
+  context: PaymentsDashboardContext | null,
+  periodMonth: string
+) {
+  if (!context) return payments;
+  if (context === "current_month") {
+    return payments.filter((payment) => paymentMonth(payment) === periodMonth);
+  }
+  if (context === "collected") {
+    return payments.filter((payment) => {
+      const status = String(payment.status || "").trim().toLowerCase();
+      return status === "recorded" || status === "paid" || status === "collected" || Boolean(payment.paidAt);
+    });
+  }
+  if (context === "needs_review") {
+    return payments.filter(paymentNeedsReview);
+  }
+  return [];
+}
+
+function dashboardContextLabel(context: PaymentsDashboardContext | null, periodMonth: string) {
+  if (context === "current_month") return `Current month payments (${periodMonth})`;
+  if (context === "collected") return "Collected payments";
+  if (context === "needs_review") return "Payments needing review";
+  if (context === "outstanding") return "Outstanding rent context";
+  return "";
+}
+
+function dashboardContextDescription(context: PaymentsDashboardContext | null) {
+  if (context === "current_month") return "Opened from Dashboard Financial Snapshot. Showing payments recorded for this month.";
+  if (context === "collected") return "Showing recorded payments that appear collected or paid.";
+  if (context === "needs_review") return "Showing payment rows with review, failed, or unmatched signals.";
+  if (context === "outstanding") return "Outstanding balances are not recorded payment rows yet. Use lease ledger views for charges and unmatched balances.";
+  return "";
+}
 
 function tenantLabelFromValue(value: any): string {
   return (
@@ -35,6 +117,7 @@ function propertyLabelFromValue(value: any): string {
 
 const PaymentsPage: React.FC = () => {
   const { payments, loading, error, refresh } = usePayments();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [rows, setRows] = useState<PaymentRecord[]>([]);
   const [exporting, setExporting] = useState<null | "csv" | "xls">(null);
   const [labelMap, setLabelMap] = useState<{ tenants: Map<string, string>; properties: Map<string, string> }>({
@@ -45,6 +128,21 @@ const PaymentsPage: React.FC = () => {
   useEffect(() => {
     setRows(payments);
   }, [payments]);
+
+  const dashboardContext = normalizeDashboardContext(searchParams.get("context"));
+  const contextPeriodMonth = normalizePeriodMonth(searchParams.get("period"));
+  const visibleRows = filterPaymentsByDashboardContext(rows, dashboardContext, contextPeriodMonth);
+  const isDashboardContextActive = Boolean(dashboardContext);
+  const contextLabel = dashboardContextLabel(dashboardContext, contextPeriodMonth);
+  const contextDescription = dashboardContextDescription(dashboardContext);
+
+  const clearDashboardContext = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("context");
+    next.delete("period");
+    next.delete("source");
+    setSearchParams(next, { replace: true });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -121,7 +219,7 @@ const PaymentsPage: React.FC = () => {
       setExporting(format);
       const blob = buildCsvBlob(
         ["tenant", "property_unit", "amount", "paid_date", "method", "notes"],
-        rows.map((payment) => [
+        visibleRows.map((payment) => [
           getTenantLabel(payment),
           getPropertyLabel(payment),
           Number(payment.amount || 0),
@@ -230,6 +328,20 @@ const PaymentsPage: React.FC = () => {
 
       <PaymentCsvImportPreviewCard onImportComplete={refresh} />
 
+      {isDashboardContextActive ? (
+        <Card>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: spacing.md, flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={{ fontWeight: 800, color: text.primary }}>{contextLabel}</div>
+              <div style={{ color: text.muted, fontSize: "0.92rem" }}>{contextDescription}</div>
+            </div>
+            <Button variant="secondary" onClick={clearDashboardContext}>
+              Clear filter
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
       <Card>
         <div style={{ display: "grid", gap: spacing.xs }}>
           <div style={{ fontSize: "1rem", fontWeight: 700, color: text.primary }}>Financial Activity</div>
@@ -248,11 +360,15 @@ const PaymentsPage: React.FC = () => {
       <Card>
         {loading && <div style={{ fontSize: "0.95rem", color: text.muted }}>Loading payments...</div>}
         {error && <div style={{ color: colors.danger, fontSize: "0.95rem" }}>Failed to load payments: {error}</div>}
-        {!loading && !error && rows.length === 0 && (
-          <div style={{ fontSize: "0.95rem", color: text.muted }}>No payments recorded yet.</div>
+        {!loading && !error && visibleRows.length === 0 && (
+          <div style={{ fontSize: "0.95rem", color: text.muted }}>
+            {isDashboardContextActive
+              ? `No payments match ${contextLabel.toLowerCase()}. Clear the filter to return to all recorded payments.`
+              : "No payments recorded yet."}
+          </div>
         )}
 
-        {!loading && !error && rows.length > 0 && (
+        {!loading && !error && visibleRows.length > 0 && (
           <div style={{ overflowX: "auto" }}>
             <table
               style={{
@@ -279,7 +395,7 @@ const PaymentsPage: React.FC = () => {
                 </tr>
               </thead>
               <tbody>
-                {rows.map((p) => (
+                {visibleRows.map((p) => (
                   <tr key={p.id} style={{ borderBottom: `1px solid ${colors.border}` }}>
                     <td style={{ padding: "0.5rem 0.4rem" }}>{getTenantLabel(p)}</td>
                     <td style={{ padding: "0.5rem 0.4rem" }}>{getPropertyLabel(p)}</td>
@@ -337,7 +453,7 @@ const PaymentsPage: React.FC = () => {
           <div className="printTitle">Payments summary</div>
           <div className="printMeta">
             <div>Generated: {new Date().toLocaleString()}</div>
-            <div>Rows: {rows.length}</div>
+            <div>Rows: {visibleRows.length}</div>
           </div>
         </div>
         <div className="printH3">Recorded payments</div>
@@ -353,7 +469,7 @@ const PaymentsPage: React.FC = () => {
             </tr>
           </thead>
           <tbody>
-            {rows.map((payment) => (
+            {visibleRows.map((payment) => (
               <tr key={payment.id}>
                 <td>{getTenantLabel(payment)}</td>
                 <td>{getPropertyLabel(payment)}</td>


### PR DESCRIPTION
## Summary
- Route Dashboard Financial Snapshot entry to Payments with `context=current_month`, the dashboard financial period, and `source=dashboard`.
- Teach Payments to recognize dashboard context query params, apply a local focus filter, and show a clearable context banner.
- Preserve direct `/payments` as the normal all-payments view.

## Scope controls
- No backend/API contract changes.
- No ledger math changes.
- No payment record mutations.
- No tenant payment view changes.
- No Dashboard redesign or Payments redesign.

## Validation
- `npm --prefix rentchain-frontend run test -- PaymentsPage.test.tsx DashboardPage.test.tsx`
- `npm --prefix rentchain-frontend run build`
- `git diff --check`

## Manual QA
Draft PR for preview QA. Please verify Dashboard Financial Snapshot -> Payments opens the current-month focused view, direct `/payments` remains unfiltered, Clear filter returns to all payments, and the empty filtered state is calm.