### PR TITLE
Fix lease ledger mobile layout and decision context

### DIFF
--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
@@ -1,8 +1,17 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import type { LeaseDelinquencySignal, LeaseObligationLedgerRow } from "@/api/leaseLedgerApi";
 import { decisionStatusCopy, type DecisionItem } from "@/lib/decisions/decisionDisplay";
 import { buildDecisionContextLinks, buildDecisionEvidenceItems } from "@/lib/decisions/decisionContext";
+
+type InternalEvidenceMode = "inline" | "advanced";
+
+function isInternalEvidenceItem(label: string): boolean {
+  return (
+    label.startsWith("Internal ") ||
+    label === "Provider payment reference"
+  );
+}
 
 export function DecisionContextPanel({
   decision,
@@ -10,15 +19,22 @@ export function DecisionContextPanel({
   delinquencySignals,
   includeAdminReviewLink = false,
   compact = false,
+  internalEvidenceMode = "inline",
 }: {
   decision: DecisionItem;
   obligationRows?: LeaseObligationLedgerRow[] | null;
   delinquencySignals?: LeaseDelinquencySignal[] | null;
   includeAdminReviewLink?: boolean;
   compact?: boolean;
+  internalEvidenceMode?: InternalEvidenceMode;
 }) {
+  const [showAdvancedEvidence, setShowAdvancedEvidence] = useState(false);
   const links = buildDecisionContextLinks(decision, { includeAdminReviewLink });
   const evidenceItems = buildDecisionEvidenceItems(decision, { obligationRows, delinquencySignals });
+  const defaultEvidenceItems =
+    internalEvidenceMode === "advanced" ? evidenceItems.filter((item) => !isInternalEvidenceItem(item.label)) : evidenceItems;
+  const advancedEvidenceItems =
+    internalEvidenceMode === "advanced" ? evidenceItems.filter((item) => isInternalEvidenceItem(item.label)) : [];
   const latestAction = decision.latestAction;
 
   return (
@@ -65,13 +81,45 @@ export function DecisionContextPanel({
       <div style={{ display: "grid", gap: 6 }}>
         <div style={{ color: "#334155", fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>Evidence</div>
         <dl style={{ display: "grid", gridTemplateColumns: compact ? "1fr" : "repeat(auto-fit, minmax(170px, 1fr))", gap: 8, margin: 0 }}>
-          {evidenceItems.map((item) => (
+          {defaultEvidenceItems.map((item) => (
             <div key={`${item.label}-${item.value}`} style={{ display: "grid", gap: 2 }}>
               <dt style={{ color: "#64748b", fontSize: 12 }}>{item.label}</dt>
               <dd style={{ color: "#0f172a", fontSize: 13, fontWeight: 700, margin: 0, overflowWrap: "anywhere" }}>{item.value}</dd>
             </div>
           ))}
         </dl>
+        {advancedEvidenceItems.length ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            <button
+              type="button"
+              aria-expanded={showAdvancedEvidence}
+              onClick={() => setShowAdvancedEvidence((current) => !current)}
+              style={{
+                justifySelf: "start",
+                border: "1px solid #cbd5e1",
+                borderRadius: 8,
+                background: "#fff",
+                padding: "6px 9px",
+                fontWeight: 800,
+              }}
+            >
+              {showAdvancedEvidence ? "Hide advanced evidence" : "Show advanced evidence"}
+            </button>
+            {showAdvancedEvidence ? (
+              <dl
+                aria-label="Advanced evidence"
+                style={{ display: "grid", gridTemplateColumns: compact ? "1fr" : "repeat(auto-fit, minmax(170px, 1fr))", gap: 8, margin: 0 }}
+              >
+                {advancedEvidenceItems.map((item) => (
+                  <div key={`${item.label}-${item.value}`} style={{ display: "grid", gap: 2 }}>
+                    <dt style={{ color: "#64748b", fontSize: 12 }}>{item.label}</dt>
+                    <dd style={{ color: "#0f172a", fontSize: 13, fontWeight: 700, margin: 0, overflowWrap: "anywhere" }}>{item.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
       <div style={{ display: "grid", gap: 4 }}>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.css
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.css
@@ -1,0 +1,194 @@
+.lease-ledger-page {
+  box-sizing: border-box;
+  display: grid;
+  gap: 14px;
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  padding: clamp(12px, 3vw, 24px);
+}
+
+.lease-ledger-page *,
+.lease-ledger-page *::before,
+.lease-ledger-page *::after {
+  box-sizing: border-box;
+}
+
+.lease-ledger-actions,
+.lease-ledger-csv-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.lease-ledger-actions {
+  justify-content: flex-end;
+}
+
+.lease-ledger-csv-card {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+  padding: 12px;
+}
+
+.lease-ledger-csv-card-header {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.lease-ledger-csv-panel,
+.lease-ledger-csv-panel section {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.lease-ledger-csv-panel pre {
+  max-width: 100%;
+}
+
+.lease-ledger-csv-panel input[type="file"] {
+  max-width: 100%;
+}
+
+.lease-ledger-advanced-reference {
+  margin-top: 4px;
+  color: #64748b;
+  font-size: 12px;
+}
+
+.lease-ledger-advanced-reference summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.lease-ledger-decision-card {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+  padding: 12px;
+}
+
+.lease-ledger-decision-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
+  gap: 8px;
+}
+
+.lease-ledger-decision-summary > div,
+.lease-ledger-next-action {
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+  padding: 10px;
+}
+
+.lease-ledger-decision-summary span,
+.lease-ledger-next-action span,
+.lease-ledger-obligation-card span {
+  display: block;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.lease-ledger-decision-summary strong,
+.lease-ledger-next-action strong,
+.lease-ledger-obligation-card strong {
+  color: #0f172a;
+  overflow-wrap: anywhere;
+}
+
+.lease-ledger-decision-primary {
+  grid-column: 1 / -1;
+}
+
+.lease-ledger-next-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.lease-ledger-next-action > div {
+  min-width: 0;
+}
+
+.lease-ledger-obligation-cards {
+  display: none;
+}
+
+.lease-ledger-obligation-card {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+  padding: 12px;
+}
+
+.lease-ledger-obligation-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.lease-ledger-obligation-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.lease-ledger-obligation-card-section {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+@media (max-width: 760px) {
+  .lease-ledger-page {
+    padding: 12px;
+  }
+
+  .lease-ledger-actions {
+    justify-content: stretch;
+    width: 100%;
+  }
+
+  .lease-ledger-actions > a,
+  .lease-ledger-actions > button,
+  .lease-ledger-csv-card-header > button,
+  .lease-ledger-next-action > button {
+    flex: 1 1 140px;
+    min-width: 0;
+  }
+
+  .lease-ledger-csv-card-header,
+  .lease-ledger-next-action {
+    align-items: stretch;
+  }
+
+  .lease-ledger-obligations-table {
+    display: none;
+  }
+
+  .lease-ledger-obligation-cards {
+    display: grid;
+    gap: 10px;
+  }
+}
+
+@media (min-width: 761px) {
+  .lease-ledger-obligations-table {
+    display: block;
+  }
+}

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.css
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.css
@@ -46,11 +46,29 @@
   max-width: 100%;
 }
 
-.lease-ledger-csv-panel pre {
+.lease-ledger-csv-panel *,
+.lease-ledger-csv-panel *::before,
+.lease-ledger-csv-panel *::after {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.lease-ledger-csv-panel section > div,
+.lease-ledger-csv-panel section > div > div {
+  min-width: 0;
   max-width: 100%;
 }
 
+.lease-ledger-csv-panel pre {
+  max-width: 100%;
+  white-space: pre;
+  word-break: normal;
+}
+
 .lease-ledger-csv-panel input[type="file"] {
+  width: 100%;
   max-width: 100%;
 }
 
@@ -92,7 +110,8 @@
 
 .lease-ledger-decision-summary span,
 .lease-ledger-next-action span,
-.lease-ledger-obligation-card span {
+.lease-ledger-obligation-card span,
+.lease-ledger-entry-card span {
   display: block;
   color: #64748b;
   font-size: 12px;
@@ -101,7 +120,8 @@
 
 .lease-ledger-decision-summary strong,
 .lease-ledger-next-action strong,
-.lease-ledger-obligation-card strong {
+.lease-ledger-obligation-card strong,
+.lease-ledger-entry-card strong {
   color: #0f172a;
   overflow-wrap: anywhere;
 }
@@ -121,11 +141,18 @@
   min-width: 0;
 }
 
-.lease-ledger-obligation-cards {
+.lease-ledger-obligation-cards,
+.lease-ledger-entry-cards {
   display: none;
 }
 
-.lease-ledger-obligation-card {
+.lease-ledger-obligations-table,
+.lease-ledger-entries-table {
+  max-width: 100%;
+}
+
+.lease-ledger-obligation-card,
+.lease-ledger-entry-card {
   display: grid;
   gap: 10px;
   min-width: 0;
@@ -135,20 +162,23 @@
   padding: 12px;
 }
 
-.lease-ledger-obligation-card-header {
+.lease-ledger-obligation-card-header,
+.lease-ledger-entry-card-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
 }
 
-.lease-ledger-obligation-card-grid {
+.lease-ledger-obligation-card-grid,
+.lease-ledger-entry-card-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
 }
 
-.lease-ledger-obligation-card-section {
+.lease-ledger-obligation-card-section,
+.lease-ledger-entry-card-section {
   display: grid;
   gap: 4px;
   min-width: 0;
@@ -177,18 +207,21 @@
     align-items: stretch;
   }
 
-  .lease-ledger-obligations-table {
+  .lease-ledger-obligations-table,
+  .lease-ledger-entries-table {
     display: none;
   }
 
-  .lease-ledger-obligation-cards {
+  .lease-ledger-obligation-cards,
+  .lease-ledger-entry-cards {
     display: grid;
     gap: 10px;
   }
 }
 
 @media (min-width: 761px) {
-  .lease-ledger-obligations-table {
+  .lease-ledger-obligations-table,
+  .lease-ledger-entries-table {
     display: block;
   }
 }

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -451,8 +451,11 @@ describe("LeaseLedgerPage", () => {
     expect((await screen.findAllByText("Harbour View · Unit 101")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$100.00").length).toBeGreaterThan(0);
-    expect(screen.getByText("+$1,450.00")).toBeInTheDocument();
-    expect(screen.getByText("-$100.00")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Method/Ref" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Ledger entry cards")).toBeInTheDocument();
+    expect(screen.getAllByText("+$1,450.00").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("-$100.00").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Balance").length).toBeGreaterThan(0);
     expect(screen.queryByText("145000")).not.toBeInTheDocument();
     expect(screen.queryByText("10000")).not.toBeInTheDocument();
   });
@@ -706,7 +709,7 @@ describe("LeaseLedgerPage", () => {
     expect(await screen.findByText("Obligation ledger is not available yet for this lease.")).toBeInTheDocument();
     expect(screen.getByText("All rent obligations are up to date.")).toBeInTheDocument();
     expect(screen.getByText("No issues detected. Everything is up to date.")).toBeInTheDocument();
-    expect(screen.getByText("+$1,450.00")).toBeInTheDocument();
+    expect(screen.getAllByText("+$1,450.00").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
   });
 

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -473,6 +473,7 @@ describe("LeaseLedgerPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Financial status" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Financial signal" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Payment obligation cards")).toBeInTheDocument();
     expect(screen.queryByRole("columnheader", { name: "Status" })).not.toBeInTheDocument();
     expect(screen.queryByRole("columnheader", { name: "Delinquency" })).not.toBeInTheDocument();
     expect(screen.getAllByText("Expected").length).toBeGreaterThan(0);
@@ -484,7 +485,7 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText("$4,200.00")).toBeInTheDocument();
     expect(screen.getAllByText("1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$1,350.00").length).toBeGreaterThan(0);
-    expect(screen.getByText("$1,500.00")).toBeInTheDocument();
+    expect(screen.getAllByText("$1,500.00").length).toBeGreaterThan(0);
     expect(screen.queryByText("1015000")).not.toBeInTheDocument();
     expect(screen.queryByText("595000")).not.toBeInTheDocument();
     expect(screen.queryByText("420000")).not.toBeInTheDocument();
@@ -494,11 +495,31 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText("Overpaid").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Missing").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
-    expect(screen.getByText("Manual review")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Reconciled").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual Review Required").length).toBeGreaterThan(0);
-    expect(screen.getByText(new Date(2026, 4, 5).toLocaleDateString())).toBeInTheDocument();
+    expect(screen.getAllByText(new Date(2026, 4, 5).toLocaleDateString()).length).toBeGreaterThan(0);
+  });
+
+  it("keeps the payment CSV import collapsed until the landlord opens it", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("AI-assisted payment CSV import")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import payments CSV" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Payment CSV file")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Import payments CSV" }));
+
+    expect(screen.getByRole("button", { name: "Hide" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Payment CSV file")).toBeInTheDocument();
+    expect(screen.getByLabelText("Payment CSV import assistant")).toBeInTheDocument();
   });
 
   it("renders delinquency summary cards and row-level signal reasons", async () => {
@@ -519,11 +540,11 @@ describe("LeaseLedgerPage", () => {
     expect(await screen.findByText("$4,250.00")).toBeInTheDocument();
     expect(screen.queryByText("425000")).not.toBeInTheDocument();
 
-    expect(screen.getByText("Overdue — Rent past due date (obligation missing after due date)")).toBeInTheDocument();
-    expect(screen.getByText("Missing — No rent payment found after due date (missing rent payment after due date)")).toBeInTheDocument();
-    expect(screen.getByText("Underpaid — Partial payment received (obligation partially paid)")).toBeInTheDocument();
-    expect(screen.getByText("Failed — Payment did not complete (obligation payment failed)")).toBeInTheDocument();
-    expect(screen.getByText("Manual review required — Payment mismatch or incomplete evidence (obligation requires manual review)")).toBeInTheDocument();
+    expect(screen.getAllByText("Overdue — Rent past due date (obligation missing after due date)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Missing — No rent payment found after due date (missing rent payment after due date)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Underpaid — Partial payment received (obligation partially paid)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Failed — Payment did not complete (obligation payment failed)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual review required — Payment mismatch or incomplete evidence (obligation requires manual review)").length).toBeGreaterThan(0);
   });
 
   it("renders read-only lease decisions derived from delinquency signals", async () => {
@@ -543,9 +564,10 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
     expect(screen.getAllByText("Financial signal").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Workflow status").length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText("Workflow actions update review handling only. Financial status is derived from payments, obligations, and reconciliation evidence.").length
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Recommended next action").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Record payment").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Property / unit").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Harbour View · Unit 101").length).toBeGreaterThan(0);
     expect(screen.getByText("Active critical decisions")).toBeInTheDocument();
     expect(screen.getByText("Active warning decisions")).toBeInTheDocument();
     expect(screen.getByText("Active decision count")).toBeInTheDocument();
@@ -560,8 +582,14 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByRole("link", { name: "Jane Tenant" })).toHaveAttribute("href", "/tenants?tenantId=tenant-1");
     expect(screen.queryByText(/Unit ref/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Tenant ref/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Internal Property ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Internal Lease ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Provider payment reference")).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Show advanced evidence" })[0]);
+    expect(screen.getAllByText("Internal Property ID").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Internal Unit ID").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Internal Tenant ID").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Internal Lease ID").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Outstanding amount").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
     expect(screen.getByText("Underpaid Rent")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -34,8 +34,10 @@ import {
   type DecisionItem,
   type DecisionSeverity,
 } from "@/lib/decisions/decisionDisplay";
+import { findRelatedDelinquencySignal, findRelatedObligationRow } from "@/lib/decisions/decisionContext";
 import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
 import { PaymentCsvImportPreviewCard } from "@/components/ledger/PaymentCsvImportPreviewCard";
+import "./LeaseLedgerPage.css";
 
 type ChargeType = "rent" | "fee" | "adjustment";
 type PaymentMethod = "cash" | "etransfer" | "cheque" | "bank" | "card" | "other";
@@ -269,6 +271,85 @@ function DecisionActionControls({
   );
 }
 
+function readableText(value: unknown, fallback = "Not available"): string {
+  const text = String(value ?? "").trim();
+  if (!text) return fallback;
+  return text.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function metadataNumber(decision: DecisionItem, key: string): number | null {
+  const value = Number(decision.metadata?.[key]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function metadataString(decision: DecisionItem, key: string): string | null {
+  const value = String(decision.metadata?.[key] ?? "").trim();
+  return value || null;
+}
+
+function recommendedDecisionAction(decision: DecisionItem): { label: string; cta: "record_payment" | "resolve"; helper: string } {
+  switch (decision.decisionType) {
+    case "review_overdue_rent":
+    case "review_underpaid_rent":
+    case "review_missing_payment":
+      return {
+        label: "Record payment or contact the tenant, then resolve once the ledger is updated.",
+        cta: "record_payment",
+        helper: "Opens the existing record payment workflow.",
+      };
+    case "review_failed_payment":
+      return {
+        label: "Review payment evidence and follow up before resolving the issue.",
+        cta: "resolve",
+        helper: "Marks the operational review item resolved only.",
+      };
+    case "review_manual_payment_issue":
+      return {
+        label: "Review the mismatch and resolve after the evidence is reconciled.",
+        cta: "resolve",
+        helper: "Marks the operational review item resolved only.",
+      };
+    default:
+      return {
+        label: "Review the issue and resolve when the source record is correct.",
+        cta: "resolve",
+        helper: "Marks the operational review item resolved only.",
+      };
+  }
+}
+
+function buildDecisionSummaryFacts(
+  decision: DecisionItem,
+  lease: LandlordActiveLease | null,
+  obligationRows: LeaseObligationLedgerRow[],
+  delinquencySignals: LeaseDelinquencySignal[]
+) {
+  const displayDecision = withDecisionReviewContext(decision, lease);
+  const reviewContext = displayDecision.metadata?.reviewContext as Record<string, string | undefined> | undefined;
+  const relatedRow = findRelatedObligationRow(displayDecision, obligationRows);
+  const relatedSignal = findRelatedDelinquencySignal(displayDecision, delinquencySignals);
+  const outstandingAmountCents =
+    relatedSignal?.outstandingAmountCents ??
+    metadataNumber(displayDecision, "outstandingAmountCents") ??
+    (relatedRow ? obligationOutstandingCents(relatedRow) : null);
+  const dueDate = relatedSignal?.dueDate || relatedRow?.dueDate || metadataString(displayDecision, "dueDate");
+  const obligationStatus = relatedRow?.obligationStatus || metadataString(displayDecision, "obligationStatus");
+  const propertyUnitLabel =
+    reviewContext?.propertyLabel && reviewContext?.unitLabel
+      ? `${reviewContext.propertyLabel} · ${reviewContext.unitLabel}`
+      : reviewContext?.propertyLabel || reviewContext?.unitLabel || "Property / unit context available";
+
+  return {
+    displayDecision,
+    tenantLabel: reviewContext?.tenantName || (displayDecision.tenantId ? "Tenant context available" : "Tenant not linked"),
+    propertyUnitLabel,
+    outstandingAmount: outstandingAmountCents != null ? formatCurrencyCents(outstandingAmountCents) : "Not available",
+    dueDate: dueDate ? formatDate(dueDate) : "Not available",
+    obligationStatus: readableText(obligationStatus),
+    recommendedAction: recommendedDecisionAction(displayDecision),
+  };
+}
+
 function buildDecisionReviewContext(lease: LandlordActiveLease | null): Record<string, string> | null {
   if (!lease) return null;
   const propertyLabel = formatOperationalLabel({
@@ -314,6 +395,7 @@ function DecisionRow({
   delinquencySignals,
   pending,
   onAction,
+  onRecordPayment,
 }: {
   decision: DecisionItem;
   lease: LandlordActiveLease | null;
@@ -321,20 +403,12 @@ function DecisionRow({
   delinquencySignals: LeaseDelinquencySignal[];
   pending: boolean;
   onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
+  onRecordPayment: () => void;
 }) {
   const copy = decisionDisplayCopy[decision.decisionType];
-  const displayDecision = withDecisionReviewContext(decision, lease);
-  const reviewContext = displayDecision.metadata?.reviewContext as Record<string, string | undefined> | undefined;
-  const propertyUnitLabel =
-    reviewContext?.propertyLabel && reviewContext?.unitLabel
-      ? `${reviewContext.propertyLabel} · ${reviewContext.unitLabel}`
-      : reviewContext?.propertyLabel || reviewContext?.unitLabel || null;
-  const context = [
-    propertyUnitLabel,
-    reviewContext?.tenantName || (decision.tenantId ? "Tenant context available" : null),
-  ].filter(Boolean);
+  const summary = buildDecisionSummaryFacts(decision, lease, obligationRows, delinquencySignals);
   return (
-    <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, background: "#fff", display: "grid", gap: 6 }}>
+    <div className="lease-ledger-decision-card">
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
         <strong>{copy.label}</strong>
       </div>
@@ -346,15 +420,56 @@ function DecisionRow({
           {decisionStatusCopy[decision.status || "detected"]}
         </span>
       </div>
-      <div style={{ color: "#475569" }}>{decision.reason}</div>
-      <div style={{ color: "#64748b", fontSize: 12 }}>
-        Workflow actions update review handling only. Financial status is derived from payments, obligations, and reconciliation evidence.
+      <div className="lease-ledger-decision-summary">
+        <div className="lease-ledger-decision-primary">
+          <span>Issue</span>
+          <strong>{decision.reason}</strong>
+        </div>
+        <div>
+          <span>Tenant</span>
+          <strong>{summary.tenantLabel}</strong>
+        </div>
+        <div>
+          <span>Property / unit</span>
+          <strong>{summary.propertyUnitLabel}</strong>
+        </div>
+        <div>
+          <span>Outstanding</span>
+          <strong>{summary.outstandingAmount}</strong>
+        </div>
+        <div>
+          <span>Due date</span>
+          <strong>{summary.dueDate}</strong>
+        </div>
+        <div>
+          <span>Obligation status</span>
+          <strong>{summary.obligationStatus}</strong>
+        </div>
       </div>
-      {context.length ? <div style={{ color: "#64748b", fontSize: 12 }}>{context.join(" · ")}</div> : null}
+      <div className="lease-ledger-next-action">
+        <div>
+          <span>Recommended next action</span>
+          <strong>{summary.recommendedAction.label}</strong>
+        </div>
+        {summary.recommendedAction.cta === "record_payment" ? (
+          <button type="button" onClick={onRecordPayment} title={summary.recommendedAction.helper}>
+            Record payment
+          </button>
+        ) : (
+          <button type="button" disabled={pending} onClick={() => onAction(decision, "resolved")} title={summary.recommendedAction.helper}>
+            {pending ? "Saving..." : "Review / resolve"}
+          </button>
+        )}
+      </div>
       {decision.latestAction ? (
         <div style={{ color: "#64748b", fontSize: 12 }}>Last action: {decisionStatusCopy[decision.latestAction.nextStatus]}</div>
       ) : null}
-      <DecisionContextPanel decision={displayDecision} obligationRows={obligationRows} delinquencySignals={delinquencySignals} />
+      <DecisionContextPanel
+        decision={summary.displayDecision}
+        obligationRows={obligationRows}
+        delinquencySignals={delinquencySignals}
+        internalEvidenceMode="advanced"
+      />
       <DecisionActionControls decision={decision} pending={pending} onAction={onAction} />
     </div>
   );
@@ -418,6 +533,52 @@ function DelinquencyIndicators({
         </span>
       ))}
     </div>
+  );
+}
+
+function ObligationMobileCard({
+  row,
+  signals,
+}: {
+  row: LeaseObligationLedgerRow;
+  signals: LeaseDelinquencySignal[];
+}) {
+  return (
+    <article className="lease-ledger-obligation-card">
+      <div className="lease-ledger-obligation-card-header">
+        <div>
+          <span>Period</span>
+          <strong>{formatPeriod(row)}</strong>
+        </div>
+        <ObligationStatusBadge status={row.obligationStatus || "unknown"} />
+      </div>
+      <div className="lease-ledger-obligation-card-grid">
+        <div>
+          <span>Due date</span>
+          <strong>{formatDate(row.dueDate)}</strong>
+        </div>
+        <div>
+          <span>Expected</span>
+          <strong>{formatCurrencyCents(row.expectedAmountCents)}</strong>
+        </div>
+        <div>
+          <span>Paid</span>
+          <strong>{formatCurrencyCents(row.paidAmountCents)}</strong>
+        </div>
+        <div>
+          <span>Outstanding</span>
+          <strong>{formatCurrencyCents(obligationOutstandingCents(row))}</strong>
+        </div>
+      </div>
+      <div className="lease-ledger-obligation-card-section">
+        <span>Financial signal</span>
+        <DelinquencyIndicators row={row} signals={signals} />
+      </div>
+      <div className="lease-ledger-obligation-card-section">
+        <span>Evidence</span>
+        <strong>{prettyEvidenceStatus(row)}</strong>
+      </div>
+    </article>
   );
 }
 
@@ -489,6 +650,7 @@ export default function LeaseLedgerPage() {
   const [lease, setLease] = useState<LandlordActiveLease | null>(null);
   const [notes, setNotes] = useState<LeaseNote[]>([]);
   const [noteText, setNoteText] = useState("");
+  const [isCsvImportOpen, setIsCsvImportOpen] = useState(false);
 
   const [chargeDate, setChargeDate] = useState(todayIso());
   const [chargeType, setChargeType] = useState<ChargeType>("rent");
@@ -730,7 +892,7 @@ export default function LeaseLedgerPage() {
   }
 
   return (
-    <div style={{ padding: 16, display: "grid", gap: 14 }}>
+    <div className="lease-ledger-page">
       <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", justifyContent: "space-between" }}>
         <div>
           <h1 style={{ margin: 0, fontSize: "1.2rem" }}>Lease Ledger</h1>
@@ -739,7 +901,10 @@ export default function LeaseLedgerPage() {
               ? `${formatOperationalLabel({ kind: "property", label: lease.propertyName || lease.propertyAddress, fallbackLabel: "Property", internalId: lease.propertyId })} · ${formatOperationalLabel({ kind: "unit", label: lease.unitNumber ? `Unit ${lease.unitNumber}` : lease.unitLabel, fallbackLabel: "Unit", internalId: lease.unitId })}`
               : "Lease ledger"}
           </div>
-          <div style={{ color: "#64748b", marginTop: 2, fontSize: 12 }}>{formatInternalReference("lease", leaseId)}</div>
+          <details className="lease-ledger-advanced-reference">
+            <summary>Advanced lease reference</summary>
+            <div>{formatInternalReference("lease", leaseId)}</div>
+          </details>
           {lease ? (
             <div style={{ color: "#334155", marginTop: 6, display: "grid", gap: 2 }}>
               <div>
@@ -749,7 +914,7 @@ export default function LeaseLedgerPage() {
             </div>
           ) : null}
         </div>
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <div className="lease-ledger-actions">
           <Link to="/leases?view=archived">View archive</Link>
           <button aria-label="Add lease note" onClick={() => setShowNoteModal(true)}>Add note</button>
           <button onClick={() => setShowChargeModal(true)}>Add charge</button>
@@ -789,7 +954,24 @@ export default function LeaseLedgerPage() {
         </div>
       </div>
 
-      <PaymentCsvImportPreviewCard />
+      <section className="lease-ledger-csv-card">
+        <div className="lease-ledger-csv-card-header">
+          <div>
+            <div style={{ fontSize: "1rem", fontWeight: 800, color: "#0f172a" }}>AI-assisted payment CSV import</div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 3 }}>
+              Upload payment rows when you need assisted matching.
+            </div>
+          </div>
+          <button type="button" onClick={() => setIsCsvImportOpen((current) => !current)}>
+            {isCsvImportOpen ? "Hide" : "Import payments CSV"}
+          </button>
+        </div>
+        {isCsvImportOpen ? (
+          <div className="lease-ledger-csv-panel">
+            <PaymentCsvImportPreviewCard onImportComplete={() => void loadLedger({ showLoading: false })} />
+          </div>
+        ) : null}
+      </section>
 
       {lease?.leaseExecution ? (
         <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 12, background: "#fff", display: "grid", gap: 8 }}>
@@ -853,6 +1035,7 @@ export default function LeaseLedgerPage() {
                   delinquencySignals={delinquencySignals}
                   pending={decisionActionPendingId === decision.decisionId}
                   onAction={handleDecisionAction}
+                  onRecordPayment={() => setShowPaymentModal(true)}
                 />
               ))}
             </div>
@@ -925,7 +1108,8 @@ export default function LeaseLedgerPage() {
             Obligation ledger is not available yet for this lease.
           </div>
         ) : (
-          <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12 }}>
+          <>
+          <div className="lease-ledger-obligations-table" style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12 }}>
             <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 1080 }}>
               <thead>
                 <tr style={{ background: "#f8fafc" }}>
@@ -954,6 +1138,12 @@ export default function LeaseLedgerPage() {
               </tbody>
             </table>
           </div>
+          <div className="lease-ledger-obligation-cards" aria-label="Payment obligation cards">
+            {obligationRows.map((row) => (
+              <ObligationMobileCard key={row.rowId} row={row} signals={delinquencySignals} />
+            ))}
+          </div>
+          </>
         )}
       </section>
 

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -582,6 +582,46 @@ function ObligationMobileCard({
   );
 }
 
+function LedgerEntryMobileCard({ entry }: { entry: LeaseLedgerEntry }) {
+  const amountColor = entry.entryType === "payment" ? "#047857" : "#0f172a";
+  return (
+    <article className="lease-ledger-entry-card">
+      <div className="lease-ledger-entry-card-header">
+        <div>
+          <span>Date</span>
+          <strong>{formatDate(entry.effectiveDate)}</strong>
+        </div>
+        <div>
+          <span>Amount</span>
+          <strong style={{ color: amountColor }}>{formatSignedCurrencyCents(entry.amountCents, entry.entryType)}</strong>
+        </div>
+      </div>
+      <div className="lease-ledger-entry-card-grid">
+        <div>
+          <span>Type</span>
+          <strong>{readableText(entry.entryType)}</strong>
+        </div>
+        <div>
+          <span>Category</span>
+          <strong>{readableText(entry.category)}</strong>
+        </div>
+        <div>
+          <span>Method/ref</span>
+          <strong>{[entry.method, entry.reference].filter(Boolean).join(" · ") || "—"}</strong>
+        </div>
+        <div>
+          <span>Balance</span>
+          <strong>{formatCurrencyCents(entry.balanceCents)}</strong>
+        </div>
+      </div>
+      <div className="lease-ledger-entry-card-section">
+        <span>Notes</span>
+        <strong>{entry.notes || "—"}</strong>
+      </div>
+    </article>
+  );
+}
+
 function prettyEvidenceStatus(row: LeaseObligationLedgerRow): string {
   const evidence = String(row.evidenceStatus || "").trim();
   if (evidence) return evidence.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
@@ -1151,25 +1191,23 @@ export default function LeaseLedgerPage() {
 
       {loading ? (
         <div>Loading ledger…</div>
+      ) : entries.length === 0 ? (
+        <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, color: "#64748b", background: "#fff" }}>
+          No ledger entries for this range.
+        </div>
       ) : (
-        <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12 }}>
-          <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 860 }}>
-            <thead>
-              <tr style={{ background: "#f8fafc" }}>
-                {["Date", "Type", "Category", "Amount", "Method/Ref", "Notes", "Balance"].map((h) => (
-                  <th key={h} style={{ textAlign: "left", padding: 10, borderBottom: "1px solid #e2e8f0" }}>{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {entries.length === 0 ? (
-                <tr>
-                  <td colSpan={7} style={{ padding: 12, color: "#64748b" }}>
-                    No ledger entries for this range.
-                  </td>
+        <>
+          <div className="lease-ledger-entries-table" style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12 }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 860 }}>
+              <thead>
+                <tr style={{ background: "#f8fafc" }}>
+                  {["Date", "Type", "Category", "Amount", "Method/Ref", "Notes", "Balance"].map((h) => (
+                    <th key={h} style={{ textAlign: "left", padding: 10, borderBottom: "1px solid #e2e8f0" }}>{h}</th>
+                  ))}
                 </tr>
-              ) : (
-                entries.map((entry) => (
+              </thead>
+              <tbody>
+                {entries.map((entry) => (
                   <tr key={entry.id}>
                     <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{entry.effectiveDate}</td>
                     <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9", textTransform: "capitalize" }}>{entry.entryType}</td>
@@ -1183,11 +1221,16 @@ export default function LeaseLedgerPage() {
                     <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{entry.notes || "—"}</td>
                     <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{formatCurrencyCents(entry.balanceCents)}</td>
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="lease-ledger-entry-cards" aria-label="Ledger entry cards">
+            {entries.map((entry) => (
+              <LedgerEntryMobileCard key={entry.id} entry={entry} />
+            ))}
+          </div>
+        </>
       )}
 
       {monthlyRows.length ? (


### PR DESCRIPTION
## Summary

Improves the lease ledger destination for payment-decision routes without changing payment, ledger, CSV import, or dashboard logic.

## Root Cause

The lease ledger page rendered the payment CSV import assistant fully expanded by default, used wide tables as the primary mobile experience, and surfaced decision evidence with internal references in the default landlord-facing context. On mobile this made the route feel crowded and actionability was buried behind projection/evidence details.

## Changes

- Adds a lease-ledger-specific responsive stylesheet.
- Collapses the payment CSV import section by default behind `Import payments CSV`.
- Keeps the CSV import UI inside a contained card when opened.
- Strengthens CSV import wrapping/containment so title text, accepted-columns copy, file inputs, and template content do not force page-level overflow.
- Adds mobile-friendly payment obligation cards while preserving the desktop obligations table.
- Adds mobile-friendly ledger entry cards for Date/Type/Category/Amount/Method/ref/Notes/Balance rows while preserving the desktop ledger table.
- Reworks lease decision cards to prioritize issue, tenant, property/unit, outstanding amount, due date, obligation status, and recommended next action.
- Moves internal decision evidence behind an explicit `Show advanced evidence` control on the lease ledger route.
- Moves the header lease internal reference behind an advanced disclosure.
- Preserves existing record payment and decision workflow actions.

## Validation

- `npm run test:single -- src/pages/LeaseLedgerPage.test.tsx src/components/decisions/DecisionContextPanel.test.tsx` passed under Node 20.20.2.
- `npm run build` passed under Node 20.20.2.
- `git diff --check` passed.

Note: a test rerun under Node 20.11.1 failed before test execution because the local Vitest/jsdom dependency chain hit `ERR_REQUIRE_ESM` in `html-encoding-sniffer`; Node 20.20.2 is available locally and satisfies the current Vite/Vitest runtime floor.

## Final Manual QA Passed

Mobile `/leases/:leaseId/ledger`:
- CSV import is collapsed by default.
- `Import payments CSV` opens the panel.
- CSV import text and accepted-columns text wrap inside the card.
- CSV input does not force viewport overflow.
- CSV import panel remains contained.
- No uncontrolled page-level horizontal scroll.
- Ledger entries render as readable mobile cards.
- Payment obligations remain readable.
- Decision context is user-friendly by default.
- Internal IDs remain hidden by default.
- `Show advanced evidence` opens correctly.
- Existing CTAs remain available.

Desktop `/leases/:leaseId/ledger`:
- Desktop remains acceptable.
- Desktop tables remain intact.
- CSV import collapsed behavior is acceptable.
- Advanced evidence opens correctly.
- Existing ledger actions remain available.

Regression routes passed:
- `/dashboard`
- `/applications`
- `/operations`
- `/leases`

## Follow-Up

- Navigation/discoverability audit captured separately: #1277 `audit/lease-ledger-navigation-discoverability-v1`.