### PR TITLE
Normalize lease ledger navigation shortcuts

### DIFF
--- a/rentchain-frontend/src/components/dashboard/RecentEventsCard.tsx
+++ b/rentchain-frontend/src/components/dashboard/RecentEventsCard.tsx
@@ -42,7 +42,7 @@ export function RecentEventsCard({
     .map((event) => String(event?.leaseId || event?.subjectLeaseId || event?.metadata?.leaseId || "").trim())
     .find(Boolean);
   const canOpenLedger = Boolean(onOpenLedger) && openLedgerEnabled !== false;
-  const ledgerButtonLabel = ledgerLeaseId ? "View ledger" : "View leases";
+  const ledgerButtonLabel = ledgerLeaseId ? "Open payment ledger" : "View leases";
 
   return (
     <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>

--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
@@ -44,7 +44,7 @@ describe("DecisionContextPanel", () => {
     );
 
     expect(screen.getByRole("link", { name: "Lease summary" })).toHaveAttribute("href", "/leases/lease-1/summary");
-    expect(screen.getByRole("link", { name: "Lease ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Payment ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Property / unit" })).toHaveAttribute("href", "/properties?propertyId=property-1&unitId=unit-1");
     expect(screen.getByRole("link", { name: "Tenant" })).toHaveAttribute("href", "/tenants?tenantId=tenant-1");
     expect(screen.getByRole("link", { name: "Lifecycle review" })).toHaveAttribute("href", "/admin/lease-lifecycle-review");
@@ -66,6 +66,6 @@ describe("DecisionContextPanel", () => {
     );
 
     expect(screen.getByText("Context unavailable")).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Lease ledger" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Payment ledger" })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -1583,7 +1583,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                         fontSize: "0.8rem",
                       }}
                     >
-                      Ledger
+                      Payment ledger
                     </button>
                   ) : null}
                 </div>
@@ -1877,7 +1877,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                               {occupancyView.ledgerHref ? (
                                 <>
                                   {" · "}
-                                  <a href={occupancyView.ledgerHref}>Ledger</a>
+                                  <a href={occupancyView.ledgerHref}>Payment ledger</a>
                                 </>
                               ) : null}
                             </div>
@@ -2026,7 +2026,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                         {occupancyView.ledgerHref ? (
                           <>
                             {" · "}
-                            <a href={occupancyView.ledgerHref}>Ledger</a>
+                            <a href={occupancyView.ledgerHref}>Payment ledger</a>
                           </>
                         ) : null}
                       </div>

