### PR TITLE
Fix Applications filters and screening setup layout

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationsPage.css
+++ b/rentchain-frontend/src/pages/ApplicationsPage.css
@@ -93,6 +93,24 @@
   word-break: break-word;
 }
 
+.rc-screening-provider-setup-shell {
+  background: #ffffff;
+  border: 1px solid rgba(203, 213, 225, 0.92);
+  border-radius: 14px;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.06);
+  color: #0f172a;
+  padding: 18px;
+}
+
+.rc-screening-provider-setup-summary {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
 .rc-applications-ai-panel {
   display: grid;
   gap: 6px;
@@ -112,11 +130,14 @@
   display: grid;
   gap: 16px;
   grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  min-width: 0;
 }
 
 .rc-viewing-requests-list-pane,
 .rc-viewing-requests-detail-pane {
   min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 @media (max-width: 768px) {
@@ -186,8 +207,28 @@
     grid-template-columns: 1fr;
   }
 
+  .rc-screening-provider-setup-shell {
+    padding: 14px;
+  }
+
+  .rc-screening-provider-setup-summary {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .rc-screening-provider-setup-summary button {
+    width: 100%;
+  }
+
   .rc-viewing-requests-layout {
+    display: flex;
+    flex-direction: column;
     grid-template-columns: 1fr;
+  }
+
+  .rc-viewing-requests-list-pane,
+  .rc-viewing-requests-detail-pane {
+    width: 100%;
   }
 }
 

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ApplicationsPage from "./ApplicationsPage";
 
@@ -248,6 +248,11 @@ vi.mock("../config/screening", () => ({
 vi.mock("@/lib/analytics", () => ({
   track: vi.fn(),
 }));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location-search">{location.search}</div>;
+};
 
 afterEach(() => {
   cleanup();
@@ -634,6 +639,109 @@ describe("ApplicationsPage", () => {
     expect(await screen.findByText("No submitted applications found")).toBeInTheDocument();
     expect(screen.getByText(/The Application Funnel includes started and in-progress application-link activity/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View all statuses" })).toBeInTheDocument();
+  });
+
+  it("clears the dashboard-provided submitted status query when All statuses is selected", async () => {
+    mocks.fetchRentalApplications.mockResolvedValue([
+      {
+        id: "link-1",
+        source: "application_link",
+        applicantName: "In-progress applicant",
+        email: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "IN_PROGRESS",
+        submittedAt: null,
+        lastActivityAt: 1_710_000_000_000,
+        completionPercent: 62,
+        partialProgress: {
+          status: "in_progress",
+          completionPercent: 62,
+          currentStep: "employment",
+          completedSections: ["personal_info", "residential_history"],
+          missingSections: ["employment", "references_assets", "consent"],
+          hasCoApplicant: false,
+          viewingChoice: "already_viewed",
+          startedAt: 1_709_999_000_000,
+          lastActivityAt: 1_710_000_000_000,
+          submittedAt: null,
+          reminderEligibleAt: 1_710_086_400_000,
+          reminderSentAt: null,
+        },
+      },
+    ]);
+    mocks.fetchRentalApplications.mockResolvedValueOnce([]);
+
+    const { container } = render(
+      <MemoryRouter initialEntries={["/applications?entry=application-funnel&status=SUBMITTED"]}>
+        <LocationProbe />
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No submitted applications found")).toBeInTheDocument();
+    const statusSelect = container.querySelector(".rc-applications-filter") as HTMLSelectElement;
+    expect(statusSelect.value).toBe("SUBMITTED");
+
+    fireEvent.change(statusSelect, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(statusSelect.value).toBe("");
+    });
+    expect(screen.getByTestId("location-search")).toHaveTextContent("?entry=application-funnel");
+    expect(await screen.findByText("In-progress applicant")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.fetchRentalApplications).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyId: undefined,
+          status: undefined,
+        })
+      );
+    });
+  });
+
+  it("clears the submitted query from the View all statuses empty-state action", async () => {
+    mocks.fetchRentalApplications.mockResolvedValue([
+      {
+        id: "link-1",
+        source: "application_link",
+        applicantName: "In-progress applicant",
+        email: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "IN_PROGRESS",
+        submittedAt: null,
+        lastActivityAt: 1_710_000_000_000,
+        completionPercent: 62,
+        partialProgress: {
+          status: "in_progress",
+          completionPercent: 62,
+          currentStep: "employment",
+          completedSections: ["personal_info", "residential_history"],
+          missingSections: ["employment", "references_assets", "consent"],
+          hasCoApplicant: false,
+          viewingChoice: "already_viewed",
+          startedAt: 1_709_999_000_000,
+          lastActivityAt: 1_710_000_000_000,
+          submittedAt: null,
+          reminderEligibleAt: 1_710_086_400_000,
+          reminderSentAt: null,
+        },
+      },
+    ]);
+    mocks.fetchRentalApplications.mockResolvedValueOnce([]);
+
+    render(
+      <MemoryRouter initialEntries={["/applications?entry=application-funnel&status=SUBMITTED"]}>
+        <LocationProbe />
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "View all statuses" }));
+
+    expect(screen.getByTestId("location-search")).toHaveTextContent("?entry=application-funnel");
+    expect(await screen.findByText("In-progress applicant")).toBeInTheDocument();
   });
 
   it("hydrates analytics application-funnel query params into valid filters", async () => {

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -124,8 +124,9 @@ vi.mock("@/api/screeningApi", () => ({
 }));
 
 vi.mock("../components/layout/ResponsiveMasterDetail", () => ({
-  ResponsiveMasterDetail: ({ master, detail }: any) => (
+  ResponsiveMasterDetail: ({ searchSlot, master, detail }: any) => (
     <div>
+      <div>{searchSlot}</div>
       <div>{master}</div>
       <div>{detail}</div>
     </div>
@@ -575,6 +576,11 @@ describe("ApplicationsPage", () => {
     });
 
     expect(screen.getByRole("button", { name: "Send screening invite" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open screening setup" })).toBeInTheDocument();
+    expect(screen.queryByText("Screening Provider")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open screening setup" }));
+
     expect(screen.getAllByText("Screening provider setup").length).toBeGreaterThan(0);
     expect(screen.getByText("Screening Provider")).toBeInTheDocument();
     expect(screen.getAllByText("Screening workflow").length).toBeGreaterThan(0);
@@ -589,6 +595,45 @@ describe("ApplicationsPage", () => {
     expect(screen.queryByText("TransUnion Connection")).not.toBeInTheDocument();
     expect(screen.getByText("Application Funnel")).toBeInTheDocument();
     expect(screen.getByText("40%")).toBeInTheDocument();
+  });
+
+  it("exposes the supported in-progress status filter and requests in-progress records", async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Jamie Stone");
+    const statusSelect = container.querySelector(".rc-applications-filter") as HTMLSelectElement;
+
+    expect(screen.getByRole("option", { name: "In progress" })).toBeInTheDocument();
+    expect(statusSelect).toBeTruthy();
+    fireEvent.change(statusSelect, { target: { value: "IN_PROGRESS" } });
+
+    await waitFor(() => {
+      expect(mocks.fetchRentalApplications).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyId: undefined,
+          status: "IN_PROGRESS",
+        })
+      );
+    });
+  });
+
+  it("explains a funnel-linked submitted filter when no submitted records are returned", async () => {
+    mocks.fetchRentalApplications.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/applications?entry=application-funnel&status=SUBMITTED"]}>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Application funnel review")).toBeInTheDocument();
+    expect(await screen.findByText("No submitted applications found")).toBeInTheDocument();
+    expect(screen.getByText(/The Application Funnel includes started and in-progress application-link activity/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View all statuses" })).toBeInTheDocument();
   });
 
   it("hydrates analytics application-funnel query params into valid filters", async () => {
@@ -659,7 +704,7 @@ describe("ApplicationsPage", () => {
 
     expect(await screen.findByText("Application Funnel")).toBeInTheDocument();
     expect(screen.getByText("Started")).toBeInTheDocument();
-    expect(screen.getByText("In progress")).toBeInTheDocument();
+    expect(screen.getAllByText("In progress").length).toBeGreaterThan(0);
     expect(screen.getByText("Completed")).toBeInTheDocument();
     expect(screen.getByText("Conversion")).toBeInTheDocument();
     expect(screen.getByText("40%")).toBeInTheDocument();
@@ -742,6 +787,8 @@ describe("ApplicationsPage", () => {
     );
 
     await screen.findAllByRole("heading", { name: "Applications" });
+    fireEvent.click(screen.getByRole("button", { name: "Open screening setup" }));
+
     expect(
       screen.getAllByText("Next step: choose an applicant, then start screening from that application.").length
     ).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -1275,10 +1275,11 @@ const ApplicationsPage: React.FC = () => {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const nextStatus = normalizeApplicationStatusParam(params.get("status"));
-    if (nextStatus && nextStatus !== statusFilter) {
-      setStatusFilter(nextStatus);
-    }
-  }, [location.search, statusFilter]);
+    setStatusFilter((current) => {
+      if (nextStatus) return nextStatus;
+      return current ? "" : current;
+    });
+  }, [location.search]);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -1626,6 +1627,27 @@ const ApplicationsPage: React.FC = () => {
     setSendAppOpen(true);
   };
 
+  const updateStatusFilter = useCallback(
+    (nextStatusValue: string) => {
+      const nextStatus = nextStatusValue ? normalizeApplicationStatusParam(nextStatusValue) || "" : "";
+      setStatusFilter(nextStatus);
+
+      const params = new URLSearchParams(location.search);
+      if (nextStatus) {
+        params.set("status", nextStatus);
+      } else {
+        params.delete("status");
+      }
+
+      const nextSearch = params.toString();
+      const currentSearch = location.search.replace(/^\?/, "");
+      if (nextSearch !== currentSearch) {
+        navigate({ pathname: location.pathname, search: nextSearch }, { replace: false });
+      }
+    },
+    [location.pathname, location.search, navigate]
+  );
+
   const handleRowScreen = (applicationId: string) => {
     if (!SCREENING_ENABLED) return;
     const application = applications.find((entry) => entry.id === applicationId);
@@ -1964,7 +1986,7 @@ const ApplicationsPage: React.FC = () => {
           ? `The Application Funnel includes started and in-progress application-link activity, while this list only shows records that match ${selectedStatusLabel}.${inProgressHint} Change the status filter to All statuses or In progress to review unfinished applicants.`
           : `No application records match ${selectedStatusLabel}. Change the status filter to All statuses to review the rest of the queue.`,
         action: (
-          <Button type="button" variant="secondary" onClick={() => setStatusFilter("")}>
+          <Button type="button" variant="secondary" onClick={() => updateStatusFilter("")}>
             View all statuses
           </Button>
         ),
@@ -2007,6 +2029,7 @@ const ApplicationsPage: React.FC = () => {
     propertiesReady,
     search,
     statusFilter,
+    updateStatusFilter,
   ]);
 
   const handleSendReminder = useCallback(
@@ -2684,7 +2707,7 @@ const ApplicationsPage: React.FC = () => {
               <select
                 className="rc-applications-filter"
                 value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value)}
+                onChange={(e) => updateStatusFilter(e.target.value)}
                 style={{ padding: "8px 10px", borderRadius: radius.md, border: `1px solid ${colors.border}` }}
               >
                 <option value="">All statuses</option>

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -113,7 +113,8 @@ import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
 import { UpgradeCTA } from "@/components/billing/UpgradeCTA";
 import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 import { FREE_TIER_UPGRADE_GUIDANCE } from "@/constants/tiers";
-const statusOptions: RentalApplicationStatus[] = [
+const statusFilterOptions: RentalApplicationStatus[] = [
+  "IN_PROGRESS",
   "SUBMITTED",
   "IN_REVIEW",
   "APPROVED",
@@ -121,6 +122,29 @@ const statusOptions: RentalApplicationStatus[] = [
   "CONDITIONAL_COSIGNER",
   "CONDITIONAL_DEPOSIT",
 ];
+
+const statusActionOptions: RentalApplicationStatus[] = [
+  "SUBMITTED",
+  "IN_REVIEW",
+  "APPROVED",
+  "DECLINED",
+  "CONDITIONAL_COSIGNER",
+  "CONDITIONAL_DEPOSIT",
+];
+
+const statusLabels: Record<RentalApplicationStatus, string> = {
+  DRAFT: "Draft",
+  IN_PROGRESS: "In progress",
+  SUBMITTED: "Submitted",
+  IN_REVIEW: "In review",
+  APPROVED: "Approved",
+  DECLINED: "Declined",
+  CONDITIONAL_COSIGNER: "Conditional - cosigner",
+  CONDITIONAL_DEPOSIT: "Conditional - deposit",
+};
+
+const formatApplicationStatus = (status: RentalApplicationStatus | string) =>
+  statusLabels[status as RentalApplicationStatus] || String(status).replace(/_/g, " ").toLowerCase();
 
 const supportedAnalyticsApplicationEntries = ["application-funnel", "screening-checkout"] as const;
 type AnalyticsApplicationEntry = (typeof supportedAnalyticsApplicationEntries)[number];
@@ -130,7 +154,7 @@ const isAnalyticsApplicationEntry = (value: string | null): value is AnalyticsAp
 
 const normalizeApplicationStatusParam = (value: string | null): RentalApplicationStatus | null => {
   const normalized = String(value || "").trim().toUpperCase();
-  return statusOptions.includes(normalized as RentalApplicationStatus) ? (normalized as RentalApplicationStatus) : null;
+  return statusFilterOptions.includes(normalized as RentalApplicationStatus) ? (normalized as RentalApplicationStatus) : null;
 };
 
 const analyticsApplicationEntryCopy: Record<AnalyticsApplicationEntry, { title: string; body: string }> = {
@@ -569,6 +593,7 @@ const ApplicationsPage: React.FC = () => {
   const [transUnionAccessOpen, setTransUnionAccessOpen] = useState(false);
   const [transUnionConnectOpen, setTransUnionConnectOpen] = useState(false);
   const [transUnionUpdateOpen, setTransUnionUpdateOpen] = useState(false);
+  const [screeningSetupExpanded, setScreeningSetupExpanded] = useState(false);
   const [transUnionAccessSource, setTransUnionAccessSource] = useState("applications_page");
   const APPLICATION_REMINDER_RESEND_COOLDOWN_MS = 24 * 60 * 60 * 1000;
   const APPLICATION_HIGH_PRIORITY_ACTIVITY_MS = 3 * 24 * 60 * 60 * 1000;
@@ -1923,6 +1948,67 @@ const ApplicationsPage: React.FC = () => {
     };
   }, [funnel]);
 
+  const applicationsEmptyState = useMemo(() => {
+    if (statusFilter) {
+      const selectedStatusLabel = formatApplicationStatus(statusFilter);
+      const hasFunnelActivity =
+        Boolean(analyticsEntryContext) ||
+        Boolean(funnelSummary && (funnelSummary.started > 0 || funnelSummary.inProgress > 0 || funnelSummary.completed > 0));
+      const inProgressHint =
+        funnelSummary && funnelSummary.inProgress > 0
+          ? ` ${funnelSummary.inProgress} applicant${funnelSummary.inProgress === 1 ? " is" : "s are"} still in progress.`
+          : "";
+      return {
+        title: `No ${selectedStatusLabel.toLowerCase()} applications found`,
+        body: hasFunnelActivity
+          ? `The Application Funnel includes started and in-progress application-link activity, while this list only shows records that match ${selectedStatusLabel}.${inProgressHint} Change the status filter to All statuses or In progress to review unfinished applicants.`
+          : `No application records match ${selectedStatusLabel}. Change the status filter to All statuses to review the rest of the queue.`,
+        action: (
+          <Button type="button" variant="secondary" onClick={() => setStatusFilter("")}>
+            View all statuses
+          </Button>
+        ),
+      };
+    }
+
+    if (search.trim()) {
+      return {
+        title: "No matching applications",
+        body: "No applications match this search. Clear the search to review the full queue.",
+        action: (
+          <Button type="button" variant="secondary" onClick={() => setSearch("")}>
+            Clear search
+          </Button>
+        ),
+      };
+    }
+
+    return {
+      title: "No applications yet",
+      body: "Applications keep screening decisions and applicant details in one auditable flow.",
+      action: (
+        <Button
+          variant="secondary"
+          onClick={() => {
+            track("empty_state_cta_clicked", { pageKey: "applications", ctaKey: "create_application" });
+            handleCreateApplication(false);
+          }}
+          disabled={!propertiesReady}
+        >
+          {propertiesLoaded ? "Send application link" : "Loading properties..."}
+        </Button>
+      ),
+    };
+  }, [
+    analyticsEntryContext,
+    funnelSummary,
+    handleCreateApplication,
+    propertiesLoaded,
+    propertiesReady,
+    search,
+    statusFilter,
+  ]);
+
   const handleSendReminder = useCallback(
     async (application: RentalApplicationSummary) => {
       if (application.source !== "application_link") return;
@@ -2327,38 +2413,66 @@ const ApplicationsPage: React.FC = () => {
         ) : null}
       </Card>
 
-      <ScreeningProviderSetupCard
-        integration={transUnionIntegration}
-        loading={transUnionLoading}
-        readyToScreen={Boolean(detail)}
-        screeningEnabled={SCREENING_ENABLED}
-        workflowStatus={displayScreeningStatus || manualScreeningStatus?.status || null}
-        selectedApplicationLabel={buildApplicantLabel(detail)}
-        onChooseApplicant={guideToApplicationsForScreening}
-        screeningsCompletedCount={
-          detail
-            ? screeningHistory.filter((item) => item.status === "completed").length
-            : null
-        }
-        lastScreeningDate={detail ? screeningHistory[0]?.screenedAt || screeningHistory[0]?.requestedAt || null : null}
-        onGetAccess={() => {
-          emitTransUnionUsageEvent("tu_get_access_clicked", "applications_page");
-          openTransUnionAccess("applications_page");
-        }}
-        onConnectExisting={() => {
-          emitTransUnionUsageEvent("tu_have_credentials_clicked", "applications_page");
-          setTransUnionConnectOpen(true);
-        }}
-        onEnterDetails={() => setTransUnionConnectOpen(true)}
-        onViewInstructions={() => openTransUnionAccess("applications_page")}
-        onUpdateCredentials={() => setTransUnionUpdateOpen(true)}
-        onDisconnect={() => void handleTransUnionDisconnect()}
-        onStartScreening={
-          detail
-            ? () => handleRowScreen(detail.id)
-            : guideToApplicationsForScreening
-        }
-      />
+      <section className="rc-screening-provider-setup-shell" aria-label="Screening provider setup">
+        <div className="rc-screening-provider-setup-summary">
+          <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+            <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Screening provider setup</div>
+            <div style={{ color: text.muted, fontSize: "0.94rem", lineHeight: 1.6 }}>
+              Screening setup is available when you need provider access, credentials, or workflow details.
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: spacing.sm, alignItems: "center", flexWrap: "wrap" }}>
+            <Pill tone={isTransUnionConnected ? "accent" : "muted"}>
+              {isTransUnionConnected ? "Connected" : "Not connected"}
+            </Pill>
+            <Button
+              type="button"
+              variant="secondary"
+              aria-expanded={screeningSetupExpanded}
+              aria-controls="screening-provider-setup-panel"
+              onClick={() => setScreeningSetupExpanded((value) => !value)}
+            >
+              {screeningSetupExpanded ? "Hide screening setup" : "Open screening setup"}
+            </Button>
+          </div>
+        </div>
+      </section>
+      {screeningSetupExpanded ? (
+        <div id="screening-provider-setup-panel">
+          <ScreeningProviderSetupCard
+            integration={transUnionIntegration}
+            loading={transUnionLoading}
+            readyToScreen={Boolean(detail)}
+            screeningEnabled={SCREENING_ENABLED}
+            workflowStatus={displayScreeningStatus || manualScreeningStatus?.status || null}
+            selectedApplicationLabel={buildApplicantLabel(detail)}
+            onChooseApplicant={guideToApplicationsForScreening}
+            screeningsCompletedCount={
+              detail
+                ? screeningHistory.filter((item) => item.status === "completed").length
+                : null
+            }
+            lastScreeningDate={detail ? screeningHistory[0]?.screenedAt || screeningHistory[0]?.requestedAt || null : null}
+            onGetAccess={() => {
+              emitTransUnionUsageEvent("tu_get_access_clicked", "applications_page");
+              openTransUnionAccess("applications_page");
+            }}
+            onConnectExisting={() => {
+              emitTransUnionUsageEvent("tu_have_credentials_clicked", "applications_page");
+              setTransUnionConnectOpen(true);
+            }}
+            onEnterDetails={() => setTransUnionConnectOpen(true)}
+            onViewInstructions={() => openTransUnionAccess("applications_page")}
+            onUpdateCredentials={() => setTransUnionUpdateOpen(true)}
+            onDisconnect={() => void handleTransUnionDisconnect()}
+            onStartScreening={
+              detail
+                ? () => handleRowScreen(detail.id)
+                : guideToApplicationsForScreening
+            }
+          />
+        </div>
+      ) : null}
 
       <Card elevated style={{ display: "grid", gap: spacing.md }}>
         <div style={{ display: "grid", gap: 4 }}>
@@ -2394,11 +2508,6 @@ const ApplicationsPage: React.FC = () => {
         </div>
         <div
           className="rc-viewing-requests-layout"
-          style={{
-            display: "grid",
-            gap: spacing.md,
-            gridTemplateColumns: "minmax(260px, 320px) minmax(0, 1fr)",
-          }}
         >
           <div className="rc-viewing-requests-list-pane">
             {viewingLoading ? (
@@ -2579,9 +2688,9 @@ const ApplicationsPage: React.FC = () => {
                 style={{ padding: "8px 10px", borderRadius: radius.md, border: `1px solid ${colors.border}` }}
               >
                 <option value="">All statuses</option>
-                {statusOptions.map((s) => (
+                {statusFilterOptions.map((s) => (
                   <option key={s} value={s}>
-                    {s}
+                    {formatApplicationStatus(s)}
                   </option>
                 ))}
               </select>
@@ -2613,20 +2722,9 @@ const ApplicationsPage: React.FC = () => {
                 />
               ) : filtered.length === 0 ? (
                 <EmptyState
-                  title="No applications yet"
-                  body="Applications keep screening decisions and applicant details in one auditable flow."
-                  action={
-                    <Button
-                      variant="secondary"
-                      onClick={() => {
-                        track("empty_state_cta_clicked", { pageKey: "applications", ctaKey: "create_application" });
-                        handleCreateApplication(false);
-                      }}
-                      disabled={!propertiesReady}
-                    >
-                      {propertiesLoaded ? "Send application link" : "Loading properties..."}
-                    </Button>
-                  }
+                  title={applicationsEmptyState.title}
+                  body={applicationsEmptyState.body}
+                  action={applicationsEmptyState.action}
                 />
               ) : (
                 <div style={{ display: "grid", gap: spacing.sm }}>
@@ -2698,7 +2796,7 @@ const ApplicationsPage: React.FC = () => {
                           {app.email || "No email"}
                         </div>
                         <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-                          <Pill>{app.status}</Pill>
+                          <Pill>{formatApplicationStatus(app.status)}</Pill>
                           {isPartial && typeof app.completionPercent === "number" ? (
                             <span style={{ color: text.subtle, fontSize: 12 }}>{app.completionPercent}% complete</span>
                           ) : null}
@@ -2892,9 +2990,9 @@ const ApplicationsPage: React.FC = () => {
                     Print / Save PDF
                   </Button>
                   <div className="rc-applications-status-row">
-                    {statusOptions.map((s) => (
+                    {statusActionOptions.map((s) => (
                       <Button key={s} variant={detail.status === s ? "primary" : "secondary"} onClick={() => void setStatus(s)}>
-                        {s.replace("_", " ")}
+                        {formatApplicationStatus(s)}
                       </Button>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary

Fixes #1273.

This PR improves the Applications page route QA issues found after the Dashboard Decision Queue Preview mobile layout fix.

## Root Cause

- The frontend status filter list omitted the supported `IN_PROGRESS` application status even though application summaries can include in-progress application-link rows.
- The Applications empty state used the same generic copy for every zero-record result, so an analytics funnel entry with `status=SUBMITTED` could look contradictory when funnel activity existed but no submitted records matched the filter.
- The dashboard-routed `status=SUBMITTED` query param kept rehydrating the selected filter after the user selected `All statuses`.
- The Viewing Requests layout had inline grid columns, which prevented the mobile CSS class from reliably stacking the list and detail panes.
- The screening provider setup card was always expanded above the Applications queue, so provider setup dominated the page even when the landlord was only trying to review applications.

## Changes

- Adds an `In progress` status filter and user-friendly status labels for filters, row badges, and status actions.
- Adds a funnel-aware selected-status empty state with a `View all statuses` action.
- Keeps `entry=application-funnel` context while clearing/replacing the `status` query param when users intentionally change status filters.
- Collapses Screening provider setup by default behind an `Open screening setup` button while preserving the existing setup workflow after expansion.
- Moves Viewing Requests layout control into CSS and strengthens mobile stacking styles.
- Updates Applications page tests for the in-progress filter, submitted-filter empty copy, filter query escape behavior, collapsed setup panel, and filter-slot rendering.

## Validation

- `npm run test:single -- src/pages/ApplicationsPage.test.tsx` passed.
- `npm run build` passed under Node 20.11.1. Note: Vite emitted its existing warning that it prefers Node 20.19+ or 22.12+.
- `git diff --check` passed.

## Manual QA Passed

- `/applications?entry=application-funnel&status=SUBMITTED` displays the Application Funnel panel.
- Selecting `All statuses` from the funnel route does not revert to `Submitted`.
- `View all statuses` clears the submitted filter and reveals in-progress applications.
- Intentional status filter selection still works.
- `/applications` all-status view shows the in-progress application.
- Status filters are visible and behave as expected.
- Mobile Viewing Requests layout stacks correctly.
- Desktop and mobile Screening provider setup is collapsed by default behind `Open screening setup` and opens correctly.
- Regression routes passed: `/dashboard`, `/operations`, `/leases`.

## Follow-up

Non-blocking reminder eligibility polish found during QA: `fix/in-progress-application-reminder-eligibility-label-v1`.

Scope: hide or disable `Send again` and avoid `Ready to remind` when an in-progress applicant has no email; show `Missing email` / `Reminder unavailable until applicant email is added.` Preserve reminders for eligible in-progress applications.