### PR TITLE
docs: design delegated access implementation plan

### DIFF
--- a/docs/design/delegated-access-audit-architecture-v1.md
+++ b/docs/design/delegated-access-audit-architecture-v1.md
@@ -1,0 +1,226 @@
+# Delegated Access Audit Architecture V1
+
+## Scope
+
+This document defines the audit architecture needed for Delegated Access V1 implementation.
+
+This is design-only. It does not implement audit storage, event helpers, exports, backend routes, UI, Firestore schema, or security rules.
+
+## Audit Objective
+
+Delegated access must preserve defensible activity history.
+
+The platform should be able to answer:
+
+- Who authenticated?
+- Which landlord did they act for?
+- Which grant, role, and scope authorized the action?
+- What resource was accessed or changed?
+- What changed?
+- Was the action allowed, denied, revoked, expired, or failed?
+- When did it happen?
+- What session, IP, and device metadata were available?
+
+## Actor Attribution
+
+Delegated actions must distinguish actor from landlord.
+
+Required attribution:
+
+| Field | Meaning |
+| --- | --- |
+| `actorUserId` | Authenticated user who performed the action. |
+| `actingForLandlordId` | Landlord workspace represented. |
+| `relationship` | `owner` or `delegate`. |
+| `delegateGrantId` | Active grant evaluated for delegate actions. |
+| `delegatedRole` | Role evaluated at action time. |
+| `permissionScope` | Evaluated scope at action time. |
+
+Audit labels should represent:
+
+`Delegate acted for landlord`
+
+not:
+
+`Landlord acted`
+
+## Event Storage
+
+Preferred approach:
+
+- Use the existing canonical audit/event infrastructure if available.
+- Add delegated access event types to that infrastructure.
+- Store immutable, append-safe, metadata-first events.
+- Keep lifecycle events and high-risk use events queryable by landlord, actor, role, and timestamp.
+
+If a separate delegated audit collection is needed, it should still follow canonical audit conventions and not become a competing event system.
+
+## Event Categories
+
+### Lifecycle Events
+
+- `delegated_invite_created`
+- `delegated_invite_sent`
+- `delegated_invite_accepted`
+- `delegated_invite_expired`
+- `delegated_invite_cancelled`
+- `delegated_role_changed`
+- `delegated_scope_changed`
+- `delegated_access_revoked`
+- `delegated_session_invalidated`
+
+### Use Events
+
+- `delegated_workspace_opened`
+- `delegated_resource_viewed`
+- `delegated_message_sent`
+- `delegated_operation_assigned`
+- `delegated_work_order_updated`
+- `delegated_schedule_updated`
+- `delegated_payment_viewed`
+- `delegated_payment_action_attempted`
+- `delegated_evidence_uploaded`
+- `delegated_export_generated`
+- `delegated_access_denied`
+
+## Required Event Fields
+
+| Field | Requirement |
+| --- | --- |
+| `eventId` | Required immutable event identifier. |
+| `eventType` | Required stable event name. |
+| `actorUserId` | Required. |
+| `actingForLandlordId` | Required. |
+| `delegateGrantId` | Required for delegate actions. |
+| `delegatedRole` | Required for delegate actions. |
+| `permissionScope` | Required evaluated scope. |
+| `actionType` | Required action verb. |
+| `targetResourceType` | Required where applicable. |
+| `targetResourceId` | Required where applicable, internal only. |
+| `timestamp` | Required server timestamp. |
+| `outcome` | Required `allowed`, `denied`, `revoked`, `expired`, `failed`, or `blocked`. |
+| `sessionId` | Recommended where available. |
+| `ipAddress` | If available. |
+| `deviceMetadata` | If available and normalized. |
+| `before` | Required for material mutations where safe. |
+| `after` | Required for material mutations where safe. |
+| `metadataOnly` | Required `true`. |
+| `appendOnly` | Required `true`. |
+| `immutable` | Required `true`. |
+
+## Immutable Record Requirements
+
+Delegated audit events must be:
+
+- Written server-side.
+- Append-only.
+- Server timestamped.
+- Non-overwritable.
+- Preserved after revocation.
+- Preserved after invite cancellation.
+- Preserved after delegate account removal where legally and operationally appropriate.
+- Exportable later with redaction.
+
+High-risk actions should not silently proceed if required audit capture fails.
+
+## Evidence Requirements
+
+Evidence and exports require heightened audit treatment.
+
+Events should capture:
+
+- Actor and landlord attribution.
+- Grant and role.
+- Export or evidence package scope.
+- Target resources included.
+- Timestamp.
+- Outcome.
+- Redaction/export profile where applicable.
+
+Events should not copy:
+
+- Raw provider payloads.
+- Private message bodies unless explicitly redacted and approved.
+- Full documents.
+- Storage paths.
+- Tokens.
+- Credentials.
+- Payment method secrets.
+- Full screening reports.
+
+## Payment Audit Requirements
+
+Payment surfaces are high-risk.
+
+V1 recommended audit:
+
+- Log delegate payment views when the role is permitted to view payment data.
+- Log all payment export attempts.
+- Log all payment mutation attempts, including denied attempts.
+- Keep payment method and processor details out of audit metadata unless already safe and necessary.
+
+Payment mutation should remain owner-only in V1 unless a future approved model changes that.
+
+## Privacy Requirements
+
+Audit events must not become a shadow copy of sensitive records.
+
+Audit payloads should use:
+
+- Safe resource references.
+- Redacted display labels where needed.
+- Minimal before/after fields.
+- Reason codes instead of raw sensitive context.
+
+Tenant-facing and delegate-facing activity projections must not expose internal IDs or private metadata.
+
+## Reporting And Export Considerations
+
+Future owner-facing audit views should support:
+
+- Filter by delegate.
+- Filter by property.
+- Filter by workspace.
+- Filter by action type.
+- Filter by outcome.
+- Filter by date range.
+- Highlight high-risk actions.
+- Export scoped audit summaries.
+
+Read-only auditors may receive export access only when explicitly scoped.
+
+## Denied Action Audit
+
+Denied actions should be captured for:
+
+- Revoked grants.
+- Expired grants.
+- Out-of-scope property access.
+- Out-of-scope workspace access.
+- Contractor attempts outside assigned jobs.
+- Payment mutation/export attempts.
+- Evidence/export attempts.
+- Billing/settings attempts.
+
+Denied audit events help detect stale sessions, shared devices, malicious access, and misconfigured roles.
+
+## Retention Considerations
+
+Retention policy should be decided before implementation.
+
+Recommended posture:
+
+- Delegate lifecycle events should be retained for the life of the landlord account plus approved retention window.
+- High-risk access and export events should be retained consistently with evidence/export governance.
+- Low-risk view events may have a shorter retention policy if volume becomes a concern.
+
+No retention changes are implemented by this document.
+
+## Non-Goals
+
+- No legal certification.
+- No chain-of-custody implementation.
+- No SIEM integration.
+- No audit export route.
+- No audit UI.
+- No immutable storage migration.

