### PR TITLE
chore: add PM company preview fixture path

### DIFF
--- a/docs/runbooks/property-manager-company-preview-fixtures-v1.md
+++ b/docs/runbooks/property-manager-company-preview-fixtures-v1.md
@@ -1,0 +1,206 @@
+# Property Manager Company Preview Fixtures v1
+
+## Purpose
+
+This runbook documents the controlled QA fixture path for Property Manager Company Management preview QA.
+
+PR #1229 depends on at least one active Property Manager Company record being discoverable by safe company label. Without this fixture, landlord-side relationship creation QA cannot exercise:
+
+1. Search active PM company.
+2. Select PM company.
+3. Create pending relationship.
+4. PM Company Owner/Admin accepts.
+5. Company admin assigns staff.
+
+This fixture path creates or updates exactly one QA PM company and one active Company Owner/Admin membership. It does not create customer data, landlord data, relationships, assignments, billing records, tenant records, contractor records, or emails.
+
+## Fixture Records
+
+The fixture script targets deterministic Firestore document keys derived from `PM_COMPANY_QA_FIXTURE_KEY`. Normal output reports safe labels and statuses only; it does not print raw document IDs or user IDs.
+
+The setup path writes:
+
+- one `propertyManagerCompanies` record
+- one `propertyManagerCompanyMemberships` record
+
+Default company label:
+
+```text
+Acme Property Management QA
+```
+
+Default fixture key:
+
+```text
+pm-company-preview-qa-v1
+```
+
+The records include:
+
+- `qaFixture: true`
+- `qaFixtureKey`
+- `managedBy.source: chore/property-manager-company-preview-fixtures-v1`
+- `managedBy.purpose: Property Manager Company preview QA fixture`
+- timestamps
+
+## Prerequisites
+
+Before running the script:
+
+1. Confirm the target Firebase/Firestore project is the approved preview/QA project.
+2. Confirm `gcloud` or application-default credentials are authenticated for that project.
+3. Confirm the PM company admin QA user already exists in Firebase Auth.
+4. Use a dedicated QA email, not a customer or production operator account.
+5. Do not paste passwords, tokens, service account keys, or raw internal IDs into logs or PR comments.
+6. Use `ALLOW_LOCAL_PROD_FIRESTORE=true` only for this explicitly approved preview fixture operation.
+
+Required identity input:
+
+- `PM_COMPANY_QA_USER_EMAIL`, or
+- `PM_COMPANY_QA_USER_ID`
+
+If the user cannot be resolved through Firebase Auth, the script fails closed and writes nothing.
+
+## Dry Run
+
+Dry-run is the default. It still requires the explicit enable flag so operators do not accidentally probe the wrong environment.
+
+From repo root:
+
+```bash
+cd rentchain-api
+PM_COMPANY_QA_FIXTURE_ENABLED=true \
+ALLOW_LOCAL_PROD_FIRESTORE=true \
+PM_COMPANY_QA_USER_EMAIL=pm-company-admin-qa@example.test \
+npm run fixture:pm-company-preview
+```
+
+Optional overrides:
+
+```bash
+PM_COMPANY_QA_FIXTURE_ENABLED=true \
+ALLOW_LOCAL_PROD_FIRESTORE=true \
+PM_COMPANY_QA_FIXTURE_KEY=pm-company-preview-qa-v1 \
+PM_COMPANY_QA_COMPANY_LABEL="Acme Property Management QA" \
+PM_COMPANY_QA_USER_EMAIL=pm-company-admin-qa@example.test \
+PM_COMPANY_QA_ROLE=company_admin \
+npm run fixture:pm-company-preview
+```
+
+Expected safe dry-run output shape:
+
+```json
+{
+  "ok": true,
+  "mode": "dry-run",
+  "fixtureMode": "upsert",
+  "company": {
+    "action": "create",
+    "label": "Acme Property Management QA",
+    "status": "active",
+    "qaFixture": true,
+    "qaFixtureKey": "pm-company-preview-qa-v1"
+  },
+  "membership": {
+    "action": "create",
+    "staffLabel": "pm-company-admin-qa@example.test",
+    "role": "company_admin",
+    "status": "active",
+    "qaFixture": true,
+    "qaFixtureKey": "pm-company-preview-qa-v1"
+  },
+  "rawIdsPrinted": false,
+  "writePerformed": false
+}
+```
+
+`action` may be `update` when the deterministic fixture already exists.
+
+## Write Fixture
+
+Only run write mode after the dry-run output has been reviewed and the operator approves preview fixture setup.
+
+```bash
+cd rentchain-api
+PM_COMPANY_QA_FIXTURE_ENABLED=true \
+ALLOW_LOCAL_PROD_FIRESTORE=true \
+PM_COMPANY_QA_USER_EMAIL=pm-company-admin-qa@example.test \
+npm run fixture:pm-company-preview -- --write
+```
+
+Write mode requires both:
+
+- `PM_COMPANY_QA_FIXTURE_ENABLED=true`
+- `--write`
+
+If either is missing, the script writes nothing.
+
+Expected safe write output is the same as dry-run except:
+
+```json
+{
+  "mode": "write",
+  "writePerformed": true
+}
+```
+
+## Cleanup / Suspend
+
+Do not hard-delete fixture records by default. To remove the fixture from active QA discovery while preserving history, run suspend mode after approval:
+
+```bash
+cd rentchain-api
+PM_COMPANY_QA_FIXTURE_ENABLED=true \
+ALLOW_LOCAL_PROD_FIRESTORE=true \
+PM_COMPANY_QA_USER_EMAIL=pm-company-admin-qa@example.test \
+npm run fixture:pm-company-preview -- --suspend --write
+```
+
+Suspend mode updates the deterministic fixture records:
+
+- company status becomes `archived`
+- membership status becomes `removed`
+- membership removal metadata is set
+
+Expected safe output includes:
+
+```json
+{
+  "fixtureMode": "suspend",
+  "company": {
+    "status": "archived"
+  },
+  "membership": {
+    "status": "removed"
+  },
+  "writePerformed": true
+}
+```
+
+## Validation After Write
+
+After setup:
+
+1. Open the #1229 Vercel preview.
+2. Log in as a landlord owner.
+3. Navigate to PM Company Management.
+4. Search for `Acme Property Management QA`.
+5. Confirm the safe company label appears and no raw IDs are visible.
+6. Select the company.
+7. Confirm `Selected Company` appears.
+8. Create the pending relationship.
+9. Confirm the relationship appears as `Pending`.
+10. Confirm the landlord cannot activate it directly.
+11. Log in as the QA Company Owner/Admin.
+12. Accept the pending relationship.
+13. Continue assignment QA as scoped by #1229.
+
+## Safety Notes
+
+- This script is not a broad demo seed.
+- It does not create landlord, tenant, lease, property, unit, contractor, billing, or email records.
+- It must not be used for production customer data.
+- It fails closed when the QA user cannot be resolved.
+- It should be run only against the approved preview/QA project.
+- Normal script output must not be modified to print raw document IDs or user IDs.
+- `ALLOW_LOCAL_PROD_FIRESTORE=true` is required by the existing Firestore safety guard for approved local preview diagnostics and writes. Do not commit it to env templates.

