### PR TITLE
polish: bridge operations to unified inbox

### DIFF
--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -637,6 +637,10 @@ describe("OperationalCommandCenterPage", () => {
 
     expect(await screen.findByRole("heading", { name: "Operational command center" })).toBeInTheDocument();
     expect(screen.getByText(/does not execute actions, enforce legal timelines, or modify records/i)).toBeInTheDocument();
+    expect(screen.getByText("Operational inbox bridge")).toBeInTheDocument();
+    expect(screen.getByText(/Review messages and source-linked actions tied to applications, leases, maintenance, payments, or work orders/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open operational inbox" })).toHaveAttribute("href", "/landlord/unified-inbox");
+    expect(screen.getByRole("link", { name: "Open decision inbox" })).toHaveAttribute("href", "/decision-inbox");
 
     await waitFor(() => {
       expect(mocks.fetchDecisionInbox).toHaveBeenCalled();

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { AlertTriangle, Building2, ClipboardList, FileText, Home, ReceiptText, ShieldCheck } from "lucide-react";
+import { AlertTriangle, Building2, ClipboardList, FileText, Home, Inbox, ReceiptText, ShieldCheck } from "lucide-react";
 import { fetchDashboardSummary, type DashboardSummaryData } from "@/api/dashboard";
 import {
   fetchDecisionInbox,
@@ -1159,9 +1159,47 @@ export default function OperationalCommandCenterPage() {
                 This page prioritizes source workflow issues only; it does not execute actions, enforce legal timelines, or modify records.
               </div>
             </div>
-            <Link to="/decision-inbox" style={{ color: "#2563eb", fontWeight: 900 }}>
-              Open decision inbox
-            </Link>
+            <Card
+              style={{
+                borderRadius: 10,
+                padding: 14,
+                display: "grid",
+                gap: 10,
+                minWidth: 0,
+                border: "1px solid #bfdbfe",
+                background: "#eff6ff",
+              }}
+            >
+              <div style={{ display: "flex", gap: 8, alignItems: "center", color: "#1d4ed8", fontWeight: 900 }}>
+                <Inbox size={18} />
+                <span>Operational inbox bridge</span>
+              </div>
+              <div style={{ color: "#334155", lineHeight: 1.45, fontSize: 13 }}>
+                Review messages and source-linked actions tied to applications, leases, maintenance, payments, or work orders
+                when that context is available.
+              </div>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                <Link
+                  to="/landlord/unified-inbox"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    borderRadius: 999,
+                    padding: "9px 12px",
+                    background: "#2563eb",
+                    color: "#fff",
+                    fontWeight: 900,
+                    textDecoration: "none",
+                  }}
+                >
+                  Open operational inbox
+                </Link>
+                <Link to="/decision-inbox" style={{ color: "#2563eb", fontWeight: 900 }}>
+                  Open decision inbox
+                </Link>
+              </div>
+            </Card>
           </div>
         </Section>
 


### PR DESCRIPTION
## Summary
- Adds a compact Operations header bridge to the canonical landlord Unified Inbox.
- Explains that the inbox reviews messages and source-linked actions tied to applications, leases, maintenance, payments, or work orders when context is available.
- Preserves the existing decision inbox access as a secondary specialized review link.

## Scope
- Frontend-only Operations page polish.
- Unified Inbox backend/sourceAction projection logic was not reopened.
- No backend, data, queue, read-state, Application Review Summary, or navigation architecture changes.

## Reduced desktop and mobile
- The bridge uses the existing responsive header grid and wrapped action row.
- The CTA copy avoids promising exact routing for every inbox record.

## Validation
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/OperationalCommandCenterPage.test.tsx src/pages/UnifiedInboxPage.test.tsx
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build
- git diff --check
- git diff --cached --check