### PR TITLE
feat: add property manager company acceptance api

### DIFF
--- a/docs/design/mission-briefs/property-manager-company-acceptance-api-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-acceptance-api-v1.html
@@ -1,0 +1,387 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Property Manager Company Acceptance API V1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #eef1f5;
+        color: #142033;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #eef1f5;
+      }
+
+      .brief {
+        max-width: 1280px;
+        margin: 0 auto;
+        background: #ffffff;
+        border: 1px solid #d7dde7;
+        box-shadow: 0 18px 50px rgba(20, 32, 51, 0.12);
+      }
+
+      header {
+        padding: 28px 32px;
+        border-bottom: 1px solid #d7dde7;
+        background: #142033;
+        color: #ffffff;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: 26px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      h1 span {
+        color: #8fd6ff;
+      }
+
+      .subtitle {
+        max-width: 900px;
+        color: #d6e7f4;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
+      }
+
+      section {
+        padding: 28px 32px;
+      }
+
+      .left {
+        border-right: 1px solid #d7dde7;
+      }
+
+      .block {
+        margin-bottom: 24px;
+      }
+
+      .block:last-child {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        margin-bottom: 10px;
+        color: #142033;
+        font-size: 15px;
+        line-height: 1.25;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        color: #2b3c55;
+        font-size: 14px;
+        line-height: 1.3;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 14px;
+        line-height: 1.48;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .card {
+        padding: 14px;
+        border: 1px solid #d7dde7;
+        background: #f8fafc;
+      }
+
+      .card strong {
+        display: block;
+        margin-bottom: 5px;
+        color: #142033;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        padding: 6px 9px;
+        border: 1px solid #c8d2df;
+        background: #f4f7fb;
+        color: #26374f;
+        font-size: 12px;
+        font-weight: 700;
+      }
+
+      .panel {
+        padding: 14px 16px;
+        border-left: 4px solid #246bfe;
+        background: #f4f8ff;
+      }
+
+      .warning {
+        border-left-color: #b7791f;
+        background: #fff8e8;
+      }
+
+      .success {
+        border-left-color: #16895a;
+        background: #f0fff7;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid #d7dde7;
+        background: #ffffff;
+      }
+
+      .table th,
+      .table td {
+        padding: 9px 10px;
+        border-bottom: 1px solid #e4e9f1;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .table th {
+        background: #f4f7fb;
+        color: #142033;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        color: #1b4f9c;
+      }
+
+      .compact li {
+        font-size: 13px;
+      }
+
+      @media (max-width: 920px) {
+        body {
+          padding: 16px;
+        }
+
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        .left {
+          border-right: 0;
+          border-bottom: 1px solid #d7dde7;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <h1>Next Mission: <span>feat/property-manager-company-acceptance-api-v1</span></h1>
+        <div class="subtitle">
+          Backend/API-only acceptance endpoint for pending landlord-to-property-manager-company relationships. This
+          completes the mutual-acceptance lifecycle by allowing an authorized PM Company Owner or Admin to move a
+          landlord-created pending relationship to active, without adding UI, email, dashboards, billing delegation, or
+          staff assignment workflows.
+        </div>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>Mission Goal</h2>
+            <p>
+              Implement the company-side acceptance API for pending landlord-company relationships. The API must require
+              an authenticated active Company Owner/Admin membership for the target PM company, validate that the
+              relationship belongs to that company and is still pending, transition it to active, and append a
+              metadata-only audit event.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Accepted Lifecycle</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Step</th>
+                  <th>Actor</th>
+                  <th>State</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Relationship creation</td>
+                  <td>Landlord Owner</td>
+                  <td><code>pending</code>; no company authority is granted.</td>
+                </tr>
+                <tr>
+                  <td>Relationship acceptance</td>
+                  <td>PM Company Owner/Admin</td>
+                  <td><code>pending -> active</code>; company consent is recorded.</td>
+                </tr>
+                <tr>
+                  <td>Future authority evaluation</td>
+                  <td>Company staff</td>
+                  <td>Active relationship can later support scoped authority through membership, role, and scope checks.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>Required API</h2>
+            <div class="panel">
+              Proposed route: <code>POST /api/property-manager-companies/:companyId/relationships/:relationshipId/accept</code>.
+              The route is company-scoped and must not rely on landlord identifiers supplied in the query or body.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Acceptance Contract</h2>
+            <ul>
+              <li>Authenticated user is required.</li>
+              <li>User must have active PM company membership for <code>:companyId</code>.</li>
+              <li>User role must be <code>company_owner</code> or <code>company_admin</code>.</li>
+              <li>Company acceptance is performed only on behalf of the user's own PM company.</li>
+              <li>Relationship must belong to the same PM company.</li>
+              <li>Relationship status must be <code>pending</code>.</li>
+              <li>Accepted relationship records preserve landlord ownership and approved scope.</li>
+              <li>Acceptance cannot transfer relationships, alter company ownership, or modify landlord-approved scope.</li>
+              <li>Pending relationship does not grant access before acceptance.</li>
+              <li>Active relationship does not grant billing/settings authority.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Own-Company Governance Rule</h2>
+            <div class="panel">
+              A PM Company Owner/Admin may accept only for their own company. They may not activate another company's
+              relationship, transfer the relationship, change company ownership, or negotiate property/workspace scope
+              during acceptance. Acceptance means <strong>agree to the landlord-approved relationship</strong>, not
+              alter the relationship.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Audit Contract</h2>
+            <p>Acceptance must append a metadata-only event:</p>
+            <div class="pill-row">
+              <span class="pill">landlord_company_relationship_activated</span>
+              <span class="pill">relationship_activated</span>
+              <span class="pill">pending -> active</span>
+            </div>
+            <p style="margin-top: 12px">
+              Metadata must include actor user, actor company, PM company, landlord context, relationship, status
+              transition, property and workspace scope, outcome, timestamp, and target resource. Audit payloads must not
+              contain secrets, provider payloads, or user-facing raw ID labels.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <div class="block">
+            <h2>Security Model</h2>
+            <ul class="compact">
+              <li>Landlord owners cannot activate relationships through this route.</li>
+              <li>Non-admin company staff cannot accept relationships.</li>
+              <li>Inactive, suspended, removed, malformed, or mismatched memberships fail closed.</li>
+              <li>Relationships for a different PM company fail closed.</li>
+              <li>Active, suspended, or terminated relationships cannot be accepted.</li>
+              <li>Malformed relationship status or scope fails closed.</li>
+              <li>No cross-landlord data is exposed beyond the accepted relationship projection.</li>
+              <li>Route company ID must match both active membership and relationship company ownership.</li>
+              <li>Landlord scope, property scope, and workspace scope cannot be overridden from body or query parameters.</li>
+              <li>Billing/settings remains landlord-owner only.</li>
+              <li>No contractor organization access or staff assignment authority is introduced.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Files To Inspect First</h2>
+            <ul class="compact">
+              <li><code>rentchain-api/src/services/propertyManagerCompanyRelationshipService.ts</code></li>
+              <li><code>rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyModel.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/permissionEvaluation.ts</code></li>
+              <li><code>rentchain-api/src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts</code></li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Non-Goals</h2>
+            <div class="panel warning">
+              No UI, company dashboard, invite emails, contractor organizations, billing delegation, custom permissions,
+              staff assignment UI, frontend routes, production data migration, or backfill work.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Validation Plan</h2>
+            <ul class="compact">
+              <li>Focused backend route and service tests for company-side acceptance.</li>
+              <li>Company Owner/Admin authority tests.</li>
+              <li>Non-admin member, removed member, suspended member, landlord owner, and unauthenticated denial tests.</li>
+              <li>Cross-company relationship denial tests.</li>
+              <li>Invalid transition tests for active, suspended, terminated, and malformed relationships.</li>
+              <li>Audit event shape tests for pending-to-active metadata.</li>
+              <li>Permission evaluator assertion that pending relationships do not grant access.</li>
+              <li>Backend build and <code>git diff --check</code>.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Review Gate</h2>
+            <div class="panel success">
+              Stop after this Mission Brief is reviewed. Implementation should begin only after approval, then proceed
+              in a draft PR on <code>feat/property-manager-company-acceptance-api-v1</code>.
+            </div>
+          </div>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -160,7 +160,9 @@ import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordDecisionQueueRoutes from "./routes/landlordDecisionQueueRoutes";
 import delegatedAccessInvitationRoutes, { delegatedAccessSelfRoutes } from "./routes/delegatedAccessInvitationRoutes";
-import propertyManagerCompanyRelationshipRoutes from "./routes/propertyManagerCompanyRelationshipRoutes";
+import propertyManagerCompanyRelationshipRoutes, {
+  propertyManagerCompanyRoutes,
+} from "./routes/propertyManagerCompanyRelationshipRoutes";
 import landlordInstitutionalExportGenerationRoutes from "./routes/landlordInstitutionalExportGenerationRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
@@ -523,6 +525,8 @@ app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), dele
 console.log("[route-mount] delegatedAccessInvitationRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("propertyManagerCompanyRelationshipRoutes.ts"), propertyManagerCompanyRelationshipRoutes);
 console.log("[route-mount] propertyManagerCompanyRelationshipRoutes mounted at /api/landlord");
+app.use("/api/property-manager-companies", routeSource("propertyManagerCompanyRelationshipRoutes.ts:company"), propertyManagerCompanyRoutes);
+console.log("[route-mount] propertyManagerCompanyRoutes mounted at /api/property-manager-companies");
 app.use("/api/landlord/institutional-exports", rateLimitEvidenceExportReview);
 app.use("/api/landlord", routeSource("landlordInstitutionalExportGenerationRoutes.ts"), landlordInstitutionalExportGenerationRoutes);
 console.log("[route-mount] landlordInstitutionalExportGenerationRoutes mounted at /api/landlord");

--- a/rentchain-api/src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts
@@ -114,6 +114,9 @@ async function invokeRouter(
 const ownerUser = { id: "owner-user-1", role: "landlord", landlordId: "landlord-1", email: "owner@example.com" };
 const otherOwnerUser = { id: "owner-user-2", role: "landlord", landlordId: "landlord-2", email: "other@example.com" };
 const delegateUser = { id: "delegate-user-1", role: "delegate", landlordId: null, email: "delegate@example.com" };
+const companyOwnerUser = { id: "company-owner-1", role: "property_manager_company", email: "owner@elite.example" };
+const companyAdminUser = { id: "company-admin-1", role: "property_manager_company", email: "admin@elite.example" };
+const companyStaffUser = { id: "company-staff-1", role: "property_manager_company", email: "staff@elite.example" };
 
 const validRelationshipBody = {
   propertyManagerCompanyId: "pm-company-1",
@@ -134,6 +137,27 @@ function seedCompany(overrides: Partial<StoredDoc> = {}) {
   };
   writeCollectionDoc("propertyManagerCompanies", company.companyId, company);
   return company;
+}
+
+function seedMembership(overrides: Partial<StoredDoc> = {}) {
+  const membership = {
+    membershipId: overrides.membershipId || `pm-membership-${readCollection("propertyManagerCompanyMemberships").length + 1}`,
+    companyId: "pm-company-1",
+    userId: "company-admin-1",
+    role: "company_admin",
+    status: "active",
+    invitedByUserId: "company-owner-1",
+    createdByUserId: "company-owner-1",
+    createdAt: "2026-06-24T00:30:00.000Z",
+    updatedAt: "2026-06-24T00:30:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    removedAt: null,
+    removedByUserId: null,
+    ...overrides,
+  };
+  writeCollectionDoc("propertyManagerCompanyMemberships", membership.membershipId, membership);
+  return membership;
 }
 
 function seedRelationship(overrides: Partial<StoredDoc> = {}) {
@@ -292,6 +316,240 @@ describe("property manager company relationship routes", () => {
     });
     expect(delegate.status).toBe(403);
     expect(delegate.body.error).toBe("FORBIDDEN");
+  });
+
+  it("allows active company owners and admins to accept pending relationships for their own company", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedMembership({ userId: "company-admin-1", role: "company_admin" });
+    const pending = seedRelationship({
+      relationshipId: "relationship-pending",
+      status: "pending",
+      acceptedByCompanyAdminUserId: null,
+      startedAt: null,
+      relationshipScope: {
+        propertyScope: { mode: "selected_properties", propertyIds: ["property-1", "property-2"] },
+        workspaceScopes: ["dashboard", "operations"],
+      },
+    });
+
+    const response = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/relationships/relationship-pending/accept",
+      user: companyAdminUser,
+      body: {
+        landlordId: "landlord-override",
+        relationshipScope: {
+          propertyScope: { mode: "all_current_properties", propertyIds: [] },
+          workspaceScopes: ["settings_billing"],
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.relationship).toEqual(
+      expect.objectContaining({
+        relationshipId: "relationship-pending",
+        landlordId: "landlord-1",
+        propertyManagerCompanyId: "pm-company-1",
+        propertyManagerCompanyLabel: "Elite Property Management",
+        status: "active",
+        acceptedByCompanyAdminUserId: "company-admin-1",
+      })
+    );
+    expect(response.body.relationship.relationshipScope).toEqual(pending.relationshipScope);
+    expect(response.body.relationship).not.toHaveProperty("auditEventIds");
+
+    const stored = readCollection("landlordCompanyRelationships").find(
+      (relationship) => relationship.relationshipId === "relationship-pending"
+    );
+    expect(stored).toEqual(
+      expect.objectContaining({
+        status: "active",
+        acceptedByCompanyAdminUserId: "company-admin-1",
+      })
+    );
+    expect(stored?.relationshipScope).toEqual(pending.relationshipScope);
+
+    const auditEvents = readCollection("propertyManagerCompanyAuditEvents");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toEqual(
+      expect.objectContaining({
+        eventType: "landlord_company_relationship_activated",
+        actorUserId: "company-admin-1",
+        actorCompanyId: "pm-company-1",
+        propertyManagerCompanyId: "pm-company-1",
+        actingForLandlordId: "landlord-1",
+        relationshipId: "relationship-pending",
+        role: "company_admin",
+        scope: pending.relationshipScope,
+        outcome: "allowed",
+        statusTransition: { from: "pending", to: "active" },
+        metadataOnly: true,
+      })
+    );
+
+    seedMembership({
+      membershipId: "pm-membership-owner",
+      userId: "company-owner-1",
+      role: "company_owner",
+    });
+    seedRelationship({
+      relationshipId: "relationship-owner-pending",
+      status: "pending",
+      acceptedByCompanyAdminUserId: null,
+      startedAt: null,
+    });
+    const ownerAccepted = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/relationships/relationship-owner-pending/accept",
+      user: companyOwnerUser,
+    });
+    expect(ownerAccepted.status).toBe(200);
+    expect(ownerAccepted.body.relationship.acceptedByCompanyAdminUserId).toBe("company-owner-1");
+  });
+
+  it("denies non-admin, inactive, removed, and malformed memberships during acceptance", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    const deniedRoles = ["property_manager", "leasing_agent", "maintenance_coordinator", "read_only_staff", "regional_manager", "unknown"];
+
+    for (const role of deniedRoles) {
+      collections.get("propertyManagerCompanyMemberships")?.clear();
+      collections.get("landlordCompanyRelationships")?.clear();
+      seedMembership({ role, userId: "company-staff-1" });
+      seedRelationship({
+        relationshipId: `relationship-${role}`,
+        status: "pending",
+        acceptedByCompanyAdminUserId: null,
+        startedAt: null,
+      });
+
+      const response = await invokeRouter(propertyManagerCompanyRoutes, {
+        method: "POST",
+        url: `/pm-company-1/relationships/relationship-${role}/accept`,
+        user: companyStaffUser,
+      });
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe("PROPERTY_MANAGER_COMPANY_ACCEPTANCE_ROLE_NOT_ALLOWED");
+    }
+
+    const deniedStatuses = ["suspended", "removed", "invited", "unknown"];
+    for (const status of deniedStatuses) {
+      collections.get("propertyManagerCompanyMemberships")?.clear();
+      collections.get("landlordCompanyRelationships")?.clear();
+      seedMembership({ status, userId: "company-admin-1", role: "company_admin" });
+      seedRelationship({
+        relationshipId: `relationship-membership-${status}`,
+        status: "pending",
+        acceptedByCompanyAdminUserId: null,
+        startedAt: null,
+      });
+
+      const response = await invokeRouter(propertyManagerCompanyRoutes, {
+        method: "POST",
+        url: `/pm-company-1/relationships/relationship-membership-${status}/accept`,
+        user: companyAdminUser,
+      });
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe("PROPERTY_MANAGER_COMPANY_MEMBERSHIP_NOT_ACTIVE");
+    }
+  });
+
+  it("prevents landlord-only, cross-company, and inactive-company acceptance", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedMembership({ userId: "company-admin-1", role: "company_admin" });
+    seedRelationship({
+      relationshipId: "relationship-pending",
+      status: "pending",
+      acceptedByCompanyAdminUserId: null,
+      startedAt: null,
+    });
+
+    const landlordAttempt = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/relationships/relationship-pending/accept",
+      user: ownerUser,
+    });
+    expect(landlordAttempt.status).toBe(403);
+    expect(landlordAttempt.body.error).toBe("PROPERTY_MANAGER_COMPANY_MEMBERSHIP_NOT_FOUND");
+
+    seedCompany({ companyId: "pm-company-2", companyName: "Second Company", safeDisplayLabel: "Second Company" });
+    seedRelationship({
+      relationshipId: "relationship-company-2",
+      propertyManagerCompanyId: "pm-company-2",
+      status: "pending",
+      acceptedByCompanyAdminUserId: null,
+      startedAt: null,
+    });
+    const crossCompany = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/relationships/relationship-company-2/accept",
+      user: companyAdminUser,
+    });
+    expect(crossCompany.status).toBe(404);
+    expect(crossCompany.body.error).toBe("LANDLORD_COMPANY_RELATIONSHIP_NOT_FOUND");
+
+    seedCompany({ companyId: "pm-company-suspended", status: "suspended" });
+    seedMembership({
+      membershipId: "suspended-company-membership",
+      companyId: "pm-company-suspended",
+      userId: "company-admin-1",
+      role: "company_admin",
+    });
+    seedRelationship({
+      relationshipId: "relationship-suspended-company",
+      propertyManagerCompanyId: "pm-company-suspended",
+      status: "pending",
+      acceptedByCompanyAdminUserId: null,
+      startedAt: null,
+    });
+    const inactiveCompany = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-suspended/relationships/relationship-suspended-company/accept",
+      user: companyAdminUser,
+    });
+    expect(inactiveCompany.status).toBe(409);
+    expect(inactiveCompany.body.error).toBe("PROPERTY_MANAGER_COMPANY_NOT_ACTIVE");
+  });
+
+  it("fails closed for non-pending or malformed relationships during acceptance", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedMembership({ userId: "company-admin-1", role: "company_admin" });
+    const deniedStatuses = ["active", "suspended", "terminated", "unknown"];
+
+    for (const status of deniedStatuses) {
+      seedRelationship({
+        relationshipId: `relationship-${status}`,
+        status,
+        acceptedByCompanyAdminUserId: status === "active" ? "company-admin-1" : null,
+        startedAt: status === "active" ? "2026-06-24T02:00:00.000Z" : null,
+      });
+
+      const response = await invokeRouter(propertyManagerCompanyRoutes, {
+        method: "POST",
+        url: `/pm-company-1/relationships/relationship-${status}/accept`,
+        user: companyAdminUser,
+      });
+      expect(response.status).toBe(409);
+      expect(response.body.error).toBe("RELATIONSHIP_NOT_PENDING");
+    }
+
+    seedRelationship({
+      relationshipId: "relationship-malformed-scope",
+      status: "pending",
+      acceptedByCompanyAdminUserId: null,
+      startedAt: null,
+      relationshipScope: {
+        propertyScope: { mode: "selected_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard"],
+      },
+    });
+    const malformedScope = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/relationships/relationship-malformed-scope/accept",
+      user: companyAdminUser,
+    });
+    expect(malformedScope.status).toBe(400);
+    expect(malformedScope.body.error).toBe("MISSING_SELECTED_PROPERTY_SCOPE");
   });
 
   it("supports active to suspended to active to terminated lifecycle transitions with audit", async () => {

--- a/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
+++ b/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { requireAuth } from "../middleware/requireAuth";
 import {
+  acceptLandlordCompanyRelationshipRecord,
   createLandlordCompanyRelationshipRecord,
   listLandlordCompanyRelationshipRecords,
   reactivateLandlordCompanyRelationshipRecord,
@@ -9,6 +10,7 @@ import {
 } from "../services/propertyManagerCompanyRelationshipService";
 
 const router = Router();
+const companyRouter = Router();
 
 function asString(value: unknown, max = 240): string {
   return String(value ?? "").trim().slice(0, max);
@@ -23,6 +25,12 @@ function ownerContext(req: any): { actorUserId: string; landlordId: string } | n
   return { actorUserId, landlordId };
 }
 
+function actorContext(req: any): { actorUserId: string } | null {
+  const actorUserId = asString(req.user?.id || req.user?.uid || req.user?.sub, 240);
+  if (!actorUserId) return null;
+  return { actorUserId };
+}
+
 function forbidden(res: any) {
   return res.status(403).json({ ok: false, error: "FORBIDDEN" });
 }
@@ -35,6 +43,7 @@ function handleError(res: any, error: unknown) {
   if (
     code === "relationship_not_active" ||
     code === "relationship_not_suspended" ||
+    code === "relationship_not_pending" ||
     code === "relationship_already_terminated" ||
     code === "invalid_relationship_status_transition" ||
     code === "relationship_activation_requires_company_acceptance"
@@ -43,6 +52,14 @@ function handleError(res: any, error: unknown) {
   }
   if (code === "property_manager_company_not_active") {
     return res.status(409).json({ ok: false, error: "PROPERTY_MANAGER_COMPANY_NOT_ACTIVE" });
+  }
+  if (
+    code === "property_manager_company_membership_not_found" ||
+    code === "property_manager_company_membership_not_active" ||
+    code === "property_manager_company_acceptance_role_not_allowed" ||
+    code === "property_manager_company_membership_mismatch"
+  ) {
+    return res.status(403).json({ ok: false, error: code.toUpperCase() });
   }
   if (
     code.startsWith("invalid_") ||
@@ -142,4 +159,23 @@ router.post("/property-manager-company-relationships/:relationshipId/terminate",
   }
 });
 
+companyRouter.use(requireAuth);
+
+companyRouter.post("/:companyId/relationships/:relationshipId/accept", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await acceptLandlordCompanyRelationshipRecord({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+      relationshipId: req.params.relationshipId,
+    });
+    return res.status(200).json({ ok: true, relationship: result.relationship });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+export const propertyManagerCompanyRoutes = companyRouter;
 export default router;

--- a/rentchain-api/src/services/propertyManagerCompanyRelationshipService.ts
+++ b/rentchain-api/src/services/propertyManagerCompanyRelationshipService.ts
@@ -1,6 +1,8 @@
 import { db } from "../firebase";
 import {
+  activateLandlordCompanyRelationship,
   buildPropertyManagerCompanyAuditEvent,
+  buildRelationshipScope,
   createLandlordCompanyRelationship,
   reactivateLandlordCompanyRelationship,
   suspendLandlordCompanyRelationship,
@@ -10,10 +12,12 @@ import {
   type PropertyManagerCompany,
   type PropertyManagerCompanyAuditEvent,
   type PropertyManagerCompanyAuditOutcome,
+  type PropertyManagerCompanyMembership,
   type PropertyManagerCompanyPropertyScope,
 } from "../lib/propertyManagerCompany";
 
 export const PROPERTY_MANAGER_COMPANIES_COLLECTION = "propertyManagerCompanies";
+export const PROPERTY_MANAGER_COMPANY_MEMBERSHIPS_COLLECTION = "propertyManagerCompanyMemberships";
 export const LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION = "landlordCompanyRelationships";
 export const PROPERTY_MANAGER_COMPANY_AUDIT_EVENTS_COLLECTION = "propertyManagerCompanyAuditEvents";
 
@@ -57,6 +61,13 @@ type LifecycleInput = {
   now?: string;
 };
 
+type AcceptRelationshipInput = {
+  actorUserId: string;
+  companyId: string;
+  relationshipId: string;
+  now?: string;
+};
+
 type ServiceOptions = {
   firestore?: PropertyManagerCompanyRelationshipFirestoreLike;
 };
@@ -93,6 +104,12 @@ function companyFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompany | n
   return data as PropertyManagerCompany;
 }
 
+function membershipFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompanyMembership | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as PropertyManagerCompanyMembership;
+}
+
 function safeCompanyLabel(company: PropertyManagerCompany | null, propertyManagerCompanyId: string): string {
   const label = cleanString(company?.safeDisplayLabel || company?.companyName, 160).replace(/\s+/g, " ");
   if (!label || label === propertyManagerCompanyId) return "Property manager company";
@@ -111,6 +128,18 @@ async function loadCompany(
   return companyFromSnapshot(snapshot);
 }
 
+async function loadRelationship(
+  relationshipId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<LandlordCompanyRelationship | null> {
+  const ref = firestore
+    .collection<LandlordCompanyRelationship>(LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION)
+    .doc(relationshipId);
+  const snapshot = await ref.get?.();
+  if (!snapshot?.exists) return null;
+  return relationshipFromSnapshot(snapshot);
+}
+
 async function requireActiveCompany(
   propertyManagerCompanyId: string,
   firestore: PropertyManagerCompanyRelationshipFirestoreLike
@@ -119,6 +148,35 @@ async function requireActiveCompany(
   if (!company) throw new Error("property_manager_company_not_found");
   if (company.status !== "active") throw new Error("property_manager_company_not_active");
   return company;
+}
+
+async function requireCompanyAcceptanceMembership(
+  companyId: string,
+  actorUserId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<PropertyManagerCompanyMembership> {
+  const snapshot = await firestore.collection<PropertyManagerCompanyMembership>(PROPERTY_MANAGER_COMPANY_MEMBERSHIPS_COLLECTION).get?.();
+  const membership = (snapshot?.docs || [])
+    .map(membershipFromSnapshot)
+    .find((candidate): candidate is PropertyManagerCompanyMembership => {
+      return Boolean(candidate && candidate.companyId === companyId && candidate.userId === actorUserId);
+    });
+  if (!membership) throw new Error("property_manager_company_membership_not_found");
+  if (membership.companyId !== companyId || membership.userId !== actorUserId) {
+    throw new Error("property_manager_company_membership_mismatch");
+  }
+  if (membership.status !== "active") throw new Error("property_manager_company_membership_not_active");
+  if (!["company_owner", "company_admin"].includes(membership.role)) {
+    throw new Error("property_manager_company_acceptance_role_not_allowed");
+  }
+  return membership;
+}
+
+function assertRelationshipScopeValid(relationship: LandlordCompanyRelationship) {
+  buildRelationshipScope({
+    propertyScope: relationship.relationshipScope?.propertyScope as PropertyManagerCompanyPropertyScope,
+    workspaceScopes: relationship.relationshipScope?.workspaceScopes || [],
+  });
 }
 
 async function projectRelationship(
@@ -177,6 +235,7 @@ async function loadRelationshipForLandlord(
 function buildRelationshipAuditEvent(input: {
   eventType:
     | "landlord_company_relationship_created"
+    | "landlord_company_relationship_activated"
     | "landlord_company_relationship_suspended"
     | "landlord_company_relationship_reactivated"
     | "landlord_company_relationship_terminated";
@@ -190,15 +249,17 @@ function buildRelationshipAuditEvent(input: {
   outcome: PropertyManagerCompanyAuditOutcome;
   timestamp: string;
   reason?: string | null;
+  actorCompanyId?: string | null;
+  role?: PropertyManagerCompanyMembership["role"] | null;
 }): PropertyManagerCompanyAuditEvent {
   return buildPropertyManagerCompanyAuditEvent({
     eventType: input.eventType,
     actorUserId: input.actorUserId,
-    actorCompanyId: null,
+    actorCompanyId: input.actorCompanyId || null,
     propertyManagerCompanyId: input.propertyManagerCompanyId,
     actingForLandlordId: input.landlordId,
     relationshipId: input.relationshipId,
-    role: null,
+    role: input.role || null,
     scope: input.relationshipScope,
     targetResourceType: "landlord_company_relationship",
     targetResourceId: input.relationshipId,
@@ -302,6 +363,49 @@ export async function suspendLandlordCompanyRelationshipRecord(
     reason: input.reason || null,
   });
   const withAudit = { ...suspended, auditEventIds: [...suspended.auditEventIds, auditEvent.eventId] };
+  await saveRelationship(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { relationship: await projectRelationship(withAudit, firestore), auditEvent };
+}
+
+export async function acceptLandlordCompanyRelationshipRecord(
+  input: AcceptRelationshipInput,
+  options: ServiceOptions = {}
+): Promise<{ relationship: LandlordCompanyRelationshipProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = relationshipDb(options.firestore);
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const relationshipId = requireString(input.relationshipId, "missing_relationship_id");
+  const now = input.now || new Date().toISOString();
+
+  await requireActiveCompany(companyId, firestore);
+  const membership = await requireCompanyAcceptanceMembership(companyId, actorUserId, firestore);
+  const relationship = await loadRelationship(relationshipId, firestore);
+  if (!relationship || relationship.propertyManagerCompanyId !== companyId) {
+    throw new Error("landlord_company_relationship_not_found");
+  }
+  if (relationship.status !== "pending") throw new Error("relationship_not_pending");
+  assertRelationshipScopeValid(relationship);
+
+  const activated = activateLandlordCompanyRelationship(relationship, {
+    acceptedByCompanyAdminUserId: actorUserId,
+    startedAt: now,
+  });
+  const auditEvent = buildRelationshipAuditEvent({
+    eventType: "landlord_company_relationship_activated",
+    actorUserId,
+    actorCompanyId: companyId,
+    propertyManagerCompanyId: activated.propertyManagerCompanyId,
+    landlordId: activated.landlordId,
+    relationshipId: activated.relationshipId,
+    relationshipScope: activated.relationshipScope,
+    from: "pending",
+    to: "active",
+    outcome: "allowed",
+    timestamp: now,
+    role: membership.role,
+  });
+  const withAudit = { ...activated, auditEventIds: [...activated.auditEventIds, auditEvent.eventId] };
   await saveRelationship(withAudit, firestore);
   await appendAuditEvent(auditEvent, firestore);
   return { relationship: await projectRelationship(withAudit, firestore), auditEvent };


### PR DESCRIPTION
## Summary
- add the mission brief for the property manager company acceptance API
- add a company-scoped relationship acceptance route for pending landlord-company relationships
- require active Company Owner/Admin membership for the target company before pending relationships can become active
- preserve landlord-approved property/workspace scope and append metadata-only activation audit events

## Scope
- backend/API only
- no UI, dashboard, email dispatch, contractor organization work, billing delegation, custom permissions, or frontend routes
- landlord-side relationship routes remain owner-only and cannot activate relationships unilaterally

## Validation
- npm run test:single -- src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts
- npm run build
- git diff --check
- git diff --cached --check