### PR TITLE
feat: add delegated access invitation history filters

### DIFF
--- a/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
@@ -121,6 +121,9 @@ describe("DelegatedAccessPage", () => {
     expect(await screen.findByRole("heading", { name: "Delegate Management" })).toBeInTheDocument();
     expect(container.firstElementChild).toHaveStyle({ margin: "0 auto", maxWidth: "1320px" });
     expect(screen.getByText("Never share your login. Invite delegates to their own account.")).toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: "Delegated access status filters" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Active access" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Invitation history" })).toBeInTheDocument();
     expect(screen.getByText("assistant@example.com")).toBeInTheDocument();
     expect(screen.getAllByText("manager@example.com").length).toBeGreaterThan(0);
     expect(screen.getByText("Property Manager")).toBeInTheDocument();
@@ -295,7 +298,7 @@ describe("DelegatedAccessPage", () => {
     render(<DelegatedAccessPage />);
 
     expect(await screen.findByText("assistant@example.com")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Revoked" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Revoked" }));
 
     const visibleRecords = screen.getAllByTestId("delegated-access-record");
     expect(visibleRecords).toHaveLength(1);
@@ -303,5 +306,24 @@ describe("DelegatedAccessPage", () => {
     expect(visibleRecords[0]).toHaveTextContent("former@example.com");
     expect(visibleRecords[0]).not.toHaveTextContent("assistant@example.com");
     expect(visibleRecords[0]).not.toHaveTextContent("manager@example.com");
+  });
+
+  it("shows filter-specific empty states without hiding preserved history", async () => {
+    render(<DelegatedAccessPage />);
+
+    expect(await screen.findByText("assistant@example.com")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Cancelled" })).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Cancelled" }));
+
+    expect(screen.getByRole("tab", { name: "Cancelled" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("No cancelled records")).toBeInTheDocument();
+    expect(screen.getByText("History is preserved here when records enter this state.")).toBeInTheDocument();
+    expect(screen.queryByText("assistant@example.com")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "All" }));
+
+    expect(await screen.findByText("assistant@example.com")).toBeInTheDocument();
+    expect(screen.getAllByText("manager@example.com").length).toBeGreaterThan(0);
   });
 });

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DelegatedAccessPage from "./DelegatedAccessPage";
 import type { DelegatedAccessGrant, DelegatedAccessInvitation } from "../api/delegatedAccessApi";
