### PR TITLE
fix: clarify dashboard and operations review queues

### DIFF
--- a/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
+++ b/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
@@ -24,6 +24,12 @@ export type LandlordDecisionQueueItem = {
   id: string;
   sourceType: string;
   sourceId: string;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  leaseId?: string | null;
+  maintenanceRequestId?: string | null;
+  noticeId?: string | null;
   workspace: LandlordDecisionQueueWorkspace;
   severity: LandlordDecisionQueueSeverity;
   title: string;

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
@@ -50,6 +50,7 @@ describe("OperationalReviewQueue", () => {
     expect(screen.getByText("Delinquency or payment evidence review")).toBeInTheDocument();
     expect(screen.getAllByText("Operations owned").length).toBeGreaterThan(0);
     expect(screen.getByText("Review required")).toBeInTheDocument();
+    expect(screen.getByText("Details and manual controls")).toBeInTheDocument();
     expect(screen.getByLabelText("Review status for Review missing payment")).toHaveValue("open");
     expect(screen.getByLabelText("Assigned reviewer for Review missing payment")).toHaveValue("operations");
     expect(screen.getByText("Manual status: Open")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
@@ -53,6 +53,15 @@ function metadata(labelText: string, value: string | null | undefined) {
   );
 }
 
+function compactMetadata(labelText: string, value: string | null | undefined) {
+  if (!value) return null;
+  return (
+    <span style={{ color: "#334155", fontSize: 13, fontWeight: 800, lineHeight: 1.35 }}>
+      {labelText}: <span style={{ color: "#0f172a" }}>{value}</span>
+    </span>
+  );
+}
+
 const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
   item,
   onManualReviewChange,
@@ -114,7 +123,7 @@ const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
         padding: 12,
         border: "1px solid rgba(15, 23, 42, 0.08)",
         display: "grid",
-        gap: 10,
+        gap: 12,
         minWidth: 0,
         overflowWrap: "anywhere",
       }}
@@ -130,60 +139,82 @@ const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
 
       <div
         style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+          display: "flex",
+          flexWrap: "wrap",
           gap: 8,
+          alignItems: "center",
           minWidth: 0,
         }}
       >
-        {metadataItems.map((entry) => (
-          <React.Fragment key={entry.labelText}>{metadata(entry.labelText, entry.value)}</React.Fragment>
-        ))}
+        {compactMetadata("Manual status", item.reviewStatus)}
+        {compactMetadata("Assigned reviewer", item.assignmentLabel)}
       </div>
 
-      <ReviewAssignmentStatusControls
-        itemId={item.queueItemId}
-        title={display.title}
-        initialStatus={item.reviewStatus}
-        initialAssignment={item.assignmentLabel}
-        onChange={(next) => onManualReviewChange?.(item, next)}
-      />
+      <Link to={item.destination} style={{
+        color: "#2563eb",
+        fontSize: 14,
+        fontWeight: 900,
+        padding: "8px 0",
+        minHeight: 44,
+        display: "inline-flex",
+        alignItems: "center",
+        textDecoration: "none",
+        borderRadius: 4,
+        width: "fit-content"
+      }}>
+        {display.evidence}
+      </Link>
 
-      <div style={{ display: "grid", gap: 5 }}>
-        <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Scoped evidence/resource links</span>
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-          <Link to={item.destination} style={{
-            color: "#2563eb",
-            fontSize: 14,
-            fontWeight: 900,
-            padding: "8px 0",
-            minHeight: 44,
-            display: "inline-flex",
-            alignItems: "center",
-            textDecoration: "none",
-            borderRadius: 4
-          }}>
-            {display.evidence}
-          </Link>
-          <span
+      <details style={{ borderTop: "1px solid #e2e8f0", paddingTop: 10 }}>
+        <summary style={{ color: "#334155", fontSize: 13, fontWeight: 900, cursor: "pointer", minHeight: 32 }}>
+          Details and manual controls
+        </summary>
+        <div style={{ display: "grid", gap: 10, marginTop: 10 }}>
+          <div
             style={{
-              border: "1px solid #e2e8f0",
-              borderRadius: 999,
-              padding: "8px 12px",
-              color: "#475569",
-              fontSize: 13,
-              fontWeight: 800,
-              background: "#fff",
-              minHeight: 44,
-              display: "inline-flex",
-              alignItems: "center",
-              lineHeight: 1.4,
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+              gap: 8,
+              minWidth: 0,
             }}
           >