--- a/docs/design/delegated-access-data-model-v1.md
+++ b/docs/design/delegated-access-data-model-v1.md
@@ -1,0 +1,297 @@
+# Delegated Access Firestore/Data Model Proposal V1
+
+## Scope
+
+This document proposes the Firestore data model for Delegated Access V1.
+
+This is design-only. It does not create collections, indexes, rules, migrations, backend routes, or UI.
+
+## Data Model Goals
+
+The data model should support:
+
+- Landlord owner authority.
+- Delegate-owned user accounts.
+- Role assignments.
+- Property scoping.
+- Workspace scoping.
+- Resource scoping for contractors and auditors.
+- Invitation lifecycle.
+- Revocation history.
+- Immutable audit references.
+- Future property manager company and contractor organization layers.
+
+## Ownership Model
+
+Existing landlord ownership remains the source of account authority.
+
+Recommended relationship:
+
+```text
+landlord workspace
+  ownerUserId
+  active delegate grants
+  pending invitations
+  revoked grant history
+  delegated activity audit references
+```
+
+The landlord owner is not represented as a delegate grant. Owner authority should be resolved from the existing landlord ownership model.
+
+## Proposed Collections
+
+Collection names are proposals and should be confirmed during implementation.
+
+| Collection | Purpose |
+| --- | --- |
+| `delegatedAccessInvitations` | Pending, accepted, expired, or cancelled invitations. |
+| `delegatedAccessGrants` | Active or revoked access grants from landlord to delegate. |
+| `delegatedAccessGrantHistory` | Append-safe role/scope/revocation history for grants. |
+| `delegatedAccessAuditEvents` | Immutable delegated access lifecycle and use events, or references into a canonical audit collection. |
+
+If the existing audit system has a canonical collection, `delegatedAccessAuditEvents` should be implemented as event types within that system instead of a duplicate audit store.
+
+## Landlord Owner Relationship
+
+Landlord owner authority should resolve from existing landlord account data.
+
+Required owner fields:
+
+| Field | Purpose |
+| --- | --- |
+| `landlordId` | Canonical landlord workspace reference. |
+| `ownerUserId` | Authenticated user with owner authority. |
+| `ownerEmail` | Optional display/support metadata, not authority by itself. |
+| `billingOwnerUserId` | Optional explicit billing owner if later separated. In V1, owner-only billing remains enforced. |
+
+Email must not be used as the only authorization key.
+
+## Delegate Accounts
+
+Delegates must use their own authenticated accounts.
+
+Delegate identity fields:
+
+| Field | Purpose |
+| --- | --- |
+| `delegateUserId` | Authenticated Firebase user ID after acceptance. |
+| `delegateEmail` | Invitation and display metadata. |
+| `delegateDisplayName` | Optional display label. |
+| `delegateAuthProvider` | Optional provider metadata. |
+| `mfaRecommendedAt` | Optional recommendation metadata. |
+| `mfaVerifiedAt` | Optional future enforcement metadata. |
+
+Before acceptance, invitation records may only know `inviteeEmail`.
+
+## Role Assignments
+
+Active grants should carry one role at a time in V1.
+
+Recommended grant fields:
+
+| Field | Purpose |
+| --- | --- |
+| `grantId` | Canonical grant identifier. |
+| `landlordId` | Landlord workspace being delegated. |
+| `delegateUserId` | Authenticated delegate account. |
+| `role` | Predefined delegated role. |
+| `status` | `active`, `revoked`, `suspended`, or `expired`. |
+| `createdByUserId` | Landlord owner who created the grant or invitation. |
+| `acceptedAt` | Acceptance timestamp. |
+| `updatedAt` | Last grant metadata update timestamp. |
+| `revokedAt` | Revocation timestamp when applicable. |
+| `revokedByUserId` | Actor who revoked access. |
+| `revocationReason` | Optional sanitized reason. |
+
+V1 roles:
+
+- `property_manager`
+- `assistant_office_admin`
+- `maintenance_coordinator`
+- `contractor`
+- `contractor_admin`
+- `read_only_auditor`
+
+`landlord_owner` is not inviteable and should not be stored as a delegate role.
+
+## Property Scoping
+
+Property scope should be explicit.
+
+Recommended shape:
+
+```json
+{
+  "propertyScope": {
+    "mode": "selected",
+    "propertyIds": ["property_ref_1", "property_ref_2"],
+    "unitIds": []
+  }
+}
+```
+
+Modes:
+
+| Mode | Meaning |
+| --- | --- |
+| `all_current_properties` | All current properties for the landlord. Use sparingly. |
+| `selected` | Only listed properties. Preferred default. |
+| `resource_only` | No property-wide access; only assigned resources. |
+| `none` | No property access. |
+
+Property IDs are internal authorization references. User-facing projections should show safe property labels.
+
+## Workspace Scoping
+
+Workspace scope should be a list of allowed workspace keys.
+
+Recommended workspace keys:
+
+- `dashboard`
+- `operations`
+- `properties`
+- `tenants`
+- `leases`
+- `payments`
+- `unified_inbox`
+- `scheduling`
+- `work_orders`
+- `evidence_exports`
+- `settings_billing`
+
+V1 should reject `settings_billing` for all delegate roles.
+
+## Resource Scoping
+
+Resource scope supports contractors, contractor admins, auditors, exports, and future company models.
+
+Recommended shape:
+
+```json
+{
+  "resourceScope": {
+    "workOrderIds": [],
+    "maintenanceRequestIds": [],
+    "messageThreadIds": [],
+    "evidencePackageIds": [],
+    "exportPackageIds": [],
+    "contractorJobIds": []
+  }
+}
+```
+
+Resource scope should be evaluated together with property and workspace scope. Resource scope must not widen property scope unless explicitly designed.
+
+## Invitation Records
+
+Invitation records should be separate from grants until accepted.
+
+Recommended invitation fields:
+
+| Field | Purpose |
+| --- | --- |
+| `invitationId` | Canonical invitation identifier. |
+| `landlordId` | Landlord workspace being delegated. |
+| `inviteeEmail` | Email address invited. |
+| `role` | Proposed role. |
+| `propertyScope` | Proposed property scope. |
+| `workspaceScope` | Proposed workspace scope. |
+| `resourceScope` | Proposed resource scope. |
+| `status` | `pending`, `accepted`, `expired`, `cancelled`. |
+| `tokenHash` | Hashed invitation token. |
+| `expiresAt` | Expiration timestamp. |
+| `createdByUserId` | Landlord owner who invited. |
+| `createdAt` | Creation timestamp. |
+| `acceptedByUserId` | Delegate user who accepted. |
+| `acceptedAt` | Acceptance timestamp. |
+| `cancelledByUserId` | Actor who cancelled invitation. |
+| `cancelledAt` | Cancellation timestamp. |
+
+Raw invitation tokens should not be stored.
+
+## Revocation Records
+
+Revocation can be represented in grant history and audit events. If a separate record is useful, it should be append-only.
+
+Recommended revocation fields:
+
+| Field | Purpose |
+| --- | --- |
+| `revocationId` | Canonical revocation identifier. |
+| `grantId` | Grant revoked. |
+| `landlordId` | Landlord workspace. |
+| `delegateUserId` | Delegate revoked. |
+| `previousRole` | Role before revocation. |
+| `previousScope` | Scope before revocation. |
+| `revokedByUserId` | Landlord owner who revoked. |
+| `revokedAt` | Server timestamp. |
+| `reason` | Optional sanitized reason. |
+
+Revoked grants should remain queryable for audit and owner history.
+
+## Audit References
+
+Grant, invitation, and revocation records should include audit references where useful.
+
+Recommended fields:
+
+| Field | Purpose |
+| --- | --- |
+| `createdAuditEventId` | Invitation or grant creation event. |
+| `acceptedAuditEventId` | Acceptance event. |
+| `roleChangedAuditEventIds` | Optional list or queryable history reference. |
+| `scopeChangedAuditEventIds` | Optional list or queryable history reference. |
+| `revokedAuditEventId` | Revocation event. |
+
+Audit events should remain the durable activity source. Records should not need to duplicate full audit payloads.
+
+## Future Company Compatibility
+
+The model should allow a future organization layer without rewriting V1 grants.
+
+Future property manager company fields:
+
+- `propertyManagerCompanyId`
+- `companyAdminUserId`
+- `companyStaffUserIds`
+- `landlordToCompanyGrantId`
+- `companyStaffAssignmentId`
+
+Future contractor organization fields:
+
+- `contractorOrganizationId`
+- `contractorAdminUserId`
+- `technicianUserIds`
+- `assignedJobIds`
+
+V1 individual grants should remain valid even after organization support is added.
+
+## Security Rule Posture
+
+Security rules are not implemented in this design.
+
+Implementation should not rely on client-readable Firestore paths for delegated authorization. Server-side authorization should remain authoritative for landlord workspace APIs.
+
+## Index Considerations
+
+Likely query patterns:
+
+- Active grants by `landlordId`.
+- Active grants by `delegateUserId`.
+- Grant by `landlordId` and `delegateUserId`.
+- Invitations by `landlordId` and `status`.
+- Invitations by token hash during acceptance.
+- Grant history by `grantId`.
+- Audit events by `actingForLandlordId`, `actorUserId`, `eventType`, and timestamp.
+
+Index implementation should be done in the implementation phase, not in this docs-only mission.
+
+## Non-Goals
+
+- No Firestore collection creation.
+- No index creation.
+- No security rule change.
+- No migration.
+- No backfill.
+- No billing delegation.
+- No custom permission builder.

