### PR TITLE
docs: add RC1 enterprise demo readiness plan

### DIFF
--- a/docs/strategy/rc1-enterprise-demo-readiness-plan-v1.md
+++ b/docs/strategy/rc1-enterprise-demo-readiness-plan-v1.md
@@ -1,0 +1,115 @@
+# RC1 Enterprise Demo Readiness Plan v1
+
+Branch: `docs/rc1-enterprise-demo-readiness-plan-v1`
+Scope: docs, audit, planning, and mission sequencing only; no product implementation.
+Planning issue: #1250
+
+## RC1 Goal
+
+Release Candidate 1 prepares RentChain for credible enterprise demo readiness and one-building pilot validation.
+
+The operating question is:
+
+```text
+Would we confidently put RentChain in front of a 3,000-unit operator and ask:
+"Would you put one building on this?"
+```
+
+RC1 is not an enterprise-complete release. It is a polish, hardening, reconnection, and evidence pass over the current platform so RentChain can be evaluated as a Governed Housing Operations Platform by a large operator without overclaiming readiness.
+
+## Enterprise Demo Persona
+
+The RC1 demo persona is an enterprise or larger portfolio operator evaluating whether RentChain can safely support one building as a pilot.
+
+The persona cares about:
+
+- governed landlord and property manager workflows
+- clean permission boundaries
+- staff accountability
+- reliable lease and document flows
+- renewal and vacancy continuity
+- operational evidence and audit history
+- clear distinction between current capability and roadmap
+
+## Pilot Target
+
+The RC1 target is one building, not a full 3,000-unit migration.
+
+The pilot should prove:
+
+- landlord and PM company collaboration works without shared logins
+- staff assignment is visible and auditable
+- lease signing and signed-document retrieval are dependable
+- renewal visibility is understandable
+- workflow handoffs are coherent enough for operations review
+- missing or future capabilities are clearly framed
+
+## Success Criteria
+
+RC1 is successful when:
+
+- a landlord can demonstrate PM Company relationship and assignment workflows cleanly
+- PM Company Admin users can authenticate and manage accepted relationships without landlord profiles
+- signed lease document states do not create broken or misleading links
+- renewal and vacancy visibility gaps are identified and sequenced
+- critical workflow handoffs have an owner, risk rating, and next mission
+- the demo script distinguishes demo-ready behavior from roadmap behavior
+- no demo path relies on raw IDs, private data, or unsupported integrations
+
+## Non-Goals
+
+RC1 does not:
+
+- make RentChain enterprise-complete
+- implement PAD
+- implement screening automation
+- implement vacancy feed APIs
+- add contractor organization architecture
+- add billing delegation
+- introduce new broad architecture
+- replace Free, Starter, Pro, or Elite tier documentation
+- claim full portfolio migration readiness
+
+## Enterprise Strategy Fit
+
+RC1 advances:
+
+- Revenue: by preparing PAD, screening, vacancy, lease-up, and pilot readiness paths.
+- Operational efficiency: by tightening PM Company, assignment, lease, and renewal workflows.
+- Enterprise readiness: by turning recent architecture into demonstrable workflows.
+- Customer validation: by preparing the "one building" pilot conversation.
+
+## Release Readiness Checklist
+
+Before an enterprise demo, confirm:
+
+- PM Company relationship lifecycle works in preview.
+- PM Company email notification scope is implemented or explicitly called roadmap.
+- Assignment grouping and history are readable for landlord and PM company users.
+- Signed lease retrieval handles signed, cancelled, missing, and unavailable states clearly.
+- Renewal visibility is audited and reachable from the intended operational surfaces.
+- Demo-safe data exists and is clearly marked.
+- No raw internal IDs are shown as user-facing labels.
+- Mobile layouts are usable for core demo paths.
+- Empty states explain what is missing without implying deletion.
+- All roadmap capabilities are described as roadmap, not current behavior.
+
+## Required RC1 Workstreams
+
+1. PM Company polish.
+2. Lease lifecycle hardening.
+3. Renewal pipeline visibility.
+4. Workflow continuity audit.
+5. Enterprise demo walkthrough.
+6. RC1 mission queue and issue tracking.
+
+## Merge Readiness For RC1 Planning PR
+
+This planning PR is ready only when:
+
+- all requested docs exist under `docs/strategy/`
+- docs do not add backend, frontend, schema, infrastructure, or runtime changes
+- issue queue is created or updated without duplicates
+- `git diff --check` passes
+- new docs are searched for explicit competitor names
+- PR is opened as draft

