### PR TITLE
feat: add delegated access foundations

### DIFF
--- a/rentchain-api/src/lib/delegatedAccess/__tests__/delegatedAccessAudit.test.ts
+++ b/rentchain-api/src/lib/delegatedAccess/__tests__/delegatedAccessAudit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { createDelegatedAccessGrant } from "../delegatedAccessModel";
+import { buildDelegatedAccessAuditEvent } from "../delegatedAccessAudit";
+
+describe("delegated access audit foundations", () => {
+  it("builds immutable metadata-only delegated audit events with actor attribution", () => {
+    const grant = createDelegatedAccessGrant({
+      landlordId: "landlord-1",
+      delegateUserId: "delegate-1",
+      role: "assistant_office_admin",
+      propertyScope: {
+        mode: "selected",
+        propertyIds: ["property-1"],
+      },
+      workspaceScopes: ["unified_inbox"],
+      permissionFlags: ["view", "message"],
+      createdByUserId: "owner-1",
+    });
+
+    const event = buildDelegatedAccessAuditEvent({
+      eventType: "delegated_message_sent",
+      actorUserId: "delegate-1",
+      actingForLandlordId: "landlord-1",
+      delegatedRole: grant.role,
+      permissionScope: grant.permissionScope,
+      sessionId: "session-1",
+      actionType: "message",
+      targetResourceType: "message_thread",
+      targetResourceId: "thread-1",
+      timestamp: "2026-06-22T12:00:00.000Z",
+      ipAddress: "203.0.113.10",
+      deviceMetadata: {
+        userAgent: "test-browser",
+      },
+      outcome: "allowed",
+      reason: "scoped_message_reply",
+    });
+
+    expect(event).toMatchObject({
+      eventType: "delegated_message_sent",
+      actorUserId: "delegate-1",
+      actingForLandlordId: "landlord-1",
+      delegatedRole: "assistant_office_admin",
+      actionType: "message",
+      targetResourceType: "message_thread",
+      targetResourceId: "thread-1",
+      timestamp: "2026-06-22T12:00:00.000Z",
+      outcome: "allowed",
+      metadataOnly: true,
+      appendOnly: true,
+      immutable: true,
+    });
+    expect(event.eventId).toMatch(/^delegated_audit_/);
+    expect(event.permissionScope?.billingAccess).toBe(false);
+  });
+
+  it("rejects unknown delegated audit event types", () => {
+    expect(() =>
+      buildDelegatedAccessAuditEvent({
+        eventType: "unknown_event",
+        actorUserId: "delegate-1",
+        actingForLandlordId: "landlord-1",
+        actionType: "view",
+        targetResourceType: "dashboard",
+        outcome: "denied",
+      })
+    ).toThrow("invalid_delegated_audit_event_type");
+  });
+});

--- a/rentchain-api/src/lib/delegatedAccess/__tests__/delegatedAccessModel.test.ts
+++ b/rentchain-api/src/lib/delegatedAccess/__tests__/delegatedAccessModel.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  DelegatedAccessValidationError,
+  createDelegatedAccessGrant,
+  createDelegatedAccessInvitation,
+  isDelegatedInvitationExpired,
+  revokeDelegatedAccessGrant,
+  transitionDelegatedInvitationStatus,
+} from "../delegatedAccessModel";
+
+const selectedPropertyScope = {
+  mode: "selected" as const,
+  propertyIds: ["property-1"],
+};
+
+describe("delegated access model foundations", () => {
+  it("creates pending invitation records with predefined roles and scoped permissions", () => {
+    const invitation = createDelegatedAccessInvitation({
+      landlordId: "landlord-1",
+      inviteeEmail: "Manager@Example.com",
+      role: "property_manager",
+      propertyScope: selectedPropertyScope,
+      workspaceScopes: ["dashboard", "operations", "properties"],
+      permissionFlags: ["view", "edit", "message"],
+      tokenHash: "token_hash",
+      expiresAt: "2026-07-01T00:00:00.000Z",
+      createdByUserId: "owner-1",
+      createdAt: "2026-06-22T10:00:00.000Z",
+    });
+
+    expect(invitation).toMatchObject({
+      landlordId: "landlord-1",
+      inviteeEmail: "manager@example.com",
+      role: "property_manager",
+      status: "pending",
+      workspaceScopes: ["dashboard", "operations", "properties"],
+      permissionFlags: ["view", "edit", "message"],
+      acceptedByUserId: null,
+      cancelledByUserId: null,
+    });
+    expect(invitation.invitationId).toMatch(/^delegated_invitation_/);
+  });
+
+  it("rejects unsupported roles and owner-only delegated scopes", () => {
+    expect(() =>
+      createDelegatedAccessInvitation({
+        landlordId: "landlord-1",
+        inviteeEmail: "delegate@example.com",
+        role: "super_admin",
+        propertyScope: selectedPropertyScope,
+        workspaceScopes: ["dashboard"],
+        permissionFlags: ["view"],
+        tokenHash: "token_hash",
+        expiresAt: "2026-07-01T00:00:00.000Z",
+        createdByUserId: "owner-1",
+      })
+    ).toThrow(new DelegatedAccessValidationError("invalid_delegated_role"));
+
+    expect(() =>
+      createDelegatedAccessGrant({
+        landlordId: "landlord-1",
+        delegateUserId: "delegate-1",
+        role: "assistant_office_admin",
+        propertyScope: selectedPropertyScope,
+        workspaceScopes: ["settings_billing"],
+        permissionFlags: ["view"],
+        createdByUserId: "owner-1",
+      })
+    ).toThrow(new DelegatedAccessValidationError("delegated_billing_scope_not_allowed"));
+  });
+
+  it("supports invitation acceptance, cancellation, and expiration lifecycle", () => {
+    const invitation = createDelegatedAccessInvitation({
+      landlordId: "landlord-1",
+      inviteeEmail: "delegate@example.com",
+      role: "assistant_office_admin",
+      propertyScope: selectedPropertyScope,
+      workspaceScopes: ["dashboard", "unified_inbox"],
+      permissionFlags: ["view", "message"],
+      tokenHash: "token_hash",
+      expiresAt: "2026-07-01T00:00:00.000Z",
+      createdByUserId: "owner-1",
+      createdAt: "2026-06-22T10:00:00.000Z",
+    });
+
+    expect(isDelegatedInvitationExpired(invitation, "2026-06-30T00:00:00.000Z")).toBe(false);
+    expect(isDelegatedInvitationExpired(invitation, "2026-07-01T00:00:00.000Z")).toBe(true);
+
+    const accepted = transitionDelegatedInvitationStatus(invitation, "accepted", {
+      acceptedByUserId: "delegate-1",
+      timestamp: "2026-06-23T00:00:00.000Z",
+    });
+    expect(accepted).toMatchObject({
+      status: "accepted",
+      acceptedByUserId: "delegate-1",
+      acceptedAt: "2026-06-23T00:00:00.000Z",
+    });
+
+    const cancelled = transitionDelegatedInvitationStatus(invitation, "cancelled", {
+      actorUserId: "owner-1",
+      timestamp: "2026-06-24T00:00:00.000Z",
+    });
+    expect(cancelled).toMatchObject({
+      status: "cancelled",
+      cancelledByUserId: "owner-1",
+      cancelledAt: "2026-06-24T00:00:00.000Z",
+    });
+
+    expect(() =>
+      transitionDelegatedInvitationStatus(invitation, "accepted", {
+        acceptedByUserId: "delegate-1",
+        timestamp: "2026-07-02T00:00:00.000Z",
+      })
+    ).toThrow(new DelegatedAccessValidationError("invitation_expired"));
+  });
+
+  it("creates and revokes role assignment records without changing landlord ownership", () => {
+    const grant = createDelegatedAccessGrant({
+      landlordId: "landlord-1",
+      delegateUserId: "delegate-1",
+      delegateEmail: "Delegate@Example.com",
+      role: "maintenance_coordinator",
+      propertyScope: selectedPropertyScope,
+      workspaceScopes: ["work_orders", "scheduling"],
+      permissionFlags: ["view", "edit", "assign", "message"],
+      createdByUserId: "owner-1",
+      createdAt: "2026-06-22T10:00:00.000Z",
+      acceptedAt: "2026-06-22T11:00:00.000Z",
+    });
+
+    expect(grant).toMatchObject({
+      landlordId: "landlord-1",
+      delegateUserId: "delegate-1",
+      delegateEmail: "delegate@example.com",
+      role: "maintenance_coordinator",
+      status: "active",
+      createdByUserId: "owner-1",
+      acceptedAt: "2026-06-22T11:00:00.000Z",
+    });
+    expect(grant.permissionScope.billingAccess).toBe(false);
+
+    const revoked = revokeDelegatedAccessGrant(grant, {
+      revokedByUserId: "owner-1",
+      revokedAt: "2026-06-25T00:00:00.000Z",
+      reason: "Staff changed",
+    });
+    expect(revoked).toMatchObject({
+      status: "revoked",
+      revokedByUserId: "owner-1",
+      revokedAt: "2026-06-25T00:00:00.000Z",
+      revocationReason: "Staff changed",
+    });
+  });
+});