--- a/docs/design/delegated-access-implementation-plan-v1.md
+++ b/docs/design/delegated-access-implementation-plan-v1.md
@@ -1,0 +1,291 @@
+# Delegated Access Implementation Plan V1
+
+## Scope
+
+This document translates the approved delegated access governance audit into an implementation-ready plan.
+
+This is design-only. It does not implement code, backend routes, UI, Firestore schema changes, security rules, email delivery, billing changes, or deployment changes.
+
+Source governance:
+
+- `docs/audit/delegated-access-governance-v1.md`
+- `docs/audit/delegated-roles-permissions-matrix-v1.md`
+- `docs/audit/delegated-access-audit-activity-model-v1.md`
+- `docs/audit/delegated-access-invitation-revocation-flow-v1.md`
+
+## Product Objective
+
+Delegated Access V1 should make RentChain safe for multi-operator landlord work without turning delegated access into impersonation.
+
+The system should support:
+
+1. Landlord owner remains account authority.
+2. Delegates use their own accounts.
+3. Access is granted by explicit role and scope.
+4. Authorization is evaluated server-side.
+5. Revocation fails closed.
+6. Delegated activity is auditable and attributable.
+
+Billing/settings remain landlord-owner only in V1.
+
+## Implementation Principles
+
+- Landlord ownership is not transferable through delegation.
+- Shared logins are explicitly unsupported.
+- Delegated access grants are relationships, not identity replacement.
+- Every delegated request must resolve the authenticated actor and the landlord being represented.
+- Permission evaluation must happen before projection, mutation, export, message send, or evidence access.
+- Audit capture must preserve actor attribution without copying sensitive payloads.
+- V1 should prefer predefined roles over a custom permission builder.
+- Contractor organizations and property manager companies must fit the model later without changing the V1 meaning.
+
+## Phase 0: Design Lock And Vocabulary
+
+Goal: lock the vocabulary before implementation begins.
+
+Work:
+
+- Define canonical role constants.
+- Define workspace scope constants.
+- Define permission flag constants.
+- Define target resource type vocabulary.
+- Define delegated access lifecycle event names.
+- Confirm owner-only actions for V1.
+
+Outputs:
+
+- Shared permission vocabulary.
+- Implementation checklist for backend and UI phases.
+- Test matrix for delegated role and scope behavior.
+
+Dependencies:
+
+- Merged governance audit package.
+- Current landlord auth helper patterns.
+- Current audit/event helper patterns.
+
+Validation:
+
+- Architecture review confirms vocabulary matches the approved matrix.
+- No code or schema changes in this phase unless a later implementation PR explicitly opens them.
+
+## Phase 1: Data Model And Backend Authorization Foundation
+
+Goal: introduce the storage and authorization foundation without exposing delegate management UI yet.
+
+Work:
+
+- Add Firestore collections for invitations, grants, grant history, and audit references.
+- Add backend permission resolver that distinguishes landlord owner from delegate.
+- Add server-side grant lookup by authenticated user and acting landlord.
+- Add property, workspace, and resource scope evaluation.
+- Add explicit deny handling for revoked, expired, inactive, or out-of-scope access.
+- Add audit event helper integration for delegated lifecycle and denied access events.
+
+Outputs:
+
+- Delegated access grant model.
+- Invitation model.
+- Revocation history model.
+- Permission evaluation helper.
+- Audit helper surface for delegated events.
+
+Non-goals:
+
+- No owner-facing delegate management UI yet.
+- No contractor organization hierarchy.
+- No delegated billing access.
+- No broad route rewrites.
+
+Validation:
+
+- Unit tests for owner access.
+- Unit tests for active delegate access.
+- Unit tests for revoked delegate fail-closed behavior.
+- Unit tests for property and workspace scope denial.
+- Unit tests for billing/settings owner-only behavior.
+
+## Phase 2: Invitation, Acceptance, And Revocation APIs
+
+Goal: implement the delegated access lifecycle behind authenticated backend routes.
+
+Work:
+
+- Add landlord-owner-only invite creation route.
+- Add invitation email token generation and acceptance route.
+- Add invite expiration and cancellation behavior.
+- Add role/scope change route.
+- Add revocation route.
+- Add current grants and pending invites retrieval for owner review.
+- Add active grant checks to invalidate stale permission assumptions.
+
+Outputs:
+
+- Invite creation API.
+- Invite acceptance API.
+- Invite cancellation and expiration behavior.
+- Delegate grant management API.
+- Revocation API.
+- Owner-visible delegate list API.
+
+Non-goals:
+
+- No custom role builder.
+- No delegated billing.
+- No property manager company account model.
+- No contractor organization implementation.
+
+Validation:
+
+- Auth tests for owner-only invite, scope change, and revoke actions.
+- Token acceptance tests for valid, expired, cancelled, already accepted, and wrong-account cases.
+- Revoked grant tests across representative landlord routes.
+- Audit tests for lifecycle events.
+
+## Phase 3: Owner And Delegate UX
+
+Goal: make delegated access usable without expanding permissions.
+
+Work:
+
+- Add owner-facing delegate management surface.
+- Add pending, active, revoked, and expired invite states.
+- Add role and scope selection using predefined roles.
+- Add concise permission review before send.
+- Add delegate acceptance experience.
+- Add delegate workspace entry and scoped navigation.
+- Add revoked access state.
+- Add owner-visible recent delegated activity view.
+
+Outputs:
+
+- Delegate management UI.
+- Invitation send and resend UI.
+- Role/scope edit UI.
+- Revoke UI.
+- Delegate acceptance UI.
+- Scoped workspace entry for delegates.
+
+Validation:
+
+- Manual preview QA for owner invite, delegate accept, scoped access, revoked access, and mobile.
+- Frontend tests for role/scope selection and revoked state.
+- Backend tests remain authoritative for permission enforcement.
+
+## Phase 4: Route-by-Route Enforcement Expansion
+
+Goal: safely expand delegated access across landlord workspaces.
+
+Recommended sequence:
+
+1. Dashboard read access.
+2. Scheduling read/create/edit for scoped roles.
+3. Unified Inbox view/message for scoped roles.
+4. Work Orders and maintenance workflows.
+5. Properties and units for scoped operational roles.
+6. Tenants and leases with conservative projection.
+7. Payments read-only summaries where approved.
+8. Evidence and exports with heightened audit.
+
+Route expansion should be incremental. Each route should define:
+
+- Required permission flag.
+- Workspace scope.
+- Property/resource scope.
+- Projection rules.
+- Audit requirements.
+- Owner-only exceptions.
+
+## Rollout Sequencing
+
+Recommended rollout:
+
+1. Internal development seed data and unit tests.
+2. Owner-only delegate management hidden behind a guarded route or feature flag.
+3. Limited staff roles on non-payment, non-evidence workspaces.
+4. Add payment summaries only after projection and audit review.
+5. Add evidence/export visibility only after export audit review.
+6. Add contractor and company-level layers in later missions.
+
+Do not launch broad delegated access until revocation and denied-access behavior are verified.
+
+## Dependencies
+
+Technical dependencies:
+
+- Firebase Auth user identity.
+- Existing landlord workspace authorization helpers.
+- Existing Firestore access patterns.
+- Existing audit/event helper patterns.
+- Email sending infrastructure for invitations.
+- Current workspace navigation and sticky shell.
+
+Governance dependencies:
+
+- Approved role matrix.
+- Approved audit fields.
+- Owner-only billing/settings rule.
+- Projection-safe tenant, payment, message, evidence, and export behavior.
+
+## Migration Strategy
+
+V1 should be additive.
+
+Recommended migration:
+
+- Existing landlord owners remain unchanged.
+- No existing landlord data is rewritten.
+- Delegate collections start empty.
+- Existing routes continue requiring landlord owner until each route explicitly opts into delegate authorization.
+- Admin/support impersonation or support workflows remain separate and must not be conflated with delegation.
+- Historical actions remain landlord-owner actions unless captured under delegated fields after launch.
+
+Backfill is not required for V1.
+
+## Implementation Readiness Checklist
+
+Before implementation starts:
+
+- Confirm data model document is accepted.
+- Confirm permission evaluation model is accepted.
+- Confirm audit architecture is accepted.
+- Confirm invitation architecture is accepted.
+- Confirm risk register has no Critical unresolved blockers.
+- Choose first implementation PR boundary.
+
+Recommended first implementation PR:
+
+`feat/delegated-access-foundation-v1`
+
+Suggested scope:
+
+- Constants and types.
+- Firestore model helpers.
+- Permission evaluation helper.
+- Audit event type definitions.
+- Unit tests.
+
+No UI in the first implementation PR.
+
+## Manual QA Expectations
+
+Docs-only design does not require manual QA.
+
+Implementation phases will require manual QA when:
+
+- Delegate management UI is introduced.
+- Invitation acceptance is introduced.
+- Delegated workspace navigation is introduced.
+- Any route exposes landlord data to non-owner accounts.
+
+## Deferred Scope
+
+- Custom permission builder.
+- Delegated billing.
+- Property manager company hierarchy.
+- Contractor organization hierarchy.
+- SSO/SCIM.
+- Mandatory MFA enforcement.
+- Access certification campaigns.
+- Legal hold and evidence chain-of-custody implementation.
+- Automated AI action delegation.

