### PR TITLE
fix: persist unified inbox read state

### DIFF
--- a/rentchain-api/src/routes/landlord.test.ts
+++ b/rentchain-api/src/routes/landlord.test.ts
@@ -320,6 +320,21 @@ describe("landlord unified inbox route", () => {
     expectSafeResponse(after.body);
   });
 
+  it("registers the read-state route expected by the /api/landlord mount", async () => {
+    const router = (await import("./landlordInboxRoutes")).default;
+    const registeredRoutes = (router as any).stack
+      .filter((layer: any) => layer?.route)
+      .map((layer: any) => ({
+        path: layer.route.path,
+        methods: layer.route.methods,
+      }));
+
+    expect(registeredRoutes).toContainEqual({
+      path: "/inbox/:recordId/read",
+      methods: expect.objectContaining({ post: true }),
+    });
+  });
+
   it("rejects cross-landlord property access before deriving inbox data", async () => {
     const router = (await import("./landlordInboxRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/landlord.test.ts
+++ b/rentchain-api/src/routes/landlord.test.ts
@@ -30,6 +30,10 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
         const entry = collection.get(id);
         return { id, exists: Boolean(entry), data: () => entry?.data };
       },
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = collection.get(id)?.data || {};
+        collection.set(id, { id, data: options?.merge ? { ...current, ...value } : value });
+      },
     };
   }
 
@@ -87,20 +91,20 @@ vi.mock("../middleware/requireLandlord", () => ({
   },
 }));
 
