### PR TITLE
feat: add property manager company management read APIs

### DIFF
--- a/docs/design/mission-briefs/property-manager-company-management-read-api-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-management-read-api-v1.html
@@ -1,0 +1,445 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Property Manager Company Management Read API V1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #eef2f6;
+        color: #142033;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 28px;
+        background: #eef2f6;
+      }
+
+      .brief {
+        max-width: 1280px;
+        margin: 0 auto;
+        border: 1px solid #d5dde8;
+        background: #ffffff;
+        box-shadow: 0 18px 50px rgba(20, 32, 51, 0.12);
+      }
+
+      header {
+        padding: 26px 30px;
+        background: #142033;
+        color: #ffffff;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: 26px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      h1 span {
+        color: #8fd6ff;
+      }
+
+      .subtitle {
+        max-width: 930px;
+        color: #d8e7f4;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.05fr) minmax(390px, 0.95fr);
+      }
+
+      section {
+        padding: 26px 30px;
+      }
+
+      .left {
+        border-right: 1px solid #d5dde8;
+      }
+
+      .block {
+        margin-bottom: 23px;
+      }
+
+      .block:last-child {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        margin-bottom: 10px;
+        color: #142033;
+        font-size: 14px;
+        line-height: 1.25;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        color: #2a3d55;
+        font-size: 14px;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 13.5px;
+        line-height: 1.46;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .card {
+        padding: 14px;
+        border: 1px solid #d5dde8;
+        background: #f8fafc;
+      }
+
+      .card strong {
+        display: block;
+        margin-bottom: 5px;
+      }
+
+      .panel {
+        padding: 14px 16px;
+        border-left: 4px solid #246bfe;
+        background: #f4f8ff;
+      }
+
+      .warning {
+        border-left-color: #b7791f;
+        background: #fff8e8;
+      }
+
+      .success {
+        border-left-color: #16895a;
+        background: #f0fff7;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid #d5dde8;
+        background: #ffffff;
+      }
+
+      .table th,
+      .table td {
+        padding: 8px 9px;
+        border-bottom: 1px solid #e3e9f1;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .table th {
+        background: #f4f7fb;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        padding: 6px 9px;
+        border: 1px solid #c8d2df;
+        background: #f4f7fb;
+        color: #26374f;
+        font-size: 12px;
+        font-weight: 800;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        color: #1b4f9c;
+      }
+
+      @media (max-width: 920px) {
+        body {
+          padding: 14px;
+        }
+
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        .left {
+          border-right: 0;
+          border-bottom: 1px solid #d5dde8;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <h1>Mission Brief: <span>Property Manager Company Management Read API V1</span></h1>
+        <p class="subtitle">
+          Add safe read-only backend APIs required before the PM Company Management UI can be implemented. This mission
+          fills discovery and projection gaps only; it must not add write behavior, UI routes, emails, billing authority,
+          contractor organization behavior, or custom permissions.
+        </p>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>1. Mission Goal</h2>
+            <p>
+              Provide server-authorized, projection-safe read surfaces for landlord owners and PM Company Owners/Admins
+              so the next UI mission can render company relationships, company context, staff membership, and assignment
+              state without raw-ID entry or cross-tenant/company leakage.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>2. Scope</h2>
+            <div class="grid">
+              <div class="card">
+                <strong>Landlord Reads</strong>
+                <ul>
+                  <li>Safe PM company discovery/lookup for relationship creation.</li>
+                  <li>Landlord-scoped relationship list with safe company label and relationship scope.</li>
+                  <li>Landlord-visible staff assignment summaries under landlord-owned relationships.</li>
+                </ul>
+              </div>
+              <div class="card">
+                <strong>Company Reads</strong>
+                <ul>
+                  <li>Actor company context list for active Company Owner/Admin memberships.</li>
+                  <li>Company-scoped relationship list with safe landlord workspace label.</li>
+                  <li>Company member list and assignment projections for management UI.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>3. Required Read Surfaces</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Surface</th>
+                  <th>Expected Projection</th>
+                  <th>Authority</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Company discovery / lookup</td>
+                  <td>Company reference token/id for API use, safe display label, status if needed.</td>
+                  <td>Authenticated landlord owner; no private company metadata.</td>
+                </tr>
+                <tr>
+                  <td>Landlord relationship listing</td>
+                  <td>Company label, relationship status, scope, lifecycle timestamps, safe assignment summary.</td>
+                  <td>Landlord scope from auth context only.</td>
+                </tr>
+                <tr>
+                  <td>Company relationship listing</td>
+                  <td>Safe landlord workspace label, status, scope, pending acceptance marker, timestamps.</td>
+                  <td>Active Company Owner/Admin membership for that company.</td>
+                </tr>
+                <tr>
+                  <td>Company membership/staff listing</td>
+                  <td>Safe staff label, role, status, lifecycle timestamps needed by UI.</td>
+                  <td>Active Company Owner/Admin membership for that company.</td>
+                </tr>
+                <tr>
+                  <td>Staff assignment projections</td>
+                  <td>Staff label, role, status, scope, relationship reference, lifecycle timestamps.</td>
+                  <td>Company Owner/Admin or landlord owner scoped to the relationship.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>4. Proposed API Shape</h2>
+            <ul>
+              <li><code>GET /api/landlord/property-manager-companies/search?q=...</code></li>
+              <li><code>GET /api/landlord/property-manager-company-relationships</code> with enriched safe summaries.</li>
+              <li><code>GET /api/landlord/property-manager-company-relationships/:relationshipId/staff-assignments</code></li>
+              <li><code>GET /api/property-manager-companies/my-companies</code></li>
+              <li><code>GET /api/property-manager-companies/:companyId/relationships</code></li>
+              <li><code>GET /api/property-manager-companies/:companyId/members</code></li>
+              <li><code>GET /api/property-manager-companies/:companyId/staff-assignments?relationshipId=...</code> safe projection hardening.</li>
+            </ul>
+            <p>
+              Exact route names may follow local conventions during implementation, but the authority and projection
+              contracts above are required.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>5. Projection Rules</h2>
+            <ul>
+              <li>Raw IDs may be returned only as opaque API references needed for follow-up API calls, never as labels.</li>
+              <li>User-facing labels must use safe company, landlord workspace, and staff display labels.</li>
+              <li>Do not expose audit event IDs, internal membership IDs as labels, token-like fields, private metadata, billing data, or unrelated PII.</li>
+              <li>Assignment summaries must preserve role, status, scope, and timestamps without widening visibility.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>6. Security Model</h2>
+            <ul>
+              <li>Landlord reads derive landlord scope from authenticated landlord owner context only.</li>
+              <li>Company reads require active Company Owner/Admin membership for the requested company.</li>
+              <li>Query/body cannot override landlord or company authority.</li>
+              <li>Cross-landlord and cross-company records are hidden or denied fail-closed.</li>
+              <li>Malformed company, membership, relationship, or assignment records fail closed.</li>
+              <li>Billing/settings remain out of scope and must not be included in management projections.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <div class="block">
+            <h2>7. Non-Goals</h2>
+            <div class="pill-row">
+              <span class="pill">No UI</span>
+              <span class="pill">No dashboard</span>
+              <span class="pill">No create/update/delete behavior</span>
+              <span class="pill">No emails</span>
+              <span class="pill">No contractor organizations</span>
+              <span class="pill">No billing delegation</span>
+              <span class="pill">No custom permissions</span>
+              <span class="pill">No migrations/backfills</span>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>8. Existing API Gap</h2>
+            <div class="panel warning">
+              <p>
+                Current write/lifecycle APIs require known company, relationship, and staff user identifiers. The UI
+                cannot safely collect those identifiers from humans. This mission adds the missing read model layer that
+                lets the UI select safe labels while still sending canonical API references server-side.
+              </p>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>9. Implementation Plan</h2>
+            <ul>
+              <li>Add backend read service helpers near existing PM company relationship/assignment services.</li>
+              <li>Reuse existing Firestore collection constants and projection-safe patterns.</li>
+              <li>Add landlord routes under the existing landlord PM company route namespace.</li>
+              <li>Add company routes under <code>/api/property-manager-companies</code>.</li>
+              <li>Keep existing write APIs unchanged except for projection hardening if needed.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>10. Tests</h2>
+            <ul>
+              <li>Company discovery returns only safe active company projections.</li>
+              <li>Landlord relationship list is auth-landlord scoped and includes safe assignment summary.</li>
+              <li>Company relationship list requires active Company Owner/Admin and denies non-admin roles.</li>
+              <li>Company member list includes active, suspended, and removed members with safe staff labels, role, status, and no private metadata.</li>
+              <li>Landlord and company assignment projections deny cross-landlord/cross-company reads.</li>
+              <li>Malformed records and unknown roles/statuses fail closed.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>11. QA / Validation</h2>
+            <ul>
+              <li>Focused backend route/service tests for each read surface.</li>
+              <li>Cross-landlord and cross-company denial tests.</li>
+              <li>Safe projection tests for no audit IDs, no raw IDs as labels, no private metadata leakage.</li>
+              <li>Backend build.</li>
+              <li><code>git diff --check</code>.</li>
+              <li>No frontend build required unless implementation unexpectedly touches frontend, which is out of scope.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>12. Risks</h2>
+            <ul>
+              <li>Company discovery could overexpose private company data if not tightly projected.</li>
+              <li>Staff labels may be limited until user profile display-name data is available; email-safe labels may be needed.</li>
+              <li>Landlord-visible staff assignment summaries must not become staff management authority.</li>
+              <li>Relationship assignment summaries must not imply billing/settings access.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>13. Acceptance Criteria</h2>
+            <ul>
+              <li>All required read surfaces exist and are covered by backend tests.</li>
+              <li>Landlord reads cannot escape authenticated landlord scope.</li>
+              <li>Company reads cannot escape active Company Owner/Admin company scope.</li>
+              <li>Safe projections include labels/status/scope/timestamps and exclude private metadata.</li>
+              <li>No write behavior, UI, emails, billing delegation, contractor orgs, custom permissions, or migrations are added.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>14. Merge Readiness Criteria</h2>
+            <div class="panel success">
+              <ul>
+                <li>Mission Brief reviewed and accepted before implementation.</li>
+                <li>Focused backend tests pass.</li>
+                <li>Backend build passes.</li>
+                <li><code>git diff --check</code> passes.</li>
+                <li>Contract review confirms safe projections and no scope creep.</li>
+                <li>PR remains draft until checks and contract review are complete.</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>15. Next Mission Unblocked</h2>
+            <p>
+              After this read API lands, the UI mission
+              <code>feat/property-manager-company-management-ui-v1</code> can proceed with safe selectable company,
+              relationship, member, and assignment data.
+            </p>
+          </div>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/rentchain-api/src/routes/__tests__/propertyManagerCompanyManagementReadRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertyManagerCompanyManagementReadRoutes.test.ts
@@ -1,0 +1,477 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = Record<string, any>;
+
+const collections = vi.hoisted(() => new Map<string, Map<string, StoredDoc>>());
+const fakeDb = vi.hoisted(() => ({
+  collection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    const collection = collections.get(name)!;
+    return {
+      doc(id?: string) {
+        const docId = id || `test_doc_${collection.size + 1}`;
+        return {
+          id: docId,
+          async get() {
+            return {
+              id: docId,
+              exists: collection.has(docId),
+              data: () => collection.get(docId),
+            };
+          },
+          async set(data: StoredDoc) {
+            collection.set(docId, data);
+          },
+          async create(data: StoredDoc) {
+            if (collection.has(docId)) throw new Error("already_exists");
+            collection.set(docId, data);
+          },
+        };
+      },
+      async get() {
+        return {
+          docs: Array.from(collection.entries()).map(([id, data]) => ({
+            id,
+            exists: true,
+            data: () => data,
+          })),
+        };
+      },
+    };
+  },
+}));
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+function readCollection(name: string): StoredDoc[] {
+  return Array.from((collections.get(name) || new Map()).values());
+}
+
+function writeCollectionDoc(name: string, id: string, data: StoredDoc) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  collections.get(name)!.set(id, data);
+}
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: Record<string, unknown> }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+const ownerUser = { id: "owner-user-1", role: "landlord", landlordId: "landlord-1", email: "owner@example.com" };
+const otherOwnerUser = { id: "owner-user-2", role: "landlord", landlordId: "landlord-2", email: "other@example.com" };
+const delegateUser = { id: "delegate-user-1", role: "delegate", email: "delegate@example.com" };
+const companyAdminUser = { id: "company-admin-1", role: "property_manager_company", email: "admin@elite.example" };
+const companyStaffUser = { id: "company-staff-1", role: "property_manager_company", email: "staff@elite.example" };
+const otherCompanyAdminUser = { id: "company-admin-2", role: "property_manager_company", email: "admin@other.example" };
+
+function seedCompany(overrides: Partial<StoredDoc> = {}) {
+  const company = {
+    companyId: overrides.companyId || "pm-company-1",
+    companyName: "Elite Property Management",
+    safeDisplayLabel: "Elite Property Management",
+    status: "active",
+    createdByUserId: "company-owner-1",
+    createdAt: "2026-06-24T00:00:00.000Z",
+    updatedAt: "2026-06-24T00:00:00.000Z",
+    privateNotes: "do not expose",
+    tokenSecret: "secret-token",
+    ...overrides,
+  };
+  writeCollectionDoc("propertyManagerCompanies", company.companyId, company);
+  return company;
+}
+
+function seedMembership(overrides: Partial<StoredDoc> = {}) {
+  const membership = {
+    membershipId: overrides.membershipId || `pm-membership-${readCollection("propertyManagerCompanyMemberships").length + 1}`,
+    companyId: "pm-company-1",
+    userId: "company-admin-1",
+    safeDisplayLabel: "Alex Admin",
+    role: "company_admin",
+    status: "active",
+    invitedByUserId: "company-owner-1",
+    createdByUserId: "company-owner-1",
+    createdAt: "2026-06-24T00:30:00.000Z",
+    updatedAt: "2026-06-24T00:30:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    removedAt: null,
+    removedByUserId: null,
+    privateNotes: "membership private",
+    ...overrides,
+  };
+  writeCollectionDoc("propertyManagerCompanyMemberships", membership.membershipId, membership);
+  return membership;
+}
+
+function seedRelationship(overrides: Partial<StoredDoc> = {}) {
+  const relationship = {
+    relationshipId: overrides.relationshipId || "relationship-active",
+    landlordId: "landlord-1",
+    landlordWorkspaceLabel: "Halifax Portfolio",
+    propertyManagerCompanyId: "pm-company-1",
+    status: "active",
+    relationshipScope: {
+      propertyScope: { mode: "selected_properties", propertyIds: ["property-a", "property-b"] },
+      workspaceScopes: ["dashboard", "operations"],
+    },
+    createdByLandlordOwnerUserId: "owner-user-1",
+    acceptedByCompanyAdminUserId: "company-admin-1",
+    createdAt: "2026-06-24T01:00:00.000Z",
+    updatedAt: "2026-06-24T02:00:00.000Z",
+    startedAt: "2026-06-24T02:00:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    reactivatedAt: null,
+    terminatedAt: null,
+    terminatedByUserId: null,
+    terminationReason: null,
+    auditEventIds: ["audit-secret"],
+    ...overrides,
+  };
+  writeCollectionDoc("landlordCompanyRelationships", relationship.relationshipId, relationship);
+  return relationship;
+}
+
+function seedAssignment(overrides: Partial<StoredDoc> = {}) {
+  const assignment = {
+    assignmentId: overrides.assignmentId || `assignment-${readCollection("propertyManagerCompanyStaffAssignments").length + 1}`,
+    propertyManagerCompanyId: "pm-company-1",
+    relationshipId: "relationship-active",
+    staffUserId: "company-staff-1",
+    assignedByUserId: "company-admin-1",
+    staffRole: "property_manager",
+    status: "active",
+    propertyScope: { mode: "selected_properties", propertyIds: ["property-a"] },
+    workspaceScopes: ["dashboard"],
+    createdAt: "2026-06-24T03:00:00.000Z",
+    updatedAt: "2026-06-24T03:00:00.000Z",
+    suspendedAt: null,
+    suspendedByUserId: null,
+    suspendedReason: null,
+    reactivatedAt: null,
+    reactivatedByUserId: null,
+    removedAt: null,
+    removedByUserId: null,
+    removedReason: null,
+    auditEventIds: ["assignment-audit-secret"],
+    ...overrides,
+  };
+  writeCollectionDoc("propertyManagerCompanyStaffAssignments", assignment.assignmentId, assignment);
+  return assignment;
+}
+
+function seedBaseCompanyData() {
+  seedCompany();
+  seedMembership({ membershipId: "admin-membership", userId: "company-admin-1", role: "company_admin", safeDisplayLabel: "Alex Admin" });
+  seedMembership({ membershipId: "staff-membership", userId: "company-staff-1", role: "property_manager", safeDisplayLabel: "Pat Manager" });
+  seedRelationship();
+}
+
+describe("property manager company management read routes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("supports safe PM company discovery for landlord owners only", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedCompany();
+    seedCompany({ companyId: "pm-company-2", companyName: "Harbour Managers", safeDisplayLabel: "Harbour Managers" });
+    seedCompany({ companyId: "pm-company-suspended", status: "suspended", safeDisplayLabel: "Suspended Managers" });
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-companies/search?q=elite",
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.companies).toEqual([
+      {
+        propertyManagerCompanyId: "pm-company-1",
+        companyLabel: "Elite Property Management",
+        status: "active",
+      },
+    ]);
+    expect(JSON.stringify(response.body.companies)).not.toContain("privateNotes");
+    expect(JSON.stringify(response.body.companies)).not.toContain("secret-token");
+    expect(JSON.stringify(response.body.companies)).not.toContain("companyName");
+
+    const denied = await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-companies/search",
+      user: delegateUser,
+    });
+    expect(denied.status).toBe(403);
+  });
+
+  it("lists landlord-scoped relationships with safe company labels and staff assignment summary", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedBaseCompanyData();
+    seedRelationship({ relationshipId: "relationship-other-landlord", landlordId: "landlord-2" });
+    seedAssignment({ assignmentId: "assignment-active", status: "active" });
+    seedAssignment({ assignmentId: "assignment-suspended", status: "suspended" });
+    seedAssignment({ assignmentId: "assignment-other-landlord", relationshipId: "relationship-other-landlord" });
+    seedRelationship({ relationshipId: "relationship-malformed", status: "unknown" });
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-company-relationships?landlordId=landlord-2",
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.relationships).toHaveLength(1);
+    expect(response.body.relationships[0]).toEqual(
+      expect.objectContaining({
+        relationshipId: "relationship-active",
+        landlordId: "landlord-1",
+        propertyManagerCompanyId: "pm-company-1",
+        propertyManagerCompanyLabel: "Elite Property Management",
+        landlordWorkspaceLabel: "Halifax Portfolio",
+        status: "active",
+        staffAssignmentSummary: {
+          total: 2,
+          active: 1,
+          suspended: 1,
+          removed: 0,
+        },
+      })
+    );
+    const serialized = JSON.stringify(response.body.relationships);
+    expect(serialized).not.toContain("auditEventIds");
+    expect(serialized).not.toContain("terminationReason");
+    expect(serialized).not.toContain("relationship-other-landlord");
+  });
+
+  it("allows landlord owners to view staff assigned under their relationship only", async () => {
+    const { default: router } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedBaseCompanyData();
+    seedAssignment();
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-company-relationships/relationship-active/staff-assignments",
+      user: ownerUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignments).toHaveLength(1);
+    expect(response.body.assignments[0]).toEqual(
+      expect.objectContaining({
+        assignmentId: expect.any(String),
+        relationshipId: "relationship-active",
+        staffUserId: "company-staff-1",
+        staffLabel: "Pat Manager",
+        staffRole: "property_manager",
+        status: "active",
+      })
+    );
+    expect(JSON.stringify(response.body.assignments)).not.toContain("auditEventIds");
+    expect(JSON.stringify(response.body.assignments)).not.toContain("suspendedReason");
+
+    const crossLandlord = await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-company-relationships/relationship-active/staff-assignments",
+      user: otherOwnerUser,
+    });
+    expect(crossLandlord.status).toBe(404);
+    expect(crossLandlord.body.error).toBe("LANDLORD_COMPANY_RELATIONSHIP_NOT_FOUND");
+  });
+
+  it("lists actor PM company contexts only for active owner/admin memberships", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedCompany();
+    seedCompany({ companyId: "pm-company-2", safeDisplayLabel: "Second Company" });
+    seedCompany({ companyId: "pm-company-3", safeDisplayLabel: "Staff Company" });
+    seedMembership({ membershipId: "admin-company-1", userId: "company-admin-1", companyId: "pm-company-1", role: "company_admin" });
+    seedMembership({ membershipId: "admin-company-2", userId: "company-admin-1", companyId: "pm-company-2", role: "company_owner" });
+    seedMembership({ membershipId: "staff-company-3", userId: "company-admin-1", companyId: "pm-company-3", role: "property_manager" });
+
+    const response = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/my-companies",
+      user: companyAdminUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.companies.map((company: any) => company.companyLabel)).toEqual([
+      "Elite Property Management",
+      "Second Company",
+    ]);
+    expect(JSON.stringify(response.body.companies)).not.toContain("Staff Company");
+    expect(JSON.stringify(response.body.companies)).not.toContain("membershipId");
+  });
+
+  it("lists company relationships for active Company Owner/Admin without cross-company leakage", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedBaseCompanyData();
+    seedRelationship({ relationshipId: "relationship-pending", status: "pending", startedAt: null });
+    seedRelationship({ relationshipId: "relationship-other-company", propertyManagerCompanyId: "pm-company-2", landlordWorkspaceLabel: "Other Portfolio" });
+    seedMembership({ membershipId: "other-company-admin", companyId: "pm-company-2", userId: "company-admin-2", role: "company_admin" });
+
+    const response = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/relationships?companyId=pm-company-2",
+      user: companyAdminUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.relationships.map((relationship: any) => relationship.relationshipId)).toEqual([
+      "relationship-active",
+      "relationship-pending",
+    ]);
+    expect(response.body.relationships[0]).toEqual(
+      expect.objectContaining({
+        landlordWorkspaceLabel: "Halifax Portfolio",
+        propertyManagerCompanyLabel: "Elite Property Management",
+      })
+    );
+    expect(JSON.stringify(response.body.relationships)).not.toContain("relationship-other-company");
+    expect(JSON.stringify(response.body.relationships)).not.toContain("auditEventIds");
+
+    const staffDenied = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/relationships",
+      user: companyStaffUser,
+    });
+    expect(staffDenied.status).toBe(403);
+
+    const crossCompanyDenied = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/relationships",
+      user: otherCompanyAdminUser,
+    });
+    expect(crossCompanyDenied.status).toBe(403);
+  });
+
+  it("lists company members with safe labels and lifecycle statuses only", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedBaseCompanyData();
+    seedMembership({
+      membershipId: "suspended-member",
+      userId: "company-suspended-1",
+      safeDisplayLabel: "Sam Suspended",
+      role: "leasing_agent",
+      status: "suspended",
+      suspendedAt: "2026-06-24T04:00:00.000Z",
+    });
+    seedMembership({
+      membershipId: "removed-member",
+      userId: "company-removed-1",
+      safeDisplayLabel: "Riley Removed",
+      role: "read_only_staff",
+      status: "removed",
+      removedAt: "2026-06-24T05:00:00.000Z",
+    });
+
+    const response = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/members",
+      user: companyAdminUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.members.map((member: any) => member.status).sort()).toEqual(["active", "active", "removed", "suspended"]);
+    expect(response.body.members).toContainEqual(
+      expect.objectContaining({ staffUserId: "company-suspended-1", staffLabel: "Sam Suspended", status: "suspended" })
+    );
+    const serialized = JSON.stringify(response.body.members);
+    expect(serialized).not.toContain("membershipId");
+    expect(serialized).not.toContain("invitedByUserId");
+    expect(serialized).not.toContain("createdByUserId");
+    expect(serialized).not.toContain("privateNotes");
+  });
+
+  it("lists company assignment projections by relationship with safe staff labels", async () => {
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedBaseCompanyData();
+    seedRelationship({ relationshipId: "relationship-second" });
+    seedAssignment({ assignmentId: "assignment-active", relationshipId: "relationship-active" });
+    seedAssignment({ assignmentId: "assignment-second", relationshipId: "relationship-second", status: "removed" });
+    seedAssignment({ assignmentId: "assignment-other-company", propertyManagerCompanyId: "pm-company-2", relationshipId: "relationship-other" });
+
+    const response = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/staff-assignments?relationshipId=relationship-active",
+      user: companyAdminUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignments).toHaveLength(1);
+    expect(response.body.assignments[0]).toEqual(
+      expect.objectContaining({
+        assignmentId: "assignment-active",
+        staffLabel: "Pat Manager",
+        staffDisplayLabel: "Pat Manager",
+        staffRole: "property_manager",
+        status: "active",
+      })
+    );
+    const serialized = JSON.stringify(response.body.assignments);
+    expect(serialized).not.toContain("assignment-other-company");
+    expect(serialized).not.toContain("auditEventIds");
+    expect(serialized).not.toContain("removedReason");
+    expect(serialized).not.toContain("assignedByUserId");
+
+    const crossRelationship = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/staff-assignments?relationshipId=relationship-other",
+      user: companyAdminUser,
+    });
+    expect(crossRelationship.status).toBe(404);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/propertyManagerCompanyManagementReadRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertyManagerCompanyManagementReadRoutes.test.ts
@@ -266,6 +266,13 @@ describe("property manager company management read routes", () => {
     seedAssignment({ assignmentId: "assignment-suspended", status: "suspended" });
     seedAssignment({ assignmentId: "assignment-other-landlord", relationshipId: "relationship-other-landlord" });
     seedRelationship({ relationshipId: "relationship-malformed", status: "unknown" });
+    seedRelationship({
+      relationshipId: "relationship-billing-scope",
+      relationshipScope: {
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: ["settings_billing"],
+      },
+    });
 
     const response = await invokeRouter(router, {
       method: "GET",
@@ -295,6 +302,7 @@ describe("property manager company management read routes", () => {
     expect(serialized).not.toContain("auditEventIds");
     expect(serialized).not.toContain("terminationReason");
     expect(serialized).not.toContain("relationship-other-landlord");
+    expect(serialized).not.toContain("relationship-billing-scope");
   });
 
   it("allows landlord owners to view staff assigned under their relationship only", async () => {
@@ -443,6 +451,8 @@ describe("property manager company management read routes", () => {
     seedAssignment({ assignmentId: "assignment-active", relationshipId: "relationship-active" });
     seedAssignment({ assignmentId: "assignment-second", relationshipId: "relationship-second", status: "removed" });
     seedAssignment({ assignmentId: "assignment-other-company", propertyManagerCompanyId: "pm-company-2", relationshipId: "relationship-other" });
+    seedAssignment({ assignmentId: "assignment-billing-scope", workspaceScopes: ["settings_billing"] });
+    seedAssignment({ assignmentId: "assignment-invalid-role", staffRole: "company_admin" });
 
     const response = await invokeRouter(propertyManagerCompanyRoutes, {
       method: "GET",
@@ -463,6 +473,8 @@ describe("property manager company management read routes", () => {
     );
     const serialized = JSON.stringify(response.body.assignments);
     expect(serialized).not.toContain("assignment-other-company");
+    expect(serialized).not.toContain("assignment-billing-scope");
+    expect(serialized).not.toContain("assignment-invalid-role");
     expect(serialized).not.toContain("auditEventIds");
     expect(serialized).not.toContain("removedReason");
     expect(serialized).not.toContain("assignedByUserId");
@@ -473,5 +485,40 @@ describe("property manager company management read routes", () => {
       user: companyAdminUser,
     });
     expect(crossRelationship.status).toBe(404);
+  });
+
+  it("does not mutate stored records when serving read projections", async () => {
+    const { default: router, propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    seedBaseCompanyData();
+    seedAssignment({ assignmentId: "assignment-active" });
+    const before = JSON.stringify(Array.from(collections.entries()));
+
+    await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-companies/search",
+      user: ownerUser,
+    });
+    await invokeRouter(router, {
+      method: "GET",
+      url: "/property-manager-company-relationships",
+      user: ownerUser,
+    });
+    await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/relationships",
+      user: companyAdminUser,
+    });
+    await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/members",
+      user: companyAdminUser,
+    });
+    await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/pm-company-1/staff-assignments",
+      user: companyAdminUser,
+    });
+
+    expect(JSON.stringify(Array.from(collections.entries()))).toBe(before);
   });
 });

