### PR TITLE
polish: compact maintenance calendar by default

### DIFF
--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -369,6 +369,15 @@ describe("landlord maintenance workspace", () => {
   });
 
   it("opens the related request from the scheduled maintenance calendar", async () => {
+    const scheduledStart = new Date();
+    scheduledStart.setDate(scheduledStart.getDate() + 2);
+    scheduledStart.setHours(13, 0, 0, 0);
+    const scheduledEnd = new Date(scheduledStart);
+    scheduledEnd.setHours(15, 0, 0, 0);
+    const confirmationUpdatedAt = new Date(scheduledStart);
+    confirmationUpdatedAt.setDate(confirmationUpdatedAt.getDate() - 1);
+    confirmationUpdatedAt.setHours(10, 0, 0, 0);
+
     maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
       items: [
         {
@@ -405,11 +414,11 @@ describe("landlord maintenance workspace", () => {
           priority: "normal",
           status: "scheduled",
           assignedContractorName: "North Shore Plumbing",
-          serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
-          serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
+          serviceWindowStartAt: scheduledStart.getTime(),
+          serviceWindowEndAt: scheduledEnd.getTime(),
           accessRequired: false,
           tenantConfirmationStatus: "confirmed",
-          tenantConfirmationUpdatedAt: Date.UTC(2026, 3, 14, 10, 0),
+          tenantConfirmationUpdatedAt: confirmationUpdatedAt.getTime(),
           createdAt: 100,
           updatedAt: 200,
           statusHistory: [],
@@ -426,6 +435,16 @@ describe("landlord maintenance workspace", () => {
     );
 
     expect((await screen.findAllByText(/Scheduled maintenance calendar/i)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Compact 7-day view of scheduled maintenance windows/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Next 7 days").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Show 30-day calendar" }).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Show 30-day calendar" })[0]);
+    expect(screen.getAllByText(/Read-only 30-day view of scheduled maintenance windows/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Show compact 7-day view" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Previous" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Next" }).length).toBeGreaterThan(0);
+
     fireEvent.click((await screen.findAllByRole("button", { name: /Leaky pipe/i }))[0]);
 
     expect(await screen.findAllByText(/Leaky pipe/i)).not.toHaveLength(0);

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -140,6 +140,19 @@ function buildCalendarDays(value: Date) {
   });
 }
 
+function startOfDay(value: Date) {
+  return new Date(value.getFullYear(), value.getMonth(), value.getDate());
+}
+
+function buildCompactCalendarDays(value: Date) {
+  const firstCell = startOfDay(value);
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = new Date(firstCell);
+    date.setDate(firstCell.getDate() + index);
+    return date;
+  });
+}
+
 function dayKey(date: Date) {
   const pad = (value: number) => String(value).padStart(2, "0");
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
@@ -183,6 +196,8 @@ export default function MaintenanceRequestsPage() {
   const [vendorCostInput, setVendorCostInput] = React.useState("");
   const [costNote, setCostNote] = React.useState("");
   const [calendarMonth, setCalendarMonth] = React.useState(() => new Date());
+  const [calendarExpanded, setCalendarExpanded] = React.useState(false);
+  const [compactCalendarStart] = React.useState(() => startOfDay(new Date()));
 
   const load = React.useCallback(async () => {
     setLoading(true);
@@ -486,17 +501,20 @@ export default function MaintenanceRequestsPage() {
   const portfolioRollup = React.useMemo(() => buildMaintenancePortfolioCostRollupView(items), [items]);
   const propertyIntelligence = React.useMemo(() => buildPropertyFinancialIntelligenceView(items), [items]);
   const calendarDays = React.useMemo(() => buildCalendarDays(calendarMonth), [calendarMonth]);
+  const compactCalendarDays = React.useMemo(() => buildCompactCalendarDays(compactCalendarStart), [compactCalendarStart]);
+  const visibleCalendarDays = calendarExpanded ? calendarDays : compactCalendarDays;
   const calendarEventMap = React.useMemo(() => {
     const next = new Map<string, typeof calendarEvents>();
-    calendarDays.forEach((date) => next.set(dayKey(date), []));
+    visibleCalendarDays.forEach((date) => next.set(dayKey(date), []));
     calendarEvents.forEach((event) => {
       const key = dayKey(new Date(event.startAt));
+      if (!next.has(key)) return;
       const list = next.get(key) || [];
       list.push(event);
       next.set(key, list);
     });
     return next;
-  }, [calendarDays, calendarEvents]);
+  }, [visibleCalendarDays, calendarEvents]);
 
   const saveCost = React.useCallback(async () => {
     if (!selected || !selected.workOrderId || !selectedCost?.canRecordCost) return;
@@ -1042,24 +1060,35 @@ export default function MaintenanceRequestsPage() {
             <div>
               <div style={{ fontWeight: 800, color: text.primary }}>Scheduled maintenance calendar</div>
               <div style={{ color: text.muted, marginTop: 4 }}>
-                Read-only month view of scheduled maintenance windows. Select an item to open the related request.
+                {calendarExpanded
+                  ? "Read-only 30-day view of scheduled maintenance windows. Select an item to open the related request."
+                  : "Compact 7-day view of scheduled maintenance windows. Expand when you need the full calendar."}
               </div>
             </div>
             <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-              <Button
-                variant="secondary"
-                onClick={() => setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1))}
-              >
-                Previous
-              </Button>
+              {calendarExpanded ? (
+                <Button
+                  variant="secondary"
+                  onClick={() => setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1))}
+                >
+                  Previous
+                </Button>
+              ) : null}
               <div style={{ fontWeight: 700, color: text.primary, minWidth: 160, textAlign: "center" }}>
-                {calendarMonth.toLocaleDateString(undefined, { month: "long", year: "numeric" })}
+                {calendarExpanded
+                  ? calendarMonth.toLocaleDateString(undefined, { month: "long", year: "numeric" })
+                  : "Next 7 days"}
               </div>
-              <Button
-                variant="secondary"
-                onClick={() => setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1))}
-              >
-                Next
+              {calendarExpanded ? (
+                <Button
+                  variant="secondary"
+                  onClick={() => setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1))}
+                >
+                  Next
+                </Button>
+              ) : null}
+              <Button variant="secondary" onClick={() => setCalendarExpanded((value) => !value)}>
+                {calendarExpanded ? "Show compact 7-day view" : "Show 30-day calendar"}
               </Button>
             </div>
           </div>
@@ -1075,15 +1104,15 @@ export default function MaintenanceRequestsPage() {
                 {label}
               </div>
             ))}
-            {calendarDays.map((date) => {
+            {visibleCalendarDays.map((date) => {
               const key = dayKey(date);
               const dayEvents = calendarEventMap.get(key) || [];
-              const inMonth = date.getMonth() === calendarMonth.getMonth();
+              const inMonth = calendarExpanded ? date.getMonth() === calendarMonth.getMonth() : true;
               return (
                 <div
                   key={key}
                   style={{
-                    minHeight: 120,
+                    minHeight: calendarExpanded ? 120 : 82,
                     border: `1px solid ${colors.border}`,
                     borderRadius: radius.md,
                     padding: 8,
@@ -1126,7 +1155,7 @@ export default function MaintenanceRequestsPage() {
                       );
                     })
                   ) : (
-                    <div style={{ fontSize: 12, color: text.muted }}>No scheduled service</div>
+                    <div style={{ fontSize: 12, color: text.muted }}>{calendarExpanded ? "No scheduled service" : "No service"}</div>
                   )}
                 </div>
               );


### PR DESCRIPTION
## Summary
- Default `/maintenance` to a compact 7-day scheduled-maintenance calendar so request context is visible sooner.
- Keep the existing full month calendar available behind a `Show 30-day calendar` toggle.
- Preserve request list behavior, filters, refresh/print actions, and calendar item selection.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/MaintenanceRequestsPage.test.tsx` (12 tests passed)
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` (passed; existing Vite chunk-size warning)
- `git diff --check`
- `git diff --cached --check`

## Manual QA
Passed.

Desktop `/maintenance`:
- Request list appears without excessive scroll.
- Compact 7-day calendar no longer dominates the page.
- `Show 30-day calendar` works.
- Filters still work.
- Request list still works.
- Refresh/print actions remain usable.

Mobile `/maintenance`:
- Request list is reachable quickly.
- Compact calendar is readable.
- No horizontal overflow observed.

Unified Inbox route regression:
- From `/landlord/unified-inbox`, maintenance CTA routes to `/maintenance`.
- Maintenance request context is easier to locate than before.

Print / Save PDF review:
- PDF includes maintenance workflow summary, generated timestamp, request count, portfolio summary, request list, selected request details, lifecycle, execution, and resolution summary.
- Output is two pages and readable.

Regression routes confirmed:
- `/dashboard`
- `/operations`
- `/applications`
- `/leases`