### PR TITLE
polish: align tenant entry surfaces with warm brand

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -287,9 +287,7 @@ describe("Routes: /tenant", () => {
       </MemoryRouter>
     );
 
-    expect(
-      await screen.findByText(/Your rental profile\. Secure, organized, and in your control\./i)
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Access your rental workspace\./i)).toBeInTheDocument();
     expect(screen.queryByText(/Create free account/i)).not.toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.test.tsx
@@ -52,6 +52,9 @@ describe("TenantInviteRedeemPage", () => {
       expect(tenantPortalApi.redeemTenantWorkspaceInvite).toHaveBeenCalledWith("token-123");
     });
     expect(await screen.findByText(/Invite redeemed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Your tenant workspace is connected/i)).toBeInTheDocument();
+    expect(screen.queryByText("prop-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("app-1")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Continue to application readiness/i })).toHaveAttribute(
       "href",
       "/tenant/application?entry=invite&inviteToken=app-1"

--- a/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.test.tsx
@@ -60,4 +60,37 @@ describe("TenantInviteRedeemPage", () => {
       "/tenant/application?entry=invite&inviteToken=app-1"
     );
   });
+
+  it("keeps invite redeem loading and error states clear", async () => {
+    let rejectInvite: (error: Error) => void = () => {};
+    tenantPortalApi.redeemTenantWorkspaceInvite.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectInvite = reject;
+        })
+    );
+
+    render(
+      <MemoryRouter>
+        <TenantInviteRedeemPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: /Invite token/i }), {
+      target: { value: "expired-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Redeem invite/i }));
+
+    expect(screen.getByRole("button", { name: /Redeeming/i })).toBeDisabled();
+
+    rejectInvite(new Error("Invite expired."));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/We couldn't redeem that invite right now/i);
+    });
+    expect(screen.getByRole("alert")).toHaveStyle({
+      color: "#b42318",
+    });
+    expect(screen.getByRole("button", { name: /Redeem invite/i })).toBeEnabled();
+  });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
@@ -6,10 +6,16 @@ import {
   type TenantWorkspaceContext,
 } from "../../api/tenantPortal";
 import { TenantInfoCard, TenantSurfaceShell } from "./TenantWorkspaceShared";
-import { colors, radius, spacing, text as textTokens } from "../../styles/tokens";
+import { radius, spacing, text as textTokens } from "../../styles/tokens";
 import { buildTenantApplicationEntryPath } from "./tenantApplicationFlow";
 import { buildTenantWorkspaceModeView } from "./tenantWorkspaceMode";
 import TenantWorkspaceModeBanner from "./TenantWorkspaceModeBanner";
