### PR TITLE
fix/payment-decision-ledger-signal-consistency-v1

### DIFF
--- a/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
@@ -16,7 +16,13 @@ function leaseDecision(overrides: Partial<Decision> = {}): Decision {
     severity: "critical",
     status: "detected",
     reason: "Expected rent payment is missing.",
-    metadata: { source: "delinquency_signal" },
+    metadata: {
+      source: "delinquency_signal",
+      dueDate: "2026-05-01",
+      expectedAmountCents: 180000,
+      paidAmountCents: 0,
+      outstandingAmountCents: 180000,
+    },
     createdAt: "2026-05-05T12:00:00.000Z",
     updatedAt: "2026-05-05T12:00:00.000Z",
     ...overrides,
@@ -83,7 +89,10 @@ describe("deriveDecisionInbox", () => {
           status: "open",
           type: "billing",
           source: "lease_ledger",
+          description:
+            "Expected rent payment is missing. Due 2026-05-01; Expected $1,800.00; paid $0.00; outstanding $1,800.00.",
           destination: "/leases/lease-1/ledger",
+          dueAt: "2026-05-01T00:00:00.000Z",
           automationEligible: false,
           workflow: expect.objectContaining({
             queue: "delinquency_review",

--- a/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
+++ b/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
@@ -88,6 +88,7 @@ export type DecisionInboxItem = {
   automatedWorkflow?: AutomatedWorkflowPreview;
   agentActions?: PolicyGatedAgentAction[];
   delinquencyActions?: DelinquencyActionDescriptor[];
+  dueAt?: string | null;
   createdAt: string | null;
   updatedAt: string | null;
 };

--- a/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
+++ b/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
@@ -154,6 +154,33 @@ function destinationForLeaseDecision(decision: SourceDecision): string | null {
   return `/leases/${encodeURIComponent(leaseId)}/summary`;
 }
 
+function formatCurrencyCents(value: unknown): string | null {
+  const cents = Number(value);
+  if (!Number.isFinite(cents) || cents < 0) return null;
+  return `$${(Math.round(cents) / 100).toLocaleString("en-CA", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function paymentDecisionDescription(decision: SourceDecision): string {
+  const base = asString(decision.reason, 1000) || "Decision context is available for review.";
+  const type = asString(decision.decisionType, 120) || "";
+  if (!type.includes("rent") && !type.includes("payment")) return base;
+
+  const dueDate = normalizeDate(decision.metadata?.dueDate);
+  const expected = formatCurrencyCents(decision.metadata?.expectedAmountCents);
+  const paid = formatCurrencyCents(decision.metadata?.paidAmountCents);
+  const outstanding = formatCurrencyCents(decision.metadata?.outstandingAmountCents);
+  const details = [
+    dueDate ? `Due ${dueDate.slice(0, 10)}` : null,
+    expected ? `Expected ${expected}` : null,
+    paid ? `paid ${paid}` : null,
+    outstanding ? `outstanding ${outstanding}` : null,
+  ].filter(Boolean);
+  return details.length ? `${base} ${details.join("; ")}.` : base;
+}
+
 function relatedEntityForLeaseDecision(decision: SourceDecision): DecisionInboxItem["relatedEntity"] {
   const leaseId = asString(decision.leaseId, 240);
   if (leaseId) {
@@ -190,7 +217,7 @@ export function decisionInboxItemFromLeaseDecision(decision: SourceDecision): De
   const base: Omit<DecisionInboxItem, "workflow"> = {
     id: asString(decision.decisionId, 600) || fallbackId("lease_ledger", decision.decisionId, decision.decisionType),
     title: titleCase(decision.decisionType),
-    description: asString(decision.reason, 1000) || "Decision context is available for review.",
+    description: paymentDecisionDescription(decision),
     severity: decisionEngineSeverity(decision.severity),
     status: decisionStatus(decision.status),
     type,
@@ -198,6 +225,7 @@ export function decisionInboxItemFromLeaseDecision(decision: SourceDecision): De
     relatedEntity: relatedEntityForLeaseDecision(decision),
     destination: destinationForLeaseDecision(decision),
     automationEligible: false,
+    dueAt: normalizeDate(decision.metadata?.dueDate),
     createdAt: normalizeDate(decision.createdAt),
     updatedAt: normalizeDate(decision.updatedAt),
   };
@@ -221,6 +249,7 @@ export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDe
     relatedEntity: relatedEntityForAnalyticsDecision(decision),
     destination: asString(decision.destination || decision.href, 500),
     automationEligible: false,
+    dueAt: null,
     createdAt: null,
     updatedAt: normalizeDate(decision.reviewedAt || decision.executedAt || decision.executionOutcomeAt),
   };

--- a/rentchain-api/src/lib/payments/leasePaymentObligationEvidence.ts
+++ b/rentchain-api/src/lib/payments/leasePaymentObligationEvidence.ts
@@ -1,0 +1,120 @@
+import { db } from "../../firebase";
+import type { PaymentObligationCanonicalPaymentInput } from "./paymentObligationLedger";
+
+const LEDGER_COLLECTION = "ledgerEntries";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function paymentEntryAmountCents(value: unknown): number {
+  const amount = Number(value || 0);
+  if (!Number.isFinite(amount)) return 0;
+  return Math.abs(Math.round(amount));
+}
+
+export async function loadLeaseLedgerEntriesForObligationEvidence(
+  leaseId: string,
+  landlordId: string
+): Promise<any[]> {
+  const snap = await db
+    .collection(LEDGER_COLLECTION)
+    .where("landlordId", "==", landlordId)
+    .where("leaseId", "==", leaseId)
+    .get()
+    .catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .sort((a: any, b: any) => {
+      const dateDiff = asString(a?.effectiveDate, 120).localeCompare(asString(b?.effectiveDate, 120));
+      if (dateDiff !== 0) return dateDiff;
+      return asString(a?.createdAt, 120).localeCompare(asString(b?.createdAt, 120));
+    });
+}
+
+export async function loadLeaseCanonicalPaymentsForObligationLedger(
+  leaseId: string,
+  landlordId: string
+): Promise<PaymentObligationCanonicalPaymentInput[]> {
+  const snap = await db
+    .collection("payments")
+    .where("leaseId", "==", leaseId)
+    .get()
+    .catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => asString(record?.landlordId, 240) === landlordId)
+    .filter((record: any) => {
+      const source = asString(record?.source, 120).toLowerCase();
+      const status = asString(record?.status, 120).toLowerCase();
+      if (source === "rent_payment_checkout") return false;
+      return !status || status === "recorded" || status === "paid" || status === "completed";
+    })
+    .map((record: any) => ({
+      id: asString(record?.id, 240),
+      paymentDocumentId: asString(record?.paymentDocumentId || record?.id, 240) || null,
+      leaseId: asString(record?.leaseId, 240),
+      tenantId: asString(record?.tenantId, 240),
+      landlordId: asString(record?.landlordId, 240),
+      propertyId: asString(record?.propertyId, 240) || null,
+      unitId: asString(record?.unitId, 240) || null,
+      amountCents: Math.max(0, Math.round(Number(record?.amountCents || 0))),
+      currency: asString(record?.currency || "cad", 20).toLowerCase() || "cad",
+      status: asString(record?.status || "recorded", 80).toLowerCase() || "recorded",
+      paidAt: asString(record?.paidAt, 120) || null,
+      effectiveDate: asString(record?.effectiveDate || record?.paidAt, 120) || null,
+      method: asString(record?.method, 120) || null,
+      reference: asString(record?.reference, 240) || null,
+      source: asString(record?.source, 120) || null,
+      ledgerEntryId: asString(record?.ledgerEntryId, 240) || null,
+    }));
+}
+
+export function buildCanonicalPaymentEvidenceFromLedgerEntries(
+  entries: any[],
+  existingPayments: PaymentObligationCanonicalPaymentInput[]
+): PaymentObligationCanonicalPaymentInput[] {
+  const existingPaymentDocumentIds = new Set(
+    existingPayments.map((payment) => asString(payment.paymentDocumentId || payment.id, 240)).filter(Boolean)
+  );
+  const existingLedgerEntryIds = new Set(
+    existingPayments.map((payment) => asString(payment.ledgerEntryId, 240)).filter(Boolean)
+  );
+  return (entries || [])
+    .filter((entry: any) => asString(entry?.entryType || entry?.type, 80).toLowerCase() === "payment")
+    .filter((entry: any) => {
+      const entryId = asString(entry?.id, 240);
+      const paymentDocumentId = asString(entry?.paymentDocumentId, 240);
+      if (entryId && existingLedgerEntryIds.has(entryId)) return false;
+      if (paymentDocumentId && existingPaymentDocumentIds.has(paymentDocumentId)) return false;
+      return true;
+    })
+    .map((entry: any) => ({
+      id: asString(entry?.paymentDocumentId || entry?.id, 240),
+      paymentDocumentId: asString(entry?.paymentDocumentId, 240) || null,
+      leaseId: asString(entry?.leaseId, 240),
+      tenantId: asString(entry?.tenantId, 240) || null,
+      landlordId: asString(entry?.landlordId, 240) || null,
+      propertyId: asString(entry?.propertyId, 240) || null,
+      unitId: asString(entry?.unitId, 240) || null,
+      amountCents: paymentEntryAmountCents(entry?.amountCents),
+      currency: "cad",
+      status: "recorded",
+      paidAt: asString(entry?.paidAt || entry?.effectiveDate, 120) || null,
+      effectiveDate: asString(entry?.effectiveDate || entry?.paidAt, 120) || null,
+      method: asString(entry?.method, 120) || null,
+      reference: asString(entry?.reference, 240) || null,
+      source: asString(entry?.source || "ledger_entry_payment", 120) || "ledger_entry_payment",
+      ledgerEntryId: asString(entry?.id, 240) || null,
+    }));
+}
+
+export async function loadLeaseCanonicalPaymentEvidenceForObligationLedger(
+  leaseId: string,
+  landlordId: string,
+  entries?: any[] | null
+): Promise<PaymentObligationCanonicalPaymentInput[]> {
+  const canonicalPayments = await loadLeaseCanonicalPaymentsForObligationLedger(leaseId, landlordId);
+  const ledgerEntries = entries || (await loadLeaseLedgerEntriesForObligationEvidence(leaseId, landlordId));
+  return [...canonicalPayments, ...buildCanonicalPaymentEvidenceFromLedgerEntries(ledgerEntries, canonicalPayments)];
+}

--- a/rentchain-api/src/lib/payments/leasePaymentObligationEvidence.ts
+++ b/rentchain-api/src/lib/payments/leasePaymentObligationEvidence.ts
@@ -48,7 +48,7 @@ export async function loadLeaseCanonicalPaymentsForObligationLedger(
       const source = asString(record?.source, 120).toLowerCase();
       const status = asString(record?.status, 120).toLowerCase();
       if (source === "rent_payment_checkout") return false;
-      return !status || status === "recorded" || status === "paid" || status === "completed";
+      return !status || status === "recorded" || status === "paid" || status === "completed" || status === "reconciled";
     })
     .map((record: any) => ({
       id: asString(record?.id, 240),

--- a/rentchain-api/src/lib/payments/paymentObligationLedger.ts
+++ b/rentchain-api/src/lib/payments/paymentObligationLedger.ts
@@ -329,7 +329,7 @@ function paymentFallsWithinLeaseTerm(payment: PaymentObligationCanonicalPaymentI
 function canonicalPaymentCanReconcile(payment: PaymentObligationCanonicalPaymentInput): boolean {
   const status = asString(payment.status, 80);
   if (!status) return true;
-  return status === "recorded" || status === "paid" || status === "completed";
+  return status === "recorded" || status === "paid" || status === "completed" || status === "reconciled";
 }
 
 export function derivePaymentObligationStatus(input: StatusInput): {

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -360,6 +360,153 @@ describe("landlordDecisionInboxRoutes", () => {
     expect(res.body.summary.total).toBe(0);
   });
 
+  it("suppresses stale analytics missing-payment decisions when the ledger destination uses a persisted lease alias", async () => {
+    seedDoc("leases", "lease-doc-1", {
+      leaseId: "lease-public-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      tenantId: "tenant-1",
+      monthlyRent: 1800,
+      startDate: "2026-04-01",
+      endDate: "2027-03-31",
+      dueDate: "2026-04-01",
+      signedAt: "2026-04-01T00:00:00.000Z",
+      status: "active",
+    });
+    seedDoc("ledgerEntries", "ledger-payment-alias-settled", {
+      leaseId: "lease-public-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "payment",
+      amountCents: 220000,
+      effectiveDate: "2026-04-01",
+      source: "manual_ledger_payment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_missing_payment:lease-public-1",
+            decisionType: "missing_payment",
+            actionLabel: "Review Missing Payment",
+            recommendedAction: "Review Missing Payment",
+            destination: "/leases/lease-public-1/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "lease-public-1" },
+          }),
+        ],
+      },
+    });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+  });
+
+  it("suppresses stale analytics missing-payment decisions when the related lease id is stale but the ledger destination is settled", async () => {
+    seedLease({ id: "76c2961b-eae5-4574-9f51-66096976b5dc", monthlyRent: 1500 });
+    seedDoc("ledgerEntries", "ledger-payment-settled-route-id", {
+      leaseId: "76c2961b-eae5-4574-9f51-66096976b5dc",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "payment",
+      amountCents: 150000,
+      effectiveDate: "2026-04-01",
+      source: "manual_ledger_payment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_missing_payment:internal-source-lease-id",
+            decisionType: "missing_payment",
+            actionLabel: "Review Missing Payment",
+            recommendedAction: "Review Missing Payment",
+            destination: "/leases/76c2961b-eae5-4574-9f51-66096976b5dc/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "internal-source-lease-id" },
+          }),
+        ],
+      },
+    });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+  });
+
+  it("suppresses stale analytics missing-payment decisions for an overpaid up-to-date lease", async () => {
+    seedLease({ id: "bd89a684-7e0a-439e-9b88-29d11de1bcfe", monthlyRent: 1500 });
+    seedDoc("payments", "payment-canonical-overpaid-bd89", {
+      leaseId: "bd89a684-7e0a-439e-9b88-29d11de1bcfe",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      amountCents: 180000,
+      currency: "cad",
+      status: "reconciled",
+      effectiveDate: "2026-04-01",
+      source: "imported_bank_payment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_missing_payment:bd89a684-7e0a-439e-9b88-29d11de1bcfe",
+            decisionType: "missing_payment",
+            actionLabel: "Review Missing Payment",
+            recommendedAction: "Review Missing Payment",
+            destination: "/leases/bd89a684-7e0a-439e-9b88-29d11de1bcfe/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "bd89a684-7e0a-439e-9b88-29d11de1bcfe" },
+          }),
+        ],
+      },
+    });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+    expect(JSON.stringify(res.body)).not.toContain("bd89a684-7e0a-439e-9b88-29d11de1bcfe");
+    expect(JSON.stringify(res.body)).not.toContain("Review Missing Payment");
+  });
+
+  it("suppresses analytics missing-payment decisions that cannot be validated by a live unsettled lease obligation", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_missing_payment:missing-source-lease",
+            decisionType: "missing_payment",
+            actionLabel: "Review Missing Payment",
+            recommendedAction: "Review Missing Payment",
+            destination: "/leases/missing-source-lease/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "missing-source-lease" },
+          }),
+        ],
+      },
+    });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+  });
+
   it("preserves genuine missing-payment decisions when no payment evidence covers the lease obligation", async () => {
     seedLease();
     loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
@@ -375,6 +522,36 @@ describe("landlordDecisionInboxRoutes", () => {
           type: "billing",
           title: "Review Missing Payment",
           destination: "/leases/lease-1/ledger",
+          dueAt: "2026-04-01T00:00:00.000Z",
+          description: expect.stringContaining("outstanding $1,800.00"),
+        }),
+      ])
+    );
+  });
+
+  it("preserves genuine overdue missing-payment decisions with safe obligation context", async () => {
+    seedLease({
+      id: "y7XM6BFXIzWW0fV3mu1L",
+      monthlyRent: 2000,
+      dueDate: "2026-04-01",
+      startDate: "2026-04-01",
+      endDate: "2027-03-31",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "lease_ledger",
+          type: "billing",
+          title: "Review Missing Payment",
+          destination: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+          dueAt: "2026-04-01T00:00:00.000Z",
+          description: expect.stringContaining("Expected $2,000.00"),
         }),
       ])
     );

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -277,6 +277,109 @@ describe("landlordDecisionInboxRoutes", () => {
     );
   });
 
+  it("does not emit active missing-payment decisions when canonical payment evidence covers the lease obligation", async () => {
+    seedLease();
+    seedDoc("payments", "payment-canonical-overpaid", {
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      amountCents: 220000,
+      currency: "cad",
+      status: "recorded",
+      effectiveDate: "2026-04-01",
+      source: "imported_bank_payment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+  });
+
+  it("does not emit active missing-payment decisions when ledger-entry payment evidence covers the lease obligation", async () => {
+    seedLease();
+    seedDoc("ledgerEntries", "ledger-payment-overpaid", {
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "payment",
+      amountCents: -220000,
+      effectiveDate: "2026-04-01",
+      source: "manual_ledger_payment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+  });
+
+  it("suppresses stale analytics missing-payment decisions when current lease ledger evidence is settled", async () => {
+    seedLease();
+    seedDoc("ledgerEntries", "ledger-payment-settled", {
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "payment",
+      amountCents: 220000,
+      effectiveDate: "2026-04-01",
+      source: "manual_ledger_payment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_missing_payment:lease-1",
+            decisionType: "missing_payment",
+            actionLabel: "Review Missing Payment",
+            recommendedAction: "Review Missing Payment",
+            destination: "/leases/lease-1/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "lease-1" },
+          }),
+        ],
+      },
+    });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+  });
+
+  it("preserves genuine missing-payment decisions when no payment evidence covers the lease obligation", async () => {
+    seedLease();
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "lease_ledger",
+          type: "billing",
+          title: "Review Missing Payment",
+          destination: "/leases/lease-1/ledger",
+        }),
+      ])
+    );
+  });
+
   it("does not expose another landlord's lease decisions", async () => {
     seedLease({ id: "lease-other", landlordId: "landlord-2" });
     loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });

--- a/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
@@ -306,6 +306,164 @@ describe("landlordDecisionQueueRoutes", () => {
     );
   });
 
+  it("does not reintroduce stale payment decisions suppressed by the settled-payment-aware inbox", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_missing_payment:76c2961b-eae5-4574-9f51-66096976b5dc",
+            decisionType: "missing_payment",
+            actionLabel: "Review Missing Payment",
+            recommendedAction: "Review Missing Payment",
+            destination: "/leases/76c2961b-eae5-4574-9f51-66096976b5dc/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "76c2961b-eae5-4574-9f51-66096976b5dc" },
+          }),
+        ],
+      },
+    });
+    derivePaymentConsistentDecisionInbox.mockResolvedValue({
+      items: [],
+      filters: { severity: [], status: [], type: [], queue: [], workflowState: [], escalationLevel: [] },
+      summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+      workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
+      automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+      agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
+    });
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [],
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue?status=open_state&limit=6" });
+
+    expect(res.status).toBe(200);
+    expect(derivePaymentConsistentDecisionInbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        analyticsDecisions: expect.arrayContaining([
+          expect.objectContaining({ id: "stale_missing_payment:76c2961b-eae5-4574-9f51-66096976b5dc" }),
+        ]),
+      })
+    );
+    expect(res.body.items).toEqual([]);
+    expect(JSON.stringify(res.body)).not.toContain("Review Missing Payment");
+    expect(JSON.stringify(res.body)).not.toContain("76c2961b-eae5-4574-9f51-66096976b5dc");
+  });
+
+  it("does not show overpaid up-to-date leases as dashboard missing-payment decisions after inbox suppression", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_missing_payment:bd89a684-7e0a-439e-9b88-29d11de1bcfe",
+            decisionType: "missing_payment",
+            actionLabel: "Review Missing Payment",
+            recommendedAction: "Review Missing Payment",
+            destination: "/leases/bd89a684-7e0a-439e-9b88-29d11de1bcfe/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "bd89a684-7e0a-439e-9b88-29d11de1bcfe" },
+          }),
+        ],
+      },
+    });
+    derivePaymentConsistentDecisionInbox.mockResolvedValue({
+      items: [],
+      filters: { severity: [], status: [], type: [], queue: [], workflowState: [], escalationLevel: [] },
+      summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+      workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
+      automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+      agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
+    });
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [],
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue?status=open_state&limit=6" });
+
+    expect(res.status).toBe(200);
+    expect(derivePaymentConsistentDecisionInbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        analyticsDecisions: expect.arrayContaining([
+          expect.objectContaining({ id: "stale_missing_payment:bd89a684-7e0a-439e-9b88-29d11de1bcfe" }),
+        ]),
+      })
+    );
+    expect(res.body.items).toEqual([]);
+    expect(JSON.stringify(res.body)).not.toContain("Review Missing Payment");
+    expect(JSON.stringify(res.body)).not.toContain("bd89a684-7e0a-439e-9b88-29d11de1bcfe");
+  });
+
+  it("returns dashboard payment decisions with due-date context when the settled-payment-aware inbox finds a genuine unpaid obligation", async () => {
+    derivePaymentConsistentDecisionInbox.mockResolvedValue({
+      items: [
+        {
+          id: "decision:review_missing_payment:y7XM6BFXIzWW0fV3mu1L",
+          title: "Review Missing Payment",
+          description: "Expected rent payment is missing. Due 2026-04-01; Expected $2,000.00; paid $0.00; outstanding $2,000.00.",
+          severity: "critical",
+          status: "open",
+          type: "billing",
+          source: "lease_ledger",
+          relatedEntity: { kind: "lease", id: "y7XM6BFXIzWW0fV3mu1L", label: "Lease y7XM6BFXIzWW0fV3mu1L" },
+          destination: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+          automationEligible: false,
+          dueAt: "2026-04-01T00:00:00.000Z",
+          createdAt: "2026-04-02T00:00:00.000Z",
+          updatedAt: "2026-04-02T00:00:00.000Z",
+          workflow: {
+            queue: "delinquency_review",
+            workflowState: "new",
+            ownershipType: "landlord",
+            reviewPriority: "critical",
+            escalationLevel: "critical",
+            manualOnly: true,
+          },
+        },
+      ],
+      filters: { severity: [], status: [], type: [], queue: [], workflowState: [], escalationLevel: [] },
+      summary: { total: 1, critical: 1, high: 0, open: 1, blocked: 0 },
+      workflowSummary: { new: 1, underReview: 0, escalated: 0, critical: 1 },
+      automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+      agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
+    });
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [],
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue?status=open_state&limit=6" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([
+      expect.objectContaining({
+        title: "Review Missing Payment",
+        workspace: "payments",
+        recommendedActionHref: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+        dueAt: "2026-04-01T00:00:00.000Z",
+        description: expect.stringContaining("outstanding $2,000.00"),
+      }),
+    ]);
+  });
+
   it("keeps messaging source types and excludes non-landlord inbox records", async () => {
     getUnifiedInbox.mockResolvedValue({
       ok: true,

--- a/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadLandlordAnalyticsSnapshot = vi.hoisted(() => vi.fn());
 const deriveLeaseDecisionsForInbox = vi.hoisted(() => vi.fn());
+const derivePaymentConsistentDecisionInbox = vi.hoisted(() => vi.fn());
 const getUnifiedInbox = vi.hoisted(() => vi.fn());
 const writeCanonicalEventMock = vi.hoisted(() => vi.fn());
 let mockUser: any;
@@ -10,11 +11,10 @@ vi.mock("../../services/landlord/landlordAnalyticsSnapshot", () => ({
   loadLandlordAnalyticsSnapshot,
 }));
 
-vi.mock("../landlordDecisionInboxRoutes", async (importOriginal) => {
-  const original = await importOriginal<typeof import("../landlordDecisionInboxRoutes")>();
+vi.mock("../landlordDecisionInboxRoutes", () => {
   return {
-    ...original,
     deriveLeaseDecisionsForInbox,
+    derivePaymentConsistentDecisionInbox,
   };
 });
 
@@ -125,6 +125,10 @@ describe("landlordDecisionQueueRoutes", () => {
     mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
     loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [analyticsDecision()] } });
     deriveLeaseDecisionsForInbox.mockResolvedValue([]);
+    derivePaymentConsistentDecisionInbox.mockImplementation(async ({ analyticsDecisions, leaseDecisions }: any) => {
+      const { deriveDecisionInbox } = await import("../../lib/decisions/deriveDecisionInbox");
+      return deriveDecisionInbox({ analyticsDecisions, leaseDecisions });
+    });
     getUnifiedInbox.mockResolvedValue({
       ok: true,
       role: "landlord",

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -110,16 +110,37 @@ async function loadDecisionActionsForLease(leaseId: string) {
 }
 
 async function loadLeaseForLandlord(leaseId: string, landlordId: string) {
-  const snap = await db.collection("leases").doc(leaseId).get().catch(() => null);
-  if (!snap?.exists) return null;
-  const lease = { id: snap.id, ...((snap.data() as any) || {}) };
-  return [lease?.landlordId, lease?.ownerId, lease?.userId].some((value) => asString(value, 240) === landlordId)
-    ? lease
-    : null;
+  const normalizedLeaseId = asString(leaseId, 240);
+  if (!normalizedLeaseId) return null;
+
+  const candidates = new Map<string, any>();
+  const directSnap = await db.collection("leases").doc(normalizedLeaseId).get().catch(() => null);
+  if (directSnap?.exists) {
+    candidates.set(directSnap.id, { id: directSnap.id, ...((directSnap.data() as any) || {}) });
+  }
+
+  async function collectByField(field: "id" | "leaseId") {
+    const snap = await db.collection("leases").where(field, "==", normalizedLeaseId).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      candidates.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+
+  await Promise.all([collectByField("id"), collectByField("leaseId")]);
+
+  return (
+    Array.from(candidates.values()).find((lease) => {
+      const isScopedToLandlord = [lease?.landlordId, lease?.ownerId, lease?.userId].some(
+        (value) => asString(value, 240) === landlordId
+      );
+      if (!isScopedToLandlord) return false;
+      return [lease?.id, lease?.leaseId].some((value) => asString(value, 240) === normalizedLeaseId);
+    }) || null
+  );
 }
 
 async function buildLeaseObligationRowsForDecisionInbox(lease: any, landlordId: string) {
-  const leaseId = asString(lease?.id, 240);
+  const leaseId = asString(lease?.leaseId || lease?.id, 240);
   if (!leaseId) return [];
   const [rentPayments, paymentIntents, canonicalPaymentEvidence] = await Promise.all([
     loadLeaseRentPayments(leaseId, landlordId),
@@ -152,7 +173,7 @@ export async function deriveLeaseDecisionsForInbox(landlordId: string): Promise<
   const leases = await loadLandlordLeases(landlordId);
   const nested = await Promise.all(
     leases.map(async (lease) => {
-      const leaseId = asString(lease?.id, 240);
+      const leaseId = asString(lease?.leaseId || lease?.id, 240);
       if (!leaseId) return [];
       const [obligationRows, actions] = await Promise.all([
         buildLeaseObligationRowsForDecisionInbox(lease, landlordId),
@@ -177,48 +198,62 @@ export async function deriveLeaseDecisionsForInbox(landlordId: string): Promise<
   return nested.flat();
 }
 
-function leaseIdFromDecisionItem(item: DecisionInboxItem): string {
+function leaseIdsFromDecisionItem(item: DecisionInboxItem): string[] {
+  const ids: string[] = [];
   const relatedLeaseId = item.relatedEntity?.kind === "lease" ? asString(item.relatedEntity.id, 240) : "";
-  if (relatedLeaseId) return relatedLeaseId;
+  if (relatedLeaseId) ids.push(relatedLeaseId);
   const destination = asString(item.destination, 600);
   const match = destination.match(/\/leases\/([^/?#]+)\/ledger(?:[/?#]|$)/);
-  if (!match?.[1]) return "";
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return match[1];
+  if (match?.[1]) {
+    try {
+      ids.push(decodeURIComponent(match[1]));
+    } catch {
+      ids.push(match[1]);
+    }
   }
+  return Array.from(new Set(ids.map((id) => asString(id, 240)).filter(Boolean)));
 }
 
 function isActivePaymentDecisionItem(item: DecisionInboxItem): boolean {
   if (item.status === "resolved" || item.status === "dismissed") return false;
   if (item.type !== "billing" && item.workflow?.queue !== "delinquency_review") return false;
-  return Boolean(leaseIdFromDecisionItem(item));
+  return leaseIdsFromDecisionItem(item).length > 0;
 }
 
-async function isLeasePaymentObligationSettled(leaseId: string, landlordId: string): Promise<boolean> {
+type LeasePaymentObligationState = "settled" | "unsettled" | "unknown";
+
+async function getLeasePaymentObligationState(leaseId: string, landlordId: string): Promise<LeasePaymentObligationState> {
   const lease = await loadLeaseForLandlord(leaseId, landlordId);
-  if (!lease) return false;
+  if (!lease) return "unknown";
   const obligationRows = await buildLeaseObligationRowsForDecisionInbox(lease, landlordId);
-  if (obligationRows.length === 0) return false;
+  if (obligationRows.length === 0) return "unknown";
   const summary = summarizePaymentObligationLedger(obligationRows);
-  if (summary.outstandingAmountCents > 0) return false;
-  return deriveDelinquencySignals(obligationRows).length === 0;
+  if (summary.outstandingAmountCents > 0) return "unsettled";
+  return deriveDelinquencySignals(obligationRows).length === 0 ? "settled" : "unsettled";
 }
 
 async function suppressSettledPaymentDecisionItems(landlordId: string, items: DecisionInboxItem[]) {
-  const settledByLeaseId = new Map<string, boolean>();
+  const obligationStateByLeaseId = new Map<string, LeasePaymentObligationState>();
   const result: DecisionInboxItem[] = [];
   for (const item of items) {
     if (!isActivePaymentDecisionItem(item)) {
       result.push(item);
       continue;
     }
-    const leaseId = leaseIdFromDecisionItem(item);
-    if (!settledByLeaseId.has(leaseId)) {
-      settledByLeaseId.set(leaseId, await isLeasePaymentObligationSettled(leaseId, landlordId));
+    const leaseIds = leaseIdsFromDecisionItem(item);
+    let settled = false;
+    let unsettled = false;
+    for (const leaseId of leaseIds) {
+      if (!obligationStateByLeaseId.has(leaseId)) {
+        obligationStateByLeaseId.set(leaseId, await getLeasePaymentObligationState(leaseId, landlordId));
+      }
+      const state = obligationStateByLeaseId.get(leaseId);
+      settled = settled || state === "settled";
+      unsettled = unsettled || state === "unsettled";
     }
-    if (!settledByLeaseId.get(leaseId)) result.push(item);
+    if (settled) continue;
+    if (item.source === "analytics" && !unsettled) continue;
+    result.push(item);
   }
   return result;
 }

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -4,13 +4,16 @@ import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
 import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
+import type { LandlordAgentDecision } from "../lib/analytics/analyticsTypes";
+import type { DecisionInboxItem, DecisionInboxResult } from "../lib/decisions/decisionInboxTypes";
 import { deriveAutomatedWorkflowTransitions } from "../lib/automatedWorkflows/deriveAutomatedWorkflowTransitions";
 import { derivePolicyGatedAgentActions } from "../lib/agentActions/derivePolicyGatedAgentActions";
 import { deriveAgentSupervisionSnapshot } from "../lib/agentSupervision/deriveAgentSupervisionSnapshot";
 import { deriveDecisions, type Decision } from "../lib/decisions/decisionEngine";
 import { applyDecisionActions, DECISION_ACTIONS_COLLECTION } from "../lib/decisions/decisionActions";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
-import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import { buildPaymentObligationLedgerRows, summarizePaymentObligationLedger } from "../lib/payments/paymentObligationLedger";
+import { loadLeaseCanonicalPaymentEvidenceForObligationLedger } from "../lib/payments/leasePaymentObligationEvidence";
 import { deriveDelinquencySignals } from "../lib/payments/delinquencySignals";
 import type { RentPaymentRecord } from "../services/rentPayments/rentPaymentService";
 
@@ -106,36 +109,56 @@ async function loadDecisionActionsForLease(leaseId: string) {
   return (snap?.docs || []).map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
 }
 
+async function loadLeaseForLandlord(leaseId: string, landlordId: string) {
+  const snap = await db.collection("leases").doc(leaseId).get().catch(() => null);
+  if (!snap?.exists) return null;
+  const lease = { id: snap.id, ...((snap.data() as any) || {}) };
+  return [lease?.landlordId, lease?.ownerId, lease?.userId].some((value) => asString(value, 240) === landlordId)
+    ? lease
+    : null;
+}
+
+async function buildLeaseObligationRowsForDecisionInbox(lease: any, landlordId: string) {
+  const leaseId = asString(lease?.id, 240);
+  if (!leaseId) return [];
+  const [rentPayments, paymentIntents, canonicalPaymentEvidence] = await Promise.all([
+    loadLeaseRentPayments(leaseId, landlordId),
+    loadLeasePaymentIntents(leaseId, landlordId),
+    loadLeaseCanonicalPaymentEvidenceForObligationLedger(leaseId, landlordId),
+  ]);
+  const reconciliationRecords = await loadLeaseReconciliationRecords({
+    leaseId,
+    paymentIntentIds: paymentIntents.map((record: any) => asString(record?.paymentIntentId, 240)).filter(Boolean),
+    rentPaymentIds: rentPayments.map((record) => asString(record?.id, 240)).filter(Boolean),
+  });
+  const lifecycle = deriveLeaseLifecycleState({ id: leaseId, ...lease });
+  return buildPaymentObligationLedgerRows({
+    leases: [
+      {
+        ...lease,
+        id: leaseId,
+        amountCents: normalizeLeaseRentAmountCents(lease?.monthlyRent),
+        derivedLifecycleState: lifecycle.state,
+      },
+    ],
+    paymentIntents,
+    rentPayments,
+    canonicalPayments: canonicalPaymentEvidence,
+    reconciliationRecords,
+  });
+}
+
 export async function deriveLeaseDecisionsForInbox(landlordId: string): Promise<Decision[]> {
   const leases = await loadLandlordLeases(landlordId);
   const nested = await Promise.all(
     leases.map(async (lease) => {
       const leaseId = asString(lease?.id, 240);
       if (!leaseId) return [];
-      const [rentPayments, paymentIntents, actions] = await Promise.all([
-        loadLeaseRentPayments(leaseId, landlordId),
-        loadLeasePaymentIntents(leaseId, landlordId),
+      const [obligationRows, actions] = await Promise.all([
+        buildLeaseObligationRowsForDecisionInbox(lease, landlordId),
         loadDecisionActionsForLease(leaseId),
       ]);
-      const reconciliationRecords = await loadLeaseReconciliationRecords({
-        leaseId,
-        paymentIntentIds: paymentIntents.map((record: any) => asString(record?.paymentIntentId, 240)).filter(Boolean),
-        rentPaymentIds: rentPayments.map((record) => asString(record?.id, 240)).filter(Boolean),
-      });
       const lifecycle = deriveLeaseLifecycleState({ id: leaseId, ...lease });
-      const obligationRows = buildPaymentObligationLedgerRows({
-        leases: [
-          {
-            ...lease,
-            id: leaseId,
-            amountCents: normalizeLeaseRentAmountCents(lease?.monthlyRent),
-            derivedLifecycleState: lifecycle.state,
-          },
-        ],
-        paymentIntents,
-        rentPayments,
-        reconciliationRecords,
-      });
       const delinquencySignals = deriveDelinquencySignals(obligationRows);
       const decisions = deriveDecisions({
         delinquencySignals,
@@ -154,6 +177,120 @@ export async function deriveLeaseDecisionsForInbox(landlordId: string): Promise<
   return nested.flat();
 }
 
+function leaseIdFromDecisionItem(item: DecisionInboxItem): string {
+  const relatedLeaseId = item.relatedEntity?.kind === "lease" ? asString(item.relatedEntity.id, 240) : "";
+  if (relatedLeaseId) return relatedLeaseId;
+  const destination = asString(item.destination, 600);
+  const match = destination.match(/\/leases\/([^/?#]+)\/ledger(?:[/?#]|$)/);
+  if (!match?.[1]) return "";
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+function isActivePaymentDecisionItem(item: DecisionInboxItem): boolean {
+  if (item.status === "resolved" || item.status === "dismissed") return false;
+  if (item.type !== "billing" && item.workflow?.queue !== "delinquency_review") return false;
+  return Boolean(leaseIdFromDecisionItem(item));
+}
+
+async function isLeasePaymentObligationSettled(leaseId: string, landlordId: string): Promise<boolean> {
+  const lease = await loadLeaseForLandlord(leaseId, landlordId);
+  if (!lease) return false;
+  const obligationRows = await buildLeaseObligationRowsForDecisionInbox(lease, landlordId);
+  if (obligationRows.length === 0) return false;
+  const summary = summarizePaymentObligationLedger(obligationRows);
+  if (summary.outstandingAmountCents > 0) return false;
+  return deriveDelinquencySignals(obligationRows).length === 0;
+}
+
+async function suppressSettledPaymentDecisionItems(landlordId: string, items: DecisionInboxItem[]) {
+  const settledByLeaseId = new Map<string, boolean>();
+  const result: DecisionInboxItem[] = [];
+  for (const item of items) {
+    if (!isActivePaymentDecisionItem(item)) {
+      result.push(item);
+      continue;
+    }
+    const leaseId = leaseIdFromDecisionItem(item);
+    if (!settledByLeaseId.has(leaseId)) {
+      settledByLeaseId.set(leaseId, await isLeasePaymentObligationSettled(leaseId, landlordId));
+    }
+    if (!settledByLeaseId.get(leaseId)) result.push(item);
+  }
+  return result;
+}
+
+function summarizeDecisionInboxItems(items: DecisionInboxItem[]) {
+  return {
+    total: items.length,
+    critical: items.filter((item) => item.severity === "critical").length,
+    high: items.filter((item) => item.severity === "high").length,
+    open: items.filter((item) => item.status === "open").length,
+    blocked: items.filter((item) => item.status === "blocked").length,
+  };
+}
+
+function summarizeDecisionWorkflowItems(items: DecisionInboxItem[]) {
+  return {
+    new: items.filter((item) => item.workflow?.workflowState === "new").length,
+    underReview: items.filter((item) => item.workflow?.workflowState === "under_review").length,
+    escalated: items.filter((item) => item.workflow?.workflowState === "escalated").length,
+    critical: items.filter((item) => item.workflow?.escalationLevel === "critical").length,
+  };
+}
+
+function summarizeDecisionAutomationItems(items: DecisionInboxItem[]) {
+  return {
+    total: items.filter((item) => item.automatedWorkflow).length,
+    pending: items.filter((item) => item.automatedWorkflow?.status === "pending").length,
+    derived: items.filter((item) => item.automatedWorkflow?.status === "derived").length,
+    blocked: items.filter((item) => item.automatedWorkflow?.status === "blocked").length,
+    completed: items.filter((item) => item.automatedWorkflow?.status === "completed").length,
+    escalationFlagged: items.filter((item) =>
+      (item.automatedWorkflow?.canonicalEvents || []).some((event) => event.eventType === "automated_workflow_escalation_flagged")
+    ).length,
+    reviewRequired: items.filter((item) => item.automatedWorkflow?.manualReviewRequired === true).length,
+  };
+}
+
+function summarizeDecisionAgentActionItems(items: DecisionInboxItem[]) {
+  const actions = items.flatMap((item) => item.agentActions || []);
+  return {
+    total: actions.length,
+    suggested: actions.filter((action) => action.status === "suggested").length,
+    blocked: actions.filter((action) => action.status === "blocked").length,
+    unavailable: actions.filter((action) => action.status === "unavailable").length,
+    acknowledged: actions.filter((action) => action.status === "acknowledged").length,
+    reviewRequired: actions.filter((action) => action.manualReviewRequired === true).length,
+    escalationSuggested: actions.filter((action) => action.actionType === "suggest_escalation").length,
+  };
+}
+
+export async function derivePaymentConsistentDecisionInbox(input: {
+  landlordId: string;
+  analyticsDecisions?: LandlordAgentDecision[] | null;
+  leaseDecisions?: Decision[] | null;
+  filters?: Parameters<typeof deriveDecisionInbox>[0]["filters"];
+}): Promise<DecisionInboxResult> {
+  const inbox = deriveDecisionInbox({
+    analyticsDecisions: input.analyticsDecisions || [],
+    leaseDecisions: input.leaseDecisions || [],
+    filters: input.filters,
+  });
+  const items = await suppressSettledPaymentDecisionItems(input.landlordId, inbox.items);
+  return {
+    ...inbox,
+    items,
+    summary: summarizeDecisionInboxItems(items),
+    workflowSummary: summarizeDecisionWorkflowItems(items),
+    automationSummary: summarizeDecisionAutomationItems(items),
+    agentActionSummary: summarizeDecisionAgentActionItems(items),
+  };
+}
+
 router.get("/decision-inbox", requireAuth, requireLandlord, async (req: any, res) => {
   try {
     const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
@@ -170,7 +307,8 @@ router.get("/decision-inbox", requireAuth, requireLandlord, async (req: any, res
       deriveLeaseDecisionsForInbox(landlordId),
     ]);
 
-    const inbox = deriveDecisionInbox({
+    const inbox = await derivePaymentConsistentDecisionInbox({
+      landlordId,
       analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
       leaseDecisions,
       filters: {
@@ -206,7 +344,8 @@ router.get("/automated-workflows/preview", requireAuth, requireLandlord, async (
       deriveLeaseDecisionsForInbox(landlordId),
     ]);
 
-    const inbox = deriveDecisionInbox({
+    const inbox = await derivePaymentConsistentDecisionInbox({
+      landlordId,
       analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
       leaseDecisions,
       filters: {
@@ -257,7 +396,8 @@ router.get("/agent-actions/suggestions", requireAuth, requireLandlord, async (re
       deriveLeaseDecisionsForInbox(landlordId),
     ]);
 
-    const inbox = deriveDecisionInbox({
+    const inbox = await derivePaymentConsistentDecisionInbox({
+      landlordId,
       analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
       leaseDecisions,
       filters: {
@@ -309,7 +449,8 @@ router.get("/agent-supervision/snapshot", requireAuth, requireLandlord, async (r
       deriveLeaseDecisionsForInbox(landlordId),
     ]);
 
-    const inbox = deriveDecisionInbox({
+    const inbox = await derivePaymentConsistentDecisionInbox({
+      landlordId,
       analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
       leaseDecisions,
       filters: {

--- a/rentchain-api/src/routes/landlordDecisionQueueRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionQueueRoutes.ts
@@ -2,8 +2,7 @@ import { Router } from "express";
 import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
-import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
-import { deriveLeaseDecisionsForInbox } from "./landlordDecisionInboxRoutes";
+import { deriveLeaseDecisionsForInbox, derivePaymentConsistentDecisionInbox } from "./landlordDecisionInboxRoutes";
 import { getUnifiedInbox } from "../services/unifiedInbox";
 import {
   deriveLandlordDecisionQueue,
@@ -95,7 +94,8 @@ router.get("/decision-queue", requireAuth, requireLandlord, async (req: any, res
       getUnifiedInbox({ role: "landlord", landlordId }, { limit: MAX_LIMIT }),
     ]);
 
-    const decisionInbox = deriveDecisionInbox({
+    const decisionInbox = await derivePaymentConsistentDecisionInbox({
+      landlordId,
       analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
       leaseDecisions,
     });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -44,8 +44,11 @@ import {
 import {
   buildPaymentObligationLedgerRows,
   summarizePaymentObligationLedger,
-  type PaymentObligationCanonicalPaymentInput,
 } from "../lib/payments/paymentObligationLedger";
+import {
+  buildCanonicalPaymentEvidenceFromLedgerEntries,
+  loadLeaseCanonicalPaymentsForObligationLedger,
+} from "../lib/payments/leasePaymentObligationEvidence";
 import {
   deriveDelinquencySignals,
   summarizeDelinquencySignals,
@@ -1804,83 +1807,6 @@ async function loadLeasePaymentIntentsForObligationLedger(leaseId: string, landl
   return (snap?.docs || [])
     .map((doc: any) => ({ paymentIntentId: doc.id, ...((doc.data() as any) || {}) }))
     .filter((record: any) => String(record?.landlordId || "").trim() === landlordId);
-}
-
-async function loadLeaseCanonicalPaymentsForObligationLedger(
-  leaseId: string,
-  landlordId: string
-): Promise<PaymentObligationCanonicalPaymentInput[]> {
-  const snap = await db
-    .collection("payments")
-    .where("leaseId", "==", leaseId)
-    .get()
-    .catch(() => null);
-  return (snap?.docs || [])
-    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
-    .filter((record: any) => String(record?.landlordId || "").trim() === landlordId)
-    .filter((record: any) => {
-      const source = String(record?.source || "").trim().toLowerCase();
-      const status = String(record?.status || "").trim().toLowerCase();
-      if (source === "rent_payment_checkout") return false;
-      return !status || status === "recorded" || status === "paid" || status === "completed";
-    })
-    .map((record: any) => ({
-      id: String(record?.id || "").trim(),
-      paymentDocumentId: String(record?.paymentDocumentId || record?.id || "").trim() || null,
-      leaseId: String(record?.leaseId || "").trim(),
-      tenantId: String(record?.tenantId || "").trim(),
-      landlordId: String(record?.landlordId || "").trim(),
-      propertyId: String(record?.propertyId || "").trim() || null,
-      unitId: String(record?.unitId || "").trim() || null,
-      amountCents: Math.max(0, Math.round(Number(record?.amountCents || 0))),
-      currency: String(record?.currency || "cad").trim().toLowerCase() || "cad",
-      status: String(record?.status || "recorded").trim().toLowerCase() || "recorded",
-      paidAt: String(record?.paidAt || "").trim() || null,
-      effectiveDate: String(record?.effectiveDate || record?.paidAt || "").trim() || null,
-      method: String(record?.method || "").trim() || null,
-      reference: String(record?.reference || "").trim() || null,
-      source: String(record?.source || "").trim() || null,
-      ledgerEntryId: String(record?.ledgerEntryId || "").trim() || null,
-    }));
-}
-
-function buildCanonicalPaymentEvidenceFromLedgerEntries(
-  entries: any[],
-  existingPayments: PaymentObligationCanonicalPaymentInput[]
-): PaymentObligationCanonicalPaymentInput[] {
-  const existingPaymentDocumentIds = new Set(
-    existingPayments.map((payment) => String(payment.paymentDocumentId || payment.id || "").trim()).filter(Boolean)
-  );
-  const existingLedgerEntryIds = new Set(
-    existingPayments.map((payment) => String(payment.ledgerEntryId || "").trim()).filter(Boolean)
-  );
-  return (entries || [])
-    .filter((entry: any) => String(entry?.entryType || entry?.type || "").trim().toLowerCase() === "payment")
-    .filter((entry: any) => {
-      const entryId = String(entry?.id || "").trim();
-      const paymentDocumentId = String(entry?.paymentDocumentId || "").trim();
-      if (entryId && existingLedgerEntryIds.has(entryId)) return false;
-      if (paymentDocumentId && existingPaymentDocumentIds.has(paymentDocumentId)) return false;
-      return true;
-    })
-    .map((entry: any) => ({
-      id: String(entry?.paymentDocumentId || entry?.id || "").trim(),
-      paymentDocumentId: String(entry?.paymentDocumentId || "").trim() || null,
-      leaseId: String(entry?.leaseId || "").trim(),
-      tenantId: String(entry?.tenantId || "").trim() || null,
-      landlordId: String(entry?.landlordId || "").trim() || null,
-      propertyId: String(entry?.propertyId || "").trim() || null,
-      unitId: String(entry?.unitId || "").trim() || null,
-      amountCents: Math.max(0, Math.round(Number(entry?.amountCents || 0))),
-      currency: "cad",
-      status: "recorded",
-      paidAt: String(entry?.paidAt || entry?.effectiveDate || "").trim() || null,
-      effectiveDate: String(entry?.effectiveDate || entry?.paidAt || "").trim() || null,
-      method: String(entry?.method || "").trim() || null,
-      reference: String(entry?.reference || "").trim() || null,
-      source: String(entry?.source || "ledger_entry_payment").trim() || "ledger_entry_payment",
-      ledgerEntryId: String(entry?.id || "").trim() || null,
-    }));
 }
 
 async function loadLeaseReconciliationRecordsForObligationLedger(params: {

--- a/rentchain-api/src/services/landlordDecisionQueue/__tests__/landlordDecisionQueueService.test.ts
+++ b/rentchain-api/src/services/landlordDecisionQueue/__tests__/landlordDecisionQueueService.test.ts
@@ -15,6 +15,7 @@ function decisionInboxItem(overrides: Partial<DecisionInboxItem> = {}): Decision
     relatedEntity: { kind: "lease", id: "lease-1", label: "Lease 1" },
     destination: "/leases/lease-1/ledger",
     automationEligible: false,
+    dueAt: null,
     workflow: {
       queue: "delinquency_review",
       workflowState: "new",
@@ -62,6 +63,7 @@ describe("landlordDecisionQueueService", () => {
           severity: "critical",
           type: "billing",
           destination: "/leases/lease-1/ledger",
+          dueAt: "2026-05-01T00:00:00.000Z",
         }),
       ],
     });
@@ -78,6 +80,7 @@ describe("landlordDecisionQueueService", () => {
       ["decision_queue:decision_inbox:payment-critical", "critical", "payments"],
       ["decision_queue:decision_inbox:lease-warning", "warning", "lease"],
     ]);
+    expect(queue.items.find((item) => item.sourceId === "payment-critical")?.dueAt).toBe("2026-05-01T00:00:00.000Z");
   });
 
   it("includes messaging source types without importing the entire inbox as critical work", () => {

--- a/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueService.ts
+++ b/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueService.ts
@@ -200,7 +200,7 @@ export function normalizeDecisionInboxItems(
       description: asString(item.description, 500) || "Review this decision context.",
       recommendedActionLabel: "Review",
       recommendedActionHref: safeHref(item.destination, "/operations"),
-      dueAt: null,
+      dueAt: normalizeDate(item.dueAt),
       createdAt: normalizeDate(item.createdAt),
       updatedAt: normalizeDate(item.updatedAt),
       status: statusFromDecisionInbox(item.status),

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -676,6 +676,62 @@ describe("OperationalCommandCenterPage", () => {
     expect(mocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ title: "Operational command center" }));
   });
 
+  it("does not recreate a missing-payment review card when the decision inbox suppresses a paid ledger", async () => {
+    mocks.fetchDecisionInbox.mockResolvedValueOnce({
+      items: [],
+      filters: { severity: [], status: [], type: [], queue: [], workflowState: [], escalationLevel: [] },
+      summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+      workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
+      automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+      agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
+    });
+    mocks.getActiveLeasesForLandlord.mockResolvedValueOnce({
+      leases: [
+        lease({
+          id: "76c2961b-eae5-4574-9f51-66096976b5dc",
+          paymentReadiness: {
+            readinessStatus: "ready_to_configure",
+            readinessLabel: "Payment setup ready",
+            readinessDescription: "Rent terms and payment setup are ready.",
+            requiredNextAction: "none",
+            rentTerms: {
+              rentAmountAvailable: true,
+              dueDateAvailable: true,
+              leaseDatesAvailable: true,
+              tenantLinked: true,
+              leaseExecuted: true,
+            },
+            paymentSetup: {
+              processorConnected: true,
+              moneyMovementEnabled: true,
+              storedPaymentMethod: true,
+            },
+          },
+          stateCoherence: { ...lease().stateCoherence, flags: { ...lease().stateCoherence.flags, requiresReview: false, hasStateConflict: false } },
+          leaseExecution: { ...lease().leaseExecution, executionStatus: "fully_executed" },
+          signatureStatus: "signed",
+          leasePdfStatus: "ready",
+          jurisdictionPolicies: [],
+          endDate: "2027-07-31",
+        }),
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <OperationalCommandCenterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Operational command center" })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchDecisionInbox).toHaveBeenCalled());
+
+    expect(screen.queryByText("Payment Ledger Review")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Review Missing Payment/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Decision inbox · Delinquency Review/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Financial status: Review required/i)).not.toBeInTheDocument();
+  });
+
   it("keeps free-safe operations content visible when lease-driven signals are locked", async () => {
     mocks.useEntitlements.mockReturnValue({
       loading: false,


### PR DESCRIPTION
## Summary

Aligns landlord payment decision signals with the richer lease-ledger payment evidence path used by `/leases/:leaseId/ledger`.

- Extracts canonical/imported payment and ledger-entry payment evidence loading into a shared backend helper.
- Uses that shared evidence in `deriveLeaseDecisionsForInbox(...)` before deriving delinquency decisions.
- Keeps the lease ledger route on the same evidence conversion path.
- Treats ledger-entry payment amounts with ledger semantics, including signed/negative payment entries.
- Treats reconciled canonical payments as valid obligation evidence, matching existing payment status vocabulary and the lease ledger paid/reconciled state.
- Suppresses stale active payment decisions after decision inbox normalization when current lease obligation evidence is paid/overpaid with outstanding `$0.00`.
- Routes Dashboard decision queue derivation through the same settled-payment-aware decision inbox result used by `/operations`.
- Resolves persisted lease aliases (`id` / `leaseId`) and evaluates all candidate lease identifiers on payment decisions, including stale `relatedEntity.id` values and visible `/leases/:leaseId/ledger` destination ids.
- Requires analytics-derived payment decisions to validate against a live unsettled lease obligation before they remain visible; unresolved/stale analytics payment decisions are suppressed.
- Carries safe due-date and obligation amount context into genuine payment decisions, and forwards due dates to the Dashboard decision queue when a valid payment decision remains.
- Preserves genuine missing-payment decisions when ledger evidence still shows an unpaid obligation.

## Scope

Backend runtime change plus one frontend test-only regression for the Operations page path.

Changed files are limited to payment evidence helpers, landlord decision inbox/queue routes, decision inbox/queue projection helpers, and tests.

No frontend runtime display changes, no payment model changes, no financial-record mutation, no PAD/payment processing, no dashboard redesign, no ledger redesign, no schema changes, and no Operations UI runtime changes.

## QA Repair Notes

Manual QA found that `/dashboard` and `/operations` could still show active `Review Missing Payment` items after the earlier repair. This update covers the actual rendered paths:

- `/operations` uses `/api/landlord/decision-inbox`.
- `/dashboard` uses `/api/landlord/decision-queue?status=open_state&limit=6`.
- Both routes now depend on the same settled-payment-aware inbox result.
- Persisted/stale analytics payment decisions are suppressed unless live ledger evidence proves an unsettled obligation.
- A paid/reconciled ledger with expected `$1,500`, paid `$1,500`, outstanding `$0.00`, and no delinquency signals suppresses the active missing-payment card.
- Reconciled canonical payment evidence is counted as settlement evidence, so overpaid/up-to-date ledgers are not reclassified as missing payment.
- The exact QA lease `76c2961b-eae5-4574-9f51-66096976b5dc` is covered by route-level tests for the decision inbox and Dashboard decision queue paths.
- The exact overpaid/up-to-date QA lease `bd89a684-7e0a-439e-9b88-29d11de1bcfe` is covered by route-level tests for the decision inbox and Dashboard decision queue paths.
- A genuine overdue lease shape matching `y7XM6BFXIzWW0fV3mu1L` with outstanding `$2,000.00` is still emitted with safe due-date and amount context.

## Backend Parity Status

Option B validation is currently the only completed PR-head backend validation.

The Vercel preview rewrites `/api/:path*` to the shared Cloud Run backend at `https://rentchain-landlord-api-915921057662.us-central1.run.app/api/:path*`. Until that Cloud Run backend is deployed to this PR head, manual browser QA against the Vercel preview validates the deployed backend, not this PR backend code.

## Validation

Passed against PR head:

- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- landlordDecisionInboxRoutes.test.ts landlordDecisionQueueRoutes.test.ts deriveDecisionInbox.test.ts landlordDecisionQueueService.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` in `rentchain-frontend`
- `git diff --check`

Route-level coverage now includes:

- `/api/landlord/decision-inbox`
- `/api/landlord/decision-queue?status=open_state&limit=6`
- paid/reconciled lease `76c2961b-eae5-4574-9f51-66096976b5dc`
- overpaid/up-to-date lease `bd89a684-7e0a-439e-9b88-29d11de1bcfe`
- genuine overdue lease `y7XM6BFXIzWW0fV3mu1L`
- due-date and outstanding amount context for genuine unpaid decisions

Attempted but blocked locally before test execution:

- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- OperationalCommandCenterPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test:single -- OperationalCommandCenterPage.test.tsx`

Both local frontend test attempts failed at Vitest worker startup with `ERR_REQUIRE_ESM` from `html-encoding-sniffer` requiring `@exodus/bytes/encoding-lite.js`. The new Operations regression is test-only and frontend build passed; CI frontend check should remain the source of truth for that test runner in this environment.

Earlier validation on this PR: `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- leaseRoutes.integrity.test.ts` passed with local socket permission; sandbox-only runs of this suite can fail with `listen EPERM` because Supertest binds a local listener.

## Preview QA Notes

Manual preview QA is not valid for this PR backend until the backend serving `/api` contains this PR head.

After backend deployment/parity is confirmed, manual QA should verify:

- `/operations`: no `Payment Ledger Review / Review Missing Payment` remains for lease `76c2961b-eae5-4574-9f51-66096976b5dc` when its ledger shows expected `$1,500`, paid `$1,500`, outstanding `$0.00`, and up-to-date status.
- `/dashboard`: no false critical `Review Missing Payment` remains for the same lease.
- `/operations` and `/dashboard`: no false missing-payment card remains for overpaid/up-to-date lease `bd89a684-7e0a-439e-9b88-29d11de1bcfe`.
- `/dashboard`: genuine payment decisions, if present in preview data, still open `/leases/:leaseId/ledger` and include due context rather than `No due date`.
- `/leases/:leaseId/ledger`: paid/overpaid/outstanding state remains correct and no financial record values were altered.
- Regression surfaces: `/leases`, `/operations`, `/portfolio-health?entry=lease-renewals`.

## Deferred Follow-ups

Kept separate from this PR:

- `audit/dashboard-payment-decision-queue-clarity-v1`
- `audit/leases-table-status-layout-clarity-v1`
- `fix/operations-manual-review-assignment-persistence-v1`
- `audit/operations-navigation-visibility-v1`
- `feat/operations-priority-routing-export-v1`