-            {display.relatedResource}
-          </span>
+            {metadataItems.map((entry) => (
+              <React.Fragment key={entry.labelText}>{metadata(entry.labelText, entry.value)}</React.Fragment>
+            ))}
+          </div>
+
+          <ReviewAssignmentStatusControls
+            itemId={item.queueItemId}
+            title={display.title}
+            initialStatus={item.reviewStatus}
+            initialAssignment={item.assignmentLabel}
+            onChange={(next) => onManualReviewChange?.(item, next)}
+          />
+
+          <div style={{ display: "grid", gap: 5 }}>
+            <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Related resource context</span>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+              <span
+                style={{
+                  border: "1px solid #e2e8f0",
+                  borderRadius: 999,
+                  padding: "8px 12px",
+                  color: "#475569",
+                  fontSize: 13,
+                  fontWeight: 800,
+                  background: "#fff",
+                  minHeight: 44,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  lineHeight: 1.4,
+                }}
+              >
+                {display.relatedResource}
+              </span>
+            </div>
+          </div>
         </div>
-      </div>
+      </details>
     </Card>
   );
 });

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -192,10 +192,10 @@ function queueResponse(overrides: Partial<LandlordDecisionQueueResponse> = {}): 
         workspace: "payments",
         severity: "upcoming",
         title: "Review outstanding rent",
-        description: "A rent collection item is coming due.",
-        recommendedActionLabel: "Open payments",
-        recommendedActionHref: "/payments",
-        dueAt: null,
+        description: "Outstanding $2,000.00 for the March rent period.",
+        recommendedActionLabel: "Open ledger",
+        recommendedActionHref: "/leases/lease-1/ledger",
+        dueAt: "2026-03-31T00:00:00.000Z",
         createdAt: "2026-06-18T12:00:00.000Z",
         updatedAt: "2026-06-19T12:00:00.000Z",
         status: "pending",
@@ -271,6 +271,15 @@ describe("DashboardPage", () => {
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Decision Queue Preview");
     expect(screen.getByText("Highest-priority decisions needing attention.")).toBeInTheDocument();
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Resolve lease renewal");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("A lease needs a renewal decision before the notice window closes.");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Lease workspace -> Open lease workspace");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Due");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review outstanding rent");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Outstanding $2,000.00 for the March rent period.");
+    expect(screen.getByRole("link", { name: /Open ledger: Review outstanding rent/i })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/ledger"
+    );
     expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Upcoming Actions");
     expect(screen.getByTestId("calendar-preview-section")).toHaveTextContent("Calendar Preview");
     expect(screen.getByTestId("calendar-preview-section")).toHaveTextContent("Resolve lease renewal");
