### PR TITLE
fix: complete application review summary context

### DIFF
--- a/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
+++ b/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
@@ -135,4 +135,34 @@ describe("review summary export contract", () => {
     expect(rendered).not.toContain("Application ID");
     expect(rendered).not.toContain("Screening reference");
   });
+
+  it("does not use raw ID-shaped context values as property or unit labels", () => {
+    const rawUnitId = "ixcRcv8tTgz0lKvDRw66";
+    const rawPropertyId = "prpRcv8tTgz0lKvDRw66";
+    const summary = buildReviewSummary("raw-app-id-456", {
+      status: "SUBMITTED",
+      propertyName: rawPropertyId,
+      unitApplied: rawUnitId,
+      requestedRent: null,
+      applicant: {
+        firstName: "Phil",
+        lastName: "Jones",
+      },
+    });
+
+    const applicationContext = buildReviewSummaryPdfSections(summary).find(
+      (section) => section.title === "Application Context"
+    );
+
+    expect(applicationContext?.rows).toEqual(
+      expect.arrayContaining([
+        { label: "Property", value: "Not provided" },
+        { label: "Unit", value: "Not provided" },
+        { label: "Requested rent", value: "Not provided" },
+      ])
+    );
+    expect(JSON.stringify(applicationContext)).not.toContain(rawUnitId);
+    expect(JSON.stringify(applicationContext)).not.toContain(rawPropertyId);
+    expect(JSON.stringify(applicationContext)).not.toContain("raw-app-id-456");
+  });
 });

--- a/rentchain-api/src/lib/reviewSummary.ts
+++ b/rentchain-api/src/lib/reviewSummary.ts
@@ -130,14 +130,33 @@ function stringOrNull(value: unknown): string | null {
   return raw ? raw : null;
 }
 
+function looksLikeInternalId(value: string): boolean {
+  const raw = value.trim();
+  if (/^(app|application|lease|property|prop|tenant|unit)[-_][A-Za-z0-9_-]+$/i.test(raw)) return true;
+  if (!/^[A-Za-z0-9_-]{16,}$/.test(raw)) return false;
+  return /[a-z]/.test(raw) && /[A-Z]/.test(raw) && /\d/.test(raw);
+}
+
+function safeContextLabel(value: unknown): string | null {
+  const raw = stringOrNull(value);
+  if (!raw || looksLikeInternalId(raw)) return null;
+  return raw;
+}
+
 function numberOrNull(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }
 
+function positiveCentsOrNull(value: unknown): number | null {
+  const cents = numberOrNull(value);
+  return cents != null && cents > 0 ? cents : null;
+}
+
 function amountToCents(value: unknown): number | null {
+  if (value == null || String(value).trim() === "") return null;
   const amount = numberOrNull(value);
-  if (amount == null) return null;
+  if (amount == null || amount <= 0) return null;
   return Math.round(amount * 100);
 }
 
