### PR TITLE
design: refresh marketing landing page

### DIFF
--- a/docs/strategy/marketing-landing-refresh/CODEX_PROMPT.md
+++ b/docs/strategy/marketing-landing-refresh/CODEX_PROMPT.md
@@ -1,0 +1,46 @@
+# Final Codex prompt
+
+Copy everything in the block below into Codex.
+
+---
+
+You are working in the existing **rentchain-frontend** repo (React + Vite + TypeScript). Implement a new native marketing landing page. **Frontend only. Scope strictly to the marketing landing page — do not touch logged-in dashboards or migrate the app-wide design system.**
+
+**Task:** Replace the contents of `src/pages/marketing/LandingPage.tsx` (already routed at `/` and `/site`) with a high-fidelity native React implementation of the RentChain landing design.
+
+**Use these provided files** (place under `src/pages/marketing/landing/`):
+- `landingContent.ts` — all copy + structured data. Do not hardcode copy in components; read from here.
+- `marketingLandingStyles.ts` — marketing-only tokens (colors, typography, radii, shadows, spacing, card/badge/button style objects, layout sizes). Wire into CSS variables on the marketing page root (or your styling layer). Keep isolated to this page.
+- `rentchain-mark.svg` — logo mark; place in the repo's brand asset directory.
+
+**Build these components** under `src/pages/marketing/landing/` and compose them in order in `LandingPage.tsx`:
+`MarketingHeader`, `HeroSection` (+ `HeroNetworkVisual`), `TrustFlowSection`, `WhyRentChainSection`, `AudienceSection`, `LifecycleSection`, `FeatureShowcaseSection` (+ reusable `FeatureRow`), `OperationalTrustSection`, `AboutVisionSection`, `FinalCtaSection`, `MarketingFooter`, plus shared `LedgerRow` and `RevealOnScroll`. Reuse the app's existing Button/Link/routing primitives where they exist.
+
+**Visual system (exact values in `marketingLandingStyles.ts`):**
+- Page bg warm paper `#FAF7F2`; alternating `#F3EDE2` bands with `1px #E5DECF` hairlines; dark surfaces (hero, command-center block, final CTA, footer) navy `#0A1428`.
+- Fonts: Source Serif 4 (display, 700, −0.02em), Public Sans (body/UI), Spline Sans Mono (**all numbers, dates, kicker labels**). Load from Google Fonts unless licensed files exist.
+- Cards: white, `1px #E5DECF`, radius 16, warm `--shadow-card`. Pill buttons/badges. The only gradient allowed is the hero ambient glow (`heroGlow`). No textures, no photography. ✓ is the only expressive glyph; no emoji. Sentence case everywhere except tiny uppercase mono kickers.
+- Accent CTA = amber `#E8A33D` with **ink text `#20251F` (never white — contrast)**; pine `#1E5F4E` is primary; 3px pine focus ring on every interactive element.
+
+**Behavior:**
+- Header: transparent over hero; after 24px scroll switch to paper-blur solid (`rgba(250,247,242,0.9)` + 14px backdrop-blur + hairline) and flip nav/logo text light→ink. Inline nav collapses to a mobile menu ≤900px.
+- Login dropdown: `<button aria-haspopup="true" aria-expanded={open}>`; Escape closes and restores focus; click-outside closes; items keyboard-navigable.
+- Lifecycle: 8-step tablist, auto-advance every 3800ms, pause permanently once the user selects a step; active step drives the detail panel + ledger record card. Horizontal-scroll tab row.
+- Scroll reveal: IntersectionObserver fade + 22px rise (600–700ms `cubic-bezier(0.22,1,0.36,1)`).
+- `prefers-reduced-motion: reduce`: disable reveal, stop lifecycle auto-advance, freeze all SVG/persona animations, show content immediately.
+
+**Responsive:** container max 1120px, inline pad `clamp(1.25rem,5vw,2.5rem)`, section pad `clamp(4rem,9vw,6.5rem)`. Hero network visual hidden ≤760px. Trust-flow grid 4→2 col ≤720px with connectors hidden. Feature rows flex-wrap; alternating rows use `wrap-reverse` so the mock leads on desktop. Footer columns `auto-fit minmax(150px,1fr)`.
+
+**Accessibility:** exactly one `<h1>` (hero); ordered `<h2>/<h3>`; semantic landmarks (`header`/`nav[aria-label]`/`section`/`footer`/`figure`); decorative SVGs `aria-hidden`; lifecycle tabs as a proper tablist; visible focus rings; ≥44px touch targets; verify AA contrast (ink-on-amber, `#F2F1EA` on navy).
+
+**Content rules (already reflected in `landingContent.ts` — keep them):**
+- No fabricated aggregate metrics. The proof section uses capability statements, not the old "3,100+ / $48M / 62% / 100%" numbers.
+- No fictional testimonials or U.S. cities. `operationalTrust.testimonials` is empty until real, consented quotes exist — render that block only when non-empty.
+- Canadian payment rails: `EFT` (not ACH). Footer copyright `© 2026 RentChain` until the registered entity is confirmed. Command-center numbers are illustrative sample UI data only.
+- Replace all `#`/`CONFIRM`-marked links with real app routes/URLs or omit; confirm the free-pricing microcopy before shipping (use neutral CTA copy if unconfirmed).
+
+**Preserve:** the existing page's signup/login/analytics/acquisition-tracking wiring on CTAs and login links.
+
+**Do NOT:** ship the design prototype's `support.js`, serve any `.dc.html`, introduce fake claims, alter product dashboards, or globally change the app design system.
+
+Deliver the components, wire them into `LandingPage.tsx`, and ensure the page builds and type-checks.

--- a/docs/strategy/marketing-landing-refresh/COMPONENT_NOTES.md
+++ b/docs/strategy/marketing-landing-refresh/COMPONENT_NOTES.md
@@ -1,0 +1,114 @@
+# Component-by-component implementation notes
+
+Native React (TSX) for `rentchain-frontend`. All components live under
+`src/pages/marketing/landing/`. Content comes from `landingContent.ts`; tokens/styles
+from `marketingLandingStyles.ts`. Compose in order inside `LandingPage.tsx`.
+
+Legend — each component lists: **Props** · **Content source** · **State/interaction** · **Accessibility** · **Responsive**.
+
+---
+
+## LandingPage.tsx (composition root)
+- **Props:** none.
+- **Content:** imports `landingContent`.
+- **State/interaction:** none of its own — thin composition. Renders the 11 sections in order inside a page root that sets `background: paper100`, `color: ink900`, `font-family: sans`, `overflow-x: hidden`. Wire marketing tokens to CSS vars here (or a `<MarketingThemeProvider>`). **Preserve existing signup/login/analytics wiring** on the page.
+- **A11y:** owns the single document outline; ensure exactly one `<h1>` downstream (hero).
+- **Responsive:** none directly; children handle it.
+
+## MarketingHeader.tsx
+- **Props:** `nav`, `logins`, `ctaLabel`, `ctaHref` (from `header`).
+- **Content:** `landingContent.header`.
+- **State/interaction:** `scrolled` (scroll listener, flips at >24px → `headerSolid` style, nav/logo text light→ink); `loginOpen` dropdown; `mobileOpen` for ≤900px menu. Fixed position, z-index ~60.
+- **A11y:** `<header>` + `<nav aria-label="Main">`; login trigger `<button aria-haspopup="true" aria-expanded={loginOpen}>`; **Escape closes dropdown & restores focus to trigger**; click-outside closes; dropdown items are focusable links with a leading color dot (`dotToken`). Mobile menu button `aria-expanded`. 3px pine focus ring on all.
+- **Responsive:** inline nav hidden ≤900px → hamburger opens a sheet/drawer; login + CTA stay visible. Transparent over hero, paper-blur solid after scroll.
+
+## HeroSection.tsx (+ HeroNetworkVisual.tsx)
+- **Props:** `hero` object; visual takes `personas`.
+- **Content:** `landingContent.hero`.
+- **State/interaction:** none (visual animations are CSS/SVG). Primary CTA = accent button, secondary = ghost-on-dark.
+- **A11y:** single `<h1>` (title line 1 + accent "Connected."); kicker is decorative mono label; **network SVG + persona nodes `aria-hidden="true"`**; CTAs are real links/buttons preserving acquisition tracking.
+- **Responsive:** two-column flex (`flex: 1 1 420px`), wraps to stacked; **HeroNetworkVisual hidden ≤760px**. bg navy950 + `heroGlow` (only gradient). Freeze SVG dash/bob/pulse animations under `prefers-reduced-motion`.
+
+## TrustFlowSection.tsx
+- **Props:** `trustFlow` (kicker, title, nodes[], hubKicker, hubTitle).
+- **Content:** `landingContent.trustFlow`.
+- **State/interaction:** none. 4 role nodes → animated converging SVG connectors → shared-record hub card (tint/pine).
+- **A11y:** `<section>` + `<h2>`; node titles `<h3>`; **connector SVG `aria-hidden`**; hub uses the logo mark with `alt=""`.
+- **Responsive:** 4-col grid → 2-col ≤720px; **connectors hidden ≤720px**, hub gets top margin. Reduced-motion freezes the dashed flow.
+
+## WhyRentChainSection.tsx
+- **Props:** `whyRentChain` (kicker, titlePlain, titleAccent, rows[]).
+- **Content:** `landingContent.whyRentChain`.
+- **State/interaction:** none. Comparison table: header row (Traditional software / RentChain) + 5 `from → to` rows inside a bordered card.
+- **A11y:** `<h2>`; the comparison is a semantic table or a list of labeled pairs (not just visual columns); arrow glyph decorative (`aria-hidden`).
+- **Responsive:** 3-col grid (`1fr auto 1fr`) stays; on very narrow, reduce padding (`clamp`) — keep both columns legible; band bg paper200 with hairlines.
+
+## AudienceSection.tsx
+- **Props:** `audiences` (kicker, title, cards[]); **optional** `visibleKeys?: string[]` if the four cards are made configurable (prototype tweak — see README §11).
+- **Content:** `landingContent.audiences`.
+- **State/interaction:** static by default. If configurable, column count = number of visible cards (`repeat(N, minmax(0,1fr))`) so they fill one row.
+- **A11y:** `<h2>`; each card title `<h3>`; bullet lists are real `<ul>`; ✓ marks decorative.
+- **Responsive:** grid columns = visible-card count on desktop; collapse to 2/1 columns on mobile. Cards equal-height (flex column).
+
+## LifecycleSection.tsx
+- **Props:** `lifecycle` (kicker, title, subtitle, autoAdvanceMs, steps[]).
+- **Content:** `landingContent.lifecycle`.
+- **State/interaction:** `activeStep` index; **auto-advance every `autoAdvanceMs` (3800)**; pause permanently once the user selects a tab (`userPicked`). Active step drives the detail copy + the ledger record card (title/meta/amount/status badge).
+- **A11y:** implement tabs as `role="tablist"`/`role="tab"` with `aria-selected`, or as buttons updating a live region so the active step's detail is announced; step badge reflects `statusLabel`. Keyboard: arrow/tab between steps.
+- **Responsive:** horizontal-scroll tab row (`overflow-x:auto`) at all sizes; detail panel flex-wraps — copy + record card side-by-side on desktop, stacked on narrow (card `width: min(100%, 320px)`). **Stop auto-advance under reduced-motion.**
+
+## FeatureShowcaseSection.tsx (+ FeatureRow.tsx)
+- **Props:** section = `features` (kicker, title, rows[], commandCenter). `FeatureRow` props: `kicker`, `title`, `body`, `mockLeads`, and a `mock` render slot/children.
+- **Content:** `landingContent.features`.
+- **State/interaction:** none. 4 alternating rows via `FeatureRow` (reused) + 1 dark command-center block (2×2 sample-stat grid).
+- **A11y:** each row title `<h3>`; the UI mockups (ledger cards, chat thread, stat grid) are illustrative — decorative avatars get `aria-hidden` or role labels; **command-center numbers are sample data, never presented as company metrics** (see README §4b).
+- **Responsive:** rows are `flex-wrap` (`flex: 1 1 340–360px`); rows with `mockLeads:true` use `flex-wrap: wrap-reverse` so the mock leads on desktop but text leads when stacked. Command-center grid stays 2-col.
+
+## OperationalTrustSection.tsx
+- **Props:** `operationalTrust` (kicker, title, capabilities[], testimonials[]).
+- **Content:** `landingContent.operationalTrust`.
+- **State/interaction:** none. **Replaces the prototype "social proof" section** — renders capability statements (no fabricated numbers). Render the testimonials block only if `testimonials.length > 0` (empty until real, consented quotes exist).
+- **A11y:** `<h2>`; capabilities are a list; any real quotes use `<figure>/<figcaption>`.
+- **Responsive:** capability cards `repeat(auto-fit, minmax(...))`; reflow to fewer columns on mobile. Band bg paper200.
+
+## AboutVisionSection.tsx
+- **Props:** `aboutVision` (kicker, title, body[], visionTitle, tags[]).
+- **Content:** `landingContent.aboutVision`.
+- **State/interaction:** none.
+- **A11y:** `<h2>` for "Housing operations are fragmented", `<h3>` for the vision title; tags are a list of pill spans (decorative styling, real text).
+- **Responsive:** two-column flex (`flex: 1 1 360px` / `1 1 320px`), stacks on narrow; tags wrap.
+
+## FinalCtaSection.tsx
+- **Props:** `finalCta` (kicker, title, subtitle, primaryCta, secondaryCta, microcopy).
+- **Content:** `landingContent.finalCta`.
+- **State/interaction:** none. Dark rounded panel (navy950, radius 28) with center CTAs; preserve tracking on the buttons.
+- **A11y:** `<h2>`; accent CTA uses ink-on-amber (not white-on-amber); ghost CTA on dark; focus ring visible.
+- **Responsive:** panel padding via `clamp`; CTAs wrap and center.
+
+## MarketingFooter.tsx
+- **Props:** `footer` (blurb, columns[], legal, social[]).
+- **Content:** `landingContent.footer`.
+- **State/interaction:** none. **Replace all `#`/CONFIRM hrefs with real routes** or omit.
+- **A11y:** `<footer>`; column headings `<h3>` (visually small, uppercase); `<nav aria-label="Legal">` and `<nav aria-label="Social">`; logo home link `aria-label`.
+- **Responsive:** columns `repeat(auto-fit, minmax(150px, 1fr))` — 4 → 2/1; logo blurb spans full width; legal/social row wraps. bg navy950.
+
+## Shared: LedgerRow.tsx
+- **Props:** `title`, `meta?`, `amount?`, `status?` ("verified" | "pending" | "info"), `checked?`.
+- **Content:** passed by lifecycle + feature mockups.
+- **State/interaction:** none — presentational. ✓ in a mint circle when `checked`; amount in mono; optional status badge.
+- **A11y:** ✓ decorative; amount readable; keep as list rows (`role="listitem"` inside a `role="list"` ledger).
+- **Responsive:** single-row flex; title/meta stack in the main column, amount right-aligned.
+
+## Shared: RevealOnScroll.tsx
+- **Props:** `children`, `as?`, `delay?`.
+- **State/interaction:** IntersectionObserver → fade + 22px rise, 600–700ms `cubic-bezier(0.22,1,0.36,1)`, unobserve after reveal; safety timeout reveals all after ~2.4s.
+- **A11y/reduced-motion:** if `prefers-reduced-motion: reduce`, render fully visible immediately (no transform/opacity animation).
+- **Responsive:** wrapper only; no layout impact.
+
+---
+
+### Cross-cutting reminders
+- Load Source Serif 4, Public Sans, Spline Sans Mono (Google Fonts unless licensed files exist).
+- All numbers/dates/kicker labels render in **mono**.
+- Every interactive element gets the 3px pine focus ring.
+- Apply the README §4 content cleanup (no fake metrics/testimonials, EFT not ACH, neutral entity, real links) — the data files already reflect it.

