### PR TITLE
feat: add property manager company staff assignment foundations

### DIFF
--- a/docs/design/mission-briefs/property-manager-company-staff-assignment-foundations-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-staff-assignment-foundations-v1.html
@@ -1,0 +1,421 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Property Manager Company Staff Assignment Foundations V1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #eef1f5;
+        color: #142033;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #eef1f5;
+      }
+
+      .brief {
+        max-width: 1280px;
+        margin: 0 auto;
+        background: #ffffff;
+        border: 1px solid #d7dde7;
+        box-shadow: 0 18px 50px rgba(20, 32, 51, 0.12);
+      }
+
+      header {
+        padding: 28px 32px;
+        border-bottom: 1px solid #d7dde7;
+        background: #142033;
+        color: #ffffff;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: 26px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      h1 span {
+        color: #8fd6ff;
+      }
+
+      .subtitle {
+        max-width: 900px;
+        color: #d6e7f4;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
+      }
+
+      section {
+        padding: 28px 32px;
+      }
+
+      .left {
+        border-right: 1px solid #d7dde7;
+      }
+
+      .block {
+        margin-bottom: 24px;
+      }
+
+      .block:last-child {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        margin-bottom: 10px;
+        color: #142033;
+        font-size: 15px;
+        line-height: 1.25;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        color: #2b3c55;
+        font-size: 14px;
+        line-height: 1.3;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 14px;
+        line-height: 1.48;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .card {
+        padding: 14px;
+        border: 1px solid #d7dde7;
+        background: #f8fafc;
+      }
+
+      .card strong {
+        display: block;
+        margin-bottom: 5px;
+        color: #142033;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        padding: 6px 9px;
+        border: 1px solid #c8d2df;
+        background: #f4f7fb;
+        color: #26374f;
+        font-size: 12px;
+        font-weight: 700;
+      }
+
+      .panel {
+        padding: 14px 16px;
+        border-left: 4px solid #246bfe;
+        background: #f4f8ff;
+      }
+
+      .warning {
+        border-left-color: #b7791f;
+        background: #fff8e8;
+      }
+
+      .success {
+        border-left-color: #16895a;
+        background: #f0fff7;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid #d7dde7;
+        background: #ffffff;
+      }
+
+      .table th,
+      .table td {
+        padding: 9px 10px;
+        border-bottom: 1px solid #e4e9f1;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .table th {
+        background: #f4f7fb;
+        color: #142033;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        color: #1b4f9c;
+      }
+
+      .compact li {
+        font-size: 13px;
+      }
+
+      @media (max-width: 920px) {
+        body {
+          padding: 16px;
+        }
+
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        .left {
+          border-right: 0;
+          border-bottom: 1px solid #d7dde7;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <h1>Next Mission: <span>feat/property-manager-company-staff-assignment-foundations-v1</span></h1>
+        <div class="subtitle">
+          Backend foundations for assigning Property Manager Company staff to accepted landlord-company relationships.
+          This mission adds assignment records, lifecycle helpers, scope ceiling checks, audit foundations, and
+          permission-evaluation preparation without UI, dashboards, emails, billing delegation, or contractor work.
+        </div>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>Mission Goal</h2>
+            <p>
+              Add backend-only foundations for assigning active PM company staff to active landlord-company
+              relationships. Assignment authority must stay inside the PM company owner/admin hierarchy, staff access
+              must remain capped by the landlord-approved relationship scope, and assignment history must be preserved
+              through append-safe audit metadata.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Foundation Scope</h2>
+            <div class="grid">
+              <div class="card">
+                <strong>Membership distinction</strong>
+                Company membership means the user belongs to the PM company. Staff assignment means the user is
+                authorized to operate for one specific landlord-company relationship. Membership never implies
+                assignment.
+              </div>
+              <div class="card">
+                <strong>Assignment model</strong>
+                assignmentId, propertyManagerCompanyId, relationshipId, staffUserId, assignedByUserId,
+                staffRole/template, status, propertyScope, workspaceScope, timestamps, and lifecycle reasons.
+              </div>
+              <div class="card">
+                <strong>Lifecycle helpers</strong>
+                create, suspend, reactivate, and remove assignments. No hard delete. Suspended and removed assignments
+                block access while preserving history.
+              </div>
+              <div class="card">
+                <strong>Scope ceiling</strong>
+                assignment property/workspace scope cannot exceed the active landlord-company relationship scope.
+                Assignment only narrows authority already granted by the relationship. Billing/settings stays
+                landlord-owner only in V1.
+              </div>
+              <div class="card">
+                <strong>Permission prep</strong>
+                Prepare helper logic for future evaluation requiring actor, active membership, active relationship,
+                active assignment, role template, scope, and explicit-deny handling.
+              </div>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Authority Rule</h2>
+            <div class="panel">
+              A staff assignment may be created only after both active company membership and an active
+              landlord-company relationship exist. Assignment never creates authority by itself; it only narrows
+              landlord-approved operating authority already granted through the active relationship. A PM company member
+              may belong to the company and still have zero landlord assignments.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Assignment Lifecycle</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Action</th>
+                  <th>Required state</th>
+                  <th>Result</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Create</td>
+                  <td>Active Company Owner/Admin, active company membership, active relationship, valid staff role.</td>
+                  <td><code>active</code> assignment with scope at or below relationship ceiling.</td>
+                </tr>
+                <tr>
+                  <td>Suspend</td>
+                  <td>Active assignment managed by active Company Owner/Admin.</td>
+                  <td><code>suspended</code>; access blocked temporarily, history preserved.</td>
+                </tr>
+                <tr>
+                  <td>Reactivate</td>
+                  <td>Suspended assignment, active relationship, active staff membership, scope still valid.</td>
+                  <td><code>active</code>; access can be evaluated again.</td>
+                </tr>
+                <tr>
+                  <td>Remove</td>
+                  <td>Active or suspended assignment managed by active Company Owner/Admin.</td>
+                  <td><code>removed</code>; access blocked and history preserved. Recreate explicitly if needed.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>Role Templates</h2>
+            <p>Assignment roles are predefined operating templates only:</p>
+            <div class="pill-row">
+              <span class="pill">regional_manager</span>
+              <span class="pill">property_manager</span>
+              <span class="pill">leasing_agent</span>
+              <span class="pill">office_administrator</span>
+              <span class="pill">maintenance_coordinator</span>
+              <span class="pill">read_only_staff</span>
+            </div>
+            <p style="margin-top: 12px">
+              Company Owner/Admin are management roles and do not automatically grant landlord-workspace access unless a
+              separate scoped assignment is created. Custom permissions are out of scope.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Audit Contract</h2>
+            <p>Assignment lifecycle actions must build metadata-only events:</p>
+            <div class="pill-row">
+              <span class="pill">staff_assignment_created</span>
+              <span class="pill">staff_assignment_suspended</span>
+              <span class="pill">staff_assignment_reactivated</span>
+              <span class="pill">staff_assignment_removed</span>
+            </div>
+            <p style="margin-top: 12px">
+              Metadata should include actorUserId, actorCompanyId, propertyManagerCompanyId, actingForLandlordId,
+              relationshipId, assignmentId, staffUserId, role/template, scope, status transition, outcome, timestamp,
+              and reason where applicable. Do not include secrets, provider payloads, or user-facing raw ID labels.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <div class="block">
+            <h2>Security Model</h2>
+            <ul class="compact">
+              <li>Assignment creation/suspension/reactivation/removal requires active Company Owner/Admin membership.</li>
+              <li>Non-admin PM staff cannot assign or manage staff assignments.</li>
+              <li>Assignment target staff must have active company membership for the same PM company.</li>
+              <li>Relationship must exist, belong to the same PM company, and be <code>active</code>.</li>
+              <li>Pending, suspended, terminated, malformed, or cross-company relationships fail closed.</li>
+              <li>Assignment scope cannot exceed relationship property scope or workspace scope.</li>
+              <li>Selected-property ceilings must reject properties outside the relationship scope.</li>
+              <li>Workspace ceilings must reject scopes not granted by the relationship.</li>
+              <li><code>settings_billing</code> is always denied for assignments in V1.</li>
+              <li>Explicit deny wins in future access evaluation.</li>
+              <li>Suspended or removed assignments deny access.</li>
+              <li>No landlord-facing staff management or revocation UI is introduced in this mission.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Files To Inspect First</h2>
+            <ul class="compact">
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyTypes.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyModel.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/permissionEvaluation.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyAudit.ts</code></li>
+              <li><code>rentchain-api/src/services/propertyManagerCompanyRelationshipService.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/__tests__/</code></li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Non-Goals</h2>
+            <div class="panel warning">
+              No UI, company dashboard, frontend routes, emails, contractor organizations, billing delegation, custom
+              permissions, landlord-facing staff management UI, production data migration, or backfill work.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Validation Plan</h2>
+            <ul class="compact">
+              <li>Focused backend tests for assignment model validation and lifecycle transitions.</li>
+              <li>Company Owner/Admin authority tests, plus non-admin and inactive membership denial tests.</li>
+              <li>Relationship status tests for active allow and pending/suspended/terminated denial.</li>
+              <li>Scope ceiling tests for selected properties, all-current-properties, workspace scope, and billing denial.</li>
+              <li>Permission-evaluation tests for suspended/removed assignment denial and active assignment preparation.</li>
+              <li>Role validation tests for allowed assignment templates and custom/unknown role denial.</li>
+              <li>Audit event shape tests for created, suspended, reactivated, and removed events.</li>
+              <li>Malformed persisted data fail-closed tests.</li>
+              <li>Backend build and <code>git diff --check</code>.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Review Gate</h2>
+            <div class="panel success">
+              Stop after this Mission Brief is reviewed. Implementation should begin only after approval, then proceed
+              in a draft PR on <code>feat/property-manager-company-staff-assignment-foundations-v1</code>.
+            </div>
+          </div>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/rentchain-api/src/lib/propertyManagerCompany/__tests__/permissionEvaluation.test.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/__tests__/permissionEvaluation.test.ts
@@ -3,7 +3,9 @@ import {
   activateLandlordCompanyRelationship,
   createLandlordCompanyRelationship,
   createPropertyManagerCompanyMembership,
+  createPropertyManagerCompanyStaffAssignment,
   suspendLandlordCompanyRelationship,
+  suspendPropertyManagerCompanyStaffAssignment,
   terminateLandlordCompanyRelationship,
 } from "../propertyManagerCompanyModel";
 import { evaluatePropertyManagerCompanyAccess } from "../permissionEvaluation";
@@ -39,6 +41,31 @@ function activeRelationship() {
   });
 }
 
+function adminMembership() {
+  return createPropertyManagerCompanyMembership({
+    companyId: "pm-company-1",
+    userId: "company-admin-1",
+    role: "company_admin",
+    createdByUserId: "company-owner-1",
+    createdAt: "2026-06-24T00:00:00.000Z",
+  });
+}
+
+function activeAssignment(role: Parameters<typeof createPropertyManagerCompanyStaffAssignment>[0]["staffRole"] = "property_manager") {
+  return createPropertyManagerCompanyStaffAssignment({
+    relationship: activeRelationship(),
+    assignedByMembership: adminMembership(),
+    staffMembership: activeMembership("property_manager"),
+    staffRole: role,
+    propertyScope: {
+      mode: "selected_properties",
+      propertyIds: ["property-1"],
+    },
+    workspaceScopes: ["dashboard", "operations", "properties"],
+    createdAt: "2026-06-24T04:00:00.000Z",
+  });
+}
+
 const baseRequest = {
   actorUserId: "staff-user-1",
   actingForLandlordId: "landlord-1",
@@ -55,6 +82,7 @@ describe("property manager company permission evaluation", () => {
       ...baseRequest,
       membership: activeMembership(),
       relationship: activeRelationship(),
+      assignment: activeAssignment(),
     });
 
     expect(decision).toMatchObject({
@@ -68,12 +96,27 @@ describe("property manager company permission evaluation", () => {
     });
   });
 
+  it("does not imply landlord access from company membership without staff assignment", () => {
+    const decision = evaluatePropertyManagerCompanyAccess({
+      ...baseRequest,
+      membership: activeMembership(),
+      relationship: activeRelationship(),
+      assignment: null,
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "missing_staff_assignment",
+    });
+  });
+
   it("fails closed when membership is missing, inactive, or mismatched to actor", () => {
     expect(
       evaluatePropertyManagerCompanyAccess({
         ...baseRequest,
         membership: null,
         relationship: activeRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -89,6 +132,7 @@ describe("property manager company permission evaluation", () => {
         ...baseRequest,
         membership: suspendedMembership,
         relationship: activeRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -103,6 +147,7 @@ describe("property manager company permission evaluation", () => {
           userId: "other-user",
         },
         relationship: activeRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -116,6 +161,7 @@ describe("property manager company permission evaluation", () => {
         ...baseRequest,
         membership: activeMembership(),
         relationship: pendingRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -131,6 +177,7 @@ describe("property manager company permission evaluation", () => {
         ...baseRequest,
         membership: activeMembership(),
         relationship: suspended,
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -146,6 +193,7 @@ describe("property manager company permission evaluation", () => {
         ...baseRequest,
         membership: activeMembership(),
         relationship: terminated,
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -161,6 +209,7 @@ describe("property manager company permission evaluation", () => {
         targetResourceType: "landlord_workspace",
         membership: activeMembership(),
         relationship: activeRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -174,6 +223,7 @@ describe("property manager company permission evaluation", () => {
         targetResourceId: "property-2",
         membership: activeMembership(),
         relationship: activeRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -190,6 +240,7 @@ describe("property manager company permission evaluation", () => {
         targetResourceType: "billing_settings",
         membership: activeMembership("company_owner"),
         relationship: activeRelationship(),
+        assignment: activeAssignment("regional_manager"),
       })
     ).toMatchObject({
       allowed: false,
@@ -204,6 +255,7 @@ describe("property manager company permission evaluation", () => {
         action: "edit",
         membership: activeMembership("read_only_staff"),
         relationship: activeRelationship(),
+        assignment: activeAssignment("read_only_staff"),
       })
     ).toMatchObject({
       allowed: false,
@@ -216,6 +268,7 @@ describe("property manager company permission evaluation", () => {
         action: "edit",
         membership: activeMembership("property_manager"),
         relationship: activeRelationship(),
+        assignment: activeAssignment("property_manager"),
       })
     ).toMatchObject({
       allowed: true,
@@ -232,6 +285,7 @@ describe("property manager company permission evaluation", () => {
           role: "custom_role" as any,
         },
         relationship: activeRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -246,6 +300,7 @@ describe("property manager company permission evaluation", () => {
           status: "paused" as any,
         },
         relationship: activeRelationship(),
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -260,6 +315,7 @@ describe("property manager company permission evaluation", () => {
           ...activeRelationship(),
           status: "paused" as any,
         },
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
@@ -280,10 +336,132 @@ describe("property manager company permission evaluation", () => {
             workspaceScopes: ["properties"],
           },
         },
+        assignment: activeAssignment(),
       })
     ).toMatchObject({
       allowed: false,
       reason: "invalid_scope",
+    });
+  });
+
+  it("fails closed for suspended, removed, mismatched, or malformed assignments", () => {
+    const active = activeAssignment();
+    expect(
+      evaluatePropertyManagerCompanyAccess({
+        ...baseRequest,
+        membership: activeMembership(),
+        relationship: activeRelationship(),
+        assignment: suspendPropertyManagerCompanyStaffAssignment(active, {
+          actorMembership: adminMembership(),
+          suspendedAt: "2026-06-25T00:00:00.000Z",
+        }),
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "assignment_not_active",
+    });
+
+    expect(
+      evaluatePropertyManagerCompanyAccess({
+        ...baseRequest,
+        membership: activeMembership(),
+        relationship: activeRelationship(),
+        assignment: {
+          ...active,
+          status: "removed",
+        },
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "assignment_not_active",
+    });
+
+    expect(
+      evaluatePropertyManagerCompanyAccess({
+        ...baseRequest,
+        membership: activeMembership(),
+        relationship: activeRelationship(),
+        assignment: {
+          ...active,
+          staffUserId: "other-user",
+        },
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "assignment_actor_mismatch",
+    });
+
+    expect(
+      evaluatePropertyManagerCompanyAccess({
+        ...baseRequest,
+        membership: activeMembership(),
+        relationship: activeRelationship(),
+        assignment: {
+          ...active,
+          relationshipId: "other-relationship",
+        },
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "assignment_relationship_mismatch",
+    });
+
+    expect(
+      evaluatePropertyManagerCompanyAccess({
+        ...baseRequest,
+        membership: activeMembership(),
+        relationship: activeRelationship(),
+        assignment: {
+          ...active,
+          staffRole: "custom_role" as any,
+        },
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "invalid_assignment_role",
+    });
+  });
+
+  it("enforces assignment scope as a ceiling below the landlord relationship", () => {
+    const dashboardOnly = createPropertyManagerCompanyStaffAssignment({
+      relationship: activeRelationship(),
+      assignedByMembership: adminMembership(),
+      staffMembership: activeMembership("property_manager"),
+      staffRole: "property_manager",
+      propertyScope: {
+        mode: "selected_properties",
+        propertyIds: ["property-1"],
+      },
+      workspaceScopes: ["dashboard"],
+    });
+
+    expect(
+      evaluatePropertyManagerCompanyAccess({
+        ...baseRequest,
+        routeWorkspace: "operations",
+        targetResourceType: "landlord_workspace",
+        membership: activeMembership(),
+        relationship: activeRelationship(),
+        assignment: dashboardOnly,
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "workspace_scope_denied",
+    });
+
+    expect(
+      evaluatePropertyManagerCompanyAccess({
+        ...baseRequest,
+        membership: activeMembership(),
+        relationship: activeRelationship(),
+        assignment: {
+          ...activeAssignment(),
+          propertyScope: { mode: "selected_properties", propertyIds: ["property-1", "property-2"] },
+        },
+      })
+    ).toMatchObject({
+      allowed: false,
+      reason: "assignment_scope_exceeds_relationship",
     });
   });
 });

--- a/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyAudit.test.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyAudit.test.ts
@@ -114,6 +114,46 @@ describe("property manager company audit foundations", () => {
     });
   });
 
+  it("builds metadata-only staff assignment audit events", () => {
+    const activeRelationship = relationship();
+    const event = buildPropertyManagerCompanyAuditEvent({
+      eventType: "staff_assignment_created",
+      actorUserId: "company-admin-1",
+      actorCompanyId: "pm-company-1",
+      propertyManagerCompanyId: "pm-company-1",
+      actingForLandlordId: "landlord-1",
+      relationshipId: activeRelationship.relationshipId,
+      assignmentId: "assignment-1",
+      staffUserId: "staff-user-1",
+      role: "property_manager",
+      scope: activeRelationship.relationshipScope,
+      targetResourceType: "staff_assignment",
+      targetResourceId: "assignment-1",
+      outcome: "created",
+      timestamp: "2026-06-24T04:00:00.000Z",
+      statusTransition: { from: null, to: "active" },
+    });
+
+    expect(event).toMatchObject({
+      eventType: "staff_assignment_created",
+      actorUserId: "company-admin-1",
+      actorCompanyId: "pm-company-1",
+      propertyManagerCompanyId: "pm-company-1",
+      actingForLandlordId: "landlord-1",
+      relationshipId: activeRelationship.relationshipId,
+      assignmentId: "assignment-1",
+      staffUserId: "staff-user-1",
+      role: "property_manager",
+      targetResourceType: "staff_assignment",
+      targetResourceId: "assignment-1",
+      outcome: "created",
+      statusTransition: { from: null, to: "active" },
+      metadataOnly: true,
+      appendOnly: true,
+      immutable: true,
+    });
+  });
+
   it("rejects unknown audit event types", () => {
     expect(() =>
       buildPropertyManagerCompanyAuditEvent({

--- a/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyModel.test.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/__tests__/propertyManagerCompanyModel.test.ts
@@ -5,9 +5,13 @@ import {
   createLandlordCompanyRelationship,
   createPropertyManagerCompany,
   createPropertyManagerCompanyMembership,
+  createPropertyManagerCompanyStaffAssignment,
   removePropertyManagerCompanyMembership,
+  removePropertyManagerCompanyStaffAssignment,
+  reactivatePropertyManagerCompanyStaffAssignment,
   suspendLandlordCompanyRelationship,
   suspendPropertyManagerCompanyMembership,
+  suspendPropertyManagerCompanyStaffAssignment,
   terminateLandlordCompanyRelationship,
 } from "../propertyManagerCompanyModel";
 
@@ -214,5 +218,214 @@ describe("property manager company model foundations", () => {
         createdByLandlordOwnerUserId: "landlord-owner-1",
       })
     ).toThrow(new PropertyManagerCompanyValidationError("company_billing_scope_not_allowed"));
+  });
+
+  it("creates staff assignments only under active membership and active relationship scope ceilings", () => {
+    const pending = createLandlordCompanyRelationship({
+      landlordId: "landlord-1",
+      propertyManagerCompanyId: "pm-company-1",
+      propertyScope: {
+        mode: "selected_properties",
+        propertyIds: ["property-a", "property-b"],
+      },
+      workspaceScopes: ["dashboard", "operations"],
+      createdByLandlordOwnerUserId: "landlord-owner-1",
+      createdAt: "2026-06-24T02:00:00.000Z",
+    });
+    const relationship = activateLandlordCompanyRelationship(pending, {
+      acceptedByCompanyAdminUserId: "company-admin-1",
+      startedAt: "2026-06-24T03:00:00.000Z",
+    });
+    const adminMembership = createPropertyManagerCompanyMembership({
+      companyId: "pm-company-1",
+      userId: "company-admin-1",
+      role: "company_admin",
+      createdByUserId: "company-owner-1",
+    });
+    const staffMembership = createPropertyManagerCompanyMembership({
+      companyId: "pm-company-1",
+      userId: "staff-user-1",
+      role: "property_manager",
+      createdByUserId: "company-admin-1",
+    });
+
+    const assignment = createPropertyManagerCompanyStaffAssignment({
+      relationship,
+      assignedByMembership: adminMembership,
+      staffMembership,
+      staffRole: "property_manager",
+      propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+      workspaceScopes: ["dashboard"],
+      createdAt: "2026-06-24T04:00:00.000Z",
+    });
+
+    expect(assignment).toMatchObject({
+      propertyManagerCompanyId: "pm-company-1",
+      relationshipId: relationship.relationshipId,
+      staffUserId: "staff-user-1",
+      assignedByUserId: "company-admin-1",
+      staffRole: "property_manager",
+      status: "active",
+      propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+      workspaceScopes: ["dashboard"],
+      createdAt: "2026-06-24T04:00:00.000Z",
+      suspendedAt: null,
+      removedAt: null,
+    });
+    expect(assignment.assignmentId).toMatch(/^pm_staff_assignment_/);
+
+    expect(() =>
+      createPropertyManagerCompanyStaffAssignment({
+        relationship,
+        assignedByMembership: adminMembership,
+        staffMembership,
+        staffRole: "property_manager",
+        propertyScope: { mode: "selected_properties", propertyIds: ["property-a", "property-b", "property-c"] },
+        workspaceScopes: ["dashboard"],
+      })
+    ).toThrow(new PropertyManagerCompanyValidationError("assignment_scope_exceeds_relationship_scope"));
+
+    expect(() =>
+      createPropertyManagerCompanyStaffAssignment({
+        relationship,
+        assignedByMembership: adminMembership,
+        staffMembership,
+        staffRole: "property_manager",
+        propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+        workspaceScopes: ["dashboard", "operations", "settings_billing"],
+      })
+    ).toThrow(new PropertyManagerCompanyValidationError("company_billing_scope_not_allowed"));
+
+    expect(() =>
+      createPropertyManagerCompanyStaffAssignment({
+        relationship: pending,
+        assignedByMembership: adminMembership,
+        staffMembership,
+        staffRole: "property_manager",
+        propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+        workspaceScopes: ["dashboard"],
+      })
+    ).toThrow(new PropertyManagerCompanyValidationError("relationship_not_active"));
+  });
+
+  it("requires Company Owner/Admin authority and predefined assignment roles", () => {
+    const relationship = activateLandlordCompanyRelationship(
+      createLandlordCompanyRelationship({
+        landlordId: "landlord-1",
+        propertyManagerCompanyId: "pm-company-1",
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard", "operations"],
+        createdByLandlordOwnerUserId: "landlord-owner-1",
+      }),
+      { acceptedByCompanyAdminUserId: "company-admin-1" }
+    );
+    const propertyManagerMembership = createPropertyManagerCompanyMembership({
+      companyId: "pm-company-1",
+      userId: "property-manager-1",
+      role: "property_manager",
+      createdByUserId: "company-admin-1",
+    });
+    const staffMembership = createPropertyManagerCompanyMembership({
+      companyId: "pm-company-1",
+      userId: "staff-user-1",
+      role: "leasing_agent",
+      createdByUserId: "company-admin-1",
+    });
+
+    expect(() =>
+      createPropertyManagerCompanyStaffAssignment({
+        relationship,
+        assignedByMembership: propertyManagerMembership,
+        staffMembership,
+        staffRole: "leasing_agent",
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard"],
+      })
+    ).toThrow(new PropertyManagerCompanyValidationError("company_assignment_manager_required"));
+
+    const adminMembership = createPropertyManagerCompanyMembership({
+      companyId: "pm-company-1",
+      userId: "company-admin-1",
+      role: "company_admin",
+      createdByUserId: "company-owner-1",
+    });
+    expect(() =>
+      createPropertyManagerCompanyStaffAssignment({
+        relationship,
+        assignedByMembership: adminMembership,
+        staffMembership,
+        staffRole: "company_admin",
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard"],
+      })
+    ).toThrow(new PropertyManagerCompanyValidationError("invalid_staff_assignment_role"));
+  });
+
+  it("supports staff assignment suspend, reactivate, and remove without hard delete", () => {
+    const relationship = activateLandlordCompanyRelationship(
+      createLandlordCompanyRelationship({
+        landlordId: "landlord-1",
+        propertyManagerCompanyId: "pm-company-1",
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard", "operations"],
+        createdByLandlordOwnerUserId: "landlord-owner-1",
+      }),
+      { acceptedByCompanyAdminUserId: "company-admin-1" }
+    );
+    const adminMembership = createPropertyManagerCompanyMembership({
+      companyId: "pm-company-1",
+      userId: "company-admin-1",
+      role: "company_admin",
+      createdByUserId: "company-owner-1",
+    });
+    const staffMembership = createPropertyManagerCompanyMembership({
+      companyId: "pm-company-1",
+      userId: "staff-user-1",
+      role: "maintenance_coordinator",
+      createdByUserId: "company-admin-1",
+    });
+    const assignment = createPropertyManagerCompanyStaffAssignment({
+      relationship,
+      assignedByMembership: adminMembership,
+      staffMembership,
+      staffRole: "maintenance_coordinator",
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: ["operations"],
+    });
+
+    const suspended = suspendPropertyManagerCompanyStaffAssignment(assignment, {
+      actorMembership: adminMembership,
+      suspendedAt: "2026-06-25T00:00:00.000Z",
+      reason: "Coverage pause",
+    });
+    expect(suspended).toMatchObject({
+      status: "suspended",
+      suspendedByUserId: "company-admin-1",
+      suspendedReason: "Coverage pause",
+    });
+
+    const reactivated = reactivatePropertyManagerCompanyStaffAssignment(suspended, {
+      actorMembership: adminMembership,
+      staffMembership,
+      relationship,
+      reactivatedAt: "2026-06-26T00:00:00.000Z",
+    });
+    expect(reactivated).toMatchObject({
+      status: "active",
+      reactivatedByUserId: "company-admin-1",
+      reactivatedAt: "2026-06-26T00:00:00.000Z",
+    });
+
+    const removed = removePropertyManagerCompanyStaffAssignment(reactivated, {
+      actorMembership: adminMembership,
+      removedAt: "2026-06-27T00:00:00.000Z",
+      reason: "Staff changed",
+    });
+    expect(removed).toMatchObject({
+      status: "removed",
+      removedByUserId: "company-admin-1",
+      removedReason: "Staff changed",
+    });
+    expect(removed.assignmentId).toBe(assignment.assignmentId);
   });
 });

--- a/rentchain-api/src/lib/propertyManagerCompany/permissionEvaluation.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/permissionEvaluation.ts
@@ -5,18 +5,21 @@ import type {
   PropertyManagerCompanyEvaluationReason,
   PropertyManagerCompanyMembership,
   PropertyManagerCompanyRelationshipScope,
+  PropertyManagerCompanyStaffAssignment,
+  PropertyManagerCompanyStaffAssignmentRole,
 } from "./propertyManagerCompanyTypes";
 import {
   LANDLORD_COMPANY_RELATIONSHIP_STATUSES,
   PROPERTY_MANAGER_COMPANY_MEMBERSHIP_STATUSES,
   PROPERTY_MANAGER_COMPANY_PROPERTY_SCOPE_MODES,
   PROPERTY_MANAGER_COMPANY_ROLES,
+  PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES,
+  PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES,
   PROPERTY_MANAGER_COMPANY_WORKSPACE_SCOPES,
 } from "./propertyManagerCompanyTypes";
+import { buildRelationshipScope, isAssignmentScopeWithinRelationshipScope } from "./propertyManagerCompanyModel";
 
-const ROLE_ALLOWED_ACTIONS: Record<PropertyManagerCompanyMembership["role"], readonly string[]> = {
-  company_owner: ["view", "create", "edit", "approve", "export", "assign", "message"],
-  company_admin: ["view", "create", "edit", "approve", "export", "assign", "message"],
+const ROLE_ALLOWED_ACTIONS: Record<PropertyManagerCompanyStaffAssignmentRole, readonly string[]> = {
   regional_manager: ["view", "edit", "approve", "assign", "message", "export"],
   property_manager: ["view", "create", "edit", "approve", "assign", "message", "export"],
   leasing_agent: ["view", "create", "edit", "message"],
@@ -38,7 +41,7 @@ function denied(
     actorCompanyId: request.membership?.companyId || request.relationship?.propertyManagerCompanyId || null,
     actingForLandlordId: request.actingForLandlordId || null,
     relationshipId: request.relationship?.relationshipId || null,
-    role: request.membership?.role || null,
+    role: request.assignment?.staffRole || request.membership?.role || null,
     scope: scope || request.relationship?.relationshipScope || null,
     auditRequired: true,
   };
@@ -56,7 +59,7 @@ function allowed(
     actorCompanyId: request.membership?.companyId || null,
     actingForLandlordId: request.actingForLandlordId || null,
     relationshipId: request.relationship?.relationshipId || null,
-    role: request.membership?.role || null,
+    role: request.assignment?.staffRole || null,
     scope,
     auditRequired:
       request.action !== "view" || request.routeWorkspace === "payments" || request.routeWorkspace === "evidence_exports",
@@ -77,6 +80,13 @@ function hasPropertyAccess(scope: PropertyManagerCompanyRelationshipScope, prope
   return scope.propertyScope.propertyIds.includes(propertyId);
 }
 
+function assignmentScope(assignment: PropertyManagerCompanyStaffAssignment): PropertyManagerCompanyRelationshipScope {
+  return {
+    propertyScope: assignment.propertyScope,
+    workspaceScopes: assignment.workspaceScopes,
+  };
+}
+
 function hasValidMembershipShape(membership: PropertyManagerCompanyMembership): PropertyManagerCompanyEvaluationReason | null {
   if (!PROPERTY_MANAGER_COMPANY_ROLES.includes(membership.role)) return "invalid_membership_role";
   if (!PROPERTY_MANAGER_COMPANY_MEMBERSHIP_STATUSES.includes(membership.status)) return "invalid_membership_status";
@@ -91,6 +101,27 @@ function hasValidRelationshipShape(relationship: LandlordCompanyRelationship): P
   if (!Array.isArray(scope.workspaceScopes)) return "invalid_scope";
   if (!scope.workspaceScopes.every((workspace) => PROPERTY_MANAGER_COMPANY_WORKSPACE_SCOPES.includes(workspace))) {
     return "invalid_scope";
+  }
+  return null;
+}
+
+function hasValidAssignmentShape(assignment: PropertyManagerCompanyStaffAssignment): PropertyManagerCompanyEvaluationReason | null {
+  if (!PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES.includes(assignment.staffRole)) return "invalid_assignment_role";
+  if (!PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES.includes(assignment.status)) return "invalid_assignment_status";
+  const scope = assignmentScope(assignment);
+  if (!PROPERTY_MANAGER_COMPANY_PROPERTY_SCOPE_MODES.includes(scope.propertyScope?.mode)) return "invalid_assignment_scope";
+  if (!Array.isArray(scope.propertyScope.propertyIds)) return "invalid_assignment_scope";
+  if (!Array.isArray(scope.workspaceScopes)) return "invalid_assignment_scope";
+  if (!scope.workspaceScopes.every((workspace) => PROPERTY_MANAGER_COMPANY_WORKSPACE_SCOPES.includes(workspace))) {
+    return "invalid_assignment_scope";
+  }
+  try {
+    buildRelationshipScope({
+      propertyScope: scope.propertyScope,
+      workspaceScopes: scope.workspaceScopes,
+    });
+  } catch {
+    return "invalid_assignment_scope";
   }
   return null;
 }
@@ -122,10 +153,29 @@ export function evaluatePropertyManagerCompanyAccess(
     return denied(request, "relationship_landlord_mismatch", relationship.relationshipScope);
   }
 
-  const scope = relationship.relationshipScope;
+  const assignment = request.assignment;
+  if (!assignment) return denied(request, "missing_staff_assignment", relationship.relationshipScope);
+  const invalidAssignmentReason = hasValidAssignmentShape(assignment);
+  const assignmentResolvedScope = assignmentScope(assignment);
+  if (invalidAssignmentReason) return denied(request, invalidAssignmentReason, assignmentResolvedScope);
+  if (assignment.propertyManagerCompanyId !== membership.companyId) {
+    return denied(request, "assignment_company_mismatch", assignmentResolvedScope);
+  }
+  if (assignment.relationshipId !== relationship.relationshipId) {
+    return denied(request, "assignment_relationship_mismatch", assignmentResolvedScope);
+  }
+  if (assignment.staffUserId !== request.actorUserId) {
+    return denied(request, "assignment_actor_mismatch", assignmentResolvedScope);
+  }
+  if (assignment.status !== "active") return denied(request, "assignment_not_active", assignmentResolvedScope);
+  if (!isAssignmentScopeWithinRelationshipScope(assignmentResolvedScope, relationship.relationshipScope)) {
+    return denied(request, "assignment_scope_exceeds_relationship", assignmentResolvedScope);
+  }
+
+  const scope = assignmentResolvedScope;
   if (!scope.workspaceScopes.includes(request.routeWorkspace)) return denied(request, "workspace_scope_denied", scope);
   if (!hasPropertyAccess(scope, request.propertyId)) return denied(request, "property_scope_denied", scope);
-  if (!ROLE_ALLOWED_ACTIONS[membership.role].includes(request.action)) return denied(request, "role_template_denied", scope);
+  if (!ROLE_ALLOWED_ACTIONS[assignment.staffRole].includes(request.action)) return denied(request, "role_template_denied", scope);
 
   return allowed(request, scope);
 }

--- a/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyAudit.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyAudit.ts
@@ -18,6 +18,8 @@ type AuditInput = {
   propertyManagerCompanyId?: string | null;
   actingForLandlordId?: string | null;
   relationshipId?: string | null;
+  assignmentId?: string | null;
+  staffUserId?: string | null;
   role?: PropertyManagerCompanyRole | null;
   scope?: PropertyManagerCompanyRelationshipScope | null;
   targetResourceType: PropertyManagerCompanyAuditTargetResourceType;
@@ -70,6 +72,8 @@ function stableEventId(input: Omit<AuditInput, "eventId"> & { timestamp: string 
         input.propertyManagerCompanyId,
         input.actingForLandlordId,
         input.relationshipId,
+        input.assignmentId,
+        input.staffUserId,
         input.role,
         input.targetResourceType,
         input.targetResourceId,
@@ -93,6 +97,8 @@ export function buildPropertyManagerCompanyAuditEvent(input: AuditInput): Proper
     propertyManagerCompanyId: input.propertyManagerCompanyId ? cleanString(input.propertyManagerCompanyId, 200) : null,
     actingForLandlordId: input.actingForLandlordId ? cleanString(input.actingForLandlordId, 200) : null,
     relationshipId: input.relationshipId ? cleanString(input.relationshipId, 200) : null,
+    assignmentId: input.assignmentId ? cleanString(input.assignmentId, 200) : null,
+    staffUserId: input.staffUserId ? cleanString(input.staffUserId, 200) : null,
     role: input.role || null,
     scope: input.scope || null,
     targetResourceType: assertTargetResourceType(input.targetResourceType),

--- a/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyModel.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyModel.ts
@@ -4,6 +4,8 @@ import {
   PROPERTY_MANAGER_COMPANY_MEMBERSHIP_STATUSES,
   PROPERTY_MANAGER_COMPANY_PROPERTY_SCOPE_MODES,
   PROPERTY_MANAGER_COMPANY_ROLES,
+  PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES,
+  PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES,
   PROPERTY_MANAGER_COMPANY_STATUSES,
   PROPERTY_MANAGER_COMPANY_WORKSPACE_SCOPES,
   type LandlordCompanyRelationship,
@@ -14,6 +16,9 @@ import {
   type PropertyManagerCompanyPropertyScope,
   type PropertyManagerCompanyRelationshipScope,
   type PropertyManagerCompanyRole,
+  type PropertyManagerCompanyStaffAssignment,
+  type PropertyManagerCompanyStaffAssignmentRole,
+  type PropertyManagerCompanyStaffAssignmentStatus,
   type PropertyManagerCompanyStatus,
   type PropertyManagerCompanyWorkspaceScope,
 } from "./propertyManagerCompanyTypes";
@@ -48,6 +53,17 @@ type RelationshipInput = {
   status?: LandlordCompanyRelationshipStatus;
   createdAt?: string;
   startedAt?: string | null;
+};
+
+type StaffAssignmentInput = {
+  assignmentId?: string;
+  relationship: LandlordCompanyRelationship;
+  assignedByMembership: PropertyManagerCompanyMembership;
+  staffMembership: PropertyManagerCompanyMembership;
+  staffRole: string;
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: string[];
+  createdAt?: string;
 };
 
 export class PropertyManagerCompanyValidationError extends Error {
@@ -95,12 +111,27 @@ export function isPropertyManagerCompanyRole(value: unknown): value is PropertyM
   return PROPERTY_MANAGER_COMPANY_ROLES.includes(value as PropertyManagerCompanyRole);
 }
 
+export function isPropertyManagerCompanyStaffAssignmentRole(value: unknown): value is PropertyManagerCompanyStaffAssignmentRole {
+  return PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES.includes(value as PropertyManagerCompanyStaffAssignmentRole);
+}
+
+export function isPropertyManagerCompanyStaffAssignmentStatus(value: unknown): value is PropertyManagerCompanyStaffAssignmentStatus {
+  return PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES.includes(value as PropertyManagerCompanyStaffAssignmentStatus);
+}
+
 export function isLandlordCompanyRelationshipStatus(value: unknown): value is LandlordCompanyRelationshipStatus {
   return LANDLORD_COMPANY_RELATIONSHIP_STATUSES.includes(value as LandlordCompanyRelationshipStatus);
 }
 
 export function assertPropertyManagerCompanyRole(value: unknown): PropertyManagerCompanyRole {
   if (!isPropertyManagerCompanyRole(value)) throw new PropertyManagerCompanyValidationError("invalid_company_role");
+  return value;
+}
+
+export function assertPropertyManagerCompanyStaffAssignmentRole(value: unknown): PropertyManagerCompanyStaffAssignmentRole {
+  if (!isPropertyManagerCompanyStaffAssignmentRole(value)) {
+    throw new PropertyManagerCompanyValidationError("invalid_staff_assignment_role");
+  }
   return value;
 }
 
@@ -149,6 +180,94 @@ export function buildRelationshipScope(input: {
     propertyScope: normalizeCompanyPropertyScope(input.propertyScope),
     workspaceScopes: normalizeWorkspaceScopes(input.workspaceScopes),
   };
+}
+
+function assignmentScope(assignment: Pick<PropertyManagerCompanyStaffAssignment, "propertyScope" | "workspaceScopes">): PropertyManagerCompanyRelationshipScope {
+  return {
+    propertyScope: assignment.propertyScope,
+    workspaceScopes: assignment.workspaceScopes,
+  };
+}
+
+export function isAssignmentScopeWithinRelationshipScope(
+  assignmentScopeInput: PropertyManagerCompanyRelationshipScope,
+  relationshipScope: PropertyManagerCompanyRelationshipScope
+): boolean {
+  const normalizedAssignmentScope = buildRelationshipScope({
+    propertyScope: assignmentScopeInput.propertyScope,
+    workspaceScopes: assignmentScopeInput.workspaceScopes,
+  });
+  const normalizedRelationshipScope = buildRelationshipScope({
+    propertyScope: relationshipScope.propertyScope,
+    workspaceScopes: relationshipScope.workspaceScopes,
+  });
+  const workspaceAllowed = normalizedAssignmentScope.workspaceScopes.every((workspace) =>
+    normalizedRelationshipScope.workspaceScopes.includes(workspace)
+  );
+  if (!workspaceAllowed) return false;
+
+  if (normalizedRelationshipScope.propertyScope.mode === "all_current_properties") return true;
+  if (normalizedAssignmentScope.propertyScope.mode === "all_current_properties") return false;
+  return normalizedAssignmentScope.propertyScope.propertyIds.every((propertyId) =>
+    normalizedRelationshipScope.propertyScope.propertyIds.includes(propertyId)
+  );
+}
+
+function requireActiveMembershipForCompany(
+  membership: PropertyManagerCompanyMembership,
+  companyId: string,
+  codePrefix: string
+) {
+  if (!isPropertyManagerCompanyRole(membership.role)) {
+    throw new PropertyManagerCompanyValidationError("invalid_company_role");
+  }
+  if (!isPropertyManagerCompanyMembershipStatus(membership.status)) {
+    throw new PropertyManagerCompanyValidationError("invalid_membership_status");
+  }
+  if (membership.companyId !== companyId) {
+    throw new PropertyManagerCompanyValidationError(`${codePrefix}_membership_company_mismatch`);
+  }
+  if (membership.status !== "active") {
+    throw new PropertyManagerCompanyValidationError("membership_not_active");
+  }
+}
+
+function requireAssignmentManager(membership: PropertyManagerCompanyMembership, companyId: string) {
+  requireActiveMembershipForCompany(membership, companyId, "assignment_manager");
+  if (!["company_owner", "company_admin"].includes(membership.role)) {
+    throw new PropertyManagerCompanyValidationError("company_assignment_manager_required");
+  }
+}
+
+function requireStaffMembership(membership: PropertyManagerCompanyMembership, companyId: string) {
+  requireActiveMembershipForCompany(membership, companyId, "staff_assignment");
+}
+
+function requireActiveRelationshipForAssignment(relationship: LandlordCompanyRelationship) {
+  if (!isLandlordCompanyRelationshipStatus(relationship.status)) {
+    throw new PropertyManagerCompanyValidationError("invalid_relationship_status");
+  }
+  if (relationship.status !== "active") {
+    throw new PropertyManagerCompanyValidationError("relationship_not_active");
+  }
+  buildRelationshipScope({
+    propertyScope: relationship.relationshipScope.propertyScope,
+    workspaceScopes: relationship.relationshipScope.workspaceScopes,
+  });
+}
+
+function validateAssignmentScopeWithinRelationship(
+  assignmentScopeInput: PropertyManagerCompanyRelationshipScope,
+  relationshipScope: PropertyManagerCompanyRelationshipScope
+) {
+  if (!isAssignmentScopeWithinRelationshipScope(assignmentScopeInput, relationshipScope)) {
+    throw new PropertyManagerCompanyValidationError("assignment_scope_exceeds_relationship_scope");
+  }
+}
+
+function cleanReason(value: string | null | undefined): string | null {
+  const text = cleanString(value, 500);
+  return text || null;
 }
 
 export function createPropertyManagerCompany(input: CompanyInput): PropertyManagerCompany {
@@ -325,5 +444,111 @@ export function terminateLandlordCompanyRelationship(
     terminatedByUserId,
     terminationReason: context.reason ? cleanString(context.reason, 500) : null,
     updatedAt: terminatedAt,
+  };
+}
+
+export function createPropertyManagerCompanyStaffAssignment(input: StaffAssignmentInput): PropertyManagerCompanyStaffAssignment {
+  const relationship = input.relationship;
+  requireActiveRelationshipForAssignment(relationship);
+  requireAssignmentManager(input.assignedByMembership, relationship.propertyManagerCompanyId);
+  requireStaffMembership(input.staffMembership, relationship.propertyManagerCompanyId);
+  const staffRole = assertPropertyManagerCompanyStaffAssignmentRole(input.staffRole);
+  const createdAt = input.createdAt ? parseDate(input.createdAt, "invalid_created_at") : new Date().toISOString();
+  const scope = buildRelationshipScope({
+    propertyScope: input.propertyScope,
+    workspaceScopes: input.workspaceScopes,
+  });
+  validateAssignmentScopeWithinRelationship(scope, relationship.relationshipScope);
+
+  return {
+    assignmentId:
+      input.assignmentId ||
+      hashId("pm_staff_assignment", [relationship.relationshipId, input.staffMembership.userId, staffRole, createdAt]),
+    propertyManagerCompanyId: relationship.propertyManagerCompanyId,
+    relationshipId: relationship.relationshipId,
+    staffUserId: input.staffMembership.userId,
+    assignedByUserId: input.assignedByMembership.userId,
+    staffRole,
+    status: "active",
+    propertyScope: scope.propertyScope,
+    workspaceScopes: scope.workspaceScopes,
+    createdAt,
+    updatedAt: createdAt,
+    suspendedAt: null,
+    suspendedByUserId: null,
+    suspendedReason: null,
+    reactivatedAt: null,
+    reactivatedByUserId: null,
+    removedAt: null,
+    removedByUserId: null,
+    removedReason: null,
+    auditEventIds: [],
+  };
+}
+
+export function suspendPropertyManagerCompanyStaffAssignment(
+  assignment: PropertyManagerCompanyStaffAssignment,
+  context: { actorMembership: PropertyManagerCompanyMembership; suspendedAt?: string; reason?: string | null }
+): PropertyManagerCompanyStaffAssignment {
+  requireAssignmentManager(context.actorMembership, assignment.propertyManagerCompanyId);
+  if (assignment.status !== "active") throw new PropertyManagerCompanyValidationError("staff_assignment_not_active");
+  const suspendedAt = context.suspendedAt ? parseDate(context.suspendedAt, "invalid_suspended_at") : new Date().toISOString();
+  return {
+    ...assignment,
+    status: "suspended",
+    suspendedAt,
+    suspendedByUserId: context.actorMembership.userId,
+    suspendedReason: cleanReason(context.reason),
+    updatedAt: suspendedAt,
+  };
+}
+
+export function reactivatePropertyManagerCompanyStaffAssignment(
+  assignment: PropertyManagerCompanyStaffAssignment,
+  context: {
+    actorMembership: PropertyManagerCompanyMembership;
+    staffMembership: PropertyManagerCompanyMembership;
+    relationship: LandlordCompanyRelationship;
+    reactivatedAt?: string;
+  }
+): PropertyManagerCompanyStaffAssignment {
+  requireAssignmentManager(context.actorMembership, assignment.propertyManagerCompanyId);
+  requireStaffMembership(context.staffMembership, assignment.propertyManagerCompanyId);
+  if (context.staffMembership.userId !== assignment.staffUserId) {
+    throw new PropertyManagerCompanyValidationError("staff_assignment_membership_mismatch");
+  }
+  if (context.relationship.relationshipId !== assignment.relationshipId) {
+    throw new PropertyManagerCompanyValidationError("staff_assignment_relationship_mismatch");
+  }
+  requireActiveRelationshipForAssignment(context.relationship);
+  if (assignment.status !== "suspended") throw new PropertyManagerCompanyValidationError("staff_assignment_not_suspended");
+  validateAssignmentScopeWithinRelationship(assignmentScope(assignment), context.relationship.relationshipScope);
+  const reactivatedAt = context.reactivatedAt ? parseDate(context.reactivatedAt, "invalid_reactivated_at") : new Date().toISOString();
+  return {
+    ...assignment,
+    status: "active",
+    reactivatedAt,
+    reactivatedByUserId: context.actorMembership.userId,
+    updatedAt: reactivatedAt,
+  };
+}
+
+export function removePropertyManagerCompanyStaffAssignment(
+  assignment: PropertyManagerCompanyStaffAssignment,
+  context: { actorMembership: PropertyManagerCompanyMembership; removedAt?: string; reason?: string | null }
+): PropertyManagerCompanyStaffAssignment {
+  requireAssignmentManager(context.actorMembership, assignment.propertyManagerCompanyId);
+  if (assignment.status === "removed") throw new PropertyManagerCompanyValidationError("staff_assignment_already_removed");
+  if (!isPropertyManagerCompanyStaffAssignmentStatus(assignment.status)) {
+    throw new PropertyManagerCompanyValidationError("invalid_staff_assignment_status");
+  }
+  const removedAt = context.removedAt ? parseDate(context.removedAt, "invalid_removed_at") : new Date().toISOString();
+  return {
+    ...assignment,
+    status: "removed",
+    removedAt,
+    removedByUserId: context.actorMembership.userId,
+    removedReason: cleanReason(context.reason),
+    updatedAt: removedAt,
   };
 }

--- a/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyTypes.ts
+++ b/rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyTypes.ts
@@ -19,6 +19,21 @@ export const PROPERTY_MANAGER_COMPANY_ROLES = [
 
 export type PropertyManagerCompanyRole = (typeof PROPERTY_MANAGER_COMPANY_ROLES)[number];
 
+export const PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES = [
+  "regional_manager",
+  "property_manager",
+  "leasing_agent",
+  "office_administrator",
+  "maintenance_coordinator",
+  "read_only_staff",
+] as const;
+
+export type PropertyManagerCompanyStaffAssignmentRole = (typeof PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES)[number];
+
+export const PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES = ["active", "suspended", "removed"] as const;
+
+export type PropertyManagerCompanyStaffAssignmentStatus = (typeof PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES)[number];
+
 export const LANDLORD_COMPANY_RELATIONSHIP_STATUSES = ["pending", "active", "suspended", "terminated"] as const;
 
 export type LandlordCompanyRelationshipStatus = (typeof LANDLORD_COMPANY_RELATIONSHIP_STATUSES)[number];
@@ -66,6 +81,10 @@ export const PROPERTY_MANAGER_COMPANY_AUDIT_EVENT_TYPES = [
   "landlord_company_relationship_suspended",
   "landlord_company_relationship_reactivated",
   "landlord_company_relationship_terminated",
+  "staff_assignment_created",
+  "staff_assignment_suspended",
+  "staff_assignment_reactivated",
+  "staff_assignment_removed",
   "property_manager_company_staff_assignment_changed",
 ] as const;
 
@@ -140,6 +159,29 @@ export type LandlordCompanyRelationship = {
   auditEventIds: string[];
 };
 
+export type PropertyManagerCompanyStaffAssignment = {
+  assignmentId: string;
+  propertyManagerCompanyId: string;
+  relationshipId: string;
+  staffUserId: string;
+  assignedByUserId: string;
+  staffRole: PropertyManagerCompanyStaffAssignmentRole;
+  status: PropertyManagerCompanyStaffAssignmentStatus;
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: PropertyManagerCompanyWorkspaceScope[];
+  createdAt: string;
+  updatedAt: string;
+  suspendedAt: string | null;
+  suspendedByUserId: string | null;
+  suspendedReason: string | null;
+  reactivatedAt: string | null;
+  reactivatedByUserId: string | null;
+  removedAt: string | null;
+  removedByUserId: string | null;
+  removedReason: string | null;
+  auditEventIds: string[];
+};
+
 export type PropertyManagerCompanyEvaluationRequest = {
   actorUserId: string | null;
   actingForLandlordId: string | null;
@@ -150,6 +192,7 @@ export type PropertyManagerCompanyEvaluationRequest = {
   propertyId?: string | null;
   membership?: PropertyManagerCompanyMembership | null;
   relationship?: LandlordCompanyRelationship | null;
+  assignment?: PropertyManagerCompanyStaffAssignment | null;
   explicitDenyReasons?: string[];
 };
 
@@ -168,6 +211,15 @@ export type PropertyManagerCompanyEvaluationReason =
   | "invalid_scope"
   | "relationship_not_active"
   | "relationship_landlord_mismatch"
+  | "missing_staff_assignment"
+  | "invalid_assignment_status"
+  | "invalid_assignment_role"
+  | "invalid_assignment_scope"
+  | "assignment_not_active"
+  | "assignment_actor_mismatch"
+  | "assignment_relationship_mismatch"
+  | "assignment_company_mismatch"
+  | "assignment_scope_exceeds_relationship"
   | "workspace_scope_denied"
   | "property_scope_denied"
   | "role_template_denied"
@@ -188,6 +240,11 @@ export type PropertyManagerCompanyEvaluationDecision = {
 
 export type PropertyManagerCompanyAuditOutcome = "allowed" | "denied" | "created" | "suspended" | "removed" | "terminated" | "failed";
 
+export type PropertyManagerCompanyAuditTransitionStatus =
+  | LandlordCompanyRelationshipStatus
+  | PropertyManagerCompanyMembershipStatus
+  | PropertyManagerCompanyStaffAssignmentStatus;
+
 export type PropertyManagerCompanyAuditEvent = {
   eventId: string;
   eventType: PropertyManagerCompanyAuditEventType;
@@ -196,6 +253,8 @@ export type PropertyManagerCompanyAuditEvent = {
   propertyManagerCompanyId: string | null;
   actingForLandlordId: string | null;
   relationshipId: string | null;
+  assignmentId: string | null;
+  staffUserId: string | null;
   role: PropertyManagerCompanyRole | null;
   scope: PropertyManagerCompanyRelationshipScope | null;
   targetResourceType: PropertyManagerCompanyAuditTargetResourceType;
@@ -204,8 +263,8 @@ export type PropertyManagerCompanyAuditEvent = {
   timestamp: string;
   reason: string | null;
   statusTransition: {
-    from: LandlordCompanyRelationshipStatus | null;
-    to: LandlordCompanyRelationshipStatus | null;
+    from: PropertyManagerCompanyAuditTransitionStatus | null;
+    to: PropertyManagerCompanyAuditTransitionStatus | null;
   } | null;
   metadataOnly: true;
   appendOnly: true;


### PR DESCRIPTION
## Summary
- add the Mission Brief for property manager company staff assignment foundations
- add staff assignment record types, lifecycle helpers, role templates, and scope ceiling validation
- extend PM company access evaluation so membership alone does not imply landlord-workspace authority
- extend metadata-only audit events with staff assignment attribution

## Scope
- backend foundations only
- no UI, dashboard, frontend routes, emails, contractor organizations, billing delegation, custom permissions, landlord-facing staff management UI, migration, or backfill

## Validation
- npm run test:single -- src/lib/propertyManagerCompany
- npm run test:single -- src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts
- npm run build
- git diff --check
- git diff --cached --check