### PR TITLE
polish: improve review summary secondary panel density

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -188,6 +188,10 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
     expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
     expect(await screen.findByText("Recent activity")).toBeInTheDocument();
+    expect(screen.getByLabelText("Secondary review context")).toHaveStyle({
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 420px), 1fr))",
+    });
     expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Documents & records").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -882,125 +882,137 @@ function ApplicationReviewSummaryPageBody() {
                 ))}
               </div>
 
-              <Card style={{ display: "grid", gap: 8 }}>
-                <div style={{ fontWeight: 700 }}>Shared package categories</div>
-                <div style={{ fontSize: 12, color: text.subtle }}>
-                  These categories match the tenant-facing package language and only reflect records available in the current authorized review summary.
-                </div>
-                {intakeView.packageCategories.map((item, index) => {
-                  const tone =
-                    item.status === "ready"
-                      ? { color: "#166534", background: "#dcfce7", label: "Available to review" }
-                      : item.status === "partial"
-                      ? { color: "#1d4ed8", background: "#dbeafe", label: "Partly available" }
-                      : { color: "#9a3412", background: "#ffedd5", label: "Missing" };
-                  return (
-                    <div
-                      key={`${item.key}-${index}`}
-                      style={{
-                        border: `1px solid ${colors.border}`,
-                        borderRadius: 10,
-                        padding: 10,
-                        display: "grid",
-                        gap: 6,
-                      }}
-                    >
-                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                        <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
+              <div
+                aria-label="Secondary review context"
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 420px), 1fr))",
+                  gap: 10,
+                  alignItems: "start",
+                }}
+              >
+                <Card style={{ display: "grid", gap: 8 }}>
+                  <div style={{ fontWeight: 700 }}>Shared package categories</div>
+                  <div style={{ fontSize: 12, color: text.subtle }}>
+                    These categories match the tenant-facing package language and only reflect records available in the current authorized review summary.
+                  </div>
+                  {intakeView.packageCategories.map((item, index) => {
+                    const tone =
+                      item.status === "ready"
+                        ? { color: "#166534", background: "#dcfce7", label: "Available to review" }
+                        : item.status === "partial"
+                        ? { color: "#1d4ed8", background: "#dbeafe", label: "Partly available" }
+                        : { color: "#9a3412", background: "#ffedd5", label: "Missing" };
+                    return (
+                      <div
+                        key={`${item.key}-${index}`}
+                        style={{
+                          border: `1px solid ${colors.border}`,
+                          borderRadius: 10,
+                          padding: 10,
+                          display: "grid",
+                          gap: 6,
+                        }}
+                      >
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                          <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
+                          <div
+                            style={{
+                              padding: "4px 8px",
+                              borderRadius: 999,
+                              fontSize: 12,
+                              fontWeight: 700,
+                              color: tone.color,
+                              background: tone.background,
+                            }}
+                          >
+                            {tone.label}
+                          </div>
+                        </div>
+                        <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
+                      </div>
+                    );
+                  })}
+                </Card>
+
+                <div style={{ display: "grid", gap: 10, minWidth: 0 }}>
+                  <Card style={{ display: "grid", gap: 8 }}>
+                    <div style={{ fontWeight: 700 }}>Missing items</div>
+                    <div style={{ fontSize: 12, color: text.subtle }}>
+                      Missing categories stay high-level so this view does not imply access to anything the tenant has not shared.
+                    </div>
+                    {intakeView.missingItems.length ? (
+                      intakeView.missingItems.map((item) => (
                         <div
+                          key={item.label}
                           style={{
-                            padding: "4px 8px",
-                            borderRadius: 999,
-                            fontSize: 12,
-                            fontWeight: 700,
-                            color: tone.color,
-                            background: tone.background,
+                            border: `1px solid ${colors.border}`,
+                            borderRadius: 10,
+                            padding: 10,
+                            display: "grid",
+                            gap: 6,
                           }}
                         >
-                          {tone.label}
+                          <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
+                          <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
                         </div>
+                      ))
+                    ) : (
+                      <div style={{ fontSize: 13, color: text.subtle }}>
+                        No major intake gaps are surfaced in the current review summary.
                       </div>
-                      <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
+                    )}
+                    <div style={{ fontSize: 12, color: text.subtle }}>
+                      Shared with tenant permission and current server-authorized review access.
                     </div>
-                  );
-                })}
-              </Card>
+                  </Card>
 