@@ -276,13 +295,31 @@ export function buildReviewSummary(applicationId: string, application: any): Rev
     application: {
       status: stringOrNull(application?.status),
       submittedAt: toIso(application?.submittedAt || application?.createdAt),
-      propertyName: stringOrNull(application?.propertyName),
-      unitLabel: stringOrNull(application?.unitApplied || application?.unit || application?.unitLabel),
+      propertyName: safeContextLabel(
+        application?.propertyName ||
+          application?.property?.name ||
+          application?.propertyAddress ||
+          application?.address
+      ),
+      unitLabel: safeContextLabel(
+        application?.unitLabel ||
+          application?.unitName ||
+          application?.unitNumber ||
+          application?.unitApplied ||
+          application?.unit
+      ),
       leaseStartDate: toIso(application?.leaseStartDate || application?.moveInDate),
       requestedRentAmountCents:
-        numberOrNull(application?.requestedRentAmountCents) ??
-        numberOrNull(application?.requestedRentCents) ??
-        amountToCents(application?.requestedRent),
+        positiveCentsOrNull(application?.requestedRentAmountCents) ??
+        positiveCentsOrNull(application?.requestedRentCents) ??
+        positiveCentsOrNull(application?.monthlyRentAmountCents) ??
+        positiveCentsOrNull(application?.monthlyRentCents) ??
+        positiveCentsOrNull(application?.rentAmountCents) ??
+        positiveCentsOrNull(application?.rentCents) ??
+        amountToCents(application?.requestedRent) ??
+        amountToCents(application?.monthlyRent) ??
+        amountToCents(application?.rentAmount) ??
+        amountToCents(application?.rent),
       moveInDate: toIso(application?.moveInDate),
     },
     applicant: {

--- a/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
@@ -373,10 +373,100 @@ describe("rentalApplications review summary risk surface", () => {
     expect(res.body?.risk ?? null).toBeNull();
   });
 
+  it("hydrates review-summary context with landlord-safe property and unit labels", async () => {
+    getLatestApplicationRiskMock.mockResolvedValue(null);
+    const reviewSummary = await import("../../lib/reviewSummary");
+    vi.mocked(reviewSummary.buildReviewSummary).mockClear();
+    upsertDoc("properties", "property-1", {
+      landlordId: "landlord-1",
+      name: "Kentville Suites",
+      addressLine1: "8282 Kentella",
+    });
+    upsertDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "105",
+    });
+    upsertDoc("rentalApplications", "app-1", {
+      id: "app-1",
+      landlordId: "landlord-1",
+      status: "SUBMITTED",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      unitApplied: "unit-1",
+      leaseStartDate: "2026-09-01",
+      requestedRent: 1500,
+    });
+
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/rental-applications/app-1/review-summary")
+      .set("Authorization", "Bearer landlord");
+
+    expect(res.status).toBe(200);
+    expect(reviewSummary.buildReviewSummary).toHaveBeenCalledWith(
+      "app-1",
+      expect.objectContaining({
+        propertyName: "Kentville Suites",
+        unitLabel: "105",
+        leaseStartDate: "2026-09-01",
+        requestedRentAmountCents: 150000,
+      })
+    );
+  });
+
+  it("does not fall back to raw property or unit identifiers when safe labels are unavailable", async () => {
+    getLatestApplicationRiskMock.mockResolvedValue(null);
+    const reviewSummary = await import("../../lib/reviewSummary");
+    vi.mocked(reviewSummary.buildReviewSummary).mockClear();
+    const rawPropertyId = "prpRcv8tTgz0lKvDRw66";
+    const rawUnitId = "ixcRcv8tTgz0lKvDRw66";
+    upsertDoc("rentalApplications", "app-1", {
+      id: "app-1",
+      landlordId: "landlord-1",
+      status: "SUBMITTED",
+      propertyId: rawPropertyId,
+      unitId: rawUnitId,
+      unitApplied: rawUnitId,
+    });
+
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/rental-applications/app-1/review-summary")
+      .set("Authorization", "Bearer landlord");
+
+    expect(res.status).toBe(200);
+    const hydratedApplication = vi.mocked(reviewSummary.buildReviewSummary).mock.calls[0]?.[1] || {};
+    expect(hydratedApplication.propertyName).toBeNull();
+    expect(hydratedApplication.unitLabel).toBeNull();
+    expect(hydratedApplication.propertyName).not.toBe(rawPropertyId);
+    expect(hydratedApplication.unitLabel).not.toBe(rawUnitId);
+  });
+
   it("passes decision context to the review-summary PDF export", async () => {
     getLatestApplicationRiskMock.mockResolvedValue(null);
     const reviewSummary = await import("../../lib/reviewSummary");
+    vi.mocked(reviewSummary.buildReviewSummary).mockClear();
     vi.mocked(reviewSummary.buildReviewSummaryPdf).mockResolvedValue(Buffer.from("%PDF-1.4"));
+    upsertDoc("properties", "property-1", {
+      landlordId: "landlord-1",
+      name: "Kentville Suites",
+    });
+    upsertDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "105",
+    });
+    upsertDoc("rentalApplications", "app-1", {
+      id: "app-1",
+      landlordId: "landlord-1",
+      status: "SUBMITTED",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      unitApplied: "unit-1",
+      leaseStartDate: "2026-09-01",
+      requestedRentAmountCents: 150000,
+    });
     const previousBucket = process.env.GCS_UPLOAD_BUCKET;
     delete process.env.GCS_UPLOAD_BUCKET;
 
