### PR TITLE
feat: add delegated access email dispatch

### DIFF
--- a/docs/design/mission-briefs/delegated-access-email-dispatch-v1.html
+++ b/docs/design/mission-briefs/delegated-access-email-dispatch-v1.html
@@ -1,0 +1,489 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Delegated Access Email Dispatch V1</title>
+    <style>
+      @page {
+        size: 16in 9in;
+        margin: 0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: #f4f7fb;
+        color: #091532;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      .brief {
+        width: 1600px;
+        min-height: 900px;
+        margin: 0 auto;
+        background:
+          linear-gradient(180deg, #071a37 0, #071a37 120px, transparent 120px),
+          #ffffff;
+        box-shadow: 0 20px 80px rgba(9, 21, 50, 0.18);
+      }
+
+      header {
+        height: 120px;
+        display: grid;
+        place-items: center;
+        text-align: center;
+        padding: 18px 48px 20px;
+        color: #ffffff;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 38px;
+        line-height: 1.1;
+        letter-spacing: 0;
+        font-weight: 800;
+      }
+
+      h1 span {
+        color: #7ee36d;
+      }
+
+      .subtitle {
+        margin-top: 8px;
+        font-size: 22px;
+        color: rgba(255, 255, 255, 0.86);
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: 39% 61%;
+        min-height: 780px;
+      }
+
+      section {
+        padding: 22px 28px;
+      }
+
+      .left {
+        border-right: 1px solid #dce3ee;
+      }
+
+      .right {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 18px;
+      }
+
+      h2 {
+        margin: 0 0 10px;
+        font-size: 23px;
+        line-height: 1.15;
+        color: #091532;
+      }
+
+      h3 {
+        margin: 0 0 8px;
+        font-size: 17px;
+        color: #132b5c;
+      }
+
+      p {
+        margin: 0 0 12px;
+        font-size: 15px;
+        line-height: 1.36;
+      }
+
+      .block {
+        margin-bottom: 15px;
+        padding-bottom: 15px;
+        border-bottom: 1px solid #e2e8f0;
+      }
+
+      .block:last-child {
+        border-bottom: 0;
+        margin-bottom: 0;
+        padding-bottom: 0;
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 7px;
+      }
+
+      li {
+        position: relative;
+        padding-left: 22px;
+        font-size: 14px;
+        line-height: 1.28;
+      }
+
+      li::before {
+        content: "";
+        position: absolute;
+        left: 2px;
+        top: 8px;
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: #12a150;
+      }
+
+      .non-goals {
+        border: 1px solid #f1b7b7;
+        background: #fff8f8;
+        border-radius: 8px;
+        padding: 13px 16px;
+      }
+
+      .non-goals h2 {
+        color: #9f1239;
+        font-size: 20px;
+      }
+
+      .non-goals li::before {
+        background: #e11d48;
+      }
+
+      .principles {
+        display: grid;
+        gap: 9px;
+      }
+
+      .principle {
+        display: grid;
+        grid-template-columns: 28px 1fr;
+        gap: 10px;
+        align-items: start;
+        font-size: 14px;
+        line-height: 1.35;
+      }
+
+      .icon {
+        width: 26px;
+        height: 26px;
+        border: 1px solid #193a76;
+        border-radius: 7px;
+        display: grid;
+        place-items: center;
+        color: #193a76;
+        font-weight: 800;
+        font-size: 13px;
+      }
+
+      .flow {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 8px;
+      }
+
+      .step {
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        background: #f8fafc;
+        padding: 10px;
+        min-height: 78px;
+      }
+
+      .step strong {
+        display: block;
+        color: #132b5c;
+        font-size: 14px;
+        margin-bottom: 5px;
+      }
+
+      .step span {
+        display: block;
+        color: #334155;
+        font-size: 12px;
+        line-height: 1.25;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        overflow: hidden;
+        border: 1px solid #dce3ee;
+        border-radius: 4px;
+      }
+
+      .table th {
+        background: #071a37;
+        color: #ffffff;
+        text-align: left;
+        padding: 9px 10px;
+        font-size: 13px;
+      }
+
+      .table td {
+        border-top: 1px solid #e2e8f0;
+        padding: 9px 10px;
+        vertical-align: top;
+      }
+
+      .method {
+        display: inline-flex;
+        min-width: 62px;
+        justify-content: center;
+        border-radius: 4px;
+        padding: 5px 8px;
+        font-weight: 800;
+        font-size: 12px;
+      }
+
+      .post {
+        color: #b91c1c;
+        background: #fff1f2;
+        border: 1px solid #fecdd3;
+      }
+
+      .panel {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 13px 15px;
+        margin-bottom: 13px;
+      }
+
+      .panel.blue {
+        background: #eff6ff;
+        border-color: #bfdbfe;
+      }
+
+      .panel.green {
+        background: #f0fdf4;
+        border-color: #bbf7d0;
+      }
+
+      .panel.amber {
+        background: #fffbeb;
+        border-color: #fde68a;
+      }
+
+      .panel.red {
+        background: #fff8f8;
+        border-color: #fecdd3;
+      }
+
+      .compact {
+        display: grid;
+        gap: 6px;
+      }
+
+      code {
+        color: #0f3b73;
+        background: #eef4ff;
+        border: 1px solid #d9e6ff;
+        border-radius: 4px;
+        padding: 1px 4px;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="brief">
+      <header>
+        <div>
+          <h1>Next Mission: <span>feat/delegated-access-email-dispatch-v1</span></h1>
+          <div class="subtitle">Backend email delivery for delegated-access invitation acceptance.</div>
+        </div>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>Mission Goal</h2>
+            <p>
+              Complete the delegated-access invitation delivery step so owner-created invitations send a secure
+              acceptance email and support safe resend behavior without exposing raw tokens through APIs or logs.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Scope</h2>
+            <ul>
+              <li>Send invitation email after successful delegated-access invitation creation.</li>
+              <li>Use existing approved email provider and service patterns.</li>
+              <li>Generate acceptance URL containing the one-time raw token.</li>
+              <li>Add narrow resend behavior if it fits existing lifecycle safely.</li>
+              <li>Record metadata-only audit events for dispatch and resend outcomes.</li>
+              <li>Keep API list responses free of tokens and token hashes.</li>
+            </ul>
+          </div>
+
+          <div class="block non-goals">
+            <h2>Non-goals</h2>
+            <ul>
+              <li>No property manager company model.</li>
+              <li>No contractor organization model.</li>
+              <li>No billing delegation or custom roles.</li>
+              <li>No delegate dashboard redesign.</li>
+              <li>No marketing email behavior.</li>
+              <li>No scheduling integration.</li>
+              <li>No security rule changes unless absolutely required.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Key Principles</h2>
+            <div class="principles">
+              <div class="principle"><div class="icon">1</div><div><strong>Owner-controlled:</strong> invitation delivery happens only from owner-authorized invitation creation or resend.</div></div>
+              <div class="principle"><div class="icon">2</div><div><strong>Token-minimal:</strong> raw token appears only inside the generated acceptance URL.</div></div>
+              <div class="principle"><div class="icon">3</div><div><strong>Fail closed:</strong> expired, cancelled, accepted, or invalid invitations cannot be accepted or resent unsafely.</div></div>
+              <div class="principle"><div class="icon">4</div><div><strong>Audit safe:</strong> audit records contain delivery metadata, never raw tokens, token hashes, or provider payloads.</div></div>
+              <div class="principle"><div class="icon">5</div><div><strong>Own account:</strong> email wording reinforces that delegates must use their own account, not shared landlord credentials.</div></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="right">
+          <div>
+            <div class="panel blue">
+              <h2>Email Flow</h2>
+              <div class="flow">
+                <div class="step"><strong>Invite</strong><span>Owner creates scoped invitation.</span></div>
+                <div class="step"><strong>Dispatch</strong><span>Email sent with acceptance URL.</span></div>
+                <div class="step"><strong>Accept</strong><span>Delegate authenticates and accepts token.</span></div>
+                <div class="step"><strong>Active</strong><span>Grant becomes active with role and scope.</span></div>
+                <div class="step"><strong>Revoke</strong><span>Owner revokes future access.</span></div>
+              </div>
+            </div>
+
+            <div class="panel">
+              <h2>API Endpoints / Changes</h2>
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>Method</th>
+                    <th>Endpoint</th>
+                    <th>Expected behavior</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><span class="method post">POST</span></td>
+                    <td><code>/api/landlord/delegated-access/invitations</code></td>
+                    <td>Create pending invitation and dispatch email after successful record creation.</td>
+                  </tr>
+                  <tr>
+                    <td><span class="method post">POST</span></td>
+                    <td><code>/api/landlord/delegated-access/invitations/:id/resend</code></td>
+                    <td>Optional narrow resend for pending, unexpired invitations only.</td>
+                  </tr>
+                  <tr>
+                    <td><span class="method post">POST</span></td>
+                    <td><code>/api/delegated-access/invitations/accept</code></td>
+                    <td>Existing acceptance flow continues to enforce lifecycle and token hash checks.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="panel">
+              <h2>Acceptance Link Behavior</h2>
+              <ul>
+                <li>Email contains acceptance URL with raw token as the only raw-token surface.</li>
+                <li>Server stores and compares token hash only.</li>
+                <li>List, management, and audit APIs never return raw token or token hash.</li>
+                <li>Invalid tokens return safe errors without revealing invitation existence.</li>
+              </ul>
+            </div>
+
+            <div class="panel amber">
+              <h2>Expiration / Resend / Cancel</h2>
+              <ul>
+                <li>Expired invitations cannot be accepted or resent as usable links.</li>
+                <li>Cancelled invitations cannot be accepted or resent.</li>
+                <li>Accepted invitations cannot be reused or resent.</li>
+                <li>Resend is owner-only, pending-only, and cannot create duplicate active grants.</li>
+                <li>Resend preserves or safely refreshes delivery metadata without changing role or scope.</li>
+                <li>Cancel remains owner-only and withdraws acceptance eligibility immediately.</li>
+              </ul>
+            </div>
+          </div>
+
+          <div>
+            <div class="panel green">
+              <h2>Email Content</h2>
+              <ul>
+                <li>Who invited the delegate.</li>
+                <li>Assigned delegated role.</li>
+                <li>Workspace and property scope when safe to show.</li>
+                <li>Expiration time or date.</li>
+                <li>Clear warning: use your own account; never share landlord credentials.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>Audit Events</h2>
+              <ul>
+                <li><code>delegate.invitation.email_dispatched</code></li>
+                <li><code>delegate.invitation.email_resend_requested</code></li>
+                <li><code>delegate.invitation.email_dispatch_failed</code></li>
+                <li>Include actorUserId, actingForLandlordId, invitationId, outcome, provider key if safe, and timestamp.</li>
+                <li>Exclude raw token, token hash, full provider response, and sensitive message payload.</li>
+              </ul>
+            </div>
+
+            <div class="panel red">
+              <h2>Risks / Failure States</h2>
+              <ul>
+                <li>Email provider unavailable or misconfigured.</li>
+                <li>Dispatch succeeds but provider later bounces.</li>
+                <li>Failed dispatch must not be shown or stored as delivered.</li>
+                <li>Invitation may remain pending with clear dispatch_failed or resend_available state.</li>
+                <li>Raw token leaks through logs, responses, or audit metadata.</li>
+                <li>Resend accidentally revives cancelled or expired invitations.</li>
+                <li>Cross-landlord invitation metadata leaks through resend or errors.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>Acceptance Criteria</h2>
+              <ul>
+                <li>Creating a valid invitation sends one delegated-access invitation email.</li>
+                <li>Email includes a working acceptance URL and no unrelated marketing content.</li>
+                <li>Raw token is not returned by create, list, owner-management, or audit responses.</li>
+                <li>Pending unexpired invites may be resent if implemented; other states fail closed.</li>
+                <li>Cancelled, expired, and accepted invitations remain non-accepting.</li>
+                <li>Email failure leaves invitation lifecycle safe and visibly retryable, not falsely delivered.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>QA Checklist</h2>
+              <ul>
+                <li>Create invite in test mode and verify email delivery or mocked dispatch.</li>
+                <li>Open acceptance link and confirm pending invite can be accepted.</li>
+                <li>Confirm cancelled, expired, and accepted links fail closed.</li>
+                <li>Confirm resend behavior and audit event if resend is included.</li>
+                <li>Confirm no token appears in API responses, logs, or audit metadata.</li>
+              </ul>
+            </div>
+
+            <div class="panel">
+              <h2>Merge Readiness</h2>
+              <ul>
+                <li>Focused backend tests pass.</li>
+                <li>Email service tests or provider mocks pass.</li>
+                <li>Acceptance link and token safety tests pass.</li>
+                <li>Backend build passes.</li>
+                <li>Frontend build only if a UI status update is made.</li>
+                <li><code>git diff --check</code> passes.</li>
+                <li>Manual email QA completed if real preview/test dispatch is enabled.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -159,7 +159,7 @@ import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScore
 import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordDecisionQueueRoutes from "./routes/landlordDecisionQueueRoutes";
-import delegatedAccessInvitationRoutes from "./routes/delegatedAccessInvitationRoutes";
+import delegatedAccessInvitationRoutes, { delegatedAccessSelfRoutes } from "./routes/delegatedAccessInvitationRoutes";
 import landlordInstitutionalExportGenerationRoutes from "./routes/landlordInstitutionalExportGenerationRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
@@ -516,6 +516,8 @@ app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlord
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordDecisionQueueRoutes.ts"), landlordDecisionQueueRoutes);
 console.log("[route-mount] landlordDecisionQueueRoutes mounted at /api/landlord");
+app.use("/api/delegated-access", routeSource("delegatedAccessInvitationRoutes.ts:self"), delegatedAccessSelfRoutes);
+console.log("[route-mount] delegatedAccessSelfRoutes mounted at /api/delegated-access");
 app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), delegatedAccessInvitationRoutes);
 console.log("[route-mount] delegatedAccessInvitationRoutes mounted at /api/landlord");
 app.use("/api/landlord/institutional-exports", rateLimitEvidenceExportReview);

--- a/rentchain-api/src/auth/rbac.ts
+++ b/rentchain-api/src/auth/rbac.ts
@@ -3,6 +3,7 @@ export type Role =
   | "admin"
   | "landlord"
   | "contractor"
+  | "delegate"
   | "manager"
   | "staff"
   | "tenant"
@@ -45,6 +46,7 @@ export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     "billing.manage",
   ],
   contractor: [],
+  delegate: [],
   manager: [
     "properties.edit",
     "units.manage",

--- a/rentchain-api/src/lib/delegatedAccess/delegatedAccessModel.ts
+++ b/rentchain-api/src/lib/delegatedAccess/delegatedAccessModel.ts
@@ -211,6 +211,14 @@ export function createDelegatedAccessInvitation(input: InvitationInput): Delegat
     acceptedAt: null,
     cancelledByUserId: null,
     cancelledAt: null,
+    emailDispatch: {
+      status: "not_sent",
+      attemptCount: 0,
+      lastAttemptAt: null,
+      lastSentAt: null,
+      lastFailedAt: null,
+      lastFailureReason: null,
+    },
     auditEventIds: [],
   };
 }

--- a/rentchain-api/src/lib/delegatedAccess/delegatedAccessTypes.ts
+++ b/rentchain-api/src/lib/delegatedAccess/delegatedAccessTypes.ts
@@ -150,6 +150,7 @@ export type DelegatedAccessInvitation = {
   acceptedAt: string | null;
   cancelledByUserId: string | null;
   cancelledAt: string | null;
+  emailDispatch: DelegatedAccessEmailDispatchMetadata | null;
   auditEventIds: string[];
 };
 
@@ -215,6 +216,17 @@ export type DelegatedAccessEvaluationDecision = {
 };
 
 export type DelegatedAccessAuditOutcome = "allowed" | "denied" | "revoked" | "expired" | "failed" | "blocked";
