### PR TITLE
fix: clarify lease workflow guidance status and layout

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -354,6 +354,54 @@ describe("leaseRoutes GET /active", () => {
     expect(res.body?.leases?.[0]?.paymentMethod).toBeUndefined();
   });
 
+  it("returns lifecycle summary on landlord-scoped single lease detail responses", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      dueDay: 1,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      nextNoticeDueAt: "2099-10-01T00:00:00.000Z",
+      createdAt: 1,
+      updatedAt: 2,
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/lease-1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.lease).toEqual(
+      expect.objectContaining({
+        id: "lease-1",
+        propertyName: "Harbour View",
+        tenantName: "Jane Tenant",
+        leaseLifecycleSummary: expect.objectContaining({
+          lifecycleStatus: "active",
+          lifecycleLabel: "Active",
+          requiredNextAction: "none",
+          daysUntilExpiry: expect.any(Number),
+        }),
+        jurisdictionProvince: "NS",
+        jurisdictionPolicies: expect.arrayContaining([
+          expect.objectContaining({
+            jurisdiction: "NS",
+            legalAdvice: false,
+          }),
+        ]),
+      })
+    );
+    expect(res.body?.lease?.leaseLifecycleSummary?.daysUntilExpiry).toBeGreaterThan(0);
+  });
+
   it("does not project an active lease as signed without signature metadata", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -1511,6 +1511,48 @@ async function enrichLeaseRow(raw: any) {
   };
 }
 
