### PR TITLE
polish: stabilize operations expanded card layout

### DIFF
--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
@@ -34,6 +34,10 @@ function queueItem(overrides: Partial<OperationalReviewQueueItem> = {}): Operati
   };
 }
 
+function openDetails(title = "Review missing payment") {
+  fireEvent.click(screen.getByRole("button", { name: new RegExp(`Details and manual controls for ${title}`, "i") }));
+}
+
 describe("OperationalReviewQueue", () => {
   it("renders manual-only review queue metadata without action controls", () => {
     render(
@@ -47,25 +51,68 @@ describe("OperationalReviewQueue", () => {
     expect(screen.getByText("Review missing payment")).toBeInTheDocument();
     expect(screen.getAllByText("North Towers · Unit 104 · James Smith").length).toBeGreaterThan(0);
     expect(screen.getByText("Payment Ledger Review")).toBeInTheDocument();
+    expect(screen.getByText("Assigned reviewer: Operations owned")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Details and manual controls for Review missing payment/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Delinquency or payment evidence review")).not.toBeInTheDocument();
+    openDetails();
+    expect(screen.getByRole("button", { name: /Hide details and manual controls for Review missing payment/i })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("operational-review-card-grid")).not.toContainElement(
+      screen.getByTestId("operational-review-details-panel")
+    );
     expect(screen.getByText("Delinquency or payment evidence review")).toBeInTheDocument();
-    expect(screen.getAllByText("Operations owned").length).toBeGreaterThan(0);
     expect(screen.getByText("Review required")).toBeInTheDocument();
-    expect(screen.getByText("Details and manual controls")).toBeInTheDocument();
     expect(screen.getByLabelText("Review status for Review missing payment")).toHaveValue("open");
     expect(screen.getByLabelText("Assigned reviewer for Review missing payment")).toHaveValue("operations");
-    expect(screen.getByText("Manual status: Open")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual status: Open").length).toBeGreaterThan(0);
     expect(screen.getByText("Manual assignment: Operations owned")).toBeInTheDocument();
     expect(screen.getByText(/They do not route work automatically, change source records, or alter financial status/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Payments / obligations source workflow" })).toHaveAttribute(
       "href",
       "/leases/lease-1/ledger"
     );
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
     expect(screen.queryByText(/create review workspace/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/auto.?route/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/mutate ledger/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/institutional sharing/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
+  });
+
+  it("renders one full-width details panel outside the card grid when switching expanded cards", () => {
+    render(
+      <MemoryRouter>
+        <OperationalReviewQueue
+          items={[
+            queueItem(),
+            queueItem({
+              queueItemId: "manual-review-queue:lease:lease-2",
+              title: "Review lease lifecycle",
+              contextLabel: "South Towers · Unit 205",
+              destination: "/leases/lease-2/workflows/renewal",
+              workspaceType: "lease_lifecycle_review",
+              evidenceLabel: "Lease lifecycle source workflow",
+              relatedResourceLabel: "South Towers · Unit 205",
+              manualReviewScope: "workflow",
+              manualReviewScopeId: "lease-2",
+            }),
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    openDetails();
+    expect(screen.getByTestId("operational-review-card-grid")).not.toContainElement(
+      screen.getByTestId("operational-review-details-panel")
+    );
+    expect(screen.getByRole("button", { name: /Hide details and manual controls for Review missing payment/i })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /Details and manual controls for Review lease lifecycle/i })).toHaveAttribute("aria-expanded", "false");
+
+    openDetails("Review lease lifecycle");
+
+    expect(screen.getAllByTestId("operational-review-details-panel")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: /Details and manual controls for Review missing payment/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /Hide details and manual controls for Review lease lifecycle/i })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("operational-review-details-panel")).toHaveTextContent("Review lease lifecycle");
+    expect(screen.getByTestId("operational-review-details-panel")).toHaveTextContent("South Towers · Unit 205");
   });
 
   it("updates manual assignment and status metadata without adding mutation actions", () => {
@@ -74,6 +121,8 @@ describe("OperationalReviewQueue", () => {
         <OperationalReviewQueue items={[queueItem()]} />
       </MemoryRouter>
     );
+
+    openDetails();
 
     fireEvent.change(screen.getByLabelText("Review status for Review missing payment"), {
       target: { value: "in_review" },
@@ -116,6 +165,7 @@ describe("OperationalReviewQueue", () => {
     expect(screen.getByText("Operational review item")).toBeInTheDocument();
     expect(screen.getByText("Operational review context")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open source workflow evidence" })).toBeInTheDocument();
+    openDetails("Operational review item");
     expect(screen.getByText("Scoped resource context")).toBeInTheDocument();
     expect(screen.queryByText(/Decision decision:/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Lease JK6S7JQ2HsMj8m8RFI76/i)).not.toBeInTheDocument();
@@ -138,6 +188,8 @@ describe("OperationalReviewQueue", () => {
         <OperationalReviewQueue items={[queueItem()]} />
       </MemoryRouter>
     );
+
+    openDetails();
 
     // Check that interactive elements have adequate touch target sizing
     const selectElements = container.querySelectorAll('select');
@@ -162,6 +214,8 @@ describe("OperationalReviewQueue", () => {
       </MemoryRouter>
     );
 
+    openDetails();
+
     const statusSelect = screen.getByLabelText("Review status for Review missing payment");
     expect(statusSelect).toHaveAttribute('aria-describedby');
 
@@ -179,6 +233,8 @@ describe("OperationalReviewQueue", () => {
         <OperationalReviewQueue items={[queueItem()]} />
       </MemoryRouter>
     );
+
+    openDetails();
 
     // Change status to trigger confirmation
     fireEvent.change(screen.getByLabelText("Review status for Review missing payment"), {
@@ -211,7 +267,8 @@ describe("OperationalReviewQueue", () => {
     );
 
     // Initially shows current status
-    expect(screen.getByText("Manual status: Open")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual status: Open").length).toBeGreaterThan(0);
+    openDetails();
 
     // Change assignment
     fireEvent.change(screen.getByLabelText("Assigned reviewer for Review missing payment"), {
@@ -219,7 +276,7 @@ describe("OperationalReviewQueue", () => {
     });
 
     // Status should still show original value until confirmed
-    expect(screen.getByText("Manual status: Open")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual status: Open").length).toBeGreaterThan(0);
 
     // Should show pending state
     expect(screen.getByText(/Change pending confirmation/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx
@@ -56,7 +56,7 @@ describe("OperationalReviewQueue", () => {
     expect(screen.queryByText("Delinquency or payment evidence review")).not.toBeInTheDocument();
     openDetails();
     expect(screen.getByRole("button", { name: /Hide details and manual controls for Review missing payment/i })).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByTestId("operational-review-card-grid")).not.toContainElement(
+    expect(screen.getAllByTestId("operational-review-card-row")[0].nextElementSibling).toBe(
       screen.getByTestId("operational-review-details-panel")
     );
     expect(screen.getByText("Delinquency or payment evidence review")).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe("OperationalReviewQueue", () => {
     expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
   });
 
-  it("renders one full-width details panel outside the card grid when switching expanded cards", () => {
+  it("renders one full-width details panel after the row containing the selected card", () => {
     render(
       <MemoryRouter>
         <OperationalReviewQueue
@@ -94,25 +94,39 @@ describe("OperationalReviewQueue", () => {
               manualReviewScope: "workflow",
               manualReviewScopeId: "lease-2",
             }),
+            queueItem({
+              queueItemId: "manual-review-queue:deposit:lease-3",
+              title: "Review deposit issue",
+              contextLabel: "West Towers · Unit 309",
+              destination: "/leases/lease-3/workflows/deposit",
+              workspaceType: "deposit_review",
+              evidenceLabel: "Deposit source workflow",
+              relatedResourceLabel: "West Towers · Unit 309",
+              manualReviewScope: "workflow",
+              manualReviewScopeId: "lease-3",
+            }),
           ]}
         />
       </MemoryRouter>
     );
 
     openDetails();
-    expect(screen.getByTestId("operational-review-card-grid")).not.toContainElement(
-      screen.getByTestId("operational-review-details-panel")
-    );
+    let rows = screen.getAllByTestId("operational-review-card-row");
+    expect(rows[0].nextElementSibling).toBe(screen.getByTestId("operational-review-details-panel"));
     expect(screen.getByRole("button", { name: /Hide details and manual controls for Review missing payment/i })).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: /Details and manual controls for Review lease lifecycle/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /Details and manual controls for Review deposit issue/i })).toHaveAttribute("aria-expanded", "false");
 
-    openDetails("Review lease lifecycle");
+    openDetails("Review deposit issue");
 
+    rows = screen.getAllByTestId("operational-review-card-row");
     expect(screen.getAllByTestId("operational-review-details-panel")).toHaveLength(1);
+    expect(rows[1].nextElementSibling).toBe(screen.getByTestId("operational-review-details-panel"));
     expect(screen.getByRole("button", { name: /Details and manual controls for Review missing payment/i })).toHaveAttribute("aria-expanded", "false");
-    expect(screen.getByRole("button", { name: /Hide details and manual controls for Review lease lifecycle/i })).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByTestId("operational-review-details-panel")).toHaveTextContent("Review lease lifecycle");
-    expect(screen.getByTestId("operational-review-details-panel")).toHaveTextContent("South Towers · Unit 205");
+    expect(screen.getByRole("button", { name: /Details and manual controls for Review lease lifecycle/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /Hide details and manual controls for Review deposit issue/i })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("operational-review-details-panel")).toHaveTextContent("Review deposit issue");
+    expect(screen.getByTestId("operational-review-details-panel")).toHaveTextContent("West Towers · Unit 309");
   });
 
   it("updates manual assignment and status metadata without adding mutation actions", () => {

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from "react";
+import React, { memo, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
 import {
@@ -57,31 +57,47 @@ function compactMetadata(labelText: string, value: string | null | undefined) {
   if (!value) return null;
   return (
     <span style={{ color: "#334155", fontSize: 13, fontWeight: 800, lineHeight: 1.35 }}>
-      {labelText}: <span style={{ color: "#0f172a" }}>{value}</span>
+      {labelText}: {value}
     </span>
   );
 }
 
+function displayForItem(item: OperationalReviewQueueItem) {
+  return {
+    title: safeDisplayLabel(item.title, "Operational review item"),
+    context: safeDisplayLabel(item.contextLabel, "Operational review context"),
+    workspaceType: label(item.workspaceType),
+    sensitivity: label(item.sensitivityClass),
+    visibility: label(item.visibilityClass),
+    evidence: safeDisplayLabel(item.evidenceLabel, "Open source workflow evidence"),
+    relatedResource: safeDisplayLabel(item.relatedResourceLabel, "Scoped resource context"),
+  };
+}
+
+function metadataItemsForItem(item: OperationalReviewQueueItem, display: ReturnType<typeof displayForItem>) {
+  return [
+    { labelText: "Routing reason", value: item.routingReason },
+    { labelText: "Source", value: item.sourceLabel },
+    { labelText: "Review status", value: item.reviewStatus },
+    { labelText: "Assignment", value: item.assignmentLabel },
+    { labelText: "Workflow status", value: item.workflowStatus },
+    { labelText: "Financial status", value: item.financialStatus || null },
+    { labelText: "Sensitivity", value: display.sensitivity },
+    { labelText: "Visibility", value: display.visibility },
+  ];
+}
+
 const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
   item,
-  onManualReviewChange,
+  isExpanded,
+  onToggleDetails,
 }: {
   item: OperationalReviewQueueItem;
-  onManualReviewChange?: (
-    item: OperationalReviewQueueItem,
-    next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }
-  ) => void | Promise<void>;
+  isExpanded: boolean;
+  onToggleDetails: (item: OperationalReviewQueueItem) => void;
 }) {
   const display = useMemo(
-    () => ({
-      title: safeDisplayLabel(item.title, "Operational review item"),
-      context: safeDisplayLabel(item.contextLabel, "Operational review context"),
-      workspaceType: label(item.workspaceType),
-      sensitivity: label(item.sensitivityClass),
-      visibility: label(item.visibilityClass),
-      evidence: safeDisplayLabel(item.evidenceLabel, "Open source workflow evidence"),
-      relatedResource: safeDisplayLabel(item.relatedResourceLabel, "Scoped resource context"),
-    }),
+    () => displayForItem(item),
     [
       item.contextLabel,
       item.evidenceLabel,
@@ -90,29 +106,6 @@ const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
       item.title,
       item.visibilityClass,
       item.workspaceType,
-    ]
-  );
-
-  const metadataItems = useMemo(
-    () => [
-      { labelText: "Routing reason", value: item.routingReason },
-      { labelText: "Source", value: item.sourceLabel },
-      { labelText: "Review status", value: item.reviewStatus },
-      { labelText: "Assignment", value: item.assignmentLabel },
-      { labelText: "Workflow status", value: item.workflowStatus },
-      { labelText: "Financial status", value: item.financialStatus || null },
-      { labelText: "Sensitivity", value: display.sensitivity },
-      { labelText: "Visibility", value: display.visibility },
-    ],
-    [
-      display.sensitivity,
-      display.visibility,
-      item.assignmentLabel,
-      item.financialStatus,
-      item.reviewStatus,
-      item.routingReason,
-      item.sourceLabel,
-      item.workflowStatus,
     ]
   );
 
@@ -165,56 +158,151 @@ const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
         {display.evidence}
       </Link>
 
-      <details style={{ borderTop: "1px solid #e2e8f0", paddingTop: 10 }}>
-        <summary style={{ color: "#334155", fontSize: 13, fontWeight: 900, cursor: "pointer", minHeight: 32 }}>
-          Details and manual controls
-        </summary>
-        <div style={{ display: "grid", gap: 10, marginTop: 10 }}>
-          <div
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        aria-label={`${isExpanded ? "Hide details and manual controls" : "Details and manual controls"} for ${display.title}`}
+        onClick={() => onToggleDetails(item)}
+        style={{
+          border: `1px solid ${isExpanded ? "#93c5fd" : "#dbe3ef"}`,
+          background: isExpanded ? "#eff6ff" : "#ffffff",
+          color: "#1d4ed8",
+          borderRadius: 6,
+          padding: "8px 12px",
+          minHeight: 44,
+          width: "fit-content",
+          fontSize: 13,
+          fontWeight: 900,
+          cursor: "pointer",
+        }}
+      >
+        {isExpanded ? "Hide details and manual controls" : "Details and manual controls"}
+      </button>
+    </Card>
+  );
+});
+
+const OperationalReviewQueueDetailsPanel = memo(function OperationalReviewQueueDetailsPanel({
+  item,
+  onManualReviewChange,
+  onClose,
+}: {
+  item: OperationalReviewQueueItem;
+  onManualReviewChange?: (
+    item: OperationalReviewQueueItem,
+    next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }
+  ) => void | Promise<void>;
+  onClose: () => void;
+}) {
+  const display = useMemo(
+    () => displayForItem(item),
+    [
+      item.contextLabel,
+      item.evidenceLabel,
+      item.relatedResourceLabel,
+      item.sensitivityClass,
+      item.title,
+      item.visibilityClass,
+      item.workspaceType,
+    ]
+  );
+  const metadataItems = useMemo(
+    () => metadataItemsForItem(item, display),
+    [
+      display,
+      item.assignmentLabel,
+      item.financialStatus,
+      item.reviewStatus,
+      item.routingReason,
+      item.sourceLabel,
+      item.workflowStatus,
+    ]
+  );
+
+  return (
+    <Card
+      data-testid="operational-review-details-panel"
+      style={{
+        borderRadius: 10,
+        padding: 14,
+        border: "1px solid #bfdbfe",
+        background: "#f8fbff",
+        display: "grid",
+        gap: 12,
+        minWidth: 0,
+        boxSizing: "border-box",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+        <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+          <span style={{ color: "#1d4ed8", fontSize: 12, fontWeight: 900, textTransform: "uppercase" }}>
+            Details and manual controls
+          </span>
+          <strong style={{ color: "#0f172a", fontSize: 16, overflowWrap: "anywhere" }}>{display.title}</strong>
+          <span style={{ color: "#475569", fontSize: 13, lineHeight: 1.5 }}>{display.context}</span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          style={{
+            border: "1px solid #cbd5e1",
+            background: "#ffffff",
+            color: "#334155",
+            borderRadius: 6,
+            padding: "8px 12px",
+            minHeight: 44,
+            fontSize: 13,
+            fontWeight: 900,
+            cursor: "pointer",
+          }}
+        >
+          Close details
+        </button>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
+          gap: 10,
+          minWidth: 0,
+        }}
+      >
+        {metadataItems.map((entry) => (
+          <React.Fragment key={entry.labelText}>{metadata(entry.labelText, entry.value)}</React.Fragment>
+        ))}
+      </div>
+
+      <ReviewAssignmentStatusControls
+        itemId={item.queueItemId}
+        title={display.title}
+        initialStatus={item.reviewStatus}
+        initialAssignment={item.assignmentLabel}
+        onChange={(next) => onManualReviewChange?.(item, next)}
+      />
+
+      <div style={{ display: "grid", gap: 5 }}>
+        <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Related resource context</span>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <span
             style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
-              gap: 8,
-              minWidth: 0,
+              border: "1px solid #dbe3ef",
+              borderRadius: 999,
+              padding: "8px 12px",
+              color: "#475569",
+              fontSize: 13,
+              fontWeight: 800,
+              background: "#fff",
+              minHeight: 44,
+              display: "inline-flex",
+              alignItems: "center",
+              lineHeight: 1.4,
             }}
           >
-            {metadataItems.map((entry) => (
-              <React.Fragment key={entry.labelText}>{metadata(entry.labelText, entry.value)}</React.Fragment>
-            ))}
-          </div>
-
-          <ReviewAssignmentStatusControls
-            itemId={item.queueItemId}
-            title={display.title}
-            initialStatus={item.reviewStatus}
-            initialAssignment={item.assignmentLabel}
-            onChange={(next) => onManualReviewChange?.(item, next)}
-          />
-
-          <div style={{ display: "grid", gap: 5 }}>
-            <span style={{ color: "#334155", fontSize: 12, fontWeight: 900 }}>Related resource context</span>
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-              <span
-                style={{
-                  border: "1px solid #e2e8f0",
-                  borderRadius: 999,
-                  padding: "8px 12px",
-                  color: "#475569",
-                  fontSize: 13,
-                  fontWeight: 800,
-                  background: "#fff",
-                  minHeight: 44,
-                  display: "inline-flex",
-                  alignItems: "center",
-                  lineHeight: 1.4,
-                }}
-              >
-                {display.relatedResource}
-              </span>
-            </div>
-          </div>
+            {display.relatedResource}
+          </span>
         </div>
-      </details>
+      </div>
     </Card>
   );
 });
@@ -229,10 +317,25 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
     next: { status: ReviewLifecycleStatus; assignment: ReviewAssignmentTarget }
   ) => void | Promise<void>;
 }) {
+  const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
   const assignedCount = useMemo(
     () => items.filter((item) => !/^unassigned$/i.test(item.assignmentLabel)).length,
     [items]
   );
+  const expandedItem = useMemo(
+    () => items.find((item) => item.queueItemId === expandedItemId) || null,
+    [expandedItemId, items]
+  );
+
+  useEffect(() => {
+    if (expandedItemId && !expandedItem) {
+      setExpandedItemId(null);
+    }
+  }, [expandedItem, expandedItemId]);
+
+  const handleToggleDetails = React.useCallback((item: OperationalReviewQueueItem) => {
+    setExpandedItemId((current) => (current === item.queueItemId ? null : item.queueItemId));
+  }, []);
 
   return (
     <Card
@@ -264,6 +367,7 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
 
       {items.length ? (
         <div
+          data-testid="operational-review-card-grid"
           style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
@@ -272,7 +376,12 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
           }}
         >
           {items.map((item) => (
-            <OperationalReviewQueueCard key={item.queueItemId} item={item} onManualReviewChange={onManualReviewChange} />
+            <OperationalReviewQueueCard
+              key={item.queueItemId}
+              item={item}
+              isExpanded={expandedItemId === item.queueItemId}
+              onToggleDetails={handleToggleDetails}
+            />
           ))}
         </div>
       ) : (
@@ -281,6 +390,13 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
           operational queue.
         </div>
       )}
+      {expandedItem ? (
+        <OperationalReviewQueueDetailsPanel
+          item={expandedItem}
+          onManualReviewChange={onManualReviewChange}
+          onClose={() => setExpandedItemId(null)}
+        />
+      ) : null}
     </Card>
   );
 });

--- a/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
+++ b/rentchain-frontend/src/components/reviewWorkspaces/OperationalReviewQueue.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useState } from "react";
+import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
 import {
@@ -85,6 +85,23 @@ function metadataItemsForItem(item: OperationalReviewQueueItem, display: ReturnT
     { labelText: "Sensitivity", value: display.sensitivity },
     { labelText: "Visibility", value: display.visibility },
   ];
+}
+
+const REVIEW_CARD_MIN_WIDTH = 280;
+const REVIEW_CARD_GRID_GAP = 10;
+
+function cardsPerReviewRowForWidth(width: number) {
+  if (!Number.isFinite(width) || width <= 0) return 2;
+  return Math.max(1, Math.floor((width + REVIEW_CARD_GRID_GAP) / (REVIEW_CARD_MIN_WIDTH + REVIEW_CARD_GRID_GAP)));
+}
+
+function chunkReviewRows<T>(items: T[], cardsPerRow: number) {
+  const size = Math.max(1, cardsPerRow);
+  const rows: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    rows.push(items.slice(index, index + size));
+  }
+  return rows;
 }
 
 const OperationalReviewQueueCard = memo(function OperationalReviewQueueCard({
@@ -318,6 +335,8 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
   ) => void | Promise<void>;
 }) {
   const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const [cardsPerRow, setCardsPerRow] = useState(2);
   const assignedCount = useMemo(
     () => items.filter((item) => !/^unassigned$/i.test(item.assignmentLabel)).length,
     [items]
@@ -326,12 +345,30 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
     () => items.find((item) => item.queueItemId === expandedItemId) || null,
     [expandedItemId, items]
   );
+  const itemRows = useMemo(() => chunkReviewRows(items, cardsPerRow), [cardsPerRow, items]);
 
   useEffect(() => {
     if (expandedItemId && !expandedItem) {
       setExpandedItemId(null);
     }
   }, [expandedItem, expandedItemId]);
+
+  useEffect(() => {
+    const updateCardsPerRow = () => {
+      setCardsPerRow(cardsPerReviewRowForWidth(gridRef.current?.clientWidth || 0));
+    };
+
+    updateCardsPerRow();
+
+    if (typeof ResizeObserver !== "undefined" && gridRef.current) {
+      const observer = new ResizeObserver(updateCardsPerRow);
+      observer.observe(gridRef.current);
+      return () => observer.disconnect();
+    }
+
+    window.addEventListener("resize", updateCardsPerRow);
+    return () => window.removeEventListener("resize", updateCardsPerRow);
+  }, []);
 
   const handleToggleDetails = React.useCallback((item: OperationalReviewQueueItem) => {
     setExpandedItemId((current) => (current === item.queueItemId ? null : item.queueItemId));
@@ -368,21 +405,45 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
       {items.length ? (
         <div
           data-testid="operational-review-card-grid"
+          ref={gridRef}
           style={{
             display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
             gap: 10,
             minWidth: 0,
           }}
         >
-          {items.map((item) => (
-            <OperationalReviewQueueCard
-              key={item.queueItemId}
-              item={item}
-              isExpanded={expandedItemId === item.queueItemId}
-              onToggleDetails={handleToggleDetails}
-            />
-          ))}
+          {itemRows.map((row, rowIndex) => {
+            const rowHasExpandedItem = row.some((item) => item.queueItemId === expandedItemId);
+            return (
+              <React.Fragment key={row.map((item) => item.queueItemId).join("|") || rowIndex}>
+                <div
+                  data-testid="operational-review-card-row"
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
+                    gap: 10,
+                    minWidth: 0,
+                  }}
+                >
+                  {row.map((item) => (
+                    <OperationalReviewQueueCard
+                      key={item.queueItemId}
+                      item={item}
+                      isExpanded={expandedItemId === item.queueItemId}
+                      onToggleDetails={handleToggleDetails}
+                    />
+                  ))}
+                </div>
+                {rowHasExpandedItem && expandedItem ? (
+                  <OperationalReviewQueueDetailsPanel
+                    item={expandedItem}
+                    onManualReviewChange={onManualReviewChange}
+                    onClose={() => setExpandedItemId(null)}
+                  />
+                ) : null}
+              </React.Fragment>
+            );
+          })}
         </div>
       ) : (
         <div style={{ color: "#64748b", fontSize: 13, lineHeight: 1.5 }}>
@@ -390,13 +451,6 @@ export const OperationalReviewQueue = memo(function OperationalReviewQueue({
           operational queue.
         </div>
       )}
-      {expandedItem ? (
-        <OperationalReviewQueueDetailsPanel
-          item={expandedItem}
-          onManualReviewChange={onManualReviewChange}
-          onClose={() => setExpandedItemId(null)}
-        />
-      ) : null}
     </Card>
   );
 });

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -675,6 +675,7 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getByText("Operational review queue")).toBeInTheDocument();
     expect(screen.getByText(/does not create workspaces, route work automatically, or change source records/i)).toBeInTheDocument();
     expect(screen.getAllByText("Details and manual controls").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: /Details and manual controls for Review missing payment/i }));
     expect(screen.getAllByText("Related resource context").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(1);
     expect(screen.getAllByText(/does not create a workspace, route work automatically, or change source records/i).length).toBeGreaterThan(0);
@@ -862,6 +863,8 @@ describe("OperationalCommandCenterPage", () => {
     );
 
     await waitFor(() => expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByRole("button", { name: /Details and manual controls for Review missing payment/i }));
 
     fireEvent.change(screen.getAllByLabelText("Review status for Review missing payment")[0], {
       target: { value: "in_review" },


### PR DESCRIPTION
## Summary
- Moves Operations review queue expanded metadata and manual controls out of individual cards into a single full-width detail panel below the card grid.
- Keeps collapsed Operations cards compact and consistent while preserving visible manual status, assigned reviewer, and source workflow links.
- Allows one expanded card at a time and keeps manual review controls accessible in the detail panel.

## Scope guard
- Frontend layout polish only.
- No backend changes.
- No payment signal changes.
- No ledger logic changes.
- No manual metadata persistence rewrite.
- No schema changes, CSV/PDF export, PAD, or workflow automation.

## Validation
- npm run test -- src/components/reviewWorkspaces/OperationalReviewQueue.test.tsx src/pages/OperationalCommandCenterPage.test.tsx
- npm run build with Node 20.20.2
- git diff --check

## Manual QA checklist
- /operations: collapsed cards remain compact and scannable.
- Expand Details and manual controls on one card and confirm neighboring cards remain stable.
- Switch expansion to another card and confirm only one full-width detail panel is shown.
- Save manual status/reviewer from the detail panel, refresh, and confirm persistence.
- Apply filters and confirm expanded behavior remains usable.
- Regression: /dashboard, /leases, /portfolio-health?entry=lease-renewals.