### PR TITLE
feat: add PM company auth profile support

### DIFF
--- a/docs/design/mission-briefs/property-manager-company-auth-profile-v1.html
+++ b/docs/design/mission-briefs/property-manager-company-auth-profile-v1.html
@@ -1,0 +1,391 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mission Brief - Property Manager Company Auth Profile V1</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #eef2f6;
+        color: #142033;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 28px;
+        background: #eef2f6;
+      }
+
+      .brief {
+        max-width: 1280px;
+        margin: 0 auto;
+        border: 1px solid #d5dde8;
+        background: #ffffff;
+        box-shadow: 0 18px 50px rgba(20, 32, 51, 0.12);
+      }
+
+      header {
+        padding: 26px 30px;
+        background: #142033;
+        color: #ffffff;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: 26px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      h1 span {
+        color: #8fd6ff;
+      }
+
+      .subtitle {
+        max-width: 940px;
+        color: #d8e7f4;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.05fr) minmax(390px, 0.95fr);
+      }
+
+      section {
+        padding: 26px 30px;
+      }
+
+      .left {
+        border-right: 1px solid #d5dde8;
+      }
+
+      .block {
+        margin-bottom: 23px;
+      }
+
+      .block:last-child {
+        margin-bottom: 0;
+      }
+
+      h2 {
+        margin-bottom: 10px;
+        color: #142033;
+        font-size: 14px;
+        line-height: 1.25;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      h3 {
+        margin-bottom: 8px;
+        color: #2a3d55;
+        font-size: 14px;
+      }
+
+      p,
+      li,
+      td,
+      th {
+        font-size: 13.5px;
+        line-height: 1.46;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .card {
+        padding: 14px;
+        border: 1px solid #d5dde8;
+        background: #f8fafc;
+      }
+
+      .card strong {
+        display: block;
+        margin-bottom: 5px;
+      }
+
+      .panel {
+        padding: 14px 16px;
+        border-left: 4px solid #246bfe;
+        background: #f4f8ff;
+      }
+
+      .warning {
+        border-left-color: #b7791f;
+        background: #fff8e8;
+      }
+
+      .success {
+        border-left-color: #16895a;
+        background: #f0fff7;
+      }
+
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid #d5dde8;
+        background: #ffffff;
+      }
+
+      .table th,
+      .table td {
+        padding: 8px 9px;
+        border-bottom: 1px solid #e3e9f1;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .table th {
+        background: #f4f7fb;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        padding: 6px 9px;
+        border: 1px solid #c8d2df;
+        background: #f4f7fb;
+        color: #26374f;
+        font-size: 12px;
+        font-weight: 800;
+      }
+
+      code {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        color: #1b4f9c;
+      }
+
+      @media (max-width: 920px) {
+        body {
+          padding: 14px;
+        }
+
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        .left {
+          border-right: 0;
+          border-bottom: 1px solid #d5dde8;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <article class="brief">
+      <header>
+        <h1>Mission Brief: <span>Property Manager Company Auth Profile V1</span></h1>
+        <p class="subtitle">
+          Add safe PM-company app profile and session support so a PM Company Owner/Admin can log in and reach company
+          management APIs without becoming a landlord owner, without creating a landlord workspace, and without weakening
+          existing delegate, contractor, or landlord login behavior.
+        </p>
+      </header>
+
+      <main>
+        <section class="left">
+          <div class="block">
+            <h2>1. Mission Goal</h2>
+            <p>
+              Introduce the minimum backend auth/profile foundation required for PM company users. The immediate QA
+              target is <code>admin+propertymanager@rentchain.ai</code>, which has a Firebase Auth user and an active
+              <code>company_admin</code> membership for <code>Acme Property Management QA</code>, but currently cannot
+              safely log in because password login is landlord-biased.
+            </p>
+          </div>
+
+          <div class="block">
+            <h2>2. Current Blocker</h2>
+            <div class="panel warning">
+              <p>
+                <code>/api/auth/login</code> calls <code>validateLandlordCredentials()</code>, which authenticates with
+                Firebase and then reads or creates <code>landlords/{uid}</code>. PM company users must not pass through
+                that provisioning path. Existing delegate signup avoided this by writing <code>users/{uid}</code> and
+                <code>accounts/{uid}</code> with <code>role: delegate</code>, and login has an explicit delegate branch.
+              </p>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>3. Proposed Profile Contract</h2>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Field</th>
+                  <th>V1 Contract</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>role</code></td>
+                  <td><code>property_manager_company</code> as a non-landlord session role.</td>
+                </tr>
+                <tr>
+                  <td><code>accountType</code></td>
+                  <td><code>property_manager_company</code> for explicit profile classification.</td>
+                </tr>
+                <tr>
+                  <td><code>landlordId</code></td>
+                  <td><code>null</code>; never infer the user id as landlord scope for this role.</td>
+                </tr>
+                <tr>
+                  <td><code>approved/status</code></td>
+                  <td><code>approved: true</code>, <code>status: active</code> for governed QA profile setup.</td>
+                </tr>
+                <tr>
+                  <td>Authority source</td>
+                  <td>Active <code>propertyManagerCompanyMemberships</code>, not role claims alone.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="block">
+            <h2>4. Implementation Scope</h2>
+            <div class="grid">
+              <div class="card">
+                <strong>Login path hardening</strong>
+                Split Firebase password validation from landlord profile loading. After Firebase auth succeeds, load
+                <code>users/accounts</code>, resolve persisted safe roles first, and only run landlord provisioning for
+                confirmed landlord users.
+              </div>
+              <div class="card">
+                <strong>PM company session branch</strong>
+                Issue a token/session with a non-landlord role, <code>landlordId: null</code>, empty owner permissions,
+                and no billing/settings authority.
+              </div>
+              <div class="card">
+                <strong>Governed profile setup</strong>
+                Add a narrow dry-run-first setup path for PM company app profiles. It may create/update
+                <code>users/{uid}</code> and <code>accounts/{uid}</code> only, with safe PM company fields.
+              </div>
+              <div class="card">
+                <strong>Authorization compatibility</strong>
+                Preserve current PM company APIs: company authority still comes from active Company Owner/Admin
+                membership checks using the authenticated actor id.
+              </div>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>5. Non-Goals</h2>
+            <ul>
+              <li>No PM Company UI changes in this mission.</li>
+              <li>No relationship, acceptance, or staff assignment feature changes.</li>
+              <li>No billing delegation, contractor organizations, tenant-facing PM UI, or custom permissions.</li>
+              <li>No customer data migration and no broad auth redesign beyond safe PM-company profile support.</li>
+              <li>No creation of <code>landlords/{uid}</code>, landlord workspace, landlord account, or owner billing authority for PM company users.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section>
+          <div class="block">
+            <h2>6. Safety Rules</h2>
+            <ul>
+              <li>PM company login must fail closed for missing, malformed, disabled, or ambiguous app profiles.</li>
+              <li>Persisted <code>delegate</code> and <code>contractor</code> login branches must remain safe.</li>
+              <li>Landlord login behavior must remain available for existing landlord users.</li>
+              <li>PM company users must not receive landlord owner permissions, billing/settings access, or landlord workspace defaults.</li>
+              <li>Normal setup output must not print raw IDs; safe labels only.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>7. QA Profile Target</h2>
+            <div class="panel">
+              <p>
+                The governed setup path should support the existing Firebase Auth user
+                <code>admin+propertymanager@rentchain.ai</code> and create/update a neutral PM-company app profile only
+                after review. The existing fixture membership remains the source of company admin authority.
+              </p>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>8. Required Tests</h2>
+            <ul>
+              <li>PM company admin login succeeds with a safe PM company profile.</li>
+              <li>PM company admin login does not create <code>landlords/{uid}</code>.</li>
+              <li>PM company session role is non-landlord and carries no landlordId.</li>
+              <li>PM company admin can call <code>/api/property-manager-companies/my-companies</code>.</li>
+              <li>PM company admin cannot call landlord-owner relationship routes.</li>
+              <li>Existing landlord, delegate, and contractor login tests still pass.</li>
+              <li>Unknown, missing, disabled, or malformed profiles fail closed.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>9. Validation Plan</h2>
+            <ul>
+              <li>Focused backend auth/session tests.</li>
+              <li>Focused PM company route authority tests if route expectations change.</li>
+              <li>Backend build.</li>
+              <li>Frontend build only if frontend route guards or role typing are touched.</li>
+              <li><code>git diff --check</code>.</li>
+            </ul>
+          </div>
+
+          <div class="block">
+            <h2>10. Acceptance Criteria</h2>
+            <div class="panel success">
+              <p>
+                A PM Company Admin can authenticate as a non-landlord actor, resolve company authority through active
+                membership, and access PM company admin APIs. The same actor cannot access landlord-owner routes, and no
+                landlord profile or workspace is created as a side effect.
+              </p>
+            </div>
+          </div>
+
+          <div class="block">
+            <h2>11. Post-Merge Gate</h2>
+            <p>
+              After this mission merges, use the governed setup path to create the safe app profile for
+              <code>admin+propertymanager@rentchain.ai</code>, confirm login, then resume #1229 manual QA. #1229 remains
+              draft until that QA passes.
+            </p>
+          </div>
+        </section>
+      </main>
+    </article>
+  </body>
+</html>

--- a/docs/runbooks/property-manager-company-auth-profile-v1.md
+++ b/docs/runbooks/property-manager-company-auth-profile-v1.md
@@ -1,0 +1,131 @@
+# Property Manager Company Auth Profile Setup v1
+
+## Purpose
+
+This runbook documents the governed setup path for a PM company app profile. It exists so a PM Company Owner/Admin can authenticate as a non-landlord actor and have company authority resolved from `propertyManagerCompanyMemberships`.
+
+This setup is required before #1229 manual QA can continue with:
+
+- `admin+propertymanager@rentchain.ai`
+- `Acme Property Management QA`
+- active `company_admin` membership
+
+## Safety Rules
+
+- Do not use the landlord-profile creation routes for PM company users.
+- Do not create `landlords/{uid}`.
+- Do not create a landlord workspace.
+- Do not create customer data.
+- Do not grant billing/settings authority.
+- Do not print raw user IDs or document IDs in normal output.
+- Dry-run first; write only after explicit operator approval.
+
+## Target Profile Shape
+
+The setup path creates or updates only:
+
+- `users/{uid}`
+- `accounts/{uid}`
+
+Safe profile fields include:
+
+- `role: property_manager_company`
+- `accountType: property_manager_company`
+- `landlordId: null`
+- `status: active`
+- `approved: true`
+- `qaProfile: true`
+- `managedBy.source: feat/property-manager-company-auth-profile-v1`
+
+Company authority is not granted by these profile documents. Company authority is granted only by active `propertyManagerCompanyMemberships`.
+
+## Prerequisites
+
+1. Confirm the target Firebase/Firestore project is the approved preview/QA project.
+2. Confirm the Firebase Auth user already exists.
+3. Confirm the user has an active PM company membership if company-admin route access is expected.
+4. Confirm application-default credentials are authenticated for the preview/QA project.
+5. Use a dedicated QA account, not a landlord owner account.
+
+Current QA target:
+
+```text
+admin+propertymanager@rentchain.ai
+```
+
+## Dry Run
+
+From repo root:
+
+```bash
+cd rentchain-api
+PM_COMPANY_AUTH_PROFILE_SETUP_ENABLED=true \
+ALLOW_LOCAL_PROD_FIRESTORE=true \
+PM_COMPANY_QA_USER_EMAIL=admin+propertymanager@rentchain.ai \
+npm run setup:pm-company-auth-profile
+```
+
+Expected safe output shape:
+
+```json
+{
+  "ok": true,
+  "mode": "dry-run",
+  "userProfile": {
+    "action": "create",
+    "email": "admin+propertymanager@rentchain.ai",
+    "role": "property_manager_company",
+    "accountType": "property_manager_company",
+    "landlordId": null,
+    "status": "active",
+    "approved": true,
+    "qaProfile": true
+  },
+  "accountProfile": {
+    "action": "create",
+    "email": "admin+propertymanager@rentchain.ai",
+    "role": "property_manager_company",
+    "accountType": "property_manager_company",
+    "landlordId": null,
+    "status": "active",
+    "approved": true,
+    "qaProfile": true
+  },
+  "landlordProfileAction": "none",
+  "rawIdsPrinted": false,
+  "writePerformed": false
+}
+```
+
+`action` may be `update` when the safe profile already exists.
+
+## Write
+
+Only after dry-run review and explicit operator approval:
+
+```bash
+cd rentchain-api
+PM_COMPANY_AUTH_PROFILE_SETUP_ENABLED=true \
+ALLOW_LOCAL_PROD_FIRESTORE=true \
+PM_COMPANY_QA_USER_EMAIL=admin+propertymanager@rentchain.ai \
+npm run setup:pm-company-auth-profile -- --write
+```
+
+Write mode requires both:
+
+- `PM_COMPANY_AUTH_PROFILE_SETUP_ENABLED=true`
+- `--write`
+
+## Cleanup
+
+No hard-delete cleanup is provided in this mission. If the QA profile should be disabled later, use a separately reviewed profile-suspension mission or manual operator procedure that preserves audit/history and does not delete PM company relationship or assignment records.
+
+## Post-Setup Validation
+
+After approved write:
+
+1. Login as `admin+propertymanager@rentchain.ai`.
+2. Confirm `/api/me` reports a non-landlord PM company role.
+3. Confirm `/api/property-manager-companies/my-companies` returns `Acme Property Management QA`.
+4. Confirm landlord owner routes fail closed for the PM company user.
+5. Resume #1229 manual QA.

--- a/rentchain-api/package.json
+++ b/rentchain-api/package.json
@@ -26,6 +26,7 @@
     "test:e2e:ui": "npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false playwright test --config=../playwright.config.ts --project=api-chromium --ui",
     "test:e2e:debug": "npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false playwright test --config=../playwright.config.ts --project=api-chromium --headed --debug",
     "fixture:pm-company-preview": "npm run preflight && ts-node-dev --transpile-only --exit-child src/scripts/propertyManagerCompanyPreviewFixture.ts",
+    "setup:pm-company-auth-profile": "npm run preflight && ts-node-dev --transpile-only --exit-child src/scripts/propertyManagerCompanyAuthProfileSetup.ts",
     "test:docker": "docker run --rm -v \"$PWD/..:/workspace/rentchain\" -w /workspace/rentchain/rentchain-api rentchain-dev npm run test:e2e",
     "storage-state:export": "npm run preflight && ts-node tests/storage-state/export-storage-state.ts ./.smoke-storage-state",
     "smoke": "node scripts/smoke-safe-build.js",

--- a/rentchain-api/src/auth/rbac.ts
+++ b/rentchain-api/src/auth/rbac.ts
@@ -4,6 +4,7 @@ export type Role =
   | "landlord"
   | "contractor"
   | "delegate"
+  | "property_manager_company"
   | "manager"
   | "staff"
   | "tenant"
@@ -47,6 +48,7 @@ export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
   ],
   contractor: [],
   delegate: [],
+  property_manager_company: [],
   manager: [
     "properties.edit",
     "units.manage",

--- a/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
+++ b/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 type StoredDoc = Record<string, any>;
 
 const collections = vi.hoisted(() => new Map<string, Map<string, StoredDoc>>());
+const reads = vi.hoisted(() => new Map<string, number>());
 const signInWithPasswordMock = vi.hoisted(() => vi.fn());
 const getUserMock = vi.hoisted(() => vi.fn());
 
@@ -24,6 +25,8 @@ const fakeDb = vi.hoisted(() => ({
         return {
           id: docId,
           async get() {
+            const key = `${name}/${docId}`;
+            reads.set(key, (reads.get(key) || 0) + 1);
             return {
               id: docId,
               exists: collection.has(docId),
@@ -40,6 +43,8 @@ const fakeDb = vi.hoisted(() => ({
         return {
           limit: (_count: number) => ({
             async get() {
+              const key = `${name}:query:${field}`;
+              reads.set(key, (reads.get(key) || 0) + 1);
               const docs = Array.from(collection.entries())
                 .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
                 .map(([id, data]) => ({ id, exists: true, data: () => copy(data) }));
@@ -186,6 +191,7 @@ function seedProfile(uid: string, email: string, role: string, extra: StoredDoc 
 describe("auth login property manager company profiles", () => {
   beforeEach(() => {
     collections.clear();
+    reads.clear();
     vi.clearAllMocks();
     process.env.JWT_SECRET = "test-secret";
     process.env.FIREBASE_API_KEY = "test-firebase-key";
@@ -235,6 +241,8 @@ describe("auth login property manager company profiles", () => {
       approved: true,
     });
     expect(collectionSize("landlords")).toBe(0);
+    expect(reads.get("landlords/pm-admin-user-1") || 0).toBe(0);
+    expect(reads.get("landlords:query:email") || 0).toBe(0);
 
     const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
     const companyContext = await invokeRouter(propertyManagerCompanyRoutes, {
@@ -272,6 +280,26 @@ describe("auth login property manager company profiles", () => {
 
     expect(landlordResponse.status).toBe(403);
     expect(landlordResponse.body.error).toBe("FORBIDDEN");
+  });
+
+  it("fails closed when a PM company profile includes landlord scope", async () => {
+    seedAuthUser("pm-admin-user-1", "admin+propertymanager@rentchain.ai");
+    seedProfile("pm-admin-user-1", "admin+propertymanager@rentchain.ai", "property_manager_company", {
+      landlordId: "landlord-scope-1",
+    });
+
+    const authRouter = (await import("../authRoutes")).default;
+    const response = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "admin+propertymanager@rentchain.ai", password: "secretpass" },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe("UNSUPPORTED_ACCOUNT_ROLE");
+    expect(collectionSize("landlords")).toBe(0);
+    expect(reads.get("landlords/pm-admin-user-1") || 0).toBe(0);
+    expect(reads.get("landlords:query:email") || 0).toBe(0);
   });
 
   it("keeps existing landlord login behavior", async () => {

--- a/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
+++ b/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = Record<string, any>;
+
+const collections = vi.hoisted(() => new Map<string, Map<string, StoredDoc>>());
+const signInWithPasswordMock = vi.hoisted(() => vi.fn());
+const getUserMock = vi.hoisted(() => vi.fn());
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  return collections.get(name)!;
+}
+
+function copy<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+const fakeDb = vi.hoisted(() => ({
+  collection(name: string) {
+    const collection = ensureCollection(name);
+    return {
+      doc(id?: string) {
+        const docId = id || `doc_${collection.size + 1}`;
+        return {
+          id: docId,
+          async get() {
+            return {
+              id: docId,
+              exists: collection.has(docId),
+              data: () => copy(collection.get(docId)),
+            };
+          },
+          async set(data: StoredDoc, opts?: { merge?: boolean }) {
+            const current = collection.get(docId) || {};
+            collection.set(docId, opts?.merge ? { ...current, ...copy(data) } : copy(data));
+          },
+        };
+      },
+      where(field: string, op: string, value: unknown) {
+        return {
+          limit: (_count: number) => ({
+            async get() {
+              const docs = Array.from(collection.entries())
+                .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
+                .map(([id, data]) => ({ id, exists: true, data: () => copy(data) }));
+              return { docs, empty: docs.length === 0 };
+            },
+          }),
+        };
+      },
+      async get() {
+        return {
+          docs: Array.from(collection.entries()).map(([id, data]) => ({
+            id,
+            exists: true,
+            data: () => copy(data),
+          })),
+        };
+      },
+    };
+  },
+}));
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+    arrayUnion: (...values: any[]) => values,
+  },
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({
+      getUser: getUserMock,
+    }),
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => "__server_timestamp__",
+      },
+    },
+  },
+}));
+
+vi.mock("../../services/authService", async () => {
+  const actual = await vi.importActual<any>("../../services/authService");
+  return {
+    ...actual,
+    signInWithPassword: signInWithPasswordMock,
+    generateJwtForLandlord: vi.fn(() => "demo-token"),
+  };
+});
+
+vi.mock("../../services/emailService", () => ({
+  sendEmail: vi.fn(),
+  sendLandlordWelcomeEmail: vi.fn(),
+}));
+
+vi.mock("../../services/microLiveGrant", () => ({
+  maybeGrantMicroLiveFromLead: vi.fn(),
+}));
+
+function writeDoc(collectionName: string, id: string, data: StoredDoc) {
+  ensureCollection(collectionName).set(id, copy(data));
+}
+
+function readDoc(collectionName: string, id: string) {
+  return ensureCollection(collectionName).get(id);
+}
+
+function collectionSize(collectionName: string) {
+  return ensureCollection(collectionName).size;
+}
+
+async function invokeRouter(
+  router: any,
+  options: {
+    method: string;
+    url: string;
+    body?: Record<string, unknown>;
+    token?: string;
+  }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: options.token ? { authorization: `Bearer ${options.token}` } : {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedAuthUser(uid: string, email: string) {
+  signInWithPasswordMock.mockResolvedValue({ uid, email });
+  getUserMock.mockResolvedValue({ uid, email, emailVerified: true });
+}
+
+function seedProfile(uid: string, email: string, role: string, extra: StoredDoc = {}) {
+  const profile = {
+    id: uid,
+    email,
+    role,
+    accountType: role,
+    landlordId: role === "landlord" ? uid : null,
+    approved: true,
+    status: "active",
+    permissions: [],
+    revokedPermissions: [],
+    ...extra,
+  };
+  writeDoc("users", uid, profile);
+  writeDoc("accounts", uid, profile);
+}
+
+describe("auth login property manager company profiles", () => {
+  beforeEach(() => {
+    collections.clear();
+    vi.clearAllMocks();
+    process.env.JWT_SECRET = "test-secret";
+    process.env.FIREBASE_API_KEY = "test-firebase-key";
+    process.env.AUTH_HYDRATE_FROM_DB = "true";
+    process.env.PASSWORD_LOGIN_ENABLED = "true";
+  });
+
+  it("logs in a PM company admin without creating a landlord profile", async () => {
+    seedAuthUser("pm-admin-user-1", "admin+propertymanager@rentchain.ai");
+    seedProfile("pm-admin-user-1", "admin+propertymanager@rentchain.ai", "property_manager_company");
+    writeDoc("propertyManagerCompanies", "pm-company-1", {
+      companyId: "pm-company-1",
+      companyName: "Acme Property Management QA",
+      safeDisplayLabel: "Acme Property Management QA",
+      status: "active",
+      createdByUserId: "pm-admin-user-1",
+      createdAt: "2026-06-24T00:00:00.000Z",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+    });
+    writeDoc("propertyManagerCompanyMemberships", "pm-membership-1", {
+      membershipId: "pm-membership-1",
+      companyId: "pm-company-1",
+      userId: "pm-admin-user-1",
+      role: "company_admin",
+      status: "active",
+      safeDisplayLabel: "admin+propertymanager@rentchain.ai",
+      createdAt: "2026-06-24T00:00:00.000Z",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      suspendedAt: null,
+      removedAt: null,
+    });
+
+    const authRouter = (await import("../authRoutes")).default;
+    const login = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "admin+propertymanager@rentchain.ai", password: "secretpass" },
+    });
+
+    expect(login.status).toBe(200);
+    expect(login.body.user).toMatchObject({
+      id: "pm-admin-user-1",
+      email: "admin+propertymanager@rentchain.ai",
+      role: "property_manager_company",
+      actorRole: "property_manager_company",
+      landlordId: null,
+      approved: true,
+    });
+    expect(collectionSize("landlords")).toBe(0);
+
+    const { propertyManagerCompanyRoutes } = await import("../propertyManagerCompanyRelationshipRoutes");
+    const companyContext = await invokeRouter(propertyManagerCompanyRoutes, {
+      method: "GET",
+      url: "/my-companies",
+      token: login.body.token,
+    });
+
+    expect(companyContext.status).toBe(200);
+    expect(companyContext.body.companies).toEqual([
+      expect.objectContaining({
+        companyLabel: "Acme Property Management QA",
+        role: "company_admin",
+        status: "active",
+      }),
+    ]);
+  });
+
+  it("denies PM company users landlord-owner routes", async () => {
+    seedAuthUser("pm-admin-user-1", "admin+propertymanager@rentchain.ai");
+    seedProfile("pm-admin-user-1", "admin+propertymanager@rentchain.ai", "property_manager_company");
+
+    const authRouter = (await import("../authRoutes")).default;
+    const login = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "admin+propertymanager@rentchain.ai", password: "secretpass" },
+    });
+    const landlordRouter = (await import("../propertyManagerCompanyRelationshipRoutes")).default;
+    const landlordResponse = await invokeRouter(landlordRouter, {
+      method: "GET",
+      url: "/property-manager-company-relationships",
+      token: login.body.token,
+    });
+
+    expect(landlordResponse.status).toBe(403);
+    expect(landlordResponse.body.error).toBe("FORBIDDEN");
+  });
+
+  it("keeps existing landlord login behavior", async () => {
+    seedAuthUser("landlord-user-1", "owner@example.com");
+
+    const authRouter = (await import("../authRoutes")).default;
+    const response = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "owner@example.com", password: "secretpass" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.user.role).toBe("landlord");
+    expect(readDoc("landlords", "landlord-user-1")).toMatchObject({
+      id: "landlord-user-1",
+      landlordId: "landlord-user-1",
+      email: "owner@example.com",
+      role: "landlord",
+    });
+  });
+
+  it("keeps existing delegate and contractor login branches safe", async () => {
+    const authRouter = (await import("../authRoutes")).default;
+
+    seedAuthUser("delegate-user-1", "delegate@example.com");
+    seedProfile("delegate-user-1", "delegate@example.com", "delegate");
+    const delegate = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "delegate@example.com", password: "secretpass" },
+    });
+    expect(delegate.status).toBe(200);
+    expect(delegate.body.user).toMatchObject({ role: "delegate", landlordId: null });
+
+    seedAuthUser("contractor-user-1", "contractor@example.com");
+    seedProfile("contractor-user-1", "contractor@example.com", "contractor", {
+      contractorId: "contractor-user-1",
+    });
+    const contractor = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "contractor@example.com", password: "secretpass" },
+    });
+    expect(contractor.status).toBe(200);
+    expect(contractor.body.user).toMatchObject({ role: "contractor", contractorId: "contractor-user-1" });
+    expect(collectionSize("landlords")).toBe(0);
+  });
+
+  it("fails closed for malformed persisted roles", async () => {
+    seedAuthUser("bad-user-1", "bad@example.com");
+    seedProfile("bad-user-1", "bad@example.com", "mystery_role");
+
+    const authRouter = (await import("../authRoutes")).default;
+    const response = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "bad@example.com", password: "secretpass" },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe("UNSUPPORTED_ACCOUNT_ROLE");
+    expect(collectionSize("landlords")).toBe(0);
+  });
+});

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -3,7 +3,7 @@ import { Router, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 import crypto from "crypto";
 import admin from "firebase-admin";
-import { generateJwtForLandlord } from "../services/authService";
+import { generateJwtForLandlord, signInWithPassword } from "../services/authService";
 import { authenticateJwt } from "../middleware/authMiddleware";
 import { DEMO_LANDLORD, DEMO_LANDLORD_EMAIL } from "../config/authConfig";
 import {
@@ -20,7 +20,6 @@ import { resolvePlan } from "../entitlements/plans";
 import { z } from "zod";
 import { maybeGrantMicroLiveFromLead } from "../services/microLiveGrant";
 import { signAuthToken, verifyAuthToken } from "../auth/jwt";
-import { validateLandlordCredentials } from "../services/authService";
 import { getOrCreateAccount } from "../services/accountService";
 import { getOrCreateLandlordProfile } from "../services/landlordProfileService";
 import { db, FieldValue } from "../firebase";
@@ -113,6 +112,42 @@ function asOnboardString(value: unknown): string | null {
 function normalizeOnboardEmail(value: unknown): string | null {
   const next = String(value || "").trim().toLowerCase();
   return next || null;
+}
+
+function normalizePersistedLoginRole(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function isKnownPersistedLoginRole(role: string): boolean {
+  return [
+    "",
+    "admin",
+    "contractor",
+    "delegate",
+    "landlord",
+    "owner",
+    "property_manager_company",
+  ].includes(role);
+}
+
+async function validateFirebasePasswordIdentity(
+  email: string,
+  password: string
+): Promise<{ id: string; email: string } | null> {
+  const fb = await signInWithPassword(email, password);
+  if (!fb) return null;
+
+  const authUser = await admin.auth().getUser(fb.uid);
+  if (!authUser.emailVerified) {
+    const err: any = new Error("EMAIL_NOT_VERIFIED");
+    err.code = "EMAIL_NOT_VERIFIED";
+    throw err;
+  }
+
+  return {
+    id: fb.uid,
+    email: String(authUser.email || fb.email || email).trim().toLowerCase(),
+  };
 }
 
 async function loadApplicationForTenantInvite(applicationId: string | null) {
@@ -1686,7 +1721,7 @@ router.post("/login", rateLimitAuth, async (req, res) => {
     }
 
     step = "firebase_signin";
-    const fbUser = await validateLandlordCredentials(email, password);
+    const fbUser = await validateFirebasePasswordIdentity(email, password);
     if (!fbUser) {
       return loginError(res, 401, "INVALID_CREDENTIALS");
     }
@@ -1698,15 +1733,16 @@ router.post("/login", rateLimitAuth, async (req, res) => {
     ]);
     const persistedUser = userSnap.exists ? (userSnap.data() as any) : {};
     const persistedAccount = accountSnap.exists ? (accountSnap.data() as any) : {};
-    const persistedRole = String(
+    const persistedRole = normalizePersistedLoginRole(
       persistedUser?.actorRole ||
         persistedUser?.role ||
         persistedAccount?.actorRole ||
         persistedAccount?.role ||
         ""
-    )
-      .trim()
-      .toLowerCase();
+    );
+    if (!isKnownPersistedLoginRole(persistedRole)) {
+      return loginError(res, 403, "UNSUPPORTED_ACCOUNT_ROLE", "Unsupported account profile role");
+    }
 
     let claims: any;
     let sessionUser: any;
@@ -1776,6 +1812,40 @@ router.post("/login", rateLimitAuth, async (req, res) => {
           ...sessionUser,
           role: "delegate",
           actorRole: "delegate",
+          landlordId: null,
+        },
+      });
+    }
+
+    if (persistedRole === "property_manager_company") {
+      step = "property_manager_company_jwt_sign";
+      claims = {
+        sub: fbUser.id,
+        email: fbUser.email,
+        role: "property_manager_company",
+        landlordId: undefined,
+        permissions: Array.isArray(persistedUser?.permissions)
+          ? persistedUser.permissions
+          : Array.isArray(persistedAccount?.permissions)
+          ? persistedAccount.permissions
+          : [],
+        revokedPermissions: Array.isArray(persistedUser?.revokedPermissions)
+          ? persistedUser.revokedPermissions
+          : Array.isArray(persistedAccount?.revokedPermissions)
+          ? persistedAccount.revokedPermissions
+          : [],
+      } as const;
+      const token = signAuthToken(claims, { expiresIn: "7d" });
+      sessionUser = await buildCanonicalSessionUserFromClaims({ ...claims, ver: 1 } as any, {
+        requestCache: {},
+      });
+      return res.status(200).json({
+        ok: true,
+        token,
+        user: {
+          ...sessionUser,
+          role: "property_manager_company",
+          actorRole: "property_manager_company",
           landlordId: null,
         },
       });

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -1819,6 +1819,16 @@ router.post("/login", rateLimitAuth, async (req, res) => {
 
     if (persistedRole === "property_manager_company") {
       step = "property_manager_company_jwt_sign";
+      const persistedLandlordId = String(persistedUser?.landlordId || persistedAccount?.landlordId || "").trim();
+      if (persistedLandlordId) {
+        return loginError(
+          res,
+          403,
+          "UNSUPPORTED_ACCOUNT_ROLE",
+          "Property manager company profile cannot include landlord scope"
+        );
+      }
+
       claims = {
         sub: fbUser.id,
         email: fbUser.email,

--- a/rentchain-api/src/scripts/__tests__/propertyManagerCompanyAuthProfilePlan.test.ts
+++ b/rentchain-api/src/scripts/__tests__/propertyManagerCompanyAuthProfilePlan.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPropertyManagerCompanyAuthProfile,
+  buildPropertyManagerCompanyAuthProfileSafeSummary,
+} from "../propertyManagerCompanyAuthProfilePlan";
+
+describe("property manager company auth profile plan", () => {
+  it("builds safe non-landlord users and accounts profiles", () => {
+    const profile = buildPropertyManagerCompanyAuthProfile({
+      userId: "pm-admin-user-1",
+      userEmail: "ADMIN+PropertyManager@RentChain.ai",
+      now: "2026-06-24T14:00:00.000Z",
+    });
+
+    expect(profile.userProfile).toMatchObject({
+      id: "pm-admin-user-1",
+      email: "admin+propertymanager@rentchain.ai",
+      role: "property_manager_company",
+      accountType: "property_manager_company",
+      landlordId: null,
+      status: "active",
+      approved: true,
+      approvedBy: "feat/property-manager-company-auth-profile-v1",
+      permissions: [],
+      revokedPermissions: [],
+      qaProfile: true,
+    });
+    expect(profile.accountProfile).toEqual(profile.userProfile);
+  });
+
+  it("builds safe summaries without raw ids or landlord actions", () => {
+    const profile = buildPropertyManagerCompanyAuthProfile({
+      userId: "pm-admin-user-1",
+      userEmail: "admin+propertymanager@rentchain.ai",
+      now: "2026-06-24T14:00:00.000Z",
+    });
+
+    const summary = buildPropertyManagerCompanyAuthProfileSafeSummary({
+      write: false,
+      userProfileExists: false,
+      accountProfileExists: true,
+      userProfile: profile.userProfile,
+      accountProfile: profile.accountProfile,
+    });
+
+    expect(summary).toMatchObject({
+      mode: "dry-run",
+      userProfile: {
+        action: "create",
+        email: "admin+propertymanager@rentchain.ai",
+        role: "property_manager_company",
+        accountType: "property_manager_company",
+        landlordId: null,
+      },
+      accountProfile: {
+        action: "update",
+        email: "admin+propertymanager@rentchain.ai",
+        role: "property_manager_company",
+        accountType: "property_manager_company",
+        landlordId: null,
+      },
+      landlordProfileAction: "none",
+      rawIdsPrinted: false,
+    });
+    expect(JSON.stringify(summary)).not.toContain("pm-admin-user-1");
+  });
+});

--- a/rentchain-api/src/scripts/propertyManagerCompanyAuthProfilePlan.ts
+++ b/rentchain-api/src/scripts/propertyManagerCompanyAuthProfilePlan.ts
@@ -1,0 +1,109 @@
+export const DEFAULT_PM_COMPANY_AUTH_PROFILE_ROLE = "property_manager_company";
+export const DEFAULT_PM_COMPANY_AUTH_PROFILE_ACCOUNT_TYPE = "property_manager_company";
+export const PM_COMPANY_AUTH_PROFILE_MANAGED_BY = "feat/property-manager-company-auth-profile-v1";
+
+export type PropertyManagerCompanyAuthProfileMode = "upsert";
+
+export type PropertyManagerCompanyAuthProfileOptions = {
+  userId: string;
+  userEmail: string;
+  now?: string;
+};
+
+export type PropertyManagerCompanyAuthProfileMetadata = {
+  qaProfile: true;
+  managedBy: {
+    source: string;
+    purpose: string;
+  };
+};
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireString(value: unknown, code: string, max = 500): string {
+  const text = cleanString(value, max);
+  if (!text) throw new Error(code);
+  return text;
+}
+
+function isoTimestamp(value?: string): string {
+  if (!value) return new Date().toISOString();
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error("invalid_profile_timestamp");
+  return new Date(parsed).toISOString();
+}
+
+function profileMetadata(): PropertyManagerCompanyAuthProfileMetadata {
+  return {
+    qaProfile: true,
+    managedBy: {
+      source: PM_COMPANY_AUTH_PROFILE_MANAGED_BY,
+      purpose: "Property Manager Company auth profile setup",
+    },
+  };
+}
+
+export function buildPropertyManagerCompanyAuthProfile(options: PropertyManagerCompanyAuthProfileOptions) {
+  const userId = requireString(options.userId, "missing_user_id", 200);
+  const email = requireString(options.userEmail, "missing_user_email", 320).toLowerCase();
+  const now = isoTimestamp(options.now);
+  const metadata = profileMetadata();
+  const profile = {
+    id: userId,
+    email,
+    role: DEFAULT_PM_COMPANY_AUTH_PROFILE_ROLE,
+    accountType: DEFAULT_PM_COMPANY_AUTH_PROFILE_ACCOUNT_TYPE,
+    landlordId: null,
+    status: "active",
+    approved: true,
+    approvedAt: now,
+    approvedBy: PM_COMPANY_AUTH_PROFILE_MANAGED_BY,
+    permissions: [],
+    revokedPermissions: [],
+    createdAt: now,
+    updatedAt: now,
+    ...metadata,
+  };
+
+  return {
+    userProfile: profile,
+    accountProfile: profile,
+  };
+}
+
+export function buildPropertyManagerCompanyAuthProfileSafeSummary(input: {
+  write: boolean;
+  userProfileExists: boolean;
+  accountProfileExists: boolean;
+  userProfile: ReturnType<typeof buildPropertyManagerCompanyAuthProfile>["userProfile"];
+  accountProfile: ReturnType<typeof buildPropertyManagerCompanyAuthProfile>["accountProfile"];
+}) {
+  return {
+    ok: true,
+    mode: input.write ? "write" : "dry-run",
+    userProfile: {
+      action: input.userProfileExists ? "update" : "create",
+      email: input.userProfile.email,
+      role: input.userProfile.role,
+      accountType: input.userProfile.accountType,
+      landlordId: null,
+      status: input.userProfile.status,
+      approved: input.userProfile.approved,
+      qaProfile: input.userProfile.qaProfile,
+    },
+    accountProfile: {
+      action: input.accountProfileExists ? "update" : "create",
+      email: input.accountProfile.email,
+      role: input.accountProfile.role,
+      accountType: input.accountProfile.accountType,
+      landlordId: null,
+      status: input.accountProfile.status,
+      approved: input.accountProfile.approved,
+      qaProfile: input.accountProfile.qaProfile,
+    },
+    landlordProfileAction: "none",
+    rawIdsPrinted: false,
+  };
+}

--- a/rentchain-api/src/scripts/propertyManagerCompanyAuthProfileSetup.ts
+++ b/rentchain-api/src/scripts/propertyManagerCompanyAuthProfileSetup.ts
@@ -1,0 +1,101 @@
+import {
+  buildPropertyManagerCompanyAuthProfile,
+  buildPropertyManagerCompanyAuthProfileSafeSummary,
+} from "./propertyManagerCompanyAuthProfilePlan";
+
+type FirestoreDb = (typeof import("../firebase"))["db"];
+type FirebaseAdmin = typeof import("firebase-admin");
+
+type Args = {
+  write: boolean;
+  userEmail: string;
+  userId: string;
+};
+
+function envValue(key: string): string {
+  return String(process.env[key] || "").trim();
+}
+
+function flagEnabled(key: string): boolean {
+  return envValue(key).toLowerCase() === "true";
+}
+
+function readArgValue(args: string[], name: string): string {
+  const inline = args.find((arg) => arg.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1).trim();
+  const index = args.indexOf(name);
+  if (index >= 0) return String(args[index + 1] || "").trim();
+  return "";
+}
+
+function parseArgs(argv: string[]): Args {
+  return {
+    write: argv.includes("--write"),
+    userEmail: (readArgValue(argv, "--qa-user-email") || envValue("PM_COMPANY_QA_USER_EMAIL")).toLowerCase(),
+    userId: readArgValue(argv, "--qa-user-id") || envValue("PM_COMPANY_QA_USER_ID"),
+  };
+}
+
+async function resolveQaUser(admin: FirebaseAdmin, args: Args): Promise<{ userId: string; userEmail: string }> {
+  if (!args.userEmail && !args.userId) {
+    throw new Error("Provide PM_COMPANY_QA_USER_EMAIL or PM_COMPANY_QA_USER_ID.");
+  }
+  if (args.userEmail) {
+    const user = await admin.auth().getUserByEmail(args.userEmail);
+    return { userId: user.uid, userEmail: user.email || args.userEmail };
+  }
+  const user = await admin.auth().getUser(args.userId);
+  if (!user.email) {
+    throw new Error("Resolved QA user has no email.");
+  }
+  return { userId: user.uid, userEmail: user.email };
+}
+
+async function docExists(db: FirestoreDb, collection: string, docId: string): Promise<boolean> {
+  const snapshot = await db.collection(collection).doc(docId).get();
+  return snapshot.exists;
+}
+
+async function run() {
+  if (!flagEnabled("PM_COMPANY_AUTH_PROFILE_SETUP_ENABLED")) {
+    throw new Error("PM_COMPANY_AUTH_PROFILE_SETUP_ENABLED=true is required.");
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  const [admin, firebase] = await Promise.all([import("firebase-admin"), import("../firebase")]);
+  const qaUser = await resolveQaUser(admin, args);
+  const profile = buildPropertyManagerCompanyAuthProfile({
+    userId: qaUser.userId,
+    userEmail: qaUser.userEmail,
+  });
+  const [userProfileExists, accountProfileExists] = await Promise.all([
+    docExists(firebase.db, "users", qaUser.userId),
+    docExists(firebase.db, "accounts", qaUser.userId),
+  ]);
+  const safeSummary = buildPropertyManagerCompanyAuthProfileSafeSummary({
+    write: args.write,
+    userProfileExists,
+    accountProfileExists,
+    userProfile: profile.userProfile,
+    accountProfile: profile.accountProfile,
+  });
+
+  if (!args.write) {
+    console.log(JSON.stringify({ ...safeSummary, writePerformed: false }, null, 2));
+    return;
+  }
+
+  await firebase.db.collection("users").doc(qaUser.userId).set(profile.userProfile, { merge: true });
+  await firebase.db.collection("accounts").doc(qaUser.userId).set(profile.accountProfile, { merge: true });
+
+  console.log(JSON.stringify({ ...safeSummary, writePerformed: true }, null, 2));
+}
+
+if (require.main === module) {
+  run()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(JSON.stringify({ ok: false, error: String(err?.message || err), rawIdsPrinted: false }, null, 2));
+      process.exit(1);
+    });
+}

--- a/rentchain-api/src/services/entitlementsService.ts
+++ b/rentchain-api/src/services/entitlementsService.ts
@@ -102,11 +102,20 @@ export async function getUserEntitlements(
   const role = normalizeRole(user?.role ?? hints.claimsRole);
   const landlordIdHint = String(user?.landlordId || hints.landlordIdHint || "").trim() || null;
   const emailHint = String(user?.email || hints.emailHint || "").trim().toLowerCase() || null;
-  const landlordContext = await loadLandlordPlan({
-    landlordId: landlordIdHint,
-    userId: cleanUserId,
-    email: emailHint,
-  });
+  if (role === "property_manager_company" && landlordIdHint) {
+    throw new Error("LANDLORD_SCOPE_MISMATCH");
+  }
+
+  const effectiveLandlordIdHint = role === "property_manager_company" ? null : landlordIdHint;
+  const shouldLoadLandlordPlan =
+    role === "landlord" || role === "admin" || Boolean(effectiveLandlordIdHint);
+  const landlordContext = shouldLoadLandlordPlan
+    ? await loadLandlordPlan({
+        landlordId: effectiveLandlordIdHint,
+        userId: cleanUserId,
+        email: emailHint,
+      })
+    : { landlordId: null, planRaw: null };
 
   const planRaw =
     (landlordContext.planRaw && String(landlordContext.planRaw).trim()) ||
@@ -135,9 +144,11 @@ export async function getUserEntitlements(
   }
 
   const scopedLandlordId =
-    role === "landlord"
-      ? landlordContext.landlordId || landlordIdHint || cleanUserId
-      : landlordIdHint;
+    role === "property_manager_company"
+      ? null
+      : role === "landlord"
+      ? landlordContext.landlordId || effectiveLandlordIdHint || cleanUserId
+      : effectiveLandlordIdHint;
 
   const entitlements: UserEntitlements = {
     userId: cleanUserId,

--- a/rentchain-api/src/services/sessionUserService.ts
+++ b/rentchain-api/src/services/sessionUserService.ts
@@ -7,7 +7,7 @@ export type HydratedSessionUser = {
   id: string;
   email?: string;
   role: Role;
-  landlordId?: string;
+  landlordId?: string | null;
   tenantId?: string;
   approved?: boolean;
   plan?: string;
@@ -34,7 +34,7 @@ type BaseUser = {
   id: string;
   email?: string;
   role: Role;
-  landlordId?: string;
+  landlordId?: string | null;
   tenantId?: string;
   permissions?: Permission[];
   revokedPermissions?: Permission[];
@@ -54,6 +54,10 @@ async function applyEntitlements(
   claimsPlan: string | null,
   requestCache: Record<string, UserEntitlements> | undefined
 ): Promise<HydratedSessionUser> {
+  if (baseUser.role === "property_manager_company" && String(baseUser.landlordId || "").trim()) {
+    throw new Error("LANDLORD_SCOPE_MISMATCH");
+  }
+
   const entitlements = await getUserEntitlements(baseUser.id, {
     claimsRole: baseUser.role,
     claimsPlan,
@@ -61,16 +65,18 @@ async function applyEntitlements(
     emailHint: baseUser.email,
     requestCache,
   });
+  const resolvedRole = entitlements.role as Role;
+  const resolvedLandlordId =
+    resolvedRole === "property_manager_company"
+      ? null
+      : entitlements.landlordId ||
+        (resolvedRole === "landlord" || resolvedRole === "admin" ? baseUser.id : baseUser.landlordId);
 
   return {
     ...baseUser,
-    role: entitlements.role as Role,
-    landlordId:
-      entitlements.landlordId ||
-      (entitlements.role === "landlord" || entitlements.role === "admin"
-        ? baseUser.id
-        : baseUser.landlordId),
-    approved: entitlements.role === "admin" || entitlements.role === "tenant" ? true : approved,
+    role: resolvedRole,
+    landlordId: resolvedLandlordId,
+    approved: resolvedRole === "admin" || resolvedRole === "tenant" ? true : approved,
     plan: entitlements.plan,
     capabilities: entitlements.capabilities,
     entitlements,
@@ -133,13 +139,17 @@ export async function buildCanonicalSessionUserFromClaims(
       if (typeof leadApproved === "boolean") approved = leadApproved;
     }
 
+    const unhydratedLandlordId =
+      baseUser.role === "property_manager_company"
+        ? null
+        : baseUser.role === "landlord" || baseUser.role === "admin"
+        ? baseUser.landlordId || baseUser.id
+        : baseUser.landlordId;
+
     return applyEntitlements(
       {
         ...baseUser,
-        landlordId:
-          baseUser.role === "landlord" || baseUser.role === "admin"
-            ? baseUser.landlordId || baseUser.id
-            : baseUser.landlordId,
+        landlordId: unhydratedLandlordId,
       },
       approved,
       claimsPlan,
@@ -158,8 +168,13 @@ export async function buildCanonicalSessionUserFromClaims(
   const userDoc = userSnap.exists ? (userSnap.data() as any) : {};
   const accountDoc = accountSnap.exists ? (accountSnap.data() as any) : {};
   const mergedDoc = { ...accountDoc, ...userDoc } as any;
+  const mergedRole = (mergedDoc.role ?? baseUser.role) as Role;
   if (mergedDoc?.disabled === true) {
     throw new Error("ACCOUNT_DISABLED");
+  }
+
+  if (mergedRole === "property_manager_company" && String(mergedDoc?.landlordId || baseUser.landlordId || "").trim()) {
+    throw new Error("LANDLORD_SCOPE_MISMATCH");
   }
 
   if (mergedDoc?.landlordId && baseUser.landlordId && mergedDoc.landlordId !== baseUser.landlordId) {
@@ -241,15 +256,12 @@ export async function buildCanonicalSessionUserFromClaims(
     {
       id: baseUser.id,
       email: mergedDoc.email ?? baseUser.email,
-      role: (mergedDoc.role ?? baseUser.role) as Role,
+      role: mergedRole,
       landlordId:
-        (mergedDoc.landlordId ?? baseUser.landlordId) ||
-        (mergedDoc.role === "landlord" ||
-        mergedDoc.role === "admin" ||
-        baseUser.role === "landlord" ||
-        baseUser.role === "admin"
-          ? baseUser.id
-          : undefined),
+        mergedRole === "property_manager_company"
+          ? null
+          : (mergedDoc.landlordId ?? baseUser.landlordId) ||
+            (mergedRole === "landlord" || mergedRole === "admin" ? baseUser.id : undefined),
       tenantId: mergedDoc.tenantId ?? baseUser.tenantId,
       permissions: Array.isArray(mergedDoc.permissions) ? mergedDoc.permissions : baseUser.permissions,
       revokedPermissions: Array.isArray(mergedDoc.revokedPermissions)


### PR DESCRIPTION
## Summary
- add a non-landlord property_manager_company auth role with no base permissions
- harden password login to resolve persisted safe roles before landlord profile provisioning
- add a governed dry-run-first PM company auth profile setup path for users/accounts only
- document the Mission Brief and setup runbook

## Root cause
PM company admins could not safely use the current password login path because /api/auth/login validated through landlord credential/profile logic before role resolution. A Firebase Auth PM company user could be pushed toward landlord profile provisioning instead of a neutral company-scoped session.

## Safety
- PM company sessions carry no landlordId and no landlord owner permissions
- company authority still resolves from active propertyManagerCompanyMemberships
- setup script does not create Firebase Auth users, landlords/{uid}, or customer data
- setup script defaults to dry-run and requires PM_COMPANY_AUTH_PROFILE_SETUP_ENABLED=true plus --write for mutation

## Validation
- npm run test:single -- src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts src/scripts/__tests__/propertyManagerCompanyAuthProfilePlan.test.ts
- npm run build
- npm run setup:pm-company-auth-profile fails closed without enable flag
- git diff --check

## Non-goals
- no #1229 UI changes
- no relationship/staff assignment feature changes
- no billing delegation
- no contractor organizations
- no manual Firestore mutation