### PR TITLE
polish: improve applications page spacing

### DIFF
--- a/rentchain-frontend/src/components/applications/LandlordDecisionPanel.css
+++ b/rentchain-frontend/src/components/applications/LandlordDecisionPanel.css
@@ -1,0 +1,18 @@
+.rc-landlord-decision-panel__risk-summary-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  min-width: 0;
+}
+
+.rc-landlord-decision-panel__risk-summary-grid > * {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 768px) {
+  .rc-landlord-decision-panel__risk-summary-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+}

--- a/rentchain-frontend/src/components/applications/LandlordDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/applications/LandlordDecisionPanel.test.tsx
@@ -8,7 +8,7 @@ afterEach(() => {
 
 describe("LandlordDecisionPanel", () => {
   it("renders the structured risk summary, factors, flags, and recommendations", () => {
-    render(
+    const { container } = render(
       <LandlordDecisionPanel
         riskSnapshot={{
           version: "risk-v1",
@@ -38,6 +38,7 @@ describe("LandlordDecisionPanel", () => {
     );
 
     expect(screen.getByText("Landlord Decision Panel")).toBeInTheDocument();
+    expect(container.querySelector(".rc-landlord-decision-panel__risk-summary-grid")).toBeTruthy();
     expect(screen.getByText("78")).toBeInTheDocument();
     expect(screen.getByText("Grade B")).toBeInTheDocument();
     expect(screen.getByText("Lower risk")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/applications/LandlordDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/applications/LandlordDecisionPanel.tsx
@@ -5,6 +5,7 @@ import type {
   RiskAgentReviewSnapshot,
 } from "@/types/applicationDecisionSummary";
 import { colors, radius, shadows, spacing, text } from "@/styles/tokens";
+import "./LandlordDecisionPanel.css";
 
 type LandlordDecisionPanelProps = {
   riskSnapshot?: RiskAgentReviewSnapshot;
@@ -214,7 +215,7 @@ export const LandlordDecisionPanel: React.FC<LandlordDecisionPanelProps> = ({
             <div style={{ color: text.muted, fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>
               Risk Summary
             </div>
-            <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1.2fr) minmax(0, 1fr)", gap: spacing.md }}>
+            <div className="rc-landlord-decision-panel__risk-summary-grid">
               <div
                 style={{
                   borderRadius: radius.lg,

--- a/rentchain-frontend/src/pages/ApplicationsPage.css
+++ b/rentchain-frontend/src/pages/ApplicationsPage.css
@@ -1,3 +1,15 @@
+.rc-applications-page {
+  display: grid;
+  gap: 18px;
+  margin: 0 auto;
+  max-width: min(100%, 1320px);
+  min-width: 0;
+  padding: 16px;
+  width: 100%;
+  border-radius: 24px;
+  background: #f8fafc;
+}
+
 .rc-applications-grid {
   display: block;
   min-height: 0;
@@ -141,6 +153,13 @@
 }
 
 @media (max-width: 768px) {
+  .rc-applications-page {
+    gap: 14px;
+    padding: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
   .rc-applications-grid {
     overflow: visible;
   }

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -2343,7 +2343,7 @@ const ApplicationsPage: React.FC = () => {
 
   return (
     <>
-      <div className="rc-applications-page" style={{ display: "grid", gap: spacing.lg }}>
+      <div className="rc-applications-page">
       <Card elevated className="rc-applications-header">
         <div className="rc-applications-header-row" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
           <div>


### PR DESCRIPTION
## Summary
- Added a desktop/tablet page shell for `/applications` so cards and panels have breathing room on wider layouts.
- Preserved the existing mobile layout by resetting the added page padding/background at mobile width.
- Fixed the Landlord Decision Panel Risk Summary responsive layout so Risk Score and Decision Guidance stack/read cleanly on narrow mobile viewports.
- Kept status filters, application reminder states, viewing requests, screening setup logic, routing, backend behavior, and Risk Agent logic unchanged.

## Validation
- `npm run test:single -- src/pages/ApplicationsPage.test.tsx src/components/applications/LandlordDecisionPanel.test.tsx`
- `npm run build`
- `git diff --check`

## Manual QA
- Desktop `/applications`: confirm page spacing/padding is improved, filters/status tabs still work, and cards/panels remain readable.
- Mobile `/applications`: open the Landlord Decision Panel / Risk Summary and confirm Risk Score and Decision Guidance are readable with no horizontal overflow.
- Regression routes: `/dashboard`, `/properties`, `/leases`, `/operations`, `/landlord/unified-inbox`.