--- a/docs/strategy/rc1-enterprise-demo-walkthrough-plan-v1.md
+++ b/docs/strategy/rc1-enterprise-demo-walkthrough-plan-v1.md
@@ -1,0 +1,140 @@
+# RC1 Enterprise Demo Walkthrough Plan v1
+
+Branch: `docs/rc1-enterprise-demo-readiness-plan-v1`
+Scope: demo planning only; no product implementation.
+
+## Purpose
+
+This walkthrough defines the RC1 enterprise demo structure for a large operator evaluating whether to pilot one building on RentChain.
+
+The demo must be honest: show what is working today, identify what needs polish before the demo, and label roadmap capabilities clearly.
+
+## Demo 1: Landlord -> PM Company -> Staff Assignment
+
+### Demo-Ready Today
+
+- landlord searches for an active PM company
+- landlord creates pending relationship
+- PM Company Admin accepts relationship
+- relationship becomes active
+- PM Company Admin creates staff assignment
+- assignment lifecycle preserves history
+- PM company user remains non-landlord
+
+### Needs Polish Before Demo
+
+- email notifications
+- assignment grouping by staff user
+- relationship and assignment timeline
+- mobile scanability
+- empty-state clarity
+
+### Roadmap, Not Current Functionality
+
+- contractor organization integration
+- custom permission builder
+- billing delegation
+- broad enterprise organization hierarchy
+
+## Demo 2: Lease Renewal -> Renewal Decision -> Vacancy Visibility
+
+### Demo-Ready Today
+
+- lease and renewal-related surfaces exist
+- portfolio health and lease workflows contain renewal signals
+
+### Needs Polish Before Demo
+
+- route/navigation visibility audit
+- clearer renewal work queue
+- explicit renewal states
+- connection from declined/non-renewed lease to pending vacancy
+
+### Roadmap, Not Current Functionality
+
+- complete renewal-to-public-listing automation
+- vacancy publishing feed
+- public inquiry intake
+
+## Demo 3: Application -> Screening Readiness -> Lease
+
+### Demo-Ready Today
+
+- application foundations exist
+- screening strategy and consent boundaries are documented
+- lease workflow foundations exist
+
+### Needs Polish Before Demo
+
+- manual screening readiness audit
+- application-to-lease handoff audit
+- clear demo copy for manual review state
+
+### Roadmap, Not Current Functionality
+
+- automated screening dispatch as a complete production add-on
+- autonomous screening decisions
+- raw provider report exposure
+
+## Demo 4: Lease Signing -> Tenant Portal -> View Signed Lease
+
+### Demo-Ready Today
+
+- lease signing and tenant portal paths exist
+- signed lease viewing can work when provider/storage lifecycle is healthy
+
+### Needs Polish Before Demo
+
+- signed-document and cancelled-state hardening
+- missing-document UI state
+- no broken generic fallback
+- consistent landlord and tenant signed-document visibility
+
+### Roadmap, Not Current Functionality
+
+- enterprise document package export
+- bulk lease execution orchestration
+
+## Demo 5: Maintenance / Work Order -> Evidence / Audit
+
+### Demo-Ready Today
+
+- operations and maintenance-related surfaces exist
+- evidence/audit foundations exist
+
+### Needs Polish Before Demo
+
+- workflow continuity audit from work order to evidence
+- contractor and invoice/expense boundary clarity
+- demo-safe data that shows operational history without private leakage
+
+### Roadmap, Not Current Functionality
+
+- contractor organization model
+- invoice/payment export automation
+- enterprise audit console
+
+## Demo Safety Rules
+
+- Do not demo unsupported PAD automation as current.
+- Do not demo automated screening as current.
+- Do not demo vacancy API/public listings as current.
+- Do not expose raw internal IDs.
+- Do not use production customer data.
+- Use one-building pilot framing.
+- Label roadmap capabilities explicitly.
+
+## Recommended Demo Sequence
+
+1. Governance: landlord, PM company, staff assignment.
+2. Revenue risk: renewal and vacancy visibility.
+3. Leasing: application, screening readiness, lease.
+4. Evidence: signed lease and tenant portal.
+5. Operations: maintenance/work order and audit trail.
+
+## Acceptance Criteria
+
+- demo can be run without overclaiming enterprise completeness
+- every roadmap item is marked as roadmap
+- every current capability has a safe path and safe data
+- gaps are tied to RC1 missions