--- a/rentchain-api/src/lib/delegatedAccess/__tests__/permissionEvaluation.test.ts
+++ b/rentchain-api/src/lib/delegatedAccess/__tests__/permissionEvaluation.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import { createDelegatedAccessGrant, revokeDelegatedAccessGrant } from "../delegatedAccessModel";
+import { evaluateDelegatedAccessPermission } from "../permissionEvaluation";
+
+function grant() {
+  return createDelegatedAccessGrant({
+    landlordId: "landlord-1",
+    delegateUserId: "delegate-1",
+    role: "property_manager",
+    propertyScope: {
+      mode: "selected",
+      propertyIds: ["property-1"],
+    },
+    workspaceScopes: ["dashboard", "operations", "properties"],
+    permissionFlags: ["view", "edit", "message"],
+    createdByUserId: "owner-1",
+    createdAt: "2026-06-22T10:00:00.000Z",
+  });
+}
+
+const baseRequest = {
+  actorUserId: "delegate-1",
+  actingForLandlordId: "landlord-1",
+  isLandlordOwner: false,
+  routeWorkspace: "properties" as const,
+  action: "view" as const,
+  targetResourceType: "property" as const,
+  targetResourceId: "property-1",
+  propertyId: "property-1",
+};
+
+describe("delegated access permission evaluation", () => {
+  it("allows landlord owner override without a delegate grant", () => {
+    const decision = evaluateDelegatedAccessPermission({
+      ...baseRequest,
+      actorUserId: "owner-1",
+      isLandlordOwner: true,
+      action: "billing_access",
+      routeWorkspace: "settings_billing",
+      targetResourceType: "billing_settings",
+      grant: null,
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      relationship: "owner",
+      reason: "allowed_owner",
+      delegatedRole: null,
+      permissionScope: null,
+    });
+  });
+
+  it("allows active delegate access inside workspace, property, and action scope", () => {
+    const decision = evaluateDelegatedAccessPermission({
+      ...baseRequest,
+      grant: grant(),
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      relationship: "delegate",
+      reason: "allowed_delegate",
+      delegatedRole: "property_manager",
+      auditRequired: false,
+    });
+    expect(decision.permissionScope?.workspaceScopes).toContain("properties");
+  });
+
+  it("fails closed when grant is missing, revoked, mismatched, or explicitly denied", () => {
+    expect(evaluateDelegatedAccessPermission({ ...baseRequest, grant: null })).toMatchObject({
+      allowed: false,
+      reason: "missing_delegate_grant",
+    });
+
+    const revokedGrant = revokeDelegatedAccessGrant(grant(), {
+      revokedByUserId: "owner-1",
+      revokedAt: "2026-06-23T00:00:00.000Z",
+    });
+    expect(evaluateDelegatedAccessPermission({ ...baseRequest, grant: revokedGrant })).toMatchObject({
+      allowed: false,
+      reason: "grant_not_active",
+      delegatedRole: "property_manager",
+    });
+
+    expect(
+      evaluateDelegatedAccessPermission({
+        ...baseRequest,
+        actingForLandlordId: "landlord-2",
+        grant: grant(),
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "grant_landlord_mismatch",
+    });
+
+    expect(
+      evaluateDelegatedAccessPermission({
+        ...baseRequest,
+        grant: grant(),
+        explicitDenyReasons: ["manual_hold"],
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "explicit_deny",
+    });
+  });
+
+  it("denies out-of-scope workspace, property, action, and owner-only permissions", () => {
+    expect(
+      evaluateDelegatedAccessPermission({
+        ...baseRequest,
+        routeWorkspace: "payments",
+        targetResourceType: "payment",
+        grant: grant(),
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "workspace_scope_denied",
+    });
+
+    expect(
+      evaluateDelegatedAccessPermission({
+        ...baseRequest,
+        propertyId: "property-2",
+        grant: grant(),
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "property_scope_denied",
+    });
+
+    expect(
+      evaluateDelegatedAccessPermission({
+        ...baseRequest,
+        action: "approve",
+        grant: grant(),
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "permission_flag_denied",
+    });
+
+    expect(
+      evaluateDelegatedAccessPermission({
+        ...baseRequest,
+        action: "billing_access",
+        routeWorkspace: "settings_billing",
+        targetResourceType: "billing_settings",
+        grant: grant(),
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "owner_only_action",
+    });
+  });
+
+  it("requires explicit resource scope for resource-only contractor access", () => {
+    const contractorGrant = createDelegatedAccessGrant({
+      landlordId: "landlord-1",
+      delegateUserId: "contractor-1",
+      role: "contractor",
+      propertyScope: {
+        mode: "resource_only",
+        propertyIds: [],
+      },
+      resourceScope: {
+        workOrderIds: ["work-order-1"],
+      },
+      workspaceScopes: ["work_orders"],
+      permissionFlags: ["view", "edit", "message"],
+      createdByUserId: "owner-1",
+    });
+
+    expect(
+      evaluateDelegatedAccessPermission({
+        actorUserId: "contractor-1",
+        actingForLandlordId: "landlord-1",
+        isLandlordOwner: false,
+        routeWorkspace: "work_orders",
+        action: "view",
+        targetResourceType: "work_order",
+        targetResourceId: "work-order-1",
+        resourceId: "work-order-1",
+        grant: contractorGrant,
+      })
+    ).toMatchObject({
+      allowed: true,
+      reason: "allowed_delegate",
+    });
+
+    expect(
+      evaluateDelegatedAccessPermission({
+        actorUserId: "contractor-1",
+        actingForLandlordId: "landlord-1",
+        isLandlordOwner: false,
+        routeWorkspace: "work_orders",
+        action: "view",
+        targetResourceType: "work_order",
+        targetResourceId: "work-order-2",
+        resourceId: "work-order-2",
+        grant: contractorGrant,
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "resource_scope_denied",
+    });
+  });
+});

--- a/rentchain-api/src/lib/delegatedAccess/delegatedAccessAudit.ts
+++ b/rentchain-api/src/lib/delegatedAccess/delegatedAccessAudit.ts
@@ -1,0 +1,111 @@
+import crypto from "crypto";
+import {
+  DELEGATED_ACCESS_AUDIT_EVENT_TYPES,
+  type DelegatedAccessAuditEvent,
+  type DelegatedAccessAuditEventType,
+  type DelegatedAccessAuditOutcome,
+  type DelegatedAccessPermissionScope,
+  type DelegatedAccessRole,
+  type DelegatedAccessTargetResourceType,
+} from "./delegatedAccessTypes";
+
+type AuditInput = {
+  eventId?: string;
+  eventType: string;
+  actorUserId: string;
+  actingForLandlordId: string;
+  delegatedRole?: DelegatedAccessRole | "landlord_owner" | null;
+  permissionScope?: DelegatedAccessPermissionScope | null;
+  sessionId?: string | null;
+  actionType: string;
+  targetResourceType: DelegatedAccessTargetResourceType;
+  targetResourceId?: string | null;
+  timestamp?: string;
+  ipAddress?: string | null;
+  deviceMetadata?: Record<string, string> | null;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  outcome: DelegatedAccessAuditOutcome;
+  reason?: string | null;
+};
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new Error(code);
+  return text;
+}
+
+function normalizeTimestamp(value: unknown): string {
+  const raw = cleanString(value, 120);
+  if (!raw) return new Date().toISOString();
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function assertAuditEventType(value: string): DelegatedAccessAuditEventType {
+  if (!DELEGATED_ACCESS_AUDIT_EVENT_TYPES.includes(value as DelegatedAccessAuditEventType)) {
+    throw new Error("invalid_delegated_audit_event_type");
+  }
+  return value as DelegatedAccessAuditEventType;
+}
+
+function stableEventId(input: Omit<AuditInput, "eventId"> & { timestamp: string }): string {
+  const digest = crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify([
+        input.eventType,
+        input.actorUserId,
+        input.actingForLandlordId,
+        input.delegatedRole,
+        input.actionType,
+        input.targetResourceType,
+        input.targetResourceId,
+        input.timestamp,
+        input.outcome,
+      ])
+    )
+    .digest("hex")
+    .slice(0, 32);
+  return `delegated_audit_${digest}`;
+}
+
+function normalizeDeviceMetadata(value: Record<string, string> | null | undefined): Record<string, string> | null {
+  if (!value) return null;
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, entry]) => [cleanString(key, 80), cleanString(entry, 300)] as const)
+      .filter(([key, entry]) => key && entry)
+  );
+}
+
+export function buildDelegatedAccessAuditEvent(input: AuditInput): DelegatedAccessAuditEvent {
+  const timestamp = normalizeTimestamp(input.timestamp);
+  const normalizedInput = { ...input, timestamp };
+  return {
+    eventId: input.eventId || stableEventId(normalizedInput),
+    eventType: assertAuditEventType(input.eventType),
+    actorUserId: requireString(input.actorUserId, "missing_actor_user_id"),
+    actingForLandlordId: requireString(input.actingForLandlordId, "missing_acting_for_landlord_id"),
+    delegatedRole: input.delegatedRole || null,
+    permissionScope: input.permissionScope || null,
+    sessionId: input.sessionId ? cleanString(input.sessionId, 200) : null,
+    actionType: requireString(input.actionType, "missing_action_type", 160),
+    targetResourceType: input.targetResourceType,
+    targetResourceId: input.targetResourceId ? cleanString(input.targetResourceId, 300) : null,
+    timestamp,
+    ipAddress: input.ipAddress ? cleanString(input.ipAddress, 120) : null,
+    deviceMetadata: normalizeDeviceMetadata(input.deviceMetadata),
+    before: input.before || null,
+    after: input.after || null,
+    outcome: input.outcome,
+    reason: input.reason ? cleanString(input.reason, 500) : null,
+    metadataOnly: true,
+    appendOnly: true,
+    immutable: true,
+  };
+}

--- a/rentchain-api/src/lib/delegatedAccess/delegatedAccessModel.ts
+++ b/rentchain-api/src/lib/delegatedAccess/delegatedAccessModel.ts
@@ -1,0 +1,292 @@
+import crypto from "crypto";
+import {
+  DELEGATED_ACCESS_GRANT_STATUSES,
+  DELEGATED_ACCESS_INVITATION_STATUSES,
+  DELEGATED_ACCESS_PERMISSION_ACTIONS,
+  DELEGATED_ACCESS_PROPERTY_SCOPE_MODES,
+  DELEGATED_ACCESS_ROLES,
+  DELEGATED_ACCESS_WORKSPACE_SCOPES,
+  type DelegatedAccessGrant,
+  type DelegatedAccessGrantStatus,
+  type DelegatedAccessInvitation,
+  type DelegatedAccessInvitationStatus,
+  type DelegatedAccessPermissionAction,
+  type DelegatedAccessPermissionScope,
+  type DelegatedAccessPropertyScope,
+  type DelegatedAccessResourceScope,
+  type DelegatedAccessRole,
+  type DelegatedAccessWorkspaceScope,
+} from "./delegatedAccessTypes";
+
+type InvitationInput = {
+  invitationId?: string;
+  landlordId: string;
+  inviteeEmail: string;
+  role: string;
+  propertyScope: DelegatedAccessPropertyScope;
+  workspaceScopes: string[];
+  resourceScope?: DelegatedAccessResourceScope;
+  permissionFlags: string[];
+  tokenHash: string;
+  expiresAt: string;
+  createdByUserId: string;
+  createdAt?: string;
+};
+
+type GrantInput = {
+  grantId?: string;
+  landlordId: string;
+  delegateUserId: string;
+  delegateEmail?: string | null;
+  role: string;
+  propertyScope: DelegatedAccessPropertyScope;
+  workspaceScopes: string[];
+  resourceScope?: DelegatedAccessResourceScope;
+  permissionFlags: string[];
+  createdByUserId: string;
+  createdAt?: string;
+  acceptedAt?: string | null;
+};
+
+export class DelegatedAccessValidationError extends Error {
+  constructor(public readonly code: string) {
+    super(code);
+    this.name = "DelegatedAccessValidationError";
+  }
+}
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new DelegatedAccessValidationError(code);
+  return text;
+}
+
+function parseDate(value: unknown, code: string): string {
+  const text = requireString(value, code, 120);
+  const parsed = Date.parse(text);
+  if (!Number.isFinite(parsed)) throw new DelegatedAccessValidationError(code);
+  return new Date(parsed).toISOString();
+}
+
+function hashId(prefix: string, parts: readonly unknown[]): string {
+  const digest = crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 24);
+  return `${prefix}_${digest}`;
+}
+
+export function isDelegatedAccessRole(value: unknown): value is DelegatedAccessRole {
+  return DELEGATED_ACCESS_ROLES.includes(value as DelegatedAccessRole);
+}
+
+export function assertDelegatedAccessRole(value: unknown): DelegatedAccessRole {
+  if (!isDelegatedAccessRole(value)) throw new DelegatedAccessValidationError("invalid_delegated_role");
+  return value;
+}
+
+export function isDelegatedAccessInvitationStatus(value: unknown): value is DelegatedAccessInvitationStatus {
+  return DELEGATED_ACCESS_INVITATION_STATUSES.includes(value as DelegatedAccessInvitationStatus);
+}
+
+export function isDelegatedAccessGrantStatus(value: unknown): value is DelegatedAccessGrantStatus {
+  return DELEGATED_ACCESS_GRANT_STATUSES.includes(value as DelegatedAccessGrantStatus);
+}
+
+export function assertDelegatedWorkspaceScope(value: unknown): DelegatedAccessWorkspaceScope {
+  if (!DELEGATED_ACCESS_WORKSPACE_SCOPES.includes(value as DelegatedAccessWorkspaceScope)) {
+    throw new DelegatedAccessValidationError("invalid_workspace_scope");
+  }
+  return value as DelegatedAccessWorkspaceScope;
+}
+
+export function assertDelegatedPermissionAction(value: unknown): DelegatedAccessPermissionAction {
+  if (!DELEGATED_ACCESS_PERMISSION_ACTIONS.includes(value as DelegatedAccessPermissionAction)) {
+    throw new DelegatedAccessValidationError("invalid_permission_action");
+  }
+  return value as DelegatedAccessPermissionAction;
+}
+
+function dedupeStrings<T extends string>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function validateWorkspaceScopes(values: string[]): DelegatedAccessWorkspaceScope[] {
+  const scopes = dedupeStrings(values.map(assertDelegatedWorkspaceScope));
+  if (scopes.length === 0) throw new DelegatedAccessValidationError("missing_workspace_scope");
+  if (scopes.includes("settings_billing")) {
+    throw new DelegatedAccessValidationError("delegated_billing_scope_not_allowed");
+  }
+  return scopes;
+}
+
+function validatePermissionFlags(values: string[]): DelegatedAccessPermissionAction[] {
+  const flags = dedupeStrings(values.map(assertDelegatedPermissionAction));
+  if (flags.length === 0) throw new DelegatedAccessValidationError("missing_permission_flags");
+  if (flags.includes("billing_access") || flags.includes("revoke")) {
+    throw new DelegatedAccessValidationError("owner_only_permission_not_allowed");
+  }
+  return flags;
+}
+
+export function normalizeDelegatedPropertyScope(scope: DelegatedAccessPropertyScope): DelegatedAccessPropertyScope {
+  if (!DELEGATED_ACCESS_PROPERTY_SCOPE_MODES.includes(scope?.mode)) {
+    throw new DelegatedAccessValidationError("invalid_property_scope_mode");
+  }
+  const propertyIds = dedupeStrings((scope.propertyIds || []).map((id) => requireString(id, "invalid_property_scope")));
+  const unitIds = dedupeStrings((scope.unitIds || []).map((id) => requireString(id, "invalid_unit_scope")));
+  if (scope.mode === "selected" && propertyIds.length === 0) {
+    throw new DelegatedAccessValidationError("missing_selected_property_scope");
+  }
+  if ((scope.mode === "none" || scope.mode === "resource_only") && propertyIds.length > 0) {
+    throw new DelegatedAccessValidationError("property_scope_mode_mismatch");
+  }
+  return {
+    mode: scope.mode,
+    propertyIds,
+    ...(unitIds.length ? { unitIds } : {}),
+  };
+}
+
+function normalizeResourceScope(scope: DelegatedAccessResourceScope = {}): DelegatedAccessResourceScope {
+  const normalize = (values: string[] | undefined, code: string) =>
+    values?.map((value) => requireString(value, code)).filter(Boolean) || [];
+  return {
+    workOrderIds: dedupeStrings(normalize(scope.workOrderIds, "invalid_work_order_scope")),
+    maintenanceRequestIds: dedupeStrings(normalize(scope.maintenanceRequestIds, "invalid_maintenance_scope")),
+    messageThreadIds: dedupeStrings(normalize(scope.messageThreadIds, "invalid_message_scope")),
+    evidencePackageIds: dedupeStrings(normalize(scope.evidencePackageIds, "invalid_evidence_scope")),
+    exportPackageIds: dedupeStrings(normalize(scope.exportPackageIds, "invalid_export_scope")),
+    contractorJobIds: dedupeStrings(normalize(scope.contractorJobIds, "invalid_contractor_job_scope")),
+  };
+}
+
+export function buildDelegatedPermissionScope(input: {
+  role: string;
+  workspaceScopes: string[];
+  propertyScope: DelegatedAccessPropertyScope;
+  resourceScope?: DelegatedAccessResourceScope;
+  permissionFlags: string[];
+}): DelegatedAccessPermissionScope {
+  const role = assertDelegatedAccessRole(input.role);
+  const workspaceScopes = validateWorkspaceScopes(input.workspaceScopes);
+  const permissionFlags = validatePermissionFlags(input.permissionFlags);
+  return {
+    role,
+    workspaceScopes,
+    propertyScope: normalizeDelegatedPropertyScope(input.propertyScope),
+    resourceScope: normalizeResourceScope(input.resourceScope),
+    permissionFlags,
+    billingAccess: false,
+    exportAccess: permissionFlags.includes("export"),
+  };
+}
+
+export function createDelegatedAccessInvitation(input: InvitationInput): DelegatedAccessInvitation {
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const inviteeEmail = requireString(input.inviteeEmail, "missing_invitee_email").toLowerCase();
+  const createdByUserId = requireString(input.createdByUserId, "missing_created_by_user_id");
+  const tokenHash = requireString(input.tokenHash, "missing_token_hash");
+  const expiresAt = parseDate(input.expiresAt, "invalid_expires_at");
+  const createdAt = input.createdAt ? parseDate(input.createdAt, "invalid_created_at") : new Date().toISOString();
+  const permissionScope = buildDelegatedPermissionScope(input);
+  return {
+    invitationId:
+      input.invitationId ||
+      hashId("delegated_invitation", [landlordId, inviteeEmail, permissionScope.role, tokenHash, createdAt]),
+    landlordId,
+    inviteeEmail,
+    role: permissionScope.role,
+    propertyScope: permissionScope.propertyScope,
+    workspaceScopes: permissionScope.workspaceScopes,
+    resourceScope: permissionScope.resourceScope,
+    permissionFlags: permissionScope.permissionFlags,
+    status: "pending",
+    tokenHash,
+    expiresAt,
+    createdByUserId,
+    createdAt,
+    acceptedByUserId: null,
+    acceptedAt: null,
+    cancelledByUserId: null,
+    cancelledAt: null,
+    auditEventIds: [],
+  };
+}
+
+export function transitionDelegatedInvitationStatus(
+  invitation: DelegatedAccessInvitation,
+  nextStatus: DelegatedAccessInvitationStatus,
+  context: { actorUserId?: string | null; timestamp?: string; acceptedByUserId?: string | null } = {}
+): DelegatedAccessInvitation {
+  if (!isDelegatedAccessInvitationStatus(nextStatus)) {
+    throw new DelegatedAccessValidationError("invalid_invitation_status");
+  }
+  if (invitation.status !== "pending") {
+    throw new DelegatedAccessValidationError("invitation_not_pending");
+  }
+  const timestamp = context.timestamp ? parseDate(context.timestamp, "invalid_invitation_transition_timestamp") : new Date().toISOString();
+  if (nextStatus === "accepted") {
+    if (Date.parse(invitation.expiresAt) <= Date.parse(timestamp)) {
+      throw new DelegatedAccessValidationError("invitation_expired");
+    }
+    const acceptedByUserId = requireString(context.acceptedByUserId, "missing_accepted_by_user_id");
+    return { ...invitation, status: "accepted", acceptedByUserId, acceptedAt: timestamp };
+  }
+  if (nextStatus === "cancelled") {
+    const cancelledByUserId = requireString(context.actorUserId, "missing_cancelled_by_user_id");
+    return { ...invitation, status: "cancelled", cancelledByUserId, cancelledAt: timestamp };
+  }
+  if (nextStatus === "expired") {
+    return { ...invitation, status: "expired" };
+  }
+  return invitation;
+}
+
+export function isDelegatedInvitationExpired(invitation: DelegatedAccessInvitation, now: string | Date = new Date()): boolean {
+  const nowMs = typeof now === "string" ? Date.parse(now) : now.getTime();
+  return invitation.status === "pending" && Number.isFinite(nowMs) && Date.parse(invitation.expiresAt) <= nowMs;
+}
+
+export function createDelegatedAccessGrant(input: GrantInput): DelegatedAccessGrant {
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const delegateUserId = requireString(input.delegateUserId, "missing_delegate_user_id");
+  const createdByUserId = requireString(input.createdByUserId, "missing_created_by_user_id");
+  const createdAt = input.createdAt ? parseDate(input.createdAt, "invalid_created_at") : new Date().toISOString();
+  const permissionScope = buildDelegatedPermissionScope(input);
+  return {
+    grantId: input.grantId || hashId("delegated_grant", [landlordId, delegateUserId, permissionScope.role, createdAt]),
+    landlordId,
+    delegateUserId,
+    delegateEmail: input.delegateEmail ? cleanString(input.delegateEmail, 320).toLowerCase() : null,
+    role: permissionScope.role,
+    status: "active",
+    permissionScope,
+    createdByUserId,
+    createdAt,
+    acceptedAt: input.acceptedAt ? parseDate(input.acceptedAt, "invalid_accepted_at") : null,
+    updatedAt: createdAt,
+    revokedAt: null,
+    revokedByUserId: null,
+    revocationReason: null,
+    auditEventIds: [],
+  };
+}
+
+export function revokeDelegatedAccessGrant(
+  grant: DelegatedAccessGrant,
+  context: { revokedByUserId: string; revokedAt?: string; reason?: string | null }
+): DelegatedAccessGrant {
+  if (grant.status !== "active") throw new DelegatedAccessValidationError("grant_not_active");
+  const revokedByUserId = requireString(context.revokedByUserId, "missing_revoked_by_user_id");
+  const revokedAt = context.revokedAt ? parseDate(context.revokedAt, "invalid_revoked_at") : new Date().toISOString();
+  return {
+    ...grant,
+    status: "revoked",
+    revokedAt,
+    revokedByUserId,
+    revocationReason: context.reason ? cleanString(context.reason, 500) : null,
+    updatedAt: revokedAt,
+  };
+}