@@ -388,6 +478,15 @@ describe("rentalApplications review summary risk surface", () => {
 
       expect(res.status).toBe(200);
       expect(res.headers["content-type"]).toContain("application/pdf");
+      expect(reviewSummary.buildReviewSummary).toHaveBeenCalledWith(
+        "app-1",
+        expect.objectContaining({
+          propertyName: "Kentville Suites",
+          unitLabel: "105",
+          leaseStartDate: "2026-09-01",
+          requestedRentAmountCents: 150000,
+        })
+      );
       expect(reviewSummary.buildReviewSummaryPdf).toHaveBeenCalledWith(
         expect.objectContaining({ applicationId: "app-1" }),
         {

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -283,6 +283,96 @@ async function hydrateApplicationDisplayContext(application: any) {
   return next;
 }
 
+function safeReviewContextText(value: unknown): string | null {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  if (/^(app|application|lease|property|prop|tenant|unit)[-_][A-Za-z0-9_-]+$/i.test(raw)) return null;
+  if (/^[A-Za-z0-9_-]{16,}$/.test(raw) && /[a-z]/.test(raw) && /[A-Z]/.test(raw) && /\d/.test(raw)) {
+    return null;
+  }
+  return raw;
+}
+
+function firstSafeReviewContextText(...values: unknown[]): string | null {
+  for (const value of values) {
+    const safe = safeReviewContextText(value);
+    if (safe) return safe;
+  }
+  return null;
+}
+
+function reviewSummaryRentCents(application: any): number | null {
+  return (
+    centsFromValue(application?.requestedRentAmountCents) ||
+    centsFromValue(application?.requestedRentCents) ||
+    centsFromValue(application?.monthlyRentAmountCents) ||
+    centsFromValue(application?.monthlyRentCents) ||
+    centsFromValue(application?.rentAmountCents) ||
+    centsFromValue(application?.rentCents) ||
+    centsFromValue(application?.requestedRent) ||
+    centsFromValue(application?.monthlyRent) ||
+    centsFromValue(application?.rentAmount) ||
+    centsFromValue(application?.rent)
+  );
+}
+
+async function hydrateReviewSummaryApplicationContext(application: any) {
+  const next = { ...(application || {}) };
+  const applicationLandlordId = String(next.landlordId || "").trim();
+  const propertyId = String(next.propertyId || "").trim();
+  const unitReference = String(next.unitId || next.unitApplied || next.unit || "").trim();
+
+  next.propertyName = firstSafeReviewContextText(
+    next.propertyName,
+    next.property?.name,
+    next.propertyAddress,
+    next.address
+  );
+  next.unitLabel =
+    firstSafeReviewContextText(next.unitLabel, next.unitName, next.unitNumber) ||
+    (!next.unitId ? firstSafeReviewContextText(next.unitApplied, next.unit) : null);
+
+  if (!next.propertyName && propertyId) {
+    try {
+      const propSnap = await db.collection("properties").doc(propertyId).get();
+      if (propSnap.exists) {
+        const prop = propSnap.data() as any;
+        const propLandlordId = String(prop?.landlordId || "").trim();
+        if (!applicationLandlordId || !propLandlordId || propLandlordId === applicationLandlordId) {
+          next.propertyName = firstSafeReviewContextText(prop?.name, prop?.addressLine1, prop?.address);
+        }
+      }
+    } catch {
+      // best-effort display context only
+    }
+  }
+
+  if (!next.unitLabel && unitReference) {
+    try {
+      const unitSnap = await db.collection("units").doc(unitReference).get();
+      if (unitSnap.exists) {
+        const unit = unitSnap.data() as any;
+        const unitLandlordId = String(unit?.landlordId || "").trim();
+        const unitPropertyId = String(unit?.propertyId || "").trim();
+        const landlordMatches = !applicationLandlordId || !unitLandlordId || unitLandlordId === applicationLandlordId;
+        const propertyMatches = !propertyId || !unitPropertyId || unitPropertyId === propertyId;
+        if (landlordMatches && propertyMatches) {
+          next.unitLabel = firstSafeReviewContextText(unit?.unitNumber, unit?.name, unit?.label);
+        }
+      }
+    } catch {
+      // best-effort display context only
+    }
+  }
+
+  const rentCents = reviewSummaryRentCents(next);
+  if (rentCents != null) {
+    next.requestedRentAmountCents = rentCents;
+  }
+
+  return next;
+}
+
 async function sendRentalApplicationDecisionEmail(params: {
   action: (typeof APPLICATION_DECISION_ACTIONS)[number];
   application: any;
@@ -4223,7 +4313,8 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
         error: access.error,
       });
     }
-    const summary = buildReviewSummary(id, access.data);
+    const summaryApplication = await hydrateReviewSummaryApplicationContext(access.data);
+    const summary = buildReviewSummary(id, summaryApplication);
     const [risk, tenantIdentitySummary] = await Promise.all([
       getLatestApplicationRisk({ applicationId: id }),
       loadLandlordSafeTenantIdentitySummary({ applicationId: id, application: access.data }),
@@ -4326,7 +4417,7 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
     });
     const decisionSummary = buildApplicationDecisionSummary({
       applicationId: id,
-      application: access.data,
+      application: summaryApplication,
       reviewSummary: summary,
     });
     const networkReuseSummary = deriveNetworkReuseSummary({
@@ -4371,10 +4462,11 @@ router.get("/rental-applications/:id/review-summary.pdf", async (req: any, res) 
         error: access.error,
       });
     }
-    const summary = buildReviewSummary(id, access.data);
+    const summaryApplication = await hydrateReviewSummaryApplicationContext(access.data);
+    const summary = buildReviewSummary(id, summaryApplication);
     const decisionSummary = buildApplicationDecisionSummary({
       applicationId: id,
-      application: access.data,
+      application: summaryApplication,
       reviewSummary: summary,
     });
     const pdfBuffer = await buildReviewSummaryPdf(summary, { decisionSummary });

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -4,6 +4,15 @@ import type { ApplicationDecisionSummary, RiskAgentReviewSnapshot } from "@/type
 type ReviewSummaryCore = {
   applicationId: string;
   generatedAt: string;
+  application: {
+    status: string | null;
+    submittedAt: string | null;
+    propertyName: string | null;
+    unitLabel: string | null;
+    leaseStartDate: string | null;
+    requestedRentAmountCents: number | null;
+    moveInDate: string | null;
+  };
   applicant: {
     name: string | null;
     email: string | null;

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -70,6 +70,15 @@ describe("ApplicationReviewSummaryPage", () => {
     vi.mocked(fetchReviewSummary).mockResolvedValue({
       applicationId: "app-1",
       generatedAt: "2026-04-01T00:00:00.000Z",
+      application: {
+        status: "SUBMITTED",
+        submittedAt: "2026-04-01T10:00:00.000Z",
+        propertyName: "Kentville Suites",
+        unitLabel: "Unit 105",
+        leaseStartDate: "2026-09-01T00:00:00.000Z",
+        requestedRentAmountCents: 150000,
+        moveInDate: "2026-09-01T00:00:00.000Z",
+      },
       applicant: {
         name: "Jane Applicant",
         email: "jane@example.com",
@@ -164,6 +173,13 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(screen.getByRole("link", { name: "Back to applications" })).toHaveAttribute("href", "/applications");
     expect(screen.queryByText(/Application ID:/i)).not.toBeInTheDocument();
     expect(await screen.findByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
+    expect(await screen.findByText("Application Context")).toBeInTheDocument();
+    expect(await screen.findByText("Kentville Suites")).toBeInTheDocument();
+    expect(await screen.findByText("Unit 105")).toBeInTheDocument();
+    expect(screen.getByText(/CA\$1,500/)).toBeInTheDocument();
+    expect(screen.queryByText("ixcRcv8tTgz0lKvDRw66")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy reference ID" })).not.toBeInTheDocument();
+    expect(screen.queryByText("TU-1")).not.toBeInTheDocument();
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
     expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
     expect(await screen.findByText("Recent activity")).toBeInTheDocument();
@@ -231,6 +247,8 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: "Screening" }));
+    expect(screen.queryByText("Reference ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("TU-1")).not.toBeInTheDocument();
     expect(await screen.findByText("Trust guidance")).toBeInTheDocument();
     expect(await screen.findByText("Credibility summary")).toBeInTheDocument();
     expect(await screen.findByText("Credibility established")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -57,6 +57,12 @@ function dateOr(value: string | null | undefined): string {
   return Number.isNaN(parsed.getTime()) ? "Not provided" : parsed.toLocaleString();
 }
 
+function dateOnlyOr(value: string | null | undefined): string {
+  if (!value) return "Not provided";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? "Not provided" : parsed.toLocaleDateString();
+}
+
 function ratio(value: number | null): string {
   if (value == null || !Number.isFinite(value)) return "Not provided";
   return `${value.toFixed(2)}x`;
@@ -630,14 +636,6 @@ function ApplicationReviewSummaryPageBody() {
           </Link>
           <Button variant="secondary" onClick={() => void downloadPdf()}>Download PDF</Button>
           <Button variant="secondary" onClick={() => void copyText(shareUrl, "Share link copied")}>Copy link</Button>
-          {summary?.screening?.referenceId ? (
-            <Button
-              variant="secondary"
-              onClick={() => void copyText(summary.screening.referenceId || "", "Reference ID copied")}
-            >
-              Copy reference ID
-            </Button>
-          ) : null}
         </div>
       </div>
 
@@ -712,6 +710,23 @@ function ApplicationReviewSummaryPageBody() {
               aria-labelledby="review-summary-tab-overview"
               style={{ display: "grid", gap: 12 }}
             >
+          <Card style={{ display: "grid", gap: 12 }}>
+            <div>
+              <div style={{ fontWeight: 700 }}>Application Context</div>
+              <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                Landlord-safe property, unit, lease, and rent context available for this application.
+              </div>
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 8 }}>
+              {kv("Status", summary.application?.status || "Not provided")}
+              {kv("Submitted", dateOr(summary.application?.submittedAt))}
+              {kv("Property", summary.application?.propertyName || "Not provided")}
+              {kv("Unit", summary.application?.unitLabel || "Not provided")}
+              {kv("Lease start", dateOnlyOr(summary.application?.leaseStartDate))}
+              {kv("Requested rent", money(summary.application?.requestedRentAmountCents ?? null))}
+            </div>
+          </Card>
+
           {intakeView ? (
             <Card style={{ display: "grid", gap: 12 }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
@@ -1869,7 +1884,6 @@ function ApplicationReviewSummaryPageBody() {
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
               {kv("Screening status", summary.screening.status || "not_run")}
               {kv("Screening provider", summary.screening.provider || "Not provided")}
-              {kv("Reference ID", summary.screening.referenceId || "Not provided")}
               {kv(
                 "Completeness",
                 `${summary.derived.completeness.label} (${Math.round(summary.derived.completeness.score * 100)}%)`


### PR DESCRIPTION
## Summary
- Hydrate Application Review Summary JSON and PDF generation with landlord-safe property/unit display context before building the shared summary.
- Extend review-summary context mapping to use safe property/unit aliases, lease start, and positive requested-rent values when available.
- Add an Application Context card to the browser review-summary overview so the page and PDF expose the same safe context.
- Remove the visible/copyable screening reference ID from the review-summary page and keep provider/internal IDs out of the PDF context.

## Root cause
The review-summary endpoints built from the raw rental application document. If the application had only `propertyId`/`unitId` plus safe labels available in related property/unit records, the shared summary builder received no safe display context and emitted `Not provided`. The browser page also did not render the `summary.application` context at all.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/lib/__tests__/reviewSummary.test.ts src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationReviewSummaryPage.test.tsx` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` passed in `rentchain-api`.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` passed in `rentchain-frontend` with the existing large-chunk warning.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Manual QA Required
1. `/applications/ixcRcv8tTgz0lKvDRw66/review-summary`
   - Confirm Application Context is populated where safe property/unit/lease/rent values exist.
   - Confirm truly missing values still show `Not provided`.
   - Confirm no raw application/property/unit/tenant/provider/internal IDs are visible.
   - Confirm `Back to applications` still works.
   - Confirm `Download PDF` still works.

2. Downloaded PDF
   - Confirm Application Context displays safe property/unit/lease/rent values where available.
   - Confirm applicant, employment, screening, risk, notes, flags, and insights sections remain present.
   - Confirm no raw IDs or screening references are visible.

3. Regression
   - `/applications`
   - `/dashboard`
   - `/leases`
   - `/analytics`