### PR TITLE
fix: add safe unified inbox source actions

### DIFF
--- a/rentchain-api/src/services/unifiedInbox/types.ts
+++ b/rentchain-api/src/services/unifiedInbox/types.ts
@@ -50,6 +50,20 @@ export type UnifiedInboxSourceRef = {
   ref: string;
 };
 
+export type UnifiedInboxSourceActionRouteKind =
+  | "applications_workspace"
+  | "leases_workspace"
+  | "maintenance_workspace"
+  | "payment_workspace"
+  | "work_order_workspace";
+
+export type UnifiedInboxSourceAction = {
+  label: string;
+  href: string;
+  helper: string;
+  routeKind: UnifiedInboxSourceActionRouteKind;
+};
+
 export type UnifiedInboxEvent = UnifiedInboxSafetyFlags & {
   id: string;
   sourceKind: SourceKind;
@@ -68,7 +82,9 @@ export type UnifiedInboxEvent = UnifiedInboxSafetyFlags & {
 export type UnifiedInboxPublicRecord = Pick<
   UnifiedInboxEvent,
   "id" | "sourceKind" | "audienceRole" | "title" | "body" | "priority" | "status" | "occurredAt" | "readAt"
->;
+> & {
+  sourceAction: UnifiedInboxSourceAction | null;
+};
 
 export type UnifiedInboxPage = {
   items: UnifiedInboxEvent[];

--- a/rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts
+++ b/rentchain-api/src/services/unifiedInbox/unifiedInboxService.ts
@@ -4,7 +4,7 @@ import {
   deriveLandlordUnifiedInbox,
   deriveTenantUnifiedInbox,
 } from "./deriveUnifiedInbox";
-import type { SourceKind, UnifiedInboxEvent, UnifiedInboxPublicRecord } from "./types";
+import type { SourceKind, UnifiedInboxEvent, UnifiedInboxPublicRecord, UnifiedInboxSourceAction } from "./types";
 
 const MAX_LIMIT = 100;
 const DEFAULT_LIMIT = 20;
@@ -203,6 +203,68 @@ function applySafeFilters(items: UnifiedInboxEvent[], request: UnifiedInboxReque
   });
 }
 
+function isPaymentLike(item: UnifiedInboxEvent) {
+  return /\b(payment|payments|rent|invoice|charge|balance|outstanding|collection)\b/i.test(`${item.title} ${item.body}`);
+}
+
+function buildLandlordSourceAction(item: UnifiedInboxEvent): UnifiedInboxSourceAction | null {
+  if (item.audienceRole !== "landlord") return null;
+
+  if (item.sourceKind === "landlord.maintenance") {
+    return {
+      href: "/maintenance",
+      label: "Open maintenance workspace",
+      helper: "Open the maintenance workspace to review available maintenance requests.",
+      routeKind: "maintenance_workspace",
+    };
+  }
+
+  if (item.sourceKind === "landlord.work_order") {
+    return {
+      href: "/work-orders",
+      label: "Open related work orders",
+      helper: "Open the work order workspace to review available work-order records.",
+      routeKind: "work_order_workspace",
+    };
+  }
+
+  if (item.sourceKind === "landlord.lease") {
+    const paymentLike = isPaymentLike(item);
+    return {
+      href: "/leases",
+      label: paymentLike ? "Open related leases" : "Open lease workspace",
+      helper: paymentLike
+        ? "Open the lease workspace to find the related summary or payment ledger."
+        : "Open the lease workspace to find the related lease record.",
+      routeKind: "leases_workspace",
+    };
+  }
+
+  if (
+    item.sourceKind === "landlord.application" ||
+    item.sourceKind === "landlord.screening" ||
+    item.sourceKind === "landlord.viewing"
+  ) {
+    return {
+      href: "/applications",
+      label: "Open related applications",
+      helper: "Open the application workspace to find the related application, screening, or viewing record.",
+      routeKind: "applications_workspace",
+    };
+  }
+
+  if (isPaymentLike(item)) {
+    return {
+      href: "/payments",
+      label: "Open payment workspace",
+      helper: "Open Payments to review payment setup, balances, or collection activity.",
+      routeKind: "payment_workspace",
+    };
+  }
+
+  return null;
+}
+
 export function toPublicInboxRecord(item: UnifiedInboxEvent): UnifiedInboxPublicRecord {
   return {
     id: item.id,
@@ -214,6 +276,7 @@ export function toPublicInboxRecord(item: UnifiedInboxEvent): UnifiedInboxPublic
     status: item.status,
     occurredAt: item.occurredAt,
     readAt: item.readAt,
+    sourceAction: buildLandlordSourceAction(item),
   };
 }
 

--- a/rentchain-api/src/tests/unifiedInbox/unifiedInboxRoute.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/unifiedInboxRoute.test.ts
@@ -33,7 +33,18 @@ vi.mock("../../middleware/requireAuth", () => ({
   },
 }));
 
