### PR TITLE
feat: add delegated access owner management api

### DIFF
--- a/docs/design/mission-briefs/delegated-access-owner-management-api-v1.html
+++ b/docs/design/mission-briefs/delegated-access-owner-management-api-v1.html
@@ -1,0 +1,496 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Delegated Access Owner Management API V1</title>
+    <style>
+      @page {
+        size: 16in 9in;
+        margin: 0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: #f5f7fb;
+        color: #091532;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      .brief {
+        width: 1600px;
+        min-height: 900px;
+        margin: 0 auto;
+        background:
+          linear-gradient(180deg, #071a37 0, #071a37 120px, transparent 120px),
+          #ffffff;
+        box-shadow: 0 20px 80px rgba(9, 21, 50, 0.18);
+      }
+
+      header {
+        height: 120px;
+        display: grid;
+        place-items: center;
+        text-align: center;
+        padding: 18px 48px 20px;
+        color: #ffffff;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 40px;
+        line-height: 1.1;
+        letter-spacing: 0;
+        font-weight: 800;
+      }
+
+      h1 span {
+        color: #7ee36d;
+      }
+
+      .subtitle {
+        margin-top: 8px;
+        font-size: 22px;
+        color: rgba(255, 255, 255, 0.86);
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: 42% 58%;
+        gap: 0;
+        min-height: 780px;
+      }
+
+      section {
+        padding: 22px 28px;
+      }
+
+      .left {
+        border-right: 1px solid #dce3ee;
+      }
+
+      .right {
+        display: grid;
+        grid-template-columns: 1.45fr 0.82fr;
+        gap: 18px;
+      }
+
+      h2 {
+        margin: 0 0 10px;
+        font-size: 25px;
+        line-height: 1.15;
+        color: #091532;
+      }
+
+      h3 {
+        margin: 0 0 8px;
+        font-size: 17px;
+        color: #132b5c;
+      }
+
+      p {
+        margin: 0 0 12px;
+        font-size: 17px;
+        line-height: 1.38;
+      }
+
+      .block {
+        margin-bottom: 18px;
+        padding-bottom: 18px;
+        border-bottom: 1px solid #e2e8f0;
+      }
+
+      .block:last-child {
+        border-bottom: 0;
+        margin-bottom: 0;
+        padding-bottom: 0;
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 8px;
+      }
+
+      li {
+        position: relative;
+        padding-left: 24px;
+        font-size: 16px;
+        line-height: 1.3;
+      }
+
+      li::before {
+        content: "";
+        position: absolute;
+        left: 2px;
+        top: 8px;
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: #12a150;
+      }
+
+      .non-goals {
+        border: 1px solid #f1b7b7;
+        background: #fff8f8;
+        border-radius: 8px;
+        padding: 16px 18px;
+      }
+
+      .non-goals h2 {
+        color: #9f1239;
+        font-size: 20px;
+      }
+
+      .non-goals li::before {
+        background: #e11d48;
+      }
+
+      .principles {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+      }
+
+      .principle {
+        display: grid;
+        grid-template-columns: 28px 1fr;
+        gap: 10px;
+        align-items: start;
+        font-size: 15px;
+        line-height: 1.35;
+      }
+
+      .icon {
+        width: 26px;
+        height: 26px;
+        border: 1px solid #193a76;
+        border-radius: 7px;
+        display: grid;
+        place-items: center;
+        color: #193a76;
+        font-weight: 800;
+        font-size: 13px;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 15px;
+        overflow: hidden;
+        border: 1px solid #dce3ee;
+        border-radius: 4px;
+      }
+
+      .table th {
+        background: #071a37;
+        color: #ffffff;
+        text-align: left;
+        padding: 12px 14px;
+        font-size: 15px;
+      }
+
+      .table td {
+        border-top: 1px solid #e2e8f0;
+        padding: 12px 14px;
+        vertical-align: top;
+      }
+
+      .method {
+        display: inline-flex;
+        min-width: 64px;
+        justify-content: center;
+        border-radius: 4px;
+        padding: 6px 8px;
+        font-weight: 800;
+        font-size: 13px;
+      }
+
+      .get {
+        color: #047857;
+        background: #ecfdf5;
+        border: 1px solid #a7f3d0;
+      }
+
+      .post {
+        color: #b91c1c;
+        background: #fff1f2;
+        border: 1px solid #fecdd3;
+      }
+
+      code,
+      pre {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      }
+
+      pre {
+        margin: 0;
+        padding: 14px;
+        font-size: 13px;
+        line-height: 1.32;
+        color: #0f172a;
+        background: #f8fafc;
+        border: 1px solid #dce3ee;
+        border-radius: 6px;
+        white-space: pre-wrap;
+      }
+
+      .side-card {
+        background: #f5f7fb;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+
+      .side-card h2 {
+        font-size: 19px;
+      }
+
+      .side-card li {
+        font-size: 15px;
+      }
+
+      .criteria-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+        margin-top: 16px;
+      }
+
+      .criteria {
+        border: 1px solid #dce3ee;
+        border-radius: 8px;
+        padding: 14px;
+        background: #ffffff;
+      }
+
+      .criteria h2 {
+        font-size: 18px;
+      }
+
+      .criteria li {
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <div>
+          <h1>Next Mission: <span>feat/delegated-access-owner-management-api-v1</span></h1>
+          <div class="subtitle">Backend-only owner management APIs for delegated access.</div>
+        </div>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>Mission Goal</h2>
+            <p>
+              Provide landlord-owner-only APIs to view delegates, view grants, and revoke access with
+              landlord-scoped reads, safe responses, and metadata-only audit coverage.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Scope</h2>
+            <ul>
+              <li>List delegates for the authenticated landlord owner.</li>
+              <li>List active and revoked grants for the authenticated landlord owner.</li>
+              <li>Revoke an active grant by grantId without deleting the grant record.</li>
+              <li>Resolve landlord scope only from auth context.</li>
+              <li>Record metadata-only audit events for revocation.</li>
+            </ul>
+          </div>
+
+          <div class="block non-goals">
+            <h2>Non-goals</h2>
+            <ul>
+              <li>No UI or delegate management screens.</li>
+              <li>No email dispatch or notifications.</li>
+              <li>No new invitation creation or acceptance behavior.</li>
+              <li>No Firestore security rule changes unless absolutely required.</li>
+              <li>No billing delegation.</li>
+              <li>No property manager company hierarchy.</li>
+              <li>No contractor organizations.</li>
+              <li>No scheduling integration.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Key Principles</h2>
+            <div class="principles">
+              <div class="principle">
+                <div class="icon">O</div>
+                <div><strong>Owner-only:</strong> all endpoints require landlord owner privileges.</div>
+              </div>
+              <div class="principle">
+                <div class="icon">L</div>
+                <div><strong>Landlord scoped:</strong> query and body params cannot override auth landlordId.</div>
+              </div>
+              <div class="principle">
+                <div class="icon">F</div>
+                <div><strong>Fail closed:</strong> unknown grants, unknown landlords, and invalid states deny access.</div>
+              </div>
+              <div class="principle">
+                <div class="icon">S</div>
+                <div><strong>Safe responses:</strong> do not expose tokens, hashes, or sensitive internal metadata.</div>
+              </div>
+              <div class="principle">
+                <div class="icon">A</div>
+                <div><strong>Audit continuity:</strong> revocation creates append-safe metadata-only audit records.</div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="right">
+          <div>
+            <div class="block">
+              <h2>API Endpoints</h2>
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th style="width: 110px;">Method</th>
+                    <th>Endpoint</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><span class="method get">GET</span></td>
+                    <td><code>/api/landlord/delegated-access/delegates</code></td>
+                    <td>List delegate summaries for the landlord.</td>
+                  </tr>
+                  <tr>
+                    <td><span class="method get">GET</span></td>
+                    <td><code>/api/landlord/delegated-access/grants</code></td>
+                    <td>List active and revoked grants for the landlord.</td>
+                  </tr>
+                  <tr>
+                    <td><span class="method post">POST</span></td>
+                    <td><code>/api/landlord/delegated-access/grants/:grantId/revoke</code></td>
+                    <td>Revoke an active delegate grant by ID.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="block">
+              <h2>Data Returned</h2>
+              <h3>Delegates summary</h3>
+              <pre>[
+  {
+    "delegateUserId": "user_abc123",
+    "email": "delegate@example.com",
+    "roles": ["property_manager"],
+    "activeGrantCount": 2,
+    "revokedGrantCount": 1,
+    "workspaceScopes": ["operations", "properties"],
+    "propertyScopeSummary": "selected",
+    "lastActiveAt": null
+  }
+]</pre>
+              <h3 style="margin-top: 14px;">Grant detail</h3>
+              <pre>[
+  {
+    "grantId": "grant_abc123",
+    "delegateUserId": "user_abc123",
+    "delegateEmail": "delegate@example.com",
+    "role": "property_manager",
+    "status": "active",
+    "permissionScope": {
+      "workspaceScopes": ["operations"],
+      "propertyScope": { "mode": "selected", "propertyIds": ["property_001"] },
+      "resourceScope": {},
+      "permissionFlags": ["view", "edit"],
+      "billingAccess": false
+    },
+    "createdAt": "2026-06-22T10:00:00.000Z",
+    "revokedAt": null,
+    "revokedByUserId": null
+  }
+]</pre>
+            </div>
+
+            <div class="criteria-grid">
+              <div class="criteria">
+                <h2>Acceptance Criteria</h2>
+                <ul>
+                  <li>Owner can list delegates and grants for their landlord only.</li>
+                  <li>Query/body landlord overrides are ignored.</li>
+                  <li>Active grants revoke successfully.</li>
+                  <li>Revoked or unknown grants cannot be revoked again.</li>
+                  <li>Responses exclude token/hash and sensitive metadata.</li>
+                </ul>
+              </div>
+              <div class="criteria">
+                <h2>Validation Requirements</h2>
+                <ul>
+                  <li>Focused backend tests.</li>
+                  <li>Backend build.</li>
+                  <li><code>git diff --check</code>.</li>
+                  <li>No manual preview QA required unless consumed by UI.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <aside>
+            <div class="side-card">
+              <h2>Revocation Behavior</h2>
+              <ul>
+                <li>Only active grants can be revoked.</li>
+                <li>Revocation marks status as revoked.</li>
+                <li>Grant record is preserved.</li>
+                <li>Permission evaluator must deny revoked grants immediately.</li>
+                <li>Revocation stores actor, timestamp, and optional reason.</li>
+              </ul>
+            </div>
+
+            <div class="side-card">
+              <h2>Audit Events</h2>
+              <ul>
+                <li>Record delegated_access_revoked.</li>
+                <li>Include actorUserId and actingForLandlordId.</li>
+                <li>Include target grant and delegate user references.</li>
+                <li>Include role, scope summary, reason, outcome, and timestamp.</li>
+                <li>Keep audit metadata-only; no tokens or sensitive payloads.</li>
+              </ul>
+            </div>
+
+            <div class="side-card">
+              <h2>Risk Controls</h2>
+              <ul>
+                <li>Fail closed on ambiguous owner, landlord, grant, or scope.</li>
+                <li>Do not allow cross-landlord grant visibility.</li>
+                <li>Do not expose invitation tokens or token hashes.</li>
+                <li>Keep billing and settings owner-only.</li>
+                <li>Preserve immutable audit trail for access removal.</li>
+              </ul>
+            </div>
+
+            <div class="side-card">
+              <h2>Merge Readiness Criteria</h2>
+              <ul>
+                <li>Contract review confirms owner-only scope and safe responses.</li>
+                <li>Focused tests cover list, scope, revoke, denied states, and audit.</li>
+                <li>Backend build and diff check pass.</li>
+                <li>No unrelated files or adjacent roadmap work included.</li>
+                <li>Review gate satisfied or explicit override authorized.</li>
+              </ul>
+            </div>
+          </aside>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -162,6 +162,37 @@ function seedInvitation(overrides: Partial<StoredDoc> = {}) {
   return invitation;
 }
 
+function seedGrant(overrides: Partial<StoredDoc> = {}) {
+  const grant = {
+    grantId: overrides.grantId || `delegated_grant_${readCollection("delegatedAccessGrants").length + 1}`,
+    landlordId: "landlord-1",
+    delegateUserId: "delegate-user-1",
+    delegateEmail: "manager@example.com",
+    role: "property_manager",
+    status: "active",
+    permissionScope: {
+      role: "property_manager",
+      workspaceScopes: ["dashboard", "operations", "properties"],
+      propertyScope: { mode: "selected", propertyIds: ["property-1"], unitIds: ["unit-1"] },
+      resourceScope: { workOrderIds: ["work-order-1"] },
+      permissionFlags: ["view", "edit", "assign"],
+      billingAccess: false,
+      exportAccess: false,
+    },
+    createdByUserId: "owner-user-1",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    acceptedAt: "2026-06-22T12:00:00.000Z",
+    updatedAt: "2026-06-22T12:00:00.000Z",
+    revokedAt: null,
+    revokedByUserId: null,
+    revocationReason: null,
+    auditEventIds: [],
+    ...overrides,
+  };
+  writeCollectionDoc("delegatedAccessGrants", grant.grantId, grant);
+  return grant;
+}
+
 async function acceptInvite(router: any, token = "valid-token", user: Record<string, unknown> | null = {
   id: "delegate-user-1",
   role: "landlord_delegate",
@@ -528,5 +559,228 @@ describe("delegatedAccessInvitationRoutes", () => {
     expect(second.body.error).toBe("INVITATION_NOT_PENDING");
     expect(readCollection("delegatedAccessGrants")).toHaveLength(1);
     expect(readCollection("delegatedAccessAuditEvents")).toHaveLength(1);
+  });
+
+  it("lists grants for the authenticated landlord only and ignores query landlord scope", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedGrant({ grantId: "active-grant", status: "active" });
+    seedGrant({
+      grantId: "revoked-grant",
+      status: "revoked",
+      revokedAt: "2026-06-23T12:00:00.000Z",
+      revokedByUserId: "owner-user-1",
+      updatedAt: "2026-06-23T12:00:00.000Z",
+    });
+    seedGrant({ grantId: "other-landlord-grant", landlordId: "landlord-2" });
+    seedGrant({ grantId: "suspended-grant", status: "suspended" });
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/delegated-access/grants?landlordId=landlord-2",
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.grants.map((grant: any) => grant.grantId).sort()).toEqual(["active-grant", "revoked-grant"]);
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+    expect(JSON.stringify(response.body)).not.toContain("valid-token");
+  });
+
+  it("lists delegate summaries for active and revoked grants", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedGrant({ grantId: "active-grant" });
+    seedGrant({
+      grantId: "revoked-grant",
+      status: "revoked",
+      role: "maintenance_coordinator",
+      revokedAt: "2026-06-23T12:00:00.000Z",
+      revokedByUserId: "owner-user-1",
+      updatedAt: "2026-06-23T12:00:00.000Z",
+      permissionScope: {
+        role: "maintenance_coordinator",
+        workspaceScopes: ["work_orders"],
+        propertyScope: { mode: "selected", propertyIds: ["property-2"] },
+        resourceScope: {},
+        permissionFlags: ["view", "assign"],
+        billingAccess: false,
+        exportAccess: false,
+      },
+    });
+    seedGrant({
+      grantId: "second-delegate",
+      delegateUserId: "delegate-user-2",
+      delegateEmail: "auditor@example.com",
+      role: "read_only_auditor",
+      permissionScope: {
+        role: "read_only_auditor",
+        workspaceScopes: ["evidence_exports"],
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        resourceScope: {},
+        permissionFlags: ["view", "export"],
+        billingAccess: false,
+        exportAccess: true,
+      },
+    });
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/delegated-access/delegates?landlordId=landlord-2",
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.delegates).toHaveLength(2);
+    expect(response.body.delegates[0]).toEqual(
+      expect.objectContaining({
+        delegateUserId: expect.any(String),
+        roles: expect.any(Array),
+        activeGrantCount: expect.any(Number),
+        revokedGrantCount: expect.any(Number),
+        workspaceScopes: expect.any(Array),
+      })
+    );
+    const manager = response.body.delegates.find((delegate: any) => delegate.delegateUserId === "delegate-user-1");
+    expect(manager).toEqual(
+      expect.objectContaining({
+        delegateEmail: "manager@example.com",
+        roles: ["maintenance_coordinator", "property_manager"],
+        activeGrantCount: 1,
+        revokedGrantCount: 1,
+        propertyScopeSummary: "selected:2",
+      })
+    );
+    expect(manager.workspaceScopes).toEqual(["dashboard", "operations", "properties", "work_orders"]);
+  });
+
+  it("requires owner privileges for delegate and grant management routes", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedGrant();
+    const delegateUser = { id: "delegate-user-1", role: "landlord_delegate", landlordId: "landlord-1" };
+
+    const delegates = await invokeRouter(router, {
+      method: "GET",
+      url: "/delegated-access/delegates",
+      user: delegateUser,
+    });
+    expect(delegates.status).toBe(403);
+
+    const grants = await invokeRouter(router, {
+      method: "GET",
+      url: "/delegated-access/grants",
+      user: delegateUser,
+    });
+    expect(grants.status).toBe(403);
+
+    const revoke = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/grants/delegated_grant_1/revoke",
+      user: delegateUser,
+      body: { reason: "turnover" },
+    });
+    expect(revoke.status).toBe(403);
+  });
+
+  it("revokes an active grant without deleting it and records metadata-only audit", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const { evaluateDelegatedAccessPermission } = await import("../../lib/delegatedAccess");
+    seedGrant({ grantId: "grant-to-revoke" });
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/grants/grant-to-revoke/revoke",
+      user: ownerUser,
+      body: { reason: "Staff turnover", landlordId: "landlord-2" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.grant).toEqual(
+      expect.objectContaining({
+        grantId: "grant-to-revoke",
+        landlordId: "landlord-1",
+        status: "revoked",
+        revokedByUserId: "owner-user-1",
+        revocationReason: "Staff turnover",
+      })
+    );
+    expect(readCollection("delegatedAccessGrants")).toHaveLength(1);
+    expect(readCollection("delegatedAccessGrants")[0].status).toBe("revoked");
+
+    const decision = evaluateDelegatedAccessPermission({
+      actorUserId: "delegate-user-1",
+      actingForLandlordId: "landlord-1",
+      isLandlordOwner: false,
+      routeWorkspace: "operations",
+      action: "view",
+      targetResourceType: "operation",
+      propertyId: "property-1",
+      resourceId: "work-order-1",
+      grant: response.body.grant,
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("grant_not_active");
+
+    const auditEvents = readCollection("delegatedAccessAuditEvents");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toEqual(
+      expect.objectContaining({
+        eventType: "delegated_access_revoked",
+        actorUserId: "owner-user-1",
+        actingForLandlordId: "landlord-1",
+        delegatedRole: "landlord_owner",
+        actionType: "grant_revoked",
+        targetResourceType: "delegate_grant",
+        targetResourceId: "grant-to-revoke",
+        outcome: "revoked",
+        metadataOnly: true,
+        immutable: true,
+      })
+    );
+    expect(auditEvents[0].after).toEqual(
+      expect.objectContaining({
+        status: "revoked",
+        delegateUserId: "delegate-user-1",
+        role: "property_manager",
+        propertyScopeMode: "selected",
+        reason: "Staff turnover",
+      })
+    );
+    expect(JSON.stringify(auditEvents[0])).not.toContain("tokenHash");
+    expect(JSON.stringify(auditEvents[0])).not.toContain("valid-token");
+  });
+
+  it("fails closed for unknown, cross-landlord, and already revoked grant revocation", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedGrant({ grantId: "other-landlord-grant", landlordId: "landlord-2" });
+    seedGrant({
+      grantId: "already-revoked",
+      status: "revoked",
+      revokedByUserId: "owner-user-1",
+      revokedAt: "2026-06-23T12:00:00.000Z",
+      updatedAt: "2026-06-23T12:00:00.000Z",
+    });
+
+    const unknown = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/grants/missing-grant/revoke",
+      user: ownerUser,
+    });
+    expect(unknown.status).toBe(404);
+    expect(unknown.body.error).toBe("GRANT_NOT_FOUND");
+
+    const crossLandlord = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/grants/other-landlord-grant/revoke",
+      user: ownerUser,
+    });
+    expect(crossLandlord.status).toBe(404);
+
+    const alreadyRevoked = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/grants/already-revoked/revoke",
+      user: ownerUser,
+    });
+    expect(alreadyRevoked.status).toBe(409);
+    expect(alreadyRevoked.body.error).toBe("GRANT_NOT_ACTIVE");
+    expect(readCollection("delegatedAccessAuditEvents")).toHaveLength(0);
   });
 });

