### PR TITLE
polish: improve dashboard reduced desktop density

### DIFF
--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -487,13 +487,14 @@ describe("DashboardPage", () => {
     expect(screen.getByText("No dated schedule items are visible for this week. Upcoming dated decisions will appear here.")).toBeInTheDocument();
   });
 
-  it("collapses the primary dashboard grid on narrow viewports", async () => {
+  it("stacks the decision and upcoming-actions grid on reduced desktop widths", async () => {
     installMatchMedia(true);
 
     renderDashboard();
 
     await waitFor(() => {
-      expect(screen.getByTestId("dashboard-operational-grid")).toHaveStyle({ gridTemplateColumns: "1fr" });
+      expect(window.matchMedia).toHaveBeenCalledWith("(max-width: 1120px)");
+      expect(screen.getByTestId("dashboard-decision-layout-grid")).toHaveStyle({ gridTemplateColumns: "1fr" });
     });
   });
 });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -288,11 +288,11 @@ function isOpenMaintenanceRequest(request: { status?: unknown }): boolean {
   return !["completed", "cancelled", "canceled", "resolved", "closed"].includes(status);
 }
 
-function useNarrowDashboardLayout(): boolean {
+function useReducedDashboardLayout(): boolean {
   const [isNarrow, setIsNarrow] = React.useState(false);
 
   React.useEffect(() => {
-    const media = window.matchMedia("(max-width: 900px)");
+    const media = window.matchMedia("(max-width: 1120px)");
     const update = () => setIsNarrow(media.matches);
     update();
     media.addEventListener("change", update);
@@ -919,7 +919,7 @@ function WorkspaceRoutingSection() {
 }
 
 export default function DashboardPage() {
-  const isNarrow = useNarrowDashboardLayout();
+  const isReducedDashboardLayout = useReducedDashboardLayout();
   const [portfolio, setPortfolio] = React.useState<Loadable<LandlordPortfolioStatusFinancialResponse>>({
     data: null,
     loading: true,
@@ -1048,9 +1048,10 @@ export default function DashboardPage() {
           </div>
 
           <div
+            data-testid="dashboard-decision-layout-grid"
             style={{
               display: "grid",
-              gridTemplateColumns: isNarrow ? "1fr" : "minmax(0, 1.15fr) minmax(300px, 0.85fr)",
+              gridTemplateColumns: isReducedDashboardLayout ? "1fr" : "minmax(0, 1.15fr) minmax(300px, 0.85fr)",
               gap: spacing.lg,
               minWidth: 0,
             }}


### PR DESCRIPTION
## Summary
- raise the Dashboard decision/upcoming-actions responsive breakpoint so reduced desktop widths stack into a readable one-column flow
- add a test hook for the dashboard decision layout grid and cover the reduced-desktop behavior
- preserve the existing full desktop two-column layout and mobile path

## Validation
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/DashboardPage.test.tsx
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build
- git diff --check
- git diff --cached --check

## Manual QA Required
- /dashboard full desktop: confirm current polished appearance remains acceptable and no awkward wrapping
- /dashboard reduced desktop, approximately 821px-1180px: confirm density/readability improves, no horizontal overflow, and top landlord nav still wraps cleanly
- /dashboard mobile: confirm mobile layout and bottom nav remain unchanged
- regression routes: /operations, /applications, /leases, /maintenance, /contractors, /verified-screenings