### PR TITLE
polish: add review summary lease next action

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -236,6 +236,7 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText(/Derived from current review state/i)).toBeInTheDocument();
     expect(await screen.findByText("Lease step")).toBeInTheDocument();
     expect(await screen.findByText("Not ready for lease step")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Continue to lease workspace" })).not.toBeInTheDocument();
     expect(await screen.findByText("Lease blockers")).toBeInTheDocument();
     expect(await screen.findByText("Lease preparation")).toBeInTheDocument();
     expect((await screen.findAllByText("Not started")).length).toBeGreaterThan(0);
@@ -439,6 +440,11 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Ready for decision")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for next step")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for lease step")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Continue lease follow-through")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/This review summary does not create a lease or guess an exact lease record/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Continue to lease workspace" })).toHaveAttribute("href", "/leases");
     expect((await screen.findAllByText("Awaiting next action")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Move-in readiness")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Awaiting next action")).length).toBeGreaterThan(1);
@@ -524,6 +530,7 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Hold for later")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Not ready for lease step")).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link", { name: "Continue to lease workspace" })).not.toBeInTheDocument();
     expect((await screen.findAllByText("Not started")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Not ready for execution")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Not ready for signing")).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -183,6 +183,12 @@ function leaseTransitionTone(
   return { color: "#9a3412", background: "#ffedd5", label: "Not ready for lease step" };
 }
 
+function shouldShowLeaseWorkspaceAction(
+  state: "not_ready_for_lease" | "ready_for_lease_step" | "lease_step_started" | "awaiting_next_action"
+) {
+  return state === "ready_for_lease_step" || state === "lease_step_started";
+}
+
 function leasePreparationTone(
   state: "not_started" | "preparing_lease" | "needs_attention" | "ready_for_execution" | "awaiting_next_action"
 ) {
@@ -1399,6 +1405,47 @@ function ApplicationReviewSummaryPageBody() {
                       ))}
                     </div>
                   </div>
+
+                  {shouldShowLeaseWorkspaceAction(leaseTransition.transitionState) ? (
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 12,
+                        display: "grid",
+                        gap: 10,
+                        background: "#f8fafc",
+                      }}
+                    >
+                      <div style={{ display: "grid", gap: 4 }}>
+                        <div style={{ fontWeight: 800, color: text.main }}>Continue lease follow-through</div>
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          Open Leases to continue lease setup, execution readiness, signing, ledger, and rent-payment follow-through.
+                          This review summary does not create a lease or guess an exact lease record.
+                        </div>
+                      </div>
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                        <Link
+                          to="/leases"
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            minHeight: 38,
+                            padding: "8px 12px",
+                            borderRadius: 8,
+                            border: `1px solid ${colors.border}`,
+                            background: "#fff",
+                            color: text.main,
+                            textDecoration: "none",
+                            fontWeight: 800,
+                          }}
+                        >
+                          Continue to lease workspace
+                        </Link>
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
 


### PR DESCRIPTION
## Summary

Adds a focused landlord-facing next action on Application Review Summary for application states that are ready for lease follow-through.

The Decision tab now shows `Continue lease follow-through` with a `Continue to lease workspace` action when the existing lease-transition state is ready or already started. The action routes broadly to `/leases` because the Review Summary response does not expose a safe exact lease route today.

## State behavior

- Shows lease-oriented guidance for `ready_for_lease_step` and `lease_step_started` states.
- Does not show the lease workspace action for not-ready, hold/review-required, or denied/not-proceeding states.
- Uses honest fallback copy that says the review summary does not create a lease or guess an exact lease record.

## Scope and safety

- Frontend-only.
- No backend changes.
- No screening logic changes.
- No PDF/export changes.
- No application decision logic changes.
- No raw/internal/provider/storage IDs exposed.
- Exact lease routing remains deferred until a safe backend-projected lease action exists.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationReviewSummaryPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`
- `git diff --cached --check`

## Manual QA requirements

- `/applications/:applicationId/review-summary` for an approved/lease-ready application: confirm the lease next-action appears and routes to `/leases`.
- Submitted/review-required application: confirm no inappropriate lease-prep action appears.
- Denied/not-proceeding application if available: confirm no lease-prep action appears.
- Confirm `Back to applications`, `Download PDF`, and `Copy link` still work.
- Confirm reduced desktop/mobile action rows remain readable with no horizontal overflow.
- Regression: `/applications`, `/leases`, `/leases/:leaseId/summary`, `/leases/:leaseId/ledger`.