### PR TITLE
fix: persist operations manual review assignments

### DIFF
--- a/rentchain-api/src/lib/operatorReviews/buildOperatorReviewSession.ts
+++ b/rentchain-api/src/lib/operatorReviews/buildOperatorReviewSession.ts
@@ -3,11 +3,15 @@ import type {
   OperatorReviewActor,
   OperatorReviewCloseRequest,
   OperatorReviewEvidenceReference,
+  OperatorReviewManualMetadata,
+  OperatorReviewManualMetadataUpdateRequest,
   OperatorReviewNote,
   OperatorReviewNoteRequest,
   OperatorReviewOpenRequest,
   OperatorReviewOutcome,
   OperatorReviewOutcomeResult,
+  OperatorManualAssignmentTarget,
+  OperatorManualReviewStatus,
   OperatorReviewScope,
   OperatorReviewSession,
   OperatorReviewStatus,
@@ -28,6 +32,23 @@ const VALID_OUTCOMES = new Set<OperatorReviewOutcomeResult>([
   "unresolved",
 ]);
 const VALID_CLOSE_STATUSES = new Set<OperatorReviewStatus>(["completed", "escalated", "abandoned"]);
+const VALID_MANUAL_REVIEW_STATUSES = new Set<OperatorManualReviewStatus>([
+  "open",
+  "needs_review",
+  "in_review",
+  "awaiting_information",
+  "blocked",
+  "resolved",
+  "closed",
+]);
+const VALID_MANUAL_ASSIGNMENT_TARGETS = new Set<OperatorManualAssignmentTarget>([
+  "unassigned",
+  "operations",
+  "property_manager",
+  "finance_reviewer",
+  "document_reviewer",
+  "screening_reviewer",
+]);
 
 function asString(value: unknown, max = 1000): string {
   return String(value ?? "").trim().slice(0, max);
@@ -60,6 +81,15 @@ export function operatorReviewSessionId(input: {
   scopeId: string;
 }): string {
   const clean = cleanIdPart(["operator_review", input.landlordId, input.scope, input.scopeId].join(":"));
+  return clean || crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+export function operatorReviewManualMetadataId(input: {
+  landlordId: string;
+  scope: OperatorReviewScope;
+  scopeId: string;
+}): string {
+  const clean = cleanIdPart(["operator_review_manual_metadata", input.landlordId, input.scope, input.scopeId].join(":"));
   return clean || crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex");
 }
 
@@ -164,6 +194,43 @@ export function normalizeOperatorReviewSession(raw: unknown): OperatorReviewSess
   };
 }
 
+export function normalizeOperatorReviewManualMetadata(raw: unknown): OperatorReviewManualMetadata | null {
+  const data = (raw || {}) as Record<string, unknown>;
+  const manualMetadataId = asString(data.manualMetadataId || data.id, 240);
+  const landlordId = asString(data.landlordId, 240);
+  const scope = asString(data.scope, 80) as OperatorReviewScope;
+  const scopeId = asString(data.scopeId, 500);
+  const reviewStatus = asString(data.reviewStatus, 80) as OperatorManualReviewStatus;
+  const assignmentTarget = asString(data.assignmentTarget, 80) as OperatorManualAssignmentTarget;
+  const createdAt = toIsoDate(data.createdAt);
+  const updatedAt = toIsoDate(data.updatedAt) || createdAt;
+  if (
+    !manualMetadataId ||
+    !landlordId ||
+    !VALID_SCOPES.has(scope) ||
+    !scopeId ||
+    !VALID_MANUAL_REVIEW_STATUSES.has(reviewStatus) ||
+    !VALID_MANUAL_ASSIGNMENT_TARGETS.has(assignmentTarget) ||
+    !createdAt ||
+    !updatedAt
+  ) {
+    return null;
+  }
+  return {
+    manualMetadataId,
+    landlordId,
+    scope,
+    scopeId,
+    reviewStatus,
+    assignmentTarget,
+    manualOnly: true,
+    systemGenerated: false,
+    createdAt,
+    updatedAt,
+    updatedBy: normalizeOperatorReviewActor(data.updatedBy),
+  };
+}
+
 export function parseOperatorReviewOpenRequest(body: unknown): OperatorReviewOpenRequest | null {
   const data = (body || {}) as Record<string, unknown>;
   const scope = asString(data.scope, 80) as OperatorReviewScope;
@@ -174,6 +241,30 @@ export function parseOperatorReviewOpenRequest(body: unknown): OperatorReviewOpe
     scopeId,
     linkedEvidence: normalizeEvidenceReferences(data.linkedEvidence),
     note: sanitizeOperatorReviewNote(data.note) || null,
+  };
+}
+
+export function parseOperatorReviewManualMetadataUpdateRequest(
+  body: unknown
+): OperatorReviewManualMetadataUpdateRequest | null {
+  const data = (body || {}) as Record<string, unknown>;
+  const scope = asString(data.scope, 80) as OperatorReviewScope;
+  const scopeId = asString(data.scopeId, 500);
+  const reviewStatus = asString(data.reviewStatus, 80) as OperatorManualReviewStatus;
+  const assignmentTarget = asString(data.assignmentTarget, 80) as OperatorManualAssignmentTarget;
+  if (
+    !VALID_SCOPES.has(scope) ||
+    !scopeId ||
+    !VALID_MANUAL_REVIEW_STATUSES.has(reviewStatus) ||
+    !VALID_MANUAL_ASSIGNMENT_TARGETS.has(assignmentTarget)
+  ) {
+    return null;
+  }
+  return {
+    scope,
+    scopeId,
+    reviewStatus,
+    assignmentTarget,
   };
 }
 
@@ -232,6 +323,35 @@ export function buildOperatorReviewSession(input: {
     manualOnly: true,
     systemGenerated: false,
     updatedAt: openedAt,
+  };
+}
+
+export function buildOperatorReviewManualMetadata(input: {
+  landlordId: string;
+  request: OperatorReviewManualMetadataUpdateRequest;
+  actor: OperatorReviewActor;
+  existing?: OperatorReviewManualMetadata | null;
+  now?: string;
+}): OperatorReviewManualMetadata {
+  const updatedAt = toIsoDate(input.now) || new Date().toISOString();
+  return {
+    manualMetadataId:
+      input.existing?.manualMetadataId ||
+      operatorReviewManualMetadataId({
+        landlordId: input.landlordId,
+        scope: input.request.scope,
+        scopeId: input.request.scopeId,
+      }),
+    landlordId: input.landlordId,
+    scope: input.request.scope,
+    scopeId: input.request.scopeId,
+    reviewStatus: input.request.reviewStatus,
+    assignmentTarget: input.request.assignmentTarget,
+    manualOnly: true,
+    systemGenerated: false,
+    createdAt: input.existing?.createdAt || updatedAt,
+    updatedAt,
+    updatedBy: input.actor,
   };
 }
 

