### PR TITLE
fix/lease-rent-collection-setup-action-visibility-v1

### DIFF
--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -336,6 +336,93 @@ describe("LandlordActiveLeasesPage", () => {
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 
+  it("shows a staged rent-terms action instead of enablement when payment setup is not ready", async () => {
+    mocks.enableLeasePaymentRail.mockClear();
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          propertyId: "prop-1",
+          propertyName: "Harbour View",
+          unitNumber: "101",
+          monthlyRent: 1850,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          tenantName: "Jane Tenant",
+          tenantEmail: "jane@example.com",
+          documentUrl: "https://example.com/lease.pdf",
+          leaseExecution: {
+            executionStatus: "tenant_signed",
+            executionLabel: "Lease execution in progress",
+            executionDescription: "The lease still needs landlord execution.",
+            requiredNextAction: "landlord_signature",
+            tenantSignatureStatus: "completed",
+            landlordSignatureStatus: "needed",
+            pdfStatus: "generated",
+            completedAt: null,
+          },
+          paymentReadiness: {
+            readinessStatus: "not_ready",
+            readinessLabel: "Review rent terms",
+            readinessDescription:
+              "The lease is visible, but some rent-term details should be reviewed before future payment setup planning.",
+            requiredNextAction: "review_rent_terms",
+            rentTerms: {
+              rentAmountAvailable: true,
+              dueDateAvailable: false,
+              leaseDatesAvailable: true,
+              tenantLinked: true,
+              leaseExecuted: false,
+            },
+            paymentSetup: {
+              processorConnected: false,
+              moneyMovementEnabled: false,
+              storedPaymentMethod: false,
+            },
+          },
+          rentPaymentSummary: {
+            paymentRail: {
+              enabled: false,
+              enabledAt: null,
+              processor: null,
+              blockedReason: "payment_readiness_not_ready",
+            },
+            latestPayment: null,
+            paymentExperience: {
+              history: [],
+              latestStatus: null,
+              retryAvailable: false,
+              receiptSummary: {
+                available: false,
+                label: "No payment summary available yet",
+                amountCents: null,
+                paidAt: null,
+                leaseReference: null,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Rent collection not enabled/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Due day missing/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Payment setup: Due day missing")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Enable rent collection/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Review rent terms" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/summary?section=rent-payment"
+    );
+    expect(mocks.enableLeasePaymentRail).not.toHaveBeenCalled();
+  });
+
   it("navigates compact workflow buttons to distinct summary section URLs", async () => {
     render(
       <MemoryRouter>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -269,6 +269,13 @@ function paymentReadinessChecklist(lease: LandlordActiveLease) {
   return missing.join(" · ");
 }
 
+function paymentSetupReviewLabel(lease: LandlordActiveLease) {
+  const nextAction = lease.paymentReadiness?.requiredNextAction;
+  if (nextAction === "complete_lease_details") return "Complete lease details";
+  if (nextAction === "review_rent_terms") return "Review rent terms";
+  return "Complete payment setup";
+}
+
 function lifecycleNextActionLabel(
   value:
     | "review_expiring_lease"
@@ -636,6 +643,12 @@ export default function LandlordActiveLeasesPage() {
     const primaryDocumentUrl = primaryLeaseDocumentUrl(lease);
     const canOpenPrimaryDocument = canOpenPrimaryLeaseDocumentFromList(lease);
     const scheduleAUrl = scheduleADocumentUrl(lease);
+    const rentPaymentSetupPath = `${summaryPath}?section=rent-payment`;
+    const rentCollectionEnabled = lease.rentPaymentSummary?.paymentRail.enabled === true;
+    const canEnableRentCollection = !rentCollectionEnabled && lease.paymentReadiness?.readinessStatus === "ready_to_configure";
+    const shouldReviewPaymentSetup =
+      view !== "archived" && !rentCollectionEnabled && Boolean(lease.paymentReadiness) && !canEnableRentCollection;
+    const paymentSetupReason = shouldReviewPaymentSetup ? paymentReadinessChecklist(lease) : null;
     return (
       <div style={{ display: "grid", gap: 12 }}>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
@@ -726,8 +739,7 @@ export default function LandlordActiveLeasesPage() {
             </button>
           ) : (
             <>
-              {lease.rentPaymentSummary?.paymentRail.enabled !== true &&
-              lease.paymentReadiness?.readinessStatus === "ready_to_configure" ? (
+              {canEnableRentCollection ? (
                 <button
                   type="button"
                   onClick={() => void handleEnableRentCollection(lease)}
@@ -736,6 +748,14 @@ export default function LandlordActiveLeasesPage() {
                 >
                   {paymentRailBusyLeaseId === lease.id ? "Enabling..." : "Enable rent collection"}
                 </button>
+              ) : shouldReviewPaymentSetup ? (
+                <Link
+                  to={rentPaymentSetupPath}
+                  title={paymentSetupReason || lease.paymentReadiness?.readinessDescription || "Review payment setup details."}
+                  style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a", textDecoration: "none" }}
+                >
+                  {paymentSetupReviewLabel(lease)}
+                </Link>
               ) : null}
               <button
                 type="button"
@@ -747,6 +767,9 @@ export default function LandlordActiveLeasesPage() {
             </>
           )}
         </div>
+        {paymentSetupReason ? (
+          <div style={{ color: "#64748b", fontSize: 12 }}>Payment setup: {paymentSetupReason}</div>
+        ) : null}
         {view !== "archived" ? <LeaseSigningDashboard leaseId={lease.id} tenantEmail={lease.tenantEmail} /> : null}
       </div>
     );


### PR DESCRIPTION
## Summary
- Adds a staged rent collection setup action on /leases when rent collection is not enabled but the lease is not ready for enablement.
- Keeps the existing Enable rent collection CTA only for ready-to-configure leases so the UI does not offer an action the backend would reject.
- Routes not-ready leases to the existing lease summary rent/payment section with a visible payment setup reason such as Due day missing.

## Root cause
The /leases page already had an Enable rent collection action, but it only rendered when paymentReadiness.readinessStatus was ready_to_configure. For leases with missing prerequisites such as due day, backend eligibility correctly blocks rail enablement, but the frontend hid the enable action without showing a staged landlord next step.

## Validation
- npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx (Node 20.20.2)
- npm run build (Node 20.20.2)
- git diff --check

## Notes
- Frontend lease page only.
- No backend changes.
- No payment processing, Stripe, ledger, lease signing, tenant portal, or schema changes.
- Node 20.11.1 build also passed, but Vitest hit an existing jsdom dependency ESM loader issue on 20.11.1 before loading tests; tests passed on Node 20.20.2.