-const PUBLIC_RECORD_KEYS = ["audienceRole", "body", "id", "occurredAt", "priority", "readAt", "sourceKind", "status", "title"];
+const PUBLIC_RECORD_KEYS = [
+  "audienceRole",
+  "body",
+  "id",
+  "occurredAt",
+  "priority",
+  "readAt",
+  "sourceAction",
+  "sourceKind",
+  "status",
+  "title",
+];
 const EXCLUDED_RESPONSE_FIELDS = [
   "sourceId",
   "sourceRef",
@@ -143,6 +154,7 @@ describe("unifiedInboxRoutes", () => {
     expect(res.body).toMatchObject({ ok: true, role: "tenant", total: 2 });
     const body = res.body as { items: Array<Record<string, unknown>>; records: Array<Record<string, unknown>> };
     expect(body.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
+    expect(body.items.map((item) => item.sourceAction)).toEqual([null, null]);
     expect(body.records).toEqual(body.items);
     const json = JSON.stringify(res.body);
     expect(json).toContain("tenant.viewing");
@@ -169,6 +181,12 @@ describe("unifiedInboxRoutes", () => {
     expect(res.body).toMatchObject({ ok: true, role: "landlord", total: 1 });
     const body = res.body as { items: Array<Record<string, unknown>> };
     expect(body.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS]);
+    expect(body.items[0]?.sourceAction).toEqual({
+      href: "/work-orders",
+      label: "Open related work orders",
+      helper: "Open the work order workspace to review available work-order records.",
+      routeKind: "work_order_workspace",
+    });
     expect(JSON.stringify(res.body)).toContain("landlord.work_order");
     expect(JSON.stringify(res.body)).not.toContain("work-order-1");
     for (const field of EXCLUDED_RESPONSE_FIELDS) {
@@ -201,6 +219,7 @@ describe("unifiedInboxRoutes", () => {
     expect(contractor.body).toMatchObject({ ok: true, role: "contractor", total: 1 });
     const body = contractor.body as { items: Array<Record<string, unknown>> };
     expect(body.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS]);
+    expect(body.items[0]?.sourceAction).toBeNull();
     const json = JSON.stringify(contractor.body);
     expect(json).not.toContain("contractor-1");
     for (const field of EXCLUDED_RESPONSE_FIELDS) {

--- a/rentchain-api/src/tests/unifiedInbox/unifiedInboxService.test.ts
+++ b/rentchain-api/src/tests/unifiedInbox/unifiedInboxService.test.ts
@@ -24,7 +24,18 @@ const dbMock = {
 
 vi.mock("../../firebase", () => ({ db: dbMock }));
 
-const PUBLIC_RECORD_KEYS = ["audienceRole", "body", "id", "occurredAt", "priority", "readAt", "sourceKind", "status", "title"];
+const PUBLIC_RECORD_KEYS = [
+  "audienceRole",
+  "body",
+  "id",
+  "occurredAt",
+  "priority",
+  "readAt",
+  "sourceAction",
+  "sourceKind",
+  "status",
+  "title",
+];
 const EXCLUDED_RESPONSE_FIELDS = [
   "sourceId",
   "sourceRef",
@@ -94,6 +105,7 @@ describe("unified inbox service", () => {
     expect(result.items.map((item) => item.audienceRole)).toEqual(["tenant", "tenant"]);
     expect(result.items.map((item) => item.sourceKind)).toEqual(["tenant.viewing", "tenant.message"]);
     expect(result.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
+    expect(result.items.map((item) => item.sourceAction)).toEqual([null, null]);
     expect(result.records).toEqual(result.items);
     const json = JSON.stringify(result.items);
     expect(json).not.toContain("tenant-workspace-1");
@@ -111,6 +123,20 @@ describe("unified inbox service", () => {
     const landlordResult = await getUnifiedInbox({ role: "landlord", landlordId: "landlord-1" }, {});
     expect(landlordResult.items.map((item) => item.sourceKind)).toEqual(["landlord.viewing", "landlord.work_order"]);
     expect(landlordResult.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
+    expect(landlordResult.items.map((item) => item.sourceAction)).toEqual([
+      {
+        href: "/applications",
+        label: "Open related applications",
+        helper: "Open the application workspace to find the related application, screening, or viewing record.",
+        routeKind: "applications_workspace",
+      },
+      {
+        href: "/work-orders",
+        label: "Open related work orders",
+        helper: "Open the work order workspace to review available work-order records.",
+        routeKind: "work_order_workspace",
+      },
+    ]);
     expect(JSON.stringify(landlordResult.items)).not.toContain("landlord-1");
     expect(JSON.stringify(landlordResult.items)).not.toContain("work-order-1");
     for (const field of EXCLUDED_RESPONSE_FIELDS) {
@@ -120,6 +146,7 @@ describe("unified inbox service", () => {
     const contractorResult = await getUnifiedInbox({ role: "contractor", contractorId: "contractor-1" }, {});
     expect(contractorResult.items.map((item) => item.sourceKind)).toEqual(["contractor.work_order", "contractor.message"]);
     expect(contractorResult.items.map((item) => Object.keys(item).sort())).toEqual([PUBLIC_RECORD_KEYS, PUBLIC_RECORD_KEYS]);
+    expect(contractorResult.items.map((item) => item.sourceAction)).toEqual([null, null]);
     expect(JSON.stringify(contractorResult.items)).not.toContain("contractor-1");
     expect(JSON.stringify(contractorResult.items)).not.toContain("landlord-1");
     for (const field of EXCLUDED_RESPONSE_FIELDS) {
@@ -141,5 +168,74 @@ describe("unified inbox service", () => {
       status: 400,
       code: "INVALID_SOURCE",
     });
+  });
+
+  it("projects landlord source actions without exposing source lineage", async () => {
+    const { toPublicInboxRecord } = await import("../../services/unifiedInbox/unifiedInboxService");
+    const baseEvent = {
+      rawIdsIncluded: false,
+      tokensIncluded: false,
+      secretsIncluded: false,
+      providerPayloadIncluded: false,
+      storagePathIncluded: false,
+      privateNotesIncluded: false,
+      id: "inbox_v1_safe_public",
+      sourceId: "inbox_v1_hidden_source",
+      audienceRole: "landlord" as const,
+      audienceScopeKey: "scope_v1_hidden",
+      title: "Maintenance update",
+      body: "Status: submitted",
+      priority: "normal" as const,
+      status: "unread" as const,
+      occurredAt: "2026-06-09T12:00:00.000Z",
+      readAt: null,
+      sourceRef: { kind: "landlord.maintenance" as const, ref: "inbox_v1_hidden_source_ref" },
+    };
+
+    const maintenance = toPublicInboxRecord({ ...baseEvent, sourceKind: "landlord.maintenance" });
+    const application = toPublicInboxRecord({
+      ...baseEvent,
+      sourceKind: "landlord.application",
+      title: "Application status updated",
+      body: "Applicant package is ready.",
+      sourceRef: { kind: "landlord.application" as const, ref: "inbox_v1_hidden_application_ref" },
+    });
+    const leasePayment = toPublicInboxRecord({
+      ...baseEvent,
+      sourceKind: "landlord.lease",
+      title: "Outstanding rent balance",
+      body: "Payment follow-up needed.",
+      sourceRef: { kind: "landlord.lease" as const, ref: "inbox_v1_hidden_lease_ref" },
+    });
+    const plainMessage = toPublicInboxRecord({
+      ...baseEvent,
+      sourceKind: "landlord.message",
+      title: "Tenant replied",
+      body: "Thanks for the update.",
+      sourceRef: { kind: "landlord.message" as const, ref: "inbox_v1_hidden_message_ref" },
+    });
+
+    expect(maintenance.sourceAction).toMatchObject({
+      href: "/maintenance",
+      label: "Open maintenance workspace",
+      routeKind: "maintenance_workspace",
+    });
+    expect(application.sourceAction).toMatchObject({
+      href: "/applications",
+      label: "Open related applications",
+      routeKind: "applications_workspace",
+    });
+    expect(leasePayment.sourceAction).toMatchObject({
+      href: "/leases",
+      label: "Open related leases",
+      routeKind: "leases_workspace",
+    });
+    expect(plainMessage.sourceAction).toBeNull();
+
+    const json = JSON.stringify([maintenance, application, leasePayment, plainMessage]);
+    expect(json).not.toContain("sourceId");
+    expect(json).not.toContain("sourceRef");
+    expect(json).not.toContain("audienceScopeKey");
+    expect(json).not.toContain("hidden_source");
   });
 });

--- a/rentchain-frontend/src/api/unifiedInboxApi.ts
+++ b/rentchain-frontend/src/api/unifiedInboxApi.ts
@@ -26,6 +26,19 @@ export type UnifiedInboxSourceKind =
   | "contractor.work_order"
   | "contractor.message";
 
+export type UnifiedInboxSourceAction = {
+  label: string;
+  href: string;
+  helper: string;
+  routeKind?:
+    | "applications_workspace"
+    | "leases_workspace"
+    | "maintenance_workspace"
+    | "payment_workspace"
+    | "work_order_workspace"
+    | string;
+};
+
 export type UnifiedInboxRecord = {
   id: string;
   sourceKind: UnifiedInboxSourceKind;
@@ -36,6 +49,7 @@ export type UnifiedInboxRecord = {
   status: UnifiedInboxStatus;
   occurredAt: string;
   readAt: string | null;
+  sourceAction?: UnifiedInboxSourceAction | null;
 };
 
 export type UnifiedInboxResponse = {

--- a/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
+++ b/rentchain-frontend/src/components/UnifiedInbox/UnifiedInboxList.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { ArrowUpRight, ChevronRight, Inbox } from "lucide-react";
-import type { UnifiedInboxRecord, UnifiedInboxRole, UnifiedInboxSourceKind } from "../../api/unifiedInboxApi";
+import type {
+  UnifiedInboxRecord,
+  UnifiedInboxRole,
+  UnifiedInboxSourceAction,
+  UnifiedInboxSourceKind,
+} from "../../api/unifiedInboxApi";
 import { Card } from "../ui/Ui";
 import { colors, radius, spacing, text } from "../../styles/tokens";
 
@@ -55,9 +60,23 @@ type WorkspaceAction = {
   helper: string;
 };
 
+function isSafeRelativeHref(value: string) {
+  return value.startsWith("/") && !value.startsWith("//") && !/[<>"'`\\]/.test(value) && !/\/\.\.(?:\/|$)/.test(value);
+}
+
+function sourceActionForRecord(action: UnifiedInboxSourceAction | null | undefined): WorkspaceAction | null {
+  const href = String(action?.href || "").trim();
+  const label = String(action?.label || "").trim();
+  const helper = String(action?.helper || "").trim();
+  if (!href || !label || !helper || !isSafeRelativeHref(href)) return null;
+  return { href, label, helper };
+}
+
 function workspaceForRecord(record: UnifiedInboxRecord, role: UnifiedInboxRole): WorkspaceAction | null {
   if (role === "tenant") return null;
   if (role === "contractor") return null;
+  const sourceAction = sourceActionForRecord(record.sourceAction);
+  if (sourceAction) return sourceAction;
   const recordBody = `${record.title} ${record.body}`;
   const isPaymentLike = /\b(payment|payments|rent|invoice|charge|balance|outstanding|collection)\b/i.test(recordBody);
   if (record.sourceKind.includes("maintenance")) {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -152,7 +152,7 @@ describe("UnifiedInboxPage", () => {
     render(<UnifiedInboxPage role="landlord" />);
 
     expect(await screen.findByRole("heading", { name: "Unified inbox" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Application status updated/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Application status updated/i }));
 
     expect(screen.getByText("Open the application workspace from the server-projected safe action.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open application workspace/i })).toHaveAttribute("href", "/applications");

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -125,6 +125,40 @@ describe("UnifiedInboxPage", () => {
     expect(screen.getAllByText("Work order").length).toBeGreaterThan(0);
   });
 
+  it("prefers backend-provided safe source actions over broad frontend fallback", async () => {
+    const sourceActionRecord = record({
+      id: "application-safe-action",
+      audienceRole: "landlord",
+      sourceKind: "landlord.application",
+      title: "Application status updated",
+      body: "Applicant package is ready.",
+      sourceAction: {
+        href: "/applications",
+        label: "Open application workspace",
+        helper: "Open the application workspace from the server-projected safe action.",
+        routeKind: "applications_workspace",
+      },
+    });
+    mocks.fetchUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [sourceActionRecord],
+      records: [sourceActionRecord],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+
+    render(<UnifiedInboxPage role="landlord" />);
+
+    expect(await screen.findByRole("heading", { name: "Unified inbox" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Application status updated/i }));
+
+    expect(screen.getByText("Open the application workspace from the server-projected safe action.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open application workspace/i })).toHaveAttribute("href", "/applications");
+    expect(screen.queryByText("Open the application workspace to find the related application, screening, or viewing record.")).not.toBeInTheDocument();
+  });
+
   it("filters landlord inbox records with operational tabs, status, and search", async () => {
     mocks.fetchUnifiedInbox.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- Adds a backend-generated `sourceAction` projection to public landlord Unified Inbox records with safe `label`, `href`, `helper`, and `routeKind` fields.
- Keeps raw/internal lineage excluded from the public payload: `sourceId`, `sourceRef`, `audienceScopeKey`, raw Firestore IDs, provider refs, storage paths, and safety flags remain absent.
- Covers safe fixed-route workspace actions for applications/screening/viewing, leases, maintenance, work orders, and payment-like records.
- Updates the frontend to prefer backend-provided safe actions and preserve the existing broad fallback behavior when `sourceAction` is absent.
- Leaves read-state persistence unchanged.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/tests/unifiedInbox/unifiedInboxService.test.ts src/tests/unifiedInbox/unifiedInboxRoute.test.ts src/tests/unifiedInbox/landlordInboxAdapters.test.ts` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/UnifiedInboxPage.test.tsx` in `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
- `git diff --check`
- `git diff --cached --check`

## Preview / backend parity
This PR changes backend payload generation. If the Vercel preview rewrites `/api/*` to shared Cloud Run instead of a PR-specific backend, browser QA may not validate the new `sourceAction` payload until Cloud Run is deployed from this PR or a merge commit containing it. In that case, use local/backend tests as pre-merge proof and perform post-deploy Cloud Run QA.

## Manual QA
- Open `/landlord/unified-inbox`.
- Select application/screening/viewing, lease, maintenance, work-order, payment-like, and plain-message items where available.
- Confirm backend-provided safe action labels/helper copy render when present.
- Confirm broad fallback remains when `sourceAction` is absent.
- Confirm no raw/internal/provider/storage IDs are visible.
- Confirm opening unread messages still persists read state.
- Regression route load: `/dashboard`, `/operations`, `/applications`, `/leases`, `/maintenance`.