### PR TITLE
feat: add property manager company relationship api

### DIFF
--- a/docs/design/mission-briefs/property-manager-company-relationship-api-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-relationship-api-v1.html
@@ -1,0 +1,450 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Property Manager Company Relationship API V1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #eef1f5;
+        color: #142033;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #eef1f5;
+      }
+
+      .brief {
+        max-width: 1280px;
+        margin: 0 auto;
+        background: #ffffff;
+        border: 1px solid #d7dde7;
+        box-shadow: 0 18px 50px rgba(20, 32, 51, 0.12);
+      }
+
+      header {
+        padding: 28px 32px;
+        border-bottom: 1px solid #d7dde7;
+        background: #142033;
+        color: #ffffff;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: 26px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      h1 span {
+        color: #8fd6ff;
+      }
+
+      .subtitle {
+        max-width: 900px;
+        color: #d6e7f4;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
+      }
+
+      section {
+        padding: 28px 32px;
+      }
+
+      .left {
+        border-right: 1px solid #d7dde7;
+      }
+
+      .block {
+        margin-bottom: 24px;
+      }
+
+      .block:last-child {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        margin-bottom: 10px;
+        color: #142033;
+        font-size: 15px;
+        line-height: 1.25;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        color: #2b3c55;
+        font-size: 14px;
+        line-height: 1.3;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 14px;
+        line-height: 1.48;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .card {
+        padding: 14px;
+        border: 1px solid #d7dde7;
+        background: #f8fafc;
+      }
+
+      .card strong {
+        display: block;
+        margin-bottom: 5px;
+        color: #142033;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        padding: 6px 9px;
+        border: 1px solid #c8d2df;
+        background: #f4f7fb;
+        color: #26374f;
+        font-size: 12px;
+        font-weight: 700;
+      }
+
+      .panel {
+        padding: 14px 16px;
+        border-left: 4px solid #246bfe;
+        background: #f4f8ff;
+      }
+
+      .warning {
+        border-left-color: #b7791f;
+        background: #fff8e8;
+      }
+
+      .success {
+        border-left-color: #16895a;
+        background: #f0fff7;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid #d7dde7;
+        background: #ffffff;
+      }
+
+      .table th,
+      .table td {
+        padding: 9px 10px;
+        border-bottom: 1px solid #e4e9f1;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .table th {
+        background: #f4f7fb;
+        color: #142033;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        color: #1b4f9c;
+      }
+
+      .compact li {
+        font-size: 13px;
+      }
+
+      @media (max-width: 920px) {
+        body {
+          padding: 16px;
+        }
+
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        .left {
+          border-right: 0;
+          border-bottom: 1px solid #d7dde7;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <h1>Next Mission: <span>feat/property-manager-company-relationship-api-v1</span></h1>
+        <div class="subtitle">
+          Backend/API-only lifecycle endpoints for landlord-to-property-manager-company relationships, built on the
+          merged Property Manager Company foundations. The mission keeps landlord ownership authoritative, fails closed
+          on ambiguous scope, requires mutual acceptance before activation, and records metadata-only audit events for
+          every lifecycle action.
+        </div>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>Mission Goal</h2>
+            <p>
+              Expose backend API foundations that let landlord owners list, create, suspend, reactivate, and terminate
+              Property Manager Company relationships, while modeling activation as a PM Company Admin acceptance step.
+              New relationships must start pending and must not grant company authority until the company side accepts.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Ownership And Acceptance Model</h2>
+            <div class="panel">
+              Landlord relationship authority originates from the landlord side, but activation requires mutual
+              acceptance: Landlord Owner creates the relationship, the record starts pending, and a PM Company Admin
+              acceptance action moves it to active. The PM company cannot self-grant access, and the landlord remains
+              the data owner.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Proposed API Surface</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Action</th>
+                  <th>Endpoint Shape</th>
+                  <th>Contract</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>List</td>
+                  <td><code>GET /api/landlord/property-manager-company-relationships</code></td>
+                  <td>Return only relationships for the authenticated landlord owner context.</td>
+                </tr>
+                <tr>
+                  <td>Create</td>
+                  <td><code>POST /api/landlord/property-manager-company-relationships</code></td>
+                  <td>Create a preserved relationship record in pending status. Do not create active relationships by default.</td>
+                </tr>
+                <tr>
+                  <td>Accept / Activate</td>
+                  <td><code>POST /api/property-manager-company/relationships/:relationshipId/accept</code></td>
+                  <td>
+                    Move a pending relationship to active only when an authorized PM Company Admin accepts. If this
+                    route is deferred, the service model must still assume mutual acceptance.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Suspend</td>
+                  <td><code>POST /api/landlord/property-manager-company-relationships/:relationshipId/suspend</code></td>
+                  <td>Temporarily block access while preserving relationship and audit history.</td>
+                </tr>
+                <tr>
+                  <td>Reactivate</td>
+                  <td><code>POST /api/landlord/property-manager-company-relationships/:relationshipId/reactivate</code></td>
+                  <td>Return a suspended relationship to active when scope and ownership still validate.</td>
+                </tr>
+                <tr>
+                  <td>Terminate</td>
+                  <td><code>POST /api/landlord/property-manager-company-relationships/:relationshipId/terminate</code></td>
+                  <td>Block access, preserve history, and store termination metadata. No hard delete.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>Status Behavior</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Transition</th>
+                  <th>Allowed</th>
+                  <th>Meaning</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>pending -> active</code></td>
+                  <td>Yes, by PM Company Admin acceptance</td>
+                  <td>Company consent is recorded before scoped authority can exist.</td>
+                </tr>
+                <tr>
+                  <td><code>active -> suspended</code></td>
+                  <td>Yes, by landlord owner</td>
+                  <td>Temporarily blocks access while preserving relationship history.</td>
+                </tr>
+                <tr>
+                  <td><code>suspended -> active</code></td>
+                  <td>Yes, by landlord owner reactivation</td>
+                  <td>Restores an existing accepted relationship when scope and ownership still validate.</td>
+                </tr>
+                <tr>
+                  <td><code>active -> terminated</code></td>
+                  <td>Yes, by landlord owner</td>
+                  <td>Ends the relationship, blocks access, and preserves audit/history.</td>
+                </tr>
+                <tr>
+                  <td><code>suspended -> terminated</code></td>
+                  <td>Yes, by landlord owner</td>
+                  <td>Ends a paused relationship without reactivating it first.</td>
+                </tr>
+                <tr>
+                  <td><code>pending -> terminated</code></td>
+                  <td>Yes, by landlord owner</td>
+                  <td>Stops a proposed relationship before company acceptance without deleting history.</td>
+                </tr>
+                <tr>
+                  <td><code>pending -> suspended</code></td>
+                  <td>No in V1</td>
+                  <td>Use termination semantics for a pending relationship that should not proceed.</td>
+                </tr>
+                <tr>
+                  <td>Other transitions</td>
+                  <td>No</td>
+                  <td>
+                    <code>terminated -> active</code>, <code>terminated -> suspended</code>, repeated same-status
+                    mutations, unknown statuses, and malformed records fail closed.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>Audit Contract</h2>
+            <p>Each lifecycle action creates a metadata-only event:</p>
+            <div class="pill-row">
+              <span class="pill">relationship_created</span>
+              <span class="pill">relationship_activated</span>
+              <span class="pill">relationship_suspended</span>
+              <span class="pill">relationship_reactivated</span>
+              <span class="pill">relationship_terminated</span>
+            </div>
+            <p style="margin-top: 12px">
+              Event metadata must preserve actor user, property manager company, landlord context, relationship,
+              status transition, property and workspace scope, target resource, outcome, timestamp, and reason where
+              applicable. Audit payloads must not contain secrets, raw provider payloads, or user-facing raw ID labels.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <div class="block">
+            <h2>Security Model</h2>
+            <ul class="compact">
+              <li>Landlord-side relationship management is landlord-owner only.</li>
+              <li>PM company activation requires an authorized PM Company Admin acceptance action.</li>
+              <li>Landlord scope resolves from authenticated server context, not query or body input.</li>
+              <li>Cross-landlord relationship reads or mutations are denied.</li>
+              <li>Property Manager Company existence and active company status are validated before creation.</li>
+              <li>Suspended or terminated companies cannot receive new active relationships.</li>
+              <li>Property and workspace scopes are validated before create or status mutation.</li>
+              <li>Relationship scope supports all current properties, selected properties, and workspace scope.</li>
+              <li>Relationship scope is a ceiling; future staff assignments cannot exceed it.</li>
+              <li>Invalid status transitions are rejected and audited as failures where appropriate.</li>
+              <li>Billing and settings authority remains landlord-owner only.</li>
+              <li>Malformed persisted records, unknown statuses, and unsupported scopes fail closed.</li>
+              <li>Responses use safe labels and projections; raw internal IDs are not user-facing labels.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Future Compatibility</h2>
+            <ul class="compact">
+              <li>One landlord can hold relationships with multiple PM companies.</li>
+              <li>One PM company can serve many landlords through separate landlord-approved relationships.</li>
+              <li>The relationship model must support future staff assignments without changing ownership semantics.</li>
+              <li>The future PM company console must consume accepted relationships, not self-created grants.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Implementation Boundaries</h2>
+            <div class="panel warning">
+              Backend/API only. No frontend routes, no landlord or company dashboard, no invite emails, no staff
+              assignment UI, no contractor organizations, no billing delegation, no custom permissions, and no migration
+              or backfill work.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Files To Inspect First</h2>
+            <ul class="compact">
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/*</code></li>
+              <li>Existing landlord owner route and service patterns under <code>rentchain-api/src</code></li>
+              <li>Existing audit append helpers and delegated-access lifecycle tests</li>
+              <li>Backend test setup for authenticated landlord owner and cross-landlord denial coverage</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Validation Plan</h2>
+            <ul class="compact">
+              <li>Focused backend route and service tests for all six lifecycle actions.</li>
+              <li>Owner/auth scope tests proving landlord scope cannot be overridden by request input.</li>
+              <li>Status transition tests for pending, active, suspended, reactivated, and terminated behavior.</li>
+              <li>Cross-landlord denial tests for list, mutation, and malformed relationship records.</li>
+              <li>Audit event shape tests for required metadata and safe failure outcomes.</li>
+              <li>Backend build and <code>git diff --check</code>.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Review Gate</h2>
+            <div class="panel success">
+              Stop after this Mission Brief is reviewed. Implementation should begin only after approval, then proceed
+              in a draft PR on <code>feat/property-manager-company-relationship-api-v1</code>.
+            </div>
+          </div>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -160,6 +160,7 @@ import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordDecisionQueueRoutes from "./routes/landlordDecisionQueueRoutes";
 import delegatedAccessInvitationRoutes, { delegatedAccessSelfRoutes } from "./routes/delegatedAccessInvitationRoutes";
+import propertyManagerCompanyRelationshipRoutes from "./routes/propertyManagerCompanyRelationshipRoutes";
 import landlordInstitutionalExportGenerationRoutes from "./routes/landlordInstitutionalExportGenerationRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
@@ -520,6 +521,8 @@ app.use("/api/delegated-access", routeSource("delegatedAccessInvitationRoutes.ts
 console.log("[route-mount] delegatedAccessSelfRoutes mounted at /api/delegated-access");
 app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), delegatedAccessInvitationRoutes);
 console.log("[route-mount] delegatedAccessInvitationRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("propertyManagerCompanyRelationshipRoutes.ts"), propertyManagerCompanyRelationshipRoutes);
+console.log("[route-mount] propertyManagerCompanyRelationshipRoutes mounted at /api/landlord");
 app.use("/api/landlord/institutional-exports", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordInstitutionalExportGenerationRoutes.ts"), landlordInstitutionalExportGenerationRoutes);
 console.log("[route-mount] landlordInstitutionalExportGenerationRoutes mounted at /api/landlord");

--- a/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyAudit.test.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyAudit.test.ts
@@ -29,6 +29,7 @@ describe("property manager company audit foundations", () => {
       eventType: "landlord_company_relationship_activated",
       actorUserId: "company-admin-1",
       actorCompanyId: "pm-company-1",
+      propertyManagerCompanyId: "pm-company-1",
       actingForLandlordId: "landlord-1",
       relationshipId: activeRelationship.relationshipId,
       role: "company_admin",
@@ -38,12 +39,14 @@ describe("property manager company audit foundations", () => {
       outcome: "allowed",
       timestamp: "2026-06-24T02:00:00.000Z",
       reason: "relationship accepted",
+      statusTransition: { from: "pending", to: "active" },
     });
 
     expect(event).toMatchObject({
       eventType: "landlord_company_relationship_activated",
       actorUserId: "company-admin-1",
       actorCompanyId: "pm-company-1",
+      propertyManagerCompanyId: "pm-company-1",
       actingForLandlordId: "landlord-1",
       relationshipId: activeRelationship.relationshipId,
       role: "company_admin",
@@ -51,6 +54,7 @@ describe("property manager company audit foundations", () => {
       targetResourceId: activeRelationship.relationshipId,
       outcome: "allowed",
       timestamp: "2026-06-24T02:00:00.000Z",
+      statusTransition: { from: "pending", to: "active" },
       metadataOnly: true,
       appendOnly: true,
       immutable: true,
@@ -64,6 +68,7 @@ describe("property manager company audit foundations", () => {
       eventType: "property_manager_company_membership_created",
       actorUserId: "company-admin-1",
       actorCompanyId: "pm-company-1",
+      propertyManagerCompanyId: "pm-company-1",
       role: "company_admin",
       targetResourceType: "company_membership",
       targetResourceId: "membership-1",
@@ -85,22 +90,26 @@ describe("property manager company audit foundations", () => {
       eventType: "landlord_company_relationship_terminated",
       actorUserId: "landlord-owner-1",
       actingForLandlordId: "landlord-1",
+      propertyManagerCompanyId: "pm-company-1",
       relationshipId: "relationship-1",
       targetResourceType: "landlord_company_relationship",
       targetResourceId: "relationship-1",
       outcome: "terminated",
       timestamp: "2026-06-26T00:00:00.000Z",
       reason: "Contract ended",
+      statusTransition: { from: "suspended", to: "terminated" },
     });
 
     expect(terminationEvent).toMatchObject({
       eventType: "landlord_company_relationship_terminated",
       actorUserId: "landlord-owner-1",
       actorCompanyId: null,
+      propertyManagerCompanyId: "pm-company-1",
       actingForLandlordId: "landlord-1",
       relationshipId: "relationship-1",
       outcome: "terminated",
       reason: "Contract ended",
+      statusTransition: { from: "suspended", to: "terminated" },
       metadataOnly: true,
     });
   });

--- a/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyModel.test.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyModel.test.ts
@@ -111,6 +111,36 @@ describe("property manager company model foundations", () => {
     expect(relationship.relationshipId).toMatch(/^landlord_pm_relationship_/);
   });
 
+  it("does not allow relationship creation to bypass company-admin acceptance", () => {
+    expect(() =>
+      createLandlordCompanyRelationship({
+        landlordId: "landlord-1",
+        propertyManagerCompanyId: "pm-company-1",
+        propertyScope: {
+          mode: "all_current_properties",
+          propertyIds: [],
+        },
+        workspaceScopes: ["dashboard"],
+        createdByLandlordOwnerUserId: "landlord-owner-1",
+        status: "active",
+      })
+    ).toThrow(new PropertyManagerCompanyValidationError("relationship_activation_requires_company_acceptance"));
+
+    expect(() =>
+      createLandlordCompanyRelationship({
+        landlordId: "landlord-1",
+        propertyManagerCompanyId: "pm-company-1",
+        propertyScope: {
+          mode: "all_current_properties",
+          propertyIds: [],
+        },
+        workspaceScopes: ["dashboard"],
+        createdByLandlordOwnerUserId: "landlord-owner-1",
+        acceptedByCompanyAdminUserId: "company-admin-1",
+      })
+    ).toThrow(new PropertyManagerCompanyValidationError("relationship_activation_requires_company_acceptance"));
+  });
+
   it("supports active, suspended, reactivated, and terminated relationship transitions", () => {
     const pending = createLandlordCompanyRelationship({
       landlordId: "landlord-1",

--- a/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyAudit.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyAudit.ts
@@ -15,6 +15,7 @@ type AuditInput = {
   eventType: string;
   actorUserId: string;
   actorCompanyId?: string | null;
+  propertyManagerCompanyId?: string | null;
   actingForLandlordId?: string | null;
   relationshipId?: string | null;
   role?: PropertyManagerCompanyRole | null;
@@ -24,6 +25,7 @@ type AuditInput = {
   outcome: PropertyManagerCompanyAuditOutcome;
   timestamp?: string;
   reason?: string | null;
+  statusTransition?: PropertyManagerCompanyAuditEvent["statusTransition"];
 };
 
 function cleanString(value: unknown, max = 500): string {
@@ -65,6 +67,7 @@ function stableEventId(input: Omit<AuditInput, "eventId"> & { timestamp: string 
         input.eventType,
         input.actorUserId,
         input.actorCompanyId,
+        input.propertyManagerCompanyId,
         input.actingForLandlordId,
         input.relationshipId,
         input.role,
@@ -87,6 +90,7 @@ export function buildPropertyManagerCompanyAuditEvent(input: AuditInput): Proper
     eventType: assertAuditEventType(input.eventType),
     actorUserId: requireString(input.actorUserId, "missing_actor_user_id"),
     actorCompanyId: input.actorCompanyId ? cleanString(input.actorCompanyId, 200) : null,
+    propertyManagerCompanyId: input.propertyManagerCompanyId ? cleanString(input.propertyManagerCompanyId, 200) : null,
     actingForLandlordId: input.actingForLandlordId ? cleanString(input.actingForLandlordId, 200) : null,
     relationshipId: input.relationshipId ? cleanString(input.relationshipId, 200) : null,
     role: input.role || null,
@@ -96,6 +100,7 @@ export function buildPropertyManagerCompanyAuditEvent(input: AuditInput): Proper
     outcome: input.outcome,
     timestamp,
     reason: input.reason ? cleanString(input.reason, 500) : null,
+    statusTransition: input.statusTransition || null,
     metadataOnly: true,
     appendOnly: true,
     immutable: true,

--- a/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyModel.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyModel.ts
@@ -236,8 +236,14 @@ export function createLandlordCompanyRelationship(input: RelationshipInput): Lan
   if (!isLandlordCompanyRelationshipStatus(status)) {
     throw new PropertyManagerCompanyValidationError("invalid_relationship_status");
   }
+  if (status !== "pending") {
+    throw new PropertyManagerCompanyValidationError("relationship_activation_requires_company_acceptance");
+  }
   const relationshipScope = buildRelationshipScope(input);
-  const startedAt = input.startedAt ? parseDate(input.startedAt, "invalid_started_at") : status === "active" ? createdAt : null;
+  if (input.acceptedByCompanyAdminUserId) {
+    throw new PropertyManagerCompanyValidationError("relationship_activation_requires_company_acceptance");
+  }
+  if (input.startedAt) throw new PropertyManagerCompanyValidationError("relationship_activation_requires_company_acceptance");
   return {
     relationshipId: input.relationshipId || hashId("landlord_pm_relationship", [landlordId, propertyManagerCompanyId, createdAt]),
     landlordId,
@@ -245,10 +251,10 @@ export function createLandlordCompanyRelationship(input: RelationshipInput): Lan
     status,
     relationshipScope,
     createdByLandlordOwnerUserId,
-    acceptedByCompanyAdminUserId: input.acceptedByCompanyAdminUserId ? cleanString(input.acceptedByCompanyAdminUserId, 200) : null,
+    acceptedByCompanyAdminUserId: null,
     createdAt,
     updatedAt: createdAt,
-    startedAt,
+    startedAt: null,
     suspendedAt: null,
     suspendedByUserId: null,
     reactivatedAt: null,

--- a/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyTypes.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyTypes.ts
@@ -193,6 +193,7 @@ export type PropertyManagerCompanyAuditEvent = {
   eventType: PropertyManagerCompanyAuditEventType;
   actorUserId: string;
   actorCompanyId: string | null;
+  propertyManagerCompanyId: string | null;
   actingForLandlordId: string | null;
   relationshipId: string | null;
   role: PropertyManagerCompanyRole | null;
@@ -202,6 +203,10 @@ export type PropertyManagerCompanyAuditEvent = {
   outcome: PropertyManagerCompanyAuditOutcome;
   timestamp: string;
   reason: string | null;
+  statusTransition: {
+    from: LandlordCompanyRelationshipStatus | null;
+    to: LandlordCompanyRelationshipStatus | null;
+  } | null;
   metadataOnly: true;
   appendOnly: true;
   immutable: true;

--- a/rentchain-api/src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts
@@ -1,0 +1,427 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = Record<string, any>;
+
+const collections = vi.hoisted(() => new Map<string, Map<string, StoredDoc>>());
+const generatedIds = vi.hoisted(() => ({ value: 0 }));
+const fakeDb = vi.hoisted(() => ({
+  collection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    const collection = collections.get(name)!;
+    return {
+      doc(id?: string) {
+        const docId = id || `test_doc_${++generatedIds.value}`;
+        return {
+          id: docId,
+          async get() {
+            return {
+              id: docId,
+              exists: collection.has(docId),
+              data: () => collection.get(docId),
+            };
+          },
+          async set(data: StoredDoc) {
+            collection.set(docId, data);
+          },
+          async create(data: StoredDoc) {
+            if (collection.has(docId)) throw new Error("already_exists");
+            collection.set(docId, data);
+          },
+        };
+      },
+      async get() {
+        return {
+          docs: Array.from(collection.entries()).map(([id, data]) => ({
+            id,
+            exists: true,
+            data: () => data,
+          })),
+        };
+      },
+    };
+  },
+}));
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+function readCollection(name: string): StoredDoc[] {
+  return Array.from((collections.get(name) || new Map()).values());
+}
+
+function writeCollectionDoc(name: string, id: string, data: StoredDoc) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  collections.get(name)!.set(id, data);
+}
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: Record<string, unknown> }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+const ownerUser = { id: "owner-user-1", role: "landlord", landlordId: "landlord-1", email: "owner@example.com" };
+const otherOwnerUser = { id: "owner-user-2", role: "landlord", landlordId: "landlord-2", email: "other@example.com" };
+const delegateUser = { id: "delegate-user-1", role: "delegate", landlordId: null, email: "delegate@example.com" };
+
+const validRelationshipBody = {
+  propertyManagerCompanyId: "pm-company-1",
+  propertyScope: { mode: "all_current_properties", propertyIds: [] },
+  workspaceScopes: ["dashboard", "operations", "properties"],
+};
+
+function seedCompany(overrides: Partial<StoredDoc> = {}) {
+  const company = {
+    companyId: overrides.companyId || "pm-company-1",
+    companyName: "Elite Property Management",
+    safeDisplayLabel: "Elite Property Management",
+    status: "active",
+    createdByUserId: "company-owner-1",
+    createdAt: "2026-06-24T00:00:00.000Z",
+    updatedAt: "2026-06-24T00:00:00.000Z",
+    ...overrides,
+  };
+  writeCollectionDoc("propertyManagerCompanies", company.companyId, company);
+  return company;
+}
+
+function seedRelationship(overrides: Partial<StoredDoc> = {}) {
+  const relationship = {
+    relationshipId: overrides.relationshipId || `landlord_pm_relationship_${readCollection("landlordCompanyRelationships").length + 1}`,
+    landlordId: "landlord-1",
+    propertyManagerCompanyId: "pm-company-1",
+    status: "active",
+    relationshipScope: {
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: ["dashboard", "operations", "properties"],
+    },
+    createdByLandlordOwnerUserId: "owner-user-1",
+    acceptedByCompanyAdminUserId: "company-admin-1",
+    createdAt: "2026-06-24T01:00:00.000Z",
+    updatedAt: "2026-06-24T02:00:00.000Z",
+    startedAt: "2026-06-24T02:00:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    reactivatedAt: null,
+    terminatedAt: null,
+    terminatedByUserId: null,
+    terminationReason: null,
+    auditEventIds: [],
+    ...overrides,
+  };
+  writeCollectionDoc("landlordCompanyRelationships", relationship.relationshipId, relationship);
+  return relationship;
+}
+
+describe("property manager company relationship routes", () => {
+  beforeEach(() => {
+    collections.clear();
+    generatedIds.value = 0;
+    seedCompany();
+  });
+
+  it("creates pending landlord-company relationships from landlord owner scope only", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships",
+      user: ownerUser,
+      body: {
+        ...validRelationshipBody,
+        landlordId: "landlord-2",
+        status: "pending",
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.relationship).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        propertyManagerCompanyId: "pm-company-1",
+        propertyManagerCompanyLabel: "Elite Property Management",
+        status: "pending",
+        createdByLandlordOwnerUserId: "owner-user-1",
+        acceptedByCompanyAdminUserId: null,
+        startedAt: null,
+      })
+    );
+    expect(response.body.relationship).not.toHaveProperty("auditEventIds");
+
+    const relationships = readCollection("landlordCompanyRelationships");
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toEqual(expect.objectContaining({ landlordId: "landlord-1", status: "pending" }));
+
+    const auditEvents = readCollection("propertyManagerCompanyAuditEvents");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toEqual(
+      expect.objectContaining({
+        eventType: "landlord_company_relationship_created",
+        actorUserId: "owner-user-1",
+        propertyManagerCompanyId: "pm-company-1",
+        actingForLandlordId: "landlord-1",
+        relationshipId: relationships[0].relationshipId,
+        outcome: "created",
+        statusTransition: { from: null, to: "pending" },
+        metadataOnly: true,
+      })
+    );
+  });
+
+  it("rejects landlord-only active creation and inactive PM companies", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+
+    const activeAttempt = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships",
+      user: ownerUser,
+      body: { ...validRelationshipBody, status: "active" },
+    });
+    expect(activeAttempt.status).toBe(409);
+    expect(activeAttempt.body.error).toBe("RELATIONSHIP_ACTIVATION_REQUIRES_COMPANY_ACCEPTANCE");
+
+    seedCompany({ companyId: "pm-company-suspended", status: "suspended" });
+    const inactiveCompany = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships",
+      user: ownerUser,
+      body: { ...validRelationshipBody, propertyManagerCompanyId: "pm-company-suspended" },
+    });
+    expect(inactiveCompany.status).toBe(409);
+    expect(inactiveCompany.body.error).toBe("PROPERTY_MANAGER_COMPANY_NOT_ACTIVE");
+
+    const missingCompany = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships",
+      user: ownerUser,
+      body: { ...validRelationshipBody, propertyManagerCompanyId: "missing-company" },
+    });
+    expect(missingCompany.status).toBe(404);
+    expect(missingCompany.body.error).toBe("PROPERTY_MANAGER_COMPANY_NOT_FOUND");
+  });
+
+  it("lists only the authenticated landlord owner relationships and safe labels", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedRelationship({ relationshipId: "relationship-landlord-1", landlordId: "landlord-1" });
+    seedRelationship({ relationshipId: "relationship-landlord-2", landlordId: "landlord-2" });
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-company-relationships?landlordId=landlord-2",
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.relationships).toHaveLength(1);
+    expect(response.body.relationships[0]).toEqual(
+      expect.objectContaining({
+        relationshipId: "relationship-landlord-1",
+        landlordId: "landlord-1",
+        propertyManagerCompanyLabel: "Elite Property Management",
+      })
+    );
+    expect(JSON.stringify(response.body.relationships[0])).not.toContain("auditEventIds");
+  });
+
+  it("requires landlord owner role for landlord-side relationship management", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+
+    const unauthenticated = await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-company-relationships",
+      user: null,
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const delegate = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships",
+      user: delegateUser,
+      body: validRelationshipBody,
+    });
+    expect(delegate.status).toBe(403);
+    expect(delegate.body.error).toBe("FORBIDDEN");
+  });
+
+  it("supports active to suspended to active to terminated lifecycle transitions with audit", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedRelationship({ relationshipId: "relationship-active", status: "active" });
+
+    const suspended = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-active/suspend",
+      user: ownerUser,
+      body: { reason: "Operational pause" },
+    });
+    expect(suspended.status).toBe(200);
+    expect(suspended.body.relationship).toEqual(
+      expect.objectContaining({
+        relationshipId: "relationship-active",
+        status: "suspended",
+        suspendedByUserId: "owner-user-1",
+      })
+    );
+
+    const reactivated = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-active/reactivate",
+      user: ownerUser,
+    });
+    expect(reactivated.status).toBe(200);
+    expect(reactivated.body.relationship.status).toBe("active");
+
+    const terminated = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-active/terminate",
+      user: ownerUser,
+      body: { reason: "Contract ended" },
+    });
+    expect(terminated.status).toBe(200);
+    expect(terminated.body.relationship).toEqual(
+      expect.objectContaining({
+        status: "terminated",
+        terminatedByUserId: "owner-user-1",
+        terminationReason: "Contract ended",
+      })
+    );
+
+    const auditEvents = readCollection("propertyManagerCompanyAuditEvents");
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "landlord_company_relationship_suspended",
+      "landlord_company_relationship_reactivated",
+      "landlord_company_relationship_terminated",
+    ]);
+    expect(auditEvents.map((event) => event.statusTransition)).toEqual([
+      { from: "active", to: "suspended" },
+      { from: "suspended", to: "active" },
+      { from: "active", to: "terminated" },
+    ]);
+  });
+
+  it("allows pending termination but fails closed on invalid transitions", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedRelationship({ relationshipId: "relationship-pending", status: "pending", startedAt: null });
+    seedRelationship({ relationshipId: "relationship-terminated", status: "terminated" });
+
+    const suspendPending = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-pending/suspend",
+      user: ownerUser,
+    });
+    expect(suspendPending.status).toBe(409);
+    expect(suspendPending.body.error).toBe("RELATIONSHIP_NOT_ACTIVE");
+
+    const terminatePending = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-pending/terminate",
+      user: ownerUser,
+    });
+    expect(terminatePending.status).toBe(200);
+    expect(terminatePending.body.relationship.status).toBe("terminated");
+
+    const reactivateTerminated = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-terminated/reactivate",
+      user: ownerUser,
+    });
+    expect(reactivateTerminated.status).toBe(409);
+    expect(reactivateTerminated.body.error).toBe("RELATIONSHIP_NOT_SUSPENDED");
+
+    const terminateTerminated = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-terminated/terminate",
+      user: ownerUser,
+    });
+    expect(terminateTerminated.status).toBe(409);
+    expect(terminateTerminated.body.error).toBe("INVALID_RELATIONSHIP_STATUS_TRANSITION");
+  });
+
+  it("denies cross-landlord mutations and rejects invalid scope", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedRelationship({ relationshipId: "relationship-landlord-1", landlordId: "landlord-1" });
+
+    const crossLandlord = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships/relationship-landlord-1/suspend",
+      user: otherOwnerUser,
+    });
+    expect(crossLandlord.status).toBe(404);
+    expect(crossLandlord.body.error).toBe("LANDLORD_COMPANY_RELATIONSHIP_NOT_FOUND");
+
+    const selectedWithoutProperties = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships",
+      user: ownerUser,
+      body: {
+        propertyManagerCompanyId: "pm-company-1",
+        propertyScope: { mode: "selected_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard"],
+      },
+    });
+    expect(selectedWithoutProperties.status).toBe(400);
+    expect(selectedWithoutProperties.body.error).toBe("MISSING_SELECTED_PROPERTY_SCOPE");
+
+    const billingScope = await invokeRouter(router, {
+      method: "POST",
+      url: "/property-manager-company-relationships",
+      user: ownerUser,
+      body: {
+        ...validRelationshipBody,
+        workspaceScopes: ["settings_billing"],
+      },
+    });
+    expect(billingScope.status).toBe(400);
+    expect(billingScope.body.error).toBe("COMPANY_BILLING_SCOPE_NOT_ALLOWED");
+  });
+});

--- a/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
+++ b/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
@@ -1,0 +1,145 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import {
+  createLandlordCompanyRelationshipRecord,
+  listLandlordCompanyRelationshipRecords,
+  reactivateLandlordCompanyRelationshipRecord,
+  suspendLandlordCompanyRelationshipRecord,
+  terminateLandlordCompanyRelationshipRecord,
+} from "../services/propertyManagerCompanyRelationshipService";
+
+const router = Router();
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function ownerContext(req: any): { actorUserId: string; landlordId: string } | null {
+  const role = asString(req.user?.role, 80).toLowerCase();
+  if (role !== "landlord") return null;
+  const actorUserId = asString(req.user?.id || req.user?.uid || req.user?.sub, 240);
+  const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+  if (!actorUserId || !landlordId) return null;
+  return { actorUserId, landlordId };
+}
+
+function forbidden(res: any) {
+  return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+}
+
+function handleError(res: any, error: unknown) {
+  const code = error instanceof Error ? error.message : "property_manager_company_relationship_failed";
+  if (code === "landlord_company_relationship_not_found" || code === "property_manager_company_not_found") {
+    return res.status(404).json({ ok: false, error: code.toUpperCase() });
+  }
+  if (
+    code === "relationship_not_active" ||
+    code === "relationship_not_suspended" ||
+    code === "relationship_already_terminated" ||
+    code === "invalid_relationship_status_transition" ||
+    code === "relationship_activation_requires_company_acceptance"
+  ) {
+    return res.status(409).json({ ok: false, error: code.toUpperCase() });
+  }
+  if (code === "property_manager_company_not_active") {
+    return res.status(409).json({ ok: false, error: "PROPERTY_MANAGER_COMPANY_NOT_ACTIVE" });
+  }
+  if (
+    code.startsWith("invalid_") ||
+    code.startsWith("missing_") ||
+    code.includes("_not_allowed") ||
+    code.includes("_mismatch")
+  ) {
+    return res.status(400).json({ ok: false, error: code.toUpperCase() });
+  }
+  console.error("[property-manager-company-relationships] request failed", code);
+  return res.status(500).json({ ok: false, error: "PROPERTY_MANAGER_COMPANY_RELATIONSHIP_FAILED" });
+}
+
+router.use(requireAuth);
+
+router.get("/property-manager-company-relationships", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listLandlordCompanyRelationshipRecords({
+      landlordId: context.landlordId,
+    });
+    return res.status(200).json({ ok: true, relationships: result.relationships });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/property-manager-company-relationships", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await createLandlordCompanyRelationshipRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      propertyManagerCompanyId: req.body?.propertyManagerCompanyId,
+      propertyScope: req.body?.propertyScope,
+      workspaceScopes: Array.isArray(req.body?.workspaceScopes) ? req.body.workspaceScopes : [],
+      requestedStatus: req.body?.status,
+    });
+    return res.status(201).json({ ok: true, relationship: result.relationship });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/property-manager-company-relationships/:relationshipId/suspend", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await suspendLandlordCompanyRelationshipRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      relationshipId: req.params.relationshipId,
+      reason: req.body?.reason,
+    });
+    return res.status(200).json({ ok: true, relationship: result.relationship });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/property-manager-company-relationships/:relationshipId/reactivate", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await reactivateLandlordCompanyRelationshipRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      relationshipId: req.params.relationshipId,
+      reason: req.body?.reason,
+    });
+    return res.status(200).json({ ok: true, relationship: result.relationship });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/property-manager-company-relationships/:relationshipId/terminate", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await terminateLandlordCompanyRelationshipRecord({
+      landlordId: context.landlordId,
+      actorUserId: context.actorUserId,
+      relationshipId: req.params.relationshipId,
+      reason: req.body?.reason,
+    });
+    return res.status(200).json({ ok: true, relationship: result.relationship });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/propertyManagerCompanyRelationshipService.ts
+++ b/rentchain-api/src/services/propertyManagerCompanyRelationshipService.ts
@@ -1,0 +1,378 @@
+import { db } from "../firebase";
+import {
+  buildPropertyManagerCompanyAuditEvent,
+  createLandlordCompanyRelationship,
+  reactivateLandlordCompanyRelationship,
+  suspendLandlordCompanyRelationship,
+  terminateLandlordCompanyRelationship,
+  type LandlordCompanyRelationship,
+  type LandlordCompanyRelationshipStatus,
+  type PropertyManagerCompany,
+  type PropertyManagerCompanyAuditEvent,
+  type PropertyManagerCompanyAuditOutcome,
+  type PropertyManagerCompanyPropertyScope,
+} from "../lib/propertyManagerCompany";
+
+export const PROPERTY_MANAGER_COMPANIES_COLLECTION = "propertyManagerCompanies";
+export const LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION = "landlordCompanyRelationships";
+export const PROPERTY_MANAGER_COMPANY_AUDIT_EVENTS_COLLECTION = "propertyManagerCompanyAuditEvents";
+
+type SnapshotLike = {
+  id?: string;
+  exists?: boolean;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type DocumentRefLike<T> = {
+  id?: string;
+  get?: () => Promise<SnapshotLike>;
+  set?: (data: T, options?: { merge?: boolean }) => Promise<unknown>;
+  create?: (data: T) => Promise<unknown>;
+};
+
+type CollectionLike<T> = {
+  doc: (id?: string) => DocumentRefLike<T>;
+  get?: () => Promise<{ docs: SnapshotLike[] }>;
+};
+
+export type PropertyManagerCompanyRelationshipFirestoreLike = {
+  collection: <T = Record<string, unknown>>(name: string) => CollectionLike<T>;
+};
+
+type CreateRelationshipInput = {
+  landlordId: string;
+  actorUserId: string;
+  propertyManagerCompanyId: string;
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: string[];
+  requestedStatus?: unknown;
+  now?: string;
+};
+
+type LifecycleInput = {
+  landlordId: string;
+  actorUserId: string;
+  relationshipId: string;
+  reason?: string | null;
+  now?: string;
+};
+
+type ServiceOptions = {
+  firestore?: PropertyManagerCompanyRelationshipFirestoreLike;
+};
+
+export type LandlordCompanyRelationshipProjection = Omit<LandlordCompanyRelationship, "auditEventIds"> & {
+  propertyManagerCompanyLabel: string;
+};
+
+function relationshipDb(
+  firestore?: PropertyManagerCompanyRelationshipFirestoreLike
+): PropertyManagerCompanyRelationshipFirestoreLike {
+  return firestore || (db as unknown as PropertyManagerCompanyRelationshipFirestoreLike);
+}
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new Error(code);
+  return text;
+}
+
+function relationshipFromSnapshot(snapshot: SnapshotLike): LandlordCompanyRelationship | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as LandlordCompanyRelationship;
+}
+
+function companyFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompany | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as PropertyManagerCompany;
+}
+
+function safeCompanyLabel(company: PropertyManagerCompany | null, propertyManagerCompanyId: string): string {
+  const label = cleanString(company?.safeDisplayLabel || company?.companyName, 160).replace(/\s+/g, " ");
+  if (!label || label === propertyManagerCompanyId) return "Property manager company";
+  return label;
+}
+
+async function loadCompany(
+  propertyManagerCompanyId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<PropertyManagerCompany | null> {
+  const ref = firestore
+    .collection<PropertyManagerCompany>(PROPERTY_MANAGER_COMPANIES_COLLECTION)
+    .doc(propertyManagerCompanyId);
+  const snapshot = await ref.get?.();
+  if (!snapshot?.exists) return null;
+  return companyFromSnapshot(snapshot);
+}
+
+async function requireActiveCompany(
+  propertyManagerCompanyId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<PropertyManagerCompany> {
+  const company = await loadCompany(propertyManagerCompanyId, firestore);
+  if (!company) throw new Error("property_manager_company_not_found");
+  if (company.status !== "active") throw new Error("property_manager_company_not_active");
+  return company;
+}
+
+async function projectRelationship(
+  relationship: LandlordCompanyRelationship,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<LandlordCompanyRelationshipProjection> {
+  const { auditEventIds: _auditEventIds, ...safe } = relationship;
+  const company = await loadCompany(relationship.propertyManagerCompanyId, firestore);
+  return {
+    ...safe,
+    propertyManagerCompanyLabel: safeCompanyLabel(company, relationship.propertyManagerCompanyId),
+  };
+}
+
+async function appendAuditEvent(
+  event: PropertyManagerCompanyAuditEvent,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+) {
+  const ref = firestore
+    .collection<PropertyManagerCompanyAuditEvent>(PROPERTY_MANAGER_COMPANY_AUDIT_EVENTS_COLLECTION)
+    .doc(event.eventId);
+  if (ref.create) {
+    await ref.create(event);
+    return;
+  }
+  if (!ref.set) throw new Error("property_manager_company_audit_append_unavailable");
+  await ref.set(event, { merge: false });
+}
+
+async function saveRelationship(
+  relationship: LandlordCompanyRelationship,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+) {
+  const ref = firestore
+    .collection<LandlordCompanyRelationship>(LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION)
+    .doc(relationship.relationshipId);
+  if (!ref.set) throw new Error("landlord_company_relationship_write_unavailable");
+  await ref.set(relationship, { merge: false });
+}
+
+async function loadRelationshipForLandlord(
+  landlordId: string,
+  relationshipId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<LandlordCompanyRelationship | null> {
+  const ref = firestore
+    .collection<LandlordCompanyRelationship>(LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION)
+    .doc(relationshipId);
+  const snapshot = await ref.get?.();
+  if (!snapshot?.exists) return null;
+  const relationship = relationshipFromSnapshot(snapshot);
+  if (!relationship || relationship.landlordId !== landlordId) return null;
+  return relationship;
+}
+
+function buildRelationshipAuditEvent(input: {
+  eventType:
+    | "landlord_company_relationship_created"
+    | "landlord_company_relationship_suspended"
+    | "landlord_company_relationship_reactivated"
+    | "landlord_company_relationship_terminated";
+  actorUserId: string;
+  propertyManagerCompanyId: string;
+  landlordId: string;
+  relationshipId: string;
+  relationshipScope: LandlordCompanyRelationship["relationshipScope"];
+  from: LandlordCompanyRelationshipStatus | null;
+  to: LandlordCompanyRelationshipStatus;
+  outcome: PropertyManagerCompanyAuditOutcome;
+  timestamp: string;
+  reason?: string | null;
+}): PropertyManagerCompanyAuditEvent {
+  return buildPropertyManagerCompanyAuditEvent({
+    eventType: input.eventType,
+    actorUserId: input.actorUserId,
+    actorCompanyId: null,
+    propertyManagerCompanyId: input.propertyManagerCompanyId,
+    actingForLandlordId: input.landlordId,
+    relationshipId: input.relationshipId,
+    role: null,
+    scope: input.relationshipScope,
+    targetResourceType: "landlord_company_relationship",
+    targetResourceId: input.relationshipId,
+    outcome: input.outcome,
+    timestamp: input.timestamp,
+    reason: input.reason || null,
+    statusTransition: {
+      from: input.from,
+      to: input.to,
+    },
+  });
+}
+
+export async function listLandlordCompanyRelationshipRecords(
+  input: { landlordId: string },
+  options: ServiceOptions = {}
+): Promise<{ relationships: LandlordCompanyRelationshipProjection[] }> {
+  const firestore = relationshipDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const snapshot = await firestore.collection<LandlordCompanyRelationship>(LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION).get?.();
+  const relationships = (snapshot?.docs || [])
+    .map(relationshipFromSnapshot)
+    .filter((relationship): relationship is LandlordCompanyRelationship => Boolean(relationship))
+    .filter((relationship) => relationship.landlordId === landlordId)
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
+  return {
+    relationships: await Promise.all(relationships.map((relationship) => projectRelationship(relationship, firestore))),
+  };
+}
+
+export async function createLandlordCompanyRelationshipRecord(
+  input: CreateRelationshipInput,
+  options: ServiceOptions = {}
+): Promise<{ relationship: LandlordCompanyRelationshipProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = relationshipDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const propertyManagerCompanyId = requireString(input.propertyManagerCompanyId, "missing_property_manager_company_id");
+  const requestedStatus = cleanString(input.requestedStatus, 80).toLowerCase();
+  if (requestedStatus && requestedStatus !== "pending") {
+    throw new Error("relationship_activation_requires_company_acceptance");
+  }
+  const company = await requireActiveCompany(propertyManagerCompanyId, firestore);
+  const now = input.now || new Date().toISOString();
+  const relationship = createLandlordCompanyRelationship({
+    landlordId,
+    propertyManagerCompanyId: company.companyId,
+    propertyScope: input.propertyScope,
+    workspaceScopes: input.workspaceScopes,
+    createdByLandlordOwnerUserId: actorUserId,
+    status: "pending",
+    createdAt: now,
+  });
+  const auditEvent = buildRelationshipAuditEvent({
+    eventType: "landlord_company_relationship_created",
+    actorUserId,
+    propertyManagerCompanyId: relationship.propertyManagerCompanyId,
+    landlordId,
+    relationshipId: relationship.relationshipId,
+    relationshipScope: relationship.relationshipScope,
+    from: null,
+    to: "pending",
+    outcome: "created",
+    timestamp: now,
+  });
+  const withAudit = { ...relationship, auditEventIds: [auditEvent.eventId] };
+  await saveRelationship(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return {
+    relationship: {
+      ...(await projectRelationship(withAudit, firestore)),
+      propertyManagerCompanyLabel: safeCompanyLabel(company, relationship.propertyManagerCompanyId),
+    },
+    auditEvent,
+  };
+}
+
+export async function suspendLandlordCompanyRelationshipRecord(
+  input: LifecycleInput,
+  options: ServiceOptions = {}
+): Promise<{ relationship: LandlordCompanyRelationshipProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = relationshipDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const relationshipId = requireString(input.relationshipId, "missing_relationship_id");
+  const relationship = await loadRelationshipForLandlord(landlordId, relationshipId, firestore);
+  if (!relationship) throw new Error("landlord_company_relationship_not_found");
+  const now = input.now || new Date().toISOString();
+  const suspended = suspendLandlordCompanyRelationship(relationship, { suspendedByUserId: actorUserId, suspendedAt: now });
+  const auditEvent = buildRelationshipAuditEvent({
+    eventType: "landlord_company_relationship_suspended",
+    actorUserId,
+    propertyManagerCompanyId: suspended.propertyManagerCompanyId,
+    landlordId,
+    relationshipId: suspended.relationshipId,
+    relationshipScope: suspended.relationshipScope,
+    from: relationship.status,
+    to: "suspended",
+    outcome: "suspended",
+    timestamp: now,
+    reason: input.reason || null,
+  });
+  const withAudit = { ...suspended, auditEventIds: [...suspended.auditEventIds, auditEvent.eventId] };
+  await saveRelationship(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { relationship: await projectRelationship(withAudit, firestore), auditEvent };
+}
+
+export async function reactivateLandlordCompanyRelationshipRecord(
+  input: LifecycleInput,
+  options: ServiceOptions = {}
+): Promise<{ relationship: LandlordCompanyRelationshipProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = relationshipDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const relationshipId = requireString(input.relationshipId, "missing_relationship_id");
+  const relationship = await loadRelationshipForLandlord(landlordId, relationshipId, firestore);
+  if (!relationship) throw new Error("landlord_company_relationship_not_found");
+  await requireActiveCompany(relationship.propertyManagerCompanyId, firestore);
+  const now = input.now || new Date().toISOString();
+  const reactivated = reactivateLandlordCompanyRelationship(relationship, { reactivatedAt: now });
+  const auditEvent = buildRelationshipAuditEvent({
+    eventType: "landlord_company_relationship_reactivated",
+    actorUserId,
+    propertyManagerCompanyId: reactivated.propertyManagerCompanyId,
+    landlordId,
+    relationshipId: reactivated.relationshipId,
+    relationshipScope: reactivated.relationshipScope,
+    from: relationship.status,
+    to: "active",
+    outcome: "allowed",
+    timestamp: now,
+    reason: input.reason || null,
+  });
+  const withAudit = { ...reactivated, auditEventIds: [...reactivated.auditEventIds, auditEvent.eventId] };
+  await saveRelationship(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { relationship: await projectRelationship(withAudit, firestore), auditEvent };
+}
+
+export async function terminateLandlordCompanyRelationshipRecord(
+  input: LifecycleInput,
+  options: ServiceOptions = {}
+): Promise<{ relationship: LandlordCompanyRelationshipProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = relationshipDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const relationshipId = requireString(input.relationshipId, "missing_relationship_id");
+  const relationship = await loadRelationshipForLandlord(landlordId, relationshipId, firestore);
+  if (!relationship) throw new Error("landlord_company_relationship_not_found");
+  if (!["pending", "active", "suspended"].includes(relationship.status)) {
+    throw new Error("invalid_relationship_status_transition");
+  }
+  const now = input.now || new Date().toISOString();
+  const terminated = terminateLandlordCompanyRelationship(relationship, {
+    terminatedByUserId: actorUserId,
+    terminatedAt: now,
+    reason: input.reason || null,
+  });
+  const auditEvent = buildRelationshipAuditEvent({
+    eventType: "landlord_company_relationship_terminated",
+    actorUserId,
+    propertyManagerCompanyId: terminated.propertyManagerCompanyId,
+    landlordId,
+    relationshipId: terminated.relationshipId,
+    relationshipScope: terminated.relationshipScope,
+    from: relationship.status,
+    to: "terminated",
+    outcome: "terminated",
+    timestamp: now,
+    reason: input.reason || null,
+  });
+  const withAudit = { ...terminated, auditEventIds: [...terminated.auditEventIds, auditEvent.eventId] };
+  await saveRelationship(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { relationship: await projectRelationship(withAudit, firestore), auditEvent };
+}


### PR DESCRIPTION
## Summary

- Adds the Property Manager Company relationship API Mission Brief artifact.
- Adds backend landlord-owner APIs to list, create, suspend, reactivate, and terminate landlord-company relationships.
- Keeps new relationships pending by default and blocks landlord-created active relationships so company-admin acceptance remains required.
- Adds metadata-only relationship audit events with property manager company attribution and status transition metadata.
- Adds focused backend route and model tests for owner scope, cross-landlord denial, lifecycle transitions, invalid transitions, company status validation, and scope validation.

## Key decisions

- No landlord-only activate endpoint was added. Activation is deferred until a company-admin acceptance API can enforce PM company authority.
- Relationship creation rejects active status and acceptance metadata so pending records cannot bypass mutual acceptance.
- Relationship management scope comes from authenticated landlord context, not query or request body landlord identifiers.
- Billing/settings workspace scope remains denied for PM company relationships.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20 && npm run test:single -- src/lib/propertyManagerCompany src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20 && npm run build`
- `git diff --check`
- Explicit whitespace checks for new files with `git diff --no-index --check`

## Non-goals

- No UI or frontend routes.
- No company dashboard.
- No invite emails.
- No staff assignment UI.
- No contractor organizations.
- No billing delegation.
- No custom permissions.
- No migration or backfill.
