### PR TITLE
fix/analytics-mobile-card-layout-v1

### DIFF
--- a/rentchain-frontend/src/components/analytics/AnalyticsKpiCard.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsKpiCard.tsx
@@ -14,9 +14,13 @@ type Props = {
 
 export function AnalyticsKpiCard({ label, value, hint, delta, periodLabel = "period", formatAbsoluteDelta }: Props) {
   return (
-    <Card style={{ display: "grid", gap: 6 }}>
-      <div style={{ color: "#64748b", fontSize: "0.82rem", fontWeight: 600 }}>{label}</div>
-      <div style={{ color: "#0f172a", fontSize: "1.7rem", fontWeight: 700 }}>{value}</div>
+    <Card className="analytics-kpi-card" style={{ display: "grid", gap: 6 }}>
+      <div className="analytics-kpi-card__label" style={{ color: "#64748b", fontSize: "0.82rem", fontWeight: 600 }}>
+        {label}
+      </div>
+      <div className="analytics-kpi-card__value" style={{ color: "#0f172a", fontSize: "1.7rem", fontWeight: 700 }}>
+        {value}
+      </div>
       {hint ? <div style={{ color: "#475569", fontSize: "0.92rem" }}>{hint}</div> : null}
       <TrendDeltaBadge delta={delta} periodLabel={periodLabel} formatAbsoluteDelta={formatAbsoluteDelta} />
     </Card>

--- a/rentchain-frontend/src/components/analytics/AnalyticsKpiGrid.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsKpiGrid.tsx
@@ -18,11 +18,11 @@ type Props = {
 export function AnalyticsKpiGrid({ items, periodLabel = "period" }: Props) {
   return (
     <div
+      className="analytics-kpi-grid"
       data-testid="analytics-kpi-grid"
       style={{
         display: "grid",
         gap: 12,
-        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
       }}
     >
       {items.map((item) => (

--- a/rentchain-frontend/src/components/analytics/AnalyticsSectionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsSectionPanel.tsx
@@ -34,16 +34,15 @@ export function AnalyticsSectionPanel({ title, description, metrics, emptyMessag
           <div style={{ display: "grid", gap: 10 }}>
             {metrics.map((metric) => (
               <div
+                className="analytics-section-metric-row"
                 key={metric.label}
                 style={{
-                  display: "flex",
-                  justifyContent: "space-between",
                   gap: 16,
                   padding: "10px 0",
                   borderTop: "1px solid #e2e8f0",
                 }}
               >
-                <div style={{ display: "grid", gap: 2 }}>
+                <div className="analytics-section-metric-row__body" style={{ display: "grid", gap: 2 }}>
                   <div style={{ fontWeight: 600, color: "#0f172a" }}>{metric.label}</div>
                   {metric.hint ? <div style={{ color: "#64748b", fontSize: "0.88rem" }}>{metric.hint}</div> : null}
                   <TrendDeltaBadge
@@ -52,7 +51,9 @@ export function AnalyticsSectionPanel({ title, description, metrics, emptyMessag
                     formatAbsoluteDelta={metric.formatAbsoluteDelta}
                   />
                 </div>
-                <div style={{ fontWeight: 700, color: "#0f172a", textAlign: "right" }}>{metric.value}</div>
+                <div className="analytics-section-metric-row__value" style={{ fontWeight: 700, color: "#0f172a" }}>
+                  {metric.value}
+                </div>
               </div>
             ))}
           </div>

--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -508,6 +508,41 @@ button,
   color: #fff;
 }
 
+.analytics-kpi-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 200px), 1fr));
+}
+
+.analytics-kpi-card {
+  min-width: 0;
+}
+
+.analytics-kpi-card__label {
+  overflow-wrap: anywhere;
+}
+
+.analytics-kpi-card__value {
+  white-space: nowrap;
+  overflow-wrap: normal;
+  line-height: 1.15;
+}
+
+.analytics-section-metric-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: start;
+}
+
+.analytics-section-metric-row__body {
+  min-width: 0;
+}
+
+.analytics-section-metric-row__value {
+  max-width: 100%;
+  text-align: right;
+  white-space: nowrap;
+  overflow-wrap: normal;
+}
+
 .analytics-print-summary .printKpis {
   grid-template-columns: repeat(3, 1fr);
 }
@@ -528,6 +563,20 @@ button,
 
   .analytics-workspace-header__top {
     margin-bottom: 12px;
+  }
+
+  .analytics-kpi-grid,
+  .analytics-workspace-summary-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  .analytics-section-metric-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .analytics-section-metric-row__value {
+    text-align: left;
   }
 }
 

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -517,7 +517,11 @@ describe("LandlordAnalyticsPage", () => {
     expect(within(controlArea).getByLabelText(/Analytics property/i)).toBeInTheDocument();
     const tabPanel = screen.getByRole("tabpanel", { name: "Analytics alerts" });
     const kpiGrid = screen.getByTestId("analytics-kpi-grid");
+    expect(kpiGrid).toHaveClass("analytics-kpi-grid");
     expect(Boolean(tabPanel.compareDocumentPosition(kpiGrid) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    const scheduledRentKpi = within(kpiGrid).getByText("Scheduled rent").closest(".analytics-kpi-card");
+    expect(scheduledRentKpi).toBeTruthy();
+    expect(within(scheduledRentKpi as HTMLElement).getByText("$6,600")).toHaveClass("analytics-kpi-card__value");
     expect(screen.getByRole("tab", { name: "Analytics alerts" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Portfolio benchmarking" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Decision outcomes" })).toBeInTheDocument();
@@ -561,6 +565,13 @@ describe("LandlordAnalyticsPage", () => {
 
     expect(screen.getByRole("heading", { name: /Applications/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Revenue signal/i })).toBeInTheDocument();
+    const estimatedScheduledRentRow = screen
+      .getByText("Estimated scheduled rent")
+      .closest(".analytics-section-metric-row");
+    expect(estimatedScheduledRentRow).toBeTruthy();
+    expect(within(estimatedScheduledRentRow as HTMLElement).getByText("$6,600")).toHaveClass(
+      "analytics-section-metric-row__value"
+    );
     expect(screen.getAllByText(/vs prior 90 days/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(macShellSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Analytics", showTopNav: false }));
@@ -870,6 +881,20 @@ describe("LandlordAnalyticsPage", () => {
         propertyId: "prop-2",
       })
     );
+  });
+
+  it("hydrates vacancy readiness focus from destination query params", async () => {
+    await mockEntitlements();
+    await mockApiResolved();
+
+    render(
+      <MemoryRouter initialEntries={["/analytics?entry=vacancy-readiness"]}>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Focused from decisions: Vacancy readiness/i)).toBeInTheDocument();
+    expect(screen.getByTestId("analytics-kpi-grid")).toHaveClass("analytics-kpi-grid");
   });
 
   it("shows a loading state while analytics are being fetched", async () => {


### PR DESCRIPTION
## Summary
- Improves analytics mobile card layout for dashboard-routed analytics destination views.
- Makes summary KPI cards stack to one column on mobile and keeps metric values such as scheduled rent together.
- Updates analytics section metric rows so labels, hints, deltas, and values stack cleanly on narrow screens.
- Adds test coverage for revenue-pressure and vacancy-readiness destination focus plus responsive analytics layout hooks.

## Scope
- Frontend analytics layout only.
- No analytics calculation changes.
- No backend changes.
- No dashboard changes.

## Validation
- npm run test:single -- src/pages/landlord/LandlordAnalyticsPage.test.tsx
- npm run test:single -- src/pages/DashboardPage.test.tsx
- npm run build
- git diff --check

## Manual QA
- Mobile /analytics?entry=revenue-pressure: confirm cards stack cleanly, labels and amounts are readable, and no horizontal overflow.
- Mobile /analytics?entry=vacancy-readiness: confirm the same.
- Desktop /analytics?entry=revenue-pressure and /analytics?entry=vacancy-readiness: confirm layout remains acceptable.
- Regression: /dashboard, /leases, /operations.