### PR TITLE
fix: improve lease renewal navigation visibility

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -129,7 +129,10 @@ vi.mock("./pages/admin/PortfolioScoreHistoryPage", () => ({
 }));
 
 vi.mock("./pages/landlord/PortfolioHealthSummaryPage", () => ({
-  default: () => <h1>Portfolio Health Summary</h1>,
+  default: () => {
+    const location = useLocation();
+    return <h1>{`Portfolio Health Summary ${location.pathname}${location.search}`}</h1>;
+  },
 }));
 
 vi.mock("./pages/landlord/LandlordAnalyticsPage", () => ({
@@ -983,6 +986,20 @@ describe("Routes: /portfolio-health", () => {
     );
 
     expect(await screen.findByText(/Portfolio Health Summary/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /lease-renewal", () => {
+  it("redirects the legacy renewal route to the portfolio renewal workbench", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/lease-renewal"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Portfolio Health Summary /portfolio-health?entry=lease-renewals")).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -913,6 +913,7 @@ function App() {
             </RequireAuth>
           }
         />
+        <Route path="/lease-renewal" element={<Navigate to="/portfolio-health?entry=lease-renewals" replace />} />
         <Route
           path="/portfolio-score"
           element={

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -284,6 +284,7 @@ describe("DashboardPage", () => {
       "/payments?context=current_month&period=2026-06&source=dashboard"
     );
     expect(screen.getByTestId("workspace-routing-section")).toHaveTextContent("Operations full queue");
+    expect(screen.getByRole("link", { name: /Renewals/i })).toHaveAttribute("href", "/lease-renewal");
 
     expect(mocks.fetchLandlordPortfolioStatusFinancialMock).toHaveBeenCalledWith({ periodMonth: expect.stringMatching(/^\d{4}-\d{2}$/) });
     expect(mocks.fetchLandlordDecisionQueueMock).toHaveBeenCalledWith({ status: "open_state", limit: 6 });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -773,6 +773,7 @@ function WorkspaceRoutingSection() {
     { label: "Operations full queue", href: "/operations", icon: <ClipboardList size={17} />, helper: "Execution workspace" },
     { label: "Properties", href: "/properties", icon: <Building2 size={17} />, helper: "Portfolio records" },
     { label: "Leases", href: "/leases", icon: <Route size={17} />, helper: "Lease workspace" },
+    { label: "Renewals", href: "/lease-renewal", icon: <CalendarDays size={17} />, helper: "Renewal workbench" },
     { label: "Payments", href: "/payments", icon: <WalletCards size={17} />, helper: "Financial workspace" },
   ];
   return (

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -141,4 +141,17 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(await screen.findByRole("heading", { name: "Execution Review" })).toBeInTheDocument();
     expect(screen.getByText("Review the lease package, signature state, and document readiness before treating execution as complete.")).toBeInTheDocument();
   });
+
+  it("preserves the lease renewal workflow and links to portfolio renewal inputs", async () => {
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+
+    expect(await screen.findByRole("heading", { name: "Renewal Review" })).toBeInTheDocument();
+    expect(screen.getByText("Review lease end timing and renewal context before deciding on renewal, continuation, or move-out next steps.")).toBeInTheDocument();
+    expect(screen.getByText("Expiring soon")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Renewal operator inputs" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open renewal inputs" })).toHaveAttribute(
+      "href",
+      "/portfolio-health?entry=lease-renewals&propertyId=prop-1"
+    );
+  });
 });

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -174,6 +174,12 @@ function daysUntilEndLabel(lease: LandlordActiveLease) {
   return `${days} days`;
 }
 
+function portfolioRenewalInputsPath(lease: LandlordActiveLease) {
+  const params = new URLSearchParams({ entry: "lease-renewals" });
+  if (lease.propertyId) params.set("propertyId", lease.propertyId);
+  return `/portfolio-health?${params.toString()}`;
+}
+
 function matchingPolicy(lease: LandlordActiveLease, config: WorkflowConfig): JurisdictionPolicyGuidance | null {
   const policies = Array.isArray(lease.jurisdictionPolicies) ? lease.jurisdictionPolicies : [];
   return policies.find((policy) => config.policyKeys.includes(policy.policyKey)) || null;
@@ -267,6 +273,19 @@ export default function LandlordLeaseWorkflowPage() {
               ))}
             </ul>
           </section>
+
+          {workflow.key === "renewal" ? (
+            <section style={panelStyle} aria-label="Renewal operator inputs">
+              <h2 style={sectionHeadingStyle}>Renewal operator inputs</h2>
+              <div style={{ color: "#334155", lineHeight: 1.6 }}>
+                Use the portfolio renewal workbench to review unit-specific renewal inputs such as proposed rent,
+                term dates, response deadline, and renewal recommendation before preparing tenant-facing notices.
+              </div>
+              <Link to={portfolioRenewalInputsPath(lease)} style={{ ...buttonLinkStyle, width: "fit-content" }}>
+                Open renewal inputs
+              </Link>
+            </section>
+          ) : null}
 
           <section style={panelStyle} aria-label="Jurisdiction context">
             <h2 style={sectionHeadingStyle}>Jurisdiction context</h2>

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -454,6 +454,23 @@ describe("deriveCommandCenterSignals", () => {
         contextLabel: "North Towers · 101 · John Smith",
       })
     );
