### PR TITLE
fix: suppress final-state application decision actions

### DIFF
--- a/rentchain-frontend/src/components/applications/ApplicationDecisionSummaryCard.test.tsx
+++ b/rentchain-frontend/src/components/applications/ApplicationDecisionSummaryCard.test.tsx
@@ -188,6 +188,69 @@ describe("ApplicationDecisionSummaryCard", () => {
     expect(onDecision).toHaveBeenCalledWith("approve", "Looks strong overall.");
   });
 
+  it("hides active decision controls for approved applications", () => {
+    const onDecision = vi.fn();
+
+    render(
+      <ApplicationDecisionSummaryCard
+        summary={{
+          applicationId: "app-approved",
+          status: "APPROVED",
+          riskSnapshot: {
+            version: "risk-v1",
+            status: "completed",
+            score: 88,
+            grade: "A",
+            confidence: 0.94,
+            factors: [],
+            flags: [],
+            recommendations: [],
+            updatedAt: "2026-04-01T00:00:00.000Z",
+          },
+        }}
+        onDecision={onDecision}
+      />
+    );
+
+    expect(screen.getByText("Application approved")).toBeInTheDocument();
+    expect(screen.getByText(/This application has already been approved/i)).toBeInTheDocument();
+    expect(screen.getByText(/Continue lease follow-through/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request More Info" })).not.toBeInTheDocument();
+  });
+
+  it("hides active decision controls for declined applications", () => {
+    const onDecision = vi.fn();
+
+    render(
+      <ApplicationDecisionSummaryCard
+        summary={{
+          applicationId: "app-denied",
+          status: "DENIED",
+          riskSnapshot: {
+            version: "risk-v1",
+            status: "completed",
+            score: 44,
+            grade: "D",
+            confidence: 0.8,
+            factors: [],
+            flags: ["Reference could not be verified"],
+            recommendations: [],
+            updatedAt: "2026-04-01T00:00:00.000Z",
+          },
+        }}
+        onDecision={onDecision}
+      />
+    );
+
+    expect(screen.getByText("Application declined")).toBeInTheDocument();
+    expect(screen.getByText(/This decision has already been recorded/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request More Info" })).not.toBeInTheDocument();
+  });
+
   it("renders request-more-info content inline inside the decision support panel", () => {
     render(
       <ApplicationDecisionSummaryCard

--- a/rentchain-frontend/src/components/applications/ApplicationDecisionSummaryCard.tsx
+++ b/rentchain-frontend/src/components/applications/ApplicationDecisionSummaryCard.tsx
@@ -49,6 +49,25 @@ function providerDisplayLabel(provider?: string | null, providerLabel?: string |
   return raw;
 }
 
+function finalDecisionStateForStatus(status?: string | null) {
+  const normalized = String(status || "").trim().toUpperCase();
+  if (["APPROVED", "APPROVE", "ACCEPTED", "CONVERTED"].includes(normalized)) {
+    return {
+      title: "Application approved",
+      description: "This application has already been approved. Pre-decision controls are no longer shown from this review panel.",
+      nextAction: "Continue lease follow-through from the lease workspace when a safe lease route is available.",
+    };
+  }
+  if (["REJECTED", "DECLINED", "DENIED"].includes(normalized)) {
+    return {
+      title: "Application declined",
+      description: "This decision has already been recorded. Pre-decision controls are no longer shown from this review panel.",
+      nextAction: "Keep the application summary available for review history and audit context.",
+    };
+  }
+  return null;
+}
+
 const PillList: React.FC<{ items: string[]; emptyLabel: string }> = ({ items, emptyLabel }) => {
   if (!items.length) {
     return <div style={{ color: text.subtle, fontSize: 12 }}>{emptyLabel}</div>;
@@ -93,6 +112,7 @@ export const ApplicationDecisionSummaryCard: React.FC<ApplicationDecisionSummary
   const decisionSupport = summary?.decisionSupport ?? null;
   const hasContent = Boolean(riskSnapshot || risk || questions.length || screeningRecommendation || screeningSummary?.available || decisionSupport?.summaryLine || onEvaluateRisk);
   const screeningTone = priorityTone(screeningRecommendation?.priority);
+  const finalDecisionState = finalDecisionStateForStatus(summary?.status);
 
   return (
     <section
@@ -135,6 +155,7 @@ export const ApplicationDecisionSummaryCard: React.FC<ApplicationDecisionSummary
             evaluatingRisk={evaluatingRisk}
             onDecision={onDecision}
             submittingDecision={submittingDecision}
+            finalDecisionState={finalDecisionState}
           />
           {requestInfoDrawer}
 

--- a/rentchain-frontend/src/components/applications/LandlordDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/applications/LandlordDecisionPanel.test.tsx
@@ -85,4 +85,60 @@ describe("LandlordDecisionPanel", () => {
 
     expect(onDecision).toHaveBeenCalledWith("request_info", "Need one more paystub before final call.");
   });
+
+  it("renders recorded final-decision copy instead of active decision actions", () => {
+    const onDecision = vi.fn();
+
+    render(
+      <LandlordDecisionPanel
+        riskSnapshot={{
+          version: "risk-v1",
+          status: "completed",
+          score: 82,
+          grade: "A",
+          confidence: 0.9,
+          factors: [],
+          flags: [],
+          recommendations: [],
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        }}
+        onDecision={onDecision}
+        finalDecisionState={{
+          title: "Application approved",
+          description: "This application has already been approved.",
+          nextAction: "Continue lease follow-through from the lease workspace.",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Recorded Decision")).toBeInTheDocument();
+    expect(screen.getByText("Application approved")).toBeInTheDocument();
+    expect(screen.getByText("This application has already been approved.")).toBeInTheDocument();
+    expect(screen.getByText("Next step: Continue lease follow-through from the lease workspace.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request More Info" })).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Optional decision notes for your team audit trail")).not.toBeInTheDocument();
+  });
+
+  it("renders recorded final-decision copy even without a risk snapshot", () => {
+    const onEvaluateRisk = vi.fn();
+
+    render(
+      <LandlordDecisionPanel
+        riskSnapshot={null}
+        onEvaluateRisk={onEvaluateRisk}
+        finalDecisionState={{
+          title: "Application declined",
+          description: "This decision has already been recorded.",
+          nextAction: "Keep the application summary available for review history.",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Application declined")).toBeInTheDocument();
+    expect(screen.getByText("This decision has already been recorded.")).toBeInTheDocument();
+    expect(screen.queryByText("No risk snapshot is available yet. Evaluate risk first to unlock the decision panel.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Evaluate risk" })).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/applications/LandlordDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/applications/LandlordDecisionPanel.tsx
@@ -13,6 +13,11 @@ type LandlordDecisionPanelProps = {
   evaluatingRisk?: boolean;
   onDecision?: ((decision: LandlordDecisionAction, notes: string) => void | Promise<void>) | null;
   submittingDecision?: boolean;
+  finalDecisionState?: {
+    title: string;
+    description: string;
+    nextAction?: string | null;
+  } | null;
 };
 
 function formatConfidence(value?: number | null) {
@@ -134,12 +139,43 @@ const ItemList: React.FC<{ title: string; items: string[]; emptyLabel: string; t
   </div>
 );
 
+const FinalDecisionNotice: React.FC<{
+  finalDecisionState: NonNullable<LandlordDecisionPanelProps["finalDecisionState"]>;
+}> = ({ finalDecisionState }) => (
+  <div style={{ display: "grid", gap: 8 }}>
+    <div style={{ color: text.muted, fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+      Recorded Decision
+    </div>
+    <div
+      style={{
+        borderRadius: radius.lg,
+        border: `1px solid ${colors.border}`,
+        background: "rgba(248,250,252,0.94)",
+        padding: spacing.md,
+        display: "grid",
+        gap: 6,
+      }}
+    >
+      <div style={{ color: text.primary, fontWeight: 800 }}>{finalDecisionState.title}</div>
+      <div style={{ color: text.secondary, fontSize: 13, lineHeight: 1.6 }}>
+        {finalDecisionState.description}
+      </div>
+      {finalDecisionState.nextAction ? (
+        <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.55 }}>
+          Next step: {finalDecisionState.nextAction}
+        </div>
+      ) : null}
+    </div>
+  </div>
+);
+
 export const LandlordDecisionPanel: React.FC<LandlordDecisionPanelProps> = ({
   riskSnapshot = null,
   onEvaluateRisk = null,
   evaluatingRisk = false,
   onDecision = null,
   submittingDecision = false,
+  finalDecisionState = null,
 }) => {
   const [notes, setNotes] = useState("");
 
@@ -169,11 +205,15 @@ export const LandlordDecisionPanel: React.FC<LandlordDecisionPanelProps> = ({
       <div style={{ display: "grid", gap: 4 }}>
         <div style={{ color: text.primary, fontWeight: 800, fontSize: 16 }}>Landlord Decision Panel</div>
         <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.55 }}>
-          Use the latest Risk Agent snapshot to decide whether to approve, reject, or request more information. These actions stay landlord-triggered and only update the application after you confirm them.
+          {finalDecisionState
+            ? "This application already has a recorded decision. Review the context below without changing the application status from this panel."
+            : "Use the latest Risk Agent snapshot to decide whether to approve, reject, or request more information. These actions stay landlord-triggered and only update the application after you confirm them."}
         </div>
       </div>
 
-      {!riskSnapshot ? (
+      {!riskSnapshot && finalDecisionState ? (
+        <FinalDecisionNotice finalDecisionState={finalDecisionState} />
+      ) : !riskSnapshot ? (
         <div
           style={{
             borderRadius: radius.lg,
@@ -282,80 +322,84 @@ export const LandlordDecisionPanel: React.FC<LandlordDecisionPanelProps> = ({
           <ItemList title="Flags" items={riskSnapshot.flags || []} emptyLabel="No flagged warnings right now." tone="warning" />
           <ItemList title="Next Step Guidance" items={riskSnapshot.recommendations || []} emptyLabel="No next-step guidance right now." />
 
-          <div style={{ display: "grid", gap: 8 }}>
-            <div style={{ color: text.muted, fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>
-              Decision Actions
+          {finalDecisionState ? (
+            <FinalDecisionNotice finalDecisionState={finalDecisionState} />
+          ) : (
+            <div style={{ display: "grid", gap: 8 }}>
+              <div style={{ color: text.muted, fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                Decision Actions
+              </div>
+              <textarea
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                placeholder="Optional decision notes for your team audit trail"
+                rows={3}
+                style={{
+                  width: "100%",
+                  resize: "vertical",
+                  borderRadius: radius.lg,
+                  border: `1px solid ${colors.border}`,
+                  padding: "10px 12px",
+                  font: "inherit",
+                  color: text.primary,
+                  background: "#fff",
+                }}
+              />
+              <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  onClick={() => void handleDecision("approve")}
+                  disabled={!onDecision || submittingDecision}
+                  style={{
+                    borderRadius: radius.pill,
+                    border: "1px solid rgba(34,197,94,0.28)",
+                    background: "rgba(220,252,231,0.96)",
+                    color: "#166534",
+                    fontSize: 13,
+                    fontWeight: 800,
+                    padding: "9px 14px",
+                    cursor: !onDecision || submittingDecision ? "not-allowed" : "pointer",
+                  }}
+                >
+                  {submittingDecision ? "Saving..." : "Approve"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleDecision("reject")}
+                  disabled={!onDecision || submittingDecision}
+                  style={{
+                    borderRadius: radius.pill,
+                    border: "1px solid rgba(239,68,68,0.28)",
+                    background: "rgba(254,226,226,0.96)",
+                    color: "#b91c1c",
+                    fontSize: 13,
+                    fontWeight: 800,
+                    padding: "9px 14px",
+                    cursor: !onDecision || submittingDecision ? "not-allowed" : "pointer",
+                  }}
+                >
+                  Reject
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleDecision("request_info")}
+                  disabled={!onDecision || submittingDecision}
+                  style={{
+                    borderRadius: radius.pill,
+                    border: "1px solid rgba(59,130,246,0.24)",
+                    background: "rgba(239,246,255,0.96)",
+                    color: "#1d4ed8",
+                    fontSize: 13,
+                    fontWeight: 800,
+                    padding: "9px 14px",
+                    cursor: !onDecision || submittingDecision ? "not-allowed" : "pointer",
+                  }}
+                >
+                  Request More Info
+                </button>
+              </div>
             </div>
-            <textarea
-              value={notes}
-              onChange={(event) => setNotes(event.target.value)}
-              placeholder="Optional decision notes for your team audit trail"
-              rows={3}
-              style={{
-                width: "100%",
-                resize: "vertical",
-                borderRadius: radius.lg,
-                border: `1px solid ${colors.border}`,
-                padding: "10px 12px",
-                font: "inherit",
-                color: text.primary,
-                background: "#fff",
-              }}
-            />
-            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <button
-                type="button"
-                onClick={() => void handleDecision("approve")}
-                disabled={!onDecision || submittingDecision}
-                style={{
-                  borderRadius: radius.pill,
-                  border: "1px solid rgba(34,197,94,0.28)",
-                  background: "rgba(220,252,231,0.96)",
-                  color: "#166534",
-                  fontSize: 13,
-                  fontWeight: 800,
-                  padding: "9px 14px",
-                  cursor: !onDecision || submittingDecision ? "not-allowed" : "pointer",
-                }}
-              >
-                {submittingDecision ? "Saving..." : "Approve"}
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleDecision("reject")}
-                disabled={!onDecision || submittingDecision}
-                style={{
-                  borderRadius: radius.pill,
-                  border: "1px solid rgba(239,68,68,0.28)",
-                  background: "rgba(254,226,226,0.96)",
-                  color: "#b91c1c",
-                  fontSize: 13,
-                  fontWeight: 800,
-                  padding: "9px 14px",
-                  cursor: !onDecision || submittingDecision ? "not-allowed" : "pointer",
-                }}
-              >
-                Reject
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleDecision("request_info")}
-                disabled={!onDecision || submittingDecision}
-                style={{
-                  borderRadius: radius.pill,
-                  border: "1px solid rgba(59,130,246,0.24)",
-                  background: "rgba(239,246,255,0.96)",
-                  color: "#1d4ed8",
-                  fontSize: 13,
-                  fontWeight: 800,
-                  padding: "9px 14px",
-                  cursor: !onDecision || submittingDecision ? "not-allowed" : "pointer",
-                }}
-              >
-                Request More Info
-              </button>
-            </div>
-          </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Makes the shared Application Decision Panel state-aware for final application decisions.
- Suppresses active `Approve`, `Reject`, and `Request More Info` controls for approved/converted-style states and declined/denied/rejected states.
- Shows retrospective recorded-decision copy instead, including lease follow-through guidance for approved applications.
- Preserves active decision controls for non-final review states such as submitted, in-review, and review-required.

## Scope Notes

- Frontend-only.
- No backend decision workflow changes.
- No screening logic changes.
- No PDF/export behavior changes.
- No verified-screenings changes.
- Existing Application Review Summary lease follow-through CTA remains intact.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/components/applications/LandlordDecisionPanel.test.tsx src/components/applications/ApplicationDecisionSummaryCard.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationReviewSummaryPage.test.tsx src/pages/ApplicationsPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`
- `git diff --cached --check`

## Manual QA Required

1. `/applications`
   - Open an approved application.
   - Confirm Application Decision Panel no longer shows active `Approve`, `Reject`, or `Request More Info` controls.
   - Confirm retrospective approved copy appears.
   - Confirm existing `Open review summary`, `Print / Save PDF`, and application navigation still work.
   - Open a submitted/in-review application if available and confirm active decision controls still appear.

2. `/applications/:applicationId/review-summary`
   - Confirm approved application Decision tab shows retrospective copy rather than active decision controls.
   - Confirm lease follow-through remains available where existing lease-transition state supports it.
   - Confirm `Back to applications` and `Download PDF` still work.

3. Regression
   - `/applications`
   - `/applications/:applicationId/review-summary`
   - `/leases`
   - `/verified-screenings`