--- a/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
+++ b/rentchain-api/src/routes/propertyManagerCompanyRelationshipRoutes.ts
@@ -3,14 +3,21 @@ import { requireAuth } from "../middleware/requireAuth";
 import {
   acceptLandlordCompanyRelationshipRecord,
   createLandlordCompanyRelationshipRecord,
-  listLandlordCompanyRelationshipRecords,
   reactivateLandlordCompanyRelationshipRecord,
   suspendLandlordCompanyRelationshipRecord,
   terminateLandlordCompanyRelationshipRecord,
 } from "../services/propertyManagerCompanyRelationshipService";
 import {
+  listCompanyMembersForManagement,
+  listCompanyRelationshipManagementRecords,
+  listCompanyStaffAssignmentsForManagement,
+  listLandlordPropertyManagerRelationshipManagementRecords,
+  listLandlordRelationshipStaffAssignmentsForManagement,
+  listMyPropertyManagerCompanyContexts,
+  searchPropertyManagerCompaniesForLandlord,
+} from "../services/propertyManagerCompanyManagementReadService";
+import {
   createPropertyManagerCompanyStaffAssignmentRecord,
-  listPropertyManagerCompanyStaffAssignmentRecords,
   reactivatePropertyManagerCompanyStaffAssignmentRecord,
   removePropertyManagerCompanyStaffAssignmentRecord,
   suspendPropertyManagerCompanyStaffAssignmentRecord,
@@ -74,6 +81,7 @@ function handleError(res: any, error: unknown) {
     code === "property_manager_company_acceptance_role_not_allowed" ||
     code === "property_manager_company_membership_mismatch" ||
     code === "company_assignment_manager_required" ||
+    code === "company_management_read_role_not_allowed" ||
     code === "membership_not_active" ||
     code === "invalid_company_role" ||
     code === "invalid_membership_status"
@@ -95,12 +103,26 @@ function handleError(res: any, error: unknown) {
 
 router.use(requireAuth);
 
+router.get("/property-manager-companies/search", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await searchPropertyManagerCompaniesForLandlord({
+      query: req.query?.q,
+    });
+    return res.status(200).json({ ok: true, companies: result.companies });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
 router.get("/property-manager-company-relationships", async (req: any, res) => {
   const context = ownerContext(req);
   if (!context) return forbidden(res);
 
   try {
-    const result = await listLandlordCompanyRelationshipRecords({
+    const result = await listLandlordPropertyManagerRelationshipManagementRecords({
       landlordId: context.landlordId,
     });
     return res.status(200).json({ ok: true, relationships: result.relationships });
@@ -123,6 +145,21 @@ router.post("/property-manager-company-relationships", async (req: any, res) => 
       requestedStatus: req.body?.status,
     });
     return res.status(201).json({ ok: true, relationship: result.relationship });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.get("/property-manager-company-relationships/:relationshipId/staff-assignments", async (req: any, res) => {
+  const context = ownerContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listLandlordRelationshipStaffAssignmentsForManagement({
+      landlordId: context.landlordId,
+      relationshipId: req.params.relationshipId,
+    });
+    return res.status(200).json({ ok: true, assignments: result.assignments });
   } catch (error) {
     return handleError(res, error);
   }
@@ -181,12 +218,56 @@ router.post("/property-manager-company-relationships/:relationshipId/terminate",
 
 companyRouter.use(requireAuth);
 
+companyRouter.get("/my-companies", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listMyPropertyManagerCompanyContexts({
+      actorUserId: context.actorUserId,
+    });
+    return res.status(200).json({ ok: true, companies: result.companies });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+companyRouter.get("/:companyId/relationships", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listCompanyRelationshipManagementRecords({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+    });
+    return res.status(200).json({ ok: true, relationships: result.relationships });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+companyRouter.get("/:companyId/members", async (req: any, res) => {
+  const context = actorContext(req);
+  if (!context) return forbidden(res);
+
+  try {
+    const result = await listCompanyMembersForManagement({
+      actorUserId: context.actorUserId,
+      companyId: req.params.companyId,
+    });
+    return res.status(200).json({ ok: true, members: result.members });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
 companyRouter.get("/:companyId/staff-assignments", async (req: any, res) => {
   const context = actorContext(req);
   if (!context) return forbidden(res);
 
   try {
-    const result = await listPropertyManagerCompanyStaffAssignmentRecords({
+    const result = await listCompanyStaffAssignmentsForManagement({
       actorUserId: context.actorUserId,
       companyId: req.params.companyId,
       relationshipId: req.query?.relationshipId,

--- a/rentchain-api/src/services/propertyManagerCompanyManagementReadService.ts
+++ b/rentchain-api/src/services/propertyManagerCompanyManagementReadService.ts
@@ -1,0 +1,486 @@
+import { db } from "../firebase";
+import {
+  LANDLORD_COMPANY_RELATIONSHIP_STATUSES,
+  PROPERTY_MANAGER_COMPANY_MEMBERSHIP_STATUSES,
+  PROPERTY_MANAGER_COMPANY_ROLES,
+  PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES,
+  PROPERTY_MANAGER_COMPANY_STATUSES,
+  type LandlordCompanyRelationship,
+  type PropertyManagerCompany,
+  type PropertyManagerCompanyMembership,
+  type PropertyManagerCompanyRelationshipScope,
+  type PropertyManagerCompanyStaffAssignment,
+} from "../lib/propertyManagerCompany";
+import {
+  LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION,
+  PROPERTY_MANAGER_COMPANIES_COLLECTION,
+  PROPERTY_MANAGER_COMPANY_MEMBERSHIPS_COLLECTION,
+  type PropertyManagerCompanyRelationshipFirestoreLike,
+} from "./propertyManagerCompanyRelationshipService";
+import { PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENTS_COLLECTION } from "./propertyManagerCompanyStaffAssignmentService";
+
+type SnapshotLike = {
+  id?: string;
+  exists?: boolean;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type ServiceOptions = {
+  firestore?: PropertyManagerCompanyRelationshipFirestoreLike;
+};
+
+type StaffAssignmentSummary = {
+  total: number;
+  active: number;
+  suspended: number;
+  removed: number;
+};
+
+export type PropertyManagerCompanyLookupProjection = {
+  propertyManagerCompanyId: string;
+  companyLabel: string;
+  status: PropertyManagerCompany["status"];
+};
+
+export type PropertyManagerCompanyRelationshipManagementProjection = {
+  relationshipId: string;
+  landlordId?: string;
+  propertyManagerCompanyId: string;
+  propertyManagerCompanyLabel: string;
+  landlordWorkspaceLabel: string;
+  status: LandlordCompanyRelationship["status"];
+  relationshipScope: PropertyManagerCompanyRelationshipScope;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  suspendedAt: string | null;
+  reactivatedAt: string | null;
+  terminatedAt: string | null;
+  staffAssignmentSummary: StaffAssignmentSummary;
+};
+
+export type PropertyManagerCompanyMembershipProjection = {
+  staffUserId: string;
+  staffLabel: string;
+  role: PropertyManagerCompanyMembership["role"];
+  status: PropertyManagerCompanyMembership["status"];
+  createdAt: string;
+  updatedAt: string;
+  suspendedAt: string | null;
+  removedAt: string | null;
+};
+
+export type PropertyManagerCompanyStaffAssignmentReadProjection = {
+  assignmentId: string;
+  propertyManagerCompanyId: string;
+  relationshipId: string;
+  staffUserId: string;
+  staffLabel: string;
+  staffDisplayLabel: string;
+  staffRole: PropertyManagerCompanyStaffAssignment["staffRole"];
+  status: PropertyManagerCompanyStaffAssignment["status"];
+  propertyScope: PropertyManagerCompanyStaffAssignment["propertyScope"];
+  workspaceScopes: PropertyManagerCompanyStaffAssignment["workspaceScopes"];
+  createdAt: string;
+  updatedAt: string;
+  suspendedAt: string | null;
+  reactivatedAt: string | null;
+  removedAt: string | null;
+};
+
+function readDb(
+  firestore?: PropertyManagerCompanyRelationshipFirestoreLike
+): PropertyManagerCompanyRelationshipFirestoreLike {
+  return firestore || (db as unknown as PropertyManagerCompanyRelationshipFirestoreLike);
+}
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new Error(code);
+  return text;
+}
+
+function normalizedLabel(value: unknown, fallback: string, unsafeValue?: string): string {
+  const label = cleanString(value, 160).replace(/\s+/g, " ");
+  if (!label || label === unsafeValue) return fallback;
+  return label;
+}
+
+function companyFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompany | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as PropertyManagerCompany;
+}
+
+function relationshipFromSnapshot(snapshot: SnapshotLike): LandlordCompanyRelationship | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as LandlordCompanyRelationship;
+}
+
+function membershipFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompanyMembership | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as PropertyManagerCompanyMembership;
+}
+
+function assignmentFromSnapshot(snapshot: SnapshotLike): PropertyManagerCompanyStaffAssignment | null {
+  const data = snapshot.data();
+  if (!data) return null;
+  return data as PropertyManagerCompanyStaffAssignment;
+}
+
+function hasValidCompanyShape(company: PropertyManagerCompany | null): company is PropertyManagerCompany {
+  return Boolean(
+    company &&
+      cleanString(company.companyId, 200) &&
+      PROPERTY_MANAGER_COMPANY_STATUSES.includes(company.status)
+  );
+}
+
+function hasValidRelationshipShape(
+  relationship: LandlordCompanyRelationship | null
+): relationship is LandlordCompanyRelationship {
+  return Boolean(
+    relationship &&
+      cleanString(relationship.relationshipId, 200) &&
+      cleanString(relationship.landlordId, 200) &&
+      cleanString(relationship.propertyManagerCompanyId, 200) &&
+      LANDLORD_COMPANY_RELATIONSHIP_STATUSES.includes(relationship.status)
+  );
+}
+
+function hasValidMembershipShape(membership: PropertyManagerCompanyMembership | null): membership is PropertyManagerCompanyMembership {
+  return Boolean(
+    membership &&
+      cleanString(membership.companyId, 200) &&
+      cleanString(membership.userId, 200) &&
+      PROPERTY_MANAGER_COMPANY_ROLES.includes(membership.role) &&
+      PROPERTY_MANAGER_COMPANY_MEMBERSHIP_STATUSES.includes(membership.status)
+  );
+}
+
+function hasValidAssignmentShape(
+  assignment: PropertyManagerCompanyStaffAssignment | null
+): assignment is PropertyManagerCompanyStaffAssignment {
+  return Boolean(
+    assignment &&
+      cleanString(assignment.assignmentId, 200) &&
+      cleanString(assignment.propertyManagerCompanyId, 200) &&
+      cleanString(assignment.relationshipId, 200) &&
+      cleanString(assignment.staffUserId, 200) &&
+      PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES.includes(assignment.status)
+  );
+}
+
+async function loadCompanies(firestore: PropertyManagerCompanyRelationshipFirestoreLike): Promise<PropertyManagerCompany[]> {
+  const snapshot = await firestore.collection<PropertyManagerCompany>(PROPERTY_MANAGER_COMPANIES_COLLECTION).get?.();
+  return (snapshot?.docs || []).map(companyFromSnapshot).filter(hasValidCompanyShape);
+}
+
+async function loadRelationships(
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<LandlordCompanyRelationship[]> {
+  const snapshot = await firestore.collection<LandlordCompanyRelationship>(LANDLORD_COMPANY_RELATIONSHIPS_COLLECTION).get?.();
+  return (snapshot?.docs || []).map(relationshipFromSnapshot).filter(hasValidRelationshipShape);
+}
+
+async function loadMemberships(
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<PropertyManagerCompanyMembership[]> {
+  const snapshot = await firestore.collection<PropertyManagerCompanyMembership>(PROPERTY_MANAGER_COMPANY_MEMBERSHIPS_COLLECTION).get?.();
+  return (snapshot?.docs || []).map(membershipFromSnapshot).filter(hasValidMembershipShape);
+}
+
+async function loadAssignments(
+  firestore: PropertyManagerCompanyRelationshipFirestoreLike
+): Promise<PropertyManagerCompanyStaffAssignment[]> {
+  const snapshot = await firestore.collection<PropertyManagerCompanyStaffAssignment>(PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENTS_COLLECTION).get?.();
+  return (snapshot?.docs || []).map(assignmentFromSnapshot).filter(hasValidAssignmentShape);
+}
+
+function safeCompanyLabel(company: PropertyManagerCompany | null, companyId: string): string {
+  return normalizedLabel(company?.safeDisplayLabel || company?.companyName, "Property manager company", companyId);
+}
+
+function safeStaffLabel(membership: PropertyManagerCompanyMembership | null, staffUserId: string): string {
+  const record = membership as (PropertyManagerCompanyMembership & { safeDisplayLabel?: unknown; displayName?: unknown }) | null;
+  return normalizedLabel(record?.safeDisplayLabel || record?.displayName, "Company staff", staffUserId);
+}
+
+function safeLandlordWorkspaceLabel(relationship: LandlordCompanyRelationship): string {
+  const record = relationship as LandlordCompanyRelationship & { landlordWorkspaceLabel?: unknown; landlordLabel?: unknown };
+  return normalizedLabel(record.landlordWorkspaceLabel || record.landlordLabel, "Landlord workspace", relationship.landlordId);
+}
+
+function assignmentSummary(assignments: PropertyManagerCompanyStaffAssignment[]): StaffAssignmentSummary {
+  return assignments.reduce(
+    (summary, assignment) => {
+      summary.total += 1;
+      if (assignment.status === "active") summary.active += 1;
+      if (assignment.status === "suspended") summary.suspended += 1;
+      if (assignment.status === "removed") summary.removed += 1;
+      return summary;
+    },
+    { total: 0, active: 0, suspended: 0, removed: 0 }
+  );
+}
+
+function projectRelationship(input: {
+  relationship: LandlordCompanyRelationship;
+  company: PropertyManagerCompany | null;
+  assignments: PropertyManagerCompanyStaffAssignment[];
+  includeLandlordId?: boolean;
+}): PropertyManagerCompanyRelationshipManagementProjection {
+  const projection: PropertyManagerCompanyRelationshipManagementProjection = {
+    relationshipId: input.relationship.relationshipId,
+    propertyManagerCompanyId: input.relationship.propertyManagerCompanyId,
+    propertyManagerCompanyLabel: safeCompanyLabel(input.company, input.relationship.propertyManagerCompanyId),
+    landlordWorkspaceLabel: safeLandlordWorkspaceLabel(input.relationship),
+    status: input.relationship.status,
+    relationshipScope: input.relationship.relationshipScope,
+    createdAt: input.relationship.createdAt,
+    updatedAt: input.relationship.updatedAt,
+    startedAt: input.relationship.startedAt,
+    suspendedAt: input.relationship.suspendedAt,
+    reactivatedAt: input.relationship.reactivatedAt,
+    terminatedAt: input.relationship.terminatedAt,
+    staffAssignmentSummary: assignmentSummary(input.assignments),
+  };
+  if (input.includeLandlordId) projection.landlordId = input.relationship.landlordId;
+  return projection;
+}
+
+function projectMembership(membership: PropertyManagerCompanyMembership): PropertyManagerCompanyMembershipProjection {
+  return {
+    staffUserId: membership.userId,
+    staffLabel: safeStaffLabel(membership, membership.userId),
+    role: membership.role,
+    status: membership.status,
+    createdAt: membership.createdAt,
+    updatedAt: membership.updatedAt,
+    suspendedAt: membership.suspendedAt,
+    removedAt: membership.removedAt,
+  };
+}
+
+function projectAssignment(
+  assignment: PropertyManagerCompanyStaffAssignment,
+  membership: PropertyManagerCompanyMembership | null
+): PropertyManagerCompanyStaffAssignmentReadProjection {
+  const staffLabel = safeStaffLabel(membership, assignment.staffUserId);
+  return {
+    assignmentId: assignment.assignmentId,
+    propertyManagerCompanyId: assignment.propertyManagerCompanyId,
+    relationshipId: assignment.relationshipId,
+    staffUserId: assignment.staffUserId,
+    staffLabel,
+    staffDisplayLabel: staffLabel,
+    staffRole: assignment.staffRole,
+    status: assignment.status,
+    propertyScope: assignment.propertyScope,
+    workspaceScopes: assignment.workspaceScopes,
+    createdAt: assignment.createdAt,
+    updatedAt: assignment.updatedAt,
+    suspendedAt: assignment.suspendedAt,
+    reactivatedAt: assignment.reactivatedAt,
+    removedAt: assignment.removedAt,
+  };
+}
+
+function requireCompanyManagerMembership(
+  memberships: PropertyManagerCompanyMembership[],
+  companyId: string,
+  actorUserId: string
+): PropertyManagerCompanyMembership {
+  const membership = memberships.find((candidate) => candidate.companyId === companyId && candidate.userId === actorUserId);
+  if (!membership) throw new Error("property_manager_company_membership_not_found");
+  if (membership.status !== "active") throw new Error("property_manager_company_membership_not_active");
+  if (!["company_owner", "company_admin"].includes(membership.role)) {
+    throw new Error("company_management_read_role_not_allowed");
+  }
+  return membership;
+}
+
+export async function searchPropertyManagerCompaniesForLandlord(
+  input: { query?: string | null },
+  options: ServiceOptions = {}
+): Promise<{ companies: PropertyManagerCompanyLookupProjection[] }> {
+  const firestore = readDb(options.firestore);
+  const query = cleanString(input.query, 120).toLowerCase();
+  const companies = (await loadCompanies(firestore))
+    .filter((company) => company.status === "active")
+    .filter((company) => {
+      if (!query) return true;
+      return safeCompanyLabel(company, company.companyId).toLowerCase().includes(query);
+    })
+    .sort((a, b) => safeCompanyLabel(a, a.companyId).localeCompare(safeCompanyLabel(b, b.companyId)))
+    .slice(0, 25)
+    .map((company) => ({
+      propertyManagerCompanyId: company.companyId,
+      companyLabel: safeCompanyLabel(company, company.companyId),
+      status: company.status,
+    }));
+  return { companies };
+}
+
+export async function listLandlordPropertyManagerRelationshipManagementRecords(
+  input: { landlordId: string },
+  options: ServiceOptions = {}
+): Promise<{ relationships: PropertyManagerCompanyRelationshipManagementProjection[] }> {
+  const firestore = readDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const [companies, relationships, assignments] = await Promise.all([
+    loadCompanies(firestore),
+    loadRelationships(firestore),
+    loadAssignments(firestore),
+  ]);
+  const companyById = new Map(companies.map((company) => [company.companyId, company]));
+  const relationshipsForLandlord = relationships
+    .filter((relationship) => relationship.landlordId === landlordId)
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
+  return {
+    relationships: relationshipsForLandlord.map((relationship) =>
+      projectRelationship({
+        relationship,
+        company: companyById.get(relationship.propertyManagerCompanyId) || null,
+        assignments: assignments.filter((assignment) => assignment.relationshipId === relationship.relationshipId),
+        includeLandlordId: true,
+      })
+    ),
+  };
+}
+
+export async function listMyPropertyManagerCompanyContexts(
+  input: { actorUserId: string },
+  options: ServiceOptions = {}
+): Promise<{ companies: Array<PropertyManagerCompanyLookupProjection & { role: PropertyManagerCompanyMembership["role"] }> }> {
+  const firestore = readDb(options.firestore);
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const [companies, memberships] = await Promise.all([loadCompanies(firestore), loadMemberships(firestore)]);
+  const companyById = new Map(companies.map((company) => [company.companyId, company]));
+  const contexts = memberships
+    .filter((membership) => membership.userId === actorUserId)
+    .filter((membership) => membership.status === "active")
+    .filter((membership) => ["company_owner", "company_admin"].includes(membership.role))
+    .map((membership) => ({ membership, company: companyById.get(membership.companyId) || null }))
+    .filter((context): context is { membership: PropertyManagerCompanyMembership; company: PropertyManagerCompany } =>
+      hasValidCompanyShape(context.company)
+    )
+    .sort((a, b) =>
+      safeCompanyLabel(a.company, a.company.companyId).localeCompare(safeCompanyLabel(b.company, b.company.companyId))
+    )
+    .map(({ membership, company }) => ({
+      propertyManagerCompanyId: company.companyId,
+      companyLabel: safeCompanyLabel(company, company.companyId),
+      status: company.status,
+      role: membership.role,
+    }));
+  return { companies: contexts };
+}
+
+export async function listCompanyRelationshipManagementRecords(
+  input: { actorUserId: string; companyId: string },
+  options: ServiceOptions = {}
+): Promise<{ relationships: PropertyManagerCompanyRelationshipManagementProjection[] }> {
+  const firestore = readDb(options.firestore);
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const [companies, memberships, relationships, assignments] = await Promise.all([
+    loadCompanies(firestore),
+    loadMemberships(firestore),
+    loadRelationships(firestore),
+    loadAssignments(firestore),
+  ]);
+  requireCompanyManagerMembership(memberships, companyId, actorUserId);
+  const company = companies.find((candidate) => candidate.companyId === companyId) || null;
+  const relationshipsForCompany = relationships
+    .filter((relationship) => relationship.propertyManagerCompanyId === companyId)
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)));
+  return {
+    relationships: relationshipsForCompany.map((relationship) =>
+      projectRelationship({
+        relationship,
+        company,
+        assignments: assignments.filter((assignment) => assignment.relationshipId === relationship.relationshipId),
+      })
+    ),
+  };
+}
+
+export async function listCompanyMembersForManagement(
+  input: { actorUserId: string; companyId: string },
+  options: ServiceOptions = {}
+): Promise<{ members: PropertyManagerCompanyMembershipProjection[] }> {
+  const firestore = readDb(options.firestore);
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const memberships = await loadMemberships(firestore);
+  requireCompanyManagerMembership(memberships, companyId, actorUserId);
+  const members = memberships
+    .filter((membership) => membership.companyId === companyId)
+    .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)))
+    .map(projectMembership);
+  return { members };
+}
+
+export async function listCompanyStaffAssignmentsForManagement(
+  input: { actorUserId: string; companyId: string; relationshipId?: string | null },
+  options: ServiceOptions = {}
+): Promise<{ assignments: PropertyManagerCompanyStaffAssignmentReadProjection[] }> {
+  const firestore = readDb(options.firestore);
+  const actorUserId = requireString(input.actorUserId, "missing_actor_user_id");
+  const companyId = requireString(input.companyId, "missing_property_manager_company_id");
+  const relationshipId = cleanString(input.relationshipId, 200);
+  const [memberships, relationships, assignments] = await Promise.all([
+    loadMemberships(firestore),
+    loadRelationships(firestore),
+    loadAssignments(firestore),
+  ]);
+  requireCompanyManagerMembership(memberships, companyId, actorUserId);
+  if (relationshipId && !relationships.some((relationship) => relationship.relationshipId === relationshipId && relationship.propertyManagerCompanyId === companyId)) {
+    throw new Error("landlord_company_relationship_not_found");
+  }
+  const membershipByUserId = new Map(
+    memberships.filter((membership) => membership.companyId === companyId).map((membership) => [membership.userId, membership])
+  );
+  return {
+    assignments: assignments
+      .filter((assignment) => assignment.propertyManagerCompanyId === companyId)
+      .filter((assignment) => !relationshipId || assignment.relationshipId === relationshipId)
+      .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)))
+      .map((assignment) => projectAssignment(assignment, membershipByUserId.get(assignment.staffUserId) || null)),
+  };
+}
+
+export async function listLandlordRelationshipStaffAssignmentsForManagement(
+  input: { landlordId: string; relationshipId: string },
+  options: ServiceOptions = {}
+): Promise<{ assignments: PropertyManagerCompanyStaffAssignmentReadProjection[] }> {
+  const firestore = readDb(options.firestore);
+  const landlordId = requireString(input.landlordId, "missing_landlord_id");
+  const relationshipId = requireString(input.relationshipId, "missing_relationship_id");
+  const [memberships, relationships, assignments] = await Promise.all([
+    loadMemberships(firestore),
+    loadRelationships(firestore),
+    loadAssignments(firestore),
+  ]);
+  const relationship = relationships.find((candidate) => candidate.relationshipId === relationshipId && candidate.landlordId === landlordId);
+  if (!relationship) throw new Error("landlord_company_relationship_not_found");
+  const membershipByUserId = new Map(
+    memberships
+      .filter((membership) => membership.companyId === relationship.propertyManagerCompanyId)
+      .map((membership) => [membership.userId, membership])
+  );
+  return {
+    assignments: assignments
+      .filter((assignment) => assignment.relationshipId === relationship.relationshipId)
+      .filter((assignment) => assignment.propertyManagerCompanyId === relationship.propertyManagerCompanyId)
+      .sort((a, b) => String(b.updatedAt || b.createdAt).localeCompare(String(a.updatedAt || a.createdAt)))
+      .map((assignment) => projectAssignment(assignment, membershipByUserId.get(assignment.staffUserId) || null)),
+  };
+}

--- a/rentchain-api/src/services/propertyManagerCompanyManagementReadService.ts
+++ b/rentchain-api/src/services/propertyManagerCompanyManagementReadService.ts
@@ -3,8 +3,10 @@ import {
   LANDLORD_COMPANY_RELATIONSHIP_STATUSES,
   PROPERTY_MANAGER_COMPANY_MEMBERSHIP_STATUSES,
   PROPERTY_MANAGER_COMPANY_ROLES,
+  PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES,
   PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES,
   PROPERTY_MANAGER_COMPANY_STATUSES,
+  buildRelationshipScope,
   type LandlordCompanyRelationship,
   type PropertyManagerCompany,
   type PropertyManagerCompanyMembership,
@@ -145,13 +147,26 @@ function hasValidCompanyShape(company: PropertyManagerCompany | null): company i
 function hasValidRelationshipShape(
   relationship: LandlordCompanyRelationship | null
 ): relationship is LandlordCompanyRelationship {
-  return Boolean(
-    relationship &&
+  if (
+    !(
+      relationship &&
       cleanString(relationship.relationshipId, 200) &&
       cleanString(relationship.landlordId, 200) &&
       cleanString(relationship.propertyManagerCompanyId, 200) &&
       LANDLORD_COMPANY_RELATIONSHIP_STATUSES.includes(relationship.status)
-  );
+    )
+  ) {
+    return false;
+  }
+  try {
+    buildRelationshipScope({
+      propertyScope: relationship.relationshipScope?.propertyScope,
+      workspaceScopes: relationship.relationshipScope?.workspaceScopes || [],
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function hasValidMembershipShape(membership: PropertyManagerCompanyMembership | null): membership is PropertyManagerCompanyMembership {
@@ -167,14 +182,28 @@ function hasValidMembershipShape(membership: PropertyManagerCompanyMembership | 
 function hasValidAssignmentShape(
   assignment: PropertyManagerCompanyStaffAssignment | null
 ): assignment is PropertyManagerCompanyStaffAssignment {
-  return Boolean(
-    assignment &&
+  if (
+    !(
+      assignment &&
       cleanString(assignment.assignmentId, 200) &&
       cleanString(assignment.propertyManagerCompanyId, 200) &&
       cleanString(assignment.relationshipId, 200) &&
       cleanString(assignment.staffUserId, 200) &&
+      PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_ROLES.includes(assignment.staffRole) &&
       PROPERTY_MANAGER_COMPANY_STAFF_ASSIGNMENT_STATUSES.includes(assignment.status)
-  );
+    )
+  ) {
+    return false;
+  }
+  try {
+    buildRelationshipScope({
+      propertyScope: assignment.propertyScope,
+      workspaceScopes: assignment.workspaceScopes,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function loadCompanies(firestore: PropertyManagerCompanyRelationshipFirestoreLike): Promise<PropertyManagerCompany[]> {


### PR DESCRIPTION
## Summary
- adds Mission Brief for PM company management read API V1
- adds safe landlord/company read projections for PM company management UI prerequisites
- adds landlord PM company discovery, enriched landlord relationship listing, landlord assignment view
- adds company context, company relationship, company member, and company assignment read surfaces

## Scope
- Backend/API only
- Read APIs only
- No UI
- No dashboard
- No emails
- No create/update/delete behavior
- No contractor organizations
- No billing delegation
- No custom permissions
- No migrations/backfills

## Validation
- npm test -- propertyManagerCompanyManagementReadRoutes.test.ts
- npm test -- propertyManagerCompanyRelationshipRoutes.test.ts propertyManagerCompanyStaffAssignmentRoutes.test.ts
- npm run build
- git diff --check