### PR TITLE
fix: improve mobile contractors and screenings routes

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -1000,9 +1000,11 @@ function App() {
           path="/verified-screenings"
           element={
             <RequireAuth>
-              <Suspense fallback={null}>
-                <AdminVerifiedScreeningsPage />
-              </Suspense>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <AdminVerifiedScreeningsPage audience="landlord" shell="none" />
+                </Suspense>
+              </LandlordNav>
             </RequireAuth>
           }
         />

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -115,6 +115,32 @@
   color: #1d4ed8;
 }
 
+@media (min-width: 821px) and (max-width: 1180px) {
+  .rc-landlord-workspace-bar {
+    height: auto;
+    min-height: var(--rc-landlord-workspace-bar-height);
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    overflow: visible;
+  }
+
+  .rc-landlord-workspace-context {
+    width: 100%;
+  }
+
+  .rc-landlord-workspace-links {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+    overflow-x: visible;
+    row-gap: 8px;
+  }
+
+  .rc-landlord-workspace-links a {
+    padding: 7px 9px;
+  }
+}
+
 .rc-landlord-content {
   padding: 0 0 24px;
   box-sizing: border-box;

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -194,6 +194,13 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByText("PM Companies", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
   });
 
+  it("keeps verified screenings inside the landlord shell with bottom navigation", () => {
+    renderLandlordNav("/verified-screenings");
+
+    expect(screen.getByRole("navigation", { name: "Bottom navigation" })).toBeInTheDocument();
+    expect(screen.getByText("Verified Screenings", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
+  });
+
   it("keeps the mobile tab bar and close control available while the drawer is open", () => {
     renderLandlordNav();
 

--- a/rentchain-frontend/src/components/marketplace/ContractorCard.tsx
+++ b/rentchain-frontend/src/components/marketplace/ContractorCard.tsx
@@ -16,24 +16,24 @@ export default function ContractorCard({
   disabled?: boolean;
 }) {
   return (
-    <Card style={{ display: "grid", gap: 8 }}>
-      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start" }}>
-        <div style={{ display: "grid", gap: 4 }}>
-          <div style={{ fontWeight: 700 }}>{contractor.displayName}</div>
-          {contractor.businessName ? <div style={{ color: "#475569" }}>{contractor.businessName}</div> : null}
+    <Card style={{ display: "grid", gap: 8, minWidth: 0 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start", flexWrap: "wrap", minWidth: 0 }}>
+        <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+          <div className="rc-wrap-text" style={{ fontWeight: 700 }}>{contractor.displayName}</div>
+          {contractor.businessName ? <div className="rc-wrap-text" style={{ color: "#475569" }}>{contractor.businessName}</div> : null}
         </div>
         <span style={{ fontSize: "0.85rem", color: "#334155" }}>{contractor.availabilityStatus}</span>
       </div>
-      <div style={{ color: "#64748b", fontSize: "0.92rem" }}>
+      <div className="rc-wrap-text" style={{ color: "#64748b", fontSize: "0.92rem" }}>
         {contractor.summary || "Service profile available for maintenance assignment."}
       </div>
-      <div style={{ color: "#475569", fontSize: "0.92rem" }}>
+      <div className="rc-wrap-text" style={{ color: "#475569", fontSize: "0.92rem" }}>
         Categories: {contractor.serviceCategories.length ? contractor.serviceCategories.join(", ") : "-"}
       </div>
-      <div style={{ color: "#475569", fontSize: "0.92rem" }}>
+      <div className="rc-wrap-text" style={{ color: "#475569", fontSize: "0.92rem" }}>
         Areas: {contractor.serviceAreas.length ? contractor.serviceAreas.join(", ") : "-"}
       </div>
-      <div style={{ color: "#475569", fontSize: "0.92rem" }}>
+      <div className="rc-wrap-text" style={{ color: "#475569", fontSize: "0.92rem" }}>
         Contact: {contractor.contact.email || contractor.contact.phone || "-"}
       </div>
       {actions?.length ? (

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AdminVerifiedScreeningsPage from "./AdminVerifiedScreeningsPage";
+
+const mocks = vi.hoisted(() => ({
+  listVerifiedScreenings: vi.fn(),
+  fetchVerifiedScreening: vi.fn(),
+  updateVerifiedScreening: vi.fn(),
+  showToast: vi.fn(),
+  user: { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.test" },
+}));
+
+vi.mock("../api/adminVerifiedScreeningsApi", () => ({
+  listVerifiedScreenings: mocks.listVerifiedScreenings,
+  fetchVerifiedScreening: mocks.fetchVerifiedScreening,
+  updateVerifiedScreening: mocks.updateVerifiedScreening,
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: () => ({ user: mocks.user }),
+}));
+
+vi.mock("../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+describe("AdminVerifiedScreeningsPage landlord mode", () => {
+  beforeEach(() => {
+    cleanup();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    mocks.listVerifiedScreenings.mockReset();
+    mocks.fetchVerifiedScreening.mockReset();
+    mocks.updateVerifiedScreening.mockReset();
+    mocks.showToast.mockReset();
+    mocks.user = { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.test" };
+    mocks.listVerifiedScreenings.mockResolvedValue([
+      {
+        id: "screening-1",
+        createdAt: Date.UTC(2026, 5, 1, 12, 0),
+        updatedAt: Date.UTC(2026, 5, 1, 12, 0),
+        status: "COMPLETE",
+        serviceLevel: "VERIFIED",
+        landlordId: "landlord_raw_123",
+        applicationId: "app_raw_123",
+        orderId: "order_raw_123",
+        propertyId: "property_raw_123",
+        unitId: "unit_raw_123",
+        applicant: { name: "Phil Jones", email: "phil@example.test" },
+        aiIncluded: true,
+        scoreAddOn: false,
+        totalAmountCents: 4999,
+        currency: "CAD",
+        notesInternal: "Internal-only note",
+        reviewer: { email: "reviewer@example.test" },
+        completedAt: Date.UTC(2026, 5, 1, 13, 0),
+        resultSummary: "Screening review completed.",
+        recommendation: "APPROVE",
+      },
+    ]);
+  });
+
+  it("shows landlord-safe screening detail without raw internal or provider identifiers", async () => {
+    render(
+      <MemoryRouter>
+        <AdminVerifiedScreeningsPage audience="landlord" shell="none" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Phil Jones")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search applicant or email")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Phil Jones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Result summary")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Screening review completed.")).toBeInTheDocument();
+    expect(screen.getByText("APPROVE")).toBeInTheDocument();
+    expect(screen.getAllByText("$49.99 CAD").length).toBeGreaterThan(0);
+    expect(mocks.fetchVerifiedScreening).not.toHaveBeenCalled();
+
+    expect(screen.queryByText(/Application ID/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/app_raw_123/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Order ID/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/order_raw_123/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Property ID/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/property_raw_123/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unit ID/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/unit_raw_123/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Internal-only note/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
@@ -15,6 +15,8 @@ import { colors, spacing, text, radius } from "../styles/tokens";
 
 const statusOptions = ["QUEUED", "IN_PROGRESS", "COMPLETE", "CANCELLED"] as const;
 const recommendationOptions = ["APPROVE", "DECLINE", "CONDITIONAL"] as const;
+type VerifiedScreeningsAudience = "admin" | "landlord";
+type VerifiedScreeningsShell = "mac" | "none";
 type QueueViewState =
   | "ready"
   | "empty"
@@ -23,7 +25,70 @@ type QueueViewState =
   | "forbidden"
   | "error";
 
-const AdminVerifiedScreeningsPage: React.FC = () => {
+type AdminVerifiedScreeningsPageProps = {
+  audience?: VerifiedScreeningsAudience;
+  shell?: VerifiedScreeningsShell;
+};
+
+function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) {
+  return (
+    <div style={{ display: "grid", gap: spacing.md }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 8 }}>
+        <div style={{ minWidth: 0 }}>
+          <div className="rc-wrap-text" style={{ fontSize: "1.1rem", fontWeight: 700 }}>
+            {item.applicant?.name || "Applicant"}
+          </div>
+          <div style={{ color: text.muted }} className="rc-wrap-text">
+            {item.applicant?.email || "No email"}
+          </div>
+        </div>
+        <div className="rc-wrap-row">
+          <Pill>{item.serviceLevel}</Pill>
+          <Pill>{item.status}</Pill>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(min(180px,100%),1fr))", gap: 8 }}>
+        <div>
+          <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>Paid</div>
+          <div>
+            ${(item.totalAmountCents / 100).toFixed(2)} {item.currency}
+          </div>
+        </div>
+        <div>
+          <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>Created</div>
+          <div>{item.createdAt ? new Date(item.createdAt).toLocaleString() : "-"}</div>
+        </div>
+        <div>
+          <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>Recommendation</div>
+          <div>{item.recommendation || "Pending review"}</div>
+        </div>
+        <div>
+          <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>AI review</div>
+          <div>{item.aiIncluded ? "Included" : "Not included"}</div>
+        </div>
+      </div>
+
+      {item.resultSummary ? (
+        <div style={{ display: "grid", gap: 6 }}>
+          <div style={{ fontWeight: 700 }}>Result summary</div>
+          <div className="rc-wrap-text" style={{ color: text.muted }}>
+            {item.resultSummary}
+          </div>
+        </div>
+      ) : (
+        <div style={{ color: text.muted }}>
+          Detailed screening results are not available in this workspace yet.
+        </div>
+      )}
+    </div>
+  );
+}
+
+const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = ({
+  audience = "admin",
+  shell = "mac",
+}) => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const { showToast } = useToast();
@@ -37,6 +102,8 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
   const [viewMessage, setViewMessage] = useState<string | null>(null);
 
   const isAdmin = String(user?.role || "").toLowerCase() === "admin";
+  const isAdminAudience = audience === "admin";
+  const pageTitle = isAdminAudience ? "Admin · Verified Screenings" : "Verified Screenings";
 
   const load = async () => {
     try {
@@ -89,8 +156,8 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
         showToast({ message: "Failed to load detail", description: err?.message || "", variant: "error" });
       }
     };
-    if (isAdmin) void loadDetail();
-  }, [selectedId, isAdmin]);
+    if (isAdminAudience && isAdmin) void loadDetail();
+  }, [selectedId, isAdmin, isAdminAudience]);
 
   const filtered = useMemo(() => {
     if (!search.trim()) return items;
@@ -98,9 +165,21 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
     return items.filter((i) => {
       const name = (i.applicant?.name || "").toLowerCase();
       const email = (i.applicant?.email || "").toLowerCase();
-      return name.includes(q) || email.includes(q) || i.applicationId?.toLowerCase().includes(q);
+      return name.includes(q) || email.includes(q) || (isAdminAudience && i.applicationId?.toLowerCase().includes(q));
     });
-  }, [items, search]);
+  }, [isAdminAudience, items, search]);
+
+  const selectedSummary = useMemo(
+    () => (selectedId ? items.find((item) => item.id === selectedId) || null : null),
+    [items, selectedId]
+  );
+
+  const renderShell = (children: React.ReactNode) =>
+    shell === "mac" ? (
+      <MacShell title={pageTitle}>{children}</MacShell>
+    ) : (
+      <div style={{ display: "grid", gap: spacing.lg }}>{children}</div>
+    );
 
   const handleSave = async () => {
     if (!detail) return;
@@ -133,8 +212,7 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
             : viewState === "forbidden"
               ? "You do not have access to this queue."
               : "Unable to load verified screenings.";
-    return (
-      <MacShell title="Admin · Verified Screenings">
+    return renderShell(
         <Section>
           <Card elevated style={{ display: "grid", gap: 12 }}>
             <h1 style={{ margin: 0, fontSize: "1.2rem" }}>{heading}</h1>
@@ -156,12 +234,10 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
             </div>
           </Card>
         </Section>
-      </MacShell>
     );
   }
 
-  return (
-    <MacShell title="Admin · Verified Screenings">
+  return renderShell(
       <Section style={{ display: "grid", gap: spacing.md }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: spacing.sm }}>
           <h1 style={{ margin: 0, fontSize: "1.3rem" }}>Verified Screening Queue</h1>
@@ -179,7 +255,7 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
               <Input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search applicant or application ID"
+                placeholder={isAdminAudience ? "Search applicant or application ID" : "Search applicant or email"}
                 style={{ width: "100%" }}
               />
             }
@@ -238,12 +314,16 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
               ) : null
             }
             hasSelection={Boolean(selectedId)}
-            selectedLabel={detail?.applicant?.name || "Screening"}
+            selectedLabel={(isAdminAudience ? detail?.applicant?.name : selectedSummary?.applicant?.name) || "Screening"}
             onClearSelection={() => setSelectedId(null)}
             detail={
               <Card>
-                {!detail ? (
+                {isAdminAudience && !detail ? (
                   <div style={{ color: text.muted }}>Select a queue item.</div>
+                ) : !isAdminAudience && !selectedSummary ? (
+                  <div style={{ color: text.muted }}>Select a screening.</div>
+                ) : !isAdminAudience && selectedSummary ? (
+                  <ScreeningSummaryDetail item={selectedSummary} />
                 ) : (
                   <div style={{ display: "grid", gap: spacing.md }}>
                     <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 8 }}>
@@ -329,7 +409,6 @@ const AdminVerifiedScreeningsPage: React.FC = () => {
           />
         </Card>
       </Section>
-    </MacShell>
   );
 };
 

--- a/rentchain-frontend/src/pages/landlord/ContractorsPage.css
+++ b/rentchain-frontend/src/pages/landlord/ContractorsPage.css
@@ -1,0 +1,99 @@
+.rc-contractors-page,
+.rc-contractors-page * {
+  box-sizing: border-box;
+}
+
+.rc-contractors-page {
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+.rc-contractors-invite-form-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
+  min-width: 0;
+}
+
+.rc-contractors-wrap-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.rc-contractors-invite-table-wrap {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.rc-contractors-invite-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.rc-contractors-invite-table th,
+.rc-contractors-invite-table td {
+  padding: 8px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.rc-contractors-invite-table thead tr {
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.rc-contractors-invite-table tbody tr {
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.rc-contractors-invite-table td {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.rc-contractors-invite-cards {
+  display: none;
+}
+
+.rc-contractors-invite-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.rc-contractors-invite-card-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(min(150px, 100%), 1fr));
+}
+
+.rc-contractors-invite-card-label {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.rc-contractors-invite-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+@media (max-width: 720px) {
+  .rc-contractors-invite-table-wrap {
+    display: none;
+  }
+
+  .rc-contractors-invite-cards {
+    display: grid;
+    gap: 10px;
+  }
+}

--- a/rentchain-frontend/src/pages/landlord/ContractorsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ContractorsPage.test.tsx
@@ -93,6 +93,40 @@ describe("ContractorsPage", () => {
     expect(screen.getByText(/No invites yet\./i)).toBeInTheDocument();
   });
 
+  it("renders invite history in a mobile-safe presentation with invite actions", async () => {
+    mocks.listContractorInvites.mockResolvedValue([
+      {
+        id: "invite-1",
+        email: "very.long.contractor.email@example.test",
+        status: "pending",
+        inviteLink: "https://example.test/invite/one",
+        createdAtMs: Date.UTC(2026, 5, 1, 12, 0),
+        expiresAtMs: Date.UTC(2026, 5, 8, 12, 0),
+        acceptedAtMs: null,
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <ContractorsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByLabelText("Invite history table")).toBeInTheDocument();
+    expect(screen.getByLabelText("Invite history cards")).toBeInTheDocument();
+    expect(screen.getAllByText("very.long.contractor.email@example.test").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Open invite link/i })).toHaveAttribute(
+      "href",
+      "https://example.test/invite/one"
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Resend/i })[0]);
+
+    await waitFor(() => {
+      expect(mocks.resendContractorInvite).toHaveBeenCalledWith("invite-1");
+    });
+  });
+
   it("renders a teaser state when marketplace directory access is unavailable", async () => {
     mocks.useEntitlements.mockReturnValue({
       loading: false,

--- a/rentchain-frontend/src/pages/landlord/ContractorsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/ContractorsPage.tsx
@@ -18,6 +18,7 @@ import {
 import ContractorCard from "../../components/marketplace/ContractorCard";
 import ContractorFilterBar from "../../components/marketplace/ContractorFilterBar";
 import ContractorProfileForm from "../../components/marketplace/ContractorProfileForm";
+import "./ContractorsPage.css";
 
 function formatDate(ms?: number | null) {
   if (!ms) return "-";
@@ -101,7 +102,7 @@ export default function ContractorsPage() {
   }
 
   return (
-    <div style={{ display: "grid", gap: 14 }}>
+    <div className="rc-contractors-page" style={{ display: "grid", gap: 14 }}>
       <Card>
         <div style={{ fontWeight: 700, fontSize: "1.06rem" }}>Contractor directory</div>
         <div style={{ color: "#64748b", marginTop: 4 }}>
@@ -234,7 +235,7 @@ export default function ContractorsPage() {
       {canViewMarketplaceDirectory ? (
         <Card style={{ display: "grid", gap: 10 }}>
           <div style={{ fontWeight: 600 }}>Invite contractor</div>
-          <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))" }}>
+          <div className="rc-contractors-invite-form-grid">
             <Input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="contractor@email.com" />
             <Input value={message} onChange={(e) => setMessage(e.target.value)} placeholder="Optional message" />
           </div>
@@ -272,36 +273,92 @@ export default function ContractorsPage() {
           ) : invites.length === 0 ? (
             <div style={{ color: "#64748b" }}>No invites yet.</div>
           ) : (
-            <table style={{ width: "100%", borderCollapse: "collapse" }}>
-              <thead>
-                <tr style={{ textAlign: "left", borderBottom: "1px solid #e2e8f0" }}>
-                  <th style={{ padding: 8 }}>Email</th>
-                  <th style={{ padding: 8 }}>Status</th>
-                  <th style={{ padding: 8 }}>Created</th>
-                  <th style={{ padding: 8 }}>Expires</th>
-                  <th style={{ padding: 8 }}>Accepted</th>
-                  <th style={{ padding: 8 }}>Invite Link</th>
-                  <th style={{ padding: 8 }}>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
+            <>
+              <div className="rc-contractors-invite-table-wrap" aria-label="Invite history table">
+                <table className="rc-contractors-invite-table">
+                  <thead>
+                    <tr>
+                      <th>Email</th>
+                      <th>Status</th>
+                      <th>Created</th>
+                      <th>Expires</th>
+                      <th>Accepted</th>
+                      <th>Invite Link</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {invites.map((invite) => (
+                      <tr key={invite.id}>
+                        <td>{invite.email}</td>
+                        <td>{invite.status}</td>
+                        <td>{formatDate(invite.createdAtMs)}</td>
+                        <td>{formatDate(invite.expiresAtMs || null)}</td>
+                        <td>{formatDate(invite.acceptedAtMs)}</td>
+                        <td>
+                          {invite.inviteLink ? (
+                            <a href={invite.inviteLink} target="_blank" rel="noreferrer">
+                              Open
+                            </a>
+                          ) : (
+                            "-"
+                          )}
+                        </td>
+                        <td>
+                          {invite.status !== "accepted" ? (
+                            <Button
+                              variant="ghost"
+                              onClick={async () => {
+                                try {
+                                  await resendContractorInvite(invite.id);
+                                  await load();
+                                } catch (err: any) {
+                                  setError(String(err?.message || "Failed to resend invite"));
+                                }
+                              }}
+                            >
+                              Resend
+                            </Button>
+                          ) : (
+                            "-"
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="rc-contractors-invite-cards" aria-label="Invite history cards">
                 {invites.map((invite) => (
-                  <tr key={invite.id} style={{ borderBottom: "1px solid #f1f5f9" }}>
-                    <td style={{ padding: 8 }}>{invite.email}</td>
-                    <td style={{ padding: 8 }}>{invite.status}</td>
-                    <td style={{ padding: 8 }}>{formatDate(invite.createdAtMs)}</td>
-                    <td style={{ padding: 8 }}>{formatDate(invite.expiresAtMs || null)}</td>
-                    <td style={{ padding: 8 }}>{formatDate(invite.acceptedAtMs)}</td>
-                    <td style={{ padding: 8 }}>
+                  <div className="rc-contractors-invite-card" key={invite.id}>
+                    <div>
+                      <div className="rc-contractors-invite-card-label">Email</div>
+                      <div className="rc-contractors-wrap-text">{invite.email}</div>
+                    </div>
+                    <div className="rc-contractors-invite-card-grid">
+                      <div>
+                        <div className="rc-contractors-invite-card-label">Status</div>
+                        <div>{invite.status}</div>
+                      </div>
+                      <div>
+                        <div className="rc-contractors-invite-card-label">Created</div>
+                        <div>{formatDate(invite.createdAtMs)}</div>
+                      </div>
+                      <div>
+                        <div className="rc-contractors-invite-card-label">Expires</div>
+                        <div>{formatDate(invite.expiresAtMs || null)}</div>
+                      </div>
+                      <div>
+                        <div className="rc-contractors-invite-card-label">Accepted</div>
+                        <div>{formatDate(invite.acceptedAtMs)}</div>
+                      </div>
+                    </div>
+                    <div className="rc-contractors-invite-card-actions">
                       {invite.inviteLink ? (
                         <a href={invite.inviteLink} target="_blank" rel="noreferrer">
-                          Open
+                          Open invite link
                         </a>
-                      ) : (
-                        "-"
-                      )}
-                    </td>
-                    <td style={{ padding: 8 }}>
+                      ) : null}
                       {invite.status !== "accepted" ? (
                         <Button
                           variant="ghost"
@@ -316,14 +373,12 @@ export default function ContractorsPage() {
                         >
                           Resend
                         </Button>
-                      ) : (
-                        "-"
-                      )}
-                    </td>
-                  </tr>
+                      ) : null}
+                    </div>
+                  </div>
                 ))}
-              </tbody>
-            </table>
+              </div>
+            </>
           )}
         </Card>
       ) : null}


### PR DESCRIPTION
## Summary
- Makes `/contractors` responsive at mobile/reduced widths by adding a scoped route stylesheet, mobile-safe invite-history cards, a bounded desktop invite-history table, and safer contractor text wrapping.
- Moves landlord-facing `/verified-screenings` into `LandlordNav` so the landlord mobile shell and bottom navigation are present.
- Adds a landlord-safe read-only verified-screening detail mode that uses list data and avoids raw internal/provider identifiers by default; `/admin/verified-screenings` keeps the existing admin edit/detail behavior.

## Root Cause
- `/contractors` already used the landlord shell, but dense route content and the seven-column invite-history table could force narrow layouts or horizontal overflow.
- `/verified-screenings` rendered `AdminVerifiedScreeningsPage` directly through `MacShell`, outside `LandlordNav`, so landlord mobile bottom navigation was absent.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/landlord/ContractorsPage.test.tsx src/pages/AdminVerifiedScreeningsPage.test.tsx src/components/layout/LandlordNav.test.tsx` (32 tests passed)
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` (passed; existing chunk-size warning)
- `git diff --check`
- `git diff --cached --check`

## Manual QA
- `/contractors` desktop: confirm filters, contractor cards, create/edit form, invite form, invite history, and existing actions still work.
- `/contractors` mobile/reduced desktop: confirm no horizontal overflow, contractor cards/forms are readable, invite history is readable, and landlord bottom nav/drawer remain available.
- `/verified-screenings` desktop: confirm the landlord-facing route loads in the landlord shell and does not show raw internal/provider IDs by default.
- `/verified-screenings` mobile/reduced desktop: confirm landlord bottom nav appears, queue/detail layout is readable, and no horizontal overflow occurs.
- `/admin/verified-screenings`: confirm admin route still works for admin review/editing if available.
- Regression: `/dashboard`, `/operations`, `/applications`, `/leases`, `/maintenance`.