### PR TITLE
feat: add delegated access invitation api

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -159,6 +159,7 @@ import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScore
 import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordDecisionQueueRoutes from "./routes/landlordDecisionQueueRoutes";
+import delegatedAccessInvitationRoutes from "./routes/delegatedAccessInvitationRoutes";
 import landlordInstitutionalExportGenerationRoutes from "./routes/landlordInstitutionalExportGenerationRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
@@ -515,6 +516,8 @@ app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlord
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordDecisionQueueRoutes.ts"), landlordDecisionQueueRoutes);
 console.log("[route-mount] landlordDecisionQueueRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), delegatedAccessInvitationRoutes);
+console.log("[route-mount] delegatedAccessInvitationRoutes mounted at /api/landlord");
 app.use("/api/landlord/institutional-exports", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordInstitutionalExportGenerationRoutes.ts"), landlordInstitutionalExportGenerationRoutes);
 console.log("[route-mount] landlordInstitutionalExportGenerationRoutes mounted at /api/landlord");

--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = Record<string, any>;
+
+const collections = vi.hoisted(() => new Map<string, Map<string, StoredDoc>>());
+const generatedIds = vi.hoisted(() => ({ value: 0 }));
+const fakeDb = vi.hoisted(() => ({
+  collection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    const collection = collections.get(name)!;
+    return {
+      doc(id?: string) {
+        const docId = id || `test_doc_${++generatedIds.value}`;
+        return {
+          id: docId,
+          async get() {
+            return {
+              id: docId,
+              exists: collection.has(docId),
+              data: () => collection.get(docId),
+            };
+          },
+          async set(data: StoredDoc) {
+            collection.set(docId, data);
+          },
+          async create(data: StoredDoc) {
+            if (collection.has(docId)) throw new Error("already_exists");
+            collection.set(docId, data);
+          },
+        };
+      },
+      async get() {
+        return {
+          docs: Array.from(collection.entries()).map(([id, data]) => ({
+            id,
+            exists: true,
+            data: () => data,
+          })),
+        };
+      },
+    };
+  },
+}));
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+function readCollection(name: string): StoredDoc[] {
+  return Array.from((collections.get(name) || new Map()).values());
+}
+
+function writeCollectionDoc(name: string, id: string, data: StoredDoc) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  collections.get(name)!.set(id, data);
+}
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: Record<string, unknown> }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+const ownerUser = { id: "owner-user-1", role: "landlord", landlordId: "landlord-1" };
+
+const validInviteBody = {
+  inviteeEmail: "manager@example.com",
+  role: "property_manager",
+  propertyScope: { mode: "selected", propertyIds: ["property-1"] },
+  workspaceScopes: ["dashboard", "operations", "properties"],
+  permissionFlags: ["view", "edit", "assign"],
+  expiresAt: "2026-07-22T12:00:00.000Z",
+};
+
+async function createInvite(router: any, body: Record<string, unknown> = {}, user = ownerUser) {
+  return await invokeRouter(router, {
+    method: "POST",
+    url: "/delegated-access/invitations",
+    user,
+    body: { ...validInviteBody, ...body },
+  });
+}
+
+describe("delegatedAccessInvitationRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+    generatedIds.value = 0;
+    vi.clearAllMocks();
+  });
+
+  it("allows a landlord owner to create a scoped pending invitation with an audit event", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+
+    const response = await createInvite(router, { landlordId: "other-landlord" });
+
+    expect(response.status).toBe(201);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.invitation).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        inviteeEmail: "manager@example.com",
+        role: "property_manager",
+        status: "pending",
+        workspaceScopes: ["dashboard", "operations", "properties"],
+      })
+    );
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+
+    const invitations = readCollection("delegatedAccessInvitations");
+    expect(invitations).toHaveLength(1);
+    expect(invitations[0]).toEqual(expect.objectContaining({ tokenHash: expect.any(String) }));
+    expect(invitations[0].landlordId).toBe("landlord-1");
+
+    const auditEvents = readCollection("delegatedAccessAuditEvents");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toEqual(
+      expect.objectContaining({
+        eventType: "delegated_invite_created",
+        actorUserId: "owner-user-1",
+        actingForLandlordId: "landlord-1",
+        targetResourceType: "delegate_invitation",
+        metadataOnly: true,
+        immutable: true,
+      })
+    );
+    expect(auditEvents[0].after).not.toHaveProperty("tokenHash");
+    expect(auditEvents.map((event) => event.eventType)).not.toContain("delegated_invite_sent");
+  });
+
+  it("rejects non-owner invitation creation", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+
+    const response = await createInvite(router, {}, { id: "tenant-1", role: "tenant", landlordId: "landlord-1" });
+
+    expect(response.status).toBe(403);
+    expect(readCollection("delegatedAccessInvitations")).toHaveLength(0);
+  });
+
+  it("rejects invalid roles and invalid scopes", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+
+    const invalidRole = await createInvite(router, { role: "owner" });
+    expect(invalidRole.status).toBe(400);
+    expect(invalidRole.body.error).toBe("INVALID_DELEGATED_ROLE");
+
+    const invalidScope = await createInvite(router, { propertyScope: { mode: "selected", propertyIds: [] } });
+    expect(invalidScope.status).toBe(400);
+    expect(invalidScope.body.error).toBe("MISSING_SELECTED_PROPERTY_SCOPE");
+
+    const ownerOnlyScope = await createInvite(router, { workspaceScopes: ["settings_billing"] });
+    expect(ownerOnlyScope.status).toBe(400);
+    expect(ownerOnlyScope.body.error).toBe("DELEGATED_BILLING_SCOPE_NOT_ALLOWED");
+  });
+
+  it("lists only invitations for the authenticated landlord and ignores query landlord scope", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    await createInvite(router, { inviteeEmail: "manager-1@example.com" }, ownerUser);
+    await createInvite(
+      router,
+      { inviteeEmail: "manager-2@example.com" },
+      { id: "owner-user-2", role: "landlord", landlordId: "landlord-2" }
+    );
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/delegated-access/invitations?landlordId=landlord-2",
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.invitations).toHaveLength(1);
+    expect(response.body.invitations[0]).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        inviteeEmail: "manager-1@example.com",
+      })
+    );
+  });
+
+  it("cancels pending invitations and records a metadata-only audit event", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const created = await createInvite(router);
+    const invitationId = created.body.invitation.invitationId;
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${invitationId}/cancel`,
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.invitation.status).toBe("cancelled");
+    expect(response.body.invitation.cancelledByUserId).toBe("owner-user-1");
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+
+    const auditEvents = readCollection("delegatedAccessAuditEvents");
+    expect(auditEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["delegated_invite_created", "delegated_invite_cancelled"])
+    );
+    expect(auditEvents.find((event) => event.eventType === "delegated_invite_cancelled")).toEqual(
+      expect.objectContaining({
+        actionType: "invite_cancelled",
+        outcome: "allowed",
+        metadataOnly: true,
+      })
+    );
+  });
+
+  it("does not allow cancelling accepted or expired invitations", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const accepted = await createInvite(router, { inviteeEmail: "accepted@example.com" });
+    const acceptedInvitation = readCollection("delegatedAccessInvitations")[0];
+    writeCollectionDoc("delegatedAccessInvitations", accepted.body.invitation.invitationId, {
+      ...acceptedInvitation,
+      status: "accepted",
+      acceptedByUserId: "delegate-user-1",
+      acceptedAt: "2026-06-25T12:00:00.000Z",
+    });
+
+    const acceptedCancel = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${accepted.body.invitation.invitationId}/cancel`,
+      user: ownerUser,
+    });
+    expect(acceptedCancel.status).toBe(409);
+
+    const expired = await createInvite(router, {
+      inviteeEmail: "expired@example.com",
+      expiresAt: "2026-06-01T12:00:00.000Z",
+    });
+    const expireResponse = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${expired.body.invitation.invitationId}/expire`,
+      user: ownerUser,
+      body: { now: "2026-06-22T12:00:00.000Z" },
+    });
+    expect(expireResponse.status).toBe(200);
+    expect(expireResponse.body.changed).toBe(true);
+
+    const expiredCancel = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${expired.body.invitation.invitationId}/cancel`,
+      user: ownerUser,
+    });
+    expect(expiredCancel.status).toBe(409);
+  });
+
+  it("expires stale pending invitations and leaves non-expired invitations unchanged", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const stale = await createInvite(router, { expiresAt: "2026-06-01T12:00:00.000Z" });
+    const current = await createInvite(router, {
+      inviteeEmail: "current@example.com",
+      expiresAt: "2026-08-01T12:00:00.000Z",
+    });
+
+    const staleResponse = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${stale.body.invitation.invitationId}/expire`,
+      user: ownerUser,
+      body: { now: "2026-06-22T12:00:00.000Z" },
+    });
+    expect(staleResponse.status).toBe(200);
+    expect(staleResponse.body.changed).toBe(true);
+    expect(staleResponse.body.invitation.status).toBe("expired");
+
+    const currentResponse = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${current.body.invitation.invitationId}/expire`,
+      user: ownerUser,
+      body: { now: "2026-06-22T12:00:00.000Z" },
+    });
+    expect(currentResponse.status).toBe(200);
+    expect(currentResponse.body.changed).toBe(false);
+    expect(currentResponse.body.invitation.status).toBe("pending");
+
+    const auditEvents = readCollection("delegatedAccessAuditEvents");
+    expect(auditEvents.map((event) => event.eventType)).toContain("delegated_invite_expired");
+  });
+
+  it("denies cross-landlord cancellation attempts", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const created = await createInvite(router, {}, ownerUser);
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${created.body.invitation.invitationId}/cancel`,
+      user: { id: "owner-user-2", role: "landlord", landlordId: "landlord-2" },
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
+++ b/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
@@ -1,0 +1,115 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import {
+  cancelDelegatedAccessInvitationRecord,
+  createDelegatedAccessInvitationRecord,
+  expireDelegatedAccessInvitationRecord,
+  listDelegatedAccessInvitationRecords,
+} from "../services/delegatedAccessInvitationService";
+
+const router = Router();
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function ownerContext(req: any): { actorUserId: string; landlordId: string } | null {
+  const role = asString(req.user?.role, 80).toLowerCase();
+  if (role !== "landlord") return null;
+  const actorUserId = asString(req.user?.id || req.user?.uid || req.user?.sub, 240);
+  const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+  if (!actorUserId || !landlordId) return null;
+  return { actorUserId, landlordId };
+}
+
+function forbidden(res: any) {
+  return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+}
+
+function handleError(res: any, error: unknown) {
+  const code = error instanceof Error ? error.message : "delegated_access_invitation_failed";
+  if (code === "delegated_invitation_not_found") {
+    return res.status(404).json({ ok: false, error: "INVITATION_NOT_FOUND" });
+  }
+  if (code === "invitation_not_pending") {
+    return res.status(409).json({ ok: false, error: "INVITATION_NOT_PENDING" });
+  }
+  if (code.startsWith("invalid_") || code.startsWith("missing_") || code.includes("_not_allowed")) {
+    return res.status(400).json({ ok: false, error: code.toUpperCase() });
+  }
+  console.error("[delegated-access-invitations] request failed", code);
+  return res.status(500).json({ ok: false, error: "DELEGATED_ACCESS_INVITATION_FAILED" });
+}
+
+router.use(requireAuth);
+
+router.post("/delegated-access/invitations", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await createDelegatedAccessInvitationRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      inviteeEmail: req.body?.inviteeEmail,
+      role: req.body?.role,
+      propertyScope: req.body?.propertyScope,
+      workspaceScopes: Array.isArray(req.body?.workspaceScopes) ? req.body.workspaceScopes : [],
+      resourceScope: req.body?.resourceScope,
+      permissionFlags: Array.isArray(req.body?.permissionFlags) ? req.body.permissionFlags : [],
+      expiresAt: req.body?.expiresAt,
+    });
+    return res.status(201).json({ ok: true, invitation: result.invitation });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.get("/delegated-access/invitations", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listDelegatedAccessInvitationRecords({
+      landlordId: context.landlordId,
+    });
+    return res.status(200).json({ ok: true, invitations: result.invitations });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/delegated-access/invitations/:invitationId/cancel", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await cancelDelegatedAccessInvitationRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      invitationId: req.params.invitationId,
+    });
+    return res.status(200).json({ ok: true, invitation: result.invitation });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/delegated-access/invitations/:invitationId/expire", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await expireDelegatedAccessInvitationRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      invitationId: req.params.invitationId,
+      now: req.body?.now,
+    });
+    return res.status(200).json({ ok: true, changed: result.changed, invitation: result.invitation });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/delegatedAccessInvitationService.ts
+++ b/rentchain-api/src/services/delegatedAccessInvitationService.ts
@@ -1,0 +1,272 @@
+import crypto from "crypto";
+import { db } from "../firebase";
+import {
+  buildDelegatedAccessAuditEvent,
+  createDelegatedAccessInvitation,
+  isDelegatedInvitationExpired,
+  transitionDelegatedInvitationStatus,
+  type DelegatedAccessAuditEvent,
+  type DelegatedAccessInvitation,
+  type DelegatedAccessInvitationStatus,
+  type DelegatedAccessPropertyScope,
+  type DelegatedAccessResourceScope,
+} from "../lib/delegatedAccess";
+
+export const DELEGATED_ACCESS_INVITATIONS_COLLECTION = "delegatedAccessInvitations";
+export const DELEGATED_ACCESS_AUDIT_EVENTS_COLLECTION = "delegatedAccessAuditEvents";
+
+type SnapshotLike = {
+  id?: string;
+  exists?: boolean;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type DocumentRefLike<T> = {
+  id?: string;
+  get?: () => Promise<SnapshotLike>;
+  set?: (data: T, options?: { merge?: boolean }) => Promise<unknown>;
+  create?: (data: T) => Promise<unknown>;
+};
+
+type CollectionLike<T> = {
+  doc: (id?: string) => DocumentRefLike<T>;
+  get?: () => Promise<{ docs: SnapshotLike[] }>;
+};
+
+export type DelegatedAccessFirestoreLike = {
+  collection: <T = Record<string, unknown>>(name: string) => CollectionLike<T>;
+};
+
+export type DelegatedInvitationProjection = Omit<DelegatedAccessInvitation, "tokenHash">;
+
+type CreateInvitationInput = {
+  landlordId: string;
+  actorUserId: string;
+  inviteeEmail: string;
+  role: string;
+  propertyScope: DelegatedAccessPropertyScope;
+  workspaceScopes: string[];
+  resourceScope?: DelegatedAccessResourceScope;
+  permissionFlags: string[];
+  expiresAt: string;
+  now?: string;
+};
+
+type ServiceOptions = {
+  firestore?: DelegatedAccessFirestoreLike;
+};
+
+function delegatedDb(firestore?: DelegatedAccessFirestoreLike): DelegatedAccessFirestoreLike {
+  return firestore || (db as unknown as DelegatedAccessFirestoreLike);
+}
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new Error(code);
+  return text;
+}
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function createTokenHash(): string {
+  return sha256(crypto.randomBytes(32).toString("hex"));
+}
+
+function projectInvitation(invitation: DelegatedAccessInvitation): DelegatedInvitationProjection {
+  const { tokenHash: _tokenHash, ...safe } = invitation;
+  return safe;
+}
+
+function invitationFromSnapshot(snapshot: SnapshotLike): DelegatedAccessInvitation | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as DelegatedAccessInvitation;
+}
+
+async function appendAuditEvent(event: DelegatedAccessAuditEvent, firestore: DelegatedAccessFirestoreLike) {
+  const ref = firestore.collection<DelegatedAccessAuditEvent>(DELEGATED_ACCESS_AUDIT_EVENTS_COLLECTION).doc(event.eventId);
+  if (ref.create) {
+    await ref.create(event);
+    return;
+  }
+  if (!ref.set) throw new Error("delegated_access_audit_append_unavailable");
+  await ref.set(event, { merge: false });
+}
+
+async function saveInvitation(invitation: DelegatedAccessInvitation, firestore: DelegatedAccessFirestoreLike) {
+  const ref = firestore
+    .collection<DelegatedAccessInvitation>(DELEGATED_ACCESS_INVITATIONS_COLLECTION)
+    .doc(invitation.invitationId);
+  if (!ref.set) throw new Error("delegated_access_invitation_write_unavailable");
+  await ref.set(invitation, { merge: false });
+}
+
+export async function createDelegatedAccessInvitationRecord(
+  input: CreateInvitationInput,
+  options: ServiceOptions = {}
+): Promise<{ invitation: DelegatedInvitationProjection; auditEvent: DelegatedAccessAuditEvent }> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const now = input.now || new Date().toISOString();
+  const invitation = createDelegatedAccessInvitation({
+    landlordId,
+    inviteeEmail: input.inviteeEmail,
+    role: input.role,
+    propertyScope: input.propertyScope,
+    workspaceScopes: input.workspaceScopes,
+    resourceScope: input.resourceScope,
+    permissionFlags: input.permissionFlags,
+    tokenHash: createTokenHash(),
+    expiresAt: input.expiresAt,
+    createdByUserId: actorUserId,
+    createdAt: now,
+  });
+  const auditEvent = buildDelegatedAccessAuditEvent({
+    eventType: "delegated_invite_created",
+    actorUserId,
+    actingForLandlordId: landlordId,
+    delegatedRole: "landlord_owner",
+    permissionScope: {
+      role: invitation.role,
+      workspaceScopes: invitation.workspaceScopes,
+      propertyScope: invitation.propertyScope,
+      resourceScope: invitation.resourceScope,
+      permissionFlags: invitation.permissionFlags,
+      billingAccess: false,
+      exportAccess: invitation.permissionFlags.includes("export"),
+    },
+    actionType: "invite_created",
+    targetResourceType: "delegate_invitation",
+    targetResourceId: invitation.invitationId,
+    timestamp: now,
+    outcome: "allowed",
+    after: {
+      status: invitation.status,
+      role: invitation.role,
+      workspaceScopes: invitation.workspaceScopes,
+      propertyScopeMode: invitation.propertyScope.mode,
+      expiresAt: invitation.expiresAt,
+    },
+  });
+  const withAudit: DelegatedAccessInvitation = {
+    ...invitation,
+    auditEventIds: [auditEvent.eventId],
+  };
+  await saveInvitation(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { invitation: projectInvitation(withAudit), auditEvent };
+}
+
+export async function listDelegatedAccessInvitationRecords(
+  input: { landlordId: string; now?: string },
+  options: ServiceOptions = {}
+): Promise<{ invitations: DelegatedInvitationProjection[]; expiredInvitationIds: string[] }> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const snapshot = await firestore.collection<DelegatedAccessInvitation>(DELEGATED_ACCESS_INVITATIONS_COLLECTION).get?.();
+  const invitations = (snapshot?.docs || [])
+    .map(invitationFromSnapshot)
+    .filter((invitation): invitation is DelegatedAccessInvitation => Boolean(invitation))
+    .filter((invitation) => invitation.landlordId === landlordId)
+    .map((invitation) => {
+      if (isDelegatedInvitationExpired(invitation, input.now || new Date())) {
+        return { ...invitation, status: "expired" as DelegatedAccessInvitationStatus };
+      }
+      return invitation;
+    })
+    .sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)));
+  return {
+    invitations: invitations.map(projectInvitation),
+    expiredInvitationIds: invitations.filter((invitation) => invitation.status === "expired").map((i) => i.invitationId),
+  };
+}
+
+async function loadInvitationForLandlord(
+  landlordId: string,
+  invitationId: string,
+  firestore: DelegatedAccessFirestoreLike
+): Promise<DelegatedAccessInvitation | null> {
+  const ref = firestore.collection<DelegatedAccessInvitation>(DELEGATED_ACCESS_INVITATIONS_COLLECTION).doc(invitationId);
+  const snapshot = await ref.get?.();
+  if (!snapshot?.exists) return null;
+  const invitation = invitationFromSnapshot(snapshot);
+  if (!invitation || invitation.landlordId !== landlordId) return null;
+  return invitation;
+}
+
+export async function cancelDelegatedAccessInvitationRecord(
+  input: { landlordId: string; actorUserId: string; invitationId: string; now?: string },
+  options: ServiceOptions = {}
+): Promise<{ invitation: DelegatedInvitationProjection; auditEvent: DelegatedAccessAuditEvent }> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const invitationId = requireString(input.invitationId, "missing_invitation_id");
+  const invitation = await loadInvitationForLandlord(landlordId, invitationId, firestore);
+  if (!invitation) throw new Error("delegated_invitation_not_found");
+  const now = input.now || new Date().toISOString();
+  const cancelled = transitionDelegatedInvitationStatus(invitation, "cancelled", {
+    actorUserId,
+    timestamp: now,
+  });
+  const auditEvent = buildDelegatedAccessAuditEvent({
+    eventType: "delegated_invite_cancelled",
+    actorUserId,
+    actingForLandlordId: landlordId,
+    delegatedRole: "landlord_owner",
+    permissionScope: null,
+    actionType: "invite_cancelled",
+    targetResourceType: "delegate_invitation",
+    targetResourceId: cancelled.invitationId,
+    timestamp: now,
+    outcome: "allowed",
+    before: { status: invitation.status },
+    after: { status: cancelled.status },
+  });
+  const withAudit = { ...cancelled, auditEventIds: [...cancelled.auditEventIds, auditEvent.eventId] };
+  await saveInvitation(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { invitation: projectInvitation(withAudit), auditEvent };
+}
+
+export async function expireDelegatedAccessInvitationRecord(
+  input: { landlordId: string; actorUserId: string; invitationId: string; now?: string },
+  options: ServiceOptions = {}
+): Promise<{ invitation: DelegatedInvitationProjection; auditEvent: DelegatedAccessAuditEvent | null; changed: boolean }> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const invitationId = requireString(input.invitationId, "missing_invitation_id");
+  const invitation = await loadInvitationForLandlord(landlordId, invitationId, firestore);
+  if (!invitation) throw new Error("delegated_invitation_not_found");
+  const now = input.now || new Date().toISOString();
+  if (!isDelegatedInvitationExpired(invitation, now)) {
+    return { invitation: projectInvitation(invitation), auditEvent: null, changed: false };
+  }
+  const expired = transitionDelegatedInvitationStatus(invitation, "expired", { timestamp: now });
+  const auditEvent = buildDelegatedAccessAuditEvent({
+    eventType: "delegated_invite_expired",
+    actorUserId,
+    actingForLandlordId: landlordId,
+    delegatedRole: "landlord_owner",
+    permissionScope: null,
+    actionType: "invite_expired",
+    targetResourceType: "delegate_invitation",
+    targetResourceId: expired.invitationId,
+    timestamp: now,
+    outcome: "expired",
+    before: { status: invitation.status },
+    after: { status: expired.status },
+  });
+  const withAudit = { ...expired, auditEventIds: [...expired.auditEventIds, auditEvent.eventId] };
+  await saveInvitation(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { invitation: projectInvitation(withAudit), auditEvent, changed: true };
+}


### PR DESCRIPTION
## Summary
- add owner-only delegated access invitation API routes under /api/landlord/delegated-access/invitations
- add invitation create/list/cancel/expire service behavior on top of the delegated access foundation model
- add metadata-only audit event creation for invitation create/cancel/expire lifecycle changes

## Security / Scope
- landlord scope is resolved from the authenticated owner context; request query/body landlordId cannot override it
- non-landlord owners are rejected
- invalid roles, workspace scopes, property scopes, and owner-only billing/revoke permissions fail closed
- invitation token hashes are persisted only server-side and stripped from API responses
- no email dispatch, UI, invite acceptance flow, delegate login, security rules, billing delegation, PM company hierarchy, contractor orgs, or scheduling integration

## Validation
- npm --prefix rentchain-api run test:single -- src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
- npm --prefix rentchain-api run build
- git diff --check