### PR TITLE
fix/dashboard-decision-queue-mobile-card-layout-v1

### DIFF
--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -412,6 +412,21 @@ describe("DashboardPage", () => {
     );
   });
 
+  it("stacks Dashboard decision card actions below content on mobile", async () => {
+    installMatchMedia(true);
+
+    renderDashboard();
+
+    const decisionRows = await screen.findAllByTestId("dashboard-decision-row");
+    expect(decisionRows[0]).toHaveStyle("grid-template-columns: minmax(0, 1fr)");
+
+    const action = screen.getByRole("link", { name: /Open lease workspace: Resolve lease renewal/i });
+    expect(action).toHaveStyle("width: 100%");
+    expect(action).toHaveStyle("white-space: normal");
+    expect(action).toHaveStyle("justify-self: stretch");
+    expect(action).toHaveAttribute("href", "/leases");
+  });
+
   it("keeps decision queue content visible when portfolio data fails", async () => {
     mocks.fetchLandlordPortfolioStatusFinancialMock.mockRejectedValue(new Error("Portfolio API unavailable"));
 

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -211,6 +211,28 @@ function decisionReason(item: LandlordDecisionQueueItem): string {
   return description || "Review the recommended next step for this operational decision.";
 }
 
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+    return window.matchMedia(query).matches;
+  });
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
+    const mediaQuery = window.matchMedia(query);
+    const updateMatches = () => setMatches(mediaQuery.matches);
+    updateMatches();
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", updateMatches);
+      return () => mediaQuery.removeEventListener("change", updateMatches);
+    }
+    mediaQuery.addListener(updateMatches);
+    return () => mediaQuery.removeListener(updateMatches);
+  }, [query]);
+
+  return matches;
+}
+
 function formatShortWeekday(value: Date): string {
   return new Intl.DateTimeFormat(undefined, { weekday: "short" }).format(value);
 }
@@ -630,11 +652,13 @@ function DecisionQueuePreview({ queue }: { queue: LandlordDecisionQueueResponse 
 
 function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
   const destinationLabel = decisionDestinationLabel(item);
+  const isMobileDecisionCard = useMediaQuery("(max-width: 640px)");
   return (
     <div
+      data-testid="dashboard-decision-row"
       style={{
         display: "grid",
-        gridTemplateColumns: "minmax(0, 1fr) auto",
+        gridTemplateColumns: isMobileDecisionCard ? "minmax(0, 1fr)" : "minmax(0, 1fr) auto",
         gap: 12,
         alignItems: "start",
         padding: 12,
@@ -660,7 +684,17 @@ function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
           </span>
         </div>
       </div>
-      <Link to={operationalHref(item)} aria-label={`${destinationLabel}: ${item.title || "Review required"}`} style={{ ...compactButton, width: "fit-content", whiteSpace: "nowrap" }}>
+      <Link
+        to={operationalHref(item)}
+        aria-label={`${destinationLabel}: ${item.title || "Review required"}`}
+        style={{
+          ...compactButton,
+          width: isMobileDecisionCard ? "100%" : "fit-content",
+          whiteSpace: isMobileDecisionCard ? "normal" : "nowrap",
+          justifySelf: isMobileDecisionCard ? "stretch" : "end",
+          textAlign: "center",
+        }}
+      >
         {destinationLabel}
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- Adjust Dashboard Decision Queue Preview cards so narrow/mobile layouts stack the CTA below full-width card content.
- Preserve the existing desktop content-plus-CTA layout and all destination labels/routes from PR #1268.
- Add a targeted Dashboard test for the mobile stacked card behavior.

## Scope
- Frontend only.
- Dashboard Decision Queue Preview mobile card layout only.
- No decision logic changes.
- No backend, Operations, routing, payment signal, ledger, or schema changes.

## Validation
- `npm run test -- src/pages/DashboardPage.test.tsx`
- `npm run build` with Node `20.20.2`
- `git diff --check`

## Manual QA Required
- `/dashboard` at mobile width: confirm Decision Queue Preview cards use full-width readable content and CTA stacks below content.
- Confirm CTA routes still work: `Open ledger`, `Review applications`, `View revenue analytics`, `View vacancy readiness`, `Review renewals` when present.
- Regression: `/dashboard` desktop width, `/operations`, `/leases`.

Closes #1271.