--- a/docs/strategy/rc1-lease-lifecycle-hardening-plan-v1.md
+++ b/docs/strategy/rc1-lease-lifecycle-hardening-plan-v1.md
@@ -1,0 +1,126 @@
+# RC1 Lease Lifecycle Hardening Plan v1
+
+Branch: `docs/rc1-enterprise-demo-readiness-plan-v1`
+Scope: planning only; no lease, storage, provider, backend, or frontend implementation.
+
+## Purpose
+
+Lease signing and signed-document retrieval must be credible before an enterprise demo. A signed lease shown as clickable while the signed document returns unavailable or redirects to a generic fallback is not acceptable for pilot validation.
+
+## Current Hardening Driver
+
+Related issue: #1233
+
+Observed post-merge hardening case:
+
+- a lease appeared signed in landlord `/leases`
+- "View lease" was clickable
+- signed document retrieval returned not found
+- the UI fell back to a generic `/leases` route
+- a signing request had later been cancelled
+- resending and signing resolved the immediate user-facing issue
+
+The original mismatch remains important because signed/cancelled lifecycle state must be explicit.
+
+## RC1 Hardening Goals
+
+RC1 should ensure:
+
+- signed lease document retrieval is resilient
+- cancelled-after-signing states are explicit
+- missing signed documents show clear unavailable/admin-review states
+- "View lease" never silently falls back to a broken generic route
+- tenant and landlord document visibility remains projection-safe
+- provider lifecycle events are represented in audit/history
+
+## View Lease Resilience
+
+The "View lease" action should handle:
+
+- signed document available
+- signed document not yet available
+- signed document unavailable
+- signing request cancelled
+- signing provider state mismatch
+- storage path missing
+- access denied
+- provider retrieval failed
+
+Each state should produce clear UI copy and avoid false success.
+
+## Signing Provider Lifecycle Edge Cases
+
+RC1 should review lifecycle handling for:
+
+- request created
+- viewed
+- reminder sent
+- signed
+- downloaded or document fetched
+- cancelled
+- cancelled after prior signing activity
+- resend or replacement signing request
+
+The lifecycle should avoid repeated reminders after a terminal signed/cancelled state.
+
+## Signed / Cancelled State Clarity
+
+Lease status should avoid collapsing different states into one ambiguous "signed" label when document retrieval is not possible.
+
+Recommended display states:
+
+- awaiting signature
+- signature completed, document processing
+- signed document available
+- signing cancelled
+- signed document unavailable
+- admin review needed
+
+## Missing Document UI States
+
+When signed document retrieval fails, the UI should show:
+
+- a clear unavailable state
+- whether cancellation is known
+- whether retry/resend/admin review is recommended
+- no raw storage paths or provider payloads
+
+## Audit Trail Expectations
+
+Audit and timeline should preserve:
+
+- signing request created
+- reminder sent
+- signed event received
+- provider document fetch attempt
+- document stored or unavailable
+- cancellation event
+- resend/replacement event
+- user who initiated cancellation or resend where available
+
+Audit should remain metadata-first and avoid raw provider payload exposure.
+
+## Tenant And Landlord Document Visibility
+
+Tenant and landlord document views should:
+
+- use safe projections
+- enforce server-side authorization
+- avoid raw storage paths
+- show the same terminal state consistently
+- make missing document state clear without exposing private diagnostics
+
+## Suggested Mission
+
+```text
+fix/lease-signed-document-retrieval-and-cancelled-state-v1
+```
+
+## Acceptance Criteria For RC1
+
+- signed document link opens the correct document when available
+- missing document states are explicit
+- cancelled signing states are explicit
+- generic route fallback is removed or prevented
+- reminders stop after terminal lifecycle state
+- audit/timeline preserves lifecycle evidence

