### PR TITLE
fix: landlord screening visible safe language

### DIFF
--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -223,6 +223,7 @@ async function buildRuntimeOwnershipApp() {
   const adminSecurityIncidentRoutes = (await import("../adminSecurityIncidentRoutes")).default;
   const adminSupportEscalationRoutes = (await import("../adminSupportEscalationRoutes")).default;
   const governedReviewWorkspaceRoutes = (await import("../governedReviewWorkspaceRoutes")).default;
+  const verifiedScreeningRoutes = (await import("../verifiedScreeningRoutes")).default;
   const screeningJobsAdminRoutes = (await import("../screeningJobsAdminRoutes")).default;
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
@@ -267,6 +268,7 @@ async function buildRuntimeOwnershipApp() {
   app.use("/api/admin", routeSource("adminSecurityIncidentRoutes.ts"), adminSecurityIncidentRoutes);
   app.use("/api/admin", routeSource("adminSupportEscalationRoutes.ts"), adminSupportEscalationRoutes);
   app.use("/api/admin", routeSource("governedReviewWorkspaceRoutes.ts"), governedReviewWorkspaceRoutes);
+  app.use("/api", routeSource("verifiedScreeningRoutes.ts"), verifiedScreeningRoutes);
   app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes);
   app.use("/api", (_req, res) => {
     res.setHeader("x-route-source", "not-found");
@@ -311,6 +313,9 @@ describe("API route ownership regression", () => {
     const riskAgentMount = source.indexOf('app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes)');
     const tenantPortalMount = source.indexOf('app.use("/api/tenant", routeSource("tenantPortalRoutes.ts"), tenantPortalRoutes)');
     const referralsMount = source.indexOf('app.use("/api", referralsRoutes)');
+    const verifiedScreeningMount = source.indexOf(
+      'app.use("/api", routeSource("verifiedScreeningRoutes.ts"), verifiedScreeningRoutes)'
+    );
     const screeningJobsMount = source.indexOf('app.use("/api", routeSource("screeningJobsAdminRoutes.ts"), screeningJobsAdminRoutes)');
     const buildProbeRoute = source.indexOf('app.get("/api/_build", rateLimitDiagnostics');
     const apiCatchall = source.indexOf('app.use("/api", (_req, res) => {');
@@ -332,6 +337,7 @@ describe("API route ownership regression", () => {
     expect(riskAgentMount).toBeGreaterThan(-1);
     expect(tenantPortalMount).toBeGreaterThan(-1);
     expect(referralsMount).toBeGreaterThan(-1);
+    expect(verifiedScreeningMount).toBeGreaterThan(-1);
     expect(screeningJobsMount).toBeGreaterThan(-1);
     expect(buildProbeRoute).toBeGreaterThan(-1);
     expect(apiCatchall).toBeGreaterThan(-1);
@@ -355,6 +361,8 @@ describe("API route ownership regression", () => {
     expect(tenantPortalMount).toBeLessThan(screeningJobsMount);
     expect(telemetryMount).toBeLessThan(screeningJobsMount);
     expect(screeningRoutesMount).toBeLessThan(screeningJobsMount);
+    expect(verifiedScreeningMount).toBeLessThan(screeningJobsMount);
+    expect(verifiedScreeningMount).toBeLessThan(apiCatchall);
     expect(screeningJobsMount).toBeLessThan(apiCatchall);
     expect(source).not.toContain('app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes)');
   });
@@ -543,6 +551,22 @@ describe("API route ownership regression", () => {
         manualOnly: true,
       })
     );
+  });
+
+  it("keeps landlord verified screenings owned by verified screening routes before screening job fallback", async () => {
+    authState.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    const app = await buildRuntimeOwnershipApp();
+
+    const res = await invokeApp(app, {
+      method: "GET",
+      url: "/api/landlord/verified-screenings",
+      headers: { authorization: "Bearer landlord-token" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("verifiedScreeningRoutes.ts");
+    expect(res.headers["x-route-source"]).not.toBe("screeningJobsAdminRoutes.ts");
+    expect(res.body).toEqual({ ok: true, data: [] });
   });
 
   it("keeps telemetry and screening history owned by explicit routers before screening job fallback", async () => {

--- a/rentchain-api/src/routes/__tests__/verifiedScreeningRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/verifiedScreeningRoutes.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: Record<string, any> };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, StoredDoc>());
+    return collections.get(name)!;
+  }
+
+  function buildSnapshot(entries: StoredDoc[]) {
+    const docs = entries.map((entry) => ({
+      id: entry.id,
+      data: () => entry.data,
+    }));
+    return { docs, empty: docs.length === 0, size: docs.length };
+  }
+
+  function queryCollection(name: string, filters: Array<{ field: string; value: any }> = [], limitCount?: number) {
+    const execute = () => {
+      const entries = Array.from(ensureCollection(name).values()).filter((entry) =>
+        filters.every((filter) => entry.data?.[filter.field] === filter.value)
+      );
+      return buildSnapshot(limitCount == null ? entries : entries.slice(0, limitCount));
+    };
+    return {
+      where(field: string, op: string, value: any) {
+        if (op !== "==") throw new Error(`Unsupported test operator ${op}`);
+        return queryCollection(name, [...filters, { field, value }], limitCount);
+      },
+      limit(count: number) {
+        return queryCollection(name, filters, count);
+      },
+      get: async () => execute(),
+      doc(id: string) {
+        return {
+          id,
+          get: async () => {
+            const entry = ensureCollection(name).get(id);
+            return {
+              id,
+              exists: Boolean(entry),
+              data: () => entry?.data,
+            };
+          },
+          set: async (payload: any, options?: { merge?: boolean }) => {
+            const col = ensureCollection(name);
+            const current = col.get(id)?.data || {};
+            col.set(id, { id, data: options?.merge ? { ...current, ...(payload || {}) } : payload });
+          },
+        };
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => queryCollection(name),
+    },
+    resetDb: () => collections.clear(),
+    seedDoc: (collectionName: string, id: string, data: Record<string, any>) => {
+      ensureCollection(collectionName).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../firebase", () => ({ db: dbMock }));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const token = String(req.headers?.authorization || "").replace(/^Bearer\s+/i, "").trim().toLowerCase();
+    if (token === "admin") {
+      req.user = { id: "admin-1", landlordId: "admin-1", role: "admin" };
+      return next();
+    }
+    if (token === "other-landlord") {
+      req.user = { id: "landlord-2", landlordId: "landlord-2", role: "landlord" };
+      return next();
+    }
+    if (token === "tenant") {
+      req.user = { id: "tenant-1", role: "tenant" };
+      return next();
+    }
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    return next();
+  },
+}));
+
+async function invokeRouter(options: { method: string; url: string; authorization?: string }) {
+  const router = (await import("../verifiedScreeningRoutes")).default;
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      params: {},
+      query: Object.fromEntries(query.entries()),
+      headers: options.authorization ? { authorization: options.authorization } : {},
+      body: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[String(name).toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedVerifiedScreening(id: string, overrides: Record<string, any> = {}) {
+  seedDoc("verifiedScreeningQueue", id, {
+    landlordId: "landlord-1",
+    applicationId: "app_raw_123",
+    orderId: "order_raw_123",
+    providerRef: "provider_ref_raw_123",
+    propertyId: "property_raw_123",
+    unitId: "unit_raw_123",
+    storagePath: "gs://bucket/raw-screening.pdf",
+    notesInternal: "Internal-only support note",
+    reviewer: { email: "reviewer@example.test" },
+    applicant: { name: "Phil Jones", email: "phil@example.test" },
+    createdAt: Date.UTC(2026, 5, 1, 12, 0),
+    updatedAt: Date.UTC(2026, 5, 1, 12, 30),
+    status: "IN_PROGRESS",
+    serviceLevel: "VERIFIED_AI",
+    aiIncluded: true,
+    scoreAddOn: false,
+    totalAmountCents: 4999,
+    currency: "CAD",
+    completedAt: null,
+    resultSummary: "Screening is underway.",
+    recommendation: null,
+    ...overrides,
+  });
+}
+
+describe("verifiedScreeningRoutes", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("returns a landlord-scoped safe verified-screening list without support identifiers", async () => {
+    seedVerifiedScreening("queue_doc_raw_1");
+    seedVerifiedScreening("queue_doc_other", {
+      landlordId: "landlord-2",
+      applicationId: "other_app_raw",
+      orderId: "other_order_raw",
+      applicant: { name: "Other Applicant", email: "other@example.test" },
+    });
+
+    const res = await invokeRouter({
+      method: "GET",
+      url: "/landlord/verified-screenings",
+      authorization: "Bearer landlord",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.ok).toBe(true);
+    expect(res.body?.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({
+      id: "verified-screening-1",
+      applicant: { name: "Phil Jones", email: "phil@example.test" },
+      status: "IN_PROGRESS",
+      serviceLevel: "VERIFIED_AI",
+      totalAmountCents: 4999,
+      currency: "CAD",
+    });
+
+    const publicPayload = JSON.stringify(res.body.data[0]);
+    expect(publicPayload).not.toContain("queue_doc_raw_1");
+    expect(publicPayload).not.toContain("landlord-1");
+    expect(publicPayload).not.toContain("app_raw_123");
+    expect(publicPayload).not.toContain("order_raw_123");
+    expect(publicPayload).not.toContain("provider_ref_raw_123");
+    expect(publicPayload).not.toContain("property_raw_123");
+    expect(publicPayload).not.toContain("unit_raw_123");
+    expect(publicPayload).not.toContain("gs://bucket/raw-screening.pdf");
+    expect(publicPayload).not.toContain("Internal-only support note");
+    expect(publicPayload).not.toContain("reviewer@example.test");
+    expect(publicPayload).not.toContain("other_app_raw");
+  });
+
+  it("rejects non-landlord users on the landlord verified-screenings route", async () => {
+    const res = await invokeRouter({
+      method: "GET",
+      url: "/landlord/verified-screenings",
+      authorization: "Bearer tenant",
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body?.error).toBe("FORBIDDEN");
+  });
+
+  it("preserves admin support identifiers on the admin verified-screenings route", async () => {
+    seedVerifiedScreening("queue_doc_raw_1");
+
+    const res = await invokeRouter({
+      method: "GET",
+      url: "/admin/verified-screenings",
+      authorization: "Bearer admin",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.[0]).toMatchObject({
+      id: "queue_doc_raw_1",
+      landlordId: "landlord-1",
+      applicationId: "app_raw_123",
+      orderId: "order_raw_123",
+      propertyId: "property_raw_123",
+      unitId: "unit_raw_123",
+      notesInternal: "Internal-only support note",
+    });
+  });
+});

--- a/rentchain-api/src/routes/verifiedScreeningRoutes.ts
+++ b/rentchain-api/src/routes/verifiedScreeningRoutes.ts
@@ -14,9 +14,75 @@ function ensureAdmin(req: any, res: any) {
   return true;
 }
 
+function resolveLandlordId(req: any) {
+  return String(req.user?.landlordId || req.user?.id || req.user?.uid || "").trim();
+}
+
+function ensureLandlordWorkspace(req: any, res: any) {
+  const role = String(req.user?.role || "").toLowerCase();
+  const landlordId = resolveLandlordId(req);
+  if (!["landlord", "admin"].includes(role) || !landlordId) {
+    res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    return null;
+  }
+  return landlordId;
+}
+
+function asNumber(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function asNullableString(value: unknown) {
+  const text = String(value || "").trim();
+  return text || null;
+}
+
+function projectLandlordVerifiedScreeningItem(data: any, index: number) {
+  return {
+    id: `verified-screening-${index + 1}`,
+    createdAt: asNumber(data?.createdAt),
+    updatedAt: asNumber(data?.updatedAt),
+    status: String(data?.status || "QUEUED").toUpperCase(),
+    serviceLevel: String(data?.serviceLevel || "VERIFIED").toUpperCase(),
+    applicant: {
+      name: asNullableString(data?.applicant?.name) || "Applicant",
+      email: asNullableString(data?.applicant?.email) || null,
+    },
+    aiIncluded: Boolean(data?.aiIncluded),
+    scoreAddOn: Boolean(data?.scoreAddOn),
+    totalAmountCents: asNumber(data?.totalAmountCents),
+    currency: String(data?.currency || "CAD").toUpperCase(),
+    completedAt: data?.completedAt == null ? null : asNumber(data.completedAt),
+    resultSummary: asNullableString(data?.resultSummary),
+    recommendation: asNullableString(data?.recommendation)?.toUpperCase() || null,
+  };
+}
+
 router.use(authenticateJwt);
 
 router.get("/screening/report", handleScreeningReport);
+
+router.get("/landlord/verified-screenings", async (req: any, res) => {
+  try {
+    const landlordId = ensureLandlordWorkspace(req, res);
+    if (!landlordId) return;
+
+    const snap = await db
+      .collection("verifiedScreeningQueue")
+      .where("landlordId", "==", landlordId)
+      .limit(200)
+      .get();
+    const items = snap.docs
+      .map((doc) => doc.data() as any)
+      .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0))
+      .map((item, index) => projectLandlordVerifiedScreeningItem(item, index));
+    return res.json({ ok: true, data: items });
+  } catch (err: any) {
+    console.error("[verified-screenings] landlord list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "VERIFIED_SCREENINGS_LIST_FAILED" });
+  }
+});
 
 router.get("/admin/verified-screenings", async (req: any, res) => {
   try {

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -1027,11 +1027,11 @@ function App() {
         <Route
           path="/admin/verified-screenings"
           element={
-            <RequireAuth>
+            <RequireAdmin>
               <Suspense fallback={null}>
                 <AdminVerifiedScreeningsPage />
               </Suspense>
-            </RequireAuth>
+            </RequireAdmin>
           }
         />
         <Route

--- a/rentchain-frontend/src/api/adminVerifiedScreeningsApi.test.ts
+++ b/rentchain-frontend/src/api/adminVerifiedScreeningsApi.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiJsonMock } = vi.hoisted(() => ({
+  apiJsonMock: vi.fn(),
+}));
+
+vi.mock("../lib/apiClient", () => ({
+  apiJson: apiJsonMock,
+}));
+
+describe("adminVerifiedScreeningsApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiJsonMock.mockResolvedValue({ ok: true, data: [] });
+  });
+
+  it("lists landlord verified screenings through the landlord-safe route", async () => {
+    const { listVerifiedScreenings } = await import("./adminVerifiedScreeningsApi");
+
+    await listVerifiedScreenings("landlord");
+
+    expect(apiJsonMock).toHaveBeenCalledWith("/landlord/verified-screenings");
+  });
+
+  it("keeps admin verified screenings on the admin route", async () => {
+    const { listVerifiedScreenings } = await import("./adminVerifiedScreeningsApi");
+
+    await listVerifiedScreenings("admin");
+
+    expect(apiJsonMock).toHaveBeenCalledWith("/admin/verified-screenings");
+  });
+});

--- a/rentchain-frontend/src/api/adminVerifiedScreeningsApi.ts
+++ b/rentchain-frontend/src/api/adminVerifiedScreeningsApi.ts
@@ -6,26 +6,34 @@ export type VerifiedScreeningQueueItem = {
   updatedAt: number;
   status: "QUEUED" | "IN_PROGRESS" | "COMPLETE" | "CANCELLED";
   serviceLevel: "VERIFIED" | "VERIFIED_AI";
-  landlordId: string;
-  applicationId: string;
-  orderId: string;
-  propertyId: string;
-  unitId: string | null;
+  landlordId?: string;
+  applicationId?: string;
+  orderId?: string;
+  propertyId?: string;
+  unitId?: string | null;
   applicant: { name: string; email: string };
   aiIncluded: boolean;
   scoreAddOn: boolean;
   totalAmountCents: number;
   currency: string;
-  notesInternal: string | null;
-  reviewer: { email?: string | null } | null;
+  notesInternal?: string | null;
+  reviewer?: { email?: string | null } | null;
   completedAt: number | null;
   resultSummary: string | null;
   recommendation: "APPROVE" | "DECLINE" | "CONDITIONAL" | null;
 };
 
-export async function listVerifiedScreenings(): Promise<VerifiedScreeningQueueItem[]> {
+export type VerifiedScreeningsAudience = "admin" | "landlord";
+
+export async function listVerifiedScreenings(
+  audience: VerifiedScreeningsAudience = "admin"
+): Promise<VerifiedScreeningQueueItem[]> {
+  const path =
+    audience === "landlord"
+      ? "/landlord/verified-screenings"
+      : "/admin/verified-screenings";
   const res = await apiJson<{ ok: boolean; data: VerifiedScreeningQueueItem[] }>(
-    "/admin/verified-screenings"
+    path
   );
   return res?.data || [];
 }

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
@@ -155,6 +155,50 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
       expect(mocks.listVerifiedScreenings).toHaveBeenLastCalledWith("admin");
     });
     expect(await screen.findByText("Jordan Admincase")).toBeInTheDocument();
+
+    mocks.user = { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.test" };
+    mocks.listVerifiedScreenings.mockResolvedValue([
+      {
+        id: "screening-2",
+        createdAt: Date.UTC(2026, 5, 3, 12, 0),
+        updatedAt: Date.UTC(2026, 5, 3, 12, 0),
+        status: "COMPLETE",
+        serviceLevel: "VERIFIED",
+        applicant: { name: "Riley Renter", email: "riley@example.test" },
+        aiIncluded: false,
+        scoreAddOn: false,
+        totalAmountCents: 3999,
+        currency: "CAD",
+        completedAt: Date.UTC(2026, 5, 3, 13, 0),
+        resultSummary: "Screening review completed.",
+        recommendation: "APPROVE",
+      },
+    ]);
+
+    view.rerender(
+      <MemoryRouter>
+        <AdminVerifiedScreeningsPage audience="landlord" shell="none" />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mocks.listVerifiedScreenings).toHaveBeenLastCalledWith("landlord");
+    });
+    expect(await screen.findByText("Riley Renter")).toBeInTheDocument();
+  });
+
+  it("does not render the admin queue for landlord users", async () => {
+    render(
+      <MemoryRouter>
+        <AdminVerifiedScreeningsPage shell="none" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Access denied")).toBeInTheDocument();
+    expect(screen.getByText("You do not have admin access for this queue.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open landlord screening workspace" })).toBeInTheDocument();
+    expect(screen.queryByText("Verified Screening Queue")).not.toBeInTheDocument();
+    expect(mocks.listVerifiedScreenings).not.toHaveBeenCalled();
   });
 });
 

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
@@ -88,10 +88,15 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
       expect(screen.getByText("Result summary")).toBeInTheDocument();
     });
     expect(screen.getByText("Screening review completed.")).toBeInTheDocument();
-    expect(screen.getByText("APPROVE")).toBeInTheDocument();
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+    expect(screen.getAllByText("Completed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Verified screening").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$49.99 CAD").length).toBeGreaterThan(0);
     expect(mocks.fetchVerifiedScreening).not.toHaveBeenCalled();
 
+    expect(screen.queryByText("COMPLETE")).not.toBeInTheDocument();
+    expect(screen.queryByText("VERIFIED")).not.toBeInTheDocument();
+    expect(screen.queryByText("APPROVE")).not.toBeInTheDocument();
     expect(screen.queryByText(/Application ID/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/app_raw_123/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Order ID/i)).not.toBeInTheDocument();
@@ -101,5 +106,56 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
     expect(screen.queryByText(/Unit ID/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unit_raw_123/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Internal-only note/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("AdminVerifiedScreeningsPage admin mode", () => {
+  beforeEach(() => {
+    cleanup();
+    mocks.listVerifiedScreenings.mockReset();
+    mocks.fetchVerifiedScreening.mockReset();
+    mocks.updateVerifiedScreening.mockReset();
+    mocks.showToast.mockReset();
+    mocks.user = { id: "admin-1", role: "admin", actorRole: "admin", email: "admin@example.test" };
+    const item = {
+      id: "screening-1",
+      createdAt: Date.UTC(2026, 5, 1, 12, 0),
+      updatedAt: Date.UTC(2026, 5, 1, 12, 0),
+      status: "IN_PROGRESS",
+      serviceLevel: "VERIFIED_AI",
+      landlordId: "landlord_raw_123",
+      applicationId: "app_raw_123",
+      orderId: "order_raw_123",
+      propertyId: "property_raw_123",
+      unitId: "unit_raw_123",
+      applicant: { name: "Phil Jones", email: "phil@example.test" },
+      aiIncluded: true,
+      scoreAddOn: false,
+      totalAmountCents: 4999,
+      currency: "CAD",
+      notesInternal: "Internal-only note",
+      reviewer: { email: "reviewer@example.test" },
+      completedAt: null,
+      resultSummary: null,
+      recommendation: null,
+    };
+    mocks.listVerifiedScreenings.mockResolvedValue([item]);
+    mocks.fetchVerifiedScreening.mockResolvedValue(item);
+  });
+
+  it("preserves admin support identifiers on the admin route", async () => {
+    render(
+      <MemoryRouter>
+        <AdminVerifiedScreeningsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Phil Jones")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Phil Jones/i }));
+
+    expect(await screen.findByText("Order ID: order_raw_123")).toBeInTheDocument();
+    expect(screen.getByText("Application ID: app_raw_123")).toBeInTheDocument();
+    expect(screen.getByText("Property ID: property_raw_123")).toBeInTheDocument();
+    expect(screen.getByText("Unit ID: unit_raw_123")).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
@@ -80,6 +80,7 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
     );
 
     expect(await screen.findByText("Phil Jones")).toBeInTheDocument();
+    expect(mocks.listVerifiedScreenings).toHaveBeenCalledWith("landlord");
     expect(screen.getByPlaceholderText("Search applicant or email")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Phil Jones/i }));
@@ -151,6 +152,7 @@ describe("AdminVerifiedScreeningsPage admin mode", () => {
     );
 
     expect(await screen.findByText("Phil Jones")).toBeInTheDocument();
+    expect(mocks.listVerifiedScreenings).toHaveBeenCalledWith("admin");
     fireEvent.click(screen.getByRole("button", { name: /Phil Jones/i }));
 
     expect(await screen.findByText("Order ID: order_raw_123")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
@@ -108,6 +108,54 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
     expect(screen.queryByText(/unit_raw_123/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Internal-only note/i)).not.toBeInTheDocument();
   });
+
+  it("reloads through the admin endpoint when the route audience changes", async () => {
+    const view = render(
+      <MemoryRouter>
+        <AdminVerifiedScreeningsPage audience="landlord" shell="none" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Phil Jones")).toBeInTheDocument();
+    expect(mocks.listVerifiedScreenings).toHaveBeenCalledWith("landlord");
+
+    mocks.user = { id: "admin-1", role: "admin", actorRole: "admin", email: "admin@example.test" };
+    mocks.listVerifiedScreenings.mockResolvedValue([
+      {
+        id: "admin-screening-1",
+        createdAt: Date.UTC(2026, 5, 2, 12, 0),
+        updatedAt: Date.UTC(2026, 5, 2, 12, 0),
+        status: "IN_PROGRESS",
+        serviceLevel: "VERIFIED_AI",
+        landlordId: "landlord_raw_123",
+        applicationId: "app_raw_456",
+        orderId: "order_raw_456",
+        propertyId: "property_raw_456",
+        unitId: "unit_raw_456",
+        applicant: { name: "Jordan Admincase", email: "jordan@example.test" },
+        aiIncluded: true,
+        scoreAddOn: false,
+        totalAmountCents: 4999,
+        currency: "CAD",
+        notesInternal: "Internal-only note",
+        reviewer: { email: "reviewer@example.test" },
+        completedAt: null,
+        resultSummary: null,
+        recommendation: null,
+      },
+    ]);
+
+    view.rerender(
+      <MemoryRouter>
+        <AdminVerifiedScreeningsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mocks.listVerifiedScreenings).toHaveBeenLastCalledWith("admin");
+    });
+    expect(await screen.findByText("Jordan Admincase")).toBeInTheDocument();
+  });
 });
 
 describe("AdminVerifiedScreeningsPage admin mode", () => {

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
@@ -137,9 +137,18 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
 
   const isAdmin = String(user?.role || "").toLowerCase() === "admin";
   const isAdminAudience = audience === "admin";
+  const adminAccessDenied = isAdminAudience && !isAdmin;
   const pageTitle = isAdminAudience ? "Admin · Verified Screenings" : "Verified Screenings";
 
   const load = useCallback(async () => {
+    if (adminAccessDenied) {
+      setItems([]);
+      setSelectedId(null);
+      setDetail(null);
+      setViewMessage("Admin access is required to view this queue.");
+      setViewState("forbidden");
+      return;
+    }
     try {
       setLoading(true);
       setViewMessage(null);
@@ -173,7 +182,7 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
     } finally {
       setLoading(false);
     }
-  }, [audience, showToast]);
+  }, [adminAccessDenied, audience, showToast]);
 
   useEffect(() => {
     void load();
@@ -236,6 +245,22 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
       setSaving(false);
     }
   };
+
+  if (adminAccessDenied) {
+    return renderShell(
+      <Section>
+        <Card elevated style={{ display: "grid", gap: 12 }}>
+          <h1 style={{ margin: 0, fontSize: "1.2rem" }}>Access denied</h1>
+          <div style={{ color: text.muted }}>You do not have admin access for this queue.</div>
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            <Button type="button" onClick={() => navigate("/verified-screenings")}>
+              Open landlord screening workspace
+            </Button>
+          </div>
+        </Card>
+      </Section>
+    );
+  }
 
   if (viewState !== "ready") {
     const heading =

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { MacShell } from "../components/layout/MacShell";
 import { Card, Section, Button, Pill, Input } from "../components/ui/Ui";
@@ -139,10 +139,12 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
   const isAdminAudience = audience === "admin";
   const pageTitle = isAdminAudience ? "Admin · Verified Screenings" : "Verified Screenings";
 
-  const load = async () => {
+  const load = useCallback(async () => {
     try {
       setLoading(true);
       setViewMessage(null);
+      setSelectedId(null);
+      setDetail(null);
       const list = await listVerifiedScreenings(audience);
       setItems(list);
       setViewState(list.length === 0 ? "empty" : "ready");
@@ -171,11 +173,11 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
     } finally {
       setLoading(false);
     }
-  };
+  }, [audience, showToast]);
 
   useEffect(() => {
     void load();
-  }, []);
+  }, [load]);
 
   useEffect(() => {
     const loadDetail = async () => {

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
@@ -143,7 +143,7 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
     try {
       setLoading(true);
       setViewMessage(null);
-      const list = await listVerifiedScreenings();
+      const list = await listVerifiedScreenings(audience);
       setItems(list);
       setViewState(list.length === 0 ? "empty" : "ready");
     } catch (err: any) {

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
@@ -30,6 +30,40 @@ type AdminVerifiedScreeningsPageProps = {
   shell?: VerifiedScreeningsShell;
 };
 
+function formatVerifiedScreeningStatus(value?: string | null) {
+  const normalized = String(value || "").trim().toUpperCase();
+  const labels: Record<string, string> = {
+    QUEUED: "Waiting to start",
+    IN_PROGRESS: "In progress",
+    COMPLETE: "Completed",
+    COMPLETED: "Completed",
+    CANCELLED: "Cancelled",
+    CANCELED: "Cancelled",
+    FAILED: "Needs attention",
+    NOT_REQUESTED: "Not requested",
+  };
+  return labels[normalized] || String(value || "Status unavailable").replace(/_/g, " ");
+}
+
+function formatVerifiedScreeningServiceLevel(value?: string | null) {
+  const normalized = String(value || "").trim().toUpperCase();
+  const labels: Record<string, string> = {
+    VERIFIED: "Verified screening",
+    VERIFIED_AI: "Verified screening with assisted review",
+  };
+  return labels[normalized] || String(value || "Screening package").replace(/_/g, " ");
+}
+
+function formatVerifiedScreeningRecommendation(value?: string | null) {
+  const normalized = String(value || "").trim().toUpperCase();
+  const labels: Record<string, string> = {
+    APPROVE: "Approve",
+    DECLINE: "Decline",
+    CONDITIONAL: "Conditional",
+  };
+  return labels[normalized] || "Pending review";
+}
+
 function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) {
   return (
     <div style={{ display: "grid", gap: spacing.md }}>
@@ -43,8 +77,8 @@ function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) 
           </div>
         </div>
         <div className="rc-wrap-row">
-          <Pill>{item.serviceLevel}</Pill>
-          <Pill>{item.status}</Pill>
+          <Pill>{formatVerifiedScreeningServiceLevel(item.serviceLevel)}</Pill>
+          <Pill>{formatVerifiedScreeningStatus(item.status)}</Pill>
         </div>
       </div>
 
@@ -61,7 +95,7 @@ function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) 
         </div>
         <div>
           <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>Recommendation</div>
-          <div>{item.recommendation || "Pending review"}</div>
+          <div>{formatVerifiedScreeningRecommendation(item.recommendation)}</div>
         </div>
         <div>
           <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>AI review</div>
@@ -286,8 +320,8 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
                       <div style={{ fontWeight: 700, color: text.primary }}>{item.applicant?.name || "Applicant"}</div>
                       <div style={{ color: text.muted, fontSize: 12 }}>{item.applicant?.email || "No email"}</div>
                       <div className="rc-wrap-row">
-                        <Pill>{item.status}</Pill>
-                        <Pill>{item.serviceLevel}</Pill>
+                        <Pill>{isAdminAudience ? item.status : formatVerifiedScreeningStatus(item.status)}</Pill>
+                        <Pill>{isAdminAudience ? item.serviceLevel : formatVerifiedScreeningServiceLevel(item.serviceLevel)}</Pill>
                       </div>
                       <div style={{ fontSize: 12, color: text.muted }}>
                         ${(item.totalAmountCents / 100).toFixed(2)} {item.currency}

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -1083,6 +1083,101 @@ describe("ApplicationsPage", () => {
     expect(screen.getAllByRole("button", { name: "Choose applicant" }).length).toBeGreaterThan(0);
   });
 
+  it("renders completed screening details with landlord-safe labels and no raw vendor references", async () => {
+    mocks.entitlementsMock.mockReturnValue({
+      loading: false,
+      plan: "starter",
+      role: "landlord",
+      isAdmin: false,
+      capabilities: {},
+      hasCapability: () => true,
+      requiredPlanFor: () => "starter",
+      canScreen: true,
+      canViewScreeningHistory: true,
+      canExportPdf: true,
+      hasMoveInReadiness: false,
+      canUseWorkOrders: false,
+      canViewReviewSummary: false,
+    });
+    mocks.getTransUnionIntegration.mockResolvedValue({
+      provider: "transunion",
+      status: "connected",
+      version: 1,
+    });
+    mocks.fetchRentalApplication.mockResolvedValue({
+      id: "app-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      applicationLinkId: "link-1",
+      createdAt: Date.now(),
+      submittedAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "SUBMITTED",
+      applicant: { firstName: "Jamie", lastName: "Stone", email: "jamie@example.com" },
+      residentialHistory: [],
+      employment: { applicant: {} },
+      consent: { creditConsent: true, referenceConsent: true, dataSharingConsent: true, acceptedAt: Date.now() },
+      screeningStatus: "complete",
+      screeningProvider: "STUB",
+      screening: {
+        requested: true,
+        status: "COMPLETE",
+        serviceLevel: "VERIFIED_AI",
+        orderId: "order_raw_123",
+        provider: "STUB",
+        totalAmountCents: 4999,
+        currency: "CAD",
+        paidAt: "2026-06-01T12:00:00.000Z",
+        result: {
+          riskBand: "Low",
+          matchConfidence: "High",
+          fileFound: true,
+          score: 720,
+          notes: "",
+        },
+      },
+      landlordNote: null,
+    });
+    mocks.fetchScreeningReceipt.mockResolvedValue({
+      ok: true,
+      receipt: {
+        status: "paid",
+        provider: "STUB",
+        inquiryType: "Soft inquiry (no score impact)",
+        consentVersion: "v1",
+        consentTimestamp: "2026-06-01T12:00:00.000Z",
+        referenceId: "provider_ref_raw_123",
+        generatedAt: "2026-06-01T12:05:00.000Z",
+        reportUrl: "https://example.test/report",
+        pdfUrl: "https://example.test/report.pdf",
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    const applicantName = await screen.findByText("Jamie Stone");
+    const applicantRow = applicantName.closest('[role="button"]');
+    expect(applicantRow).toBeTruthy();
+    fireEvent.click(applicantRow as HTMLElement);
+
+    expect(await screen.findByText("Screening package: Verified screening with assisted review")).toBeInTheDocument();
+    expect(screen.getAllByText("Screening partner: Demo screening").length).toBeGreaterThan(0);
+    expect(await screen.findByText("Screening receipt")).toBeInTheDocument();
+    expect(screen.getByText("Pre-approval screening summary recorded.")).toBeInTheDocument();
+
+    expect(screen.queryByText(/Order ID/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/order_raw_123/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Reference ID/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/provider_ref_raw_123/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Copy reference ID/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/STUB/i)).not.toBeInTheDocument();
+  });
+
   it("shows Starter-aligned screening upgrade copy instead of the old Pro gate", async () => {
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
 

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -218,8 +218,25 @@ const formatScreeningStatus = (value?: string | null) => {
 const formatScreeningProviderLabel = (value?: string | null) => {
   const normalized = String(value || "").trim().toLowerCase();
   if (!normalized) return "Configured screening provider";
+  if (normalized === "stub" || normalized === "demo" || normalized === "test") return "Demo screening";
   if (normalized === "transunion" || normalized === "transunion_manual") return "TransUnion";
+  if (/^[a-z0-9]+(?:[_-][a-z0-9]+)+$/i.test(normalized)) {
+    return normalized.replace(/[_-]/g, " ").replace(/\b\w/g, (match) => match.toUpperCase());
+  }
   return String(value);
+};
+
+const formatScreeningPackageLabel = (value?: string | null) => {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return null;
+  const labels: Record<string, string> = {
+    basic: "Basic screening",
+    verify: "Verified screening",
+    verified: "Verified screening",
+    verified_ai: "Verified screening with assisted review",
+    premium: "Premium screening",
+  };
+  return labels[normalized] || normalized.replace(/[_-]/g, " ").replace(/\b\w/g, (match) => match.toUpperCase());
 };
 
 function ScreeningProviderSetupCard({
@@ -770,6 +787,9 @@ const ApplicationsPage: React.FC = () => {
       coApplicant: detail.coApplicant || null,
       consent: detail.consent || null,
       decisionSummary,
+      screeningProvider: formatScreeningProviderLabel(
+        detail.screeningProvider || detail.screening?.provider || null
+      ),
       viewingRequests: matchingViewingRequests,
     };
   }, [decisionSummary, detail, properties, showCancelledViewingRequests, viewingRequests]);
@@ -3297,7 +3317,7 @@ const ApplicationsPage: React.FC = () => {
                       ) : null}
                       {screeningStatus?.provider ? (
                         <span style={{ fontSize: 12, color: text.subtle }}>
-                          Provider: {formatScreeningProviderLabel(screeningStatus.provider)}
+                          Screening partner: {formatScreeningProviderLabel(screeningStatus.provider)}
                         </span>
                       ) : null}
                     </div>
@@ -3423,9 +3443,8 @@ const ApplicationsPage: React.FC = () => {
                     {detail.screening?.status === "COMPLETE" && detail.screening.result ? (
                       <div className="rc-applications-screening-grid">
                         {detail.screening.serviceLevel ? (
-                          <div>Service level: {detail.screening.serviceLevel.replace("_", " ")}</div>
+                          <div>Screening package: {formatScreeningPackageLabel(detail.screening.serviceLevel)}</div>
                         ) : null}
-                        {detail.screening.orderId ? <div>Order ID: {detail.screening.orderId}</div> : null}
                         {typeof detail.screening.totalAmountCents === "number" ? (
                           <div>
                             Paid: ${(detail.screening.totalAmountCents / 100).toFixed(2)} {detail.screening.currency || "CAD"}
@@ -3443,13 +3462,13 @@ const ApplicationsPage: React.FC = () => {
                         {detail.screening.paidAt ? (
                           <div>Paid at: {new Date(detail.screening.paidAt).toLocaleString()}</div>
                         ) : null}
-                        <div>Provider: {detail.screening.provider || "STUB"}</div>
+                        <div>Screening partner: {formatScreeningProviderLabel(detail.screening.provider)}</div>
                         <div>Risk band: {detail.screening.result.riskBand}</div>
                         <div>Match confidence: {detail.screening.result.matchConfidence}</div>
                         <div>File found: {detail.screening.result.fileFound ? "Yes" : "No"}</div>
                         {detail.screening.result.score ? <div>Score: {detail.screening.result.score}</div> : null}
                         <div style={{ fontSize: 12, color: text.muted }}>
-                          {detail.screening.result.notes || "This is a pre-approval report (stub)."}
+                          {detail.screening.result.notes || "Pre-approval screening summary recorded."}
                         </div>
                         {detail.screening.ai ? (
                           <div className="rc-applications-ai-panel" style={{ borderTop: `1px solid ${colors.border}`, paddingTop: 8 }}>
@@ -3600,7 +3619,7 @@ const ApplicationsPage: React.FC = () => {
                   <div style={{ display: "grid", gap: 6, fontSize: 12 }}>
                     <div style={{ fontWeight: 700, fontSize: 13 }}>Screening receipt</div>
                     {receiptStatusLabel ? <div>Status: {receiptStatusLabel}</div> : null}
-                    <div>Provider: {formatScreeningProviderLabel(screeningReceipt.provider)}</div>
+                    <div>Screening partner: {formatScreeningProviderLabel(screeningReceipt.provider)}</div>
                     <div>Inquiry type: {screeningReceipt.inquiryType || "Soft inquiry (no score impact)"}</div>
                     <div>
                       Consent: {screeningReceipt.consentVersion || CONSENT_VERSION}
@@ -3608,7 +3627,6 @@ const ApplicationsPage: React.FC = () => {
                         ? ` · ${new Date(screeningReceipt.consentTimestamp).toLocaleString()}`
                         : ""}
                     </div>
-                    {screeningReceipt.referenceId ? <div>Reference ID: {screeningReceipt.referenceId}</div> : null}
                     {screeningReceipt.generatedAt ? (
                       <div>Generated: {new Date(screeningReceipt.generatedAt).toLocaleString()}</div>
                     ) : null}
@@ -3636,18 +3654,6 @@ const ApplicationsPage: React.FC = () => {
                         ) : (
                           <UpgradeCTA featureKey="pdf_export" label="Upgrade for PDF Export" variant="secondary" />
                         )
-                      ) : null}
-                      {screeningReceipt.referenceId ? (
-                        <Button
-                          variant="ghost"
-                          onClick={() => {
-                            if (!screeningReceipt.referenceId) return;
-                            navigator.clipboard.writeText(screeningReceipt.referenceId);
-                            showToast({ message: "Reference ID copied", variant: "success" });
-                          }}
-                        >
-                          Copy reference ID
-                        </Button>
                       ) : null}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

Replaces landlord-visible screening provider/vendor/internal language with safer landlord-facing labels on the Applications and Verified Screenings surfaces.

## What changed

- `/applications`
  - Replaced completed-screening `Service level` copy with `Screening package` using safe display labels.
  - Removed landlord-visible `Order ID` from completed screening details.
  - Replaced `Provider:` with `Screening partner:` and maps `STUB`/demo/test fallback values to `Demo screening`.
  - Replaced the raw `STUB` fallback note with `Pre-approval screening summary recorded.`
  - Removed landlord-visible `Reference ID` and `Copy reference ID` from screening receipt output.
  - Passed the same safe screening partner label into the browser print/export model so print output does not show raw `STUB` provider text.
- `/verified-screenings`
  - Maps landlord-facing queue status values such as `QUEUED`, `IN_PROGRESS`, `COMPLETE`, and `NOT_REQUESTED` to readable labels.
  - Maps landlord-facing service-level codes such as `VERIFIED` and `VERIFIED_AI` to readable screening package labels.
  - Maps landlord-facing recommendations such as `APPROVE` to readable labels.
  - Preserves admin route support details on `/admin/verified-screenings`, including admin-only raw identifiers where that route already exposes them.

## Scope notes

- Frontend-only.
- Screening workflow/backend values were not changed.
- Provider integrations were not changed.
- Application Review Summary was not reopened.
- Admin route behavior is preserved intentionally through route-aware rendering.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationsPage.test.tsx` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/AdminVerifiedScreeningsPage.test.tsx` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Manual QA needed

- `/applications`: select an application with completed screening/receipt data and confirm no `Order ID`, `Reference ID`, `Copy reference ID`, or raw `STUB` text is visible; confirm print/export also avoids raw provider fallback text.
- `/verified-screenings`: confirm landlord queue/status/package labels are readable and not enum-style.
- `/admin/verified-screenings`: confirm admin support identifiers remain available.
- Regression routes: `/dashboard`, `/operations`, `/applications/:applicationId/review-summary`.