--- a/rentchain-api/src/lib/operatorReviews/operatorReviewTypes.ts
+++ b/rentchain-api/src/lib/operatorReviews/operatorReviewTypes.ts
@@ -1,4 +1,5 @@
 export const OPERATOR_REVIEW_SESSIONS_COLLECTION = "operatorReviewSessions";
+export const OPERATOR_REVIEW_MANUAL_METADATA_COLLECTION = "operatorReviewManualMetadata";
 
 export type OperatorReviewScope =
   | "decision"
@@ -8,6 +9,21 @@ export type OperatorReviewScope =
   | "audit_compliance";
 
 export type OperatorReviewStatus = "open" | "completed" | "escalated" | "abandoned";
+export type OperatorManualReviewStatus =
+  | "open"
+  | "needs_review"
+  | "in_review"
+  | "awaiting_information"
+  | "blocked"
+  | "resolved"
+  | "closed";
+export type OperatorManualAssignmentTarget =
+  | "unassigned"
+  | "operations"
+  | "property_manager"
+  | "finance_reviewer"
+  | "document_reviewer"
+  | "screening_reviewer";
 
 export type OperatorReviewOutcomeResult =
   | "reviewed"
@@ -62,6 +78,20 @@ export type OperatorReviewSession = {
   updatedAt: string;
 };
 