--- a/docs/design/delegated-access-invitation-architecture-v1.md
+++ b/docs/design/delegated-access-invitation-architecture-v1.md
@@ -1,0 +1,206 @@
+# Delegated Access Invitation Architecture V1
+
+## Scope
+
+This document defines the implementation-ready invitation architecture for Delegated Access V1.
+
+This is design-only. It does not implement invitation routes, email sending, token storage, UI, Firestore schema, security rules, or MFA enforcement.
+
+## Invitation Principles
+
+- Landlord owner initiates invitation.
+- Delegate uses their own account.
+- Invitation does not grant access until accepted.
+- Role, property scope, workspace scope, and resource scope are selected before send.
+- Token acceptance fails closed.
+- Every lifecycle step is audited.
+- Billing/settings access remains owner-only in V1.
+
+## Invite Creation
+
+Required actor:
+
+- Landlord Owner only in V1.
+
+Required inputs:
+
+| Input | Purpose |
+| --- | --- |
+| `inviteeEmail` | Recipient email. |
+| `role` | Predefined delegate role. |
+| `propertyScope` | All current properties, selected properties, resource-only, or none. |
+| `workspaceScope` | Allowed workspaces. |
+| `resourceScope` | Assigned resources where applicable. |
+| `expiresAt` | Expiration timestamp. |
+| `note` | Optional sanitized owner note. |
+
+Creation behavior:
+
+1. Validate actor is landlord owner.
+2. Validate role is inviteable.
+3. Validate scope is compatible with role.
+4. Reject billing/settings scope in V1.
+5. Create pending invitation.
+6. Store hashed token only.
+7. Queue invitation email.
+8. Emit `delegated_invite_created`.
+9. Emit `delegated_invite_sent` when email is queued/sent.
+
+## Email Flow
+
+Invitation email should:
+
+- Identify RentChain and the inviting landlord workspace.
+- Show the role at a concise level.
+- Link to acceptance with expiring token.
+- Require sign in or account creation.
+- Avoid exposing tenant, lease, payment, evidence, or private message details.
+- Never include landlord credentials.
+
+If email delivery fails, invitation should remain pending only if resend/retry behavior is explicit and visible to the owner.
+
+## Acceptance
+
+Acceptance behavior:
+
+1. Recipient opens invite link.
+2. Recipient signs in or creates their own account.
+3. Backend validates token hash.
+4. Backend validates invitation status is pending.
+5. Backend validates invitation has not expired.
+6. Backend validates invitation has not been cancelled.
+7. Backend validates account/email policy.
+8. Backend creates delegated access grant.
+9. Backend marks invitation accepted.
+10. Backend emits `delegated_invite_accepted`.
+11. Delegate enters only scoped landlord workspace access.
+
+The exact email matching policy should be decided during implementation. Conservative default: accepting account email should match the invited email unless owner-approved remap exists.
+
+## Expiration
+
+Invitations should expire.
+
+Recommended behavior:
+
+- Expired token cannot be accepted.
+- Status becomes `expired`.
+- Owner may send a new invitation.
+- Expiration is audit logged.
+- Expired invitation does not create a grant.
+
+Expiration can be processed lazily at acceptance time or through scheduled cleanup. Authorization must treat expired invites as inactive either way.
+
+## Cancellation
+
+Landlord owner may cancel pending invitations.
+
+Cancellation behavior:
+
+- Mark invitation `cancelled`.
+- Record cancelling actor and timestamp.
+- Prevent token acceptance.
+- Emit `delegated_invite_cancelled`.
+
+Cancellation is not the same as revocation because no grant exists yet.
+
+## Revocation
+
+Revocation applies to an accepted grant.
+
+Revocation behavior:
+
+1. Landlord owner selects active delegate.
+2. Backend marks grant revoked.
+3. Backend records revoking actor, timestamp, previous role, previous scope, and optional reason.
+4. Backend prevents future delegated requests under that grant.
+5. Backend invalidates stale authorization assumptions where supported.
+6. Backend emits `delegated_access_revoked`.
+7. Delegate no longer sees landlord workspace access.
+
+Revocation must preserve historical grant and audit data.
+
+## Role Changes
+
+Role changes should be owner-controlled.
+
+Recommended behavior:
+
+- Validate actor is landlord owner.
+- Validate new role is inviteable/delegatable.
+- Validate new scope is compatible.
+- Preserve previous role/scope in grant history.
+- Update active grant.
+- Require permission refresh on new requests.
+- Emit `delegated_role_changed` and/or `delegated_scope_changed`.
+
+High-risk role upgrades may require delegate reauthentication or re-acceptance in later phases.
+
+## Active Session Behavior
+
+Delegated authorization must evaluate current grant state on each sensitive request.
+
+If grant changes:
+
+- New requests evaluate updated scope.
+- Stale frontend state must not preserve old access.
+- High-risk surfaces may require refresh or reauthentication.
+
+If grant is revoked:
+
+- New requests are denied.
+- Delegate exits landlord context or sees revoked access state.
+- Pending local UI should not continue to submit landlord-scoped changes.
+
+## MFA Considerations
+
+V1 should recommend MFA for delegates.
+
+MFA should be strongly recommended for:
+
+- Property Managers.
+- Assistants with message access.
+- Any role with payment visibility.
+- Any role with evidence/export visibility.
+- Contractor Admins.
+
+Future phases may require MFA for high-risk roles before acceptance or before sensitive workspaces open.
+
+## Resend Behavior
+
+Resend should:
+
+- Be owner-only.
+- Create a fresh token or fresh invitation event.
+- Preserve prior invitation history.
+- Avoid indefinite token reuse.
+- Audit resend activity.
+
+## Duplicate Invitation Behavior
+
+Recommended behavior:
+
+- If an active grant already exists for the same user and landlord, prevent duplicate active access.
+- If a pending invite exists for the same email, allow resend or replace only through explicit owner action.
+- If a revoked grant exists, require a fresh invitation or explicit reactivation flow with audit.
+
+## Failure Cases
+
+| Failure | Behavior |
+| --- | --- |
+| Invalid token | Reject and show safe invalid invite state. |
+| Expired token | Reject and show expired invite state. |
+| Cancelled token | Reject and show cancelled invite state. |
+| Already accepted | Reject or route existing delegate to appropriate context. |
+| Wrong account/email | Fail closed or require owner-approved remap. |
+| Grant creation fails | Do not mark invite accepted. |
+| Audit write fails for acceptance | Fail closed for grant creation unless implementation explicitly classifies it safe. |
+
+## Non-Goals
+
+- No custom role builder.
+- No delegated billing access.
+- No mandatory MFA enforcement in V1.
+- No property manager company invitation model.
+- No contractor organization invitation model.
+- No automated AI action delegation.