--- a/rentchain-api/package.json
+++ b/rentchain-api/package.json
@@ -25,6 +25,7 @@
     "test:e2e": "npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false playwright test --config=../playwright.config.ts --project=api-chromium",
     "test:e2e:ui": "npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false playwright test --config=../playwright.config.ts --project=api-chromium --ui",
     "test:e2e:debug": "npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false playwright test --config=../playwright.config.ts --project=api-chromium --headed --debug",
+    "fixture:pm-company-preview": "npm run preflight && ts-node-dev --transpile-only --exit-child src/scripts/propertyManagerCompanyPreviewFixture.ts",
     "test:docker": "docker run --rm -v \"$PWD/..:/workspace/rentchain\" -w /workspace/rentchain/rentchain-api rentchain-dev npm run test:e2e",
     "storage-state:export": "npm run preflight && ts-node tests/storage-state/export-storage-state.ts ./.smoke-storage-state",
     "smoke": "node scripts/smoke-safe-build.js",

--- a/rentchain-api/src/scripts/__tests__/propertyManagerCompanyPreviewFixturePlan.test.ts
+++ b/rentchain-api/src/scripts/__tests__/propertyManagerCompanyPreviewFixturePlan.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPropertyManagerCompanyPreviewFixture,
+  buildPropertyManagerCompanyPreviewFixtureSafeSummary,
+  stablePreviewFixtureId,
+} from "../propertyManagerCompanyPreviewFixturePlan";
+
+describe("propertyManagerCompanyPreviewFixturePlan", () => {
+  it("builds deterministic active QA company and admin membership records", () => {
+    const first = buildPropertyManagerCompanyPreviewFixture({
+      fixtureKey: "pm-company-preview-qa-v1",
+      companyLabel: "Acme Property Management QA",
+      userId: "qa-user-internal",
+      userEmail: "pm-admin@example.test",
+      role: "company_admin",
+      now: "2026-06-24T12:00:00.000Z",
+    });
+    const second = buildPropertyManagerCompanyPreviewFixture({
+      fixtureKey: "pm-company-preview-qa-v1",
+      companyLabel: "Acme Property Management QA",
+      userId: "qa-user-internal",
+      userEmail: "pm-admin@example.test",
+      role: "company_admin",
+      now: "2026-06-24T12:00:00.000Z",
+    });
+
+    expect(first.company.companyId).toBe(second.company.companyId);
+    expect(first.membership.membershipId).toBe(second.membership.membershipId);
+    expect(first.company).toMatchObject({
+      companyName: "Acme Property Management QA",
+      safeDisplayLabel: "Acme Property Management QA",
+      status: "active",
+      qaFixture: true,
+      qaFixtureKey: "pm-company-preview-qa-v1",
+    });
+    expect(first.membership).toMatchObject({
+      role: "company_admin",
+      status: "active",
+      safeDisplayLabel: "pm-admin@example.test",
+      qaFixture: true,
+      qaFixtureKey: "pm-company-preview-qa-v1",
+    });
+  });
+
+  it("supports a governed suspend cleanup mode without hard-delete semantics", () => {
+    const fixture = buildPropertyManagerCompanyPreviewFixture({
+      fixtureKey: "pm-company-preview-qa-v1",
+      companyLabel: "Acme Property Management QA",
+      userId: "qa-user-internal",
+      userEmail: "pm-admin@example.test",
+      role: "company_owner",
+      now: "2026-06-24T12:00:00.000Z",
+      mode: "suspend",
+    });
+
+    expect(fixture.company.status).toBe("archived");
+    expect(fixture.membership.status).toBe("removed");
+    expect(fixture.membership.removedAt).toBe("2026-06-24T12:00:00.000Z");
+    expect(fixture.membership.removedByUserId).toBe("qa-user-internal");
+  });
+
+  it("rejects ordinary staff roles for the admin fixture membership", () => {
+    expect(() =>
+      buildPropertyManagerCompanyPreviewFixture({
+        fixtureKey: "pm-company-preview-qa-v1",
+        companyLabel: "Acme Property Management QA",
+        userId: "qa-user-internal",
+        userEmail: "pm-admin@example.test",
+        role: "property_manager",
+      } as any)
+    ).toThrow("qa_fixture_company_admin_or_owner_required");
+  });
+
+  it("safe summaries report labels and statuses without exposing raw IDs", () => {
+    const fixture = buildPropertyManagerCompanyPreviewFixture({
+      fixtureKey: "pm-company-preview-qa-v1",
+      companyLabel: "Acme Property Management QA",
+      userId: "qa-user-internal",
+      userEmail: "pm-admin@example.test",
+      role: "company_admin",
+      now: "2026-06-24T12:00:00.000Z",
+    });
+    const summary = buildPropertyManagerCompanyPreviewFixtureSafeSummary({
+      mode: "upsert",
+      write: false,
+      company: fixture.company,
+      membership: fixture.membership,
+      companyExists: false,
+      membershipExists: true,
+    });
+
+    expect(summary).toMatchObject({
+      mode: "dry-run",
+      fixtureMode: "upsert",
+      company: {
+        action: "create",
+        label: "Acme Property Management QA",
+        status: "active",
+      },
+      membership: {
+        action: "update",
+        staffLabel: "pm-admin@example.test",
+        role: "company_admin",
+        status: "active",
+      },
+      rawIdsPrinted: false,
+    });
+    expect(JSON.stringify(summary)).not.toContain(fixture.company.companyId);
+    expect(JSON.stringify(summary)).not.toContain(fixture.membership.membershipId);
+    expect(stablePreviewFixtureId("pm_company_qa", ["pm-company-preview-qa-v1"])).toBe(fixture.company.companyId);
+  });
+});

