### PR TITLE
polish: simplify application review summary decision tab

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -234,6 +234,16 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Outcome blockers")).toBeInTheDocument();
     expect(await screen.findByText("Outcome next steps")).toBeInTheDocument();
     expect(await screen.findByText(/Derived from current review state/i)).toBeInTheDocument();
+    const leaseReadinessButton = await screen.findByRole("button", { name: "Show lease readiness details" });
+    expect(leaseReadinessButton).toHaveAttribute("aria-expanded", "false");
+    expect(await screen.findByText("Detailed lease readiness")).toBeInTheDocument();
+    expect(screen.queryByText("Lease step")).not.toBeInTheDocument();
+    expect(screen.queryByText("Lease preparation")).not.toBeInTheDocument();
+    expect(screen.queryByText("Move-in readiness")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deposit / first payment")).not.toBeInTheDocument();
+
+    fireEvent.click(leaseReadinessButton);
+    expect(screen.getByRole("button", { name: "Hide lease readiness details" })).toHaveAttribute("aria-expanded", "true");
     expect(await screen.findByText("Lease step")).toBeInTheDocument();
     expect(await screen.findByText("Not ready for lease step")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Continue to lease workspace" })).not.toBeInTheDocument();
@@ -439,13 +449,20 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for decision")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for next step")).length).toBeGreaterThan(0);
-    expect((await screen.findAllByText("Ready for lease step")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Continue lease follow-through")).toBeInTheDocument();
     expect(
       await screen.findByText(/This review summary does not create a lease or guess an exact lease record/i)
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Continue to lease workspace" })).toHaveAttribute("href", "/leases");
-    expect((await screen.findAllByText("Awaiting next action")).length).toBeGreaterThan(0);
+    const leaseReadinessButton = await screen.findByRole("button", { name: "Show lease readiness details" });
+    expect(leaseReadinessButton).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Move-in readiness")).not.toBeInTheDocument();
+    expect(screen.queryByText("Lease execution workspace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Lease signing")).not.toBeInTheDocument();
+
+    fireEvent.click(leaseReadinessButton);
+    expect(screen.getByRole("button", { name: "Hide lease readiness details" })).toHaveAttribute("aria-expanded", "true");
+    expect((await screen.findAllByText("Ready for lease step")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Move-in readiness")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Awaiting next action")).length).toBeGreaterThan(1);
     expect((await screen.findAllByText("Lease execution workspace")).length).toBeGreaterThan(0);
@@ -529,6 +546,15 @@ describe("ApplicationReviewSummaryPage", () => {
     fireEvent.click(await screen.findByRole("tab", { name: "Decision" }));
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Hold for later")).length).toBeGreaterThan(0);
+    const leaseReadinessButton = await screen.findByRole("button", { name: "Show lease readiness details" });
+    expect(leaseReadinessButton).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Not ready for lease step")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not started")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not ready for execution")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not ready for signing")).not.toBeInTheDocument();
+
+    fireEvent.click(leaseReadinessButton);
+    expect(screen.getByRole("button", { name: "Hide lease readiness details" })).toHaveAttribute("aria-expanded", "true");
     expect((await screen.findAllByText("Not ready for lease step")).length).toBeGreaterThan(0);
     expect(screen.queryByRole("link", { name: "Continue to lease workspace" })).not.toBeInTheDocument();
     expect((await screen.findAllByText("Not started")).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -407,6 +407,7 @@ function ApplicationReviewSummaryPageBody() {
   const [evaluatingRisk, setEvaluatingRisk] = useState(false);
   const [savingDecision, setSavingDecision] = useState(false);
   const [activeReviewTab, setActiveReviewTab] = useState<ReviewSummaryTab>("overview");
+  const [showLeaseReadinessDetails, setShowLeaseReadinessDetails] = useState(false);
 
   const loadSummary = React.useCallback(async () => {
     if (!entitlements.canViewReviewSummary) {
@@ -442,6 +443,10 @@ function ApplicationReviewSummaryPageBody() {
   useEffect(() => {
     void loadSummary();
   }, [loadSummary]);
+
+  useEffect(() => {
+    setShowLeaseReadinessDetails(false);
+  }, [id]);
 
   const shareUrl = useMemo(() => {
     if (typeof window === "undefined") return "";
@@ -658,6 +663,9 @@ function ApplicationReviewSummaryPageBody() {
           })
         : null,
     [signingWorkspace]
+  );
+  const hasLeaseReadinessDetails = Boolean(
+    leaseTransition || leasePreparation || moveInReadiness || executionWorkspace || signingWorkspace || paymentWorkspace
   );
 
   const recentActivity = useMemo(
@@ -1449,6 +1457,52 @@ function ApplicationReviewSummaryPageBody() {
                 </div>
               ) : null}
 
+              {hasLeaseReadinessDetails ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 12,
+                    display: "grid",
+                    gap: 10,
+                    background: "#fff",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                    <div style={{ display: "grid", gap: 4 }}>
+                      <div style={{ fontWeight: 800, color: text.main }}>Detailed lease readiness</div>
+                      <div style={{ fontSize: 13, color: text.subtle }}>
+                        Downstream lease preparation, move-in, signing, and payment readiness stay available here without crowding
+                        the application decision summary.
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      aria-expanded={showLeaseReadinessDetails}
+                      aria-controls="review-summary-lease-readiness-details"
+                      onClick={() => setShowLeaseReadinessDetails((current) => !current)}
+                      style={{
+                        minHeight: 38,
+                        padding: "8px 12px",
+                        borderRadius: 8,
+                        border: `1px solid ${colors.border}`,
+                        background: showLeaseReadinessDetails ? "#f8fafc" : "#fff",
+                        color: text.main,
+                        fontWeight: 800,
+                        cursor: "pointer",
+                      }}
+                    >
+                      {showLeaseReadinessDetails ? "Hide lease readiness details" : "Show lease readiness details"}
+                    </button>
+                  </div>
+
+                  <div style={{ fontSize: 12, color: text.subtle }}>
+                    Use the lease workspace for operational follow-through. This summary keeps the application decision and safe handoff
+                    visible first.
+                  </div>
+
+                  {showLeaseReadinessDetails ? (
+                    <div id="review-summary-lease-readiness-details" style={{ display: "grid", gap: 10 }}>
               {leaseTransition ? (
                 <div
                   style={{
@@ -2013,6 +2067,10 @@ function ApplicationReviewSummaryPageBody() {
                       This payment workspace is a structured request and status view only. It does not imply RentChain is holding funds or operating as the payment processor.
                     </div>
                   </div>
+                </div>
+              ) : null}
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </Card>


### PR DESCRIPTION
## Summary

- Simplifies the Application Review Summary Decision tab first pass.
- Keeps decision status/outcome, final-state recorded decision or non-final controls, lease follow-through, and insights visible by default.
- Moves downstream lease-readiness panels behind a default-closed `Detailed lease readiness` disclosure.
- Preserves PDF/export behavior, backend behavior, screening logic, and lease follow-through routing.

## Primary sections left visible

- Decision workspace/status
- Decision outcome and next steps
- `Continue lease follow-through` CTA when existing lease-transition state supports it
- Application decision support / recorded decision behavior
- Insights

## Sections moved behind disclosure

- Lease step
- Lease preparation
- Move-in readiness
- Lease execution workspace
- Lease signing
- Deposit / first payment

## Behavior notes

- Final approved/declined state behavior from #1325 is unchanged.
- Non-final submitted/in-review states still preserve appropriate decision controls.
- The lease follow-through CTA from #1319 remains visible when supported.
- PDF/download behavior is unchanged.
- No backend, screening, decision workflow, or lease workflow logic was changed.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/ApplicationReviewSummaryPage.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`
- `git diff --cached --check`

## Manual QA required

1. `/applications/:applicationId/review-summary`
   - Confirm the Decision tab is simpler at first glance.
   - Confirm decision status/outcome remains visible.
   - Confirm recorded final-state copy remains correct for approved/declined applications.
   - Confirm non-final applications still show appropriate decision controls.
   - Confirm lease follow-through CTA remains visible when appropriate.
   - Open `Show lease readiness details` and confirm the downstream lease sections are still available.
   - Confirm `Download PDF` still works and exported PDF content is unchanged.

2. Reduced desktop/mobile
   - Confirm action rows and the disclosure control remain readable.
   - Confirm no horizontal overflow.

3. Regression
   - `/applications`
   - `/leases`
   - `/verified-screenings`
