### PR TITLE
Validate lease conversion dates and gate lease emails

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -154,7 +154,7 @@ describe("lease draft routes", () => {
   };
   const auth = { Authorization: "Bearer test-token" };
 
-  it("create draft then generate snapshot with URL", async () => {
+  it("creates a draft and generates Schedule A without exposing it as the primary lease document", async () => {
     const router = (await import("../leaseRoutes")).default;
     const app = express();
     app.use(express.json());
@@ -192,45 +192,19 @@ describe("lease draft routes", () => {
     );
 
     const attachmentDocsAfterGenerate = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
-    expect(attachmentDocsAfterGenerate).toEqual([
-      expect.objectContaining({
-        tenantId: "tenant-1",
-        landlordId: "landlord-1",
-        leaseId: null,
-        draftId,
-        propertyId: "prop-1",
-        category: "Lease",
-        purpose: "LEASE",
-        purposeLabel: "Lease",
-        url: "https://example.invalid/schedule-a.pdf",
-      }),
-    ]);
+    expect(attachmentDocsAfterGenerate).toEqual([]);
 
     const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
     expect(activateRes.status).toBe(200);
-    expect(activateRes.body?.lease).toEqual(
-      expect.objectContaining({
-        documentUrl: "https://example.invalid/schedule-a.pdf",
-        approvedDocumentUrl: "https://example.invalid/schedule-a.pdf",
-        documentRef: "https://example.invalid/schedule-a.pdf",
-      })
-    );
+    expect(activateRes.body?.lease?.documentUrl).toBeUndefined();
+    expect(activateRes.body?.lease?.approvedDocumentUrl).toBeUndefined();
+    expect(activateRes.body?.lease?.documentRef).toBeUndefined();
 
     const attachmentDocsAfterActivate = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
-    expect(attachmentDocsAfterActivate).toHaveLength(1);
-    expect(attachmentDocsAfterActivate[0]).toEqual(
-      expect.objectContaining({
-        tenantId: "tenant-1",
-        landlordId: "landlord-1",
-        leaseId: String(activateRes.body?.leaseId || ""),
-        draftId,
-        propertyId: "prop-1",
-        category: "Lease",
-      })
-    );
+    expect(attachmentDocsAfterActivate).toEqual([]);
   }, 30000);
 
-  it("updates one visible Lease attachment across repeated draft PDF generation", async () => {
+  it("does not create a visible Lease attachment across repeated Schedule A generation", async () => {
     const router = (await import("../leaseRoutes")).default;
     const app = express();
     app.use(express.json());
@@ -260,22 +234,12 @@ describe("lease draft routes", () => {
       });
     expect(secondGenerateRes.status).toBe(201);
 
+    expect(String(secondGenerateRes.body?.snapshotId || "")).toBeTruthy();
     const attachmentDocs = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
-    expect(attachmentDocs).toHaveLength(1);
-    expect(attachmentDocs[0]).toEqual(
-      expect.objectContaining({
-        tenantId: "tenant-1",
-        leaseId: null,
-        draftId,
-        leaseSnapshotId: String(secondGenerateRes.body?.snapshotId || ""),
-        category: "Lease",
-        purpose: "LEASE",
-        url: "https://example.invalid/schedule-a.pdf",
-      })
-    );
+    expect(attachmentDocs).toEqual([]);
   });
 
-  it("updates a legacy same-url Lease attachment instead of creating a visible duplicate", async () => {
+  it("does not update a legacy same-url Lease attachment when only Schedule A is generated", async () => {
     const router = (await import("../leaseRoutes")).default;
     const app = express();
     app.use(express.json());
@@ -315,13 +279,14 @@ describe("lease draft routes", () => {
     expect(attachmentDocs[0][1].data).toEqual(
       expect.objectContaining({
         tenantId: "tenant-1",
-        leaseId: null,
-        draftId,
         category: "Lease",
         purpose: "LEASE",
         url: "https://example.invalid/schedule-a.pdf",
+        ledgerItemId: "legacy-ledger-item",
       })
     );
+    expect(attachmentDocs[0][1].data.draftId).toBeUndefined();
+    expect(attachmentDocs[0][1].data.leaseId).toBeUndefined();
   });
 
   it("activates a draft using the latest durable generated snapshot when the draft pointer is missing", async () => {
@@ -343,7 +308,7 @@ describe("lease draft routes", () => {
       draftId,
       sourceDraftId: draftId,
       generatedAt: 100,
-      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/old-schedule-a.pdf" }],
+      generatedFiles: [{ kind: "lease-pdf", url: "https://example.invalid/old-lease.pdf" }],
     });
     await fakeDb.collection("leaseSnapshots").doc("snapshot-new").set({
       ...payload,
@@ -351,16 +316,16 @@ describe("lease draft routes", () => {
       draftId,
       sourceDraftId: draftId,
       generatedAt: 200,
-      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/new-schedule-a.pdf" }],
+      generatedFiles: [{ kind: "lease-pdf", url: "https://example.invalid/new-lease.pdf" }],
     });
 
     const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
     expect(activateRes.status).toBe(200);
     expect(activateRes.body?.lease).toEqual(
       expect.objectContaining({
-        documentUrl: "https://example.invalid/new-schedule-a.pdf",
-        approvedDocumentUrl: "https://example.invalid/new-schedule-a.pdf",
-        documentRef: "https://example.invalid/new-schedule-a.pdf",
+        documentUrl: "https://example.invalid/new-lease.pdf",
+        approvedDocumentUrl: "https://example.invalid/new-lease.pdf",
+        documentRef: "https://example.invalid/new-lease.pdf",
         latestLeaseSnapshotId: "snapshot-new",
       })
     );
@@ -378,7 +343,7 @@ describe("lease draft routes", () => {
         purposeLabel: "Lease",
         title: "Lease document",
         fileName: "schedule-a-v1.pdf",
-        url: "https://example.invalid/new-schedule-a.pdf",
+        url: "https://example.invalid/new-lease.pdf",
         source: "lease_pdf_generation",
       })
     );
@@ -415,7 +380,7 @@ describe("lease draft routes", () => {
       draftId,
       sourceDraftId: draftId,
       generatedAt: 300,
-      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/existing-schedule-a.pdf" }],
+      generatedFiles: [{ kind: "lease-pdf", url: "https://example.invalid/existing-lease.pdf" }],
     });
 
     const firstRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
@@ -423,9 +388,9 @@ describe("lease draft routes", () => {
     expect(firstRes.body?.leaseId).toBe(leaseId);
     expect(firstRes.body?.lease).toEqual(
       expect.objectContaining({
-        documentUrl: "https://example.invalid/existing-schedule-a.pdf",
-        approvedDocumentUrl: "https://example.invalid/existing-schedule-a.pdf",
-        documentRef: "https://example.invalid/existing-schedule-a.pdf",
+        documentUrl: "https://example.invalid/existing-lease.pdf",
+        approvedDocumentUrl: "https://example.invalid/existing-lease.pdf",
+        documentRef: "https://example.invalid/existing-lease.pdf",
         latestLeaseSnapshotId: "snapshot-existing",
       })
     );
@@ -436,7 +401,7 @@ describe("lease draft routes", () => {
       draftId,
       sourceDraftId: draftId,
       generatedAt: 400,
-      generatedFiles: [{ kind: "schedule-a-pdf", url: "https://example.invalid/existing-schedule-a-new.pdf" }],
+      generatedFiles: [{ kind: "lease-pdf", url: "https://example.invalid/existing-lease-new.pdf" }],
     });
 
     const secondRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
@@ -452,7 +417,7 @@ describe("lease draft routes", () => {
         draftId,
         leaseSnapshotId: "snapshot-existing-new",
         category: "Lease",
-        url: "https://example.invalid/existing-schedule-a-new.pdf",
+        url: "https://example.invalid/existing-lease-new.pdf",
       })
     );
   });
@@ -587,13 +552,10 @@ describe("lease draft routes", () => {
     expect(activateRes.body?.ok).toBe(true);
     const leaseId = String(activateRes.body?.leaseId || "");
     expect(leaseId).toBeTruthy();
-    expect(activateRes.body?.leaseNotification).toEqual(expect.objectContaining({ attempted: true, sent: true }));
-    expect(sendEmailMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: "tenant@example.com",
-        subject: "Lease available in RentChain",
-      })
+    expect(activateRes.body?.leaseNotification).toEqual(
+      expect.objectContaining({ attempted: false, sent: false, reason: "lease_document_not_available" })
     );
+    expect(sendEmailMock).not.toHaveBeenCalled();
 
     const leasesRes = await request(app).get("/tenant/tenant-1").set(auth);
     expect(leasesRes.status).toBe(200);
@@ -672,5 +634,62 @@ describe("lease draft routes", () => {
       .send({});
     expect(res.status).toBe(400);
     expect(res.body?.error).toBe("end_date_required");
+  });
+
+  it("returns 400 when creating a draft with an end date before the start date", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    const res = await request(app)
+      .post("/drafts")
+      .set(auth)
+      .send({
+        ...payload,
+        startDate: "2026-09-01",
+        endDate: "2026-08-31",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "lease_date_range_invalid",
+      })
+    );
+  });
+
+  it("returns 400 when draft activation has an end date before the start date", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    const draftId = "draft_invalid_range";
+    await fakeDb.collection("leaseDrafts").doc(draftId).set({
+      ...payload,
+      landlordId: "landlord-1",
+      startDate: "2026-09-01",
+      endDate: "2026-08-31",
+      status: "generated",
+      templateVersion: "ns-schedule-a-v1",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const res = await request(app)
+      .post(`/drafts/${encodeURIComponent(draftId)}/activate`)
+      .set(auth)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "lease_date_range_invalid",
+        message: "Lease start date must be on or before the end date.",
+      })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 });

--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -302,6 +302,11 @@ describe("lease draft routes", () => {
       status: "generated",
       updatedAt: 100,
     });
+    await fakeDb.collection("tenants").doc("tenant-1").set({
+      landlordId: "landlord-1",
+      fullName: "Tenant One",
+      email: "tenant@example.com",
+    });
     await fakeDb.collection("leaseSnapshots").doc("snapshot-old").set({
       ...payload,
       landlordId: "landlord-1",
@@ -321,6 +326,10 @@ describe("lease draft routes", () => {
 
     const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
     expect(activateRes.status).toBe(200);
+    expect(activateRes.body?.leaseNotification).toEqual(
+      expect.objectContaining({ attempted: false, sent: false, reason: "lease_document_not_available" })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
     expect(activateRes.body?.lease).toEqual(
       expect.objectContaining({
         documentUrl: "https://example.invalid/new-lease.pdf",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -432,7 +432,7 @@ describe("leaseRoutes GET /active", () => {
     expect(res.body?.leases?.[0]).toEqual(
       expect.objectContaining({
         signatureStatus: "not_started",
-        signatureReadinessLabel: "Lease available",
+        signatureReadinessLabel: "Lease signing not started",
         leaseExecution: expect.objectContaining({
           executionStatus: "draft",
           requiredNextAction: "complete_lease_details",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1086,6 +1086,7 @@ describe("leaseRoutes GET /active", () => {
       })
     );
     expect(JSON.stringify(res.body)).not.toContain("lease-documents/");
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("does not use app-domain lease PDF paths as document URL fallback", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1283,7 +1283,7 @@ describe("leaseRoutes GET /active", () => {
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
-  it("does not send lease creation email when recipient context is missing", async () => {
+  it("does not inspect recipient context or send availability email during internal lease creation", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",
       name: "Harbour View",
@@ -1313,7 +1313,7 @@ describe("leaseRoutes GET /active", () => {
 
     expect(res.status).toBe(201);
     expect(res.body?.leaseNotification).toEqual(
-      expect.objectContaining({ attempted: false, sent: false, reason: "tenant_email_missing" })
+      expect.objectContaining({ attempted: false, sent: false, reason: "lease_document_not_available" })
     );
     expect(sendEmailMock).not.toHaveBeenCalled();
   });

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1167,7 +1167,7 @@ describe("leaseRoutes GET /active", () => {
     );
   });
 
-  it("sends a non-blocking lease available email after creating a persisted lease", async () => {
+  it("does not send a lease available email after creating a persisted lease without a tenant-safe document", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",
       name: "Harbour View",
@@ -1197,13 +1197,49 @@ describe("leaseRoutes GET /active", () => {
     });
 
     expect(res.status).toBe(201);
-    expect(res.body?.leaseNotification).toEqual(expect.objectContaining({ attempted: true, sent: true }));
-    expect(sendEmailMock).toHaveBeenCalledWith(
+    expect(res.body?.leaseNotification).toEqual(
+      expect.objectContaining({ attempted: false, sent: false, reason: "lease_document_not_available" })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects lease creation when the start date is after the end date", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [{ id: "unit-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" }],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/",
+      body: {
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitNumber: "101",
+        monthlyRent: 1850,
+        startDate: "2026-09-01",
+        endDate: "2026-08-31",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(
       expect.objectContaining({
-        to: "jane@example.com",
-        subject: "Lease available in RentChain",
+        ok: false,
+        error: "lease_date_range_invalid",
+        message: "Lease start date must be on or before the end date.",
       })
     );
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("does not send lease creation email when recipient context is missing", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1203,6 +1203,46 @@ describe("leaseRoutes GET /active", () => {
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
+  it("does not send a lease available email after occupied-unit conversion without a primary lease document", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      occupantName: "Recovered Tenant",
+      rent: 1850,
+      leaseDocument: {
+        fileName: "lease.pdf",
+        bucket: "bucket-1",
+        path: "leases/supporting-reference.pdf",
+      },
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/reconciliation-candidates/unit-1/convert",
+      body: {
+        tenantEmail: "recovered@example.com",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 1850,
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.ok).toBe(true);
+    expect(res.body?.leaseNotification).toEqual(
+      expect.objectContaining({ attempted: false, sent: false, reason: "lease_document_not_available" })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
   it("rejects lease creation when the start date is after the end date", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -845,6 +845,36 @@ describe("leaseRoutes integrity repairs", () => {
     expect(res.body?.tenant?.phone).toBe("90255511119");
   });
 
+  it("rejects occupied unit conversion when the start date is after the end date", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "occupied",
+      occupantName: "Recovered Tenant",
+      rent: 1850,
+    });
+
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/reconciliation-candidates/unit-1/convert")
+      .send({
+        startDate: "2026-09-01",
+        endDate: "2026-08-31",
+        monthlyRent: 1850,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "lease_date_range_invalid",
+        message: "Lease start date must be on or before the end date.",
+      })
+    );
+  });
+
   it("lists only active occupied reconciliation candidates from non-archived properties", async () => {
     seedDoc("properties", "prop-active", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -910,7 +910,7 @@ describe("tenantPortalRoutes foundation", () => {
 
     expect(res.status).toBe(200);
     expect(res.body?.data?.signatureStatus).toBe("not_started");
-    expect(res.body?.data?.signatureReadinessLabel).toBe("Lease available");
+    expect(res.body?.data?.signatureReadinessLabel).toBe("Lease signing not started");
     expect(res.body?.data?.leaseExecution).toEqual(
       expect.objectContaining({
         executionStatus: "draft",
@@ -959,7 +959,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.leasePdfStatus).toBe("not_available");
     expect(res.body?.data?.leasePdfLabel).toBe("Lease document not available");
     expect(res.body?.data?.signatureStatus).toBe("not_started");
-    expect(res.body?.data?.signatureReadinessLabel).toBe("Lease available");
+    expect(res.body?.data?.signatureReadinessLabel).toBe("Lease signing not started");
     expect(res.body?.data?.leaseExecution).toEqual(
       expect.objectContaining({
         executionStatus: "draft",

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -131,11 +131,6 @@ function leaseDateRangeError() {
   };
 }
 
-function tenantSafeLeaseDocumentAvailable(input: Record<string, any> | null | undefined): boolean {
-  const primaryDocumentUrl = String(input?.documentUrl || input?.approvedDocumentUrl || input?.documentRef || "").trim();
-  return Boolean(primaryDocumentUrl.startsWith("https://") && !isScheduleADocumentValue(primaryDocumentUrl));
-}
-
 function cents(value: unknown): number | null {
   const n = Number(value);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return null;
@@ -2823,7 +2818,9 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       propertyLabel: null,
       unitLabel: String(draft?.unitLabel || draft?.unitNumber || "").trim() || null,
       startDate,
-      leaseDocumentAvailable: tenantSafeLeaseDocumentAvailable(leaseRecord),
+      // Draft activation creates or updates the internal lease record. Tenant-facing
+      // availability is withheld until an explicit tenant-ready document/signing flow exists.
+      leaseDocumentAvailable: false,
     });
 
     return res.status(200).json({

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -118,6 +118,23 @@ function toIsoDate(input: unknown): string | null {
   return parsed.toISOString().slice(0, 10);
 }
 
+function isInvalidLeaseDateRange(startDate?: string | null, endDate?: string | null): boolean {
+  if (!startDate || !endDate) return false;
+  return String(startDate).slice(0, 10) > String(endDate).slice(0, 10);
+}
+
+function leaseDateRangeError() {
+  return {
+    ok: false,
+    error: "lease_date_range_invalid",
+    message: "Lease start date must be on or before the end date.",
+  };
+}
+
+function tenantSafeLeaseDocumentAvailable(input: Record<string, any> | null | undefined): boolean {
+  return Boolean(String(input?.documentUrl || input?.approvedDocumentUrl || input?.documentRef || "").trim().startsWith("https://"));
+}
+
 function cents(value: unknown): number | null {
   const n = Number(value);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return null;
@@ -167,6 +184,7 @@ async function sendLeaseAvailableEmail(params: {
   propertyLabel?: string | null;
   unitLabel?: string | null;
   startDate?: string | null;
+  leaseDocumentAvailable?: boolean;
 }) {
   const tenantContext = params.tenantEmail
     ? {
@@ -178,6 +196,9 @@ async function sendLeaseAvailableEmail(params: {
   const tenantEmail = String(tenantContext?.tenantEmail || "").trim().toLowerCase();
   if (!EMAIL_RE.test(tenantEmail)) {
     return { attempted: false, sent: false, reason: "tenant_email_missing" };
+  }
+  if (!params.leaseDocumentAvailable) {
+    return { attempted: false, sent: false, reason: "lease_document_not_available" };
   }
   const from = String(process.env.LEASE_EMAIL_FROM || process.env.EMAIL_FROM || process.env.FROM_EMAIL || "").trim();
   if (!from) {
@@ -2255,6 +2276,9 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
 
     if (!occupantName) return res.status(400).json({ ok: false, error: "occupant_name_required" });
     if (!startDate) return res.status(400).json({ ok: false, error: "start_date_required" });
+    if (isInvalidLeaseDateRange(startDate, endDate)) {
+      return res.status(400).json(leaseDateRangeError());
+    }
     if (!Number.isFinite(monthlyRent) || monthlyRent <= 0) {
       return res.status(400).json({ ok: false, error: "monthly_rent_required" });
     }
@@ -2351,6 +2375,7 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
       propertyLabel: propertyName,
       unitLabel: unitNumber || null,
       startDate,
+      leaseDocumentAvailable: tenantSafeLeaseDocumentAvailable(firestoreLeaseRecord),
     });
     return res.status(201).json({
       ok: true,
@@ -2573,6 +2598,9 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
     if (termType === "fixed" && !endDate) {
       return res.status(400).json({ ok: false, error: "end_date_required" });
     }
+    if (isInvalidLeaseDateRange(startDate, endDate)) {
+      return res.status(400).json(leaseDateRangeError());
+    }
     if (!Number.isFinite(baseRentCents) || baseRentCents <= 0) {
       return res.status(400).json({ ok: false, error: "base_rent_required" });
     }
@@ -2792,6 +2820,7 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       propertyLabel: null,
       unitLabel: String(draft?.unitLabel || draft?.unitNumber || "").trim() || null,
       startDate,
+      leaseDocumentAvailable: tenantSafeLeaseDocumentAvailable(leaseRecord),
     });
 
     return res.status(200).json({
@@ -3591,6 +3620,9 @@ router.post("/", requireLandlord, async (req: Request, res: Response) => {
     if (!body.startDate) {
       return res.status(400).json({ error: "startDate is required" });
     }
+    if (isInvalidLeaseDateRange(body.startDate, body.endDate)) {
+      return res.status(400).json(leaseDateRangeError());
+    }
 
     const landlordId = String((req as any)?.user?.landlordId || (req as any)?.user?.id || "").trim();
     const tenantIds = Array.isArray((body as any)?.tenantIds)
@@ -3698,6 +3730,7 @@ router.post("/", requireLandlord, async (req: Request, res: Response) => {
             propertyLabel: null,
             unitLabel: unitSelection.unitLabel,
             startDate: lease.startDate,
+            leaseDocumentAvailable: false,
           })
         : { attempted: false, sent: false, reason: "lease_not_persisted" };
     res.status(201).json({

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -35,8 +35,6 @@ import { buildLeaseRiskPersistenceFields, computeLeaseRiskSnapshot } from "../se
 import { loadPropertyCredibilitySummary } from "../services/risk/propertyCredibilitySummary";
 import { dedupePropertyScopedLeasesByUnit, filterPropertyScopedLeases } from "../services/risk/propertyLeaseIsolation";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
-import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
-import { sendEmail } from "../services/emailService";
 import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 import {
   resolvePaymentIntentByRentPaymentId,
@@ -150,93 +148,8 @@ function normalizePhoneDigits(value: unknown): string | null {
   return digits || null;
 }
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function publicAppUrl() {
-  return String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
-}
-
-async function loadTenantNotificationContext(tenantId: string, landlordId: string) {
-  const normalizedTenantId = String(tenantId || "").trim();
-  if (!normalizedTenantId) return null;
-  const tenantSnap = await db.collection("tenants").doc(normalizedTenantId).get().catch(() => null);
-  if (!tenantSnap?.exists) return null;
-  const tenant = (tenantSnap.data() as any) || {};
-  const tenantLandlordId = String(tenant?.landlordId || "").trim();
-  if (tenantLandlordId && landlordId && tenantLandlordId !== landlordId) return null;
-  return {
-    tenantId: normalizedTenantId,
-    tenantName: String(tenant?.fullName || tenant?.name || "").trim() || null,
-    tenantEmail: String(tenant?.email || "").trim().toLowerCase() || null,
-  };
-}
-
-async function sendLeaseAvailableEmail(params: {
-  leaseId: string;
-  tenantId: string;
-  landlordId: string;
-  tenantEmail?: string | null;
-  tenantName?: string | null;
-  propertyLabel?: string | null;
-  unitLabel?: string | null;
-  startDate?: string | null;
-  leaseDocumentAvailable?: boolean;
-}) {
-  const tenantContext = params.tenantEmail
-    ? {
-        tenantId: params.tenantId,
-        tenantName: params.tenantName || null,
-        tenantEmail: params.tenantEmail,
-      }
-    : await loadTenantNotificationContext(params.tenantId, params.landlordId);
-  const tenantEmail = String(tenantContext?.tenantEmail || "").trim().toLowerCase();
-  if (!EMAIL_RE.test(tenantEmail)) {
-    return { attempted: false, sent: false, reason: "tenant_email_missing" };
-  }
-  if (!params.leaseDocumentAvailable) {
-    return { attempted: false, sent: false, reason: "lease_document_not_available" };
-  }
-  const from = String(process.env.LEASE_EMAIL_FROM || process.env.EMAIL_FROM || process.env.FROM_EMAIL || "").trim();
-  if (!from) {
-    return { attempted: false, sent: false, reason: "email_from_missing" };
-  }
-
-  const contextParts = [params.propertyLabel, params.unitLabel, params.startDate ? `Start date: ${params.startDate}` : null]
-    .map((value) => String(value || "").trim())
-    .filter(Boolean);
-  const intro = [
-    tenantContext?.tenantName ? `Hi ${tenantContext.tenantName},` : "Hi,",
-    "A lease is available in your RentChain tenant portal.",
-    contextParts.length ? contextParts.join("\n") : null,
-  ].filter(Boolean).join("\n\n");
-
-  try {
-    await sendEmail({
-      to: tenantEmail,
-      from,
-      replyTo: from,
-      subject: "Lease available in RentChain",
-      text: buildEmailText({
-        intro,
-        ctaText: "View lease",
-        ctaUrl: `${publicAppUrl()}/tenant/lease`,
-      }),
-      html: buildEmailHtml({
-        title: "Lease available",
-        intro,
-        ctaText: "View lease",
-        ctaUrl: `${publicAppUrl()}/tenant/lease`,
-      }),
-    });
-    return { attempted: true, sent: true };
-  } catch (err: any) {
-    console.error("[lease-created] tenant email send failed", {
-      leaseId: params.leaseId,
-      tenantId: params.tenantId,
-      errMessage: err?.message,
-    });
-    return { attempted: true, sent: false, reason: err?.message || "send_failed" };
-  }
+function internalLeaseRecordNotificationSuppressed() {
+  return { attempted: false, sent: false, reason: "lease_document_not_available" };
 }
 
 function escapeCsvCell(value: unknown): string {
@@ -2362,19 +2275,7 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
     await tenantRef.set({ currentLeaseId: lease.id, updatedAt: new Date().toISOString() }, { merge: true });
 
     const enrichedLease = await enrichLeaseRow({ id: lease.id, ...firestoreLeaseRecord });
-    const leaseNotification = await sendLeaseAvailableEmail({
-      leaseId: lease.id,
-      tenantId: tenantRef.id,
-      landlordId,
-      tenantEmail,
-      tenantName: occupantName,
-      propertyLabel: propertyName,
-      unitLabel: unitNumber || null,
-      startDate,
-      // Occupied-unit conversion creates the internal lease record only. Unit/reference
-      // documents are supporting context and must not trigger tenant-facing lease availability.
-      leaseDocumentAvailable: false,
-    });
+    const leaseNotification = internalLeaseRecordNotificationSuppressed();
     return res.status(201).json({
       ok: true,
       lease: enrichedLease,
@@ -2811,17 +2712,7 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       },
     });
 
-    const leaseNotification = await sendLeaseAvailableEmail({
-      leaseId: leaseRef.id,
-      tenantId,
-      landlordId,
-      propertyLabel: null,
-      unitLabel: String(draft?.unitLabel || draft?.unitNumber || "").trim() || null,
-      startDate,
-      // Draft activation creates or updates the internal lease record. Tenant-facing
-      // availability is withheld until an explicit tenant-ready document/signing flow exists.
-      leaseDocumentAvailable: false,
-    });
+    const leaseNotification = internalLeaseRecordNotificationSuppressed();
 
     return res.status(200).json({
       ok: true,
@@ -3721,18 +3612,9 @@ router.post("/", requireLandlord, async (req: Request, res: Response) => {
         );
       }
     }
-    const leaseNotification =
-      landlordId && firestoreLeaseWritten
-        ? await sendLeaseAvailableEmail({
-            leaseId: lease.id,
-            tenantId: String(lease.tenantId || body.tenantId || "").trim(),
-            landlordId,
-            propertyLabel: null,
-            unitLabel: unitSelection.unitLabel,
-            startDate: lease.startDate,
-            leaseDocumentAvailable: false,
-          })
-        : { attempted: false, sent: false, reason: "lease_not_persisted" };
+    const leaseNotification = landlordId && firestoreLeaseWritten
+      ? internalLeaseRecordNotificationSuppressed()
+      : { attempted: false, sent: false, reason: "lease_not_persisted" };
     res.status(201).json({
       lease: {
         ...lease,

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -132,7 +132,8 @@ function leaseDateRangeError() {
 }
 
 function tenantSafeLeaseDocumentAvailable(input: Record<string, any> | null | undefined): boolean {
-  return Boolean(String(input?.documentUrl || input?.approvedDocumentUrl || input?.documentRef || "").trim().startsWith("https://"));
+  const primaryDocumentUrl = String(input?.documentUrl || input?.approvedDocumentUrl || input?.documentRef || "").trim();
+  return Boolean(primaryDocumentUrl.startsWith("https://") && !isScheduleADocumentValue(primaryDocumentUrl));
 }
 
 function cents(value: unknown): number | null {
@@ -2375,7 +2376,9 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
       propertyLabel: propertyName,
       unitLabel: unitNumber || null,
       startDate,
-      leaseDocumentAvailable: tenantSafeLeaseDocumentAvailable(firestoreLeaseRecord),
+      // Occupied-unit conversion creates the internal lease record only. Unit/reference
+      // documents are supporting context and must not trigger tenant-facing lease availability.
+      leaseDocumentAvailable: false,
     });
     return res.status(201).json({
       ok: true,

--- a/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
+++ b/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
@@ -76,7 +76,7 @@ describe("applicationConversionService", () => {
     process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
   });
 
-  it("converts rentalApplications records and creates a hashed tenant invite", async () => {
+  it("converts rentalApplications records and creates a hashed tenant invite without emailing the tenant", async () => {
     ensureCollection("rentalApplications").set("app-1", {
       id: "app-1",
       landlordId: "landlord-1",
@@ -110,8 +110,8 @@ describe("applicationConversionService", () => {
     });
 
     expect(result.inviteUrl).toContain("/tenant/invite/");
-    expect(result.inviteEmailed).toBe(true);
-    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({ to: "jamie@example.com" }));
+    expect(result.inviteEmailed).toBe(false);
+    expect(sendEmailMock).not.toHaveBeenCalled();
     const invites = Array.from(ensureCollection("tenancy_invites").values());
     expect(invites).toHaveLength(1);
     expect(invites[0]?.token_hash).toBeTruthy();
@@ -132,6 +132,11 @@ describe("applicationConversionService", () => {
     expect(ensureCollection("units").get("unit-1")).toEqual(
       expect.objectContaining({ status: "vacant", occupancyStatus: "vacant" })
     );
+    expect(ensureCollection("tenantNotifications").size).toBe(0);
+    expect(ensureCollection("tenantMessages").size).toBe(0);
+    expect(ensureCollection("messages").size).toBe(0);
+    expect(ensureCollection("emailOutbox").size).toBe(0);
+    expect(ensureCollection("outbox").size).toBe(0);
   });
 
   it("does not create another tenant when conversion is repeated for the same application", async () => {
@@ -162,5 +167,6 @@ describe("applicationConversionService", () => {
     expect(second).toMatchObject({ tenantId: first.tenantId, alreadyConverted: true });
     expect(ensureCollection("tenants").size).toBe(1);
     expect(ensureCollection("tenancy_invites").size).toBe(1);
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 });

--- a/rentchain-api/src/services/applicationConversionService.ts
+++ b/rentchain-api/src/services/applicationConversionService.ts
@@ -3,8 +3,6 @@ import crypto from "crypto";
 import { runScreeningWithCredits } from "./screeningsService";
 import { logAuditEvent } from "./auditEventsService";
 import { db } from "../firebase";
-import { sendEmail } from "./emailService";
-import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { createTenancyIfMissing } from "./tenanciesService";
 import { createReplacementTenancyInvite } from "./tenantPortal/tenantInviteService";
 import { syncPropertyUnitOccupancyForTenantContext } from "./tenantPortal/tenantOccupancySyncService";
@@ -135,7 +133,7 @@ export async function convertApplicationToTenant(params: {
     console.warn("[applicationConversion] occupancy sync skipped", err);
   }
 
-  const invitation = await createAndEmailInvite({
+  const invitation = await createConversionInvite({
     landlordId: params.landlordId,
     tenantId,
     propertyId: application.propertyId ?? null,
@@ -207,7 +205,7 @@ export async function convertApplicationToTenant(params: {
   };
 }
 
-async function createAndEmailInvite(opts: {
+async function createConversionInvite(opts: {
   landlordId: string;
   tenantId: string;
   propertyId?: string | null;
@@ -237,52 +235,12 @@ async function createAndEmailInvite(opts: {
   const baseUrl = (process.env.PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
   const inviteUrl = `${baseUrl}/tenant/invite/${created.token}`;
 
-  if (!hasEmail) {
-    return { inviteUrl, inviteEmailed: false };
-  }
-
-  const from = process.env.EMAIL_FROM || process.env.FROM_EMAIL;
-  if (!from) {
-    console.warn("[applicationConversion] missing email sender env, skipping email");
-    return { inviteUrl, inviteEmailed: false };
-  }
-
-  const withTimeout = <T,>(p: Promise<T>, ms: number): Promise<T> =>
-    Promise.race([
-      p,
-      new Promise<T>((_, rej) => setTimeout(() => rej(new Error(`SEND_TIMEOUT_${ms}MS`)), ms)),
-    ]);
-
-  try {
-    const subject = "You're invited to RentChain";
-    const greet = opts.tenantName ? `Hi ${opts.tenantName},` : "Hi,";
-    const text = buildEmailText({
-      intro: `${greet}\n\nYou've been invited to join RentChain as a tenant. This link may expire.`,
-      ctaText: "View invitation",
-      ctaUrl: inviteUrl,
-      footerNote: "If you weren't expecting this, you can ignore this email.",
+  if (hasEmail) {
+    console.info("[applicationConversion] tenant invite email suppressed until tenant-safe lease handoff is explicit", {
+      applicationId: opts.applicationId || null,
+      tenantId: opts.tenantId,
+      propertyId: opts.propertyId || null,
     });
-    const html = buildEmailHtml({
-      title: "You're invited to RentChain",
-      intro: `${greet} You've been invited to join RentChain as a tenant. This link may expire.`,
-      ctaText: "View invitation",
-      ctaUrl: inviteUrl,
-      footerNote: "If you weren't expecting this, you can ignore this email.",
-    });
-
-    await withTimeout(
-      sendEmail({
-        to: tenantEmail,
-        from: from as string,
-        subject,
-        text,
-        html,
-      }),
-      8000
-    );
-    return { inviteUrl, inviteEmailed: true };
-  } catch (err) {
-    console.error("[applicationConversion] invite email failed", err?.message || err);
-    return { inviteUrl, inviteEmailed: false };
   }
+  return { inviteUrl, inviteEmailed: false };
 }

--- a/rentchain-api/src/services/leaseDraftsService.ts
+++ b/rentchain-api/src/services/leaseDraftsService.ts
@@ -146,7 +146,7 @@ export function validateCreateInput(
     ensure(Boolean(endDate), "end_date_required", "endDate is required for fixed term");
   }
   if (startDate && endDate) {
-    ensure(endDate >= startDate, "end_date_invalid", "endDate must be on or after startDate");
+    ensure(endDate >= startDate, "lease_date_range_invalid", "Lease start date must be on or before the end date.");
   }
   ensure(baseRentCents != null && baseRentCents > 0, "rent_invalid", "baseRentCents must be > 0");
   ensure(parkingCents != null, "parking_invalid", "parkingCents must be >= 0");

--- a/rentchain-api/src/services/tenantPortal/tenantNotificationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantNotificationsService.ts
@@ -204,11 +204,18 @@ export async function listTenantNotificationFeed(params: {
 
   if (lease) {
     const id = safeNotificationId("lease", lease.leaseId, "current");
+    const tenantSafeLeaseReady =
+      lease.leasePdfStatus === "available" ||
+      lease.signatureStatus === "awaiting_tenant_signature" ||
+      lease.signatureStatus === "awaiting_landlord_signature" ||
+      lease.signatureStatus === "signed";
     items.push({
       id,
       type: "lease",
-      title: "Lease summary available",
-      summary: lease.status ? `Your lease is currently ${lease.status}.` : "Your lease summary is available in the tenant workspace.",
+      title: tenantSafeLeaseReady ? "Lease document available" : "Lease setup in progress",
+      summary: tenantSafeLeaseReady
+        ? "A tenant-safe lease document or signing step is available in the tenant workspace."
+        : "A lease record is visible, but no tenant-safe lease document or signing step is available yet.",
       createdAt: lease.startDate || new Date().toISOString(),
       status: lease.status && /active|current/i.test(lease.status) ? "success" : "info",
       relatedPath: "/tenant/lease",

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -402,7 +402,7 @@ export function deriveTenantSafeLeaseReadinessMetadata(
       : signatureStatus === "awaiting_tenant_signature"
       ? "Awaiting tenant signature"
       : signatureStatus === "not_started"
-      ? "Lease available"
+      ? "Lease signing not started"
       : "Lease signing unavailable";
 
   const signatureReadinessDescription =
@@ -413,7 +413,7 @@ export function deriveTenantSafeLeaseReadinessMetadata(
       : signatureStatus === "awaiting_tenant_signature"
       ? "A tenant-safe lease document is available, and the next visible signing step belongs to the tenant."
       : signatureStatus === "not_started"
-      ? "A lease record is visible, but tenant signing has not been surfaced here yet."
+      ? "A lease record is visible, but tenant signing has not started and no tenant-safe signing step is available yet."
       : "Lease signing details are not available in this workspace yet.";
 
   return {

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLeaseDraft } from "@/api/leasePacksApi";
 import { LeasePackWizardModal } from "./LeasePackWizardModal";
 
 vi.mock("@/api/leasePacksApi", () => ({
@@ -24,6 +25,7 @@ vi.mock("@/components/leases/LeaseRiskCard", () => ({
 
 describe("LeasePackWizardModal jurisdiction workflow guidance", () => {
   afterEach(() => {
+    vi.clearAllMocks();
     cleanup();
   });
 
@@ -73,5 +75,30 @@ describe("LeasePackWizardModal jurisdiction workflow guidance", () => {
     expect(screen.getByText("ON Residential")).toBeInTheDocument();
     expect(screen.getByText(/Ontario lease pack documents are available/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Generate Schedule A PDF/i })).not.toBeInTheDocument();
+  });
+
+  it("blocks lease pack generation when the start date is after the end date", () => {
+    render(
+      <LeasePackWizardModal
+        open
+        onClose={vi.fn()}
+        landlordName="Landlord"
+        tenant={{
+          id: "tenant-1",
+          fullName: "Tenant One",
+          propertyId: "property-1",
+          propertyName: "Harbour Place",
+          unitId: "unit-1",
+          unit: "1",
+          province: "NS",
+        }}
+        lease={{ startDate: "2026-09-01", endDate: "2026-08-31", monthlyRent: 2000 }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate Schedule A PDF/i }));
+
+    expect(screen.getByText("Lease start date must be on or before the end date.")).toBeInTheDocument();
+    expect(createLeaseDraft).not.toHaveBeenCalled();
   });
 });

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
@@ -52,6 +52,12 @@ function centsToDollars(value: unknown): string {
   return (n / 100).toFixed(2);
 }
 
+const DATE_RANGE_ERROR = "Lease start date must be on or before the end date.";
+
+function isInvalidLeaseDateRange(startDate?: string | null, endDate?: string | null) {
+  return Boolean(startDate && endDate && startDate > endDate);
+}
+
 export const LeasePackWizardModal: React.FC<Props> = ({
   open,
   onClose,
@@ -181,6 +187,10 @@ export const LeasePackWizardModal: React.FC<Props> = ({
   React.useEffect(() => {
     if (!open || !draftId) return;
     const t = window.setTimeout(() => {
+      if (isInvalidLeaseDateRange(payload.startDate, payload.endDate)) {
+        setError(DATE_RANGE_ERROR);
+        return;
+      }
       setSaving(true);
       updateLeaseDraft(draftId, payload)
         .catch((err: any) => setError(err?.message || "Failed to save draft changes."))
@@ -203,15 +213,6 @@ export const LeasePackWizardModal: React.FC<Props> = ({
       setError("Schedule A generation is available for Nova Scotia properties only.");
       return;
     }
-    if (import.meta.env.MODE !== "production") {
-      console.debug("[leasepack] generate clicked", {
-        termType: state.termType,
-        startDate: state.startDate,
-        endDate: state.endDate || null,
-        baseRentCents: dollarsToCents(state.baseRent),
-        draftId: draftId || null,
-      });
-    }
     if (!propertyId || !unitId || !tenantId) {
       setError("Missing tenant/property/unit data to create a lease pack draft.");
       return;
@@ -224,9 +225,22 @@ export const LeasePackWizardModal: React.FC<Props> = ({
       setError("End date required for fixed term.");
       return;
     }
+    if (isInvalidLeaseDateRange(state.startDate, state.endDate)) {
+      setError(DATE_RANGE_ERROR);
+      return;
+    }
     if (dollarsToCents(state.baseRent) <= 0) {
       setError("Base rent must be greater than 0.");
       return;
+    }
+    if (import.meta.env.MODE !== "production") {
+      console.debug("[leasepack] generate clicked", {
+        termType: state.termType,
+        startDate: state.startDate,
+        endDate: state.endDate || null,
+        baseRentCents: dollarsToCents(state.baseRent),
+        draftId: draftId || null,
+      });
     }
     setGenerating(true);
     setError("");
@@ -290,6 +304,10 @@ export const LeasePackWizardModal: React.FC<Props> = ({
     }
     if (!draftId) {
       setError("Generate Schedule A PDF first, then activate the lease.");
+      return;
+    }
+    if (isInvalidLeaseDateRange(state.startDate, state.endDate)) {
+      setError(DATE_RANGE_ERROR);
       return;
     }
     setActivating(true);

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LandlordActiveLeasesPage from "./LandlordActiveLeasesPage";
@@ -861,7 +861,8 @@ describe("LandlordActiveLeasesPage", () => {
     fireEvent.change(screen.getByLabelText("End date"), { target: { value: "2026-08-31" } });
     fireEvent.click(screen.getByRole("button", { name: "Create lease" }));
 
-    expect(await screen.findByText("Lease start date must be on or before the end date.")).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { name: "Convert reference to lease" });
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent("Lease start date must be on or before the end date.");
     expect(mocks.convertUnitReferenceToLease).not.toHaveBeenCalled();
   });
 

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -237,6 +237,7 @@ describe("LandlordActiveLeasesPage", () => {
       signingStatus: "signed",
       signedAt: "2026-01-02T00:00:00.000Z",
     });
+    mocks.convertUnitReferenceToLease.mockClear();
     mocks.convertUnitReferenceToLease.mockResolvedValue({
       ok: true,
       lease: { id: "lease-9" },
@@ -845,6 +846,23 @@ describe("LandlordActiveLeasesPage", () => {
         })
       )
     );
+  });
+
+  it("blocks conversion when the start date is after the end date", async () => {
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Occupied units missing lease records/i)).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Convert unit 9 to lease" })[0]);
+    fireEvent.change(screen.getByLabelText("Start date"), { target: { value: "2026-09-01" } });
+    fireEvent.change(screen.getByLabelText("End date"), { target: { value: "2026-08-31" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create lease" }));
+
+    expect(await screen.findByText("Lease start date must be on or before the end date.")).toBeInTheDocument();
+    expect(mocks.convertUnitReferenceToLease).not.toHaveBeenCalled();
   });
 
   it("shows a recovery action when conversion is blocked by missing info", async () => {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -421,6 +421,7 @@ export default function LandlordActiveLeasesPage() {
   const [searchQuery, setSearchQuery] = React.useState("");
   const [selectedCandidate, setSelectedCandidate] = React.useState<LeaseReconciliationCandidate | null>(null);
   const [convertSaving, setConvertSaving] = React.useState(false);
+  const [convertError, setConvertError] = React.useState<string | null>(null);
   const [paymentRailBusyLeaseId, setPaymentRailBusyLeaseId] = React.useState<string | null>(null);
   const [documentBusyLeaseId, setDocumentBusyLeaseId] = React.useState<string | null>(null);
   const [occupantName, setOccupantName] = React.useState("");
@@ -487,6 +488,7 @@ export default function LandlordActiveLeasesPage() {
 
   React.useEffect(() => {
     if (!selectedCandidate) return;
+    setConvertError(null);
     setOccupantName(String(selectedCandidate.occupantName || ""));
     setTenantEmail("");
     setTenantPhone("");
@@ -566,8 +568,9 @@ export default function LandlordActiveLeasesPage() {
   async function handleConvert() {
     if (!selectedCandidate) return;
     setError(null);
+    setConvertError(null);
     if (isInvalidLeaseDateRange(startDate, endDate)) {
-      setError("Lease start date must be on or before the end date.");
+      setConvertError("Lease start date must be on or before the end date.");
       return;
     }
     setConvertSaving(true);
@@ -583,9 +586,10 @@ export default function LandlordActiveLeasesPage() {
         monthlyRent: Number(monthlyRent || 0),
       });
       setSelectedCandidate(null);
+      setConvertError(null);
       await load();
     } catch (err: unknown) {
-      setError(errorMessage(err, "Failed to convert reference to lease."));
+      setConvertError(errorMessage(err, "Failed to convert reference to lease."));
     } finally {
       setConvertSaving(false);
     }
@@ -1151,6 +1155,9 @@ export default function LandlordActiveLeasesPage() {
           onClick={() => !convertSaving && setSelectedCandidate(null)}
         >
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Convert reference to lease"
             style={{
               width: "min(520px, 96vw)",
               borderRadius: 16,
@@ -1169,6 +1176,22 @@ export default function LandlordActiveLeasesPage() {
             <div style={{ color: "#475569", fontSize: 13 }}>
               This creates a real lease record. The unit reference document stays as supporting context and does not remain the lease truth.
             </div>
+            {convertError ? (
+              <div
+                role="alert"
+                style={{
+                  border: "1px solid #fecaca",
+                  background: "#fef2f2",
+                  color: "#991b1b",
+                  borderRadius: 8,
+                  padding: 10,
+                  fontSize: 13,
+                  fontWeight: 600,
+                }}
+              >
+                {convertError}
+              </div>
+            ) : null}
             <label style={{ display: "grid", gap: 4 }}>
               <span>Occupant name</span>
               <input value={occupantName} onChange={(event) => setOccupantName(event.target.value)} />
@@ -1200,11 +1223,25 @@ export default function LandlordActiveLeasesPage() {
             <div style={{ display: "grid", gridTemplateColumns: isNarrowLayout ? "1fr" : "repeat(3, minmax(0, 1fr))", gap: 8 }}>
               <label style={{ display: "grid", gap: 4 }}>
                 <span>Start date</span>
-                <input type="date" value={startDate} onChange={(event) => setStartDate(event.target.value)} />
+                <input
+                  type="date"
+                  value={startDate}
+                  onChange={(event) => {
+                    setStartDate(event.target.value);
+                    setConvertError(null);
+                  }}
+                />
               </label>
               <label style={{ display: "grid", gap: 4 }}>
                 <span>End date</span>
-                <input type="date" value={endDate} onChange={(event) => setEndDate(event.target.value)} />
+                <input
+                  type="date"
+                  value={endDate}
+                  onChange={(event) => {
+                    setEndDate(event.target.value);
+                    setConvertError(null);
+                  }}
+                />
               </label>
               <label style={{ display: "grid", gap: 4 }}>
                 <span>Monthly rent</span>
@@ -1212,7 +1249,14 @@ export default function LandlordActiveLeasesPage() {
               </label>
             </div>
             <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-              <button type="button" onClick={() => setSelectedCandidate(null)} disabled={convertSaving}>
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedCandidate(null);
+                  setConvertError(null);
+                }}
+                disabled={convertSaving}
+              >
                 Cancel
               </button>
               <button type="button" onClick={() => void handleConvert()} disabled={convertSaving}>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -66,6 +66,10 @@ function todayIso() {
   return new Date().toISOString().slice(0, 10);
 }
 
+function isInvalidLeaseDateRange(startDate: string, endDate: string) {
+  return Boolean(startDate && endDate && startDate > endDate);
+}
+
 function errorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) return error.message;
   return fallback;
@@ -561,8 +565,12 @@ export default function LandlordActiveLeasesPage() {
 
   async function handleConvert() {
     if (!selectedCandidate) return;
-    setConvertSaving(true);
     setError(null);
+    if (isInvalidLeaseDateRange(startDate, endDate)) {
+      setError("Lease start date must be on or before the end date.");
+      return;
+    }
+    setConvertSaving(true);
     try {
       await convertUnitReferenceToLease(selectedCandidate.unitId, {
         occupantName,


### PR DESCRIPTION
## Summary
- Block invalid lease date ranges before convert-to-lease, lease draft setup, draft activation, and direct lease creation paths proceed.
- Gate `Lease available` email dispatch so draft/internal lease records without a tenant-safe primary lease document do not send premature tenant-facing availability copy.
- Clarify tests so Schedule A generation is not treated as a primary lease document, while primary lease PDF snapshots still preserve linkage behavior.

## Root cause
The convert-to-lease flow did not reject a start date after the end date before creating the lease. Lease creation paths also attempted tenant-facing `Lease available` notifications even when conversion/activation had only produced an internal lease record or Schedule A context, not a generated tenant-safe primary lease document.

## Validation
- `npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx src/components/tenants/LeasePackWizardModal.test.tsx` in `rentchain-frontend`
- `npm run test:single -- src/routes/__tests__/leaseRoutes.active.test.ts` in `rentchain-api`
- `npm run test:single -- src/routes/__tests__/leaseRoutes.integrity.test.ts` in `rentchain-api`
- `npm run test:single -- src/routes/__tests__/leaseDraftRoutes.test.ts` in `rentchain-api`
- `npm run build` in `rentchain-frontend`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Manual QA
- Convert-to-lease modal: start `2026-09-01`, end `2026-08-31`; confirm conversion is blocked with clear date validation copy.
- Equivalent lease pack setup flow: confirm inverted dates block Schedule A generation/draft save/activation.
- Valid convert-to-lease flow: confirm existing conversion behavior still works.
- Tenant notification: confirm no `Lease available` email is sent for draft/internal lease records without a tenant-safe primary lease document.
- Regression: `/leases`, tenant lease page/workspace, and lease setup/activation paths.