### PR TITLE
fix: add operations to landlord mobile nav

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -93,6 +93,7 @@ describe("LandlordNav mobile drawer", () => {
     const drawer = screen.getByRole("dialog", { name: "Navigation menu" });
     expect(drawer).toHaveClass("is-open");
     expect(within(drawer).getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
+    expect(within(drawer).getByRole("button", { name: "Operations" })).toBeInTheDocument();
     expect(within(drawer).getByRole("button", { name: "Payments" })).toBeInTheDocument();
     expect(within(drawer).getByRole("button", { name: "Work Orders" })).toBeInTheDocument();
   });
@@ -252,12 +253,14 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(tabbar).getByText("Properties")).toBeInTheDocument();
     expect(within(tabbar).getByText("Applicants")).toBeInTheDocument();
     expect(within(tabbar).getByText("Inbox")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Operations")).toBeInTheDocument();
     expect(within(tabbar).getByText("More")).toBeInTheDocument();
     expect(within(tabbar).getAllByRole("button").map((button) => button.textContent)).toEqual([
       "Dashboard",
       "Properties",
       "Applicants",
       "Inbox",
+      "Operations",
       "More",
     ]);
     expect(within(tabbar).queryByText("Tenants")).not.toBeInTheDocument();
@@ -274,6 +277,13 @@ describe("LandlordNav mobile drawer", () => {
       "Applications",
       "Inbox",
     ]);
+    expect(NAV_ITEMS.find((item) => item.id === "operations")).toEqual(
+      expect.objectContaining({
+        label: "Operations",
+        to: "/operations",
+        showInDrawer: true,
+      })
+    );
   });
 
   it("shows one landlord drawer inbox entry pointing to the unified inbox", async () => {
@@ -305,6 +315,16 @@ describe("LandlordNav mobile drawer", () => {
 
     fireEvent.click(within(tabbar).getByRole("button", { name: "Inbox" }));
     expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
+
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Operations" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/operations");
+  });
+
+  it("marks the Operations tab active on the operations route", () => {
+    renderLandlordNav("/operations");
+
+    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+    expect(within(tabbar).getByRole("button", { name: "Operations" })).toHaveClass("active");
   });
 
   it("marks the unified inbox tab active on the landlord unified inbox route", () => {

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Building2, Inbox, LayoutDashboard, Menu, ScrollText, X } from "lucide-react";
+import { Building2, ClipboardList, Inbox, LayoutDashboard, Menu, ScrollText, X } from "lucide-react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
@@ -21,6 +21,7 @@ const landlordMobileTabs = [
   { to: "/properties", label: "Properties", icon: Building2 },
   { to: "/applications", label: "Applicants", icon: ScrollText },
   { to: "/landlord/unified-inbox", label: "Inbox", icon: Inbox },
+  { to: "/operations", label: "Operations", icon: ClipboardList },
 ];
 
 const stickyWorkspaceIds = new Set([

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -43,7 +43,7 @@ export const NAV_ITEMS: NavItem[] = [
     label: "Operations",
     to: "/operations",
     icon: ClipboardList,
-    showInDrawer: false,
+    showInDrawer: true,
     requiresLandlordOrAdmin: true,
   },
   {


### PR DESCRIPTION
## Summary
- Add `Operations` as a direct landlord mobile bottom-nav destination while preserving Dashboard, Properties, Applicants, Inbox, and More.
- Use the existing `ClipboardList` navigation icon for Operations and route the tab to `/operations`.
- Make Operations visible in the landlord drawer so mobile drawer discovery aligns with desktop workspace navigation.
- Update landlord nav tests for tab order, routing, active state, drawer visibility, and tenant/admin non-regression coverage.

## Validation
- `npm run test:single -- src/components/layout/LandlordNav.test.tsx src/components/layout/TenantNav.test.tsx`
- `npm run build`
- `git diff --check`

## Manual QA
- Mobile `/dashboard`: confirm Operations appears and routes to `/operations`.
- Mobile `/operations`: confirm Operations tab active state.
- Mobile `/properties`, `/applications`, `/landlord/unified-inbox`: confirm existing tabs still work.
- Mobile drawer/topbar: confirm overflow pages remain accessible.
- Tablet/narrow desktop: confirm no nav overflow.
- Tenant mobile workspace: confirm tenant nav unchanged.
- Desktop landlord routes: confirm workspace nav remains acceptable.