### PR TITLE
feat: add property manager company staff assignment API

### DIFF
--- a/docs/design/mission-briefs/property-manager-company-staff-assignment-api-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-staff-assignment-api-v1.html
@@ -1,0 +1,414 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Property Manager Company Staff Assignment API V1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #eef1f5;
+        color: #142033;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #eef1f5;
+      }
+
+      .brief {
+        max-width: 1280px;
+        margin: 0 auto;
+        background: #ffffff;
+        border: 1px solid #d7dde7;
+        box-shadow: 0 18px 50px rgba(20, 32, 51, 0.12);
+      }
+
+      header {
+        padding: 28px 32px;
+        border-bottom: 1px solid #d7dde7;
+        background: #142033;
+        color: #ffffff;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: 26px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      h1 span {
+        color: #8fd6ff;
+      }
+
+      .subtitle {
+        max-width: 900px;
+        color: #d6e7f4;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
+      }
+
+      section {
+        padding: 28px 32px;
+      }
+
+      .left {
+        border-right: 1px solid #d7dde7;
+      }
+
+      .block {
+        margin-bottom: 24px;
+      }
+
+      .block:last-child {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        margin-bottom: 10px;
+        color: #142033;
+        font-size: 15px;
+        line-height: 1.25;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        color: #2b3c55;
+        font-size: 14px;
+        line-height: 1.3;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 14px;
+        line-height: 1.48;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .card {
+        padding: 14px;
+        border: 1px solid #d7dde7;
+        background: #f8fafc;
+      }
+
+      .card strong {
+        display: block;
+        margin-bottom: 5px;
+        color: #142033;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        padding: 6px 9px;
+        border: 1px solid #c8d2df;
+        background: #f4f7fb;
+        color: #26374f;
+        font-size: 12px;
+        font-weight: 700;
+      }
+
+      .panel {
+        padding: 14px 16px;
+        border-left: 4px solid #246bfe;
+        background: #f4f8ff;
+      }
+
+      .warning {
+        border-left-color: #b7791f;
+        background: #fff8e8;
+      }
+
+      .success {
+        border-left-color: #16895a;
+        background: #f0fff7;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid #d7dde7;
+        background: #ffffff;
+      }
+
+      .table th,
+      .table td {
+        padding: 9px 10px;
+        border-bottom: 1px solid #e4e9f1;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .table th {
+        background: #f4f7fb;
+        color: #142033;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        color: #1b4f9c;
+      }
+
+      .compact li {
+        font-size: 13px;
+      }
+
+      @media (max-width: 920px) {
+        body {
+          padding: 16px;
+        }
+
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        .left {
+          border-right: 0;
+          border-bottom: 1px solid #d7dde7;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <h1>Next Mission: <span>feat/property-manager-company-staff-assignment-api-v1</span></h1>
+        <div class="subtitle">
+          Backend/API-only routes and services for Company Owner/Admin staff assignment management. This mission exposes
+          controlled create, list, suspend, reactivate, and remove operations on top of the merged staff assignment
+          foundations, while preserving scope ceilings, metadata-only audit events, and fail-closed authority.
+        </div>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>Mission Goal</h2>
+            <p>
+              Add company-scoped backend APIs that let active Company Owners/Admins manage PM company staff assignments
+              for active landlord-company relationships. Assignment APIs must preserve the distinction between company
+              membership and landlord relationship authority: membership alone grants no landlord access, and assignment
+              only narrows authority already granted by an active relationship.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>Required APIs</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Operation</th>
+                  <th>Contract</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Create assignment</td>
+                  <td>Company Owner/Admin creates an active assignment under an active landlord-company relationship.</td>
+                </tr>
+                <tr>
+                  <td>List assignments</td>
+                  <td>Company Owner/Admin gets company-scoped list, optionally relationship-scoped, using safe projections only.</td>
+                </tr>
+                <tr>
+                  <td>Suspend assignment</td>
+                  <td><code>active -> suspended</code>; access blocked temporarily and audit preserved.</td>
+                </tr>
+                <tr>
+                  <td>Reactivate assignment</td>
+                  <td><code>suspended -> active</code>; only if relationship, membership, and scope remain valid.</td>
+                </tr>
+                <tr>
+                  <td>Remove assignment</td>
+                  <td><code>active/suspended -> removed</code>; no hard delete, history preserved.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>Route Shape</h2>
+            <div class="panel">
+              Proposed mount: <code>/api/property-manager-companies/:companyId/staff-assignments</code>, with
+              relationship-specific filtering via path or query where practical. All company and relationship authority
+              must resolve server-side; request body/query data cannot override company, landlord, relationship, or scope
+              ownership.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Create Contract</h2>
+            <ul>
+              <li>Authenticated actor is required.</li>
+              <li>Actor must have active Company Owner/Admin membership for <code>:companyId</code>.</li>
+              <li>Target staff user must have active membership in the same PM company.</li>
+              <li>Relationship must exist, belong to the same PM company, and be <code>active</code>.</li>
+              <li>Staff role must be one predefined assignment template.</li>
+              <li>Assignment property/workspace scope must be within the relationship ceiling.</li>
+              <li>Billing/settings scope remains denied.</li>
+              <li>Assignment creation cannot broaden landlord-approved authority or activate access by itself.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Lifecycle Contract</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Valid</th>
+                  <th>Invalid</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>active -> suspended</code></td>
+                  <td><code>removed -> active</code></td>
+                </tr>
+                <tr>
+                  <td><code>suspended -> active</code></td>
+                  <td><code>removed -> suspended</code></td>
+                </tr>
+                <tr>
+                  <td><code>active -> removed</code></td>
+                  <td><code>removed -> removed</code></td>
+                </tr>
+                <tr>
+                  <td><code>suspended -> removed</code></td>
+                  <td><code>suspended -> suspended</code> and <code>active -> active</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>Audit Contract</h2>
+            <p>Every lifecycle action must append metadata-only audit events:</p>
+            <div class="pill-row">
+              <span class="pill">staff_assignment_created</span>
+              <span class="pill">staff_assignment_suspended</span>
+              <span class="pill">staff_assignment_reactivated</span>
+              <span class="pill">staff_assignment_removed</span>
+            </div>
+            <p style="margin-top: 12px">
+              Metadata must include actorUserId, actorCompanyId, actingForLandlordId, relationshipId, assignmentId,
+              staffUserId, role/template, scope, transition, outcome, timestamp, and reason where applicable. Audit
+              payloads must not expose secrets, provider payloads, or user-facing raw ID labels.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <div class="block">
+            <h2>Security Model</h2>
+            <ul class="compact">
+              <li>Company Owner/Admin only for create, list, suspend, reactivate, and remove.</li>
+              <li>Regional Manager, Property Manager, Leasing Agent, Office Administrator, Maintenance Coordinator, Read-only Staff, and unknown roles are denied.</li>
+              <li>Inactive actor memberships and inactive target staff memberships are denied.</li>
+              <li>Company-scoped only; no cross-company assignment access.</li>
+              <li>No cross-landlord access or body/query landlord override.</li>
+              <li>Pending, suspended, terminated, missing, or malformed relationships fail closed.</li>
+              <li>Malformed assignment, membership, relationship, role, status, or scope fails closed.</li>
+              <li>Assignment scope may narrow but never broaden relationship scope.</li>
+              <li><code>settings_billing</code> remains denied in V1.</li>
+              <li>Explicit deny wins in service/evaluator flows.</li>
+              <li>Safe projections must omit audit internals and avoid raw IDs as user-facing labels.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Files To Inspect First</h2>
+            <ul class="compact">
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyTypes.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyModel.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/permissionEvaluation.ts</code></li>
+              <li><code>rentchain-api/src/lib/propertyManagerCompany/propertyManagerCompanyAudit.ts</code></li>
+              <li><code>rentchain-api/src/services/propertyManagerCompanyRelationshipService.ts</code></li>
+              <li><code>rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts</code></li>
+              <li><code>rentchain-api/src/routes/__tests__/propertyManagerCompanyRelationshipRoutes.test.ts</code></li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Non-Goals</h2>
+            <div class="panel warning">
+              No UI, company dashboard, emails, contractor organizations, billing delegation, custom permissions,
+              frontend routes, production data migration, or backfill work.
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Validation Plan</h2>
+            <ul class="compact">
+              <li>Focused backend route and service tests for create, list, suspend, reactivate, and remove.</li>
+              <li>Company Owner/Admin authority tests and non-admin/unknown role denial tests.</li>
+              <li>Scope ceiling tests for selected properties, all-current-properties, workspace scope, and billing denial.</li>
+              <li>Cross-company and cross-landlord denial tests.</li>
+              <li>Lifecycle transition tests for active, suspended, removed, and invalid states.</li>
+              <li>Audit event shape tests for all assignment lifecycle events.</li>
+              <li>Safe projection tests: no raw audit internals and no user-facing raw ID labels.</li>
+              <li>Regression tests for relationship lifecycle and delegated-access behavior where touched.</li>
+              <li>Backend build and <code>git diff --check</code>.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>Review Gate</h2>
+            <div class="panel success">
+              Stop after this Mission Brief is reviewed. Implementation should begin only after approval, then proceed
+              in a draft PR on <code>feat/property-manager-company-staff-assignment-api-v1</code>.
+            </div>
+          </div>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/rentchain-api/src/routes/__tests__/propertyManagerCompanyStaffAssignmentRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertyManagerCompanyStaffAssignmentRoutes.test.ts
@@ -1,0 +1,537 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = Record<string, any>;
+
+const collections = vi.hoisted(() => new Map<string, Map<string, StoredDoc>>());
+const fakeDb = vi.hoisted(() => ({
+  collection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    const collection = collections.get(name)!;
+    return {
+      doc(id?: string) {
+        const docId = id || `test_doc_${collection.size + 1}`;
+        return {
+          id: docId,
+          async get() {
+            return {
+              id: docId,
+              exists: collection.has(docId),
+              data: () => collection.get(docId),
+            };
+          },
+          async set(data: StoredDoc) {
+            collection.set(docId, data);
+          },
+          async create(data: StoredDoc) {
+            if (collection.has(docId)) throw new Error("already_exists");
+            collection.set(docId, data);
+          },
+        };
+      },
+      async get() {
+        return {
+          docs: Array.from(collection.entries()).map(([id, data]) => ({
+            id,
+            exists: true,
+            data: () => data,
+          })),
+        };
+      },
+    };
+  },
+}));
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+function readCollection(name: string): StoredDoc[] {
+  return Array.from((collections.get(name) || new Map()).values());
+}
+
+function writeCollectionDoc(name: string, id: string, data: StoredDoc) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  collections.get(name)!.set(id, data);
+}
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: Record<string, unknown> }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+const companyAdminUser = { id: "company-admin-1", role: "property_manager_company", email: "admin@elite.example" };
+const companyOwnerUser = { id: "company-owner-1", role: "property_manager_company", email: "owner@elite.example" };
+const companyStaffUser = { id: "company-staff-1", role: "property_manager_company", email: "staff@elite.example" };
+const otherCompanyAdminUser = { id: "company-admin-2", role: "property_manager_company", email: "admin@other.example" };
+
+const validAssignmentBody = {
+  relationshipId: "relationship-active",
+  staffUserId: "company-staff-1",
+  staffRole: "property_manager",
+  propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+  workspaceScopes: ["dashboard"],
+};
+
+function seedMembership(overrides: Partial<StoredDoc> = {}) {
+  const membership = {
+    membershipId: overrides.membershipId || `pm-membership-${readCollection("propertyManagerCompanyMemberships").length + 1}`,
+    companyId: "pm-company-1",
+    userId: "company-admin-1",
+    role: "company_admin",
+    status: "active",
+    invitedByUserId: "company-owner-1",
+    createdByUserId: "company-owner-1",
+    createdAt: "2026-06-24T00:30:00.000Z",
+    updatedAt: "2026-06-24T00:30:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    removedAt: null,
+    removedByUserId: null,
+    ...overrides,
+  };
+  writeCollectionDoc("propertyManagerCompanyMemberships", membership.membershipId, membership);
+  return membership;
+}
+
+function seedRelationship(overrides: Partial<StoredDoc> = {}) {
+  const relationship = {
+    relationshipId: overrides.relationshipId || "relationship-active",
+    landlordId: "landlord-1",
+    propertyManagerCompanyId: "pm-company-1",
+    status: "active",
+    relationshipScope: {
+      propertyScope: { mode: "selected_properties", propertyIds: ["property-a", "property-b"] },
+      workspaceScopes: ["dashboard", "operations"],
+    },
+    createdByLandlordOwnerUserId: "landlord-owner-1",
+    acceptedByCompanyAdminUserId: "company-admin-1",
+    createdAt: "2026-06-24T01:00:00.000Z",
+    updatedAt: "2026-06-24T02:00:00.000Z",
+    startedAt: "2026-06-24T02:00:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    reactivatedAt: null,
+    terminatedAt: null,
+    terminatedByUserId: null,
+    terminationReason: null,
+    auditEventIds: [],
+    ...overrides,
+  };
+  writeCollectionDoc("landlordCompanyRelationships", relationship.relationshipId, relationship);
+  return relationship;
+}
+
+function seedAssignment(overrides: Partial<StoredDoc> = {}) {
+  const assignment = {
+    assignmentId: overrides.assignmentId || `pm-staff-assignment-${readCollection("propertyManagerCompanyStaffAssignments").length + 1}`,
+    propertyManagerCompanyId: "pm-company-1",
+    relationshipId: "relationship-active",
+    staffUserId: "company-staff-1",
+    assignedByUserId: "company-admin-1",
+    staffRole: "property_manager",
+    status: "active",
+    propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+    workspaceScopes: ["dashboard"],
+    createdAt: "2026-06-24T03:00:00.000Z",
+    updatedAt: "2026-06-24T03:00:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    suspendedReason: null,
+    reactivatedAt: null,
+    reactivatedByUserId: null,
+    removedAt: null,
+    removedByUserId: null,
+    removedReason: null,
+    auditEventIds: [],
+    ...overrides,
+  };
+  writeCollectionDoc("propertyManagerCompanyStaffAssignments", assignment.assignmentId, assignment);
+  return assignment;
+}
+
+function seedActiveCompanyAccess() {
+  seedMembership({ membershipId: "membership-admin", userId: "company-admin-1", role: "company_admin" });
+  seedMembership({ membershipId: "membership-owner", userId: "company-owner-1", role: "company_owner" });
+  seedMembership({ membershipId: "membership-staff", userId: "company-staff-1", role: "property_manager" });
+  seedRelationship();
+}
+
+describe("property manager company staff assignment routes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("creates active staff assignments with owner/admin authority and metadata-only audit", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+
+    const response = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+      body: {
+        ...validAssignmentBody,
+        relationshipId: "relationship-active",
+        propertyManagerCompanyId: "pm-company-2",
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.assignment).toEqual(
+      expect.objectContaining({
+        propertyManagerCompanyId: "pm-company-1",
+        relationshipId: "relationship-active",
+        staffUserId: "company-staff-1",
+        staffRole: "property_manager",
+        status: "active",
+        propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+        workspaceScopes: ["dashboard"],
+        staffDisplayLabel: "Company staff",
+      })
+    );
+    expect(response.body.assignment).not.toHaveProperty("auditEventIds");
+
+    const assignments = readCollection("propertyManagerCompanyStaffAssignments");
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0]).toEqual(expect.objectContaining({ status: "active", assignedByUserId: "company-admin-1" }));
+
+    const auditEvents = readCollection("propertyManagerCompanyAuditEvents");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toEqual(
+      expect.objectContaining({
+        eventType: "staff_assignment_created",
+        actorUserId: "company-admin-1",
+        actorCompanyId: "pm-company-1",
+        propertyManagerCompanyId: "pm-company-1",
+        actingForLandlordId: "landlord-1",
+        relationshipId: "relationship-active",
+        assignmentId: assignments[0].assignmentId,
+        staffUserId: "company-staff-1",
+        role: "property_manager",
+        outcome: "created",
+        statusTransition: { from: null, to: "active" },
+        metadataOnly: true,
+      })
+    );
+
+    const ownerCreated = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments",
+      user: companyOwnerUser,
+      body: { ...validAssignmentBody, staffRole: "leasing_agent", workspaceScopes: ["operations"] },
+    });
+    expect(ownerCreated.status).toBe(201);
+  });
+
+  it("lists company-scoped and relationship-scoped assignments with safe projections only", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+    seedAssignment({ assignmentId: "assignment-active", relationshipId: "relationship-active", updatedAt: "2026-06-24T03:00:00.000Z" });
+    seedRelationship({ relationshipId: "relationship-second" });
+    seedAssignment({ assignmentId: "assignment-second", relationshipId: "relationship-second", updatedAt: "2026-06-24T04:00:00.000Z" });
+    seedAssignment({ assignmentId: "assignment-other-company", propertyManagerCompanyId: "pm-company-2", relationshipId: "relationship-other" });
+
+    const all = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+    });
+    expect(all.status).toBe(200);
+    expect(all.body.assignments.map((assignment: any) => assignment.assignmentId)).toEqual(["assignment-second", "assignment-active"]);
+    expect(JSON.stringify(all.body.assignments)).not.toContain("auditEventIds");
+
+    const relationshipScoped = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/staff-assignments?relationshipId=relationship-active",
+      user: companyAdminUser,
+    });
+    expect(relationshipScoped.status).toBe(200);
+    expect(relationshipScoped.body.assignments).toHaveLength(1);
+    expect(relationshipScoped.body.assignments[0]).toEqual(expect.objectContaining({ assignmentId: "assignment-active" }));
+  });
+
+  it("denies non-admin, unknown role, and inactive actor memberships", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+
+    const deniedRoles = [
+      "regional_manager",
+      "property_manager",
+      "leasing_agent",
+      "office_administrator",
+      "maintenance_coordinator",
+      "read_only_staff",
+      "unknown",
+    ];
+    for (const role of deniedRoles) {
+      collections.get("propertyManagerCompanyMemberships")?.delete("membership-admin");
+      seedMembership({ membershipId: "membership-admin", userId: "company-admin-1", role });
+      const response = await invokeRouter(propertyManagerCompanyRoutes, {
+        method: "POST",
+        url: "/pm-company-1/staff-assignments",
+        user: companyAdminUser,
+        body: validAssignmentBody,
+      });
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe(role === "unknown" ? "INVALID_COMPANY_ROLE" : "COMPANY_ASSIGNMENT_MANAGER_REQUIRED");
+    }
+
+    collections.get("propertyManagerCompanyMemberships")?.delete("membership-admin");
+    seedMembership({ membershipId: "membership-admin", userId: "company-admin-1", role: "company_admin", status: "suspended" });
+    const inactive = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+    });
+    expect(inactive.status).toBe(403);
+    expect(inactive.body.error).toBe("PROPERTY_MANAGER_COMPANY_MEMBERSHIP_NOT_ACTIVE");
+  });
+
+  it("requires active target staff membership and active landlord-company relationship", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+
+    collections.get("propertyManagerCompanyMemberships")?.delete("membership-staff");
+    seedMembership({ membershipId: "membership-staff", userId: "company-staff-1", role: "property_manager", status: "suspended" });
+    const inactiveStaff = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+      body: validAssignmentBody,
+    });
+    expect(inactiveStaff.status).toBe(403);
+    expect(inactiveStaff.body.error).toBe("MEMBERSHIP_NOT_ACTIVE");
+
+    for (const status of ["pending", "suspended", "terminated"]) {
+      collections.get("landlordCompanyRelationships")?.clear();
+      seedRelationship({ relationshipId: `relationship-${status}`, status });
+      collections.get("propertyManagerCompanyMemberships")?.delete("membership-staff");
+      seedMembership({ membershipId: "membership-staff", userId: "company-staff-1", role: "property_manager", status: "active" });
+      const response = await invokeRouter(propertyManagerCompanyRoutes, {
+        method: "POST",
+        url: "/pm-company-1/staff-assignments",
+        user: companyAdminUser,
+        body: { ...validAssignmentBody, relationshipId: `relationship-${status}` },
+      });
+      expect(response.status).toBe(409);
+      expect(response.body.error).toBe("RELATIONSHIP_NOT_ACTIVE");
+    }
+  });
+
+  it("enforces property and workspace scope ceilings, including billing/settings denial", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+
+    const propertyOutsideRelationship = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+      body: { ...validAssignmentBody, propertyScope: { mode: "selected_properties", propertyIds: ["property-c"] } },
+    });
+    expect(propertyOutsideRelationship.status).toBe(400);
+    expect(propertyOutsideRelationship.body.error).toBe("ASSIGNMENT_SCOPE_EXCEEDS_RELATIONSHIP_SCOPE");
+
+    const workspaceOutsideRelationship = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+      body: { ...validAssignmentBody, workspaceScopes: ["leases"] },
+    });
+    expect(workspaceOutsideRelationship.status).toBe(400);
+    expect(workspaceOutsideRelationship.body.error).toBe("ASSIGNMENT_SCOPE_EXCEEDS_RELATIONSHIP_SCOPE");
+
+    const billingScope = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+      body: { ...validAssignmentBody, workspaceScopes: ["settings_billing"] },
+    });
+    expect(billingScope.status).toBe(400);
+    expect(billingScope.body.error).toBe("COMPANY_BILLING_SCOPE_NOT_ALLOWED");
+  });
+
+  it("supports suspend, reactivate, and remove lifecycle with audit events", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+    seedAssignment({ assignmentId: "assignment-lifecycle" });
+
+    const suspended = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-lifecycle/suspend",
+      user: companyAdminUser,
+      body: { reason: "coverage change" },
+    });
+    expect(suspended.status).toBe(200);
+    expect(suspended.body.assignment).toEqual(
+      expect.objectContaining({
+        assignmentId: "assignment-lifecycle",
+        status: "suspended",
+        suspendedByUserId: "company-admin-1",
+        suspendedReason: "coverage change",
+      })
+    );
+
+    const reactivated = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-lifecycle/reactivate",
+      user: companyAdminUser,
+    });
+    expect(reactivated.status).toBe(200);
+    expect(reactivated.body.assignment.status).toBe("active");
+
+    const removed = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-lifecycle/remove",
+      user: companyAdminUser,
+      body: { reason: "handover complete" },
+    });
+    expect(removed.status).toBe(200);
+    expect(removed.body.assignment).toEqual(
+      expect.objectContaining({
+        status: "removed",
+        removedByUserId: "company-admin-1",
+        removedReason: "handover complete",
+      })
+    );
+
+    const auditEvents = readCollection("propertyManagerCompanyAuditEvents");
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "staff_assignment_suspended",
+      "staff_assignment_reactivated",
+      "staff_assignment_removed",
+    ]);
+    expect(auditEvents.map((event) => event.statusTransition)).toEqual([
+      { from: "active", to: "suspended" },
+      { from: "suspended", to: "active" },
+      { from: "active", to: "removed" },
+    ]);
+  });
+
+  it("fails closed on invalid lifecycle transitions", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+    seedAssignment({ assignmentId: "assignment-active", status: "active" });
+    seedAssignment({ assignmentId: "assignment-suspended", status: "suspended" });
+    seedAssignment({ assignmentId: "assignment-removed", status: "removed" });
+
+    const activeToActive = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-active/reactivate",
+      user: companyAdminUser,
+    });
+    expect(activeToActive.status).toBe(409);
+    expect(activeToActive.body.error).toBe("STAFF_ASSIGNMENT_NOT_SUSPENDED");
+
+    const suspendedToSuspended = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-suspended/suspend",
+      user: companyAdminUser,
+    });
+    expect(suspendedToSuspended.status).toBe(409);
+    expect(suspendedToSuspended.body.error).toBe("STAFF_ASSIGNMENT_NOT_ACTIVE");
+
+    const removedToActive = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-removed/reactivate",
+      user: companyAdminUser,
+    });
+    expect(removedToActive.status).toBe(409);
+    expect(removedToActive.body.error).toBe("STAFF_ASSIGNMENT_NOT_SUSPENDED");
+
+    const removedToRemoved = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-removed/remove",
+      user: companyAdminUser,
+    });
+    expect(removedToRemoved.status).toBe(409);
+    expect(removedToRemoved.body.error).toBe("STAFF_ASSIGNMENT_ALREADY_REMOVED");
+  });
+
+  it("denies cross-company assignment access", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedActiveCompanyAccess();
+    seedMembership({
+      membershipId: "other-company-admin",
+      companyId: "pm-company-2",
+      userId: "company-admin-2",
+      role: "company_admin",
+    });
+    seedRelationship({
+      relationshipId: "relationship-company-2",
+      propertyManagerCompanyId: "pm-company-2",
+    });
+    seedAssignment({
+      assignmentId: "assignment-company-2",
+      propertyManagerCompanyId: "pm-company-2",
+      relationshipId: "relationship-company-2",
+    });
+
+    const crossCompanyCreate = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments",
+      user: otherCompanyAdminUser,
+      body: validAssignmentBody,
+    });
+    expect(crossCompanyCreate.status).toBe(403);
+    expect(crossCompanyCreate.body.error).toBe("PROPERTY_MANAGER_COMPANY_MEMBERSHIP_NOT_FOUND");
+
+    const crossCompanyLifecycle = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "POST",
+      url: "/pm-company-1/staff-assignments/assignment-company-2/suspend",
+      user: companyAdminUser,
+    });
+    expect(crossCompanyLifecycle.status).toBe(404);
+    expect(crossCompanyLifecycle.body.error).toBe("PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_NOT_FOUND");
+  });
+});