--- a/docs/design/delegated-access-permission-evaluation-v1.md
+++ b/docs/design/delegated-access-permission-evaluation-v1.md
@@ -1,0 +1,225 @@
+# Delegated Access Permission Evaluation Model V1
+
+## Scope
+
+This document defines the intended permission evaluation model for Delegated Access V1.
+
+This is design-only. It does not implement authorization helpers, backend routes, UI, Firestore rules, or tests.
+
+## Evaluation Objective
+
+Every landlord-scoped request should answer:
+
+1. Who is authenticated?
+2. Which landlord workspace is being accessed?
+3. Is the actor the landlord owner?
+4. If not owner, is there an active delegated grant?
+5. Does the grant permit the workspace, property, resource, and action?
+6. Should the action be allowed, denied, or owner-only?
+7. What audit event is required?
+
+Authorization must be server-side. Frontend navigation and hidden buttons are not security boundaries.
+
+## Request Context
+
+Recommended authorization context:
+
+| Field | Purpose |
+| --- | --- |
+| `actorUserId` | Authenticated user from Firebase Auth. |
+| `actingForLandlordId` | Landlord workspace being accessed. |
+| `routeWorkspace` | Workspace owning the request. |
+| `action` | `view`, `create`, `edit`, `approve`, `export`, `assign`, `message`, `revoke`, or `billing_access`. |
+| `targetResourceType` | Resource type being accessed. |
+| `targetResourceId` | Resource identifier when available. |
+| `propertyId` | Property scope to evaluate when known. |
+| `unitId` | Unit scope to evaluate when known. |
+| `sensitivity` | Optional `standard`, `payment`, `evidence`, `privacy`, or `billing`. |
+
+## Authorization Flow
+
+Recommended flow:
+
+1. Authenticate request.
+2. Resolve requested landlord workspace server-side.
+3. Check whether `actorUserId` is the landlord owner.
+4. If owner, allow unless the route has another independent blocker.
+5. If not owner, load active delegate grant for `actorUserId` and landlord.
+6. If no active grant, deny.
+7. If grant is revoked, suspended, expired, or pending, deny.
+8. Check workspace scope.
+9. Check property scope.
+10. Check resource scope where applicable.
+11. Check permission flag for action.
+12. Apply high-risk owner-only constraints.
+13. Return allow/deny decision with evaluated permission scope.
+14. Emit required audit event for lifecycle, denied, high-risk, mutation, export, or message actions.
+
+## Role Inheritance
+
+V1 should not implement complex inheritance.
+
+Recommended behavior:
+
+- Landlord Owner authority comes from account ownership, not role inheritance.
+- Delegate roles map to predefined permission templates.
+- Scope narrows role permissions.
+- Explicit deny and owner-only rules override role permissions.
+- Contractor Admin may manage contractor staff only in future contractor organization scope, not landlord delegates.
+- Read-only Auditor cannot inherit mutation rights.
+
+If future company-level delegation is added, company membership should produce an evaluated grant context but should not make company staff indistinguishable from the company admin.
+
+## Explicit Deny Behavior
+
+Explicit deny must win.
+
+Examples:
+
+| Condition | Result |
+| --- | --- |
+| Grant revoked | Deny. |
+| Invitation pending | Deny. |
+| Invitation expired | Deny. |
+| Role lacks workspace scope | Deny. |
+| Role lacks property scope | Deny. |
+| Role lacks required permission flag | Deny. |
+| Action is billing/settings in V1 | Deny for delegates. |
+| Payment mutation by delegate in V1 | Deny unless a future approved model exists. |
+| Evidence export without explicit export scope | Deny. |
+| Contractor attempts non-assigned job access | Deny. |
+
+Denied decisions should be audited when practical, especially for payment, evidence, billing, revoked, or out-of-scope attempts.
+
+## Property-Level Restrictions
+
+Property-level evaluation should be required for landlord resources tied to a property or unit.
+
+Recommended rules:
+
+- `selected` property scope allows only listed properties.
+- `all_current_properties` allows all current properties for landlord, but should be used sparingly.
+- `resource_only` allows only resources specifically assigned to the delegate.
+- `none` denies property-scoped access.
+- Unit access must resolve to property scope server-side.
+- A client-provided property ID must not be trusted without server-side ownership verification.
+
+If a resource cannot be safely resolved to a property or assigned resource, authorization should fail closed.
+
+## Workspace-Level Restrictions
+
+Workspace-level scope controls which product surfaces can be accessed.
+
+Recommended mapping:
+
+| Workspace | Scope key |
+| --- | --- |
+| Dashboard | `dashboard` |
+| Operations | `operations` |
+| Properties | `properties` |
+| Tenants | `tenants` |
+| Leases | `leases` |
+| Payments | `payments` |
+| Unified Inbox | `unified_inbox` |
+| Scheduling | `scheduling` |
+| Work Orders | `work_orders` |
+| Evidence / Exports | `evidence_exports` |
+| Settings / Billing | `settings_billing` |
+
+V1 delegates should not receive `settings_billing` access.
+
+Workspace scope alone is not sufficient. Property/resource and action permissions must also pass.
+
+## Owner Override Behavior
+
+The landlord owner can:
+
+- View and manage delegates.
+- Create invitations.
+- Change role/scope.
+- Revoke access.
+- View delegated activity.
+- Access billing/settings.
+- Perform final approvals.
+
+Owner override does not mean:
+
+- Owner can bypass platform-wide auth.
+- Owner can alter immutable audit history.
+- Owner can make a delegate action appear as owner action.
+- Owner can avoid audit on high-risk actions where audit is required.
+
+## High-Risk Action Rules
+
+V1 conservative constraints:
+
+| Surface | V1 rule |
+| --- | --- |
+| Billing/settings | Owner-only. |
+| Delegate revocation | Owner-only. |
+| Payment mutation | Owner-only unless future explicit delegation exists. |
+| Payment exports | Owner-only by default. |
+| Evidence exports | Explicit scope and audit required. |
+| Lease approval/finalization | Owner-only or explicitly delegated later. |
+| Contractor access | Assigned-job/resource-only by default. |
+| Tenant privacy data | Scoped projection only. |
+
+## Projection Interaction
+
+Permission evaluation should happen before data projection.
+
+After authorization:
+
+- Return only fields allowed for role and workspace.
+- Preserve tenant-facing whitelist projection boundaries.
+- Do not leak admin/support metadata.
+- Do not expose raw internal IDs as labels.
+- Do not include sensitive provider payloads.
+
+Delegated access should never be implemented as broad owner data plus frontend filtering.
+
+## Audit Decision Output
+
+Authorization helper should return a decision object suitable for audit.
+
+Recommended shape:
+
+```json
+{
+  "allowed": true,
+  "actorUserId": "user_ref",
+  "actingForLandlordId": "landlord_ref",
+  "relationship": "delegate",
+  "delegatedRole": "property_manager",
+  "permissionScope": {
+    "workspaceScopes": ["dashboard", "operations"],
+    "propertyScopeMode": "selected",
+    "permissionFlags": ["view", "edit", "message"]
+  },
+  "auditRequired": true
+}
+```
+
+For denied decisions, include a safe denial reason code such as `grant_revoked`, `workspace_scope_denied`, `property_scope_denied`, or `owner_only_action`.
+
+## Failure Modes
+
+Authorization should fail closed when:
+
+- Auth context is missing.
+- Landlord scope cannot be resolved.
+- Grant lookup fails.
+- Resource ownership cannot be resolved.
+- Permission vocabulary is unknown.
+- Scope data is malformed.
+- Route attempts to use delegate support before it has been reviewed.
+
+Service availability failures should be logged and surfaced safely. They should not silently allow access.
+
+## Non-Goals
+
+- No custom permission builder.
+- No organization-level inheritance in V1.
+- No delegated billing permissions.
+- No frontend-only enforcement.
+- No impersonation mode.

