### PR TITLE
feat: add delegated access acceptance flow

### DIFF
--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = Record<string, any>;
@@ -60,6 +61,10 @@ function readCollection(name: string): StoredDoc[] {
 function writeCollectionDoc(name: string, id: string, data: StoredDoc) {
   if (!collections.has(name)) collections.set(name, new Map());
   collections.get(name)!.set(id, data);
+}
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
 }
 
 async function invokeRouter(
@@ -128,6 +133,45 @@ async function createInvite(router: any, body: Record<string, unknown> = {}, use
     url: "/delegated-access/invitations",
     user,
     body: { ...validInviteBody, ...body },
+  });
+}
+
+function seedInvitation(overrides: Partial<StoredDoc> = {}) {
+  const invitation = {
+    invitationId: overrides.invitationId || `delegated_invitation_${readCollection("delegatedAccessInvitations").length + 1}`,
+    landlordId: "landlord-1",
+    inviteeEmail: "manager@example.com",
+    role: "property_manager",
+    propertyScope: { mode: "selected", propertyIds: ["property-1"], unitIds: ["unit-1"] },
+    workspaceScopes: ["dashboard", "operations", "properties"],
+    resourceScope: { workOrderIds: ["work-order-1"] },
+    permissionFlags: ["view", "edit", "assign"],
+    status: "pending",
+    tokenHash: sha256("valid-token"),
+    expiresAt: "2026-07-22T12:00:00.000Z",
+    createdByUserId: "owner-user-1",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    acceptedByUserId: null,
+    acceptedAt: null,
+    cancelledByUserId: null,
+    cancelledAt: null,
+    auditEventIds: [],
+    ...overrides,
+  };
+  writeCollectionDoc("delegatedAccessInvitations", invitation.invitationId, invitation);
+  return invitation;
+}
+
+async function acceptInvite(router: any, token = "valid-token", user: Record<string, unknown> | null = {
+  id: "delegate-user-1",
+  role: "landlord_delegate",
+  email: "manager@example.com",
+}) {
+  return await invokeRouter(router, {
+    method: "POST",
+    url: "/delegated-access/invitations/accept",
+    user,
+    body: { token },
   });
 }
 
@@ -338,5 +382,151 @@ describe("delegatedAccessInvitationRoutes", () => {
     });
 
     expect(response.status).toBe(404);
