### PR TITLE
polish: align auth pages with warm neutral brand theme

### DIFF
--- a/rentchain-frontend/src/components/auth/LoginForm.test.tsx
+++ b/rentchain-frontend/src/components/auth/LoginForm.test.tsx
@@ -94,6 +94,34 @@ describe("LoginForm", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Invalid email or password");
   });
 
+  it("uses the warm neutral auth theme without blue primary links or controls", () => {
+    renderForm();
+
+    const email = screen.getByLabelText("Email");
+    const submit = screen.getByRole("button", { name: "Sign in" });
+    const forgot = screen.getByRole("link", { name: "Forgot password?" });
+
+    expect(email).toHaveStyle({
+      background: "#fffdf8",
+    });
+    expect(email).toHaveStyle("border-color: rgba(105, 82, 49, 0.22)");
+    fireEvent.focus(email);
+    expect(email).toHaveStyle({
+      borderColor: "rgba(63, 54, 37, 0.72)",
+      boxShadow: "0 0 0 3px rgba(105, 82, 49, 0.22)",
+    });
+    expect(submit).toHaveStyle({
+      background: "#171411",
+      color: "#fffaf1",
+    });
+    expect(forgot).toHaveStyle({
+      color: "#171411",
+    });
+    expect(screen.getByText("Landlord access")).toHaveStyle({
+      background: "#dfe4d5",
+    });
+  });
+
   it("can disable submit separately from loading state", () => {
     renderForm({ disabled: true, submitLabel: "Email me a login link" });
 

--- a/rentchain-frontend/src/components/auth/LoginForm.tsx
+++ b/rentchain-frontend/src/components/auth/LoginForm.tsx
@@ -1,7 +1,21 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Button, Card, Input } from "../ui/Ui";
-import { colors, spacing, text } from "../../styles/tokens";
+import { spacing } from "../../styles/tokens";
+import {
+  authBannerStyle,
+  authBodyStyle,
+  authCardStyle,
+  authEyebrowStyle,
+  authHeadingStyle,
+  authInputProps,
+  authLabelTextStyle,
+  authLinkStyle,
+  authPalette,
+  authPrimaryButtonStyle,
+  authRoleBadgeStyle,
+  authShellStyle,
+} from "./authPageStyles";
 
 export type LoginFormBanner = {
   title: string;
@@ -33,33 +47,12 @@ type LoginFormProps = {
   children?: React.ReactNode;
 };
 
-const shellStyle: React.CSSProperties = {
-  minHeight: "100vh",
-  backgroundColor: colors.bg,
-  backgroundImage: colors.bgAmbient,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  padding: "clamp(16px, 5vw, 40px)",
-  overflowX: "hidden",
-};
-
 const fieldLabelStyle: React.CSSProperties = {
   display: "flex",
   flexDirection: "column",
   gap: spacing.xs,
   width: "100%",
 };
-
-const bannerStyle = (tone: LoginFormBanner["tone"] = "info"): React.CSSProperties => ({
-  marginBottom: spacing.sm,
-  padding: "8px 12px",
-  borderRadius: 10,
-  background: tone === "warning" ? "rgba(239,68,68,0.08)" : "rgba(37,99,235,0.08)",
-  border: tone === "warning" ? "1px solid rgba(239,68,68,0.3)" : "1px solid rgba(37,99,235,0.25)",
-  color: tone === "warning" ? colors.danger : "#1d4ed8",
-  fontSize: "0.9rem",
-});
 
 export const LoginForm: React.FC<LoginFormProps> = ({
   eyebrow = "RentChain Secure Access",
@@ -85,46 +78,27 @@ export const LoginForm: React.FC<LoginFormProps> = ({
   children,
 }) => {
   return (
-    <div style={shellStyle}>
-      <Card elevated style={{ width: "min(460px, 92vw)", padding: spacing.lg }}>
-        <div style={{ marginBottom: spacing.xs, color: text.subtle, fontSize: "0.9rem" }}>
+    <div style={authShellStyle}>
+      <Card elevated style={authCardStyle()}>
+        <div style={authEyebrowStyle}>
           {eyebrow}
         </div>
         <h1
-          style={{
-            fontSize: "1.6rem",
-            fontWeight: 700,
-            marginBottom: spacing.xs,
-            letterSpacing: "-0.01em",
-            color: text.primary,
-          }}
+          style={authHeadingStyle}
         >
           {title}
         </h1>
         {roleLabel ? (
-          <div
-            style={{
-              display: "inline-flex",
-              width: "fit-content",
-              marginBottom: spacing.sm,
-              padding: "5px 10px",
-              borderRadius: 999,
-              border: `1px solid ${colors.border}`,
-              background: colors.accentSoft,
-              color: text.primary,
-              fontSize: "0.82rem",
-              fontWeight: 700,
-            }}
-          >
+          <div style={authRoleBadgeStyle}>
             {roleLabel}
           </div>
         ) : null}
-        <p style={{ marginTop: 0, marginBottom: spacing.sm, color: text.muted }}>
+        <p style={{ ...authBodyStyle, marginBottom: spacing.sm }}>
           {subtitle}
         </p>
 
         {banner ? (
-          <div style={bannerStyle(banner.tone)}>
+          <div style={authBannerStyle(banner.tone)}>
             <div style={{ fontWeight: 700, marginBottom: 4 }}>{banner.title}</div>
             <div>{banner.body}</div>
           </div>
@@ -135,7 +109,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
           style={{ display: "flex", flexDirection: "column", gap: spacing.sm, width: "100%" }}
         >
           <label style={fieldLabelStyle}>
-            <span style={{ fontSize: "0.9rem", color: text.muted }}>Email</span>
+            <span style={authLabelTextStyle}>Email</span>
             <Input
               type="email"
               value={email}
@@ -143,14 +117,14 @@ export const LoginForm: React.FC<LoginFormProps> = ({
               onClick={(event) => event.stopPropagation()}
               placeholder="you@example.com"
               autoComplete="email"
-              style={{ width: "100%" }}
+              {...authInputProps({ width: "100%" })}
               required
             />
           </label>
 
           {passwordRequired ? (
             <label style={fieldLabelStyle}>
-              <span style={{ fontSize: "0.9rem", color: text.muted }}>Password</span>
+              <span style={authLabelTextStyle}>Password</span>
               <Input
                 type="password"
                 value={password}
@@ -158,7 +132,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
                 onClick={(event) => event.stopPropagation()}
                 placeholder="Password"
                 autoComplete="current-password"
-                style={{ width: "100%" }}
+                {...authInputProps({ width: "100%" })}
                 required
               />
             </label>
@@ -168,7 +142,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
             <div style={{ display: "flex", justifyContent: "flex-end" }}>
               <Link
                 to="/forgot-password"
-                style={{ color: colors.accent, fontWeight: 600, fontSize: "0.9rem" }}
+                style={{ ...authLinkStyle, fontSize: "0.9rem" }}
               >
                 Forgot password?
               </Link>
@@ -181,6 +155,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
             type="submit"
             disabled={isLoading || disabled}
             style={{
+              ...authPrimaryButtonStyle,
               width: "100%",
               opacity: isLoading || disabled ? 0.8 : 1,
               cursor: isLoading || disabled ? "not-allowed" : "pointer",
@@ -200,7 +175,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
             marginTop: spacing.sm,
             minHeight: "1.2rem",
             fontSize: "0.9rem",
-            color: error ? colors.danger : text.muted,
+            color: error ? authPalette.danger : authPalette.muted,
           }}
         >
           {error || statusMessage || subtitle}
@@ -208,7 +183,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
 
         {footer ? (
           <div style={{ marginTop: spacing.sm, display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-            {footer}
+            <div style={{ display: "contents", color: authPalette.muted }}>{footer}</div>
           </div>
         ) : null}
       </Card>

--- a/rentchain-frontend/src/components/auth/authPageStyles.ts
+++ b/rentchain-frontend/src/components/auth/authPageStyles.ts
@@ -1,0 +1,166 @@
+import type React from "react";
+
+export const authPalette = {
+  page: "#f4efe6",
+  pageGlow:
+    "radial-gradient(circle at 12% 12%, rgba(215, 173, 107, 0.18), transparent 32%), linear-gradient(135deg, #f4efe6 0%, #efe6d7 48%, #f8f3ea 100%)",
+  card: "#fffaf1",
+  field: "#fffdf8",
+  fieldBorder: "rgba(105, 82, 49, 0.22)",
+  fieldBorderFocus: "rgba(63, 54, 37, 0.72)",
+  ink: "#171411",
+  charcoal: "#2c2924",
+  muted: "#5f5a51",
+  subtle: "#756f64",
+  button: "#171411",
+  buttonHover: "#2c2924",
+  link: "#171411",
+  beige: "#eadfcd",
+  beigeSoft: "rgba(234, 223, 205, 0.72)",
+  sage: "#dfe4d5",
+  sageBorder: "rgba(88, 103, 75, 0.22)",
+  danger: "#b42318",
+};
+
+export const authShellStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  backgroundColor: authPalette.page,
+  backgroundImage: authPalette.pageGlow,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "clamp(16px, 5vw, 40px)",
+  overflowX: "hidden",
+  color: authPalette.ink,
+};
+
+export const authCardStyle = (
+  width: string = "min(460px, 92vw)"
+): React.CSSProperties => ({
+  width,
+  padding: "clamp(22px, 4vw, 32px)",
+  background: authPalette.card,
+  border: `1px solid ${authPalette.fieldBorder}`,
+  boxShadow: "0 22px 52px rgba(69, 55, 33, 0.14)",
+  color: authPalette.ink,
+});
+
+export const authEyebrowStyle: React.CSSProperties = {
+  marginBottom: "0.5rem",
+  color: authPalette.subtle,
+  fontSize: "0.9rem",
+  fontWeight: 700,
+};
+
+export const authHeadingStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: "0.5rem",
+  fontSize: "1.65rem",
+  fontWeight: 760,
+  letterSpacing: "-0.02em",
+  color: authPalette.ink,
+};
+
+export const authBodyStyle: React.CSSProperties = {
+  marginTop: 0,
+  color: authPalette.muted,
+  lineHeight: 1.55,
+};
+
+export const authLabelTextStyle: React.CSSProperties = {
+  color: authPalette.muted,
+  fontSize: "0.9rem",
+  fontWeight: 650,
+};
+
+export const authInputBaseStyle: React.CSSProperties = {
+  background: authPalette.field,
+  border: `1px solid ${authPalette.fieldBorder}`,
+  color: authPalette.ink,
+};
+
+export function authInputProps(style?: React.CSSProperties): {
+  style: React.CSSProperties;
+  onFocus: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+} {
+  return {
+    style: { ...authInputBaseStyle, ...style },
+    onFocus: (event) => {
+      event.currentTarget.style.borderColor = authPalette.fieldBorderFocus;
+      event.currentTarget.style.boxShadow = "0 0 0 3px rgba(105, 82, 49, 0.22)";
+    },
+    onBlur: (event) => {
+      event.currentTarget.style.borderColor = authPalette.fieldBorder;
+      event.currentTarget.style.boxShadow = "none";
+    },
+  };
+}
+
+export const authTextareaStyle: React.CSSProperties = {
+  ...authInputBaseStyle,
+  width: "100%",
+  padding: "10px 12px",
+  borderRadius: "0.7rem",
+  resize: "vertical",
+  outline: "none",
+};
+
+export const authPrimaryButtonStyle: React.CSSProperties = {
+  background: authPalette.button,
+  color: "#fffaf1",
+  boxShadow: "0 14px 26px rgba(23, 20, 17, 0.16)",
+};
+
+export const authSecondaryButtonStyle: React.CSSProperties = {
+  background: authPalette.beigeSoft,
+  color: authPalette.ink,
+  border: `1px solid ${authPalette.fieldBorder}`,
+  boxShadow: "none",
+};
+
+export const authGhostButtonStyle: React.CSSProperties = {
+  background: "transparent",
+  color: authPalette.ink,
+  border: `1px solid ${authPalette.fieldBorder}`,
+  boxShadow: "none",
+};
+
+export const authLinkStyle: React.CSSProperties = {
+  color: authPalette.link,
+  textDecoration: "underline",
+  textUnderlineOffset: 3,
+  fontWeight: 700,
+};
+
+export const authMutedLinkStyle: React.CSSProperties = {
+  color: authPalette.muted,
+  textDecoration: "none",
+  fontWeight: 650,
+};
+
+export const authRoleBadgeStyle: React.CSSProperties = {
+  display: "inline-flex",
+  width: "fit-content",
+  marginBottom: "0.75rem",
+  padding: "5px 10px",
+  borderRadius: 999,
+  border: `1px solid ${authPalette.sageBorder}`,
+  background: authPalette.sage,
+  color: authPalette.ink,
+  fontSize: "0.82rem",
+  fontWeight: 750,
+};
+
+export const authBannerStyle = (tone: "info" | "warning" = "info"): React.CSSProperties => ({
+  marginBottom: "0.75rem",
+  padding: "10px 12px",
+  borderRadius: 12,
+  background: tone === "warning" ? "rgba(254, 242, 242, 0.92)" : authPalette.sage,
+  border:
+    tone === "warning"
+      ? "1px solid rgba(180, 35, 24, 0.24)"
+      : `1px solid ${authPalette.sageBorder}`,
+  color: tone === "warning" ? authPalette.danger : authPalette.ink,
+  fontSize: "0.9rem",
+});

--- a/rentchain-frontend/src/components/marketing/RequestAccessModal.tsx
+++ b/rentchain-frontend/src/components/marketing/RequestAccessModal.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect, useState } from "react";
 import { Button, Input } from "../ui/Ui";
-import { colors, radius, spacing, text } from "../../styles/tokens";
+import { radius, spacing } from "../../styles/tokens";
 import { requestLandlordInquiry } from "../../api/public";
+import {
+  authGhostButtonStyle,
+  authInputProps,
+  authLabelTextStyle,
+  authPalette,
+  authPrimaryButtonStyle,
+  authSecondaryButtonStyle,
+  authTextareaStyle,
+} from "../auth/authPageStyles";
 
 type Props = {
   open: boolean;
@@ -49,7 +58,7 @@ export const RequestAccessModal: React.FC<Props> = ({ open, onClose, referralCod
       style={{
         position: "fixed",
         inset: 0,
-        background: "rgba(15, 23, 42, 0.45)",
+        background: "rgba(23, 20, 17, 0.48)",
         zIndex: 4000,
         display: "flex",
         alignItems: "center",
@@ -63,11 +72,11 @@ export const RequestAccessModal: React.FC<Props> = ({ open, onClose, referralCod
       <div
         style={{
           width: "min(560px, 95vw)",
-          background: colors.card,
+          background: authPalette.card,
           borderRadius: radius.lg,
-          border: `1px solid ${colors.border}`,
+          border: `1px solid ${authPalette.fieldBorder}`,
           padding: spacing.lg,
-          boxShadow: "0 18px 40px rgba(15,23,42,0.2)",
+          boxShadow: "0 22px 52px rgba(69, 55, 33, 0.16)",
           display: "flex",
           flexDirection: "column",
           gap: spacing.md,
@@ -75,20 +84,20 @@ export const RequestAccessModal: React.FC<Props> = ({ open, onClose, referralCod
       >
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
           <div>
-            <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>Request Access</div>
-            <div style={{ color: text.muted, fontSize: "0.95rem" }}>
+            <div style={{ fontWeight: 760, fontSize: "1.1rem", color: authPalette.ink }}>Request Access</div>
+            <div style={{ color: authPalette.muted, fontSize: "0.95rem" }}>
               Tell us a bit about your portfolio and we’ll follow up.
             </div>
           </div>
-          <Button type="button" variant="ghost" onClick={onClose}>
+          <Button type="button" variant="ghost" onClick={onClose} style={authGhostButtonStyle}>
             Close
           </Button>
         </div>
 
         {sent ? (
-          <div style={{ color: text.primary }}>
+          <div style={{ color: authPalette.ink }}>
             <div style={{ fontWeight: 700 }}>Thanks — we’ll be in touch shortly.</div>
-            <div style={{ color: text.muted, marginTop: spacing.xs }}>
+            <div style={{ color: authPalette.muted, marginTop: spacing.xs }}>
               Watch your inbox for a confirmation email.
             </div>
           </div>
@@ -98,58 +107,61 @@ export const RequestAccessModal: React.FC<Props> = ({ open, onClose, referralCod
               <div
                 style={{
                   padding: "10px 12px",
-                  border: `1px solid ${colors.border}`,
+                  border: `1px solid ${authPalette.sageBorder}`,
                   borderRadius: radius.md,
-                  background: "#f8fafc",
-                  color: text.muted,
+                  background: authPalette.sage,
+                  color: authPalette.ink,
                 }}
               >
                 You were invited by a RentChain landlord.
               </div>
             ) : null}
             <div style={{ display: "grid", gap: 6 }}>
-              <label style={{ fontWeight: 600 }}>Email</label>
+              <label style={authLabelTextStyle}>Email</label>
               <Input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="you@company.com"
+                {...authInputProps()}
                 required
               />
             </div>
             <div style={{ display: "grid", gap: 6 }}>
-              <label style={{ fontWeight: 600 }}>First name</label>
+              <label style={authLabelTextStyle}>First name</label>
               <Input
                 value={firstName}
                 onChange={(e) => setFirstName(e.target.value)}
                 placeholder="Jamie"
+                {...authInputProps()}
                 required
               />
             </div>
             <div style={{ display: "grid", gap: 6 }}>
-              <label style={{ fontWeight: 600 }}>Portfolio size</label>
+              <label style={authLabelTextStyle}>Portfolio size</label>
               <Input
                 value={portfolioSize}
                 onChange={(e) => setPortfolioSize(e.target.value)}
                 placeholder="e.g. 5 units, 2 properties"
+                {...authInputProps()}
                 required
               />
             </div>
             <div style={{ display: "grid", gap: 6 }}>
-              <label style={{ fontWeight: 600 }}>Notes (optional)</label>
+              <label style={authLabelTextStyle}>Notes (optional)</label>
               <textarea
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
                 placeholder="Tell us what you’re looking for."
                 rows={3}
-                style={{
-                  width: "100%",
-                  padding: "10px 12px",
-                  borderRadius: radius.md,
-                  border: `1px solid ${colors.border}`,
-                  background: colors.card,
-                  color: text.primary,
-                  resize: "vertical",
+                style={authTextareaStyle}
+                onFocus={(event) => {
+                  event.currentTarget.style.borderColor = authPalette.fieldBorderFocus;
+                  event.currentTarget.style.boxShadow = "0 0 0 3px rgba(105, 82, 49, 0.22)";
+                }}
+                onBlur={(event) => {
+                  event.currentTarget.style.borderColor = authPalette.fieldBorder;
+                  event.currentTarget.style.boxShadow = "none";
                 }}
               />
             </div>
@@ -159,10 +171,10 @@ export const RequestAccessModal: React.FC<Props> = ({ open, onClose, referralCod
             ) : null}
 
             <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-              <Button type="submit" disabled={loading}>
+              <Button type="submit" disabled={loading} style={authPrimaryButtonStyle}>
                 {loading ? "Submitting…" : "Request access"}
               </Button>
-              <Button type="button" variant="ghost" onClick={onClose}>
+              <Button type="button" variant="ghost" onClick={onClose} style={authSecondaryButtonStyle}>
                 Cancel
               </Button>
             </div>

--- a/rentchain-frontend/src/pages/ForgotPasswordPage.tsx
+++ b/rentchain-frontend/src/pages/ForgotPasswordPage.tsx
@@ -2,8 +2,20 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { sendPasswordResetEmail } from "firebase/auth";
 import { Card, Input, Button } from "@/components/ui/Ui";
-import { colors, spacing, text } from "@/styles/tokens";
+import { spacing } from "@/styles/tokens";
 import { getFirebaseAuth } from "@/lib/firebase";
+import {
+  authBodyStyle,
+  authCardStyle,
+  authEyebrowStyle,
+  authHeadingStyle,
+  authInputProps,
+  authLabelTextStyle,
+  authLinkStyle,
+  authPalette,
+  authPrimaryButtonStyle,
+  authShellStyle,
+} from "@/components/auth/authPageStyles";
 
 const SUCCESS_MESSAGE = "If an account exists, a reset email has been sent.";
 
@@ -55,45 +67,28 @@ const ForgotPasswordPage: React.FC = () => {
   };
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: colors.bg,
-        backgroundImage: colors.bgAmbient,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: spacing.xl,
-      }}
-    >
-      <Card elevated style={{ width: "100%", maxWidth: 460, padding: spacing.lg }}>
-        <div style={{ marginBottom: spacing.xs, color: text.subtle, fontSize: "0.9rem" }}>
+    <div style={{ ...authShellStyle, padding: spacing.xl }}>
+      <Card elevated style={authCardStyle("min(460px, 100%)")}>
+        <div style={authEyebrowStyle}>
           RentChain Secure Access
         </div>
-        <h1
-          style={{
-            fontSize: "1.6rem",
-            fontWeight: 700,
-            marginBottom: spacing.md,
-            letterSpacing: "-0.01em",
-            color: text.primary,
-          }}
-        >
+        <h1 style={{ ...authHeadingStyle, marginBottom: spacing.md }}>
           Reset your password
         </h1>
-        <p style={{ marginTop: 0, marginBottom: spacing.sm, color: text.muted }}>
+        <p style={{ ...authBodyStyle, marginBottom: spacing.sm }}>
           Enter your email to receive a password reset link.
         </p>
 
         <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: spacing.sm }}>
           <label style={{ display: "flex", flexDirection: "column", gap: spacing.xs }}>
-            <span style={{ fontSize: "0.9rem", color: text.muted }}>Email</span>
+            <span style={authLabelTextStyle}>Email</span>
             <Input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              {...authInputProps()}
               required
             />
           </label>
@@ -102,6 +97,7 @@ const ForgotPasswordPage: React.FC = () => {
             type="submit"
             disabled={submitting}
             style={{
+              ...authPrimaryButtonStyle,
               width: "100%",
               opacity: submitting ? 0.8 : 1,
               cursor: submitting ? "not-allowed" : "pointer",
@@ -117,14 +113,14 @@ const ForgotPasswordPage: React.FC = () => {
             marginTop: spacing.sm,
             minHeight: "1.2rem",
             fontSize: "0.9rem",
-            color: error ? colors.danger : text.muted,
+            color: error ? authPalette.danger : authPalette.muted,
           }}
         >
           {error ? error : success ? success : "We will email you a reset link."}
         </div>
 
         <div style={{ marginTop: spacing.sm }}>
-          <Link to="/login" style={{ color: colors.accent, fontWeight: 600, fontSize: "0.9rem" }}>
+          <Link to="/login" style={{ ...authLinkStyle, fontSize: "0.9rem" }}>
             Back to login
           </Link>
         </div>

--- a/rentchain-frontend/src/pages/InviteRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/InviteRedeemPage.tsx
@@ -1,10 +1,23 @@
 import React, { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Card, Input, Button } from "../components/ui/Ui";
-import { colors, spacing, text } from "../styles/tokens";
+import { spacing } from "../styles/tokens";
 import { useAuth } from "../context/useAuth";
 import { apiFetch } from "../api/http";
 import { setAuthToken } from "../lib/authToken";
+import {
+  authBodyStyle,
+  authCardStyle,
+  authEyebrowStyle,
+  authHeadingStyle,
+  authInputProps,
+  authLabelTextStyle,
+  authLinkStyle,
+  authMutedLinkStyle,
+  authPalette,
+  authPrimaryButtonStyle,
+  authShellStyle,
+} from "../components/auth/authPageStyles";
 
 type InviteRedeemResponse = {
   ok: boolean;
@@ -79,74 +92,77 @@ const InviteRedeemPage: React.FC = () => {
   };
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: colors.bg,
-        backgroundImage: colors.bgAmbient,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "clamp(16px, 5vw, 40px)",
-      }}
-    >
-      <Card elevated style={{ width: "min(540px, 94vw)", padding: spacing.lg }}>
-        <div style={{ marginBottom: spacing.xs, color: text.subtle, fontSize: "0.9rem" }}>
+    <div style={authShellStyle}>
+      <Card elevated style={authCardStyle("min(540px, 94vw)")}>
+        <div style={authEyebrowStyle}>
           RentChain
         </div>
-        <h1 style={{ marginTop: 0, marginBottom: spacing.xs, fontSize: "1.7rem" }}>I have an invite</h1>
-        <p style={{ marginTop: 0, color: text.muted }}>
+        <h1 style={authHeadingStyle}>I have an invite</h1>
+        <p style={authBodyStyle}>
           Redeem your invite code to activate your account.
         </p>
 
         <form onSubmit={redeem} style={{ display: "grid", gap: spacing.sm }}>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Invite code</span>
-            <Input value={code} onChange={(e) => setCode(e.target.value)} placeholder="Paste invite code" required />
+            <span style={authLabelTextStyle}>Invite code</span>
+            <Input
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="Paste invite code"
+              {...authInputProps()}
+              required
+            />
           </label>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Email</span>
+            <span style={authLabelTextStyle}>Email</span>
             <Input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              {...authInputProps()}
             />
           </label>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Full name (optional)</span>
-            <Input value={fullName} onChange={(e) => setFullName(e.target.value)} placeholder="Your name" />
+            <span style={authLabelTextStyle}>Full name (optional)</span>
+            <Input
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              placeholder="Your name"
+              {...authInputProps()}
+            />
           </label>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Password</span>
+            <span style={authLabelTextStyle}>Password</span>
             <Input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Choose a password"
               autoComplete="new-password"
+              {...authInputProps()}
               required
             />
           </label>
 
-          <Button type="submit" disabled={submitting} style={{ justifyContent: "center" }}>
+          <Button type="submit" disabled={submitting} style={{ ...authPrimaryButtonStyle, justifyContent: "center" }}>
             {submitting ? "Redeeming..." : "Redeem invite"}
           </Button>
         </form>
 
-        <div style={{ marginTop: spacing.sm, minHeight: "1.2rem", color: error ? colors.danger : text.muted }}>
+        <div style={{ marginTop: spacing.sm, minHeight: "1.2rem", color: error ? authPalette.danger : authPalette.muted }}>
           {error || "Need access without a code? Use Request access."}
         </div>
 
         <div style={{ marginTop: spacing.sm, display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-          <Link to="/request-access" style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}>
+          <Link to="/request-access" style={authLinkStyle}>
             Request access
           </Link>
-          <Link to="/signup" style={{ color: text.muted, textDecoration: "none" }}>
+          <Link to="/signup" style={authMutedLinkStyle}>
             Sign up (Free)
           </Link>
-          <Link to="/login" style={{ color: text.muted, textDecoration: "none" }}>
+          <Link to="/login" style={authMutedLinkStyle}>
             Login
           </Link>
         </div>

--- a/rentchain-frontend/src/pages/LoginPage.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.tsx
@@ -2,9 +2,9 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import { useAuth } from "../context/useAuth";
-import { colors, text } from "../styles/tokens";
 import { Button } from "../components/ui/Ui";
 import { LoginForm } from "../components/auth/LoginForm";
+import { authGhostButtonStyle, authLinkStyle, authMutedLinkStyle } from "../components/auth/authPageStyles";
 import { DEBUG_AUTH_KEY, JUST_LOGGED_IN_KEY } from "../lib/authKeys";
 import { getAuthToken } from "../lib/authToken";
 import { useToast } from "../components/ui/ToastProvider";
@@ -249,7 +249,7 @@ export const LoginPage: React.FC = () => {
             type="button"
             variant="ghost"
             onClick={handleDemoLogin}
-            style={{ width: "100%" }}
+            style={{ ...authGhostButtonStyle, width: "100%" }}
           >
             Login as Demo (dev)
           </Button>
@@ -259,17 +259,17 @@ export const LoginPage: React.FC = () => {
         <>
           <Link
             to={nextPath !== "/dashboard" ? `/signup?next=${encodeURIComponent(nextPath)}` : "/signup"}
-            style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}
+            style={authLinkStyle}
           >
             Create free account
           </Link>
-          <Link to="/tenant" style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}>
+          <Link to="/tenant" style={authLinkStyle}>
             Are you a tenant? Access your profile
           </Link>
-          <Link to="/request-access" style={{ color: text.muted, textDecoration: "none" }}>
+          <Link to="/request-access" style={authMutedLinkStyle}>
             Request access
           </Link>
-          <Link to="/invite" style={{ color: text.muted, textDecoration: "none" }}>
+          <Link to="/invite" style={authMutedLinkStyle}>
             Have an invite?
           </Link>
         </>

--- a/rentchain-frontend/src/pages/SignupPage.tsx
+++ b/rentchain-frontend/src/pages/SignupPage.tsx
@@ -1,10 +1,24 @@
 import React, { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Card, Input, Button } from "../components/ui/Ui";
-import { colors, spacing, text } from "../styles/tokens";
+import { spacing } from "../styles/tokens";
 import { useAuth } from "../context/useAuth";
 import { resolvePostAuthDestination } from "../lib/authDestination";
 import { trackAuthEvent } from "../lib/authAnalytics";
+import {
+  authBannerStyle,
+  authBodyStyle,
+  authCardStyle,
+  authEyebrowStyle,
+  authHeadingStyle,
+  authInputProps,
+  authLabelTextStyle,
+  authLinkStyle,
+  authMutedLinkStyle,
+  authPalette,
+  authPrimaryButtonStyle,
+  authShellStyle,
+} from "../components/auth/authPageStyles";
 
 function maskEmail(value: string): string {
   const email = String(value || "").trim().toLowerCase();
@@ -185,39 +199,19 @@ const SignupPage: React.FC = () => {
   };
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: colors.bg,
-        backgroundImage: colors.bgAmbient,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "clamp(16px, 5vw, 40px)",
-      }}
-    >
-      <Card elevated style={{ width: "min(520px, 94vw)", padding: spacing.lg }}>
-        <div style={{ marginBottom: spacing.xs, color: text.subtle, fontSize: "0.9rem" }}>
+    <div style={authShellStyle}>
+      <Card elevated style={authCardStyle("min(520px, 94vw)")}>
+        <div style={authEyebrowStyle}>
           RentChain
         </div>
-        <h1 style={{ marginTop: 0, marginBottom: spacing.xs, fontSize: "1.7rem" }}>
+        <h1 style={authHeadingStyle}>
           Create your RentChain account
         </h1>
-        <p style={{ marginTop: 0, color: text.muted }}>
+        <p style={authBodyStyle}>
           Create an account to access your RentChain workspace.
         </p>
         {inviteBanner ? (
-          <div
-            style={{
-              marginBottom: spacing.sm,
-              padding: "8px 12px",
-              borderRadius: 10,
-              background: "rgba(37,99,235,0.08)",
-              border: "1px solid rgba(37,99,235,0.25)",
-              color: "#1d4ed8",
-              fontSize: "0.9rem",
-            }}
-          >
+          <div style={authBannerStyle("info")}>
             <div style={{ fontWeight: 700, marginBottom: 4 }}>{inviteBanner.title}</div>
             <div>{inviteBanner.body}</div>
           </div>
@@ -225,63 +219,75 @@ const SignupPage: React.FC = () => {
 
         <form onSubmit={onSubmit} style={{ display: "grid", gap: spacing.sm }}>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Full name (optional)</span>
-            <Input value={fullName} onChange={(e) => setFullName(e.target.value)} placeholder="Your name" />
+            <span style={authLabelTextStyle}>Full name (optional)</span>
+            <Input
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              placeholder="Your name"
+              {...authInputProps()}
+            />
           </label>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Email</span>
+            <span style={authLabelTextStyle}>Email</span>
             <Input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              {...authInputProps()}
               required
             />
           </label>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Password</span>
+            <span style={authLabelTextStyle}>Password</span>
             <Input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="At least 6 characters"
               autoComplete="new-password"
+              {...authInputProps()}
               required
             />
           </label>
           <label style={{ display: "grid", gap: spacing.xs }}>
-            <span style={{ color: text.muted, fontSize: "0.9rem" }}>Confirm password</span>
+            <span style={authLabelTextStyle}>Confirm password</span>
             <Input
               type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               placeholder="Re-enter password"
               autoComplete="new-password"
+              {...authInputProps()}
               required
             />
           </label>
 
-          <Button type="submit" disabled={submitting || isLoading} style={{ justifyContent: "center" }}>
+          <Button
+            type="submit"
+            disabled={submitting || isLoading}
+            style={{ ...authPrimaryButtonStyle, justifyContent: "center" }}
+          >
             {submitting ? "Creating account..." : "Create free account"}
           </Button>
         </form>
 
-        <div style={{ marginTop: spacing.sm, minHeight: "1.2rem", color: error ? colors.danger : text.muted }}>
+        <div style={{ marginTop: spacing.sm, minHeight: "1.2rem", color: error ? authPalette.danger : authPalette.muted }}>
           {error || "Already have an account? Sign in below."}
         </div>
 
         <div style={{ marginTop: spacing.sm, display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
           <Link
             to={nextPath !== "/dashboard" ? `/login?next=${encodeURIComponent(nextPath)}` : "/login"}
-            style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}
+            style={authLinkStyle}
           >
             Go to login
           </Link>
-          <Link to="/request-access" style={{ color: text.muted, textDecoration: "none" }}>
+          <Link to="/request-access" style={authMutedLinkStyle}>
             Request access
           </Link>
-          <Link to="/invite" style={{ color: text.muted, textDecoration: "none" }}>
+          <Link to="/invite" style={authMutedLinkStyle}>
             I have an invite
           </Link>
         </div>

--- a/rentchain-frontend/src/pages/contractor/ContractorInviteAcceptPage.tsx
+++ b/rentchain-frontend/src/pages/contractor/ContractorInviteAcceptPage.tsx
@@ -3,6 +3,15 @@ import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { Button, Card } from "../../components/ui/Ui";
 import { acceptContractorInvite, getPublicContractorInvite, type PublicContractorInviteStatus } from "../../api/workOrdersApi";
 import { useAuth } from "../../context/useAuth";
+import {
+  authBodyStyle,
+  authCardStyle,
+  authGhostButtonStyle,
+  authPalette,
+  authPrimaryButtonStyle,
+  authSecondaryButtonStyle,
+  authShellStyle,
+} from "../../components/auth/authPageStyles";
 
 export default function ContractorInviteAcceptPage() {
   const { user, logout } = useAuth();
@@ -53,28 +62,28 @@ export default function ContractorInviteAcceptPage() {
   }, [token]);
 
   return (
-    <div style={{ minHeight: "70vh", display: "grid", placeItems: "center", padding: 16 }}>
-      <Card style={{ width: "min(620px, 100%)", display: "grid", gap: 10 }}>
-        <div style={{ fontWeight: 700, fontSize: "1.08rem" }}>Contractor Invite</div>
+    <div style={authShellStyle}>
+      <Card style={{ ...authCardStyle("min(620px, 94vw)"), display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 760, fontSize: "1.08rem", color: authPalette.ink }}>Contractor Invite</div>
         {inviteMeta?.landlordName ? (
-          <div style={{ color: "#334155" }}>
+          <div style={{ color: authPalette.charcoal }}>
             Invite from: <strong>{inviteMeta.landlordName}</strong>
           </div>
         ) : null}
         {inviteMeta?.emailMasked ? (
-          <div style={{ color: "#64748b" }}>Invited email: {inviteMeta.emailMasked}</div>
+          <div style={{ color: authPalette.muted }}>Invited email: {inviteMeta.emailMasked}</div>
         ) : null}
-        {inviteStatus === "loading" ? <div style={{ color: "#64748b" }}>Checking invite...</div> : null}
-        {!token ? <div style={{ color: "#991b1b" }}>Invitation not found</div> : null}
+        {inviteStatus === "loading" ? <div style={{ color: authPalette.muted }}>Checking invite...</div> : null}
+        {!token ? <div style={{ color: authPalette.danger }}>Invitation not found</div> : null}
         {inviteStatus === "expired" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>This invitation has expired</div>
-            <div>This contractor invitation is no longer active.</div>
-            <div>Please contact the landlord who invited you and ask them to resend the invitation.</div>
+            <div style={authBodyStyle}>This contractor invitation is no longer active.</div>
+            <div style={authBodyStyle}>Please contact the landlord who invited you and ask them to resend the invitation.</div>
             <Link to="/login">
-              <Button>Back to sign in</Button>
+              <Button style={authPrimaryButtonStyle}>Back to sign in</Button>
             </Link>
-            <div style={{ color: "#64748b", fontSize: "0.95rem" }}>
+            <div style={{ color: authPalette.muted, fontSize: "0.95rem" }}>
               If you already have a contractor account, you can still sign in to RentChain.
             </div>
           </div>
@@ -82,14 +91,14 @@ export default function ContractorInviteAcceptPage() {
         {inviteStatus === "accepted" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>This invitation has already been accepted</div>
-            <div>This contractor invitation is no longer available.</div>
-            <div>If this is your account, sign in to continue to your contractor dashboard.</div>
+            <div style={authBodyStyle}>This contractor invitation is no longer available.</div>
+            <div style={authBodyStyle}>If this is your account, sign in to continue to your contractor dashboard.</div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <Link to={`/login?next=${encodeURIComponent("/contractor")}`}>
-                <Button>Sign in</Button>
+                <Button style={authPrimaryButtonStyle}>Sign in</Button>
               </Link>
               <Link to="/contractor">
-                <Button variant="secondary">Go to Contractor Dashboard</Button>
+                <Button variant="secondary" style={authSecondaryButtonStyle}>Go to Contractor Dashboard</Button>
               </Link>
             </div>
           </div>
@@ -98,10 +107,10 @@ export default function ContractorInviteAcceptPage() {
         {inviteStatus === "not_found" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Invitation not found</div>
-            <div>This contractor invitation link is invalid or no longer available.</div>
-            <div>Please check the link in your email or contact the landlord who invited you.</div>
+            <div style={authBodyStyle}>This contractor invitation link is invalid or no longer available.</div>
+            <div style={authBodyStyle}>Please check the link in your email or contact the landlord who invited you.</div>
             <Link to="/login">
-              <Button>Back to sign in</Button>
+              <Button style={authPrimaryButtonStyle}>Back to sign in</Button>
             </Link>
           </div>
         ) : null}
@@ -109,17 +118,17 @@ export default function ContractorInviteAcceptPage() {
         {inviteStatus === "valid" && !user && redeemState !== "done" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>You’ve been invited to join RentChain as a contractor</div>
-            <div>A landlord has invited you to join RentChain to view and manage assigned work orders.</div>
-            <div>Create a contractor account or sign in to accept this invitation.</div>
+            <div style={authBodyStyle}>A landlord has invited you to join RentChain to view and manage assigned work orders.</div>
+            <div style={authBodyStyle}>Create a contractor account or sign in to accept this invitation.</div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <Link to={`/signup?next=${encodeURIComponent(nextPath)}`}>
-                <Button>Create contractor account</Button>
+                <Button style={authPrimaryButtonStyle}>Create contractor account</Button>
               </Link>
               <Link to={`/login?next=${encodeURIComponent(nextPath)}`}>
-                <Button variant="secondary">Sign in</Button>
+                <Button variant="secondary" style={authSecondaryButtonStyle}>Sign in</Button>
               </Link>
             </div>
-            <div style={{ color: "#64748b", fontSize: "0.95rem" }}>
+            <div style={{ color: authPalette.muted, fontSize: "0.95rem" }}>
               By continuing, you’ll be able to view assigned jobs, update work progress, and manage your contractor profile in RentChain.
             </div>
           </div>
@@ -128,10 +137,11 @@ export default function ContractorInviteAcceptPage() {
         {inviteStatus === "valid" && !!user && blockedRole && redeemState !== "done" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>This invitation needs a contractor account</div>
-            <div>You’re currently signed in with an account that cannot accept this contractor invitation.</div>
-            <div>To continue, sign out and create a contractor account, or sign in with an existing contractor account.</div>
+            <div style={authBodyStyle}>You’re currently signed in with an account that cannot accept this contractor invitation.</div>
+            <div style={authBodyStyle}>To continue, sign out and create a contractor account, or sign in with an existing contractor account.</div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <Button
+                style={authPrimaryButtonStyle}
                 onClick={async () => {
                   await logout();
                   navigate(nextPath, { replace: true });
@@ -141,6 +151,7 @@ export default function ContractorInviteAcceptPage() {
               </Button>
               <Button
                 variant="secondary"
+                style={authSecondaryButtonStyle}
                 onClick={async () => {
                   await logout();
                   navigate(`/login?next=${encodeURIComponent(nextPath)}`, { replace: true });
@@ -149,7 +160,7 @@ export default function ContractorInviteAcceptPage() {
                 Use another account
               </Button>
             </div>
-            <div style={{ color: "#64748b", fontSize: "0.95rem" }}>
+            <div style={{ color: authPalette.muted, fontSize: "0.95rem" }}>
               This helps keep landlord and contractor access separate and secure.
             </div>
           </div>
@@ -158,11 +169,12 @@ export default function ContractorInviteAcceptPage() {
         {inviteStatus === "valid" && !!user && !blockedRole && redeemState !== "done" && redeemState !== "error" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Accept contractor invitation</div>
-            <div>You’re signed in and ready to accept this invitation.</div>
-            <div>Once accepted, you’ll be able to view assigned work orders and manage your contractor profile in RentChain.</div>
+            <div style={authBodyStyle}>You’re signed in and ready to accept this invitation.</div>
+            <div style={authBodyStyle}>Once accepted, you’ll be able to view assigned work orders and manage your contractor profile in RentChain.</div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <Button
                 disabled={redeemState === "saving"}
+                style={authPrimaryButtonStyle}
                 onClick={async () => {
                   if (!token) return;
                   setRedeemState("saving");
@@ -178,7 +190,7 @@ export default function ContractorInviteAcceptPage() {
               >
                 {redeemState === "saving" ? "Accepting..." : "Accept invitation"}
               </Button>
-              <Button variant="secondary" onClick={() => navigate("/", { replace: true })}>
+              <Button variant="secondary" onClick={() => navigate("/", { replace: true })} style={authGhostButtonStyle}>
                 Cancel
               </Button>
             </div>
@@ -188,14 +200,14 @@ export default function ContractorInviteAcceptPage() {
         {redeemState === "done" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Invitation accepted</div>
-            <div>Your contractor account is now connected to RentChain.</div>
-            <div>You can now view assigned jobs, track progress, and manage your contractor profile.</div>
+            <div style={authBodyStyle}>Your contractor account is now connected to RentChain.</div>
+            <div style={authBodyStyle}>You can now view assigned jobs, track progress, and manage your contractor profile.</div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <Link to="/contractor">
-                <Button>Go to Contractor Dashboard</Button>
+                <Button style={authPrimaryButtonStyle}>Go to Contractor Dashboard</Button>
               </Link>
               <Link to="/contractor/jobs">
-                <Button variant="secondary">View Jobs</Button>
+                <Button variant="secondary" style={authSecondaryButtonStyle}>View Jobs</Button>
               </Link>
             </div>
           </div>
@@ -204,13 +216,13 @@ export default function ContractorInviteAcceptPage() {
         {redeemState === "error" ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>We couldn’t complete your invitation</div>
-            <div>Something went wrong while accepting your contractor invitation.</div>
-            <div>Please try again. If the issue continues, contact support or ask the landlord to resend the invitation.</div>
-            {error ? <div style={{ color: "#991b1b" }}>{error}</div> : null}
+            <div style={authBodyStyle}>Something went wrong while accepting your contractor invitation.</div>
+            <div style={authBodyStyle}>Please try again. If the issue continues, contact support or ask the landlord to resend the invitation.</div>
+            {error ? <div style={{ color: authPalette.danger }}>{error}</div> : null}
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              <Button onClick={() => setRedeemState("idle")}>Try again</Button>
+              <Button onClick={() => setRedeemState("idle")} style={authPrimaryButtonStyle}>Try again</Button>
               <Link to={`/login?next=${encodeURIComponent(nextPath)}`}>
-                <Button variant="secondary">Sign in</Button>
+                <Button variant="secondary" style={authSecondaryButtonStyle}>Sign in</Button>
               </Link>
             </div>
           </div>

--- a/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.tsx
@@ -3,26 +3,19 @@ import { Link, useLocation } from "react-router-dom";
 import { apiFetch } from "../../api/apiFetch";
 import { LoginForm } from "../../components/auth/LoginForm";
 import {
+  authBodyStyle,
+  authCardStyle,
+  authGhostButtonStyle,
+  authLinkStyle,
+  authPalette,
+  authSecondaryButtonStyle,
+  authShellStyle,
+} from "../../components/auth/authPageStyles";
+import {
   resolveTenantPostAuthDestination,
   TENANT_DEFAULT_DESTINATION,
 } from "../../lib/authDestination";
 import { trackAuthEvent } from "../../lib/authAnalytics";
-
-function Card({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      style={{
-        border: "1px solid rgba(0,0,0,0.08)",
-        borderRadius: 12,
-        padding: 16,
-        boxShadow: "0 6px 20px rgba(0,0,0,0.06)",
-        background: "white",
-      }}
-    >
-      {children}
-    </div>
-  );
-}
 
 const TenantLoginPageV2: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -90,8 +83,8 @@ const TenantLoginPageV2: React.FC = () => {
             : null
         }
         footer={
-          <div style={{ fontSize: 13, color: "#64748b" }}>
-            Have an invite link? Open it to accept your invite. <Link to="/">Back to main</Link>
+          <div style={{ fontSize: 13, color: authPalette.muted }}>
+            Have an invite link? Open it to accept your invite. <Link to="/" style={authLinkStyle}>Back to main</Link>
           </div>
         }
       />
@@ -99,24 +92,22 @@ const TenantLoginPageV2: React.FC = () => {
   }
 
   return (
-    <div style={{ maxWidth: 480, margin: "48px auto", padding: 16 }}>
-      <Card>
-        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800 }}>Tenant login</h1>
-        <p style={{ marginTop: 8, opacity: 0.75 }}>We will email you a one-time login link.</p>
+    <div style={authShellStyle}>
+      <div style={authCardStyle("min(480px, 92vw)")}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, color: authPalette.ink }}>Tenant login</h1>
+        <p style={{ ...authBodyStyle, marginTop: 8 }}>We will email you a one-time login link.</p>
           <div style={{ marginTop: 16, display: "grid", gap: 10 }}>
-            <div style={{ color: "green", fontWeight: 700 }}>
+            <div style={{ color: "#365314", fontWeight: 700 }}>
               If an account exists for that email, we sent a login link.
             </div>
-            <div style={{ color: "#6b7280", fontSize: 13 }}>Check your spam/junk folder.</div>
+            <div style={{ color: authPalette.muted, fontSize: 13 }}>Check your spam/junk folder.</div>
             <div style={{ display: "flex", gap: 8 }}>
               <a
                 href={next || "/tenant"}
                 style={{
+                  ...authSecondaryButtonStyle,
                   padding: "10px 12px",
                   borderRadius: 10,
-                  border: "1px solid rgba(0,0,0,0.15)",
-                  background: "#f3f4f6",
-                  color: "#111",
                   fontWeight: 700,
                   textDecoration: "none",
                 }}
@@ -127,11 +118,9 @@ const TenantLoginPageV2: React.FC = () => {
                 type="button"
                 onClick={() => setSent(false)}
                 style={{
+                  ...authGhostButtonStyle,
                   padding: "10px 12px",
                   borderRadius: 10,
-                  border: "1px solid rgba(0,0,0,0.15)",
-                  background: "white",
-                  color: "#111",
                   fontWeight: 700,
                   cursor: "pointer",
                 }}
@@ -140,7 +129,7 @@ const TenantLoginPageV2: React.FC = () => {
               </button>
             </div>
           </div>
-      </Card>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Mission audit
- Auth/public surfaces share two patterns: the shared LoginForm for login/tenant login and direct inline Card/Input/Button layouts for signup, forgot password, invite redeem, request access, and contractor invite acceptance.
- Blue came from shared tokens (colors.accent / accentSoft / focus shadow) and blue inline banner/link styles on auth/public forms.
- I did not change shared tokens, Ui primitives, logged-in product routes, backend/API code, Cloud Build, or deployment config.
- The safe approach is a scoped auth/public theme helper at rentchain-frontend/src/components/auth/authPageStyles.ts, applied only to auth/public entry surfaces.

## Implementation
- Added auth-local warm neutral page/card/input/button/link/badge/banner styles.
- Updated LoginForm so /login and tenant auth forms use warm beige shell, cream card, off-white inputs, near-black primary CTA/links, muted sage badge, and warm focus states.
- Updated /signup, /forgot-password, /invite, /site/request-access modal, /contractor/invite, and tenant magic-link success state to use the same auth-local visual language.
- Preserved auth submission logic, redirects, validation, tenant token behavior, invite redemption behavior, request-access submission behavior, and route behavior.
- Landing page styling remains untouched and /login does not mount .rc-landing.

## Deferred / intentionally unchanged
- AuthOnboardPage was left unchanged because it is a post-auth onboarding workflow and broadening it could affect product onboarding surfaces.
- Tenant landing was already mostly warm/neutral and not a form gateway; tenant login component behavior is covered by tests, while the local dev route currently renders the tenant portal coming-soon gate.
- No logged-in dashboards/workspaces/admin/tenant/contractor dashboards were restyled.

## Validation
- npm run test -- LoginForm LoginPage SignupPage TenantLoginPage LandingPage: passed (31 tests).
- npm run build: passed. Existing Vite large chunk warning only.
- git diff --check: passed.
- git diff --cached --check: passed before commit.

## Browser QA
- Verified /login, /signup, /forgot-password, /invite, /site/request-access, /contractor/invite, and / on local dev.
- Verified desktop and mobile for /login, /signup, /forgot-password, and /invite.
- Confirmed black primary auth CTAs, warm input surfaces, visible warm focus states, no bright-blue auth links, no horizontal overflow, no console errors, landing still mounts .rc-landing, and auth pages do not mount .rc-landing.
- Local /tenant/login renders tenant portal coming-soon in this dev environment; TenantLoginPage and TenantLoginPage.v2 component tests passed.