--- a/docs/strategy/rc1-mission-queue-v1.md
+++ b/docs/strategy/rc1-mission-queue-v1.md
@@ -1,0 +1,175 @@
+# RC1 Mission Queue v1
+
+Branch: `docs/rc1-enterprise-demo-readiness-plan-v1`
+Scope: mission sequencing only; no implementation authorization.
+
+## Queue Rule
+
+RC1 missions should prepare RentChain for enterprise demo readiness and one-building pilot validation.
+
+Every implementation mission must pass the Enterprise Validation Phase filter:
+
+- Does it advance revenue?
+- Does it improve operational efficiency?
+- Does it increase enterprise readiness?
+- Does it support customer validation?
+
+If not, challenge it before implementation.
+
+## A. Audit / Planning
+
+### `audit/lease-renewal-route-visibility-v1`
+
+Issue: #1243
+
+Scope:
+
+- audit current renewal route/navigation visibility
+- confirm whether `/lease-renewal` should exist, redirect, or remain retired
+- define renewal source of truth
+- connect renewal to vacancy and lease-up pipeline
+
+### `audit/rc1-workflow-continuity-v1`
+
+Issue: #1251
+
+Scope:
+
+- audit handoffs across PM company, lease, renewal, vacancy, application, screening, signing, tenant portal, maintenance, payment, evidence, and audit
+- assign risk and next missions
+
+### `audit/pm-company-mobile-ux-v1`
+
+Scope:
+
+- audit PM Company mobile layout and action reachability
+- review relationship, assignment, history, and confirmation surfaces
+
+### `audit/lease-document-lifecycle-v1`
+
+Scope:
+
+- audit signed/cancelled/missing document lifecycle
+- verify landlord and tenant document visibility
+- identify provider/storage state gaps
+
+## B. Polish / Hardening
+
+### `feat/property-manager-company-email-notifications-v1`
+
+Issue: #1232
+
+Scope:
+
+- lifecycle notifications for landlord and PM company relationship/assignment changes
+- failed email dispatch must not block state changes
+
+### `fix/lease-signed-document-retrieval-and-cancelled-state-v1`
+
+Issue: #1233
+
+Scope:
+
+- harden View Lease and signed/cancelled document states
+- avoid broken fallback
+- show unavailable/admin-review states
+
+### `feat/delegated-access-mobile-information-architecture`
+
+Issue: #1221
+
+Scope:
+
+- improve delegated access mobile scanability
+- preserve history and audit visibility
+
+### `feat/property-manager-company-assignment-grouping-v1`
+
+Issue: #1252
+
+Scope:
+
+- group assignments by user, relationship, and status
+- improve landlord and company-admin scanning
+
+### `feat/property-manager-company-timeline-history-v1`
+
+Issue: #1253
+
+Scope:
+
+- relationship and assignment lifecycle timeline
+- status transition history
+- metadata-only audit references
+
+### `fix/lease-renewal-navigation-visibility-v1`
+
+Scope:
+
+- implement the outcome of `audit/lease-renewal-route-visibility-v1`
+- improve renewal discovery from the selected source-of-truth surfaces
+
+## C. Demo Readiness
+
+### `docs/enterprise-demo-script-v1`
+
+Issue: #1254
+
+Scope:
+
+- one-building pilot demo script
+- current capability vs roadmap language
+- safe demo data checklist
+
+### `feat/demo-safe-enterprise-seed-data-v1`
+
+Scope:
+
+- demo-safe fixture data if needed
+- no production customer data
+- deterministic setup and cleanup
+
+This mission should only proceed if existing demo data is insufficient.
+
+### `docs/jl-one-building-pilot-readiness-v1`
+
+Issue: #1255
+
+Scope:
+
+- pilot readiness checklist
+- what to ask the enterprise operator
+- what would block one-building adoption
+
+## Dependency Order
+
+1. `audit/lease-renewal-route-visibility-v1`
+2. `audit/rc1-workflow-continuity-v1`
+3. `audit/pm-company-mobile-ux-v1`
+4. `audit/lease-document-lifecycle-v1`
+5. `feat/property-manager-company-email-notifications-v1`
+6. `fix/lease-signed-document-retrieval-and-cancelled-state-v1`
+7. `feat/property-manager-company-assignment-grouping-v1`
+8. `feat/property-manager-company-timeline-history-v1`
+9. `fix/lease-renewal-navigation-visibility-v1`
+10. `docs/enterprise-demo-script-v1`
+11. `docs/jl-one-building-pilot-readiness-v1`
+
+## Non-Goals
+
+- no PAD implementation in RC1 planning
+- no screening automation implementation in RC1 planning
+- no vacancy API implementation in RC1 planning
+- no contractor organization work
+- no billing delegation
+- no broad enterprise layer implementation
+
+## Readiness Gate
+
+RC1 is ready for demo rehearsal when:
+
+- PM Company relationship and assignment flows are polished enough to demo
+- lease document failure states are hardened
+- renewal visibility is clear
+- core handoffs have risk ratings and mission owners
+- demo script clearly marks roadmap vs current functionality