--- a/rentchain-api/src/lib/delegatedAccess/delegatedAccessTypes.ts
+++ b/rentchain-api/src/lib/delegatedAccess/delegatedAccessTypes.ts
@@ -1,0 +1,240 @@
+export const DELEGATED_ACCESS_ROLES = [
+  "property_manager",
+  "assistant_office_admin",
+  "maintenance_coordinator",
+  "contractor",
+  "contractor_admin",
+  "read_only_auditor",
+] as const;
+
+export type DelegatedAccessRole = (typeof DELEGATED_ACCESS_ROLES)[number];
+
+export const DELEGATED_ACCESS_INVITATION_STATUSES = ["pending", "accepted", "expired", "cancelled"] as const;
+
+export type DelegatedAccessInvitationStatus = (typeof DELEGATED_ACCESS_INVITATION_STATUSES)[number];
+
+export const DELEGATED_ACCESS_GRANT_STATUSES = ["active", "revoked", "suspended", "expired"] as const;
+
+export type DelegatedAccessGrantStatus = (typeof DELEGATED_ACCESS_GRANT_STATUSES)[number];
+
+export const DELEGATED_ACCESS_WORKSPACE_SCOPES = [
+  "dashboard",
+  "operations",
+  "properties",
+  "tenants",
+  "leases",
+  "payments",
+  "unified_inbox",
+  "scheduling",
+  "work_orders",
+  "evidence_exports",
+  "settings_billing",
+] as const;
+
+export type DelegatedAccessWorkspaceScope = (typeof DELEGATED_ACCESS_WORKSPACE_SCOPES)[number];
+
+export const DELEGATED_ACCESS_PERMISSION_ACTIONS = [
+  "view",
+  "create",
+  "edit",
+  "approve",
+  "export",
+  "assign",
+  "message",
+  "revoke",
+  "billing_access",
+] as const;
+
+export type DelegatedAccessPermissionAction = (typeof DELEGATED_ACCESS_PERMISSION_ACTIONS)[number];
+
+export const DELEGATED_ACCESS_PROPERTY_SCOPE_MODES = [
+  "all_current_properties",
+  "selected",
+  "resource_only",
+  "none",
+] as const;
+
+export type DelegatedAccessPropertyScopeMode = (typeof DELEGATED_ACCESS_PROPERTY_SCOPE_MODES)[number];
+
+export const DELEGATED_ACCESS_TARGET_RESOURCE_TYPES = [
+  "landlord_workspace",
+  "dashboard",
+  "operation",
+  "property",
+  "unit",
+  "tenant",
+  "lease",
+  "payment",
+  "message_thread",
+  "inbox_record",
+  "schedule_item",
+  "schedule_note",
+  "maintenance_request",
+  "work_order",
+  "contractor_job",
+  "screening_activity",
+  "evidence_item",
+  "export_package",
+  "delegate_invitation",
+  "delegate_grant",
+  "billing_settings",
+] as const;
+
+export type DelegatedAccessTargetResourceType = (typeof DELEGATED_ACCESS_TARGET_RESOURCE_TYPES)[number];
+
+export const DELEGATED_ACCESS_AUDIT_EVENT_TYPES = [
+  "delegated_invite_created",
+  "delegated_invite_sent",
+  "delegated_invite_accepted",
+  "delegated_invite_expired",
+  "delegated_invite_cancelled",
+  "delegated_role_changed",
+  "delegated_scope_changed",
+  "delegated_access_revoked",
+  "delegated_session_invalidated",
+  "delegated_workspace_opened",
+  "delegated_resource_viewed",
+  "delegated_message_sent",
+  "delegated_operation_assigned",
+  "delegated_work_order_updated",
+  "delegated_schedule_updated",
+  "delegated_payment_viewed",
+  "delegated_payment_action_attempted",
+  "delegated_evidence_uploaded",
+  "delegated_export_generated",
+  "delegated_access_denied",
+] as const;
+
+export type DelegatedAccessAuditEventType = (typeof DELEGATED_ACCESS_AUDIT_EVENT_TYPES)[number];
+
+export type DelegatedAccessPropertyScope = {
+  mode: DelegatedAccessPropertyScopeMode;
+  propertyIds: string[];
+  unitIds?: string[];
+};
+
+export type DelegatedAccessResourceScope = {
+  workOrderIds?: string[];
+  maintenanceRequestIds?: string[];
+  messageThreadIds?: string[];
+  evidencePackageIds?: string[];
+  exportPackageIds?: string[];
+  contractorJobIds?: string[];
+};
+
+export type DelegatedAccessPermissionScope = {
+  role: DelegatedAccessRole;
+  workspaceScopes: DelegatedAccessWorkspaceScope[];
+  propertyScope: DelegatedAccessPropertyScope;
+  resourceScope: DelegatedAccessResourceScope;
+  permissionFlags: DelegatedAccessPermissionAction[];
+  billingAccess: false;
+  exportAccess: boolean;
+};
+
+export type DelegatedAccessInvitation = {
+  invitationId: string;
+  landlordId: string;
+  inviteeEmail: string;
+  role: DelegatedAccessRole;
+  propertyScope: DelegatedAccessPropertyScope;
+  workspaceScopes: DelegatedAccessWorkspaceScope[];
+  resourceScope: DelegatedAccessResourceScope;
+  permissionFlags: DelegatedAccessPermissionAction[];
+  status: DelegatedAccessInvitationStatus;
+  tokenHash: string;
+  expiresAt: string;
+  createdByUserId: string;
+  createdAt: string;
+  acceptedByUserId: string | null;
+  acceptedAt: string | null;
+  cancelledByUserId: string | null;
+  cancelledAt: string | null;
+  auditEventIds: string[];
+};
+
+export type DelegatedAccessGrant = {
+  grantId: string;
+  landlordId: string;
+  delegateUserId: string;
+  delegateEmail: string | null;
+  role: DelegatedAccessRole;
+  status: DelegatedAccessGrantStatus;
+  permissionScope: DelegatedAccessPermissionScope;
+  createdByUserId: string;
+  createdAt: string;
+  acceptedAt: string | null;
+  updatedAt: string;
+  revokedAt: string | null;
+  revokedByUserId: string | null;
+  revocationReason: string | null;
+  auditEventIds: string[];
+};
+
+export type DelegatedAccessActorContext = {
+  actorUserId: string | null;
+  actingForLandlordId: string | null;
+  isLandlordOwner: boolean;
+};
+
+export type DelegatedAccessEvaluationRequest = DelegatedAccessActorContext & {
+  routeWorkspace: DelegatedAccessWorkspaceScope;
+  action: DelegatedAccessPermissionAction;
+  targetResourceType: DelegatedAccessTargetResourceType;
+  targetResourceId?: string | null;
+  propertyId?: string | null;
+  resourceId?: string | null;
+  grant?: DelegatedAccessGrant | null;
+  explicitDenyReasons?: string[];
+};
+
+export type DelegatedAccessDecisionReason =
+  | "allowed_owner"
+  | "allowed_delegate"
+  | "missing_actor"
+  | "missing_landlord_scope"
+  | "explicit_deny"
+  | "missing_delegate_grant"
+  | "grant_not_active"
+  | "grant_landlord_mismatch"
+  | "workspace_scope_denied"
+  | "property_scope_denied"
+  | "resource_scope_denied"
+  | "permission_flag_denied"
+  | "owner_only_action";
+
+export type DelegatedAccessEvaluationDecision = {
+  allowed: boolean;
+  relationship: "owner" | "delegate" | "none";
+  reason: DelegatedAccessDecisionReason;
+  actorUserId: string | null;
+  actingForLandlordId: string | null;
+  delegatedRole: DelegatedAccessRole | null;
+  permissionScope: DelegatedAccessPermissionScope | null;
+  auditRequired: boolean;
+};
+
+export type DelegatedAccessAuditOutcome = "allowed" | "denied" | "revoked" | "expired" | "failed" | "blocked";
+
+export type DelegatedAccessAuditEvent = {
+  eventId: string;
+  eventType: DelegatedAccessAuditEventType;
+  actorUserId: string;
+  actingForLandlordId: string;
+  delegatedRole: DelegatedAccessRole | "landlord_owner" | null;
+  permissionScope: DelegatedAccessPermissionScope | null;
+  sessionId: string | null;
+  actionType: string;
+  targetResourceType: DelegatedAccessTargetResourceType;
+  targetResourceId: string | null;
+  timestamp: string;
+  ipAddress: string | null;
+  deviceMetadata: Record<string, string> | null;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  outcome: DelegatedAccessAuditOutcome;
+  reason: string | null;
+  metadataOnly: true;
+  appendOnly: true;
+  immutable: true;
+};