+export type OperatorReviewManualMetadata = {
+  manualMetadataId: string;
+  landlordId: string;
+  scope: OperatorReviewScope;
+  scopeId: string;
+  reviewStatus: OperatorManualReviewStatus;
+  assignmentTarget: OperatorManualAssignmentTarget;
+  manualOnly: true;
+  systemGenerated: false;
+  createdAt: string;
+  updatedAt: string;
+  updatedBy: OperatorReviewActor;
+};
+
 export type OperatorReviewOpenRequest = {
   scope: OperatorReviewScope;
   scopeId: string;
@@ -79,8 +109,16 @@ export type OperatorReviewCloseRequest = {
   status?: OperatorReviewStatus | null;
 };
 
+export type OperatorReviewManualMetadataUpdateRequest = {
+  scope: OperatorReviewScope;
+  scopeId: string;
+  reviewStatus: OperatorManualReviewStatus;
+  assignmentTarget: OperatorManualAssignmentTarget;
+};
+
 export type OperatorReviewEventType =
   | "operator_review_session_opened"
   | "operator_review_note_added"
   | "operator_review_outcome_recorded"
-  | "operator_review_session_closed";
+  | "operator_review_session_closed"
+  | "operator_review_manual_metadata_updated";

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -216,6 +216,7 @@ async function buildRuntimeOwnershipApp() {
   const messagesRoutes = (await import("../messagesRoutes")).default;
   const landlordEvidencePackRoutes = (await import("../landlordEvidencePackRoutes")).default;
   const landlordEvidencePackageGenerationRoutes = (await import("../landlordEvidencePackageGenerationRoutes")).default;
+  const landlordOperatorReviewRoutes = (await import("../landlordOperatorReviewRoutes")).default;
   const internalReportsRoutes = (await import("../internalReportsRoutes")).default;
   const telemetryRoutes = (await import("../telemetryRoutes")).default;
   const screeningRoutes = (await import("../screeningRoutes")).default;
@@ -233,6 +234,7 @@ async function buildRuntimeOwnershipApp() {
   app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
   app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
   app.use("/api/landlord", routeSource("landlordEvidencePackageGenerationRoutes.ts"), landlordEvidencePackageGenerationRoutes);
+  app.use("/api/landlord", routeSource("landlordOperatorReviewRoutes.ts"), landlordOperatorReviewRoutes);
   app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
   app.get("/api/__probe/revision", routeSource("app.build.ts:/api/__probe/revision"), (_req, res) =>
     res.json({
@@ -511,6 +513,36 @@ describe("API route ownership regression", () => {
     expect(res.headers["x-route-source"]).toBe("leaseRoutes.ts");
     expect(res.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
     expect(res.body?.error).not.toBe("Not Found");
+  });
+
+  it("keeps operator review manual metadata owned by operator review routes before screening job fallback", async () => {
+    authState.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.test" };
+    const app = await buildRuntimeOwnershipApp();
+
+    const res = await invokeApp(app, {
+      method: "PUT",
+      url: "/api/landlord/operator-reviews/manual-metadata",
+      headers: { authorization: "Bearer landlord-token" },
+      body: {
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("landlordOperatorReviewRoutes.ts");
+    expect(res.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
+    expect(res.body?.metadata).toEqual(
+      expect.objectContaining({
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+        manualOnly: true,
+      })
+    );
   });
 
   it("keeps telemetry and screening history owned by explicit routers before screening job fallback", async () => {

--- a/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
@@ -208,6 +208,96 @@ describe("landlordOperatorReviewRoutes", () => {
     expect(res.body.sessions).toEqual([]);
   });
 
+  it("persists landlord-scoped manual review metadata and rehydrates it by scope", async () => {
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+
+    const update = await invokeRouter(router, {
+      method: "PUT",
+      url: "/operator-reviews/manual-metadata",
+      body: {
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+      },
+    });
+
+    expect(update.status).toBe(200);
+    expect(update.body.metadata).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+        manualOnly: true,
+        systemGenerated: false,
+      })
+    );
+
+    const list = await invokeRouter(router, {
+      method: "GET",
+      url: "/operator-reviews/manual-metadata?scope=decision&scopeId=decision-1",
+    });
+
+    expect(list.status).toBe(200);
+    expect(list.body.metadata).toEqual([
+      expect.objectContaining({
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+      }),
+    ]);
+    expect(listDocs("canonicalEvents")).toEqual([
+      expect.objectContaining({
+        eventType: "operator_review_manual_metadata_updated",
+        visibility: "landlord_operator_internal",
+        appendOnly: true,
+        rawIdsIncluded: false,
+      }),
+    ]);
+  });
+
+  it("keeps manual review metadata isolated per landlord", async () => {
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+    await invokeRouter(router, {
+      method: "PUT",
+      url: "/operator-reviews/manual-metadata",
+      body: {
+        scope: "workflow",
+        scopeId: "lease-coherence:lease-1",
+        reviewStatus: "blocked",
+        assignmentTarget: "property_manager",
+      },
+    });
+
+    mockUser = { id: "landlord-2", landlordId: "landlord-2", role: "landlord", email: "other@example.com" };
+    const list = await invokeRouter(router, { method: "GET", url: "/operator-reviews/manual-metadata" });
+
+    expect(list.status).toBe(200);
+    expect(list.body.metadata).toEqual([]);
+  });
+
+  it("fails closed for invalid manual review metadata values", async () => {
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "PUT",
+      url: "/operator-reviews/manual-metadata",
+      body: {
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "active",
+        assignmentTarget: "landlord_owner",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("OPERATOR_REVIEW_MANUAL_METADATA_INVALID");
+    expect(listDocs("operatorReviewManualMetadata")).toEqual([]);
+  });
+
   it("blocks non-landlord users", async () => {
     mockUser = { id: "tenant-1", role: "tenant" };
     const router = (await import("../landlordOperatorReviewRoutes")).default;

--- a/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
@@ -298,6 +298,25 @@ describe("landlordOperatorReviewRoutes", () => {
     expect(listDocs("operatorReviewManualMetadata")).toEqual([]);
   });
 
+  it("requires authentication for manual review metadata updates", async () => {
+    mockUser = null;
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "PUT",
+      url: "/operator-reviews/manual-metadata",
+      body: {
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    expect(listDocs("operatorReviewManualMetadata")).toEqual([]);
+  });
+
   it("blocks non-landlord users", async () => {
     mockUser = { id: "tenant-1", role: "tenant" };
     const router = (await import("../landlordOperatorReviewRoutes")).default;

--- a/rentchain-api/src/routes/landlordOperatorReviewRoutes.ts
+++ b/rentchain-api/src/routes/landlordOperatorReviewRoutes.ts
@@ -5,17 +5,22 @@ import { requireLandlord } from "../middleware/requireLandlord";
 import { appendCanonicalAuditEvent, safeAuditReference } from "../lib/canonicalAudit/appendCanonicalAuditEvent";
 import {
   addOperatorReviewNote,
+  buildOperatorReviewManualMetadata,
   buildOperatorReviewSession,
   closeOperatorReviewSession,
+  normalizeOperatorReviewManualMetadata,
   normalizeOperatorReviewActor,
   normalizeOperatorReviewSession,
+  parseOperatorReviewManualMetadataUpdateRequest,
   parseOperatorReviewCloseRequest,
   parseOperatorReviewNoteRequest,
   parseOperatorReviewOpenRequest,
 } from "../lib/operatorReviews/buildOperatorReviewSession";
 import {
+  OPERATOR_REVIEW_MANUAL_METADATA_COLLECTION,
   OPERATOR_REVIEW_SESSIONS_COLLECTION,
   type OperatorReviewEventType,
+  type OperatorReviewManualMetadata,
   type OperatorReviewScope,
   type OperatorReviewSession,
 } from "../lib/operatorReviews/operatorReviewTypes";
@@ -82,12 +87,57 @@ async function writeReviewEvent(input: {
   });
 }
 
+async function writeManualMetadataEvent(input: {
+  metadata: OperatorReviewManualMetadata;
+  previous: OperatorReviewManualMetadata | null;
+  actor: ReturnType<typeof actorFromReq>;
+}) {
+  await appendCanonicalAuditEvent({
+    eventType: "operator_review_manual_metadata_updated",
+    actor: {
+      role: input.actor.role,
+      operatorRef: input.actor.userId,
+      rawIdsIncluded: false,
+    },
+    authority: {
+      role: input.actor.role,
+      landlordRef: input.metadata.landlordId,
+      supportAllowed: false,
+      rawIdsIncluded: false,
+    },
+    sourceReferenceId: input.metadata.manualMetadataId,
+    timestamp: input.metadata.updatedAt,
+    visibility: "landlord_operator_internal",
+    metadata: {
+      reviewSessionId: safeAuditReference("manual_review_metadata", input.metadata.manualMetadataId),
+      scope: input.metadata.scope,
+      scopeId: safeAuditReference("review_scope", input.metadata.scopeId),
+      reviewStatus: input.metadata.reviewStatus,
+      assignmentTarget: input.metadata.assignmentTarget,
+      previousReviewStatus: input.previous?.reviewStatus || null,
+      previousAssignmentTarget: input.previous?.assignmentTarget || null,
+      noteSummary: "Manual review metadata updated.",
+      manualOnly: true,
+      metadataOnly: true,
+      rawIdsIncluded: false,
+    },
+  });
+}
+
 async function loadSessionForLandlord(reviewSessionId: string, landlordId: string) {
   const snap = await db.collection(OPERATOR_REVIEW_SESSIONS_COLLECTION).doc(reviewSessionId).get();
   if (!snap.exists) return null;
   const session = normalizeOperatorReviewSession({ id: snap.id, ...((snap.data() as any) || {}) });
   if (!session || session.landlordId !== landlordId) return null;
   return session;
+}
+
+async function loadManualMetadataForLandlord(manualMetadataId: string, landlordId: string) {
+  const snap = await db.collection(OPERATOR_REVIEW_MANUAL_METADATA_COLLECTION).doc(manualMetadataId).get();
+  if (!snap.exists) return null;
+  const metadata = normalizeOperatorReviewManualMetadata({ id: snap.id, ...((snap.data() as any) || {}) });
+  if (!metadata || metadata.landlordId !== landlordId) return null;
+  return metadata;
 }
 
 router.get("/operator-reviews", requireAuth, requireLandlord, async (req: any, res) => {
@@ -133,6 +183,52 @@ router.post("/operator-reviews", requireAuth, requireLandlord, async (req: any, 
   } catch (err: any) {
     console.error("[landlordOperatorReviewRoutes] open failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_OPEN_FAILED" });
+  }
+});
+
+router.get("/operator-reviews/manual-metadata", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const scope = asString(req.query?.scope, 80) as OperatorReviewScope;
+    const scopeId = asString(req.query?.scopeId, 500);
+    let query: any = db.collection(OPERATOR_REVIEW_MANUAL_METADATA_COLLECTION).where("landlordId", "==", landlordId);
+    if (scope) query = query.where("scope", "==", scope);
+    if (scopeId) query = query.where("scopeId", "==", scopeId);
+    const snap = await query.get();
+    const metadata = (snap.docs || [])
+      .map((doc: any) => normalizeOperatorReviewManualMetadata({ id: doc.id, ...((doc.data() as any) || {}) }))
+      .filter(Boolean)
+      .sort((a: OperatorReviewManualMetadata, b: OperatorReviewManualMetadata) => b.updatedAt.localeCompare(a.updatedAt));
+    return res.json({ ok: true, metadata });
+  } catch (err: any) {
+    console.error("[landlordOperatorReviewRoutes] manual metadata list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_MANUAL_METADATA_LIST_FAILED" });
+  }
+});
+
+router.put("/operator-reviews/manual-metadata", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const request = parseOperatorReviewManualMetadataUpdateRequest(req.body);
+    if (!landlordId || !request) {
+      return res.status(400).json({ ok: false, error: "OPERATOR_REVIEW_MANUAL_METADATA_INVALID" });
+    }
+    const actor = actorFromReq(req);
+    const manualMetadataId = buildOperatorReviewManualMetadata({ landlordId, request, actor }).manualMetadataId;
+    const previous = await loadManualMetadataForLandlord(manualMetadataId, landlordId);
+    const metadata = buildOperatorReviewManualMetadata({
+      landlordId,
+      request,
+      actor,
+      existing: previous,
+    });
+    await db.collection(OPERATOR_REVIEW_MANUAL_METADATA_COLLECTION).doc(metadata.manualMetadataId).set(metadata, { merge: false });
+    await writeManualMetadataEvent({ metadata, previous, actor });
+    return res.json({ ok: true, metadata });
+  } catch (err: any) {
+    console.error("[landlordOperatorReviewRoutes] manual metadata update failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_MANUAL_METADATA_UPDATE_FAILED" });
   }
 });
 

--- a/rentchain-api/src/types/canonicalAuditEvent.ts
+++ b/rentchain-api/src/types/canonicalAuditEvent.ts
@@ -9,6 +9,7 @@ export const CANONICAL_AUDIT_EVENT_TYPES = [
   "operator_review_note_added",
   "operator_review_outcome_recorded",
   "operator_review_session_closed",
+  "operator_review_manual_metadata_updated",
 ] as const;
 
 export type CanonicalAuditEventType = (typeof CANONICAL_AUDIT_EVENT_TYPES)[number];
@@ -69,6 +70,9 @@ export type OperatorReviewAuditMetadata = {
   scope: string;
   scopeId: string;
   reviewStatus: string;
+  assignmentTarget?: string;
+  previousReviewStatus?: string | null;
+  previousAssignmentTarget?: string | null;
   noteSummary?: string;
   outcome?: string | null;
   manualOnly: true;

--- a/rentchain-frontend/src/api/operatorReviewApi.ts
+++ b/rentchain-frontend/src/api/operatorReviewApi.ts
@@ -8,6 +8,21 @@ export type OperatorReviewScope =
   | "audit_compliance";
 
 export type OperatorReviewStatus = "open" | "completed" | "escalated" | "abandoned";
+export type OperatorManualReviewStatus =
+  | "open"
+  | "needs_review"
+  | "in_review"
+  | "awaiting_information"
+  | "blocked"
+  | "resolved"
+  | "closed";
+export type OperatorManualAssignmentTarget =
+  | "unassigned"
+  | "operations"
+  | "property_manager"
+  | "finance_reviewer"
+  | "document_reviewer"
+  | "screening_reviewer";
 
 export type OperatorReviewOutcomeResult =
   | "reviewed"
@@ -58,6 +73,19 @@ export type OperatorReviewSession = {
   updatedAt: string;
 };
 
+export type OperatorReviewManualMetadata = {
+  manualMetadataId: string;
+  landlordId: string;
+  scope: OperatorReviewScope;
+  scopeId: string;
+  reviewStatus: OperatorManualReviewStatus;
+  assignmentTarget: OperatorManualAssignmentTarget;
+  manualOnly: true;
+  systemGenerated: false;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type OpenOperatorReviewSessionInput = {
   scope: OperatorReviewScope;
   scopeId: string;
@@ -71,6 +99,13 @@ export type CloseOperatorReviewSessionInput = {
   status?: OperatorReviewStatus;
 };
 
+export type UpdateOperatorReviewManualMetadataInput = {
+  scope: OperatorReviewScope;
+  scopeId: string;
+  reviewStatus: OperatorManualReviewStatus;
+  assignmentTarget: OperatorManualAssignmentTarget;
+};
+
 export async function fetchOperatorReviewSessions(params: {
   scope: OperatorReviewScope;
   scopeId: string;
@@ -80,6 +115,33 @@ export async function fetchOperatorReviewSessions(params: {
     `/landlord/operator-reviews?${search.toString()}`
   );
   return response.sessions || [];
+}
+
+export async function fetchOperatorReviewManualMetadata(params: {
+  scope?: OperatorReviewScope;
+  scopeId?: string;
+} = {}): Promise<OperatorReviewManualMetadata[]> {
+  const search = new URLSearchParams();
+  if (params.scope) search.set("scope", params.scope);
+  if (params.scopeId) search.set("scopeId", params.scopeId);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; metadata: OperatorReviewManualMetadata[] }>(
+    `/landlord/operator-reviews/manual-metadata${suffix}`
+  );
+  return response.metadata || [];
+}
+
+export async function updateOperatorReviewManualMetadata(
+  input: UpdateOperatorReviewManualMetadataInput
+): Promise<OperatorReviewManualMetadata> {
+  const response = await apiFetch<{ ok: true; metadata: OperatorReviewManualMetadata }>(
+    "/landlord/operator-reviews/manual-metadata",
+    {
+      method: "PUT",
+      body: input,
+    }
+  );
+  return response.metadata;
 }
 
 export async function openOperatorReviewSession(

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { OperationalReviewQueue, type OperationalReviewQueueItem } from "./OperationalReviewQueue";
 
@@ -26,6 +26,8 @@ function queueItem(overrides: Partial<OperationalReviewQueueItem> = {}): Operati
     visibilityClass: "landlord_operational",
     evidenceLabel: "Payments / obligations source workflow",
     relatedResourceLabel: "North Towers · Unit 104 · James Smith",
+    manualReviewScope: "decision",
+    manualReviewScopeId: "decision-1",
     manualOnly: true,
     autonomousActionsEnabled: false,
     ...overrides,
@@ -200,7 +202,7 @@ describe("OperationalReviewQueue", () => {
     expect(parseInt(cancelStyle.minHeight, 10)).toBeGreaterThanOrEqual(44);
   });
 
-  it("prevents auto-submit and requires explicit confirmation for mobile UX", () => {
+  it("prevents auto-submit and requires explicit confirmation for mobile UX", async () => {
     render(
       <MemoryRouter>
         <OperationalReviewQueue items={[queueItem()]} />
@@ -226,7 +228,7 @@ describe("OperationalReviewQueue", () => {
     fireEvent.click(confirmButton);
 
     // Now should show updated status
-    expect(screen.getByText("Manual assignment: Finance reviewer")).toBeInTheDocument();
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Manual assignment: Finance reviewer")).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 });

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
@@ -1,7 +1,11 @@
 import React, { memo, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
-import { ReviewAssignmentStatusControls } from "./ReviewAssignmentStatusControls";
+import {
+  ReviewAssignmentStatusControls,
+  type ReviewAssignmentTarget,
+  type ReviewLifecycleStatus,
+} from "./ReviewAssignmentStatusControls";
 
 export type OperationalReviewQueueItem = {
   queueItemId: string;
@@ -20,6 +24,8 @@ export type OperationalReviewQueueItem = {
   visibilityClass: string;
   evidenceLabel: string;
   relatedResourceLabel: string;
+  manualReviewScope: string;
+  manualReviewScopeId: string;
   manualOnly: true;
   autonomousActionsEnabled: false;
 };
@@ -47,7 +53,16 @@ function metadata(labelText: string, value: string | null | undefined) {
   );
 }
 
-const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({ item }: { item: OperationalReviewQueueItem }) {
+const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
+  item,
+  onManualReviewChange,
+}: {
+  item: OperationalReviewQueueItem;
+  onManualReviewChange?: (
+    item: OperationalReviewQueueItem,
+    next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }
+  ) => void | Promise<void>;
+}) {
   const display = useMemo(
     () => ({
       title: safeDisplayLabel(item.title, "Operational review item"),
@@ -131,6 +146,7 @@ const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({ it
         title={display.title}
         initialStatus={item.reviewStatus}
         initialAssignment={item.assignmentLabel}
+        onChange={(next) => onManualReviewChange?.(item, next)}
       />
 
       <div style={{ display: "grid", gap: 5 }}>
@@ -172,7 +188,16 @@ const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({ it
   );
 });
 
-export const OperationalReviewQueue = memo(function OperationalReviewQueue({ items }: { items: OperationalReviewQueueItem[] }) {
+export const OperationalReviewQueue = memo(function OperationalReviewQueue({
+  items,
+  onManualReviewChange,
+}: {
+  items: OperationalReviewQueueItem[];
+  onManualReviewChange?: (
+    item: OperationalReviewQueueItem,
+    next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }
+  ) => void | Promise<void>;
+}) {
   const assignedCount = useMemo(
     () => items.filter((item) => !/^unassigned$/i.test(item.assignmentLabel)).length,
     [items]
@@ -216,7 +241,7 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({ ite
           }}
         >
           {items.map((item) => (
-            <OperationalReviewQueueCard key={item.queueItemId} item={item} />
+            <OperationalReviewQueueCard key={item.queueItemId} item={item} onManualReviewChange={onManualReviewChange} />
           ))}
         </div>
       ) : (

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewAssignmentStatusControls.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewAssignmentStatusControls.tsx
@@ -96,6 +96,11 @@ function selectedAssignmentReason(value: ReviewAssignmentTarget) {
   return REVIEW_ASSIGNMENT_OPTIONS.find((option) => option.value === value)?.reason || REVIEW_ASSIGNMENT_OPTIONS[0].reason;
 }
 
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Manual review metadata could not be saved.";
+}
+
 export function ReviewAssignmentStatusControls({
   itemId,
   title,
@@ -107,7 +112,7 @@ export function ReviewAssignmentStatusControls({
   title: string;
   initialStatus: string;
   initialAssignment: string;
-  onChange?: (next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }) => void;
+  onChange?: (next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }) => void | Promise<void>;
 }) {
   const [status, setStatus] = React.useState<ReviewLifecycleStatus>(() => normalizeReviewLifecycleStatus(initialStatus));
   const [assignment, setAssignment] = React.useState<ReviewAssignmentTarget>(() =>
@@ -117,6 +122,8 @@ export function ReviewAssignmentStatusControls({
   const [showConfirmation, setShowConfirmation] = React.useState<boolean>(false);
   const [pendingStatus, setPendingStatus] = React.useState<ReviewLifecycleStatus | null>(null);
   const [pendingAssignment, setPendingAssignment] = React.useState<ReviewAssignmentTarget | null>(null);
+  const [saving, setSaving] = React.useState<boolean>(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     setStatus(normalizeReviewLifecycleStatus(initialStatus));
@@ -131,6 +138,7 @@ export function ReviewAssignmentStatusControls({
       setPendingStatus(nextStatus);
       setPendingChanges(true);
       setShowConfirmation(true);
+      setSaveError(null);
     }
   }
 
@@ -139,19 +147,25 @@ export function ReviewAssignmentStatusControls({
       setPendingAssignment(nextAssignment);
       setPendingChanges(true);
       setShowConfirmation(true);
+      setSaveError(null);
     }
   }
 
-  function confirmChanges() {
-    if (pendingStatus !== null) {
-      setStatus(pendingStatus);
-      onChange?.({ status: pendingStatus, assignment });
+  async function confirmChanges() {
+    const nextStatus = pendingStatus ?? status;
+    const nextAssignment = pendingAssignment ?? assignment;
+    try {
+      setSaving(true);
+      setSaveError(null);
+      await onChange?.({ status: nextStatus, assignment: nextAssignment });
+      setStatus(nextStatus);
+      setAssignment(nextAssignment);
+      resetPendingState();
+    } catch (error) {
+      setSaveError(errorMessage(error));
+    } finally {
+      setSaving(false);
     }
-    if (pendingAssignment !== null) {
-      setAssignment(pendingAssignment);
-      onChange?.({ status, assignment: pendingAssignment });
-    }
-    resetPendingState();
   }
 
   function cancelChanges() {
@@ -163,6 +177,7 @@ export function ReviewAssignmentStatusControls({
     setPendingAssignment(null);
     setPendingChanges(false);
     setShowConfirmation(false);
+    setSaveError(null);
   }
 
   return (
@@ -242,6 +257,12 @@ export function ReviewAssignmentStatusControls({
         <span>Review status note: {selectedStatusDescription(pendingStatus ?? status)}</span>
       </div>
 
+      {saveError ? (
+        <div role="alert" style={{ color: "#b91c1c", fontSize: 12, fontWeight: 800, lineHeight: 1.4 }}>
+          {saveError}
+        </div>
+      ) : null}
+
       {showConfirmation && (
         <div
           role="dialog"
@@ -268,24 +289,26 @@ export function ReviewAssignmentStatusControls({
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <button
               onClick={confirmChanges}
+              disabled={saving}
               style={{
-                backgroundColor: "#059669",
+                backgroundColor: saving ? "#94a3b8" : "#059669",
                 color: "#fff",
                 border: "none",
                 borderRadius: 6,
                 padding: "10px 16px",
                 fontSize: 14,
                 fontWeight: 600,
-                cursor: "pointer",
+                cursor: saving ? "not-allowed" : "pointer",
                 minHeight: 44,
                 minWidth: 80,
               }}
               aria-describedby={`${itemId}-confirm-help`}
             >
-              Confirm changes
+              {saving ? "Saving..." : "Confirm changes"}
             </button>
             <button
               onClick={cancelChanges}
+              disabled={saving}
               style={{
                 backgroundColor: "#6b7280",
                 color: "#fff",
@@ -294,7 +317,7 @@ export function ReviewAssignmentStatusControls({
                 padding: "10px 16px",
                 fontSize: 14,
                 fontWeight: 600,
-                cursor: "pointer",
+                cursor: saving ? "not-allowed" : "pointer",
                 minHeight: 44,
                 minWidth: 80,
               }}

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.test.tsx
@@ -16,6 +16,8 @@ function workspace(overrides: Partial<ReviewWorkspaceUiModel> = {}): ReviewWorks
     reviewPriority: "Critical",
     routingReason: "Delinquency or payment evidence review",
     assignmentLabel: "Operations owned",
+    manualReviewScope: "decision",
+    manualReviewScopeId: "decision-1",
     sensitivityClass: "sensitive",
     visibilityClass: "landlord_operational",
     manualOnly: true,

--- a/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/ReviewWorkspacePanel.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
-import { ReviewAssignmentStatusControls } from "./ReviewAssignmentStatusControls";
+import {
+  ReviewAssignmentStatusControls,
+  type ReviewAssignmentTarget,
+  type ReviewLifecycleStatus,
+} from "./ReviewAssignmentStatusControls";
 
 export type ReviewWorkspaceUiLink = {
   label: string;
@@ -21,6 +25,8 @@ export type ReviewWorkspaceUiModel = {
   reviewPriority: string;
   routingReason: string;
   assignmentLabel: string;
+  manualReviewScope: string;
+  manualReviewScopeId: string;
   sensitivityClass: "sensitive" | "restricted" | string;
   visibilityClass: "landlord_operational" | "admin_support" | string;
   manualOnly: true;
@@ -49,7 +55,16 @@ function metadataCell(labelText: string, value: string) {
   );
 }
 
-export function ReviewWorkspacePanel({ workspace }: { workspace: ReviewWorkspaceUiModel }) {
+export function ReviewWorkspacePanel({
+  workspace,
+  onManualReviewChange,
+}: {
+  workspace: ReviewWorkspaceUiModel;
+  onManualReviewChange?: (
+    workspace: ReviewWorkspaceUiModel,
+    next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }
+  ) => void | Promise<void>;
+}) {
   return (
     <Card
       style={{
@@ -111,6 +126,7 @@ export function ReviewWorkspacePanel({ workspace }: { workspace: ReviewWorkspace
         title={label(workspace.workspaceType)}
         initialStatus={workspace.reviewStatus}
         initialAssignment={workspace.assignmentLabel}
+        onChange={(next) => onManualReviewChange?.(workspace, next)}
       />
 
       <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
@@ -185,7 +201,7 @@ export function ReviewWorkspacePanel({ workspace }: { workspace: ReviewWorkspace
       </div>
 
       <div style={{ color: "#64748b", fontSize: 12 }}>
-        Internal workspace reference: {safeLabel(workspace.workspaceReference, "Manual review handoff preview")}
+        Internal workspace reference: Manual review handoff preview
       </div>
     </Card>
   );

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   fetchDecisionInbox: vi.fn(),
   fetchDashboardSummary: vi.fn(),
   getActiveLeasesForLandlord: vi.fn(),
+  fetchOperatorReviewManualMetadata: vi.fn(),
+  updateOperatorReviewManualMetadata: vi.fn(),
   fetchProperties: vi.fn(),
   macShellProps: vi.fn(),
   useEntitlements: vi.fn(),
@@ -36,6 +38,15 @@ vi.mock("@/api/leasesApi", async () => {
   return {
     ...actual,
     getActiveLeasesForLandlord: mocks.getActiveLeasesForLandlord,
+  };
+});
+
+vi.mock("@/api/operatorReviewApi", async () => {
+  const actual = await vi.importActual<any>("@/api/operatorReviewApi");
+  return {
+    ...actual,
+    fetchOperatorReviewManualMetadata: mocks.fetchOperatorReviewManualMetadata,
+    updateOperatorReviewManualMetadata: mocks.updateOperatorReviewManualMetadata,
   };
 });
 
@@ -379,7 +390,7 @@ describe("deriveCommandCenterSignals", () => {
     const preview = reviewWorkspacePreviewForSignal(sourceSignal!);
     expect(preview).toEqual(
       expect.objectContaining({
-        workspaceReference: "manual-review-preview:payments:critical",
+        workspaceReference: "manual-review-preview:decision:decision-1",
         workspaceType: "payment_ledger_review",
         reviewStatus: "Open",
         reviewPriority: "Critical",
@@ -556,6 +567,8 @@ describe("OperationalCommandCenterPage", () => {
     mocks.fetchDecisionInbox.mockReset();
     mocks.fetchDashboardSummary.mockReset();
     mocks.getActiveLeasesForLandlord.mockReset();
+    mocks.fetchOperatorReviewManualMetadata.mockReset();
+    mocks.updateOperatorReviewManualMetadata.mockReset();
     mocks.fetchProperties.mockReset();
     mocks.macShellProps.mockReset();
     mocks.useEntitlements.mockReset();
@@ -587,6 +600,19 @@ describe("OperationalCommandCenterPage", () => {
       events: [],
     });
     mocks.getActiveLeasesForLandlord.mockResolvedValue({ leases: [lease()] });
+    mocks.fetchOperatorReviewManualMetadata.mockResolvedValue([]);
+    mocks.updateOperatorReviewManualMetadata.mockImplementation(async (input: any) => ({
+      manualMetadataId: `metadata:${input.scope}:${input.scopeId}`,
+      landlordId: "landlord-1",
+      scope: input.scope,
+      scopeId: input.scopeId,
+      reviewStatus: input.reviewStatus,
+      assignmentTarget: input.assignmentTarget,
+      manualOnly: true,
+      systemGenerated: false,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    }));
     mocks.fetchProperties.mockResolvedValue({
       properties: [
         {
@@ -781,6 +807,80 @@ describe("OperationalCommandCenterPage", () => {
     fireEvent.change(screen.getByLabelText("Search operational items"), { target: { value: "no matching workflow" } });
     expect(screen.getByText("No operational items match this triage view.")).toBeInTheDocument();
     expect(screen.getByText(/Current filters:/)).toBeInTheDocument();
+  });
+
+  it("rehydrates persisted manual review metadata for payment and non-payment operations cards", async () => {
+    mocks.fetchOperatorReviewManualMetadata.mockResolvedValueOnce([
+      {
+        manualMetadataId: "metadata:decision:decision-1",
+        landlordId: "landlord-1",
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+        manualOnly: true,
+        systemGenerated: false,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      },
+      {
+        manualMetadataId: "metadata:workflow:lease-coherence:lease-1",
+        landlordId: "landlord-1",
+        scope: "workflow",
+        scopeId: "lease-coherence:lease-1",
+        reviewStatus: "blocked",
+        assignmentTarget: "property_manager",
+        manualOnly: true,
+        systemGenerated: false,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <OperationalCommandCenterPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(mocks.fetchOperatorReviewManualMetadata).toHaveBeenCalled());
+
+    expect(screen.getAllByText("Review status: In review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Assignment: Finance reviewer").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review status: Blocked").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Assignment: Property manager").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual status: In review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual assignment: Finance reviewer").length).toBeGreaterThan(0);
+  });
+
+  it("persists manual review status and assigned reviewer changes from Operations controls", async () => {
+    render(
+      <MemoryRouter>
+        <OperationalCommandCenterPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0));
+
+    fireEvent.change(screen.getAllByLabelText("Review status for Review missing payment")[0], {
+      target: { value: "in_review" },
+    });
+    fireEvent.change(screen.getAllByLabelText("Assigned reviewer for Review missing payment")[0], {
+      target: { value: "finance_reviewer" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm changes/i }));
+
+    await waitFor(() =>
+      expect(mocks.updateOperatorReviewManualMetadata).toHaveBeenCalledWith({
+        scope: "decision",
+        scopeId: "decision-1",
+        reviewStatus: "in_review",
+        assignmentTarget: "finance_reviewer",
+      })
+    );
+
+    await waitFor(() => expect(screen.getAllByText("Manual status: In review").length).toBeGreaterThan(0));
+    expect(screen.getAllByText("Assignment: Finance reviewer").length).toBeGreaterThan(0);
   });
 
   it("supports combined triage facets while preserving search and reset behavior", async () => {

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -8,6 +8,12 @@ import {
   type DecisionInboxResponse,
 } from "@/api/decisionInboxApi";
 import { getActiveLeasesForLandlord, type LandlordActiveLease } from "@/api/leasesApi";
+import {
+  fetchOperatorReviewManualMetadata,
+  updateOperatorReviewManualMetadata,
+  type OperatorReviewManualMetadata,
+  type OperatorReviewScope,
+} from "@/api/operatorReviewApi";
 import { fetchProperties, type Property } from "@/api/propertiesApi";
 import { MacShell } from "@/components/layout/MacShell";
 import { LockedFeature } from "@/components/billing/LockedFeature";
@@ -15,6 +21,12 @@ import {
   OperationalReviewQueue,
   type OperationalReviewQueueItem,
 } from "@/components/reviewWorkspaces/OperationalReviewQueue";
+import {
+  reviewAssignmentLabel,
+  reviewStatusLabel,
+  type ReviewAssignmentTarget,
+  type ReviewLifecycleStatus,
+} from "@/components/reviewWorkspaces/ReviewAssignmentStatusControls";
 import { ReviewWorkspacePanel, type ReviewWorkspaceUiModel } from "@/components/reviewWorkspaces/ReviewWorkspacePanel";
 import { Card, Section } from "@/components/ui/Ui";
 import { useEntitlements } from "@/hooks/useEntitlements";
@@ -77,6 +89,8 @@ export type CommandCenterSignal = {
   timingState?: "upcoming" | "current";
   riskState?: "delinquent" | "high_risk" | "review" | "informational";
   scopedLeaseId?: string | null;
+  manualReviewScope?: OperatorReviewScope;
+  manualReviewScopeId?: string;
 };
 
 type CategoryConfig = {
@@ -301,6 +315,49 @@ function leaseRenewalWorkflowDestination(leaseId: string) {
   return `/leases/${encodeURIComponent(leaseId)}/workflows/renewal`;
 }
 
+function manualReviewScopeForSignal(signal: CommandCenterSignal): { scope: OperatorReviewScope; scopeId: string } {
+  if (signal.id.startsWith("decision:")) {
+    return { scope: "decision", scopeId: signal.id.replace(/^decision:/, "") };
+  }
+  return { scope: "workflow", scopeId: signal.id };
+}
+
+function manualMetadataKey(scope: OperatorReviewScope, scopeId: string) {
+  return `${scope}:${scopeId}`;
+}
+
+function metadataMap(items: OperatorReviewManualMetadata[]) {
+  const next: Record<string, OperatorReviewManualMetadata> = {};
+  for (const item of items || []) {
+    if (!item?.scope || !item?.scopeId) continue;
+    next[manualMetadataKey(item.scope, item.scopeId)] = item;
+  }
+  return next;
+}
+
+function applyManualReviewMetadata(
+  signals: CommandCenterSignal[],
+  metadataByKey: Record<string, OperatorReviewManualMetadata>
+) {
+  return signals.map((signal) => {
+    const scope = manualReviewScopeForSignal(signal);
+    const metadata = metadataByKey[manualMetadataKey(scope.scope, scope.scopeId)];
+    const base = {
+      ...signal,
+      manualReviewScope: scope.scope,
+      manualReviewScopeId: scope.scopeId,
+    };
+    if (!metadata) return base;
+    const assignmentLabel = reviewAssignmentLabel(metadata.assignmentTarget as ReviewAssignmentTarget);
+    return {
+      ...base,
+      reviewStatus: reviewStatusLabel(metadata.reviewStatus as ReviewLifecycleStatus),
+      assignmentState: metadata.assignmentTarget === "unassigned" ? "unassigned" : "assigned",
+      assignmentLabel,
+    };
+  });
+}
+
 export function scopedSourceDestinationForSignal(signal: CommandCenterSignal) {
   const scopedLeaseId = String(signal.scopedLeaseId || "").trim();
   if (scopedLeaseId && signal.destination === "/leases") return leaseSummaryDestination(scopedLeaseId);
@@ -308,13 +365,18 @@ export function scopedSourceDestinationForSignal(signal: CommandCenterSignal) {
 }
 
 export function reviewWorkspacePreviewForSignal(signal: CommandCenterSignal): ReviewWorkspaceUiModel {
+  const scope = signal.manualReviewScope && signal.manualReviewScopeId
+    ? { scope: signal.manualReviewScope, scopeId: signal.manualReviewScopeId }
+    : manualReviewScopeForSignal(signal);
   return {
-    workspaceReference: `manual-review-preview:${signal.category}:${signal.priorityGroup}`,
+    workspaceReference: `manual-review-preview:${scope.scope}:${scope.scopeId}`,
     workspaceType: workspaceTypeForSignal(signal),
     reviewStatus: signal.reviewStatus,
     reviewPriority: label(signal.priorityGroup),
     routingReason: routingReasonForSignal(signal),
     assignmentLabel: signal.assignmentLabel || "Unassigned",
+    manualReviewScope: scope.scope,
+    manualReviewScopeId: scope.scopeId,
     sensitivityClass: signal.category === "screening" || signal.category === "documents" ? "restricted" : "sensitive",
     visibilityClass: "landlord_operational",
     manualOnly: true,
@@ -357,6 +419,8 @@ export function deriveOperationalReviewQueueItems(signals: CommandCenterSignal[]
       visibilityClass: preview.visibilityClass,
       evidenceLabel: evidenceLink?.label || "Source workflow evidence",
       relatedResourceLabel: relatedResource?.label || "Scoped operational context",
+      manualReviewScope: preview.manualReviewScope,
+      manualReviewScopeId: preview.manualReviewScopeId,
       manualOnly: true,
       autonomousActionsEnabled: false,
     };
@@ -956,6 +1020,7 @@ export default function OperationalCommandCenterPage() {
   const [dashboardData, setDashboardData] = React.useState<DashboardSummaryData | null>(null);
   const [leases, setLeases] = React.useState<LandlordActiveLease[]>([]);
   const [properties, setProperties] = React.useState<Property[]>([]);
+  const [manualReviewMetadata, setManualReviewMetadata] = React.useState<Record<string, OperatorReviewManualMetadata>>({});
   const [leaseSignalsLocked, setLeaseSignalsLocked] = React.useState(false);
   const [search, setSearch] = React.useState("");
   const [activeFilter, setActiveFilter] = React.useState<CommandCenterFilter>("all");
@@ -983,11 +1048,12 @@ export default function OperationalCommandCenterPage() {
                 throw err;
               })
           : Promise.resolve({ locked: true, leases: [] as LandlordActiveLease[] });
-        const [[decisionResponse, dashboardResponse, propertyResponse], leaseResponse] = await Promise.all([
+        const [[decisionResponse, dashboardResponse, propertyResponse, manualMetadataResponse], leaseResponse] = await Promise.all([
           Promise.all([
             fetchDecisionInbox(),
             fetchDashboardSummary(),
             fetchProperties({ status: "active" }),
+            fetchOperatorReviewManualMetadata().catch(() => []),
           ]),
           leaseRequest,
         ]);
@@ -997,6 +1063,7 @@ export default function OperationalCommandCenterPage() {
         setLeases(leaseResponse.leases || []);
         setLeaseSignalsLocked(leaseResponse.locked);
         setProperties(propertyResponse.properties || propertyResponse.items || []);
+        setManualReviewMetadata(metadataMap(manualMetadataResponse || []));
       } catch (err) {
         if (!mounted) return;
         setError(errorMessage(err));
@@ -1009,9 +1076,13 @@ export default function OperationalCommandCenterPage() {
     };
   }, [entitlements.loading, leaseSignalsEnabled]);
 
-  const signals = React.useMemo(
+  const baseSignals = React.useMemo(
     () => deriveCommandCenterSignals({ decisions: decisionData?.items || [], leases, properties }),
     [decisionData?.items, leases, properties]
+  );
+  const signals = React.useMemo(
+    () => applyManualReviewMetadata(baseSignals, manualReviewMetadata),
+    [baseSignals, manualReviewMetadata]
   );
   const visibleSignals = React.useMemo(
     () => filterOperationalItems(signals, { search, filter: activeFilter, workflowType, reviewStatus, assignment, escalation, timingRisk }),
@@ -1038,6 +1109,23 @@ export default function OperationalCommandCenterPage() {
   function clearFilters() {
     setSearch("");
     applySavedView("all_operational");
+  }
+
+  async function persistManualReviewChange(
+    scope: OperatorReviewScope,
+    scopeId: string,
+    next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }
+  ) {
+    const metadata = await updateOperatorReviewManualMetadata({
+      scope,
+      scopeId,
+      reviewStatus: next.status,
+      assignmentTarget: next.assignment,
+    });
+    setManualReviewMetadata((current) => ({
+      ...current,
+      [manualMetadataKey(metadata.scope, metadata.scopeId)]: metadata,
+    }));
   }
 
   return (
@@ -1397,7 +1485,14 @@ export default function OperationalCommandCenterPage() {
               <span>Adjust the view or reset filters to return to the full operational queue.</span>
             </Card>
           ) : null}
-          {!loading && !error && visibleSignals.length ? <OperationalReviewQueue items={reviewQueueItems} /> : null}
+          {!loading && !error && visibleSignals.length ? (
+            <OperationalReviewQueue
+              items={reviewQueueItems}
+              onManualReviewChange={(item, next) =>
+                persistManualReviewChange(item.manualReviewScope as OperatorReviewScope, item.manualReviewScopeId, next)
+              }
+            />
+          ) : null}
           {!loading && !error && visibleSignals.length ? (
             <div style={{ display: "grid", gap: 16 }}>
               {prioritySummary.map((group) => (
@@ -1480,7 +1575,16 @@ export default function OperationalCommandCenterPage() {
                             <span>Assignment: {signal.assignmentLabel || "Unassigned"}</span>
                             <span>Escalation: {signal.escalationLabel || "Not escalated"}</span>
                           </div>
-                          <ReviewWorkspacePanel workspace={reviewWorkspacePreviewForSignal(signal)} />
+                          <ReviewWorkspacePanel
+                            workspace={reviewWorkspacePreviewForSignal(signal)}
+                            onManualReviewChange={(workspace, next) =>
+                              persistManualReviewChange(
+                                workspace.manualReviewScope as OperatorReviewScope,
+                                workspace.manualReviewScopeId,
+                                next
+                              )
+                            }
+                          />
                         </Card>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary
- Add landlord-scoped manual review metadata persistence for Operations review status and assigned reviewer controls.
- Rehydrate persisted metadata into `/operations` signals so full, filtered, queue, and inline card views agree after refresh.
- Keep metadata manual-only: no source lease/payment/ledger/financial records are mutated.
- Add safe audit event coverage for manual metadata updates and remove internal review keys from visible workspace labels.

## Root Cause
The Operations manual review controls only updated local React state. The page did not pass a persistence callback, and generated Operations signals were rebuilt from decision/lease projections on refresh, so manual status and reviewer selections reverted. The inline workspace panel also used a broad `category:priority` key, which was not stable per card.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- landlordOperatorReviewRoutes.test.ts` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm test -- landlordOperatorReviewRoutes.test.ts apiRouteOwnershipRegression.test.ts` in `rentchain-api`
- `npm test -- OperationalCommandCenterPage.test.tsx ReviewAssignmentStatusControls.test.tsx OperationalReviewQueue.test.tsx ReviewWorkspacePanel.test.tsx` in `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` in `rentchain-frontend` (Vite reports its Node 20.19+ recommendation, build succeeds under repo-pinned Node 20.11.1)
- `git diff --check`

## Option B Validation Decision
Browser QA through the Vercel preview was not treated as PR-head backend validation because the preview rewrites `/api/:path*` to the shared Cloud Run backend. That shared backend was not confirmed to be running this PR head before merge.

Accepted PR-head validation is route-level backend coverage plus frontend test/build coverage. The exact endpoint ownership is covered for:

- `PUT /api/landlord/operator-reviews/manual-metadata`
- authenticated landlord success
- unauthenticated denial
- route ownership before the screening fallback

Post-merge Cloud Run QA is required after the backend deploys the merge commit.

## Post-Deploy QA Required
- Confirm Cloud Build image tag / commit matches the merge commit or resulting `main` commit.
- Confirm Cloud Run active revision is serving that image.
- Confirm `/health` and `/api/health` return 200.
- Confirm unauthenticated `PUT /api/landlord/operator-reviews/manual-metadata` returns 401, not 404.
- Authenticated `/operations` QA: save status, refresh, verify persisted; save reviewer, refresh, verify persisted; filter `Review Missing Payment`, verify consistency; navigate to source workflow and return, verify metadata persists.
- Confirm no lease/payment/ledger/financial values changed.
- Confirm no internal review key is visible.

## Manual QA Checklist
- Open `/operations` full view, change manual review status on one card, confirm, refresh, verify persisted state remains.
- Change assigned reviewer on one card, confirm, refresh, verify persisted reviewer remains.
- Filter to `Review Missing Payment`, verify the same persisted metadata appears for the same card.
- Return from a source workflow link to `/operations`, verify persisted metadata still appears.
- Repeat on a non-payment review card if preview data is available.
- Confirm source financial/lease/payment/ledger values are unchanged.

## Scope Guard
- No payment signal derivation changes.
- No financial-record mutation.
- No Dashboard redesign.
- No Operations redesign.
- No CSV/PDF export.
- No PAD/payment processing.
- No Operations navigation changes.