### PR TITLE
fix: tighten landlord verified screenings projection

### DIFF
--- a/rentchain-api/src/routes/__tests__/verifiedScreeningRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/verifiedScreeningRoutes.test.ts
@@ -185,16 +185,23 @@ describe("verifiedScreeningRoutes", () => {
     expect(res.body?.ok).toBe(true);
     expect(res.body?.data).toHaveLength(1);
     expect(res.body.data[0]).toMatchObject({
-      id: "verified-screening-1",
+      displayId: "Screening 1",
       applicant: { name: "Phil Jones", email: "phil@example.test" },
-      status: "IN_PROGRESS",
-      serviceLevel: "VERIFIED_AI",
+      statusLabel: "In progress",
+      packageLabel: "Verified screening with assisted review",
       totalAmountCents: 4999,
       currency: "CAD",
+      recommendationLabel: "Pending review",
     });
 
     const publicPayload = JSON.stringify(res.body.data[0]);
+    expect(res.body.data[0]).not.toHaveProperty("id");
+    expect(res.body.data[0]).not.toHaveProperty("status");
+    expect(res.body.data[0]).not.toHaveProperty("serviceLevel");
+    expect(res.body.data[0]).not.toHaveProperty("recommendation");
     expect(publicPayload).not.toContain("queue_doc_raw_1");
+    expect(publicPayload).not.toContain("IN_PROGRESS");
+    expect(publicPayload).not.toContain("VERIFIED_AI");
     expect(publicPayload).not.toContain("landlord-1");
     expect(publicPayload).not.toContain("app_raw_123");
     expect(publicPayload).not.toContain("order_raw_123");
@@ -205,6 +212,32 @@ describe("verifiedScreeningRoutes", () => {
     expect(publicPayload).not.toContain("Internal-only support note");
     expect(publicPayload).not.toContain("reviewer@example.test");
     expect(publicPayload).not.toContain("other_app_raw");
+  });
+
+  it("returns landlord-facing labels for completed verified-screening results", async () => {
+    seedVerifiedScreening("queue_doc_raw_1", {
+      status: "COMPLETE",
+      serviceLevel: "VERIFIED",
+      recommendation: "APPROVE",
+    });
+
+    const res = await invokeRouter({
+      method: "GET",
+      url: "/landlord/verified-screenings",
+      authorization: "Bearer landlord",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.[0]).toMatchObject({
+      displayId: "Screening 1",
+      statusLabel: "Completed",
+      packageLabel: "Verified screening",
+      recommendationLabel: "Approve",
+    });
+    const publicPayload = JSON.stringify(res.body.data[0]);
+    expect(publicPayload).not.toContain("COMPLETE");
+    expect(publicPayload).not.toContain("VERIFIED");
+    expect(publicPayload).not.toContain("APPROVE");
   });
 
   it("rejects non-landlord users on the landlord verified-screenings route", async () => {

--- a/rentchain-api/src/routes/verifiedScreeningRoutes.ts
+++ b/rentchain-api/src/routes/verifiedScreeningRoutes.ts
@@ -38,13 +38,47 @@ function asNullableString(value: unknown) {
   return text || null;
 }
 
+function verifiedScreeningStatusLabel(value: unknown) {
+  const normalized = String(value || "QUEUED").trim().toUpperCase();
+  const labels: Record<string, string> = {
+    QUEUED: "Waiting to start",
+    IN_PROGRESS: "In progress",
+    COMPLETE: "Completed",
+    COMPLETED: "Completed",
+    CANCELLED: "Cancelled",
+    CANCELED: "Cancelled",
+    FAILED: "Needs attention",
+    NOT_REQUESTED: "Not requested",
+  };
+  return labels[normalized] || "Status unavailable";
+}
+
+function verifiedScreeningPackageLabel(value: unknown) {
+  const normalized = String(value || "VERIFIED").trim().toUpperCase();
+  const labels: Record<string, string> = {
+    VERIFIED: "Verified screening",
+    VERIFIED_AI: "Verified screening with assisted review",
+  };
+  return labels[normalized] || "Verified screening";
+}
+
+function verifiedScreeningRecommendationLabel(value: unknown) {
+  const normalized = String(value || "").trim().toUpperCase();
+  const labels: Record<string, string> = {
+    APPROVE: "Approve",
+    DECLINE: "Decline",
+    CONDITIONAL: "Conditional",
+  };
+  return labels[normalized] || "Pending review";
+}
+
 function projectLandlordVerifiedScreeningItem(data: any, index: number) {
   return {
-    id: `verified-screening-${index + 1}`,
+    displayId: `Screening ${index + 1}`,
     createdAt: asNumber(data?.createdAt),
     updatedAt: asNumber(data?.updatedAt),
-    status: String(data?.status || "QUEUED").toUpperCase(),
-    serviceLevel: String(data?.serviceLevel || "VERIFIED").toUpperCase(),
+    statusLabel: verifiedScreeningStatusLabel(data?.status),
+    packageLabel: verifiedScreeningPackageLabel(data?.serviceLevel),
     applicant: {
       name: asNullableString(data?.applicant?.name) || "Applicant",
       email: asNullableString(data?.applicant?.email) || null,
@@ -55,7 +89,7 @@ function projectLandlordVerifiedScreeningItem(data: any, index: number) {
     currency: String(data?.currency || "CAD").toUpperCase(),
     completedAt: data?.completedAt == null ? null : asNumber(data.completedAt),
     resultSummary: asNullableString(data?.resultSummary),
-    recommendation: asNullableString(data?.recommendation)?.toUpperCase() || null,
+    recommendationLabel: verifiedScreeningRecommendationLabel(data?.recommendation),
   };
 }
 

--- a/rentchain-frontend/src/api/adminVerifiedScreeningsApi.ts
+++ b/rentchain-frontend/src/api/adminVerifiedScreeningsApi.ts
@@ -1,11 +1,14 @@
 import { apiJson } from "../lib/apiClient";
 
 export type VerifiedScreeningQueueItem = {
-  id: string;
+  id?: string;
+  displayId?: string;
   createdAt: number;
   updatedAt: number;
-  status: "QUEUED" | "IN_PROGRESS" | "COMPLETE" | "CANCELLED";
-  serviceLevel: "VERIFIED" | "VERIFIED_AI";
+  status?: "QUEUED" | "IN_PROGRESS" | "COMPLETE" | "CANCELLED";
+  statusLabel?: string;
+  serviceLevel?: "VERIFIED" | "VERIFIED_AI";
+  packageLabel?: string;
   landlordId?: string;
   applicationId?: string;
   orderId?: string;
@@ -20,7 +23,8 @@ export type VerifiedScreeningQueueItem = {
   reviewer?: { email?: string | null } | null;
   completedAt: number | null;
   resultSummary: string | null;
-  recommendation: "APPROVE" | "DECLINE" | "CONDITIONAL" | null;
+  recommendation?: "APPROVE" | "DECLINE" | "CONDITIONAL" | null;
+  recommendationLabel?: string;
 };
 
 export type VerifiedScreeningsAudience = "admin" | "landlord";

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
@@ -48,26 +48,19 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
     mocks.user = { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.test" };
     mocks.listVerifiedScreenings.mockResolvedValue([
       {
-        id: "screening-1",
+        displayId: "Screening 1",
         createdAt: Date.UTC(2026, 5, 1, 12, 0),
         updatedAt: Date.UTC(2026, 5, 1, 12, 0),
-        status: "COMPLETE",
-        serviceLevel: "VERIFIED",
-        landlordId: "landlord_raw_123",
-        applicationId: "app_raw_123",
-        orderId: "order_raw_123",
-        propertyId: "property_raw_123",
-        unitId: "unit_raw_123",
+        statusLabel: "Completed",
+        packageLabel: "Verified screening",
         applicant: { name: "Phil Jones", email: "phil@example.test" },
         aiIncluded: true,
         scoreAddOn: false,
         totalAmountCents: 4999,
         currency: "CAD",
-        notesInternal: "Internal-only note",
-        reviewer: { email: "reviewer@example.test" },
         completedAt: Date.UTC(2026, 5, 1, 13, 0),
         resultSummary: "Screening review completed.",
-        recommendation: "APPROVE",
+        recommendationLabel: "Approve",
       },
     ]);
   });
@@ -159,11 +152,11 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
     mocks.user = { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.test" };
     mocks.listVerifiedScreenings.mockResolvedValue([
       {
-        id: "screening-2",
+        displayId: "Screening 2",
         createdAt: Date.UTC(2026, 5, 3, 12, 0),
         updatedAt: Date.UTC(2026, 5, 3, 12, 0),
-        status: "COMPLETE",
-        serviceLevel: "VERIFIED",
+        statusLabel: "Completed",
+        packageLabel: "Verified screening",
         applicant: { name: "Riley Renter", email: "riley@example.test" },
         aiIncluded: false,
         scoreAddOn: false,
@@ -171,7 +164,7 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
         currency: "CAD",
         completedAt: Date.UTC(2026, 5, 3, 13, 0),
         resultSummary: "Screening review completed.",
-        recommendation: "APPROVE",
+        recommendationLabel: "Approve",
       },
     ]);
 

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
@@ -45,6 +45,10 @@ function formatVerifiedScreeningStatus(value?: string | null) {
   return labels[normalized] || String(value || "Status unavailable").replace(/_/g, " ");
 }
 
+function verifiedScreeningStatusDisplay(item: VerifiedScreeningQueueItem) {
+  return item.statusLabel || formatVerifiedScreeningStatus(item.status);
+}
+
 function formatVerifiedScreeningServiceLevel(value?: string | null) {
   const normalized = String(value || "").trim().toUpperCase();
   const labels: Record<string, string> = {
@@ -52,6 +56,10 @@ function formatVerifiedScreeningServiceLevel(value?: string | null) {
     VERIFIED_AI: "Verified screening with assisted review",
   };
   return labels[normalized] || String(value || "Screening package").replace(/_/g, " ");
+}
+
+function verifiedScreeningPackageDisplay(item: VerifiedScreeningQueueItem) {
+  return item.packageLabel || formatVerifiedScreeningServiceLevel(item.serviceLevel);
 }
 
 function formatVerifiedScreeningRecommendation(value?: string | null) {
@@ -62,6 +70,14 @@ function formatVerifiedScreeningRecommendation(value?: string | null) {
     CONDITIONAL: "Conditional",
   };
   return labels[normalized] || "Pending review";
+}
+
+function verifiedScreeningRecommendationDisplay(item: VerifiedScreeningQueueItem) {
+  return item.recommendationLabel || formatVerifiedScreeningRecommendation(item.recommendation);
+}
+
+function verifiedScreeningListKey(item: VerifiedScreeningQueueItem, index: number) {
+  return item.id || item.displayId || `${item.applicant?.email || "screening"}-${item.createdAt || index}`;
 }
 
 function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) {
@@ -77,8 +93,8 @@ function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) 
           </div>
         </div>
         <div className="rc-wrap-row">
-          <Pill>{formatVerifiedScreeningServiceLevel(item.serviceLevel)}</Pill>
-          <Pill>{formatVerifiedScreeningStatus(item.status)}</Pill>
+          <Pill>{verifiedScreeningPackageDisplay(item)}</Pill>
+          <Pill>{verifiedScreeningStatusDisplay(item)}</Pill>
         </div>
       </div>
 
@@ -95,7 +111,7 @@ function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) 
         </div>
         <div>
           <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>Recommendation</div>
-          <div>{formatVerifiedScreeningRecommendation(item.recommendation)}</div>
+          <div>{verifiedScreeningRecommendationDisplay(item)}</div>
         </div>
         <div>
           <div style={{ color: text.muted, fontSize: 12, fontWeight: 700 }}>AI review</div>
@@ -215,7 +231,10 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
   }, [isAdminAudience, items, search]);
 
   const selectedSummary = useMemo(
-    () => (selectedId ? items.find((item) => item.id === selectedId) || null : null),
+    () =>
+      selectedId
+        ? items.find((item, index) => verifiedScreeningListKey(item, index) === selectedId) || null
+        : null,
     [items, selectedId]
   );
 
@@ -228,6 +247,10 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
 
   const handleSave = async () => {
     if (!detail) return;
+    if (!detail.id) {
+      showToast({ message: "Save failed", description: "Missing admin queue identifier.", variant: "error" });
+      return;
+    }
     try {
       setSaving(true);
       const updated = await updateVerifiedScreening(detail.id, {
@@ -328,15 +351,17 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
                 ) : filtered.length === 0 ? (
                   <div style={{ color: text.muted }}>No verified screenings.</div>
                 ) : (
-                  filtered.map((item) => (
+                  filtered.map((item, index) => {
+                    const itemKey = verifiedScreeningListKey(item, index);
+                    return (
                     <button
-                      key={item.id}
+                      key={itemKey}
                       type="button"
-                      onClick={() => setSelectedId(item.id)}
+                      onClick={() => setSelectedId(itemKey)}
                       style={{
                         textAlign: "left",
-                        border: `1px solid ${item.id === selectedId ? colors.accent : colors.border}`,
-                        background: item.id === selectedId ? "rgba(37,99,235,0.08)" : colors.card,
+                        border: `1px solid ${itemKey === selectedId ? colors.accent : colors.border}`,
+                        background: itemKey === selectedId ? "rgba(37,99,235,0.08)" : colors.card,
                         borderRadius: radius.md,
                         padding: "10px 12px",
                         cursor: "pointer",
@@ -347,14 +372,15 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
                       <div style={{ fontWeight: 700, color: text.primary }}>{item.applicant?.name || "Applicant"}</div>
                       <div style={{ color: text.muted, fontSize: 12 }}>{item.applicant?.email || "No email"}</div>
                       <div className="rc-wrap-row">
-                        <Pill>{isAdminAudience ? item.status : formatVerifiedScreeningStatus(item.status)}</Pill>
-                        <Pill>{isAdminAudience ? item.serviceLevel : formatVerifiedScreeningServiceLevel(item.serviceLevel)}</Pill>
+                        <Pill>{isAdminAudience ? item.status : verifiedScreeningStatusDisplay(item)}</Pill>
+                        <Pill>{isAdminAudience ? item.serviceLevel : verifiedScreeningPackageDisplay(item)}</Pill>
                       </div>
                       <div style={{ fontSize: 12, color: text.muted }}>
                         ${(item.totalAmountCents / 100).toFixed(2)} {item.currency}
                       </div>
                     </button>
-                  ))
+                    );
+                  })
                 )}
               </div>
             }
@@ -366,8 +392,8 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
                   className="rc-full-width-mobile"
                 >
                   <option value="">Select screening</option>
-                  {filtered.map((item) => (
-                    <option key={item.id} value={item.id}>
+                  {filtered.map((item, index) => (
+                    <option key={verifiedScreeningListKey(item, index)} value={verifiedScreeningListKey(item, index)}>
                       {item.applicant?.name || "Applicant"}
                     </option>
                   ))}
@@ -412,7 +438,7 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
                     <div style={{ display: "grid", gap: 8 }}>
                       <label style={{ fontSize: 12, fontWeight: 600 }}>Status</label>
                       <select
-                        value={detail.status}
+                        value={detail.status || "QUEUED"}
                         onChange={(e) => setDetail({ ...detail, status: e.target.value as any })}
                         style={{ padding: "8px 10px", borderRadius: radius.md, border: `1px solid ${colors.border}` }}
                       >


### PR DESCRIPTION
## Summary

- Tightens `GET /api/landlord/verified-screenings` to return landlord-facing projection fields instead of raw enum/service-level values.
- Replaces landlord payload `id`, `status`, `serviceLevel`, and `recommendation` with safe presentation fields: `displayId`, `statusLabel`, `packageLabel`, and `recommendationLabel`.
- Keeps `/api/admin/verified-screenings` unchanged so admin support identifiers and queue update behavior remain available.
- Updates the landlord verified-screenings UI contract to consume the label-first DTO while preserving admin route behavior.

## Safety

- Landlord response no longer exposes raw queue document IDs, raw status enums, service-level/provider codes, or recommendation enums.
- Existing support-only fields remain excluded from the landlord response.
- Admin route still uses the admin endpoint and preserves support identifiers.
- Screening workflow/provider behavior was not changed.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/routes/__tests__/verifiedScreeningRoutes.test.ts src/routes/__tests__/apiRouteOwnershipRegression.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/AdminVerifiedScreeningsPage.test.tsx src/api/adminVerifiedScreeningsApi.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
- `git diff --check`
- `git diff --cached --check`

## Manual QA Required

- Landlord: open `/verified-screenings` after backend parity is available and confirm response/UI use landlord-facing labels such as `Waiting to start` and `Verified screening with assisted review`.
- Confirm landlord payload/UI does not expose raw `id`, `QUEUED`, `IN_PROGRESS`, `VERIFIED_AI`, provider/service codes, raw order/reference IDs, storage paths, or internal scope keys.
- Admin: open `/admin/verified-screenings` and confirm admin list/detail/update behavior and support identifiers remain available.
- Confirm landlord users still cannot access `/admin/verified-screenings`.
- Regression: `/dashboard`, `/operations`, `/applications`, `/verified-screenings`, `/admin/verified-screenings`.

## Backend Parity Note

This PR changes the backend landlord projection. Vercel preview may still route `/api/*` to shared Cloud Run until this backend is deployed, so browser verification of the tightened payload may be backend-parity-limited. Post-deploy Cloud Run QA should confirm the live landlord endpoint serves the merged projection.