@@ -295,7 +304,6 @@ describe("DashboardPage", () => {
     expect(mocks.fetchUnifiedInboxMock).toHaveBeenCalledWith("landlord");
     expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.queryByText("payment-1")).not.toBeInTheDocument();
-    expect(screen.queryByText("A lease needs a renewal decision before the notice window closes.")).not.toBeInTheDocument();
   });
 
   it("keeps decision queue content visible when portfolio data fails", async () => {
@@ -354,7 +362,7 @@ describe("DashboardPage", () => {
     renderDashboard();
 
     expect(await screen.findByText("No open decisions. New operational decisions will appear here before routing to their owning workspace.")).toBeInTheDocument();
-    expect(screen.getByText("No dated actions are due right now. When lease, payment, notice, or maintenance decisions have dates, they appear here.")).toBeInTheDocument();
+    expect(screen.getByText("No upcoming dated actions are due right now. Reviewable work may still appear in Decision Queue Preview or the Operations review queue.")).toBeInTheDocument();
     expect(screen.getByText("No dated schedule items are visible for this week. Upcoming dated decisions will appear here.")).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -272,7 +272,7 @@ describe("DashboardPage", () => {
     expect(screen.getByText("Highest-priority decisions needing attention.")).toBeInTheDocument();
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Resolve lease renewal");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("A lease needs a renewal decision before the notice window closes.");
-    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Lease workspace -> Open lease workspace");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Lease · Open lease workspace");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Due");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review outstanding rent");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Outstanding $2,000.00 for the March rent period.");
@@ -281,6 +281,7 @@ describe("DashboardPage", () => {
       "/leases/lease-1/ledger"
     );
     expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Upcoming Actions");
+    expect(screen.getByRole("link", { name: /Open Operations/i })).toHaveAttribute("href", "/operations");
     expect(screen.getByTestId("calendar-preview-section")).toHaveTextContent("Calendar Preview");
     expect(screen.getByTestId("calendar-preview-section")).toHaveTextContent("Resolve lease renewal");
     expect(screen.getByRole("link", { name: /Open Full Schedule/i })).toHaveAttribute("href", "/scheduling");
@@ -304,6 +305,111 @@ describe("DashboardPage", () => {
     expect(mocks.fetchUnifiedInboxMock).toHaveBeenCalledWith("landlord");
     expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.queryByText("payment-1")).not.toBeInTheDocument();
+  });
+
+  it("uses specific Dashboard decision destination labels for common RC1 cards", async () => {
+    mocks.fetchLandlordDecisionQueueMock.mockResolvedValue(
+      queueResponse({
+        items: [
+          {
+            id: "applications-decision",
+            sourceType: "application",
+            sourceId: "application-source",
+            workspace: "operations",
+            severity: "needs_review",
+            title: "Review submitted applications",
+            description: "Submitted applications are ready for review.",
+            recommendedActionLabel: "Review",
+            recommendedActionHref: "/applications?entry=application-funnel&status=SUBMITTED",
+            dueAt: null,
+            createdAt: "2026-06-18T12:00:00.000Z",
+            updatedAt: "2026-06-19T12:00:00.000Z",
+            status: "open",
+            dedupeKey: "applications",
+            sortKey: "1",
+            priorityRank: 10,
+          },
+          {
+            id: "revenue-decision",
+            sourceType: "analytics",
+            sourceId: "revenue-source",
+            workspace: "payments",
+            severity: "critical",
+            title: "Review revenue pressure",
+            description: "Revenue exposure needs attention.",
+            recommendedActionLabel: "Review",
+            recommendedActionHref: "/analytics?entry=revenue-pressure",
+            dueAt: null,
+            createdAt: "2026-06-18T12:00:00.000Z",
+            updatedAt: "2026-06-19T12:00:00.000Z",
+            status: "open",
+            dedupeKey: "revenue",
+            sortKey: "2",
+            priorityRank: 20,
+          },
+          {
+            id: "vacancy-decision",
+            sourceType: "analytics",
+            sourceId: "vacancy-source",
+            workspace: "lease",
+            severity: "warning",
+            title: "View vacancy readiness",
+            description: "Vacancy readiness needs review.",
+            recommendedActionLabel: "Review",
+            recommendedActionHref: "/analytics?entry=vacancy-readiness",
+            dueAt: null,
+            createdAt: "2026-06-18T12:00:00.000Z",
+            updatedAt: "2026-06-19T12:00:00.000Z",
+            status: "open",
+            dedupeKey: "vacancy",
+            sortKey: "3",
+            priorityRank: 30,
+          },
+          {
+            id: "renewals-decision",
+            sourceType: "lease",
+            sourceId: "renewals-source",
+            workspace: "lease",
+            severity: "needs_review",
+            title: "Open renewals focus",
+            description: "Renewal operator inputs need review.",
+            recommendedActionLabel: "Review",
+            recommendedActionHref: "/portfolio-health?entry=lease-renewals",
+            dueAt: null,
+            createdAt: "2026-06-18T12:00:00.000Z",
+            updatedAt: "2026-06-19T12:00:00.000Z",
+            status: "open",
+            dedupeKey: "renewals",
+            sortKey: "4",
+            priorityRank: 40,
+          },
+        ],
+      })
+    );
+
+    renderDashboard();
+
+    expect(await screen.findByText("Review submitted applications")).toBeInTheDocument();
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Applications · Review funnel");
+    expect(screen.getByRole("link", { name: /Review applications: Review submitted applications/i })).toHaveAttribute(
+      "href",
+      "/applications?entry=application-funnel&status=SUBMITTED"
+    );
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Revenue analytics · Review exposure");
+    expect(screen.getByRole("link", { name: /View revenue analytics: Review revenue pressure/i })).toHaveAttribute(
+      "href",
+      "/analytics?entry=revenue-pressure"
+    );
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Vacancy analytics · Review readiness");
+    expect(screen.getByRole("link", { name: /View vacancy readiness: View vacancy readiness/i })).toHaveAttribute(
+      "href",
+      "/analytics?entry=vacancy-readiness"
+    );
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Lease renewals · Review operator inputs");
+    expect(screen.getByRole("link", { name: /Review renewals: Open renewals focus/i })).toHaveAttribute(
+      "href",
+      "/portfolio-health?entry=lease-renewals"
+    );
   });
 
   it("keeps decision queue content visible when portfolio data fails", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -163,22 +163,47 @@ function decisionTimingLabel(item: LandlordDecisionQueueItem): string {
   return "Action needed";
 }
 
-function decisionDestinationLabel(item: LandlordDecisionQueueItem): string {
-  const label = String(item.recommendedActionLabel || "").trim();
-  if (label) return label;
+function isGenericActionLabel(label: string): boolean {
+  return ["open", "review", "view"].includes(label.trim().toLowerCase());
+}
+
+function decisionDestinationCopy(item: LandlordDecisionQueueItem): { meta: string; action: string } {
   const href = String(item.recommendedActionHref || "").trim();
-  if (href.includes("/ledger")) return "Open ledger";
-  if (href.includes("/applications")) return "Open applications";
-  if (href.includes("/analytics")) return "Open analytics";
-  if (href.includes("/messages")) return "Open messages";
-  if (href.includes("/operations")) return "Open operations";
-  return `Open ${workspaceLabel(item.workspace).toLowerCase()}`;
+  const label = String(item.recommendedActionLabel || "").trim();
+
+  if (href.includes("/applications")) {
+    return { meta: "Applications · Review funnel", action: "Review applications" };
+  }
+  if (href.includes("entry=revenue-pressure")) {
+    return { meta: "Revenue analytics · Review exposure", action: "View revenue analytics" };
+  }
+  if (href.includes("entry=vacancy-readiness")) {
+    return { meta: "Vacancy analytics · Review readiness", action: "View vacancy readiness" };
+  }
+  if (href.includes("entry=lease-renewals")) {
+    return { meta: "Lease renewals · Review operator inputs", action: "Review renewals" };
+  }
+  if (href.includes("/ledger")) {
+    return { meta: "Payment ledger · Review obligation", action: label && !isGenericActionLabel(label) ? label : "Open ledger" };
+  }
+  if (href.includes("/messages")) {
+    return { meta: "Messages · Review thread", action: label && !isGenericActionLabel(label) ? label : "Open messages" };
+  }
+  if (href.includes("/operations")) {
+    return { meta: "Operations queue · Review work", action: label && !isGenericActionLabel(label) ? label : "Open operations" };
+  }
+  if (label && !isGenericActionLabel(label)) {
+    return { meta: `${workspaceLabel(item.workspace)} · ${label}`, action: label };
+  }
+  return { meta: `${workspaceLabel(item.workspace)} · Review next step`, action: `Open ${workspaceLabel(item.workspace).toLowerCase()}` };
+}
+
+function decisionDestinationLabel(item: LandlordDecisionQueueItem): string {
+  return decisionDestinationCopy(item).action;
 }
 
 function decisionContextLabel(item: LandlordDecisionQueueItem): string {
-  const destination = decisionDestinationLabel(item);
-  if (item.workspace === "payments") return `${workspaceLabel(item.workspace)} decision -> ${destination}`;
-  return `${workspaceLabel(item.workspace)} workspace -> ${destination}`;
+  return decisionDestinationCopy(item).meta;
 }
 
 function decisionReason(item: LandlordDecisionQueueItem): string {
@@ -653,7 +678,7 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
         title="Upcoming Actions"
         subtitle="Time-sensitive next steps from the operations queue."
         action={
-          <Link to="/operations?status=open_state" style={compactButton}>
+          <Link to="/operations" style={compactButton}>
             Open Operations <ArrowRight size={16} />
           </Link>
         }

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -157,6 +157,35 @@ function formatDate(value: string | null | undefined): string {
   return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
 }
 
+function decisionTimingLabel(item: LandlordDecisionQueueItem): string {
+  if (item.dueAt) return `Due ${formatDate(item.dueAt)}`;
+  if (item.severity === "upcoming") return "Upcoming action";
+  return "Action needed";
+}
+
+function decisionDestinationLabel(item: LandlordDecisionQueueItem): string {
+  const label = String(item.recommendedActionLabel || "").trim();
+  if (label) return label;
+  const href = String(item.recommendedActionHref || "").trim();
+  if (href.includes("/ledger")) return "Open ledger";
+  if (href.includes("/applications")) return "Open applications";
+  if (href.includes("/analytics")) return "Open analytics";
+  if (href.includes("/messages")) return "Open messages";
+  if (href.includes("/operations")) return "Open operations";
+  return `Open ${workspaceLabel(item.workspace).toLowerCase()}`;
+}
+
+function decisionContextLabel(item: LandlordDecisionQueueItem): string {
+  const destination = decisionDestinationLabel(item);
+  if (item.workspace === "payments") return `${workspaceLabel(item.workspace)} decision -> ${destination}`;
+  return `${workspaceLabel(item.workspace)} workspace -> ${destination}`;
+}
+
+function decisionReason(item: LandlordDecisionQueueItem): string {
+  const description = String(item.description || "").replace(/\s+/g, " ").trim();
+  return description || "Review the recommended next step for this operational decision.";
+}
+
 function formatShortWeekday(value: Date): string {
   return new Intl.DateTimeFormat(undefined, { weekday: "short" }).format(value);
 }
@@ -575,31 +604,39 @@ function DecisionQueuePreview({ queue }: { queue: LandlordDecisionQueueResponse 
 }
 
 function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
+  const destinationLabel = decisionDestinationLabel(item);
   return (
     <div
       style={{
-        display: "flex",
-        justifyContent: "space-between",
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) auto",
         gap: 12,
-        alignItems: "center",
-        flexWrap: "wrap",
+        alignItems: "start",
         padding: 12,
         border: `1px solid ${colors.border}`,
         borderRadius: 8,
         background: "#fff",
       }}
     >
-      <div style={{ display: "grid", gap: 5, minWidth: 0, flex: "1 1 240px" }}>
+      <div style={{ display: "grid", gap: 7, minWidth: 0 }}>
         <div style={{ fontWeight: 850, color: text.primary, overflowWrap: "anywhere" }}>{item.title || "Review required"}</div>
         <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.35, overflowWrap: "anywhere" }}>
-          {workspaceLabel(item.workspace)} workspace · {formatDate(item.dueAt)}
+          {decisionContextLabel(item)}
         </div>
-        <span style={{ ...severityStyle(item.severity), borderRadius: 8, padding: "3px 8px", fontSize: 12, fontWeight: 850, width: "fit-content", whiteSpace: "nowrap" }}>
-          {item.severity.replace(/_/g, " ")}
-        </span>
+        <div style={{ color: "#334155", fontSize: 13, lineHeight: 1.45, overflowWrap: "anywhere" }}>
+          {decisionReason(item)}
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <span style={{ ...severityStyle(item.severity), borderRadius: 8, padding: "3px 8px", fontSize: 12, fontWeight: 850, width: "fit-content", whiteSpace: "nowrap" }}>
+            {item.severity.replace(/_/g, " ")}
+          </span>
+          <span style={{ color: text.muted, fontSize: 12, fontWeight: 750 }}>
+            {decisionTimingLabel(item)}
+          </span>
+        </div>
       </div>
-      <Link to={operationalHref(item)} style={{ ...compactButton, width: "fit-content" }}>
-        Open
+      <Link to={operationalHref(item)} aria-label={`${destinationLabel}: ${item.title || "Review required"}`} style={{ ...compactButton, width: "fit-content", whiteSpace: "nowrap" }}>
+        {destinationLabel}
       </Link>
     </div>
   );
@@ -623,7 +660,7 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
       />
       {actions.length === 0 ? (
         <div style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: 14, color: text.muted }}>
-          No dated actions are due right now. When lease, payment, notice, or maintenance decisions have dates, they appear here.
+          No upcoming dated actions are due right now. Reviewable work may still appear in Decision Queue Preview or the Operations review queue.
         </div>
       ) : (
         <div style={{ display: "grid", gap: 10 }}>

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -674,7 +674,8 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getByTestId("operational-review-queue")).toBeInTheDocument();
     expect(screen.getByText("Operational review queue")).toBeInTheDocument();
     expect(screen.getByText(/does not create workspaces, route work automatically, or change source records/i)).toBeInTheDocument();
-    expect(screen.getAllByText("Scoped evidence/resource links").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Details and manual controls").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Related resource context").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(1);
     expect(screen.getAllByText(/does not create a workspace, route work automatically, or change source records/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Payment Ledger Review").length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Improves Dashboard Decision Queue Preview cards with clearer decision context, reason text, timing labels, and destination-specific actions.
- Clarifies Upcoming Actions empty state so it does not imply all review work is absent.
- Simplifies Operations review queue cards by keeping primary context/status/assignment/action visible and moving governance metadata, manual controls, and related resource context into a details section.

## Scope guard
- Frontend-only clarity change.
- No payment signal derivation changes.
- No ledger logic changes.
- No manual metadata persistence rewrite.
- No financial-record mutation.
- No dashboard or Operations redesign beyond the approved queue/card clarity scope.
- No PAD/payment processing, CSV/PDF export, or schema changes.

## Validation
- npm run test -- src/pages/DashboardPage.test.tsx src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx src/pages/OperationalCommandCenterPage.test.tsx
- npm run build with Node 20.20.2
- git diff --check

## Manual QA checklist
- /dashboard: Decision Queue Preview is clearer; payment items show due/amount context when available; non-payment destinations are understandable; Upcoming Actions empty state is clearer.
- /operations: cards are more compact/scannable; details section contains secondary governance/source metadata and manual controls; filtering still works.
- Regression: /leases, /portfolio-health?entry=lease-renewals, and one /leases/:leaseId/ledger payment decision route.