--- a/docs/strategy/rc1-pm-company-polish-plan-v1.md
+++ b/docs/strategy/rc1-pm-company-polish-plan-v1.md
@@ -1,0 +1,178 @@
+# RC1 PM Company Polish Plan v1
+
+Branch: `docs/rc1-enterprise-demo-readiness-plan-v1`
+Scope: planning only; no UI, backend, schema, auth, or notification implementation.
+
+## Purpose
+
+PM Company workflows are one of RentChain's strongest enterprise validation surfaces. RC1 should make these workflows credible for a one-building pilot demo by improving clarity, feedback, history, mobile behavior, and operational confidence.
+
+## Current State
+
+Implemented PM Company capabilities include:
+
+- non-landlord PM company auth/profile support
+- landlord-created pending relationships
+- PM Company Admin acceptance
+- active, suspended, terminated relationship lifecycle
+- staff assignment creation and lifecycle
+- scope ceilings
+- landlord and PM company management UI
+
+Known polish gaps remain around notifications, mobile information architecture, grouping, timeline/history, and relationship/assignment readability.
+
+## RC1 Polish Areas
+
+### PM Company Mobile IA
+
+Related issue: #1221
+
+RC1 should audit and improve mobile scanability for:
+
+- relationship cards
+- assignment cards
+- history sections
+- status summaries
+- action buttons
+- confirmation dialogs
+
+Mobile should avoid dense desktop-table assumptions.
+
+### PM Company Email Notifications
+
+Related issue: #1232
+
+RC1 should add or plan notifications for:
+
+- landlord creates pending relationship
+- PM Company Admin accepts relationship
+- assignment created
+- assignment suspended/reactivated/removed
+- landlord suspends/reactivates/terminates relationship
+
+Failed email dispatch must not block lifecycle state changes.
+
+### Assignment Grouping By User
+
+Assignments should be easier to review by:
+
+- staff user
+- relationship
+- landlord workspace
+- role template
+- active/suspended/removed status
+
+Grouping should not hide removed assignment history.
+
+### Timeline And History Improvements
+
+Relationship and assignment history should show:
+
+- created
+- accepted
+- suspended
+- reactivated
+- terminated
+- assignment created
+- assignment suspended
+- assignment reactivated
+- assignment removed
+
+History should remain metadata-first and avoid raw internal IDs as labels.
+
+### Empty-State Improvements
+
+Empty states should distinguish:
+
+- no relationships yet
+- pending relationship waiting for company acceptance
+- active relationship with no assignments
+- no active assignments because all were removed or suspended
+- no company context available
+
+Empty states should explain next actions without implying records were deleted.
+
+### Visual Polish
+
+RC1 visual polish should focus on:
+
+- consistent status badges
+- readable role labels
+- clear primary actions
+- restrained confirmations for destructive actions
+- card spacing and mobile wrapping
+- no nested-card clutter
+
+### Role And Status Clarity
+
+Role templates should remain predefined:
+
+- Company Owner
+- Company Admin
+- Regional Manager
+- Property Manager
+- Leasing Agent
+- Office Administrator
+- Maintenance Coordinator
+- Read-only Staff
+
+Assignment statuses should remain:
+
+- active
+- suspended
+- removed
+
+Relationship statuses should remain:
+
+- pending
+- active
+- suspended
+- terminated
+
+### Landlord And PM Company View Consistency
+
+The landlord and PM company views should agree on:
+
+- relationship label
+- status
+- scope
+- assigned staff summary
+- assignment status
+- lifecycle history
+
+Landlord views should preserve visibility without allowing landlord direct management of PM company employees beyond relationship controls.
+
+### Performance Review
+
+RC1 should review:
+
+- relationship list load behavior
+- assignment projection load behavior
+- repeated reads when switching tabs
+- large relationship/assignment list behavior
+- safe empty/loading/error states
+
+## Risks
+
+- A polished UI can accidentally imply enterprise-complete readiness.
+- Relationship and assignment data can become difficult to scan if history is shown without grouping.
+- Email notification failures could create distrust if lifecycle states are correct but users miss context.
+- Mobile overload can weaken demo confidence.
+
+## Suggested Missions
+
+1. `feat/property-manager-company-email-notifications-v1`
+2. `audit/pm-company-mobile-ux-v1`
+3. `feat/property-manager-company-assignment-grouping-v1`
+4. `feat/property-manager-company-timeline-history-v1`
+5. `feat/property-manager-company-empty-state-polish-v1`
+
+## Acceptance Criteria For RC1
+
+- landlord and PM company views remain consistent
+- no raw IDs appear as user-facing labels
+- action confirmations remain clear
+- assignment grouping is easy to scan
+- removed/suspended history remains visible
+- mobile core paths are usable
+- notification behavior is either implemented or clearly roadmap-scoped

