### PR TITLE
feat: add delegated access delegate management ui

### DIFF
--- a/docs/design/mission-briefs/delegated-access-delegate-management-ui-v1.html
+++ b/docs/design/mission-briefs/delegated-access-delegate-management-ui-v1.html
@@ -1,0 +1,472 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Delegated Access Delegate Management UI V1</title>
+    <style>
+      @page {
+        size: 16in 9in;
+        margin: 0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: #f5f7fb;
+        color: #091532;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      .brief {
+        width: 1600px;
+        min-height: 900px;
+        margin: 0 auto;
+        background:
+          linear-gradient(180deg, #071a37 0, #071a37 120px, transparent 120px),
+          #ffffff;
+        box-shadow: 0 20px 80px rgba(9, 21, 50, 0.18);
+      }
+
+      header {
+        height: 120px;
+        display: grid;
+        place-items: center;
+        text-align: center;
+        padding: 18px 48px 20px;
+        color: #ffffff;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 39px;
+        line-height: 1.1;
+        letter-spacing: 0;
+        font-weight: 800;
+      }
+
+      h1 span {
+        color: #7ee36d;
+      }
+
+      .subtitle {
+        margin-top: 8px;
+        font-size: 22px;
+        color: rgba(255, 255, 255, 0.86);
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: 40% 60%;
+        min-height: 780px;
+      }
+
+      section {
+        padding: 22px 28px;
+      }
+
+      .left {
+        border-right: 1px solid #dce3ee;
+      }
+
+      .right {
+        display: grid;
+        grid-template-columns: 1.1fr 0.9fr;
+        gap: 18px;
+      }
+
+      h2 {
+        margin: 0 0 10px;
+        font-size: 24px;
+        line-height: 1.15;
+        color: #091532;
+      }
+
+      h3 {
+        margin: 0 0 8px;
+        font-size: 17px;
+        color: #132b5c;
+      }
+
+      p {
+        margin: 0 0 12px;
+        font-size: 16px;
+        line-height: 1.36;
+      }
+
+      .block {
+        margin-bottom: 16px;
+        padding-bottom: 16px;
+        border-bottom: 1px solid #e2e8f0;
+      }
+
+      .block:last-child {
+        border-bottom: 0;
+        margin-bottom: 0;
+        padding-bottom: 0;
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 7px;
+      }
+
+      li {
+        position: relative;
+        padding-left: 22px;
+        font-size: 15px;
+        line-height: 1.28;
+      }
+
+      li::before {
+        content: "";
+        position: absolute;
+        left: 2px;
+        top: 8px;
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: #12a150;
+      }
+
+      .non-goals {
+        border: 1px solid #f1b7b7;
+        background: #fff8f8;
+        border-radius: 8px;
+        padding: 14px 16px;
+      }
+
+      .non-goals h2 {
+        color: #9f1239;
+        font-size: 20px;
+      }
+
+      .non-goals li::before {
+        background: #e11d48;
+      }
+
+      .principles {
+        display: grid;
+        gap: 9px;
+      }
+
+      .principle {
+        display: grid;
+        grid-template-columns: 28px 1fr;
+        gap: 10px;
+        align-items: start;
+        font-size: 15px;
+        line-height: 1.35;
+      }
+
+      .icon {
+        width: 26px;
+        height: 26px;
+        border: 1px solid #193a76;
+        border-radius: 7px;
+        display: grid;
+        place-items: center;
+        color: #193a76;
+        font-weight: 800;
+        font-size: 13px;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+        overflow: hidden;
+        border: 1px solid #dce3ee;
+        border-radius: 4px;
+      }
+
+      .table th {
+        background: #071a37;
+        color: #ffffff;
+        text-align: left;
+        padding: 10px 12px;
+        font-size: 14px;
+      }
+
+      .table td {
+        border-top: 1px solid #e2e8f0;
+        padding: 10px 12px;
+        vertical-align: top;
+      }
+
+      .method {
+        display: inline-flex;
+        min-width: 64px;
+        justify-content: center;
+        border-radius: 4px;
+        padding: 6px 8px;
+        font-weight: 800;
+        font-size: 13px;
+      }
+
+      .get {
+        color: #047857;
+        background: #ecfdf5;
+        border: 1px solid #a7f3d0;
+      }
+
+      .post {
+        color: #b91c1c;
+        background: #fff1f2;
+        border: 1px solid #fecdd3;
+      }
+
+      .panel {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 14px 16px;
+        margin-bottom: 14px;
+      }
+
+      .status-row {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 8px;
+      }
+
+      .status {
+        border: 1px solid #dce3ee;
+        border-radius: 7px;
+        padding: 9px 10px;
+        background: #ffffff;
+        font-size: 13px;
+        font-weight: 800;
+        text-align: center;
+      }
+
+      .pending {
+        color: #92400e;
+        background: #fffbeb;
+      }
+
+      .active {
+        color: #047857;
+        background: #ecfdf5;
+      }
+
+      .revoked {
+        color: #7f1d1d;
+        background: #fef2f2;
+      }
+
+      .expired {
+        color: #475569;
+        background: #f1f5f9;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, monospace;
+        font-size: 13px;
+        color: #0f2f68;
+        white-space: nowrap;
+      }
+
+      .compact {
+        font-size: 14px;
+        line-height: 1.25;
+      }
+
+      .warning {
+        border-left: 4px solid #d97706;
+        background: #fffbeb;
+      }
+
+      .success {
+        border-left: 4px solid #12a150;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="brief">
+      <header>
+        <div>
+          <h1>Next Mission: <span>feat/delegated-access-delegate-management-ui-v1</span></h1>
+          <div class="subtitle">Landlord-facing delegated access management without shared logins.</div>
+        </div>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>Mission Goal</h2>
+            <p>
+              Create the first owner-facing UI for landlord delegates so owners can view pending invitations,
+              active/revoked grants, invite delegates, and revoke access using the merged backend contracts.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Scope</h2>
+            <ul>
+              <li>Delegate Management page or Settings subpage for landlord owners.</li>
+              <li>List delegates, invitations, and grants with clear statuses.</li>
+              <li>Invite Delegate workflow using existing invitation API.</li>
+              <li>Revoke Access action using owner-management API.</li>
+              <li>Role and scope display suitable for v1 landlord review.</li>
+              <li>Calm empty state and security messaging against shared logins.</li>
+            </ul>
+          </div>
+
+          <div class="block non-goals">
+            <h2>Non-goals</h2>
+            <ul>
+              <li>No email dispatch or notification sending.</li>
+              <li>No invite acceptance UI unless already safe and minimal.</li>
+              <li>No property manager companies or contractor organizations.</li>
+              <li>No billing delegation or custom roles.</li>
+              <li>No security rule changes or backend redesign.</li>
+              <li>No exposure of internal IDs, tokens, token hashes, or sensitive metadata.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Key Principles</h2>
+            <div class="principles">
+              <div class="principle"><div class="icon">O</div><div><strong>Owner-first:</strong> only landlord owners can manage delegate access.</div></div>
+              <div class="principle"><div class="icon">F</div><div><strong>Fail-closed:</strong> ambiguous entitlement or auth state blocks management actions.</div></div>
+              <div class="principle"><div class="icon">S</div><div><strong>No shared logins:</strong> delegates must use their own accounts.</div></div>
+              <div class="principle"><div class="icon">R</div><div><strong>Revocation clarity:</strong> access removal must feel immediate and understandable.</div></div>
+              <div class="principle"><div class="icon">P</div><div><strong>Projection-safe UI:</strong> show human-readable role/scope/status without raw secrets.</div></div>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Security / Privacy Warning</h2>
+            <div class="panel warning compact">
+              Primary copy: <strong>Never share your login. Invite delegates to their own account.</strong>
+              The UI should explain that revoking access prevents future delegated actions while preserving audit history.
+            </div>
+          </div>
+        </section>
+
+        <section class="right">
+          <div>
+            <div class="block">
+              <h2>UX Flow</h2>
+              <ul>
+                <li>Owner opens Delegate Management from Settings or landlord workspace navigation.</li>
+                <li>Owner sees overview: pending, active, revoked, expired.</li>
+                <li>Owner invites a delegate by email, predefined role, property scope, workspace scope.</li>
+                <li>Owner reviews delegates/grants and revokes an active grant when needed.</li>
+                <li>Empty state explains delegated access without implying email dispatch.</li>
+              </ul>
+            </div>
+
+            <div class="block">
+              <h2>API Endpoints Used</h2>
+              <table class="table">
+                <thead>
+                  <tr><th>Method</th><th>Endpoint</th><th>Use</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td><span class="method get">GET</span></td><td><code>/api/landlord/delegated-access/delegates</code></td><td>Delegate summary list.</td></tr>
+                  <tr><td><span class="method get">GET</span></td><td><code>/api/landlord/delegated-access/grants</code></td><td>Active and revoked grants.</td></tr>
+                  <tr><td><span class="method get">GET</span></td><td><code>/api/landlord/delegated-access/invitations</code></td><td>Pending, accepted, cancelled, expired invitations.</td></tr>
+                  <tr><td><span class="method post">POST</span></td><td><code>/api/landlord/delegated-access/invitations</code></td><td>Create pending invite.</td></tr>
+                  <tr><td><span class="method post">POST</span></td><td><code>/api/landlord/delegated-access/grants/:grantId/revoke</code></td><td>Revoke active grant.</td></tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="block">
+              <h2>Data Displayed</h2>
+              <div class="status-row">
+                <div class="status pending">Pending</div>
+                <div class="status active">Active</div>
+                <div class="status revoked">Revoked</div>
+                <div class="status expired">Expired</div>
+              </div>
+              <div class="panel compact" style="margin-top: 12px">
+                Display: delegate email/name if available, predefined role, status, workspace scope, property scope summary,
+                created/updated/revoked timestamps, and last activity when safely available.
+              </div>
+            </div>
+
+            <div class="block">
+              <h2>Acceptance Criteria</h2>
+              <ul>
+                <li>Owner can view delegates, grants, and invitations without duplicate inbox/workspace concepts.</li>
+                <li>Non-owner or ambiguous auth state cannot access the management UI.</li>
+                <li>Owner can create a pending invitation with valid role/scope.</li>
+                <li>Owner can revoke an active grant and see the revoked state immediately.</li>
+                <li>Empty, loading, error, and mobile states are intentional.</li>
+              </ul>
+            </div>
+          </div>
+
+          <div>
+            <div class="panel success">
+              <h2>Revocation Behavior</h2>
+              <ul>
+                <li>Only active grants can be revoked.</li>
+                <li>Grant record is preserved, not deleted.</li>
+                <li>UI updates grant status to Revoked immediately after success.</li>
+                <li>Copy clarifies revocation affects future delegated access.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>Risks</h2>
+              <ul>
+                <li>Owner-only UI guard must not rely on client assumptions alone.</li>
+                <li>Role/scope labels must not expose internal implementation details.</li>
+                <li>No token/hash data should appear in logs, UI, tests, or errors.</li>
+                <li>Email expectations must be clear because dispatch is out of scope.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>QA Checklist</h2>
+              <ul>
+                <li>Owner route loads and shows security message.</li>
+                <li>Invite form validates role, email, property scope, workspace scope.</li>
+                <li>Delegates, grants, and invitations render correct status labels.</li>
+                <li>Revoke action works and cannot be repeated as active revoke.</li>
+                <li>Mobile layout has no horizontal overflow.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>Validation Requirements</h2>
+              <ul>
+                <li>Frontend tests for page, invite workflow, revoke workflow, and owner-only states.</li>
+                <li>Backend tests only if a small API adapter change requires them.</li>
+                <li>Frontend build.</li>
+                <li><code>git diff --check</code>.</li>
+                <li>Manual preview QA before merge.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>Merge Readiness Criteria</h2>
+              <ul>
+                <li>Mission Brief reviewed and accepted before implementation.</li>
+                <li>Implemented scope matches this brief.</li>
+                <li>Checks are green and manual preview QA passes or findings are triaged.</li>
+                <li>No backend redesign, email dispatch, billing delegation, custom roles, or org hierarchy added.</li>
+              </ul>
+            </div>
+
+            <div class="panel compact">
+              <h3>Audit Events</h3>
+              Existing backend audit events are consumed as contract behavior. UI should not create client-side audit records.
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -136,6 +136,10 @@ vi.mock("./pages/SchedulingWorkspacePage", () => ({
   default: () => <h1>Scheduling Workspace Page</h1>,
 }));
 
+vi.mock("./pages/DelegatedAccessPage", () => ({
+  default: () => <h1>Delegate Management Page</h1>,
+}));
+
 vi.mock("./pages/DecisionInboxPage", () => ({
   default: () => <h1>Decision Inbox Page</h1>,
 }));
@@ -377,6 +381,20 @@ describe("Routes: /scheduling", () => {
     );
 
     expect(await screen.findByText(/Scheduling Workspace Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /account/delegated-access", () => {
+  it("renders the delegated access management route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/account/delegated-access"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Delegate Management Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -191,6 +191,7 @@ const ReferralsPage = lazy(() => import("./pages/ReferralsPage"));
 const AccountPage = lazy(() => import("./pages/AccountPage"));
 const AccountProfilePage = lazy(() => import("./pages/account/AccountProfilePage"));
 const AccountDataPage = lazy(() => import("./pages/account/AccountDataPage"));
+const DelegatedAccessPage = lazy(() => import("./pages/DelegatedAccessPage"));
 const ExpensesPage = lazy(() => import("./pages/ExpensesPage"));
 const WorkOrdersPage = lazy(() => import("./pages/landlord/WorkOrdersPage"));
 const WorkOrderNewPage = lazy(() => import("./pages/landlord/WorkOrderNewPage"));
@@ -928,6 +929,20 @@ function App() {
                 <Suspense fallback={null}>
                   <ReferralsPage />
                 </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/account/delegated-access"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <AccountRouteGate>
+                  <Suspense fallback={null}>
+                    <DelegatedAccessPage />
+                  </Suspense>
+                </AccountRouteGate>
               </LandlordNav>
             </RequireAuth>
           }

--- a/rentchain-frontend/src/api/delegatedAccessApi.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.ts
@@ -1,0 +1,135 @@
+import { apiFetch } from "./apiFetch";
+
+export type DelegatedAccessRole =
+  | "property_manager"
+  | "assistant_office_admin"
+  | "maintenance_coordinator"
+  | "contractor"
+  | "contractor_admin"
+  | "read_only_auditor";
+
+export type DelegatedAccessInvitationStatus = "pending" | "accepted" | "expired" | "cancelled";
+export type DelegatedAccessGrantStatus = "active" | "revoked" | "suspended" | "expired";
+export type DelegatedAccessWorkspaceScope =
+  | "dashboard"
+  | "operations"
+  | "properties"
+  | "tenants"
+  | "leases"
+  | "payments"
+  | "unified_inbox"
+  | "scheduling"
+  | "work_orders"
+  | "evidence_exports";
+export type DelegatedAccessPermissionAction = "view" | "create" | "edit" | "approve" | "export" | "assign" | "message";
+export type DelegatedAccessPropertyScopeMode = "all_current_properties" | "selected" | "resource_only" | "none";
+
+export type DelegatedAccessPropertyScope = {
+  mode: DelegatedAccessPropertyScopeMode;
+  propertyIds: string[];
+  unitIds?: string[];
+};
+
+export type DelegatedAccessResourceScope = {
+  workOrderIds?: string[];
+  maintenanceRequestIds?: string[];
+  messageThreadIds?: string[];
+  evidencePackageIds?: string[];
+  exportPackageIds?: string[];
+  contractorJobIds?: string[];
+};
+
+export type DelegatedAccessPermissionScope = {
+  role: DelegatedAccessRole;
+  workspaceScopes: DelegatedAccessWorkspaceScope[];
+  propertyScope: DelegatedAccessPropertyScope;
+  resourceScope: DelegatedAccessResourceScope;
+  permissionFlags: DelegatedAccessPermissionAction[];
+  billingAccess: false;
+  exportAccess: boolean;
+};
+
+export type DelegatedAccessInvitation = {
+  invitationId: string;
+  inviteeEmail: string;
+  role: DelegatedAccessRole;
+  propertyScope: DelegatedAccessPropertyScope;
+  workspaceScopes: DelegatedAccessWorkspaceScope[];
+  resourceScope?: DelegatedAccessResourceScope;
+  permissionFlags: DelegatedAccessPermissionAction[];
+  status: DelegatedAccessInvitationStatus;
+  expiresAt: string;
+  createdAt: string;
+  acceptedAt: string | null;
+  cancelledAt: string | null;
+};
+
+export type DelegatedAccessGrant = {
+  grantId: string;
+  delegateUserId: string;
+  delegateEmail: string | null;
+  role: DelegatedAccessRole;
+  status: DelegatedAccessGrantStatus;
+  permissionScope: DelegatedAccessPermissionScope;
+  createdAt: string;
+  acceptedAt: string | null;
+  updatedAt: string;
+  revokedAt: string | null;
+  revocationReason: string | null;
+};
+
+export type DelegatedAccessDelegateSummary = {
+  delegateUserId: string;
+  delegateEmail: string | null;
+  roles: DelegatedAccessRole[];
+  activeGrantCount: number;
+  revokedGrantCount: number;
+  workspaceScopes: DelegatedAccessWorkspaceScope[];
+  propertyScopeSummary: string;
+  lastActiveAt: string | null;
+};
+
+export type CreateDelegatedAccessInvitationInput = {
+  inviteeEmail: string;
+  role: DelegatedAccessRole;
+  propertyScope: DelegatedAccessPropertyScope;
+  workspaceScopes: DelegatedAccessWorkspaceScope[];
+  permissionFlags: DelegatedAccessPermissionAction[];
+  expiresAt: string;
+};
+
+export async function fetchDelegatedAccessDelegates(): Promise<DelegatedAccessDelegateSummary[]> {
+  const response = await apiFetch<{ ok: true; delegates: DelegatedAccessDelegateSummary[] }>(
+    "/landlord/delegated-access/delegates"
+  );
+  return response.delegates || [];
+}
+
+export async function fetchDelegatedAccessGrants(): Promise<DelegatedAccessGrant[]> {
+  const response = await apiFetch<{ ok: true; grants: DelegatedAccessGrant[] }>("/landlord/delegated-access/grants");
+  return response.grants || [];
+}
+
+export async function fetchDelegatedAccessInvitations(): Promise<DelegatedAccessInvitation[]> {
+  const response = await apiFetch<{ ok: true; invitations: DelegatedAccessInvitation[] }>(
+    "/landlord/delegated-access/invitations"
+  );
+  return response.invitations || [];
+}
+
+export async function createDelegatedAccessInvitation(input: CreateDelegatedAccessInvitationInput) {
+  return apiFetch<{ ok: true; invitation: DelegatedAccessInvitation }>("/landlord/delegated-access/invitations", {
+    method: "POST",
+    body: input,
+  });
+}
+
+export async function revokeDelegatedAccessGrant(grantId: string, reason?: string) {
+  return apiFetch<{ ok: true; grant: DelegatedAccessGrant }>(
+    `/landlord/delegated-access/grants/${encodeURIComponent(grantId)}/revoke`,
+    {
+      method: "POST",
+      body: { reason: String(reason || "").trim() || null },
+    }
+  );
+}

--- a/rentchain-frontend/src/api/delegatedAccessApi.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.ts
@@ -124,6 +124,15 @@ export async function createDelegatedAccessInvitation(input: CreateDelegatedAcce
   });
 }
 
+export async function cancelDelegatedAccessInvitation(invitationId: string) {
+  return apiFetch<{ ok: true; invitation: DelegatedAccessInvitation }>(
+    `/landlord/delegated-access/invitations/${encodeURIComponent(invitationId)}/cancel`,
+    {
+      method: "POST",
+    }
+  );
+}
+
 export async function revokeDelegatedAccessGrant(grantId: string, reason?: string) {
   return apiFetch<{ ok: true; grant: DelegatedAccessGrant }>(
     `/landlord/delegated-access/grants/${encodeURIComponent(grantId)}/revoke`,

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -167,6 +167,21 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByText("Inbox", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
   });
 
+  it("keeps delegate management in the sticky workspace shell", () => {
+    renderLandlordNav("/account/delegated-access");
+
+    const context = screen.getByLabelText("Workspace context");
+    const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
+    const topNav = document.querySelector(".rc-landlord-topnav");
+    const content = document.querySelector(".rc-landlord-content");
+
+    expect(topNav).toBeInTheDocument();
+    expect(content).toHaveClass("rc-landlord-content--sticky-offset");
+    expect(context).toHaveTextContent("Delegate Management");
+    expect(within(workspaceNav).getByRole("link", { name: "Delegate Management" })).toHaveClass("active");
+    expect(screen.getByText("Delegate Management", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
+  });
+
   it("keeps the mobile tab bar and close control available while the drawer is open", () => {
     renderLandlordNav();
 

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -33,9 +33,11 @@ const stickyWorkspaceIds = new Set([
   "scheduling",
   "unified-inbox",
   "work-orders",
+  "delegated-access",
 ]);
 
 const workspaceAliases: Array<{ prefix: string; label: string }> = [
+  { prefix: "/account/delegated-access", label: "Delegate Management" },
   { prefix: "/landlord/inbox", label: "Inbox" },
   { prefix: "/landlord/unified-inbox", label: "Inbox" },
   { prefix: "/work-orders", label: "Work Orders" },

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -174,6 +174,15 @@ export const NAV_ITEMS: NavItem[] = [
     requiresLandlordOrAdmin: true,
   },
   {
+    id: "delegated-access",
+    label: "Delegate Management",
+    to: "/account/delegated-access",
+    icon: User,
+    showInDrawer: false,
+    showInTabs: false,
+    requiresLandlordOrAdmin: true,
+  },
+  {
     id: "onboarding-hardening",
     label: "Onboarding",
     to: "/onboarding-hardening",

--- a/rentchain-frontend/src/pages/AccountPage.test.tsx
+++ b/rentchain-frontend/src/pages/AccountPage.test.tsx
@@ -70,5 +70,7 @@ describe("AccountPage", () => {
       screen.getByText("Uses the same billing access level shown in your workspace and checkout flow.")
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Security controls coming soon" })).toBeDisabled();
+    expect(screen.getByText("Delegated Access")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Manage delegates" })).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/AccountPage.tsx
+++ b/rentchain-frontend/src/pages/AccountPage.tsx
@@ -121,6 +121,12 @@ const AccountPage: React.FC = () => {
           </Button>
         </HubCard>
 
+        <HubCard title="Delegated Access" description="Invite staff or trusted collaborators to use their own account instead of sharing yours.">
+          <Button type="button" onClick={() => navigate("/account/delegated-access")}>
+            Manage delegates
+          </Button>
+        </HubCard>
+
         <HubCard title="Billing & Plans" description="View your plan, receipts, and manage paid upgrades with pricing that matches checkout.">
           <Button type="button" onClick={() => navigate("/billing")}>
             Billing

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DelegatedAccessPage from "./DelegatedAccessPage";
+import type { DelegatedAccessGrant, DelegatedAccessInvitation } from "../api/delegatedAccessApi";
+
+const mocks = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  showToast: vi.fn(),
+  fetchDelegates: vi.fn(),
+  fetchGrants: vi.fn(),
+  fetchInvitations: vi.fn(),
+  createInvitation: vi.fn(),
+  revokeGrant: vi.fn(),
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: mocks.useAuthMock,
+}));
+
+vi.mock("../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+vi.mock("../api/delegatedAccessApi", async () => {
+  const actual = await vi.importActual<object>("../api/delegatedAccessApi");
+  return {
+    ...actual,
+    fetchDelegatedAccessDelegates: mocks.fetchDelegates,
+    fetchDelegatedAccessGrants: mocks.fetchGrants,
+    fetchDelegatedAccessInvitations: mocks.fetchInvitations,
+    createDelegatedAccessInvitation: mocks.createInvitation,
+    revokeDelegatedAccessGrant: mocks.revokeGrant,
+  };
+});
+
+function grant(overrides: Partial<DelegatedAccessGrant> = {}): DelegatedAccessGrant {
+  return {
+    grantId: "grant-internal-1",
+    delegateUserId: "delegate-user-1",
+    delegateEmail: "manager@example.com",
+    role: "property_manager",
+    status: "active",
+    permissionScope: {
+      role: "property_manager",
+      workspaceScopes: ["dashboard", "operations"],
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      resourceScope: {},
+      permissionFlags: ["view", "edit"],
+      billingAccess: false,
+      exportAccess: false,
+    },
+    createdAt: "2026-06-22T12:00:00.000Z",
+    acceptedAt: "2026-06-22T12:00:00.000Z",
+    updatedAt: "2026-06-22T12:00:00.000Z",
+    revokedAt: null,
+    revocationReason: null,
+    ...overrides,
+  };
+}
+
+function invitation(overrides: Partial<DelegatedAccessInvitation> = {}): DelegatedAccessInvitation {
+  return {
+    invitationId: "invitation-internal-1",
+    inviteeEmail: "assistant@example.com",
+    role: "assistant_office_admin",
+    propertyScope: { mode: "all_current_properties", propertyIds: [] },
+    workspaceScopes: ["dashboard", "unified_inbox"],
+    resourceScope: {},
+    permissionFlags: ["view", "message"],
+    status: "pending",
+    expiresAt: "2026-07-22T23:59:59.000Z",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    acceptedAt: null,
+    cancelledAt: null,
+    ...overrides,
+  };
+}
+
+describe("DelegatedAccessPage", () => {
+  beforeEach(() => {
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "owner-user-1", role: "landlord", email: "owner@example.com" },
+    });
+    mocks.fetchDelegates.mockResolvedValue([
+      {
+        delegateUserId: "delegate-user-1",
+        delegateEmail: "manager@example.com",
+        roles: ["property_manager"],
+        activeGrantCount: 1,
+        revokedGrantCount: 0,
+        workspaceScopes: ["dashboard", "operations"],
+        propertyScopeSummary: "all_current_properties",
+        lastActiveAt: "2026-06-22T12:00:00.000Z",
+      },
+    ]);
+    mocks.fetchGrants.mockResolvedValue([grant()]);
+    mocks.fetchInvitations.mockResolvedValue([invitation()]);
+    mocks.createInvitation.mockResolvedValue({ ok: true, invitation: invitation({ inviteeEmail: "new@example.com" }) });
+    mocks.revokeGrant.mockResolvedValue({ ok: true, grant: grant({ status: "revoked" }) });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("lists delegates, pending invitations, and active grants without showing internal ids or token data", async () => {
+    render(<DelegatedAccessPage />);
+
+    expect(await screen.findByRole("heading", { name: "Delegate Management" })).toBeInTheDocument();
+    expect(screen.getByText("Never share your login. Invite delegates to their own account.")).toBeInTheDocument();
+    expect(screen.getByText("assistant@example.com")).toBeInTheDocument();
+    expect(screen.getAllByText("manager@example.com").length).toBeGreaterThan(0);
+    expect(screen.getByText("Property Manager")).toBeInTheDocument();
+    expect(screen.getByText("Assistant / Office Admin · All current properties")).toBeInTheDocument();
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/grant-internal/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/invitation-internal/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/tokenHash|valid-token/i)).not.toBeInTheDocument();
+  });
+
+  it("creates a pending invitation with role, scope, and permission fields", async () => {
+    render(<DelegatedAccessPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Invite Delegate" }));
+    fireEvent.change(screen.getByLabelText("Delegate email"), { target: { value: "new@example.com" } });
+    fireEvent.change(screen.getByLabelText("Delegate role"), { target: { value: "maintenance_coordinator" } });
+    fireEvent.click(screen.getByLabelText("Properties"));
+    fireEvent.click(screen.getByLabelText("Assign"));
+    fireEvent.click(screen.getByRole("button", { name: "Create Invitation" }));
+
+    await waitFor(() => expect(mocks.createInvitation).toHaveBeenCalledTimes(1));
+    expect(mocks.createInvitation.mock.calls[0][0]).toMatchObject({
+      inviteeEmail: "new@example.com",
+      role: "maintenance_coordinator",
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: expect.arrayContaining(["dashboard", "operations", "properties"]),
+      permissionFlags: expect.arrayContaining(["view", "assign"]),
+    });
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Delegate invitation created",
+        description: expect.stringMatching(/Email dispatch is not enabled yet/i),
+      })
+    );
+  });
+
+  it("revokes an active grant and leaves revoked grants as non-repeatable records", async () => {
+    mocks.fetchGrants.mockResolvedValue([
+      grant(),
+      grant({
+        grantId: "grant-internal-2",
+        delegateEmail: "former@example.com",
+        status: "revoked",
+        revokedAt: "2026-06-23T12:00:00.000Z",
+        revocationReason: "Staff turnover",
+      }),
+    ]);
+    render(<DelegatedAccessPage />);
+
+    await screen.findByText("former@example.com");
+    expect(screen.getAllByRole("button", { name: "Revoke Access" })).toHaveLength(1);
+    fireEvent.change(screen.getByLabelText("Revocation reason for manager@example.com"), {
+      target: { value: "Staff turnover" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Revoke Access" }));
+
+    await waitFor(() => expect(mocks.revokeGrant).toHaveBeenCalledWith("grant-internal-1", "Staff turnover"));
+    expect(screen.getByText("Reason: Staff turnover")).toBeInTheDocument();
+  });
+
+  it("shows a calm empty state when there are no delegates, grants, or invitations", async () => {
+    mocks.fetchDelegates.mockResolvedValue([]);
+    mocks.fetchGrants.mockResolvedValue([]);
+    mocks.fetchInvitations.mockResolvedValue([]);
+
+    render(<DelegatedAccessPage />);
+
+    expect(await screen.findByText("No delegated access yet")).toBeInTheDocument();
+    expect(screen.getByText(/Invite delegates when you need staff or external collaborators/i)).toBeInTheDocument();
+  });
+
+  it("blocks non-owner users before loading delegate data", async () => {
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "delegate-user-1", role: "landlord_delegate", email: "delegate@example.com" },
+    });
+
+    render(<DelegatedAccessPage />);
+
+    expect(screen.getByText("Delegate management is available only to landlord owners.")).toBeInTheDocument();
+    expect(mocks.fetchDelegates).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Invite Delegate" })).not.toBeInTheDocument();
+  });
+
+  it("filters visible records by status", async () => {
+    mocks.fetchGrants.mockResolvedValue([grant(), grant({ grantId: "revoked-grant", delegateEmail: "former@example.com", status: "revoked" })]);
+    mocks.fetchInvitations.mockResolvedValue([
+      invitation(),
+      invitation({ invitationId: "expired-invitation", inviteeEmail: "expired@example.com", status: "expired" }),
+    ]);
+
+    render(<DelegatedAccessPage />);
+
+    expect(await screen.findByText("assistant@example.com")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Revoked" }));
+
+    const visibleRecords = screen.getAllByTestId("delegated-access-record");
+    expect(visibleRecords).toHaveLength(1);
+    expect(visibleRecords[0]).toHaveAttribute("data-status", "revoked");
+    expect(visibleRecords[0]).toHaveTextContent("former@example.com");
+    expect(visibleRecords[0]).not.toHaveTextContent("assistant@example.com");
+    expect(visibleRecords[0]).not.toHaveTextContent("manager@example.com");
+  });
+});

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
@@ -106,9 +106,10 @@ describe("DelegatedAccessPage", () => {
   });
 
   it("lists delegates, pending invitations, and active grants without showing internal ids or token data", async () => {
-    render(<DelegatedAccessPage />);
+    const { container } = render(<DelegatedAccessPage />);
 
     expect(await screen.findByRole("heading", { name: "Delegate Management" })).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveStyle({ margin: "0 auto", maxWidth: "1320px" });
     expect(screen.getByText("Never share your login. Invite delegates to their own account.")).toBeInTheDocument();
     expect(screen.getByText("assistant@example.com")).toBeInTheDocument();
     expect(screen.getAllByText("manager@example.com").length).toBeGreaterThan(0);
@@ -186,12 +187,33 @@ describe("DelegatedAccessPage", () => {
     mocks.useAuthMock.mockReturnValue({
       user: { id: "delegate-user-1", role: "landlord_delegate", email: "delegate@example.com" },
     });
+    mocks.fetchDelegates.mockResolvedValue([
+      {
+        delegateUserId: "delegate-user-1",
+        delegateEmail: "manager@example.com",
+        roles: ["property_manager"],
+        activeGrantCount: 1,
+        revokedGrantCount: 0,
+        workspaceScopes: ["dashboard"],
+        propertyScopeSummary: "all_current_properties",
+        lastActiveAt: "2026-06-22T12:00:00.000Z",
+      },
+    ]);
+    mocks.fetchGrants.mockResolvedValue([grant()]);
+    mocks.fetchInvitations.mockResolvedValue([invitation()]);
 
     render(<DelegatedAccessPage />);
 
     expect(screen.getByText("Delegate management is available only to landlord owners.")).toBeInTheDocument();
     expect(mocks.fetchDelegates).not.toHaveBeenCalled();
+    expect(mocks.fetchGrants).not.toHaveBeenCalled();
+    expect(mocks.fetchInvitations).not.toHaveBeenCalled();
+    expect(mocks.createInvitation).not.toHaveBeenCalled();
+    expect(mocks.revokeGrant).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: "Invite Delegate" })).not.toBeInTheDocument();
+    expect(screen.queryByText("manager@example.com")).not.toBeInTheDocument();
+    expect(screen.queryByText("assistant@example.com")).not.toBeInTheDocument();
+    expect(screen.queryByText("Property Manager")).not.toBeInTheDocument();
   });
 
   it("filters visible records by status", async () => {

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   fetchGrants: vi.fn(),
   fetchInvitations: vi.fn(),
   createInvitation: vi.fn(),
+  cancelInvitation: vi.fn(),
   revokeGrant: vi.fn(),
 }));
 
@@ -30,6 +31,7 @@ vi.mock("../api/delegatedAccessApi", async () => {
     fetchDelegatedAccessGrants: mocks.fetchGrants,
     fetchDelegatedAccessInvitations: mocks.fetchInvitations,
     createDelegatedAccessInvitation: mocks.createInvitation,
+    cancelDelegatedAccessInvitation: mocks.cancelInvitation,
     revokeDelegatedAccessGrant: mocks.revokeGrant,
   };
 });
@@ -97,6 +99,10 @@ describe("DelegatedAccessPage", () => {
     mocks.fetchGrants.mockResolvedValue([grant()]);
     mocks.fetchInvitations.mockResolvedValue([invitation()]);
     mocks.createInvitation.mockResolvedValue({ ok: true, invitation: invitation({ inviteeEmail: "new@example.com" }) });
+    mocks.cancelInvitation.mockResolvedValue({
+      ok: true,
+      invitation: invitation({ status: "cancelled", cancelledAt: "2026-06-23T12:00:00.000Z" }),
+    });
     mocks.revokeGrant.mockResolvedValue({ ok: true, grant: grant({ status: "revoked" }) });
   });
 
@@ -146,6 +152,41 @@ describe("DelegatedAccessPage", () => {
         description: expect.stringMatching(/Email dispatch is not enabled yet/i),
       })
     );
+  });
+
+  it("cancels pending invitations and removes the cancel action after cancellation", async () => {
+    render(<DelegatedAccessPage />);
+
+    expect(await screen.findByText("assistant@example.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel Invitation" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel Invitation" }));
+
+    await waitFor(() => expect(mocks.cancelInvitation).toHaveBeenCalledWith("invitation-internal-1"));
+    const visibleRecords = screen.getAllByTestId("delegated-access-record");
+    const invitationRecord = visibleRecords.find((record) => record.textContent?.includes("assistant@example.com"));
+    expect(invitationRecord).toBeTruthy();
+    expect(invitationRecord).toHaveAttribute("data-status", "cancelled");
+    expect(invitationRecord).toHaveTextContent("Cancelled");
+    expect(screen.queryByRole("button", { name: "Cancel Invitation" })).not.toBeInTheDocument();
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Invitation cancelled",
+      })
+    );
+  });
+
+  it("does not offer cancel for cancelled or expired invitations", async () => {
+    mocks.fetchInvitations.mockResolvedValue([
+      invitation({ invitationId: "cancelled-invitation", inviteeEmail: "cancelled@example.com", status: "cancelled" }),
+      invitation({ invitationId: "expired-invitation", inviteeEmail: "expired@example.com", status: "expired" }),
+    ]);
+
+    render(<DelegatedAccessPage />);
+
+    expect(await screen.findByText("cancelled@example.com")).toBeInTheDocument();
+    expect(screen.getByText("expired@example.com")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel Invitation" })).not.toBeInTheDocument();
   });
 
   it("revokes an active grant and leaves revoked grants as non-repeatable records", async () => {

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -1,0 +1,634 @@
+import React from "react";
+import { ShieldCheck, UserPlus } from "lucide-react";
+import { Button, Card, EmptyState, Input, Pill, Section, SkeletonBlock } from "../components/ui/Ui";
+import { useToast } from "../components/ui/ToastProvider";
+import { useAuth } from "../context/useAuth";
+import {
+  createDelegatedAccessInvitation,
+  fetchDelegatedAccessDelegates,
+  fetchDelegatedAccessGrants,
+  fetchDelegatedAccessInvitations,
+  revokeDelegatedAccessGrant,
+  type CreateDelegatedAccessInvitationInput,
+  type DelegatedAccessDelegateSummary,
+  type DelegatedAccessGrant,
+  type DelegatedAccessInvitation,
+  type DelegatedAccessPermissionAction,
+  type DelegatedAccessPropertyScopeMode,
+  type DelegatedAccessRole,
+  type DelegatedAccessWorkspaceScope,
+} from "../api/delegatedAccessApi";
+import { colors, radius, spacing, text } from "../styles/tokens";
+
+const roleLabels: Record<DelegatedAccessRole, string> = {
+  property_manager: "Property Manager",
+  assistant_office_admin: "Assistant / Office Admin",
+  maintenance_coordinator: "Maintenance Coordinator",
+  contractor: "Contractor",
+  contractor_admin: "Contractor Admin",
+  read_only_auditor: "Read-only Auditor",
+};
+
+const workspaceLabels: Record<DelegatedAccessWorkspaceScope, string> = {
+  dashboard: "Dashboard",
+  operations: "Operations",
+  properties: "Properties",
+  tenants: "Tenants",
+  leases: "Leases",
+  payments: "Payments",
+  unified_inbox: "Unified Inbox",
+  scheduling: "Scheduling",
+  work_orders: "Work Orders",
+  evidence_exports: "Evidence / Exports",
+};
+
+const permissionLabels: Record<DelegatedAccessPermissionAction, string> = {
+  view: "View",
+  create: "Create",
+  edit: "Edit",
+  approve: "Approve",
+  export: "Export",
+  assign: "Assign",
+  message: "Message",
+};
+
+const roles = Object.keys(roleLabels) as DelegatedAccessRole[];
+const workspaces = Object.keys(workspaceLabels) as DelegatedAccessWorkspaceScope[];
+const permissions = Object.keys(permissionLabels) as DelegatedAccessPermissionAction[];
+
+const defaultWorkspaces: DelegatedAccessWorkspaceScope[] = ["dashboard", "operations"];
+const defaultPermissions: DelegatedAccessPermissionAction[] = ["view"];
+
+function labelList<T extends string>(items: T[], labels: Record<T, string>) {
+  if (!items.length) return "None";
+  return items.map((item) => labels[item] || item).join(", ");
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "Unavailable";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Unavailable";
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+function defaultExpiryDate() {
+  const date = new Date();
+  date.setDate(date.getDate() + 14);
+  return date.toISOString().slice(0, 10);
+}
+
+function toIsoDate(value: string) {
+  if (!value) return new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString();
+  return new Date(`${value}T23:59:59.000Z`).toISOString();
+}
+
+function propertyScopeLabel(mode: DelegatedAccessPropertyScopeMode, selectedSummary?: string) {
+  if (mode === "all_current_properties") return "All current properties";
+  if (mode === "selected") return selectedSummary || "Selected properties";
+  if (mode === "resource_only") return "Resource-only";
+  return "No property scope";
+}
+
+function statusTone(status: string): "accent" | "muted" {
+  return status === "active" || status === "pending" ? "accent" : "muted";
+}
+
+function statusLabel(status: string) {
+  return status
+    .split("_")
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function isOwnerRole(user: any) {
+  const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
+  return role === "landlord";
+}
+
+function ToggleChip({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 10px",
+        borderRadius: radius.pill,
+        border: `1px solid ${checked ? colors.accent : colors.border}`,
+        background: checked ? colors.accentSoft : colors.card,
+        fontSize: 13,
+        fontWeight: 700,
+        cursor: "pointer",
+      }}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        style={{ margin: 0 }}
+      />
+      {label}
+    </label>
+  );
+}
+
+function StatusCard({ label, value }: { label: string; value: number }) {
+  return (
+    <Card style={{ padding: spacing.md, display: "grid", gap: 4 }}>
+      <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontSize: 26, fontWeight: 900 }}>{value}</div>
+    </Card>
+  );
+}
+
+export default function DelegatedAccessPage() {
+  const { user } = useAuth();
+  const { showToast } = useToast();
+  const [delegates, setDelegates] = React.useState<DelegatedAccessDelegateSummary[]>([]);
+  const [grants, setGrants] = React.useState<DelegatedAccessGrant[]>([]);
+  const [invitations, setInvitations] = React.useState<DelegatedAccessInvitation[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = React.useState<"all" | "pending" | "active" | "revoked" | "expired">("all");
+  const [inviteOpen, setInviteOpen] = React.useState(false);
+  const [inviteEmail, setInviteEmail] = React.useState("");
+  const [inviteRole, setInviteRole] = React.useState<DelegatedAccessRole>("property_manager");
+  const [propertyScopeMode, setPropertyScopeMode] = React.useState<DelegatedAccessPropertyScopeMode>("all_current_properties");
+  const [workspaceScopes, setWorkspaceScopes] = React.useState<DelegatedAccessWorkspaceScope[]>(defaultWorkspaces);
+  const [permissionFlags, setPermissionFlags] = React.useState<DelegatedAccessPermissionAction[]>(defaultPermissions);
+  const [expiresAt, setExpiresAt] = React.useState(defaultExpiryDate());
+  const [submitting, setSubmitting] = React.useState(false);
+  const [revokingGrantId, setRevokingGrantId] = React.useState<string | null>(null);
+  const [revocationReason, setRevocationReason] = React.useState("");
+  const canManage = isOwnerRole(user);
+
+  const load = React.useCallback(async () => {
+    if (!canManage) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const [delegateRows, grantRows, inviteRows] = await Promise.all([
+        fetchDelegatedAccessDelegates(),
+        fetchDelegatedAccessGrants(),
+        fetchDelegatedAccessInvitations(),
+      ]);
+      setDelegates(delegateRows);
+      setGrants(grantRows);
+      setInvitations(inviteRows);
+    } catch (err: any) {
+      setError(err?.message || "Unable to load delegated access");
+    } finally {
+      setLoading(false);
+    }
+  }, [canManage]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  const pendingInvitations = invitations.filter((invitation) => invitation.status === "pending");
+  const expiredInvitations = invitations.filter((invitation) => invitation.status === "expired");
+  const activeGrants = grants.filter((grant) => grant.status === "active");
+  const revokedGrants = grants.filter((grant) => grant.status === "revoked");
+  const accessRows = [
+    ...pendingInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
+    ...expiredInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
+    ...grants.map((grant) => ({ kind: "grant" as const, status: grant.status, grant })),
+  ].filter((row) => statusFilter === "all" || row.status === statusFilter);
+
+  const resetInvite = () => {
+    setInviteEmail("");
+    setInviteRole("property_manager");
+    setPropertyScopeMode("all_current_properties");
+    setWorkspaceScopes(defaultWorkspaces);
+    setPermissionFlags(defaultPermissions);
+    setExpiresAt(defaultExpiryDate());
+  };
+
+  const toggleWorkspace = (workspace: DelegatedAccessWorkspaceScope, checked: boolean) => {
+    setWorkspaceScopes((current) => {
+      const next = checked ? [...current, workspace] : current.filter((item) => item !== workspace);
+      return Array.from(new Set(next));
+    });
+  };
+
+  const togglePermission = (permission: DelegatedAccessPermissionAction, checked: boolean) => {
+    setPermissionFlags((current) => {
+      const next = checked ? [...current, permission] : current.filter((item) => item !== permission);
+      return Array.from(new Set(next));
+    });
+  };
+
+  const handleInvite = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (workspaceScopes.length === 0 || permissionFlags.length === 0) {
+      showToast({
+        message: "Invite needs role scope",
+        description: "Choose at least one workspace and one permission.",
+        variant: "warning",
+      });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const input: CreateDelegatedAccessInvitationInput = {
+        inviteeEmail: inviteEmail,
+        role: inviteRole,
+        propertyScope: { mode: propertyScopeMode, propertyIds: [] },
+        workspaceScopes,
+        permissionFlags,
+        expiresAt: toIsoDate(expiresAt),
+      };
+      await createDelegatedAccessInvitation(input);
+      showToast({
+        message: "Delegate invitation created",
+        description: "Email dispatch is not enabled yet. Share acceptance instructions only when that flow is approved.",
+        variant: "success",
+      });
+      resetInvite();
+      setInviteOpen(false);
+      await load();
+    } catch (err: any) {
+      showToast({
+        message: "Could not create invitation",
+        description: err?.message || "The invitation was not saved.",
+        variant: "error",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRevoke = async (grant: DelegatedAccessGrant) => {
+    if (grant.status !== "active") return;
+    setRevokingGrantId(grant.grantId);
+    try {
+      await revokeDelegatedAccessGrant(grant.grantId, revocationReason);
+      showToast({
+        message: "Access revoked",
+        description: "Future delegated actions for this grant are now blocked.",
+        variant: "success",
+      });
+      setRevocationReason("");
+      await load();
+    } catch (err: any) {
+      showToast({
+        message: "Could not revoke access",
+        description: err?.message || "The grant is unchanged.",
+        variant: "error",
+      });
+    } finally {
+      setRevokingGrantId(null);
+    }
+  };
+
+  if (!canManage) {
+    return (
+      <Section style={{ maxWidth: 1080, margin: "0 auto", display: "grid", gap: spacing.md }}>
+        <Card elevated>
+          <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Delegate Management</h1>
+          <p style={{ margin: "8px 0 0", color: text.muted }}>
+            Delegate management is available only to landlord owners.
+          </p>
+        </Card>
+      </Section>
+    );
+  }
+
+  return (
+    <Section style={{ maxWidth: 1180, margin: "0 auto", display: "grid", gap: spacing.md }}>
+      <Card elevated style={{ display: "grid", gap: spacing.md }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.55rem", fontWeight: 900 }}>Delegate Management</h1>
+            <p style={{ margin: 0, color: text.muted }}>
+              Never share your login. Invite delegates to their own account.
+            </p>
+          </div>
+          <Button type="button" onClick={() => setInviteOpen((open) => !open)}>
+            {inviteOpen ? "Hide Invite" : "Invite Delegate"}
+          </Button>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: spacing.sm,
+            alignItems: "center",
+            color: text.secondary,
+            fontSize: 14,
+          }}
+        >
+          <ShieldCheck size={18} />
+          <span>Revoking access blocks future delegated actions and preserves the audit history.</span>
+        </div>
+      </Card>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: spacing.sm }}>
+        <StatusCard label="Pending" value={pendingInvitations.length} />
+        <StatusCard label="Active" value={activeGrants.length} />
+        <StatusCard label="Revoked" value={revokedGrants.length} />
+        <StatusCard label="Expired" value={expiredInvitations.length} />
+      </div>
+
+      {inviteOpen ? (
+        <Card style={{ display: "grid", gap: spacing.md }}>
+          <div style={{ display: "flex", alignItems: "center", gap: spacing.sm }}>
+            <UserPlus size={20} />
+            <div>
+              <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Invite Delegate</h2>
+              <div style={{ color: text.muted, fontSize: 13 }}>Creates a pending invitation. Email dispatch is out of scope for v1.</div>
+            </div>
+          </div>
+          <form onSubmit={handleInvite} style={{ display: "grid", gap: spacing.md }}>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: spacing.sm }}>
+              <label style={{ display: "grid", gap: 6, fontWeight: 700 }}>
+                Delegate email
+                <Input
+                  aria-label="Delegate email"
+                  type="email"
+                  value={inviteEmail}
+                  onChange={(event) => setInviteEmail(event.target.value)}
+                  required
+                  placeholder="delegate@example.com"
+                />
+              </label>
+              <label style={{ display: "grid", gap: 6, fontWeight: 700 }}>
+                Role
+                <select
+                  aria-label="Delegate role"
+                  value={inviteRole}
+                  onChange={(event) => setInviteRole(event.target.value as DelegatedAccessRole)}
+                  style={{
+                    minHeight: 42,
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    background: colors.card,
+                    padding: "10px 12px",
+                    color: text.primary,
+                  }}
+                >
+                  {roles.map((role) => (
+                    <option key={role} value={role}>
+                      {roleLabels[role]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={{ display: "grid", gap: 6, fontWeight: 700 }}>
+                Property scope
+                <select
+                  aria-label="Property scope"
+                  value={propertyScopeMode}
+                  onChange={(event) => setPropertyScopeMode(event.target.value as DelegatedAccessPropertyScopeMode)}
+                  style={{
+                    minHeight: 42,
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    background: colors.card,
+                    padding: "10px 12px",
+                    color: text.primary,
+                  }}
+                >
+                  <option value="all_current_properties">All current properties</option>
+                  <option value="none">No property scope</option>
+                </select>
+              </label>
+              <label style={{ display: "grid", gap: 6, fontWeight: 700 }}>
+                Expires
+                <Input
+                  aria-label="Invitation expiration date"
+                  type="date"
+                  value={expiresAt}
+                  onChange={(event) => setExpiresAt(event.target.value)}
+                  required
+                />
+              </label>
+            </div>
+
+            <div style={{ display: "grid", gap: spacing.xs }}>
+              <div style={{ fontWeight: 800 }}>Workspace scope</div>
+              <div style={{ display: "flex", gap: spacing.xs, flexWrap: "wrap" }}>
+                {workspaces.map((workspace) => (
+                  <ToggleChip
+                    key={workspace}
+                    checked={workspaceScopes.includes(workspace)}
+                    label={workspaceLabels[workspace]}
+                    onChange={(checked) => toggleWorkspace(workspace, checked)}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <div style={{ display: "grid", gap: spacing.xs }}>
+              <div style={{ fontWeight: 800 }}>Permissions</div>
+              <div style={{ display: "flex", gap: spacing.xs, flexWrap: "wrap" }}>
+                {permissions.map((permission) => (
+                  <ToggleChip
+                    key={permission}
+                    checked={permissionFlags.includes(permission)}
+                    label={permissionLabels[permission]}
+                    onChange={(checked) => togglePermission(permission, checked)}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? "Creating..." : "Create Invitation"}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  resetInvite();
+                  setInviteOpen(false);
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
+
+      <Card style={{ display: "grid", gap: spacing.md }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Access Overview</h2>
+            <div style={{ color: text.muted, fontSize: 13 }}>Who can access this landlord workspace and what state they are in.</div>
+          </div>
+          <div style={{ display: "flex", gap: spacing.xs, flexWrap: "wrap" }}>
+            {(["all", "pending", "active", "revoked", "expired"] as const).map((status) => (
+              <Button
+                key={status}
+                type="button"
+                variant={statusFilter === status ? "primary" : "secondary"}
+                onClick={() => setStatusFilter(status)}
+                style={{ padding: "8px 12px", fontSize: 13 }}
+              >
+                {statusLabel(status)}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {loading ? <SkeletonBlock lines={4} label="Loading delegated access" /> : null}
+        {error ? (
+          <EmptyState
+            title="Unable to load delegated access"
+            body={error}
+            action={<Button type="button" variant="secondary" onClick={load}>Retry</Button>}
+          />
+        ) : null}
+        {!loading && !error && accessRows.length === 0 ? (
+          <EmptyState
+            title="No delegated access yet"
+            body="Invite delegates when you need staff or external collaborators to use their own account instead of sharing yours."
+            action={<Button type="button" onClick={() => setInviteOpen(true)}>Invite Delegate</Button>}
+          />
+        ) : null}
+
+        {!loading && !error && accessRows.length > 0 ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {accessRows.map((row) => {
+              if (row.kind === "invitation") {
+                const invitation = row.invitation;
+                return (
+                  <div
+                    key={`invitation-${invitation.invitationId}`}
+                    data-testid="delegated-access-record"
+                    data-status={invitation.status}
+                    style={{
+                      display: "grid",
+                      gap: spacing.xs,
+                      padding: spacing.md,
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      background: colors.card,
+                    }}
+                  >
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+                      <div>
+                        <div style={{ fontWeight: 900 }}>{invitation.inviteeEmail}</div>
+                        <div style={{ color: text.muted, fontSize: 13 }}>
+                          {roleLabels[invitation.role]} · {propertyScopeLabel(invitation.propertyScope.mode)}
+                        </div>
+                      </div>
+                      <Pill tone={statusTone(invitation.status)}>{statusLabel(invitation.status)}</Pill>
+                    </div>
+                    <div style={{ color: text.secondary, fontSize: 13 }}>
+                      Workspaces: {labelList(invitation.workspaceScopes, workspaceLabels)} · Permissions:{" "}
+                      {labelList(invitation.permissionFlags, permissionLabels)}
+                    </div>
+                    <div style={{ color: text.muted, fontSize: 13 }}>Expires {formatDate(invitation.expiresAt)}</div>
+                  </div>
+                );
+              }
+
+              const grant = row.grant;
+              return (
+                <div
+                  key={`grant-${grant.grantId}`}
+                  data-testid="delegated-access-record"
+                  data-status={grant.status}
+                  style={{
+                    display: "grid",
+                    gap: spacing.sm,
+                    padding: spacing.md,
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    background: grant.status === "revoked" ? "#f8fafc" : colors.card,
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+                    <div>
+                      <div style={{ fontWeight: 900 }}>{grant.delegateEmail || "Delegate account"}</div>
+                      <div style={{ color: text.muted, fontSize: 13 }}>
+                        {roleLabels[grant.role]} ·{" "}
+                        {propertyScopeLabel(grant.permissionScope.propertyScope.mode)}
+                      </div>
+                    </div>
+                    <Pill tone={statusTone(grant.status)}>{statusLabel(grant.status)}</Pill>
+                  </div>
+                  <div style={{ color: text.secondary, fontSize: 13 }}>
+                    Workspaces: {labelList(grant.permissionScope.workspaceScopes, workspaceLabels)} · Permissions:{" "}
+                    {labelList(grant.permissionScope.permissionFlags, permissionLabels)}
+                  </div>
+                  <div style={{ color: text.muted, fontSize: 13 }}>
+                    Accepted {formatDate(grant.acceptedAt)} · Updated {formatDate(grant.updatedAt)}
+                    {grant.revokedAt ? ` · Revoked ${formatDate(grant.revokedAt)}` : ""}
+                  </div>
+                  {grant.status === "active" ? (
+                    <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", alignItems: "center" }}>
+                      <Input
+                        aria-label={`Revocation reason for ${grant.delegateEmail || "delegate"}`}
+                        value={revokingGrantId === grant.grantId ? revocationReason : revocationReason}
+                        onChange={(event) => setRevocationReason(event.target.value)}
+                        placeholder="Optional revocation reason"
+                        style={{ maxWidth: 320 }}
+                      />
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        disabled={Boolean(revokingGrantId)}
+                        onClick={() => void handleRevoke(grant)}
+                      >
+                        {revokingGrantId === grant.grantId ? "Revoking..." : "Revoke Access"}
+                      </Button>
+                    </div>
+                  ) : grant.revocationReason ? (
+                    <div style={{ color: text.muted, fontSize: 13 }}>Reason: {grant.revocationReason}</div>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+      </Card>
+
+      <Card style={{ display: "grid", gap: spacing.sm }}>
+        <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Delegates Summary</h2>
+        {delegates.length === 0 ? (
+          <div style={{ color: text.muted }}>Delegate summaries will appear after invitations are accepted.</div>
+        ) : (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {delegates.map((delegate) => (
+              <div
+                key={delegate.delegateUserId}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "minmax(180px, 1fr) auto",
+                  gap: spacing.sm,
+                  padding: spacing.sm,
+                  borderRadius: radius.md,
+                  border: `1px solid ${colors.border}`,
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 900 }}>{delegate.delegateEmail || "Delegate account"}</div>
+                  <div style={{ color: text.muted, fontSize: 13 }}>{labelList(delegate.roles, roleLabels)}</div>
+                </div>
+                <div style={{ color: text.muted, fontSize: 13, textAlign: "right" }}>
+                  {delegate.activeGrantCount} active · {delegate.revokedGrantCount} revoked
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </Section>
+  );
+}

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -4,6 +4,7 @@ import { Button, Card, EmptyState, Input, Pill, SkeletonBlock } from "../compone
 import { useToast } from "../components/ui/ToastProvider";
 import { useAuth } from "../context/useAuth";
 import {
+  cancelDelegatedAccessInvitation,
   createDelegatedAccessInvitation,
   fetchDelegatedAccessDelegates,
   fetchDelegatedAccessGrants,
@@ -158,7 +159,7 @@ export default function DelegatedAccessPage() {
   const [invitations, setInvitations] = React.useState<DelegatedAccessInvitation[]>([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
-  const [statusFilter, setStatusFilter] = React.useState<"all" | "pending" | "active" | "revoked" | "expired">("all");
+  const [statusFilter, setStatusFilter] = React.useState<"all" | "pending" | "active" | "revoked" | "expired" | "cancelled">("all");
   const [inviteOpen, setInviteOpen] = React.useState(false);
   const [inviteEmail, setInviteEmail] = React.useState("");
   const [inviteRole, setInviteRole] = React.useState<DelegatedAccessRole>("property_manager");
@@ -168,6 +169,7 @@ export default function DelegatedAccessPage() {
   const [expiresAt, setExpiresAt] = React.useState(defaultExpiryDate());
   const [submitting, setSubmitting] = React.useState(false);
   const [revokingGrantId, setRevokingGrantId] = React.useState<string | null>(null);
+  const [cancellingInvitationId, setCancellingInvitationId] = React.useState<string | null>(null);
   const [revocationReason, setRevocationReason] = React.useState("");
   const canManage = isOwnerRole(user);
 
@@ -199,11 +201,13 @@ export default function DelegatedAccessPage() {
   }, [load]);
 
   const pendingInvitations = invitations.filter((invitation) => invitation.status === "pending");
+  const cancelledInvitations = invitations.filter((invitation) => invitation.status === "cancelled");
   const expiredInvitations = invitations.filter((invitation) => invitation.status === "expired");
   const activeGrants = grants.filter((grant) => grant.status === "active");
   const revokedGrants = grants.filter((grant) => grant.status === "revoked");
   const accessRows = [
     ...pendingInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
+    ...cancelledInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
     ...expiredInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
     ...grants.map((grant) => ({ kind: "grant" as const, status: grant.status, grant })),
   ].filter((row) => statusFilter === "all" || row.status === statusFilter);
@@ -294,6 +298,30 @@ export default function DelegatedAccessPage() {
     }
   };
 
+  const handleCancelInvitation = async (invitation: DelegatedAccessInvitation) => {
+    if (invitation.status !== "pending") return;
+    setCancellingInvitationId(invitation.invitationId);
+    try {
+      const result = await cancelDelegatedAccessInvitation(invitation.invitationId);
+      setInvitations((current) =>
+        current.map((item) => (item.invitationId === invitation.invitationId ? result.invitation : item))
+      );
+      showToast({
+        message: "Invitation cancelled",
+        description: "The pending invitation can no longer be accepted.",
+        variant: "success",
+      });
+    } catch (err: any) {
+      showToast({
+        message: "Could not cancel invitation",
+        description: err?.message || "The invitation is unchanged.",
+        variant: "error",
+      });
+    } finally {
+      setCancellingInvitationId(null);
+    }
+  };
+
   if (!canManage) {
     return (
       <div
@@ -355,6 +383,7 @@ export default function DelegatedAccessPage() {
         <StatusCard label="Pending" value={pendingInvitations.length} />
         <StatusCard label="Active" value={activeGrants.length} />
         <StatusCard label="Revoked" value={revokedGrants.length} />
+        <StatusCard label="Cancelled" value={cancelledInvitations.length} />
         <StatusCard label="Expired" value={expiredInvitations.length} />
       </div>
 
@@ -487,7 +516,7 @@ export default function DelegatedAccessPage() {
             <div style={{ color: text.muted, fontSize: 13 }}>Who can access this landlord workspace and what state they are in.</div>
           </div>
           <div style={{ display: "flex", gap: spacing.xs, flexWrap: "wrap" }}>
-            {(["all", "pending", "active", "revoked", "expired"] as const).map((status) => (
+            {(["all", "pending", "active", "revoked", "cancelled", "expired"] as const).map((status) => (
               <Button
                 key={status}
                 type="button"
@@ -549,7 +578,27 @@ export default function DelegatedAccessPage() {
                       Workspaces: {labelList(invitation.workspaceScopes, workspaceLabels)} · Permissions:{" "}
                       {labelList(invitation.permissionFlags, permissionLabels)}
                     </div>
-                    <div style={{ color: text.muted, fontSize: 13 }}>Expires {formatDate(invitation.expiresAt)}</div>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        gap: spacing.sm,
+                        alignItems: "center",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <div style={{ color: text.muted, fontSize: 13 }}>Expires {formatDate(invitation.expiresAt)}</div>
+                      {invitation.status === "pending" ? (
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          disabled={cancellingInvitationId === invitation.invitationId}
+                          onClick={() => void handleCancelInvitation(invitation)}
+                        >
+                          {cancellingInvitationId === invitation.invitationId ? "Cancelling..." : "Cancel Invitation"}
+                        </Button>
+                      ) : null}
+                    </div>
                   </div>
                 );
               }

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ShieldCheck, UserPlus } from "lucide-react";
-import { Button, Card, EmptyState, Input, Pill, Section, SkeletonBlock } from "../components/ui/Ui";
+import { Button, Card, EmptyState, Input, Pill, SkeletonBlock } from "../components/ui/Ui";
 import { useToast } from "../components/ui/ToastProvider";
 import { useAuth } from "../context/useAuth";
 import {
@@ -296,19 +296,35 @@ export default function DelegatedAccessPage() {
 
   if (!canManage) {
     return (
-      <Section style={{ maxWidth: 1080, margin: "0 auto", display: "grid", gap: spacing.md }}>
+      <div
+        style={{
+          maxWidth: 1180,
+          margin: "0 auto",
+          width: "calc(100% - 32px)",
+          display: "grid",
+          gap: spacing.md,
+        }}
+      >
         <Card elevated>
           <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Delegate Management</h1>
           <p style={{ margin: "8px 0 0", color: text.muted }}>
             Delegate management is available only to landlord owners.
           </p>
         </Card>
-      </Section>
+      </div>
     );
   }
 
   return (
-    <Section style={{ maxWidth: 1180, margin: "0 auto", display: "grid", gap: spacing.md }}>
+    <div
+      style={{
+        maxWidth: 1320,
+        margin: "0 auto",
+        width: "calc(100% - 32px)",
+        display: "grid",
+        gap: spacing.md,
+      }}
+    >
       <Card elevated style={{ display: "grid", gap: spacing.md }}>
         <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
           <div style={{ display: "grid", gap: 6 }}>
@@ -629,6 +645,6 @@ export default function DelegatedAccessPage() {
           </div>
         )}
       </Card>
-    </Section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add the approved Mission Brief artifact for delegated access delegate management UI
- add a landlord-owner Delegate Management page under /account/delegated-access
- add a thin frontend API adapter for existing delegated access invitation and owner-management routes
- link My Account to Delegate Management and add route coverage

## Scope
- Frontend/UI only plus frontend API adapter
- No backend redesign
- No email dispatch
- No property manager companies
- No contractor organizations
- No billing delegation
- No custom roles
- No security rule changes

## Validation
- npm --prefix rentchain-frontend run test -- DelegatedAccessPage.test.tsx AccountPage.test.tsx App.routes.test.tsx
- npm --prefix rentchain-frontend run build
- git diff --check

## QA
Manual preview QA required before merge.