### PR TITLE
fix: make application review summary guidance status-aware

### DIFF
--- a/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
+++ b/rentchain-api/src/lib/__tests__/reviewSummary.test.ts
@@ -127,6 +127,7 @@ describe("review summary export contract", () => {
     const rendered = JSON.stringify(sections);
     expect(rendered).toContain("Harbour View");
     expect(rendered).toContain("Unit 203");
+    expect(rendered).toContain("Screening complete");
     expect(rendered).toContain("One child");
     expect(rendered).toContain("Stable employment");
     expect(rendered).toContain("Call references before approval.");
@@ -164,5 +165,34 @@ describe("review summary export contract", () => {
     expect(JSON.stringify(applicationContext)).not.toContain(rawUnitId);
     expect(JSON.stringify(applicationContext)).not.toContain(rawPropertyId);
     expect(JSON.stringify(applicationContext)).not.toContain("raw-app-id-456");
+  });
+
+  it("renders landlord-facing screening labels without raw provider implementation details", () => {
+    const summary = buildReviewSummary("raw-app-id-789", {
+      status: "APPROVED",
+      screeningStatus: "not_requested",
+      screeningProvider: "STUB",
+      applicant: {
+        firstName: "Phil",
+        lastName: "Jones",
+      },
+    });
+
+    const sections = buildReviewSummaryPdfSections(summary);
+    const screeningSection = sections.find((section) => section.title === "Screening & Deterministic Signals");
+    const rendered = JSON.stringify(sections);
+
+    expect(summary.screening.status).toBe("not_requested");
+    expect(summary.screening.statusLabel).toBe("Screening not requested");
+    expect(summary.screening.providerLabel).toBeNull();
+    expect(screeningSection?.rows).toEqual(
+      expect.arrayContaining([
+        { label: "Screening status", value: "Screening not requested" },
+        { label: "Screening provider", value: "Not provided" },
+      ])
+    );
+    expect(rendered).not.toContain("not_requested");
+    expect(rendered).not.toContain("STUB");
+    expect(rendered).not.toContain("raw-app-id-789");
   });
 });

