### PR TITLE
polish: add RC1 demo back links and next actions

### DIFF
--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -483,6 +483,49 @@ button,
   gap: 14px;
 }
 
+.analytics-demo-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.analytics-demo-actions__copy {
+  display: grid;
+  gap: 3px;
+  min-width: min(100%, 320px);
+  color: #334155;
+}
+
+.analytics-demo-actions__copy strong {
+  color: #0f172a;
+}
+
+.analytics-demo-actions__copy span {
+  font-size: 0.92rem;
+}
+
+.analytics-demo-actions__links {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.analytics-demo-actions__links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0f172a;
+  font-weight: 800;
+  text-decoration: none;
+}
+
 .analytics-workspace-tabs {
   display: flex;
   gap: 8px;
@@ -580,6 +623,12 @@ button,
 
   .analytics-workspace-header__top {
     margin-bottom: 12px;
+  }
+
+  .analytics-demo-actions,
+  .analytics-demo-actions__links,
+  .analytics-demo-actions__links a {
+    width: 100%;
   }
 
   .analytics-kpi-grid,

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -161,6 +161,7 @@ describe("ApplicationReviewSummaryPage", () => {
 
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
     expect(await screen.findByText("Landlord review packet for the selected application.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to applications" })).toHaveAttribute("href", "/applications");
     expect(screen.queryByText(/Application ID:/i)).not.toBeInTheDocument();
     expect(await screen.findByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { Card, Button } from "../components/ui/Ui";
 import { colors, text } from "../styles/tokens";
 import { useEntitlements } from "@/hooks/useEntitlements";
@@ -323,7 +323,6 @@ class ReviewSummaryErrorBoundary extends React.Component<
 
 function ApplicationReviewSummaryPageBody() {
   const { id = "" } = useParams();
-  const navigate = useNavigate();
   const { showToast } = useToast();
   const entitlements = useEntitlements();
   const [loading, setLoading] = useState(true);
@@ -612,7 +611,23 @@ function ApplicationReviewSummaryPageBody() {
           </div>
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-          <Button variant="ghost" onClick={() => navigate(-1)}>Back</Button>
+          <Link
+            to="/applications"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              minHeight: 38,
+              padding: "8px 12px",
+              borderRadius: 8,
+              border: `1px solid ${colors.border}`,
+              color: text.main,
+              textDecoration: "none",
+              fontWeight: 700,
+            }}
+          >
+            Back to applications
+          </Link>
           <Button variant="secondary" onClick={() => void downloadPdf()}>Download PDF</Button>
           <Button variant="secondary" onClick={() => void copyText(shareUrl, "Share link copied")}>Copy link</Button>
           {summary?.screening?.referenceId ? (

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -142,6 +142,7 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download evidence package" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
+    expect(screen.getByRole("link", { name: "Open operations" })).toHaveAttribute("href", "/operations");
   });
 
   it("scrolls to and highlights requested lease summary workflow sections after data loads", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -169,6 +169,12 @@ export default function LandlordLeaseSummaryPage() {
         >
           Back to leases
         </Link>
+        <Link
+          to="/operations"
+          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+        >
+          Open operations
+        </Link>
       </div>
 
       {loading ? <div>Loading lease summary…</div> : null}

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -437,6 +437,8 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText(/Renewal pending/i)).toBeInTheDocument();
     expect(screen.getByText("Waiting for landlord signature")).toBeInTheDocument();
     expect(screen.getByText("Call tenant next week")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to lease summary" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByRole("link", { name: "Open operations" })).toHaveAttribute("href", "/operations");
   });
 
   it("formats ledger cents as readable dollars and cents", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -1011,6 +1011,8 @@ export default function LeaseLedgerPage() {
           ) : null}
         </div>
         <div className="lease-ledger-actions">
+          <Link to={`/leases/${encodeURIComponent(leaseId)}/summary`}>Back to lease summary</Link>
+          <Link to="/operations">Open operations</Link>
           <Link to="/leases?view=archived">View archive</Link>
           <button aria-label="Add lease note" onClick={() => setShowNoteModal(true)}>Add note</button>
           <button onClick={() => setShowChargeModal(true)}>Add charge</button>

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -538,6 +538,7 @@ describe("LandlordAnalyticsPage", () => {
     expect(screen.getByRole("tab", { name: "Predictive metrics" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Attention-worthy insights" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Portfolio-level execution state summary" })).toBeInTheDocument();
+    expect(screen.queryByText("Continue the demo flow")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Review leases/i })).toHaveAttribute("href", "/portfolio-health");
     expect(container.querySelector(".analytics-workspace-summary-grid")).toBeTruthy();
 
@@ -883,6 +884,9 @@ describe("LandlordAnalyticsPage", () => {
     );
 
     expect(await screen.findByText(/Focused from decisions: Revenue pressure/i)).toBeInTheDocument();
+    expect(screen.getByText("Continue the demo flow")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to dashboard" })).toHaveAttribute("href", "/dashboard");
+    expect(screen.getByRole("link", { name: "Open operations" })).toHaveAttribute("href", "/operations");
     expect(fetchLandlordAnalyticsSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({
         period: "90d",
@@ -902,6 +906,9 @@ describe("LandlordAnalyticsPage", () => {
     );
 
     expect(await screen.findByText(/Focused from decisions: Vacancy readiness/i)).toBeInTheDocument();
+    expect(screen.getByText("Continue the demo flow")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to dashboard" })).toHaveAttribute("href", "/dashboard");
+    expect(screen.getByRole("link", { name: "Open operations" })).toHaveAttribute("href", "/operations");
     expect(screen.getByTestId("analytics-kpi-grid")).toHaveClass("analytics-kpi-grid");
   });
 

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { fetchLandlordAnalyticsSnapshot, type AnalyticsPeriod, type LandlordAnalyticsSnapshot } from "../../api/landlordAnalyticsApi";
 import {
   fetchLandlordAnalyticsAlerts,
@@ -491,21 +491,35 @@ export default function LandlordAnalyticsPage() {
     <MacShell title="Analytics" showTopNav={false} maxWidth="min(100%, 1500px)">
       <div className="analytics-workspace-page">
         {analyticsEnabled ? (
-          <AnalyticsWorkspaceHeader
-            title="Analytics"
-            description="A calm view of portfolio health, application activity, leasing pressure, maintenance burden, and rent signals."
-            focusLabel={routedEntryLabel}
-            activeTab={activeTab}
-            tabs={ANALYTICS_WORKSPACE_TABS}
-            period={period}
-            propertyId={propertyId}
-            properties={snapshot?.properties || []}
-            disabled={loading}
-            onTabChange={setActiveTab}
-            onPeriodChange={setPeriod}
-            onPropertyChange={setPropertyId}
-            onPrint={() => void printSummaryDocument("summary")}
-          />
+          <>
+            <AnalyticsWorkspaceHeader
+              title="Analytics"
+              description="A calm view of portfolio health, application activity, leasing pressure, maintenance burden, and rent signals."
+              focusLabel={routedEntryLabel}
+              activeTab={activeTab}
+              tabs={ANALYTICS_WORKSPACE_TABS}
+              period={period}
+              propertyId={propertyId}
+              properties={snapshot?.properties || []}
+              disabled={loading}
+              onTabChange={setActiveTab}
+              onPeriodChange={setPeriod}
+              onPropertyChange={setPropertyId}
+              onPrint={() => void printSummaryDocument("summary")}
+            />
+            {routedEntryLabel ? (
+              <Card className="analytics-demo-actions no-print">
+                <div className="analytics-demo-actions__copy">
+                  <strong>Continue the demo flow</strong>
+                  <span>Return to the operational home or open the review queue after checking this signal.</span>
+                </div>
+                <div className="analytics-demo-actions__links">
+                  <Link to="/dashboard">Back to dashboard</Link>
+                  <Link to="/operations">Open operations</Link>
+                </div>
+              </Card>
+            ) : null}
+          </>
         ) : (
           <Section>
             <div style={{ display: "grid", gap: 6 }}>


### PR DESCRIPTION
## Summary
- add deterministic return access from Application Review Summary back to Applications
- add lease-context actions on Lease Ledger and Lease Summary so deep lease destinations can continue to summary, operations, or existing ledger flows
- add a focused Analytics demo-action strip for revenue-pressure and vacancy-readiness entry routes with Back to dashboard and Open operations actions

## Scope
- frontend navigation/action polish only
- no backend changes
- no route architecture changes
- no analytics, ledger, lease, or application data/model changes
- no new source-context inference or raw ID labels

## Validation
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationReviewSummaryPage.test.tsx src/pages/LeaseLedgerPage.test.tsx src/pages/LandlordLeaseSummaryPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build
- git diff --check
- git diff --cached --check

## Manual QA Required
- /applications/:applicationId/review-summary: direct load and confirm Back to applications works; Download PDF still works
- /leases/:leaseId/ledger: confirm Back to lease summary and Open operations actions are visible and route correctly; ledger actions still work
- /leases/:leaseId/summary?section=rent-payment: confirm Back to leases, Open operations, and Open payment ledger are visible and route correctly
- /analytics?entry=revenue-pressure: confirm Continue the demo flow appears with Back to dashboard and Open operations
- /analytics?entry=vacancy-readiness: same checks
- normal /analytics without entry: confirm the demo-action strip is not shown
- mobile widths for the touched routes: confirm action rows wrap cleanly with no horizontal overflow
- regression: /dashboard, /operations, /applications, /leases