--- a/rentchain-api/src/scripts/propertyManagerCompanyPreviewFixture.ts
+++ b/rentchain-api/src/scripts/propertyManagerCompanyPreviewFixture.ts
@@ -1,0 +1,131 @@
+import {
+  DEFAULT_PM_COMPANY_QA_FIXTURE_KEY,
+  DEFAULT_PM_COMPANY_QA_LABEL,
+  DEFAULT_PM_COMPANY_QA_ROLE,
+  buildPropertyManagerCompanyPreviewFixture,
+  buildPropertyManagerCompanyPreviewFixtureSafeSummary,
+  stablePreviewFixtureId,
+  type PropertyManagerCompanyPreviewFixtureMode,
+} from "./propertyManagerCompanyPreviewFixturePlan";
+
+type FirestoreDb = (typeof import("../firebase"))["db"];
+type FirebaseAdmin = typeof import("firebase-admin");
+
+type Args = {
+  write: boolean;
+  mode: PropertyManagerCompanyPreviewFixtureMode;
+  fixtureKey: string;
+  companyLabel: string;
+  userEmail: string;
+  userId: string;
+  role: "company_owner" | "company_admin";
+};
+
+function envValue(key: string): string {
+  return String(process.env[key] || "").trim();
+}
+
+function flagEnabled(key: string): boolean {
+  return envValue(key).toLowerCase() === "true";
+}
+
+function readArgValue(args: string[], name: string): string {
+  const inline = args.find((arg) => arg.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1).trim();
+  const index = args.indexOf(name);
+  if (index >= 0) return String(args[index + 1] || "").trim();
+  return "";
+}
+
+function parseArgs(argv: string[]): Args {
+  const write = argv.includes("--write");
+  const suspend = argv.includes("--suspend");
+  const role = (readArgValue(argv, "--role") || envValue("PM_COMPANY_QA_ROLE") || DEFAULT_PM_COMPANY_QA_ROLE) as
+    | "company_owner"
+    | "company_admin";
+  if (!["company_owner", "company_admin"].includes(role)) {
+    throw new Error("PM_COMPANY_QA_ROLE must be company_owner or company_admin");
+  }
+
+  return {
+    write,
+    mode: suspend ? "suspend" : "upsert",
+    fixtureKey: readArgValue(argv, "--fixture-key") || envValue("PM_COMPANY_QA_FIXTURE_KEY") || DEFAULT_PM_COMPANY_QA_FIXTURE_KEY,
+    companyLabel: readArgValue(argv, "--company-label") || envValue("PM_COMPANY_QA_COMPANY_LABEL") || DEFAULT_PM_COMPANY_QA_LABEL,
+    userEmail: (readArgValue(argv, "--qa-user-email") || envValue("PM_COMPANY_QA_USER_EMAIL")).toLowerCase(),
+    userId: readArgValue(argv, "--qa-user-id") || envValue("PM_COMPANY_QA_USER_ID"),
+    role,
+  };
+}
+
+async function resolveQaUser(admin: FirebaseAdmin, args: Args): Promise<{ userId: string; userEmail: string }> {
+  if (!args.userEmail && !args.userId) {
+    throw new Error("Provide PM_COMPANY_QA_USER_EMAIL or PM_COMPANY_QA_USER_ID.");
+  }
+  if (args.userEmail) {
+    const user = await admin.auth().getUserByEmail(args.userEmail);
+    return { userId: user.uid, userEmail: user.email || args.userEmail };
+  }
+  const user = await admin.auth().getUser(args.userId);
+  if (!user.email) {
+    throw new Error("Resolved QA user has no email.");
+  }
+  return { userId: user.uid, userEmail: user.email };
+}
+
+async function docExists(db: FirestoreDb, collection: string, docId: string): Promise<boolean> {
+  const snapshot = await db.collection(collection).doc(docId).get();
+  return snapshot.exists;
+}
+
+async function run() {
+  if (!flagEnabled("PM_COMPANY_QA_FIXTURE_ENABLED")) {
+    throw new Error("PM_COMPANY_QA_FIXTURE_ENABLED=true is required.");
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  const [admin, firebase] = await Promise.all([import("firebase-admin"), import("../firebase")]);
+  const qaUser = await resolveQaUser(admin, args);
+  const fixture = buildPropertyManagerCompanyPreviewFixture({
+    fixtureKey: args.fixtureKey,
+    companyLabel: args.companyLabel,
+    userId: qaUser.userId,
+    userEmail: qaUser.userEmail,
+    role: args.role,
+    mode: args.mode,
+  });
+  const companyId = stablePreviewFixtureId("pm_company_qa", [args.fixtureKey]);
+  const membershipId = stablePreviewFixtureId("pm_membership_qa", [args.fixtureKey, qaUser.userId]);
+  const [companyExists, membershipExists] = await Promise.all([
+    docExists(firebase.db, "propertyManagerCompanies", companyId),
+    docExists(firebase.db, "propertyManagerCompanyMemberships", membershipId),
+  ]);
+
+  const safeSummary = buildPropertyManagerCompanyPreviewFixtureSafeSummary({
+    mode: args.mode,
+    write: args.write,
+    company: fixture.company,
+    membership: fixture.membership,
+    companyExists,
+    membershipExists,
+  });
+
+  if (!args.write) {
+    console.log(JSON.stringify({ ...safeSummary, writePerformed: false }, null, 2));
+    return;
+  }
+
+  await firebase.db.collection("propertyManagerCompanies").doc(companyId).set(fixture.company, { merge: true });
+  await firebase.db.collection("propertyManagerCompanyMemberships").doc(membershipId).set(fixture.membership, { merge: true });
+
+  console.log(JSON.stringify({ ...safeSummary, writePerformed: true }, null, 2));
+}
+
+if (require.main === module) {
+  run()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(JSON.stringify({ ok: false, error: String(err?.message || err), rawIdsPrinted: false }, null, 2));
+      process.exit(1);
+    });
+}