-              <Card style={{ display: "grid", gap: 8 }}>
-                <div style={{ fontWeight: 700 }}>Missing items</div>
-                <div style={{ fontSize: 12, color: text.subtle }}>
-                  Missing categories stay high-level so this view does not imply access to anything the tenant has not shared.
-                </div>
-                {intakeView.missingItems.length ? (
-                  intakeView.missingItems.map((item) => (
-                    <div
-                      key={item.label}
-                      style={{
-                        border: `1px solid ${colors.border}`,
-                        borderRadius: 10,
-                        padding: 10,
-                        display: "grid",
-                        gap: 6,
-                      }}
-                    >
-                      <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
-                      <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
+                  <Card style={{ display: "grid", gap: 8 }}>
+                    <div style={{ fontWeight: 700 }}>Recent activity</div>
+                    <div style={{ fontSize: 12, color: text.subtle }}>
+                      Recent review-state updates are shown here using the same authorized summary and current package state.
                     </div>
-                  ))
-                ) : (
-                  <div style={{ fontSize: 13, color: text.subtle }}>
-                    No major intake gaps are surfaced in the current review summary.
-                  </div>
-                )}
-                <div style={{ fontSize: 12, color: text.subtle }}>
-                  Shared with tenant permission and current server-authorized review access.
-                </div>
-              </Card>
-
-              <Card style={{ display: "grid", gap: 8 }}>
-                <div style={{ fontWeight: 700 }}>Recent activity</div>
-                <div style={{ fontSize: 12, color: text.subtle }}>
-                  Recent review-state updates are shown here using the same authorized summary and current package state.
-                </div>
-                {recentActivity.length ? (
-                  recentActivity.map((item) => (
-                    <div
-                      key={item.id}
-                      style={{
-                        border: `1px solid ${colors.border}`,
-                        borderRadius: 10,
-                        padding: 10,
-                        display: "grid",
-                        gap: 6,
-                      }}
-                    >
-                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                        <div style={{ fontWeight: 600, color: text.main }}>{item.title}</div>
+                    {recentActivity.length ? (
+                      recentActivity.map((item) => (
                         <div
+                          key={item.id}
                           style={{
-                            padding: "4px 8px",
-                            borderRadius: 999,
-                            fontSize: 12,
-                            fontWeight: 700,
-                            color: item.actionRequired ? "#9a3412" : "#1d4ed8",
-                            background: item.actionRequired ? "#ffedd5" : "#dbeafe",
+                            border: `1px solid ${colors.border}`,
+                            borderRadius: 10,
+                            padding: 10,
+                            display: "grid",
+                            gap: 6,
                           }}
                         >
-                          {item.actionRequired ? "Needs attention" : "Updated"}
+                          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                            <div style={{ fontWeight: 600, color: text.main }}>{item.title}</div>
+                            <div
+                              style={{
+                                padding: "4px 8px",
+                                borderRadius: 999,
+                                fontSize: 12,
+                                fontWeight: 700,
+                                color: item.actionRequired ? "#9a3412" : "#1d4ed8",
+                                background: item.actionRequired ? "#ffedd5" : "#dbeafe",
+                              }}
+                            >
+                              {item.actionRequired ? "Needs attention" : "Updated"}
+                            </div>
+                          </div>
+                          <div style={{ fontSize: 13, color: text.subtle }}>{item.description}</div>
+                          <div style={{ fontSize: 12, color: text.subtle }}>
+                            {(item.actorLabel ? `${item.actorLabel} • ` : "") + dateOr(item.occurredAt)}
+                          </div>
                         </div>
+                      ))
+                    ) : (
+                      <div style={{ fontSize: 13, color: text.subtle }}>
+                        No recent review activity is available from the current summary yet.
                       </div>
-                      <div style={{ fontSize: 13, color: text.subtle }}>{item.description}</div>
-                      <div style={{ fontSize: 12, color: text.subtle }}>
-                        {(item.actorLabel ? `${item.actorLabel} • ` : "") + dateOr(item.occurredAt)}
-                      </div>
-                    </div>
-                  ))
-                ) : (
-                  <div style={{ fontSize: 13, color: text.subtle }}>
-                    No recent review activity is available from the current summary yet.
-                  </div>
-                )}
-              </Card>
+                    )}
+                  </Card>
+                </div>
+              </div>
             </Card>
           ) : null}
 


### PR DESCRIPTION
## Summary
- Places the Application Review Summary secondary intake panels into a responsive desktop grid.
- Keeps Shared package categories visible as the primary secondary panel while Missing items and Recent activity stack in the companion column.
- Preserves the #1313 at-a-glance summary, Application Context, Applicant Overview, Employment and Income, status-aware screening guidance, actions, and PDF behavior.

## Scope notes
- Frontend Application Review Summary layout only.
- No backend changes.
- No PDF generation changes.
- No screening, risk, decision, or application status logic changes.
- No raw/internal/provider ID exposure added.

## Validation
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationReviewSummaryPage.test.tsx
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build
- git diff --check
- git diff --cached --check

## Manual QA
1. Open /applications/ixcRcv8tTgz0lKvDRw66/review-summary on full desktop.
2. Confirm Shared package categories and Recent activity use horizontal space better and no longer feel overly wide/sparse.
3. Confirm Missing items remains readable.
4. Confirm the first-screen at-a-glance card from #1313 is unchanged.
5. Confirm Application Context remains visible and safe.
6. Confirm Applicant Overview and Employment and Income remain readable.
7. Confirm status-aware screening copy remains correct.
8. Confirm Back to applications works.
9. Confirm Download PDF works and exported PDF content remains unchanged.
10. Confirm no raw application, property, unit, provider, screening reference, or internal IDs are visible.
11. Reduced desktop and mobile: confirm panels stack cleanly with no horizontal overflow.
12. Regression: /applications, /dashboard, /leases, /analytics.