--- a/docs/strategy/rc1-renewal-pipeline-visibility-plan-v1.md
+++ b/docs/strategy/rc1-renewal-pipeline-visibility-plan-v1.md
@@ -1,0 +1,83 @@
+# RC1 Renewal Pipeline Visibility Plan v1
+
+Branch: `docs/rc1-enterprise-demo-readiness-plan-v1`
+Scope: planning only; no route, navigation, lease, vacancy, application, or screening implementation.
+
+## Purpose
+
+Renewal visibility is a revenue workflow risk. RC1 should clarify where renewal belongs and how it connects to vacancy, listing, inquiry, application, screening, lease, occupancy, and operations.
+
+## Current Visibility Finding
+
+The existing enterprise strategy notes that `/lease-renewal` visibility appears hidden or reduced after Dashboard V2.0 changes.
+
+Current strategy docs indicate:
+
+- no standalone `/lease-renewal` route was found during prior audit
+- renewal work appears through portfolio health and lease-specific renewal workflows
+- this may be valid, but it weakens renewal as a first-class revenue workflow if users cannot find it
+
+RC1 should audit route, navigation, and workflow visibility before implementation.
+
+## Where Renewal Should Surface
+
+Renewal should be discoverable from:
+
+- Dashboard
+- Operations
+- Leases
+- Properties / Units
+
+Each surface should serve a distinct purpose:
+
+- Dashboard: urgent renewal decisions and portfolio summary
+- Operations: work queue and follow-up
+- Leases: lease-specific lifecycle and document context
+- Properties / Units: unit availability, occupancy, and pending vacancy context
+
+## Key Renewal States
+
+RC1 should define or audit support for:
+
+- expiring soon
+- renewal notice pending
+- renewal sent
+- tenant accepted
+- tenant declined
+- vacancy scheduled
+
+States should be source-of-truth aligned and must not duplicate lease status in a separate uncontrolled store.
+
+## Lease-Up Pipeline Connection
+
+Renewal should connect to:
+
+```text
+Renewal -> Vacancy -> Listing -> Inquiry -> Application -> Screening -> Lease
+```
+
+For RC1, the priority is visibility and source-of-truth readiness, not implementing the full pipeline.
+
+## Audit Questions
+
+1. Should `/lease-renewal` exist as a route, redirect, or be retired?
+2. Is renewal currently discoverable by a landlord operator without knowing the URL?
+3. Did Dashboard V2.0 remove or hide a revenue-critical path?
+4. Which object owns renewal state: lease, unit, property, portfolio health, or operations queue?
+5. When a tenant declines or renewal is not offered, where is vacancy scheduled?
+6. What should be shown when renewal data is absent?
+7. What is the safe public boundary for later vacancy publishing?
+
+## Suggested Mission
+
+```text
+audit/lease-renewal-route-visibility-v1
+```
+
+## Acceptance Criteria For RC1
+
+- renewal canonical path is documented
+- visibility gaps are identified
+- no duplicate state model is introduced
+- next implementation mission is scoped
+- renewal is explicitly connected to vacancy and lease-up strategy