--- a/docs/design/delegated-access-risk-register-v1.md
+++ b/docs/design/delegated-access-risk-register-v1.md
@@ -1,0 +1,138 @@
+# Delegated Access Risk Register V1
+
+## Scope
+
+This document identifies implementation risks for Delegated Access V1.
+
+This is design-only. It does not implement code, backend routes, UI, Firestore schema, security rules, audit storage, billing changes, or deployment changes.
+
+## Risk Summary
+
+Delegated access risk is mainly about authority and evidence:
+
+- If permission evaluation is loose, delegates can over-access landlord, tenant, payment, or evidence data.
+- If revocation is weak, stale access persists.
+- If audit attribution is incomplete, actions become hard to defend.
+- If contractor or property manager company access is improvised, turnover creates privacy and operational risk.
+- If billing/settings are delegated too early, account ownership becomes unclear.
+
+## Privilege Escalation Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Delegate route treats delegate as landlord owner | Critical data and account control exposure. | Medium | Resolve owner versus delegate server-side and deny owner-only actions. | Fix before implementation. |
+| Client controls landlord or property scope | Cross-property or cross-landlord exposure. | Medium | Resolve landlord, property, unit, and resource ownership server-side. | Fix before implementation. |
+| Workspace scope is checked but action flag is not | Delegates can mutate where only view was intended. | Medium | Require workspace, property/resource, and action checks. | Fix before implementation. |
+| Contractor receives property-wide access | Tenant/payment/lease exposure beyond job need. | Medium | Contractor default must be resource/job scoped. | Fix before contractor support. |
+| Read-only Auditor receives mutation rights through shared helper | Evidence or record mutation by auditor. | Low to medium | Explicit deny mutation and message actions for auditor role. | Fix before auditor support. |
+
+## Stale Access Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Revoked delegate keeps access through active session | Privacy and payment exposure. | Medium | Evaluate current grant state on each sensitive request. | Fix in V1 foundation. |
+| Role change does not refresh permissions | Old role remains effective. | Medium | Permission helper must load current grant and reject stale assumptions. | Fix in V1 foundation. |
+| Expired invite still accepts | Unauthorized access grant. | Low to medium | Validate invitation status and expiration on acceptance. | Fix in invitation phase. |
+| Cancelled invite still accepts | Unauthorized access grant. | Low | Store status and fail closed on acceptance. | Fix in invitation phase. |
+
+## Contractor Turnover Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Contractor staff uses shared contractor account | Actor attribution lost. | Medium | Require individual accounts for contractor users in future org model. | Defer with model alignment. |
+| Contractor retains job access after completion | Privacy and operational exposure. | Medium | Job/resource scope should expire or be revoked on completion. | Defer to contractor implementation. |
+| Contractor sees tenant data unrelated to assigned job | Privacy exposure. | Medium | Job-scoped projection only. | Fix before contractor route access. |
+| Contractor Admin manages landlord delegates | Authority confusion. | Low | Contractor Admin scope must be organization/job-only. | Fix before contractor org support. |
+
+## Property Manager Turnover Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Individual PM leaves company but keeps landlord access | Privacy and operational exposure. | Medium | V1 supports individual revocation; future company model needs staff lifecycle controls. | Accept in V1 with clear limitation. |
+| Company access is modeled as shared account | Attribution loss. | Medium | Future company model must preserve individual actor attribution. | Defer, but keep model-compatible. |
+| Company admin cannot see staff access history | Weak accountability. | Medium | Future company layer should include staff activity visibility. | Defer. |
+| Landlord cannot revoke company cleanly | Stale external access. | Medium | Future landlord-to-company grant should support immediate revoke. | Defer. |
+
+## Accidental Over-Sharing Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Role descriptions are too broad | Owners grant more access than intended. | Medium | Use concise role impact summaries and review step. | Fix in UI phase. |
+| `all_current_properties` becomes default | Excess property exposure. | Medium | Default to selected properties or resource-only where appropriate. | Fix in invitation phase. |
+| Workspace selection implies data access beyond projection | Sensitive fields leak. | Medium | Projection remains role and workspace aware. | Fix route by route. |
+| Frontend hides data but API returns broad records | Security failure. | Medium | Backend projection and authorization must be authoritative. | Fix route by route. |
+
+## Payment Access Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Delegate edits payment records | Financial integrity risk. | Medium | Payment mutation owner-only in V1. | Fix before payments delegation. |
+| Delegate exports payment data | Privacy and financial exposure. | Medium | Payment exports owner-only by default. | Fix before payments delegation. |
+| Payment summaries expose too much tenant detail | Privacy exposure. | Medium | Use scoped summaries and safe labels. | Fix before payments delegation. |
+| Denied payment mutation is not logged | Suspicious access invisible. | Medium | Audit denied high-risk attempts. | Fix in audit phase. |
+
+## Evidence Access Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Delegate exports evidence without explicit scope | Evidence/privacy exposure. | Medium | Evidence exports require explicit scope and audit. | Fix before evidence delegation. |
+| Audit copies raw evidence payloads | Sensitive data replicated. | Low to medium | Metadata-only audit. | Fix in audit architecture. |
+| Contractor uploads evidence to wrong job | Record integrity issue. | Medium | Job-scoped upload validation. | Fix before contractor evidence support. |
+| Auditor access becomes implicit full export access | Over-sharing. | Low to medium | Auditor export must be explicitly scoped. | Fix before auditor support. |
+
+## Privacy Exposure Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Tenant PII broadly visible to maintenance roles | Privacy breach. | Medium | Maintenance projection should show only required contact/context. | Fix before maintenance delegation. |
+| Message bodies exposed beyond scope | Privacy breach. | Medium | Inbox/message projection by role and workspace. | Fix before inbox delegation. |
+| Lease data exposed to contractors | Privacy breach. | Low to medium | Contractors receive only job-required occupancy context. | Fix before contractor support. |
+| Raw internal IDs become user-facing labels | Privacy and support risk. | Low | Use safe labels in UI/export projections. | Fix route by route. |
+
+## Audit Gap Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Delegated actions audit as landlord owner | Attribution failure. | Medium | Always include `actorUserId` and `actingForLandlordId`. | Fix in foundation. |
+| Revocation event omits previous scope | Weak history. | Medium | Store previous role/scope in grant history and audit. | Fix in revocation phase. |
+| Denied high-risk actions are not logged | Abuse detection gap. | Medium | Audit denied payment/evidence/billing/revoked attempts. | Fix in audit phase. |
+| Audit write failure silently allows high-risk mutation | Evidence defensibility risk. | Low to medium | Fail closed for high-risk required audit capture. | Fix before mutations. |
+
+## Migration Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Existing owner routes accidentally become delegate-enabled | Unreviewed exposure. | Medium | Route-by-route opt-in for delegate authorization. | Fix in implementation plan. |
+| Existing admin/support impersonation is conflated with delegation | Governance confusion. | Low to medium | Keep admin/support workflows separate. | Fix in design review. |
+| Backfill attempts rewrite old actor history | Audit meaning changes. | Low | No V1 backfill. Future actions only. | Accept intentionally. |
+| Firestore security rules change before backend model is stable | Access regression. | Low to medium | No rules changes until backend enforcement is reviewed. | Defer. |
+
+## Release Risks
+
+| Risk | Impact | Likelihood | Mitigation | Recommendation |
+| --- | --- | --- | --- | --- |
+| One large PR implements data, routes, UI, and audit | Hard review and high regression risk. | Medium | Split foundation, lifecycle API, UI, and route opt-in. | Fix in sequencing. |
+| Manual QA starts too late | Invitation and revocation bugs reach users. | Medium | Require preview QA once UI/routes exist. | Fix in rollout. |
+| Billing/settings accidentally appear in delegate nav | Owner authority confusion. | Low to medium | Owner-only nav gating and backend denial. | Fix before UI. |
+| Delegate UX overpromises access before route support exists | Confusing product experience. | Medium | Show scoped workspace availability based on implemented route support. | Fix in UI phase. |
+
+## Accepted V1 Limitations
+
+- No custom permission builder.
+- No delegated billing/settings access.
+- No property manager company hierarchy.
+- No contractor organization hierarchy.
+- No mandatory MFA enforcement.
+- No SSO/SCIM.
+- No legal chain-of-custody implementation.
+- No historical audit backfill.
+
+## Not Accepted
+
+- Shared landlord logins as an operational pattern.
+- Delegate actions appearing as landlord owner actions.
+- Frontend-only authorization.
+- Broad data return followed by client filtering.
+- Revoked access remaining effective.
+- Payment mutation by delegates in V1.
+- Billing/settings access by delegates in V1.


### PR DESCRIPTION
## Summary

Adds the implementation-ready Delegated Access design package that translates the merged governance audit into scoped future implementation guidance.

Included docs:
- `docs/design/delegated-access-implementation-plan-v1.md`
- `docs/design/delegated-access-data-model-v1.md`
- `docs/design/delegated-access-permission-evaluation-v1.md`
- `docs/design/delegated-access-audit-architecture-v1.md`
- `docs/design/delegated-access-invitation-architecture-v1.md`
- `docs/design/delegated-access-risk-register-v1.md`

## Scope

Docs/design only.

No code changes, no backend routes, no UI, no Firestore changes, no security rule changes, no deployment changes.

## Validation

- `git diff --cached --check`
- `git diff --check`

## Notes

This package preserves the accepted constraints from the governance audit:
- landlord remains account owner
- shared logins are prohibited
- delegated access is not impersonation
- billing/settings remain owner-only in V1
- future contractor organizations and property manager companies must inherit the model