### PR TITLE
Fix lease ledger print PDF content

### DIFF
--- a/rentchain-frontend/src/pages/LeaseLedgerPage.css
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.css
@@ -225,3 +225,76 @@
     display: block;
   }
 }
+
+@media print {
+  .lease-ledger-print-root {
+    color: #0f172a !important;
+    font-size: 11px !important;
+  }
+
+  .lease-ledger-print-root .lease-ledger-page {
+    display: block !important;
+    width: 100% !important;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: #fff !important;
+  }
+
+  .lease-ledger-print-root .lease-ledger-page > * {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    margin-bottom: 10px;
+  }
+
+  .lease-ledger-print-root .lease-ledger-actions,
+  .lease-ledger-print-root .lease-ledger-csv-card,
+  .lease-ledger-print-root input,
+  .lease-ledger-print-root select,
+  .lease-ledger-print-root textarea,
+  .lease-ledger-print-root button {
+    display: none !important;
+  }
+
+  .lease-ledger-print-root .lease-ledger-obligations-table,
+  .lease-ledger-print-root .lease-ledger-entries-table {
+    display: none !important;
+  }
+
+  .lease-ledger-print-root .lease-ledger-obligation-cards,
+  .lease-ledger-print-root .lease-ledger-entry-cards {
+    display: grid !important;
+    gap: 8px !important;
+  }
+
+  .lease-ledger-print-root .lease-ledger-obligation-card,
+  .lease-ledger-print-root .lease-ledger-entry-card,
+  .lease-ledger-print-root .lease-ledger-decision-card,
+  .lease-ledger-print-root .lease-ledger-next-action,
+  .lease-ledger-print-root .lease-ledger-decision-summary > div {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    border-color: #cbd5e1 !important;
+    box-shadow: none !important;
+  }
+
+  .lease-ledger-print-root .lease-ledger-obligation-card-grid,
+  .lease-ledger-print-root .lease-ledger-entry-card-grid,
+  .lease-ledger-print-root .lease-ledger-decision-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+
+  .lease-ledger-print-root .lease-ledger-next-action {
+    display: grid !important;
+    gap: 6px !important;
+  }
+
+  .lease-ledger-print-root *,
+  .lease-ledger-print-root *::before,
+  .lease-ledger-print-root *::after {
+    max-width: 100% !important;
+    overflow: visible !important;
+    overflow-wrap: anywhere !important;
+    word-break: normal !important;
+  }
+}

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -826,7 +826,20 @@ describe("LeaseLedgerPage", () => {
   });
 
   it("opens browser print preview for lease ledger PDF output", async () => {
-    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {
+      const printRoot = document.querySelector('[data-print-root="true"].lease-ledger-print-root');
+      expect(document.body.getAttribute("data-print-root-active")).toBe("true");
+      expect(document.body.getAttribute("data-print-mode")).toBe("lease-ledger");
+      expect(printRoot?.textContent).toContain("Lease Ledger");
+      expect(printRoot?.textContent).toContain("Harbour View · Unit 101");
+      expect(printRoot?.textContent).toContain("Charges");
+      expect(printRoot?.textContent).toContain("Payment obligations");
+      expect(printRoot?.textContent).toContain("Financial delinquency summary");
+      expect(printRoot?.textContent).toContain("Decisions");
+      expect(printRoot?.querySelector('[aria-label="Ledger entry cards"]')).not.toBeNull();
+      expect(printRoot?.querySelector('[aria-label="Payment obligation cards"]')).not.toBeNull();
+      window.dispatchEvent(new Event("afterprint"));
+    });
 
     render(
       <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
@@ -839,11 +852,13 @@ describe("LeaseLedgerPage", () => {
     await screen.findAllByText("Harbour View · Unit 101");
     fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
 
-    expect(printSpy).toHaveBeenCalled();
+    await waitFor(() => expect(printSpy).toHaveBeenCalled());
     expect(global.fetch).not.toHaveBeenCalledWith(
       expect.stringContaining("/api/leases/lease-1/ledger/export.pdf"),
       expect.anything()
     );
+    expect(document.querySelector('[data-print-root="true"].lease-ledger-print-root')).not.toBeInTheDocument();
+    expect(document.body.hasAttribute("data-print-root-active")).toBe(false);
     printSpy.mockRestore();
   });
 

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -14,7 +14,13 @@ import {
 } from "../api/leaseLedgerApi";
 import { downloadAuthenticatedExport } from "../api/exportDownload";
 import { patchDecisionAction } from "@/api/decisionApi";
-import { triggerDocumentDownload } from "../lib/documentRendering";
+import {
+  createPrintRoot,
+  nextRenderFrame,
+  PRINT_MODE_ATTRIBUTE,
+  PRINT_ROOT_ACTIVE_ATTRIBUTE,
+  triggerDocumentDownload,
+} from "../lib/documentRendering";
 import {
   archiveLeaseRecord,
   createLeaseNote,
@@ -679,6 +685,7 @@ const modalCard: React.CSSProperties = {
 
 export default function LeaseLedgerPage() {
   const { leaseId = "" } = useParams();
+  const printSourceRef = React.useRef<HTMLDivElement | null>(null);
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
   const [loading, setLoading] = useState(true);
@@ -939,14 +946,49 @@ export default function LeaseLedgerPage() {
 
   async function printOrExportLedgerPdf() {
     if (typeof window !== "undefined" && typeof window.print === "function") {
-      window.print();
+      const printableSource = printSourceRef.current;
+      if (!printableSource || typeof document === "undefined") {
+        window.print();
+        return;
+      }
+
+      const body = document.body;
+      const previousMode = body.getAttribute(PRINT_MODE_ATTRIBUTE);
+      const printableRoot = createPrintRoot(document);
+      printableRoot.classList.add("lease-ledger-print-root");
+      printableRoot.appendChild(printableSource.cloneNode(true));
+      let cleanedUp = false;
+
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        window.removeEventListener("afterprint", cleanup);
+        printableRoot.remove();
+        body.removeAttribute(PRINT_ROOT_ACTIVE_ATTRIBUTE);
+        if (previousMode) {
+          body.setAttribute(PRINT_MODE_ATTRIBUTE, previousMode);
+        } else {
+          body.removeAttribute(PRINT_MODE_ATTRIBUTE);
+        }
+      };
+
+      try {
+        body.setAttribute(PRINT_MODE_ATTRIBUTE, "lease-ledger");
+        body.setAttribute(PRINT_ROOT_ACTIVE_ATTRIBUTE, "true");
+        body.appendChild(printableRoot);
+        window.addEventListener("afterprint", cleanup, { once: true });
+        await nextRenderFrame(window);
+        window.print();
+      } finally {
+        window.setTimeout(cleanup, 250);
+      }
       return;
     }
     await exportLedger("pdf");
   }
 
   return (
-    <div className="lease-ledger-page">
+    <div className="lease-ledger-page" ref={printSourceRef}>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", justifyContent: "space-between" }}>
         <div>
           <h1 style={{ margin: 0, fontSize: "1.2rem" }}>Lease Ledger</h1>


### PR DESCRIPTION
## Summary
- Fixes the lease ledger Print / Save PDF flow so browser print output contains the ledger content instead of being hidden by global print rules.
- Uses the existing print-root mechanism to clone the live lease ledger content into a temporary print root before calling `window.print()`.
- Adds lease-ledger print styles that hide operational controls/CSV import UI and render obligations and ledger entries as readable stacked cards to avoid horizontal clipping.

## Root Cause
The lease ledger page called `window.print()` directly. Global print CSS hides normal app content unless a recognized print root is active, so the ledger DOM could be hidden during print and the output could show only shell/header/footer content. Wide ledger tables also risked clipping in printed output.

## Changed Files
- `rentchain-frontend/src/pages/LeaseLedgerPage.tsx`
- `rentchain-frontend/src/pages/LeaseLedgerPage.css`
- `rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx`

## Validation
- `npm run test:single -- src/pages/LeaseLedgerPage.test.tsx` — passed
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` — passed
  - Note: Vite reports its existing Node version warning for Node 20.11.1, but the repo preflight passes and the production build completes successfully.
- `git diff --check` — passed

## Manual QA Required
- Open a lease ledger with visible entries/obligations.
- Use browser Print / Save PDF.
- Confirm the preview/PDF includes lease/property/unit context, ledger summary, decisions/context, obligations, ledger entries, balances/statuses, and monthly/notes content as applicable.
- Confirm multi-page output remains readable.
- Confirm no horizontal clipping in print output.
- Confirm normal on-screen lease ledger layout remains unchanged.
- Regression routes: `/leases`, `/operations`, `/dashboard`, `/applications`.