--- a/docs/strategy/rc1-workflow-continuity-audit-plan-v1.md
+++ b/docs/strategy/rc1-workflow-continuity-audit-plan-v1.md
@@ -1,0 +1,53 @@
+# RC1 Workflow Continuity Audit Plan v1
+
+Branch: `docs/rc1-enterprise-demo-readiness-plan-v1`
+Scope: audit planning only; no workflow implementation.
+
+## Purpose
+
+Enterprise demos fail when workflow handoffs look disconnected. RC1 should audit whether current RentChain workflows connect cleanly enough to support a one-building pilot conversation.
+
+Each handoff should be assessed for current state, known gaps, risk level, and suggested mission.
+
+## Handoff Audit Matrix
+
+| Handoff | Current State | Known Gaps | Risk | Suggested Mission |
+| --- | --- | --- | --- | --- |
+| PM Company -> Staff Assignment -> Operations | PM Company relationships and staff assignment management exist. | Assignment-to-operations visibility and staff work routing need validation. | Medium | `audit/pm-company-to-operations-continuity-v1` |
+| Lease -> Renewal -> Vacancy | Lease and renewal surfaces exist, but renewal visibility appears reduced after Dashboard V2.0 changes. | Renewal-to-vacancy transition is not first-class. | High | `audit/lease-renewal-route-visibility-v1` |
+| Vacancy -> Public Listing -> Inquiry | Vacancy publishing is roadmap, not current production capability. | Source of truth, publish approval, safe projection, and inquiry intake need definition. | High | `audit/vacancy-publishing-source-of-truth-v1` |
+| Application -> Screening -> Approval | Application and screening foundations exist. | Manual screening workflow and automated dispatch are not demo-ready as complete production flows. | High | `audit/screening-provider-readiness-v1` |
+| Approval -> Lease -> Signing | Lease drafting/signing workflows exist. | Handoff from approved application into lease execution needs audit before demo scripting. | Medium | `audit/application-to-lease-handoff-v1` |
+| Signing -> Active Lease -> Tenant Portal | Signed lease and tenant portal paths exist. | Signed-document missing/cancelled states require hardening. | High | `fix/lease-signed-document-retrieval-and-cancelled-state-v1` |
+| Maintenance -> Contractor -> Invoice/Expense | Maintenance and contractor-related foundations exist. | Contractor organization model is future; invoice/expense continuity is not RC1-ready. | Medium | `audit/maintenance-contractor-expense-continuity-v1` |
+| Payment -> Receipt -> Ledger/Export Future | Payment surfaces and export strategy exist. | PAD, ledger reconciliation, and accounting export are future work. | High | `audit/payments-pad-readiness-v1` and `feat/accounting-export-framework-v1` |
+| Evidence/Audit Continuity Across Workflows | Audit and evidence foundations exist. | Cross-workflow evidence package and enterprise audit review are not productized. | Medium | `audit/rc1-workflow-continuity-v1` |
+
+## Continuity Principles
+
+RC1 handoffs should:
+
+- preserve actor attribution
+- preserve append-safe history
+- avoid raw internal IDs as labels
+- distinguish demo-ready behavior from roadmap behavior
+- fail closed on authorization or projection ambiguity
+- keep tenant-facing and landlord-facing views consistent
+
+## Required Audit Output
+
+The RC1 workflow audit should produce:
+
+- confirmed source-of-truth object for each handoff
+- route or UI surface where each handoff is visible
+- missing states
+- blocked or broken transitions
+- unsafe projection risks
+- recommended mission order
+
+## Acceptance Criteria
+
+- every demo handoff has an explicit readiness assessment
+- high-risk gaps are linked to missions
+- no implementation is started from the audit plan itself
+- roadmap-only flows are labelled honestly during demos