+  });
+
+  it("accepts a valid pending token for the authenticated delegate account", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedInvitation();
+
+    const response = await acceptInvite(router);
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.invitation).toEqual(
+      expect.objectContaining({
+        status: "accepted",
+        acceptedByUserId: "delegate-user-1",
+        landlordId: "landlord-1",
+        role: "property_manager",
+      })
+    );
+    expect(response.body.grant).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        delegateUserId: "delegate-user-1",
+        delegateEmail: "manager@example.com",
+        role: "property_manager",
+        status: "active",
+      })
+    );
+    expect(response.body.grant.permissionScope).toEqual(
+      expect.objectContaining({
+        role: "property_manager",
+        workspaceScopes: ["dashboard", "operations", "properties"],
+        propertyScope: { mode: "selected", propertyIds: ["property-1"], unitIds: ["unit-1"] },
+        resourceScope: expect.objectContaining({ workOrderIds: ["work-order-1"] }),
+        permissionFlags: ["view", "edit", "assign"],
+        billingAccess: false,
+      })
+    );
+    expect(JSON.stringify(response.body)).not.toContain("valid-token");
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+
+    const storedInvitation = readCollection("delegatedAccessInvitations")[0];
+    expect(storedInvitation.status).toBe("accepted");
+    expect(storedInvitation.tokenHash).toBe(sha256("valid-token"));
+
+    const grants = readCollection("delegatedAccessGrants");
+    expect(grants).toHaveLength(1);
+    expect(grants[0].delegateUserId).toBe("delegate-user-1");
+    expect(grants[0].permissionScope.billingAccess).toBe(false);
+
+    const auditEvents = readCollection("delegatedAccessAuditEvents");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toEqual(
+      expect.objectContaining({
+        eventType: "delegated_invite_accepted",
+        actorUserId: "delegate-user-1",
+        actingForLandlordId: "landlord-1",
+        delegatedRole: "property_manager",
+        targetResourceType: "delegate_invitation",
+        targetResourceId: "delegated_invitation_1",
+        metadataOnly: true,
+        immutable: true,
+      })
+    );
+    expect(JSON.stringify(auditEvents[0])).not.toContain("valid-token");
+    expect(JSON.stringify(auditEvents[0])).not.toContain("tokenHash");
+  });
+
+  it("rejects invalid tokens without leaking token data", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedInvitation();
+
+    const response = await acceptInvite(router, "wrong-token");
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ ok: false, error: "INVITATION_NOT_FOUND" });
+    expect(JSON.stringify(response.body)).not.toContain("wrong-token");
+    expect(readCollection("delegatedAccessGrants")).toHaveLength(0);
+  });
+
+  it("rejects expired, cancelled, and already accepted invitations without creating duplicate grants", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedInvitation({
+      invitationId: "expired-invitation",
+      tokenHash: sha256("expired-token"),
+      expiresAt: "2026-06-01T12:00:00.000Z",
+    });
+    seedInvitation({
+      invitationId: "cancelled-invitation",
+      tokenHash: sha256("cancelled-token"),
+      status: "cancelled",
+      cancelledByUserId: "owner-user-1",
+      cancelledAt: "2026-06-20T12:00:00.000Z",
+    });
+    seedInvitation({
+      invitationId: "accepted-invitation",
+      tokenHash: sha256("accepted-token"),
+      status: "accepted",
+      acceptedByUserId: "delegate-user-2",
+      acceptedAt: "2026-06-20T12:00:00.000Z",
+    });
+
+    const expired = await acceptInvite(router, "expired-token");
+    expect(expired.status).toBe(410);
+    expect(expired.body.error).toBe("INVITATION_EXPIRED");
+
+    const cancelled = await acceptInvite(router, "cancelled-token");
+    expect(cancelled.status).toBe(409);
+    expect(cancelled.body.error).toBe("INVITATION_NOT_PENDING");
+
+    const accepted = await acceptInvite(router, "accepted-token");
+    expect(accepted.status).toBe(409);
+    expect(accepted.body.error).toBe("INVITATION_NOT_PENDING");
+
+    expect(readCollection("delegatedAccessGrants")).toHaveLength(0);
+  });
+
+  it("requires an authenticated accepting user and does not accept on behalf of another user", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedInvitation();
+
+    const unauthenticated = await acceptInvite(router, "valid-token", null);
+    expect(unauthenticated.status).toBe(401);
+
+    const response = await acceptInvite(router, "valid-token", {
+      id: "actual-delegate-user",
+      role: "landlord_delegate",
+      email: "different@example.com",
+    });
+    expect(response.status).toBe(200);
+    expect(response.body.invitation.acceptedByUserId).toBe("actual-delegate-user");
+    expect(response.body.grant.delegateUserId).toBe("actual-delegate-user");
+    expect(response.body.grant.delegateEmail).toBe("different@example.com");
+  });
+
+  it("rejects double acceptance without creating a duplicate grant", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedInvitation();
+
+    const first = await acceptInvite(router);
+    expect(first.status).toBe(200);
+
+    const second = await acceptInvite(router);
+    expect(second.status).toBe(409);
+    expect(second.body.error).toBe("INVITATION_NOT_PENDING");
+    expect(readCollection("delegatedAccessGrants")).toHaveLength(1);
+    expect(readCollection("delegatedAccessAuditEvents")).toHaveLength(1);
   });
 });

--- a/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
+++ b/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { requireAuth } from "../middleware/requireAuth";
 import {
+  acceptDelegatedAccessInvitationRecord,
   cancelDelegatedAccessInvitationRecord,
   createDelegatedAccessInvitationRecord,
   expireDelegatedAccessInvitationRecord,
@@ -22,6 +23,13 @@ function ownerContext(req: any): { actorUserId: string; landlordId: string } | n
   return { actorUserId, landlordId };
 }
 
+function actorContext(req: any): { actorUserId: string; actorEmail: string | null } | null {
+  const actorUserId = asString(req.user?.id || req.user?.uid || req.user?.sub, 240);
+  if (!actorUserId) return null;
+  const actorEmail = asString(req.user?.email, 320) || null;
+  return { actorUserId, actorEmail };
+}
+
 function forbidden(res: any) {
   return res.status(403).json({ ok: false, error: "FORBIDDEN" });
 }
