### PR TITLE
feat: add property manager company management UI

### DIFF
--- a/docs/design/mission-briefs/property-manager-company-management-ui-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-management-ui-v1.html
@@ -1,0 +1,469 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Property Manager Company Management UI V1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #eef2f6;
+        color: #142033;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 28px;
+        background: #eef2f6;
+      }
+
+      .brief {
+        max-width: 1280px;
+        margin: 0 auto;
+        border: 1px solid #d5dde8;
+        background: #ffffff;
+        box-shadow: 0 18px 50px rgba(20, 32, 51, 0.12);
+      }
+
+      header {
+        padding: 26px 30px;
+        background: #142033;
+        color: #ffffff;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: 26px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      h1 span {
+        color: #8fd6ff;
+      }
+
+      .subtitle {
+        max-width: 920px;
+        color: #d8e7f4;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.05fr) minmax(380px, 0.95fr);
+      }
+
+      section {
+        padding: 26px 30px;
+      }
+
+      .left {
+        border-right: 1px solid #d5dde8;
+      }
+
+      .block {
+        margin-bottom: 24px;
+      }
+
+      .block:last-child {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        margin-bottom: 10px;
+        color: #142033;
+        font-size: 14px;
+        line-height: 1.25;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        color: #2a3d55;
+        font-size: 14px;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 13.5px;
+        line-height: 1.46;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .card {
+        padding: 14px;
+        border: 1px solid #d5dde8;
+        background: #f8fafc;
+      }
+
+      .card strong {
+        display: block;
+        margin-bottom: 5px;
+      }
+
+      .panel {
+        padding: 14px 16px;
+        border-left: 4px solid #246bfe;
+        background: #f4f8ff;
+      }
+
+      .warning {
+        border-left-color: #b7791f;
+        background: #fff8e8;
+      }
+
+      .success {
+        border-left-color: #16895a;
+        background: #f0fff7;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid #d5dde8;
+        background: #ffffff;
+      }
+
+      .table th,
+      .table td {
+        padding: 8px 9px;
+        border-bottom: 1px solid #e3e9f1;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .table th {
+        background: #f4f7fb;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        padding: 6px 9px;
+        border: 1px solid #c8d2df;
+        background: #f4f7fb;
+        color: #26374f;
+        font-size: 12px;
+        font-weight: 800;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        color: #1b4f9c;
+      }
+
+      @media (max-width: 920px) {
+        body {
+          padding: 14px;
+        }
+
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        .left {
+          border-right: 0;
+          border-bottom: 1px solid #d5dde8;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <h1>Mission Brief: <span>Property Manager Company Management UI V1</span></h1>
+        <p class="subtitle">
+          Design the first owner/admin interface for landlord-to-property-manager-company relationships and staff
+          assignments. This brief intentionally stops before implementation because the merged backend APIs are not yet
+          sufficient for a safe, complete V1 UI without additional read/discovery endpoints.
+        </p>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>1. Mission Goal</h2>
+            <p>
+              Introduce a governed UI layer where landlord owners can review PM company relationships and where PM
+              Company Owners/Admins can accept relationships and manage staff assignments, while preserving landlord
+              data ownership, company consent, assignment scope ceilings, and fail-closed permission boundaries.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>2. Scope</h2>
+            <div class="grid">
+              <div class="card">
+                <strong>Landlord Side</strong>
+                <ul>
+                  <li>View pending, active, suspended, and terminated PM company relationships.</li>
+                  <li>Create pending relationships when the PM company can be selected by safe label.</li>
+                  <li>Suspend, reactivate, or terminate relationships with confirmation.</li>
+                  <li>Show relationship scope and clear pending acceptance copy.</li>
+                </ul>
+              </div>
+              <div class="card">
+                <strong>Company Side</strong>
+                <ul>
+                  <li>Company Owner/Admin views pending and active relationships for their company.</li>
+                  <li>Accept pending relationships without modifying landlord-approved scope.</li>
+                  <li>View and manage staff assignments for active relationships.</li>
+                  <li>Use predefined assignment role templates only.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>3. Non-Goals</h2>
+            <div class="pill-row">
+              <span class="pill">No contractor organizations</span>
+              <span class="pill">No billing delegation</span>
+              <span class="pill">No custom permissions</span>
+              <span class="pill">No public branding profile</span>
+              <span class="pill">No tenant-facing PM UI</span>
+              <span class="pill">No emails</span>
+              <span class="pill">No migrations/backfills</span>
+              <span class="pill">No dashboard redesign</span>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>4. User Roles</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Role</th>
+                  <th>V1 UI Authority</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Landlord Owner</td>
+                  <td>Creates pending relationships, sees landlord-scoped relationships, suspends/reactivates/terminates.</td>
+                </tr>
+                <tr>
+                  <td>PM Company Owner/Admin</td>
+                  <td>Accepts pending relationships and manages company staff assignments within approved scope.</td>
+                </tr>
+                <tr>
+                  <td>Regional Manager / Staff Roles</td>
+                  <td>May receive assignments later; no staff management or relationship acceptance authority in V1.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>5. Landlord UX Flow</h2>
+            <ul>
+              <li>Open PM Company Management from the landlord account/workspace shell.</li>
+              <li>Review relationship cards grouped by pending, active, suspended, and terminated.</li>
+              <li>Create a pending relationship by selecting a PM company safe label and relationship scope.</li>
+              <li>See copy: <code>Access becomes active only after the PM company accepts.</code></li>
+              <li>Confirm before suspend, reactivate, or terminate; termination must clearly preserve history.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>6. PM Company Admin UX Flow</h2>
+            <ul>
+              <li>Open PM Company Management from a company-scoped account surface.</li>
+              <li>Select one of the actor's PM companies by safe label if they belong to multiple companies.</li>
+              <li>Review pending relationships and accept without altering landlord-approved scope.</li>
+              <li>Review active relationships before creating staff assignments.</li>
+              <li>See suspended/terminated relationships as blocked, preserved history.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>7. Staff Assignment UX Flow</h2>
+            <ul>
+              <li>Company Owner/Admin selects an active landlord-company relationship.</li>
+              <li>Select active company staff from a safe member list, not by raw user ID.</li>
+              <li>Choose role template: Regional Manager, Property Manager, Leasing Agent, Office Administrator,
+                Maintenance Coordinator, or Read-only Staff.</li>
+              <li>Choose scope that narrows, never broadens, the relationship scope.</li>
+              <li>Confirm before suspend, reactivate, or remove; removed assignments remain visible as history.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>8. API Endpoints Used</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Surface</th>
+                  <th>Current Endpoint</th>
+                  <th>Readiness</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Landlord relationship list/create/lifecycle</td>
+                  <td><code>/api/landlord/property-manager-company-relationships</code></td>
+                  <td>Usable for landlord list/lifecycle; create needs safe company discovery first.</td>
+                </tr>
+                <tr>
+                  <td>Company relationship acceptance</td>
+                  <td><code>/api/property-manager-companies/:companyId/relationships/:relationshipId/accept</code></td>
+                  <td>Accept works when IDs are already known; missing company-side relationship list.</td>
+                </tr>
+                <tr>
+                  <td>Company staff assignments</td>
+                  <td><code>/api/property-manager-companies/:companyId/staff-assignments</code></td>
+                  <td>Lifecycle works when company, relationship, and staff user IDs are known; missing staff list.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <div class="block">
+            <h2>API Sufficiency Finding</h2>
+            <div class="panel warning">
+              <p>
+                Existing APIs are <strong>not sufficient</strong> for a safe complete V1 management UI. A UI would
+                currently need hidden or manually entered internal IDs for PM companies, company relationships, and staff
+                users. That would violate the no-raw-ID UX boundary and produce an unusable company admin workflow.
+              </p>
+              <p>
+                Recommended prerequisite backend mission:
+                <code>feat/property-manager-company-management-read-api-v1</code>.
+              </p>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>Missing Backend Support</h2>
+            <ul>
+              <li>Company discovery/selection by safe label for landlord relationship creation.</li>
+              <li>Authenticated company context: list companies the actor belongs to with role/status.</li>
+              <li>Company-scoped relationship list for pending/active/suspended/terminated records.</li>
+              <li>Safe active staff membership list for assignment creation.</li>
+              <li>Optional landlord-visible staff assignment list for relationship transparency.</li>
+              <li>Safe projections that include labels, statuses, scopes, and timestamps without raw IDs as labels.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>9. State/Status Display</h2>
+            <ul>
+              <li>Relationship: Pending, Active, Suspended, Terminated.</li>
+              <li>Assignment: Active, Suspended, Removed.</li>
+              <li>Pending relationship copy must emphasize PM company acceptance is required.</li>
+              <li>Suspended blocks access temporarily; terminated/removed preserve history and block access.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>10. Safety / Permission Warnings</h2>
+            <ul>
+              <li>Landlord owner, PM company, company staff, and assignments must be visually distinct.</li>
+              <li>No shared logins, staff-to-staff delegation, chain delegation, or custom permission builder.</li>
+              <li>Billing/settings remain landlord-owner only and must never be selectable.</li>
+              <li>Relationship scope is the ceiling; assignment scope can only narrow it.</li>
+              <li>Confirm suspend, terminate, and remove before API mutation.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>11. Mobile Expectations</h2>
+            <ul>
+              <li>Default to compact grouped sections with counts and clear state labels.</li>
+              <li>Relationship and assignment actions should move into menus or bottom-safe confirmation panels.</li>
+              <li>Long company/staff labels must wrap or truncate without overlapping state badges.</li>
+              <li>History sections may be collapsible but must not imply deletion.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>12. Risks</h2>
+            <ul>
+              <li>Current route set lacks safe discovery APIs, making full UI implementation premature.</li>
+              <li>Company-side navigation/auth destination is not yet modeled in frontend routing.</li>
+              <li>Staff assignment creation without staff membership list would force unsafe user ID entry.</li>
+              <li>Landlord visibility into staff assignments may require a landlord-scoped safe projection endpoint.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>13. Acceptance Criteria</h2>
+            <ul>
+              <li>Mission Brief accepted before any UI implementation starts.</li>
+              <li>If backend read APIs remain incomplete, open the backend read/discovery mission first.</li>
+              <li>If UI proceeds later, no raw company/user/landlord/property IDs appear as labels.</li>
+              <li>All mutations require confirmation and preserve backend lifecycle semantics.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>14. QA Checklist</h2>
+            <ul>
+              <li>Verify landlord relationship list and lifecycle actions with safe labels.</li>
+              <li>Verify company admin can list and accept pending relationships.</li>
+              <li>Verify staff assignment create/list/suspend/reactivate/remove with scope ceiling enforcement.</li>
+              <li>Verify non-admin staff cannot manage relationships or assignments.</li>
+              <li>Verify mobile grouped sections, confirmations, empty states, and no text overlap.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>15. Merge Readiness Criteria</h2>
+            <div class="panel success">
+              <ul>
+                <li>Brief documents API insufficiency and recommended backend prerequisite.</li>
+                <li>No implementation, backend, schema, auth, billing, contractor, or frontend runtime change in this PR.</li>
+                <li><code>git diff --check</code> passes.</li>
+                <li>Next mission is explicitly reviewed before UI implementation begins.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/docs/design/mission-briefs/property-manager-company-management-ui-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-management-ui-v1.html
@@ -216,8 +216,8 @@
         <h1>Mission Brief: <span>Property Manager Company Management UI V1</span></h1>
         <p class="subtitle">
           Design the first owner/admin interface for landlord-to-property-manager-company relationships and staff
-          assignments. This brief intentionally stops before implementation because the merged backend APIs are not yet
-          sufficient for a safe, complete V1 UI without additional read/discovery endpoints.
+          assignments. The prerequisite management read APIs are now merged, so the next implementation can proceed
+          as a frontend/UI mission using safe server projections rather than raw identifier entry.
         </p>
       </header>
 
@@ -344,17 +344,42 @@
                 <tr>
                   <td>Landlord relationship list/create/lifecycle</td>
                   <td><code>/api/landlord/property-manager-company-relationships</code></td>
-                  <td>Usable for landlord list/lifecycle; create needs safe company discovery first.</td>
+                  <td>Available for relationship list/create and suspend/reactivate/terminate.</td>
+                </tr>
+                <tr>
+                  <td>Landlord company discovery</td>
+                  <td><code>/api/landlord/property-manager-companies/search?q=...</code></td>
+                  <td>Available for safe PM company selection before pending relationship creation.</td>
+                </tr>
+                <tr>
+                  <td>Landlord staff assignment visibility</td>
+                  <td><code>/api/landlord/property-manager-company-relationships/:relationshipId/staff-assignments</code></td>
+                  <td>Available for read-only staff visibility under landlord-owned relationships.</td>
+                </tr>
+                <tr>
+                  <td>Company admin context</td>
+                  <td><code>/api/property-manager-companies/my-companies</code></td>
+                  <td>Available for selecting company context by safe label and active Owner/Admin role.</td>
+                </tr>
+                <tr>
+                  <td>Company relationship list</td>
+                  <td><code>/api/property-manager-companies/:companyId/relationships</code></td>
+                  <td>Available for pending/active/suspended/terminated company relationship views.</td>
                 </tr>
                 <tr>
                   <td>Company relationship acceptance</td>
                   <td><code>/api/property-manager-companies/:companyId/relationships/:relationshipId/accept</code></td>
-                  <td>Accept works when IDs are already known; missing company-side relationship list.</td>
+                  <td>Available; accepts pending relationships without changing landlord-approved scope.</td>
+                </tr>
+                <tr>
+                  <td>Company member list</td>
+                  <td><code>/api/property-manager-companies/:companyId/members</code></td>
+                  <td>Available for selecting active staff by safe label and showing suspended/removed history.</td>
                 </tr>
                 <tr>
                   <td>Company staff assignments</td>
                   <td><code>/api/property-manager-companies/:companyId/staff-assignments</code></td>
-                  <td>Lifecycle works when company, relationship, and staff user IDs are known; missing staff list.</td>
+                  <td>Available for safe list/create/suspend/reactivate/remove assignment workflow.</td>
                 </tr>
               </tbody>
             </table>
@@ -364,28 +389,29 @@
         <section>
           <div class="block">
             <h2>API Sufficiency Finding</h2>
-            <div class="panel warning">
+            <div class="panel success">
               <p>
-                Existing APIs are <strong>not sufficient</strong> for a safe complete V1 management UI. A UI would
-                currently need hidden or manually entered internal IDs for PM companies, company relationships, and staff
-                users. That would violate the no-raw-ID UX boundary and produce an unusable company admin workflow.
+                Existing APIs are now <strong>sufficient</strong> for a safe V1 management UI after
+                <code>feat/property-manager-company-management-read-api-v1</code>. The UI can render selectable company,
+                relationship, member, and assignment records using safe labels while retaining opaque API references only
+                inside client state and request payloads.
               </p>
               <p>
-                Recommended prerequisite backend mission:
-                <code>feat/property-manager-company-management-read-api-v1</code>.
+                Implementation should proceed as frontend/UI only, using existing read and lifecycle APIs. Do not add new
+                backend behavior unless manual QA identifies a genuine API contract gap.
               </p>
             </div>
           </div>
 
           <div class="block">
-            <h2>Missing Backend Support</h2>
+            <h2>Available Read Support</h2>
             <ul>
               <li>Company discovery/selection by safe label for landlord relationship creation.</li>
-              <li>Authenticated company context: list companies the actor belongs to with role/status.</li>
+              <li>Authenticated company context with only active Company Owner/Admin memberships.</li>
               <li>Company-scoped relationship list for pending/active/suspended/terminated records.</li>
-              <li>Safe active staff membership list for assignment creation.</li>
-              <li>Optional landlord-visible staff assignment list for relationship transparency.</li>
-              <li>Safe projections that include labels, statuses, scopes, and timestamps without raw IDs as labels.</li>
+              <li>Company member list with active, suspended, and removed members for safe staff selection/history.</li>
+              <li>Landlord-visible staff assignment list for relationship transparency.</li>
+              <li>Safe projections include labels, statuses, scopes, and timestamps without raw IDs as labels.</li>
             </ul>
           </div>
 
@@ -423,20 +449,21 @@
           <div class="block">
             <h2>12. Risks</h2>
             <ul>
-              <li>Current route set lacks safe discovery APIs, making full UI implementation premature.</li>
               <li>Company-side navigation/auth destination is not yet modeled in frontend routing.</li>
-              <li>Staff assignment creation without staff membership list would force unsafe user ID entry.</li>
-              <li>Landlord visibility into staff assignments may require a landlord-scoped safe projection endpoint.</li>
+              <li>The UI must keep opaque API references out of visible labels, exports, and empty-state text.</li>
+              <li>Company member labels may be generic when no profile display label exists; the UI should handle that calmly.</li>
+              <li>Landlord-visible staff assignment summaries are read-only transparency, not staff management authority.</li>
             </ul>
           </div>
 
           <div class="block">
             <h2>13. Acceptance Criteria</h2>
             <ul>
-              <li>Mission Brief accepted before any UI implementation starts.</li>
-              <li>If backend read APIs remain incomplete, open the backend read/discovery mission first.</li>
-              <li>If UI proceeds later, no raw company/user/landlord/property IDs appear as labels.</li>
+              <li>Mission Brief accepted before UI implementation starts.</li>
+              <li>UI uses merged read APIs for company, relationship, member, and assignment selection.</li>
+              <li>No raw company/user/landlord/property IDs appear as visible labels.</li>
               <li>All mutations require confirmation and preserve backend lifecycle semantics.</li>
+              <li>Company-side management is limited to active Company Owner/Admin users.</li>
             </ul>
           </div>
 
@@ -455,10 +482,10 @@
             <h2>15. Merge Readiness Criteria</h2>
             <div class="panel success">
               <ul>
-                <li>Brief documents API insufficiency and recommended backend prerequisite.</li>
-                <li>No implementation, backend, schema, auth, billing, contractor, or frontend runtime change in this PR.</li>
+                <li>Brief references the merged management read APIs and approved lifecycle APIs.</li>
+                <li>No implementation, backend, schema, auth, billing, contractor, or frontend runtime change in this brief revision.</li>
                 <li><code>git diff --check</code> passes.</li>
-                <li>Next mission is explicitly reviewed before UI implementation begins.</li>
+                <li>Operator review confirms frontend/UI implementation may proceed next.</li>
               </ul>
             </div>
           </div>

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -446,7 +446,7 @@ describe("Routes: property manager company management", () => {
 
   it("renders the standalone company-admin management route", async () => {
     mockAuthState.value = {
-      user: { id: "company-admin-1", role: "property_manager_company_admin" },
+      user: { id: "company-admin-1", role: "property_manager_company", landlordId: null },
       token: "test-token",
       isLoading: false,
       ready: true,
@@ -455,6 +455,25 @@ describe("Routes: property manager company management", () => {
     const { default: App } = await import("./App");
     render(
       <MemoryRouter initialEntries={["/property-manager-companies/management"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/PM Company Management Page \/property-manager-companies\/management/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+
+  it("redirects PM company dashboard sessions to standalone PM company management", async () => {
+    mockAuthState.value = {
+      user: { id: "company-admin-1", role: "property_manager_company", landlordId: null },
+      token: "test-token",
+      isLoading: false,
+      ready: true,
+      authStatus: "authed",
+    };
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
         <App />
       </MemoryRouter>
     );

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -165,6 +165,13 @@ vi.mock("./pages/DelegatedAccessWorkspacePage", () => ({
   },
 }));
 
+vi.mock("./pages/PropertyManagerCompanyManagementPage", () => ({
+  default: () => {
+    const location = useLocation();
+    return <h1>{`PM Company Management Page ${location.pathname}`}</h1>;
+  },
+}));
+
 vi.mock("./pages/DecisionInboxPage", () => ({
   default: () => <h1>Decision Inbox Page</h1>,
 }));
@@ -420,6 +427,39 @@ describe("Routes: /account/delegated-access", () => {
     );
 
     expect(await screen.findByText(/Delegate Management Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: property manager company management", () => {
+  it("renders the landlord account management route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/account/property-manager-companies"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/PM Company Management Page \/account\/property-manager-companies/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the standalone company-admin management route", async () => {
+    mockAuthState.value = {
+      user: { id: "company-admin-1", role: "property_manager_company_admin" },
+      token: "test-token",
+      isLoading: false,
+      ready: true,
+      authStatus: "authed",
+    };
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/property-manager-companies/management"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/PM Company Management Page \/property-manager-companies\/management/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -194,6 +194,7 @@ const AccountDataPage = lazy(() => import("./pages/account/AccountDataPage"));
 const DelegatedAccessPage = lazy(() => import("./pages/DelegatedAccessPage"));
 const DelegatedAccessAcceptPage = lazy(() => import("./pages/DelegatedAccessAcceptPage"));
 const DelegatedAccessWorkspacePage = lazy(() => import("./pages/DelegatedAccessWorkspacePage"));
+const PropertyManagerCompanyManagementPage = lazy(() => import("./pages/PropertyManagerCompanyManagementPage"));
 const ExpensesPage = lazy(() => import("./pages/ExpensesPage"));
 const WorkOrdersPage = lazy(() => import("./pages/landlord/WorkOrdersPage"));
 const WorkOrderNewPage = lazy(() => import("./pages/landlord/WorkOrderNewPage"));
@@ -964,6 +965,30 @@ function App() {
                   </Suspense>
                 </AccountRouteGate>
               </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/account/property-manager-companies"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <AccountRouteGate>
+                  <Suspense fallback={null}>
+                    <PropertyManagerCompanyManagementPage />
+                  </Suspense>
+                </AccountRouteGate>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/property-manager-companies/management"
+          element={
+            <RequireAuth>
+              <Suspense fallback={null}>
+                <PropertyManagerCompanyManagementPage />
+              </Suspense>
             </RequireAuth>
           }
         />

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -367,6 +367,9 @@ const LandlordDashboardRoute: React.FC = () => {
   const { user } = useAuth();
   const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
   if (role === "delegate") return <Navigate to={getRoleDefaultDestination("delegate")} replace />;
+  if (role === "property_manager_company") {
+    return <Navigate to={getRoleDefaultDestination("property_manager_company")} replace />;
+  }
   return (
     <LandlordNav>
       <DashboardPage />

--- a/rentchain-frontend/src/api/propertyManagerCompanyManagementApi.test.ts
+++ b/rentchain-frontend/src/api/propertyManagerCompanyManagementApi.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  acceptCompanyPropertyManagerRelationship,
+  createLandlordPropertyManagerRelationship,
+  createPropertyManagerCompanyStaffAssignment,
+  fetchLandlordPropertyManagerRelationshipAssignments,
+  fetchLandlordPropertyManagerRelationships,
+  fetchMyPropertyManagerCompanies,
+  fetchPropertyManagerCompanyMembers,
+  fetchPropertyManagerCompanyStaffAssignments,
+  searchPropertyManagerCompanies,
+  suspendLandlordPropertyManagerRelationship,
+  terminateLandlordPropertyManagerRelationship,
+} from "./propertyManagerCompanyManagementApi";
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("./apiFetch", () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+describe("propertyManagerCompanyManagementApi", () => {
+  beforeEach(() => {
+    mocks.apiFetch.mockReset();
+    mocks.apiFetch.mockResolvedValue({ ok: true, companies: [], relationships: [], members: [], assignments: [] });
+  });
+
+  it("uses landlord-scoped discovery, relationship, and staff projection endpoints", async () => {
+    await searchPropertyManagerCompanies("elite");
+    await fetchLandlordPropertyManagerRelationships();
+    await fetchLandlordPropertyManagerRelationshipAssignments("relationship-1");
+
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(1, "/landlord/property-manager-companies/search?q=elite");
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(2, "/landlord/property-manager-company-relationships");
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(
+      3,
+      "/landlord/property-manager-company-relationships/relationship-1/staff-assignments"
+    );
+  });
+
+  it("creates pending landlord-company relationships with explicit scope", async () => {
+    await createLandlordPropertyManagerRelationship({
+      propertyManagerCompanyId: "pm-company-1",
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: ["dashboard", "operations"],
+    });
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/landlord/property-manager-company-relationships", {
+      method: "POST",
+      body: {
+        propertyManagerCompanyId: "pm-company-1",
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard", "operations"],
+      },
+    });
+  });
+
+  it("uses landlord lifecycle endpoints with optional reasons", async () => {
+    await suspendLandlordPropertyManagerRelationship("relationship-1", "pause");
+    await terminateLandlordPropertyManagerRelationship("relationship-1", "done");
+
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(
+      1,
+      "/landlord/property-manager-company-relationships/relationship-1/suspend",
+      { method: "POST", body: { reason: "pause" } }
+    );
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(
+      2,
+      "/landlord/property-manager-company-relationships/relationship-1/terminate",
+      { method: "POST", body: { reason: "done" } }
+    );
+  });
+
+  it("uses company-admin context, relationship, member, assignment, and accept endpoints", async () => {
+    await fetchMyPropertyManagerCompanies();
+    await fetchPropertyManagerCompanyMembers("pm-company-1");
+    await fetchPropertyManagerCompanyStaffAssignments("pm-company-1", "relationship-1");
+    await acceptCompanyPropertyManagerRelationship("pm-company-1", "relationship-1");
+
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(1, "/property-manager-companies/my-companies");
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(2, "/property-manager-companies/pm-company-1/members");
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(
+      3,
+      "/property-manager-companies/pm-company-1/staff-assignments?relationshipId=relationship-1"
+    );
+    expect(mocks.apiFetch).toHaveBeenNthCalledWith(
+      4,
+      "/property-manager-companies/pm-company-1/relationships/relationship-1/accept",
+      { method: "POST" }
+    );
+  });
+
+  it("creates company staff assignments without custom permission payloads", async () => {
+    await createPropertyManagerCompanyStaffAssignment("pm-company-1", {
+      relationshipId: "relationship-1",
+      staffUserId: "staff-1",
+      staffRole: "property_manager",
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: ["dashboard"],
+    });
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/property-manager-companies/pm-company-1/staff-assignments", {
+      method: "POST",
+      body: {
+        relationshipId: "relationship-1",
+        staffUserId: "staff-1",
+        staffRole: "property_manager",
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: ["dashboard"],
+      },
+    });
+  });
+});

--- a/rentchain-frontend/src/api/propertyManagerCompanyManagementApi.ts
+++ b/rentchain-frontend/src/api/propertyManagerCompanyManagementApi.ts
@@ -1,0 +1,279 @@
+import { apiFetch } from "./apiFetch";
+
+export type PropertyManagerCompanyRelationshipStatus = "pending" | "active" | "suspended" | "terminated";
+export type PropertyManagerCompanyMembershipStatus = "invited" | "active" | "suspended" | "removed";
+export type PropertyManagerCompanyStatus = "active" | "suspended" | "archived";
+export type PropertyManagerCompanyStaffAssignmentStatus = "active" | "suspended" | "removed";
+export type PropertyManagerCompanyRole =
+  | "company_owner"
+  | "company_admin"
+  | "regional_manager"
+  | "property_manager"
+  | "leasing_agent"
+  | "office_administrator"
+  | "maintenance_coordinator"
+  | "read_only_staff";
+export type PropertyManagerCompanyStaffAssignmentRole =
+  | "regional_manager"
+  | "property_manager"
+  | "leasing_agent"
+  | "office_administrator"
+  | "maintenance_coordinator"
+  | "read_only_staff";
+export type PropertyManagerCompanyPropertyScopeMode = "all_current_properties" | "selected_properties";
+export type PropertyManagerCompanyWorkspaceScope =
+  | "dashboard"
+  | "operations"
+  | "properties"
+  | "tenants"
+  | "leases"
+  | "payments"
+  | "unified_inbox"
+  | "scheduling"
+  | "work_orders"
+  | "evidence_exports"
+  | "settings_billing";
+
+export type PropertyManagerCompanyPropertyScope = {
+  mode: PropertyManagerCompanyPropertyScopeMode;
+  propertyIds: string[];
+};
+
+export type PropertyManagerCompanyRelationshipScope = {
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: PropertyManagerCompanyWorkspaceScope[];
+};
+
+export type StaffAssignmentSummary = {
+  total: number;
+  active: number;
+  suspended: number;
+  removed: number;
+};
+
+export type PropertyManagerCompanyLookup = {
+  propertyManagerCompanyId: string;
+  companyLabel: string;
+  status: PropertyManagerCompanyStatus;
+  role?: PropertyManagerCompanyRole;
+};
+
+export type PropertyManagerCompanyRelationship = {
+  relationshipId: string;
+  landlordId?: string;
+  propertyManagerCompanyId: string;
+  propertyManagerCompanyLabel: string;
+  landlordWorkspaceLabel: string;
+  status: PropertyManagerCompanyRelationshipStatus;
+  relationshipScope: PropertyManagerCompanyRelationshipScope;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  suspendedAt: string | null;
+  reactivatedAt: string | null;
+  terminatedAt: string | null;
+  staffAssignmentSummary: StaffAssignmentSummary;
+};
+
+export type PropertyManagerCompanyMember = {
+  staffUserId: string;
+  staffLabel: string;
+  role: PropertyManagerCompanyRole;
+  status: PropertyManagerCompanyMembershipStatus;
+  createdAt: string;
+  updatedAt: string;
+  suspendedAt: string | null;
+  removedAt: string | null;
+};
+
+export type PropertyManagerCompanyStaffAssignment = {
+  assignmentId: string;
+  propertyManagerCompanyId: string;
+  relationshipId: string;
+  staffUserId: string;
+  staffLabel: string;
+  staffDisplayLabel?: string;
+  staffRole: PropertyManagerCompanyStaffAssignmentRole;
+  status: PropertyManagerCompanyStaffAssignmentStatus;
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: PropertyManagerCompanyWorkspaceScope[];
+  createdAt: string;
+  updatedAt: string;
+  suspendedAt: string | null;
+  reactivatedAt: string | null;
+  removedAt: string | null;
+};
+
+export type CreateLandlordCompanyRelationshipInput = {
+  propertyManagerCompanyId: string;
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: PropertyManagerCompanyWorkspaceScope[];
+};
+
+export type CreateStaffAssignmentInput = {
+  relationshipId: string;
+  staffUserId: string;
+  staffRole: PropertyManagerCompanyStaffAssignmentRole;
+  propertyScope: PropertyManagerCompanyPropertyScope;
+  workspaceScopes: PropertyManagerCompanyWorkspaceScope[];
+};
+
+export async function searchPropertyManagerCompanies(query: string): Promise<PropertyManagerCompanyLookup[]> {
+  const params = new URLSearchParams();
+  const clean = String(query || "").trim();
+  if (clean) params.set("q", clean);
+  const response = await apiFetch<{ ok: true; companies: PropertyManagerCompanyLookup[] }>(
+    `/landlord/property-manager-companies/search${params.toString() ? `?${params.toString()}` : ""}`
+  );
+  return response.companies || [];
+}
+
+export async function fetchLandlordPropertyManagerRelationships(): Promise<PropertyManagerCompanyRelationship[]> {
+  const response = await apiFetch<{ ok: true; relationships: PropertyManagerCompanyRelationship[] }>(
+    "/landlord/property-manager-company-relationships"
+  );
+  return response.relationships || [];
+}
+
+export async function createLandlordPropertyManagerRelationship(input: CreateLandlordCompanyRelationshipInput) {
+  return apiFetch<{ ok: true; relationship: PropertyManagerCompanyRelationship }>(
+    "/landlord/property-manager-company-relationships",
+    {
+      method: "POST",
+      body: input,
+    }
+  );
+}
+
+export async function suspendLandlordPropertyManagerRelationship(relationshipId: string, reason?: string) {
+  return apiFetch<{ ok: true; relationship: PropertyManagerCompanyRelationship }>(
+    `/landlord/property-manager-company-relationships/${encodeURIComponent(relationshipId)}/suspend`,
+    {
+      method: "POST",
+      body: { reason: String(reason || "").trim() || null },
+    }
+  );
+}
+
+export async function reactivateLandlordPropertyManagerRelationship(relationshipId: string, reason?: string) {
+  return apiFetch<{ ok: true; relationship: PropertyManagerCompanyRelationship }>(
+    `/landlord/property-manager-company-relationships/${encodeURIComponent(relationshipId)}/reactivate`,
+    {
+      method: "POST",
+      body: { reason: String(reason || "").trim() || null },
+    }
+  );
+}
+
+export async function terminateLandlordPropertyManagerRelationship(relationshipId: string, reason?: string) {
+  return apiFetch<{ ok: true; relationship: PropertyManagerCompanyRelationship }>(
+    `/landlord/property-manager-company-relationships/${encodeURIComponent(relationshipId)}/terminate`,
+    {
+      method: "POST",
+      body: { reason: String(reason || "").trim() || null },
+    }
+  );
+}
+
+export async function fetchLandlordPropertyManagerRelationshipAssignments(
+  relationshipId: string
+): Promise<PropertyManagerCompanyStaffAssignment[]> {
+  const response = await apiFetch<{ ok: true; assignments: PropertyManagerCompanyStaffAssignment[] }>(
+    `/landlord/property-manager-company-relationships/${encodeURIComponent(relationshipId)}/staff-assignments`
+  );
+  return response.assignments || [];
+}
+
+export async function fetchMyPropertyManagerCompanies(): Promise<PropertyManagerCompanyLookup[]> {
+  const response = await apiFetch<{ ok: true; companies: PropertyManagerCompanyLookup[] }>(
+    "/property-manager-companies/my-companies"
+  );
+  return response.companies || [];
+}
+
+export async function fetchCompanyPropertyManagerRelationships(
+  companyId: string
+): Promise<PropertyManagerCompanyRelationship[]> {
+  const response = await apiFetch<{ ok: true; relationships: PropertyManagerCompanyRelationship[] }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/relationships`
+  );
+  return response.relationships || [];
+}
+
+export async function acceptCompanyPropertyManagerRelationship(companyId: string, relationshipId: string) {
+  return apiFetch<{ ok: true; relationship: PropertyManagerCompanyRelationship }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/relationships/${encodeURIComponent(relationshipId)}/accept`,
+    { method: "POST" }
+  );
+}
+
+export async function fetchPropertyManagerCompanyMembers(companyId: string): Promise<PropertyManagerCompanyMember[]> {
+  const response = await apiFetch<{ ok: true; members: PropertyManagerCompanyMember[] }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/members`
+  );
+  return response.members || [];
+}
+
+export async function fetchPropertyManagerCompanyStaffAssignments(
+  companyId: string,
+  relationshipId?: string
+): Promise<PropertyManagerCompanyStaffAssignment[]> {
+  const params = new URLSearchParams();
+  if (relationshipId) params.set("relationshipId", relationshipId);
+  const response = await apiFetch<{ ok: true; assignments: PropertyManagerCompanyStaffAssignment[] }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/staff-assignments${
+      params.toString() ? `?${params.toString()}` : ""
+    }`
+  );
+  return response.assignments || [];
+}
+
+export async function createPropertyManagerCompanyStaffAssignment(
+  companyId: string,
+  input: CreateStaffAssignmentInput
+) {
+  return apiFetch<{ ok: true; assignment: PropertyManagerCompanyStaffAssignment }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/staff-assignments`,
+    {
+      method: "POST",
+      body: input,
+    }
+  );
+}
+
+export async function suspendPropertyManagerCompanyStaffAssignment(
+  companyId: string,
+  assignmentId: string,
+  reason?: string
+) {
+  return apiFetch<{ ok: true; assignment: PropertyManagerCompanyStaffAssignment }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/staff-assignments/${encodeURIComponent(
+      assignmentId
+    )}/suspend`,
+    {
+      method: "POST",
+      body: { reason: String(reason || "").trim() || null },
+    }
+  );
+}
+
+export async function reactivatePropertyManagerCompanyStaffAssignment(companyId: string, assignmentId: string) {
+  return apiFetch<{ ok: true; assignment: PropertyManagerCompanyStaffAssignment }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/staff-assignments/${encodeURIComponent(
+      assignmentId
+    )}/reactivate`,
+    { method: "POST" }
+  );
+}
+
+export async function removePropertyManagerCompanyStaffAssignment(companyId: string, assignmentId: string, reason?: string) {
+  return apiFetch<{ ok: true; assignment: PropertyManagerCompanyStaffAssignment }>(
+    `/property-manager-companies/${encodeURIComponent(companyId)}/staff-assignments/${encodeURIComponent(
+      assignmentId
+    )}/remove`,
+    {
+      method: "POST",
+      body: { reason: String(reason || "").trim() || null },
+    }
+  );
+}

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -182,6 +182,17 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByText("Delegate Management", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
   });
 
+  it("keeps PM company management in the sticky workspace shell", () => {
+    renderLandlordNav("/account/property-manager-companies");
+
+    const context = screen.getByLabelText("Workspace context");
+    const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
+
+    expect(context).toHaveTextContent("PM Companies");
+    expect(within(workspaceNav).getByRole("link", { name: "PM Companies" })).toHaveClass("active");
+    expect(screen.getByText("PM Companies", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
+  });
+
   it("keeps the mobile tab bar and close control available while the drawer is open", () => {
     renderLandlordNav();
 

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -34,9 +34,11 @@ const stickyWorkspaceIds = new Set([
   "unified-inbox",
   "work-orders",
   "delegated-access",
+  "pm-company-management",
 ]);
 
 const workspaceAliases: Array<{ prefix: string; label: string }> = [
+  { prefix: "/account/property-manager-companies", label: "PM Companies" },
   { prefix: "/account/delegated-access", label: "Delegate Management" },
   { prefix: "/landlord/inbox", label: "Inbox" },
   { prefix: "/landlord/unified-inbox", label: "Inbox" },

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -183,6 +183,15 @@ export const NAV_ITEMS: NavItem[] = [
     requiresLandlordOrAdmin: true,
   },
   {
+    id: "pm-company-management",
+    label: "PM Companies",
+    to: "/account/property-manager-companies",
+    icon: Building2,
+    showInDrawer: false,
+    showInTabs: false,
+    requiresLandlordOrAdmin: true,
+  },
+  {
     id: "onboarding-hardening",
     label: "Onboarding",
     to: "/onboarding-hardening",

--- a/rentchain-frontend/src/lib/authDestination.test.ts
+++ b/rentchain-frontend/src/lib/authDestination.test.ts
@@ -4,6 +4,7 @@ import {
   getRoleDefaultDestination,
   PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION,
   getSafeTenantRedirect,
+  resolvePostAuthDestination,
   resolveTenantPostAuthDestination,
   TENANT_DEFAULT_DESTINATION,
 } from "./authDestination";
@@ -21,6 +22,15 @@ describe("authDestination tenant routing", () => {
     expect(getRoleDefaultDestination("property_manager_company")).toBe(
       PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION
     );
+  });
+
+  it("does not preserve dashboard as the PM company post-auth destination", () => {
+    expect(
+      resolvePostAuthDestination({
+        search: "?next=/dashboard",
+        role: "property_manager_company",
+      }).destination
+    ).toBe(PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION);
   });
 
   it("rejects public tenant entry routes as post-auth destinations", () => {

--- a/rentchain-frontend/src/lib/authDestination.test.ts
+++ b/rentchain-frontend/src/lib/authDestination.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DELEGATED_ACCESS_DEFAULT_DESTINATION,
   getRoleDefaultDestination,
+  PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION,
   getSafeTenantRedirect,
   resolveTenantPostAuthDestination,
   TENANT_DEFAULT_DESTINATION,
@@ -14,6 +15,12 @@ describe("authDestination tenant routing", () => {
 
   it("uses the delegated workspace as the delegate role default", () => {
     expect(getRoleDefaultDestination("delegate")).toBe(DELEGATED_ACCESS_DEFAULT_DESTINATION);
+  });
+
+  it("uses PM company management as the PM company role default", () => {
+    expect(getRoleDefaultDestination("property_manager_company")).toBe(
+      PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION
+    );
   });
 
   it("rejects public tenant entry routes as post-auth destinations", () => {

--- a/rentchain-frontend/src/lib/authDestination.ts
+++ b/rentchain-frontend/src/lib/authDestination.ts
@@ -1,7 +1,16 @@
-export type AuthRole = "landlord" | "tenant" | "contractor" | "admin" | "delegate" | null | undefined;
+export type AuthRole =
+  | "landlord"
+  | "tenant"
+  | "contractor"
+  | "admin"
+  | "delegate"
+  | "property_manager_company"
+  | null
+  | undefined;
 
 export const TENANT_DEFAULT_DESTINATION = "/tenant/dashboard";
 export const DELEGATED_ACCESS_DEFAULT_DESTINATION = "/delegated-access/workspace";
+export const PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION = "/property-manager-companies/management";
 
 export function getSafeInternalRedirect(raw: string | null | undefined): string | null {
   const value = String(raw || "").trim();
@@ -22,6 +31,7 @@ export function getRoleDefaultDestination(role: AuthRole): string {
   if (value === "contractor") return "/contractor";
   if (value === "admin") return "/admin";
   if (value === "delegate") return DELEGATED_ACCESS_DEFAULT_DESTINATION;
+  if (value === "property_manager_company") return PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION;
   return "/dashboard";
 }
 

--- a/rentchain-frontend/src/lib/authDestination.ts
+++ b/rentchain-frontend/src/lib/authDestination.ts
@@ -35,6 +35,14 @@ export function getRoleDefaultDestination(role: AuthRole): string {
   return "/dashboard";
 }
 
+function resolveRoleScopedDestination(role: AuthRole, destination: string): string {
+  const value = String(role || "").trim().toLowerCase();
+  if (value === "property_manager_company" && destination === "/dashboard") {
+    return PROPERTY_MANAGER_COMPANY_DEFAULT_DESTINATION;
+  }
+  return destination;
+}
+
 export function getSafeTenantRedirect(raw: string | null | undefined): string | null {
   const value = getSafeInternalRedirect(raw);
   if (!value) return null;
@@ -73,13 +81,31 @@ export function resolvePostAuthDestination(input: {
   fallback?: string;
 }): { destination: string; usedFallback: boolean; source: string } {
   const explicit = getSafeInternalRedirect(input.explicitDestination || null);
-  if (explicit) return { destination: explicit, usedFallback: false, source: "explicit" };
+  if (explicit) {
+    return {
+      destination: resolveRoleScopedDestination(input.role, explicit),
+      usedFallback: false,
+      source: "explicit",
+    };
+  }
 
   const backend = getSafeInternalRedirect(input.backendRedirect || null);
-  if (backend) return { destination: backend, usedFallback: false, source: "backend" };
+  if (backend) {
+    return {
+      destination: resolveRoleScopedDestination(input.role, backend),
+      usedFallback: false,
+      source: "backend",
+    };
+  }
 
   const fromSearch = readDestinationFromSearch(input.search || "");
-  if (fromSearch) return { destination: fromSearch, usedFallback: false, source: "query" };
+  if (fromSearch) {
+    return {
+      destination: resolveRoleScopedDestination(input.role, fromSearch),
+      usedFallback: false,
+      source: "query",
+    };
+  }
 
   if (input.role) {
     return {
@@ -90,7 +116,11 @@ export function resolvePostAuthDestination(input: {
   }
 
   const fallback = getSafeInternalRedirect(input.fallback || "/dashboard") || "/dashboard";
-  return { destination: fallback, usedFallback: true, source: "fallback" };
+  return {
+    destination: resolveRoleScopedDestination(input.role, fallback),
+    usedFallback: true,
+    source: "fallback",
+  };
 }
 
 export function resolveTenantPostAuthDestination(input: {

--- a/rentchain-frontend/src/pages/AccountPage.test.tsx
+++ b/rentchain-frontend/src/pages/AccountPage.test.tsx
@@ -72,5 +72,7 @@ describe("AccountPage", () => {
     expect(screen.getByRole("button", { name: "Security controls coming soon" })).toBeDisabled();
     expect(screen.getByText("Delegated Access")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Manage delegates" })).toBeInTheDocument();
+    expect(screen.getByText("PM Company Management")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Manage PM companies" })).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/AccountPage.tsx
+++ b/rentchain-frontend/src/pages/AccountPage.tsx
@@ -127,6 +127,12 @@ const AccountPage: React.FC = () => {
           </Button>
         </HubCard>
 
+        <HubCard title="PM Company Management" description="Coordinate property manager company relationships and staff assignments.">
+          <Button type="button" onClick={() => navigate("/account/property-manager-companies")}>
+            Manage PM companies
+          </Button>
+        </HubCard>
+
         <HubCard title="Billing & Plans" description="View your plan, receipts, and manage paid upgrades with pricing that matches checkout.">
           <Button type="button" onClick={() => navigate("/billing")}>
             Billing

--- a/rentchain-frontend/src/pages/LoginPage.test.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import LoginPage from "./LoginPage";
 
@@ -79,6 +79,42 @@ describe("LoginPage", () => {
     await waitFor(() => {
       expect(mocks.login).toHaveBeenCalledWith("landlord@example.com", "secret-password", undefined);
     });
+  });
+
+  it("routes PM company login responses to PM company management instead of dashboard", async () => {
+    mocks.login.mockResolvedValueOnce({
+      requires2fa: false,
+      user: {
+        id: "pm-company-admin-1",
+        email: "admin+propertymanager@rentchain.ai",
+        role: "property_manager_company",
+        landlordId: null,
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/login?next=/dashboard"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/dashboard" element={<div>Landlord dashboard</div>} />
+          <Route
+            path="/property-manager-companies/management"
+            element={<div>PM Company Management</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "admin+propertymanager@rentchain.ai" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "safe-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(await screen.findByText("PM Company Management")).toBeInTheDocument();
+    expect(screen.queryByText("Landlord dashboard")).not.toBeInTheDocument();
   });
 
   it("shows expired session context without changing auth behavior", () => {

--- a/rentchain-frontend/src/pages/LoginPage.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.tsx
@@ -186,6 +186,11 @@ export const LoginPage: React.FC = () => {
         return;
       }
 
+      const postLoginDestination = resolvePostAuthDestination({
+        search: location.search,
+        role: String(result.user?.role || "").toLowerCase() || undefined,
+        fallback: "/dashboard",
+      }).destination;
       const dbg = localStorage.getItem(DEBUG_AUTH_KEY) === "1";
       try {
         localStorage.setItem(JUST_LOGGED_IN_KEY, String(Date.now()));
@@ -206,6 +211,7 @@ export const LoginPage: React.FC = () => {
           destination: nextPath,
         });
       }
+      navigate(postLoginDestination, { replace: true });
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : "Invalid email or password";

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
@@ -195,8 +195,9 @@ describe("PropertyManagerCompanyManagementPage", () => {
     await waitFor(() => expect(mocks.searchCompanies).toHaveBeenCalledWith("elite"));
     expect(screen.getByText("Search results")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Elite Property Management" }));
-    expect(screen.getByText("Selected PM Company")).toBeInTheDocument();
-    expect(screen.getByText("Ready to create pending relationship")).toBeInTheDocument();
+    expect(screen.getByText("Selected Company")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Change Company" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("PM company search")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Create pending relationship" }));
 
     await waitFor(() => expect(mocks.createLandlordRelationship).toHaveBeenCalledTimes(1));
@@ -205,6 +206,22 @@ describe("PropertyManagerCompanyManagementPage", () => {
       propertyScope: { mode: "all_current_properties", propertyIds: [] },
       workspaceScopes: ["dashboard", "operations"],
     });
+  });
+
+  it("lets landlords change the selected PM company before creating a relationship", async () => {
+    render(<PropertyManagerCompanyManagementPage />);
+
+    await screen.findByText("Elite Property Management");
+    fireEvent.change(screen.getByLabelText("PM company search"), { target: { value: "elite" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search companies" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Elite Property Management" }));
+
+    expect(screen.getByText("Selected Company")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Change Company" }));
+
+    expect(screen.getByLabelText("PM company search")).toBeInTheDocument();
+    expect(screen.queryByText("Selected Company")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create pending relationship" })).toBeDisabled();
   });
 
   it("shows a clear no-results state when no active PM companies match search", async () => {
@@ -218,7 +235,7 @@ describe("PropertyManagerCompanyManagementPage", () => {
 
     expect(await screen.findByText("No PM companies found")).toBeInTheDocument();
     expect(screen.getByText("Try another company name or verify the company has been created and activated.")).toBeInTheDocument();
-    expect(screen.queryByText("Ready to create pending relationship")).not.toBeInTheDocument();
+    expect(screen.queryByText("Selected Company")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Create pending relationship" })).toBeDisabled();
   });
 

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
@@ -1,0 +1,260 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PropertyManagerCompanyManagementPage from "./PropertyManagerCompanyManagementPage";
+import type {
+  PropertyManagerCompanyMember,
+  PropertyManagerCompanyRelationship,
+  PropertyManagerCompanyStaffAssignment,
+} from "../api/propertyManagerCompanyManagementApi";
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  showToast: vi.fn(),
+  searchCompanies: vi.fn(),
+  fetchLandlordRelationships: vi.fn(),
+  createLandlordRelationship: vi.fn(),
+  suspendLandlordRelationship: vi.fn(),
+  reactivateLandlordRelationship: vi.fn(),
+  terminateLandlordRelationship: vi.fn(),
+  fetchLandlordAssignments: vi.fn(),
+  fetchMyCompanies: vi.fn(),
+  fetchCompanyRelationships: vi.fn(),
+  acceptRelationship: vi.fn(),
+  fetchMembers: vi.fn(),
+  fetchCompanyAssignments: vi.fn(),
+  createAssignment: vi.fn(),
+  suspendAssignment: vi.fn(),
+  reactivateAssignment: vi.fn(),
+  removeAssignment: vi.fn(),
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+vi.mock("../api/propertyManagerCompanyManagementApi", async () => {
+  const actual = await vi.importActual<object>("../api/propertyManagerCompanyManagementApi");
+  return {
+    ...actual,
+    searchPropertyManagerCompanies: mocks.searchCompanies,
+    fetchLandlordPropertyManagerRelationships: mocks.fetchLandlordRelationships,
+    createLandlordPropertyManagerRelationship: mocks.createLandlordRelationship,
+    suspendLandlordPropertyManagerRelationship: mocks.suspendLandlordRelationship,
+    reactivateLandlordPropertyManagerRelationship: mocks.reactivateLandlordRelationship,
+    terminateLandlordPropertyManagerRelationship: mocks.terminateLandlordRelationship,
+    fetchLandlordPropertyManagerRelationshipAssignments: mocks.fetchLandlordAssignments,
+    fetchMyPropertyManagerCompanies: mocks.fetchMyCompanies,
+    fetchCompanyPropertyManagerRelationships: mocks.fetchCompanyRelationships,
+    acceptCompanyPropertyManagerRelationship: mocks.acceptRelationship,
+    fetchPropertyManagerCompanyMembers: mocks.fetchMembers,
+    fetchPropertyManagerCompanyStaffAssignments: mocks.fetchCompanyAssignments,
+    createPropertyManagerCompanyStaffAssignment: mocks.createAssignment,
+    suspendPropertyManagerCompanyStaffAssignment: mocks.suspendAssignment,
+    reactivatePropertyManagerCompanyStaffAssignment: mocks.reactivateAssignment,
+    removePropertyManagerCompanyStaffAssignment: mocks.removeAssignment,
+  };
+});
+
+function relationship(overrides: Partial<PropertyManagerCompanyRelationship> = {}): PropertyManagerCompanyRelationship {
+  return {
+    relationshipId: "relationship-internal-1",
+    landlordId: "landlord-internal-1",
+    propertyManagerCompanyId: "pm-company-internal-1",
+    propertyManagerCompanyLabel: "Elite Property Management",
+    landlordWorkspaceLabel: "Admin Portfolio",
+    status: "active",
+    relationshipScope: {
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: ["dashboard", "operations"],
+    },
+    createdAt: "2026-06-20T12:00:00.000Z",
+    updatedAt: "2026-06-21T12:00:00.000Z",
+    startedAt: "2026-06-21T12:00:00.000Z",
+    suspendedAt: null,
+    reactivatedAt: null,
+    terminatedAt: null,
+    staffAssignmentSummary: { total: 1, active: 1, suspended: 0, removed: 0 },
+    ...overrides,
+  };
+}
+
+function member(overrides: Partial<PropertyManagerCompanyMember> = {}): PropertyManagerCompanyMember {
+  return {
+    staffUserId: "staff-internal-1",
+    staffLabel: "manager@example.com",
+    role: "property_manager",
+    status: "active",
+    createdAt: "2026-06-20T12:00:00.000Z",
+    updatedAt: "2026-06-20T12:00:00.000Z",
+    suspendedAt: null,
+    removedAt: null,
+    ...overrides,
+  };
+}
+
+function assignment(overrides: Partial<PropertyManagerCompanyStaffAssignment> = {}): PropertyManagerCompanyStaffAssignment {
+  return {
+    assignmentId: "assignment-internal-1",
+    propertyManagerCompanyId: "pm-company-internal-1",
+    relationshipId: "relationship-internal-1",
+    staffUserId: "staff-internal-1",
+    staffLabel: "manager@example.com",
+    staffDisplayLabel: "manager@example.com",
+    staffRole: "property_manager",
+    status: "active",
+    propertyScope: { mode: "all_current_properties", propertyIds: [] },
+    workspaceScopes: ["dashboard"],
+    createdAt: "2026-06-20T12:00:00.000Z",
+    updatedAt: "2026-06-20T12:00:00.000Z",
+    suspendedAt: null,
+    reactivatedAt: null,
+    removedAt: null,
+    ...overrides,
+  };
+}
+
+describe("PropertyManagerCompanyManagementPage", () => {
+  beforeEach(() => {
+    mocks.useAuth.mockReturnValue({
+      user: { id: "owner-user-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" },
+    });
+    mocks.searchCompanies.mockResolvedValue([
+      { propertyManagerCompanyId: "pm-company-internal-1", companyLabel: "Elite Property Management", status: "active" },
+    ]);
+    mocks.fetchLandlordRelationships.mockResolvedValue([
+      relationship(),
+      relationship({ relationshipId: "relationship-pending", status: "pending", propertyManagerCompanyLabel: "North PM" }),
+      relationship({ relationshipId: "relationship-suspended", status: "suspended", propertyManagerCompanyLabel: "West PM" }),
+      relationship({ relationshipId: "relationship-terminated", status: "terminated", propertyManagerCompanyLabel: "Former PM" }),
+    ]);
+    mocks.createLandlordRelationship.mockResolvedValue({ ok: true, relationship: relationship({ status: "pending" }) });
+    mocks.suspendLandlordRelationship.mockResolvedValue({ ok: true, relationship: relationship({ status: "suspended" }) });
+    mocks.reactivateLandlordRelationship.mockResolvedValue({ ok: true, relationship: relationship({ status: "active" }) });
+    mocks.terminateLandlordRelationship.mockResolvedValue({ ok: true, relationship: relationship({ status: "terminated" }) });
+    mocks.fetchLandlordAssignments.mockResolvedValue([assignment()]);
+    mocks.fetchMyCompanies.mockResolvedValue([
+      { propertyManagerCompanyId: "pm-company-internal-1", companyLabel: "Elite Property Management", status: "active", role: "company_admin" },
+    ]);
+    mocks.fetchCompanyRelationships.mockResolvedValue([
+      relationship({
+        relationshipScope: {
+          propertyScope: { mode: "all_current_properties", propertyIds: [] },
+          workspaceScopes: ["dashboard", "operations", "settings_billing"],
+        },
+      }),
+      relationship({ relationshipId: "relationship-pending", status: "pending", landlordWorkspaceLabel: "Pending Portfolio" }),
+    ]);
+    mocks.acceptRelationship.mockResolvedValue({ ok: true, relationship: relationship({ status: "active" }) });
+    mocks.fetchMembers.mockResolvedValue([
+      member(),
+      member({ staffUserId: "staff-removed", staffLabel: "removed@example.com", status: "removed" }),
+    ]);
+    mocks.fetchCompanyAssignments.mockResolvedValue([assignment()]);
+    mocks.createAssignment.mockResolvedValue({ ok: true, assignment: assignment() });
+    mocks.suspendAssignment.mockResolvedValue({ ok: true, assignment: assignment({ status: "suspended" }) });
+    mocks.reactivateAssignment.mockResolvedValue({ ok: true, assignment: assignment({ status: "active" }) });
+    mocks.removeAssignment.mockResolvedValue({ ok: true, assignment: assignment({ status: "removed" }) });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("approves the revised brief by rendering landlord relationship management from safe projections", async () => {
+    const { container } = render(<PropertyManagerCompanyManagementPage />);
+
+    expect(await screen.findByRole("heading", { name: "PM Company Management" })).toBeInTheDocument();
+    expect(screen.getByText("Elite Property Management")).toBeInTheDocument();
+    expect(screen.getByText("North PM")).toBeInTheDocument();
+    expect(screen.getByText("West PM")).toBeInTheDocument();
+    expect(screen.getByText("Former PM")).toBeInTheDocument();
+    expect(screen.getAllByText("All current properties · Dashboard, Operations").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Suspended").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Terminated").length).toBeGreaterThan(0);
+    expect(container).not.toHaveTextContent("relationship-internal");
+    expect(container).not.toHaveTextContent("pm-company-internal");
+    expect(container).not.toHaveTextContent("landlord-internal");
+  });
+
+  it("creates pending landlord relationships using discovery labels and all-current-property scope", async () => {
+    render(<PropertyManagerCompanyManagementPage />);
+
+    await screen.findByText("Elite Property Management");
+    fireEvent.change(screen.getByLabelText("PM company search"), { target: { value: "elite" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search companies" }));
+    await waitFor(() => expect(mocks.searchCompanies).toHaveBeenCalledWith("elite"));
+    fireEvent.click(screen.getByRole("button", { name: "Elite Property Management" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create pending relationship" }));
+
+    await waitFor(() => expect(mocks.createLandlordRelationship).toHaveBeenCalledTimes(1));
+    expect(mocks.createLandlordRelationship).toHaveBeenCalledWith({
+      propertyManagerCompanyId: "pm-company-internal-1",
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: ["dashboard", "operations"],
+    });
+  });
+
+  it("requires confirmation before terminating a landlord relationship", async () => {
+    render(<PropertyManagerCompanyManagementPage />);
+
+    await screen.findByText("Elite Property Management");
+    fireEvent.click(screen.getAllByRole("button", { name: "Terminate" })[0]);
+    expect(mocks.terminateLandlordRelationship).not.toHaveBeenCalled();
+    const dialog = screen.getByRole("dialog", { name: "Terminate relationship" });
+    expect(dialog).toHaveTextContent("Access will remain blocked and history will be preserved");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Terminate" }));
+
+    await waitFor(() => expect(mocks.terminateLandlordRelationship).toHaveBeenCalledWith("relationship-internal-1"));
+  });
+
+  it("lets Company Owner/Admin accept pending relationships and create scoped assignments with templates only", async () => {
+    const { container } = render(<PropertyManagerCompanyManagementPage />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "PM company admin" }));
+    expect(await screen.findByText("Pending Portfolio")).toBeInTheDocument();
+    expect(screen.getAllByText("manager@example.com").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Company Admin", { selector: "option" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Owner-only settings")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept relationship" }));
+    const acceptDialog = screen.getByRole("dialog", { name: "Accept relationship" });
+    fireEvent.click(within(acceptDialog).getByRole("button", { name: "Accept relationship" }));
+    await waitFor(() =>
+      expect(mocks.acceptRelationship).toHaveBeenCalledWith("pm-company-internal-1", "relationship-pending")
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Create assignment/i }));
+    await waitFor(() => expect(mocks.createAssignment).toHaveBeenCalledTimes(1));
+    expect(mocks.createAssignment).toHaveBeenCalledWith("pm-company-internal-1", {
+      relationshipId: "relationship-internal-1",
+      staffUserId: "staff-internal-1",
+      staffRole: "property_manager",
+      propertyScope: { mode: "all_current_properties", propertyIds: [] },
+      workspaceScopes: ["dashboard", "operations"],
+    });
+    expect(container).not.toHaveTextContent("settings_billing");
+    expect(container).not.toHaveTextContent("assignment-internal");
+  });
+
+  it("requires confirmation before removing a staff assignment", async () => {
+    render(<PropertyManagerCompanyManagementPage />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "PM company admin" }));
+    await waitFor(() => expect(screen.getAllByText("manager@example.com").length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(mocks.removeAssignment).not.toHaveBeenCalled();
+    const dialog = screen.getByRole("dialog", { name: "Remove assignment" });
+    expect(dialog).toHaveTextContent("History will be preserved");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(mocks.removeAssignment).toHaveBeenCalledWith("pm-company-internal-1", "assignment-internal-1"));
+  });
+});

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
@@ -10,6 +10,7 @@ import type {
 
 const mocks = vi.hoisted(() => ({
   useAuth: vi.fn(),
+  logout: vi.fn(),
   showToast: vi.fn(),
   searchCompanies: vi.fn(),
   fetchLandlordRelationships: vi.fn(),
@@ -122,6 +123,7 @@ describe("PropertyManagerCompanyManagementPage", () => {
   beforeEach(() => {
     mocks.useAuth.mockReturnValue({
       user: { id: "owner-user-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" },
+      logout: mocks.logout,
     });
     mocks.searchCompanies.mockResolvedValue([
       { propertyManagerCompanyId: "pm-company-internal-1", companyLabel: "Elite Property Management", status: "active" },
@@ -256,5 +258,45 @@ describe("PropertyManagerCompanyManagementPage", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Remove" }));
 
     await waitFor(() => expect(mocks.removeAssignment).toHaveBeenCalledWith("pm-company-internal-1", "assignment-internal-1"));
+  });
+
+  it("shows account context and sign out on the standalone company-admin surface", async () => {
+    render(<PropertyManagerCompanyManagementPage />);
+
+    expect(await screen.findByText("Signed in as owner@example.com")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(mocks.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows landlord and company empty states without implying deletion", async () => {
+    mocks.fetchLandlordRelationships.mockResolvedValueOnce([]);
+    mocks.fetchCompanyRelationships.mockResolvedValue([]);
+    mocks.fetchCompanyAssignments.mockResolvedValue([]);
+
+    render(<PropertyManagerCompanyManagementPage />);
+
+    expect(await screen.findByText("No PM company relationships")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "PM company admin" }));
+
+    expect(await screen.findByText("No company relationships")).toBeInTheDocument();
+    expect(screen.getByText("No staff assignments")).toBeInTheDocument();
+    expect(screen.getByText(/Assignment history will remain visible/i)).toBeInTheDocument();
+  });
+
+  it("does not show admin controls for non-admin company staff without active company admin context", async () => {
+    mocks.useAuth.mockReturnValue({
+      user: { id: "staff-user-1", role: "property_manager", email: "staff@example.com" },
+      logout: mocks.logout,
+    });
+    mocks.fetchLandlordRelationships.mockResolvedValueOnce([]);
+    mocks.fetchMyCompanies.mockResolvedValueOnce([]);
+
+    render(<PropertyManagerCompanyManagementPage />);
+
+    expect(await screen.findByText("No PM company admin context")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Landlord owner" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Create staff assignment")).not.toBeInTheDocument();
+    expect(screen.queryByText("Create pending relationship")).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.test.tsx
@@ -193,7 +193,10 @@ describe("PropertyManagerCompanyManagementPage", () => {
     fireEvent.change(screen.getByLabelText("PM company search"), { target: { value: "elite" } });
     fireEvent.click(screen.getByRole("button", { name: "Search companies" }));
     await waitFor(() => expect(mocks.searchCompanies).toHaveBeenCalledWith("elite"));
+    expect(screen.getByText("Search results")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Elite Property Management" }));
+    expect(screen.getByText("Selected PM Company")).toBeInTheDocument();
+    expect(screen.getByText("Ready to create pending relationship")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Create pending relationship" }));
 
     await waitFor(() => expect(mocks.createLandlordRelationship).toHaveBeenCalledTimes(1));
@@ -202,6 +205,21 @@ describe("PropertyManagerCompanyManagementPage", () => {
       propertyScope: { mode: "all_current_properties", propertyIds: [] },
       workspaceScopes: ["dashboard", "operations"],
     });
+  });
+
+  it("shows a clear no-results state when no active PM companies match search", async () => {
+    mocks.searchCompanies.mockResolvedValueOnce([]);
+
+    render(<PropertyManagerCompanyManagementPage />);
+
+    await screen.findByText("Elite Property Management");
+    fireEvent.change(screen.getByLabelText("PM company search"), { target: { value: "missing company" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search companies" }));
+
+    expect(await screen.findByText("No PM companies found")).toBeInTheDocument();
+    expect(screen.getByText("Try another company name or verify the company has been created and activated.")).toBeInTheDocument();
+    expect(screen.queryByText("Ready to create pending relationship")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create pending relationship" })).toBeDisabled();
   });
 
   it("requires confirmation before terminating a landlord relationship", async () => {
@@ -276,7 +294,8 @@ describe("PropertyManagerCompanyManagementPage", () => {
 
     render(<PropertyManagerCompanyManagementPage />);
 
-    expect(await screen.findByText("No PM company relationships")).toBeInTheDocument();
+    expect(await screen.findByText("No PM company relationships yet")).toBeInTheDocument();
+    expect(screen.getByText("Search for a PM company to begin a relationship.")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("tab", { name: "PM company admin" }));
 
     expect(await screen.findByText("No company relationships")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
@@ -404,7 +404,7 @@ function AssignmentRow({
 }
 
 export default function PropertyManagerCompanyManagementPage() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   const { showToast } = useToast();
   const canUseLandlordSurface = userIsLandlord(user);
   const [mode, setMode] = React.useState<SurfaceMode>(canUseLandlordSurface ? "landlord" : "company");
@@ -835,6 +835,9 @@ export default function PropertyManagerCompanyManagementPage() {
               onClick={() => setMode("company")}
             >
               PM company admin
+            </Button>
+            <Button type="button" variant="ghost" onClick={() => void logout()}>
+              Sign out
             </Button>
           </div>
         </div>

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
@@ -550,6 +550,12 @@ export default function PropertyManagerCompanyManagementPage() {
     }
   };
 
+  const changeSelectedCompany = () => {
+    setSelectedLookup(null);
+    setHasSearchedCompanies(false);
+    setSearchResults([]);
+  };
+
   const createRelationship = async () => {
     if (!selectedLookup || !relationshipWorkspaces.length) return;
     setBusy(true);
@@ -897,65 +903,68 @@ export default function PropertyManagerCompanyManagementPage() {
                   Search a Property Manager Company. Select a company. Create a pending relationship. The company must
                   accept before access becomes active.
                 </div>
-                <label className="pmc-label">
-                  PM company search
-                  <Input
-                    value={searchQuery}
-                    onChange={(event) => setSearchQuery(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter") {
-                        event.preventDefault();
-                        void searchCompanies();
-                      }
-                    }}
-                    placeholder="Search by company label"
-                  />
-                </label>
-                <Button type="button" variant="secondary" disabled={busy} onClick={searchCompanies}>
-                  Search companies
-                </Button>
-                {hasSearchedCompanies ? (
-                  <div className="pmc-search-results" aria-live="polite">
-                    <div style={{ fontWeight: 900 }}>Search results</div>
-                    {searchResults.length ? (
-                      <div style={{ display: "grid", gap: spacing.xs }}>
-                        {searchResults.map((company) => (
-                          <button
-                            key={company.propertyManagerCompanyId}
-                            type="button"
-                            className="pmc-result-button"
-                            aria-pressed={selectedLookup?.propertyManagerCompanyId === company.propertyManagerCompanyId}
-                            onClick={() => setSelectedLookup(company)}
-                          >
-                            {company.companyLabel}
-                          </button>
-                        ))}
-                      </div>
-                    ) : (
-                      <EmptyState
-                        title="No PM companies found"
-                        body="Try another company name or verify the company has been created and activated."
-                        style={{ background: colors.card }}
-                      />
-                    )}
-                  </div>
-                ) : null}
                 {selectedLookup ? (
                   <div className="pmc-selected-company" aria-live="polite">
                     <div>
                       <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>
-                        Selected PM Company
+                        Selected Company
                       </div>
-                      <div style={{ fontWeight: 900, overflowWrap: "anywhere" }}>{selectedLookup.companyLabel}</div>
-                    </div>
-                    <div>
-                      <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>
-                        Relationship Status
+                      <div style={{ display: "flex", gap: 8, alignItems: "center", fontWeight: 900, overflowWrap: "anywhere" }}>
+                        <CheckCircle2 size={18} aria-hidden="true" />
+                        {selectedLookup.companyLabel}
                       </div>
-                      <div style={{ fontWeight: 900 }}>Ready to create pending relationship</div>
                     </div>
+                    <Button type="button" variant="secondary" onClick={changeSelectedCompany}>
+                      Change Company
+                    </Button>
                   </div>
-                ) : null}
+                ) : (
+                  <>
+                    <label className="pmc-label">
+                      PM company search
+                      <Input
+                        value={searchQuery}
+                        onChange={(event) => setSearchQuery(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            void searchCompanies();
+                          }
+                        }}
+                        placeholder="Search by company label"
+                      />
+                    </label>
+                    <Button type="button" variant="secondary" disabled={busy} onClick={searchCompanies}>
+                      Search companies
+                    </Button>
+                    {hasSearchedCompanies ? (
+                      <div className="pmc-search-results" aria-live="polite">
+                        <div style={{ fontWeight: 900 }}>Search results</div>
+                        {searchResults.length ? (
+                          <div style={{ display: "grid", gap: spacing.xs }}>
+                            {searchResults.map((company) => (
+                              <button
+                                key={company.propertyManagerCompanyId}
+                                type="button"
+                                className="pmc-result-button"
+                                aria-pressed={false}
+                                onClick={() => setSelectedLookup(company)}
+                              >
+                                {company.companyLabel}
+                              </button>
+                            ))}
+                          </div>
+                        ) : (
+                          <EmptyState
+                            title="No PM companies found"
+                            body="Try another company name or verify the company has been created and activated."
+                            style={{ background: colors.card }}
+                          />
+                        )}
+                      </div>
+                    ) : null}
+                  </>
+                )}
                 {searchResults.length && !selectedLookup ? (
                   <div className="pmc-helper">Select a PM company result before creating a pending relationship.</div>
                 ) : null}

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
@@ -418,6 +418,7 @@ export default function PropertyManagerCompanyManagementPage() {
   const [companyAssignments, setCompanyAssignments] = React.useState<PropertyManagerCompanyStaffAssignment[]>([]);
   const [searchQuery, setSearchQuery] = React.useState("");
   const [searchResults, setSearchResults] = React.useState<PropertyManagerCompanyLookup[]>([]);
+  const [hasSearchedCompanies, setHasSearchedCompanies] = React.useState(false);
   const [selectedLookup, setSelectedLookup] = React.useState<PropertyManagerCompanyLookup | null>(null);
   const [relationshipWorkspaces, setRelationshipWorkspaces] =
     React.useState<PropertyManagerCompanyWorkspaceScope[]>(DEFAULT_RELATIONSHIP_WORKSPACES);
@@ -534,7 +535,14 @@ export default function PropertyManagerCompanyManagementPage() {
     setBusy(true);
     try {
       const companies = await searchPropertyManagerCompanies(searchQuery);
+      setHasSearchedCompanies(true);
       setSearchResults(companies);
+      if (
+        selectedLookup &&
+        !companies.some((company) => company.propertyManagerCompanyId === selectedLookup.propertyManagerCompanyId)
+      ) {
+        setSelectedLookup(null);
+      }
     } catch (err: any) {
       showToast({ message: "Company search failed", description: err?.message || "Try again.", variant: "error" });
     } finally {
@@ -554,6 +562,7 @@ export default function PropertyManagerCompanyManagementPage() {
       setSelectedLookup(null);
       setSearchQuery("");
       setSearchResults([]);
+      setHasSearchedCompanies(false);
       setRelationshipWorkspaces(DEFAULT_RELATIONSHIP_WORKSPACES);
       await loadLandlord();
       showToast({
@@ -750,6 +759,34 @@ export default function PropertyManagerCompanyManagementPage() {
             font-size: 13px;
             line-height: 1.45;
           }
+          .pmc-search-results,
+          .pmc-selected-company {
+            display: grid;
+            gap: ${spacing.sm};
+            border: 1px solid ${colors.border};
+            border-radius: ${radius.md};
+            padding: ${spacing.sm};
+            background: ${colors.panel};
+          }
+          .pmc-selected-company {
+            border-color: ${colors.accent};
+            background: ${colors.accentSoft};
+          }
+          .pmc-result-button {
+            width: 100%;
+            text-align: left;
+            border: 1px solid ${colors.border};
+            background: ${colors.card};
+            border-radius: ${radius.md};
+            padding: ${spacing.sm};
+            cursor: pointer;
+            font-weight: 800;
+            overflow-wrap: anywhere;
+          }
+          .pmc-result-button[aria-pressed="true"] {
+            border-color: ${colors.accent};
+            background: ${colors.accentSoft};
+          }
           .pmc-select {
             width: 100%;
             min-height: 42px;
@@ -856,46 +893,71 @@ export default function PropertyManagerCompanyManagementPage() {
                 <Building2 size={18} /> Create pending relationship
               </h2>
               <div className="pmc-form">
+                <div className="pmc-note">
+                  Search a Property Manager Company. Select a company. Create a pending relationship. The company must
+                  accept before access becomes active.
+                </div>
                 <label className="pmc-label">
                   PM company search
                   <Input
                     value={searchQuery}
                     onChange={(event) => setSearchQuery(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        void searchCompanies();
+                      }
+                    }}
                     placeholder="Search by company label"
                   />
                 </label>
                 <Button type="button" variant="secondary" disabled={busy} onClick={searchCompanies}>
                   Search companies
                 </Button>
-                {searchResults.length ? (
-                  <div style={{ display: "grid", gap: spacing.xs }}>
-                    {searchResults.map((company) => (
-                      <button
-                        key={company.propertyManagerCompanyId}
-                        type="button"
-                        onClick={() => setSelectedLookup(company)}
-                        style={{
-                          textAlign: "left",
-                          border: `1px solid ${
-                            selectedLookup?.propertyManagerCompanyId === company.propertyManagerCompanyId
-                              ? colors.accent
-                              : colors.border
-                          }`,
-                          background:
-                            selectedLookup?.propertyManagerCompanyId === company.propertyManagerCompanyId
-                              ? colors.accentSoft
-                              : colors.card,
-                          borderRadius: radius.md,
-                          padding: spacing.sm,
-                          cursor: "pointer",
-                          fontWeight: 800,
-                          overflowWrap: "anywhere",
-                        }}
-                      >
-                        {company.companyLabel}
-                      </button>
-                    ))}
+                {hasSearchedCompanies ? (
+                  <div className="pmc-search-results" aria-live="polite">
+                    <div style={{ fontWeight: 900 }}>Search results</div>
+                    {searchResults.length ? (
+                      <div style={{ display: "grid", gap: spacing.xs }}>
+                        {searchResults.map((company) => (
+                          <button
+                            key={company.propertyManagerCompanyId}
+                            type="button"
+                            className="pmc-result-button"
+                            aria-pressed={selectedLookup?.propertyManagerCompanyId === company.propertyManagerCompanyId}
+                            onClick={() => setSelectedLookup(company)}
+                          >
+                            {company.companyLabel}
+                          </button>
+                        ))}
+                      </div>
+                    ) : (
+                      <EmptyState
+                        title="No PM companies found"
+                        body="Try another company name or verify the company has been created and activated."
+                        style={{ background: colors.card }}
+                      />
+                    )}
                   </div>
+                ) : null}
+                {selectedLookup ? (
+                  <div className="pmc-selected-company" aria-live="polite">
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>
+                        Selected PM Company
+                      </div>
+                      <div style={{ fontWeight: 900, overflowWrap: "anywhere" }}>{selectedLookup.companyLabel}</div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>
+                        Relationship Status
+                      </div>
+                      <div style={{ fontWeight: 900 }}>Ready to create pending relationship</div>
+                    </div>
+                  </div>
+                ) : null}
+                {searchResults.length && !selectedLookup ? (
+                  <div className="pmc-helper">Select a PM company result before creating a pending relationship.</div>
                 ) : null}
                 <label className="pmc-label">
                   Property scope
@@ -950,8 +1012,8 @@ export default function PropertyManagerCompanyManagementPage() {
                 ))
               ) : (
                 <EmptyState
-                  title="No PM company relationships"
-                  body="Pending, active, suspended, and terminated relationships will appear here."
+                  title="No PM company relationships yet"
+                  body="Search for a PM company to begin a relationship."
                 />
               )}
             </div>

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
@@ -1,0 +1,1123 @@
+import React from "react";
+import { Building2, CheckCircle2, ShieldAlert, UserPlus, Users } from "lucide-react";
+import {
+  acceptCompanyPropertyManagerRelationship,
+  createLandlordPropertyManagerRelationship,
+  createPropertyManagerCompanyStaffAssignment,
+  fetchCompanyPropertyManagerRelationships,
+  fetchLandlordPropertyManagerRelationshipAssignments,
+  fetchLandlordPropertyManagerRelationships,
+  fetchMyPropertyManagerCompanies,
+  fetchPropertyManagerCompanyMembers,
+  fetchPropertyManagerCompanyStaffAssignments,
+  reactivateLandlordPropertyManagerRelationship,
+  reactivatePropertyManagerCompanyStaffAssignment,
+  removePropertyManagerCompanyStaffAssignment,
+  searchPropertyManagerCompanies,
+  suspendLandlordPropertyManagerRelationship,
+  suspendPropertyManagerCompanyStaffAssignment,
+  terminateLandlordPropertyManagerRelationship,
+  type PropertyManagerCompanyLookup,
+  type PropertyManagerCompanyMember,
+  type PropertyManagerCompanyPropertyScope,
+  type PropertyManagerCompanyRelationship,
+  type PropertyManagerCompanyStaffAssignment,
+  type PropertyManagerCompanyStaffAssignmentRole,
+  type PropertyManagerCompanyWorkspaceScope,
+} from "../api/propertyManagerCompanyManagementApi";
+import { Button, Card, EmptyState, InlineError, Input, Pill, SkeletonBlock } from "../components/ui/Ui";
+import { useToast } from "../components/ui/ToastProvider";
+import { useAuth } from "../context/useAuth";
+import { colors, radius, shadows, spacing, text } from "../styles/tokens";
+
+const ASSIGNMENT_ROLES: PropertyManagerCompanyStaffAssignmentRole[] = [
+  "regional_manager",
+  "property_manager",
+  "leasing_agent",
+  "office_administrator",
+  "maintenance_coordinator",
+  "read_only_staff",
+];
+
+const ROLE_LABELS: Record<PropertyManagerCompanyStaffAssignmentRole | "company_owner" | "company_admin", string> = {
+  company_owner: "Company Owner",
+  company_admin: "Company Admin",
+  regional_manager: "Regional Manager",
+  property_manager: "Property Manager",
+  leasing_agent: "Leasing Agent",
+  office_administrator: "Office Administrator",
+  maintenance_coordinator: "Maintenance Coordinator",
+  read_only_staff: "Read-only Staff",
+};
+
+const WORKSPACE_LABELS: Record<PropertyManagerCompanyWorkspaceScope, string> = {
+  dashboard: "Dashboard",
+  operations: "Operations",
+  properties: "Properties",
+  tenants: "Tenants",
+  leases: "Leases",
+  payments: "Payments",
+  unified_inbox: "Inbox",
+  scheduling: "Scheduling",
+  work_orders: "Work Orders",
+  evidence_exports: "Evidence / Exports",
+  settings_billing: "Owner-only settings",
+};
+
+const RELATIONSHIP_WORKSPACES: PropertyManagerCompanyWorkspaceScope[] = [
+  "dashboard",
+  "operations",
+  "properties",
+  "tenants",
+  "leases",
+  "payments",
+  "unified_inbox",
+  "scheduling",
+  "work_orders",
+  "evidence_exports",
+];
+
+const DEFAULT_RELATIONSHIP_WORKSPACES: PropertyManagerCompanyWorkspaceScope[] = ["dashboard", "operations"];
+
+type SurfaceMode = "landlord" | "company";
+
+type Confirmation = {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  onConfirm: () => Promise<void>;
+};
+
+function userIsLandlord(user: any) {
+  const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
+  return role === "landlord" || role === "admin";
+}
+
+function statusLabel(value: string) {
+  return value
+    .split("_")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function actionPastTense(action: string) {
+  if (action === "reactivate") return "reactivated";
+  if (action === "remove") return "removed";
+  if (action === "suspend") return "suspended";
+  if (action === "terminate") return "terminated";
+  return `${action}d`;
+}
+
+function statusTone(value: string): "accent" | "muted" {
+  return value === "active" || value === "pending" ? "accent" : "muted";
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "Unavailable";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Unavailable";
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+function visibleWorkspaces(workspaces: PropertyManagerCompanyWorkspaceScope[]) {
+  return workspaces.filter((workspace) => workspace !== "settings_billing");
+}
+
+function workspaceLabelList(workspaces: PropertyManagerCompanyWorkspaceScope[]) {
+  const visible = visibleWorkspaces(workspaces);
+  if (!visible.length) return "No operational workspace scope";
+  return visible.map((workspace) => WORKSPACE_LABELS[workspace]).join(", ");
+}
+
+function propertyScopeLabel(scope?: PropertyManagerCompanyPropertyScope | null) {
+  if (!scope) return "Unavailable property scope";
+  if (scope.mode === "all_current_properties") return "All current properties";
+  return "Approved selected properties";
+}
+
+function relationshipScopeLabel(relationship: PropertyManagerCompanyRelationship) {
+  return `${propertyScopeLabel(relationship.relationshipScope.propertyScope)} · ${workspaceLabelList(
+    relationship.relationshipScope.workspaceScopes
+  )}`;
+}
+
+function activeMembers(members: PropertyManagerCompanyMember[]) {
+  return members.filter((member) => member.status === "active");
+}
+
+function scopeForAssignment(relationship: PropertyManagerCompanyRelationship): PropertyManagerCompanyPropertyScope {
+  const propertyScope = relationship.relationshipScope.propertyScope;
+  if (propertyScope.mode === "selected_properties") {
+    return { mode: "selected_properties", propertyIds: [...propertyScope.propertyIds] };
+  }
+  return { mode: "all_current_properties", propertyIds: [] };
+}
+
+function relationshipCounts(relationships: PropertyManagerCompanyRelationship[]) {
+  return {
+    pending: relationships.filter((relationship) => relationship.status === "pending").length,
+    active: relationships.filter((relationship) => relationship.status === "active").length,
+    suspended: relationships.filter((relationship) => relationship.status === "suspended").length,
+    terminated: relationships.filter((relationship) => relationship.status === "terminated").length,
+  };
+}
+
+function ToggleChip({
+  checked,
+  label,
+  disabled,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 10px",
+        borderRadius: radius.pill,
+        border: `1px solid ${checked ? colors.accent : colors.border}`,
+        background: checked ? colors.accentSoft : colors.card,
+        color: disabled ? text.muted : text.primary,
+        fontSize: 13,
+        fontWeight: 700,
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.62 : 1,
+      }}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+        style={{ margin: 0 }}
+      />
+      {label}
+    </label>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="pmc-summary-stat">
+      <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>{label}</div>
+      <div style={{ fontSize: 24, fontWeight: 900 }}>{value}</div>
+    </div>
+  );
+}
+
+function ConfirmPanel({
+  confirmation,
+  busy,
+  onCancel,
+}: {
+  confirmation: Confirmation | null;
+  busy: boolean;
+  onCancel: () => void;
+}) {
+  if (!confirmation) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={confirmation.title}
+      style={{
+        position: "sticky",
+        top: 12,
+        zIndex: 5,
+        display: "grid",
+        gap: spacing.sm,
+        padding: spacing.md,
+        borderRadius: radius.lg,
+        border: "1px solid rgba(180,83,9,0.28)",
+        background: "#fff7ed",
+        boxShadow: shadows.md,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 10, fontWeight: 900 }}>
+        <ShieldAlert size={18} />
+        {confirmation.title}
+      </div>
+      <div style={{ color: text.secondary, lineHeight: 1.5 }}>{confirmation.body}</div>
+      <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+        <Button type="button" variant="ghost" disabled={busy} onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          disabled={busy}
+          onClick={() => {
+            void confirmation.onConfirm();
+          }}
+        >
+          {busy ? "Working..." : confirmation.confirmLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function RelationshipCard({
+  relationship,
+  staffAssignments,
+  loadingStaff,
+  onLoadStaff,
+  onSuspend,
+  onReactivate,
+  onTerminate,
+  companyMode,
+  onAccept,
+}: {
+  relationship: PropertyManagerCompanyRelationship;
+  staffAssignments?: PropertyManagerCompanyStaffAssignment[];
+  loadingStaff?: boolean;
+  onLoadStaff?: () => void;
+  onSuspend?: () => void;
+  onReactivate?: () => void;
+  onTerminate?: () => void;
+  companyMode?: boolean;
+  onAccept?: () => void;
+}) {
+  const title = companyMode ? relationship.landlordWorkspaceLabel : relationship.propertyManagerCompanyLabel;
+  return (
+    <Card data-testid="pmc-relationship-card" style={{ display: "grid", gap: spacing.md }}>
+      <div className="pmc-card-header">
+        <div style={{ minWidth: 0 }}>
+          <div className="pmc-card-title">{title}</div>
+          <div style={{ color: text.muted, fontSize: 13, overflowWrap: "anywhere" }}>
+            {relationshipScopeLabel(relationship)}
+          </div>
+        </div>
+        <Pill tone={statusTone(relationship.status)}>{statusLabel(relationship.status)}</Pill>
+      </div>
+
+      <div className="pmc-meta-grid">
+        <div>
+          <span>Updated</span>
+          <strong>{formatDate(relationship.updatedAt)}</strong>
+        </div>
+        <div>
+          <span>Active staff</span>
+          <strong>{relationship.staffAssignmentSummary.active}</strong>
+        </div>
+        <div>
+          <span>Suspended staff</span>
+          <strong>{relationship.staffAssignmentSummary.suspended}</strong>
+        </div>
+      </div>
+
+      {relationship.status === "pending" ? (
+        <div className="pmc-note">Access becomes active only after the PM company accepts.</div>
+      ) : null}
+
+      <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+        {onLoadStaff ? (
+          <Button type="button" variant="secondary" onClick={onLoadStaff}>
+            {loadingStaff ? "Loading staff..." : "View assigned staff"}
+          </Button>
+        ) : null}
+        {onAccept && relationship.status === "pending" ? (
+          <Button type="button" onClick={onAccept}>
+            Accept relationship
+          </Button>
+        ) : null}
+        {onSuspend && relationship.status === "active" ? (
+          <Button type="button" variant="secondary" onClick={onSuspend}>
+            Suspend
+          </Button>
+        ) : null}
+        {onReactivate && relationship.status === "suspended" ? (
+          <Button type="button" variant="secondary" onClick={onReactivate}>
+            Reactivate
+          </Button>
+        ) : null}
+        {onTerminate && relationship.status !== "terminated" ? (
+          <Button type="button" variant="ghost" onClick={onTerminate}>
+            Terminate
+          </Button>
+        ) : null}
+      </div>
+
+      {staffAssignments ? (
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ fontWeight: 900 }}>Assigned PM company staff</div>
+          {staffAssignments.length ? (
+            staffAssignments.map((assignment) => <AssignmentRow key={assignment.assignmentId} assignment={assignment} />)
+          ) : (
+            <EmptyState
+              title="No staff assigned"
+              body="This relationship has no visible staff assignments yet."
+              style={{ background: colors.card }}
+            />
+          )}
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function AssignmentRow({
+  assignment,
+  onSuspend,
+  onReactivate,
+  onRemove,
+}: {
+  assignment: PropertyManagerCompanyStaffAssignment;
+  onSuspend?: () => void;
+  onReactivate?: () => void;
+  onRemove?: () => void;
+}) {
+  return (
+    <div className="pmc-assignment-row" data-testid="pmc-assignment-row">
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontWeight: 900, overflowWrap: "anywhere" }}>{assignment.staffLabel}</div>
+        <div style={{ color: text.muted, fontSize: 13 }}>
+          {ROLE_LABELS[assignment.staffRole]} · {propertyScopeLabel(assignment.propertyScope)} ·{" "}
+          {workspaceLabelList(assignment.workspaceScopes)}
+        </div>
+      </div>
+      <div className="pmc-row-actions">
+        <Pill tone={statusTone(assignment.status)}>{statusLabel(assignment.status)}</Pill>
+        {onSuspend && assignment.status === "active" ? (
+          <Button type="button" variant="secondary" onClick={onSuspend}>
+            Suspend
+          </Button>
+        ) : null}
+        {onReactivate && assignment.status === "suspended" ? (
+          <Button type="button" variant="secondary" onClick={onReactivate}>
+            Reactivate
+          </Button>
+        ) : null}
+        {onRemove && assignment.status !== "removed" ? (
+          <Button type="button" variant="ghost" onClick={onRemove}>
+            Remove
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default function PropertyManagerCompanyManagementPage() {
+  const { user } = useAuth();
+  const { showToast } = useToast();
+  const canUseLandlordSurface = userIsLandlord(user);
+  const [mode, setMode] = React.useState<SurfaceMode>(canUseLandlordSurface ? "landlord" : "company");
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [landlordRelationships, setLandlordRelationships] = React.useState<PropertyManagerCompanyRelationship[]>([]);
+  const [companyContexts, setCompanyContexts] = React.useState<PropertyManagerCompanyLookup[]>([]);
+  const [selectedCompanyId, setSelectedCompanyId] = React.useState("");
+  const [companyRelationships, setCompanyRelationships] = React.useState<PropertyManagerCompanyRelationship[]>([]);
+  const [companyMembers, setCompanyMembers] = React.useState<PropertyManagerCompanyMember[]>([]);
+  const [companyAssignments, setCompanyAssignments] = React.useState<PropertyManagerCompanyStaffAssignment[]>([]);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [searchResults, setSearchResults] = React.useState<PropertyManagerCompanyLookup[]>([]);
+  const [selectedLookup, setSelectedLookup] = React.useState<PropertyManagerCompanyLookup | null>(null);
+  const [relationshipWorkspaces, setRelationshipWorkspaces] =
+    React.useState<PropertyManagerCompanyWorkspaceScope[]>(DEFAULT_RELATIONSHIP_WORKSPACES);
+  const [assignmentRelationshipId, setAssignmentRelationshipId] = React.useState("");
+  const [assignmentStaffUserId, setAssignmentStaffUserId] = React.useState("");
+  const [assignmentRole, setAssignmentRole] = React.useState<PropertyManagerCompanyStaffAssignmentRole>("property_manager");
+  const [assignmentWorkspaces, setAssignmentWorkspaces] = React.useState<PropertyManagerCompanyWorkspaceScope[]>([]);
+  const [landlordAssignments, setLandlordAssignments] = React.useState<Record<string, PropertyManagerCompanyStaffAssignment[]>>({});
+  const [loadingStaffFor, setLoadingStaffFor] = React.useState<string | null>(null);
+  const [busy, setBusy] = React.useState(false);
+  const [confirmation, setConfirmation] = React.useState<Confirmation | null>(null);
+
+  const loadLandlord = React.useCallback(async () => {
+    if (!canUseLandlordSurface) return;
+    const relationships = await fetchLandlordPropertyManagerRelationships();
+    setLandlordRelationships(relationships);
+  }, [canUseLandlordSurface]);
+
+  const loadCompanyContexts = React.useCallback(async () => {
+    const companies = await fetchMyPropertyManagerCompanies();
+    setCompanyContexts(companies);
+    setSelectedCompanyId((current) => current || companies[0]?.propertyManagerCompanyId || "");
+  }, []);
+
+  const loadInitial = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await Promise.all([loadLandlord(), loadCompanyContexts()]);
+    } catch (err: any) {
+      setError(err?.message || "Unable to load property manager company management");
+    } finally {
+      setLoading(false);
+    }
+  }, [loadCompanyContexts, loadLandlord]);
+
+  React.useEffect(() => {
+    void loadInitial();
+  }, [loadInitial]);
+
+  const loadCompany = React.useCallback(async () => {
+    if (!selectedCompanyId) {
+      setCompanyRelationships([]);
+      setCompanyMembers([]);
+      setCompanyAssignments([]);
+      return;
+    }
+    setError(null);
+    try {
+      const [relationships, members, assignments] = await Promise.all([
+        fetchCompanyPropertyManagerRelationships(selectedCompanyId),
+        fetchPropertyManagerCompanyMembers(selectedCompanyId),
+        fetchPropertyManagerCompanyStaffAssignments(selectedCompanyId),
+      ]);
+      setCompanyRelationships(relationships);
+      setCompanyMembers(members);
+      setCompanyAssignments(assignments);
+    } catch (err: any) {
+      setError(err?.message || "Unable to load company management records");
+    }
+  }, [selectedCompanyId]);
+
+  React.useEffect(() => {
+    void loadCompany();
+  }, [loadCompany]);
+
+  const selectedAssignmentRelationship = companyRelationships.find(
+    (relationship) => relationship.relationshipId === assignmentRelationshipId
+  );
+  const allowedAssignmentWorkspaces = visibleWorkspaces(
+    selectedAssignmentRelationship?.relationshipScope.workspaceScopes || []
+  );
+
+  React.useEffect(() => {
+    const activeRelationships = companyRelationships.filter((relationship) => relationship.status === "active");
+    const nextRelationship = activeRelationships[0];
+    setAssignmentRelationshipId((current) =>
+      current && activeRelationships.some((relationship) => relationship.relationshipId === current)
+        ? current
+        : nextRelationship?.relationshipId || ""
+    );
+  }, [companyRelationships]);
+
+  React.useEffect(() => {
+    if (!selectedAssignmentRelationship) {
+      setAssignmentWorkspaces([]);
+      return;
+    }
+    setAssignmentWorkspaces((current) => {
+      const allowed = visibleWorkspaces(selectedAssignmentRelationship.relationshipScope.workspaceScopes);
+      const retained = current.filter((workspace) => allowed.includes(workspace));
+      return retained.length ? retained : allowed.slice(0, Math.min(2, allowed.length));
+    });
+  }, [selectedAssignmentRelationship]);
+
+  React.useEffect(() => {
+    const staff = activeMembers(companyMembers);
+    setAssignmentStaffUserId((current) =>
+      current && staff.some((member) => member.staffUserId === current) ? current : staff[0]?.staffUserId || ""
+    );
+  }, [companyMembers]);
+
+  const executeConfirmed = async (action: () => Promise<void>) => {
+    setBusy(true);
+    try {
+      await action();
+      setConfirmation(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const searchCompanies = async () => {
+    setBusy(true);
+    try {
+      const companies = await searchPropertyManagerCompanies(searchQuery);
+      setSearchResults(companies);
+    } catch (err: any) {
+      showToast({ message: "Company search failed", description: err?.message || "Try again.", variant: "error" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const createRelationship = async () => {
+    if (!selectedLookup || !relationshipWorkspaces.length) return;
+    setBusy(true);
+    try {
+      await createLandlordPropertyManagerRelationship({
+        propertyManagerCompanyId: selectedLookup.propertyManagerCompanyId,
+        propertyScope: { mode: "all_current_properties", propertyIds: [] },
+        workspaceScopes: relationshipWorkspaces,
+      });
+      setSelectedLookup(null);
+      setSearchQuery("");
+      setSearchResults([]);
+      setRelationshipWorkspaces(DEFAULT_RELATIONSHIP_WORKSPACES);
+      await loadLandlord();
+      showToast({
+        message: "Relationship created",
+        description: "The relationship is pending PM company acceptance.",
+        variant: "success",
+      });
+    } catch (err: any) {
+      showToast({ message: "Relationship creation failed", description: err?.message || "Try again.", variant: "error" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const loadLandlordStaff = async (relationshipId: string) => {
+    setLoadingStaffFor(relationshipId);
+    try {
+      const assignments = await fetchLandlordPropertyManagerRelationshipAssignments(relationshipId);
+      setLandlordAssignments((current) => ({ ...current, [relationshipId]: assignments }));
+    } catch (err: any) {
+      showToast({ message: "Unable to load assigned staff", description: err?.message || "Try again.", variant: "error" });
+    } finally {
+      setLoadingStaffFor(null);
+    }
+  };
+
+  const confirmRelationshipAction = (
+    relationship: PropertyManagerCompanyRelationship,
+    action: "suspend" | "reactivate" | "terminate"
+  ) => {
+    const actionLabel = statusLabel(action);
+    setConfirmation({
+      title: `${actionLabel} relationship`,
+      body:
+        action === "terminate"
+          ? `Terminate the relationship with ${relationship.propertyManagerCompanyLabel}? Access will remain blocked and history will be preserved.`
+          : `${actionLabel} the relationship with ${relationship.propertyManagerCompanyLabel}?`,
+      confirmLabel: actionLabel,
+      onConfirm: () =>
+        executeConfirmed(async () => {
+          if (action === "suspend") await suspendLandlordPropertyManagerRelationship(relationship.relationshipId);
+          if (action === "reactivate") await reactivateLandlordPropertyManagerRelationship(relationship.relationshipId);
+          if (action === "terminate") await terminateLandlordPropertyManagerRelationship(relationship.relationshipId);
+          await loadLandlord();
+          showToast({ message: `Relationship ${actionPastTense(action)}`, variant: "success" });
+        }),
+    });
+  };
+
+  const confirmAcceptRelationship = (relationship: PropertyManagerCompanyRelationship) => {
+    if (!selectedCompanyId) return;
+    setConfirmation({
+      title: "Accept relationship",
+      body: `Accept the relationship for ${relationship.landlordWorkspaceLabel}? The landlord-approved scope will remain unchanged.`,
+      confirmLabel: "Accept relationship",
+      onConfirm: () =>
+        executeConfirmed(async () => {
+          await acceptCompanyPropertyManagerRelationship(selectedCompanyId, relationship.relationshipId);
+          await loadCompany();
+          showToast({ message: "Relationship accepted", variant: "success" });
+        }),
+    });
+  };
+
+  const createAssignment = async () => {
+    if (!selectedCompanyId || !selectedAssignmentRelationship || !assignmentStaffUserId || !assignmentWorkspaces.length) return;
+    setBusy(true);
+    try {
+      await createPropertyManagerCompanyStaffAssignment(selectedCompanyId, {
+        relationshipId: selectedAssignmentRelationship.relationshipId,
+        staffUserId: assignmentStaffUserId,
+        staffRole: assignmentRole,
+        propertyScope: scopeForAssignment(selectedAssignmentRelationship),
+        workspaceScopes: assignmentWorkspaces,
+      });
+      await loadCompany();
+      showToast({ message: "Staff assignment created", variant: "success" });
+    } catch (err: any) {
+      showToast({ message: "Assignment creation failed", description: err?.message || "Try again.", variant: "error" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmAssignmentAction = (
+    assignment: PropertyManagerCompanyStaffAssignment,
+    action: "suspend" | "reactivate" | "remove"
+  ) => {
+    if (!selectedCompanyId) return;
+    const actionLabel = statusLabel(action);
+    setConfirmation({
+      title: `${actionLabel} assignment`,
+      body:
+        action === "remove"
+          ? `Remove delegated company assignment for ${assignment.staffLabel}? History will be preserved.`
+          : `${actionLabel} delegated company assignment for ${assignment.staffLabel}?`,
+      confirmLabel: actionLabel,
+      onConfirm: () =>
+        executeConfirmed(async () => {
+          if (action === "suspend") {
+            await suspendPropertyManagerCompanyStaffAssignment(selectedCompanyId, assignment.assignmentId);
+          }
+          if (action === "reactivate") {
+            await reactivatePropertyManagerCompanyStaffAssignment(selectedCompanyId, assignment.assignmentId);
+          }
+          if (action === "remove") {
+            await removePropertyManagerCompanyStaffAssignment(selectedCompanyId, assignment.assignmentId);
+          }
+          await loadCompany();
+          showToast({ message: `Assignment ${actionPastTense(action)}`, variant: "success" });
+        }),
+    });
+  };
+
+  const landlordCounts = relationshipCounts(landlordRelationships);
+  const companyCounts = relationshipCounts(companyRelationships);
+  const hasCompanySurface = companyContexts.length > 0;
+  const activeCompanyRelationships = companyRelationships.filter((relationship) => relationship.status === "active");
+
+  return (
+    <div className="pmc-page">
+      <style>
+        {`
+          .pmc-page {
+            max-width: 1320px;
+            margin: 0 auto;
+            padding: 0;
+            display: grid;
+            gap: ${spacing.md};
+          }
+          .pmc-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: ${spacing.md};
+            flex-wrap: wrap;
+          }
+          .pmc-mode-tabs,
+          .pmc-action-row,
+          .pmc-chip-row,
+          .pmc-row-actions {
+            display: flex;
+            gap: ${spacing.sm};
+            flex-wrap: wrap;
+            align-items: center;
+          }
+          .pmc-grid {
+            display: grid;
+            grid-template-columns: minmax(320px, 0.8fr) minmax(0, 1.2fr);
+            gap: ${spacing.md};
+            align-items: start;
+          }
+          .pmc-card-header,
+          .pmc-assignment-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: ${spacing.md};
+          }
+          .pmc-card-title {
+            font-size: 1rem;
+            font-weight: 900;
+            overflow-wrap: anywhere;
+          }
+          .pmc-meta-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: ${spacing.sm};
+          }
+          .pmc-meta-grid > div,
+          .pmc-summary-stat {
+            display: grid;
+            gap: 4px;
+            border: 1px solid ${colors.border};
+            border-radius: ${radius.md};
+            padding: ${spacing.sm};
+            background: ${colors.panel};
+            min-width: 0;
+          }
+          .pmc-meta-grid span {
+            color: ${text.muted};
+            font-size: 12px;
+          }
+          .pmc-meta-grid strong {
+            font-size: 14px;
+            overflow-wrap: anywhere;
+          }
+          .pmc-note {
+            padding: ${spacing.sm};
+            border-radius: ${radius.md};
+            border: 1px solid ${colors.border};
+            background: ${colors.accentSoft};
+            color: ${text.secondary};
+            font-size: 13px;
+            line-height: 1.45;
+          }
+          .pmc-select {
+            width: 100%;
+            min-height: 42px;
+            border: 1px solid ${colors.border};
+            border-radius: ${radius.md};
+            padding: 10px 12px;
+            background: ${colors.card};
+            color: ${text.primary};
+          }
+          .pmc-section-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin: 0;
+            font-size: 1.1rem;
+            font-weight: 900;
+          }
+          .pmc-form {
+            display: grid;
+            gap: ${spacing.sm};
+          }
+          .pmc-label {
+            display: grid;
+            gap: 6px;
+            font-size: 13px;
+            font-weight: 800;
+          }
+          .pmc-helper {
+            color: ${text.muted};
+            font-size: 12px;
+            line-height: 1.45;
+          }
+          @media (max-width: 820px) {
+            .pmc-page {
+              padding: 0;
+            }
+            .pmc-grid {
+              grid-template-columns: 1fr;
+            }
+            .pmc-card-header,
+            .pmc-assignment-row {
+              display: grid;
+              grid-template-columns: 1fr;
+            }
+            .pmc-meta-grid {
+              grid-template-columns: 1fr;
+            }
+            .pmc-row-actions {
+              width: 100%;
+            }
+            .pmc-row-actions button {
+              flex: 1 1 150px;
+            }
+          }
+        `}
+      </style>
+
+      <Card elevated>
+        <div className="pmc-header">
+          <div style={{ display: "grid", gap: 6, minWidth: 0 }}>
+            <h1 style={{ margin: 0, fontSize: "1.55rem", fontWeight: 900 }}>PM Company Management</h1>
+            <div style={{ color: text.muted, overflowWrap: "anywhere" }}>
+              {user?.email ? `Signed in as ${user.email}` : "Signed in"}
+            </div>
+          </div>
+          <div className="pmc-mode-tabs" role="tablist" aria-label="Property manager company management surfaces">
+            {canUseLandlordSurface ? (
+              <Button
+                type="button"
+                variant={mode === "landlord" ? "primary" : "secondary"}
+                role="tab"
+                aria-selected={mode === "landlord"}
+                onClick={() => setMode("landlord")}
+              >
+                Landlord owner
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              variant={mode === "company" ? "primary" : "secondary"}
+              role="tab"
+              aria-selected={mode === "company"}
+              onClick={() => setMode("company")}
+            >
+              PM company admin
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <ConfirmPanel confirmation={confirmation} busy={busy} onCancel={() => setConfirmation(null)} />
+
+      {loading ? <SkeletonBlock lines={5} height={18} /> : null}
+      {error ? <InlineError message={error} retry={() => void loadInitial()} /> : null}
+
+      {!loading && mode === "landlord" ? (
+        canUseLandlordSurface ? (
+          <div className="pmc-grid">
+            <Card style={{ display: "grid", gap: spacing.md }}>
+              <h2 className="pmc-section-title">
+                <Building2 size={18} /> Create pending relationship
+              </h2>
+              <div className="pmc-form">
+                <label className="pmc-label">
+                  PM company search
+                  <Input
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    placeholder="Search by company label"
+                  />
+                </label>
+                <Button type="button" variant="secondary" disabled={busy} onClick={searchCompanies}>
+                  Search companies
+                </Button>
+                {searchResults.length ? (
+                  <div style={{ display: "grid", gap: spacing.xs }}>
+                    {searchResults.map((company) => (
+                      <button
+                        key={company.propertyManagerCompanyId}
+                        type="button"
+                        onClick={() => setSelectedLookup(company)}
+                        style={{
+                          textAlign: "left",
+                          border: `1px solid ${
+                            selectedLookup?.propertyManagerCompanyId === company.propertyManagerCompanyId
+                              ? colors.accent
+                              : colors.border
+                          }`,
+                          background:
+                            selectedLookup?.propertyManagerCompanyId === company.propertyManagerCompanyId
+                              ? colors.accentSoft
+                              : colors.card,
+                          borderRadius: radius.md,
+                          padding: spacing.sm,
+                          cursor: "pointer",
+                          fontWeight: 800,
+                          overflowWrap: "anywhere",
+                        }}
+                      >
+                        {company.companyLabel}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+                <label className="pmc-label">
+                  Property scope
+                  <div className="pmc-note">All current properties</div>
+                </label>
+                <div className="pmc-label">
+                  Workspace scope
+                  <div className="pmc-chip-row">
+                    {RELATIONSHIP_WORKSPACES.map((workspace) => (
+                      <ToggleChip
+                        key={workspace}
+                        checked={relationshipWorkspaces.includes(workspace)}
+                        label={WORKSPACE_LABELS[workspace]}
+                        onChange={(checked) =>
+                          setRelationshipWorkspaces((current) =>
+                            checked ? [...current, workspace] : current.filter((item) => item !== workspace)
+                          )
+                        }
+                      />
+                    ))}
+                  </div>
+                </div>
+                <Button type="button" disabled={busy || !selectedLookup || !relationshipWorkspaces.length} onClick={createRelationship}>
+                  Create pending relationship
+                </Button>
+              </div>
+            </Card>
+
+            <div style={{ display: "grid", gap: spacing.md }}>
+              <Card style={{ display: "grid", gap: spacing.sm }}>
+                <h2 className="pmc-section-title">
+                  <Users size={18} /> Landlord relationships
+                </h2>
+                <div className="pmc-meta-grid">
+                  <SummaryStat label="Pending" value={landlordCounts.pending} />
+                  <SummaryStat label="Active" value={landlordCounts.active} />
+                  <SummaryStat label="Suspended" value={landlordCounts.suspended} />
+                </div>
+              </Card>
+              {landlordRelationships.length ? (
+                landlordRelationships.map((relationship) => (
+                  <RelationshipCard
+                    key={relationship.relationshipId}
+                    relationship={relationship}
+                    staffAssignments={landlordAssignments[relationship.relationshipId]}
+                    loadingStaff={loadingStaffFor === relationship.relationshipId}
+                    onLoadStaff={() => void loadLandlordStaff(relationship.relationshipId)}
+                    onSuspend={() => confirmRelationshipAction(relationship, "suspend")}
+                    onReactivate={() => confirmRelationshipAction(relationship, "reactivate")}
+                    onTerminate={() => confirmRelationshipAction(relationship, "terminate")}
+                  />
+                ))
+              ) : (
+                <EmptyState
+                  title="No PM company relationships"
+                  body="Pending, active, suspended, and terminated relationships will appear here."
+                />
+              )}
+            </div>
+          </div>
+        ) : (
+          <EmptyState title="Landlord access required" body="This surface is available to landlord owner accounts." />
+        )
+      ) : null}
+
+      {!loading && mode === "company" ? (
+        hasCompanySurface ? (
+          <div className="pmc-grid">
+            <Card style={{ display: "grid", gap: spacing.md }}>
+              <h2 className="pmc-section-title">
+                <CheckCircle2 size={18} /> Company admin controls
+              </h2>
+              <label className="pmc-label">
+                Company
+                <select
+                  className="pmc-select"
+                  value={selectedCompanyId}
+                  onChange={(event) => setSelectedCompanyId(event.target.value)}
+                >
+                  {companyContexts.map((company) => (
+                    <option key={company.propertyManagerCompanyId} value={company.propertyManagerCompanyId}>
+                      {company.companyLabel}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="pmc-meta-grid">
+                <SummaryStat label="Pending" value={companyCounts.pending} />
+                <SummaryStat label="Active" value={companyCounts.active} />
+                <SummaryStat label="Suspended" value={companyCounts.suspended} />
+              </div>
+
+              <div className="pmc-form">
+                <h3 style={{ margin: 0, fontSize: "1rem", fontWeight: 900 }}>Create staff assignment</h3>
+                <label className="pmc-label">
+                  Active relationship
+                  <select
+                    className="pmc-select"
+                    value={assignmentRelationshipId}
+                    onChange={(event) => setAssignmentRelationshipId(event.target.value)}
+                  >
+                    {activeCompanyRelationships.map((relationship) => (
+                      <option key={relationship.relationshipId} value={relationship.relationshipId}>
+                        {relationship.landlordWorkspaceLabel}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="pmc-label">
+                  Staff member
+                  <select
+                    className="pmc-select"
+                    value={assignmentStaffUserId}
+                    onChange={(event) => setAssignmentStaffUserId(event.target.value)}
+                  >
+                    {activeMembers(companyMembers).map((member) => (
+                      <option key={member.staffUserId} value={member.staffUserId}>
+                        {member.staffLabel}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="pmc-label">
+                  Role template
+                  <select
+                    className="pmc-select"
+                    value={assignmentRole}
+                    onChange={(event) => setAssignmentRole(event.target.value as PropertyManagerCompanyStaffAssignmentRole)}
+                  >
+                    {ASSIGNMENT_ROLES.map((role) => (
+                      <option key={role} value={role}>
+                        {ROLE_LABELS[role]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <div className="pmc-label">
+                  Assignment scope
+                  <div className="pmc-note">
+                    {selectedAssignmentRelationship
+                      ? propertyScopeLabel(selectedAssignmentRelationship.relationshipScope.propertyScope)
+                      : "Select an active relationship"}
+                  </div>
+                  <div className="pmc-chip-row">
+                    {allowedAssignmentWorkspaces.map((workspace) => (
+                      <ToggleChip
+                        key={workspace}
+                        checked={assignmentWorkspaces.includes(workspace)}
+                        label={WORKSPACE_LABELS[workspace]}
+                        onChange={(checked) =>
+                          setAssignmentWorkspaces((current) =>
+                            checked ? [...current, workspace] : current.filter((item) => item !== workspace)
+                          )
+                        }
+                      />
+                    ))}
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  disabled={
+                    busy ||
+                    !selectedCompanyId ||
+                    !selectedAssignmentRelationship ||
+                    !assignmentStaffUserId ||
+                    !assignmentWorkspaces.length
+                  }
+                  onClick={createAssignment}
+                >
+                  <UserPlus size={16} /> Create assignment
+                </Button>
+                {!activeCompanyRelationships.length || !activeMembers(companyMembers).length ? (
+                  <div className="pmc-helper">Active relationships and active company members are required before assignment.</div>
+                ) : null}
+              </div>
+            </Card>
+
+            <div style={{ display: "grid", gap: spacing.md }}>
+              <Card style={{ display: "grid", gap: spacing.sm }}>
+                <h2 className="pmc-section-title">Company relationships</h2>
+                {companyRelationships.length ? (
+                  companyRelationships.map((relationship) => (
+                    <RelationshipCard
+                      key={relationship.relationshipId}
+                      relationship={relationship}
+                      companyMode
+                      onAccept={() => confirmAcceptRelationship(relationship)}
+                    />
+                  ))
+                ) : (
+                  <EmptyState
+                    title="No company relationships"
+                    body="Pending and active landlord relationships will appear here."
+                  />
+                )}
+              </Card>
+
+              <Card style={{ display: "grid", gap: spacing.sm }}>
+                <h2 className="pmc-section-title">Staff assignments</h2>
+                {companyAssignments.length ? (
+                  companyAssignments.map((assignment) => (
+                    <AssignmentRow
+                      key={assignment.assignmentId}
+                      assignment={assignment}
+                      onSuspend={() => confirmAssignmentAction(assignment, "suspend")}
+                      onReactivate={() => confirmAssignmentAction(assignment, "reactivate")}
+                      onRemove={() => confirmAssignmentAction(assignment, "remove")}
+                    />
+                  ))
+                ) : (
+                  <EmptyState
+                    title="No staff assignments"
+                    body="Assignment history will remain visible here after records are suspended or removed."
+                  />
+                )}
+              </Card>
+            </div>
+          </div>
+        ) : (
+          <EmptyState
+            title="No PM company admin context"
+            body="Company Owner/Admin memberships will appear here when available for this account."
+          />
+        )
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- adds the first PM Company Management UI for landlord-owner relationship management and PM Company Owner/Admin relationship and assignment workflows
- adds typed frontend adapters for the merged PM company read and lifecycle APIs
- wires landlord account navigation plus a standalone authenticated PM company admin route
- preserves V1 safety boundaries: predefined role templates only, no custom permissions, no billing/settings selection, confirmation before destructive lifecycle actions, and safe labels instead of user-facing raw IDs

## Validation

- `npm test -- propertyManagerCompanyManagementApi.test.ts PropertyManagerCompanyManagementPage.test.tsx AccountPage.test.tsx LandlordNav.test.tsx App.routes.test.tsx`
- `npm test -- PropertyManagerCompanyManagementPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `git diff --check`

## Notes

- Build completes under repo-required Node 20.11.1; Vite prints its existing advisory that it prefers Node 20.19+ or 22.12+.
- Backend/API behavior is unchanged in this PR.