### PR DESCRIPTION
## Summary

Adds the RC1 enterprise demo readiness planning package for the Enterprise Validation Phase.

Docs added:

- `docs/strategy/rc1-enterprise-demo-readiness-plan-v1.md`
- `docs/strategy/rc1-pm-company-polish-plan-v1.md`
- `docs/strategy/rc1-lease-lifecycle-hardening-plan-v1.md`
- `docs/strategy/rc1-renewal-pipeline-visibility-plan-v1.md`
- `docs/strategy/rc1-workflow-continuity-audit-plan-v1.md`
- `docs/strategy/rc1-enterprise-demo-walkthrough-plan-v1.md`
- `docs/strategy/rc1-mission-queue-v1.md`

## Enterprise Strategy Fit

RC1 is framed as demo readiness and one-building pilot validation, not enterprise completion. It advances:

- Revenue readiness through lease, renewal, vacancy, screening, and PAD sequencing.
- Operational efficiency through PM Company polish and workflow continuity review.
- Enterprise readiness through demo-safe handoffs and release criteria.
- Customer validation through the one-building pilot frame.

## Planning Issues

Created or updated:

- #1250 `docs/rc1-enterprise-demo-readiness-v1`
- #1243 `audit/lease-renewal-route-visibility-v1` updated with `rc1`
- #1251 `audit/rc1-workflow-continuity-v1`
- #1252 `feat/property-manager-company-assignment-grouping-v1`
- #1253 `feat/property-manager-company-timeline-history-v1`
- #1254 `docs/enterprise-demo-script-v1`
- #1255 `docs/jl-one-building-pilot-readiness-v1`

## Scope Guard

Docs, audit, planning, and mission sequencing only.

No backend code, frontend code, Firestore/schema changes, auth changes, payment implementation, screening implementation, vacancy API implementation, billing implementation, route changes, or runtime behavior changes.

## Validation

- `git diff --cached --check` passed before commit.
- Searched new docs for explicit incumbent competitor names and found none.
- Staged diff contained only the seven RC1 strategy docs.

## Notes

The docs explicitly avoid claiming RC1 is enterprise-complete. PAD, screening automation, vacancy publishing, contractor organizations, billing delegation, and broad enterprise implementation remain future roadmap items unless separately approved.