@@ -31,8 +39,14 @@ function handleError(res: any, error: unknown) {
   if (code === "delegated_invitation_not_found") {
     return res.status(404).json({ ok: false, error: "INVITATION_NOT_FOUND" });
   }
+  if (code === "invalid_invitation_token") {
+    return res.status(404).json({ ok: false, error: "INVITATION_NOT_FOUND" });
+  }
   if (code === "invitation_not_pending") {
     return res.status(409).json({ ok: false, error: "INVITATION_NOT_PENDING" });
+  }
+  if (code === "invitation_expired") {
+    return res.status(410).json({ ok: false, error: "INVITATION_EXPIRED" });
   }
   if (code.startsWith("invalid_") || code.startsWith("missing_") || code.includes("_not_allowed")) {
     return res.status(400).json({ ok: false, error: code.toUpperCase() });
@@ -42,6 +56,22 @@ function handleError(res: any, error: unknown) {
 }
 
 router.use(requireAuth);
+
+router.post("/delegated-access/invitations/accept", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await acceptDelegatedAccessInvitationRecord({
+      actorUserId: context.actorUserId,
+      actorEmail: context.actorEmail,
+      token: req.body?.token,
+    });
+    return res.status(200).json({ ok: true, invitation: result.invitation, grant: result.grant });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
 
 router.post("/delegated-access/invitations", async (req: any, res) => {
   const context = ownerContext(req);

--- a/rentchain-api/src/services/delegatedAccessInvitationService.ts
+++ b/rentchain-api/src/services/delegatedAccessInvitationService.ts
@@ -2,10 +2,12 @@ import crypto from "crypto";
 import { db } from "../firebase";
 import {
   buildDelegatedAccessAuditEvent,
+  createDelegatedAccessGrant,
   createDelegatedAccessInvitation,
   isDelegatedInvitationExpired,
   transitionDelegatedInvitationStatus,
   type DelegatedAccessAuditEvent,
+  type DelegatedAccessGrant,
   type DelegatedAccessInvitation,
   type DelegatedAccessInvitationStatus,
   type DelegatedAccessPropertyScope,
@@ -13,6 +15,7 @@ import {
 } from "../lib/delegatedAccess";
 
 export const DELEGATED_ACCESS_INVITATIONS_COLLECTION = "delegatedAccessInvitations";
+export const DELEGATED_ACCESS_GRANTS_COLLECTION = "delegatedAccessGrants";
 export const DELEGATED_ACCESS_AUDIT_EVENTS_COLLECTION = "delegatedAccessAuditEvents";
 
 type SnapshotLike = {
@@ -38,6 +41,7 @@ export type DelegatedAccessFirestoreLike = {
 };
 
 export type DelegatedInvitationProjection = Omit<DelegatedAccessInvitation, "tokenHash">;
+export type DelegatedGrantProjection = DelegatedAccessGrant;
 
 type CreateInvitationInput = {
   landlordId: string;
@@ -49,6 +53,13 @@ type CreateInvitationInput = {
   resourceScope?: DelegatedAccessResourceScope;
   permissionFlags: string[];
   expiresAt: string;
+  now?: string;
+};
+
+type AcceptInvitationInput = {
+  actorUserId: string;
+  actorEmail?: string | null;
+  token: string;
   now?: string;
 };
 
@@ -74,6 +85,12 @@ function sha256(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+function timingSafeEqualHex(a: string, b: string): boolean {
+  const left = Buffer.from(a, "hex");
+  const right = Buffer.from(b, "hex");
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
 function createTokenHash(): string {
   return sha256(crypto.randomBytes(32).toString("hex"));
 }
@@ -81,6 +98,10 @@ function createTokenHash(): string {
 function projectInvitation(invitation: DelegatedAccessInvitation): DelegatedInvitationProjection {
   const { tokenHash: _tokenHash, ...safe } = invitation;
   return safe;
+}
+
+function projectGrant(grant: DelegatedAccessGrant): DelegatedGrantProjection {
+  return grant;
 }
 
 function invitationFromSnapshot(snapshot: SnapshotLike): DelegatedAccessInvitation | null {
@@ -105,6 +126,16 @@ async function saveInvitation(invitation: DelegatedAccessInvitation, firestore: 
     .doc(invitation.invitationId);
   if (!ref.set) throw new Error("delegated_access_invitation_write_unavailable");
   await ref.set(invitation, { merge: false });
+}
+
+async function createGrant(grant: DelegatedAccessGrant, firestore: DelegatedAccessFirestoreLike) {
+  const ref = firestore.collection<DelegatedAccessGrant>(DELEGATED_ACCESS_GRANTS_COLLECTION).doc(grant.grantId);
+  if (ref.create) {
+    await ref.create(grant);
+    return;
+  }
+  if (!ref.set) throw new Error("delegated_access_grant_write_unavailable");
+  await ref.set(grant, { merge: false });
 }
 
 export async function createDelegatedAccessInvitationRecord(
@@ -199,6 +230,90 @@ async function loadInvitationForLandlord(
   const invitation = invitationFromSnapshot(snapshot);
   if (!invitation || invitation.landlordId !== landlordId) return null;
   return invitation;
+}
+
+async function loadInvitationByTokenHash(
+  tokenHash: string,
+  firestore: DelegatedAccessFirestoreLike
+): Promise<DelegatedAccessInvitation | null> {
+  const snapshot = await firestore.collection<DelegatedAccessInvitation>(DELEGATED_ACCESS_INVITATIONS_COLLECTION).get?.();
+  const invitations = (snapshot?.docs || [])
+    .map(invitationFromSnapshot)
+    .filter((invitation): invitation is DelegatedAccessInvitation => Boolean(invitation));
+  return invitations.find((invitation) => timingSafeEqualHex(invitation.tokenHash, tokenHash)) || null;
+}
+
+function stableGrantId(invitation: DelegatedAccessInvitation, delegateUserId: string): string {
+  const digest = sha256(JSON.stringify([invitation.invitationId, delegateUserId])).slice(0, 24);
+  return `delegated_grant_${digest}`;
+}
+
+export async function acceptDelegatedAccessInvitationRecord(
+  input: AcceptInvitationInput,
+  options: ServiceOptions = {}
+): Promise<{
+  invitation: DelegatedInvitationProjection;
+  grant: DelegatedGrantProjection;
+  auditEvent: DelegatedAccessAuditEvent;
+}> {
+  const firestore = delegatedDb(options.firestore);
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const rawToken = requireString(input.token, "missing_invitation_token", 2000);
+  const now = input.now || new Date().toISOString();
+  const tokenHash = sha256(rawToken);
+  const invitation = await loadInvitationByTokenHash(tokenHash, firestore);
+  if (!invitation) throw new Error("invalid_invitation_token");
+  if (invitation.status !== "pending") throw new Error("invitation_not_pending");
+  if (isDelegatedInvitationExpired(invitation, now)) throw new Error("invitation_expired");
+
+  const accepted = transitionDelegatedInvitationStatus(invitation, "accepted", {
+    acceptedByUserId: actorUserId,
+    timestamp: now,
+  });
+  const grant = createDelegatedAccessGrant({
+    grantId: stableGrantId(invitation, actorUserId),
+    landlordId: invitation.landlordId,
+    delegateUserId: actorUserId,
+    delegateEmail: input.actorEmail || invitation.inviteeEmail,
+    role: invitation.role,
+    propertyScope: invitation.propertyScope,
+    workspaceScopes: invitation.workspaceScopes,
+    resourceScope: invitation.resourceScope,
+    permissionFlags: invitation.permissionFlags,
+    createdByUserId: invitation.createdByUserId,
+    createdAt: now,
+    acceptedAt: now,
+  });
+  const auditEvent = buildDelegatedAccessAuditEvent({
+    eventType: "delegated_invite_accepted",
+    actorUserId,
+    actingForLandlordId: invitation.landlordId,
+    delegatedRole: invitation.role,
+    permissionScope: grant.permissionScope,
+    actionType: "invite_accepted",
+    targetResourceType: "delegate_invitation",
+    targetResourceId: invitation.invitationId,
+    timestamp: now,
+    outcome: "allowed",
+    before: { status: invitation.status },
+    after: {
+      status: accepted.status,
+      grantId: grant.grantId,
+      role: grant.role,
+      workspaceScopes: grant.permissionScope.workspaceScopes,
+      propertyScopeMode: grant.permissionScope.propertyScope.mode,
+    },
+  });
+  const grantWithAudit = { ...grant, auditEventIds: [auditEvent.eventId] };
+  const invitationWithAudit = { ...accepted, auditEventIds: [...accepted.auditEventIds, auditEvent.eventId] };
+  await createGrant(grantWithAudit, firestore);
+  await saveInvitation(invitationWithAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return {
+    invitation: projectInvitation(invitationWithAudit),
+    grant: projectGrant(grantWithAudit),
+    auditEvent,
+  };
 }
 
 export async function cancelDelegatedAccessInvitationRecord(


### PR DESCRIPTION
## Summary
- add authenticated delegated access invitation acceptance API
- validate submitted invitation tokens by server-side hash comparison
- create active delegate grants from pending valid invitations while preserving role, property, workspace, resource, and permission scope
- mark invitations accepted and append metadata-only audit events

## Security / Scope
- raw invite tokens are never returned, logged, or stored beyond server-side hashing
- invalid tokens return a safe not-found response
- expired, cancelled, and accepted invitations cannot create grants
- accepting user is resolved from authenticated user context and becomes the delegate user
- billing/settings remain owner-only through existing foundation validation
- no UI, email dispatch, invite creation changes, delegate management UI, security rules, PM company hierarchy, contractor organizations, billing delegation, or scheduling integration

## Validation
- npm --prefix rentchain-api run test:single -- src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
- npm --prefix rentchain-api run build
- git diff --check