--- a/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
+++ b/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
@@ -5,7 +5,10 @@ import {
   cancelDelegatedAccessInvitationRecord,
   createDelegatedAccessInvitationRecord,
   expireDelegatedAccessInvitationRecord,
+  listDelegatedAccessDelegateRecords,
+  listDelegatedAccessGrantRecords,
   listDelegatedAccessInvitationRecords,
+  revokeDelegatedAccessGrantRecord,
 } from "../services/delegatedAccessInvitationService";
 
 const router = Router();
@@ -39,11 +42,17 @@ function handleError(res: any, error: unknown) {
   if (code === "delegated_invitation_not_found") {
     return res.status(404).json({ ok: false, error: "INVITATION_NOT_FOUND" });
   }
+  if (code === "delegated_grant_not_found") {
+    return res.status(404).json({ ok: false, error: "GRANT_NOT_FOUND" });
+  }
   if (code === "invalid_invitation_token") {
     return res.status(404).json({ ok: false, error: "INVITATION_NOT_FOUND" });
   }
   if (code === "invitation_not_pending") {
     return res.status(409).json({ ok: false, error: "INVITATION_NOT_PENDING" });
+  }
+  if (code === "grant_not_active") {
+    return res.status(409).json({ ok: false, error: "GRANT_NOT_ACTIVE" });
   }
   if (code === "invitation_expired") {
     return res.status(410).json({ ok: false, error: "INVITATION_EXPIRED" });
@@ -56,6 +65,51 @@ function handleError(res: any, error: unknown) {
 }
 
 router.use(requireAuth);
+
+router.get("/delegated-access/delegates", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listDelegatedAccessDelegateRecords({
+      landlordId: context.landlordId,
+    });
+    return res.status(200).json({ ok: true, delegates: result.delegates });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.get("/delegated-access/grants", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listDelegatedAccessGrantRecords({
+      landlordId: context.landlordId,
+    });
+    return res.status(200).json({ ok: true, grants: result.grants });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/delegated-access/grants/:grantId/revoke", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await revokeDelegatedAccessGrantRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      grantId: req.params.grantId,
+      reason: req.body?.reason,
+    });
+    return res.status(200).json({ ok: true, grant: result.grant });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
 
 router.post("/delegated-access/invitations/accept", async (req: any, res) => {
   const context = actorContext(req);

--- a/rentchain-api/src/services/delegatedAccessInvitationService.ts
+++ b/rentchain-api/src/services/delegatedAccessInvitationService.ts
@@ -5,6 +5,7 @@ import {
   createDelegatedAccessGrant,
   createDelegatedAccessInvitation,
   isDelegatedInvitationExpired,
+  revokeDelegatedAccessGrant,
   transitionDelegatedInvitationStatus,
   type DelegatedAccessAuditEvent,
   type DelegatedAccessGrant,
@@ -42,6 +43,16 @@ export type DelegatedAccessFirestoreLike = {
 
 export type DelegatedInvitationProjection = Omit<DelegatedAccessInvitation, "tokenHash">;
 export type DelegatedGrantProjection = DelegatedAccessGrant;
+export type DelegatedDelegateSummary = {
+  delegateUserId: string;
+  delegateEmail: string | null;
+  roles: string[];
+  activeGrantCount: number;
+  revokedGrantCount: number;
+  workspaceScopes: string[];
+  propertyScopeSummary: string;
+  lastActiveAt: string | null;
+};
 
 type CreateInvitationInput = {
   landlordId: string;
@@ -60,6 +71,14 @@ type AcceptInvitationInput = {
   actorUserId: string;
   actorEmail?: string | null;
   token: string;
+  now?: string;
+};
+
+type RevokeGrantInput = {
+  landlordId: string;
+  actorUserId: string;
+  grantId: string;
+  reason?: string | null;
   now?: string;
 };
 
@@ -134,6 +153,12 @@ async function createGrant(grant: DelegatedAccessGrant, firestore: DelegatedAcce
     await ref.create(grant);
     return;
   }
+  if (!ref.set) throw new Error("delegated_access_grant_write_unavailable");
+  await ref.set(grant, { merge: false });
+}
+
+async function saveGrant(grant: DelegatedAccessGrant, firestore: DelegatedAccessFirestoreLike) {
+  const ref = firestore.collection<DelegatedAccessGrant>(DELEGATED_ACCESS_GRANTS_COLLECTION).doc(grant.grantId);
   if (!ref.set) throw new Error("delegated_access_grant_write_unavailable");
   await ref.set(grant, { merge: false });
 }
@@ -232,6 +257,37 @@ async function loadInvitationForLandlord(
   return invitation;
 }
 
+function grantFromSnapshot(snapshot: SnapshotLike): DelegatedAccessGrant | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as DelegatedAccessGrant;
+}
+
+async function listGrantsForLandlord(
+  landlordId: string,
+  firestore: DelegatedAccessFirestoreLike
+): Promise<DelegatedAccessGrant[]> {
+  const snapshot = await firestore.collection<DelegatedAccessGrant>(DELEGATED_ACCESS_GRANTS_COLLECTION).get?.();
+  return (snapshot?.docs || [])
+    .map(grantFromSnapshot)
+    .filter((grant): grant is DelegatedAccessGrant => Boolean(grant))
+    .filter((grant) => grant.landlordId === landlordId && ["active", "revoked"].includes(grant.status))
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
+}
+
+async function loadGrantForLandlord(
+  landlordId: string,
+  grantId: string,
+  firestore: DelegatedAccessFirestoreLike
+): Promise<DelegatedAccessGrant | null> {
+  const ref = firestore.collection<DelegatedAccessGrant>(DELEGATED_ACCESS_GRANTS_COLLECTION).doc(grantId);
+  const snapshot = await ref.get?.();
+  if (!snapshot?.exists) return null;
+  const grant = grantFromSnapshot(snapshot);
+  if (!grant || grant.landlordId !== landlordId) return null;
+  return grant;
+}
+
 async function loadInvitationByTokenHash(
   tokenHash: string,
   firestore: DelegatedAccessFirestoreLike
@@ -246,6 +302,72 @@ async function loadInvitationByTokenHash(
 function stableGrantId(invitation: DelegatedAccessInvitation, delegateUserId: string): string {
   const digest = sha256(JSON.stringify([invitation.invitationId, delegateUserId])).slice(0, 24);
   return `delegated_grant_${digest}`;
+}
+
+function propertyScopeSummary(grants: DelegatedAccessGrant[]): string {
+  const modes = Array.from(new Set(grants.map((grant) => grant.permissionScope.propertyScope.mode))).sort();
+  if (modes.includes("all_current_properties")) return "all_current_properties";
+  const propertyIds = new Set<string>();
+  for (const grant of grants) {
+    for (const propertyId of grant.permissionScope.propertyScope.propertyIds || []) {
+      propertyIds.add(propertyId);
+    }
+  }
+  if (propertyIds.size > 0) return `selected:${propertyIds.size}`;
+  return modes[0] || "none";
+}
+
+function summarizeDelegates(grants: DelegatedAccessGrant[]): DelegatedDelegateSummary[] {
+  const byDelegate = new Map<string, DelegatedAccessGrant[]>();
+  for (const grant of grants) {
+    if (!byDelegate.has(grant.delegateUserId)) byDelegate.set(grant.delegateUserId, []);
+    byDelegate.get(grant.delegateUserId)!.push(grant);
+  }
+  return Array.from(byDelegate.entries())
+    .map(([delegateUserId, delegateGrants]) => {
+      const activeGrants = delegateGrants.filter((grant) => grant.status === "active");
+      const revokedGrants = delegateGrants.filter((grant) => grant.status === "revoked");
+      const workspaceScopes = Array.from(
+        new Set(delegateGrants.flatMap((grant) => grant.permissionScope.workspaceScopes))
+      ).sort();
+      const roles = Array.from(new Set(delegateGrants.map((grant) => grant.role))).sort();
+      const newest = delegateGrants
+        .map((grant) => grant.updatedAt || grant.acceptedAt || grant.createdAt)
+        .filter(Boolean)
+        .sort()
+        .at(-1) || null;
+      return {
+        delegateUserId,
+        delegateEmail: delegateGrants.find((grant) => grant.delegateEmail)?.delegateEmail || null,
+        roles,
+        activeGrantCount: activeGrants.length,
+        revokedGrantCount: revokedGrants.length,
+        workspaceScopes,
+        propertyScopeSummary: propertyScopeSummary(delegateGrants),
+        lastActiveAt: newest,
+      };
+    })
+    .sort((a, b) => String(b.lastActiveAt || "").localeCompare(String(a.lastActiveAt || "")));
+}
+
+export async function listDelegatedAccessGrantRecords(
+  input: { landlordId: string },
+  options: ServiceOptions = {}
+): Promise<{ grants: DelegatedGrantProjection[] }> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const grants = await listGrantsForLandlord(landlordId, firestore);
+  return { grants: grants.map(projectGrant) };
+}
+
+export async function listDelegatedAccessDelegateRecords(
+  input: { landlordId: string },
+  options: ServiceOptions = {}
+): Promise<{ delegates: DelegatedDelegateSummary[] }> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const grants = await listGrantsForLandlord(landlordId, firestore);
+  return { delegates: summarizeDelegates(grants) };
 }
 
 export async function acceptDelegatedAccessInvitationRecord(
@@ -314,6 +436,50 @@ export async function acceptDelegatedAccessInvitationRecord(
     grant: projectGrant(grantWithAudit),
     auditEvent,
   };
+}
+
+export async function revokeDelegatedAccessGrantRecord(
+  input: RevokeGrantInput,
+  options: ServiceOptions = {}
+): Promise<{ grant: DelegatedGrantProjection; auditEvent: DelegatedAccessAuditEvent }> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const grantId = requireString(input.grantId, "missing_grant_id");
+  const grant = await loadGrantForLandlord(landlordId, grantId, firestore);
+  if (!grant) throw new Error("delegated_grant_not_found");
+  const now = input.now || new Date().toISOString();
+  const revoked = revokeDelegatedAccessGrant(grant, {
+    revokedByUserId: actorUserId,
+    revokedAt: now,
+    reason: input.reason || null,
+  });
+  const auditEvent = buildDelegatedAccessAuditEvent({
+    eventType: "delegated_access_revoked",
+    actorUserId,
+    actingForLandlordId: landlordId,
+    delegatedRole: "landlord_owner",
+    permissionScope: grant.permissionScope,
+    actionType: "grant_revoked",
+    targetResourceType: "delegate_grant",
+    targetResourceId: grant.grantId,
+    timestamp: now,
+    outcome: "revoked",
+    before: { status: grant.status },
+    after: {
+      status: revoked.status,
+      delegateUserId: revoked.delegateUserId,
+      role: revoked.role,
+      workspaceScopes: revoked.permissionScope.workspaceScopes,
+      propertyScopeMode: revoked.permissionScope.propertyScope.mode,
+      revokedAt: revoked.revokedAt,
+      reason: revoked.revocationReason,
+    },
+  });
+  const withAudit = { ...revoked, auditEventIds: [...revoked.auditEventIds, auditEvent.eventId] };
+  await saveGrant(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { grant: projectGrant(withAudit), auditEvent };
 }
 
 export async function cancelDelegatedAccessInvitationRecord(


### PR DESCRIPTION
## Summary
- add the approved Mission Brief artifact for delegated access owner management API v1
- add owner-only APIs to list delegate summaries, list active/revoked grants, and revoke active grants
- preserve landlord scope from authenticated owner context and ignore query/body landlord overrides
- record metadata-only audit events for grant revocation

## Security / Scope
- owner-only management routes under /api/landlord/delegated-access
- revocation preserves the grant record and marks it revoked for immediate permission-evaluator denial
- no token or token hash exposure
- no UI, email dispatch, invitation creation changes, acceptance changes, security rules, billing delegation, PM company hierarchy, contractor organizations, or scheduling integration

## Validation
- npm --prefix rentchain-api run test:single -- src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
- npm --prefix rentchain-api run build
- git diff --check