--- a/rentchain-api/src/scripts/propertyManagerCompanyPreviewFixturePlan.ts
+++ b/rentchain-api/src/scripts/propertyManagerCompanyPreviewFixturePlan.ts
@@ -1,0 +1,163 @@
+import crypto from "crypto";
+import {
+  createPropertyManagerCompany,
+  createPropertyManagerCompanyMembership,
+  type PropertyManagerCompany,
+  type PropertyManagerCompanyMembership,
+  type PropertyManagerCompanyRole,
+  type PropertyManagerCompanyStatus,
+  type PropertyManagerCompanyMembershipStatus,
+} from "../lib/propertyManagerCompany";
+
+export const DEFAULT_PM_COMPANY_QA_FIXTURE_KEY = "pm-company-preview-qa-v1";
+export const DEFAULT_PM_COMPANY_QA_LABEL = "Acme Property Management QA";
+export const DEFAULT_PM_COMPANY_QA_ROLE: PropertyManagerCompanyRole = "company_admin";
+export const PM_COMPANY_QA_MANAGED_BY = "chore/property-manager-company-preview-fixtures-v1";
+
+export type PropertyManagerCompanyPreviewFixtureMode = "upsert" | "suspend";
+
+export type PropertyManagerCompanyPreviewFixtureOptions = {
+  fixtureKey?: string;
+  companyLabel?: string;
+  userId: string;
+  userEmail: string;
+  role?: PropertyManagerCompanyRole;
+  now?: string;
+  mode?: PropertyManagerCompanyPreviewFixtureMode;
+};
+
+export type PropertyManagerCompanyPreviewFixtureMetadata = {
+  qaFixture: true;
+  qaFixtureKey: string;
+  managedBy: {
+    source: string;
+    purpose: string;
+  };
+};
+
+export type PropertyManagerCompanyPreviewFixtureCompany = PropertyManagerCompany &
+  PropertyManagerCompanyPreviewFixtureMetadata;
+
+export type PropertyManagerCompanyPreviewFixtureMembership = PropertyManagerCompanyMembership &
+  PropertyManagerCompanyPreviewFixtureMetadata & {
+    safeDisplayLabel: string;
+  };
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new Error(code);
+  return text;
+}
+
+function isoTimestamp(value?: string): string {
+  if (!value) return new Date().toISOString();
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error("invalid_fixture_timestamp");
+  return new Date(parsed).toISOString();
+}
+
+export function stablePreviewFixtureId(prefix: string, parts: readonly unknown[]): string {
+  const digest = crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 24);
+  return `${prefix}_${digest}`;
+}
+
+function fixtureMetadata(fixtureKey: string): PropertyManagerCompanyPreviewFixtureMetadata {
+  return {
+    qaFixture: true,
+    qaFixtureKey: fixtureKey,
+    managedBy: {
+      source: PM_COMPANY_QA_MANAGED_BY,
+      purpose: "Property Manager Company preview QA fixture",
+    },
+  };
+}
+
+export function buildPropertyManagerCompanyPreviewFixture(options: PropertyManagerCompanyPreviewFixtureOptions): {
+  company: PropertyManagerCompanyPreviewFixtureCompany;
+  membership: PropertyManagerCompanyPreviewFixtureMembership;
+} {
+  const fixtureKey = requireString(options.fixtureKey || DEFAULT_PM_COMPANY_QA_FIXTURE_KEY, "missing_fixture_key", 120);
+  const companyLabel = requireString(options.companyLabel || DEFAULT_PM_COMPANY_QA_LABEL, "missing_company_label", 160);
+  const userId = requireString(options.userId, "missing_user_id", 200);
+  const userEmail = requireString(options.userEmail, "missing_user_email", 320).toLowerCase();
+  const role = options.role || DEFAULT_PM_COMPANY_QA_ROLE;
+  if (!["company_owner", "company_admin"].includes(role)) {
+    throw new Error("qa_fixture_company_admin_or_owner_required");
+  }
+  const now = isoTimestamp(options.now);
+  const mode = options.mode || "upsert";
+  const companyStatus: PropertyManagerCompanyStatus = mode === "suspend" ? "archived" : "active";
+  const membershipStatus: PropertyManagerCompanyMembershipStatus = mode === "suspend" ? "removed" : "active";
+  const companyId = stablePreviewFixtureId("pm_company_qa", [fixtureKey]);
+  const membershipId = stablePreviewFixtureId("pm_membership_qa", [fixtureKey, userId]);
+  const metadata = fixtureMetadata(fixtureKey);
+
+  const company = createPropertyManagerCompany({
+    companyId,
+    companyName: companyLabel,
+    status: companyStatus,
+    createdByUserId: userId,
+    createdAt: now,
+  }) as PropertyManagerCompanyPreviewFixtureCompany;
+
+  const membership = createPropertyManagerCompanyMembership({
+    membershipId,
+    companyId,
+    userId,
+    role,
+    status: membershipStatus,
+    createdByUserId: userId,
+    createdAt: now,
+  }) as PropertyManagerCompanyPreviewFixtureMembership;
+
+  return {
+    company: {
+      ...company,
+      updatedAt: now,
+      ...metadata,
+    },
+    membership: {
+      ...membership,
+      safeDisplayLabel: userEmail,
+      updatedAt: now,
+      removedAt: mode === "suspend" ? now : null,
+      removedByUserId: mode === "suspend" ? userId : null,
+      ...metadata,
+    },
+  };
+}
+
+export function buildPropertyManagerCompanyPreviewFixtureSafeSummary(input: {
+  mode: PropertyManagerCompanyPreviewFixtureMode;
+  write: boolean;
+  company: PropertyManagerCompanyPreviewFixtureCompany;
+  membership: PropertyManagerCompanyPreviewFixtureMembership;
+  companyExists: boolean;
+  membershipExists: boolean;
+}) {
+  return {
+    ok: true,
+    mode: input.write ? "write" : "dry-run",
+    fixtureMode: input.mode,
+    company: {
+      action: input.companyExists ? "update" : "create",
+      label: input.company.safeDisplayLabel,
+      status: input.company.status,
+      qaFixture: input.company.qaFixture,
+      qaFixtureKey: input.company.qaFixtureKey,
+    },
+    membership: {
+      action: input.membershipExists ? "update" : "create",
+      staffLabel: input.membership.safeDisplayLabel,
+      role: input.membership.role,
+      status: input.membership.status,
+      qaFixture: input.membership.qaFixture,
+      qaFixtureKey: input.membership.qaFixtureKey,
+    },
+    rawIdsPrinted: false,
+  };
+}