--- a/rentchain-api/src/lib/delegatedAccess/index.ts
+++ b/rentchain-api/src/lib/delegatedAccess/index.ts
@@ -1,0 +1,4 @@
+export * from "./delegatedAccessAudit";
+export * from "./delegatedAccessModel";
+export * from "./delegatedAccessTypes";
+export * from "./permissionEvaluation";

--- a/rentchain-api/src/lib/delegatedAccess/permissionEvaluation.ts
+++ b/rentchain-api/src/lib/delegatedAccess/permissionEvaluation.ts
@@ -1,0 +1,111 @@
+import type {
+  DelegatedAccessDecisionReason,
+  DelegatedAccessEvaluationDecision,
+  DelegatedAccessEvaluationRequest,
+  DelegatedAccessGrant,
+  DelegatedAccessPermissionScope,
+} from "./delegatedAccessTypes";
+
+function denied(
+  request: DelegatedAccessEvaluationRequest,
+  reason: DelegatedAccessDecisionReason,
+  grant?: DelegatedAccessGrant | null
+): DelegatedAccessEvaluationDecision {
+  return {
+    allowed: false,
+    relationship: grant ? "delegate" : "none",
+    reason,
+    actorUserId: request.actorUserId || null,
+    actingForLandlordId: request.actingForLandlordId || null,
+    delegatedRole: grant?.role || null,
+    permissionScope: grant?.permissionScope || null,
+    auditRequired: true,
+  };
+}
+
+function allowedOwner(request: DelegatedAccessEvaluationRequest): DelegatedAccessEvaluationDecision {
+  return {
+    allowed: true,
+    relationship: "owner",
+    reason: "allowed_owner",
+    actorUserId: request.actorUserId || null,
+    actingForLandlordId: request.actingForLandlordId || null,
+    delegatedRole: null,
+    permissionScope: null,
+    auditRequired: false,
+  };
+}
+
+function allowedDelegate(
+  request: DelegatedAccessEvaluationRequest,
+  permissionScope: DelegatedAccessPermissionScope
+): DelegatedAccessEvaluationDecision {
+  return {
+    allowed: true,
+    relationship: "delegate",
+    reason: "allowed_delegate",
+    actorUserId: request.actorUserId || null,
+    actingForLandlordId: request.actingForLandlordId || null,
+    delegatedRole: permissionScope.role,
+    permissionScope,
+    auditRequired: request.action !== "view" || request.routeWorkspace === "payments" || request.routeWorkspace === "evidence_exports",
+  };
+}
+
+function resourceScopeValues(scope: DelegatedAccessPermissionScope): string[] {
+  return [
+    ...(scope.resourceScope.workOrderIds || []),
+    ...(scope.resourceScope.maintenanceRequestIds || []),
+    ...(scope.resourceScope.messageThreadIds || []),
+    ...(scope.resourceScope.evidencePackageIds || []),
+    ...(scope.resourceScope.exportPackageIds || []),
+    ...(scope.resourceScope.contractorJobIds || []),
+  ];
+}
+
+function hasPropertyAccess(scope: DelegatedAccessPermissionScope, propertyId?: string | null): boolean {
+  if (scope.propertyScope.mode === "all_current_properties") return true;
+  if (scope.propertyScope.mode === "none") return !propertyId;
+  if (scope.propertyScope.mode === "resource_only") return !propertyId;
+  if (!propertyId) return false;
+  return scope.propertyScope.propertyIds.includes(propertyId);
+}
+
+function hasResourceAccess(scope: DelegatedAccessPermissionScope, resourceId?: string | null): boolean {
+  if (!resourceId) return true;
+  return resourceScopeValues(scope).includes(resourceId);
+}
+
+function isOwnerOnlyAction(request: DelegatedAccessEvaluationRequest): boolean {
+  return (
+    request.action === "billing_access" ||
+    request.action === "revoke" ||
+    request.routeWorkspace === "settings_billing" ||
+    request.targetResourceType === "billing_settings"
+  );
+}
+
+export function evaluateDelegatedAccessPermission(
+  request: DelegatedAccessEvaluationRequest
+): DelegatedAccessEvaluationDecision {
+  if (!request.actorUserId) return denied(request, "missing_actor");
+  if (!request.actingForLandlordId) return denied(request, "missing_landlord_scope");
+  if (request.explicitDenyReasons?.length) return denied(request, "explicit_deny", request.grant);
+  if (request.isLandlordOwner) return allowedOwner(request);
+
+  const grant = request.grant;
+  if (!grant) return denied(request, "missing_delegate_grant");
+  if (grant.status !== "active") return denied(request, "grant_not_active", grant);
+  if (grant.landlordId !== request.actingForLandlordId) return denied(request, "grant_landlord_mismatch", grant);
+  if (isOwnerOnlyAction(request)) return denied(request, "owner_only_action", grant);
+
+  const scope = grant.permissionScope;
+  if (!scope.workspaceScopes.includes(request.routeWorkspace)) return denied(request, "workspace_scope_denied", grant);
+  if (!hasPropertyAccess(scope, request.propertyId)) return denied(request, "property_scope_denied", grant);
+  if (!hasResourceAccess(scope, request.resourceId)) {
+    return denied(request, "resource_scope_denied", grant);
+  }
+  if (!scope.permissionFlags.includes(request.action)) return denied(request, "permission_flag_denied", grant);
+
+  return allowedDelegate(request, scope);
+}