+
+    const renewalTimingSignal = signals.find((signal) => signal.id === "lease-ending:lease-1");
+    expect(renewalTimingSignal).toEqual(
+      expect.objectContaining({
+        destination: "/leases/lease-1/workflows/renewal",
+        scopedLeaseId: "lease-1",
+      })
+    );
+    expect(scopedSourceDestinationForSignal(renewalTimingSignal!)).toBe("/leases/lease-1/workflows/renewal");
+
+    const renewalPolicySignal = signals.find((signal) => signal.id === "policy:lease-1:lease_renewal_review");
+    expect(renewalPolicySignal).toEqual(
+      expect.objectContaining({
+        destination: "/leases/lease-1/workflows/renewal",
+        scopedLeaseId: "lease-1",
+      })
+    );
   });
 
   it("keeps the generic lease fallback when no scoped lease id is available", () => {

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -297,6 +297,10 @@ function leaseSummaryDestination(leaseId: string) {
   return `/leases/${encodeURIComponent(leaseId)}/summary`;
 }
 
+function leaseRenewalWorkflowDestination(leaseId: string) {
+  return `/leases/${encodeURIComponent(leaseId)}/workflows/renewal`;
+}
+
 export function scopedSourceDestinationForSignal(signal: CommandCenterSignal) {
   const scopedLeaseId = String(signal.scopedLeaseId || "").trim();
   if (scopedLeaseId && signal.destination === "/leases") return leaseSummaryDestination(scopedLeaseId);
@@ -726,7 +730,7 @@ export function deriveCommandCenterSignals(input: {
         title: "Lease ending soon",
         description: `Lease ends ${formatDate(lease.endDate)}. Review renewal, notice, or move-out workflow timing.`,
         contextLabel: baseLabel,
-        destination: "/leases",
+        destination: leaseRenewalWorkflowDestination(lease.id),
         source: "Lease operations · lifecycle timing",
         workflowStatus: "Upcoming",
         reviewStatus: endingIn <= 30 ? "Needs review" : "Upcoming",
@@ -747,7 +751,7 @@ export function deriveCommandCenterSignals(input: {
         title: policy.label,
         description: `${policy.reason} ${policy.disclaimer}`,
         contextLabel: baseLabel,
-        destination: "/leases",
+        destination: policy.policyKey.includes("renewal") ? leaseRenewalWorkflowDestination(lease.id) : "/leases",
         source: `Jurisdiction workflow · ${policy.jurisdiction}`,
         workflowStatus: label(policy.status),
         reviewStatus: "Review needed",


### PR DESCRIPTION
## Summary
- Add `/lease-renewal` as a legacy/discoverability redirect to `/portfolio-health?entry=lease-renewals`.
- Add a focused Dashboard Renewals entry point that routes through the redirect.
- Route Operations renewal-specific lease signals to `/leases/:leaseId/workflows/renewal` while preserving generic lease summary routing for non-renewal signals.
- Add a lease-level renewal workflow bridge back to the portfolio renewal operator-input workbench.

## Scope
- Frontend route/navigation cleanup only.
- No vacancy feed, PAD, screening automation, broad dashboard redesign, renewal collection, or standalone renewal data model.
- Operations reviewer assignment persistence is kept out of scope and remains a separate follow-up candidate: `fix/operations-manual-review-assignment-persistence-v1`.

## Validation
- `npm run test:single -- App.routes.test.tsx DashboardPage.test.tsx OperationalCommandCenterPage.test.tsx LandlordLeaseWorkflowPage.test.tsx`
- `npm run build` with Node 20.11.1 via nvm. Vite prints its existing Node 20.19+ recommendation, but the build completed successfully.
- `git diff --check`

## Manual QA Results
- `/lease-renewal` redirects to `/portfolio-health?entry=lease-renewals`.
- `/dashboard` shows the new `Renewals` entry point.
- `/operations` renewal-specific `Lease lifecycle source workflow` opens `/leases/oTmWc8UxDj9u7Asgaqe7/workflows/renewal`.
- `/leases/oTmWc8UxDj9u7Asgaqe7/workflows/renewal` opens successfully.
- Renewal workflow shows `Renewal operator inputs`, helper copy, and `Open renewal inputs`.
- `Open renewal inputs` routes to `/portfolio-health?entry=lease-renewals&propertyId=ZaeL9oqpJCSZPguWa6wR`.

## Follow-ups
- `audit/lease-workflow-guidance-layout-and-status-clarity-v1`
- `fix/operations-manual-review-assignment-persistence-v1`
- `audit/operations-navigation-visibility-v1`