### PR TITLE
fix/applications-pdf-export-content-parity-v1

### DIFF
--- a/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
+++ b/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
@@ -132,5 +132,7 @@ describe("review summary export contract", () => {
     expect(rendered).toContain("Call references before approval.");
     expect(rendered).not.toContain("raw-app-id-123");
     expect(rendered).not.toContain("provider-order-raw-id");
+    expect(rendered).not.toContain("Application ID");
+    expect(rendered).not.toContain("Screening reference");
   });
 });

--- a/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
+++ b/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReviewSummary,
+  buildReviewSummaryPdfSections,
+} from "../reviewSummary";
+
+describe("review summary export contract", () => {
+  it("builds landlord-safe PDF sections with application, household, risk, and notes context", () => {
+    const summary = buildReviewSummary("raw-app-id-123", {
+      status: "SUBMITTED",
+      submittedAt: "2026-04-01T10:00:00.000Z",
+      propertyName: "Harbour View",
+      unitApplied: "Unit 203",
+      requestedRent: 2100,
+      leaseStartDate: "2026-05-01",
+      applicant: {
+        firstName: "Jamie",
+        lastName: "Stone",
+        email: "jamie@example.com",
+      },
+      applicantProfile: {
+        currentAddress: {
+          line1: "12 North Street",
+          city: "Halifax",
+          provinceState: "NS",
+          postalCode: "B3H 1A1",
+          country: "CA",
+        },
+        timeAtCurrentAddressMonths: 18,
+        currentRentAmountCents: 180000,
+        employment: {
+          employerName: "Harbour Labs",
+          jobTitle: "Designer",
+          incomeAmountCents: 7800000,
+          incomeFrequency: "annual",
+          monthsAtJob: 24,
+        },
+        workReference: {
+          name: "Taylor Grant",
+          phone: "555-555-0100",
+        },
+        signature: {
+          type: "typed",
+          signedAt: "2026-03-31T18:00:00.000Z",
+        },
+        applicantNotes: "Prefers a September move if possible.",
+      },
+      applicationConsent: {
+        version: "v1.0",
+        acceptedAt: "2026-03-31T18:00:00.000Z",
+      },
+      coApplicant: {
+        fullName: "Riley Stone",
+        email: "riley@example.com",
+        phone: "555-555-0199",
+        monthlyIncome: 3200,
+      },
+      household: {
+        otherOccupants: "One child",
+        pets: "One cat",
+        vehicles: "One vehicle",
+        notes: "Needs parking.",
+      },
+      currentLeaseStatus: {
+        hasActiveLease: true,
+        leaseEndDate: "2026-04-30",
+        landlordAware: "yes",
+        reasonForMoving: "Moving closer to work.",
+      },
+      residentialHistory: [
+        {
+          address: "12 North Street",
+          durationMonths: 18,
+          rentAmountCents: 180000,
+          landlordName: "Morgan Lee",
+          landlordPhone: "555-555-0123",
+          reasonForLeaving: "Larger unit needed",
+        },
+      ],
+      screeningStatus: "complete",
+      screeningProvider: "Provider A",
+      screening: {
+        orderId: "provider-order-raw-id",
+      },
+      flags: ["income_review"],
+      notes: "Call reference before final approval.",
+    });
+
+    const sections = buildReviewSummaryPdfSections(summary, {
+      decisionSummary: {
+        riskInsights: {
+          score: 74,
+          grade: "B",
+          confidence: 0.82,
+          signals: ["Stable employment"],
+          recommendations: ["Verify income documents"],
+        },
+        referenceQuestions: ["Would you rent to this applicant again?"],
+        screeningRecommendation: {
+          recommended: false,
+          reason: "Screening is complete.",
+        },
+        screeningSummary: {
+          available: true,
+          highlights: ["Screening completed"],
+        },
+        decisionSupport: {
+          summaryLine: "Application is ready for landlord review.",
+          nextBestAction: "Call references before approval.",
+        },
+      },
+    });
+
+    const titles = sections.map((section) => section.title);
+    expect(titles).toEqual(
+      expect.arrayContaining([
+        "Application Context",
+        "Household & Co-applicant",
+        "Current Housing & Lease Status",
+        "Residential History",
+        "Screening & Deterministic Signals",
+        "Risk & Decision Guidance",
+        "Notes & Flags",
+      ])
+    );
+
+    const rendered = JSON.stringify(sections);
+    expect(rendered).toContain("Harbour View");
+    expect(rendered).toContain("Unit 203");
+    expect(rendered).toContain("One child");
+    expect(rendered).toContain("Stable employment");
+    expect(rendered).toContain("Call references before approval.");
+    expect(rendered).not.toContain("raw-app-id-123");
+    expect(rendered).not.toContain("provider-order-raw-id");
+  });
+});

