### PR TITLE
fix: application review summary action visibility

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -254,6 +254,11 @@ const LocationProbe = () => {
   return <div data-testid="location-search">{location.search}</div>;
 };
 
+const LocationPathProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location-path">{`${location.pathname}${location.search}`}</div>;
+};
+
 afterEach(() => {
   cleanup();
 });
@@ -554,6 +559,40 @@ describe("ApplicationsPage", () => {
     expect(printSource?.textContent).toContain("Stable employment");
     expect(printSource?.textContent).toContain("Viewing requests");
     expect(printSource?.textContent).toContain("Weekend preferred");
+  });
+
+  it("opens the application review summary from the selected application detail header", async () => {
+    mocks.entitlementsMock.mockReturnValue({
+      loading: false,
+      plan: "pro",
+      role: "landlord",
+      isAdmin: false,
+      capabilities: {},
+      hasCapability: () => true,
+      requiredPlanFor: () => "pro",
+      canScreen: true,
+      canViewScreeningHistory: true,
+      canExportPdf: true,
+      hasMoveInReadiness: false,
+      canUseWorkOrders: false,
+      canViewReviewSummary: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <LocationPathProbe />
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    const applicantName = await screen.findByText("Jamie Stone");
+    const applicantRow = applicantName.closest('[role="button"]');
+    expect(applicantRow).toBeTruthy();
+    fireEvent.click(applicantRow as HTMLElement);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open review summary" }));
+
+    expect(screen.getByTestId("location-path")).toHaveTextContent("/applications/app-1/review-summary");
   });
 
   it("hides cancelled viewing requests by default and preserves active ordering", async () => {

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -3058,6 +3058,22 @@ const ApplicationsPage: React.FC = () => {
                   <div style={{ color: text.muted, fontSize: 13 }}>{detail.applicant.email}</div>
                 </div>
                 <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", justifyContent: "flex-end" }}>
+                  {detail.id ? (
+                    canViewReviewSummary ? (
+                      <Button
+                        variant="secondary"
+                        onClick={() => navigate(`/applications/${detail.id}/review-summary`)}
+                      >
+                        Open review summary
+                      </Button>
+                    ) : (
+                      <UpgradeCTA
+                        featureKey="review_summary"
+                        label="Upgrade for Review Summary"
+                        variant="secondary"
+                      />
+                    )
+                  ) : null}
                   <Button variant="secondary" onClick={() => void printSummaryDocument("application")}>
                     Print / Save PDF
                   </Button>
@@ -3171,7 +3187,7 @@ const ApplicationsPage: React.FC = () => {
                           onClick={() => navigate(`/applications/${detail.id}/review-summary`)}
                           disabled={!detail?.id}
                         >
-                          View Screening Decision
+                          Application review summary
                         </Button>
                       ) : (
                         <UpgradeCTA


### PR DESCRIPTION
## Summary

- Adds a direct `Open review summary` action to the selected application detail header.
- Keeps the action tied to the existing `/applications/:applicationId/review-summary` route and only renders it when the selected application has a valid ID.
- Preserves the existing review-summary entitlement boundary by showing an upgrade CTA when the landlord cannot view review summaries.
- Renames the existing screening-panel affordance from `View Screening Decision` to `Application review summary` so it no longer sounds screening-only.

## Validation

- `npm run test:single -- src/pages/ApplicationsPage.test.tsx` passed in `rentchain-frontend` with Node 20.20.2.
- `npm run build` passed in `rentchain-frontend` with Node 20.20.2.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Notes

- No backend changes.
- No Application Review Summary PDF/content changes.
- No application filtering, screening, reminder, decision, or export behavior changes beyond the visible navigation affordance.
- `ApplicationReviewSummaryPage` tests were not run because that page implementation was not touched.

## Manual QA

- Desktop `/applications`: select an application, confirm `Open review summary`, click it, and confirm `/applications/:applicationId/review-summary` loads.
- Mobile `/applications`: confirm the action is visible and usable without overflow.
- Regression: `Print / Save PDF`, filters/status tabs, screening setup, `/dashboard`, `/operations`, `/leases`.
