### PR TITLE
fix: hide raw lease id on lease operations

### DIFF
--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -319,6 +319,8 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View lease" })).toBeInTheDocument();
+    expect(screen.getByText("Lease workspace")).toBeInTheDocument();
+    expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Payment ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -1004,7 +1004,7 @@ export default function LandlordActiveLeasesPage() {
                   <tr key={lease.id} style={{ borderTop: "1px solid #e2e8f0" }}>
                     <td style={{ padding: 12 }}>
                       <div style={{ fontWeight: 700, color: "#0f172a" }}>{lease.propertyName}</div>
-                      <div style={{ color: "#64748b", fontSize: 12 }}>{lease.id}</div>
+                      <div style={{ color: "#64748b", fontSize: 12 }}>Lease workspace</div>
                     </td>
                     <td style={{ padding: 12 }}>{lease.unitNumber || "—"}</td>
                     <td style={{ padding: 12 }}>


### PR DESCRIPTION
## Summary

Removes the visible raw `lease.id` subline from the `/leases` desktop table and replaces it with landlord-facing `Lease workspace` copy.

## Why

`/leases` is now the safe broad destination after Application Review Summary. Showing the internal lease identifier under the property name made the lease workspace feel less landlord-facing and could expose raw Firestore-shaped identifiers during the RC1 demo path.

## Behavior

- Desktop `/leases` table no longer displays raw lease IDs under property names.
- Replacement copy is `Lease workspace`.
- Mobile cards already used safe property/unit/tenant context and remain unchanged.
- Lease routing is unchanged: summary and ledger links still use the canonical lease ID internally.
- No lease summary, ledger, workflow, payment, or application review logic changed.

## Safety

- Frontend-only.
- No backend changes.
- No route changes.
- No raw/internal/provider/storage IDs introduced.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/LandlordActiveLeasesPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`
- `git diff --cached --check`

## Manual QA requirements

- `/leases` desktop: confirm property rows show `Lease workspace` instead of a raw lease ID.
- Confirm `Lease summary` routes to `/leases/:leaseId/summary`.
- Confirm `Payment ledger` routes to `/leases/:leaseId/ledger`.
- Confirm mobile/reduced desktop remains readable with no raw lease ID visible.
- Regression: `/leases/:leaseId/summary`, `/leases/:leaseId/ledger`, `/applications`, `/applications/:applicationId/review-summary`.