### PR TITLE
fix/tenant-lease-signed-document-projection-v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -971,6 +971,169 @@ describe("tenantPortalRoutes foundation", () => {
     );
   });
 
+  it("projects provider-signed leases as signed-copy pending when no tenant-safe document exists", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      landlordId: "landlord-1",
+      status: "active",
+      tenantSignature: null,
+      tenantSignedAt: null,
+      tenantSignatureCompletedAt: null,
+      landlordSignature: null,
+      landlordSignedAt: null,
+      landlordSignatureCompletedAt: null,
+      fullyExecutedAt: null,
+      fullySignedAt: null,
+      signatureCompletedAt: null,
+      documentUrl: null,
+      approvedDocumentUrl: null,
+      documentRef: null,
+      documentStatus: null,
+      leaseDocumentStatus: null,
+      pdfStatus: null,
+      generationStatus: null,
+    });
+    ensureCollection("leaseSigningRequests").set("request-signed-no-document", {
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      providerId: "dropbox_sign",
+      providerRequestId: "raw-provider-request-id",
+      providerRequestRef: "dropbox_sign_ref_safe",
+      currentSigningStatus: "signed",
+      currentStatusAt: "2026-07-03T10:00:00.000Z",
+      createdAt: "2026-07-03T09:00:00.000Z",
+    });
+    ensureCollection("leaseSigningEvents").set("event-signed-no-document", {
+      requestId: "request-signed-no-document",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      type: "signed",
+      occurredAt: "2026-07-03T10:00:00.000Z",
+      actorRole: "provider",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.providerSigningStatus).toBe("signed");
+    expect(res.body?.data?.signatureStatus).toBe("signed");
+    expect(res.body?.data?.leaseDocumentContext).toEqual(
+      expect.objectContaining({
+        documentStatus: "pending",
+        displayLabel: "Signed lease document pending",
+        source: "lease_signing_signed_without_document",
+        warnings: ["Signing is complete, but no tenant-safe signed lease document link is available yet."],
+      })
+    );
+    expect(res.body?.data?.leasePdfStatus).toBe("pending");
+    expect(res.body?.data?.leaseExecution).toEqual(
+      expect.objectContaining({
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        completedAt: "2026-07-03T10:00:00.000Z",
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("raw-provider-request-id");
+    expect(JSON.stringify(res.body)).not.toContain("request-signed-no-document");
+  });
+
+  it("surfaces provider signed-document storage metadata as a tenant-safe signed lease document and vault item", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      landlordId: "landlord-1",
+      status: "active",
+      tenantSignature: null,
+      tenantSignedAt: null,
+      landlordSignature: null,
+      landlordSignedAt: null,
+      documentUrl: null,
+      approvedDocumentUrl: null,
+      documentRef: null,
+    });
+    ensureCollection("leaseSigningRequests").set("request-signed-document", {
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      providerId: "dropbox_sign",
+      providerRequestId: "raw-provider-request-id",
+      providerRequestRef: "dropbox_sign_ref_safe",
+      currentSigningStatus: "signed",
+      currentStatusAt: "2026-07-03T10:00:00.000Z",
+      signedDocument: {
+        bucket: "signed-lease-documents",
+        path: "lease-signing/landlord-1/request-signed-document/signed.pdf",
+        internalReferenceOnly: true,
+      },
+      signedDocumentHash: "signed_doc_hash",
+      signedDocumentStoredAt: "2026-07-03T10:05:00.000Z",
+      createdAt: "2026-07-03T09:00:00.000Z",
+    });
+    ensureCollection("leaseSigningEvents").set("event-signed-document", {
+      requestId: "request-signed-document",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      type: "signed",
+      occurredAt: "2026-07-03T10:00:00.000Z",
+      actorRole: "provider",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+      }),
+    };
+    const leaseRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers,
+    });
+    const attachmentsRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/attachments",
+      headers,
+    });
+
+    expect(leaseRes.status).toBe(200);
+    expect(leaseRes.body?.data?.documentUrl).toBe(
+      "https://signed.example/lease-signing/landlord-1/request-signed-document/signed.pdf"
+    );
+    expect(leaseRes.body?.data?.leaseDocumentContext).toEqual(
+      expect.objectContaining({
+        documentStatus: "signed",
+        documentUrl: "https://signed.example/lease-signing/landlord-1/request-signed-document/signed.pdf",
+        displayLabel: "Signed lease document",
+        source: "leaseSigningRequests.signedDocument",
+      })
+    );
+    expect(attachmentsRes.status).toBe(200);
+    expect(attachmentsRes.body?.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Signed lease document",
+          url: "https://signed.example/lease-signing/landlord-1/request-signed-document/signed.pdf",
+        }),
+      ])
+    );
+    const payload = JSON.stringify({ lease: leaseRes.body, attachments: attachmentsRes.body });
+    expect(payload).not.toContain("signed-lease-documents");
+    expect(payload).not.toContain("raw-provider-request-id");
+  });
+
   it("links tenant lease workspace to generated unsigned lease package attachments", async () => {
     ensureCollection("leases").set("lease-1", {
       ...(ensureCollection("leases").get("lease-1") || {}),

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -98,6 +98,7 @@ import { recordSystemObservabilityEvent } from "../services/observability/record
 import { buildLeasePaymentProjection } from "../services/projections/buildLeasePaymentProjection";
 import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 import {
+  getSignedLeaseDocumentDownload,
   getTenantSigningUrl,
   loadLeaseSigningSnapshot,
   signingErrorCode,
@@ -2517,6 +2518,27 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
     }
   }
 
+  const leaseSigning = leaseDoc
+    ? await loadLeaseSigningSnapshot({
+        leaseId: leaseDoc.id,
+        landlordId: String(leaseDoc.data?.landlordId || "").trim() || null,
+        lease: leaseDoc.data,
+      }).catch(() => null)
+    : null;
+  const leaseDataWithProviderSigning =
+    leaseDoc && leaseSigning?.signingStatus && leaseSigning.signingStatus !== "not_started"
+      ? {
+          ...leaseDoc.data,
+          currentSigningStatus: leaseSigning.signingStatus,
+          providerSigningStatus: leaseSigning.signingStatus,
+          providerSignedAt: leaseSigning.signedAt || leaseDoc.data?.providerSignedAt || null,
+          signingCompletedAt:
+            leaseSigning.signingStatus === "signed"
+              ? leaseSigning.signedAt || leaseDoc.data?.signingCompletedAt || null
+              : leaseDoc.data?.signingCompletedAt || null,
+        }
+      : leaseDoc?.data;
+
   const leaseDocumentContext = leaseDoc
     ? await getTenantLeaseDocumentContext({
         leaseId: leaseDoc.id,
@@ -2524,7 +2546,7 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
         tenantEmail: context.invitedEmail,
         propertyId: String(leaseDoc.data?.propertyId || context.propertyId || "").trim() || null,
         unitId: String(leaseDoc.data?.unitId || context.unitId || "").trim() || null,
-        leaseData: leaseDoc.data,
+        leaseData: leaseDataWithProviderSigning,
       })
     : null;
   const scheduleADocumentContext = leaseDoc
@@ -2534,25 +2556,25 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
         tenantEmail: context.invitedEmail,
         propertyId: String(leaseDoc.data?.propertyId || context.propertyId || "").trim() || null,
         unitId: String(leaseDoc.data?.unitId || context.unitId || "").trim() || null,
-        leaseData: leaseDoc.data,
+        leaseData: leaseDataWithProviderSigning,
         documentKind: "schedule-a",
       })
     : null;
   const leaseProjectionData =
     leaseDoc && leaseDocumentContext?.documentUrl
       ? {
-          ...leaseDoc.data,
+          ...leaseDataWithProviderSigning,
           documentUrl: leaseDocumentContext.documentUrl,
           approvedDocumentUrl: leaseDocumentContext.documentUrl,
+          leaseDocumentStatus: leaseDocumentContext.documentStatus,
         }
-      : leaseDoc?.data;
-  const leaseSigning = leaseDoc
-    ? await loadLeaseSigningSnapshot({
-        leaseId: leaseDoc.id,
-        landlordId: String(leaseDoc.data?.landlordId || "").trim() || null,
-        lease: leaseDoc.data,
-      }).catch(() => null)
-    : null;
+      : leaseDocumentContext?.documentStatus === "pending"
+      ? {
+          ...leaseDataWithProviderSigning,
+          leaseDocumentStatus: leaseDocumentContext.documentStatus,
+          documentStatus: leaseDocumentContext.documentStatus,
+        }
+      : leaseDataWithProviderSigning;
   const lease = leaseDoc
     ? {
         ...projectTenantLease(leaseDoc.id, leaseProjectionData),
@@ -3322,8 +3344,16 @@ function isLeaseSigned(raw: any): boolean {
       raw?.signatureCompletedAt ||
       (raw?.tenantSignature?.signedAt && raw?.landlordSignature?.signedAt) ||
       (raw?.tenantSignedAt && raw?.landlordSignedAt) ||
+      isProviderSigningComplete(raw) ||
       ["signed", "executed", "fully_executed"].includes(status)
   );
+}
+
+function isProviderSigningComplete(raw: any): boolean {
+  const signingStatus = String(raw?.currentSigningStatus || raw?.signingStatus || raw?.leaseSigningStatus || raw?.providerSigningStatus || "")
+    .trim()
+    .toLowerCase();
+  return ["signed", "completed", "complete"].includes(signingStatus);
 }
 
 function isLeaseDocumentWorkflowPending(raw: any): boolean {
@@ -3543,6 +3573,27 @@ async function refreshTenantLeaseSignedUrl(storageRef: TenantLeaseDocumentStorag
   }
 }
 
+async function tenantSignedLeaseDocumentFromSigningRequest(params: {
+  leaseId: string;
+  leaseData: any;
+}): Promise<{ documentUrl: string; source: string } | null> {
+  const landlordId = String(params.leaseData?.landlordId || "").trim();
+  if (!params.leaseId || !landlordId) return null;
+  try {
+    const signedDocument = await getSignedLeaseDocumentDownload({
+      leaseId: params.leaseId,
+      landlordId,
+    });
+    if (!signedDocument?.documentUrl) return null;
+    return {
+      documentUrl: signedDocument.documentUrl,
+      source: signedDocument.source === "signedDocument" ? "leaseSigningRequests.signedDocument" : "leaseSigningRequests.signedDocumentUrl",
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function loadTenantLeaseAttachments(tenantId: string): Promise<any[]> {
   const normalizedTenantId = String(tenantId || "").trim();
   if (!normalizedTenantId) return [];
@@ -3598,6 +3649,7 @@ async function getTenantLeaseDocumentContext(params: {
   }
 
   const signed = isLeaseSigned(params.leaseData);
+  const providerSigningComplete = isProviderSigningComplete(params.leaseData);
 
   if (params.documentKind === "schedule-a") {
     const directScheduleRef = tenantScheduleAStorageRef({ leaseData: params.leaseData });
@@ -3640,6 +3692,36 @@ async function getTenantLeaseDocumentContext(params: {
       confidence: "low",
       warnings: ["No tenant-safe Schedule A link is available yet."],
     };
+  }
+
+  if (providerSigningComplete) {
+    const signedDocumentFromSigning = await tenantSignedLeaseDocumentFromSigningRequest({
+      leaseId,
+      leaseData: params.leaseData,
+    });
+    if (signedDocumentFromSigning?.documentUrl) {
+      return {
+        leaseId,
+        tenantId: tenantId || undefined,
+        propertyId: propertyId || undefined,
+        unitId: unitId || undefined,
+        leaseStatus,
+        signingStatus: "signed",
+        documentStatus: "signed",
+        documentId:
+          String(
+            params.leaseData?.signedDocumentId ||
+              params.leaseData?.documentId ||
+              params.leaseData?.latestLeaseSnapshotId ||
+              ""
+          ).trim() || undefined,
+        documentUrl: signedDocumentFromSigning.documentUrl,
+        displayLabel: "Signed lease document",
+        source: signedDocumentFromSigning.source,
+        confidence: "high",
+        warnings,
+      };
+    }
   }
 
   const directStorageRef =
@@ -3731,6 +3813,22 @@ async function getTenantLeaseDocumentContext(params: {
       source: "lease_document_workflow",
       confidence: "medium",
       warnings: ["A lease workflow is visible, but no tenant-safe document link is available yet."],
+    };
+  }
+
+  if (providerSigningComplete) {
+    return {
+      leaseId,
+      tenantId: tenantId || undefined,
+      propertyId: propertyId || undefined,
+      unitId: unitId || undefined,
+      leaseStatus,
+      signingStatus: "signed",
+      documentStatus: "pending",
+      displayLabel: "Signed lease document pending",
+      source: "lease_signing_signed_without_document",
+      confidence: "medium",
+      warnings: ["Signing is complete, but no tenant-safe signed lease document link is available yet."],
     };
   }
 

--- a/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
+++ b/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
@@ -107,7 +107,8 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
   const normalizedSigningStatus = normalizeStatus(
     raw?.currentSigningStatus || raw?.signingStatus || raw?.leaseSigningStatus || raw?.providerSigningStatus
   );
-  const providerSignedAt = ["signed", "completed", "complete"].includes(normalizedSigningStatus)
+  const providerSigningComplete = ["signed", "completed", "complete"].includes(normalizedSigningStatus);
+  const providerSignedAt = providerSigningComplete
     ? firstIso(raw, ["currentStatusAt", "signedAt", "signingCompletedAt", "providerSignedAt", "fullyExecutedAt"])
     : null;
 
@@ -156,7 +157,7 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
       fullyExecutedAt
   );
 
-  const executed = Boolean(providerSignedAt || (tenantSignatureCaptured && landlordSignatureCaptured));
+  const executed = Boolean(providerSigningComplete || providerSignedAt || (tenantSignatureCaptured && landlordSignatureCaptured));
   const landlordSigned = Boolean(!executed && landlordSignatureCaptured);
   const readyForLandlord = Boolean(!executed && !landlordSigned && statusImpliesReadyForLandlord);
   const tenantSigned = Boolean(

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -176,6 +176,7 @@ export default function TenantLeasePage() {
 
   const execution = data?.leaseExecution || null;
   const providerSigningStatus = String(data?.providerSigningStatus || "not_started");
+  const providerSigningComplete = providerSigningStatus === "signed";
   const providerSigningAvailable = data?.providerSigningAvailable === true || providerSigningStatus === "pending_signature";
   const leaseDocumentContext = data?.leaseDocumentContext || null;
   const scheduleADocumentContext = data?.scheduleADocumentContext || null;
@@ -183,6 +184,7 @@ export default function TenantLeasePage() {
   const rawScheduleAUrl = String(scheduleADocumentContext?.documentUrl || "").trim();
   const leaseDocumentUrl = rawLeaseDocumentUrl && !isScheduleADocumentUrl(rawLeaseDocumentUrl) ? rawLeaseDocumentUrl : null;
   const scheduleAUrl = rawScheduleAUrl || (isScheduleADocumentUrl(rawLeaseDocumentUrl) ? rawLeaseDocumentUrl : null);
+  const signedCopyPending = providerSigningComplete && !leaseDocumentUrl;
   const leaseDocumentLabel = leaseDocumentUrl
     ? leaseDocumentContext?.displayLabel || data?.leasePdfLabel || null
     : scheduleAUrl
@@ -206,6 +208,7 @@ export default function TenantLeasePage() {
   });
   const executionStatus = String(execution?.executionStatus || "").trim();
   const signatureWorkflowVisible =
+    providerSigningComplete ||
     Boolean(data?.tenantSignature?.signedAt) ||
     ["ready_for_tenant_signature", "tenant_signed", "ready_for_landlord_signature", "landlord_signed", "fully_executed"].includes(
       executionStatus
@@ -456,7 +459,9 @@ export default function TenantLeasePage() {
                 <div style={{ color: "var(--text-muted, #64748b)" }}>
                   {providerSigningAvailable
                     ? "Open the secure signing session to review and sign the lease."
-                    : providerSigningStatus === "signed"
+                    : providerSigningComplete && signedCopyPending
+                    ? "The provider-backed signing workflow is complete. The signed copy is still being prepared for this tenant workspace."
+                    : providerSigningComplete
                     ? "The provider-backed signing workflow is complete."
                     : data.signatureReadinessDescription || "Lease signing details are not available in this workspace yet."}
                 </div>
@@ -497,10 +502,16 @@ export default function TenantLeasePage() {
               <div style={{ display: "grid", gap: 12 }}>
                 <div style={{ display: "grid", gap: 6 }}>
                   <div style={{ fontWeight: 800 }}>
-                    {signatureWorkflowVisible ? execution.executionLabel : "Signature workflow not started"}
+                    {signedCopyPending
+                      ? "Signing complete; signed copy pending"
+                      : signatureWorkflowVisible
+                      ? execution.executionLabel
+                      : "Signature workflow not started"}
                   </div>
                   <div style={{ color: "var(--text-muted, #64748b)" }}>
-                    {signatureWorkflowVisible
+                    {signedCopyPending
+                      ? "Signing is complete, but no tenant-safe signed lease document link is available yet."
+                      : signatureWorkflowVisible
                       ? execution.executionDescription
                       : "Lease details are visible, but no tenant-safe signature workflow or execution evidence is available yet."}
                   </div>

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2421,6 +2421,59 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText("refresh failed")).toBeInTheDocument();
   });
 
+  it("shows provider-signed leases without documents as signed-copy pending instead of not started", async () => {
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-provider-signed",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1800,
+      status: "active",
+      documentUrl: null,
+      leaseDocumentContext: {
+        leaseId: "lease-provider-signed",
+        documentStatus: "pending",
+        displayLabel: "Signed lease document pending",
+        source: "lease_signing_signed_without_document",
+        confidence: "medium",
+        warnings: ["Signing is complete, but no tenant-safe signed lease document link is available yet."],
+      },
+      signatureStatus: "signed",
+      signatureReadinessLabel: "Lease signing complete",
+      signatureReadinessDescription: "The visible lease record shows the current signing stage as complete.",
+      providerSigningStatus: "signed",
+      providerSignedAt: "2026-07-03T10:00:00.000Z",
+      providerDerivedLeaseState: "active",
+      providerSigningAvailable: false,
+      leasePdfStatus: "pending",
+      leasePdfLabel: "Document preparation needed",
+      leasePdfDescription: "A lease document workflow is visible, but no approved tenant-safe lease document link is available yet.",
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "The visible lease record indicates the current execution flow is complete.",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "blocked",
+        completedAt: "2026-07-03T10:00:00.000Z",
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <TenantLeasePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/^Lease signature complete$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Signed lease document pending$/i)).toBeInTheDocument();
+    expect(screen.getByText(/signed copy is still being prepared for this tenant workspace/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Signing complete; signed copy pending$/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/no tenant-safe signed lease document link is available yet/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/^Signature workflow not started$/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View lease/i })).not.toBeInTheDocument();
+  });
+
   it("does not open Schedule A when the tenant primary lease refresh path returns it", async () => {
     tenantPortalApi.refreshTenantLeaseDocumentUrl.mockResolvedValueOnce({
       documentUrl: "https://storage.googleapis.com/lease-documents/leases/landlord/draft/schedule-a-v1.pdf",


### PR DESCRIPTION
## Summary
- Aligns tenant lease projection with provider signing lifecycle before deriving tenant-safe signature and execution state.
- Surfaces provider-signed leases without a tenant-safe signed document as `Signed lease document pending` instead of leaving the tenant workflow as not started.
- Projects signed-document storage metadata from signing requests into tenant-safe lease document context and document vault when available.
- Keeps Schedule A separate from primary signed lease document readiness.

## Root cause
The tenant portal merged provider signing status into the response after the core lease projection had already derived document and execution state. A provider request could be signed while the tenant-safe document context stayed missing, so the UI displayed signing complete alongside a not-started workflow and an empty document vault.

## Validation
- `npm run test:single -- src/pages/tenant/TenantWorkspacePage.test.tsx` in `rentchain-frontend`
- `npm run test:single -- src/routes/__tests__/tenantPortalRoutes.test.ts` in `rentchain-api` with Node 20.11.1
- `npm run test:single -- src/routes/__tests__/leaseRoutes.active.test.ts` in `rentchain-api` with Node 20.11.1
- `npm run build` in `rentchain-frontend` with Node 20.11.1
- `npm run build` in `rentchain-api` with Node 20.11.1
- `git diff --check`

## Manual QA
- Tenant lease page with provider signing signed and no tenant-safe document: confirm signed-copy-pending copy appears and `Signature workflow not started` does not.
- Tenant lease page with provider signing signed and signed document storage metadata: confirm signed lease document link appears.
- Tenant document vault: confirm signed lease appears when tenant-safe signed document context exists.
- Confirm Schedule A remains separate and does not count as primary signed lease document.
- Regression: tenant dashboard/workspace, tenant lease/workspace, send-for-signature flow.