+import {
+  tenantEntryGhostButtonStyle,
+  tenantEntryLinkStyle,
+  tenantEntryPalette,
+  tenantEntryPrimaryLinkStyle,
+} from "./tenantEntryStyles";
 
 function canLoadWorkspaceModeContext() {
   return (
@@ -129,12 +135,12 @@ export default function TenantInviteRedeemPage() {
 
   return (
     <TenantSurfaceShell
-      title="Redeem Invite"
-      subtitle="Redeem a one-time tenancy invite from inside your authenticated tenant workspace. Invite redemption stays server-scoped and follows the backend token lifecycle rules."
+      title="Redeem invite"
+      subtitle="Use an invite from your landlord or property manager to connect this tenant workspace."
     >
       <TenantWorkspaceModeBanner view={modeView} />
 
-      <TenantInfoCard heading="Invite Redemption" accent="#0f766e">
+      <TenantInfoCard heading="Invite redemption" accent={tenantEntryPalette.charcoal}>
         <form onSubmit={submit} style={{ display: "grid", gap: spacing.md }}>
           <label style={{ display: "grid", gap: 8 }}>
             <span style={{ color: textTokens.muted }}>Invite token</span>
@@ -145,9 +151,9 @@ export default function TenantInviteRedeemPage() {
               style={{
                 padding: "11px 12px",
                 borderRadius: radius.md,
-                border: `1px solid ${colors.border}`,
-                background: colors.panel,
-                color: textTokens.primary,
+                border: `1px solid ${tenantEntryPalette.fieldBorder}`,
+                background: tenantEntryPalette.field,
+                color: tenantEntryPalette.ink,
               }}
             />
           </label>
@@ -155,10 +161,10 @@ export default function TenantInviteRedeemPage() {
           {error ? (
             <div
               style={{
-                border: `1px solid ${colors.borderStrong}`,
+                border: "1px solid rgba(180, 35, 24, 0.24)",
                 borderRadius: radius.md,
-                background: "#fff7ed",
-                color: "#9a3412",
+                background: "rgba(254, 242, 242, 0.92)",
+                color: tenantEntryPalette.danger,
                 padding: "10px 12px",
               }}
             >
@@ -169,22 +175,24 @@ export default function TenantInviteRedeemPage() {
           {success ? (
             <div
               style={{
-                border: `1px solid ${colors.border}`,
+                border: `1px solid ${tenantEntryPalette.sageBorder}`,
                 borderRadius: radius.md,
-                background: "#ecfdf5",
-                color: "#166534",
+                background: tenantEntryPalette.sage,
+                color: tenantEntryPalette.ink,
                 padding: "12px 14px",
                 display: "grid",
                 gap: 6,
               }}
             >
               <div style={{ fontWeight: 800 }}>Invite redeemed</div>
-              <div>Status: {success.status || "redeemed"}</div>
-              {success.propertyId ? <div>Property: {success.propertyId}</div> : null}
-              {success.applicationId ? <div>Application: {success.applicationId}</div> : null}
+              <div>Your tenant workspace is connected. Continue when you are ready.</div>
               <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-                <Link to={nextApplicationPath}>Continue to application readiness</Link>
-                <Link to="/tenant">Return to workspace</Link>
+                <Link to={nextApplicationPath} style={tenantEntryLinkStyle}>
+                  Continue to application readiness
+                </Link>
+                <Link to="/tenant" style={tenantEntryLinkStyle}>
+                  Return to workspace
+                </Link>
               </div>
             </div>
           ) : null}
@@ -196,16 +204,23 @@ export default function TenantInviteRedeemPage() {
               style={{
                 padding: "10px 14px",
                 borderRadius: radius.md,
-                border: `1px solid ${colors.border}`,
-                background: colors.card,
-                color: textTokens.primary,
-                fontWeight: 700,
+                border: 0,
+                ...tenantEntryPrimaryLinkStyle,
+                minHeight: "auto",
                 cursor: submitting ? "not-allowed" : "pointer",
+                opacity: submitting ? 0.72 : 1,
               }}
             >
               {submitting ? "Redeeming..." : "Redeem invite"}
             </button>
-            <Link to="/tenant" style={{ alignSelf: "center" }}>
+            <Link
+              to="/tenant"
+              style={{
+                ...tenantEntryGhostButtonStyle,
+                alignSelf: "center",
+                textDecoration: "none",
+              }}
+            >
               Back to workspace
             </Link>
           </div>

--- a/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
@@ -160,6 +160,7 @@ export default function TenantInviteRedeemPage() {
 
           {error ? (
             <div
+              role="alert"
               style={{
                 border: "1px solid rgba(180, 35, 24, 0.24)",
                 borderRadius: radius.md,

--- a/rentchain-frontend/src/pages/tenant/TenantLandingPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLandingPage.test.tsx
@@ -13,9 +13,8 @@ describe("TenantLandingPage", () => {
       </MemoryRouter>
     );
 
-    expect(
-      screen.getByText(/Your rental profile\. Secure, organized, and in your control\./i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Access your rental workspace\./i)).toBeInTheDocument();
+    expect(screen.getByText(/View your lease, payments, messages, requests, and documents/i)).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Log in \/ Continue/i }).length).toBeGreaterThan(0);
     expect(screen.queryByText(/Create free account/i)).not.toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/tenant/TenantLandingPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLandingPage.tsx
@@ -1,66 +1,23 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { TENANT_DEFAULT_DESTINATION } from "../../lib/authDestination";
+import {
+  tenantEntryBadgeStyle,
+  tenantEntryBodyStyle,
+  tenantEntryContainerStyle,
+  tenantEntryInfoCardStyle,
+  tenantEntryPalette,
+  tenantEntryPrimaryLinkStyle,
+  tenantEntrySecondaryLinkStyle,
+  tenantEntryShellStyle,
+} from "./tenantEntryStyles";
 
 const tenantLoginPath = `/tenant/login?next=${encodeURIComponent(TENANT_DEFAULT_DESTINATION)}`;
 
-const primaryLinkStyle: React.CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  minHeight: 46,
-  padding: "0 18px",
-  borderRadius: 999,
-  textDecoration: "none",
-  fontWeight: 700,
-  background: "#0f172a",
-  color: "#f8fafc",
-  boxShadow: "0 16px 28px rgba(15, 23, 42, 0.16)",
-};
-
-const secondaryLinkStyle: React.CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  minHeight: 46,
-  padding: "0 18px",
-  borderRadius: 999,
-  textDecoration: "none",
-  fontWeight: 700,
-  border: "1px solid rgba(15, 23, 42, 0.12)",
-  color: "#0f172a",
-  background: "rgba(255,255,255,0.84)",
-};
-
-const infoCardStyle: React.CSSProperties = {
-  borderRadius: 20,
-  border: "1px solid rgba(148, 163, 184, 0.24)",
-  background: "rgba(255,255,255,0.84)",
-  boxShadow: "0 20px 48px rgba(148, 163, 184, 0.12)",
-  padding: "20px 22px",
-  display: "grid",
-  gap: 10,
-};
-
 export default function TenantLandingPage() {
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        background:
-          "radial-gradient(circle at top left, rgba(14, 165, 233, 0.14) 0, rgba(255,255,255,0.96) 46%, rgba(240,249,255,0.92) 100%)",
-        color: "#0f172a",
-      }}
-    >
-      <div
-        style={{
-          maxWidth: 1120,
-          margin: "0 auto",
-          padding: "clamp(24px, 5vw, 48px) clamp(16px, 4vw, 32px) 56px",
-          display: "grid",
-          gap: 32,
-        }}
-      >
+    <div style={tenantEntryShellStyle}>
+      <div style={tenantEntryContainerStyle}>
         <header
           style={{
             display: "flex",
@@ -73,7 +30,7 @@ export default function TenantLandingPage() {
           <Link
             to="/"
             style={{
-              color: "#0f172a",
+              color: tenantEntryPalette.ink,
               textDecoration: "none",
               fontWeight: 800,
               letterSpacing: "-0.02em",
@@ -83,10 +40,10 @@ export default function TenantLandingPage() {
             RentChain
           </Link>
           <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-            <Link to={tenantLoginPath} style={secondaryLinkStyle}>
+            <Link to={tenantLoginPath} style={tenantEntrySecondaryLinkStyle}>
               Log in / Continue
             </Link>
-            <Link to={`${tenantLoginPath}&intent=create-profile`} style={secondaryLinkStyle}>
+            <Link to={`${tenantLoginPath}&intent=create-profile`} style={tenantEntrySecondaryLinkStyle}>
               Get started
             </Link>
           </div>
@@ -102,18 +59,7 @@ export default function TenantLandingPage() {
         >
           <div style={{ display: "grid", gap: 18 }}>
             <div
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                width: "fit-content",
-                borderRadius: 999,
-                background: "rgba(255,255,255,0.72)",
-                border: "1px solid rgba(148, 163, 184, 0.28)",
-                color: "#0369a1",
-                padding: "8px 12px",
-                fontSize: "0.88rem",
-                fontWeight: 700,
-              }}
+              style={tenantEntryBadgeStyle}
             >
               Tenant portal
             </div>
@@ -125,51 +71,50 @@ export default function TenantLandingPage() {
                   lineHeight: 1.04,
                   letterSpacing: "-0.04em",
                   maxWidth: 640,
+                  color: tenantEntryPalette.ink,
                 }}
               >
-                Your rental profile. Secure, organized, and in your control.
+                Access your rental workspace.
               </h1>
               <p
                 style={{
-                  margin: 0,
+                  ...tenantEntryBodyStyle,
                   maxWidth: 620,
                   fontSize: "1.05rem",
-                  lineHeight: 1.7,
-                  color: "#334155",
                 }}
               >
-                Access your rental history, documents, and profile details in one place. Share
-                information when needed.
+                View your lease, payments, messages, requests, and documents in one place. Use the
+                link from your landlord or property manager to continue.
               </p>
             </div>
             <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-              <Link to={tenantLoginPath} style={primaryLinkStyle}>
+              <Link to={tenantLoginPath} style={tenantEntryPrimaryLinkStyle}>
                 Log in / Continue
               </Link>
-              <Link to="/tenant/dashboard" style={secondaryLinkStyle}>
+              <Link to="/tenant/dashboard" style={tenantEntrySecondaryLinkStyle}>
                 Preview dashboard
               </Link>
             </div>
           </div>
 
           <div style={{ display: "grid", gap: 14 }}>
-            <div style={infoCardStyle}>
+            <div style={tenantEntryInfoCardStyle}>
               <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>What you can manage here</div>
-              <div style={{ color: "#475569", lineHeight: 1.6 }}>
+              <div style={{ color: tenantEntryPalette.muted, lineHeight: 1.6 }}>
                 Keep your profile current, keep documents organized, and return to your rental
-                history whenever a landlord asks you to share information.
+                workspace when you need to review the record.
               </div>
             </div>
-            <div style={infoCardStyle}>
+            <div style={tenantEntryInfoCardStyle}>
               <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>Designed for tenants first</div>
-              <div style={{ color: "#475569", lineHeight: 1.6 }}>
-                No sales prompts, no landlord setup language, and no pressure to navigate a
-                property-management workflow just to manage your rental identity.
+              <div style={{ color: tenantEntryPalette.muted, lineHeight: 1.6 }}>
+                Tenant access stays focused on the rental information connected to your current
+                invite, application, or tenancy.
               </div>
             </div>
-            <div style={infoCardStyle}>
+            <div style={tenantEntryInfoCardStyle}>
               <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>When you are ready</div>
-              <div style={{ color: "#475569", lineHeight: 1.6 }}>
+              <div style={{ color: tenantEntryPalette.muted, lineHeight: 1.6 }}>
                 Continue into your dashboard to review profile details, application progress,
                 documents, messages, and account history.
               </div>

--- a/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.test.tsx
@@ -73,4 +73,34 @@ describe("TenantLoginPageV2", () => {
       screen.getByText("If an account exists for that email, we sent a login link.")
     ).toBeInTheDocument();
   });
+
+  it("keeps tenant login loading and error states readable", async () => {
+    let rejectRequest: (error: Error) => void = () => {};
+    mocks.apiFetch.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectRequest = reject;
+        })
+    );
+
+    render(
+      <MemoryRouter>
+        <TenantLoginPageV2 />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "tenant@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Email me a login link" }));
+
+    expect(screen.getByRole("button", { name: "Sending..." })).toBeDisabled();
+
+    rejectRequest(new Error("Couldn’t send link. Please try again."));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Couldn’t send link. Please try again.");
+    });
+    expect(screen.getByRole("button", { name: "Email me a login link" })).toBeEnabled();
+  });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import TenantMagicRedeemPage from "./TenantMagicRedeemPage";
 
 const mocks = vi.hoisted(() => ({
@@ -18,6 +18,11 @@ vi.mock("../../lib/authAnalytics", () => ({
 }));
 
 describe("TenantMagicRedeemPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
   it("shows a warm tenant-safe retry state when the magic token is missing", async () => {
     render(
       <MemoryRouter initialEntries={["/auth/magic?next=/tenant/documents"]}>
@@ -26,11 +31,34 @@ describe("TenantMagicRedeemPage", () => {
     );
 
     expect(screen.getByRole("heading", { name: /Tenant magic link/i })).toBeInTheDocument();
-    await waitFor(() => expect(screen.getByText(/Missing magic link token/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/Missing magic link token/i));
     expect(screen.getByRole("link", { name: /Request a new link/i })).toHaveAttribute(
       "href",
       "/tenant/login?next=%2Ftenant%2Fdocuments"
     );
     expect(mocks.apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps invalid magic-link errors obvious and actionable", async () => {
+    mocks.apiFetch.mockRejectedValue(new Error("This link is invalid or expired."));
+
+    render(
+      <MemoryRouter initialEntries={["/auth/magic?token=bad-token&next=/tenant/payments"]}>
+        <TenantMagicRedeemPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Verifying your magic link/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/This link is invalid or expired/i));
+    expect(screen.getByRole("link", { name: /Request a new link/i })).toHaveAttribute(
+      "href",
+      "/tenant/login?next=%2Ftenant%2Fpayments"
+    );
+    expect(mocks.trackAuthEvent).toHaveBeenCalledWith(
+      "auth.onboard.failed",
+      expect.objectContaining({
+        phase: "magic_redeem",
+      })
+    );
   });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import TenantMagicRedeemPage from "./TenantMagicRedeemPage";
+
+const mocks = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  trackAuthEvent: vi.fn(),
+}));
+
+vi.mock("../../api/apiFetch", () => ({
+  apiFetch: mocks.apiFetch,
+}));
+
+vi.mock("../../lib/authAnalytics", () => ({
+  fingerprintToken: (value: string) => `fp:${value}`,
+  trackAuthEvent: mocks.trackAuthEvent,
+}));
+
+describe("TenantMagicRedeemPage", () => {
+  it("shows a warm tenant-safe retry state when the magic token is missing", async () => {
+    render(
+      <MemoryRouter initialEntries={["/auth/magic?next=/tenant/documents"]}>
+        <TenantMagicRedeemPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: /Tenant magic link/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/Missing magic link token/i)).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: /Request a new link/i })).toHaveAttribute(
+      "href",
+      "/tenant/login?next=%2Ftenant%2Fdocuments"
+    );
+    expect(mocks.apiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.tsx
@@ -8,6 +8,13 @@ import {
   TENANT_DEFAULT_DESTINATION,
 } from "../../lib/authDestination";
 import { fingerprintToken, trackAuthEvent } from "../../lib/authAnalytics";
+import {
+  tenantEntryBodyStyle,
+  tenantEntryCardStyle,
+  tenantEntryPalette,
+  tenantEntryPrimaryLinkStyle,
+  tenantEntryShellStyle,
+} from "./tenantEntryStyles";
 
 export default function TenantMagicRedeemPage() {
   const location = useLocation();
@@ -77,37 +84,44 @@ export default function TenantMagicRedeemPage() {
 
   if (status === "ok") {
     return (
-      <div style={{ padding: 24 }}>
-        <h2>Signing you inƒ?İ</h2>
+      <div style={tenantEntryShellStyle}>
+        <div style={tenantEntryCardStyle()}>
+          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, color: tenantEntryPalette.ink }}>
+            Signing you in...
+          </h1>
+          <p style={{ ...tenantEntryBodyStyle, marginTop: 8 }}>
+            We are preparing your tenant workspace.
+          </p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div style={{ padding: 24, maxWidth: 520, margin: "48px auto", textAlign: "center" }}>
-      <h2 style={{ marginBottom: 12 }}>Tenant Magic Link</h2>
-      {status === "pending" ? (
-        <p style={{ color: "#6b7280" }}>Verifying your magic linkƒ?İ</p>
-      ) : (
-        <>
-          <p style={{ color: "#b91c1c" }}>{error || "This link is invalid or expired."}</p>
-          <a
-            href={`/tenant/login${next ? `?next=${encodeURIComponent(next)}` : ""}`}
-            style={{
-              display: "inline-block",
-              marginTop: 12,
-              padding: "10px 12px",
-              borderRadius: 10,
-              background: "#2563eb",
-              color: "#fff",
-              textDecoration: "none",
-              fontWeight: 700,
-            }}
-          >
-            Request a new link
-          </a>
-        </>
-      )}
+    <div style={tenantEntryShellStyle}>
+      <div style={{ ...tenantEntryCardStyle(), textAlign: "center" }}>
+        <h1 style={{ margin: 0, fontSize: 24, fontWeight: 800, color: tenantEntryPalette.ink }}>
+          Tenant magic link
+        </h1>
+        {status === "pending" ? (
+          <p style={{ ...tenantEntryBodyStyle, marginTop: 12 }}>Verifying your magic link...</p>
+        ) : (
+          <>
+            <p style={{ color: tenantEntryPalette.danger, fontWeight: 700 }}>
+              {error || "This link is invalid or expired."}
+            </p>
+            <a
+              href={`/tenant/login${next ? `?next=${encodeURIComponent(next)}` : ""}`}
+              style={{
+                ...tenantEntryPrimaryLinkStyle,
+                marginTop: 12,
+              }}
+            >
+              Request a new link
+            </a>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.tsx
@@ -107,7 +107,7 @@ export default function TenantMagicRedeemPage() {
           <p style={{ ...tenantEntryBodyStyle, marginTop: 12 }}>Verifying your magic link...</p>
         ) : (
           <>
-            <p style={{ color: tenantEntryPalette.danger, fontWeight: 700 }}>
+            <p role="alert" style={{ color: tenantEntryPalette.danger, fontWeight: 700 }}>
               {error || "This link is invalid or expired."}
             </p>
             <a

--- a/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.test.tsx
@@ -8,6 +8,7 @@ describe("TenantPortalComingSoon", () => {
 
     expect(screen.getByText("Tenant portal coming soon")).toBeInTheDocument();
     expect(screen.getByText(/contact your landlord for details/i)).toBeInTheDocument();
+    expect(screen.getByText(/preparing the tenant experience/i)).toBeInTheDocument();
     expect(screen.queryByText(/VITE_TENANT_PORTAL_ENABLED/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.tsx
@@ -1,31 +1,24 @@
 import React from "react";
+import {
+  tenantEntryBodyStyle,
+  tenantEntryCardStyle,
+  tenantEntryPalette,
+  tenantEntryShellStyle,
+} from "./tenantEntryStyles";
 
 export default function TenantPortalComingSoon() {
   return (
-    <div
-      style={{
-        minHeight: "60vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: 24,
-      }}
-    >
+    <div style={tenantEntryShellStyle}>
       <div
         style={{
-          maxWidth: 520,
-          width: "100%",
-          border: "1px solid rgba(0,0,0,0.08)",
-          borderRadius: 12,
-          padding: 18,
-          background: "white",
+          ...tenantEntryCardStyle("min(520px, 92vw)"),
           textAlign: "center",
         }}
       >
-        <div style={{ fontSize: 20, fontWeight: 800, marginBottom: 8 }}>
+        <div style={{ color: tenantEntryPalette.ink, fontSize: 22, fontWeight: 800, marginBottom: 8 }}>
           Tenant portal coming soon
         </div>
-        <div style={{ opacity: 0.75 }}>
+        <div style={tenantEntryBodyStyle}>
           We're preparing the tenant experience. Please check back later or contact your landlord for details.
         </div>
       </div>

--- a/rentchain-frontend/src/pages/tenant/tenantEntryStyles.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantEntryStyles.ts
@@ -1,0 +1,80 @@
+import type React from "react";
+import {
+  authBodyStyle,
+  authCardStyle,
+  authGhostButtonStyle,
+  authLinkStyle,
+  authPalette,
+  authPrimaryButtonStyle,
+  authRoleBadgeStyle,
+  authSecondaryButtonStyle,
+  authShellStyle,
+} from "../../components/auth/authPageStyles";
+
+export const tenantEntryShellStyle: React.CSSProperties = {
+  ...authShellStyle,
+  alignItems: "stretch",
+  padding: 0,
+};
+
+export const tenantEntryContainerStyle: React.CSSProperties = {
+  width: "min(1120px, 100%)",
+  margin: "0 auto",
+  padding: "clamp(24px, 5vw, 52px) clamp(16px, 4vw, 32px) 56px",
+  display: "grid",
+  gap: 32,
+};
+
+export const tenantEntryCardStyle = (width: string = "min(560px, 92vw)") => authCardStyle(width);
+
+export const tenantEntryPrimaryLinkStyle: React.CSSProperties = {
+  ...authPrimaryButtonStyle,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: 46,
+  padding: "0 18px",
+  borderRadius: 999,
+  textDecoration: "none",
+  fontWeight: 750,
+};
+
+export const tenantEntrySecondaryLinkStyle: React.CSSProperties = {
+  ...authSecondaryButtonStyle,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: 46,
+  padding: "0 18px",
+  borderRadius: 999,
+  textDecoration: "none",
+  fontWeight: 750,
+};
+
+export const tenantEntryGhostButtonStyle: React.CSSProperties = {
+  ...authGhostButtonStyle,
+  padding: "10px 12px",
+  borderRadius: 10,
+  fontWeight: 750,
+  cursor: "pointer",
+};
+
+export const tenantEntryInfoCardStyle: React.CSSProperties = {
+  borderRadius: 20,
+  border: `1px solid ${authPalette.fieldBorder}`,
+  background: "rgba(255, 250, 241, 0.86)",
+  boxShadow: "0 18px 42px rgba(69, 55, 33, 0.1)",
+  padding: "20px 22px",
+  display: "grid",
+  gap: 10,
+  color: authPalette.ink,
+};
+
+export const tenantEntryBadgeStyle: React.CSSProperties = {
+  ...authRoleBadgeStyle,
+  marginBottom: 0,
+};
+
+export const tenantEntryBodyStyle = authBodyStyle;
+export const tenantEntryLinkStyle = authLinkStyle;
+export { authPalette as tenantEntryPalette };

--- a/rentchain-frontend/src/tenant/TenantInviteRedeem.tsx
+++ b/rentchain-frontend/src/tenant/TenantInviteRedeem.tsx
@@ -4,6 +4,13 @@ import { setTenantToken } from "./tenantAuth";
 import { DEBUG_AUTH_KEY, JUST_LOGGED_IN_KEY } from "../lib/authKeys";
 import { apiFetch } from "../lib/apiClient";
 import { clearAuthToken } from "../lib/authToken";
+import {
+  tenantEntryBodyStyle,
+  tenantEntryCardStyle,
+  tenantEntryGhostButtonStyle,
+  tenantEntryPalette,
+  tenantEntryShellStyle,
+} from "../pages/tenant/tenantEntryStyles";
 
 export default function TenantInviteRedeem() {
   const { token } = useParams();
@@ -62,46 +69,56 @@ export default function TenantInviteRedeem() {
   }, [token, nav]);
 
   return (
-    <div style={{ maxWidth: 640, margin: "0 auto", padding: "24px 16px" }}>
-      <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 8 }}>Joining RentChain</h1>
-      {status === "loading" && (
-        <p style={{ color: "#6b7280", fontSize: 14 }}>Redeeming invite…</p>
-      )}
-      {status === "idle" && (
-        <p style={{ color: "#6b7280", fontSize: 14 }}>Preparing…</p>
-      )}
-      {status === "ok" && (
-        <div style={{ padding: 12, borderRadius: 10, border: "1px solid #e5e7eb" }}>
-          <p style={{ fontSize: 14 }}>Invite redeemed. Redirecting…</p>
-        </div>
-      )}
-      {status === "error" && (
-        <div
-          style={{
-            padding: 12,
-            borderRadius: 10,
-            border: "1px solid #fecdd3",
-            background: "#fef2f2",
-            color: "#b91c1c",
-            fontSize: 14,
-          }}
-        >
-          <div style={{ fontWeight: 700, marginBottom: 6 }}>Couldn’t redeem invite</div>
-          <div style={{ color: "#b91c1c" }}>{err}</div>
-          <button
-            onClick={() => nav("/", { replace: true })}
+    <div style={tenantEntryShellStyle}>
+      <div style={tenantEntryCardStyle()}>
+        <h1 style={{ fontSize: 22, fontWeight: 800, margin: 0, color: tenantEntryPalette.ink }}>
+          Joining RentChain
+        </h1>
+        {status === "loading" && (
+          <p style={{ ...tenantEntryBodyStyle, marginTop: 8 }}>Redeeming invite...</p>
+        )}
+        {status === "idle" && (
+          <p style={{ ...tenantEntryBodyStyle, marginTop: 8 }}>Preparing...</p>
+        )}
+        {status === "ok" && (
+          <div
             style={{
-              marginTop: 10,
-              padding: "8px 12px",
-              borderRadius: 8,
-              border: "1px solid #e5e7eb",
-              cursor: "pointer",
+              marginTop: 14,
+              padding: 12,
+              borderRadius: 12,
+              border: `1px solid ${tenantEntryPalette.sageBorder}`,
+              background: tenantEntryPalette.sage,
+              color: tenantEntryPalette.ink,
             }}
           >
-            Back to Home
-          </button>
-        </div>
-      )}
+            <p style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>Invite redeemed. Redirecting...</p>
+          </div>
+        )}
+        {status === "error" && (
+          <div
+            style={{
+              padding: 12,
+              borderRadius: 10,
+              border: "1px solid rgba(180, 35, 24, 0.24)",
+              background: "rgba(254, 242, 242, 0.92)",
+              color: tenantEntryPalette.danger,
+              fontSize: 14,
+            }}
+          >
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>Couldn’t redeem invite</div>
+            <div style={{ color: tenantEntryPalette.danger }}>{err}</div>
+            <button
+              onClick={() => nav("/", { replace: true })}
+              style={{
+                ...tenantEntryGhostButtonStyle,
+                marginTop: 10,
+              }}
+            >
+              Back to Home
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/rentchain-frontend/src/tenant/TenantInviteRedeem.tsx
+++ b/rentchain-frontend/src/tenant/TenantInviteRedeem.tsx
@@ -96,6 +96,7 @@ export default function TenantInviteRedeem() {
         )}
         {status === "error" && (
           <div
+            role="alert"
             style={{
               padding: 12,
               borderRadius: 10,


### PR DESCRIPTION
## Summary
- Added a tenant-entry-only styling helper that reuses the warm neutral auth/public brand palette without changing shared logged-in product styling.
- Updated tenant public/entry surfaces: /tenant, /auth/magic, tenant portal coming-soon gate, legacy invite redemption, and authenticated invite redemption onboarding copy/form styling.
- Removed tenant-facing raw property/application ID display from invite redemption success copy while preserving the existing continuation route behavior.

## Scope notes
- Frontend-only.
- No backend, auth core, tenant projection, payment, lease, dashboard, or operational tenant workspace changes.
- Tenant logged-in operational pages were audited and intentionally left untouched.
- /tenant/invite/redeem is auth-gated in browser QA; component-level tests cover the styled form/success state.

## Validation
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- TenantPortalComingSoon
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- TenantLandingPage
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- TenantMagicRedeem
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- TenantInviteRedeem
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- TenantLoginPage
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- LoginForm
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- LandingPage
- source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build
- git diff --check
- git diff --cached --check

## Browser QA
- Local dev server checked with VITE_TENANT_PORTAL_ENABLED=true at desktop 1440px and mobile 375px.
- /tenant renders refreshed tenant entry page with no console errors and no horizontal overflow.
- /tenant/login renders tenant auth entry with no console errors and no horizontal overflow.
- /auth/magic missing-token state renders refreshed warm neutral fallback with no console errors and no horizontal overflow.
- /tenant/invite/redeem redirects unauthenticated users through /tenant/login as expected.
- / and /site/pricing smoke checks remain clean with no console errors and no horizontal overflow.
- With the tenant portal flag disabled, tenant routes render the refreshed warm neutral coming-soon gate.