--- a/rentchain-frontend/src/assets/rentchain-mark.svg
+++ b/rentchain-frontend/src/assets/rentchain-mark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none" role="img" aria-label="RentChain mark">
+  <rect x="5" y="13" width="22" height="22" rx="7.5" stroke="#1E5F4E" stroke-width="4.5"></rect>
+  <rect x="21" y="13" width="22" height="22" rx="7.5" stroke="#E8A33D" stroke-width="4.5"></rect>
+  <path d="M22.5 30.75 H 24.75" stroke="#1E5F4E" stroke-width="4.5" stroke-linecap="butt"></path>
+</svg>

--- a/rentchain-frontend/src/pages/marketing/LandingPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/LandingPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LandingPage from "./LandingPage";
 
@@ -26,9 +26,16 @@ vi.mock("../../lib/analytics", () => ({
   track: mocks.track,
 }));
 
-vi.mock("./MarketingLayout", () => ({
-  MarketingLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
+function renderLanding(initialEntry = "/") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/site" element={<LandingPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
 
 describe("Marketing LandingPage", () => {
   beforeEach(() => {
@@ -37,58 +44,46 @@ describe("Marketing LandingPage", () => {
     mocks.useAuth.mockReset();
     mocks.track.mockReset();
     mocks.useAuth.mockImplementation(() => ({ user: null }));
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("renders the landlord-first value proposition and free versus paid framing", () => {
-    render(
-      <MemoryRouter>
-        <LandingPage />
-      </MemoryRouter>
-    );
+  it("renders at the root route with the handoff hero headline", () => {
+    renderLanding("/");
 
     expect(
-      screen.getByRole("heading", { name: "Keep your rentals organized and your day moving across Canada." })
+      screen.getByRole("heading", { level: 1, name: /Housing operations\. Connected\./i })
     ).toBeInTheDocument();
+    expect(screen.getByText(/The operating system for housing/i)).toBeInTheDocument();
+  });
+
+  it("renders at the /site route", () => {
+    renderLanding("/site");
+
     expect(
-      screen.getByText(
-        /RentChain helps landlords across Canada stay on top of property details, tenant activity, maintenance, and the tasks that tend to fall through the cracks\./i
-      )
-    ).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Sign Up Free" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("button", { name: "Log In" }).length).toBeGreaterThan(0);
-    expect(
-      screen.getByText(
-        /Start with your first property, see how the workflow works, and decide on paid plans only after you understand the value inside the product\./i
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/No commitment to explore\. Start free and upgrade only when your workflow needs more support\./i)
-    ).toBeInTheDocument();
-    expect(screen.getByText("Is this available across Canada?")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Yes\. RentChain is built for landlords across Canada\./i)
+      screen.getByRole("heading", { level: 1, name: /Housing operations\. Connected\./i })
     ).toBeInTheDocument();
   });
 
-  it("stores source tags and routes unauthenticated users into the product signup flow", () => {
-    render(
-      <MemoryRouter
-        initialEntries={[
-          {
-            pathname: "/",
-            search: "?utm_source=google&utm_medium=cpc&utm_campaign=halifax-ready&utm_content=variant-b",
-          },
-        ]}
-      >
-        <LandingPage />
-      </MemoryRouter>
-    );
+  it("stores source tags and routes unauthenticated users through the existing signup CTA flow", () => {
+    renderLanding("/?utm_source=google&utm_medium=cpc&utm_campaign=halifax-ready&utm_content=variant-b");
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Sign Up Free" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Start free" })[0]);
 
     expect(mocks.navigate).toHaveBeenCalledWith("/signup?next=/properties&intent=registry_readiness");
     expect(mocks.track).toHaveBeenCalledWith(
@@ -101,7 +96,6 @@ describe("Marketing LandingPage", () => {
         location: "landing_hero",
       })
     );
-
     expect(JSON.parse(window.localStorage.getItem("rentchain:registryAcquisitionAttribution") || "{}")).toEqual(
       expect.objectContaining({
         source: "google",
@@ -115,26 +109,69 @@ describe("Marketing LandingPage", () => {
   it("routes authenticated users directly into the properties workflow", () => {
     mocks.useAuth.mockImplementation(() => ({ user: { id: "landlord-1" } }));
 
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <LandingPage />
-      </MemoryRouter>
-    );
+    renderLanding("/");
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Sign Up Free" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Start free" })[0]);
 
     expect(mocks.navigate).toHaveBeenCalledWith("/properties?intent=registry_readiness");
   });
 
-  it("routes returning users to login from the landing page CTA", () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <LandingPage />
-      </MemoryRouter>
+  it("opens the login dropdown with role-specific portal links", () => {
+    renderLanding("/");
+
+    const loginButton = screen.getByRole("button", { name: "Log in" });
+    expect(loginButton).toHaveAttribute("aria-haspopup", "menu");
+    expect(loginButton).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(loginButton);
+
+    expect(loginButton).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menuitem", { name: /Landlord login/i })).toHaveAttribute(
+      "href",
+      "/login?role=landlord"
     );
+    expect(screen.getByRole("menuitem", { name: /Property manager login/i })).toHaveAttribute(
+      "href",
+      "/login?role=manager"
+    );
+    expect(screen.getByRole("menuitem", { name: /Tenant login/i })).toHaveAttribute("href", "/tenant");
+    expect(screen.getByRole("menuitem", { name: /Contractor login/i })).toHaveAttribute("href", "/contractor");
+  });
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Log In" })[0]);
+  it("keeps the book-demo action on the request access route", () => {
+    renderLanding("/");
 
-    expect(mocks.navigate).toHaveBeenCalledWith("/login");
+    expect(screen.getAllByRole("link", { name: "Book a demo" })[0]).toHaveAttribute(
+      "href",
+      "/site/request-access"
+    );
+  });
+
+  it("changes the lifecycle active step when a lifecycle control is clicked", () => {
+    renderLanding("/");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Maintenance request" }));
+
+    expect(screen.getByRole("tab", { name: "Maintenance request" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("A tenant reports an issue from their portal");
+  });
+
+  it("does not render fake testimonials or unsupported performance metrics", () => {
+    renderLanding("/");
+
+    expect(screen.queryByText(/testimonial/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("98.4%")).not.toBeInTheDocument();
+    expect(screen.queryByText("142")).not.toBeInTheDocument();
+    expect(screen.getByText(/Illustrative sample interface data, not company performance claims/i)).toBeInTheDocument();
+  });
+
+  it("does not ship placeholder footer links", () => {
+    const { container } = renderLanding("/");
+
+    const footerLinks = Array.from(container.querySelectorAll("footer a"));
+    expect(footerLinks.length).toBeGreaterThan(0);
+    expect(footerLinks.every((link) => link.getAttribute("href") && !link.getAttribute("href")?.startsWith("#"))).toBe(
+      true
+    );
   });
 });

--- a/rentchain-frontend/src/pages/marketing/LandingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/LandingPage.tsx
@@ -1,49 +1,22 @@
 import React, { useEffect, useMemo } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
-import { Button, Card } from "../../components/ui/Ui";
-import { track } from "../../lib/analytics";
-import { useAuth } from "../../context/useAuth";
-import { MarketingLayout } from "./MarketingLayout";
-import { colors, radius, shadows, spacing, text, typography } from "../../styles/tokens";
+import { useLocation, useNavigate } from "react-router-dom";
 import { saveRegistryAcquisitionAttribution } from "../../api/propertiesApi";
-
-type HowItWorksStep = {
-  title: string;
-  body: string;
-};
-
-const HOW_IT_WORKS: HowItWorksStep[] = [
-  {
-    title: "Set up your property",
-    body: "Add your first property, keep the important details together, and start the workflow without piecing it together across different tools.",
-  },
-  {
-    title: "See what needs attention",
-    body: "See what is missing early so tenant work, maintenance follow-up, and rental admin are easier to finish cleanly.",
-  },
-  {
-    title: "Add deeper support when you need it",
-    body: "Paid plans add deeper workflow support only when your rental operations outgrow the basics you can already start using now.",
-  },
-];
-
-const FAQ_ITEMS = [
-  {
-    question: "What can I use for free?",
-    answer:
-      "Free lets you organize a property, see what is missing, and try the core workflow before deciding whether you need more support.",
-  },
-  {
-    question: "What unlocks on paid plans?",
-    answer:
-      "Paid plans unlock stronger day-to-day tools, clearer filing support, safer follow-through, and a better record of what happened over time.",
-  },
-  {
-    question: "Is this available across Canada?",
-    answer:
-      "Yes. RentChain is built for landlords across Canada. You can use it to organize your properties, manage tenants, and stay on top of what needs attention—no matter where your rentals are located. Some region-specific tools, like lease templates and compliance workflows, vary by province and continue to expand.",
-  },
-];
+import { useAuth } from "../../context/useAuth";
+import { track } from "../../lib/analytics";
+import {
+  AboutVisionSection,
+  AudienceSection,
+  FeatureShowcaseSection,
+  FinalCtaSection,
+  HeroSection,
+  LifecycleSection,
+  MarketingFooter,
+  MarketingHeader,
+  OperationalTrustSection,
+  TrustFlowSection,
+  WhyRentChainSection,
+} from "./landing/LandingSections";
+import { landingPageCss } from "./landing/landingPageCss";
 
 function firstQueryValue(search: URLSearchParams, ...keys: string[]) {
   for (const key of keys) {
@@ -53,25 +26,18 @@ function firstQueryValue(search: URLSearchParams, ...keys: string[]) {
   return null;
 }
 
-const sectionHeadingStyle: React.CSSProperties = {
-  margin: 0,
-  fontSize: "1.15rem",
-  lineHeight: 1.2,
-};
+function ensureMarketingFonts() {
+  if (typeof document === "undefined" || document.getElementById("rentchain-marketing-fonts")) {
+    return;
+  }
 
-const ctaRowStyle: React.CSSProperties = {
-  display: "flex",
-  flexWrap: "wrap",
-  gap: spacing.sm,
-  alignItems: "center",
-};
-
-const ctaButtonStyle: React.CSSProperties = {
-  minHeight: 48,
-  minWidth: 148,
-  padding: "13px 20px",
-  fontWeight: 800,
-};
+  const link = document.createElement("link");
+  link.id = "rentchain-marketing-fonts";
+  link.rel = "stylesheet";
+  link.href =
+    "https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700;800&family=Source+Serif+4:wght@600;700&display=swap";
+  document.head.appendChild(link);
+}
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
@@ -89,7 +55,8 @@ const LandingPage: React.FC = () => {
   }, [location.search]);
 
   useEffect(() => {
-    document.title = "RentChain - Keep your rentals organized";
+    document.title = "RentChain - Housing operations. Connected.";
+    ensureMarketingFonts();
   }, []);
 
   const handlePrimaryCta = () => {
@@ -107,7 +74,7 @@ const LandingPage: React.FC = () => {
         location: "landing_hero",
       });
     } catch {
-      // analytics must never interrupt the landing flow
+      // Analytics must never interrupt the landing flow.
     }
 
     if (user?.id) {
@@ -118,364 +85,23 @@ const LandingPage: React.FC = () => {
     navigate("/signup?next=/properties&intent=registry_readiness");
   };
 
-  const handleLoginCta = () => {
-    navigate("/login");
-  };
-
   return (
-    <MarketingLayout>
-      <div
-        style={{
-          display: "grid",
-          gap: spacing.lg,
-          maxWidth: 1120,
-          margin: "0 auto",
-        }}
-      >
-        <section
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-            gap: spacing.lg,
-            alignItems: "stretch",
-          }}
-        >
-          <Card
-            style={{
-              padding: "clamp(22px, 3vw, 36px)",
-              background:
-                "linear-gradient(160deg, rgba(255,255,255,0.98) 0%, rgba(244,247,252,0.96) 55%, rgba(228,239,255,0.92) 100%)",
-              border: "1px solid rgba(15,23,42,0.08)",
-              boxShadow: shadows.md,
-              overflow: "hidden",
-            }}
-          >
-            <div style={{ display: "grid", gap: spacing.md }}>
-              <div
-                style={{
-                  display: "inline-flex",
-                  width: "fit-content",
-                  padding: "7px 12px",
-                  borderRadius: 999,
-                  background: "rgba(15,23,42,0.06)",
-                  color: text.secondary,
-                  fontSize: 12,
-                  fontWeight: 800,
-                  letterSpacing: "0.05em",
-                  textTransform: "uppercase",
-                }}
-              >
-                Built for landlords across Canada
-              </div>
-              <div style={{ display: "grid", gap: spacing.sm }}>
-                <h1
-                  style={{
-                    margin: 0,
-                    fontSize: "clamp(2.4rem, 5vw, 4rem)",
-                    lineHeight: 0.98,
-                    letterSpacing: "-0.04em",
-                    maxWidth: 760,
-                  }}
-                >
-                  Keep your rentals organized and your day moving across Canada.
-                </h1>
-                <p
-                  style={{
-                    margin: 0,
-                    color: text.muted,
-                    fontSize: "1.06rem",
-                    lineHeight: 1.75,
-                    maxWidth: 720,
-                  }}
-                >
-                  RentChain helps landlords across Canada stay on top of property details, tenant activity,
-                  maintenance, and the tasks that tend to fall through the cracks. When you need deeper
-                  lease, filing, or compliance support, those tools can vary by province and continue to expand.
-                </p>
-                <p
-                  style={{
-                    margin: 0,
-                    color: text.secondary,
-                    fontSize: "0.98rem",
-                    lineHeight: 1.7,
-                    maxWidth: 720,
-                    fontWeight: 600,
-                  }}
-                >
-                  Start with your first property, see how the workflow works, and decide on paid plans only after you understand the value inside the product.
-                </p>
-              </div>
-              <div style={ctaRowStyle}>
-                <Button
-                  type="button"
-                  onClick={handlePrimaryCta}
-                  aria-label="Sign Up Free"
-                  style={ctaButtonStyle}
-                >
-                  Sign Up Free
-                </Button>
-                <Button
-                  type="button"
-                  variant="navy"
-                  onClick={handleLoginCta}
-                  aria-label="Log In"
-                  style={ctaButtonStyle}
-                >
-                  Log In
-                </Button>
-                <div style={{ color: text.secondary, fontSize: "0.93rem", fontWeight: 600 }}>
-                  No commitment to explore. Start free and upgrade only when your workflow needs more support.
-                </div>
-              </div>
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))",
-                  gap: spacing.sm,
-                  marginTop: spacing.xs,
-                }}
-              >
-                {[
-                  "Set up your first property and tenant workflow in one place",
-                  "See what is missing before it becomes a larger admin problem",
-                  "Add deeper workflow support only when you actually need it",
-                ].map((item) => (
-                  <div
-                    key={item}
-                    style={{
-                      borderRadius: radius.lg,
-                      border: "1px solid rgba(15,23,42,0.08)",
-                      background: "rgba(255,255,255,0.76)",
-                      padding: "14px 16px",
-                      fontWeight: 700,
-                      lineHeight: 1.45,
-                      overflowWrap: "anywhere",
-                    }}
-                  >
-                    {item}
-                  </div>
-                ))}
-              </div>
-            </div>
-          </Card>
-
-          <Card
-            style={{
-              padding: "clamp(20px, 2.4vw, 28px)",
-              background: "linear-gradient(180deg, rgba(15,23,42,0.98) 0%, rgba(30,41,59,0.98) 100%)",
-              color: "#fff",
-              border: "1px solid rgba(255,255,255,0.08)",
-              boxShadow: shadows.md,
-            }}
-          >
-            <div style={{ display: "grid", gap: spacing.md }}>
-              <div style={{ fontSize: 12, fontWeight: 800, letterSpacing: "0.06em", textTransform: "uppercase", opacity: 0.8 }}>
-                What landlords upgrade for
-              </div>
-              <div style={{ display: "grid", gap: spacing.sm }}>
-                <div style={{ fontSize: "1.2rem", fontWeight: 800, lineHeight: 1.25 }}>
-                  Get more help as your rental operations get busier.
-                </div>
-                <p style={{ margin: 0, color: "rgba(255,255,255,0.8)", lineHeight: 1.7 }}>
-                  Paid plans are for landlords who want cleaner day-to-day control, clearer records, and
-                  stronger support when a property task needs follow-through.
-                </p>
-              </div>
-              <div style={{ display: "grid", gap: 10 }}>
-                {[
-                  "Keep property tasks, notes, and next steps easier to follow",
-                  "Get clearer filing support when a jurisdiction requires extra work",
-                  "Keep a better record of what was done and what happens next",
-                ].map((item) => (
-                  <div
-                    key={item}
-                    style={{
-                      padding: "12px 14px",
-                      borderRadius: radius.md,
-                      background: "rgba(255,255,255,0.08)",
-                      color: "rgba(255,255,255,0.92)",
-                      fontSize: "0.95rem",
-                      lineHeight: 1.6,
-                    }}
-                  >
-                    {item}
-                  </div>
-                ))}
-              </div>
-            </div>
-          </Card>
-        </section>
-
-        <section
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
-            gap: spacing.md,
-          }}
-        >
-          {HOW_IT_WORKS.map((step, index) => (
-            <Card key={step.title} style={{ padding: "22px 22px 24px" }}>
-              <div style={{ display: "grid", gap: spacing.sm }}>
-                <div
-                  style={{
-                    display: "inline-flex",
-                    width: 34,
-                    height: 34,
-                    alignItems: "center",
-                    justifyContent: "center",
-                    borderRadius: 999,
-                    background: colors.accentSoft,
-                    color: colors.accent,
-                    fontWeight: 800,
-                  }}
-                >
-                  {index + 1}
-                </div>
-                <h2 style={sectionHeadingStyle}>{step.title}</h2>
-                <p
-                  style={{
-                    margin: 0,
-                    color: text.muted,
-                    lineHeight: 1.7,
-                    overflowWrap: "anywhere",
-                  }}
-                >
-                  {step.body}
-                </p>
-              </div>
-            </Card>
-          ))}
-        </section>
-
-        <section
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-            gap: spacing.md,
-          }}
-        >
-          <Card style={{ padding: "22px 22px 24px" }}>
-            <div style={{ display: "grid", gap: spacing.sm }}>
-              <h2 style={sectionHeadingStyle}>What stays free</h2>
-              <ul style={{ margin: 0, paddingLeft: "1.1rem", color: text.muted, lineHeight: 1.8 }}>
-                <li>Set up your first property and keep the important details together</li>
-                <li>Track the basics before a task turns messy</li>
-                <li>Use the platform to get organized before paying</li>
-                <li>Try the workflow before deciding whether you need more support</li>
-              </ul>
-            </div>
-          </Card>
-          <Card style={{ padding: "22px 22px 24px" }}>
-            <div style={{ display: "grid", gap: spacing.sm }}>
-              <h2 style={sectionHeadingStyle}>Why landlords upgrade</h2>
-              <ul style={{ margin: 0, paddingLeft: "1.1rem", color: text.muted, lineHeight: 1.8 }}>
-                <li>Run day-to-day rental work with stronger tools and less friction</li>
-                <li>Keep better oversight as you manage more units or properties</li>
-                <li>Get clearer filing and compliance support when you need it</li>
-                <li>Keep a cleaner record of what was done and what happens next</li>
-              </ul>
-            </div>
-          </Card>
-        </section>
-
-        <Card style={{ padding: "24px" }}>
-          <div style={{ display: "grid", gap: spacing.md }}>
-            <div>
-              <h2 style={{ ...sectionHeadingStyle, fontSize: "1.3rem" }}>Frequently asked questions</h2>
-            </div>
-            <div
-              style={{
-                display: "grid",
-                gap: spacing.md,
-                gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
-              }}
-            >
-              {FAQ_ITEMS.map((item) => (
-                <div
-                  key={item.question}
-                  style={{
-                    display: "grid",
-                    gap: spacing.xs,
-                    padding: "16px 18px",
-                    borderRadius: radius.lg,
-                    border: "1px solid rgba(15,23,42,0.08)",
-                    background: "rgba(255,255,255,0.72)",
-                  }}
-                >
-                  <div style={{ fontWeight: 800, lineHeight: 1.35 }}>{item.question}</div>
-                  <div style={{ color: text.muted, lineHeight: 1.7, overflowWrap: "anywhere" }}>{item.answer}</div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </Card>
-
-        <Card
-          style={{
-            padding: "26px",
-            background: "linear-gradient(135deg, rgba(225,234,248,0.9) 0%, rgba(255,255,255,0.92) 100%)",
-            border: "1px solid rgba(15,23,42,0.08)",
-          }}
-        >
-          <div
-            style={{
-              display: "grid",
-              gap: spacing.md,
-              alignItems: "center",
-              justifyItems: "start",
-            }}
-          >
-            <div style={{ display: "grid", gap: spacing.xs }}>
-              <div
-                style={{
-                  fontSize: 12,
-                  fontWeight: 800,
-                  letterSpacing: "0.06em",
-                  textTransform: "uppercase",
-                  color: text.secondary,
-                }}
-              >
-                Start with the free basics
-              </div>
-              <div
-                style={{
-                  fontSize: "clamp(1.5rem, 3vw, 2rem)",
-                  fontWeight: 800,
-                  lineHeight: 1.05,
-                  fontFamily: typography.fontFamily,
-                }}
-              >
-                Start simple, then grow into the tools you need.
-              </div>
-              <p style={{ margin: 0, color: text.muted, lineHeight: 1.75, maxWidth: 760 }}>
-                Add a property, get organized, and see how the workflow feels in practice. Filing and
-                compliance support are there when you need them, but you do not have to learn the whole
-                system to get value on day one.
-              </p>
-            </div>
-              <div style={ctaRowStyle}>
-                <Button
-                  type="button"
-                  onClick={handlePrimaryCta}
-                  aria-label="Sign Up Free"
-                  style={ctaButtonStyle}
-                >
-                  Sign Up Free
-                </Button>
-                <Button
-                  type="button"
-                  variant="navy"
-                  onClick={handleLoginCta}
-                  aria-label="Log In"
-                  style={ctaButtonStyle}
-                >
-                  Log In
-                </Button>
-              </div>
-          </div>
-        </Card>
-      </div>
-    </MarketingLayout>
+    <div className="rc-landing">
+      <style>{landingPageCss}</style>
+      <MarketingHeader onPrimaryCta={handlePrimaryCta} />
+      <main>
+        <HeroSection onPrimaryCta={handlePrimaryCta} />
+        <TrustFlowSection />
+        <WhyRentChainSection />
+        <AudienceSection />
+        <LifecycleSection />
+        <FeatureShowcaseSection />
+        <OperationalTrustSection />
+        <AboutVisionSection />
+        <FinalCtaSection onPrimaryCta={handlePrimaryCta} />
+      </main>
+      <MarketingFooter />
+    </div>
   );
 };
 

--- a/rentchain-frontend/src/pages/marketing/landing/LandingSections.tsx
+++ b/rentchain-frontend/src/pages/marketing/landing/LandingSections.tsx
@@ -1,0 +1,578 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import rentchainMark from "../../../assets/rentchain-mark.svg";
+import {
+  aboutVision,
+  audiences,
+  features,
+  finalCta,
+  footer,
+  header,
+  hero,
+  lifecycle,
+  operationalTrust,
+  trustFlow,
+  whyRentChain,
+} from "./landingContent";
+import { tokens } from "./marketingLandingStyles";
+
+type LandingActionProps = {
+  onPrimaryCta: () => void;
+};
+
+const dotColors: Record<string, string> = {
+  pine500: tokens.colors.pine500,
+  pine600: tokens.colors.pine600,
+  navy200: tokens.colors.navy200,
+  navy600: tokens.colors.navy600,
+  amber500: tokens.colors.amber500,
+  slate600: tokens.colors.slate600,
+};
+
+function roleDot(token: string) {
+  return <span aria-hidden="true" className="rc-dot" style={{ background: dotColors[token] ?? tokens.colors.pine500 }} />;
+}
+
+function supportsReducedMotion() {
+  return typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function RevealOnScroll({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(() => supportsReducedMotion());
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || visible) return;
+    if (!("IntersectionObserver" in window)) {
+      setVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "0px 0px -80px" }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  return (
+    <div ref={ref} className={`rc-reveal ${visible ? "is-visible" : ""} ${className}`}>
+      {children}
+    </div>
+  );
+}
+
+export function MarketingHeader({ onPrimaryCta }: LandingActionProps) {
+  const [loginOpen, setLoginOpen] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const loginButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    function handlePointerDown(event: PointerEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setLoginOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setLoginOpen(false);
+        setMobileOpen(false);
+        loginButtonRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  return (
+    <header className="rc-marketing-header">
+      <div className="rc-container rc-marketing-header__inner">
+        <Link className="rc-brand" to="/site" aria-label="RentChain home">
+          <img src={rentchainMark} alt="" aria-hidden="true" />
+          <span className="rc-brand__text">RentChain</span>
+        </Link>
+
+        <nav className="rc-header-nav" aria-label="Marketing navigation">
+          {header.nav.map((item) => (
+            <a key={item.label} href={item.href}>
+              {item.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="rc-header-actions">
+          <div className="rc-login-menu" ref={menuRef}>
+            <button
+              ref={loginButtonRef}
+              type="button"
+              aria-haspopup="menu"
+              aria-expanded={loginOpen}
+              className="rc-button rc-button--ghost"
+              onClick={() => setLoginOpen((open) => !open)}
+            >
+              Log in
+            </button>
+            {loginOpen ? (
+              <div className="rc-login-menu__panel" role="menu" aria-label="Choose a login portal">
+                {header.logins.map((login) => (
+                  <Link key={login.label} className="rc-login-option" to={login.href} role="menuitem">
+                    {roleDot(login.dotToken)}
+                    <span>{login.label}</span>
+                  </Link>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <Link className="rc-link-button rc-link-button--primary" to={header.ctaHref}>
+            {header.ctaLabel}
+          </Link>
+        </div>
+
+        <button
+          type="button"
+          aria-expanded={mobileOpen}
+          aria-controls="rc-mobile-menu"
+          className="rc-button rc-button--ghost rc-mobile-toggle"
+          onClick={() => setMobileOpen((open) => !open)}
+        >
+          Menu
+        </button>
+      </div>
+
+      <div id="rc-mobile-menu" className={`rc-container rc-mobile-menu ${mobileOpen ? "is-open" : ""}`}>
+        {header.nav.map((item) => (
+          <a key={item.label} className="rc-mobile-link" href={item.href} onClick={() => setMobileOpen(false)}>
+            {item.label}
+          </a>
+        ))}
+        {header.logins.map((login) => (
+          <Link key={login.label} className="rc-mobile-link" to={login.href} onClick={() => setMobileOpen(false)}>
+            {login.label}
+          </Link>
+        ))}
+        <button type="button" className="rc-button rc-button--accent" onClick={onPrimaryCta}>
+          {hero.primaryCta.label}
+        </button>
+        <Link className="rc-link-button rc-link-button--primary" to={header.ctaHref}>
+          {header.ctaLabel}
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function LedgerRow({ code, title, meta, status }: { code: string; title: string; meta: string; status: string }) {
+  return (
+    <div className="rc-ledger-row">
+      <span className="rc-node-code">{code}</span>
+      <div>
+        <strong>{title}</strong>
+        <span>{meta}</span>
+      </div>
+      <strong>{status}</strong>
+    </div>
+  );
+}
+
+export function HeroSection({ onPrimaryCta }: LandingActionProps) {
+  return (
+    <section className="rc-hero" aria-labelledby="landing-hero-title">
+      <div className="rc-container rc-hero__inner">
+        <div>
+          <p className="rc-kicker">{hero.kicker}</p>
+          <h1 id="landing-hero-title">
+            {hero.titleLine1} <span className="rc-hero__accent">{hero.titleAccent}</span>
+          </h1>
+          <p className="rc-hero__subtitle">{hero.subtitle}</p>
+          <div className="rc-cta-row">
+            <button type="button" className="rc-button rc-button--accent" onClick={onPrimaryCta}>
+              {hero.primaryCta.label}
+            </button>
+            <Link className="rc-link-button rc-link-button--dark" to={hero.secondaryCta.href}>
+              {hero.secondaryCta.label}
+            </Link>
+          </div>
+          <p className="rc-microcopy">{hero.microcopy}</p>
+          <div className="rc-personas" aria-label="RentChain portals">
+            {hero.personas.map((persona) => (
+              <span key={persona.label} className="rc-persona-pill">
+                {roleDot(persona.dotToken)}
+                {persona.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="rc-hero-visual" aria-label="Sample connected operating record">
+          <div className="rc-ledger">
+            <LedgerRow code="LL" title="Lease terms approved" meta="Landlord workspace" status="Ready" />
+            <LedgerRow code="TN" title="Tenant request linked" meta="Portal message" status="Open" />
+            <LedgerRow code="CO" title="Evidence uploaded" meta="Work order record" status="Verified" />
+            <LedgerRow code="PM" title="Renewal review queued" meta="Portfolio operation" status="Next" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function TrustFlowSection() {
+  return (
+    <section className="rc-section" aria-labelledby="trust-flow-title">
+      <div className="rc-container">
+        <RevealOnScroll>
+          <div className="rc-section-heading">
+            <p className="rc-kicker">{trustFlow.kicker}</p>
+            <h2 className="rc-section-title" id="trust-flow-title">
+              {trustFlow.title}
+            </h2>
+          </div>
+        </RevealOnScroll>
+        <div className="rc-trust-flow" aria-label="RentChain role flow">
+          {trustFlow.nodes.slice(0, 2).map((node) => (
+            <RevealOnScroll key={node.role} className="rc-card rc-trust-node">
+              <span className="rc-node-code">{node.code}</span>
+              <h3>{node.role}</h3>
+              <p>{node.blurb}</p>
+            </RevealOnScroll>
+          ))}
+          <RevealOnScroll className="rc-panel rc-trust-hub">
+            <p className="rc-kicker">{trustFlow.hubKicker}</p>
+            <h3>{trustFlow.hubTitle}</h3>
+            <p>{trustFlow.hubBody}</p>
+          </RevealOnScroll>
+          {trustFlow.nodes.slice(2).map((node) => (
+            <RevealOnScroll key={node.role} className="rc-card rc-trust-node">
+              <span className="rc-node-code">{node.code}</span>
+              <h3>{node.role}</h3>
+              <p>{node.blurb}</p>
+            </RevealOnScroll>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function WhyRentChainSection() {
+  return (
+    <section className="rc-section rc-section--band" aria-labelledby="why-rentchain-title">
+      <div className="rc-container">
+        <RevealOnScroll>
+          <div className="rc-section-heading">
+            <p className="rc-kicker">{whyRentChain.kicker}</p>
+            <h2 className="rc-section-title" id="why-rentchain-title">
+              {whyRentChain.titlePlain} <span style={{ color: tokens.colors.pine700 }}>{whyRentChain.titleAccent}</span>
+            </h2>
+          </div>
+        </RevealOnScroll>
+        <div className="rc-comparison">
+          {whyRentChain.rows.map((row) => (
+            <RevealOnScroll key={row.from} className="rc-card rc-comparison-row">
+              <span>{row.from}</span>
+              <em aria-hidden="true">to</em>
+              <strong>{row.to}</strong>
+            </RevealOnScroll>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function AudienceSection() {
+  return (
+    <section className="rc-section" id="who" aria-labelledby="audience-title">
+      <div className="rc-container">
+        <div className="rc-section-heading">
+          <p className="rc-kicker">{audiences.kicker}</p>
+          <h2 className="rc-section-title" id="audience-title">
+            {audiences.title}
+          </h2>
+        </div>
+        <div className="rc-audience-grid">
+          {audiences.cards.map((card) => (
+            <RevealOnScroll key={card.key} className="rc-card rc-audience-card">
+              <span className="rc-node-code">{card.code}</span>
+              <h3>{card.role}</h3>
+              <ul>
+                {card.points.map((point) => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            </RevealOnScroll>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function LifecycleSection() {
+  const [active, setActive] = useState(0);
+  const activeStep = lifecycle.steps[active] ?? lifecycle.steps[0];
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (supportsReducedMotion()) return;
+    const interval = window.setInterval(() => {
+      setActive((current) => (current + 1) % lifecycle.steps.length);
+    }, lifecycle.autoAdvanceMs);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  function focusStep(index: number) {
+    const nextIndex = (index + lifecycle.steps.length) % lifecycle.steps.length;
+    setActive(nextIndex);
+    tabRefs.current[nextIndex]?.focus();
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, index: number) {
+    if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+      event.preventDefault();
+      focusStep(index + 1);
+    }
+    if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusStep(index - 1);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      focusStep(0);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      focusStep(lifecycle.steps.length - 1);
+    }
+  }
+
+  return (
+    <section className="rc-section rc-section--band" id="lifecycle" aria-labelledby="lifecycle-title">
+      <div className="rc-container">
+        <div className="rc-section-heading">
+          <p className="rc-kicker">{lifecycle.kicker}</p>
+          <h2 className="rc-section-title" id="lifecycle-title">
+            {lifecycle.title}
+          </h2>
+          <p className="rc-section-subtitle">{lifecycle.subtitle}</p>
+        </div>
+
+        <div className="rc-lifecycle">
+          <div className="rc-lifecycle-tabs" role="tablist" aria-label="Rental lifecycle">
+            {lifecycle.steps.map((step, index) => (
+              <button
+                key={step.label}
+                ref={(node) => {
+                  tabRefs.current[index] = node;
+                }}
+                type="button"
+                role="tab"
+                aria-selected={active === index}
+                aria-controls="lifecycle-panel"
+                className="rc-lifecycle-tab"
+                onClick={() => setActive(index)}
+                onKeyDown={(event) => handleKeyDown(event, index)}
+              >
+                {step.label}
+              </button>
+            ))}
+          </div>
+
+          <div id="lifecycle-panel" role="tabpanel" className="rc-panel rc-lifecycle-panel">
+            <span className="rc-status">{activeStep.statusLabel}</span>
+            <h3>{activeStep.title}</h3>
+            <p>{activeStep.body}</p>
+            <div className="rc-command-list">
+              <div>
+                <span>Timeline</span>
+                <strong>{activeStep.meta}</strong>
+              </div>
+              <div>
+                <span>Record detail</span>
+                <strong>{activeStep.amount}</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function FeatureShowcaseSection() {
+  return (
+    <section className="rc-section" id="features" aria-labelledby="features-title">
+      <div className="rc-container">
+        <div className="rc-section-heading">
+          <p className="rc-kicker">{features.kicker}</p>
+          <h2 className="rc-section-title" id="features-title">
+            {features.title}
+          </h2>
+        </div>
+        <div className="rc-feature-grid">
+          {features.rows.map((row) => (
+            <RevealOnScroll key={row.key} className="rc-card">
+              <p className="rc-kicker">{row.kicker}</p>
+              <h3>{row.title}</h3>
+              <p>{row.body}</p>
+            </RevealOnScroll>
+          ))}
+        </div>
+        <RevealOnScroll className="rc-panel rc-command-panel">
+          <p className="rc-kicker">{features.commandCenter.kicker}</p>
+          <h3>{features.commandCenter.title}</h3>
+          <p>{features.commandCenter.body}</p>
+          <div className="rc-command-list" aria-label="Sample command-center signals">
+            <div>
+              <span>Attention queue</span>
+              <strong>Needs review</strong>
+            </div>
+            <div>
+              <span>Maintenance</span>
+              <strong>Open requests</strong>
+            </div>
+            <div>
+              <span>Portfolio record</span>
+              <strong>Governed units</strong>
+            </div>
+          </div>
+          <p className="rc-microcopy">{features.commandCenter.sampleStatsNote}</p>
+        </RevealOnScroll>
+      </div>
+    </section>
+  );
+}
+
+export function OperationalTrustSection() {
+  return (
+    <section className="rc-section rc-section--dark" aria-labelledby="trust-title">
+      <div className="rc-container">
+        <div className="rc-section-heading">
+          <p className="rc-kicker">{operationalTrust.kicker}</p>
+          <h2 className="rc-section-title" id="trust-title">
+            {operationalTrust.title}
+          </h2>
+          <p className="rc-section-subtitle">{operationalTrust.subtitle}</p>
+        </div>
+        <div className="rc-trust-grid">
+          {operationalTrust.cards.map((card) => (
+            <RevealOnScroll key={card.title} className="rc-card">
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </RevealOnScroll>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function AboutVisionSection() {
+  return (
+    <section className="rc-section" id="vision" aria-labelledby="vision-title">
+      <div className="rc-container rc-about-grid">
+        <div>
+          <p className="rc-kicker">{aboutVision.kicker}</p>
+          <h2 className="rc-section-title" id="vision-title">
+            {aboutVision.title}
+          </h2>
+          {aboutVision.body.map((paragraph) => (
+            <p key={paragraph} className="rc-section-subtitle">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+        <aside className="rc-panel" aria-label={aboutVision.visionTitle}>
+          <h3>{aboutVision.visionTitle}</h3>
+          <div className="rc-tag-cloud">
+            {aboutVision.tags.map((tag) => (
+              <span key={tag} className="rc-tag">
+                {tag}
+              </span>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+export function FinalCtaSection({ onPrimaryCta }: LandingActionProps) {
+  return (
+    <section className="rc-section" aria-labelledby="final-cta-title">
+      <div className="rc-container">
+        <div className="rc-final-cta">
+          <p className="rc-kicker">{finalCta.kicker}</p>
+          <h2 className="rc-section-title" id="final-cta-title">
+            {finalCta.title}
+          </h2>
+          <p className="rc-section-subtitle">{finalCta.subtitle}</p>
+          <div className="rc-cta-row">
+            <button type="button" className="rc-button rc-button--accent" onClick={onPrimaryCta}>
+              {finalCta.primaryCta.label}
+            </button>
+            <Link className="rc-link-button rc-link-button--dark" to={finalCta.secondaryCta.href}>
+              {finalCta.secondaryCta.label}
+            </Link>
+          </div>
+          <p className="rc-microcopy">{finalCta.microcopy}</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function MarketingFooter() {
+  return (
+    <footer className="rc-footer">
+      <div className="rc-container">
+        <div className="rc-footer-grid">
+          <div>
+            <Link className="rc-brand" to="/site" aria-label="RentChain home">
+              <img src={rentchainMark} alt="" aria-hidden="true" />
+              <span className="rc-brand__text">RentChain</span>
+            </Link>
+            <p>{footer.blurb}</p>
+          </div>
+          {footer.columns.map((column) => (
+            <nav key={column.heading} className="rc-footer-column" aria-label={column.heading}>
+              <h2>{column.heading}</h2>
+              <ul>
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    <Link to={link.href}>{link.label}</Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
+        </div>
+        <div className="rc-footer-bottom">
+          <span>{footer.legal.copyright}</span>
+          <nav className="rc-footer-legal" aria-label="Legal links">
+            {footer.legal.links.map((link) => (
+              <Link key={link.label} to={link.href}>
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/rentchain-frontend/src/pages/marketing/landing/landingContent.ts
+++ b/rentchain-frontend/src/pages/marketing/landing/landingContent.ts
@@ -1,0 +1,368 @@
+/**
+ * landingContent.ts
+ * All copy + structured data for the RentChain marketing landing page.
+ *
+ * Production-safe content for the native React marketing landing page:
+ *  - no fabricated aggregate metrics
+ *  - no fictional testimonials / U.S. cities
+ *  - Canadian EFT payment terminology
+ *  - neutral public entity name until legal entity is confirmed
+ *  - no placeholder # social links
+ *  - conservative free/pricing microcopy
+ *
+ * Intended location:
+ * rentchain-frontend/src/pages/marketing/landing/landingContent.ts
+ */
+
+export type Accent = "pine" | "navy" | "amber" | "slate";
+export type LifecycleStatus = "verified" | "pending" | "info";
+
+export const header = {
+  nav: [
+    { label: "Features", href: "#features" },
+    { label: "Solutions", href: "#who" },
+    { label: "Platform", href: "#lifecycle" },
+    { label: "About", href: "#vision" },
+  ],
+  logins: [
+    { label: "Landlord login", dotToken: "pine600", href: "/login?role=landlord" },
+    { label: "Property manager login", dotToken: "navy600", href: "/login?role=manager" },
+    { label: "Tenant login", dotToken: "amber500", href: "/tenant" },
+    { label: "Contractor login", dotToken: "slate600", href: "/contractor" },
+  ],
+  ctaLabel: "Book a demo",
+  ctaHref: "/site/request-access",
+};
+
+export const hero = {
+  kicker: "The operating system for housing",
+  titleLine1: "Housing operations.",
+  titleAccent: "Connected.",
+  subtitle:
+    "One platform connecting landlords, tenants, contractors, and property managers — through governed workflows for communication, payments, maintenance, leasing, and evidence.",
+  primaryCta: { label: "Start free", href: "/signup?next=/properties&intent=registry_readiness" },
+  secondaryCta: { label: "Book a demo", href: "/site/request-access" },
+  microcopy: "Start with your first property · No credit card required",
+  personas: [
+    { label: "Landlords", dotToken: "pine500" },
+    { label: "Property managers", dotToken: "navy200" },
+    { label: "Tenants", dotToken: "amber500" },
+    { label: "Contractors", dotToken: "slate600" },
+  ],
+};
+
+export const trustFlow = {
+  kicker: "Built for real housing operations",
+  title: "Every role, working from one shared record",
+  nodes: [
+    { code: "LL", role: "Landlords", blurb: "Set terms, keep the proof.", accent: "pine" as Accent },
+    { code: "PM", role: "Property managers", blurb: "Coordinate teams and work.", accent: "navy" as Accent },
+    { code: "TN", role: "Tenants", blurb: "Pay, request, keep records.", accent: "amber" as Accent },
+    { code: "CO", role: "Contractors", blurb: "Do the work, upload evidence.", accent: "slate" as Accent },
+  ],
+  hubKicker: "One shared record",
+  hubTitle: "Every role writes to the same source of truth",
+  hubBody:
+    "Leases, payments, messages, maintenance activity, approvals, and evidence stay connected to the same operating history.",
+};
+
+export const whyRentChain = {
+  kicker: "The difference",
+  titlePlain: "Most platforms manage properties.",
+  titleAccent: "RentChain manages operations.",
+  rows: [
+    { from: "Property data", to: "Operational intelligence" },
+    { from: "Messages", to: "Governed communication" },
+    { from: "Documents", to: "Evidence packages" },
+    { from: "Maintenance tickets", to: "Workflow coordination" },
+    { from: "Payments", to: "Financial continuity" },
+  ],
+};
+
+export const audiences = {
+  kicker: "Who it's for",
+  title: "One system, four points of view",
+  cards: [
+    {
+      key: "landlords",
+      code: "LL",
+      role: "Landlords",
+      accent: "pine" as Accent,
+      points: ["Protect assets", "Reduce risk", "Increase visibility"],
+    },
+    {
+      key: "propertyManagers",
+      code: "PM",
+      role: "Property managers",
+      accent: "navy" as Accent,
+      points: ["Coordinate portfolios", "Manage teams", "Standardize operations"],
+    },
+    {
+      key: "tenants",
+      code: "TN",
+      role: "Tenants",
+      accent: "amber" as Accent,
+      points: ["Pay rent and keep receipts", "Send and track requests", "Keep documents in one place"],
+    },
+    {
+      key: "contractors",
+      code: "CO",
+      role: "Contractors",
+      accent: "slate" as Accent,
+      points: ["Receive work orders", "Upload evidence", "Track approvals and payment status"],
+    },
+  ],
+};
+
+export const lifecycle = {
+  kicker: "Platform overview",
+  title: "One continuous lifecycle, from lease to renewal",
+  subtitle:
+    "Every step writes to the same record. Tap through the lifecycle to see how nothing falls through the cracks.",
+  autoAdvanceMs: 3800,
+  steps: [
+    {
+      label: "Lease created",
+      title: "Lease created",
+      meta: "Apr 2 · 12-month term",
+      amount: "$1,450 / mo",
+      status: "verified" as LifecycleStatus,
+      statusLabel: "Verified",
+      body: "A signed lease opens the record. Terms, parties, and the deposit are logged once — the single source of truth everything else hangs off.",
+    },
+    {
+      label: "Tenant moves in",
+      title: "Tenant moves in",
+      meta: "Apr 15 · keys + condition report",
+      amount: "18 photos",
+      status: "info" as LifecycleStatus,
+      statusLabel: "On record",
+      body: "Move-in condition is captured with photos and a signed report, so there is less confusion later about how the unit started.",
+    },
+    {
+      label: "Rent collected",
+      title: "Rent collected",
+      meta: "May 1 · EFT ••2471",
+      amount: "$1,450.00",
+      status: "verified" as LifecycleStatus,
+      statusLabel: "Verified",
+      body: "Rent is collected and reconciled. Both sides see the same confirmation once the payment record is available.",
+    },
+    {
+      label: "Maintenance request",
+      title: "Maintenance request",
+      meta: "May 9 · water heater",
+      amount: "Priority: high",
+      status: "pending" as LifecycleStatus,
+      statusLabel: "Open",
+      body: "A tenant reports an issue from their portal. It lands as a work order — timestamped, attributed, and ready to route.",
+    },
+    {
+      label: "Contractor assigned",
+      title: "Contractor assigned",
+      meta: "May 9 · Rivera Plumbing",
+      amount: "Approved",
+      status: "info" as LifecycleStatus,
+      statusLabel: "Assigned",
+      body: "The manager approves and assigns the right contractor. The approval chain is part of the record, not a side conversation.",
+    },
+    {
+      label: "Work completed",
+      title: "Work completed",
+      meta: "May 11 · photos + invoice",
+      amount: "$320.00",
+      status: "verified" as LifecycleStatus,
+      statusLabel: "Verified",
+      body: "The contractor uploads evidence of completed work and the invoice. The record shows what happened, when it happened, and what was approved.",
+    },
+    {
+      label: "Evidence generated",
+      title: "Evidence generated",
+      meta: "May 11 · signed bundle",
+      amount: "PDF + audit log",
+      status: "verified" as LifecycleStatus,
+      statusLabel: "Sealed",
+      body: "Every step can be compiled into an evidence package for review, dispute preparation, audit support, or renewal decisions.",
+    },
+    {
+      label: "Lease renewal",
+      title: "Lease renewal",
+      meta: "Mar 2027 · renewed 12 mo",
+      amount: "$1,495 / mo",
+      status: "verified" as LifecycleStatus,
+      statusLabel: "Verified",
+      body: "When it is time to renew, the full operating history is already there. Continuity, not a fresh start from scratch.",
+    },
+  ],
+};
+
+export const features = {
+  kicker: "The platform",
+  title: "Five surfaces. One source of truth.",
+  rows: [
+    {
+      key: "leasing",
+      kicker: "Leasing & documents",
+      title: "Digital workflows that leave a clean trail",
+      body: "Send, sign, and store leases with every version tracked. Each signature becomes an evidence record you can produce on demand.",
+      mockLeads: false,
+    },
+    {
+      key: "payments",
+      kicker: "Payments",
+      title: "Rent collection with a built-in record",
+      body: "Track rent, reconcile payment activity, and give everyone the same financial picture. Every transaction is timestamped and connected to the lease.",
+      mockLeads: true,
+    },
+    {
+      key: "maintenance",
+      kicker: "Maintenance",
+      title: "From request to resolved, coordinated",
+      body: "Tenants report, managers approve, contractors deliver — and the evidence closes the loop. No more lost texts or he-said-she-said.",
+      mockLeads: false,
+    },
+    {
+      key: "communication",
+      kicker: "Communication",
+      title: "Conversations that stay on the record",
+      body: "Centralized, trackable, governed. Messages attach to the lease, unit, or work order they are about — so context never gets lost in a phone.",
+      mockLeads: true,
+    },
+  ],
+  commandCenter: {
+    kicker: "Operational command center",
+    title: "See the whole operation at a glance",
+    body: "Portfolio oversight, alerts, and decision support — so the things that need attention surface before they become problems.",
+    sampleStatsNote: "Illustrative sample interface data, not company performance claims.",
+    sampleStats: [
+      { value: "98.4%", label: "on-time rent", accent: false },
+      { value: "3", label: "need attention", accent: true },
+      { value: "12", label: "open work orders", accent: false },
+      { value: "142", label: "units governed", accent: false },
+    ],
+  },
+};
+
+export const operationalTrust = {
+  kicker: "Operational trust",
+  title: "Housing professionals need more than software",
+  subtitle:
+    "RentChain is designed around the record: who said what, who approved what, what was paid, what was signed, and what evidence supports the outcome.",
+  capabilities: [
+    "Timestamped payment records",
+    "One shared record for every party",
+    "Evidence packages on demand",
+    "Audit-ready operating history",
+  ],
+  cards: [
+    {
+      title: "Shared record",
+      body: "Every action connects to the lease, unit, tenant, property, or work order it belongs to.",
+    },
+    {
+      title: "Evidence-ready workflows",
+      body: "Documents, messages, payments, and maintenance history stay organized for review when needed.",
+    },
+    {
+      title: "Role-based access",
+      body: "Landlords, tenants, contractors, and property managers each work from the right view of the same record.",
+    },
+  ],
+  testimonials: [] as Array<{ quote: string; name: string; role: string }>,
+};
+
+export const aboutVision = {
+  kicker: "Why we built RentChain",
+  title: "Housing operations are fragmented",
+  body: [
+    "Critical information lives in emails, texts, spreadsheets, filing cabinets, and a dozen disconnected tools. When something goes wrong, no one can find the record that proves what happened.",
+    "RentChain was built to bring every housing workflow into one operational system — where the record is shared, governed, and difficult to quietly change.",
+  ],
+  visionTitle: "Building housing infrastructure for the next generation",
+  tags: [
+    "Operational governance",
+    "Institutional housing",
+    "Evidence management",
+    "Compliance support",
+    "Government partnerships",
+    "Scalable operations",
+  ],
+};
+
+export const finalCta = {
+  kicker: "Get started",
+  title: "Run housing operations with confidence",
+  subtitle:
+    "Join the platform connecting people, properties, and operations — on one shared, governed record.",
+  primaryCta: { label: "Start free", href: "/signup?next=/properties&intent=registry_readiness" },
+  secondaryCta: { label: "Book a demo", href: "/site/request-access" },
+  microcopy: "Start free · Upgrade only when your workflow needs more support",
+};
+
+export const footer = {
+  blurb:
+    "The operating infrastructure for housing — connecting people, properties, and operations on one governed record.",
+  columns: [
+    {
+      heading: "Solutions",
+      links: [
+        { label: "Landlords", href: "/site" },
+        { label: "Property managers", href: "/site" },
+        { label: "Tenants", href: "/tenant" },
+        { label: "Contractors", href: "/contractor" },
+      ],
+    },
+    {
+      heading: "Platform",
+      links: [
+        { label: "Features", href: "/site" },
+        { label: "Pricing", href: "/site/pricing" },
+        { label: "Trust", href: "/trust" },
+        { label: "Security", href: "/security" },
+      ],
+    },
+    {
+      heading: "Resources",
+      links: [
+        { label: "Help center", href: "/help" },
+        { label: "Templates", href: "/help/templates" },
+        { label: "Request access", href: "/site/request-access" },
+        { label: "Contact", href: "/contact" },
+      ],
+    },
+    {
+      heading: "Company",
+      links: [
+        { label: "About", href: "/site/about" },
+        { label: "Status", href: "/status" },
+        { label: "Accessibility", href: "/accessibility" },
+      ],
+    },
+  ],
+  legal: {
+    copyright: "© 2026 RentChain. All rights reserved.",
+    links: [
+      { label: "Privacy", href: "/privacy" },
+      { label: "Terms", href: "/terms" },
+      { label: "Acceptable use", href: "/acceptable-use" },
+      { label: "Subprocessors", href: "/subprocessors" },
+    ],
+  },
+  social: [] as Array<{ label: string; href: string }>,
+};
+
+export const landingContent = {
+  header,
+  hero,
+  trustFlow,
+  whyRentChain,
+  audiences,
+  lifecycle,
+  features,
+  operationalTrust,
+  aboutVision,
+  finalCta,
+  footer,
+};
+
+export default landingContent;

--- a/rentchain-frontend/src/pages/marketing/landing/landingPageCss.ts
+++ b/rentchain-frontend/src/pages/marketing/landing/landingPageCss.ts
@@ -1,0 +1,737 @@
+import { tokens } from "./marketingLandingStyles";
+
+const { colors, semantic, typography } = tokens;
+
+export const landingPageCss = `
+.rc-landing {
+  --rc-paper: ${colors.paper100};
+  --rc-paper-band: ${colors.paper200};
+  --rc-card: ${colors.white};
+  --rc-ink: ${colors.ink900};
+  --rc-muted: ${colors.ink500};
+  --rc-pine: ${colors.pine700};
+  --rc-pine-dark: ${colors.pine950};
+  --rc-amber: ${colors.amber500};
+  --rc-navy: ${colors.navy950};
+  --rc-line: ${colors.border};
+  --rc-focus: ${semantic.focusRing};
+  min-height: 100vh;
+  background: var(--rc-paper);
+  color: var(--rc-ink);
+  font-family: ${typography.fontSans};
+  overflow-x: hidden;
+}
+
+.rc-landing *,
+.rc-landing *::before,
+.rc-landing *::after {
+  box-sizing: border-box;
+}
+
+.rc-landing a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.rc-landing a:focus-visible,
+.rc-landing button:focus-visible {
+  outline: none;
+  box-shadow: var(--rc-focus);
+}
+
+.rc-landing button {
+  font: inherit;
+}
+
+.rc-container {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.rc-marketing-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  border-bottom: 1px solid rgba(229, 222, 207, 0.82);
+  background: rgba(250, 247, 242, 0.92);
+  backdrop-filter: blur(14px);
+}
+
+.rc-marketing-header__inner {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.rc-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  color: var(--rc-pine-dark);
+}
+
+.rc-brand img {
+  width: 34px;
+  height: 34px;
+}
+
+.rc-brand__text {
+  font-family: ${typography.fontDisplay};
+  font-size: 1.4rem;
+}
+
+.rc-header-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rc-header-nav a,
+.rc-header-nav button,
+.rc-mobile-link {
+  border-radius: 999px;
+  padding: 9px 12px;
+  color: ${colors.ink700};
+  font-weight: 700;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.rc-header-nav a:hover,
+.rc-header-nav button:hover,
+.rc-mobile-link:hover {
+  background: ${colors.pine50};
+  color: ${colors.pine900};
+}
+
+.rc-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.rc-login-menu {
+  position: relative;
+}
+
+.rc-login-menu__panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 278px;
+  padding: 10px;
+  border: 1px solid var(--rc-line);
+  border-radius: 14px;
+  background: ${colors.white};
+  box-shadow: 0 18px 50px rgba(32, 37, 31, 0.16);
+}
+
+.rc-login-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 10px;
+  color: ${colors.ink700};
+  font-weight: 750;
+}
+
+.rc-login-option:hover {
+  background: ${colors.paper100};
+}
+
+.rc-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.rc-mobile-toggle.rc-button {
+  display: none;
+}
+
+.rc-mobile-menu {
+  display: none;
+  padding: 0 0 16px;
+}
+
+.rc-button,
+.rc-link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 11px 18px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.rc-button--accent,
+.rc-link-button--accent {
+  background: var(--rc-amber);
+  color: ${colors.ink900};
+  box-shadow: 0 1px 2px rgba(14, 42, 33, 0.25);
+}
+
+.rc-button--primary,
+.rc-link-button--primary {
+  background: var(--rc-pine);
+  color: ${colors.white};
+}
+
+.rc-button--ghost,
+.rc-link-button--ghost {
+  background: transparent;
+  border-color: ${colors.borderStrong};
+  color: ${colors.ink700};
+}
+
+.rc-button--dark,
+.rc-link-button--dark {
+  background: transparent;
+  border-color: rgba(242, 241, 234, 0.28);
+  color: ${colors.textInverse};
+}
+
+.rc-hero {
+  position: relative;
+  background: ${colors.navy950};
+  color: ${colors.textInverse};
+  overflow: hidden;
+}
+
+.rc-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 90% at 80% 0%, rgba(30, 95, 78, 0.22) 0%, rgba(10, 20, 40, 0) 55%);
+  pointer-events: none;
+}
+
+.rc-hero__inner {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.85fr);
+  align-items: center;
+  gap: 44px;
+  min-height: calc(100vh - 72px);
+  padding: 64px 0;
+}
+
+.rc-kicker {
+  margin: 0 0 14px;
+  color: ${colors.pine600};
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.rc-hero .rc-kicker {
+  color: ${colors.amber500};
+}
+
+.rc-hero h1,
+.rc-section-title {
+  font-family: ${typography.fontDisplay};
+  letter-spacing: 0;
+}
+
+.rc-hero h1 {
+  margin: 0;
+  max-width: 780px;
+  font-size: 4rem;
+  line-height: 1.04;
+}
+
+.rc-hero__accent {
+  color: ${colors.amber500};
+}
+
+.rc-hero__subtitle {
+  margin: 22px 0 0;
+  max-width: 700px;
+  color: ${colors.textInverseMuted};
+  font-size: 1.1rem;
+  line-height: 1.75;
+}
+
+.rc-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-top: 28px;
+}
+
+.rc-microcopy {
+  margin: 14px 0 0;
+  color: ${colors.textInverseMuted};
+  font-size: 0.9rem;
+}
+
+.rc-personas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.rc-persona-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid rgba(242, 241, 234, 0.16);
+  border-radius: 999px;
+  padding: 7px 10px;
+  color: ${colors.textInverseMuted};
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.rc-hero-visual {
+  border: 1px solid rgba(242, 241, 234, 0.16);
+  border-radius: 24px;
+  padding: 22px;
+  background: rgba(242, 241, 234, 0.06);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.22);
+}
+
+.rc-ledger {
+  display: grid;
+  gap: 12px;
+}
+
+.rc-ledger-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  border: 1px solid rgba(242, 241, 234, 0.14);
+  border-radius: 12px;
+  padding: 14px;
+}
+
+.rc-ledger-row strong,
+.rc-ledger-row span {
+  display: block;
+}
+
+.rc-ledger-row span {
+  color: ${colors.textInverseMuted};
+  font-size: 0.86rem;
+}
+
+.rc-section {
+  padding: 84px 0;
+}
+
+.rc-section--band {
+  background: var(--rc-paper-band);
+}
+
+.rc-section--dark {
+  background: ${colors.navy950};
+  color: ${colors.textInverse};
+}
+
+.rc-section-heading {
+  max-width: 760px;
+  margin-bottom: 34px;
+}
+
+.rc-section-title {
+  margin: 0;
+  font-size: 2.35rem;
+  line-height: 1.14;
+}
+
+.rc-section-subtitle {
+  margin: 14px 0 0;
+  max-width: 760px;
+  color: var(--rc-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.rc-section--dark .rc-section-subtitle {
+  color: ${colors.textInverseMuted};
+}
+
+.rc-card,
+.rc-panel {
+  border: 1px solid var(--rc-line);
+  border-radius: 16px;
+  background: var(--rc-card);
+  box-shadow: 0 1px 2px rgba(32, 37, 31, 0.05), 0 4px 16px rgba(32, 37, 31, 0.06);
+}
+
+.rc-card {
+  padding: 22px;
+}
+
+.rc-panel {
+  padding: 28px;
+}
+
+.rc-trust-flow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.92fr) minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
+}
+
+.rc-trust-node {
+  position: relative;
+}
+
+.rc-trust-node::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 28px;
+  height: 2px;
+  background: ${colors.pine200};
+}
+
+.rc-trust-node:nth-child(odd)::after {
+  right: -28px;
+}
+
+.rc-trust-node:nth-child(even)::after {
+  left: -28px;
+}
+
+.rc-trust-hub {
+  grid-row: span 2;
+  border-color: ${colors.pine200};
+  background: ${colors.pine50};
+}
+
+.rc-node-code {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  margin-bottom: 12px;
+  background: ${colors.pine700};
+  color: ${colors.white};
+  font-weight: 850;
+}
+
+.rc-comparison {
+  display: grid;
+  gap: 12px;
+  max-width: 760px;
+}
+
+.rc-comparison-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  padding: 14px;
+}
+
+.rc-comparison-row span {
+  color: ${colors.ink500};
+}
+
+.rc-comparison-row strong {
+  color: ${colors.pine700};
+}
+
+.rc-audience-grid,
+.rc-feature-grid,
+.rc-trust-grid,
+.rc-footer-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.rc-audience-card ul,
+.rc-feature-card ul,
+.rc-footer-column ul {
+  list-style: none;
+  padding: 0;
+  margin: 14px 0 0;
+  display: grid;
+  gap: 9px;
+}
+
+.rc-audience-card li::before,
+.rc-feature-card li::before {
+  content: "";
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 8px;
+  border-radius: 999px;
+  background: ${colors.amber500};
+}
+
+.rc-lifecycle {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.rc-lifecycle-tabs {
+  display: grid;
+  gap: 8px;
+}
+
+.rc-lifecycle-tab {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--rc-line);
+  border-radius: 12px;
+  background: ${colors.white};
+  padding: 12px 14px;
+  color: ${colors.ink700};
+  cursor: pointer;
+  font-weight: 750;
+}
+
+.rc-lifecycle-tab[aria-selected="true"] {
+  border-color: ${colors.pine200};
+  background: ${colors.pine50};
+  color: ${colors.pine900};
+}
+
+.rc-lifecycle-panel {
+  min-height: 360px;
+}
+
+.rc-status {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid ${colors.pine200};
+  border-radius: 999px;
+  background: ${colors.pine50};
+  color: ${colors.pine700};
+  padding: 5px 10px;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.rc-feature-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.rc-command-panel {
+  margin-top: 18px;
+  background: ${colors.navy950};
+  color: ${colors.textInverse};
+}
+
+.rc-command-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.rc-command-list div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid rgba(242, 241, 234, 0.14);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.rc-about-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(260px, 0.9fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.rc-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.rc-tag {
+  border: 1px solid ${colors.border};
+  border-radius: 999px;
+  padding: 8px 11px;
+  background: ${colors.white};
+  color: ${colors.ink700};
+  font-weight: 750;
+}
+
+.rc-final-cta {
+  border-radius: 28px;
+  padding: 42px;
+  background: ${colors.navy950};
+  color: ${colors.textInverse};
+}
+
+.rc-footer {
+  padding: 52px 0 32px;
+  background: ${colors.pine950};
+  color: ${colors.textInverse};
+}
+
+.rc-footer a {
+  color: ${colors.textInverseMuted};
+}
+
+.rc-footer a:hover {
+  color: ${colors.white};
+}
+
+.rc-footer-grid {
+  grid-template-columns: 1.4fr repeat(4, minmax(0, 1fr));
+}
+
+.rc-footer-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 34px;
+  padding-top: 22px;
+  border-top: 1px solid rgba(242, 241, 234, 0.16);
+  color: ${colors.textInverseMuted};
+  font-size: 0.88rem;
+}
+
+.rc-footer-legal {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.rc-reveal {
+  opacity: 0;
+  transform: translateY(22px);
+  transition: opacity 600ms ease, transform 600ms ease;
+}
+
+.rc-reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+@media (max-width: 980px) {
+  .rc-header-nav,
+  .rc-header-actions {
+    display: none;
+  }
+
+  .rc-mobile-toggle.rc-button {
+    display: inline-flex;
+  }
+
+  .rc-mobile-menu.is-open {
+    display: grid;
+    gap: 8px;
+  }
+
+  .rc-mobile-menu .rc-link-button,
+  .rc-mobile-menu .rc-button,
+  .rc-mobile-link {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .rc-hero__inner,
+  .rc-lifecycle,
+  .rc-about-grid,
+  .rc-trust-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .rc-trust-hub {
+    grid-row: auto;
+    order: -1;
+  }
+
+  .rc-trust-node::after {
+    display: none;
+  }
+
+  .rc-audience-grid,
+  .rc-feature-grid,
+  .rc-trust-grid,
+  .rc-footer-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .rc-container {
+    width: min(100% - 24px, 1120px);
+  }
+
+  .rc-hero__inner {
+    min-height: auto;
+    padding: 48px 0;
+  }
+
+  .rc-hero h1 {
+    font-size: 2.7rem;
+  }
+
+  .rc-section {
+    padding: 58px 0;
+  }
+
+  .rc-section-title {
+    font-size: 2rem;
+  }
+
+  .rc-hero-visual {
+    display: none;
+  }
+
+  .rc-audience-grid,
+  .rc-feature-grid,
+  .rc-trust-grid,
+  .rc-footer-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .rc-comparison-row {
+    grid-template-columns: 1fr;
+  }
+
+  .rc-comparison-row em {
+    display: none;
+  }
+
+  .rc-final-cta {
+    padding: 26px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-landing *,
+  .rc-landing *::before,
+  .rc-landing *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+
+  .rc-reveal {
+    opacity: 1;
+    transform: none;
+  }
+}
+`;

--- a/rentchain-frontend/src/pages/marketing/landing/marketingLandingStyles.ts
+++ b/rentchain-frontend/src/pages/marketing/landing/marketingLandingStyles.ts
@@ -1,0 +1,267 @@
+/**
+ * marketingLandingStyles.ts
+ * Marketing-only design tokens for the RentChain landing page.
+ *
+ * SCOPE: isolated to src/pages/marketing/. Do NOT migrate the whole app to these.
+ * Values are the exact RentChain Design System token values.
+ *
+ * Usage: import { tokens } from "./marketingLandingStyles";
+ * Prefer wiring these into CSS variables on the marketing page root, or into
+ * your styling solution of choice (CSS Modules / styled / Tailwind theme extend).
+ */
+
+export const colors = {
+  // Paper (warm neutrals)
+  paper50: "#FCFAF6",
+  paper100: "#FAF7F2", // page background
+  paper200: "#F3EDE2", // tinted band
+  paper300: "#E9E1D2",
+  white: "#FFFFFF",
+  // Ink (text)
+  ink900: "#20251F",
+  ink700: "#3C443B",
+  ink500: "#5C665A",
+  ink400: "#7C857A",
+  ink200: "#C9CEC5",
+  // Pine (primary)
+  pine950: "#0E2A21",
+  pine900: "#143A2E",
+  pine700: "#1E5F4E",
+  pine600: "#2A7460",
+  pine500: "#3B8A73",
+  pine200: "#BBD8CC",
+  pine100: "#D9EAE2",
+  pine50: "#ECF4F0",
+  // Amber (accent)
+  amber700: "#A8650F",
+  amber600: "#C97F1F",
+  amber500: "#E8A33D",
+  amber100: "#F9ECD4",
+  amber50: "#FCF5E7",
+  // Navy (dark surfaces)
+  navy950: "#0A1428",
+  navy900: "#112240",
+  navy700: "#1E3A5F",
+  navy600: "#2B4A7A",
+  navy500: "#3B5A99",
+  navy200: "#B8CCEB",
+  navy100: "#D9E5F7",
+  navy50: "#EBF1FB",
+  // Clay (danger) / Slate (info)
+  clay600: "#A8402C",
+  clay500: "#BC4B33",
+  clay100: "#F6E0D9",
+  slate600: "#3D6A8A",
+  slate100: "#DFE9F0",
+  // Inverse text + lines
+  textInverse: "#F2F1EA",
+  textInverseMuted: "#B9C6BE",
+  border: "#E5DECF",
+  borderStrong: "#CFC6B2",
+  borderOnInverse: "rgba(242,241,234,0.16)",
+} as const;
+
+export const semantic = {
+  surfacePage: colors.paper100,
+  surfaceCard: colors.white,
+  surfaceTint: colors.pine50,
+  surfaceBand: colors.paper200,
+  surfaceInverse: colors.navy950,
+  textBody: colors.ink900,
+  textSecondary: colors.ink700,
+  textMuted: colors.ink500,
+  textFaint: colors.ink400,
+  brandPrimary: colors.pine700,
+  brandPrimaryHover: colors.pine600,
+  brandPrimaryActive: colors.pine900,
+  brandAccent: colors.amber500,
+  brandAccentHover: colors.amber600,
+  // Status (record states)
+  statusSuccess: colors.pine600,
+  statusSuccessBg: colors.pine50,
+  statusWarning: colors.amber700,
+  statusWarningBg: colors.amber50,
+  statusDanger: colors.clay600,
+  statusDangerBg: colors.clay100,
+  statusInfo: colors.slate600,
+  statusInfoBg: colors.slate100,
+  focusRing: "0 0 0 3px rgba(42,116,96,0.35)",
+} as const;
+
+export const typography = {
+  fontDisplay: '"Source Serif 4", Georgia, "Times New Roman", serif',
+  fontSans: '"Public Sans", -apple-system, "Segoe UI", sans-serif',
+  fontMono: '"Spline Sans Mono", "SF Mono", Menlo, monospace',
+  size: {
+    xs: "0.75rem", // 12 — mono labels, legal
+    sm: "0.875rem", // 14 — captions, meta
+    base: "1rem", // 16 — body
+    md: "1.125rem", // 18 — lead body
+    lg: "1.375rem", // 22 — card titles
+    xl: "1.75rem", // 28
+    xxl: "2.25rem", // 36 — section titles
+    xxxl: "3rem", // 48 — hero mobile
+    xxxxl: "4rem", // 64 — hero desktop
+  },
+  // Fluid heads
+  heroH1: "clamp(2.75rem, 6.5vw, 4.25rem)",
+  sectionH2: "clamp(1.875rem, 3.5vw, 2.25rem)",
+  leading: { tight: 1.1, snug: 1.25, normal: 1.55, relaxed: 1.7 },
+  tracking: { tight: "-0.02em", normal: "0", wide: "0.08em" },
+  weight: { regular: 400, medium: 500, semibold: 600, bold: 700 },
+} as const;
+
+export const radii = {
+  sm: "6px",
+  md: "10px",
+  lg: "16px", // cards
+  xl: "24px", // large panels / hero mockups
+  panel: "28px", // final CTA panel
+  pill: "999px",
+} as const;
+
+export const shadows = {
+  card: "0 1px 2px rgba(32,37,31,0.05), 0 4px 16px rgba(32,37,31,0.06)",
+  raised: "0 2px 4px rgba(32,37,31,0.06), 0 12px 32px rgba(32,37,31,0.10)",
+  button: "0 1px 2px rgba(14,42,33,0.25)",
+} as const;
+
+export const spacing = {
+  s1: "0.25rem",
+  s2: "0.5rem",
+  s3: "0.75rem",
+  s4: "1rem",
+  s5: "1.5rem",
+  s6: "2rem",
+  s7: "3rem",
+  s8: "4rem",
+  s9: "6rem",
+  s10: "8rem",
+  sectionY: "clamp(4rem, 9vw, 6.5rem)",
+  container: "1120px",
+  containerPad: "clamp(1.25rem, 5vw, 2.5rem)",
+} as const;
+
+export const motion = {
+  easeOut: "cubic-bezier(0.22, 1, 0.36, 1)",
+  durationFast: "150ms",
+  durationBase: "250ms",
+  durationReveal: "600ms",
+  revealTransform: "translateY(22px)",
+} as const;
+
+export const layout = {
+  container: "1120px",
+  containerPad: "clamp(1.25rem, 5vw, 2.5rem)",
+  sectionY: "clamp(4rem, 9vw, 6.5rem)",
+  headerHeight: "72px",
+  gridGap: "20px",
+  breakpoints: {
+    mobile: 720, // trust-flow → 2-col, connectors hidden
+    heroVisual: 760, // hero network visual hidden below
+    nav: 900, // inline nav → mobile menu below
+  },
+} as const;
+
+// Reusable React inline-style objects (drop straight onto elements, or read as a spec).
+export const cardStyles = {
+  base: {
+    background: colors.white,
+    border: `1px solid ${colors.border}`,
+    borderRadius: radii.lg,
+    boxShadow: shadows.card,
+    padding: "22px",
+  },
+  tint: {
+    // verified / positive summaries
+    background: colors.pine50,
+    border: `1px solid ${colors.pine100}`,
+    borderRadius: radii.lg,
+    boxShadow: shadows.card,
+    padding: "20px 24px",
+  },
+  onDark: {
+    background: "rgba(242,241,234,0.06)",
+    border: "1px solid rgba(242,241,234,0.14)",
+    borderRadius: radii.md,
+    padding: "18px",
+  },
+} as const;
+
+export const badgeStyleBase = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "5px",
+  fontFamily: typography.fontSans,
+  fontSize: typography.size.xs,
+  fontWeight: typography.weight.semibold,
+  letterSpacing: "0.02em",
+  padding: "0.2rem 0.625rem",
+  borderRadius: radii.pill,
+  border: "1px solid transparent",
+} as const;
+
+/**
+ * Button style notes (map to the app's existing Button primitive where possible):
+ * - accent (primary CTA): bg amber500, text ink900 (NOT white — contrast), pill,
+ *   shadow.button; hover amber600; press: darker + scale(0.98).
+ * - primary (pine): bg pine700; hover pine600; active pine900; text white.
+ * - ghostOnDark: transparent, 1px rgba(242,241,234,0.28) border, text #F2F1EA;
+ *   hover bg rgba(242,241,234,0.08).
+ * - sizes: sm (header, ~0.5rem/1rem pad), lg (hero/CTA, ~0.85rem/1.5rem pad).
+ * - focus: 3px pine ring (semantic.focusRing) on every button.
+ */
+export const buttonStyles = {
+  accent: { background: colors.amber500, color: colors.ink900, boxShadow: shadows.button },
+  accentHover: { background: colors.amber600 },
+  primary: { background: colors.pine700, color: colors.white },
+  primaryHover: { background: colors.pine600 },
+  primaryActive: { background: colors.pine900 },
+  ghostOnDark: {
+    background: "transparent",
+    color: colors.textInverse,
+    border: "1px solid rgba(242,241,234,0.28)",
+  },
+  ghostOnDarkHover: { background: "rgba(242,241,234,0.08)" },
+  pressScale: "scale(0.98)",
+  focusRing: semantic.focusRing,
+} as const;
+
+// Dark hero ambient glow — the ONLY gradient permitted on the page.
+export const heroGlow =
+  "radial-gradient(120% 90% at 80% 0%, rgba(30,95,78,0.22) 0%, rgba(10,20,40,0) 55%)";
+
+// Solid (scrolled) header surface.
+export const headerSolid = {
+  background: "rgba(250,247,242,0.9)",
+  backdropFilter: "blur(14px)",
+  borderBottom: `1px solid ${colors.border}`,
+} as const;
+
+// Badge theme presets (record status pills)
+export const badgeThemes = {
+  verified: { background: colors.pine50, color: colors.pine700, borderColor: colors.pine200 },
+  pending: { background: colors.amber50, color: colors.amber700, borderColor: "#EFD9AC" },
+  info: { background: colors.slate100, color: colors.slate600, borderColor: "#C3D5E2" },
+  neutral: { background: colors.paper200, color: colors.ink700, borderColor: colors.border },
+} as const;
+
+export const tokens = {
+  colors,
+  semantic,
+  typography,
+  radii,
+  shadows,
+  spacing,
+  motion,
+  layout,
+  cardStyles,
+  badgeStyleBase,
+  badgeThemes,
+  buttonStyles,
+  heroGlow,
+  headerSolid,
+} as const;
+
+export type MarketingTokens = typeof tokens;
+export default tokens;


### PR DESCRIPTION
## Summary

- Replaces the public landing page with a native React implementation using the Claude Design handoff content and page-local marketing styles.
- Adds page-local marketing sections for the header, hero, Trust Flow diagram, audience cards, interactive lifecycle tabs, feature showcase, operational trust, vision, final CTA, and footer.
- Preserves the existing primary CTA behavior: acquisition attribution, analytics tracking, signed-in `/properties?intent=registry_readiness`, and signed-out `/signup?next=/properties&intent=registry_readiness`.
- Keeps `/` and `/site` on the refreshed landing page and routes Book demo/login/footer links to real app routes.

## Handoff Placement

- `landingContent.updated.ts` source: `.tmp/design_handoff_marketing_landing/landingContent.ts` was the only available copied content file and appears to be the updated production-safe source already renamed; placed as `rentchain-frontend/src/pages/marketing/landing/landingContent.ts`.
- `marketingLandingStyles.ts`: `rentchain-frontend/src/pages/marketing/landing/marketingLandingStyles.ts`.
- `rentchain-mark.svg`: `rentchain-frontend/src/assets/rentchain-mark.svg`.
- Implementation references: `docs/strategy/marketing-landing-refresh/COMPONENT_NOTES.md` and `docs/strategy/marketing-landing-refresh/CODEX_PROMPT.md`.
- Did not ship the `.dc.html` prototype, `support.js`, design-system runtime, or reference-only bundle contents.

## Notes

- Header login dropdown supports `aria-haspopup`, `aria-expanded`, outside-click close, and Escape close.
- Lifecycle controls are accessible tabs/buttons with click and keyboard navigation.
- Trust Flow is implemented as a flowchart-style hub-and-node diagram.
- CSS is isolated under `.rc-landing`; no logged-in app tokens or shared UI primitives were changed.
- Fake testimonials and unsupported performance metrics are not rendered; command-center copy is presented as illustrative sample interface data.
- Footer links are route-only and contain no `#` placeholders.

## Validation

- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- LandingPage`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check HEAD`
- `git diff --cached --check`