### PR DESCRIPTION
## Summary
- add a gated PM company preview QA fixture script with dry-run default and explicit --write requirement
- add deterministic fixture planning helpers and tests
- add a runbook for dry-run, write, and suspend cleanup workflows

## Safety
- no Firestore writes were performed during implementation
- normal script output reports safe labels/statuses only and does not print raw IDs
- script requires PM_COMPANY_QA_FIXTURE_ENABLED=true and --write before mutating data
- runbook requires the existing ALLOW_LOCAL_PROD_FIRESTORE=true guard override for approved preview fixture operations

## Validation
- npm run test:single -- src/scripts/__tests__/propertyManagerCompanyPreviewFixturePlan.test.ts
- npm run fixture:pm-company-preview (expected fail-closed without PM_COMPANY_QA_FIXTURE_ENABLED)
- npm run build
- npx tsc --noEmit --target ES2020 --module commonjs --esModuleInterop --strict --skipLibCheck src/scripts/propertyManagerCompanyPreviewFixture.ts src/scripts/propertyManagerCompanyPreviewFixturePlan.ts
- git diff --check

## Notes
- full tsconfig no-emit remains blocked by unrelated existing repo type errors outside this mission
- #1229 should remain draft until this fixture path is reviewed, merged, run in approved write mode, and landlord-side creation QA passes