### PR TITLE
polish: clarify unified inbox source actions

### DIFF
--- a/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
+++ b/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
@@ -49,23 +49,46 @@ function priorityTone(priority: UnifiedInboxRecord["priority"]) {
   return { color: "#075985", background: "#e0f2fe" };
 }
 
-function workspaceForRecord(record: UnifiedInboxRecord, role: UnifiedInboxRole) {
+type WorkspaceAction = {
+  href: string;
+  label: string;
+  helper: string;
+};
+
+function workspaceForRecord(record: UnifiedInboxRecord, role: UnifiedInboxRole): WorkspaceAction | null {
   if (role === "tenant") return null;
   if (role === "contractor") return null;
+  const recordBody = `${record.title} ${record.body}`;
+  const isPaymentLike = /\b(payment|payments|rent|invoice|charge|balance|outstanding|collection)\b/i.test(recordBody);
   if (record.sourceKind.includes("maintenance") || record.sourceKind.includes("work_order")) {
-    return { href: "/work-orders", label: "Open work orders" };
+    return {
+      href: "/work-orders",
+      label: "Open related work orders",
+      helper: "Use the work order workspace to find the related maintenance item.",
+    };
   }
   if (record.sourceKind.includes("lease")) {
-    return { href: "/leases", label: "Open leases" };
+    return {
+      href: "/leases",
+      label: isPaymentLike ? "Open related leases" : "Open lease workspace",
+      helper: isPaymentLike
+        ? "Open the lease workspace to find the related summary or payment ledger."
+        : "Open the lease workspace to find the related lease record.",
+    };
   }
   if (record.sourceKind.includes("application") || record.sourceKind.includes("screening") || record.sourceKind.includes("viewing")) {
-    return { href: "/applications", label: "Open applications" };
+    return {
+      href: "/applications",
+      label: "Open related applications",
+      helper: "Open the application workspace to find the related application, screening, or viewing record.",
+    };
   }
-  if (/\b(payment|payments|rent|invoice|charge|balance|outstanding|collection)\b/i.test(record.title + " " + record.body)) {
-    return { href: "/payments", label: "Open payments" };
-  }
-  if (record.sourceKind.includes("message")) {
-    return { href: "/landlord/unified-inbox", label: "Stay in inbox" };
+  if (isPaymentLike) {
+    return {
+      href: "/payments",
+      label: "Open payment workspace",
+      helper: "Open Payments to review payment setup, balances, or collection activity.",
+    };
   }
   return null;
 }
@@ -202,29 +225,40 @@ export function UnifiedInboxList({ records, role, onOpenRecord }: Props) {
                     <strong>{formatDate(record.occurredAt)}</strong>
                   </div>
                 </div>
-                {selectedWorkspace ? (
-                  <a
-                    href={selectedWorkspace.href}
-                    style={{
-                      alignItems: "center",
-                      background: colors.accent,
-                      borderRadius: 999,
-                      color: "#fff",
-                      display: "inline-flex",
-                      fontSize: "0.95rem",
-                      fontWeight: 800,
-                      gap: 8,
-                      justifySelf: "start",
-                      padding: "10px 14px",
-                      textDecoration: "none",
-                    }}
-                  >
-                    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-                      {selectedWorkspace.label}
-                      <ArrowUpRight size={16} aria-hidden="true" />
-                    </span>
-                  </a>
-                ) : null}
+                <div style={{ display: "grid", gap: 8, justifyItems: "start" }}>
+                  {selectedWorkspace ? (
+                    <>
+                      <div style={{ color: text.muted, fontSize: "0.9rem", lineHeight: 1.5 }}>
+                        {selectedWorkspace.helper}
+                      </div>
+                      <a
+                        href={selectedWorkspace.href}
+                        style={{
+                          alignItems: "center",
+                          background: colors.accent,
+                          borderRadius: 999,
+                          color: "#fff",
+                          display: "inline-flex",
+                          fontSize: "0.95rem",
+                          fontWeight: 800,
+                          gap: 8,
+                          justifySelf: "start",
+                          padding: "10px 14px",
+                          textDecoration: "none",
+                        }}
+                      >
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                          {selectedWorkspace.label}
+                          <ArrowUpRight size={16} aria-hidden="true" />
+                        </span>
+                      </a>
+                    </>
+                  ) : (
+                    <div style={{ color: text.muted, fontSize: "0.9rem", lineHeight: 1.5 }}>
+                      This inbox item does not include a linked workspace action yet.
+                    </div>
+                  )}
+                </div>
               </Card>
             ) : null}
           </React.Fragment>

--- a/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
+++ b/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
@@ -60,11 +60,18 @@ function workspaceForRecord(record: UnifiedInboxRecord, role: UnifiedInboxRole):
   if (role === "contractor") return null;
   const recordBody = `${record.title} ${record.body}`;
   const isPaymentLike = /\b(payment|payments|rent|invoice|charge|balance|outstanding|collection)\b/i.test(recordBody);
-  if (record.sourceKind.includes("maintenance") || record.sourceKind.includes("work_order")) {
+  if (record.sourceKind.includes("maintenance")) {
+    return {
+      href: "/maintenance",
+      label: "Open maintenance workspace",
+      helper: "Open the maintenance workspace to review available maintenance requests.",
+    };
+  }
+  if (record.sourceKind.includes("work_order")) {
     return {
       href: "/work-orders",
       label: "Open related work orders",
-      helper: "Use the work order workspace to find the related maintenance item.",
+      helper: "Open the work order workspace to review available work-order records.",
     };
   }
   if (record.sourceKind.includes("lease")) {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -231,8 +231,8 @@ describe("UnifiedInboxPage", () => {
       background: "#f8fafc",
       boxShadow: "none",
     });
-    expect(screen.getByText("Use the work order workspace to find the related maintenance item.")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Open related work orders/i })).toHaveAttribute("href", "/work-orders");
+    expect(screen.getByText("Open the maintenance workspace to review available maintenance requests.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open maintenance workspace/i })).toHaveAttribute("href", "/maintenance");
 
     fireEvent.click(screen.getByRole("tab", { name: /Unread 1/i }));
     fireEvent.click(screen.getByRole("button", { name: /Outstanding rent balance/i }));
@@ -255,6 +255,36 @@ describe("UnifiedInboxPage", () => {
     expect(screen.getAllByText("System notice").length).toBeGreaterThan(0);
     expect(screen.queryByText("Lease renewal ready")).not.toBeInTheDocument();
     expect(screen.queryByText("Outstanding rent balance")).not.toBeInTheDocument();
+  });
+
+  it("keeps true work-order inbox actions on the work-order workspace", async () => {
+    const workOrderRecord = record({
+      id: "work-order-update",
+      audienceRole: "landlord",
+      sourceKind: "landlord.work_order",
+      title: "Work order update",
+      body: "stairs status: in progress",
+      priority: "high",
+      status: "unread",
+      readAt: null,
+    });
+    mocks.fetchUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [workOrderRecord],
+      records: [workOrderRecord],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+
+    render(<UnifiedInboxPage role="landlord" />);
+
+    expect(await screen.findByRole("heading", { name: "Unified inbox" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Work order update/i }));
+
+    expect(screen.getByText("Open the work order workspace to review available work-order records.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open related work orders/i })).toHaveAttribute("href", "/work-orders");
   });
 
   it("persists landlord read state through the API and keeps it after refresh", async () => {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -231,7 +231,8 @@ describe("UnifiedInboxPage", () => {
       background: "#f8fafc",
       boxShadow: "none",
     });
-    expect(screen.getByRole("link", { name: /Open work orders/i })).toHaveAttribute("href", "/work-orders");
+    expect(screen.getByText("Use the work order workspace to find the related maintenance item.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open related work orders/i })).toHaveAttribute("href", "/work-orders");
 
     fireEvent.click(screen.getByRole("tab", { name: /Unread 1/i }));
     fireEvent.click(screen.getByRole("button", { name: /Outstanding rent balance/i }));
@@ -240,6 +241,8 @@ describe("UnifiedInboxPage", () => {
     await waitFor(() => expect(paymentButton).toHaveTextContent("Read"));
     expect(screen.getByRole("tab", { name: /Unread 0/i })).toBeInTheDocument();
     expect(screen.getByTestId("unified-inbox-detail-panel")).toHaveTextContent("Outstanding rent balance");
+    expect(screen.getByText("Open Payments to review payment setup, balances, or collection activity.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open payment workspace/i })).toHaveAttribute("href", "/payments");
 
     fireEvent.click(screen.getByRole("tab", { name: /All 4/i }));
     fireEvent.change(screen.getByLabelText("Search inbox"), { target: { value: "balance" } });
@@ -335,6 +338,38 @@ describe("UnifiedInboxPage", () => {
     expect(screen.getByText("Not Found")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Unread 1/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Pipe leak reported/i })).toHaveTextContent("Unread");
+  });
+
+  it("shows honest source-action copy when no linked workspace action is available", async () => {
+    const messageRecord = record({
+      id: "landlord-message",
+      audienceRole: "landlord",
+      sourceKind: "landlord.message",
+      title: "Tenant replied",
+      body: "Thanks for the update.",
+      priority: "normal",
+      status: "read",
+      readAt: "2026-06-09T15:00:00.000Z",
+    });
+    mocks.fetchUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [messageRecord],
+      records: [messageRecord],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+
+    render(<UnifiedInboxPage role="landlord" />);
+
+    expect(await screen.findByRole("heading", { name: "Unified inbox" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Tenant replied/i }));
+
+    expect(screen.getByTestId("unified-inbox-detail-panel")).toHaveTextContent(
+      "This inbox item does not include a linked workspace action yet."
+    );
+    expect(screen.queryByRole("link", { name: /Stay in inbox/i })).not.toBeInTheDocument();
   });
 
   it("shows a safe error state when the inbox cannot load", async () => {


### PR DESCRIPTION
## Summary

Improves the landlord Unified Inbox detail panel so broad source actions are clearer and less misleading.

## What Changed

- Replaced generic workspace action labels with contextual labels:
  - `Open related work orders`
  - `Open related applications`
  - `Open related leases`
  - `Open payment workspace`
- Added helper copy explaining what each broad fallback will do.
- Removed the unhelpful `Stay in inbox` self-link for plain messages with no linked workspace action.
- Shows explicit copy when an inbox item has no linked workspace action yet.
- Added test coverage for contextual source-action labels and no-action message behavior.

## Root Cause / Limitation

The current public inbox projection intentionally exposes only safe display fields plus `sourceKind`. Backend tests explicitly exclude `sourceId`, `sourceRef`, and other lineage fields from public inbox responses, so exact record-level routing is not available to the frontend without a separate backend projection mission.

This PR therefore keeps the fix frontend-only: it makes broad fallbacks honest and source-aware without widening the inbox data contract or exposing raw IDs.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/UnifiedInboxPage.test.tsx` passed: 7 tests.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

Note: the same targeted test fails before loading tests on Node 20.11.1 due to the local `html-encoding-sniffer` / ESM issue. The frontend package requires `node >=20 <21`, and Node 20.20.2 is the local default compatible version.

## Manual QA

Recommended:

1. Open `/landlord/unified-inbox`.
2. Open unread/read items from work order, application/screening/viewing, lease, payment-like, and plain message categories if available.
3. Confirm source action labels are contextual and understandable.
4. Confirm plain messages without linked workspace context do not show a useless self-link.
5. Confirm read-state persistence from #1293 remains unchanged.
6. Regression pages: `/dashboard`, `/operations`, `/applications`, `/leases`.