--- a/rentchain-api/src/lib/reviewSummary.ts
+++ b/rentchain-api/src/lib/reviewSummary.ts
@@ -43,7 +43,9 @@ export type ReviewSummary = {
   };
   screening: {
     status: string;
+    statusLabel: string;
     provider: string | null;
+    providerLabel: string | null;
     referenceId: string | null;
   };
   coApplicant: {
@@ -107,6 +109,7 @@ export type ReviewSummaryPdfDecisionContext = {
   screeningSummary?: {
     available?: boolean;
     provider?: string | null;
+    providerLabel?: string | null;
     completedAt?: string | null;
     highlights?: string[];
   } | null;
@@ -211,6 +214,34 @@ function screeningStatus(raw: unknown): string {
   return value;
 }
 
+function screeningStatusLabel(raw: unknown): string {
+  const value = screeningStatus(raw);
+  if (["complete", "completed"].includes(value)) return "Screening complete";
+  if (["not_requested", "not_run", "not_started"].includes(value)) return "Screening not requested";
+  if (["processing", "external_pending", "requested", "in_progress", "provider_pending"].includes(value)) {
+    return "Screening in progress";
+  }
+  if (value === "paid") return "Screening paid; result pending";
+  if (value === "unpaid") return "Screening not started";
+  if (value === "ineligible") return "Screening unavailable";
+  if (["failed", "cancelled"].includes(value)) return value === "failed" ? "Screening failed" : "Screening cancelled";
+  return value
+    .split(/[\s_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function screeningProviderLabel(raw: unknown): string | null {
+  const value = stringOrNull(raw);
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (["stub", "stubbed_screening", "mock", "test"].includes(normalized)) return null;
+  if (normalized === "transunion_referral" || normalized === "transunion_manual") return "TransUnion";
+  if (normalized === "manual") return "Manual review";
+  return value;
+}
+
 function buildInsights(summary: Omit<ReviewSummary, "insights">): string[] {
   const insights: string[] = [];
   insights.push(`Application completeness: ${summary.derived.completeness.label}`);
@@ -224,8 +255,8 @@ function buildInsights(summary: Omit<ReviewSummary, "insights">): string[] {
     insights.push(`Time at current job: ${summary.employment.monthsAtJob} months`);
   }
   if (summary.screening.status && summary.screening.status !== "not_run") {
-    const provider = summary.screening.provider || "Provider unavailable";
-    insights.push(`Screening status: ${summary.screening.status} (${provider})`);
+    const provider = summary.screening.providerLabel || "Provider unavailable";
+    insights.push(`Screening status: ${summary.screening.statusLabel} (${provider})`);
   }
   if (summary.derived.flags.length) {
     const missing = summary.derived.flags
@@ -353,7 +384,9 @@ export function buildReviewSummary(applicationId: string, application: any): Rev
     },
     screening: {
       status: screeningStatus(application?.screeningStatus || screening?.status),
+      statusLabel: screeningStatusLabel(application?.screeningStatus || screening?.status),
       provider: stringOrNull(application?.screeningProvider || screening?.provider),
+      providerLabel: screeningProviderLabel(application?.screeningProvider || screening?.provider),
       referenceId: stringOrNull(screening?.orderId || application?.screeningSessionId || application?.screeningResultId),
     },
     coApplicant: {
@@ -564,8 +597,8 @@ export function buildReviewSummaryPdfSections(
           label: "Completeness",
           value: `${summary.derived.completeness.label} (${Math.round(summary.derived.completeness.score * 100)}%)`,
         },
-        { label: "Screening status", value: summary.screening.status || "not_run" },
-        { label: "Screening provider", value: summary.screening.provider || "Not provided" },
+        { label: "Screening status", value: summary.screening.statusLabel || "Screening not requested" },
+        { label: "Screening provider", value: summary.screening.providerLabel || "Not provided" },
         { label: "Screening recommendation", value: decision?.screeningRecommendation?.reason || "Not provided" },
         {
           label: "Screening highlights",

--- a/rentchain-api/src/services/__tests__/applicationDecisionSummary.test.ts
+++ b/rentchain-api/src/services/__tests__/applicationDecisionSummary.test.ts
@@ -143,6 +143,51 @@ describe("buildApplicationDecisionSummary", () => {
     expect(result.decisionSupport?.summaryLine).toContain("Screening is available");
   });
 
+  it("uses retrospective decision guidance for approved applications without completed screening", () => {
+    const application = buildApplication({
+      status: "APPROVED",
+      screeningStatus: "not_requested",
+      screeningProvider: "STUB",
+      screening: { requested: false, status: "NOT_REQUESTED" },
+      applicantProfile: {
+        currentAddress: {
+          line1: "123 King St",
+          city: "Halifax",
+          provinceState: "NS",
+          postalCode: "B3H1A1",
+          country: "CA",
+        },
+        timeAtCurrentAddressMonths: 18,
+        currentRentAmountCents: 180000,
+        employment: {
+          employerName: "",
+          jobTitle: "",
+          incomeAmountCents: null,
+          incomeFrequency: null,
+          monthsAtJob: null,
+        },
+        workReference: { name: "", phone: "" },
+        signature: { signedAt: null },
+      },
+    });
+
+    const reviewSummary = buildReviewSummary("app-approved", application);
+    const result = buildApplicationDecisionSummary({
+      applicationId: "app-approved",
+      application,
+      reviewSummary,
+    });
+
+    expect(result.status).toBe("APPROVED");
+    expect(result.screeningRecommendation?.recommended).toBe(false);
+    expect(result.screeningRecommendation?.reason).toContain("approved without a completed third-party screening");
+    expect(result.screeningSummary?.provider).toBe("STUB");
+    expect(result.screeningSummary?.providerLabel).toBeNull();
+    expect(result.decisionSupport?.summaryLine).toContain("Application is approved");
+    expect(result.decisionSupport?.nextBestAction).not.toContain("Complete screening before deciding");
+    expect(result.decisionSupport?.nextBestAction).toContain("decision was made without completed third-party screening");
+  });
+
   it("adds an active lease conflict risk when lease end date is more than two months away and landlord is not aware", () => {
     const futureDate = new Date();
     futureDate.setMonth(futureDate.getMonth() + 4);

--- a/rentchain-api/src/services/risk/applicationDecisionSummary.ts
+++ b/rentchain-api/src/services/risk/applicationDecisionSummary.ts
@@ -23,6 +23,7 @@ export type ApplicationDecisionSummary = {
   screeningSummary?: {
     available: boolean;
     provider?: string | null;
+    providerLabel?: string | null;
     completedAt?: string | null;
     highlights?: string[];
   } | null;
@@ -52,6 +53,28 @@ function titleCase(value: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function normalizedStatus(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function isApprovedStatus(value: unknown) {
+  return ["approved", "accepted"].includes(normalizedStatus(value));
+}
+
+function isDeniedStatus(value: unknown) {
+  return ["denied", "rejected", "declined"].includes(normalizedStatus(value));
+}
+
+function screeningProviderLabel(raw: unknown): string | null {
+  const value = String(raw ?? "").trim();
+  if (!value) return null;
+  const normalized = value.toLowerCase();
+  if (["stub", "stubbed_screening", "mock", "test"].includes(normalized)) return null;
+  if (normalized === "transunion_referral" || normalized === "transunion_manual") return "TransUnion";
+  if (normalized === "manual") return "Manual review";
+  return value;
 }
 
 function asIsoOrNull(value: unknown): string | null {
@@ -230,8 +253,23 @@ function buildReferenceQuestions(reviewSummary: ReviewSummary, riskInsights: Non
 }
 
 function buildScreeningRecommendation(application: any, reviewSummary: ReviewSummary, riskInsights: NonNullable<ApplicationDecisionRiskInsights>) {
-  const screeningStatus = String(application?.screeningStatus || application?.screening?.status || "").trim().toLowerCase();
-  if (screeningStatus === "complete") {
+  const applicationStatus = application?.status;
+  const screeningStatus = normalizedStatus(application?.screeningStatus || application?.screening?.status);
+  if (isApprovedStatus(applicationStatus) && !["complete", "completed"].includes(screeningStatus)) {
+    return {
+      recommended: false,
+      reason: "Application was approved without a completed third-party screening package.",
+      priority: "low" as const,
+    };
+  }
+  if (isDeniedStatus(applicationStatus) && !["complete", "completed"].includes(screeningStatus)) {
+    return {
+      recommended: false,
+      reason: "Application was closed without a completed third-party screening package.",
+      priority: "low" as const,
+    };
+  }
+  if (["complete", "completed"].includes(screeningStatus)) {
     return {
       recommended: false,
       reason: "Screening is already complete and can be reviewed alongside references.",
@@ -285,6 +323,7 @@ function buildScreeningSummary(application: any) {
   return {
     available,
     provider: application?.screeningProvider || application?.screening?.provider || null,
+    providerLabel: screeningProviderLabel(application?.screeningProvider || application?.screening?.provider),
     completedAt: asIsoOrNull(application?.screeningCompletedAt || application?.screening?.paidAt),
     highlights,
   };
@@ -294,8 +333,33 @@ function buildDecisionSupport(
   reviewSummary: ReviewSummary,
   screeningRecommendation: NonNullable<ApplicationDecisionSummary["screeningRecommendation"]>,
   screeningSummary: NonNullable<ApplicationDecisionSummary["screeningSummary"]>,
-  riskInsights: NonNullable<ApplicationDecisionRiskInsights>
+  riskInsights: NonNullable<ApplicationDecisionRiskInsights>,
+  applicationStatus?: string | null
 ) {
+  if (isApprovedStatus(applicationStatus)) {
+    if (screeningSummary.available) {
+      return {
+        summaryLine: "Application is approved. Screening was available as part of the review context.",
+        nextBestAction: "Use the approved application summary and supporting records for lease preparation.",
+      };
+    }
+    return {
+      summaryLine: "Application is approved. No completed third-party screening package is recorded in this review summary.",
+      nextBestAction: "Use the approved application summary and note that the decision was made without completed third-party screening.",
+    };
+  }
+  if (isDeniedStatus(applicationStatus)) {
+    if (screeningSummary.available) {
+      return {
+        summaryLine: "Application is closed. Screening was available as part of the recorded review context.",
+        nextBestAction: "Keep the completed review summary with the closed application record.",
+      };
+    }
+    return {
+      summaryLine: "Application is closed. No completed third-party screening package is recorded in this review summary.",
+      nextBestAction: "Keep the decision context with the closed application record.",
+    };
+  }
   if (screeningSummary.available) {
     return {
       summaryLine: "Screening is available. Use it with the current application signals and references to complete review.",
@@ -337,7 +401,13 @@ export function buildApplicationDecisionSummary(params: {
   const referenceQuestions = buildReferenceQuestions(reviewSummary, riskInsights);
   const screeningRecommendation = buildScreeningRecommendation(application, reviewSummary, riskInsights);
   const screeningSummary = buildScreeningSummary(application);
-  const decisionSupport = buildDecisionSupport(reviewSummary, screeningRecommendation, screeningSummary, riskInsights);
+  const decisionSupport = buildDecisionSupport(
+    reviewSummary,
+    screeningRecommendation,
+    screeningSummary,
+    riskInsights,
+    application?.status
+  );
 
   return {
     applicationId,

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -44,7 +44,9 @@ type ReviewSummaryCore = {
   };
   screening: {
     status: string;
+    statusLabel?: string | null;
     provider: string | null;
+    providerLabel?: string | null;
     referenceId: string | null;
   };
   derived: {

--- a/rentchain-frontend/src/components/applications/ApplicationDecisionSummaryCard.tsx
+++ b/rentchain-frontend/src/components/applications/ApplicationDecisionSummaryCard.tsx
@@ -41,6 +41,14 @@ function priorityTone(priority?: string | null) {
   }
 }
 
+function providerDisplayLabel(provider?: string | null, providerLabel?: string | null) {
+  if (providerLabel) return providerLabel;
+  const raw = String(provider || "").trim();
+  if (!raw) return "Provider unavailable";
+  if (["stub", "stubbed_screening", "mock", "test"].includes(raw.toLowerCase())) return "Provider unavailable";
+  return raw;
+}
+
 const PillList: React.FC<{ items: string[]; emptyLabel: string }> = ({ items, emptyLabel }) => {
   if (!items.length) {
     return <div style={{ color: text.subtle, fontSize: 12 }}>{emptyLabel}</div>;
@@ -189,7 +197,7 @@ export const ApplicationDecisionSummaryCard: React.FC<ApplicationDecisionSummary
             {screeningSummary?.available ? (
               <div style={{ display: "grid", gap: 6, color: text.secondary, fontSize: 12 }}>
                 <div>
-                  Screening summary: {screeningSummary.provider || "Provider unavailable"}
+                  Screening summary: {providerDisplayLabel(screeningSummary.provider, screeningSummary.providerLabel)}
                   {formatWhen(screeningSummary.completedAt) ? ` · completed ${formatWhen(screeningSummary.completedAt)}` : ""}
                 </div>
                 <PillList items={screeningSummary.highlights || []} emptyLabel="No screening highlights available yet." />

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -259,6 +259,103 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText(/Recommended next action: Review application/i)).toBeInTheDocument();
   });
 
+  it("shows landlord-facing screening labels without raw provider implementation details", async () => {
+    const { useEntitlements } = await import("@/hooks/useEntitlements");
+    const { fetchReviewSummary } = await import("../api/reviewSummaryApi");
+
+    vi.mocked(useEntitlements).mockReturnValue({
+      canViewReviewSummary: true,
+      canExportPdf: true,
+    } as any);
+    vi.mocked(fetchReviewSummary).mockResolvedValue({
+      applicationId: "app-1",
+      generatedAt: "2026-04-01T00:00:00.000Z",
+      application: {
+        status: "APPROVED",
+        submittedAt: "2026-04-01T10:00:00.000Z",
+        propertyName: "Kentville Suites",
+        unitLabel: "Unit 105",
+        leaseStartDate: null,
+        requestedRentAmountCents: null,
+        moveInDate: null,
+      },
+      applicant: {
+        name: "Jane Applicant",
+        email: "jane@example.com",
+        currentAddressLine: null,
+        city: null,
+        provinceState: null,
+        postalCode: null,
+        country: null,
+        timeAtCurrentAddressMonths: null,
+        currentRentAmountCents: null,
+      },
+      employment: {
+        employerName: null,
+        jobTitle: null,
+        incomeAmountCents: null,
+        incomeFrequency: null,
+        incomeMonthlyCents: null,
+        monthsAtJob: null,
+      },
+      reference: { name: null, phone: null },
+      compliance: {
+        applicationConsentAcceptedAt: null,
+        applicationConsentVersion: null,
+        signatureType: null,
+        signedAt: null,
+      },
+      screening: {
+        status: "not_requested",
+        statusLabel: "Screening not requested",
+        provider: "STUB",
+        providerLabel: null,
+        referenceId: null,
+      },
+      derived: {
+        incomeToRentRatio: null,
+        completeness: { score: 0.62, label: "Medium" },
+        flags: [],
+      },
+      insights: [],
+      decisionSummary: {
+        applicationId: "app-1",
+        status: "APPROVED",
+        screeningRecommendation: {
+          recommended: false,
+          reason: "Application was approved without a completed third-party screening package.",
+          priority: "low",
+        },
+        screeningSummary: {
+          available: false,
+          provider: "STUB",
+          providerLabel: null,
+          completedAt: null,
+          highlights: [],
+        },
+        decisionSupport: {
+          summaryLine: "Application is approved. No completed third-party screening package is recorded in this review summary.",
+          nextBestAction:
+            "Use the approved application summary and note that the decision was made without completed third-party screening.",
+        },
+      },
+    } as any);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Screening" }));
+
+    expect(await screen.findByText("Screening not requested")).toBeInTheDocument();
+    expect((await screen.findAllByText("Not provided")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("not_requested")).not.toBeInTheDocument();
+    expect(screen.queryByText("STUB")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Decision" }));
+
+    expect(await screen.findByText(/Application is approved/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Complete screening before deciding/i)).not.toBeInTheDocument();
+  });
+
   it("shows ready for decision when follow-up is resolved and review signals are organized", async () => {
     const { useEntitlements } = await import("@/hooks/useEntitlements");
     const { fetchReviewSummary } = await import("../api/reviewSummaryApi");

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -290,6 +290,25 @@ function networkReusePathSupportLabel(
   return "No reusable summaries approved yet";
 }
 
+function screeningStatusDisplayLabel(status?: string | null, label?: string | null) {
+  if (label) return label;
+  const normalized = String(status || "").trim().toLowerCase();
+  if (!normalized) return "Screening not requested";
+  if (["complete", "completed"].includes(normalized)) return "Screening complete";
+  if (["not_requested", "not_run", "not_started"].includes(normalized)) return "Screening not requested";
+  if (["processing", "external_pending", "requested", "in_progress", "provider_pending"].includes(normalized)) {
+    return "Screening in progress";
+  }
+  if (normalized === "paid") return "Screening paid; result pending";
+  if (normalized === "unpaid") return "Screening not started";
+  if (normalized === "ineligible") return "Screening unavailable";
+  return normalized
+    .split(/[\s_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
 type SummaryLoadError = {
   message: string;
   status?: number;
@@ -1882,8 +1901,8 @@ function ApplicationReviewSummaryPageBody() {
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700 }}>Screening & Compliance</div>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-              {kv("Screening status", summary.screening.status || "not_run")}
-              {kv("Screening provider", summary.screening.provider || "Not provided")}
+              {kv("Screening status", screeningStatusDisplayLabel(summary.screening.status, summary.screening.statusLabel))}
+              {kv("Screening provider", summary.screening.providerLabel || "Not provided")}
               {kv(
                 "Completeness",
                 `${summary.derived.completeness.label} (${Math.round(summary.derived.completeness.score * 100)}%)`

--- a/rentchain-frontend/src/types/applicationDecisionSummary.ts
+++ b/rentchain-frontend/src/types/applicationDecisionSummary.ts
@@ -43,6 +43,7 @@ export type ApplicationDecisionSummary = {
   screeningSummary?: {
     available: boolean;
     provider?: string | null;
+    providerLabel?: string | null;
     completedAt?: string | null;
     highlights?: string[];
   } | null;


### PR DESCRIPTION
## Summary
- Adds landlord-facing screening status and provider display labels to the Application Review Summary model.
- Updates browser Review Summary and backend PDF sections to use display labels instead of raw values such as not_requested or STUB.
- Makes decision guidance retrospective for final approved or denied application states, while preserving prospective guidance for submitted and review-required states.
- Keeps screening workflow state, decision state, and screening automation unchanged.

## Root cause
- Application Review Summary browser/PDF surfaces used the same raw screening status/provider fields directly.
- Decision support copy did not consider final application status before recommending pre-decision actions.

## Validation
- Backend targeted tests passed: npm run test:single -- src/lib/__tests__/reviewSummary.test.ts src/services/__tests__/applicationDecisionSummary.test.ts
- Frontend targeted tests passed: npm run test:single -- src/pages/ApplicationReviewSummaryPage.test.tsx src/components/applications/ApplicationDecisionSummaryCard.test.tsx
- Backend build passed.
- Frontend build passed. Existing large chunk warning remains.
- git diff --check passed.
- git diff --cached --check passed before commit.

## Notes
- Frontend targeted tests pass with an existing React duplicate-key warning from a sparse review-summary fixture path. The warning is unrelated to this screening/status copy change.

## Manual QA
1. Open an approved application review summary with no completed screening.
2. Confirm Screening status displays landlord-facing copy such as Screening not requested.
3. Confirm STUB or raw provider implementation labels are not visible.
4. Confirm decision guidance does not say Complete screening before deciding for approved or denied final states.
5. Download the PDF and confirm the same screening/provider labels and status-aware guidance appear.
6. Confirm submitted or review-required applications can still show prospective screening guidance when appropriate.
7. Confirm no raw internal application/property/unit/provider IDs or screening references are visible.
8. Regression: /applications, /dashboard, /leases, /analytics.