### PR TITLE
polish: widen analytics desktop layout

### DIFF
--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -460,6 +460,7 @@ button,
   padding: 16px;
   border-radius: 24px;
   background: #f8fafc;
+  width: 100%;
 }
 
 .analytics-workspace-header {
@@ -509,7 +510,13 @@ button,
 }
 
 .analytics-kpi-grid {
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 200px), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+}
+
+.analytics-workspace-summary-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
 }
 
 .analytics-kpi-card {
@@ -550,6 +557,16 @@ button,
 .analytics-print-summary__intro {
   color: #334155;
   margin-bottom: 8px;
+}
+
+@media (min-width: 1320px) {
+  .analytics-kpi-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .analytics-workspace-summary-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 720px) {

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -508,6 +508,13 @@ describe("LandlordAnalyticsPage", () => {
     );
 
     expect(await screen.findByText(/Analytics alerts/i)).toBeInTheDocument();
+    expect(macShellSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Analytics",
+        showTopNav: false,
+        maxWidth: "min(100%, 1500px)",
+      })
+    );
     const workspacePage = container.querySelector(".analytics-workspace-page");
     expect(workspacePage).toBeTruthy();
 
@@ -532,6 +539,7 @@ describe("LandlordAnalyticsPage", () => {
     expect(screen.getByRole("tab", { name: "Attention-worthy insights" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Portfolio-level execution state summary" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Review leases/i })).toHaveAttribute("href", "/portfolio-health");
+    expect(container.querySelector(".analytics-workspace-summary-grid")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("tab", { name: "Portfolio benchmarking" }));
     expect(screen.getByRole("heading", { name: /Portfolio benchmarking/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -488,7 +488,7 @@ export default function LandlordAnalyticsPage() {
   ) : null;
 
   return (
-    <MacShell title="Analytics" showTopNav={false}>
+    <MacShell title="Analytics" showTopNav={false} maxWidth="min(100%, 1500px)">
       <div className="analytics-workspace-page">
         {analyticsEnabled ? (
           <AnalyticsWorkspaceHeader
@@ -562,14 +562,7 @@ export default function LandlordAnalyticsPage() {
             <AnalyticsKpiGrid items={summaryItems} periodLabel={periodLabel(period)} />
 
             {canViewPortfolioScore ? (
-              <div
-                className="analytics-workspace-summary-grid"
-                style={{
-                  display: "grid",
-                  gap: 12,
-                  gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-                }}
-              >
+              <div className="analytics-workspace-summary-grid">
                 <AnalyticsSectionPanel
                   title="Applications"
                   description="Track whether interest is turning into submitted and approved applications."


### PR DESCRIPTION
## Summary
- Widen the analytics page shell on desktop/tablet so destination views can use more horizontal space.
- Move analytics summary-grid sizing into CSS and increase desktop card density for KPI and section panels.
- Preserve the mobile one-column analytics layout and existing Dashboard analytics destination routes.

## Validation
- `npm run test:single -- src/pages/landlord/LandlordAnalyticsPage.test.tsx`
- `npm run test:single -- src/pages/DashboardPage.test.tsx`
- `npm run build`
- `git diff --check`

## Manual QA
- Desktop `/analytics?entry=revenue-pressure`
- Desktop `/analytics?entry=vacancy-readiness`
- Tablet/narrow desktop width if practical
- Mobile `/analytics?entry=revenue-pressure`
- Mobile `/analytics?entry=vacancy-readiness`
- Regression: `/dashboard`, `/leases`, `/operations`