+
+export type DelegatedAccessEmailDispatchStatus = "not_sent" | "sent" | "failed";
+
+export type DelegatedAccessEmailDispatchMetadata = {
+  status: DelegatedAccessEmailDispatchStatus;
+  attemptCount: number;
+  lastAttemptAt: string | null;
+  lastSentAt: string | null;
+  lastFailedAt: string | null;
+  lastFailureReason: string | null;
+};
 
 export type DelegatedAccessAuditEvent = {
   eventId: string;

--- a/rentchain-api/src/routes/__tests__/authDelegatedAccessSignup.test.ts
+++ b/rentchain-api/src/routes/__tests__/authDelegatedAccessSignup.test.ts
@@ -1,0 +1,222 @@
+import crypto from "crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = vi.hoisted(() => new Map<string, Map<string, any>>());
+const createUserMock = vi.hoisted(() => vi.fn());
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+const dbMock = vi.hoisted(() => {
+  function ensure(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+  function copy(value: any) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+  }
+  return {
+    collection: (name: string) => ({
+      doc: (id?: string) => {
+        const docId = id || `doc_${ensure(name).size + 1}`;
+        return {
+          id: docId,
+          get: async () => ({
+            id: docId,
+            exists: ensure(name).has(docId),
+            data: () => copy(ensure(name).get(docId)),
+          }),
+          set: async (value: any, opts?: { merge?: boolean }) => {
+            const current = ensure(name).get(docId) || {};
+            ensure(name).set(docId, opts?.merge ? { ...current, ...copy(value) } : copy(value));
+          },
+          create: async (value: any) => {
+            if (ensure(name).has(docId)) throw new Error("already_exists");
+            ensure(name).set(docId, copy(value));
+          },
+        };
+      },
+      get: async () => ({
+        docs: Array.from(ensure(name).entries()).map(([id, data]) => ({
+          id,
+          exists: true,
+          data: () => copy(data),
+        })),
+      }),
+      where: (field: string, op: string, value: any) => ({
+        limit: (_count: number) => ({
+          get: async () => {
+            const docs = Array.from(ensure(name).entries())
+              .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
+              .map(([id, data]) => ({ id, exists: true, data: () => copy(data) }));
+            return { docs, empty: docs.length === 0 };
+          },
+        }),
+      }),
+    }),
+  };
+});
+
+vi.mock("../../firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+    arrayUnion: (...values: any[]) => values,
+  },
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({
+      createUser: createUserMock,
+    }),
+  },
+}));
+
+vi.mock("../../services/authService", () => ({
+  generateJwtForLandlord: vi.fn(),
+  validateLandlordCredentials: vi.fn(),
+}));
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function seedDelegatedInvitation(overrides: Record<string, any> = {}) {
+  const invitation = {
+    invitationId: "delegated_invitation_1",
+    landlordId: "owner-landlord-1",
+    inviteeEmail: "delegate@example.com",
+    role: "property_manager",
+    propertyScope: { mode: "all_current_properties", propertyIds: [] },
+    workspaceScopes: ["dashboard", "operations"],
+    permissionFlags: ["view"],
+    status: "pending",
+    tokenHash: sha256("valid-token"),
+    expiresAt: "2026-07-22T12:00:00.000Z",
+    createdByUserId: "owner-user-1",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    acceptedByUserId: null,
+    acceptedAt: null,
+    cancelledByUserId: null,
+    cancelledAt: null,
+    auditEventIds: [],
+    ...overrides,
+  };
+  ensureCollection("delegatedAccessInvitations").set(invitation.invitationId, invitation);
+  return invitation;
+}
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body || {},
+      query: {},
+      headers: {},
+      get() {
+        return undefined;
+      },
+      header() {
+        return undefined;
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("auth delegated access signup", () => {
+  beforeEach(() => {
+    collections.clear();
+    vi.clearAllMocks();
+    process.env.JWT_SECRET = "test-secret";
+    createUserMock.mockResolvedValue({ uid: "delegate-user-1" });
+  });
+
+  it("creates a delegate identity without provisioning a landlord workspace", async () => {
+    seedDelegatedInvitation();
+    const router = (await import("../authRoutes")).default;
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/signup",
+      body: {
+        email: "delegate@example.com",
+        password: "secret1",
+        fullName: "Delegate User",
+        inviteSource: "delegated_access",
+        inviteToken: "valid-token",
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.user).toMatchObject({
+      id: "delegate-user-1",
+      email: "delegate@example.com",
+      role: "delegate",
+      landlordId: null,
+    });
+    expect(response.body.showLandlordWelcome).toBe(false);
+    expect(ensureCollection("users").get("delegate-user-1")).toMatchObject({
+      role: "delegate",
+      landlordId: null,
+      approvedBy: "delegated_access_invite_signup",
+      delegatedAccess: {
+        invitationId: "delegated_invitation_1",
+        landlordId: "owner-landlord-1",
+        role: "property_manager",
+      },
+    });
+    expect(ensureCollection("accounts").get("delegate-user-1")).toMatchObject({
+      role: "delegate",
+      landlordId: null,
+    });
+    expect(ensureCollection("landlords").size).toBe(0);
+  });
+
+  it("rejects delegated signup email mismatch before creating a user", async () => {
+    seedDelegatedInvitation();
+    const router = (await import("../authRoutes")).default;
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/signup",
+      body: {
+        email: "wrong@example.com",
+        password: "secret1",
+        inviteSource: "delegated_access",
+        inviteToken: "valid-token",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe("INVITEE_EMAIL_MISMATCH");
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(ensureCollection("users").size).toBe(0);
+    expect(ensureCollection("accounts").size).toBe(0);
+    expect(ensureCollection("landlords").size).toBe(0);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -789,6 +789,40 @@ describe("delegatedAccessInvitationRoutes", () => {
     expect(JSON.stringify(response.body)).not.toContain("valid-token");
   });
 
+  it("lists only active grants assigned to the authenticated delegate without property ids", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedGrant({ grantId: "delegate-active-grant", status: "active" });
+    seedGrant({ grantId: "delegate-revoked-grant", status: "revoked" });
+    seedGrant({ grantId: "other-delegate-active-grant", delegateUserId: "delegate-user-2", status: "active" });
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/delegated-access/my-grants?landlordId=landlord-2",
+      user: { id: "delegate-user-1", role: "delegate", email: "manager@example.com" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.grants).toHaveLength(1);
+    expect(response.body.grants[0]).toEqual(
+      expect.objectContaining({
+        delegateEmail: "manager@example.com",
+        role: "property_manager",
+        status: "active",
+        propertyScopeSummary: "selected:1",
+        permissionScope: expect.objectContaining({
+          workspaceScopes: ["dashboard", "operations", "properties"],
+          propertyScope: { mode: "selected", propertyIds: [], unitIds: [] },
+        }),
+      })
+    );
+    expect(JSON.stringify(response.body)).not.toContain("landlord-1");
+    expect(JSON.stringify(response.body)).not.toContain("delegate-active-grant");
+    expect(JSON.stringify(response.body)).not.toContain("delegate-user-1");
+    expect(JSON.stringify(response.body)).not.toContain("property-1");
+    expect(JSON.stringify(response.body)).not.toContain("unit-1");
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+  });
+
   it("lists delegate summaries for active and revoked grants", async () => {
     const router = (await import("../delegatedAccessInvitationRoutes")).default;
     seedGrant({ grantId: "active-grant" });

--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -200,7 +200,7 @@ function seedGrant(overrides: Partial<StoredDoc> = {}) {
 
 async function acceptInvite(router: any, token = "valid-token", user: Record<string, unknown> | null = {
   id: "delegate-user-1",
-  role: "landlord_delegate",
+  role: "delegate",
   email: "manager@example.com",
 }) {
   return await invokeRouter(router, {
@@ -217,6 +217,8 @@ describe("delegatedAccessInvitationRoutes", () => {
     generatedIds.value = 0;
     vi.clearAllMocks();
     process.env.EMAIL_FROM = "no-reply@example.test";
+    delete process.env.DELEGATED_ACCESS_ACCEPTANCE_BASE_URL;
+    delete process.env.DELEGATED_ACCESS_FRONTEND_URL;
     process.env.PUBLIC_APP_URL = "https://app.example.test";
     sendEmailMock.mockResolvedValue(undefined);
   });
@@ -285,6 +287,17 @@ describe("delegatedAccessInvitationRoutes", () => {
     );
     expect(JSON.stringify(auditEvents)).not.toContain(rawToken!);
     expect(JSON.stringify(auditEvents)).not.toContain("tokenHash");
+  });
+
+  it("uses the delegated access acceptance URL override for preview email links", async () => {
+    process.env.DELEGATED_ACCESS_ACCEPTANCE_BASE_URL = "https://rentchain-preview.vercel.app";
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+
+    const response = await createInvite(router);
+
+    expect(response.status).toBe(201);
+    const emailPayload = sendEmailMock.mock.calls[0][0];
+    expect(emailPayload.text).toContain("https://rentchain-preview.vercel.app/delegated-access/accept?token=");
   });
 
   it("rejects non-owner invitation creation", async () => {
@@ -711,22 +724,30 @@ describe("delegatedAccessInvitationRoutes", () => {
     expect(readCollection("delegatedAccessGrants")).toHaveLength(0);
   });
 
-  it("requires an authenticated accepting user and does not accept on behalf of another user", async () => {
+  it("requires an authenticated invited delegate user and rejects mismatched or owner sessions", async () => {
     const router = (await import("../delegatedAccessInvitationRoutes")).default;
     seedInvitation();
 
     const unauthenticated = await acceptInvite(router, "valid-token", null);
     expect(unauthenticated.status).toBe(401);
 
-    const response = await acceptInvite(router, "valid-token", {
+    const mismatched = await acceptInvite(router, "valid-token", {
       id: "actual-delegate-user",
-      role: "landlord_delegate",
+      role: "delegate",
       email: "different@example.com",
     });
-    expect(response.status).toBe(200);
-    expect(response.body.invitation.acceptedByUserId).toBe("actual-delegate-user");
-    expect(response.body.grant.delegateUserId).toBe("actual-delegate-user");
-    expect(response.body.grant.delegateEmail).toBe("different@example.com");
+    expect(mismatched.status).toBe(403);
+    expect(mismatched.body.error).toBe("INVITEE_EMAIL_MISMATCH");
+
+    const ownerSession = await acceptInvite(router, "valid-token", {
+      id: "manager-owner-user",
+      role: "landlord",
+      landlordId: "manager-owner-user",
+      email: "manager@example.com",
+    });
+    expect(ownerSession.status).toBe(403);
+    expect(ownerSession.body.error).toBe("DELEGATE_ACCOUNT_ROLE_CONFLICT");
+    expect(readCollection("delegatedAccessGrants")).toHaveLength(0);
   });
 
   it("rejects double acceptance without creating a duplicate grant", async () => {
@@ -837,7 +858,7 @@ describe("delegatedAccessInvitationRoutes", () => {
   it("requires owner privileges for delegate and grant management routes", async () => {
     const router = (await import("../delegatedAccessInvitationRoutes")).default;
     seedGrant();
-    const delegateUser = { id: "delegate-user-1", role: "landlord_delegate", landlordId: "landlord-1" };
+    const delegateUser = { id: "delegate-user-1", role: "delegate", landlordId: null };
 
     const delegates = await invokeRouter(router, {
       method: "GET",

--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -5,6 +5,7 @@ type StoredDoc = Record<string, any>;
 
 const collections = vi.hoisted(() => new Map<string, Map<string, StoredDoc>>());
 const generatedIds = vi.hoisted(() => ({ value: 0 }));
+const sendEmailMock = vi.hoisted(() => vi.fn(async () => undefined));
 const fakeDb = vi.hoisted(() => ({
   collection(name: string) {
     if (!collections.has(name)) collections.set(name, new Map());
@@ -45,6 +46,10 @@ const fakeDb = vi.hoisted(() => ({
 
 vi.mock("../../firebase", () => ({
   db: fakeDb,
+}));
+
+vi.mock("../../services/emailService", () => ({
+  sendEmail: sendEmailMock,
 }));
 
 vi.mock("../../middleware/requireAuth", () => ({
@@ -116,7 +121,7 @@ async function invokeRouter(
   });
 }
 
-const ownerUser = { id: "owner-user-1", role: "landlord", landlordId: "landlord-1" };
+const ownerUser = { id: "owner-user-1", role: "landlord", landlordId: "landlord-1", email: "owner@example.com" };
 
 const validInviteBody = {
   inviteeEmail: "manager@example.com",
@@ -211,9 +216,12 @@ describe("delegatedAccessInvitationRoutes", () => {
     collections.clear();
     generatedIds.value = 0;
     vi.clearAllMocks();
+    process.env.EMAIL_FROM = "no-reply@example.test";
+    process.env.PUBLIC_APP_URL = "https://app.example.test";
+    sendEmailMock.mockResolvedValue(undefined);
   });
 
-  it("allows a landlord owner to create a scoped pending invitation with an audit event", async () => {
+  it("allows a landlord owner to create a scoped pending invitation and dispatches email without token response leakage", async () => {
     const router = (await import("../delegatedAccessInvitationRoutes")).default;
 
     const response = await createInvite(router, { landlordId: "other-landlord" });
@@ -227,17 +235,35 @@ describe("delegatedAccessInvitationRoutes", () => {
         role: "property_manager",
         status: "pending",
         workspaceScopes: ["dashboard", "operations", "properties"],
+        emailDispatch: expect.objectContaining({ status: "sent", attemptCount: 1 }),
       })
     );
     expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+    expect(response.body.emailDispatch).toEqual({ status: "sent" });
 
     const invitations = readCollection("delegatedAccessInvitations");
     expect(invitations).toHaveLength(1);
-    expect(invitations[0]).toEqual(expect.objectContaining({ tokenHash: expect.any(String) }));
+    expect(invitations[0]).toEqual(
+      expect.objectContaining({
+        tokenHash: expect.any(String),
+        emailDispatch: expect.objectContaining({ status: "sent", attemptCount: 1 }),
+      })
+    );
     expect(invitations[0].landlordId).toBe("landlord-1");
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const emailPayload = sendEmailMock.mock.calls[0][0];
+    expect(emailPayload.to).toBe("manager@example.com");
+    expect(emailPayload.subject).toContain("owner@example.com");
+    expect(emailPayload.text).toContain("Assigned role: Property Manager");
+    expect(emailPayload.text).toContain("Use your own RentChain account");
+    expect(emailPayload.text).toContain("/delegated-access/accept?token=");
+    const rawToken = String(emailPayload.text).match(/token=([A-Za-z0-9_-]+)/)?.[1];
+    expect(rawToken).toBeTruthy();
+    expect(sha256(rawToken!)).toBe(invitations[0].tokenHash);
+    expect(JSON.stringify(response.body)).not.toContain(rawToken!);
 
     const auditEvents = readCollection("delegatedAccessAuditEvents");
-    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents).toHaveLength(2);
     expect(auditEvents[0]).toEqual(
       expect.objectContaining({
         eventType: "delegated_invite_created",
@@ -249,7 +275,16 @@ describe("delegatedAccessInvitationRoutes", () => {
       })
     );
     expect(auditEvents[0].after).not.toHaveProperty("tokenHash");
-    expect(auditEvents.map((event) => event.eventType)).not.toContain("delegated_invite_sent");
+    expect(auditEvents[1]).toEqual(
+      expect.objectContaining({
+        eventType: "delegated_invite_sent",
+        actionType: "invite_email_dispatched",
+        outcome: "allowed",
+        metadataOnly: true,
+      })
+    );
+    expect(JSON.stringify(auditEvents)).not.toContain(rawToken!);
+    expect(JSON.stringify(auditEvents)).not.toContain("tokenHash");
   });
 
   it("rejects non-owner invitation creation", async () => {
@@ -259,6 +294,47 @@ describe("delegatedAccessInvitationRoutes", () => {
 
     expect(response.status).toBe(403);
     expect(readCollection("delegatedAccessInvitations")).toHaveLength(0);
+  });
+
+  it("keeps created invitation retryable when initial email dispatch fails", async () => {
+    sendEmailMock.mockRejectedValueOnce(new Error("mail_failed secret_token_like_value_abcdefghijklmnopqrstuvwxyz"));
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+
+    const response = await createInvite(router);
+
+    expect(response.status).toBe(201);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.emailDispatch).toEqual({ status: "failed" });
+    expect(response.body.invitation.emailDispatch).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        attemptCount: 1,
+        lastFailureReason: expect.stringContaining("mail_failed"),
+      })
+    );
+    expect(JSON.stringify(response.body)).not.toContain("secret_token_like_value");
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+
+    const invitations = readCollection("delegatedAccessInvitations");
+    expect(invitations).toHaveLength(1);
+    expect(invitations[0].status).toBe("pending");
+    expect(invitations[0].emailDispatch.status).toBe("failed");
+
+    const auditEvents = readCollection("delegatedAccessAuditEvents");
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "delegated_invite_created",
+      "delegated_invite_sent",
+    ]);
+    const failedEvent = auditEvents[1];
+    expect(failedEvent).toEqual(
+      expect.objectContaining({
+        actionType: "invite_email_dispatch_failed",
+        outcome: "failed",
+        metadataOnly: true,
+      })
+    );
+    expect(JSON.stringify(failedEvent)).not.toContain("secret_token_like_value");
+    expect(JSON.stringify(failedEvent)).not.toContain("tokenHash");
   });
 
   it("rejects invalid roles and invalid scopes", async () => {
@@ -413,6 +489,112 @@ describe("delegatedAccessInvitationRoutes", () => {
     });
 
     expect(response.status).toBe(404);
+  });
+
+  it("resends pending unexpired invitations and refreshes the stored token hash without token response leakage", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const created = await createInvite(router);
+    const invitationId = created.body.invitation.invitationId;
+    const originalHash = readCollection("delegatedAccessInvitations")[0].tokenHash;
+    sendEmailMock.mockClear();
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${invitationId}/resend`,
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.emailDispatch).toEqual({ status: "sent" });
+    expect(response.body.invitation.emailDispatch).toEqual(
+      expect.objectContaining({ status: "sent", attemptCount: 2 })
+    );
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+
+    const emailPayload = sendEmailMock.mock.calls[0][0];
+    const rawToken = String(emailPayload.text).match(/token=([A-Za-z0-9_-]+)/)?.[1];
+    expect(rawToken).toBeTruthy();
+    const updatedInvitation = readCollection("delegatedAccessInvitations")[0];
+    expect(updatedInvitation.tokenHash).not.toBe(originalHash);
+    expect(updatedInvitation.tokenHash).toBe(sha256(rawToken!));
+    expect(JSON.stringify(response.body)).not.toContain(rawToken!);
+
+    const auditEvents = readCollection("delegatedAccessAuditEvents");
+    expect(auditEvents.map((event) => event.actionType)).toContain("invite_email_resent");
+    expect(JSON.stringify(auditEvents)).not.toContain(rawToken!);
+    expect(JSON.stringify(auditEvents)).not.toContain("tokenHash");
+  });
+
+  it("preserves existing token hash and marks retryable failure when resend dispatch fails", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const created = await createInvite(router);
+    const invitationId = created.body.invitation.invitationId;
+    const originalHash = readCollection("delegatedAccessInvitations")[0].tokenHash;
+    sendEmailMock.mockRejectedValueOnce(new Error("provider_unavailable secret_token_like_value_abcdefghijklmnopqrstuvwxyz"));
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: `/delegated-access/invitations/${invitationId}/resend`,
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(502);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe("EMAIL_DISPATCH_FAILED");
+    expect(response.body.invitation.emailDispatch).toEqual(
+      expect.objectContaining({ status: "failed", attemptCount: 2 })
+    );
+    const updatedInvitation = readCollection("delegatedAccessInvitations")[0];
+    expect(updatedInvitation.tokenHash).toBe(originalHash);
+    expect(updatedInvitation.emailDispatch.status).toBe("failed");
+    expect(JSON.stringify(response.body)).not.toContain("secret_token_like_value");
+    expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+
+    const failedEvent = readCollection("delegatedAccessAuditEvents").find(
+      (event) => event.actionType === "invite_email_resend_failed"
+    );
+    expect(failedEvent).toEqual(expect.objectContaining({ outcome: "failed", metadataOnly: true }));
+    expect(JSON.stringify(failedEvent)).not.toContain("secret_token_like_value");
+    expect(JSON.stringify(failedEvent)).not.toContain("tokenHash");
+  });
+
+  it("fails closed when resending non-pending, expired, or cross-landlord invitations", async () => {
+    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    seedInvitation({ invitationId: "accepted-invitation", status: "accepted", acceptedByUserId: "delegate-1" });
+    seedInvitation({
+      invitationId: "expired-invitation",
+      expiresAt: "2026-06-01T12:00:00.000Z",
+      tokenHash: sha256("expired-resend-token"),
+    });
+    seedInvitation({
+      invitationId: "other-landlord-invitation",
+      landlordId: "landlord-2",
+      tokenHash: sha256("other-landlord-token"),
+    });
+
+    const accepted = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/invitations/accepted-invitation/resend",
+      user: ownerUser,
+    });
+    expect(accepted.status).toBe(409);
+
+    const expired = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/invitations/expired-invitation/resend",
+      user: ownerUser,
+    });
+    expect(expired.status).toBe(410);
+
+    const crossLandlord = await invokeRouter(router, {
+      method: "POST",
+      url: "/delegated-access/invitations/other-landlord-invitation/resend",
+      user: ownerUser,
+    });
+    expect(crossLandlord.status).toBe(404);
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("accepts a valid pending token for the authenticated delegate account", async () => {

--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -790,7 +790,7 @@ describe("delegatedAccessInvitationRoutes", () => {
   });
 
   it("lists only active grants assigned to the authenticated delegate without property ids", async () => {
-    const router = (await import("../delegatedAccessInvitationRoutes")).default;
+    const { default: router, delegatedAccessSelfRoutes } = await import("../delegatedAccessInvitationRoutes");
     seedGrant({ grantId: "delegate-active-grant", status: "active" });
     seedGrant({ grantId: "delegate-revoked-grant", status: "revoked" });
     seedGrant({ grantId: "other-delegate-active-grant", delegateUserId: "delegate-user-2", status: "active" });
@@ -821,6 +821,43 @@ describe("delegatedAccessInvitationRoutes", () => {
     expect(JSON.stringify(response.body)).not.toContain("property-1");
     expect(JSON.stringify(response.body)).not.toContain("unit-1");
     expect(JSON.stringify(response.body)).not.toContain("tokenHash");
+
+    const selfRouteResponse = await invokeRouter(delegatedAccessSelfRoutes, {
+      method: "GET",
+      url: "/my-grants",
+      user: { id: "delegate-user-1", role: "delegate", email: "manager@example.com" },
+    });
+
+    expect(selfRouteResponse.status).toBe(200);
+    expect(selfRouteResponse.body.grants).toHaveLength(1);
+    expect(JSON.stringify(selfRouteResponse.body)).not.toContain("property-1");
+  });
+
+  it("keeps delegated self grants authenticated and delegate-scoped", async () => {
+    const { delegatedAccessSelfRoutes } = await import("../delegatedAccessInvitationRoutes");
+    seedGrant({ grantId: "delegate-active-grant", status: "active" });
+
+    const unauthenticated = await invokeRouter(delegatedAccessSelfRoutes, {
+      method: "GET",
+      url: "/my-grants",
+      user: null,
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const ownerSession = await invokeRouter(delegatedAccessSelfRoutes, {
+      method: "GET",
+      url: "/my-grants",
+      user: ownerUser,
+    });
+    expect(ownerSession.status).toBe(403);
+
+    const wrongDelegate = await invokeRouter(delegatedAccessSelfRoutes, {
+      method: "GET",
+      url: "/my-grants",
+      user: { id: "delegate-user-2", role: "delegate", email: "other@example.com" },
+    });
+    expect(wrongDelegate.status).toBe(200);
+    expect(wrongDelegate.body.grants).toEqual([]);
   });
 
   it("lists delegate summaries for active and revoked grants", async () => {

--- a/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/delegatedAccessInvitationRoutes.test.ts
@@ -791,7 +791,24 @@ describe("delegatedAccessInvitationRoutes", () => {
 
   it("lists only active grants assigned to the authenticated delegate without property ids", async () => {
     const { default: router, delegatedAccessSelfRoutes } = await import("../delegatedAccessInvitationRoutes");
+    writeCollectionDoc("users", "landlord-1", { email: "owner@example.com", displayName: "Owner Raw Label" });
+    writeCollectionDoc("accounts", "landlord-2", { email: "elite-owner@example.com" });
     seedGrant({ grantId: "delegate-active-grant", status: "active" });
+    seedGrant({
+      grantId: "delegate-second-active-grant",
+      landlordId: "landlord-2",
+      status: "active",
+      updatedAt: "2026-06-23T12:00:00.000Z",
+      permissionScope: {
+        role: "property_manager",
+        workspaceScopes: ["dashboard", "operations", "properties"],
+        propertyScope: { mode: "selected", propertyIds: ["property-2"], unitIds: ["unit-2"] },
+        resourceScope: { workOrderIds: ["work-order-2"] },
+        permissionFlags: ["view", "edit", "assign"],
+        billingAccess: false,
+        exportAccess: false,
+      },
+    });
     seedGrant({ grantId: "delegate-revoked-grant", status: "revoked" });
     seedGrant({ grantId: "other-delegate-active-grant", delegateUserId: "delegate-user-2", status: "active" });
 
@@ -802,7 +819,11 @@ describe("delegatedAccessInvitationRoutes", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.body.grants).toHaveLength(1);
+    expect(response.body.grants).toHaveLength(2);
+    expect(response.body.grants.map((grant: any) => grant.landlordWorkspaceLabel).sort()).toEqual([
+      "elite-owner@example.com",
+      "owner@example.com",
+    ]);
     expect(response.body.grants[0]).toEqual(
       expect.objectContaining({
         delegateEmail: "manager@example.com",
@@ -816,10 +837,14 @@ describe("delegatedAccessInvitationRoutes", () => {
       })
     );
     expect(JSON.stringify(response.body)).not.toContain("landlord-1");
+    expect(JSON.stringify(response.body)).not.toContain("landlord-2");
     expect(JSON.stringify(response.body)).not.toContain("delegate-active-grant");
+    expect(JSON.stringify(response.body)).not.toContain("delegate-second-active-grant");
     expect(JSON.stringify(response.body)).not.toContain("delegate-user-1");
     expect(JSON.stringify(response.body)).not.toContain("property-1");
+    expect(JSON.stringify(response.body)).not.toContain("property-2");
     expect(JSON.stringify(response.body)).not.toContain("unit-1");
+    expect(JSON.stringify(response.body)).not.toContain("unit-2");
     expect(JSON.stringify(response.body)).not.toContain("tokenHash");
 
     const selfRouteResponse = await invokeRouter(delegatedAccessSelfRoutes, {
@@ -829,7 +854,7 @@ describe("delegatedAccessInvitationRoutes", () => {
     });
 
     expect(selfRouteResponse.status).toBe(200);
-    expect(selfRouteResponse.body.grants).toHaveLength(1);
+    expect(selfRouteResponse.body.grants).toHaveLength(2);
     expect(JSON.stringify(selfRouteResponse.body)).not.toContain("property-1");
   });
 

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -34,6 +34,7 @@ import {
 } from "../services/tenantPortal/tenantInviteService";
 import { createTenancyIfMissing } from "../services/tenanciesService";
 import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
+import { resolveDelegatedAccessInvitationSignupContext } from "../services/delegatedAccessInvitationService";
 
 const router = Router();
 const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
@@ -98,6 +99,10 @@ function tokenFingerprint(value: string): string {
 
 function hashToken(input: string) {
   return crypto.createHash("sha256").update(String(input || "").trim()).digest("hex");
+}
+
+function isDelegatedAccessSignupSource(value: string): boolean {
+  return value === "delegated_access" || value === "delegate" || value === "delegated-access";
 }
 
 function asOnboardString(value: unknown): string | null {
@@ -715,8 +720,62 @@ router.post("/signup", rateLimitAuth, async (req, res) => {
       landlordId: string | null;
       maskedEmail: string | null;
     } | null = null;
+    let delegatedInviteContext: {
+      token: string;
+      invitationId: string;
+      landlordId: string;
+      role: string;
+    } | null = null;
 
-    if (inviteToken || inviteSource === "contractor") {
+    if (isDelegatedAccessSignupSource(inviteSource)) {
+      if (!inviteToken) {
+        return res.status(400).json({
+          ok: false,
+          code: "MISSING_INVITE_TOKEN",
+          error: "Delegated access invite token is required for signup",
+        });
+      }
+      try {
+        const resolved = await resolveDelegatedAccessInvitationSignupContext({
+          token: inviteToken,
+          email,
+        });
+        delegatedInviteContext = {
+          token: inviteToken,
+          invitationId: resolved.invitation.invitationId,
+          landlordId: resolved.invitation.landlordId,
+          role: resolved.invitation.role,
+        };
+        onboardLog("signup_context", {
+          correlationId: signupCorrelationId,
+          inviteType: "delegated_access",
+          status: resolved.invitation.status,
+          token: tokenFingerprint(inviteToken),
+          invitationId: resolved.invitation.invitationId,
+        });
+      } catch (error: any) {
+        const code = String(error?.message || "invalid_invitation_token");
+        const status =
+          code === "invitation_expired"
+            ? 410
+            : code === "invitee_email_mismatch"
+            ? 403
+            : code === "invitation_not_pending"
+            ? 409
+            : 404;
+        onboardLog("signup_context_rejected", {
+          correlationId: signupCorrelationId,
+          inviteType: "delegated_access",
+          token: tokenFingerprint(inviteToken),
+          reason: code,
+        });
+        return res.status(status).json({
+          ok: false,
+          code: code.toUpperCase(),
+          error: "Delegated access invite is invalid or cannot be used for this account.",
+        });
+      }
+    } else if (inviteToken || inviteSource === "contractor") {
       if (!inviteToken) {
         return res.status(400).json({
           ok: false,
@@ -785,6 +844,58 @@ router.post("/signup", rateLimitAuth, async (req, res) => {
     }
 
     const uid = userRecord.uid;
+    if (delegatedInviteContext) {
+      const delegateDoc = {
+        id: uid,
+        email,
+        role: "delegate",
+        landlordId: null,
+        delegatedAccess: {
+          status: "pending_acceptance",
+          invitationId: delegatedInviteContext.invitationId,
+          landlordId: delegatedInviteContext.landlordId,
+          role: delegatedInviteContext.role,
+        },
+        status: "active",
+        approved: true,
+        approvedAt: now,
+        approvedBy: "delegated_access_invite_signup",
+        createdAt: now,
+        updatedAt: now,
+      };
+      await db.collection("users").doc(uid).set(delegateDoc, { merge: true });
+      await db.collection("accounts").doc(uid).set(delegateDoc, { merge: true });
+
+      const token = signAuthToken({
+        sub: uid,
+        email,
+        role: "delegate",
+        permissions: [],
+        revokedPermissions: [],
+      });
+      onboardLog("signup_completed", {
+        correlationId: signupCorrelationId,
+        mode: "delegated_access_invite",
+        issuedRole: "delegate",
+        token: tokenFingerprint(delegatedInviteContext.token),
+        invitationId: delegatedInviteContext.invitationId,
+        email: maskEmail(email),
+        userId: uid,
+      });
+      return res.status(201).json({
+        ok: true,
+        token,
+        showLandlordWelcome: false,
+        user: {
+          id: uid,
+          email,
+          role: "delegate",
+          landlordId: null,
+          approved: true,
+        },
+      });
+    }
+
     if (contractorInviteContext) {
       const invitedBy = contractorInviteContext.landlordId ? [contractorInviteContext.landlordId] : [];
       await db.collection("users").doc(uid).set(
@@ -1633,6 +1744,39 @@ router.post("/login", rateLimitAuth, async (req, res) => {
           role: "contractor",
           actorRole: "contractor",
           contractorId,
+        },
+      });
+    }
+
+    if (persistedRole === "delegate") {
+      step = "delegate_jwt_sign";
+      claims = {
+        sub: fbUser.id,
+        email: fbUser.email,
+        role: "delegate",
+        permissions: Array.isArray(persistedUser?.permissions)
+          ? persistedUser.permissions
+          : Array.isArray(persistedAccount?.permissions)
+          ? persistedAccount.permissions
+          : [],
+        revokedPermissions: Array.isArray(persistedUser?.revokedPermissions)
+          ? persistedUser.revokedPermissions
+          : Array.isArray(persistedAccount?.revokedPermissions)
+          ? persistedAccount.revokedPermissions
+          : [],
+      } as const;
+      const token = signAuthToken(claims, { expiresIn: "7d" });
+      sessionUser = await buildCanonicalSessionUserFromClaims({ ...claims, ver: 1 } as any, {
+        requestCache: {},
+      });
+      return res.status(200).json({
+        ok: true,
+        token,
+        user: {
+          ...sessionUser,
+          role: "delegate",
+          actorRole: "delegate",
+          landlordId: null,
         },
       });
     }

--- a/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
+++ b/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
@@ -59,6 +59,12 @@ function handleError(res: any, error: unknown) {
   if (code === "invitation_expired") {
     return res.status(410).json({ ok: false, error: "INVITATION_EXPIRED" });
   }
+  if (code === "invitee_email_mismatch") {
+    return res.status(403).json({ ok: false, error: "INVITEE_EMAIL_MISMATCH" });
+  }
+  if (code === "delegate_account_role_conflict") {
+    return res.status(403).json({ ok: false, error: "DELEGATE_ACCOUNT_ROLE_CONFLICT" });
+  }
   if (code.startsWith("invalid_") || code.startsWith("missing_") || code.includes("_not_allowed")) {
     return res.status(400).json({ ok: false, error: code.toUpperCase() });
   }
@@ -121,6 +127,7 @@ router.post("/delegated-access/invitations/accept", async (req: any, res) => {
     const result = await acceptDelegatedAccessInvitationRecord({
       actorUserId: context.actorUserId,
       actorEmail: context.actorEmail,
+      actorRole: req.user?.actorRole || req.user?.role || null,
       token: req.body?.token,
     });
     return res.status(200).json({ ok: true, invitation: result.invitation, grant: result.grant });

--- a/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
+++ b/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
@@ -14,6 +14,7 @@ import {
 } from "../services/delegatedAccessInvitationService";
 
 const router = Router();
+const selfRouter = Router();
 
 function asString(value: unknown, max = 240): string {
   return String(value ?? "").trim().slice(0, max);
@@ -81,7 +82,7 @@ function handleError(res: any, error: unknown) {
 
 router.use(requireAuth);
 
-router.get("/delegated-access/my-grants", async (req: any, res) => {
+async function handleMyDelegatedAccessGrants(req: any, res: any) {
   const context = delegateContext(req);
   if (!context) return forbidden(res);
 
@@ -93,7 +94,12 @@ router.get("/delegated-access/my-grants", async (req: any, res) => {
   } catch (error) {
     return handleError(res, error);
   }
-});
+}
+
+selfRouter.use(requireAuth);
+selfRouter.get("/my-grants", handleMyDelegatedAccessGrants);
+
+router.get("/delegated-access/my-grants", handleMyDelegatedAccessGrants);
 
 router.get("/delegated-access/delegates", async (req: any, res) => {
   const context = ownerContext(req);
@@ -253,4 +259,5 @@ router.post("/delegated-access/invitations/:invitationId/expire", async (req: an
   }
 });
 
+export const delegatedAccessSelfRoutes = selfRouter;
 export default router;

--- a/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
+++ b/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
@@ -8,6 +8,7 @@ import {
   listDelegatedAccessDelegateRecords,
   listDelegatedAccessGrantRecords,
   listDelegatedAccessInvitationRecords,
+  resendDelegatedAccessInvitationEmailRecord,
   revokeDelegatedAccessGrantRecord,
 } from "../services/delegatedAccessInvitationService";
 
@@ -17,13 +18,14 @@ function asString(value: unknown, max = 240): string {
   return String(value ?? "").trim().slice(0, max);
 }
 
-function ownerContext(req: any): { actorUserId: string; landlordId: string } | null {
+function ownerContext(req: any): { actorUserId: string; landlordId: string; actorEmail: string | null } | null {
   const role = asString(req.user?.role, 80).toLowerCase();
   if (role !== "landlord") return null;
   const actorUserId = asString(req.user?.id || req.user?.uid || req.user?.sub, 240);
   const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+  const actorEmail = asString(req.user?.email, 320) || null;
   if (!actorUserId || !landlordId) return null;
-  return { actorUserId, landlordId };
+  return { actorUserId, landlordId, actorEmail };
 }
 
 function actorContext(req: any): { actorUserId: string; actorEmail: string | null } | null {
@@ -135,6 +137,7 @@ router.post("/delegated-access/invitations", async (req: any, res) => {
     const result = await createDelegatedAccessInvitationRecord({
       landlordId: context.landlordId,
       actorUserId: context.actorUserId,
+      actorEmail: context.actorEmail,
       inviteeEmail: req.body?.inviteeEmail,
       role: req.body?.role,
       propertyScope: req.body?.propertyScope,
@@ -143,7 +146,33 @@ router.post("/delegated-access/invitations", async (req: any, res) => {
       permissionFlags: Array.isArray(req.body?.permissionFlags) ? req.body.permissionFlags : [],
       expiresAt: req.body?.expiresAt,
     });
-    return res.status(201).json({ ok: true, invitation: result.invitation });
+    return res.status(201).json({
+      ok: true,
+      invitation: result.invitation,
+      emailDispatch: { status: result.emailDispatched ? "sent" : "failed" },
+    });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/delegated-access/invitations/:invitationId/resend", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await resendDelegatedAccessInvitationEmailRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      actorEmail: context.actorEmail,
+      invitationId: req.params.invitationId,
+    });
+    return res.status(result.emailDispatched ? 200 : 502).json({
+      ok: result.emailDispatched,
+      invitation: result.invitation,
+      emailDispatch: { status: result.emailDispatched ? "sent" : "failed" },
+      ...(result.emailDispatched ? {} : { error: "EMAIL_DISPATCH_FAILED" }),
+    });
   } catch (error) {
     return handleError(res, error);
   }

--- a/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
+++ b/rentchain-api/src/routes/delegatedAccessInvitationRoutes.ts
@@ -5,6 +5,7 @@ import {
   cancelDelegatedAccessInvitationRecord,
   createDelegatedAccessInvitationRecord,
   expireDelegatedAccessInvitationRecord,
+  listActiveDelegatedAccessGrantRecordsForDelegate,
   listDelegatedAccessDelegateRecords,
   listDelegatedAccessGrantRecords,
   listDelegatedAccessInvitationRecords,
@@ -33,6 +34,12 @@ function actorContext(req: any): { actorUserId: string; actorEmail: string | nul
   if (!actorUserId) return null;
   const actorEmail = asString(req.user?.email, 320) || null;
   return { actorUserId, actorEmail };
+}
+
+function delegateContext(req: any): { actorUserId: string; actorEmail: string | null } | null {
+  const role = asString(req.user?.actorRole || req.user?.role, 80).toLowerCase();
+  if (role !== "delegate") return null;
+  return actorContext(req);
 }
 
 function forbidden(res: any) {
@@ -73,6 +80,20 @@ function handleError(res: any, error: unknown) {
 }
 
 router.use(requireAuth);
+
+router.get("/delegated-access/my-grants", async (req: any, res) => {
+  const context = delegateContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listActiveDelegatedAccessGrantRecordsForDelegate({
+      actorUserId: context.actorUserId,
+    });
+    return res.status(200).json({ ok: true, grants: result.grants });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
 
 router.get("/delegated-access/delegates", async (req: any, res) => {
   const context = ownerContext(req);

--- a/rentchain-api/src/services/delegatedAccessEmailService.ts
+++ b/rentchain-api/src/services/delegatedAccessEmailService.ts
@@ -14,7 +14,14 @@ function safeString(value: unknown, max = 500): string {
 }
 
 function appBaseUrl(): string {
-  return safeString(process.env.PUBLIC_APP_URL || process.env.APP_BASE_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+  const explicit =
+    process.env.DELEGATED_ACCESS_ACCEPTANCE_BASE_URL ||
+    process.env.DELEGATED_ACCESS_FRONTEND_URL ||
+    process.env.PUBLIC_APP_URL ||
+    process.env.APP_BASE_URL;
+  const vercelPreview = process.env.VERCEL_BRANCH_URL || process.env.VERCEL_URL;
+  const base = explicit || (vercelPreview ? `https://${vercelPreview}` : "https://www.rentchain.ai");
+  return safeString(base).replace(/\/$/, "");
 }
 
 function roleLabel(role: string): string {

--- a/rentchain-api/src/services/delegatedAccessEmailService.ts
+++ b/rentchain-api/src/services/delegatedAccessEmailService.ts
@@ -1,0 +1,88 @@
+import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
+import { sendEmail } from "./emailService";
+import type { DelegatedAccessInvitation } from "../lib/delegatedAccess";
+
+type SendDelegatedAccessInvitationEmailInput = {
+  invitation: DelegatedAccessInvitation;
+  rawToken: string;
+  invitedByEmail?: string | null;
+  invitedByName?: string | null;
+};
+
+function safeString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function appBaseUrl(): string {
+  return safeString(process.env.PUBLIC_APP_URL || process.env.APP_BASE_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+}
+
+function roleLabel(role: string): string {
+  return role
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function scopeSummary(invitation: DelegatedAccessInvitation): string {
+  const workspaces = invitation.workspaceScopes.length
+    ? `Workspaces: ${invitation.workspaceScopes.map(roleLabel).join(", ")}`
+    : "Workspaces: none";
+  const propertyScope =
+    invitation.propertyScope.mode === "selected"
+      ? `Properties: ${invitation.propertyScope.propertyIds.length} selected`
+      : `Properties: ${invitation.propertyScope.mode.replace(/_/g, " ")}`;
+  return `${workspaces}. ${propertyScope}.`;
+}
+
+export function buildDelegatedAccessAcceptanceUrl(rawToken: string): string {
+  const token = encodeURIComponent(safeString(rawToken, 2000));
+  return `${appBaseUrl()}/delegated-access/accept?token=${token}`;
+}
+
+export async function sendDelegatedAccessInvitationEmail(input: SendDelegatedAccessInvitationEmailInput): Promise<void> {
+  const from = safeString(process.env.DELEGATED_ACCESS_FROM_EMAIL || process.env.EMAIL_FROM || process.env.FROM_EMAIL);
+  if (!from) throw new Error("EMAIL_FROM missing");
+
+  const invitedBy =
+    safeString(input.invitedByName, 160) ||
+    safeString(input.invitedByEmail, 320) ||
+    "A RentChain landlord owner";
+  const role = roleLabel(input.invitation.role);
+  const expiresAt = new Date(input.invitation.expiresAt).toLocaleString("en-CA", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  });
+  const acceptanceUrl = buildDelegatedAccessAcceptanceUrl(input.rawToken);
+  const bullets = [
+    `Invited by: ${invitedBy}`,
+    `Assigned role: ${role}`,
+    scopeSummary(input.invitation),
+    `Invitation expires: ${expiresAt} UTC`,
+    "Use your own RentChain account. Never use or share the landlord owner's login credentials.",
+  ];
+
+  await sendEmail({
+    to: input.invitation.inviteeEmail,
+    from,
+    subject: `${invitedBy} invited you to RentChain`,
+    text: buildEmailText({
+      intro: "You have been invited to access a RentChain landlord workspace as a delegate.",
+      bullets,
+      ctaText: "Accept delegated access",
+      ctaUrl: acceptanceUrl,
+      footerNote: "If you were not expecting this invitation, ignore this email or contact the landlord owner.",
+    }),
+    html: buildEmailHtml({
+      title: "Accept delegated access",
+      intro: "You have been invited to access a RentChain landlord workspace as a delegate.",
+      bullets,
+      ctaText: "Accept delegated access",
+      ctaUrl: acceptanceUrl,
+      footerNote: "If you were not expecting this invitation, ignore this email or contact the landlord owner.",
+      preheader: "Use your own account to accept delegated access. Never share landlord credentials.",
+    }),
+  });
+}

--- a/rentchain-api/src/services/delegatedAccessInvitationService.ts
+++ b/rentchain-api/src/services/delegatedAccessInvitationService.ts
@@ -49,6 +49,7 @@ export type DelegatedActiveGrantProjection = Omit<
   DelegatedAccessGrant,
   "grantId" | "landlordId" | "delegateUserId" | "createdByUserId" | "revokedByUserId" | "auditEventIds"
 > & {
+  landlordWorkspaceLabel: string;
   propertyScopeSummary: string;
   permissionScope: Omit<DelegatedAccessGrant["permissionScope"], "propertyScope"> & {
     propertyScope: {
@@ -157,7 +158,53 @@ function projectGrant(grant: DelegatedAccessGrant): DelegatedGrantProjection {
   return grant;
 }
 
-function projectActiveDelegateGrant(grant: DelegatedAccessGrant): DelegatedActiveGrantProjection {
+function safeWorkspaceLabel(value: unknown, landlordId: string): string | null {
+  const label = cleanString(value, 160).replace(/\s+/g, " ");
+  if (!label || label === landlordId) return null;
+  return label;
+}
+
+function workspaceLabelFromRecord(data: Record<string, unknown> | undefined, landlordId: string): string | null {
+  if (!data) return null;
+  const candidates = [
+    data.email,
+    data.ownerEmail,
+    data.workspaceEmail,
+    data.displayName,
+    data.workspaceName,
+    data.companyName,
+    data.businessName,
+    data.legalName,
+    data.name,
+  ];
+  for (const candidate of candidates) {
+    const label = safeWorkspaceLabel(candidate, landlordId);
+    if (label) return label;
+  }
+  return null;
+}
+
+async function resolveLandlordWorkspaceLabel(
+  landlordId: string,
+  firestore: DelegatedAccessFirestoreLike
+): Promise<string> {
+  const workspaceCollections = ["users", "accounts", "landlords"] as const;
+  for (const collectionName of workspaceCollections) {
+    try {
+      const snapshot = await firestore.collection<Record<string, unknown>>(collectionName).doc(landlordId).get?.();
+      const label = workspaceLabelFromRecord(snapshot?.exists ? snapshot.data() : undefined, landlordId);
+      if (label) return label;
+    } catch {
+      // Best-effort label enrichment must not block delegate self-access.
+    }
+  }
+  return "Landlord workspace";
+}
+
+async function projectActiveDelegateGrant(
+  grant: DelegatedAccessGrant,
+  firestore: DelegatedAccessFirestoreLike
+): Promise<DelegatedActiveGrantProjection> {
   const {
     grantId: _grantId,
     landlordId: _landlordId,
@@ -169,6 +216,7 @@ function projectActiveDelegateGrant(grant: DelegatedAccessGrant): DelegatedActiv
   } = grant;
   return {
     ...safe,
+    landlordWorkspaceLabel: await resolveLandlordWorkspaceLabel(grant.landlordId, firestore),
     propertyScopeSummary: propertyScopeSummary([grant]),
     permissionScope: {
       ...grant.permissionScope,
@@ -599,7 +647,7 @@ export async function listActiveDelegatedAccessGrantRecordsForDelegate(
   const firestore = delegatedDb(options.firestore);
   const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
   const grants = await listActiveGrantsForDelegate(actorUserId, firestore);
-  return { grants: grants.map(projectActiveDelegateGrant) };
+  return { grants: await Promise.all(grants.map((grant) => projectActiveDelegateGrant(grant, firestore))) };
 }
 
 export async function resendDelegatedAccessInvitationEmailRecord(

--- a/rentchain-api/src/services/delegatedAccessInvitationService.ts
+++ b/rentchain-api/src/services/delegatedAccessInvitationService.ts
@@ -45,6 +45,19 @@ export type DelegatedAccessFirestoreLike = {
 
 export type DelegatedInvitationProjection = Omit<DelegatedAccessInvitation, "tokenHash">;
 export type DelegatedGrantProjection = DelegatedAccessGrant;
+export type DelegatedActiveGrantProjection = Omit<
+  DelegatedAccessGrant,
+  "grantId" | "landlordId" | "delegateUserId" | "createdByUserId" | "revokedByUserId" | "auditEventIds"
+> & {
+  propertyScopeSummary: string;
+  permissionScope: Omit<DelegatedAccessGrant["permissionScope"], "propertyScope"> & {
+    propertyScope: {
+      mode: DelegatedAccessPropertyScope["mode"];
+      propertyIds: [];
+      unitIds?: [];
+    };
+  };
+};
 export type DelegatedDelegateSummary = {
   delegateUserId: string;
   delegateEmail: string | null;
@@ -142,6 +155,30 @@ function projectInvitation(invitation: DelegatedAccessInvitation): DelegatedInvi
 
 function projectGrant(grant: DelegatedAccessGrant): DelegatedGrantProjection {
   return grant;
+}
+
+function projectActiveDelegateGrant(grant: DelegatedAccessGrant): DelegatedActiveGrantProjection {
+  const {
+    grantId: _grantId,
+    landlordId: _landlordId,
+    delegateUserId: _delegateUserId,
+    createdByUserId: _createdByUserId,
+    revokedByUserId: _revokedByUserId,
+    auditEventIds: _auditEventIds,
+    ...safe
+  } = grant;
+  return {
+    ...safe,
+    propertyScopeSummary: propertyScopeSummary([grant]),
+    permissionScope: {
+      ...grant.permissionScope,
+      propertyScope: {
+        mode: grant.permissionScope.propertyScope.mode,
+        propertyIds: [],
+        ...(grant.permissionScope.propertyScope.unitIds?.length ? { unitIds: [] } : {}),
+      },
+    },
+  };
 }
 
 function invitationFromSnapshot(snapshot: SnapshotLike): DelegatedAccessInvitation | null {
@@ -432,6 +469,18 @@ async function listGrantsForLandlord(
     .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
 }
 
+async function listActiveGrantsForDelegate(
+  delegateUserId: string,
+  firestore: DelegatedAccessFirestoreLike
+): Promise<DelegatedAccessGrant[]> {
+  const snapshot = await firestore.collection<DelegatedAccessGrant>(DELEGATED_ACCESS_GRANTS_COLLECTION).get?.();
+  return (snapshot?.docs || [])
+    .map(grantFromSnapshot)
+    .filter((grant): grant is DelegatedAccessGrant => Boolean(grant))
+    .filter((grant) => grant.delegateUserId === delegateUserId && grant.status === "active")
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
+}
+
 async function loadGrantForLandlord(
   landlordId: string,
   grantId: string,
@@ -541,6 +590,16 @@ export async function listDelegatedAccessDelegateRecords(
   const landlordId = requireString(input.landlordId, "missing_landlord_id");
   const grants = await listGrantsForLandlord(landlordId, firestore);
   return { delegates: summarizeDelegates(grants) };
+}
+
+export async function listActiveDelegatedAccessGrantRecordsForDelegate(
+  input: { actorUserId: string },
+  options: ServiceOptions = {}
+): Promise<{ grants: DelegatedActiveGrantProjection[] }> {
+  const firestore = delegatedDb(options.firestore);
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const grants = await listActiveGrantsForDelegate(actorUserId, firestore);
+  return { grants: grants.map(projectActiveDelegateGrant) };
 }
 
 export async function resendDelegatedAccessInvitationEmailRecord(

--- a/rentchain-api/src/services/delegatedAccessInvitationService.ts
+++ b/rentchain-api/src/services/delegatedAccessInvitationService.ts
@@ -81,6 +81,7 @@ type DispatchInvitationEmailInput = {
 type AcceptInvitationInput = {
   actorUserId: string;
   actorEmail?: string | null;
+  actorRole?: string | null;
   token: string;
   now?: string;
 };
@@ -113,6 +114,14 @@ function requireString(value: unknown, code: string, max = 500): string {
 
 function sha256(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeEmail(value: unknown): string {
+  return cleanString(value, 320).toLowerCase();
+}
+
+function normalizeRole(value: unknown): string {
+  return cleanString(value, 80).toLowerCase();
 }
 
 function timingSafeEqualHex(a: string, b: string): boolean {
@@ -447,6 +456,22 @@ async function loadInvitationByTokenHash(
   return invitations.find((invitation) => timingSafeEqualHex(invitation.tokenHash, tokenHash)) || null;
 }
 
+export async function resolveDelegatedAccessInvitationSignupContext(
+  input: { token: string; email: string; now?: string },
+  options: ServiceOptions = {}
+): Promise<{ invitation: DelegatedInvitationProjection }> {
+  const firestore = delegatedDb(options.firestore);
+  const rawToken = requireString(input.token, "missing_invitation_token", 2000);
+  const email = normalizeEmail(input.email);
+  if (!email) throw new Error("missing_invitee_email");
+  const invitation = await loadInvitationByTokenHash(sha256(rawToken), firestore);
+  if (!invitation) throw new Error("invalid_invitation_token");
+  if (invitation.status !== "pending") throw new Error("invitation_not_pending");
+  if (isDelegatedInvitationExpired(invitation, input.now || new Date())) throw new Error("invitation_expired");
+  if (normalizeEmail(invitation.inviteeEmail) !== email) throw new Error("invitee_email_mismatch");
+  return { invitation: projectInvitation(invitation) };
+}
+
 function stableGrantId(invitation: DelegatedAccessInvitation, delegateUserId: string): string {
   const digest = sha256(JSON.stringify([invitation.invitationId, delegateUserId])).slice(0, 24);
   return `delegated_grant_${digest}`;
@@ -623,12 +648,16 @@ export async function acceptDelegatedAccessInvitationRecord(
   const firestore = delegatedDb(options.firestore);
   const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
   const rawToken = requireString(input.token, "missing_invitation_token", 2000);
+  const actorEmail = normalizeEmail(input.actorEmail);
+  const actorRole = normalizeRole(input.actorRole);
   const now = input.now || new Date().toISOString();
   const tokenHash = sha256(rawToken);
   const invitation = await loadInvitationByTokenHash(tokenHash, firestore);
   if (!invitation) throw new Error("invalid_invitation_token");
   if (invitation.status !== "pending") throw new Error("invitation_not_pending");
   if (isDelegatedInvitationExpired(invitation, now)) throw new Error("invitation_expired");
+  if (!actorEmail || actorEmail !== normalizeEmail(invitation.inviteeEmail)) throw new Error("invitee_email_mismatch");
+  if (["admin", "landlord", "owner"].includes(actorRole)) throw new Error("delegate_account_role_conflict");
 
   const accepted = transitionDelegatedInvitationStatus(invitation, "accepted", {
     acceptedByUserId: actorUserId,
@@ -638,7 +667,7 @@ export async function acceptDelegatedAccessInvitationRecord(
     grantId: stableGrantId(invitation, actorUserId),
     landlordId: invitation.landlordId,
     delegateUserId: actorUserId,
-    delegateEmail: input.actorEmail || invitation.inviteeEmail,
+    delegateEmail: actorEmail,
     role: invitation.role,
     propertyScope: invitation.propertyScope,
     workspaceScopes: invitation.workspaceScopes,

--- a/rentchain-api/src/services/delegatedAccessInvitationService.ts
+++ b/rentchain-api/src/services/delegatedAccessInvitationService.ts
@@ -8,12 +8,14 @@ import {
   revokeDelegatedAccessGrant,
   transitionDelegatedInvitationStatus,
   type DelegatedAccessAuditEvent,
+  type DelegatedAccessEmailDispatchMetadata,
   type DelegatedAccessGrant,
   type DelegatedAccessInvitation,
   type DelegatedAccessInvitationStatus,
   type DelegatedAccessPropertyScope,
   type DelegatedAccessResourceScope,
 } from "../lib/delegatedAccess";
+import { sendDelegatedAccessInvitationEmail } from "./delegatedAccessEmailService";
 
 export const DELEGATED_ACCESS_INVITATIONS_COLLECTION = "delegatedAccessInvitations";
 export const DELEGATED_ACCESS_GRANTS_COLLECTION = "delegatedAccessGrants";
@@ -57,6 +59,7 @@ export type DelegatedDelegateSummary = {
 type CreateInvitationInput = {
   landlordId: string;
   actorUserId: string;
+  actorEmail?: string | null;
   inviteeEmail: string;
   role: string;
   propertyScope: DelegatedAccessPropertyScope;
@@ -64,6 +67,14 @@ type CreateInvitationInput = {
   resourceScope?: DelegatedAccessResourceScope;
   permissionFlags: string[];
   expiresAt: string;
+  now?: string;
+};
+
+type DispatchInvitationEmailInput = {
+  landlordId: string;
+  actorUserId: string;
+  actorEmail?: string | null;
+  invitationId: string;
   now?: string;
 };
 
@@ -110,8 +121,9 @@ function timingSafeEqualHex(a: string, b: string): boolean {
   return left.length === right.length && crypto.timingSafeEqual(left, right);
 }
 
-function createTokenHash(): string {
-  return sha256(crypto.randomBytes(32).toString("hex"));
+function createInvitationToken(): { rawToken: string; tokenHash: string } {
+  const rawToken = crypto.randomBytes(32).toString("base64url");
+  return { rawToken, tokenHash: sha256(rawToken) };
 }
 
 function projectInvitation(invitation: DelegatedAccessInvitation): DelegatedInvitationProjection {
@@ -163,14 +175,134 @@ async function saveGrant(grant: DelegatedAccessGrant, firestore: DelegatedAccess
   await ref.set(grant, { merge: false });
 }
 
+function maskedFailureReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : "email_dispatch_failed";
+  return cleanString(message.replace(/[A-Za-z0-9_-]{24,}/g, "[redacted]"), 160) || "email_dispatch_failed";
+}
+
+function nextDispatchMetadata(
+  current: DelegatedAccessEmailDispatchMetadata | null | undefined,
+  status: "sent" | "failed",
+  now: string,
+  failureReason: string | null = null
+): DelegatedAccessEmailDispatchMetadata {
+  return {
+    status,
+    attemptCount: Number(current?.attemptCount || 0) + 1,
+    lastAttemptAt: now,
+    lastSentAt: status === "sent" ? now : current?.lastSentAt || null,
+    lastFailedAt: status === "failed" ? now : current?.lastFailedAt || null,
+    lastFailureReason: status === "failed" ? failureReason : null,
+  };
+}
+
+function permissionScopeForInvitation(invitation: DelegatedAccessInvitation) {
+  return {
+    role: invitation.role,
+    workspaceScopes: invitation.workspaceScopes,
+    propertyScope: invitation.propertyScope,
+    resourceScope: invitation.resourceScope,
+    permissionFlags: invitation.permissionFlags,
+    billingAccess: false as const,
+    exportAccess: invitation.permissionFlags.includes("export"),
+  };
+}
+
+async function dispatchDelegatedAccessInvitationEmail(
+  input: {
+    invitation: DelegatedAccessInvitation;
+    rawToken: string;
+    actorUserId: string;
+    actorEmail?: string | null;
+    now: string;
+    actionType: "invite_email_dispatched" | "invite_email_resent";
+  },
+  firestore: DelegatedAccessFirestoreLike
+): Promise<{ invitation: DelegatedAccessInvitation; auditEvent: DelegatedAccessAuditEvent; sent: boolean }> {
+  try {
+    await sendDelegatedAccessInvitationEmail({
+      invitation: input.invitation,
+      rawToken: input.rawToken,
+      invitedByEmail: input.actorEmail || null,
+    });
+    const auditEvent = buildDelegatedAccessAuditEvent({
+      eventType: "delegated_invite_sent",
+      actorUserId: input.actorUserId,
+      actingForLandlordId: input.invitation.landlordId,
+      delegatedRole: "landlord_owner",
+      permissionScope: permissionScopeForInvitation(input.invitation),
+      actionType: input.actionType,
+      targetResourceType: "delegate_invitation",
+      targetResourceId: input.invitation.invitationId,
+      timestamp: input.now,
+      outcome: "allowed",
+      before: {
+        status: input.invitation.status,
+        emailDispatchStatus: input.invitation.emailDispatch?.status || "not_sent",
+      },
+      after: {
+        status: input.invitation.status,
+        emailDispatchStatus: "sent",
+        attemptCount: Number(input.invitation.emailDispatch?.attemptCount || 0) + 1,
+      },
+    });
+    const updated = {
+      ...input.invitation,
+      emailDispatch: nextDispatchMetadata(input.invitation.emailDispatch, "sent", input.now),
+      auditEventIds: [...input.invitation.auditEventIds, auditEvent.eventId],
+    };
+    await saveInvitation(updated, firestore);
+    await appendAuditEvent(auditEvent, firestore);
+    return { invitation: updated, auditEvent, sent: true };
+  } catch (error) {
+    const reason = maskedFailureReason(error);
+    const auditEvent = buildDelegatedAccessAuditEvent({
+      eventType: "delegated_invite_sent",
+      actorUserId: input.actorUserId,
+      actingForLandlordId: input.invitation.landlordId,
+      delegatedRole: "landlord_owner",
+      permissionScope: permissionScopeForInvitation(input.invitation),
+      actionType: input.actionType === "invite_email_resent" ? "invite_email_resend_failed" : "invite_email_dispatch_failed",
+      targetResourceType: "delegate_invitation",
+      targetResourceId: input.invitation.invitationId,
+      timestamp: input.now,
+      outcome: "failed",
+      before: {
+        status: input.invitation.status,
+        emailDispatchStatus: input.invitation.emailDispatch?.status || "not_sent",
+      },
+      after: {
+        status: input.invitation.status,
+        emailDispatchStatus: "failed",
+        attemptCount: Number(input.invitation.emailDispatch?.attemptCount || 0) + 1,
+      },
+      reason,
+    });
+    const updated = {
+      ...input.invitation,
+      emailDispatch: nextDispatchMetadata(input.invitation.emailDispatch, "failed", input.now, reason),
+      auditEventIds: [...input.invitation.auditEventIds, auditEvent.eventId],
+    };
+    await saveInvitation(updated, firestore);
+    await appendAuditEvent(auditEvent, firestore);
+    return { invitation: updated, auditEvent, sent: false };
+  }
+}
+
 export async function createDelegatedAccessInvitationRecord(
   input: CreateInvitationInput,
   options: ServiceOptions = {}
-): Promise<{ invitation: DelegatedInvitationProjection; auditEvent: DelegatedAccessAuditEvent }> {
+): Promise<{
+  invitation: DelegatedInvitationProjection;
+  auditEvent: DelegatedAccessAuditEvent;
+  emailAuditEvent: DelegatedAccessAuditEvent;
+  emailDispatched: boolean;
+}> {
   const firestore = delegatedDb(options.firestore);
   const landlordId = requireString(input.landlordId, "missing_landlord_id");
   const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
   const now = input.now || new Date().toISOString();
+  const token = createInvitationToken();
   const invitation = createDelegatedAccessInvitation({
     landlordId,
     inviteeEmail: input.inviteeEmail,
@@ -179,7 +311,7 @@ export async function createDelegatedAccessInvitationRecord(
     workspaceScopes: input.workspaceScopes,
     resourceScope: input.resourceScope,
     permissionFlags: input.permissionFlags,
-    tokenHash: createTokenHash(),
+    tokenHash: token.tokenHash,
     expiresAt: input.expiresAt,
     createdByUserId: actorUserId,
     createdAt: now,
@@ -217,7 +349,23 @@ export async function createDelegatedAccessInvitationRecord(
   };
   await saveInvitation(withAudit, firestore);
   await appendAuditEvent(auditEvent, firestore);
-  return { invitation: projectInvitation(withAudit), auditEvent };
+  const emailResult = await dispatchDelegatedAccessInvitationEmail(
+    {
+      invitation: withAudit,
+      rawToken: token.rawToken,
+      actorUserId,
+      actorEmail: input.actorEmail,
+      now,
+      actionType: "invite_email_dispatched",
+    },
+    firestore
+  );
+  return {
+    invitation: projectInvitation(emailResult.invitation),
+    auditEvent,
+    emailAuditEvent: emailResult.auditEvent,
+    emailDispatched: emailResult.sent,
+  };
 }
 
 export async function listDelegatedAccessInvitationRecords(
@@ -368,6 +516,100 @@ export async function listDelegatedAccessDelegateRecords(
   const landlordId = requireString(input.landlordId, "missing_landlord_id");
   const grants = await listGrantsForLandlord(landlordId, firestore);
   return { delegates: summarizeDelegates(grants) };
+}
+
+export async function resendDelegatedAccessInvitationEmailRecord(
+  input: DispatchInvitationEmailInput,
+  options: ServiceOptions = {}
+): Promise<{
+  invitation: DelegatedInvitationProjection;
+  auditEvent: DelegatedAccessAuditEvent;
+  emailDispatched: boolean;
+}> {
+  const firestore = delegatedDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const invitationId = requireString(input.invitationId, "missing_invitation_id");
+  const now = input.now || new Date().toISOString();
+  const invitation = await loadInvitationForLandlord(landlordId, invitationId, firestore);
+  if (!invitation) throw new Error("delegated_invitation_not_found");
+  if (invitation.status !== "pending") throw new Error("invitation_not_pending");
+  if (isDelegatedInvitationExpired(invitation, now)) throw new Error("invitation_expired");
+
+  const token = createInvitationToken();
+  const emailInvitation: DelegatedAccessInvitation = {
+    ...invitation,
+    tokenHash: token.tokenHash,
+  };
+
+  try {
+    await sendDelegatedAccessInvitationEmail({
+      invitation: emailInvitation,
+      rawToken: token.rawToken,
+      invitedByEmail: input.actorEmail || null,
+    });
+    const auditEvent = buildDelegatedAccessAuditEvent({
+      eventType: "delegated_invite_sent",
+      actorUserId,
+      actingForLandlordId: landlordId,
+      delegatedRole: "landlord_owner",
+      permissionScope: permissionScopeForInvitation(invitation),
+      actionType: "invite_email_resent",
+      targetResourceType: "delegate_invitation",
+      targetResourceId: invitation.invitationId,
+      timestamp: now,
+      outcome: "allowed",
+      before: {
+        status: invitation.status,
+        emailDispatchStatus: invitation.emailDispatch?.status || "not_sent",
+      },
+      after: {
+        status: invitation.status,
+        emailDispatchStatus: "sent",
+        attemptCount: Number(invitation.emailDispatch?.attemptCount || 0) + 1,
+      },
+    });
+    const updated = {
+      ...emailInvitation,
+      emailDispatch: nextDispatchMetadata(invitation.emailDispatch, "sent", now),
+      auditEventIds: [...invitation.auditEventIds, auditEvent.eventId],
+    };
+    await saveInvitation(updated, firestore);
+    await appendAuditEvent(auditEvent, firestore);
+    return { invitation: projectInvitation(updated), auditEvent, emailDispatched: true };
+  } catch (error) {
+    const reason = maskedFailureReason(error);
+    const auditEvent = buildDelegatedAccessAuditEvent({
+      eventType: "delegated_invite_sent",
+      actorUserId,
+      actingForLandlordId: landlordId,
+      delegatedRole: "landlord_owner",
+      permissionScope: permissionScopeForInvitation(invitation),
+      actionType: "invite_email_resend_failed",
+      targetResourceType: "delegate_invitation",
+      targetResourceId: invitation.invitationId,
+      timestamp: now,
+      outcome: "failed",
+      before: {
+        status: invitation.status,
+        emailDispatchStatus: invitation.emailDispatch?.status || "not_sent",
+      },
+      after: {
+        status: invitation.status,
+        emailDispatchStatus: "failed",
+        attemptCount: Number(invitation.emailDispatch?.attemptCount || 0) + 1,
+      },
+      reason,
+    });
+    const updated = {
+      ...invitation,
+      emailDispatch: nextDispatchMetadata(invitation.emailDispatch, "failed", now, reason),
+      auditEventIds: [...invitation.auditEventIds, auditEvent.eventId],
+    };
+    await saveInvitation(updated, firestore);
+    await appendAuditEvent(auditEvent, firestore);
+    return { invitation: projectInvitation(updated), auditEvent, emailDispatched: false };
+  }
 }
 
 export async function acceptDelegatedAccessInvitationRecord(

--- a/rentchain-api/src/services/entitlementsService.ts
+++ b/rentchain-api/src/services/entitlementsService.ts
@@ -134,12 +134,17 @@ export async function getUserEntitlements(
     if (enabled) capabilities.push(key as CapabilityKey);
   }
 
+  const scopedLandlordId =
+    role === "landlord"
+      ? landlordContext.landlordId || landlordIdHint || cleanUserId
+      : landlordIdHint;
+
   const entitlements: UserEntitlements = {
     userId: cleanUserId,
     role,
     plan,
     capabilities: sortedCapabilities(capabilities),
-    landlordId: landlordContext.landlordId || landlordIdHint || (role === "landlord" ? cleanUserId : null),
+    landlordId: scopedLandlordId || null,
   };
   if (cacheKey && hints.requestCache) hints.requestCache[cacheKey] = entitlements;
   return entitlements;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -3,9 +3,26 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockAuthState = vi.hoisted(() => ({
+  value: {
+    user: { id: "landlord_1", role: "landlord", landlordId: "landlord_1" },
+    token: "test-token",
+    isLoading: false,
+    ready: true,
+    authStatus: "authed",
+  } as any,
+}));
+
 beforeEach(() => {
   cleanup();
   mockTenantToken = null;
+  mockAuthState.value = {
+    user: { id: "landlord_1", role: "landlord", landlordId: "landlord_1" },
+    token: "test-token",
+    isLoading: false,
+    ready: true,
+    authStatus: "authed",
+  };
 });
 
 vi.stubEnv("VITE_TENANT_PORTAL_ENABLED", "true");
@@ -44,13 +61,7 @@ vi.mock("./pages/contractor/ContractorInviteAcceptPage", () => ({
 let mockTenantToken: string | null = null;
 
 vi.mock("./context/useAuth", () => ({
-  useAuth: () => ({
-    user: { id: "landlord_1", role: "landlord", landlordId: "landlord_1" },
-    token: "test-token",
-    isLoading: false,
-    ready: true,
-    authStatus: "authed",
-  }),
+  useAuth: () => mockAuthState.value,
 }));
 
 vi.mock("./lib/tenantAuth", () => ({
@@ -144,6 +155,13 @@ vi.mock("./pages/DelegatedAccessAcceptPage", () => ({
   default: () => {
     const location = useLocation();
     return <h1>{`Delegated Access Accept ${location.pathname}${location.search}`}</h1>;
+  },
+}));
+
+vi.mock("./pages/DelegatedAccessWorkspacePage", () => ({
+  default: () => {
+    const location = useLocation();
+    return <h1>{`Delegated Access Workspace ${location.pathname}${location.search}`}</h1>;
   },
 }));
 
@@ -415,6 +433,42 @@ describe("Routes: /delegated-access/accept", () => {
       </MemoryRouter>
     );
     expect(await screen.findByRole("heading", { name: /Delegated Access Accept \/delegated-access\/accept\?token=test-token/i })).toBeInTheDocument();
+  });
+});
+
+describe("Routes: /delegated-access/workspace", () => {
+  it("renders the delegated access workspace route", async () => {
+    mockAuthState.value = {
+      user: { id: "delegate-user-1", role: "delegate", landlordId: null },
+      token: "test-token",
+      isLoading: false,
+      ready: true,
+      authStatus: "authed",
+    };
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/delegated-access/workspace"]}>
+        <App />
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole("heading", { name: /Delegated Access Workspace \/delegated-access\/workspace/i })).toBeInTheDocument();
+  });
+
+  it("redirects delegated dashboard sessions to the delegated workspace", async () => {
+    mockAuthState.value = {
+      user: { id: "delegate-user-1", role: "delegate", landlordId: null },
+      token: "test-token",
+      isLoading: false,
+      ready: true,
+      authStatus: "authed",
+    };
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <App />
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole("heading", { name: /Delegated Access Workspace \/delegated-access\/workspace/i })).toBeInTheDocument();
   });
 });
 

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -140,6 +140,13 @@ vi.mock("./pages/DelegatedAccessPage", () => ({
   default: () => <h1>Delegate Management Page</h1>,
 }));
 
+vi.mock("./pages/DelegatedAccessAcceptPage", () => ({
+  default: () => {
+    const location = useLocation();
+    return <h1>{`Delegated Access Accept ${location.pathname}${location.search}`}</h1>;
+  },
+}));
+
 vi.mock("./pages/DecisionInboxPage", () => ({
   default: () => <h1>Decision Inbox Page</h1>,
 }));
@@ -396,6 +403,18 @@ describe("Routes: /account/delegated-access", () => {
 
     expect(await screen.findByText(/Delegate Management Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /delegated-access/accept", () => {
+  it("renders the delegated access acceptance route with query token preserved", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/delegated-access/accept?token=test-token"]}>
+        <App />
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole("heading", { name: /Delegated Access Accept \/delegated-access\/accept\?token=test-token/i })).toBeInTheDocument();
   });
 });
 

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -192,6 +192,7 @@ const AccountPage = lazy(() => import("./pages/AccountPage"));
 const AccountProfilePage = lazy(() => import("./pages/account/AccountProfilePage"));
 const AccountDataPage = lazy(() => import("./pages/account/AccountDataPage"));
 const DelegatedAccessPage = lazy(() => import("./pages/DelegatedAccessPage"));
+const DelegatedAccessAcceptPage = lazy(() => import("./pages/DelegatedAccessAcceptPage"));
 const ExpensesPage = lazy(() => import("./pages/ExpensesPage"));
 const WorkOrdersPage = lazy(() => import("./pages/landlord/WorkOrdersPage"));
 const WorkOrderNewPage = lazy(() => import("./pages/landlord/WorkOrderNewPage"));
@@ -408,6 +409,7 @@ function App() {
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/auth/action" element={<AuthActionPage />} />
         <Route path="/auth/onboard" element={<AuthOnboardPage />} />
+        <Route path="/delegated-access/accept" element={suspensePage(<DelegatedAccessAcceptPage />)} />
         <Route path="/signing/complete" element={<SigningCompletePage />} />
         <Route
           path="/tenant/login"

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -193,6 +193,7 @@ const AccountProfilePage = lazy(() => import("./pages/account/AccountProfilePage
 const AccountDataPage = lazy(() => import("./pages/account/AccountDataPage"));
 const DelegatedAccessPage = lazy(() => import("./pages/DelegatedAccessPage"));
 const DelegatedAccessAcceptPage = lazy(() => import("./pages/DelegatedAccessAcceptPage"));
+const DelegatedAccessWorkspacePage = lazy(() => import("./pages/DelegatedAccessWorkspacePage"));
 const ExpensesPage = lazy(() => import("./pages/ExpensesPage"));
 const WorkOrdersPage = lazy(() => import("./pages/landlord/WorkOrdersPage"));
 const WorkOrderNewPage = lazy(() => import("./pages/landlord/WorkOrderNewPage"));
@@ -361,6 +362,17 @@ const AccountRouteGate: React.FC<{ children: React.ReactNode }> = ({ children })
   return <Navigate to={getRoleDefaultDestination(role as any)} replace />;
 };
 
+const LandlordDashboardRoute: React.FC = () => {
+  const { user } = useAuth();
+  const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
+  if (role === "delegate") return <Navigate to={getRoleDefaultDestination("delegate")} replace />;
+  return (
+    <LandlordNav>
+      <DashboardPage />
+    </LandlordNav>
+  );
+};
+
 const TenantEntryRouteGate: React.FC = () => {
   const location = useLocation();
   const tenantToken = typeof window === "undefined" ? null : getTenantToken();
@@ -410,6 +422,14 @@ function App() {
         <Route path="/auth/action" element={<AuthActionPage />} />
         <Route path="/auth/onboard" element={<AuthOnboardPage />} />
         <Route path="/delegated-access/accept" element={suspensePage(<DelegatedAccessAcceptPage />)} />
+        <Route
+          path="/delegated-access/workspace"
+          element={
+            <RequireAuth>
+              {suspensePage(<DelegatedAccessWorkspacePage />)}
+            </RequireAuth>
+          }
+        />
         <Route path="/signing/complete" element={<SigningCompletePage />} />
         <Route
           path="/tenant/login"
@@ -471,9 +491,7 @@ function App() {
           path="/dashboard"
           element={
             <RequireAuth>
-              <LandlordNav>
-                <DashboardPage />
-              </LandlordNav>
+              <LandlordDashboardRoute />
             </RequireAuth>
           }
         />

--- a/rentchain-frontend/src/api/delegatedAccessApi.test.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchMyDelegatedAccessGrants } from "./delegatedAccessApi";
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("./apiFetch", () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+describe("delegatedAccessApi", () => {
+  beforeEach(() => {
+    mocks.apiFetch.mockReset();
+  });
+
+  it("loads delegate self grants from the non-landlord delegated-access route", async () => {
+    mocks.apiFetch.mockResolvedValue({ ok: true, grants: [] });
+
+    await expect(fetchMyDelegatedAccessGrants()).resolves.toEqual([]);
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/delegated-access/my-grants");
+  });
+});

--- a/rentchain-frontend/src/api/delegatedAccessApi.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.ts
@@ -62,6 +62,14 @@ export type DelegatedAccessInvitation = {
   createdAt: string;
   acceptedAt: string | null;
   cancelledAt: string | null;
+  emailDispatch?: {
+    status: "sent" | "failed" | "not_sent";
+    attemptCount?: number;
+    lastAttemptAt?: string | null;
+    lastSentAt?: string | null;
+    lastFailedAt?: string | null;
+    lastFailureReason?: string | null;
+  };
 };
 
 export type DelegatedAccessGrant = {
@@ -118,7 +126,11 @@ export async function fetchDelegatedAccessInvitations(): Promise<DelegatedAccess
 }
 
 export async function createDelegatedAccessInvitation(input: CreateDelegatedAccessInvitationInput) {
-  return apiFetch<{ ok: true; invitation: DelegatedAccessInvitation }>("/landlord/delegated-access/invitations", {
+  return apiFetch<{
+    ok: true;
+    invitation: DelegatedAccessInvitation;
+    emailDispatch?: { status: "sent" | "failed" | "not_sent" };
+  }>("/landlord/delegated-access/invitations", {
     method: "POST",
     body: input,
   });

--- a/rentchain-frontend/src/api/delegatedAccessApi.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.ts
@@ -133,6 +133,17 @@ export async function cancelDelegatedAccessInvitation(invitationId: string) {
   );
 }
 
+export async function acceptDelegatedAccessInvitation(token: string) {
+  return apiFetch<{ ok: true; invitation: DelegatedAccessInvitation; grant: DelegatedAccessGrant }>(
+    "/landlord/delegated-access/invitations/accept",
+    {
+      method: "POST",
+      body: { token },
+      suppressToasts: true,
+    }
+  );
+}
+
 export async function revokeDelegatedAccessGrant(grantId: string, reason?: string) {
   return apiFetch<{ ok: true; grant: DelegatedAccessGrant }>(
     `/landlord/delegated-access/grants/${encodeURIComponent(grantId)}/revoke`,

--- a/rentchain-frontend/src/api/delegatedAccessApi.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.ts
@@ -87,6 +87,7 @@ export type DelegatedAccessGrant = {
 };
 
 export type DelegatedAccessActiveGrant = Omit<DelegatedAccessGrant, "grantId" | "delegateUserId"> & {
+  landlordWorkspaceLabel: string;
   propertyScopeSummary: string;
 };
 

--- a/rentchain-frontend/src/api/delegatedAccessApi.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.ts
@@ -86,6 +86,10 @@ export type DelegatedAccessGrant = {
   revocationReason: string | null;
 };
 
+export type DelegatedAccessActiveGrant = Omit<DelegatedAccessGrant, "grantId" | "delegateUserId"> & {
+  propertyScopeSummary: string;
+};
+
 export type DelegatedAccessDelegateSummary = {
   delegateUserId: string;
   delegateEmail: string | null;
@@ -115,6 +119,13 @@ export async function fetchDelegatedAccessDelegates(): Promise<DelegatedAccessDe
 
 export async function fetchDelegatedAccessGrants(): Promise<DelegatedAccessGrant[]> {
   const response = await apiFetch<{ ok: true; grants: DelegatedAccessGrant[] }>("/landlord/delegated-access/grants");
+  return response.grants || [];
+}
+
+export async function fetchMyDelegatedAccessGrants(): Promise<DelegatedAccessActiveGrant[]> {
+  const response = await apiFetch<{ ok: true; grants: DelegatedAccessActiveGrant[] }>(
+    "/landlord/delegated-access/my-grants"
+  );
   return response.grants || [];
 }
 

--- a/rentchain-frontend/src/api/delegatedAccessApi.ts
+++ b/rentchain-frontend/src/api/delegatedAccessApi.ts
@@ -124,7 +124,7 @@ export async function fetchDelegatedAccessGrants(): Promise<DelegatedAccessGrant
 
 export async function fetchMyDelegatedAccessGrants(): Promise<DelegatedAccessActiveGrant[]> {
   const response = await apiFetch<{ ok: true; grants: DelegatedAccessActiveGrant[] }>(
-    "/landlord/delegated-access/my-grants"
+    "/delegated-access/my-grants"
   );
   return response.grants || [];
 }

--- a/rentchain-frontend/src/lib/authDestination.test.ts
+++ b/rentchain-frontend/src/lib/authDestination.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DELEGATED_ACCESS_DEFAULT_DESTINATION,
   getRoleDefaultDestination,
   getSafeTenantRedirect,
   resolveTenantPostAuthDestination,
@@ -9,6 +10,10 @@ import {
 describe("authDestination tenant routing", () => {
   it("uses the tenant workspace as the tenant role default", () => {
     expect(getRoleDefaultDestination("tenant")).toBe(TENANT_DEFAULT_DESTINATION);
+  });
+
+  it("uses the delegated workspace as the delegate role default", () => {
+    expect(getRoleDefaultDestination("delegate")).toBe(DELEGATED_ACCESS_DEFAULT_DESTINATION);
   });
 
   it("rejects public tenant entry routes as post-auth destinations", () => {

--- a/rentchain-frontend/src/lib/authDestination.ts
+++ b/rentchain-frontend/src/lib/authDestination.ts
@@ -1,6 +1,7 @@
-export type AuthRole = "landlord" | "tenant" | "contractor" | "admin" | null | undefined;
+export type AuthRole = "landlord" | "tenant" | "contractor" | "admin" | "delegate" | null | undefined;
 
 export const TENANT_DEFAULT_DESTINATION = "/tenant/dashboard";
+export const DELEGATED_ACCESS_DEFAULT_DESTINATION = "/delegated-access/workspace";
 
 export function getSafeInternalRedirect(raw: string | null | undefined): string | null {
   const value = String(raw || "").trim();
@@ -20,6 +21,7 @@ export function getRoleDefaultDestination(role: AuthRole): string {
   if (value === "tenant") return TENANT_DEFAULT_DESTINATION;
   if (value === "contractor") return "/contractor";
   if (value === "admin") return "/admin";
+  if (value === "delegate") return DELEGATED_ACCESS_DEFAULT_DESTINATION;
   return "/dashboard";
 }
 

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
@@ -7,7 +7,7 @@ import DelegatedAccessAcceptPage from "./DelegatedAccessAcceptPage";
 const mocks = vi.hoisted(() => ({
   acceptInvitation: vi.fn(),
   authState: {
-    user: { id: "delegate-user-1", email: "delegate@example.com", role: "landlord_delegate" },
+    user: { id: "delegate-user-1", email: "delegate@example.com", role: "delegate" },
     isLoading: false,
     ready: true,
     authStatus: "authed",
@@ -34,7 +34,7 @@ describe("DelegatedAccessAcceptPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.authState = {
-      user: { id: "delegate-user-1", email: "delegate@example.com", role: "landlord_delegate" },
+      user: { id: "delegate-user-1", email: "delegate@example.com", role: "delegate" },
       isLoading: false,
       ready: true,
       authStatus: "authed",
@@ -66,6 +66,7 @@ describe("DelegatedAccessAcceptPage", () => {
 
     expect(screen.getByRole("heading", { name: "Accept delegated access invitation" })).toBeInTheDocument();
     expect(screen.getByText("Sign in to accept this invitation.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create account to accept" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Sign in to accept" })).toBeInTheDocument();
     expect(mocks.acceptInvitation).not.toHaveBeenCalled();
   });

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DelegatedAccessAcceptPage from "./DelegatedAccessAcceptPage";
+
+const mocks = vi.hoisted(() => ({
+  acceptInvitation: vi.fn(),
+  authState: {
+    user: { id: "delegate-user-1", email: "delegate@example.com", role: "landlord_delegate" },
+    isLoading: false,
+    ready: true,
+    authStatus: "authed",
+  } as any,
+}));
+
+vi.mock("../api/delegatedAccessApi", () => ({
+  acceptDelegatedAccessInvitation: mocks.acceptInvitation,
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: () => mocks.authState,
+}));
+
+function renderPage(path = "/delegated-access/accept?token=test-token") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <DelegatedAccessAcceptPage />
+    </MemoryRouter>
+  );
+}
+
+describe("DelegatedAccessAcceptPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authState = {
+      user: { id: "delegate-user-1", email: "delegate@example.com", role: "landlord_delegate" },
+      isLoading: false,
+      ready: true,
+      authStatus: "authed",
+    };
+    mocks.acceptInvitation.mockResolvedValue({
+      ok: true,
+      invitation: { status: "accepted" },
+      grant: { status: "active" },
+    });
+  });
+
+  it("shows a safe invalid-link state when token is missing", () => {
+    renderPage("/delegated-access/accept");
+
+    expect(screen.getByRole("heading", { name: "Invalid invitation link" })).toBeInTheDocument();
+    expect(screen.getByText(/missing required information/i)).toBeInTheDocument();
+    expect(mocks.acceptInvitation).not.toHaveBeenCalled();
+  });
+
+  it("shows sign-in guidance without calling the API when unauthenticated", () => {
+    mocks.authState = {
+      user: null,
+      isLoading: false,
+      ready: true,
+      authStatus: "guest",
+    };
+
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: "Accept delegated access invitation" })).toBeInTheDocument();
+    expect(screen.getByText("Sign in to accept this invitation.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in to accept" })).toBeInTheDocument();
+    expect(mocks.acceptInvitation).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid token on click and shows the accepted state", async () => {
+    renderPage("/delegated-access/accept?token=valid-token");
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept invitation" }));
+
+    await waitFor(() => expect(mocks.acceptInvitation).toHaveBeenCalledWith("valid-token"));
+    expect(await screen.findByText("Delegated access is now active for your account.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to Dashboard" })).toBeInTheDocument();
+  });
+
+  it("shows safe failure messaging without exposing the token", async () => {
+    mocks.acceptInvitation.mockRejectedValueOnce(new Error("INVITATION_EXPIRED raw-token-should-not-render"));
+
+    renderPage("/delegated-access/accept?token=raw-token-should-not-render");
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept invitation" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("This invitation has expired.");
+    expect(screen.queryByText("raw-token-should-not-render")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
@@ -78,7 +78,7 @@ describe("DelegatedAccessAcceptPage", () => {
 
     await waitFor(() => expect(mocks.acceptInvitation).toHaveBeenCalledWith("valid-token"));
     expect(await screen.findByText("Delegated access is now active for your account.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Go to Dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to delegated workspace" })).toBeInTheDocument();
   });
 
   it("shows safe failure messaging without exposing the token", async () => {

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.test.tsx
@@ -1,16 +1,18 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DelegatedAccessAcceptPage from "./DelegatedAccessAcceptPage";
 
 const mocks = vi.hoisted(() => ({
   acceptInvitation: vi.fn(),
+  logout: vi.fn(),
   authState: {
     user: { id: "delegate-user-1", email: "delegate@example.com", role: "delegate" },
     isLoading: false,
     ready: true,
     authStatus: "authed",
+    logout: vi.fn(),
   } as any,
 }));
 
@@ -38,12 +40,17 @@ describe("DelegatedAccessAcceptPage", () => {
       isLoading: false,
       ready: true,
       authStatus: "authed",
+      logout: mocks.logout,
     };
     mocks.acceptInvitation.mockResolvedValue({
       ok: true,
       invitation: { status: "accepted" },
       grant: { status: "active" },
     });
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("shows a safe invalid-link state when token is missing", () => {
@@ -60,6 +67,7 @@ describe("DelegatedAccessAcceptPage", () => {
       isLoading: false,
       ready: true,
       authStatus: "guest",
+      logout: mocks.logout,
     };
 
     renderPage();
@@ -90,5 +98,20 @@ describe("DelegatedAccessAcceptPage", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("This invitation has expired.");
     expect(screen.queryByText("raw-token-should-not-render")).not.toBeInTheDocument();
+  });
+
+  it("explains wrong-email sessions and signs out before using another account", async () => {
+    mocks.acceptInvitation.mockRejectedValueOnce(new Error("INVITEE_EMAIL_MISMATCH"));
+
+    renderPage("/delegated-access/accept?token=valid-token");
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept invitation" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "This invitation was sent to a different email. Sign out and sign in with the invited email."
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Use another account" }));
+
+    await waitFor(() => expect(mocks.logout).toHaveBeenCalledTimes(1));
   });
 });

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
@@ -28,6 +28,9 @@ function safeFailureMessage(error: unknown): string {
   const code = String(error instanceof Error ? error.message : error || "").toUpperCase();
   if (code.includes("EXPIRED")) return "This invitation has expired. Ask the landlord owner to send a new invitation.";
   if (code.includes("NOT_PENDING")) return "This invitation is no longer pending. It may have been cancelled or already accepted.";
+  if (code.includes("INVITEE_EMAIL_MISMATCH")) {
+    return "This invitation was sent to a different email. Sign out and sign in with the invited email.";
+  }
   if (code.includes("NOT_FOUND") || code.includes("INVALID")) return "This invitation link is invalid or no longer available.";
   return "We could not accept this invitation. Ask the landlord owner to verify the invitation status.";
 }
@@ -35,7 +38,7 @@ function safeFailureMessage(error: unknown): string {
 export default function DelegatedAccessAcceptPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { user, isLoading, ready, authStatus } = useAuth();
+  const { user, isLoading, ready, authStatus, logout } = useAuth();
   const token = React.useMemo(() => new URLSearchParams(location.search).get("token")?.trim() || "", [location.search]);
   const [state, setState] = React.useState<AcceptState>("idle");
   const [message, setMessage] = React.useState("");
@@ -60,6 +63,13 @@ export default function DelegatedAccessAcceptPage() {
       setState("failed");
       setMessage(safeFailureMessage(error));
     }
+  };
+
+  const handleUseAnotherAccount = async () => {
+    if (signedIn) {
+      await logout();
+    }
+    navigate(loginUrl);
   };
 
   if (!token) {
@@ -154,7 +164,7 @@ export default function DelegatedAccessAcceptPage() {
                 </>
               )}
               {signedIn ? (
-                <Button type="button" onClick={() => navigate(loginUrl)} variant="secondary">
+                <Button type="button" onClick={handleUseAnotherAccount} variant="secondary">
                   Use another account
                 </Button>
               ) : null}

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { acceptDelegatedAccessInvitation } from "../api/delegatedAccessApi";
 import { Button, Card } from "../components/ui/Ui";
 import { useAuth } from "../context/useAuth";
+import { getRoleDefaultDestination } from "../lib/authDestination";
 
 type AcceptState = "idle" | "accepting" | "accepted" | "failed";
 
@@ -45,6 +46,7 @@ export default function DelegatedAccessAcceptPage() {
   const signupUrl = `/signup?${authSearch}`;
   const authLoading = authStatus === "restoring" || isLoading || !ready;
   const signedIn = Boolean(user);
+  const postAcceptDestination = getRoleDefaultDestination(((user as any)?.actorRole || user?.role || "delegate") as any);
 
   const handleAccept = async () => {
     if (!token || !signedIn || state === "accepting") return;
@@ -91,8 +93,8 @@ export default function DelegatedAccessAcceptPage() {
               You can now open RentChain and use the delegated workspaces assigned by the landlord owner.
             </p>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <Button type="button" onClick={() => navigate("/dashboard")}>
-                Go to Dashboard
+              <Button type="button" onClick={() => navigate(postAcceptDestination)}>
+                Go to delegated workspace
               </Button>
               <Button type="button" onClick={() => navigate("/account")} variant="secondary">
                 Go to Account

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { acceptDelegatedAccessInvitation } from "../api/delegatedAccessApi";
+import { Button, Card } from "../components/ui/Ui";
+import { useAuth } from "../context/useAuth";
+
+type AcceptState = "idle" | "accepting" | "accepted" | "failed";
+
+function pageShell(children: React.ReactNode) {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: "32px 16px",
+        background:
+          "radial-gradient(circle at top left, rgba(37,99,235,0.08) 0, rgba(14,165,233,0.06) 45%, rgba(255,255,255,0.95) 100%)",
+      }}
+    >
+      <div style={{ width: "min(560px, 100%)" }}>{children}</div>
+    </main>
+  );
+}
+
+function safeFailureMessage(error: unknown): string {
+  const code = String(error instanceof Error ? error.message : error || "").toUpperCase();
+  if (code.includes("EXPIRED")) return "This invitation has expired. Ask the landlord owner to send a new invitation.";
+  if (code.includes("NOT_PENDING")) return "This invitation is no longer pending. It may have been cancelled or already accepted.";
+  if (code.includes("NOT_FOUND") || code.includes("INVALID")) return "This invitation link is invalid or no longer available.";
+  return "We could not accept this invitation. Ask the landlord owner to verify the invitation status.";
+}
+
+export default function DelegatedAccessAcceptPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { user, isLoading, ready, authStatus } = useAuth();
+  const token = React.useMemo(() => new URLSearchParams(location.search).get("token")?.trim() || "", [location.search]);
+  const [state, setState] = React.useState<AcceptState>("idle");
+  const [message, setMessage] = React.useState("");
+
+  const currentPath = `${location.pathname}${location.search || ""}`;
+  const loginUrl = `/login?${new URLSearchParams({ next: currentPath, reason: "missing" }).toString()}`;
+  const authLoading = authStatus === "restoring" || isLoading || !ready;
+  const signedIn = Boolean(user);
+
+  const handleAccept = async () => {
+    if (!token || !signedIn || state === "accepting") return;
+    setState("accepting");
+    setMessage("");
+    try {
+      await acceptDelegatedAccessInvitation(token);
+      setState("accepted");
+      setMessage("Delegated access is now active for your account.");
+    } catch (error) {
+      setState("failed");
+      setMessage(safeFailureMessage(error));
+    }
+  };
+
+  if (!token) {
+    return pageShell(
+      <Card>
+        <h1 style={{ margin: 0, fontSize: 28 }}>Invalid invitation link</h1>
+        <p style={{ color: "#475569", lineHeight: 1.6 }}>
+          This delegated access invitation link is missing required information. Ask the landlord owner to resend the invitation.
+        </p>
+        <Button type="button" onClick={() => navigate("/login")} variant="secondary">
+          Go to sign in
+        </Button>
+      </Card>
+    );
+  }
+
+  return pageShell(
+    <Card>
+      <div style={{ display: "grid", gap: 18 }}>
+        <div>
+          <div style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, textTransform: "uppercase" }}>
+            Delegated Access
+          </div>
+          <h1 style={{ margin: "6px 0 0", fontSize: 30 }}>Accept delegated access invitation</h1>
+        </div>
+
+        {state === "accepted" ? (
+          <div style={{ display: "grid", gap: 14 }}>
+            <p style={{ color: "#166534", fontWeight: 700, margin: 0 }}>{message}</p>
+            <p style={{ color: "#475569", lineHeight: 1.6, margin: 0 }}>
+              You can now open RentChain and use the delegated workspaces assigned by the landlord owner.
+            </p>
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              <Button type="button" onClick={() => navigate("/dashboard")}>
+                Go to Dashboard
+              </Button>
+              <Button type="button" onClick={() => navigate("/account")} variant="secondary">
+                Go to Account
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: "grid", gap: 14 }}>
+            <p style={{ color: "#334155", lineHeight: 1.6, margin: 0 }}>
+              Sign in with your own RentChain account before accepting. Do not use or share the landlord owner&apos;s login credentials.
+            </p>
+
+            {!authLoading && !signedIn ? (
+              <div
+                style={{
+                  border: "1px solid #bfdbfe",
+                  background: "#eff6ff",
+                  color: "#1e3a8a",
+                  borderRadius: 12,
+                  padding: 14,
+                  lineHeight: 1.5,
+                }}
+              >
+                Sign in to accept this invitation.
+              </div>
+            ) : null}
+
+            {state === "failed" ? (
+              <div
+                role="alert"
+                style={{
+                  border: "1px solid #fecdd3",
+                  background: "#fff1f2",
+                  color: "#9f1239",
+                  borderRadius: 12,
+                  padding: 14,
+                  lineHeight: 1.5,
+                }}
+              >
+                {message}
+              </div>
+            ) : null}
+
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              {signedIn ? (
+                <Button type="button" onClick={handleAccept} disabled={state === "accepting" || authLoading}>
+                  {state === "accepting" ? "Accepting..." : "Accept invitation"}
+                </Button>
+              ) : (
+                <Button type="button" onClick={() => navigate(loginUrl)}>
+                  Sign in to accept
+                </Button>
+              )}
+              <Button type="button" onClick={() => navigate("/login")} variant="secondary">
+                Use another account
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessAcceptPage.tsx
@@ -40,7 +40,9 @@ export default function DelegatedAccessAcceptPage() {
   const [message, setMessage] = React.useState("");
 
   const currentPath = `${location.pathname}${location.search || ""}`;
-  const loginUrl = `/login?${new URLSearchParams({ next: currentPath, reason: "missing" }).toString()}`;
+  const authSearch = new URLSearchParams({ next: currentPath, reason: "missing" }).toString();
+  const loginUrl = `/login?${authSearch}`;
+  const signupUrl = `/signup?${authSearch}`;
   const authLoading = authStatus === "restoring" || isLoading || !ready;
   const signedIn = Boolean(user);
 
@@ -140,13 +142,20 @@ export default function DelegatedAccessAcceptPage() {
                   {state === "accepting" ? "Accepting..." : "Accept invitation"}
                 </Button>
               ) : (
-                <Button type="button" onClick={() => navigate(loginUrl)}>
-                  Sign in to accept
-                </Button>
+                <>
+                  <Button type="button" onClick={() => navigate(signupUrl)}>
+                    Create account to accept
+                  </Button>
+                  <Button type="button" onClick={() => navigate(loginUrl)} variant="secondary">
+                    Sign in to accept
+                  </Button>
+                </>
               )}
-              <Button type="button" onClick={() => navigate("/login")} variant="secondary">
-                Use another account
-              </Button>
+              {signedIn ? (
+                <Button type="button" onClick={() => navigate(loginUrl)} variant="secondary">
+                  Use another account
+                </Button>
+              ) : null}
             </div>
           </div>
         )}

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
@@ -136,6 +136,8 @@ describe("DelegatedAccessPage", () => {
     render(<DelegatedAccessPage />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Invite Delegate" }));
+    expect(screen.queryByRole("combobox", { name: "Property scope" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Property scope")).toHaveTextContent("All current properties");
     fireEvent.change(screen.getByLabelText("Delegate email"), { target: { value: "new@example.com" } });
     fireEvent.change(screen.getByLabelText("Delegate role"), { target: { value: "maintenance_coordinator" } });
     fireEvent.click(screen.getByLabelText("Properties"));

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
@@ -98,7 +98,11 @@ describe("DelegatedAccessPage", () => {
     ]);
     mocks.fetchGrants.mockResolvedValue([grant()]);
     mocks.fetchInvitations.mockResolvedValue([invitation()]);
-    mocks.createInvitation.mockResolvedValue({ ok: true, invitation: invitation({ inviteeEmail: "new@example.com" }) });
+    mocks.createInvitation.mockResolvedValue({
+      ok: true,
+      invitation: invitation({ inviteeEmail: "new@example.com", emailDispatch: { status: "sent" } }),
+      emailDispatch: { status: "sent" },
+    });
     mocks.cancelInvitation.mockResolvedValue({
       ok: true,
       invitation: invitation({ status: "cancelled", cancelledAt: "2026-06-23T12:00:00.000Z" }),
@@ -149,7 +153,29 @@ describe("DelegatedAccessPage", () => {
     expect(mocks.showToast).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Delegate invitation created",
-        description: expect.stringMatching(/Email dispatch is not enabled yet/i),
+        description: expect.stringMatching(/Invitation email was sent/i),
+      })
+    );
+  });
+
+  it("warns when the invitation is saved but email dispatch fails", async () => {
+    mocks.createInvitation.mockResolvedValueOnce({
+      ok: true,
+      invitation: invitation({ inviteeEmail: "new@example.com", emailDispatch: { status: "failed" } }),
+      emailDispatch: { status: "failed" },
+    });
+    render(<DelegatedAccessPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Invite Delegate" }));
+    fireEvent.change(screen.getByLabelText("Delegate email"), { target: { value: "new@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Invitation" }));
+
+    await waitFor(() => expect(mocks.createInvitation).toHaveBeenCalledTimes(1));
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Delegate invitation created",
+        description: expect.stringMatching(/email delivery failed/i),
+        variant: "warning",
       })
     );
   });
@@ -226,7 +252,7 @@ describe("DelegatedAccessPage", () => {
 
   it("blocks non-owner users before loading delegate data", async () => {
     mocks.useAuthMock.mockReturnValue({
-      user: { id: "delegate-user-1", role: "landlord_delegate", email: "delegate@example.com" },
+      user: { id: "delegate-user-1", role: "delegate", email: "delegate@example.com" },
     });
     mocks.fetchDelegates.mockResolvedValue([
       {

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -169,7 +169,6 @@ export default function DelegatedAccessPage() {
   const [inviteOpen, setInviteOpen] = React.useState(false);
   const [inviteEmail, setInviteEmail] = React.useState("");
   const [inviteRole, setInviteRole] = React.useState<DelegatedAccessRole>("property_manager");
-  const [propertyScopeMode, setPropertyScopeMode] = React.useState<DelegatedAccessPropertyScopeMode>("all_current_properties");
   const [workspaceScopes, setWorkspaceScopes] = React.useState<DelegatedAccessWorkspaceScope[]>(defaultWorkspaces);
   const [permissionFlags, setPermissionFlags] = React.useState<DelegatedAccessPermissionAction[]>(defaultPermissions);
   const [expiresAt, setExpiresAt] = React.useState(defaultExpiryDate());
@@ -221,7 +220,6 @@ export default function DelegatedAccessPage() {
   const resetInvite = () => {
     setInviteEmail("");
     setInviteRole("property_manager");
-    setPropertyScopeMode("all_current_properties");
     setWorkspaceScopes(defaultWorkspaces);
     setPermissionFlags(defaultPermissions);
     setExpiresAt(defaultExpiryDate());
@@ -256,7 +254,7 @@ export default function DelegatedAccessPage() {
       const input: CreateDelegatedAccessInvitationInput = {
         inviteeEmail: inviteEmail,
         role: inviteRole,
-        propertyScope: { mode: propertyScopeMode, propertyIds: [] },
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
         workspaceScopes,
         permissionFlags,
         expiresAt: toIsoDate(expiresAt),
@@ -437,25 +435,24 @@ export default function DelegatedAccessPage() {
                   ))}
                 </select>
               </label>
-              <label style={{ display: "grid", gap: 6, fontWeight: 700 }}>
+              <div style={{ display: "grid", gap: 6, fontWeight: 700 }}>
                 Property scope
-                <select
+                <div
                   aria-label="Property scope"
-                  value={propertyScopeMode}
-                  onChange={(event) => setPropertyScopeMode(event.target.value as DelegatedAccessPropertyScopeMode)}
                   style={{
                     minHeight: 42,
                     border: `1px solid ${colors.border}`,
                     borderRadius: radius.md,
-                    background: colors.card,
+                    background: "#f8fafc",
                     padding: "10px 12px",
                     color: text.primary,
+                    display: "flex",
+                    alignItems: "center",
                   }}
                 >
-                  <option value="all_current_properties">All current properties</option>
-                  <option value="none">No property scope</option>
-                </select>
-              </label>
+                  All current properties
+                </div>
+              </div>
               <label style={{ display: "grid", gap: 6, fontWeight: 700 }}>
                 Expires
                 <Input

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -102,6 +102,12 @@ function statusLabel(status: string) {
     .join(" ");
 }
 
+function inviteToastDescription(status?: string | null) {
+  if (status === "sent") return "Invitation email was sent to the delegate.";
+  if (status === "failed") return "Invitation was saved, but email delivery failed. Use resend after delivery is restored.";
+  return "Invitation was saved. Confirm email delivery status before relying on the link.";
+}
+
 function isOwnerRole(user: any) {
   const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
   return role === "landlord";
@@ -255,11 +261,11 @@ export default function DelegatedAccessPage() {
         permissionFlags,
         expiresAt: toIsoDate(expiresAt),
       };
-      await createDelegatedAccessInvitation(input);
+      const result = await createDelegatedAccessInvitation(input);
       showToast({
         message: "Delegate invitation created",
-        description: "Email dispatch is not enabled yet. Share acceptance instructions only when that flow is approved.",
-        variant: "success",
+        description: inviteToastDescription(result.emailDispatch?.status || result.invitation.emailDispatch?.status),
+        variant: result.emailDispatch?.status === "failed" ? "warning" : "success",
       });
       resetInvite();
       setInviteOpen(false);
@@ -393,7 +399,7 @@ export default function DelegatedAccessPage() {
             <UserPlus size={20} />
             <div>
               <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Invite Delegate</h2>
-              <div style={{ color: text.muted, fontSize: 13 }}>Creates a pending invitation. Email dispatch is out of scope for v1.</div>
+              <div style={{ color: text.muted, fontSize: 13 }}>Creates a pending invitation and sends the acceptance email.</div>
             </div>
           </div>
           <form onSubmit={handleInvite} style={{ display: "grid", gap: spacing.md }}>

--- a/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../context/useAuth", () => ({
 function grant(overrides: Partial<DelegatedAccessActiveGrant> = {}): DelegatedAccessActiveGrant {
   return {
     delegateEmail: "manager@example.com",
+    landlordWorkspaceLabel: "owner@example.com",
     role: "property_manager",
     status: "active",
     permissionScope: {
@@ -75,11 +76,21 @@ describe("DelegatedAccessWorkspacePage", () => {
   it("renders active delegated workspace assignments without owner-only labels or raw ids", async () => {
     mocks.fetchMyGrants.mockResolvedValueOnce([
       grant({
+        landlordWorkspaceLabel: "admin+elite@rentchain.ai",
         permissionScope: {
           ...grant().permissionScope,
           propertyScope: { mode: "selected", propertyIds: ["property-raw-1"] },
         },
         propertyScopeSummary: "selected:1",
+      }),
+      grant({
+        landlordWorkspaceLabel: "owner.two@example.com",
+        acceptedAt: "2026-06-23T12:00:00.000Z",
+        updatedAt: "2026-06-23T12:00:00.000Z",
+        permissionScope: {
+          ...grant().permissionScope,
+          workspaceScopes: ["dashboard"],
+        },
       }),
     ]);
     const { container } = renderPage();
@@ -90,9 +101,12 @@ describe("DelegatedAccessWorkspacePage", () => {
     expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Operations" })).toBeInTheDocument();
-    expect(screen.getByText("Property Manager")).toBeInTheDocument();
+    expect(screen.getAllByText("Property Manager").length).toBeGreaterThan(0);
+    expect(screen.getByText("Landlord workspace: admin+elite@rentchain.ai")).toBeInTheDocument();
+    expect(screen.getByText("Landlord workspace: owner.two@example.com")).toBeInTheDocument();
     expect(screen.getByText("Selected properties")).toBeInTheDocument();
     expect(container).not.toHaveTextContent("property-raw-1");
+    expect(container).not.toHaveTextContent("landlord-raw-1");
     expect(container).not.toHaveTextContent("grant-internal-1");
     expect(container).not.toHaveTextContent(/billing/i);
     expect(container).not.toHaveTextContent(/settings/i);

--- a/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DelegatedAccessWorkspacePage from "./DelegatedAccessWorkspacePage";
+import type { DelegatedAccessActiveGrant } from "../api/delegatedAccessApi";
+
+const mocks = vi.hoisted(() => ({
+  fetchMyGrants: vi.fn(),
+  useAuthMock: vi.fn(),
+}));
+
+vi.mock("../api/delegatedAccessApi", async () => {
+  const actual = await vi.importActual<object>("../api/delegatedAccessApi");
+  return {
+    ...actual,
+    fetchMyDelegatedAccessGrants: mocks.fetchMyGrants,
+  };
+});
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: mocks.useAuthMock,
+}));
+
+function grant(overrides: Partial<DelegatedAccessActiveGrant> = {}): DelegatedAccessActiveGrant {
+  return {
+    delegateEmail: "manager@example.com",
+    role: "property_manager",
+    status: "active",
+    permissionScope: {
+      role: "property_manager",
+      workspaceScopes: ["dashboard", "operations"],
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      resourceScope: {},
+      permissionFlags: ["view", "edit"],
+      billingAccess: false,
+      exportAccess: false,
+    },
+    propertyScopeSummary: "all_current_properties",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    acceptedAt: "2026-06-22T12:00:00.000Z",
+    updatedAt: "2026-06-22T12:00:00.000Z",
+    revokedAt: null,
+    revocationReason: null,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/delegated-access/workspace"]}>
+      <DelegatedAccessWorkspacePage />
+    </MemoryRouter>
+  );
+}
+
+describe("DelegatedAccessWorkspacePage", () => {
+  beforeEach(() => {
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "delegate-user-1", email: "manager@example.com", role: "delegate" },
+      isLoading: false,
+      ready: true,
+      authStatus: "authed",
+    });
+    mocks.fetchMyGrants.mockResolvedValue([grant()]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders active delegated workspace assignments without owner-only labels or raw ids", async () => {
+    mocks.fetchMyGrants.mockResolvedValueOnce([
+      grant({
+        permissionScope: {
+          ...grant().permissionScope,
+          propertyScope: { mode: "selected", propertyIds: ["property-raw-1"] },
+        },
+        propertyScopeSummary: "selected:1",
+      }),
+    ]);
+    const { container } = renderPage();
+
+    expect(await screen.findByRole("heading", { name: "Assigned Workspaces" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Operations" })).toBeInTheDocument();
+    expect(screen.getByText("Property Manager")).toBeInTheDocument();
+    expect(screen.getByText("Selected properties")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("property-raw-1");
+    expect(container).not.toHaveTextContent("grant-internal-1");
+    expect(container).not.toHaveTextContent(/billing/i);
+    expect(container).not.toHaveTextContent(/settings/i);
+  });
+
+  it("shows a clear empty state when the delegate has no active grants", async () => {
+    mocks.fetchMyGrants.mockResolvedValueOnce([
+      grant({ status: "revoked", revokedAt: "2026-06-23T12:00:00.000Z" }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText("No active delegated access")).toBeInTheDocument();
+    expect(screen.getByText("There are no active workspace assignments for this account.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DelegatedAccessWorkspacePage from "./DelegatedAccessWorkspacePage";
@@ -8,6 +8,7 @@ import type { DelegatedAccessActiveGrant } from "../api/delegatedAccessApi";
 const mocks = vi.hoisted(() => ({
   fetchMyGrants: vi.fn(),
   useAuthMock: vi.fn(),
+  logout: vi.fn(),
 }));
 
 vi.mock("../api/delegatedAccessApi", async () => {
@@ -61,6 +62,7 @@ describe("DelegatedAccessWorkspacePage", () => {
       isLoading: false,
       ready: true,
       authStatus: "authed",
+      logout: mocks.logout,
     });
     mocks.fetchMyGrants.mockResolvedValue([grant()]);
   });
@@ -83,6 +85,9 @@ describe("DelegatedAccessWorkspacePage", () => {
     const { container } = renderPage();
 
     expect(await screen.findByRole("heading", { name: "Assigned Workspaces" })).toBeInTheDocument();
+    expect(screen.getByText("RentChain")).toBeInTheDocument();
+    expect(screen.getAllByText("Delegate account").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Operations" })).toBeInTheDocument();
     expect(screen.getByText("Property Manager")).toBeInTheDocument();
@@ -91,6 +96,14 @@ describe("DelegatedAccessWorkspacePage", () => {
     expect(container).not.toHaveTextContent("grant-internal-1");
     expect(container).not.toHaveTextContent(/billing/i);
     expect(container).not.toHaveTextContent(/settings/i);
+  });
+
+  it("signs the delegate out from the workspace header", async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Sign out" }));
+
+    await waitFor(() => expect(mocks.logout).toHaveBeenCalledTimes(1));
   });
 
   it("shows a clear empty state when the delegate has no active grants", async () => {

--- a/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Navigate } from "react-router-dom";
-import { BriefcaseBusiness, LayoutDashboard, ShieldCheck } from "lucide-react";
+import { Navigate, useNavigate } from "react-router-dom";
+import { BriefcaseBusiness, LayoutDashboard, LogOut, ShieldCheck } from "lucide-react";
 import {
   fetchMyDelegatedAccessGrants,
   type DelegatedAccessActiveGrant,
@@ -55,7 +55,8 @@ function workspaceSummary(scope: DelegatedAccessWorkspaceScope): string {
 }
 
 export default function DelegatedAccessWorkspacePage() {
-  const { user, authStatus, isLoading, ready } = useAuth();
+  const navigate = useNavigate();
+  const { user, authStatus, isLoading, ready, logout } = useAuth();
   const role = String((user as any)?.actorRole || user?.role || "").trim().toLowerCase();
   const [grants, setGrants] = React.useState<DelegatedAccessActiveGrant[]>([]);
   const [loading, setLoading] = React.useState(true);
@@ -96,9 +97,54 @@ export default function DelegatedAccessWorkspacePage() {
 
   const workspaces = uniqueWorkspaces(grants);
   const selectedLabel = workspaceLabels[selectedWorkspace] || "Workspace";
+  const delegateEmail = String(user?.email || "").trim();
+
+  const handleSignOut = async () => {
+    await logout();
+    navigate("/login", { replace: true });
+  };
 
   return (
     <main style={{ minHeight: "100vh", background: "#f8fafc", color: text.primary }}>
+      <div
+        style={{
+          borderBottom: "1px solid #e2e8f0",
+          background: "#ffffff",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 1180,
+            margin: "0 auto",
+            padding: "14px 18px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 16,
+            flexWrap: "wrap",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0 }}>
+            <div style={{ fontWeight: 900, fontSize: 18, color: colors.accent }}>RentChain</div>
+            <div style={{ width: 1, height: 22, background: "#cbd5e1" }} aria-hidden="true" />
+            <div style={{ color: text.muted, fontSize: 14, fontWeight: 700 }}>Delegated workspace</div>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <Pill tone="accent">Delegate account</Pill>
+            {delegateEmail ? <span style={{ color: text.muted, fontSize: 13 }}>{delegateEmail}</span> : null}
+            <Button
+              type="button"
+              onClick={handleSignOut}
+              variant="ghost"
+              style={{ borderRadius: 8, display: "inline-flex", alignItems: "center", gap: 8 }}
+            >
+              <LogOut size={16} aria-hidden="true" />
+              Sign out
+            </Button>
+          </div>
+        </div>
+      </div>
+
       <div style={{ maxWidth: 1180, margin: "0 auto", padding: "32px 18px 48px", display: "grid", gap: 22 }}>
         <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
           <div>
@@ -107,7 +153,6 @@ export default function DelegatedAccessWorkspacePage() {
             </div>
             <h1 style={{ margin: "6px 0 0", fontSize: 30, lineHeight: 1.15 }}>Assigned Workspaces</h1>
           </div>
-          <Pill tone="accent">Delegate account</Pill>
         </header>
 
         {authLoading || loading ? (

--- a/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.tsx
@@ -220,6 +220,9 @@ export default function DelegatedAccessWorkspacePage() {
                         <strong>{roleLabels[grant.role]}</strong>
                         <Pill tone="accent">Active</Pill>
                       </div>
+                      <div style={{ color: text.primary, fontSize: 14, fontWeight: 700 }}>
+                        Landlord workspace: {grant.landlordWorkspaceLabel || "Landlord workspace"}
+                      </div>
                       <div style={{ color: text.muted, fontSize: 14 }}>{propertyScopeLabel(grant)}</div>
                       <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
                         {grant.permissionScope.workspaceScopes.map((scope) => (

--- a/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessWorkspacePage.tsx
@@ -1,0 +1,194 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { BriefcaseBusiness, LayoutDashboard, ShieldCheck } from "lucide-react";
+import {
+  fetchMyDelegatedAccessGrants,
+  type DelegatedAccessActiveGrant,
+  type DelegatedAccessRole,
+  type DelegatedAccessWorkspaceScope,
+} from "../api/delegatedAccessApi";
+import { Button, Card, Pill } from "../components/ui/Ui";
+import { useAuth } from "../context/useAuth";
+import { getRoleDefaultDestination } from "../lib/authDestination";
+import { colors, text } from "../styles/tokens";
+
+const roleLabels: Record<DelegatedAccessRole, string> = {
+  property_manager: "Property Manager",
+  assistant_office_admin: "Assistant / Office Admin",
+  maintenance_coordinator: "Maintenance Coordinator",
+  contractor: "Contractor",
+  contractor_admin: "Contractor Admin",
+  read_only_auditor: "Read-only Auditor",
+};
+
+const workspaceLabels: Record<DelegatedAccessWorkspaceScope, string> = {
+  dashboard: "Dashboard",
+  operations: "Operations",
+  properties: "Properties",
+  tenants: "Tenants",
+  leases: "Leases",
+  payments: "Payments",
+  unified_inbox: "Unified Inbox",
+  scheduling: "Scheduling",
+  work_orders: "Work Orders",
+  evidence_exports: "Evidence Exports",
+};
+
+function propertyScopeLabel(grant: DelegatedAccessActiveGrant): string {
+  const mode = grant.permissionScope.propertyScope.mode;
+  if (mode === "all_current_properties") return "All current properties";
+  if (mode === "selected") return "Selected properties";
+  if (mode === "resource_only") return "Assigned resources only";
+  return "No property scope";
+}
+
+function uniqueWorkspaces(grants: DelegatedAccessActiveGrant[]): DelegatedAccessWorkspaceScope[] {
+  return Array.from(
+    new Set(grants.flatMap((grant) => grant.permissionScope.workspaceScopes || []))
+  ).filter((scope): scope is DelegatedAccessWorkspaceScope => Boolean(workspaceLabels[scope]));
+}
+
+function workspaceSummary(scope: DelegatedAccessWorkspaceScope): string {
+  if (scope === "dashboard") return "Assigned portfolio context and delegated activity.";
+  if (scope === "operations") return "Assigned operational workflows and follow-up work.";
+  return `${workspaceLabels[scope]} access assigned by the landlord owner.`;
+}
+
+export default function DelegatedAccessWorkspacePage() {
+  const { user, authStatus, isLoading, ready } = useAuth();
+  const role = String((user as any)?.actorRole || user?.role || "").trim().toLowerCase();
+  const [grants, setGrants] = React.useState<DelegatedAccessActiveGrant[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState("");
+  const [selectedWorkspace, setSelectedWorkspace] = React.useState<DelegatedAccessWorkspaceScope>("dashboard");
+  const authLoading = authStatus === "restoring" || isLoading || !ready;
+
+  React.useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError("");
+      try {
+        const rows = await fetchMyDelegatedAccessGrants();
+        if (cancelled) return;
+        const activeRows = rows.filter((grant) => grant.status === "active");
+        setGrants(activeRows);
+        const scopes = uniqueWorkspaces(activeRows);
+        setSelectedWorkspace(scopes[0] || "dashboard");
+      } catch (err: any) {
+        if (!cancelled) setError(err?.message || "Unable to load delegated access");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    if (!authLoading && role === "delegate") {
+      void load();
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, role]);
+
+  if (!authLoading && role !== "delegate") {
+    return <Navigate to={getRoleDefaultDestination(role as any)} replace />;
+  }
+
+  const workspaces = uniqueWorkspaces(grants);
+  const selectedLabel = workspaceLabels[selectedWorkspace] || "Workspace";
+
+  return (
+    <main style={{ minHeight: "100vh", background: "#f8fafc", color: text.primary }}>
+      <div style={{ maxWidth: 1180, margin: "0 auto", padding: "32px 18px 48px", display: "grid", gap: 22 }}>
+        <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: colors.accent, fontSize: 13, fontWeight: 800, textTransform: "uppercase" }}>
+              Delegated Access
+            </div>
+            <h1 style={{ margin: "6px 0 0", fontSize: 30, lineHeight: 1.15 }}>Assigned Workspaces</h1>
+          </div>
+          <Pill tone="accent">Delegate account</Pill>
+        </header>
+
+        {authLoading || loading ? (
+          <Card>
+            <p style={{ margin: 0, color: text.muted }}>Loading delegated access...</p>
+          </Card>
+        ) : error ? (
+          <Card>
+            <h2 style={{ margin: 0, fontSize: 18 }}>Unable to load delegated access</h2>
+            <p role="alert" style={{ margin: "8px 0 0", color: text.muted }}>{error}</p>
+          </Card>
+        ) : grants.length === 0 ? (
+          <Card>
+            <h2 style={{ margin: 0, fontSize: 18 }}>No active delegated access</h2>
+            <p style={{ margin: "8px 0 0", color: text.muted }}>
+              There are no active workspace assignments for this account.
+            </p>
+          </Card>
+        ) : (
+          <>
+            <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
+              {workspaces.map((workspace) => {
+                const Icon = workspace === "dashboard" ? LayoutDashboard : BriefcaseBusiness;
+                const selected = selectedWorkspace === workspace;
+                return (
+                  <Button
+                    key={workspace}
+                    type="button"
+                    variant={selected ? "primary" : "secondary"}
+                    aria-pressed={selected}
+                    onClick={() => setSelectedWorkspace(workspace)}
+                    style={{
+                      minHeight: 74,
+                      borderRadius: 8,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "flex-start",
+                      gap: 10,
+                      textAlign: "left",
+                    }}
+                  >
+                    <Icon size={20} aria-hidden="true" />
+                    <span>{workspaceLabels[workspace]}</span>
+                  </Button>
+                );
+              })}
+            </section>
+
+            <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 360px), 1fr))", gap: 16 }}>
+              <Card style={{ minHeight: 210 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <ShieldCheck size={22} color={colors.accent} aria-hidden="true" />
+                  <h2 style={{ margin: 0, fontSize: 22 }}>{selectedLabel}</h2>
+                </div>
+                <p style={{ margin: "12px 0 0", color: text.muted, lineHeight: 1.6 }}>
+                  {workspaceSummary(selectedWorkspace)}
+                </p>
+              </Card>
+
+              <div style={{ display: "grid", gap: 12 }}>
+                {grants.map((grant, index) => (
+                  <Card key={`${grant.role}-${grant.acceptedAt || grant.createdAt}-${index}`} style={{ borderRadius: 8 }}>
+                    <div style={{ display: "grid", gap: 8 }}>
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                        <strong>{roleLabels[grant.role]}</strong>
+                        <Pill tone="accent">Active</Pill>
+                      </div>
+                      <div style={{ color: text.muted, fontSize: 14 }}>{propertyScopeLabel(grant)}</div>
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                        {grant.permissionScope.workspaceScopes.map((scope) => (
+                          <Pill key={scope}>{workspaceLabels[scope] || scope}</Pill>
+                        ))}
+                      </div>
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/rentchain-frontend/src/pages/LoginPage.test.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.test.tsx
@@ -101,4 +101,18 @@ describe("LoginPage", () => {
 
     expect(screen.getByText("Contractor invitation detected")).toBeInTheDocument();
   });
+
+  it("preserves delegated access acceptance redirect when linking to signup", () => {
+    render(
+      <MemoryRouter initialEntries={["/login?next=/delegated-access/accept%3Ftoken%3Dsafe-token"]}>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Delegated access invitation detected")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Create free account" })).toHaveAttribute(
+      "href",
+      "/signup?next=%2Fdelegated-access%2Faccept%3Ftoken%3Dsafe-token"
+    );
+  });
 });

--- a/rentchain-frontend/src/pages/LoginPage.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.tsx
@@ -40,7 +40,10 @@ export const LoginPage: React.FC = () => {
     }
     return resolved.destination;
   }, [location.search, user?.actorRole, user?.role]);
-  const inviteContextType = React.useMemo<"contractor" | "tenant" | "landlord" | null>(() => {
+  const inviteContextType = React.useMemo<"contractor" | "tenant" | "landlord" | "delegated_access" | null>(() => {
+    if (nextPath.startsWith("/delegated-access/accept?")) {
+      return "delegated_access";
+    }
     if (nextPath.startsWith("/contractor/invite/") || nextPath.startsWith("/contractor/signup?invite=")) {
       return "contractor";
     }
@@ -94,6 +97,12 @@ export const LoginPage: React.FC = () => {
       return {
         title: "Landlord setup detected",
         body: "Sign in or create an account to continue your RentChain landlord setup.",
+      };
+    }
+    if (inviteContextType === "delegated_access") {
+      return {
+        title: "Delegated access invitation detected",
+        body: "Sign in or create your own account to accept this landlord workspace invitation.",
       };
     }
     return null;
@@ -242,7 +251,10 @@ export const LoginPage: React.FC = () => {
       }
       footer={
         <>
-          <Link to="/signup" style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}>
+          <Link
+            to={nextPath !== "/dashboard" ? `/signup?next=${encodeURIComponent(nextPath)}` : "/signup"}
+            style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}
+          >
             Create free account
           </Link>
           <Link to="/tenant" style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}>

--- a/rentchain-frontend/src/pages/SignupPage.test.tsx
+++ b/rentchain-frontend/src/pages/SignupPage.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SignupPage from "./SignupPage";
+
+const mocks = vi.hoisted(() => ({
+  signup: vi.fn(),
+  trackAuthEvent: vi.fn(),
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: () => ({
+    signup: mocks.signup,
+    isLoading: false,
+    user: null,
+  }),
+}));
+
+vi.mock("../lib/authAnalytics", () => ({
+  trackAuthEvent: mocks.trackAuthEvent,
+}));
+
+describe("SignupPage", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.signup.mockReset();
+    mocks.signup.mockResolvedValue(undefined);
+    mocks.trackAuthEvent.mockReset();
+  });
+
+  it("preserves delegated access invite context during account creation", async () => {
+    render(
+      <MemoryRouter initialEntries={["/signup?next=/delegated-access/accept%3Ftoken%3Dsafe-token"]}>
+        <SignupPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Delegated access invitation")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Your name"), { target: { value: "Delegate User" } });
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), { target: { value: "delegate@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("At least 6 characters"), { target: { value: "secret1" } });
+    fireEvent.change(screen.getByPlaceholderText("Re-enter password"), { target: { value: "secret1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create free account" }));
+
+    await waitFor(() =>
+      expect(mocks.signup).toHaveBeenCalledWith("delegate@example.com", "secret1", "Delegate User", {
+        inviteToken: "safe-token",
+        inviteSource: "delegated_access",
+      })
+    );
+  });
+});

--- a/rentchain-frontend/src/pages/SignupPage.tsx
+++ b/rentchain-frontend/src/pages/SignupPage.tsx
@@ -39,7 +39,10 @@ const SignupPage: React.FC = () => {
     }
     return resolved.destination;
   }, [location.search, user?.actorRole, user?.role]);
-  const inviteContextType = React.useMemo<"contractor" | "tenant" | "landlord" | null>(() => {
+  const inviteContextType = React.useMemo<"contractor" | "tenant" | "landlord" | "delegated_access" | null>(() => {
+    if (nextPath.startsWith("/delegated-access/accept?")) {
+      return "delegated_access";
+    }
     if (nextPath.startsWith("/contractor/invite/") || nextPath.startsWith("/contractor/signup?invite=")) {
       return "contractor";
     }
@@ -95,6 +98,12 @@ const SignupPage: React.FC = () => {
         body: "Create your account to continue your RentChain landlord workspace setup.",
       };
     }
+    if (inviteContextType === "delegated_access") {
+      return {
+        title: "Delegated access invitation",
+        body: "Create your own account to accept this landlord workspace invitation. Do not use the landlord owner's login.",
+      };
+    }
     return null;
   }, [inviteContextType]);
   const contractorOnboardContext = React.useMemo(() => {
@@ -108,6 +117,15 @@ const SignupPage: React.FC = () => {
       return { token, source };
     } catch {
       return { token: "", source: "" };
+    }
+  }, [nextPath]);
+  const delegatedAccessContext = React.useMemo(() => {
+    if (!nextPath.startsWith("/delegated-access/accept?")) return { token: "" };
+    try {
+      const nextUrl = new URL(nextPath, window.location.origin);
+      return { token: String(nextUrl.searchParams.get("token") || "").trim() };
+    } catch {
+      return { token: "" };
     }
   }, [nextPath]);
   const [email, setEmail] = useState("");
@@ -131,6 +149,7 @@ const SignupPage: React.FC = () => {
       const normalizedEmail = email.trim().toLowerCase();
       const isContractorOnboardSignup =
         contractorOnboardContext.source === "contractor" && Boolean(contractorOnboardContext.token);
+      const isDelegatedAccessSignup = Boolean(delegatedAccessContext.token);
       if (import.meta.env.DEV && isContractorOnboardSignup) {
         console.info("[signup] contractor invite context detected", {
           email: maskEmail(normalizedEmail),
@@ -142,6 +161,12 @@ const SignupPage: React.FC = () => {
       await signup(normalizedEmail, password, fullName.trim() || undefined, {
         inviteToken: isContractorOnboardSignup ? contractorOnboardContext.token : undefined,
         inviteSource: isContractorOnboardSignup ? "contractor" : undefined,
+        ...(isDelegatedAccessSignup
+          ? {
+              inviteToken: delegatedAccessContext.token,
+              inviteSource: "delegated_access",
+            }
+          : {}),
       });
       if (import.meta.env.DEV) {
         console.info("[signup] completed", {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -197,7 +197,7 @@ describe("UnifiedInboxPage", () => {
     render(<UnifiedInboxPage role="landlord" />);
 
     expect(await screen.findByRole("heading", { name: "Unified inbox" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /Maintenance 1/i })).toBeInTheDocument();
+    expect(await screen.findByRole("tab", { name: /Maintenance 1/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Payments 1/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /System 1/i })).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary

- Add Mission Brief artifact for delegated access email dispatch V1.
- Send delegated-access invitation emails after successful owner-created invitations.
- Add safe pending-only resend behavior for invitation emails.
- Add invitation email dispatch metadata for sent/failed/retryable states.
- Preserve token safety: raw token appears only in generated acceptance URL, never API responses or audit metadata.
- Record metadata-only audit events for dispatch, resend, and failed dispatch attempts.

## Scope Control

- Backend/API/email integration only.
- No UI work.
- No email marketing behavior.
- No PM company model.
- No contractor organization model.
- No billing delegation.
- No custom roles.
- No security rule changes.

## Validation

- 
> rentchain-api@1.0.0 test
> npm run test:emulator delegatedAccessInvitationRoutes.test.ts


> rentchain-api@1.0.0 test:emulator
> npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false vitest run delegatedAccessInvitationRoutes.test.ts


> rentchain-api@1.0.0 preflight
> node ./scripts/check-node.js passed: 22 tests.
- 
> rentchain-api@1.0.0 test
> npm run test:emulator delegatedAccessModel.test.ts delegatedAccessAudit.test.ts permissionEvaluation.test.ts delegatedAccessInvitationRoutes.test.ts


> rentchain-api@1.0.0 test:emulator
> npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false vitest run delegatedAccessModel.test.ts delegatedAccessAudit.test.ts permissionEvaluation.test.ts delegatedAccessInvitationRoutes.test.ts


> rentchain-api@1.0.0 preflight
> node ./scripts/check-node.js passed: 33 tests.
- 
> rentchain-api@1.0.0 build
> npm run preflight && tsc -p tsconfig.build.json


> rentchain-api@1.0.0 preflight
> node ./scripts/check-node.js passed.
-  passed.

## QA Notes

- Manual email QA is required only if test email dispatch is enabled in preview/test environment.
- Frontend build was not required because no frontend files changed.