--- a/rentchain-api/src/lib/reviewSummary.ts
+++ b/rentchain-api/src/lib/reviewSummary.ts
@@ -577,17 +577,13 @@ function drawTable(
   title: string,
   rows: Array<{ label: string; value: string }>
 ) {
-  doc.moveDown(0.8);
-  if (doc.y > doc.page.height - doc.page.margins.bottom - 80) {
-    doc.addPage();
-  }
-  doc.font("Helvetica-Bold").fontSize(12).fillColor("#0f172a").text(title);
-  doc.moveDown(0.3);
   const startX = doc.page.margins.left;
   const tableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
   const labelWidth = Math.min(190, tableWidth * 0.38);
   const valueWidth = tableWidth - labelWidth;
-  for (const row of rows) {
+  const pageBottom = () => doc.page.height - doc.page.margins.bottom;
+  const maxRowHeight = Math.max(72, Math.min(132, pageBottom() - doc.page.margins.top - 24));
+  const estimateRowHeight = (row: { label: string; value: string }) => {
     const labelHeight = doc.heightOfString(row.label, {
       width: labelWidth - 12,
       align: "left",
@@ -596,8 +592,21 @@ function drawTable(
       width: valueWidth - 12,
       align: "left",
     });
-    const rowHeight = Math.max(labelHeight, valueHeight, 16) + 10;
-    if (doc.y + rowHeight > doc.page.height - doc.page.margins.bottom) {
+    return Math.min(Math.max(labelHeight, valueHeight, 16) + 10, maxRowHeight);
+  };
+  const firstRowHeight = rows[0] ? estimateRowHeight(rows[0]) : 0;
+  const sectionGap = 10;
+  const titleBlockHeight = 28;
+  if (doc.y + sectionGap + titleBlockHeight + firstRowHeight > pageBottom()) {
+    doc.addPage();
+  } else {
+    doc.moveDown(0.8);
+  }
+  doc.font("Helvetica-Bold").fontSize(12).fillColor("#0f172a").text(title);
+  doc.moveDown(0.3);
+  for (const row of rows) {
+    const rowHeight = estimateRowHeight(row);
+    if (doc.y + rowHeight > pageBottom()) {
       doc.addPage();
     }
     const y = doc.y;
@@ -610,12 +619,20 @@ function drawTable(
       .font("Helvetica-Bold")
       .fontSize(10)
       .fillColor("#374151")
-      .text(row.label, startX + 6, y + 5, { width: labelWidth - 12 });
+      .text(row.label, startX + 6, y + 5, {
+        width: labelWidth - 12,
+        height: rowHeight - 10,
+        ellipsis: true,
+      });
     doc
       .font("Helvetica")
       .fontSize(10)
       .fillColor("#0f172a")
-      .text(row.value, startX + labelWidth + 6, y + 5, { width: valueWidth - 12 });
+      .text(row.value, startX + labelWidth + 6, y + 5, {
+        width: valueWidth - 12,
+        height: rowHeight - 10,
+        ellipsis: true,
+      });
     doc.y = y + rowHeight;
   }
 }

--- a/rentchain-api/src/lib/reviewSummary.ts
+++ b/rentchain-api/src/lib/reviewSummary.ts
@@ -3,6 +3,15 @@ import PDFDocument from "pdfkit";
 export type ReviewSummary = {
   applicationId: string;
   generatedAt: string;
+  application: {
+    status: string | null;
+    submittedAt: string | null;
+    propertyName: string | null;
+    unitLabel: string | null;
+    leaseStartDate: string | null;
+    requestedRentAmountCents: number | null;
+    moveInDate: string | null;
+  };
   applicant: {
     name: string | null;
     email: string | null;
@@ -37,6 +46,38 @@ export type ReviewSummary = {
     provider: string | null;
     referenceId: string | null;
   };
+  coApplicant: {
+    name: string | null;
+    email: string | null;
+    phone: string | null;
+    monthlyIncomeCents: number | null;
+    address: string | null;
+  };
+  household: {
+    otherOccupants: string | null;
+    pets: string | null;
+    vehicles: string | null;
+    notes: string | null;
+  };
+  residentialHistory: Array<{
+    address: string | null;
+    durationMonths: number | null;
+    rentAmountCents: number | null;
+    landlordName: string | null;
+    landlordPhone: string | null;
+    reasonForLeaving: string | null;
+  }>;
+  currentLeaseStatus: {
+    hasActiveLease: boolean | null;
+    leaseEndDate: string | null;
+    landlordAware: string | null;
+    reasonForMoving: string | null;
+  };
+  notes: {
+    applicantNotes: string | null;
+    landlordNotes: string | null;
+    flags: string[];
+  };
   derived: {
     incomeToRentRatio: number | null;
     completeness: {
@@ -48,6 +89,42 @@ export type ReviewSummary = {
   insights: string[];
 };
 
+export type ReviewSummaryPdfDecisionContext = {
+  status?: string | null;
+  riskInsights?: {
+    score?: number | null;
+    grade?: string | null;
+    confidence?: number | null;
+    signals?: string[];
+    recommendations?: string[];
+  } | null;
+  referenceQuestions?: string[];
+  screeningRecommendation?: {
+    recommended?: boolean;
+    reason?: string | null;
+    priority?: string | null;
+  } | null;
+  screeningSummary?: {
+    available?: boolean;
+    provider?: string | null;
+    completedAt?: string | null;
+    highlights?: string[];
+  } | null;
+  decisionSupport?: {
+    summaryLine?: string | null;
+    nextBestAction?: string | null;
+  } | null;
+};
+
+export type ReviewSummaryPdfOptions = {
+  decisionSummary?: ReviewSummaryPdfDecisionContext | null;
+};
+
+export type ReviewSummaryPdfSection = {
+  title: string;
+  rows: Array<{ label: string; value: string }>;
+};
+
 function stringOrNull(value: unknown): string | null {
   const raw = String(value ?? "").trim();
   return raw ? raw : null;
@@ -56,6 +133,12 @@ function stringOrNull(value: unknown): string | null {
 function numberOrNull(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
+}
+
+function amountToCents(value: unknown): number | null {
+  const amount = numberOrNull(value);
+  if (amount == null) return null;
+  return Math.round(amount * 100);
 }
 
 function toIso(value: unknown): string | null {
@@ -72,6 +155,24 @@ function toIso(value: unknown): string | null {
 function formatCurrency(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
   return (cents / 100).toLocaleString("en-CA", { style: "currency", currency: "CAD" });
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Not provided";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString("en-CA", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "Not provided";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString("en-CA");
 }
 
 function formatRatio(value: number | null): string {
@@ -129,6 +230,9 @@ export function buildReviewSummary(applicationId: string, application: any): Rev
   const firstName = stringOrNull(applicant?.firstName);
   const lastName = stringOrNull(applicant?.lastName);
   const name = [firstName, lastName].filter(Boolean).join(" ").trim() || null;
+  const coApplicant = application?.coApplicant || {};
+  const household = application?.household || {};
+  const currentLeaseStatus = application?.currentLeaseStatus || null;
 
   const incomeAmountCents = numberOrNull(employment?.incomeAmountCents);
   const incomeFrequency = stringOrNull(employment?.incomeFrequency) as "monthly" | "annual" | null;
@@ -169,6 +273,18 @@ export function buildReviewSummary(applicationId: string, application: any): Rev
   const summaryBase: Omit<ReviewSummary, "insights"> = {
     applicationId,
     generatedAt: new Date().toISOString(),
+    application: {
+      status: stringOrNull(application?.status),
+      submittedAt: toIso(application?.submittedAt || application?.createdAt),
+      propertyName: stringOrNull(application?.propertyName),
+      unitLabel: stringOrNull(application?.unitApplied || application?.unit || application?.unitLabel),
+      leaseStartDate: toIso(application?.leaseStartDate || application?.moveInDate),
+      requestedRentAmountCents:
+        numberOrNull(application?.requestedRentAmountCents) ??
+        numberOrNull(application?.requestedRentCents) ??
+        amountToCents(application?.requestedRent),
+      moveInDate: toIso(application?.moveInDate),
+    },
     applicant: {
       name,
       email: stringOrNull(applicant?.email),
@@ -203,6 +319,60 @@ export function buildReviewSummary(applicationId: string, application: any): Rev
       provider: stringOrNull(application?.screeningProvider || screening?.provider),
       referenceId: stringOrNull(screening?.orderId || application?.screeningSessionId || application?.screeningResultId),
     },
+    coApplicant: {
+      name: stringOrNull(coApplicant?.fullName),
+      email: stringOrNull(coApplicant?.email),
+      phone: stringOrNull(coApplicant?.phone),
+      monthlyIncomeCents: amountToCents(coApplicant?.monthlyIncome),
+      address:
+        [
+          stringOrNull(coApplicant?.address),
+          stringOrNull(coApplicant?.city),
+          stringOrNull(coApplicant?.provinceState),
+          stringOrNull(coApplicant?.postalCode),
+        ]
+          .filter(Boolean)
+          .join(", ") || null,
+    },
+    household: {
+      otherOccupants: stringOrNull(household?.otherOccupants),
+      pets: stringOrNull(household?.pets),
+      vehicles: stringOrNull(household?.vehicles),
+      notes: stringOrNull(household?.notes),
+    },
+    residentialHistory: Array.isArray(application?.residentialHistory)
+      ? application.residentialHistory.slice(0, 5).map((entry: any) => ({
+          address: stringOrNull(entry?.address),
+          durationMonths: numberOrNull(entry?.durationMonths),
+          rentAmountCents: numberOrNull(entry?.rentAmountCents),
+          landlordName: stringOrNull(entry?.landlordName),
+          landlordPhone: stringOrNull(entry?.landlordPhone),
+          reasonForLeaving: stringOrNull(entry?.reasonForLeaving),
+        }))
+      : [],
+    currentLeaseStatus: currentLeaseStatus
+      ? {
+          hasActiveLease:
+            typeof currentLeaseStatus?.hasActiveLease === "boolean"
+              ? currentLeaseStatus.hasActiveLease
+              : null,
+          leaseEndDate: toIso(currentLeaseStatus?.leaseEndDate),
+          landlordAware: stringOrNull(currentLeaseStatus?.landlordAware),
+          reasonForMoving: stringOrNull(currentLeaseStatus?.reasonForMoving),
+        }
+      : {
+          hasActiveLease: null,
+          leaseEndDate: null,
+          landlordAware: null,
+          reasonForMoving: null,
+        },
+    notes: {
+      applicantNotes: stringOrNull(profile?.applicantNotes),
+      landlordNotes: stringOrNull(application?.landlordNote || application?.notes),
+      flags: Array.isArray(application?.flags)
+        ? application.flags.map((flag: unknown) => stringOrNull(flag)).filter(Boolean) as string[]
+        : [],
+    },
     derived: {
       incomeToRentRatio,
       completeness: {
@@ -219,12 +389,198 @@ export function buildReviewSummary(applicationId: string, application: any): Rev
   };
 }
 
+function listOrFallback(items: string[] | undefined | null, fallback = "None recorded"): string {
+  const compact = (items || []).map((item) => String(item || "").trim()).filter(Boolean);
+  return compact.length ? compact.join("; ") : fallback;
+}
+
+function yesNoUnknown(value: boolean | null): string {
+  if (value === true) return "Yes";
+  if (value === false) return "No";
+  return "Not provided";
+}
+
+function residentialHistoryRows(summary: ReviewSummary): Array<{ label: string; value: string }> {
+  if (!summary.residentialHistory.length) {
+    return [{ label: "History", value: "No residential history provided" }];
+  }
+  return summary.residentialHistory.map((entry, index) => {
+    const details = [
+      entry.durationMonths != null ? `${entry.durationMonths} months` : null,
+      entry.rentAmountCents != null ? formatCurrency(entry.rentAmountCents) : null,
+      entry.landlordName ? `Landlord: ${entry.landlordName}` : null,
+      entry.landlordPhone ? `Phone: ${entry.landlordPhone}` : null,
+      entry.reasonForLeaving ? `Reason: ${entry.reasonForLeaving}` : null,
+    ].filter(Boolean);
+    return {
+      label: `Address ${index + 1}`,
+      value: [entry.address || "Address not provided", ...details].join(" | "),
+    };
+  });
+}
+
+export function buildReviewSummaryPdfSections(
+  summary: ReviewSummary,
+  options: ReviewSummaryPdfOptions = {}
+): ReviewSummaryPdfSection[] {
+  const decision = options.decisionSummary || null;
+  const risk = decision?.riskInsights || null;
+  const sections: ReviewSummaryPdfSection[] = [
+    {
+      title: "Application Context",
+      rows: [
+        { label: "Status", value: summary.application.status || "Not provided" },
+        { label: "Submitted", value: formatDateTime(summary.application.submittedAt) },
+        { label: "Property", value: summary.application.propertyName || "Not provided" },
+        { label: "Unit", value: summary.application.unitLabel || "Not provided" },
+        { label: "Lease start", value: formatDate(summary.application.leaseStartDate) },
+        { label: "Requested rent", value: formatCurrency(summary.application.requestedRentAmountCents) },
+      ],
+    },
+    {
+      title: "Applicant Overview",
+      rows: [
+        { label: "Name", value: summary.applicant.name || "Not provided" },
+        { label: "Email", value: summary.applicant.email || "Not provided" },
+        {
+          label: "Current address",
+          value:
+            [
+              summary.applicant.currentAddressLine,
+              summary.applicant.city,
+              summary.applicant.provinceState,
+              summary.applicant.postalCode,
+              summary.applicant.country,
+            ]
+              .filter(Boolean)
+              .join(", ") || "Not provided",
+        },
+        {
+          label: "Time at current address",
+          value:
+            summary.applicant.timeAtCurrentAddressMonths != null
+              ? `${summary.applicant.timeAtCurrentAddressMonths} months`
+              : "Not provided",
+        },
+        { label: "Current rent", value: formatCurrency(summary.applicant.currentRentAmountCents) },
+      ],
+    },
+    {
+      title: "Household & Co-applicant",
+      rows: [
+        { label: "Co-applicant", value: summary.coApplicant.name || "Not provided" },
+        { label: "Co-applicant email", value: summary.coApplicant.email || "Not provided" },
+        { label: "Co-applicant phone", value: summary.coApplicant.phone || "Not provided" },
+        { label: "Co-applicant income", value: formatCurrency(summary.coApplicant.monthlyIncomeCents) },
+        { label: "Other occupants", value: summary.household.otherOccupants || "Not provided" },
+        { label: "Pets", value: summary.household.pets || "Not provided" },
+        { label: "Vehicles", value: summary.household.vehicles || "Not provided" },
+        { label: "Household notes", value: summary.household.notes || "Not provided" },
+      ],
+    },
+    {
+      title: "Employment & Income",
+      rows: [
+        { label: "Employer", value: summary.employment.employerName || "Not provided" },
+        { label: "Job title", value: summary.employment.jobTitle || "Not provided" },
+        { label: "Income", value: formatCurrency(summary.employment.incomeAmountCents) },
+        { label: "Income frequency", value: summary.employment.incomeFrequency || "Not provided" },
+        { label: "Income (monthly)", value: formatCurrency(summary.employment.incomeMonthlyCents) },
+        {
+          label: "Time at current job",
+          value:
+            summary.employment.monthsAtJob != null
+              ? `${summary.employment.monthsAtJob} months`
+              : "Not provided",
+        },
+        { label: "Income-to-rent ratio", value: formatRatio(summary.derived.incomeToRentRatio) },
+      ],
+    },
+    {
+      title: "References & Compliance",
+      rows: [
+        { label: "Work reference", value: summary.reference.name || "Not provided" },
+        { label: "Reference phone", value: summary.reference.phone || "Not provided" },
+        { label: "Signature", value: summary.compliance.signatureType || "Not provided" },
+        { label: "Signed at", value: formatDateTime(summary.compliance.signedAt) },
+        { label: "Consent version", value: summary.compliance.applicationConsentVersion || "Not provided" },
+        { label: "Consent accepted at", value: formatDateTime(summary.compliance.applicationConsentAcceptedAt) },
+      ],
+    },
+    {
+      title: "Current Housing & Lease Status",
+      rows: [
+        { label: "Active lease", value: yesNoUnknown(summary.currentLeaseStatus.hasActiveLease) },
+        { label: "Lease end date", value: formatDate(summary.currentLeaseStatus.leaseEndDate) },
+        { label: "Landlord aware", value: summary.currentLeaseStatus.landlordAware || "Not provided" },
+        { label: "Reason for moving", value: summary.currentLeaseStatus.reasonForMoving || "Not provided" },
+      ],
+    },
+    {
+      title: "Residential History",
+      rows: residentialHistoryRows(summary),
+    },
+    {
+      title: "Screening & Deterministic Signals",
+      rows: [
+        {
+          label: "Completeness",
+          value: `${summary.derived.completeness.label} (${Math.round(summary.derived.completeness.score * 100)}%)`,
+        },
+        { label: "Screening status", value: summary.screening.status || "not_run" },
+        { label: "Screening provider", value: summary.screening.provider || "Not provided" },
+        { label: "Screening recommendation", value: decision?.screeningRecommendation?.reason || "Not provided" },
+        {
+          label: "Screening highlights",
+          value: listOrFallback(decision?.screeningSummary?.highlights, "No screening highlights recorded"),
+        },
+      ],
+    },
+    {
+      title: "Risk & Decision Guidance",
+      rows: [
+        {
+          label: "Risk score",
+          value:
+            typeof risk?.score === "number"
+              ? `${risk.score}${risk.grade ? ` (${risk.grade})` : ""}`
+              : "Not provided",
+        },
+        {
+          label: "Confidence",
+          value:
+            typeof risk?.confidence === "number"
+              ? `${Math.round(risk.confidence * 100)}%`
+              : "Not provided",
+        },
+        { label: "Signals", value: listOrFallback(risk?.signals) },
+        { label: "Recommendations", value: listOrFallback(risk?.recommendations) },
+        { label: "Decision summary", value: decision?.decisionSupport?.summaryLine || "Not provided" },
+        { label: "Next action", value: decision?.decisionSupport?.nextBestAction || "Not provided" },
+        { label: "Reference questions", value: listOrFallback(decision?.referenceQuestions) },
+      ],
+    },
+    {
+      title: "Notes & Flags",
+      rows: [
+        { label: "Applicant notes", value: summary.notes.applicantNotes || "Not provided" },
+        { label: "Landlord notes", value: summary.notes.landlordNotes || "Not provided" },
+        { label: "Flags", value: listOrFallback(summary.notes.flags) },
+      ],
+    },
+  ];
+  return sections;
+}
+
 function drawTable(
   doc: any,
   title: string,
   rows: Array<{ label: string; value: string }>
 ) {
   doc.moveDown(0.8);
+  if (doc.y > doc.page.height - doc.page.margins.bottom - 80) {
+    doc.addPage();
+  }
   doc.font("Helvetica-Bold").fontSize(12).fillColor("#0f172a").text(title);
   doc.moveDown(0.3);
   const startX = doc.page.margins.left;
@@ -232,7 +588,6 @@ function drawTable(
   const labelWidth = Math.min(190, tableWidth * 0.38);
   const valueWidth = tableWidth - labelWidth;
   for (const row of rows) {
-    const y = doc.y;
     const labelHeight = doc.heightOfString(row.label, {
       width: labelWidth - 12,
       align: "left",
@@ -242,6 +597,10 @@ function drawTable(
       align: "left",
     });
     const rowHeight = Math.max(labelHeight, valueHeight, 16) + 10;
+    if (doc.y + rowHeight > doc.page.height - doc.page.margins.bottom) {
+      doc.addPage();
+    }
+    const y = doc.y;
     doc.save();
     doc.rect(startX, y, labelWidth, rowHeight).fill("#f3f4f6");
     doc.rect(startX + labelWidth, y, valueWidth, rowHeight).fill("#ffffff");
@@ -261,7 +620,10 @@ function drawTable(
   }
 }
 
-export async function buildReviewSummaryPdf(summary: ReviewSummary): Promise<Buffer> {
+export async function buildReviewSummaryPdf(
+  summary: ReviewSummary,
+  options: ReviewSummaryPdfOptions = {}
+): Promise<Buffer> {
   const doc = new PDFDocument({ size: "LETTER", margin: 54 });
   const chunks: Buffer[] = [];
   doc.on("data", (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
@@ -272,78 +634,16 @@ export async function buildReviewSummaryPdf(summary: ReviewSummary): Promise<Buf
   doc.moveDown(0.2);
   doc.font("Helvetica").fontSize(10).fillColor("#6b7280").text("Version v1.0");
   doc.moveDown(0.5);
-  doc.font("Helvetica").fontSize(10).fillColor("#0f172a").text(`Application ID: ${summary.applicationId}`);
+  doc
+    .font("Helvetica")
+    .fontSize(10)
+    .fillColor("#0f172a")
+    .text(`Application: ${summary.applicant.name || "Applicant"}${summary.application.propertyName ? ` · ${summary.application.propertyName}` : ""}`);
   doc.text(`Generated: ${new Date(summary.generatedAt).toLocaleString()}`);
 
-  drawTable(doc, "Applicant Overview", [
-    { label: "Name", value: summary.applicant.name || "Not provided" },
-    { label: "Email", value: summary.applicant.email || "Not provided" },
-    {
-      label: "Current address",
-      value: [
-        summary.applicant.currentAddressLine,
-        summary.applicant.city,
-        summary.applicant.provinceState,
-        summary.applicant.postalCode,
-        summary.applicant.country,
-      ]
-        .filter(Boolean)
-        .join(", ") || "Not provided",
-    },
-    {
-      label: "Time at current address",
-      value:
-        summary.applicant.timeAtCurrentAddressMonths != null
-          ? `${summary.applicant.timeAtCurrentAddressMonths} months`
-          : "Not provided",
-    },
-    { label: "Current rent", value: formatCurrency(summary.applicant.currentRentAmountCents) },
-  ]);
-
-  drawTable(doc, "Employment & Income", [
-    { label: "Employer", value: summary.employment.employerName || "Not provided" },
-    { label: "Job title", value: summary.employment.jobTitle || "Not provided" },
-    { label: "Income", value: formatCurrency(summary.employment.incomeAmountCents) },
-    { label: "Income frequency", value: summary.employment.incomeFrequency || "Not provided" },
-    { label: "Income (monthly)", value: formatCurrency(summary.employment.incomeMonthlyCents) },
-    {
-      label: "Time at current job",
-      value:
-        summary.employment.monthsAtJob != null
-          ? `${summary.employment.monthsAtJob} months`
-          : "Not provided",
-    },
-  ]);
-
-  drawTable(doc, "References & Compliance", [
-    { label: "Work reference", value: summary.reference.name || "Not provided" },
-    { label: "Reference phone", value: summary.reference.phone || "Not provided" },
-    { label: "Signature", value: summary.compliance.signatureType || "Not provided" },
-    {
-      label: "Signed at",
-      value: summary.compliance.signedAt
-        ? new Date(summary.compliance.signedAt).toLocaleString()
-        : "Not provided",
-    },
-    { label: "Consent version", value: summary.compliance.applicationConsentVersion || "Not provided" },
-    {
-      label: "Consent accepted at",
-      value: summary.compliance.applicationConsentAcceptedAt
-        ? new Date(summary.compliance.applicationConsentAcceptedAt).toLocaleString()
-        : "Not provided",
-    },
-  ]);
-
-  drawTable(doc, "Deterministic Signals", [
-    {
-      label: "Completeness",
-      value: `${summary.derived.completeness.label} (${Math.round(summary.derived.completeness.score * 100)}%)`,
-    },
-    { label: "Income-to-rent ratio", value: formatRatio(summary.derived.incomeToRentRatio) },
-    { label: "Screening status", value: summary.screening.status || "not_run" },
-    { label: "Screening provider", value: summary.screening.provider || "Not provided" },
-    { label: "Screening reference", value: summary.screening.referenceId || "Not provided" },
-  ]);
+  buildReviewSummaryPdfSections(summary, options).forEach((section) => {
+    drawTable(doc, section.title, section.rows);
+  });
 
   doc.moveDown(0.8);
   doc.font("Helvetica-Bold").fontSize(12).fillColor("#0f172a").text("Insights");

--- a/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
@@ -373,6 +373,39 @@ describe("rentalApplications review summary risk surface", () => {
     expect(res.body?.risk ?? null).toBeNull();
   });
 
+  it("passes decision context to the review-summary PDF export", async () => {
+    getLatestApplicationRiskMock.mockResolvedValue(null);
+    const reviewSummary = await import("../../lib/reviewSummary");
+    vi.mocked(reviewSummary.buildReviewSummaryPdf).mockResolvedValue(Buffer.from("%PDF-1.4"));
+    const previousBucket = process.env.GCS_UPLOAD_BUCKET;
+    delete process.env.GCS_UPLOAD_BUCKET;
+
+    try {
+      const app = await createApp();
+      const res = await request(app)
+        .get("/api/rental-applications/app-1/review-summary.pdf")
+        .set("Authorization", "Bearer landlord");
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("application/pdf");
+      expect(reviewSummary.buildReviewSummaryPdf).toHaveBeenCalledWith(
+        expect.objectContaining({ applicationId: "app-1" }),
+        {
+          decisionSummary: expect.objectContaining({
+            applicationId: "app-1",
+            decisionSupport: null,
+          }),
+        }
+      );
+    } finally {
+      if (previousBucket == null) {
+        delete process.env.GCS_UPLOAD_BUCKET;
+      } else {
+        process.env.GCS_UPLOAD_BUCKET = previousBucket;
+      }
+    }
+  });
+
   it("rejects unauthorized cross-landlord access", async () => {
     getLatestApplicationRiskMock.mockResolvedValue(null);
 

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -4372,7 +4372,12 @@ router.get("/rental-applications/:id/review-summary.pdf", async (req: any, res) 
       });
     }
     const summary = buildReviewSummary(id, access.data);
-    const pdfBuffer = await buildReviewSummaryPdf(summary);
+    const decisionSummary = buildApplicationDecisionSummary({
+      applicationId: id,
+      application: access.data,
+      reviewSummary: summary,
+    });
+    const pdfBuffer = await buildReviewSummaryPdf(summary, { decisionSummary });
     const bucket = String(process.env.GCS_UPLOAD_BUCKET || "").trim();
 
     if (!bucket) {

--- a/rentchain-frontend/src/components/applications/PrintApplicationView.tsx
+++ b/rentchain-frontend/src/components/applications/PrintApplicationView.tsx
@@ -53,12 +53,61 @@ const formatMoney = (value?: number | null) =>
       })}`
     : "—";
 
+const formatCents = (value?: number | null) => formatMoney(typeof value === "number" ? value / 100 : null);
+
+const formatList = (items?: Array<string | null | undefined> | null, fallback = "None recorded") => {
+  const compact = (items || []).map((item) => String(item || "").trim()).filter(Boolean);
+  return compact.length ? compact.join("; ") : fallback;
+};
+
+const yesNo = (value?: boolean | null) => {
+  if (value === true) return "Yes";
+  if (value === false) return "No";
+  return "—";
+};
+
+const formatAddressParts = (...parts: Array<string | null | undefined>) => {
+  const compact = parts.map((part) => String(part || "").trim()).filter(Boolean);
+  return compact.length ? compact.join(" · ") : "—";
+};
+
+const formatSlot = (slot?: { startAt?: string | null; endAt?: string | null; note?: string | null } | null) => {
+  if (!slot?.startAt) return null;
+  const start = new Date(slot.startAt);
+  const end = slot.endAt ? new Date(slot.endAt) : null;
+  if (Number.isNaN(start.getTime())) return null;
+  const endLabel = end && !Number.isNaN(end.getTime())
+    ? ` - ${end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+    : "";
+  return `${start.toLocaleString()}${endLabel}${slot.note ? ` · ${slot.note}` : ""}`;
+};
+
 export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
   application,
 }) => {
   const applicantName =
     application.fullName || application.applicantName || "Applicant";
   const propertyAddress = getPropertyAddress(application);
+  const app: any = application as any;
+  const profile = app.applicantProfile || {};
+  const profileAddress = profile.currentAddress || {};
+  const employment = profile.employment || {};
+  const workReference = profile.workReference || {};
+  const signature = profile.signature || {};
+  const consent = app.applicationConsent || {};
+  const household = app.household || {};
+  const coApplicant = app.coApplicant || {};
+  const currentLeaseStatus = app.currentLeaseStatus || null;
+  const decisionSummary = app.decisionSummary || null;
+  const risk = decisionSummary?.riskSnapshot || decisionSummary?.riskInsights || null;
+  const viewingRequests = Array.isArray(app.viewingRequests) ? app.viewingRequests.slice(0, 5) : [];
+  const residentialHistory = Array.isArray(app.residentialHistory) ? app.residentialHistory.slice(0, 5) : [];
+  const monthlyIncomeFromProfile =
+    typeof employment.incomeAmountCents === "number"
+      ? employment.incomeFrequency === "annual"
+        ? employment.incomeAmountCents / 12 / 100
+        : employment.incomeAmountCents / 100
+      : null;
 
   return (
     <article className="print-application-view" aria-label="Application summary print view">
@@ -99,6 +148,7 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
             border: 1px solid #d1d5db;
             border-radius: 8px;
             padding: 12px;
+            break-inside: avoid;
           }
           .print-label {
             font-size: 11px;
@@ -150,6 +200,16 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
         </div>
       </header>
 
+      <section className="print-card" aria-labelledby="print-application-context-heading" style={{ marginBottom: 12 }}>
+        <h2 id="print-application-context-heading" className="print-label">Application context</h2>
+        <div className="print-grid">
+          <div className="print-value">Status: {application.status || "—"}</div>
+          <div className="print-value">Requested rent: {formatMoney(app.requestedRent)}</div>
+          <div className="print-value">Move-in date: {formatDate(app.moveInDate)}</div>
+          <div className="print-value">Risk level: {app.riskLevel || "—"}</div>
+        </div>
+      </section>
+
       <div className="print-grid" style={{ marginBottom: 12 }}>
         <section className="print-card" aria-labelledby="print-application-contact-heading">
           <h2 id="print-application-contact-heading" className="print-label">Contact</h2>
@@ -170,6 +230,61 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
         </section>
       </div>
 
+      <section className="print-card" aria-labelledby="print-application-profile-heading" style={{ marginBottom: 12 }}>
+        <h2 id="print-application-profile-heading" className="print-label">Applicant profile</h2>
+        <div className="print-grid">
+          <div className="print-value">
+            Current address:{" "}
+            {formatAddressParts(
+              profileAddress.line1,
+              profileAddress.line2,
+              [profileAddress.city, profileAddress.provinceState].filter(Boolean).join(", "),
+              profileAddress.postalCode
+            )}
+          </div>
+          <div className="print-value">
+            Current rent: {formatCents(profile.currentRentAmountCents)}
+          </div>
+          <div className="print-value">
+            Employer: {employment.employerName || "—"}
+            {employment.jobTitle ? ` · ${employment.jobTitle}` : ""}
+          </div>
+          <div className="print-value">
+            Income: {monthlyIncomeFromProfile != null ? formatMoney(monthlyIncomeFromProfile) : "—"}
+            {employment.incomeFrequency === "annual" ? " monthly equivalent" : ""}
+          </div>
+          <div className="print-value">
+            Time at job: {employment.monthsAtJob != null ? `${employment.monthsAtJob} months` : "—"}
+          </div>
+          <div className="print-value">
+            Work reference: {workReference.name || "—"}
+            {workReference.phone ? ` · ${workReference.phone}` : ""}
+          </div>
+          <div className="print-value">
+            Signature: {signature.signedAt ? `Signed ${formatDate(signature.signedAt, true)}` : "—"}
+          </div>
+          <div className="print-value">
+            Application consent: {consent.acceptedAt ? `Accepted ${formatDate(consent.acceptedAt, true)}` : "—"}
+          </div>
+        </div>
+        {profile.applicantNotes ? (
+          <div className="print-muted" style={{ marginTop: 8 }}>Applicant notes: {profile.applicantNotes}</div>
+        ) : null}
+      </section>
+
+      <section className="print-card" aria-labelledby="print-application-household-heading" style={{ marginBottom: 12 }}>
+        <h2 id="print-application-household-heading" className="print-label">Household & co-applicant</h2>
+        <div className="print-grid">
+          <div className="print-value">Co-applicant: {coApplicant.fullName || "—"}</div>
+          <div className="print-value">Co-applicant contact: {formatAddressParts(coApplicant.email, coApplicant.phone)}</div>
+          <div className="print-value">Co-applicant income: {formatMoney(coApplicant.monthlyIncome)}</div>
+          <div className="print-value">Other occupants: {household.otherOccupants || "—"}</div>
+          <div className="print-value">Pets: {household.pets || "—"}</div>
+          <div className="print-value">Vehicles: {household.vehicles || "—"}</div>
+        </div>
+        {household.notes ? <div className="print-muted" style={{ marginTop: 8 }}>Household notes: {household.notes}</div> : null}
+      </section>
+
       <section className="print-card" aria-labelledby="print-application-references-heading" style={{ marginBottom: 12 }}>
         <h2 id="print-application-references-heading" className="print-label">References</h2>
         <div className="print-value">
@@ -181,6 +296,88 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
         <div className="print-muted" style={{ marginTop: 4 }}>
           Notes: {application.referencesNotes ? application.referencesNotes : "—"}
         </div>
+      </section>
+
+      <section className="print-card" aria-labelledby="print-application-housing-heading" style={{ marginBottom: 12 }}>
+        <h2 id="print-application-housing-heading" className="print-label">Current housing & residential history</h2>
+        <div className="print-value">
+          Active lease: {yesNo(currentLeaseStatus?.hasActiveLease)}
+          {currentLeaseStatus?.leaseEndDate ? ` · Lease end: ${formatDate(currentLeaseStatus.leaseEndDate)}` : ""}
+          {currentLeaseStatus?.landlordAware ? ` · Landlord aware: ${String(currentLeaseStatus.landlordAware).replace(/_/g, " ")}` : ""}
+        </div>
+        {currentLeaseStatus?.reasonForMoving ? (
+          <div className="print-muted" style={{ marginTop: 4 }}>Reason for moving: {currentLeaseStatus.reasonForMoving}</div>
+        ) : null}
+        <div style={{ marginTop: 8 }}>
+          {residentialHistory.length ? (
+            residentialHistory.map((entry: any, index: number) => (
+              <div key={`${entry.address || "history"}-${index}`} className="print-muted" style={{ marginTop: 4 }}>
+                {index + 1}. {entry.address || "Address not provided"}
+                {entry.durationMonths ? ` · ${entry.durationMonths} months` : ""}
+                {entry.rentAmountCents ? ` · ${formatCents(entry.rentAmountCents)}` : ""}
+                {entry.landlordName ? ` · Landlord: ${entry.landlordName}` : ""}
+                {entry.landlordPhone ? ` (${entry.landlordPhone})` : ""}
+                {entry.reasonForLeaving ? ` · Reason: ${entry.reasonForLeaving}` : ""}
+              </div>
+            ))
+          ) : (
+            <div className="print-muted">No residential history provided.</div>
+          )}
+        </div>
+      </section>
+
+      <section className="print-card" aria-labelledby="print-application-risk-heading" style={{ marginBottom: 12 }}>
+        <h2 id="print-application-risk-heading" className="print-label">Screening, risk & decision guidance</h2>
+        <div className="print-grid">
+          <div className="print-value">Screening status: {app.screeningStatus || app.screening?.status || "—"}</div>
+          <div className="print-value">Screening provider: {app.screeningProvider || app.screening?.provider || "—"}</div>
+          <div className="print-value">
+            Risk score: {risk?.score != null ? `${risk.score}${risk.grade ? ` (${risk.grade})` : ""}` : "—"}
+          </div>
+          <div className="print-value">
+            Confidence: {risk?.confidence != null ? `${Math.round(Number(risk.confidence) * 100)}%` : "—"}
+          </div>
+        </div>
+        <div className="print-muted" style={{ marginTop: 8 }}>
+          Decision summary: {decisionSummary?.decisionSupport?.summaryLine || "Not provided"}
+        </div>
+        <div className="print-muted" style={{ marginTop: 4 }}>
+          Next action: {decisionSummary?.decisionSupport?.nextBestAction || "Not provided"}
+        </div>
+        <div className="print-muted" style={{ marginTop: 4 }}>
+          Signals: {formatList(risk?.signals || risk?.flags)}
+        </div>
+        <div className="print-muted" style={{ marginTop: 4 }}>
+          Recommendations: {formatList(risk?.recommendations)}
+        </div>
+        <div className="print-muted" style={{ marginTop: 4 }}>
+          Reference questions: {formatList(decisionSummary?.referenceQuestions)}
+        </div>
+      </section>
+
+      <section className="print-card" aria-labelledby="print-application-viewings-heading" style={{ marginBottom: 12 }}>
+        <h2 id="print-application-viewings-heading" className="print-label">Viewing requests</h2>
+        {viewingRequests.length ? (
+          viewingRequests.map((request: any, index: number) => {
+            const selectedSlot = formatSlot(request.selectedSlot);
+            const proposed = Array.isArray(request.proposedSlots)
+              ? request.proposedSlots.map(formatSlot).filter(Boolean).slice(0, 3)
+              : [];
+            return (
+              <div key={request.id || index} className="print-muted" style={{ marginTop: index ? 8 : 0 }}>
+                <div className="print-value">
+                  {request.applicantName || applicantName} · {request.status || "requested"}
+                </div>
+                <div>{request.applicantEmail || "No email provided"}</div>
+                {request.requestedMessage ? <div>Message: {request.requestedMessage}</div> : null}
+                {selectedSlot ? <div>Selected time: {selectedSlot}</div> : null}
+                {proposed.length ? <div>Proposed times: {proposed.join("; ")}</div> : null}
+              </div>
+            );
+          })
+        ) : (
+          <div className="print-muted">No viewing requests recorded.</div>
+        )}
       </section>
 
       <div className="print-grid" style={{ marginBottom: 12 }}>

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -160,6 +160,8 @@ describe("ApplicationReviewSummaryPage", () => {
     renderPage();
 
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
+    expect(await screen.findByText("Landlord review packet for the selected application.")).toBeInTheDocument();
+    expect(screen.queryByText(/Application ID:/i)).not.toBeInTheDocument();
     expect(await screen.findByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
     expect(await screen.findByText("Shared package categories")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -607,7 +607,9 @@ function ApplicationReviewSummaryPageBody() {
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
         <div>
           <h1 style={{ margin: 0, fontSize: "1.2rem" }}>Application Review Summary</h1>
-          <div style={{ fontSize: 12, color: text.subtle }}>Application ID: {id}</div>
+          <div style={{ fontSize: 12, color: text.subtle }}>
+            Landlord review packet for the selected application.
+          </div>
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           <Button variant="ghost" onClick={() => navigate(-1)}>Back</Button>

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -404,6 +404,129 @@ describe("ApplicationsPage", () => {
   });
 
   it("provides a printable application summary action for the selected application", async () => {
+    mocks.fetchRentalApplication.mockResolvedValue({
+      id: "app-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      applicationLinkId: "link-1",
+      createdAt: Date.now(),
+      submittedAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "SUBMITTED",
+      applicant: { firstName: "Jamie", lastName: "Stone", email: "jamie@example.com" },
+      residentialHistory: [
+        {
+          address: "12 North Street",
+          durationMonths: 18,
+          rentAmountCents: 180000,
+          landlordName: "Morgan Lee",
+          landlordPhone: "555-555-0123",
+          reasonForLeaving: "Larger unit needed",
+        },
+      ],
+      applicantProfile: {
+        currentAddress: {
+          line1: "12 North Street",
+          city: "Halifax",
+          provinceState: "NS",
+          postalCode: "B3H 1A1",
+          country: "CA",
+        },
+        currentRentAmountCents: 180000,
+        employment: {
+          employerName: "Harbour Labs",
+          jobTitle: "Designer",
+          incomeAmountCents: 7800000,
+          incomeFrequency: "annual",
+          monthsAtJob: 24,
+        },
+        workReference: {
+          name: "Taylor Grant",
+          phone: "555-555-0100",
+        },
+        signature: {
+          type: "typed",
+          signedAt: "2026-03-31T18:00:00.000Z",
+        },
+        applicantNotes: "Prefers a September move if possible.",
+      },
+      applicationConsent: {
+        version: "v1.0",
+        acceptedAt: "2026-03-31T18:00:00.000Z",
+      },
+      coApplicant: {
+        fullName: "Riley Stone",
+        email: "riley@example.com",
+        phone: "555-555-0199",
+        monthlyIncome: 3200,
+      },
+      household: {
+        otherOccupants: "One child",
+        pets: "One cat",
+        vehicles: "One vehicle",
+        notes: "Needs parking.",
+      },
+      currentLeaseStatus: {
+        hasActiveLease: true,
+        leaseEndDate: "2026-04-30",
+        landlordAware: "yes",
+        reasonForMoving: "Moving closer to work.",
+      },
+      screeningStatus: "complete",
+      screeningProvider: "Provider A",
+      screening: { requested: true, status: "complete" },
+      employment: { applicant: {} },
+      consent: { creditConsent: true, referenceConsent: true, dataSharingConsent: true, acceptedAt: Date.now() },
+      landlordNote: "Call reference before final approval.",
+      flags: ["income_review"],
+    });
+    mocks.fetchApplicationDecisionSummary.mockResolvedValue({
+      applicationId: "app-1",
+      riskInsights: {
+        score: 74,
+        grade: "B",
+        confidence: 0.82,
+        signals: ["Stable employment"],
+        recommendations: ["Verify income documents"],
+      },
+      referenceQuestions: ["Would you rent to this applicant again?"],
+      screeningRecommendation: {
+        recommended: false,
+        reason: "Screening is complete.",
+      },
+      decisionSupport: {
+        summaryLine: "Application is ready for landlord review.",
+        nextBestAction: "Call references before approval.",
+      },
+    });
+    mocks.fetchViewingRequests.mockResolvedValueOnce([
+      {
+        id: "view-1",
+        applicantName: "Jamie Stone",
+        applicantEmail: "jamie@example.com",
+        applicantPhone: null,
+        requestedMessage: "Weekend preferred",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: "app-1",
+        status: "slots_proposed",
+        proposedSlots: [
+          {
+            id: "slot-1",
+            startAt: "2026-04-05T14:00:00.000Z",
+            endAt: "2026-04-05T14:30:00.000Z",
+            note: "Afternoon",
+            isSelected: false,
+          },
+        ],
+        selectedSlot: null,
+        requestedAt: "2026-04-03T10:00:00.000Z",
+        createdAt: "2026-04-03T10:00:00.000Z",
+        updatedAt: "2026-04-03T10:00:00.000Z",
+      },
+    ]);
+
     const { container } = render(
       <MemoryRouter>
         <ApplicationsPage />
@@ -421,6 +544,16 @@ describe("ApplicationsPage", () => {
     const printSource = container.querySelector(".print-only-application");
     expect(printSource?.textContent).toContain("Application summary");
     expect(printSource?.textContent).toContain("Jamie Stone");
+    expect(printSource?.textContent).toContain("Applicant profile");
+    expect(printSource?.textContent).toContain("Harbour Labs");
+    expect(printSource?.textContent).toContain("Household & co-applicant");
+    expect(printSource?.textContent).toContain("Riley Stone");
+    expect(printSource?.textContent).toContain("Current housing & residential history");
+    expect(printSource?.textContent).toContain("12 North Street");
+    expect(printSource?.textContent).toContain("Screening, risk & decision guidance");
+    expect(printSource?.textContent).toContain("Stable employment");
+    expect(printSource?.textContent).toContain("Viewing requests");
+    expect(printSource?.textContent).toContain("Weekend preferred");
   });
 
   it("hides cancelled viewing requests by default and preserves active ordering", async () => {

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -727,6 +727,21 @@ const ApplicationsPage: React.FC = () => {
     if (!detail) return null;
     const applicantName = `${detail.applicant.firstName} ${detail.applicant.lastName}`.trim() || "Applicant";
     const propertyName = properties.find((property) => property.id === detail.propertyId)?.name || "Property";
+    const profileIncome = detail.applicantProfile?.employment?.incomeAmountCents;
+    const profileFrequency = detail.applicantProfile?.employment?.incomeFrequency;
+    const monthlyIncomeFromProfile =
+      typeof profileIncome === "number"
+        ? profileFrequency === "annual"
+          ? profileIncome / 12 / 100
+          : profileIncome / 100
+        : null;
+    const printViewingRequests = showCancelledViewingRequests
+      ? viewingRequests
+      : viewingRequests.filter((request) => request.status !== "cancelled");
+    const matchingViewingRequests = printViewingRequests.filter((request) => {
+      const requestApplicationId = String(request.applicationId || "").trim();
+      return !requestApplicationId || requestApplicationId === detail.id;
+    });
     return {
       ...detail,
       fullName: applicantName,
@@ -736,18 +751,28 @@ const ApplicationsPage: React.FC = () => {
       applicantPhone: detail.applicant.phoneHome || detail.applicant.phoneWork || null,
       dateOfBirth: detail.applicant.dob || null,
       propertyName,
-      unitApplied: null,
+      unitApplied: (detail as any).unitApplied || (detail as any).unit || null,
       monthlyIncome:
-        typeof detail.employment?.applicant?.monthlyIncomeCents === "number"
+        monthlyIncomeFromProfile ??
+        (typeof detail.employment?.applicant?.monthlyIncomeCents === "number"
           ? detail.employment.applicant.monthlyIncomeCents / 100
-          : null,
+          : null),
       recentAddress: detail.residentialHistory?.[0]
         ? {
             streetName: detail.residentialHistory[0].address,
           }
         : null,
+      applicantProfile: detail.applicantProfile || null,
+      applicationConsent: detail.applicationConsent || null,
+      currentLeaseStatus: detail.currentLeaseStatus || null,
+      residentialHistory: detail.residentialHistory || [],
+      household: detail.household || null,
+      coApplicant: detail.coApplicant || null,
+      consent: detail.consent || null,
+      decisionSummary,
+      viewingRequests: matchingViewingRequests,
     };
-  }, [detail, properties]);
+  }, [decisionSummary, detail, properties, showCancelledViewingRequests, viewingRequests]);
   const screeningOrderId = detail?.screening?.orderId || null;
   const isTransUnionConnected = transUnionIntegration.status === "connected";
   const visibleViewingRequests = useMemo(


### PR DESCRIPTION
## Summary

Improves Applications PDF/export content parity for both current export-like surfaces:

- expands the `/applications` browser print source used by `Print / Save PDF`
- expands the backend Application Review Summary PDF contract with curated landlord-safe sections
- passes decision context into backend PDF generation
- removes raw application ID display from the backend PDF header and avoids printing raw screening references in the PDF sections

## Root cause

Applications had two separate export surfaces with separate content contracts:

- `/applications` printed a lightweight frontend-only `PrintApplicationView` with a narrow data transform.
- `/rental-applications/:id/review-summary.pdf` generated a structured backend PDF, but only rendered the core deterministic review summary and omitted richer in-app decision/risk/workflow context.

Because those paths were not aligned to a curated export contract, the PDF/export content could be much thinner than the in-app Application Summary.

## Implementation

- Extended `ReviewSummary` with application context, household/co-applicant, residential history, current lease status, notes, and flags.
- Added `buildReviewSummaryPdfSections` so PDF section content is testable without brittle binary-PDF parsing.
- Updated backend review-summary PDF output to render curated sections for application context, household, employment, references/compliance, housing, residential history, screening, risk/decision guidance, and notes.
- Updated the PDF route to pass `buildApplicationDecisionSummary` output into `buildReviewSummaryPdf`.
- Expanded `PrintApplicationView` to include richer applicant profile, household/co-applicant, current housing, residential history, screening/risk/decision guidance, and viewing request sections.
- Updated the Applications page print model to pass applicant profile, consent, lease status, decision summary, and matching viewing requests into the print view.

## Validation

- `npm run test:single -- src/pages/ApplicationsPage.test.tsx` passed in `rentchain-frontend` on Node 20.20.2.
- `npm run test:single -- src/lib/__tests__/reviewSummary.test.ts src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts` passed in `rentchain-api` on Node 20.20.2.
  - First sandboxed backend route run hit `listen EPERM` from Supertest binding a local port; rerun outside sandbox passed.
- `npm run build` passed in `rentchain-frontend`.
- `npm run build` passed in `rentchain-api`.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Manual QA

Required before merge:

- `/applications`
  - select an application with rich summary data
  - use `Print / Save PDF`
  - confirm exported/print preview includes applicant identity/contact, status, property/unit context, applicant profile, employment/income, references, consent, household/co-applicant if present, current housing/residential history, screening/risk/decision guidance, viewing requests, notes/flags
  - confirm no raw internal application/property/unit/tenant IDs or provider order IDs are visible
- `/applications/:applicationId/review-summary`
  - confirm page still loads
  - use PDF export if available
  - confirm backend PDF includes the expanded curated sections and remains readable across pages
- Regression:
  - `/dashboard`
  - `/applications`
  - `/operations`
  - `/leases`