### PR TITLE
Explain lease ledger obligation credit mismatch

### DIFF
--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
@@ -52,7 +52,7 @@ describe("DecisionContextPanel", () => {
     expect(screen.getByText("Rent past due date")).toBeInTheDocument();
     expect(screen.getByText("$1,450.00")).toBeInTheDocument();
     expect(screen.getByText("Review workflow trail")).toBeInTheDocument();
-    expect(screen.getByText("Tracks operational review actions only.")).toBeInTheDocument();
+    expect(screen.getByText(/Tracks operational review actions only; reviewed or resolved status does not mark rent paid/i)).toBeInTheDocument();
     expect(screen.getByText(/Workflow status:/)).toBeInTheDocument();
     expect(screen.getByText(/Last action:/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();

--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
@@ -124,7 +124,9 @@ export function DecisionContextPanel({
 
       <div style={{ display: "grid", gap: 4 }}>
         <div style={{ color: "#334155", fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>Review workflow trail</div>
-        <div style={{ color: "#64748b", fontSize: 12 }}>Tracks operational review actions only.</div>
+        <div style={{ color: "#64748b", fontSize: 12 }}>
+          Tracks operational review actions only; reviewed or resolved status does not mark rent paid.
+        </div>
         <div style={{ color: "#475569", fontSize: 12 }}>
           Workflow status: <strong>{decisionStatusCopy[decision.status || "detected"]}</strong>
         </div>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -505,6 +505,118 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText(new Date(2026, 4, 5).toLocaleDateString()).length).toBeGreaterThan(0);
   });
 
+  it("explains aggregate credit balances when specific obligations remain outstanding", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValueOnce({
+      ...baseLedgerResponse,
+      totals: { chargesCents: 217300, paymentsCents: 1094200, balanceCents: -876900 },
+      obligationRows: [
+        {
+          rowId: "obligation-pending-credit",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          dueDate: "2026-06-01T00:00:00.000Z",
+          expectedAmountCents: 200000,
+          paidAmountCents: 0,
+          currency: "cad",
+          obligationStatus: "pending",
+          evidenceStatus: "pending",
+          source: "payment_intent",
+          reasons: ["payment_pending"],
+        },
+      ],
+      obligationSummary: {
+        totalRows: 1,
+        expectedAmountCents: 200000,
+        paidAmountCents: 0,
+        outstandingAmountCents: 200000,
+        manualReviewCount: 0,
+        statusCounts: {
+          expected: 0,
+          pending: 1,
+          paid: 0,
+          underpaid: 0,
+          overpaid: 0,
+          failed: 0,
+          missing: 0,
+          manual_review_required: 0,
+          unknown: 0,
+        },
+      },
+      delinquencySignals: [
+        {
+          signalId: "delinquency:overdue:obligation-pending-credit",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          dueDate: "2026-06-01T00:00:00.000Z",
+          expectedAmountCents: 200000,
+          paidAmountCents: 0,
+          outstandingAmountCents: 200000,
+          signalType: "overdue",
+          severity: "critical",
+          detectedAt: "2026-07-02T00:00:00.000Z",
+          reasons: ["obligation_pending_after_due_date"],
+        },
+      ],
+      delinquencySummary: {
+        totalSignals: 1,
+        overdueCount: 1,
+        partiallyPaidCount: 0,
+        failedCount: 0,
+        missingCount: 0,
+        manualReviewCount: 0,
+        totalOutstandingCents: 200000,
+      },
+      decisions: [
+        {
+          decisionId: "decision-reviewed-overdue",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          decisionType: "review_overdue_rent",
+          severity: "critical",
+          status: "reviewed",
+          reason: "Rent obligation is overdue.",
+          metadata: {
+            signalId: "delinquency:overdue:obligation-pending-credit",
+            signalType: "overdue",
+            outstandingAmountCents: 200000,
+            obligationStatus: "pending",
+          },
+          latestAction: {
+            actionId: "action-reviewed",
+            decisionId: "decision-reviewed-overdue",
+            actionType: "reviewed",
+            previousStatus: "detected",
+            nextStatus: "reviewed",
+            createdAt: "2026-07-02T12:00:00.000Z",
+          },
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Credit balance needs allocation review")).toBeInTheDocument();
+    expect(screen.getByText(/aggregate credit balance of -\$8,769.00/i)).toBeInTheDocument();
+    expect(screen.getByText(/but \$2,000.00 remains outstanding on specific obligations/i)).toBeInTheDocument();
+    expect(screen.getByText("Review the obligation rows before resolving overdue decisions.")).toBeInTheDocument();
+    expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
+    expect(screen.getByText(/reviewed or resolved status does not mark rent paid/i)).toBeInTheDocument();
+  });
+
   it("keeps the payment CSV import collapsed until the landlord opens it", async () => {
     render(
       <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -92,6 +92,15 @@ function obligationOutstandingCents(row: LeaseObligationLedgerRow): number {
   return Math.max(0, Number(row.expectedAmountCents || 0) - Number(row.paidAmountCents || 0));
 }
 
+function totalOutstandingObligationCents(
+  obligationRows: LeaseObligationLedgerRow[],
+  obligationSummary: LeaseObligationLedgerSummary | null
+): number {
+  const summaryOutstanding = Number(obligationSummary?.outstandingAmountCents);
+  if (Number.isFinite(summaryOutstanding) && summaryOutstanding > 0) return Math.round(summaryOutstanding);
+  return obligationRows.reduce((sum, row) => sum + obligationOutstandingCents(row), 0);
+}
+
 const obligationStatusCopy: Record<PaymentObligationStatus, { label: string; bg: string; color: string; border: string }> = {
   expected: { label: "Expected", bg: "#eff6ff", color: "#1d4ed8", border: "#bfdbfe" },
   pending: { label: "Pending", bg: "#fef9c3", color: "#854d0e", border: "#fde68a" },
@@ -704,6 +713,11 @@ export default function LeaseLedgerPage() {
   const [paymentNotes, setPaymentNotes] = useState("");
 
   const decisionSummary = useMemo(() => summarizeDecisionItems(decisions), [decisions]);
+  const outstandingObligationCents = useMemo(
+    () => totalOutstandingObligationCents(obligationRows, obligationSummary),
+    [obligationRows, obligationSummary]
+  );
+  const hasUnallocatedCreditNotice = totals.balanceCents < 0 && outstandingObligationCents > 0;
 
   const monthlyRows = useMemo(() => {
     return Object.entries(monthlyTotals).sort((a, b) => (a[0] < b[0] ? 1 : -1));
@@ -993,6 +1007,17 @@ export default function LeaseLedgerPage() {
           <strong>{formatCurrencyCents(totals.balanceCents)}</strong>
         </div>
       </div>
+      {hasUnallocatedCreditNotice ? (
+        <div style={{ border: "1px solid #fde68a", borderRadius: 12, padding: 12, background: "#fffbeb", color: "#713f12", display: "grid", gap: 4 }}>
+          <strong>Credit balance needs allocation review</strong>
+          <span>
+            This lease has an aggregate credit balance of {formatCurrencyCents(totals.balanceCents)}, but{" "}
+            {formatCurrencyCents(outstandingObligationCents)} remains outstanding on specific obligations because payments have not been
+            matched or allocated to those obligations.
+          </span>
+          <span>Review the obligation rows before resolving overdue decisions.</span>
+        </div>
+      ) : null}
 
       <section className="lease-ledger-csv-card">
         <div className="lease-ledger-csv-card-header">


### PR DESCRIPTION
## Summary
- Adds a lease ledger allocation notice when the aggregate lease balance is in credit but specific obligations still show outstanding amounts.
- Clarifies in decision context that reviewed/resolved workflow status does not mark rent paid.
- Adds a targeted regression case for a reviewed overdue decision with a negative aggregate balance and pending obligation.

## Root Cause
Ledger totals and obligation status are separate views. Aggregate ledger credits can coexist with outstanding obligation rows when payments have not been matched or allocated to those specific obligations, and reviewed decision state does not change financial truth.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/LeaseLedgerPage.test.tsx src/components/decisions/DecisionContextPanel.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`

## Notes
- Frontend presentation only.
- No ledger calculation, payment allocation, decision state, backend, schema, CSV, or export changes.