@@ -124,6 +124,7 @@ describe("DelegatedAccessPage", () => {
     expect(screen.getByRole("tablist", { name: "Delegated access status filters" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Active access" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Invitation history" })).toBeInTheDocument();
+    expect(screen.getByTestId("delegate-summary-row")).toHaveStyle({ display: "flex", flexWrap: "wrap" });
     expect(screen.getByText("assistant@example.com")).toBeInTheDocument();
     expect(screen.getAllByText("manager@example.com").length).toBeGreaterThan(0);
     expect(screen.getByText("Property Manager")).toBeInTheDocument();
@@ -239,9 +240,53 @@ describe("DelegatedAccessPage", () => {
       target: { value: "Staff turnover" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Revoke Access" }));
+    expect(mocks.revokeGrant).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog", { name: "Confirm revoke access for manager@example.com" })).toHaveTextContent(
+      "Are you sure you want to revoke access for manager@example.com?"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("alertdialog", { name: "Confirm revoke access for manager@example.com" })).not.toBeInTheDocument();
+    expect(mocks.revokeGrant).not.toHaveBeenCalled();
 
+    fireEvent.click(screen.getByRole("button", { name: "Revoke Access" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm revoke" }));
     await waitFor(() => expect(mocks.revokeGrant).toHaveBeenCalledWith("grant-internal-1", "Staff turnover"));
     expect(screen.getByText("Reason: Staff turnover")).toBeInTheDocument();
+  });
+
+  it("keeps revocation reasons independent for each active grant and revokes only the confirmed grant", async () => {
+    mocks.fetchGrants.mockResolvedValue([
+      grant(),
+      grant({
+        grantId: "grant-internal-2",
+        delegateUserId: "delegate-user-2",
+        delegateEmail: "ops@example.com",
+      }),
+    ]);
+    render(<DelegatedAccessPage />);
+
+    expect(await screen.findByText("ops@example.com")).toBeInTheDocument();
+    const managerReason = screen.getByLabelText("Revocation reason for manager@example.com");
+    const opsReason = screen.getByLabelText("Revocation reason for ops@example.com");
+
+    fireEvent.change(managerReason, { target: { value: "Manager reason" } });
+    expect(managerReason).toHaveValue("Manager reason");
+    expect(opsReason).toHaveValue("");
+
+    fireEvent.change(opsReason, { target: { value: "Ops reason" } });
+    expect(managerReason).toHaveValue("Manager reason");
+    expect(opsReason).toHaveValue("Ops reason");
+
+    const opsRecord = screen
+      .getAllByTestId("delegated-access-record")
+      .find((record) => record.textContent?.includes("ops@example.com"));
+    expect(opsRecord).toBeTruthy();
+    fireEvent.click(within(opsRecord!).getByRole("button", { name: "Revoke Access" }));
+    expect(mocks.revokeGrant).not.toHaveBeenCalled();
+    fireEvent.click(within(opsRecord!).getByRole("button", { name: "Confirm revoke" }));
+
+    await waitFor(() => expect(mocks.revokeGrant).toHaveBeenCalledWith("grant-internal-2", "Ops reason"));
+    expect(mocks.revokeGrant).not.toHaveBeenCalledWith("grant-internal-1", "Manager reason");
   });
 
   it("shows a calm empty state when there are no delegates, grants, or invitations", async () => {

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -193,8 +193,9 @@ export default function DelegatedAccessPage() {
   const [expiresAt, setExpiresAt] = React.useState(defaultExpiryDate());
   const [submitting, setSubmitting] = React.useState(false);
   const [revokingGrantId, setRevokingGrantId] = React.useState<string | null>(null);
+  const [confirmingRevokeGrant, setConfirmingRevokeGrant] = React.useState<DelegatedAccessGrant | null>(null);
   const [cancellingInvitationId, setCancellingInvitationId] = React.useState<string | null>(null);
-  const [revocationReason, setRevocationReason] = React.useState("");
+  const [revocationReasons, setRevocationReasons] = React.useState<Record<string, string>>({});
   const canManage = isOwnerRole(user);
 
   const load = React.useCallback(async () => {
@@ -271,6 +272,10 @@ export default function DelegatedAccessPage() {
     });
   };
 
+  const updateRevocationReason = (grantId: string, value: string) => {
+    setRevocationReasons((current) => ({ ...current, [grantId]: value }));
+  };
+
   const handleInvite = async (event: React.FormEvent) => {
     event.preventDefault();
     if (workspaceScopes.length === 0 || permissionFlags.length === 0) {
@@ -311,17 +316,22 @@ export default function DelegatedAccessPage() {
     }
   };
 
-  const handleRevoke = async (grant: DelegatedAccessGrant) => {
+  const handleConfirmRevoke = async (grant: DelegatedAccessGrant) => {
     if (grant.status !== "active") return;
     setRevokingGrantId(grant.grantId);
     try {
-      await revokeDelegatedAccessGrant(grant.grantId, revocationReason);
+      await revokeDelegatedAccessGrant(grant.grantId, revocationReasons[grant.grantId] || "");
       showToast({
         message: "Access revoked",
         description: "Future delegated actions for this grant are now blocked.",
         variant: "success",
       });
-      setRevocationReason("");
+      setRevocationReasons((current) => {
+        const next = { ...current };
+        delete next[grant.grantId];
+        return next;
+      });
+      setConfirmingRevokeGrant(null);
       await load();
     } catch (err: any) {
       showToast({
@@ -441,22 +451,62 @@ export default function DelegatedAccessPage() {
         {grant.revokedAt ? ` · Revoked ${formatDate(grant.revokedAt)}` : ""}
       </div>
       {grant.status === "active" ? (
-        <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", alignItems: "center" }}>
-          <Input
-            aria-label={`Revocation reason for ${grant.delegateEmail || "delegate"}`}
-            value={revokingGrantId === grant.grantId ? revocationReason : revocationReason}
-            onChange={(event) => setRevocationReason(event.target.value)}
-            placeholder="Optional revocation reason"
-            style={{ maxWidth: 320 }}
-          />
-          <Button
-            type="button"
-            variant="secondary"
-            disabled={Boolean(revokingGrantId)}
-            onClick={() => void handleRevoke(grant)}
-          >
-            {revokingGrantId === grant.grantId ? "Revoking..." : "Revoke Access"}
-          </Button>
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", alignItems: "center" }}>
+            <Input
+              aria-label={`Revocation reason for ${grant.delegateEmail || "delegate"}`}
+              value={revocationReasons[grant.grantId] || ""}
+              onChange={(event) => updateRevocationReason(grant.grantId, event.target.value)}
+              placeholder="Optional revocation reason"
+              style={{ maxWidth: 320 }}
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={Boolean(revokingGrantId)}
+              onClick={() => setConfirmingRevokeGrant(grant)}
+            >
+              Revoke Access
+            </Button>
+          </div>
+          {confirmingRevokeGrant?.grantId === grant.grantId ? (
+            <div
+              role="alertdialog"
+              aria-label={`Confirm revoke access for ${grant.delegateEmail || "delegate"}`}
+              style={{
+                display: "grid",
+                gap: spacing.xs,
+                padding: spacing.sm,
+                border: `1px solid ${colors.border}`,
+                borderRadius: radius.md,
+                background: "#fff7ed",
+              }}
+            >
+              <div style={{ fontWeight: 900 }}>
+                Are you sure you want to revoke access for {grant.delegateEmail || "this delegate"}?
+              </div>
+              <div style={{ color: text.secondary, fontSize: 13 }}>
+                {roleLabels[grant.role]} · {propertyScopeLabel(grant.permissionScope.propertyScope.mode)} · Revocation blocks future delegated access.
+              </div>
+              <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={revokingGrantId === grant.grantId}
+                  onClick={() => setConfirmingRevokeGrant(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  disabled={Boolean(revokingGrantId)}
+                  onClick={() => void handleConfirmRevoke(grant)}
+                >
+                  {revokingGrantId === grant.grantId ? "Revoking..." : "Confirm revoke"}
+                </Button>
+              </div>
+            </div>
+          ) : null}
         </div>
       ) : grant.revocationReason ? (
         <div style={{ color: text.muted, fontSize: 13 }}>Reason: {grant.revocationReason}</div>
@@ -740,20 +790,25 @@ export default function DelegatedAccessPage() {
             {delegates.map((delegate) => (
               <div
                 key={delegate.delegateUserId}
+                data-testid="delegate-summary-row"
                 style={{
-                  display: "grid",
-                  gridTemplateColumns: "minmax(180px, 1fr) auto",
+                  display: "flex",
+                  alignItems: "flex-start",
+                  justifyContent: "space-between",
+                  flexWrap: "wrap",
                   gap: spacing.sm,
                   padding: spacing.sm,
                   borderRadius: radius.md,
                   border: `1px solid ${colors.border}`,
                 }}
               >
-                <div>
-                  <div style={{ fontWeight: 900 }}>{delegate.delegateEmail || "Delegate account"}</div>
+                <div style={{ flex: "1 1 220px", minWidth: 0 }}>
+                  <div style={{ fontWeight: 900, overflowWrap: "anywhere" }}>
+                    {delegate.delegateEmail || "Delegate account"}
+                  </div>
                   <div style={{ color: text.muted, fontSize: 13 }}>{labelList(delegate.roles, roleLabels)}</div>
                 </div>
-                <div style={{ color: text.muted, fontSize: 13, textAlign: "right" }}>
+                <div style={{ color: text.muted, fontSize: 13, flex: "1 1 140px", minWidth: 0 }}>
                   {delegate.activeGrantCount} active · {delegate.revokedGrantCount} revoked
                 </div>
               </div>

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -59,6 +59,12 @@ const permissions = Object.keys(permissionLabels) as DelegatedAccessPermissionAc
 
 const defaultWorkspaces: DelegatedAccessWorkspaceScope[] = ["dashboard", "operations"];
 const defaultPermissions: DelegatedAccessPermissionAction[] = ["view"];
+type AccessStatusFilter = "all" | "pending" | "active" | "cancelled" | "expired" | "revoked";
+type AccessRow =
+  | { kind: "invitation"; status: DelegatedAccessInvitation["status"]; invitation: DelegatedAccessInvitation }
+  | { kind: "grant"; status: DelegatedAccessGrant["status"]; grant: DelegatedAccessGrant };
+
+const statusFilters: AccessStatusFilter[] = ["all", "pending", "active", "cancelled", "expired", "revoked"];
 
 function labelList<T extends string>(items: T[], labels: Record<T, string>) {
   if (!items.length) return "None";
@@ -106,6 +112,19 @@ function inviteToastDescription(status?: string | null) {
   if (status === "sent") return "Invitation email was sent to the delegate.";
   if (status === "failed") return "Invitation was saved, but email delivery failed. Use resend after delivery is restored.";
   return "Invitation was saved. Confirm email delivery status before relying on the link.";
+}
+
+function filteredEmptyState(status: AccessStatusFilter) {
+  if (status === "all") {
+    return {
+      title: "No delegated access yet",
+      body: "Invite delegates when you need staff or external collaborators to use their own account instead of sharing yours.",
+    };
+  }
+  return {
+    title: `No ${statusLabel(status).toLowerCase()} records`,
+    body: "History is preserved here when records enter this state.",
+  };
 }
 
 function isOwnerRole(user: any) {
@@ -165,7 +184,7 @@ export default function DelegatedAccessPage() {
   const [invitations, setInvitations] = React.useState<DelegatedAccessInvitation[]>([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
-  const [statusFilter, setStatusFilter] = React.useState<"all" | "pending" | "active" | "revoked" | "expired" | "cancelled">("all");
+  const [statusFilter, setStatusFilter] = React.useState<AccessStatusFilter>("all");
   const [inviteOpen, setInviteOpen] = React.useState(false);
   const [inviteEmail, setInviteEmail] = React.useState("");
   const [inviteRole, setInviteRole] = React.useState<DelegatedAccessRole>("property_manager");
@@ -210,12 +229,25 @@ export default function DelegatedAccessPage() {
   const expiredInvitations = invitations.filter((invitation) => invitation.status === "expired");
   const activeGrants = grants.filter((grant) => grant.status === "active");
   const revokedGrants = grants.filter((grant) => grant.status === "revoked");
-  const accessRows = [
+  const allAccessRows: AccessRow[] = [
     ...pendingInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
     ...cancelledInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
     ...expiredInvitations.map((invitation) => ({ kind: "invitation" as const, status: invitation.status, invitation })),
     ...grants.map((grant) => ({ kind: "grant" as const, status: grant.status, grant })),
-  ].filter((row) => statusFilter === "all" || row.status === statusFilter);
+  ];
+  const accessRows = allAccessRows.filter((row) => statusFilter === "all" || row.status === statusFilter);
+  const activeAccessRows = accessRows.filter((row) => row.kind === "grant" && row.status === "active");
+  const invitationHistoryRows = accessRows.filter((row) => row.kind === "invitation");
+  const grantHistoryRows = accessRows.filter((row) => row.kind === "grant" && row.status !== "active");
+  const statusCounts: Record<AccessStatusFilter, number> = {
+    all: allAccessRows.length,
+    pending: pendingInvitations.length,
+    active: activeGrants.length,
+    cancelled: cancelledInvitations.length,
+    expired: allAccessRows.filter((row) => row.status === "expired").length,
+    revoked: revokedGrants.length,
+  };
+  const emptyState = filteredEmptyState(statusFilter);
 
   const resetInvite = () => {
     setInviteEmail("");
@@ -324,6 +356,127 @@ export default function DelegatedAccessPage() {
     } finally {
       setCancellingInvitationId(null);
     }
+  };
+
+  const renderInvitationRecord = (invitation: DelegatedAccessInvitation) => (
+    <div
+      key={`invitation-${invitation.invitationId}`}
+      data-testid="delegated-access-record"
+      data-status={invitation.status}
+      style={{
+        display: "grid",
+        gap: spacing.xs,
+        padding: spacing.md,
+        border: `1px solid ${colors.border}`,
+        borderRadius: radius.md,
+        background: colors.card,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+        <div>
+          <div style={{ fontWeight: 900 }}>{invitation.inviteeEmail}</div>
+          <div style={{ color: text.muted, fontSize: 13 }}>
+            {roleLabels[invitation.role]} · {propertyScopeLabel(invitation.propertyScope.mode)}
+          </div>
+        </div>
+        <Pill tone={statusTone(invitation.status)}>{statusLabel(invitation.status)}</Pill>
+      </div>
+      <div style={{ color: text.secondary, fontSize: 13 }}>
+        Workspaces: {labelList(invitation.workspaceScopes, workspaceLabels)} · Permissions:{" "}
+        {labelList(invitation.permissionFlags, permissionLabels)}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: spacing.sm,
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ color: text.muted, fontSize: 13 }}>Expires {formatDate(invitation.expiresAt)}</div>
+        {invitation.status === "pending" ? (
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={cancellingInvitationId === invitation.invitationId}
+            onClick={() => void handleCancelInvitation(invitation)}
+          >
+            {cancellingInvitationId === invitation.invitationId ? "Cancelling..." : "Cancel Invitation"}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  const renderGrantRecord = (grant: DelegatedAccessGrant) => (
+    <div
+      key={`grant-${grant.grantId}`}
+      data-testid="delegated-access-record"
+      data-status={grant.status}
+      style={{
+        display: "grid",
+        gap: spacing.sm,
+        padding: spacing.md,
+        border: `1px solid ${colors.border}`,
+        borderRadius: radius.md,
+        background: grant.status === "revoked" ? "#f8fafc" : colors.card,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+        <div>
+          <div style={{ fontWeight: 900 }}>{grant.delegateEmail || "Delegate account"}</div>
+          <div style={{ color: text.muted, fontSize: 13 }}>
+            {roleLabels[grant.role]} · {propertyScopeLabel(grant.permissionScope.propertyScope.mode)}
+          </div>
+        </div>
+        <Pill tone={statusTone(grant.status)}>{statusLabel(grant.status)}</Pill>
+      </div>
+      <div style={{ color: text.secondary, fontSize: 13 }}>
+        Workspaces: {labelList(grant.permissionScope.workspaceScopes, workspaceLabels)} · Permissions:{" "}
+        {labelList(grant.permissionScope.permissionFlags, permissionLabels)}
+      </div>
+      <div style={{ color: text.muted, fontSize: 13 }}>
+        Accepted {formatDate(grant.acceptedAt)} · Updated {formatDate(grant.updatedAt)}
+        {grant.revokedAt ? ` · Revoked ${formatDate(grant.revokedAt)}` : ""}
+      </div>
+      {grant.status === "active" ? (
+        <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", alignItems: "center" }}>
+          <Input
+            aria-label={`Revocation reason for ${grant.delegateEmail || "delegate"}`}
+            value={revokingGrantId === grant.grantId ? revocationReason : revocationReason}
+            onChange={(event) => setRevocationReason(event.target.value)}
+            placeholder="Optional revocation reason"
+            style={{ maxWidth: 320 }}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={Boolean(revokingGrantId)}
+            onClick={() => void handleRevoke(grant)}
+          >
+            {revokingGrantId === grant.grantId ? "Revoking..." : "Revoke Access"}
+          </Button>
+        </div>
+      ) : grant.revocationReason ? (
+        <div style={{ color: text.muted, fontSize: 13 }}>Reason: {grant.revocationReason}</div>
+      ) : null}
+    </div>
+  );
+
+  const renderSection = (title: string, body: string, rows: AccessRow[]) => {
+    if (rows.length === 0) return null;
+    return (
+      <section style={{ display: "grid", gap: spacing.sm }}>
+        <div>
+          <h3 style={{ margin: 0, fontSize: "1rem" }}>{title}</h3>
+          <div style={{ color: text.muted, fontSize: 13 }}>{body}</div>
+        </div>
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          {rows.map((row) => (row.kind === "invitation" ? renderInvitationRecord(row.invitation) : renderGrantRecord(row.grant)))}
+        </div>
+      </section>
+    );
   };
 
   if (!canManage) {
@@ -518,16 +671,20 @@ export default function DelegatedAccessPage() {
             <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Access Overview</h2>
             <div style={{ color: text.muted, fontSize: 13 }}>Who can access this landlord workspace and what state they are in.</div>
           </div>
-          <div style={{ display: "flex", gap: spacing.xs, flexWrap: "wrap" }}>
-            {(["all", "pending", "active", "revoked", "cancelled", "expired"] as const).map((status) => (
+          <div role="tablist" aria-label="Delegated access status filters" style={{ display: "flex", gap: spacing.xs, flexWrap: "wrap" }}>
+            {statusFilters.map((status) => (
               <Button
                 key={status}
                 type="button"
+                role="tab"
+                aria-selected={statusFilter === status}
+                aria-label={statusLabel(status)}
                 variant={statusFilter === status ? "primary" : "secondary"}
                 onClick={() => setStatusFilter(status)}
-                style={{ padding: "8px 12px", fontSize: 13 }}
+                style={{ padding: "8px 12px", fontSize: 13, display: "inline-flex", alignItems: "center", gap: 8 }}
               >
-                {statusLabel(status)}
+                <span>{statusLabel(status)}</span>
+                <span aria-hidden="true" style={{ opacity: 0.75 }}>{statusCounts[status]}</span>
               </Button>
             ))}
           </div>
@@ -543,126 +700,33 @@ export default function DelegatedAccessPage() {
         ) : null}
         {!loading && !error && accessRows.length === 0 ? (
           <EmptyState
-            title="No delegated access yet"
-            body="Invite delegates when you need staff or external collaborators to use their own account instead of sharing yours."
-            action={<Button type="button" onClick={() => setInviteOpen(true)}>Invite Delegate</Button>}
+            title={emptyState.title}
+            body={emptyState.body}
+            action={
+              statusFilter === "all" || statusFilter === "pending" ? (
+                <Button type="button" onClick={() => setInviteOpen(true)}>Invite Delegate</Button>
+              ) : undefined
+            }
           />
         ) : null}
 
         {!loading && !error && accessRows.length > 0 ? (
           <div style={{ display: "grid", gap: spacing.sm }}>
-            {accessRows.map((row) => {
-              if (row.kind === "invitation") {
-                const invitation = row.invitation;
-                return (
-                  <div
-                    key={`invitation-${invitation.invitationId}`}
-                    data-testid="delegated-access-record"
-                    data-status={invitation.status}
-                    style={{
-                      display: "grid",
-                      gap: spacing.xs,
-                      padding: spacing.md,
-                      border: `1px solid ${colors.border}`,
-                      borderRadius: radius.md,
-                      background: colors.card,
-                    }}
-                  >
-                    <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
-                      <div>
-                        <div style={{ fontWeight: 900 }}>{invitation.inviteeEmail}</div>
-                        <div style={{ color: text.muted, fontSize: 13 }}>
-                          {roleLabels[invitation.role]} · {propertyScopeLabel(invitation.propertyScope.mode)}
-                        </div>
-                      </div>
-                      <Pill tone={statusTone(invitation.status)}>{statusLabel(invitation.status)}</Pill>
-                    </div>
-                    <div style={{ color: text.secondary, fontSize: 13 }}>
-                      Workspaces: {labelList(invitation.workspaceScopes, workspaceLabels)} · Permissions:{" "}
-                      {labelList(invitation.permissionFlags, permissionLabels)}
-                    </div>
-                    <div
-                      style={{
-                        display: "flex",
-                        justifyContent: "space-between",
-                        gap: spacing.sm,
-                        alignItems: "center",
-                        flexWrap: "wrap",
-                      }}
-                    >
-                      <div style={{ color: text.muted, fontSize: 13 }}>Expires {formatDate(invitation.expiresAt)}</div>
-                      {invitation.status === "pending" ? (
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          disabled={cancellingInvitationId === invitation.invitationId}
-                          onClick={() => void handleCancelInvitation(invitation)}
-                        >
-                          {cancellingInvitationId === invitation.invitationId ? "Cancelling..." : "Cancel Invitation"}
-                        </Button>
-                      ) : null}
-                    </div>
-                  </div>
-                );
-              }
-
-              const grant = row.grant;
-              return (
-                <div
-                  key={`grant-${grant.grantId}`}
-                  data-testid="delegated-access-record"
-                  data-status={grant.status}
-                  style={{
-                    display: "grid",
-                    gap: spacing.sm,
-                    padding: spacing.md,
-                    border: `1px solid ${colors.border}`,
-                    borderRadius: radius.md,
-                    background: grant.status === "revoked" ? "#f8fafc" : colors.card,
-                  }}
-                >
-                  <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
-                    <div>
-                      <div style={{ fontWeight: 900 }}>{grant.delegateEmail || "Delegate account"}</div>
-                      <div style={{ color: text.muted, fontSize: 13 }}>
-                        {roleLabels[grant.role]} ·{" "}
-                        {propertyScopeLabel(grant.permissionScope.propertyScope.mode)}
-                      </div>
-                    </div>
-                    <Pill tone={statusTone(grant.status)}>{statusLabel(grant.status)}</Pill>
-                  </div>
-                  <div style={{ color: text.secondary, fontSize: 13 }}>
-                    Workspaces: {labelList(grant.permissionScope.workspaceScopes, workspaceLabels)} · Permissions:{" "}
-                    {labelList(grant.permissionScope.permissionFlags, permissionLabels)}
-                  </div>
-                  <div style={{ color: text.muted, fontSize: 13 }}>
-                    Accepted {formatDate(grant.acceptedAt)} · Updated {formatDate(grant.updatedAt)}
-                    {grant.revokedAt ? ` · Revoked ${formatDate(grant.revokedAt)}` : ""}
-                  </div>
-                  {grant.status === "active" ? (
-                    <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", alignItems: "center" }}>
-                      <Input
-                        aria-label={`Revocation reason for ${grant.delegateEmail || "delegate"}`}
-                        value={revokingGrantId === grant.grantId ? revocationReason : revocationReason}
-                        onChange={(event) => setRevocationReason(event.target.value)}
-                        placeholder="Optional revocation reason"
-                        style={{ maxWidth: 320 }}
-                      />
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        disabled={Boolean(revokingGrantId)}
-                        onClick={() => void handleRevoke(grant)}
-                      >
-                        {revokingGrantId === grant.grantId ? "Revoking..." : "Revoke Access"}
-                      </Button>
-                    </div>
-                  ) : grant.revocationReason ? (
-                    <div style={{ color: text.muted, fontSize: 13 }}>Reason: {grant.revocationReason}</div>
-                  ) : null}
-                </div>
-              );
-            })}
+            {renderSection(
+              "Active access",
+              "Accepted grants that can currently use delegated workspace access.",
+              activeAccessRows
+            )}
+            {renderSection(
+              "Invitation history",
+              "Pending, cancelled, and expired invitations remain visible for review.",
+              invitationHistoryRows
+            )}
+            {renderSection(
+              "Revoked access",
+              "Revoked grants stay preserved as historical access records.",
+              grantHistoryRows
+            )}
           </div>
         ) : null}
       </Card>


### PR DESCRIPTION
## Summary
- Add Delegate Management status tabs for All, Pending, Active, Cancelled, Expired, and Revoked records.
- Group visible records into Active access, Invitation history, and Revoked access sections.
- Add filter-specific empty states while preserving cancelled, expired, and revoked history.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/pages/DelegatedAccessPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`

## Manual QA
- Pending preview verification for filters, grouping, and empty states.

## Scope Notes
- Frontend-only cleanup.
- No backend redesign, permission model changes, email dispatch changes, or acceptance-flow changes.