+function buildLeaseWorkflowGuidanceProjection(lease: any, rawLease: any | null, latestNotice: any | null) {
+  const leaseLifecycleSummary = deriveLeaseLifecycleSummary({
+    lease: {
+      status: lease?.status,
+      leaseStartDate: lease?.startDate,
+      leaseEndDate: lease?.endDate,
+      nextNoticeDueAt: rawLease?.nextNoticeDueAt,
+    },
+    latestNotice,
+    noResponse: latestNotice ? computeNoResponseState(latestNotice) : false,
+  });
+  return {
+    leaseLifecycleSummary,
+    jurisdictionPolicies: evaluateJurisdictionPolicy({
+      province: rawLease?.province || rawLease?.provinceState || null,
+      propertyProvince: lease?.jurisdictionProvince || null,
+      jurisdictionProvince: rawLease?.jurisdictionProvince || null,
+      leaseStatus: lease?.status,
+      leaseStartDate: lease?.startDate,
+      leaseEndDate: lease?.endDate,
+      leaseExecutionStatus: lease?.leaseExecution?.executionStatus,
+      leaseLifecycleStatus: leaseLifecycleSummary.lifecycleStatus,
+      stateCoherence: lease?.stateCoherence || null,
+    }).results,
+  };
+}
+
+async function loadLatestLeaseNoticeForProjection(leaseId: string, landlordId: string) {
+  const normalizedLeaseId = String(leaseId || "").trim();
+  const normalizedLandlordId = String(landlordId || "").trim();
+  if (!normalizedLeaseId || !normalizedLandlordId) return null;
+  const noticeSnap = await db
+    .collection("leaseNotices")
+    .where("landlordId", "==", normalizedLandlordId)
+    .where("leaseId", "==", normalizedLeaseId)
+    .get()
+    .catch(() => null);
+  return (noticeSnap?.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .sort((a: any, b: any) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0))[0] || null;
+}
+
 async function listLandlordLeaseRows(landlordId: string, opts?: { archived?: boolean | null }) {
   const collectionRef: any = (db as any).collection("leases");
   if (!collectionRef || typeof collectionRef.where !== "function") {
@@ -1549,30 +1591,9 @@ async function listLandlordLeaseRows(landlordId: string, opts?: { archived?: boo
   return mergedLeases.map((lease: any) => {
     const rawLease = rawLeaseById.get(String(lease?.id || "").trim()) || null;
     const latestNotice = latestNoticeByLeaseId.get(String(lease?.id || "").trim()) || null;
-    const leaseLifecycleSummary = deriveLeaseLifecycleSummary({
-      lease: {
-        status: lease?.status,
-        leaseStartDate: lease?.startDate,
-        leaseEndDate: lease?.endDate,
-        nextNoticeDueAt: rawLease?.nextNoticeDueAt,
-      },
-      latestNotice,
-      noResponse: latestNotice ? computeNoResponseState(latestNotice) : false,
-    });
     return {
       ...lease,
-      leaseLifecycleSummary,
-      jurisdictionPolicies: evaluateJurisdictionPolicy({
-        province: rawLease?.province || rawLease?.provinceState || null,
-        propertyProvince: lease?.jurisdictionProvince || null,
-        jurisdictionProvince: rawLease?.jurisdictionProvince || null,
-        leaseStatus: lease?.status,
-        leaseStartDate: lease?.startDate,
-        leaseEndDate: lease?.endDate,
-        leaseExecutionStatus: lease?.leaseExecution?.executionStatus,
-        leaseLifecycleStatus: leaseLifecycleSummary.lifecycleStatus,
-        stateCoherence: lease?.stateCoherence || null,
-      }).results,
+      ...buildLeaseWorkflowGuidanceProjection(lease, rawLease, latestNotice),
     };
   });
 }
@@ -3452,7 +3473,15 @@ router.get("/:id", requireLandlord, async (req: any, res: Response) => {
       console.warn("[state-machine] lease advisory invalid", { route: "lease_detail" });
     }
     if (result.source === "firestore") {
-      return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(result.lease as any) }) });
+      const rawLease = { id: String(req.params?.id || "").trim(), ...(result.lease as any) };
+      const lease = await enrichLeaseRow(rawLease);
+      const latestNotice = await loadLatestLeaseNoticeForProjection(lease.id, landlordId);
+      return res.json({
+        lease: {
+          ...lease,
+          ...buildLeaseWorkflowGuidanceProjection(lease, rawLease, latestNotice),
+        },
+      });
     }
     return res.json({ lease: result.lease });
   } catch (err) {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -140,6 +140,11 @@ describe("LandlordLeaseWorkflowPage", () => {
     renderWorkflow("/leases/lease-1/workflows/execution");
     expect(await screen.findByRole("heading", { name: "Execution Review" })).toBeInTheDocument();
     expect(screen.getByText("Review the lease package, signature state, and document readiness before treating execution as complete.")).toBeInTheDocument();
+    expect(screen.getByTestId("lease-workflow-page")).toHaveStyle({ maxWidth: "1040px" });
+    expect(screen.getByLabelText("Workflow overview")).toHaveStyle({
+      background: "#f8fafc",
+      borderRadius: "8px",
+    });
   });
 
   it("preserves the lease renewal workflow and links to portfolio renewal inputs", async () => {
@@ -148,10 +153,39 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(await screen.findByRole("heading", { name: "Renewal Review" })).toBeInTheDocument();
     expect(screen.getByText("Review lease end timing and renewal context before deciding on renewal, continuation, or move-out next steps.")).toBeInTheDocument();
     expect(screen.getByText("Expiring soon")).toBeInTheDocument();
+    expect(screen.getByText("30 days")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Renewal operator inputs" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open renewal inputs" })).toHaveAttribute(
       "href",
       "/portfolio-health?entry=lease-renewals&propertyId=prop-1"
     );
+  });
+
+  it("uses lease end date fallback copy when lifecycle summary is absent", async () => {
+    mocks.getLeaseById.mockResolvedValueOnce({
+      lease: {
+        id: "lease-no-summary",
+        propertyId: "prop-1",
+        propertyName: "Harbour View",
+        unitNumber: "101",
+        monthlyRent: 1850,
+        startDate: "2026-01-01",
+        endDate: "2099-12-31",
+        status: "active",
+        tenantName: "Jane Tenant",
+        tenantEmail: "jane@example.com",
+        leaseExecution: null,
+        paymentReadiness: null,
+        jurisdictionPolicies: [],
+      },
+    });
+
+    renderWorkflow("/leases/lease-no-summary/workflows/renewal");
+
+    expect(await screen.findByRole("heading", { name: "Renewal Review" })).toBeInTheDocument();
+    expect(screen.getByText("December 31, 2099")).toBeInTheDocument();
+    expect(screen.getByText("Lifecycle summary pending")).toBeInTheDocument();
+    expect(screen.getByText(/days$/)).toBeInTheDocument();
+    expect(screen.queryByText("Not available")).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -60,7 +60,7 @@ const WORKFLOWS: Record<WorkflowKey, WorkflowConfig> = {
     policyKeys: ["notice_workflow_readiness"],
     facts: [
       { label: "Lease status", value: (lease) => prettyValue(lease.status) },
-      { label: "Lifecycle", value: (lease) => lease.leaseLifecycleSummary?.lifecycleLabel || "Lifecycle status unavailable" },
+      { label: "Lifecycle", value: (lease) => lifecycleStatusLabel(lease) },
       { label: "Next action", value: (lease) => prettyValue(lease.leaseLifecycleSummary?.requiredNextAction || "review lease context") },
     ],
     reviewItems: [
@@ -94,7 +94,7 @@ const WORKFLOWS: Record<WorkflowKey, WorkflowConfig> = {
     policyKeys: ["lease_renewal_review"],
     facts: [
       { label: "Lease end", value: (lease) => formatDate(lease.endDate) },
-      { label: "Lifecycle", value: (lease) => lease.leaseLifecycleSummary?.lifecycleLabel || "Lifecycle status unavailable" },
+      { label: "Lifecycle", value: (lease) => lifecycleStatusLabel(lease) },
       { label: "Days until end", value: (lease) => daysUntilEndLabel(lease) },
     ],
     reviewItems: [
@@ -112,7 +112,7 @@ const WORKFLOWS: Record<WorkflowKey, WorkflowConfig> = {
     facts: [
       { label: "Lease end", value: (lease) => formatDate(lease.endDate) },
       { label: "Tenant", value: (lease) => lease.tenantName || "Tenant not linked" },
-      { label: "Lifecycle", value: (lease) => lease.leaseLifecycleSummary?.lifecycleLabel || "Lifecycle status unavailable" },
+      { label: "Lifecycle", value: (lease) => lifecycleStatusLabel(lease) },
     ],
     reviewItems: [
       "Confirm move-out timing and any required notice context.",
@@ -166,11 +166,30 @@ function propertyLabel(lease: LandlordActiveLease) {
   return lease.unitNumber ? `${property} · Unit ${lease.unitNumber}` : property;
 }
 
+function daysUntilDate(value: string | null | undefined) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const today = new Date();
+  const todayDay = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+  const endDay = Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
+  return Math.ceil((endDay - todayDay) / 86_400_000);
+}
+
+function lifecycleStatusLabel(lease: LandlordActiveLease) {
+  const label = String(lease.leaseLifecycleSummary?.lifecycleLabel || "").trim();
+  if (label) return label;
+  if (lease.endDate) return "Lifecycle summary pending";
+  return "Lifecycle status unavailable";
+}
+
 function daysUntilEndLabel(lease: LandlordActiveLease) {
-  const days = lease.leaseLifecycleSummary?.daysUntilExpiry;
+  const summaryDays = lease.leaseLifecycleSummary?.daysUntilExpiry;
+  const days = typeof summaryDays === "number" ? summaryDays : daysUntilDate(lease.endDate);
   if (typeof days !== "number") return "Not available";
   if (days < 0) return "Lease end has passed";
   if (days === 0) return "Lease ends today";
+  if (days === 1) return "1 day";
   return `${days} days`;
 }
 
@@ -227,26 +246,28 @@ export default function LandlordLeaseWorkflowPage() {
   const ledgerPath = lease ? `/leases/${encodeURIComponent(lease.id)}/ledger` : `/leases/${encodeURIComponent(leaseId)}/ledger`;
 
   return (
-    <div style={{ display: "grid", gap: 16, maxWidth: 920 }}>
-      <div style={{ display: "grid", gap: 6 }}>
-        <div style={{ fontSize: 12, color: "#2563eb", fontWeight: 800, textTransform: "uppercase", letterSpacing: 0 }}>
-          {workflow.eyebrow}
+    <div data-testid="lease-workflow-page" style={workflowPageStyle}>
+      <section style={workflowOverviewStyle} aria-label="Workflow overview">
+        <div style={{ display: "grid", gap: 6 }}>
+          <div style={{ fontSize: 12, color: "#2563eb", fontWeight: 800, textTransform: "uppercase", letterSpacing: 0 }}>
+            {workflow.eyebrow}
+          </div>
+          <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{workflow.title}</h1>
+          <div style={{ color: "#475569", lineHeight: 1.6 }}>{workflow.purpose}</div>
         </div>
-        <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{workflow.title}</h1>
-        <div style={{ color: "#475569", lineHeight: 1.6 }}>{workflow.purpose}</div>
-      </div>
 
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        <Link to="/leases" style={buttonLinkStyle}>
-          Back to leases
-        </Link>
-        <Link to={summaryPath} style={buttonLinkStyle}>
-          Lease summary
-        </Link>
-        <Link to={ledgerPath} style={buttonLinkStyle}>
-          Ledger
-        </Link>
-      </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Link to="/leases" style={buttonLinkStyle}>
+            Back to leases
+          </Link>
+          <Link to={summaryPath} style={buttonLinkStyle}>
+            Lease summary
+          </Link>
+          <Link to={ledgerPath} style={buttonLinkStyle}>
+            Ledger
+          </Link>
+        </div>
+      </section>
 
       {loading ? <div>Loading workflow review…</div> : null}
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
@@ -311,6 +332,22 @@ const buttonLinkStyle: React.CSSProperties = {
   color: "#0f172a",
   background: "#fff",
   fontWeight: 700,
+};
+
+const workflowPageStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: 1040,
+  display: "grid",
+  gap: 16,
+};
+
+const workflowOverviewStyle: React.CSSProperties = {
+  border: "1px solid #dbe4ee",
+  borderRadius: 8,
+  background: "#f8fafc",
+  padding: 18,
+  display: "grid",
+  gap: 14,
 };
 
 const panelStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- Add `leaseLifecycleSummary` and jurisdiction guidance to landlord-scoped single lease detail responses by reusing the existing lifecycle derivation path.
- Keep active lease list projection behavior aligned with the new shared lifecycle/jurisdiction projection helper.
- Add frontend fallback wording for missing lifecycle summaries and derive days-until-end from `lease.endDate` when summary days are absent.
- Improve the shared lease workflow page framing with a clearer overview container while preserving the existing workflow routes and renewal operator-input bridge.

## Scope
- Backend projection reuse for `GET /api/leases/:id`.
- Shared lease workflow page presentation and clarity only.
- No new lease lifecycle data model, renewal model, schema change, Leases workspace redesign, vacancy automation, PAD, screening automation, Operations persistence work, Operations navigation work, or dashboard changes.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- src/routes/__tests__/leaseRoutes.active.test.ts` in `rentchain-api`
- `npm run test:single -- LandlordLeaseWorkflowPage.test.tsx` in `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` in `rentchain-frontend` (Vite prints its existing Node 20.19+ recommendation, build completed successfully)
- `git diff --check`

## Manual Preview QA
Manual preview QA passed for the intended lease workflow guidance status/layout mission.

Confirmed routes:
- `/leases/oTmWc8UxDj9u7Asgaqe7/workflows/renewal`
- `/leases/oTmWc8UxDj9u7Asgaqe7/workflows/execution`
- `/leases/oTmWc8UxDj9u7Asgaqe7/workflows/rent-increase`
- `/leases/oTmWc8UxDj9u7Asgaqe7/workflows/notice`
- `/leases/oTmWc8UxDj9u7Asgaqe7/workflows/deposit`

Confirmed behavior:
- Workflow pages open successfully.
- Pages have clearer width/container/border/framing.
- Days until end displays when derivable.
- Renewal operator-input section still appears.
- Renewal operator-input link still works.
- Regression surfaces checked: `/leases`, `/portfolio-health?entry=lease-renewals`, `/dashboard`, `/operations`.

## Deferred Follow-ups
- `fix/operations-manual-review-assignment-persistence-v1`
- `audit/operations-navigation-visibility-v1`
- `audit/leases-table-status-layout-clarity-v1`
- `audit/dashboard-payment-decision-queue-clarity-v1`
- `audit/lease-ledger-payment-signal-consistency-v1`