### PR TITLE
polish: center lease workflow desktop container

### DIFF
--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -141,6 +141,10 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(await screen.findByRole("heading", { name: "Execution Review" })).toBeInTheDocument();
     expect(screen.getByText("Review the lease package, signature state, and document readiness before treating execution as complete.")).toBeInTheDocument();
     expect(screen.getByTestId("lease-workflow-page")).toHaveStyle({ maxWidth: "1040px" });
+    expect(screen.getByTestId("lease-workflow-page")).toHaveStyle({
+      margin: "0 auto",
+      boxSizing: "border-box",
+    });
     expect(screen.getByLabelText("Workflow overview")).toHaveStyle({
       background: "#f8fafc",
       borderRadius: "8px",

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -337,6 +337,9 @@ const buttonLinkStyle: React.CSSProperties = {
 const workflowPageStyle: React.CSSProperties = {
   width: "100%",
   maxWidth: 1040,
+  margin: "0 auto",
+  padding: "0 16px 24px",
+  boxSizing: "border-box",
   display: "grid",
   gap: 16,
 };


### PR DESCRIPTION
## Summary
- Center the shared lease workflow page container on full desktop with `margin: 0 auto`.
- Add bounded side padding and `border-box` sizing so workflow pages no longer sit tight to the left edge.
- Applies through the shared `LandlordLeaseWorkflowPage` used by renewal, execution, rent increase, notice, and deposit workflows.
- No workflow logic, data, backend, or routing changes.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/LandlordLeaseWorkflowPage.test.tsx` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` passed with the existing large-chunk warning.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Manual QA Required
- Desktop: check `/leases/:leaseId/workflows/renewal`, `/leases/:leaseId/workflows/execution`, `/leases/:leaseId/workflows/rent-increase`, `/leases/:leaseId/workflows/notice`, and `/leases/:leaseId/workflows/deposit`; confirm content is centered, not pressed to the left edge, and remains readable.
- Reduced desktop: confirm current acceptable behavior is preserved.
- Mobile: confirm current readable behavior is preserved and there is no horizontal overflow.
- Regression: confirm `/leases`, `/dashboard`, `/operations`, and `/applications` load normally.