-async function invokeRouter(router: any, options: { url: string; user?: any }) {
+async function invokeRouter(router: any, options: { url: string; user?: any; method?: string; body?: any }) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const [path, queryString] = options.url.split("?");
     const query = new URLSearchParams(queryString || "");
     mockUser = options.user ?? null;
     const req: any = {
-      method: "GET",
+      method: options.method || "GET",
       url: options.url,
       originalUrl: options.url,
       path,
       query: Object.fromEntries(query.entries()),
       params: {},
       headers: {},
-      body: {},
+      body: options.body || {},
     };
     const res: any = {
       statusCode: 200,
@@ -279,6 +283,41 @@ describe("landlord unified inbox route", () => {
       propertyId: "prop-1",
     });
     expectSafeResponse(res.body);
+  });
+
+  it("persists read state for safe landlord inbox records across refetches", async () => {
+    const router = (await import("./landlordInboxRoutes")).default;
+    const user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+
+    const before = await invokeRouter(router, { url: "/inbox?limit=20", user });
+    expect(before.status).toBe(200);
+    const target = before.body.items.find((item: any) => item.status === "unread");
+    expect(target?.id).toMatch(/^inbox_v1_/);
+
+    const read = await invokeRouter(router, {
+      method: "POST",
+      url: `/inbox/${target.id}/read`,
+      user,
+    });
+    expect(read.status).toBe(200);
+    expect(read.body.record).toMatchObject({
+      id: target.id,
+      status: "read",
+      readAt: expect.any(String),
+    });
+
+    const after = await invokeRouter(router, { url: "/inbox?limit=20", user });
+    expect(after.status).toBe(200);
+    const refreshed = after.body.items.find((item: any) => item.id === target.id);
+    expect(refreshed).toMatchObject({
+      id: target.id,
+      status: "read",
+      readAt: read.body.record.readAt,
+    });
+    expect(after.body.items.filter((item: any) => item.status === "unread")).toHaveLength(
+      before.body.items.filter((item: any) => item.status === "unread").length - 1
+    );
+    expectSafeResponse(after.body);
   });
 
   it("rejects cross-landlord property access before deriving inbox data", async () => {

--- a/rentchain-api/src/routes/landlordInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordInboxRoutes.ts
@@ -15,6 +15,7 @@ const router = Router();
 
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 20;
+const READ_STATES_COLLECTION = "unifiedInboxReadStates";
 
 export type LandlordInboxRequest = {
   limit: number;
@@ -55,6 +56,15 @@ const SOURCE_MAP: Record<string, SourceKind> = {
 function asString(value: unknown, max = 240): string {
   const next = String(value || "").trim().slice(0, max);
   return next || "";
+}
+
+function isSafeInboxRecordId(value: string) {
+  return /^inbox_v1_[A-Za-z0-9_-]+$/.test(value);
+}
+
+function readStateDocId(landlordId: string, recordId: string) {
+  const scope = Buffer.from(landlordId, "utf8").toString("base64url");
+  return `landlord_${scope}_${recordId}`;
 }
 
 function hasLandlordScope(record: any, landlordId: string) {
@@ -149,6 +159,19 @@ async function loadCollection(name: string) {
   return (snap?.docs || []).map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
 }
 
+async function loadReadStatesByRecordId(landlordId: string) {
+  const records = await loadCollection(READ_STATES_COLLECTION);
+  const entries: Array<[string, string]> = [];
+  for (const record of records) {
+    const recordId = asString(record?.recordId, 240);
+    const readAt = asString(record?.readAt, 120);
+    if (asString(record?.landlordId, 240) === landlordId && isSafeInboxRecordId(recordId) && readAt) {
+      entries.push([recordId, readAt]);
+    }
+  }
+  return new Map<string, string>(entries);
+}
+
 async function resolvePropertyScope(landlordId: string, propertyId: string | null) {
   if (!propertyId) return { ok: true as const };
   const propertyDoc = await db.collection("properties").doc(propertyId).get().catch(() => null);
@@ -185,6 +208,47 @@ function applySafeFilters(items: UnifiedInboxEvent[], request: LandlordInboxRequ
   });
 }
 
+function applyPersistedReadStates(items: UnifiedInboxEvent[], readStatesByRecordId: Map<string, string>) {
+  return items.map((item) => {
+    const readAt = readStatesByRecordId.get(item.id);
+    if (!readAt) return item;
+    if (item.status !== "unread" && item.readAt) return item;
+    return { ...item, status: "read" as const, readAt };
+  });
+}
+
+async function deriveScopedLandlordInbox(landlordId: string, request: LandlordInboxRequest) {
+  const [snapshot, leases, maintenanceRequests, messages] = await Promise.all([
+    loadLandlordAnalyticsSnapshot({
+      landlordId,
+      propertyId: request.propertyId || undefined,
+    }),
+    loadCollection("leases"),
+    loadCollection("maintenanceRequests"),
+    loadCollection("messages"),
+  ]);
+
+  const analyticsDecisions = Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [];
+  const safePage = await deriveLandlordUnifiedInbox(landlordId, {
+    applicationItems: filterScopedRecords(
+      analyticsDecisions.filter((item: any) => asString(item?.decisionType, 120) !== "start_screening_checkout"),
+      landlordId,
+      request.propertyId
+    ),
+    screeningItems: filterScopedRecords(
+      analyticsDecisions.filter((item: any) => asString(item?.decisionType, 120) === "start_screening_checkout"),
+      landlordId,
+      request.propertyId
+    ),
+    leaseItems: filterScopedRecords(leases, landlordId, request.propertyId),
+    maintenanceRequests: filterScopedRecords(maintenanceRequests, landlordId, request.propertyId),
+    messages: filterScopedRecords(messages, landlordId, request.propertyId),
+    limit: MAX_LIMIT,
+  });
+  const readStatesByRecordId = await loadReadStatesByRecordId(landlordId);
+  return applyPersistedReadStates(safePage.items, readStatesByRecordId);
+}
+
 router.get("/inbox", requireAuth, requireLandlord, async (req: Request, res: Response) => {
   try {
     const landlordId = asString((req as any).user?.landlordId || (req as any).user?.id, 240);
@@ -207,35 +271,8 @@ router.get("/inbox", requireAuth, requireLandlord, async (req: Request, res: Res
       });
     }
 
-    const [snapshot, leases, maintenanceRequests, messages] = await Promise.all([
-      loadLandlordAnalyticsSnapshot({
-        landlordId,
-        propertyId: request.propertyId || undefined,
-      }),
-      loadCollection("leases"),
-      loadCollection("maintenanceRequests"),
-      loadCollection("messages"),
-    ]);
-
-    const analyticsDecisions = Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [];
-    const safePage = await deriveLandlordUnifiedInbox(landlordId, {
-      applicationItems: filterScopedRecords(
-        analyticsDecisions.filter((item: any) => asString(item?.decisionType, 120) !== "start_screening_checkout"),
-        landlordId,
-        request.propertyId
-      ),
-      screeningItems: filterScopedRecords(
-        analyticsDecisions.filter((item: any) => asString(item?.decisionType, 120) === "start_screening_checkout"),
-        landlordId,
-        request.propertyId
-      ),
-      leaseItems: filterScopedRecords(leases, landlordId, request.propertyId),
-      maintenanceRequests: filterScopedRecords(maintenanceRequests, landlordId, request.propertyId),
-      messages: filterScopedRecords(messages, landlordId, request.propertyId),
-      limit: MAX_LIMIT,
-    });
-
-    const filteredItems = applySafeFilters(safePage.items, request);
+    const safeItems = await deriveScopedLandlordInbox(landlordId, request);
+    const filteredItems = applySafeFilters(safeItems, request);
     const items = filteredItems.slice(request.offset, request.offset + request.limit).map(toPublicInboxRecord);
 
     return res.json({
@@ -248,6 +285,56 @@ router.get("/inbox", requireAuth, requireLandlord, async (req: Request, res: Res
   } catch (err: any) {
     console.error("[landlord-unified-inbox] failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "LANDLORD_INBOX_FAILED", message: "Unable to load inbox" });
+  }
+});
+
+router.post("/inbox/:recordId/read", requireAuth, requireLandlord, async (req: Request, res: Response) => {
+  try {
+    const landlordId = asString((req as any).user?.landlordId || (req as any).user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED", message: "Landlord context is required" });
+    }
+
+    const recordId = asString(req.params?.recordId, 240);
+    if (!recordId || !isSafeInboxRecordId(recordId)) {
+      return res.status(400).json({ ok: false, error: "INVALID_INBOX_RECORD", message: "Inbox record is not available" });
+    }
+
+    const request: LandlordInboxRequest = {
+      limit: MAX_LIMIT,
+      offset: 0,
+      propertyId: null,
+      source: null,
+      dateFrom: null,
+      dateTo: null,
+    };
+    const safeItems = await deriveScopedLandlordInbox(landlordId, request);
+    const item = safeItems.find((entry) => entry.id === recordId && entry.audienceRole === "landlord");
+    if (!item) {
+      return res.status(404).json({ ok: false, error: "INBOX_RECORD_NOT_FOUND", message: "Inbox record not found" });
+    }
+
+    const existingReadAt = item.readAt && item.status === "read" ? item.readAt : null;
+    const readAt = existingReadAt || new Date().toISOString();
+    await db
+      .collection(READ_STATES_COLLECTION)
+      .doc(readStateDocId(landlordId, recordId))
+      .set(
+        {
+          audienceRole: "landlord",
+          landlordId,
+          recordId,
+          sourceKind: item.sourceKind,
+          readAt,
+          updatedAt: readAt,
+        },
+        { merge: true }
+      );
+
+    return res.json({ ok: true, record: toPublicInboxRecord({ ...item, status: "read", readAt }) });
+  } catch (err: any) {
+    console.error("[landlord-unified-inbox] read update failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_INBOX_READ_FAILED", message: "Unable to mark inbox item read" });
   }
 });
 

--- a/rentchain-frontend/src/api/unifiedInboxApi.test.ts
+++ b/rentchain-frontend/src/api/unifiedInboxApi.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchUnifiedInbox } from "./unifiedInboxApi";
+import { fetchUnifiedInbox, markUnifiedInboxRecordRead } from "./unifiedInboxApi";
 
 const mocks = vi.hoisted(() => ({
   apiFetch: vi.fn(),
@@ -41,5 +41,18 @@ describe("fetchUnifiedInbox", () => {
 
     expect(mocks.apiFetch).toHaveBeenCalledWith("/contractor/inbox");
     expect(mocks.tenantApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("marks landlord inbox records read through the landlord persistence route", async () => {
+    await markUnifiedInboxRecordRead("landlord", "inbox_v1_safe-record");
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/landlord/inbox/inbox_v1_safe-record/read", { method: "POST" });
+  });
+
+  it("does not expose read persistence for non-landlord inbox roles", async () => {
+    await expect(markUnifiedInboxRecordRead("tenant", "inbox_v1_safe-record")).rejects.toThrow(
+      "Read-state persistence is not available"
+    );
+    expect(mocks.apiFetch).not.toHaveBeenCalled();
   });
 });

--- a/rentchain-frontend/src/api/unifiedInboxApi.ts
+++ b/rentchain-frontend/src/api/unifiedInboxApi.ts
@@ -48,6 +48,11 @@ export type UnifiedInboxResponse = {
   offset: number;
 };
 
+export type UnifiedInboxReadResponse = {
+  ok: true;
+  record: UnifiedInboxRecord;
+};
+
 export async function fetchUnifiedInbox(role: UnifiedInboxRole): Promise<UnifiedInboxResponse> {
   if (role === "tenant") {
     return tenantApiFetch<UnifiedInboxResponse>("/tenant/inbox");
@@ -56,4 +61,16 @@ export async function fetchUnifiedInbox(role: UnifiedInboxRole): Promise<Unified
     return apiFetch<UnifiedInboxResponse>("/contractor/inbox");
   }
   return apiFetch<UnifiedInboxResponse>("/landlord/inbox");
+}
+
+export async function markUnifiedInboxRecordRead(
+  role: UnifiedInboxRole,
+  recordId: string
+): Promise<UnifiedInboxReadResponse> {
+  if (role !== "landlord") {
+    throw new Error("Read-state persistence is not available for this inbox role.");
+  }
+  return apiFetch<UnifiedInboxReadResponse>(`/landlord/inbox/${encodeURIComponent(recordId)}/read`, {
+    method: "POST",
+  });
 }

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -5,6 +5,7 @@ import type { UnifiedInboxRecord } from "../api/unifiedInboxApi";
 
 const mocks = vi.hoisted(() => ({
   fetchUnifiedInbox: vi.fn(),
+  markUnifiedInboxRecordRead: vi.fn(),
 }));
 
 vi.mock("../api/unifiedInboxApi", async () => {
@@ -12,6 +13,7 @@ vi.mock("../api/unifiedInboxApi", async () => {
   return {
     ...actual,
     fetchUnifiedInbox: mocks.fetchUnifiedInbox,
+    markUnifiedInboxRecordRead: mocks.markUnifiedInboxRecordRead,
   };
 });
 
@@ -33,6 +35,20 @@ function record(overrides: Partial<UnifiedInboxRecord>): UnifiedInboxRecord {
 describe("UnifiedInboxPage", () => {
   beforeEach(() => {
     mocks.fetchUnifiedInbox.mockReset();
+    mocks.markUnifiedInboxRecordRead.mockReset();
+    mocks.markUnifiedInboxRecordRead.mockResolvedValue({
+      ok: true,
+      record: record({
+        id: "maintenance-priority",
+        audienceRole: "landlord",
+        sourceKind: "landlord.maintenance",
+        title: "Pipe leak reported",
+        body: "Maintenance priority at Unit 204",
+        priority: "high",
+        status: "read",
+        readAt: "2026-06-09T15:00:00.000Z",
+      }),
+    });
     mocks.fetchUnifiedInbox.mockResolvedValue({
       ok: true,
       role: "tenant",
@@ -207,7 +223,7 @@ describe("UnifiedInboxPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Pipe leak reported/i }));
     const pipeButton = screen.getByRole("button", { name: /Pipe leak reported/i });
     expect(pipeButton).toHaveAttribute("aria-expanded", "true");
-    expect(pipeButton).toHaveTextContent("Read");
+    await waitFor(() => expect(pipeButton).toHaveTextContent("Read"));
     expect(screen.getByRole("tab", { name: /Unread 1/i })).toBeInTheDocument();
     expect(pipeButton.nextElementSibling).toHaveTextContent("Pipe leak reported");
     expect(pipeButton.nextElementSibling).toHaveTextContent("Status");
@@ -221,7 +237,7 @@ describe("UnifiedInboxPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Outstanding rent balance/i }));
     const paymentButton = screen.getByRole("button", { name: /Outstanding rent balance/i });
     expect(paymentButton).toHaveAttribute("aria-expanded", "true");
-    expect(paymentButton).toHaveTextContent("Read");
+    await waitFor(() => expect(paymentButton).toHaveTextContent("Read"));
     expect(screen.getByRole("tab", { name: /Unread 0/i })).toBeInTheDocument();
     expect(screen.getByTestId("unified-inbox-detail-panel")).toHaveTextContent("Outstanding rent balance");
 
@@ -236,6 +252,54 @@ describe("UnifiedInboxPage", () => {
     expect(screen.getAllByText("System notice").length).toBeGreaterThan(0);
     expect(screen.queryByText("Lease renewal ready")).not.toBeInTheDocument();
     expect(screen.queryByText("Outstanding rent balance")).not.toBeInTheDocument();
+  });
+
+  it("persists landlord read state through the API and keeps it after refresh", async () => {
+    const unreadRecord = record({
+      id: "maintenance-priority",
+      audienceRole: "landlord",
+      sourceKind: "landlord.maintenance",
+      title: "Pipe leak reported",
+      body: "Maintenance priority at Unit 204",
+      priority: "high",
+      status: "unread",
+      readAt: null,
+    });
+    const readRecord = { ...unreadRecord, status: "read" as const, readAt: "2026-06-09T15:00:00.000Z" };
+    mocks.fetchUnifiedInbox
+      .mockResolvedValueOnce({
+        ok: true,
+        role: "landlord",
+        items: [unreadRecord],
+        records: [unreadRecord],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        role: "landlord",
+        items: [readRecord],
+        records: [readRecord],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      });
+    mocks.markUnifiedInboxRecordRead.mockResolvedValueOnce({ ok: true, record: readRecord });
+
+    render(<UnifiedInboxPage role="landlord" />);
+
+    expect(await screen.findByRole("tab", { name: /Unread 1/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Pipe leak reported/i }));
+
+    await waitFor(() => expect(mocks.markUnifiedInboxRecordRead).toHaveBeenCalledWith("landlord", "maintenance-priority"));
+    expect(await screen.findByRole("tab", { name: /Unread 0/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh/i }));
+
+    await waitFor(() => expect(mocks.fetchUnifiedInbox).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("tab", { name: /Unread 0/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Pipe leak reported/i })).toHaveTextContent("Read");
   });
 
   it("shows a safe error state when the inbox cannot load", async () => {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -302,6 +302,41 @@ describe("UnifiedInboxPage", () => {
     expect(screen.getByRole("button", { name: /Pipe leak reported/i })).toHaveTextContent("Read");
   });
 
+  it("keeps the inbox usable when landlord read-state persistence fails", async () => {
+    const unreadRecord = record({
+      id: "maintenance-priority",
+      audienceRole: "landlord",
+      sourceKind: "landlord.maintenance",
+      title: "Pipe leak reported",
+      body: "Maintenance priority at Unit 204",
+      priority: "high",
+      status: "unread",
+      readAt: null,
+    });
+    mocks.fetchUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [unreadRecord],
+      records: [unreadRecord],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    mocks.markUnifiedInboxRecordRead.mockRejectedValueOnce(new Error("Not Found"));
+
+    render(<UnifiedInboxPage role="landlord" />);
+
+    expect(await screen.findByRole("tab", { name: /Unread 1/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Pipe leak reported/i }));
+
+    await waitFor(() => expect(mocks.markUnifiedInboxRecordRead).toHaveBeenCalledWith("landlord", "maintenance-priority"));
+    expect(screen.queryByText("We couldn't load this inbox.")).not.toBeInTheDocument();
+    expect(screen.getByText("Read status was not saved.")).toBeInTheDocument();
+    expect(screen.getByText("Not Found")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Unread 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Pipe leak reported/i })).toHaveTextContent("Unread");
+  });
+
   it("shows a safe error state when the inbox cannot load", async () => {
     mocks.fetchUnifiedInbox.mockRejectedValue(new Error("Unable to load inbox"));
 

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
@@ -89,6 +89,7 @@ export default function UnifiedInboxPage({ role }: Props) {
   const [data, setData] = React.useState<UnifiedInboxResponse | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [readError, setReadError] = React.useState<string | null>(null);
   const [activeTab, setActiveTab] = React.useState<InboxTab>("all");
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("all");
   const [priorityFilter, setPriorityFilter] = React.useState<PriorityFilter>("all");
@@ -99,6 +100,7 @@ export default function UnifiedInboxPage({ role }: Props) {
   const load = React.useCallback(async () => {
     setLoading(true);
     setError(null);
+    setReadError(null);
     try {
       const response = await fetchUnifiedInbox(role);
       setData(response);
@@ -163,11 +165,12 @@ export default function UnifiedInboxPage({ role }: Props) {
         return;
       }
       try {
+        setReadError(null);
         const response = await markUnifiedInboxRecordRead(role, record.id);
         const readAt = response.record.readAt || new Date().toISOString();
         setLocalReadAtById((current) => ({ ...current, [record.id]: readAt }));
       } catch (err) {
-        setError(errorMessage(err));
+        setReadError(errorMessage(err));
       }
     },
     [localReadAtById, role]
@@ -217,6 +220,13 @@ export default function UnifiedInboxPage({ role }: Props) {
 
       {!loading && !error ? (
         <>
+          {readError ? (
+            <Card elevated style={{ borderColor: colors.borderStrong, color: text.secondary, display: "grid", gap: spacing.xs }}>
+              <div style={{ color: text.primary, fontWeight: 800 }}>Read status was not saved.</div>
+              <div>{readError}</div>
+            </Card>
+          ) : null}
+
           <Card style={{ display: "grid", gap: spacing.md }}>
             <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }} role="tablist" aria-label="Inbox views">
               {TABS.map((tab) => {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { RefreshCcw, Search } from "lucide-react";
 import {
   fetchUnifiedInbox,
+  markUnifiedInboxRecordRead,
   type UnifiedInboxPriority,
   type UnifiedInboxRecord,
   type UnifiedInboxResponse,
@@ -152,14 +153,25 @@ export default function UnifiedInboxPage({ role }: Props) {
   }, [filteredRecords, openedRecordId, safeRecords]);
   const unreadCount = safeRecords.filter((record) => record.status === "unread").length;
   const priorityCount = safeRecords.filter((record) => record.priority === "critical" || record.priority === "high").length;
-  const markRecordRead = React.useCallback((record: UnifiedInboxRecord) => {
-    setOpenedRecordId(record.id);
-    if (record.status !== "unread" && record.readAt) return;
-    setLocalReadAtById((current) => {
-      if (current[record.id]) return current;
-      return { ...current, [record.id]: new Date().toISOString() };
-    });
-  }, []);
+  const markRecordRead = React.useCallback(
+    async (record: UnifiedInboxRecord) => {
+      setOpenedRecordId(record.id);
+      if (record.status !== "unread" && record.readAt) return;
+      if (localReadAtById[record.id]) return;
+      if (role !== "landlord") {
+        setLocalReadAtById((current) => ({ ...current, [record.id]: new Date().toISOString() }));
+        return;
+      }
+      try {
+        const response = await markUnifiedInboxRecordRead(role, record.id);
+        const readAt = response.record.readAt || new Date().toISOString();
+        setLocalReadAtById((current) => ({ ...current, [record.id]: readAt }));
+      } catch (err) {
+        setError(errorMessage(err));
+      }
+    },
+    [localReadAtById, role]
+  );
   const resetFilterContext = React.useCallback(() => {
     setOpenedRecordId(null);
   }, []);


### PR DESCRIPTION
## Summary
- Add a landlord unified inbox read-state persistence endpoint for projected inbox records.
- Persist read state when a landlord opens an unread unified inbox message.
- Overlay persisted read state on `/landlord/inbox` refetches so unread counts remain stable after refresh.
- Add frontend and backend regression coverage for read persistence and repeated read handling.

## Root cause
`UnifiedInboxPage` only updated read state in local React state. Refreshing `/landlord/unified-inbox` refetched `/landlord/inbox`, which re-derived inbox records from source data without any persisted read-state overlay, so previously opened messages returned as unread.

## Validation
- `npm run test:single -- src/pages/UnifiedInboxPage.test.tsx src/api/unifiedInboxApi.test.ts`
- `npm run test:single -- src/routes/landlord.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts src/tests/unifiedInbox/unifiedInboxService.test.ts`
- `npm run build` in `rentchain-frontend`
- `npm run build` in `rentchain-api`
- `git diff --check`

## Manual QA
- `/landlord/unified-inbox`: note unread count, open one unread message, confirm count decreases by one, refresh, confirm same message remains read and count remains decreased.
- Open another unread message, confirm count decreases once, refresh again, confirm persistence.
- Confirm already-read messages do not decrement repeatedly.
- Regression: `/dashboard`, `/operations`, `/applications`, `/leases`.