### PR DESCRIPTION
## Summary

Adds backend-only delegated access foundations from the accepted governance and implementation design package.

Included foundation surfaces:
- predefined delegated roles, statuses, workspace scopes, permission actions, target resource types, and audit event vocabulary
- delegate invitation record builder with pending/accepted/expired/cancelled lifecycle support
- delegate grant/role assignment builder with revocation support
- fail-closed permission evaluator with owner override, explicit deny, workspace/property/resource/action checks, and owner-only billing/settings enforcement
- immutable metadata-only delegated audit event builder preserving actor and landlord attribution
- focused unit tests for model validation, invitation lifecycle, permission evaluation, owner override, fail-closed behavior, and audit event structure

## Scope Controls

Backend foundations only.

No UI, no backend routes, no Firestore writes/migrations, no security rules, no invitation emails, no invite acceptance flow, no billing delegation, no property manager company hierarchy, no contractor organizations, and no scheduling integration.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20 && npm --prefix rentchain-api run test:single -- src/lib/delegatedAccess` — 11 passed
- `source ~/.nvm/nvm.sh && nvm use 20 && npm --prefix rentchain-api run build`
- `git diff --check`

## Notes

The build/test commands require Node 20.x. A direct run under Node 25 correctly failed the repo preflight, then passed after switching to Node 20.20.2.