### PR TITLE
Fix in-progress application reminder eligibility labels

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -1106,7 +1106,7 @@ describe("ApplicationsPage", () => {
     expect(mocks.fetchRentalApplication).not.toHaveBeenCalled();
   });
 
-  it("shows Send reminder for eligible in-progress rows and updates the row after success", async () => {
+  it("shows reminder unavailable for in-progress rows without an applicant email", async () => {
     const now = Date.now();
     mocks.fetchRentalApplications.mockResolvedValue([
       {
@@ -1114,6 +1114,51 @@ describe("ApplicationsPage", () => {
         source: "application_link",
         applicantName: "In-progress applicant",
         email: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "IN_PROGRESS",
+        submittedAt: null,
+        lastActivityAt: now - 8 * 24 * 60 * 60 * 1000,
+        completionPercent: 3,
+        partialProgress: {
+          status: "in_progress",
+          completionPercent: 3,
+          currentStep: "personal_info",
+          completedSections: [],
+          missingSections: ["personal_info", "residential_history", "employment", "references_assets", "consent"],
+          hasCoApplicant: false,
+          viewingChoice: null,
+          startedAt: now - 9 * 24 * 60 * 60 * 1000,
+          lastActivityAt: now - 8 * 24 * 60 * 60 * 1000,
+          submittedAt: null,
+          reminderEligibleAt: now - 60_000,
+          reminderSentAt: now - 25 * 60 * 60 * 1000,
+        },
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Missing email")).toBeInTheDocument();
+    expect(screen.getByText("Reminder unavailable until applicant email is added.")).toBeInTheDocument();
+    expect(screen.queryByText("Ready to remind")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send again" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send reminder" })).not.toBeInTheDocument();
+    expect(mocks.sendApplicationLinkReminder).not.toHaveBeenCalled();
+  });
+
+  it("shows Send reminder for eligible in-progress rows and updates the row after success", async () => {
+    const now = Date.now();
+    mocks.fetchRentalApplications.mockResolvedValue([
+      {
+        id: "link-1",
+        source: "application_link",
+        applicantName: "In-progress applicant",
+        email: "progress@example.com",
         propertyId: "prop-1",
         unitId: "unit-1",
         status: "IN_PROGRESS",
@@ -1166,7 +1211,7 @@ describe("ApplicationsPage", () => {
         id: "link-1",
         source: "application_link",
         applicantName: "In-progress applicant",
-        email: null,
+        email: "progress@example.com",
         propertyId: "prop-1",
         unitId: "unit-1",
         status: "IN_PROGRESS",
@@ -1209,7 +1254,7 @@ describe("ApplicationsPage", () => {
         id: "link-1",
         source: "application_link",
         applicantName: "In-progress applicant",
-        email: null,
+        email: "progress@example.com",
         propertyId: "prop-1",
         unitId: "unit-1",
         status: "IN_PROGRESS",
@@ -1259,7 +1304,7 @@ describe("ApplicationsPage", () => {
         id: "link-1",
         source: "application_link",
         applicantName: "In-progress applicant",
-        email: null,
+        email: "progress@example.com",
         propertyId: "prop-1",
         unitId: "unit-1",
         status: "IN_PROGRESS",

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -1886,6 +1886,7 @@ const ApplicationsPage: React.FC = () => {
 
   const canSendPartialReminder = useCallback((application: RentalApplicationSummary) => {
     if (application.source !== "application_link") return false;
+    if (!String(application.email || "").trim()) return false;
     const partialProgress = application.partialProgress;
     if (!partialProgress) return false;
     if (partialProgress.submittedAt) return false;
@@ -1908,9 +1909,11 @@ const ApplicationsPage: React.FC = () => {
 
   const getPartialReminderState = useCallback((application: RentalApplicationSummary) => {
     const partialProgress = application.partialProgress;
+    const missingEmail = !String(application.email || "").trim();
     if (application.source !== "application_link" || !partialProgress) {
       return {
         ready: false,
+        missingEmail,
         recentlyReminded: false,
         reminderSentAt: null as number | null,
         actionLabel: "Send reminder",
@@ -1923,6 +1926,7 @@ const ApplicationsPage: React.FC = () => {
     const ready = canSendPartialReminder(application);
     return {
       ready,
+      missingEmail,
       recentlyReminded,
       reminderSentAt,
       actionLabel: reminderSentAt ? "Send again" : "Send reminder",
@@ -2851,7 +2855,27 @@ const ApplicationsPage: React.FC = () => {
                             <div style={{ color: text.subtle, fontSize: 12 }}>
                               Partial application only. Full application details appear after submission.
                             </div>
-                            {partialReminderState?.reminderSentAt ? (
+                            {partialReminderState?.missingEmail ? (
+                              <div style={{ display: "grid", gap: 4 }}>
+                                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                                  <span
+                                    style={{
+                                      color: "#92400e",
+                                      background: "rgba(245,158,11,0.14)",
+                                      borderRadius: 999,
+                                      padding: "2px 8px",
+                                      fontSize: 11,
+                                      fontWeight: 700,
+                                    }}
+                                  >
+                                    Missing email
+                                  </span>
+                                </div>
+                                <div style={{ color: text.subtle, fontSize: 12 }}>
+                                  Reminder unavailable until applicant email is added.
+                                </div>
+                              </div>
+                            ) : partialReminderState?.reminderSentAt ? (
                               <div style={{ display: "grid", gap: 4 }}>
                                 <div style={{ color: text.subtle, fontSize: 12 }}>
                                   Reminder sent {new Date(partialReminderState.reminderSentAt).toLocaleString()}


### PR DESCRIPTION
## Summary

Fixes the misleading reminder state on in-progress application cards when the applicant has no email address.

## Root Cause

The frontend reminder readiness check only considered partial-progress status, reminder eligibility timing, and cooldown state. It did not account for whether the application-link row had an applicant email, so no-email rows could show `Ready to remind` or `Send again` even though reminder delivery would fail.

## Changes

- Adds an email-presence guard to partial application reminder eligibility.
- Renders `Missing email` and `Reminder unavailable until applicant email is added.` for no-email in-progress rows.
- Hides reminder CTAs for no-email in-progress rows so users are not offered an action that is expected to fail.
- Preserves existing reminder CTA and cooldown behavior for eligible in-progress rows with email addresses.
- Adds focused Applications page test coverage for the missing-email unavailable state and updates eligible reminder fixtures to include email addresses.

## Validation

- `npm run test:single -- src/pages/ApplicationsPage.test.tsx` passed.
- `npm run build` passed under Node 20.11.1. Note: Vite emitted its existing warning that it prefers Node 20.19+ or 22.12+.
- `git diff --check` passed.

## Manual QA Passed

- `/applications` In progress filter works.
- No-email in-progress applicant displays `No email`, `Missing email`, and `Reminder unavailable until applicant email is added.`
- No-email in-progress applicant no longer shows `Ready to remind`, `Send reminder`, or `Send again`.
- The confusing red toast is avoided because no impossible reminder action is offered.
- Regression routes passed: `/applications?entry=application-funnel&status=SUBMITTED`, `/dashboard`, `/operations`, `/leases`.
- Eligible in-progress applicant with email: N/A for current dataset; no eligible in-progress applicant with email was visible during manual QA.