--- a/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyOccupancyRegression.test.tsx
@@ -344,13 +344,13 @@ describe("PropertyDetailPanel occupancy regression coverage", () => {
   it("keeps canonical ledger navigation on lease-backed occupancy rows", async () => {
     renderPropertyDetail();
 
-    const ledgerLinks = await screen.findAllByRole("link", { name: "Ledger" });
+    const ledgerLinks = await screen.findAllByRole("link", { name: "Payment ledger" });
     expect(ledgerLinks.some((link) => link.getAttribute("href") === `/leases/${lifecycleContinuityIds.activeLeaseId}/ledger`)).toBe(true);
     expect(ledgerLinks.some((link) => link.getAttribute("href") === `/leases/${lifecycleContinuityIds.upcomingLeaseId}/ledger`)).toBe(true);
 
     const activeRow = screen.getAllByRole("link", { name: "John Smith" })[0].closest("td");
     expect(activeRow).toBeTruthy();
-    expect(within(activeRow as HTMLElement).getByRole("link", { name: "Ledger" })).toHaveAttribute(
+    expect(within(activeRow as HTMLElement).getByRole("link", { name: "Payment ledger" })).toHaveAttribute(
       "href",
       `/leases/${lifecycleContinuityIds.activeLeaseId}/ledger`,
     );

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -227,8 +227,8 @@ describe("TenantDetailPanel", () => {
     expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
     expect(screen.getByText("Needs review: Draft lease / Review Required occupancy")).toBeInTheDocument();
     expect(screen.getByText("Showing the most recent charges and payments from the current lease ledger.")).toBeInTheDocument();
-    expect(screen.getByText("Use the current lease ledger to record charges and payments.")).toBeInTheDocument();
-    expect(screen.getByText("Showing the latest 10 entries here. Open current lease ledger for the full history.")).toBeInTheDocument();
+    expect(screen.getByText("Use the current payment ledger to record charges and payments.")).toBeInTheDocument();
+    expect(screen.getByText("Showing the latest 10 entries here. Open payment ledger for the full history.")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Tenant activity is recorded separately and does not add charges or payments to the current lease ledger."

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -773,7 +773,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             }}
           >
             <div style={{ color: text.muted, fontSize: "0.8rem" }}>
-              Use the current lease ledger to record charges and payments.
+              Use the current payment ledger to record charges and payments.
             </div>
             <button
               type="button"
@@ -789,7 +789,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
                 boxShadow: shadows.sm,
               }}
             >
-              Open current lease ledger →
+              Open payment ledger →
             </button>
           </div>
 
@@ -856,7 +856,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             </span>
             {ledgerMode === "lease" ? (
               <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
-                Showing the latest {RECENT_LEASE_LEDGER_ENTRY_LIMIT} entries here. Open current lease ledger for the full history.
+                Showing the latest {RECENT_LEASE_LEDGER_ENTRY_LIMIT} entries here. Open payment ledger for the full history.
               </span>
             ) : null}
             {ledgerMode === "tenant" ? (

--- a/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
@@ -39,7 +39,7 @@ describe("decisionContext", () => {
   it("builds deterministic context links from available identifiers", () => {
     expect(buildDecisionContextLinks(decision, { includeAdminReviewLink: true })).toEqual([
       expect.objectContaining({ key: "lease", label: "Lease summary", href: "/leases/lease-1/summary" }),
-      expect.objectContaining({ key: "ledger", label: "Lease ledger", href: "/leases/lease-1/ledger" }),
+      expect.objectContaining({ key: "ledger", label: "Payment ledger", href: "/leases/lease-1/ledger" }),
       expect.objectContaining({ key: "property", label: "Property / unit", href: "/properties?propertyId=property-1&unitId=unit-1" }),
       expect.objectContaining({ key: "tenant", label: "Tenant", href: "/tenants?tenantId=tenant-1" }),
       expect.objectContaining({ key: "admin_review", label: "Lifecycle review", href: "/admin/lease-lifecycle-review" }),

--- a/rentchain-frontend/src/lib/decisions/decisionContext.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.ts
@@ -131,7 +131,7 @@ export function buildDecisionContextLinks(
     });
     links.push({
       key: "ledger",
-      label: "Lease ledger",
+      label: "Payment ledger",
       href: `/leases/${encodeURIComponent(decision.leaseId)}/ledger`,
       helperText: "Review obligations and payments",
     });

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -276,7 +276,7 @@ describe("DashboardPage", () => {
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Due");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review outstanding rent");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Outstanding $2,000.00 for the March rent period.");
-    expect(screen.getByRole("link", { name: /Open ledger: Review outstanding rent/i })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Open payment ledger: Review outstanding rent/i })).toHaveAttribute(
       "href",
       "/leases/lease-1/ledger"
     );

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -167,6 +167,10 @@ function isGenericActionLabel(label: string): boolean {
   return ["open", "review", "view"].includes(label.trim().toLowerCase());
 }
 
+function isLegacyLedgerActionLabel(label: string): boolean {
+  return ["ledger", "lease ledger", "open ledger", "view ledger"].includes(label.trim().toLowerCase());
+}
+
 function decisionDestinationCopy(item: LandlordDecisionQueueItem): { meta: string; action: string } {
   const href = String(item.recommendedActionHref || "").trim();
   const label = String(item.recommendedActionLabel || "").trim();
@@ -184,7 +188,10 @@ function decisionDestinationCopy(item: LandlordDecisionQueueItem): { meta: strin
     return { meta: "Lease renewals · Review operator inputs", action: "Review renewals" };
   }
   if (href.includes("/ledger")) {
-    return { meta: "Payment ledger · Review obligation", action: label && !isGenericActionLabel(label) ? label : "Open ledger" };
+    return {
+      meta: "Payment ledger · Review obligation",
+      action: label && !isGenericActionLabel(label) && !isLegacyLedgerActionLabel(label) ? label : "Open payment ledger",
+    };
   }
   if (href.includes("/messages")) {
     return { meta: "Messages · Review thread", action: label && !isGenericActionLabel(label) ? label : "Open messages" };

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -372,7 +372,11 @@ describe("DecisionInboxPage", () => {
     expect(screen.getByText("Related: Lease context review")).toBeInTheDocument();
     expect(screen.getByText("Missing payment review is routed to delinquency review.")).toBeInTheDocument();
     expect(screen.queryByText(/Decision decision:review_missing_payment/)).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(
+      screen
+        .getAllByRole("link", { name: "Open payment ledger" })
+        .some((link) => link.getAttribute("href") === "/leases/lease-1/ledger")
+    ).toBe(true);
     expect(screen.getByText("Open cost approval")).toBeInTheDocument();
     expect(screen.getByText("No context link available")).toBeInTheDocument();
     expect(screen.getAllByText("Operator review session").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -192,6 +192,14 @@ function safeRelatedLabel(item: DecisionInboxItem) {
   return operationalReviewLabel({ value: raw || item.id, queue: item.workflow.queue });
 }
 
+function isLeaseLedgerDestination(destination: string | null | undefined) {
+  return /^\/leases\/[^/]+\/ledger(?:$|[?#])/.test(String(destination || "").trim());
+}
+
+function contextLinkLabel(destination: string | null | undefined) {
+  return isLeaseLedgerDestination(destination) ? "Open payment ledger" : "View context";
+}
+
 function safeAutomationReason(reason: string, item: DecisionInboxItem) {
   const routedMatch = reason.match(/^Decision\s+(.+?)\s+is routed to\s+([a-z_]+)\.?$/i);
   if (routedMatch) {
@@ -249,7 +257,7 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
         </span>
         {item.destination ? (
           <Link to={item.destination} style={{ color: "#2563eb", fontWeight: 800 }}>
-            View context
+            {contextLinkLabel(item.destination)}
           </Link>
         ) : (
           <span style={{ color: "#64748b", fontSize: 13 }}>No context link available</span>
@@ -314,7 +322,7 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
                 ) : null}
                 {action.status === "available" && action.destination ? (
                   <Link to={action.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13 }}>
-                    Open manual context
+                    {contextLinkLabel(action.destination)}
                   </Link>
                 ) : null}
               </div>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -318,7 +318,7 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View lease" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Payment ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",
       expect.stringContaining("mailto:jane%40example.com")
@@ -728,7 +728,7 @@ describe("LandlordActiveLeasesPage", () => {
     expect(await screen.findByText(/Needs review: Draft lease · Review needed occupancy/i)).toBeInTheDocument();
     expect(screen.getByText("Review needed")).toBeInTheDocument();
     expect(screen.getByText("Recorded ledger payment activity present")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-review/ledger");
+    expect(screen.getByRole("link", { name: "Payment ledger" })).toHaveAttribute("href", "/leases/lease-review/ledger");
   });
 
   it("maps landlord payment blockers without exposing raw codes", async () => {
@@ -811,7 +811,7 @@ describe("LandlordActiveLeasesPage", () => {
     expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Primary lease document unavailable" })).toBeDisabled();
     expect(screen.getByRole("link", { name: "Lease summary" })).toHaveAttribute("href", "/leases/lease-1/summary");
-    expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Payment ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });
 
@@ -1031,7 +1031,7 @@ describe("LandlordActiveLeasesPage", () => {
 
     expect(await screen.findByTestId("lease-mobile-card")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View lease" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Payment ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Archive lease" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -604,7 +604,7 @@ export default function LandlordActiveLeasesPage() {
         `Monthly rent: ${formatCurrency(lease.monthlyRent)}`,
         `Status: ${prettyLeaseStatus(lease.status)}`,
         `Term: ${formatDate(lease.startDate)} to ${formatDate(lease.endDate)}`,
-        `View ledger: ${ledgerUrl}`,
+        `Payment ledger: ${ledgerUrl}`,
         `Lease summary: ${typeof window !== "undefined" ? `${window.location.origin}${summaryPath}` : summaryPath}`,
       ]
         .filter(Boolean)
@@ -672,7 +672,7 @@ export default function LandlordActiveLeasesPage() {
             </button>
           ) : null}
           <Link to={ledgerPath} style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}>
-            Ledger
+            Payment ledger
           </Link>
           {emailHref ? (
             <a

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -138,7 +138,7 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getAllByText("Coburg Rd").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Tony Wenpeng").length).toBeGreaterThan(0);
     expect(screen.queryByText(/gs:\/\//i)).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Open ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Open payment ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download evidence package" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -145,7 +145,7 @@ export default function LandlordLeaseSummaryPage() {
           to={ledgerPath}
           style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
         >
-          Open ledger
+          Open payment ledger
         </Link>
           <button
             type="button"

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -264,7 +264,7 @@ export default function LandlordLeaseWorkflowPage() {
             Lease summary
           </Link>
           <Link to={ledgerPath} style={buttonLinkStyle}>
-            Ledger
+            Payment ledger
           </Link>
         </div>
       </section>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -580,7 +580,7 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByRole("button", { name: /Dismiss: Dismisses this signal from active review/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: /Resolve: Marks the operational review task as resolved/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Rent past due date").length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("link", { name: "Lease ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-1/ledger")).toBe(true);
+    expect(screen.getAllByRole("link", { name: "Payment ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-1/ledger")).toBe(true);
     expect(screen.getAllByRole("link", { name: "Harbour View · Unit 101" }).some((link) => link.getAttribute("href") === "/properties?propertyId=prop-1&unitId=unit-1")).toBe(true);
     expect(screen.getByRole("link", { name: "Jane Tenant" })).toHaveAttribute("href", "/tenants?tenantId=tenant-1");
     expect(screen.queryByText(/Unit ref/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -221,7 +221,7 @@ describe("deriveCommandCenterSignals", () => {
       workflowStatus: "New",
       reviewStatus: "Open",
       financialStatus: "Review required",
-      nextActionLabel: "Review payment evidence",
+      nextActionLabel: "Open payment ledger",
     });
     expect(signals.some((signal) => signal.title === "Lease ending soon")).toBe(true);
     expect(signals.some((signal) => signal.title === "Vacant units visible")).toBe(true);
@@ -320,7 +320,7 @@ describe("deriveCommandCenterSignals", () => {
     );
     expect(preview.evidenceLinks).toEqual([
       expect.objectContaining({
-        label: "Payments / obligations source workflow",
+        label: "Payment ledger source workflow",
         destination: "/leases/lease-1/ledger",
       }),
     ]);
@@ -402,7 +402,7 @@ describe("deriveCommandCenterSignals", () => {
     );
     expect(preview.evidenceLinks).toEqual([
       expect.objectContaining({
-        label: "Payments / obligations source workflow",
+        label: "Payment ledger source workflow",
         destination: "/leases/lease-1/ledger",
         sensitivityClass: "sensitive",
       }),
@@ -423,7 +423,7 @@ describe("deriveCommandCenterSignals", () => {
         sourceLabel: "Decision inbox · Delinquency Review",
         destination: "/leases/lease-1/ledger",
         routingReason: "Delinquency or payment evidence review",
-        evidenceLabel: "Payments / obligations source workflow",
+        evidenceLabel: "Payment ledger source workflow",
         relatedResourceLabel: "North Towers · 101 · John Smith",
         reviewStatus: "Open",
         assignmentLabel: "Operations owned",
@@ -669,7 +669,7 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Financial status: Review required").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Assignment: Operations owned").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Escalation: Critical").length).toBeGreaterThan(0);
-    expect(screen.getByText("Next action: Review payment evidence")).toBeInTheDocument();
+    expect(screen.getByText("Next action: Open payment ledger")).toBeInTheDocument();
     expect(screen.getAllByText("Review workspace readiness").length).toBeGreaterThan(0);
     expect(screen.getByTestId("operational-review-queue")).toBeInTheDocument();
     expect(screen.getByText("Operational review queue")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -364,6 +364,15 @@ export function scopedSourceDestinationForSignal(signal: CommandCenterSignal) {
   return signal.destination;
 }
 
+function isLeaseLedgerDestination(destination: string | null | undefined) {
+  return /^\/leases\/[^/]+\/ledger(?:$|[?#])/.test(String(destination || "").trim());
+}
+
+function sourceWorkflowLabelForSignal(signal: CommandCenterSignal) {
+  if (isLeaseLedgerDestination(scopedSourceDestinationForSignal(signal))) return "Payment ledger source workflow";
+  return `${CATEGORY_CONFIG[signal.category].label} source workflow`;
+}
+
 export function reviewWorkspacePreviewForSignal(signal: CommandCenterSignal): ReviewWorkspaceUiModel {
   const scope = signal.manualReviewScope && signal.manualReviewScopeId
     ? { scope: signal.manualReviewScope, scopeId: signal.manualReviewScopeId }
@@ -383,7 +392,7 @@ export function reviewWorkspacePreviewForSignal(signal: CommandCenterSignal): Re
     autonomousActionsEnabled: false,
     evidenceLinks: [
       {
-        label: `${CATEGORY_CONFIG[signal.category].label} source workflow`,
+        label: sourceWorkflowLabelForSignal(signal),
         destination: scopedSourceDestinationForSignal(signal),
         sensitivityClass: signal.category === "screening" || signal.category === "documents" ? "restricted" : "sensitive",
       },
@@ -449,7 +458,9 @@ function priorityFromDecision(item: DecisionInboxItem, category: CommandCenterCa
 }
 
 function nextActionForDecision(item: DecisionInboxItem, category: CommandCenterCategory) {
-  if (category === "payments") return "Review payment evidence";
+  if (category === "payments") {
+    return isLeaseLedgerDestination(item.destination) ? "Open payment ledger" : "Review payment evidence";
+  }
   if (category === "screening") return "Review screening workflow";
   if (category === "lease_lifecycle") return "Review lease readiness";
   if (category === "occupancy") return "Review occupancy context";
@@ -593,7 +604,7 @@ function resolveDecisionContextLabel(
   const existingLabel = String(item.relatedEntity?.label || "").trim();
   if (existingLabel && !looksLikeInternalId(existingLabel) && !hasRawReferenceLabel(existingLabel)) return existingLabel;
 
-  if (item.workflow?.queue === "delinquency_review") return "Lease ledger review";
+  if (item.workflow?.queue === "delinquency_review") return "Payment ledger review";
   if (item.workflow?.queue === "screening_review") return "Screening workflow review";
   if (item.workflow?.queue === "lease_review") return "Lease workflow review";
   if (item.relatedEntity?.kind === "property") return "Property review";

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -279,10 +279,10 @@ describe("TenantsPage", () => {
     expect(leaseLinks.length).toBeGreaterThan(0);
     expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-1/summary");
     expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
-    expect(screen.getByText("Lease ledger")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "View ledger" })).toBeEnabled();
+    expect(screen.getByText("Payment ledger")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open payment ledger" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Record payment" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Export ledger" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Export payment ledger" })).toBeEnabled();
   });
 
   it("shows the current lease from tenant detail when the list row has no currentLeaseId", async () => {
@@ -490,10 +490,10 @@ describe("TenantsPage", () => {
 
     expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
     expect(screen.getAllByText("No current lease linked").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "View ledger" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Open payment ledger" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Record payment" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Export ledger" })).toBeDisabled();
-    expect(screen.getByText("Link a current lease before using lease ledger actions.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export payment ledger" })).toBeDisabled();
+    expect(screen.getByText("Link a current lease before using payment ledger actions.")).toBeInTheDocument();
   });
 
   it("fails closed by hiding the targeted cleanup tenant ids from the landlord list", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -1053,7 +1053,7 @@ const loadTenants = useCallback(async () => {
                       >
                         <div style={{ display: "grid", gap: 4, minWidth: 220 }}>
                           <div style={{ fontSize: 16, fontWeight: 700, color: text.primary }}>
-                            Lease ledger
+                            Payment ledger
                           </div>
                           <div style={{ fontSize: 13, color: text.muted, lineHeight: 1.45 }}>
                             Current lease charges, payments, balances, and exports.
@@ -1061,9 +1061,9 @@ const loadTenants = useCallback(async () => {
                         </div>
                         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                           {[
-                            "View ledger",
+                            "Open payment ledger",
                             "Record payment",
-                            "Export ledger",
+                            "Export payment ledger",
                           ].map((label) => (
                             <button
                               key={label}
@@ -1114,7 +1114,7 @@ const loadTenants = useCallback(async () => {
                       </div>
                       {!selectedLeaseLedgerPath ? (
                         <div style={{ fontSize: 12, color: text.muted }}>
-                          Link a current lease before using lease ledger actions.
+                          Link a current lease before using payment ledger actions.
                         </div>
                       ) : null}
                     </div>

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
@@ -133,7 +133,7 @@ describe("AdminLeaseLifecycleReviewPage", () => {
     expect(screen.getByText(/No history yet/i)).toBeInTheDocument();
     expect(screen.getByText(/Related decision/i)).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: "Lease summary" }).some((link) => link.getAttribute("href") === "/leases/lease-2/summary")).toBe(true);
-    expect(screen.getAllByRole("link", { name: "Lease ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-2/ledger")).toBe(true);
+    expect(screen.getAllByRole("link", { name: "Payment ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-2/ledger")).toBe(true);
     expect(screen.getAllByRole("link", { name: "Property / unit" }).some((link) => link.getAttribute("href") === "/properties?propertyId=property-2&unitId=unit-2")).toBe(true);
     expect(screen.getAllByRole("link", { name: "Lifecycle review" }).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Evidence").length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Normalizes existing lease-context ledger shortcuts to `Payment ledger` or `Open payment ledger` across lease, property, tenant, dashboard, operations, decision inbox, and decision context surfaces.
- Preserves existing `/leases/:leaseId/ledger` routing and only changes labels where a lease-specific ledger destination already exists.
- Keeps portfolio revenue pressure routing on the analytics/portfolio path by leaving the existing revenue-pressure branch ahead of ledger destination handling.

## Implementation notes
- Lease list, lease summary, lease workflow, property detail, tenant profile, and tenant detail now use clearer payment-ledger wording.
- Dashboard decision copy maps legacy `Ledger`, `Open ledger`, and `View ledger` labels to `Open payment ledger` for lease ledger destinations while preserving more specific custom labels.
- Operations and decision inbox labels now call out payment ledger destinations when a lease ledger route is already present.
- Decision context links now label `/leases/:leaseId/ledger` as `Payment ledger`.

## Validation
- `npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx src/pages/LandlordLeaseSummaryPage.test.tsx src/components/properties/PropertyOccupancyRegression.test.tsx src/pages/TenantsPage.test.tsx src/components/tenants/TenantDetailPanel.test.tsx src/components/decisions/DecisionContextPanel.test.tsx src/lib/decisions/decisionContext.test.ts src/pages/LeaseLedgerPage.test.tsx src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx src/pages/DashboardPage.test.tsx src/pages/OperationalCommandCenterPage.test.tsx src/pages/DecisionInboxPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `git diff --check`

Note: plain `npm run build` under the default shell Node v25.8.1 fails the repo preflight because the repo requires Node 20. The build passes after switching to Node 20.11.1; Vite also prints its advisory that 20.19+ or 22.12+ is preferred.

## Manual QA
Confirmed passing:
- `/leases` ledger shortcut labels/routes.
- `/leases/:leaseId/summary` ledger shortcut.
- Lease workflow ledger shortcut.
- `/dashboard` lease-level payment decisions route to ledger.
- `/dashboard` portfolio revenue pressure remains analytics/portfolio-oriented.
- Property detail ledger shortcut.
- Tenant profile / tenant detail ledger shortcut.
- Decision inbox / decision context ledger labels.
- Recent events / related surfaces.
- Regression pages load: `/applications`, `/operations`, `/leases/:leaseId/ledger`, `/dashboard`.

Non-blocking follow-ups captured:
- `audit/operations-navigation-visibility-v1`: `/operations` visibility/discoverability outside Dashboard Upcoming Actions.
- `audit/lease-ledger-obligation-balance-consistency-v1`: investigate why a ledger with an apparent credit balance can still show an overdue/pending obligation in decision context.

Ready for review after manual QA.