--- a/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
+++ b/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
@@ -8,6 +8,13 @@ import {
   suspendLandlordCompanyRelationshipRecord,
   terminateLandlordCompanyRelationshipRecord,
 } from "../services/propertyManagerCompanyRelationshipService";
+import {
+  createPropertyManagerCompanyStaffAssignmentRecord,
+  listPropertyManagerCompanyStaffAssignmentRecords,
+  reactivatePropertyManagerCompanyStaffAssignmentRecord,
+  removePropertyManagerCompanyStaffAssignmentRecord,
+  suspendPropertyManagerCompanyStaffAssignmentRecord,
+} from "../services/propertyManagerCompanyStaffAssignmentService";
 
 const router = Router();
 const companyRouter = Router();
@@ -37,7 +44,12 @@ function forbidden(res: any) {
 
 function handleError(res: any, error: unknown) {
   const code = error instanceof Error ? error.message : "property_manager_company_relationship_failed";
-  if (code === "landlord_company_relationship_not_found" || code === "property_manager_company_not_found") {
+  if (
+    code === "landlord_company_relationship_not_found" ||
+    code === "property_manager_company_not_found" ||
+    code === "property_manager_company_staff_assignment_not_found" ||
+    code === "property_manager_company_staff_membership_not_found"
+  ) {
     return res.status(404).json({ ok: false, error: code.toUpperCase() });
   }
   if (
@@ -46,7 +58,10 @@ function handleError(res: any, error: unknown) {
     code === "relationship_not_pending" ||
     code === "relationship_already_terminated" ||
     code === "invalid_relationship_status_transition" ||
-    code === "relationship_activation_requires_company_acceptance"
+    code === "relationship_activation_requires_company_acceptance" ||
+    code === "staff_assignment_not_active" ||
+    code === "staff_assignment_not_suspended" ||
+    code === "staff_assignment_already_removed"
   ) {
     return res.status(409).json({ ok: false, error: code.toUpperCase() });
   }
@@ -57,13 +72,18 @@ function handleError(res: any, error: unknown) {
     code === "property_manager_company_membership_not_found" ||
     code === "property_manager_company_membership_not_active" ||
     code === "property_manager_company_acceptance_role_not_allowed" ||
-    code === "property_manager_company_membership_mismatch"
+    code === "property_manager_company_membership_mismatch" ||
+    code === "company_assignment_manager_required" ||
+    code === "membership_not_active" ||
+    code === "invalid_company_role" ||
+    code === "invalid_membership_status"
   ) {
     return res.status(403).json({ ok: false, error: code.toUpperCase() });
   }
   if (
     code.startsWith("invalid_") ||
     code.startsWith("missing_") ||
+    code === "assignment_scope_exceeds_relationship_scope" ||
     code.includes("_not_allowed") ||
     code.includes("_mismatch")
   ) {
@@ -160,6 +180,92 @@ router.post("/property-manager-company-relationships/:relationshipId/terminate",
 });
 
 companyRouter.use(requireAuth);
+
+companyRouter.get("/:companyId/staff-assignments", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listPropertyManagerCompanyStaffAssignmentRecords({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+      relationshipId: req.query?.relationshipId,
+    });
+    return res.status(200).json({ ok: true, assignments: result.assignments });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+companyRouter.post("/:companyId/staff-assignments", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await createPropertyManagerCompanyStaffAssignmentRecord({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+      relationshipId: req.body?.relationshipId,
+      staffUserId: req.body?.staffUserId,
+      staffRole: req.body?.staffRole,
+      propertyScope: req.body?.propertyScope,
+      workspaceScopes: Array.isArray(req.body?.workspaceScopes) ? req.body.workspaceScopes : [],
+    });
+    return res.status(201).json({ ok: true, assignment: result.assignment });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+companyRouter.post("/:companyId/staff-assignments/:assignmentId/suspend", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await suspendPropertyManagerCompanyStaffAssignmentRecord({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+      assignmentId: req.params.assignmentId,
+      reason: req.body?.reason,
+    });
+    return res.status(200).json({ ok: true, assignment: result.assignment });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+companyRouter.post("/:companyId/staff-assignments/:assignmentId/reactivate", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await reactivatePropertyManagerCompanyStaffAssignmentRecord({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+      assignmentId: req.params.assignmentId,
+    });
+    return res.status(200).json({ ok: true, assignment: result.assignment });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+companyRouter.post("/:companyId/staff-assignments/:assignmentId/remove", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await removePropertyManagerCompanyStaffAssignmentRecord({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+      assignmentId: req.params.assignmentId,
+      reason: req.body?.reason,
+    });
+    return res.status(200).json({ ok: true, assignment: result.assignment });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
 
 companyRouter.post("/:companyId/relationships/:relationshipId/accept", async (req: any, res) => {
   const context = actorContext(req);

--- a/rentchain-api/src/services/propertyManagerCompanyStaffAssignmentService.ts
+++ b/rentchain-api/src/services/propertyManagerCompanyStaffAssignmentService.ts
@@ -1,0 +1,445 @@
+import { db } from "../firebase";
+import {
+  buildPropertyManagerCompanyAuditEvent,
+  createPropertyManagerCompanyStaffAssignment,
+  reactivatePropertyManagerCompanyStaffAssignment,
+  removePropertyManagerCompanyStaffAssignment,
+  suspendPropertyManagerCompanyStaffAssignment,
+  type LandlordCompanyRelationship,
+  type PropertyManagerCompanyAuditEvent,
+  type PropertyManagerCompanyAuditOutcome,
+  type PropertyManagerCompanyMembership,
+  type PropertyManagerCompanyPropertyScope,
+  type PropertyManagerCompanyStaffAssignment,
+  type PropertyManagerCompanyStaffAssignmentStatus,
+} from "../lib/propertyManagerCompany";
+import {
+  LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION,
+  PROPERTY_MANAGER_COMPANY_AUDIT_EVENTS_COLLECTION,
+  PROPERTY_MANAGER_COMPANY_MEMBERSHIPS_COLLECTION,
+  type PropertyManagerCompanyRelationshipFirestoreLike,
+} from "./propertyManagerCompanyRelationshipService";
+
+export const PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENTS_COLLECTION = "propertyManagerCompanyStaffAssignments";
+
+type SnapshotLike = {
+  id?: string;
+  exists?: boolean;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type ServiceOptions = {
+  firestore?: PropertyManagerCompanyRelationshipFirestoreLike;
+};
+
+type CreateAssignmentInput = {
+  actorUserId: string;
+  companyId: string;
+  relationshipId: string;
+  staffUserId: string;
+  staffRole: string;
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: string[];
+  now?: string;
+};
+
+type ListAssignmentsInput = {
+  actorUserId: string;
+  companyId: string;
+  relationshipId?: string | null;
+};
+
+type AssignmentLifecycleInput = {
+  actorUserId: string;
+  companyId: string;
+  assignmentId: string;
+  reason?: string | null;
+  now?: string;
+};
+
+export type PropertyManagerCompanyStaffAssignmentProjection = Omit<PropertyManagerCompanyStaffAssignment, "auditEventIds"> & {
+  staffDisplayLabel: string;
+};
+
+function assignmentDb(
+  firestore?: PropertyManagerCompanyRelationshipFirestoreLike
+): PropertyManagerCompanyRelationshipFirestoreLike {
+  return firestore || (db as unknown as PropertyManagerCompanyRelationshipFirestoreLike);
+}
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new Error(code);
+  return text;
+}
+
+function relationshipFromSnapshot(snapshot: SnapshotLike): LandlordCompanyRelationship | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as LandlordCompanyRelationship;
+}
+
+function membershipFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompanyMembership | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as PropertyManagerCompanyMembership;
+}
+
+function assignmentFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompanyStaffAssignment | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as PropertyManagerCompanyStaffAssignment;
+}
+
+async function loadRelationship(
+  relationshipId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<LandlordCompanyRelationship | null> {
+  const ref = firestore
+    .collection<LandlordCompanyRelationship>(LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION)
+    .doc(relationshipId);
+  const snapshot = await ref.get?.();
+  if (!snapshot?.exists) return null;
+  return relationshipFromSnapshot(snapshot);
+}
+
+async function loadAssignment(
+  assignmentId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<PropertyManagerCompanyStaffAssignment | null> {
+  const ref = firestore
+    .collection<PropertyManagerCompanyStaffAssignment>(PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENTS_COLLECTION)
+    .doc(assignmentId);
+  const snapshot = await ref.get?.();
+  if (!snapshot?.exists) return null;
+  return assignmentFromSnapshot(snapshot);
+}
+
+async function loadMembership(
+  companyId: string,
+  userId: string,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike,
+  missingCode = "property_manager_company_membership_not_found"
+): Promise<PropertyManagerCompanyMembership> {
+  const snapshot = await firestore.collection<PropertyManagerCompanyMembership>(PROPERTY_MANAGER_COMPANY_MEMBERSHIPS_COLLECTION).get?.();
+  const membership = (snapshot?.docs || [])
+    .map(membershipFromSnapshot)
+    .find((candidate): candidate is PropertyManagerCompanyMembership => {
+      return Boolean(candidate && candidate.companyId === companyId && candidate.userId === userId);
+    });
+  if (!membership) throw new Error(missingCode);
+  return membership;
+}
+
+function requireCompanyAssignmentManager(membership: PropertyManagerCompanyMembership, companyId: string) {
+  if (membership.companyId !== companyId) throw new Error("property_manager_company_membership_mismatch");
+  if (membership.status !== "active") throw new Error("property_manager_company_membership_not_active");
+  if (
+    ![
+      "company_owner",
+      "company_admin",
+      "regional_manager",
+      "property_manager",
+      "leasing_agent",
+      "office_administrator",
+      "maintenance_coordinator",
+      "read_only_staff",
+    ].includes(membership.role)
+  ) {
+    throw new Error("invalid_company_role");
+  }
+  if (!["company_owner", "company_admin"].includes(membership.role)) {
+    throw new Error("company_assignment_manager_required");
+  }
+}
+
+function requireRelationshipForCompany(
+  relationship: LandlordCompanyRelationship | null,
+  companyId: string
+): LandlordCompanyRelationship {
+  if (!relationship || relationship.propertyManagerCompanyId !== companyId) {
+    throw new Error("landlord_company_relationship_not_found");
+  }
+  return relationship;
+}
+
+function requireAssignmentForCompany(
+  assignment: PropertyManagerCompanyStaffAssignment | null,
+  companyId: string
+): PropertyManagerCompanyStaffAssignment {
+  if (!assignment || assignment.propertyManagerCompanyId !== companyId) {
+    throw new Error("property_manager_company_staff_assignment_not_found");
+  }
+  return assignment;
+}
+
+function projectAssignment(assignment: PropertyManagerCompanyStaffAssignment): PropertyManagerCompanyStaffAssignmentProjection {
+  const { auditEventIds: _auditEventIds, ...safe } = assignment;
+  return {
+    ...safe,
+    staffDisplayLabel: "Company staff",
+  };
+}
+
+async function appendAuditEvent(
+  event: PropertyManagerCompanyAuditEvent,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+) {
+  const ref = firestore
+    .collection<PropertyManagerCompanyAuditEvent>(PROPERTY_MANAGER_COMPANY_AUDIT_EVENTS_COLLECTION)
+    .doc(event.eventId);
+  if (ref.create) {
+    await ref.create(event);
+    return;
+  }
+  if (!ref.set) throw new Error("property_manager_company_audit_append_unavailable");
+  await ref.set(event, { merge: false });
+}
+
+async function saveAssignment(
+  assignment: PropertyManagerCompanyStaffAssignment,
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+) {
+  const ref = firestore
+    .collection<PropertyManagerCompanyStaffAssignment>(PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENTS_COLLECTION)
+    .doc(assignment.assignmentId);
+  if (!ref.set) throw new Error("property_manager_company_staff_assignment_write_unavailable");
+  await ref.set(assignment, { merge: false });
+}
+
+function buildAssignmentAuditEvent(input: {
+  eventType:
+    | "staff_assignment_created"
+    | "staff_assignment_suspended"
+    | "staff_assignment_reactivated"
+    | "staff_assignment_removed";
+  actorUserId: string;
+  companyId: string;
+  landlordId: string;
+  relationshipId: string;
+  assignment: PropertyManagerCompanyStaffAssignment;
+  from: PropertyManagerCompanyStaffAssignmentStatus | null;
+  to: PropertyManagerCompanyStaffAssignmentStatus;
+  outcome: PropertyManagerCompanyAuditOutcome;
+  timestamp: string;
+  reason?: string | null;
+}): PropertyManagerCompanyAuditEvent {
+  return buildPropertyManagerCompanyAuditEvent({
+    eventType: input.eventType,
+    actorUserId: input.actorUserId,
+    actorCompanyId: input.companyId,
+    propertyManagerCompanyId: input.companyId,
+    actingForLandlordId: input.landlordId,
+    relationshipId: input.relationshipId,
+    assignmentId: input.assignment.assignmentId,
+    staffUserId: input.assignment.staffUserId,
+    role: input.assignment.staffRole,
+    scope: {
+      propertyScope: input.assignment.propertyScope,
+      workspaceScopes: input.assignment.workspaceScopes,
+    },
+    targetResourceType: "staff_assignment",
+    targetResourceId: input.assignment.assignmentId,
+    outcome: input.outcome,
+    timestamp: input.timestamp,
+    reason: input.reason || null,
+    statusTransition: {
+      from: input.from,
+      to: input.to,
+    },
+  });
+}
+
+export async function listPropertyManagerCompanyStaffAssignmentRecords(
+  input: ListAssignmentsInput,
+  options: ServiceOptions = {}
+): Promise<{ assignments: PropertyManagerCompanyStaffAssignmentProjection[] }> {
+  const firestore = assignmentDb(options.firestore);
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const relationshipId = cleanString(input.relationshipId, 200);
+  const actorMembership = await loadMembership(companyId, actorUserId, firestore);
+  requireCompanyAssignmentManager(actorMembership, companyId);
+
+  if (relationshipId) {
+    requireRelationshipForCompany(await loadRelationship(relationshipId, firestore), companyId);
+  }
+
+  const snapshot = await firestore.collection<PropertyManagerCompanyStaffAssignment>(PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENTS_COLLECTION).get?.();
+  const assignments = (snapshot?.docs || [])
+    .map(assignmentFromSnapshot)
+    .filter((assignment): assignment is PropertyManagerCompanyStaffAssignment => Boolean(assignment))
+    .filter((assignment) => assignment.propertyManagerCompanyId === companyId)
+    .filter((assignment) => !relationshipId || assignment.relationshipId === relationshipId)
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
+  return { assignments: assignments.map(projectAssignment) };
+}
+
+export async function createPropertyManagerCompanyStaffAssignmentRecord(
+  input: CreateAssignmentInput,
+  options: ServiceOptions = {}
+): Promise<{ assignment: PropertyManagerCompanyStaffAssignmentProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = assignmentDb(options.firestore);
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const relationshipId = requireString(input.relationshipId, "missing_relationship_id");
+  const staffUserId = requireString(input.staffUserId, "missing_staff_user_id");
+  const now = input.now || new Date().toISOString();
+
+  const actorMembership = await loadMembership(companyId, actorUserId, firestore);
+  requireCompanyAssignmentManager(actorMembership, companyId);
+  const staffMembership = await loadMembership(
+    companyId,
+    staffUserId,
+    firestore,
+    "property_manager_company_staff_membership_not_found"
+  );
+  const relationship = requireRelationshipForCompany(await loadRelationship(relationshipId, firestore), companyId);
+
+  const assignment = createPropertyManagerCompanyStaffAssignment({
+    relationship,
+    assignedByMembership: actorMembership,
+    staffMembership,
+    staffRole: input.staffRole,
+    propertyScope: input.propertyScope,
+    workspaceScopes: input.workspaceScopes,
+    createdAt: now,
+  });
+  const auditEvent = buildAssignmentAuditEvent({
+    eventType: "staff_assignment_created",
+    actorUserId,
+    companyId,
+    landlordId: relationship.landlordId,
+    relationshipId,
+    assignment,
+    from: null,
+    to: "active",
+    outcome: "created",
+    timestamp: now,
+  });
+  const withAudit = { ...assignment, auditEventIds: [auditEvent.eventId] };
+  await saveAssignment(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { assignment: projectAssignment(withAudit), auditEvent };
+}
+
+export async function suspendPropertyManagerCompanyStaffAssignmentRecord(
+  input: AssignmentLifecycleInput,
+  options: ServiceOptions = {}
+): Promise<{ assignment: PropertyManagerCompanyStaffAssignmentProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = assignmentDb(options.firestore);
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const assignmentId = requireString(input.assignmentId, "missing_assignment_id");
+  const now = input.now || new Date().toISOString();
+
+  const actorMembership = await loadMembership(companyId, actorUserId, firestore);
+  const assignment = requireAssignmentForCompany(await loadAssignment(assignmentId, firestore), companyId);
+  const relationship = requireRelationshipForCompany(await loadRelationship(assignment.relationshipId, firestore), companyId);
+  const suspended = suspendPropertyManagerCompanyStaffAssignment(assignment, {
+    actorMembership,
+    suspendedAt: now,
+    reason: input.reason || null,
+  });
+  const auditEvent = buildAssignmentAuditEvent({
+    eventType: "staff_assignment_suspended",
+    actorUserId,
+    companyId,
+    landlordId: relationship.landlordId,
+    relationshipId: relationship.relationshipId,
+    assignment: suspended,
+    from: assignment.status,
+    to: "suspended",
+    outcome: "suspended",
+    timestamp: now,
+    reason: input.reason || null,
+  });
+  const withAudit = { ...suspended, auditEventIds: [...suspended.auditEventIds, auditEvent.eventId] };
+  await saveAssignment(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { assignment: projectAssignment(withAudit), auditEvent };
+}
+
+export async function reactivatePropertyManagerCompanyStaffAssignmentRecord(
+  input: AssignmentLifecycleInput,
+  options: ServiceOptions = {}
+): Promise<{ assignment: PropertyManagerCompanyStaffAssignmentProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = assignmentDb(options.firestore);
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const assignmentId = requireString(input.assignmentId, "missing_assignment_id");
+  const now = input.now || new Date().toISOString();
+
+  const actorMembership = await loadMembership(companyId, actorUserId, firestore);
+  const assignment = requireAssignmentForCompany(await loadAssignment(assignmentId, firestore), companyId);
+  const staffMembership = await loadMembership(
+    companyId,
+    assignment.staffUserId,
+    firestore,
+    "property_manager_company_staff_membership_not_found"
+  );
+  const relationship = requireRelationshipForCompany(await loadRelationship(assignment.relationshipId, firestore), companyId);
+  const reactivated = reactivatePropertyManagerCompanyStaffAssignment(assignment, {
+    actorMembership,
+    staffMembership,
+    relationship,
+    reactivatedAt: now,
+  });
+  const auditEvent = buildAssignmentAuditEvent({
+    eventType: "staff_assignment_reactivated",
+    actorUserId,
+    companyId,
+    landlordId: relationship.landlordId,
+    relationshipId: relationship.relationshipId,
+    assignment: reactivated,
+    from: assignment.status,
+    to: "active",
+    outcome: "allowed",
+    timestamp: now,
+  });
+  const withAudit = { ...reactivated, auditEventIds: [...reactivated.auditEventIds, auditEvent.eventId] };
+  await saveAssignment(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { assignment: projectAssignment(withAudit), auditEvent };
+}
+
+export async function removePropertyManagerCompanyStaffAssignmentRecord(
+  input: AssignmentLifecycleInput,
+  options: ServiceOptions = {}
+): Promise<{ assignment: PropertyManagerCompanyStaffAssignmentProjection; auditEvent: PropertyManagerCompanyAuditEvent }> {
+  const firestore = assignmentDb(options.firestore);
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const assignmentId = requireString(input.assignmentId, "missing_assignment_id");
+  const now = input.now || new Date().toISOString();
+
+  const actorMembership = await loadMembership(companyId, actorUserId, firestore);
+  const assignment = requireAssignmentForCompany(await loadAssignment(assignmentId, firestore), companyId);
+  const relationship = requireRelationshipForCompany(await loadRelationship(assignment.relationshipId, firestore), companyId);
+  const removed = removePropertyManagerCompanyStaffAssignment(assignment, {
+    actorMembership,
+    removedAt: now,
+    reason: input.reason || null,
+  });
+  const auditEvent = buildAssignmentAuditEvent({
+    eventType: "staff_assignment_removed",
+    actorUserId,
+    companyId,
+    landlordId: relationship.landlordId,
+    relationshipId: relationship.relationshipId,
+    assignment: removed,
+    from: assignment.status,
+    to: "removed",
+    outcome: "removed",
+    timestamp: now,
+    reason: input.reason || null,
+  });
+  const withAudit = { ...removed, auditEventIds: [...removed.auditEventIds, auditEvent.eventId] };
+  await saveAssignment(withAudit, firestore);
+  await appendAuditEvent(auditEvent, firestore);
+  return { assignment: projectAssignment(withAudit), auditEvent };
+}


### PR DESCRIPTION
## Summary
- adds Mission Brief for property manager company staff assignment API V1
- adds company-scoped staff assignment service for create/list/suspend/reactivate/remove
- wires backend API routes under /api/property-manager-companies
- preserves Company Owner/Admin-only assignment management, scope ceilings, lifecycle history, and metadata-only audit events

## Scope
- Backend/API only
- No UI
- No dashboard
- No emails
- No contractor organizations
- No billing delegation
- No custom permissions
- No frontend routes
- No migration/backfill

## Validation
- npm test -- propertyManagerCompanyStaffAssignmentRoutes.test.ts
- npm test -- propertyManagerCompanyRelationshipRoutes.test.ts src/lib/propertyManagerCompany
- npm run build
- git diff --check