### PR TITLE
polish: align account and scheduling surfaces with landlord warm theme

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -29,6 +29,7 @@
   --rc-landlord-shadow-soft: 0 10px 24px rgba(59, 44, 28, 0.1);
   min-height: 100vh;
   position: relative;
+  isolation: isolate;
   width: 100%;
   max-width: 100%;
   overflow-x: hidden;
@@ -80,7 +81,7 @@
   top: 0;
   right: 0;
   left: 0;
-  z-index: 2400;
+  z-index: 3000;
   box-sizing: border-box;
   isolation: isolate;
   background: var(--rc-landlord-panel);
@@ -216,6 +217,8 @@
 }
 
 .rc-landlord-content {
+  position: relative;
+  z-index: 0;
   padding: 0 0 24px;
   box-sizing: border-box;
   width: 100%;
@@ -285,7 +288,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
-  z-index: 40;
+  z-index: 3060;
 }
 
 .rc-landlord-backdrop.is-open {
@@ -306,7 +309,7 @@
   box-shadow: -12px 0 28px rgba(59, 44, 28, 0.16);
   transform: translateX(100%);
   transition: transform 0.2s ease;
-  z-index: 50;
+  z-index: 3070;
   display: flex;
   flex-direction: column;
   padding: 18px 16px calc(18px + env(safe-area-inset-bottom));
@@ -394,7 +397,7 @@
   box-shadow: 0 -10px 28px rgba(59, 44, 28, 0.12);
   padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px));
   grid-template-columns: repeat(6, 1fr);
-  z-index: 20;
+  z-index: 3000;
   box-sizing: border-box;
   max-width: 100%;
   overflow-x: hidden;
@@ -463,7 +466,7 @@
   .rc-landlord-mobile-topbar {
     position: sticky;
     top: 0;
-    z-index: 90;
+    z-index: 3000;
     display: flex;
     align-items: center;
     gap: 10px;
@@ -572,7 +575,7 @@
   .rc-landlord-mobile-tabbar {
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
-    z-index: 100;
+    z-index: 3000;
     width: 100%;
     max-width: 100%;
     overflow-x: hidden;

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -620,6 +620,18 @@
     transform: none;
   }
 
+  .rc-landlord-backdrop--nav-safe {
+    bottom: var(--rc-mobile-drawer-bottom-offset);
+  }
+
+  .rc-landlord-drawer--nav-safe {
+    top: auto;
+    bottom: var(--rc-mobile-drawer-bottom-offset);
+    max-height: min(calc(100vh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
+    max-height: min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
+    box-shadow: 0 -18px 40px rgba(59, 44, 28, 0.18);
+  }
+
   .rc-landlord-drawer-header {
     padding-bottom: 10px;
   }

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -308,11 +308,12 @@
 
 .rc-landlord-drawer {
   position: fixed;
-  top: 12px;
-  bottom: 12px;
+  top: 0;
+  bottom: 0;
   right: 0;
   height: auto;
-  max-height: calc(100vh - 24px);
+  max-height: 100vh;
+  max-height: 100dvh;
   width: min(320px, 88vw);
   background: var(--rc-landlord-panel);
   border: 1px solid var(--rc-landlord-border);
@@ -322,7 +323,10 @@
   z-index: var(--rc-landlord-z-drawer);
   display: flex;
   flex-direction: column;
-  padding: 18px 16px calc(18px + env(safe-area-inset-bottom));
+  padding:
+    calc(18px + env(safe-area-inset-top, 0px))
+    16px
+    calc(18px + env(safe-area-inset-bottom, 0px));
   gap: 16px;
   overflow: hidden;
   pointer-events: none;
@@ -597,31 +601,23 @@
 
   .rc-landlord-drawer {
     z-index: var(--rc-landlord-z-drawer);
-    top: auto;
-    left: max(12px, env(safe-area-inset-left, 0px));
-    right: max(12px, env(safe-area-inset-right, 0px));
-    bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+    top: max(10px, env(safe-area-inset-top, 0px));
+    left: max(10px, env(safe-area-inset-left, 0px));
+    right: max(10px, env(safe-area-inset-right, 0px));
+    bottom: max(10px, env(safe-area-inset-bottom, 0px));
     width: auto;
-    max-height: min(calc(100vh - 32px - env(safe-area-inset-bottom, 0px)), 560px);
-    max-height: min(calc(100dvh - 32px - env(safe-area-inset-bottom, 0px)), 560px);
+    max-height: none;
     border-radius: 20px;
-    box-shadow: 0 -18px 40px rgba(59, 44, 28, 0.18);
-    transform: translateY(calc(100% + 24px));
-    padding: 16px 14px;
+    box-shadow: 0 18px 48px rgba(33, 28, 23, 0.24);
+    transform: translateY(0);
+    padding:
+      calc(16px + env(safe-area-inset-top, 0px))
+      14px
+      calc(16px + env(safe-area-inset-bottom, 0px));
   }
 
   .rc-landlord-drawer.is-open {
-    transform: translateY(0);
-  }
-
-  .rc-landlord-backdrop--nav-safe {
-    bottom: var(--rc-mobile-drawer-bottom-offset);
-  }
-
-  .rc-landlord-drawer--nav-safe {
-    bottom: var(--rc-mobile-drawer-bottom-offset);
-    max-height: min(calc(100vh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
-    max-height: min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
+    transform: none;
   }
 
   .rc-landlord-drawer-header {

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -9,6 +9,10 @@
     var(--rc-landlord-desktop-topnav-height) + var(--rc-landlord-workspace-bar-height) + env(safe-area-inset-top, 0px)
   );
   --rc-landlord-sticky-shell-gap: 20px;
+  --rc-landlord-z-content: 0;
+  --rc-landlord-z-nav: 4000;
+  --rc-landlord-z-backdrop: 4010;
+  --rc-landlord-z-drawer: 4020;
 }
 
 .rc-landlord-shell {
@@ -81,7 +85,7 @@
   top: 0;
   right: 0;
   left: 0;
-  z-index: 3000;
+  z-index: var(--rc-landlord-z-nav);
   box-sizing: border-box;
   isolation: isolate;
   background: var(--rc-landlord-panel);
@@ -218,13 +222,19 @@
 
 .rc-landlord-content {
   position: relative;
-  z-index: 0;
+  z-index: var(--rc-landlord-z-content);
+  isolation: isolate;
   padding: 0 0 24px;
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
   min-width: 0;
   overflow-x: hidden;
+}
+
+.rc-landlord-content > * {
+  position: relative;
+  z-index: 0;
 }
 
 .rc-landlord-content--sticky-offset {
@@ -288,7 +298,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
-  z-index: 3060;
+  z-index: var(--rc-landlord-z-backdrop);
 }
 
 .rc-landlord-backdrop.is-open {
@@ -309,7 +319,7 @@
   box-shadow: -12px 0 28px rgba(59, 44, 28, 0.16);
   transform: translateX(100%);
   transition: transform 0.2s ease;
-  z-index: 3070;
+  z-index: var(--rc-landlord-z-drawer);
   display: flex;
   flex-direction: column;
   padding: 18px 16px calc(18px + env(safe-area-inset-bottom));
@@ -397,7 +407,7 @@
   box-shadow: 0 -10px 28px rgba(59, 44, 28, 0.12);
   padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px));
   grid-template-columns: repeat(6, 1fr);
-  z-index: 3000;
+  z-index: var(--rc-landlord-z-nav);
   box-sizing: border-box;
   max-width: 100%;
   overflow-x: hidden;
@@ -466,7 +476,7 @@
   .rc-landlord-mobile-topbar {
     position: sticky;
     top: 0;
-    z-index: 3000;
+    z-index: var(--rc-landlord-z-nav);
     display: flex;
     align-items: center;
     gap: 10px;
@@ -575,18 +585,18 @@
   .rc-landlord-mobile-tabbar {
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
-    z-index: 3000;
+    z-index: var(--rc-landlord-z-nav);
     width: 100%;
     max-width: 100%;
     overflow-x: hidden;
   }
 
   .rc-landlord-backdrop {
-    z-index: 60;
+    z-index: var(--rc-landlord-z-backdrop);
   }
 
   .rc-landlord-drawer {
-    z-index: 70;
+    z-index: var(--rc-landlord-z-drawer);
     top: auto;
     left: max(12px, env(safe-area-inset-left, 0px));
     right: max(12px, env(safe-area-inset-right, 0px));

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -201,7 +201,7 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByText("Verified Screenings", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
   });
 
-  it("opens the workspace drawer as a modal above the mobile tab bar", () => {
+  it("opens the workspace sheet above the mobile tab bar", () => {
     renderLandlordNav();
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
@@ -209,7 +209,7 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByRole("navigation", { name: "Bottom navigation" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open workspace pages" })).toHaveClass("active");
     expect(document.querySelector(".rc-landlord-backdrop")).toHaveClass("is-open");
-    expect(document.querySelector(".rc-landlord-backdrop")).not.toHaveClass("rc-landlord-backdrop--nav-safe");
+    expect(document.querySelector(".rc-landlord-backdrop")).toHaveClass("rc-landlord-backdrop--nav-safe");
     expect(
       within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", {
         name: "Close menu",
@@ -232,7 +232,7 @@ describe("LandlordNav mobile drawer", () => {
     expect(moreButton).not.toHaveClass("active");
   });
 
-  it("does not use nav-safe bottom offsets that leave the mobile nav outside the modal", () => {
+  it("uses nav-safe bottom offsets so the sheet opens above the mobile nav", () => {
     renderLandlordNav();
 
     expect(document.querySelector(".rc-landlord-drawer")).not.toBeInTheDocument();
@@ -243,8 +243,22 @@ describe("LandlordNav mobile drawer", () => {
     const drawer = document.querySelector(".rc-landlord-drawer");
     const backdrop = document.querySelector(".rc-landlord-backdrop");
 
-    expect(drawer).not.toHaveClass("rc-landlord-drawer--nav-safe");
-    expect(backdrop).not.toHaveClass("rc-landlord-backdrop--nav-safe");
+    expect(drawer).toHaveClass("rc-landlord-drawer--nav-safe");
+    expect(backdrop).toHaveClass("rc-landlord-backdrop--nav-safe");
+  });
+
+  it("keeps the mobile bottom nav usable while the workspace sheet is open", async () => {
+    renderLandlordNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
+
+    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Properties" }));
+
+    await waitFor(() => {
+      expect(document.querySelector("#rc-landlord-drawer")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/properties");
   });
 
   it("closes the drawer on option select and route change", async () => {

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -85,7 +85,7 @@ describe("LandlordNav mobile drawer", () => {
     });
   });
 
-  it("opens a bottom-nav drawer with expected workspace options", async () => {
+  it("opens a modal workspace drawer with expected workspace options", async () => {
     renderLandlordNav();
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
@@ -201,13 +201,15 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByText("Verified Screenings", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
   });
 
-  it("keeps the mobile tab bar and close control available while the drawer is open", () => {
+  it("opens the workspace drawer as a modal above the mobile tab bar", () => {
     renderLandlordNav();
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
 
     expect(screen.getByRole("navigation", { name: "Bottom navigation" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open workspace pages" })).toHaveClass("active");
+    expect(document.querySelector(".rc-landlord-backdrop")).toHaveClass("is-open");
+    expect(document.querySelector(".rc-landlord-backdrop")).not.toHaveClass("rc-landlord-backdrop--nav-safe");
     expect(
       within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", {
         name: "Close menu",
@@ -225,19 +227,24 @@ describe("LandlordNav mobile drawer", () => {
     fireEvent.click(moreButton);
 
     await waitFor(() => {
-      expect(document.querySelector("#rc-landlord-drawer")).not.toHaveClass("is-open");
+      expect(document.querySelector("#rc-landlord-drawer")).not.toBeInTheDocument();
     });
     expect(moreButton).not.toHaveClass("active");
   });
 
-  it("uses a safe-area drawer offset so the sheet and backdrop stop above the mobile nav", () => {
+  it("does not use nav-safe bottom offsets that leave the mobile nav outside the modal", () => {
     renderLandlordNav();
+
+    expect(document.querySelector(".rc-landlord-drawer")).not.toBeInTheDocument();
+    expect(document.querySelector(".rc-landlord-backdrop")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
 
     const drawer = document.querySelector(".rc-landlord-drawer");
     const backdrop = document.querySelector(".rc-landlord-backdrop");
 
-    expect(drawer).toHaveClass("rc-landlord-drawer--nav-safe");
-    expect(backdrop).toHaveClass("rc-landlord-backdrop--nav-safe");
+    expect(drawer).not.toHaveClass("rc-landlord-drawer--nav-safe");
+    expect(backdrop).not.toHaveClass("rc-landlord-backdrop--nav-safe");
   });
 
   it("closes the drawer on option select and route change", async () => {
@@ -247,7 +254,7 @@ describe("LandlordNav mobile drawer", () => {
     fireEvent.click(within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", { name: "Payments" }));
 
     await waitFor(() => {
-      expect(document.querySelector("#rc-landlord-drawer")).not.toHaveClass("is-open");
+      expect(document.querySelector("#rc-landlord-drawer")).not.toBeInTheDocument();
     });
     expect(screen.getByTestId("current-path")).toHaveTextContent("/payments");
   });
@@ -372,11 +379,11 @@ describe("LandlordNav mobile drawer", () => {
     fireEvent.keyDown(document, { key: "Escape" });
 
     await waitFor(() => {
-      expect(document.querySelector("#rc-landlord-drawer")).not.toHaveClass("is-open");
+      expect(document.querySelector("#rc-landlord-drawer")).not.toBeInTheDocument();
     });
   });
 
-  it("closes immediately from the drawer close button and leaves the tab bar available", async () => {
+  it("closes immediately from the drawer close button and restores the tab bar", async () => {
     renderLandlordNav();
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
@@ -387,7 +394,7 @@ describe("LandlordNav mobile drawer", () => {
     );
 
     await waitFor(() => {
-      expect(document.querySelector("#rc-landlord-drawer")).not.toHaveClass("is-open");
+      expect(document.querySelector("#rc-landlord-drawer")).not.toBeInTheDocument();
     });
     expect(screen.getByRole("navigation", { name: "Bottom navigation" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open workspace pages" })).not.toHaveClass("active");

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -293,14 +293,22 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       {drawerOpen ? (
         <>
           <div
-            className="rc-landlord-backdrop is-open"
+            className={[
+              "rc-landlord-backdrop",
+              showMobileBottomNav ? "rc-landlord-backdrop--nav-safe" : "",
+              "is-open",
+            ].filter(Boolean).join(" ")}
             onClick={closeDrawer}
             aria-hidden="true"
           />
 
           <aside
             id="rc-landlord-drawer"
-            className="rc-landlord-drawer is-open"
+            className={[
+              "rc-landlord-drawer",
+              showMobileBottomNav ? "rc-landlord-drawer--nav-safe" : "",
+              "is-open",
+            ].filter(Boolean).join(" ")}
             role="dialog"
             aria-modal="true"
             aria-label="Navigation menu"

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -290,85 +290,80 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
         </button>
       </div>
 
-      <div
-        className={[
-          "rc-landlord-backdrop",
-          showMobileBottomNav ? "rc-landlord-backdrop--nav-safe" : "",
-          drawerOpen ? "is-open" : "",
-        ].filter(Boolean).join(" ")}
-        onClick={closeDrawer}
-        aria-hidden={!drawerOpen}
-      />
+      {drawerOpen ? (
+        <>
+          <div
+            className="rc-landlord-backdrop is-open"
+            onClick={closeDrawer}
+            aria-hidden="true"
+          />
 
-      <aside
-        id="rc-landlord-drawer"
-        className={[
-          "rc-landlord-drawer",
-          showMobileBottomNav ? "rc-landlord-drawer--nav-safe" : "",
-          drawerOpen ? "is-open" : "",
-        ].filter(Boolean).join(" ")}
-        role="dialog"
-        aria-modal={drawerOpen ? "true" : undefined}
-        aria-label="Navigation menu"
-        aria-hidden={!drawerOpen}
-      >
-        <div className="rc-landlord-drawer-header">
-          <span>Workspace</span>
-          <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              closeDrawer();
-            }}
-            aria-label="Close menu"
+          <aside
+            id="rc-landlord-drawer"
+            className="rc-landlord-drawer is-open"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navigation menu"
           >
-            Close
-          </button>
-        </div>
-        <div className="rc-landlord-drawer-scroll">
-          {navLoading ? (
-            <div className="rc-landlord-drawer-links">
-              <button type="button" disabled className="active">
-                Loading menu...
+            <div className="rc-landlord-drawer-header">
+              <span>Workspace</span>
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  closeDrawer();
+                }}
+                aria-label="Close menu"
+              >
+                Close
               </button>
             </div>
-          ) : (
-            <div className="rc-landlord-drawer-links">
-              {orderedPrimaryDrawerItems.map(({ id, to, label }) => (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => handleDrawerNavigation(to)}
-                  className={loc.pathname.startsWith(to) ? "active" : ""}
-                >
-                  {label}
-                </button>
-              ))}
+            <div className="rc-landlord-drawer-scroll">
+              {navLoading ? (
+                <div className="rc-landlord-drawer-links">
+                  <button type="button" disabled className="active">
+                    Loading menu...
+                  </button>
+                </div>
+              ) : (
+                <div className="rc-landlord-drawer-links">
+                  {orderedPrimaryDrawerItems.map(({ id, to, label }) => (
+                    <button
+                      key={id}
+                      type="button"
+                      onClick={() => handleDrawerNavigation(to)}
+                      className={loc.pathname.startsWith(to) ? "active" : ""}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <div className="rc-landlord-drawer-divider" />
+              <button type="button" className="rc-landlord-drawer-signout" onClick={logout}>
+                Sign out
+              </button>
+              {adminDrawerItems.length ? (
+                <div className="rc-landlord-drawer-divider" />
+              ) : null}
+              {adminDrawerItems.length ? (
+                <div className="rc-landlord-drawer-links">
+                  {adminDrawerItems.map(({ id, to, label }) => (
+                    <button
+                      key={id}
+                      type="button"
+                      onClick={() => handleDrawerNavigation(to)}
+                      className={loc.pathname.startsWith(to) ? "active" : ""}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
             </div>
-          )}
-          <div className="rc-landlord-drawer-divider" />
-          <button type="button" className="rc-landlord-drawer-signout" onClick={logout}>
-            Sign out
-          </button>
-          {adminDrawerItems.length ? (
-            <div className="rc-landlord-drawer-divider" />
-          ) : null}
-          {adminDrawerItems.length ? (
-            <div className="rc-landlord-drawer-links">
-              {adminDrawerItems.map(({ id, to, label }) => (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => handleDrawerNavigation(to)}
-                  className={loc.pathname.startsWith(to) ? "active" : ""}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      </aside>
+          </aside>
+        </>
+      ) : null}
 
       <UpgradeNudgeHost />
       <div className={contentClassName}>{children}</div>

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -90,7 +90,7 @@ describe("WorkspaceDrawer", () => {
       bottom: "calc(12px + env(safe-area-inset-bottom, 0px))",
       alignItems: "flex-end",
       justifyContent: "center",
-      zIndex: "3000",
+      zIndex: "var(--rc-landlord-z-drawer, 4020)",
     });
     expect(dialog).toHaveStyle({
       width: "min(420px, calc(100% - 24px))",
@@ -98,7 +98,7 @@ describe("WorkspaceDrawer", () => {
       height: "auto",
       maxHeight:
         "min(calc(100dvh - calc(12px + env(safe-area-inset-bottom, 0px)) - 16px), 620px)",
-      zIndex: "3001",
+      zIndex: "1",
     });
     expect(within(dialog).getByRole("button", { name: "Dashboard" }).parentElement).toHaveStyle({
       gridTemplateColumns: "repeat(2, minmax(0, 1fr))",

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { WorkspaceDrawer } from "./WorkspaceDrawer";
+import { WORKSPACE_DRAWER_MOBILE_QUERY, WorkspaceDrawer } from "./WorkspaceDrawer";
 
 const mocks = vi.hoisted(() => ({
   useCapabilities: vi.fn(),
@@ -102,6 +102,44 @@ describe("WorkspaceDrawer", () => {
     });
     expect(within(dialog).getByRole("button", { name: "Dashboard" }).parentElement).toHaveStyle({
       gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    });
+  });
+
+  it("uses the same mobile breakpoint as the landlord shell", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" userEmail="owner@example.com" />
+      </MemoryRouter>
+    );
+
+    expect(mocks.useIsMobile).toHaveBeenCalledWith(WORKSPACE_DRAWER_MOBILE_QUERY);
+    expect(WORKSPACE_DRAWER_MOBILE_QUERY).toBe("(max-width: 820px)");
+  });
+
+  it("uses a side drawer at reduced desktop widths instead of the bottom sheet", () => {
+    mocks.useIsMobile.mockReturnValue(false);
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" userEmail="owner@example.com" />
+      </MemoryRouter>
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Workspace navigation" });
+    expect(dialog.parentElement).toHaveStyle({
+      bottom: "0",
+      alignItems: "flex-start",
+      justifyContent: "flex-end",
+    });
+    expect(dialog).toHaveStyle({
+      width: "320px",
+      height: "100dvh",
+      maxHeight: "100dvh",
+      margin: "0",
+      borderRadius: "0",
+    });
+    expect(within(dialog).getByRole("button", { name: "Dashboard" }).parentElement).toHaveStyle({
+      gridTemplateColumns: "1fr",
     });
   });
 

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -78,7 +78,7 @@ describe("WorkspaceDrawer", () => {
     expect(screen.getByRole("button", { name: "Governed review workspaces" })).toBeInTheDocument();
   });
 
-  it("does not reserve bottom navigation space by default", () => {
+  it("uses a full-height modal panel on mobile instead of reserving bottom navigation space", () => {
     render(
       <MemoryRouter initialEntries={["/dashboard"]}>
         <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" userEmail="owner@example.com" />
@@ -87,17 +87,16 @@ describe("WorkspaceDrawer", () => {
 
     const dialog = screen.getByRole("dialog", { name: "Workspace navigation" });
     expect(dialog.parentElement).toHaveStyle({
-      bottom: "calc(12px + env(safe-area-inset-bottom, 0px))",
-      alignItems: "flex-end",
+      bottom: "0",
+      alignItems: "center",
       justifyContent: "center",
       zIndex: "var(--rc-landlord-z-drawer, 4020)",
     });
     expect(dialog).toHaveStyle({
-      width: "min(420px, calc(100% - 24px))",
-      maxWidth: "min(560px, calc(100% - 24px))",
-      height: "auto",
-      maxHeight:
-        "min(calc(100dvh - calc(12px + env(safe-area-inset-bottom, 0px)) - 16px), 620px)",
+      width: "calc(100% - 24px)",
+      maxWidth: "560px",
+      height: "calc(100dvh - 24px)",
+      maxHeight: "calc(100dvh - 24px)",
       zIndex: "1",
     });
     expect(within(dialog).getByRole("button", { name: "Dashboard" }).parentElement).toHaveStyle({
@@ -140,29 +139,6 @@ describe("WorkspaceDrawer", () => {
     });
     expect(within(dialog).getByRole("button", { name: "Dashboard" }).parentElement).toHaveStyle({
       gridTemplateColumns: "1fr",
-    });
-  });
-
-  it("can reserve bottom navigation space when explicitly requested", () => {
-    render(
-      <MemoryRouter initialEntries={["/dashboard"]}>
-        <WorkspaceDrawer
-          open
-          onClose={vi.fn()}
-          userRole="landlord"
-          userEmail="owner@example.com"
-          reserveBottomNavSpace
-        />
-      </MemoryRouter>
-    );
-
-    const dialog = screen.getByRole("dialog", { name: "Workspace navigation" });
-    expect(dialog.parentElement).toHaveStyle({
-      bottom: "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))",
-    });
-    expect(dialog).toHaveStyle({
-      maxHeight:
-        "min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px))) - 16px), 620px)",
     });
   });
 

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -78,7 +78,7 @@ describe("WorkspaceDrawer", () => {
     expect(screen.getByRole("button", { name: "Governed review workspaces" })).toBeInTheDocument();
   });
 
-  it("uses a full-height modal panel on mobile instead of reserving bottom navigation space", () => {
+  it("uses a bottom-nav-aware sheet on mobile", () => {
     render(
       <MemoryRouter initialEntries={["/dashboard"]}>
         <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" userEmail="owner@example.com" />
@@ -87,16 +87,17 @@ describe("WorkspaceDrawer", () => {
 
     const dialog = screen.getByRole("dialog", { name: "Workspace navigation" });
     expect(dialog.parentElement).toHaveStyle({
-      bottom: "0",
-      alignItems: "center",
+      bottom: "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))",
+      alignItems: "flex-end",
       justifyContent: "center",
       zIndex: "var(--rc-landlord-z-drawer, 4020)",
     });
     expect(dialog).toHaveStyle({
-      width: "calc(100% - 24px)",
-      maxWidth: "560px",
-      height: "calc(100dvh - 24px)",
-      maxHeight: "calc(100dvh - 24px)",
+      width: "min(420px, calc(100% - 24px))",
+      maxWidth: "min(560px, calc(100% - 24px))",
+      height: "auto",
+      maxHeight:
+        "min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px))) - 16px), 620px)",
       zIndex: "1",
     });
     expect(within(dialog).getByRole("button", { name: "Dashboard" }).parentElement).toHaveStyle({

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -15,6 +15,8 @@ type WorkspaceDrawerProps = {
   reserveBottomNavSpace?: boolean;
 };
 
+export const WORKSPACE_DRAWER_MOBILE_QUERY = "(max-width: 820px)";
+
 export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
   open,
   onClose,
@@ -26,7 +28,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
   const navigate = useNavigate();
   const location = useLocation();
   const { features, loading: capsLoading } = useCapabilities();
-  const isMobile = useIsMobile("(max-width: 1024px)");
+  const isMobile = useIsMobile(WORKSPACE_DRAWER_MOBILE_QUERY);
   const navLoading = !userRole || capsLoading;
   const visibleItems = navLoading ? [] : getVisibleNavItems(userRole, features);
   const drawerItems = visibleItems.filter((item) => item.showInDrawer !== false);

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
 import { useLocation, useNavigate } from "react-router-dom";
 import { colors, radius, spacing, text, shadows } from "../../styles/tokens";
 import { getVisibleNavItems } from "./navConfig";
@@ -109,7 +110,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
     </>
   );
 
-  return (
+  const overlay = (
     <div
       style={{
         position: "fixed",
@@ -117,7 +118,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
         left: 0,
         right: 0,
         bottom: isMobile ? mobileBottomNavOffset : 0,
-        zIndex: isMobile ? 3000 : 3000,
+        zIndex: "var(--rc-landlord-z-drawer, 4020)",
         display: "flex",
         justifyContent: isMobile ? "center" : "flex-end",
         alignItems: isMobile ? "flex-end" : "flex-start",
@@ -126,6 +127,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
         overscrollBehavior: "none",
         touchAction: isMobile ? "auto" : "none",
         pointerEvents: "auto",
+        isolation: "isolate",
       }}
     >
       <div
@@ -137,6 +139,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           touchAction: isMobile ? "auto" : "none",
           overscrollBehavior: "none",
           pointerEvents: "auto",
+          zIndex: 0,
         }}
       />
       <div
@@ -159,7 +162,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           boxShadow: shadows.lg,
           display: "flex",
           flexDirection: "column",
-          zIndex: isMobile ? 3001 : 3001,
+          zIndex: 1,
           overflow: "hidden",
           overscrollBehaviorY: "contain",
           contain: "layout paint",
@@ -325,4 +328,6 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
       </div>
     </div>
   );
+
+  return createPortal(overlay, document.body);
 };

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -12,7 +12,6 @@ type WorkspaceDrawerProps = {
   userEmail?: string | null;
   userRole?: string | null;
   onSignOut?: () => void;
-  reserveBottomNavSpace?: boolean;
 };
 
 export const WORKSPACE_DRAWER_MOBILE_QUERY = "(max-width: 820px)";
@@ -23,7 +22,6 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
   userEmail,
   userRole,
   onSignOut,
-  reserveBottomNavSpace = false,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -84,11 +82,6 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
     navigate(path);
     onClose();
   };
-  const mobileBottomNavOffset =
-    reserveBottomNavSpace
-      ? "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))"
-      : "calc(12px + env(safe-area-inset-bottom, 0px))";
-
   const footerContent = (
     <>
       {onSignOut ? (
@@ -119,15 +112,15 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
         top: 0,
         left: 0,
         right: 0,
-        bottom: isMobile ? mobileBottomNavOffset : 0,
+        bottom: 0,
         zIndex: "var(--rc-landlord-z-drawer, 4020)",
         display: "flex",
         justifyContent: isMobile ? "center" : "flex-end",
-        alignItems: isMobile ? "flex-end" : "flex-start",
+        alignItems: isMobile ? "center" : "flex-start",
         maxWidth: "100%",
         overflow: "hidden",
         overscrollBehavior: "none",
-        touchAction: isMobile ? "auto" : "none",
+        touchAction: "none",
         pointerEvents: "auto",
         isolation: "isolate",
       }}
@@ -138,7 +131,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           position: "absolute",
           inset: 0,
           background: "rgba(0,0,0,0.35)",
-          touchAction: isMobile ? "auto" : "none",
+          touchAction: "none",
           overscrollBehavior: "none",
           pointerEvents: "auto",
           zIndex: 0,
@@ -150,11 +143,11 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
         aria-label="Workspace navigation"
         style={{
           position: "relative",
-          width: isMobile ? "min(420px, calc(100% - 24px))" : 320,
-          maxWidth: isMobile ? "min(560px, calc(100% - 24px))" : "90vw",
-          height: isMobile ? "auto" : "100dvh",
-          maxHeight: isMobile ? `min(calc(100dvh - ${mobileBottomNavOffset} - 16px), 620px)` : "100dvh",
-          margin: isMobile ? "0 auto 8px" : 0,
+          width: isMobile ? "calc(100% - 24px)" : 320,
+          maxWidth: isMobile ? 560 : "90vw",
+          height: isMobile ? "calc(100dvh - 24px)" : "100dvh",
+          maxHeight: isMobile ? "calc(100dvh - 24px)" : "100dvh",
+          margin: isMobile ? "12px" : 0,
           minHeight: 0,
           minWidth: 0,
           background: colors.card,
@@ -170,7 +163,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           contain: "layout paint",
           isolation: "isolate",
           WebkitOverflowScrolling: "touch",
-          paddingTop: isMobile ? 0 : "env(safe-area-inset-top)",
+          paddingTop: isMobile ? "env(safe-area-inset-top, 0px)" : "env(safe-area-inset-top)",
           paddingBottom: "env(safe-area-inset-bottom, 0px)",
           pointerEvents: "auto",
         }}

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -82,6 +82,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
     navigate(path);
     onClose();
   };
+  const mobileBottomNavOffset = "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))";
   const footerContent = (
     <>
       {onSignOut ? (
@@ -112,15 +113,15 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
         top: 0,
         left: 0,
         right: 0,
-        bottom: 0,
+        bottom: isMobile ? mobileBottomNavOffset : 0,
         zIndex: "var(--rc-landlord-z-drawer, 4020)",
         display: "flex",
         justifyContent: isMobile ? "center" : "flex-end",
-        alignItems: isMobile ? "center" : "flex-start",
+        alignItems: isMobile ? "flex-end" : "flex-start",
         maxWidth: "100%",
         overflow: "hidden",
         overscrollBehavior: "none",
-        touchAction: "none",
+        touchAction: isMobile ? "auto" : "none",
         pointerEvents: "auto",
         isolation: "isolate",
       }}
@@ -131,7 +132,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           position: "absolute",
           inset: 0,
           background: "rgba(0,0,0,0.35)",
-          touchAction: "none",
+          touchAction: isMobile ? "auto" : "none",
           overscrollBehavior: "none",
           pointerEvents: "auto",
           zIndex: 0,
@@ -143,11 +144,11 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
         aria-label="Workspace navigation"
         style={{
           position: "relative",
-          width: isMobile ? "calc(100% - 24px)" : 320,
-          maxWidth: isMobile ? 560 : "90vw",
-          height: isMobile ? "calc(100dvh - 24px)" : "100dvh",
-          maxHeight: isMobile ? "calc(100dvh - 24px)" : "100dvh",
-          margin: isMobile ? "12px" : 0,
+          width: isMobile ? "min(420px, calc(100% - 24px))" : 320,
+          maxWidth: isMobile ? "min(560px, calc(100% - 24px))" : "90vw",
+          height: isMobile ? "auto" : "100dvh",
+          maxHeight: isMobile ? `min(calc(100dvh - ${mobileBottomNavOffset} - 16px), 620px)` : "100dvh",
+          margin: isMobile ? "0 auto 8px" : 0,
           minHeight: 0,
           minWidth: 0,
           background: colors.card,

--- a/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
+++ b/rentchain-frontend/src/pages/DelegatedAccessPage.tsx
@@ -19,7 +19,7 @@ import {
   type DelegatedAccessRole,
   type DelegatedAccessWorkspaceScope,
 } from "../api/delegatedAccessApi";
-import { colors, radius, spacing, text } from "../styles/tokens";
+import { radius, spacing, text } from "../styles/tokens";
 
 const roleLabels: Record<DelegatedAccessRole, string> = {
   property_manager: "Property Manager",
@@ -59,6 +59,19 @@ const permissions = Object.keys(permissionLabels) as DelegatedAccessPermissionAc
 
 const defaultWorkspaces: DelegatedAccessWorkspaceScope[] = ["dashboard", "operations"];
 const defaultPermissions: DelegatedAccessPermissionAction[] = ["view"];
+const delegatedWarm = {
+  card: "#fffaf1",
+  panel: "#fff6e8",
+  mutedPanel: "#f7efe2",
+  border: "rgba(91, 70, 48, 0.16)",
+  borderStrong: "rgba(91, 70, 48, 0.28)",
+  text: "#211c17",
+  muted: "#63594d",
+  pine: "#245842",
+  pineSoft: "rgba(36, 88, 66, 0.12)",
+  amber: "#8a5a17",
+  amberSoft: "rgba(180, 83, 9, 0.14)",
+};
 type AccessStatusFilter = "all" | "pending" | "active" | "cancelled" | "expired" | "revoked";
 type AccessRow =
   | { kind: "invitation"; status: DelegatedAccessInvitation["status"]; invitation: DelegatedAccessInvitation }
@@ -98,6 +111,28 @@ function propertyScopeLabel(mode: DelegatedAccessPropertyScopeMode, selectedSumm
 
 function statusTone(status: string): "accent" | "muted" {
   return status === "active" || status === "pending" ? "accent" : "muted";
+}
+
+function delegatedStatusStyle(status: string): React.CSSProperties {
+  if (status === "active") {
+    return {
+      background: delegatedWarm.pineSoft,
+      color: delegatedWarm.pine,
+      borderColor: "rgba(36, 88, 66, 0.28)",
+    };
+  }
+  if (status === "pending") {
+    return {
+      background: delegatedWarm.amberSoft,
+      color: delegatedWarm.amber,
+      borderColor: "rgba(180, 83, 9, 0.28)",
+    };
+  }
+  return {
+    background: delegatedWarm.mutedPanel,
+    color: delegatedWarm.muted,
+    borderColor: delegatedWarm.border,
+  };
 }
 
 function statusLabel(status: string) {
@@ -149,8 +184,9 @@ function ToggleChip({
         gap: 8,
         padding: "8px 10px",
         borderRadius: radius.pill,
-        border: `1px solid ${checked ? colors.accent : colors.border}`,
-        background: checked ? colors.accentSoft : colors.card,
+        border: `1px solid ${checked ? "rgba(36, 88, 66, 0.34)" : delegatedWarm.border}`,
+        background: checked ? delegatedWarm.pineSoft : delegatedWarm.card,
+        color: delegatedWarm.text,
         fontSize: 13,
         fontWeight: 700,
         cursor: "pointer",
@@ -169,10 +205,70 @@ function ToggleChip({
 
 function StatusCard({ label, value }: { label: string; value: number }) {
   return (
-    <Card style={{ padding: spacing.md, display: "grid", gap: 4 }}>
-      <div style={{ color: text.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>{label}</div>
+    <Card className="delegated-surface" style={{ padding: spacing.md, display: "grid", gap: 4 }}>
+      <div style={{ color: delegatedWarm.muted, fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>{label}</div>
       <div style={{ fontSize: 26, fontWeight: 900 }}>{value}</div>
     </Card>
+  );
+}
+
+function DelegatedAccessTheme() {
+  return (
+    <style>
+      {`
+        .delegated-access-page {
+          --delegated-card: ${delegatedWarm.card};
+          --delegated-panel: ${delegatedWarm.panel};
+          --delegated-muted-panel: ${delegatedWarm.mutedPanel};
+          --delegated-border: ${delegatedWarm.border};
+          --delegated-border-strong: ${delegatedWarm.borderStrong};
+          --delegated-text: ${delegatedWarm.text};
+          --delegated-muted: ${delegatedWarm.muted};
+          --delegated-pine: ${delegatedWarm.pine};
+          --delegated-pine-soft: ${delegatedWarm.pineSoft};
+        }
+        .delegated-access-page .delegated-surface {
+          background: var(--delegated-card) !important;
+          border-color: var(--delegated-border) !important;
+          box-shadow: 0 10px 24px rgba(59, 44, 28, 0.1) !important;
+        }
+        .delegated-access-page .delegated-panel {
+          background: var(--delegated-muted-panel) !important;
+          border-color: var(--delegated-border) !important;
+        }
+        .delegated-access-page input,
+        .delegated-access-page select {
+          background: var(--delegated-card) !important;
+          border-color: var(--delegated-border) !important;
+          color: var(--delegated-text) !important;
+        }
+        .delegated-access-page input:focus,
+        .delegated-access-page select:focus {
+          border-color: rgba(36, 88, 66, 0.42) !important;
+          box-shadow: 0 0 0 3px rgba(36, 88, 66, 0.18) !important;
+        }
+        .delegated-access-page button {
+          border: 1px solid var(--delegated-border) !important;
+          background: var(--delegated-card) !important;
+          color: var(--delegated-text) !important;
+          box-shadow: none !important;
+        }
+        .delegated-access-page button:hover:not(:disabled) {
+          border-color: var(--delegated-border-strong) !important;
+          background: var(--delegated-panel) !important;
+        }
+        .delegated-access-page button.delegated-primary,
+        .delegated-access-page button[aria-selected="true"] {
+          border-color: rgba(36, 88, 66, 0.42) !important;
+          background: var(--delegated-pine) !important;
+          color: #fffaf1 !important;
+        }
+        .delegated-access-page button.delegated-primary:hover:not(:disabled),
+        .delegated-access-page button[aria-selected="true"]:hover:not(:disabled) {
+          background: #1f4b39 !important;
+        }
+      `}
+    </style>
   );
 }
 
@@ -377,9 +473,9 @@ export default function DelegatedAccessPage() {
         display: "grid",
         gap: spacing.xs,
         padding: spacing.md,
-        border: `1px solid ${colors.border}`,
+        border: `1px solid ${delegatedWarm.border}`,
         borderRadius: radius.md,
-        background: colors.card,
+        background: delegatedWarm.card,
       }}
     >
       <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
@@ -389,7 +485,9 @@ export default function DelegatedAccessPage() {
             {roleLabels[invitation.role]} · {propertyScopeLabel(invitation.propertyScope.mode)}
           </div>
         </div>
-        <Pill tone={statusTone(invitation.status)}>{statusLabel(invitation.status)}</Pill>
+        <Pill tone={statusTone(invitation.status)} style={delegatedStatusStyle(invitation.status)}>
+          {statusLabel(invitation.status)}
+        </Pill>
       </div>
       <div style={{ color: text.secondary, fontSize: 13 }}>
         Workspaces: {labelList(invitation.workspaceScopes, workspaceLabels)} · Permissions:{" "}
@@ -428,9 +526,9 @@ export default function DelegatedAccessPage() {
         display: "grid",
         gap: spacing.sm,
         padding: spacing.md,
-        border: `1px solid ${colors.border}`,
+        border: `1px solid ${delegatedWarm.border}`,
         borderRadius: radius.md,
-        background: grant.status === "revoked" ? "#f8fafc" : colors.card,
+        background: grant.status === "revoked" ? delegatedWarm.mutedPanel : delegatedWarm.card,
       }}
     >
       <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
@@ -440,7 +538,9 @@ export default function DelegatedAccessPage() {
             {roleLabels[grant.role]} · {propertyScopeLabel(grant.permissionScope.propertyScope.mode)}
           </div>
         </div>
-        <Pill tone={statusTone(grant.status)}>{statusLabel(grant.status)}</Pill>
+        <Pill tone={statusTone(grant.status)} style={delegatedStatusStyle(grant.status)}>
+          {statusLabel(grant.status)}
+        </Pill>
       </div>
       <div style={{ color: text.secondary, fontSize: 13 }}>
         Workspaces: {labelList(grant.permissionScope.workspaceScopes, workspaceLabels)} · Permissions:{" "}
@@ -471,15 +571,16 @@ export default function DelegatedAccessPage() {
           </div>
           {confirmingRevokeGrant?.grantId === grant.grantId ? (
             <div
+              className="delegated-panel"
               role="alertdialog"
               aria-label={`Confirm revoke access for ${grant.delegateEmail || "delegate"}`}
               style={{
                 display: "grid",
                 gap: spacing.xs,
                 padding: spacing.sm,
-                border: `1px solid ${colors.border}`,
+                border: `1px solid ${delegatedWarm.border}`,
                 borderRadius: radius.md,
-                background: "#fff7ed",
+                background: delegatedWarm.panel,
               }}
             >
               <div style={{ fontWeight: 900 }}>
@@ -539,8 +640,10 @@ export default function DelegatedAccessPage() {
           display: "grid",
           gap: spacing.md,
         }}
+        className="delegated-access-page"
       >
-        <Card elevated>
+        <DelegatedAccessTheme />
+        <Card elevated className="delegated-surface">
           <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Delegate Management</h1>
           <p style={{ margin: "8px 0 0", color: text.muted }}>
             Delegate management is available only to landlord owners.
@@ -559,8 +662,10 @@ export default function DelegatedAccessPage() {
         display: "grid",
         gap: spacing.md,
       }}
+      className="delegated-access-page"
     >
-      <Card elevated style={{ display: "grid", gap: spacing.md }}>
+      <DelegatedAccessTheme />
+      <Card elevated className="delegated-surface" style={{ display: "grid", gap: spacing.md }}>
         <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
           <div style={{ display: "grid", gap: 6 }}>
             <h1 style={{ margin: 0, fontSize: "1.55rem", fontWeight: 900 }}>Delegate Management</h1>
@@ -568,7 +673,7 @@ export default function DelegatedAccessPage() {
               Never share your login. Invite delegates to their own account.
             </p>
           </div>
-          <Button type="button" onClick={() => setInviteOpen((open) => !open)}>
+          <Button type="button" className="delegated-primary" onClick={() => setInviteOpen((open) => !open)}>
             {inviteOpen ? "Hide Invite" : "Invite Delegate"}
           </Button>
         </div>
@@ -595,7 +700,7 @@ export default function DelegatedAccessPage() {
       </div>
 
       {inviteOpen ? (
-        <Card style={{ display: "grid", gap: spacing.md }}>
+        <Card className="delegated-surface" style={{ display: "grid", gap: spacing.md }}>
           <div style={{ display: "flex", alignItems: "center", gap: spacing.sm }}>
             <UserPlus size={20} />
             <div>
@@ -624,9 +729,9 @@ export default function DelegatedAccessPage() {
                   onChange={(event) => setInviteRole(event.target.value as DelegatedAccessRole)}
                   style={{
                     minHeight: 42,
-                    border: `1px solid ${colors.border}`,
+                    border: `1px solid ${delegatedWarm.border}`,
                     borderRadius: radius.md,
-                    background: colors.card,
+                    background: delegatedWarm.card,
                     padding: "10px 12px",
                     color: text.primary,
                   }}
@@ -644,9 +749,9 @@ export default function DelegatedAccessPage() {
                   aria-label="Property scope"
                   style={{
                     minHeight: 42,
-                    border: `1px solid ${colors.border}`,
+                    border: `1px solid ${delegatedWarm.border}`,
                     borderRadius: radius.md,
-                    background: "#f8fafc",
+                    background: delegatedWarm.mutedPanel,
                     padding: "10px 12px",
                     color: text.primary,
                     display: "flex",
@@ -697,7 +802,7 @@ export default function DelegatedAccessPage() {
             </div>
 
             <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-              <Button type="submit" disabled={submitting}>
+              <Button type="submit" className="delegated-primary" disabled={submitting}>
                 {submitting ? "Creating..." : "Create Invitation"}
               </Button>
               <Button
@@ -715,7 +820,7 @@ export default function DelegatedAccessPage() {
         </Card>
       ) : null}
 
-      <Card style={{ display: "grid", gap: spacing.md }}>
+      <Card className="delegated-surface" style={{ display: "grid", gap: spacing.md }}>
         <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
           <div>
             <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Access Overview</h2>
@@ -754,7 +859,7 @@ export default function DelegatedAccessPage() {
             body={emptyState.body}
             action={
               statusFilter === "all" || statusFilter === "pending" ? (
-                <Button type="button" onClick={() => setInviteOpen(true)}>Invite Delegate</Button>
+                <Button type="button" className="delegated-primary" onClick={() => setInviteOpen(true)}>Invite Delegate</Button>
               ) : undefined
             }
           />
@@ -781,7 +886,7 @@ export default function DelegatedAccessPage() {
         ) : null}
       </Card>
 
-      <Card style={{ display: "grid", gap: spacing.sm }}>
+      <Card className="delegated-surface" style={{ display: "grid", gap: spacing.sm }}>
         <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Delegates Summary</h2>
         {delegates.length === 0 ? (
           <div style={{ color: text.muted }}>Delegate summaries will appear after invitations are accepted.</div>
@@ -799,7 +904,8 @@ export default function DelegatedAccessPage() {
                   gap: spacing.sm,
                   padding: spacing.sm,
                   borderRadius: radius.md,
-                  border: `1px solid ${colors.border}`,
+                  border: `1px solid ${delegatedWarm.border}`,
+                  background: delegatedWarm.mutedPanel,
                 }}
               >
                 <div style={{ flex: "1 1 220px", minWidth: 0 }}>

--- a/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
+++ b/rentchain-frontend/src/pages/PropertyManagerCompanyManagementPage.tsx
@@ -28,7 +28,7 @@ import {
 import { Button, Card, EmptyState, InlineError, Input, Pill, SkeletonBlock } from "../components/ui/Ui";
 import { useToast } from "../components/ui/ToastProvider";
 import { useAuth } from "../context/useAuth";
-import { colors, radius, shadows, spacing, text } from "../styles/tokens";
+import { radius, shadows, spacing, text } from "../styles/tokens";
 
 const ASSIGNMENT_ROLES: PropertyManagerCompanyStaffAssignmentRole[] = [
   "regional_manager",
@@ -78,6 +78,19 @@ const RELATIONSHIP_WORKSPACES: PropertyManagerCompanyWorkspaceScope[] = [
 ];
 
 const DEFAULT_RELATIONSHIP_WORKSPACES: PropertyManagerCompanyWorkspaceScope[] = ["dashboard", "operations"];
+const pmcWarm = {
+  card: "#fffaf1",
+  panel: "#fff6e8",
+  mutedPanel: "#f7efe2",
+  border: "rgba(91, 70, 48, 0.16)",
+  borderStrong: "rgba(91, 70, 48, 0.28)",
+  text: "#211c17",
+  muted: "#63594d",
+  pine: "#245842",
+  pineSoft: "rgba(36, 88, 66, 0.12)",
+  amber: "#8a5a17",
+  amberSoft: "rgba(180, 83, 9, 0.14)",
+};
 
 type SurfaceMode = "landlord" | "company";
 
@@ -110,6 +123,28 @@ function actionPastTense(action: string) {
 
 function statusTone(value: string): "accent" | "muted" {
   return value === "active" || value === "pending" ? "accent" : "muted";
+}
+
+function pmcStatusStyle(value: string): React.CSSProperties {
+  if (value === "active") {
+    return {
+      background: pmcWarm.pineSoft,
+      color: pmcWarm.pine,
+      borderColor: "rgba(36, 88, 66, 0.28)",
+    };
+  }
+  if (value === "pending") {
+    return {
+      background: pmcWarm.amberSoft,
+      color: pmcWarm.amber,
+      borderColor: "rgba(180, 83, 9, 0.28)",
+    };
+  }
+  return {
+    background: pmcWarm.mutedPanel,
+    color: pmcWarm.muted,
+    borderColor: pmcWarm.border,
+  };
 }
 
 function formatDate(value?: string | null) {
@@ -181,8 +216,8 @@ function ToggleChip({
         gap: 8,
         padding: "8px 10px",
         borderRadius: radius.pill,
-        border: `1px solid ${checked ? colors.accent : colors.border}`,
-        background: checked ? colors.accentSoft : colors.card,
+        border: `1px solid ${checked ? "rgba(36, 88, 66, 0.34)" : pmcWarm.border}`,
+        background: checked ? pmcWarm.pineSoft : pmcWarm.card,
         color: disabled ? text.muted : text.primary,
         fontSize: 13,
         fontWeight: 700,
@@ -285,7 +320,7 @@ function RelationshipCard({
 }) {
   const title = companyMode ? relationship.landlordWorkspaceLabel : relationship.propertyManagerCompanyLabel;
   return (
-    <Card data-testid="pmc-relationship-card" style={{ display: "grid", gap: spacing.md }}>
+    <Card data-testid="pmc-relationship-card" className="pmc-surface" style={{ display: "grid", gap: spacing.md }}>
       <div className="pmc-card-header">
         <div style={{ minWidth: 0 }}>
           <div className="pmc-card-title">{title}</div>
@@ -293,7 +328,9 @@ function RelationshipCard({
             {relationshipScopeLabel(relationship)}
           </div>
         </div>
-        <Pill tone={statusTone(relationship.status)}>{statusLabel(relationship.status)}</Pill>
+        <Pill tone={statusTone(relationship.status)} style={pmcStatusStyle(relationship.status)}>
+          {statusLabel(relationship.status)}
+        </Pill>
       </div>
 
       <div className="pmc-meta-grid">
@@ -352,7 +389,7 @@ function RelationshipCard({
             <EmptyState
               title="No staff assigned"
               body="This relationship has no visible staff assignments yet."
-              style={{ background: colors.card }}
+              style={{ background: pmcWarm.card }}
             />
           )}
         </div>
@@ -382,7 +419,9 @@ function AssignmentRow({
         </div>
       </div>
       <div className="pmc-row-actions">
-        <Pill tone={statusTone(assignment.status)}>{statusLabel(assignment.status)}</Pill>
+        <Pill tone={statusTone(assignment.status)} style={pmcStatusStyle(assignment.status)}>
+          {statusLabel(assignment.status)}
+        </Pill>
         {onSuspend && assignment.status === "active" ? (
           <Button type="button" variant="secondary" onClick={onSuspend}>
             Suspend
@@ -693,11 +732,48 @@ export default function PropertyManagerCompanyManagementPage() {
       <style>
         {`
           .pmc-page {
+            --pmc-card: ${pmcWarm.card};
+            --pmc-panel: ${pmcWarm.panel};
+            --pmc-muted-panel: ${pmcWarm.mutedPanel};
+            --pmc-border: ${pmcWarm.border};
+            --pmc-border-strong: ${pmcWarm.borderStrong};
+            --pmc-text: ${pmcWarm.text};
+            --pmc-muted: ${pmcWarm.muted};
+            --pmc-pine: ${pmcWarm.pine};
+            --pmc-pine-soft: ${pmcWarm.pineSoft};
             max-width: 1320px;
             margin: 0 auto;
             padding: 0;
             display: grid;
             gap: ${spacing.md};
+            color: var(--pmc-text);
+          }
+          .pmc-surface {
+            background: var(--pmc-card) !important;
+            border-color: var(--pmc-border) !important;
+            box-shadow: 0 10px 24px rgba(59, 44, 28, 0.1) !important;
+          }
+          .pmc-page button {
+            border: 1px solid var(--pmc-border) !important;
+            background: var(--pmc-card) !important;
+            color: var(--pmc-text) !important;
+            box-shadow: none !important;
+          }
+          .pmc-page button:hover:not(:disabled) {
+            border-color: var(--pmc-border-strong) !important;
+            background: var(--pmc-panel) !important;
+          }
+          .pmc-page button.pmc-primary-action,
+          .pmc-page button[aria-selected="true"] {
+            border-color: rgba(36, 88, 66, 0.42) !important;
+            background: var(--pmc-pine) !important;
+            color: #fffaf1 !important;
+          }
+          .pmc-page input,
+          .pmc-page select {
+            background: var(--pmc-card) !important;
+            border-color: var(--pmc-border) !important;
+            color: var(--pmc-text) !important;
           }
           .pmc-header {
             display: flex;
@@ -742,10 +818,10 @@ export default function PropertyManagerCompanyManagementPage() {
           .pmc-summary-stat {
             display: grid;
             gap: 4px;
-            border: 1px solid ${colors.border};
+            border: 1px solid var(--pmc-border);
             border-radius: ${radius.md};
             padding: ${spacing.sm};
-            background: ${colors.panel};
+            background: var(--pmc-muted-panel);
             min-width: 0;
           }
           .pmc-meta-grid span {
@@ -759,9 +835,9 @@ export default function PropertyManagerCompanyManagementPage() {
           .pmc-note {
             padding: ${spacing.sm};
             border-radius: ${radius.md};
-            border: 1px solid ${colors.border};
-            background: ${colors.accentSoft};
-            color: ${text.secondary};
+            border: 1px solid var(--pmc-border);
+            background: var(--pmc-pine-soft);
+            color: var(--pmc-muted);
             font-size: 13px;
             line-height: 1.45;
           }
@@ -769,20 +845,20 @@ export default function PropertyManagerCompanyManagementPage() {
           .pmc-selected-company {
             display: grid;
             gap: ${spacing.sm};
-            border: 1px solid ${colors.border};
+            border: 1px solid var(--pmc-border);
             border-radius: ${radius.md};
             padding: ${spacing.sm};
-            background: ${colors.panel};
+            background: var(--pmc-muted-panel);
           }
           .pmc-selected-company {
-            border-color: ${colors.accent};
-            background: ${colors.accentSoft};
+            border-color: rgba(36, 88, 66, 0.34);
+            background: var(--pmc-pine-soft);
           }
           .pmc-result-button {
             width: 100%;
             text-align: left;
-            border: 1px solid ${colors.border};
-            background: ${colors.card};
+            border: 1px solid var(--pmc-border);
+            background: var(--pmc-card);
             border-radius: ${radius.md};
             padding: ${spacing.sm};
             cursor: pointer;
@@ -790,17 +866,17 @@ export default function PropertyManagerCompanyManagementPage() {
             overflow-wrap: anywhere;
           }
           .pmc-result-button[aria-pressed="true"] {
-            border-color: ${colors.accent};
-            background: ${colors.accentSoft};
+            border-color: rgba(36, 88, 66, 0.34);
+            background: var(--pmc-pine-soft);
           }
           .pmc-select {
             width: 100%;
             min-height: 42px;
-            border: 1px solid ${colors.border};
+            border: 1px solid var(--pmc-border);
             border-radius: ${radius.md};
             padding: 10px 12px;
-            background: ${colors.card};
-            color: ${text.primary};
+            background: var(--pmc-card);
+            color: var(--pmc-text);
           }
           .pmc-section-title {
             display: flex;
@@ -850,7 +926,7 @@ export default function PropertyManagerCompanyManagementPage() {
         `}
       </style>
 
-      <Card elevated>
+      <Card elevated className="pmc-surface">
         <div className="pmc-header">
           <div style={{ display: "grid", gap: 6, minWidth: 0 }}>
             <h1 style={{ margin: 0, fontSize: "1.55rem", fontWeight: 900 }}>PM Company Management</h1>
@@ -862,6 +938,7 @@ export default function PropertyManagerCompanyManagementPage() {
             {canUseLandlordSurface ? (
               <Button
                 type="button"
+                className={mode === "landlord" ? "pmc-primary-action" : undefined}
                 variant={mode === "landlord" ? "primary" : "secondary"}
                 role="tab"
                 aria-selected={mode === "landlord"}
@@ -872,6 +949,7 @@ export default function PropertyManagerCompanyManagementPage() {
             ) : null}
             <Button
               type="button"
+              className={mode === "company" ? "pmc-primary-action" : undefined}
               variant={mode === "company" ? "primary" : "secondary"}
               role="tab"
               aria-selected={mode === "company"}
@@ -894,7 +972,7 @@ export default function PropertyManagerCompanyManagementPage() {
       {!loading && mode === "landlord" ? (
         canUseLandlordSurface ? (
           <div className="pmc-grid">
-            <Card style={{ display: "grid", gap: spacing.md }}>
+            <Card className="pmc-surface" style={{ display: "grid", gap: spacing.md }}>
               <h2 className="pmc-section-title">
                 <Building2 size={18} /> Create pending relationship
               </h2>
@@ -958,7 +1036,7 @@ export default function PropertyManagerCompanyManagementPage() {
                           <EmptyState
                             title="No PM companies found"
                             body="Try another company name or verify the company has been created and activated."
-                            style={{ background: colors.card }}
+                            style={{ background: pmcWarm.card }}
                           />
                         )}
                       </div>
@@ -989,14 +1067,19 @@ export default function PropertyManagerCompanyManagementPage() {
                     ))}
                   </div>
                 </div>
-                <Button type="button" disabled={busy || !selectedLookup || !relationshipWorkspaces.length} onClick={createRelationship}>
+                <Button
+                  type="button"
+                  className="pmc-primary-action"
+                  disabled={busy || !selectedLookup || !relationshipWorkspaces.length}
+                  onClick={createRelationship}
+                >
                   Create pending relationship
                 </Button>
               </div>
             </Card>
 
             <div style={{ display: "grid", gap: spacing.md }}>
-              <Card style={{ display: "grid", gap: spacing.sm }}>
+              <Card className="pmc-surface" style={{ display: "grid", gap: spacing.sm }}>
                 <h2 className="pmc-section-title">
                   <Users size={18} /> Landlord relationships
                 </h2>
@@ -1035,7 +1118,7 @@ export default function PropertyManagerCompanyManagementPage() {
       {!loading && mode === "company" ? (
         hasCompanySurface ? (
           <div className="pmc-grid">
-            <Card style={{ display: "grid", gap: spacing.md }}>
+            <Card className="pmc-surface" style={{ display: "grid", gap: spacing.md }}>
               <h2 className="pmc-section-title">
                 <CheckCircle2 size={18} /> Company admin controls
               </h2>
@@ -1127,6 +1210,7 @@ export default function PropertyManagerCompanyManagementPage() {
                 </div>
                 <Button
                   type="button"
+                  className="pmc-primary-action"
                   disabled={
                     busy ||
                     !selectedCompanyId ||
@@ -1145,7 +1229,7 @@ export default function PropertyManagerCompanyManagementPage() {
             </Card>
 
             <div style={{ display: "grid", gap: spacing.md }}>
-              <Card style={{ display: "grid", gap: spacing.sm }}>
+              <Card className="pmc-surface" style={{ display: "grid", gap: spacing.sm }}>
                 <h2 className="pmc-section-title">Company relationships</h2>
                 {companyRelationships.length ? (
                   companyRelationships.map((relationship) => (
@@ -1164,7 +1248,7 @@ export default function PropertyManagerCompanyManagementPage() {
                 )}
               </Card>
 
-              <Card style={{ display: "grid", gap: spacing.sm }}>
+              <Card className="pmc-surface" style={{ display: "grid", gap: spacing.sm }}>
                 <h2 className="pmc-section-title">Staff assignments</h2>
                 {companyAssignments.length ? (
                   companyAssignments.map((assignment) => (

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -11,7 +11,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { Button, Card, Input } from "../components/ui/Ui";
-import { colors, radius, spacing, text } from "../styles/tokens";
+import { radius, spacing, text } from "../styles/tokens";
 
 type CalendarView = "month" | "week";
 
@@ -155,7 +155,7 @@ function WorkspaceList({
   actionLabel: string;
 }) {
   return (
-    <Card style={{ display: "grid", gap: spacing.md }}>
+    <Card className="scheduling-card" style={{ display: "grid", gap: spacing.md }}>
       <SectionHeader icon={icon} title={title} actionTo={actionTo} actionLabel={actionLabel} />
       <div className="scheduling-item-list">
         {items.map((item) => (
@@ -233,11 +233,52 @@ export default function SchedulingWorkspacePage() {
     <div className="scheduling-workspace">
       <style>{`
         .scheduling-workspace {
+          --schedule-card: #fffaf1;
+          --schedule-panel: #fff6e8;
+          --schedule-muted-panel: #f7efe2;
+          --schedule-border: rgba(91, 70, 48, 0.16);
+          --schedule-border-strong: rgba(91, 70, 48, 0.28);
+          --schedule-text: #211c17;
+          --schedule-muted: #63594d;
+          --schedule-pine: #245842;
+          --schedule-pine-soft: rgba(36, 88, 66, 0.12);
+          --schedule-shadow: 0 10px 24px rgba(59, 44, 28, 0.1);
           display: grid;
           gap: ${spacing.lg};
-          color: ${text.primary};
+          color: var(--schedule-text);
           max-width: 1320px;
           margin: 0 auto;
+        }
+        .scheduling-card {
+          background: var(--schedule-card) !important;
+          border-color: var(--schedule-border) !important;
+          box-shadow: var(--schedule-shadow) !important;
+        }
+        .scheduling-workspace input {
+          background: var(--schedule-card) !important;
+          border-color: var(--schedule-border) !important;
+          color: var(--schedule-text) !important;
+        }
+        .scheduling-workspace input:focus {
+          border-color: rgba(36, 88, 66, 0.42) !important;
+          box-shadow: 0 0 0 3px rgba(36, 88, 66, 0.18) !important;
+        }
+        .scheduling-workspace button:not(.scheduling-day) {
+          border: 1px solid var(--schedule-border) !important;
+          background: var(--schedule-card) !important;
+          color: var(--schedule-text) !important;
+          box-shadow: none !important;
+        }
+        .scheduling-workspace button:not(.scheduling-day):hover,
+        .scheduling-link-button:hover,
+        .scheduling-item-row:hover {
+          border-color: var(--schedule-border-strong) !important;
+          background: var(--schedule-panel) !important;
+        }
+        .scheduling-workspace button.scheduling-primary-action {
+          border-color: rgba(36, 88, 66, 0.42) !important;
+          background: var(--schedule-pine) !important;
+          color: #fffaf1 !important;
         }
         .scheduling-hero {
           display: flex;
@@ -253,7 +294,7 @@ export default function SchedulingWorkspacePage() {
         }
         .scheduling-hero p {
           margin: 6px 0 0;
-          color: ${text.muted};
+          color: var(--schedule-muted);
           line-height: 1.5;
         }
         .scheduling-layout {
@@ -284,24 +325,24 @@ export default function SchedulingWorkspacePage() {
         .scheduling-view-toggle {
           display: inline-flex;
           padding: 3px;
-          border: 1px solid ${colors.border};
+          border: 1px solid var(--schedule-border);
           border-radius: ${radius.pill};
-          background: #f8fafc;
+          background: var(--schedule-muted-panel);
         }
         .scheduling-view-toggle button,
         .scheduling-month-controls button {
           border: 0;
           border-radius: ${radius.pill};
           background: transparent;
-          color: ${text.secondary};
+          color: var(--schedule-muted);
           font-weight: 800;
           padding: 8px 11px;
           cursor: pointer;
         }
         .scheduling-view-toggle button.is-active {
-          background: ${colors.card};
-          color: ${colors.accent};
-          box-shadow: 0 1px 2px rgba(15,23,42,0.12);
+          background: var(--schedule-card) !important;
+          color: var(--schedule-pine) !important;
+          box-shadow: 0 1px 2px rgba(59,44,28,0.12) !important;
         }
         .scheduling-calendar-grid {
           display: grid;
@@ -309,17 +350,17 @@ export default function SchedulingWorkspacePage() {
           gap: 7px;
         }
         .scheduling-weekday {
-          color: ${text.subtle};
+          color: var(--schedule-muted);
           font-size: 0.78rem;
           font-weight: 800;
           text-align: center;
         }
         .scheduling-day {
           min-height: 70px;
-          border: 1px solid ${colors.border};
+          border: 1px solid var(--schedule-border);
           border-radius: ${radius.md};
-          background: #fff;
-          color: ${text.primary};
+          background: var(--schedule-card);
+          color: var(--schedule-text);
           cursor: pointer;
           display: grid;
           align-content: space-between;
@@ -327,12 +368,13 @@ export default function SchedulingWorkspacePage() {
           text-align: left;
         }
         .scheduling-day.is-muted {
-          color: ${text.subtle};
-          background: #f8fafc;
+          color: var(--schedule-muted);
+          background: var(--schedule-muted-panel);
         }
         .scheduling-day.is-selected {
-          border-color: ${colors.accent};
-          box-shadow: 0 0 0 3px rgba(37,99,235,0.16);
+          border-color: rgba(36, 88, 66, 0.42);
+          background: var(--schedule-pine-soft);
+          box-shadow: 0 0 0 3px rgba(36,88,66,0.16);
         }
         .scheduling-day strong {
           font-size: 0.9rem;
@@ -341,8 +383,8 @@ export default function SchedulingWorkspacePage() {
           justify-self: start;
           font-size: 0.72rem;
           font-weight: 800;
-          color: #166534;
-          background: rgba(34,197,94,0.12);
+          color: var(--schedule-pine);
+          background: var(--schedule-pine-soft);
           border-radius: ${radius.pill};
           padding: 3px 6px;
         }
@@ -361,12 +403,12 @@ export default function SchedulingWorkspacePage() {
           justify-content: center;
           min-height: 36px;
           padding: 8px 12px;
-          border: 1px solid ${colors.border};
+          border: 1px solid var(--schedule-border);
           border-radius: ${radius.pill};
-          color: ${text.primary};
+          color: var(--schedule-text);
           text-decoration: none;
           font-weight: 800;
-          background: #fff;
+          background: var(--schedule-card);
           white-space: nowrap;
         }
         .scheduling-item-list {
@@ -379,11 +421,11 @@ export default function SchedulingWorkspacePage() {
           justify-content: space-between;
           gap: ${spacing.sm};
           padding: 12px;
-          border: 1px solid ${colors.border};
+          border: 1px solid var(--schedule-border);
           border-radius: ${radius.md};
           text-decoration: none;
-          color: ${text.primary};
-          background: #f8fafc;
+          color: var(--schedule-text);
+          background: var(--schedule-muted-panel);
         }
         .scheduling-item-row span {
           display: grid;
@@ -391,13 +433,13 @@ export default function SchedulingWorkspacePage() {
           min-width: 0;
         }
         .scheduling-item-row small {
-          color: ${text.muted};
+          color: var(--schedule-muted);
           line-height: 1.35;
         }
         .scheduling-item-row em {
           font-style: normal;
           font-weight: 800;
-          color: ${colors.accent};
+          color: var(--schedule-pine);
           white-space: nowrap;
         }
         .scheduling-note-actions,
@@ -414,9 +456,9 @@ export default function SchedulingWorkspacePage() {
         }
         .scheduling-note-row {
           align-items: center;
-          border: 1px solid ${colors.border};
+          border: 1px solid var(--schedule-border);
           border-radius: ${radius.md};
-          background: #f8fafc;
+          background: var(--schedule-muted-panel);
           padding: ${spacing.sm};
         }
         .scheduling-note-row input {
@@ -424,7 +466,7 @@ export default function SchedulingWorkspacePage() {
           min-width: 0;
         }
         .scheduling-local-note {
-          color: ${text.subtle};
+          color: var(--schedule-muted);
           font-size: 0.82rem;
           line-height: 1.4;
         }
@@ -436,11 +478,11 @@ export default function SchedulingWorkspacePage() {
           gap: ${spacing.sm};
         }
         .scheduling-review-list li {
-          border: 1px solid ${colors.border};
+          border: 1px solid var(--schedule-border);
           border-radius: ${radius.md};
           padding: 11px 12px;
-          background: #f8fafc;
-          color: ${text.secondary};
+          background: var(--schedule-muted-panel);
+          color: var(--schedule-muted);
           line-height: 1.45;
         }
         @media (max-width: 980px) {
@@ -482,7 +524,7 @@ export default function SchedulingWorkspacePage() {
         }
       `}</style>
 
-      <Card elevated className="scheduling-hero">
+      <Card elevated className="scheduling-hero scheduling-card">
         <div>
           <h1>Scheduling</h1>
           <p>Calendar view for viewings, maintenance, work orders, screening, and notes.</p>
@@ -494,7 +536,7 @@ export default function SchedulingWorkspacePage() {
 
       <div className="scheduling-layout">
         <div className="scheduling-left">
-          <Card style={{ display: "grid", gap: spacing.md }}>
+          <Card className="scheduling-card" style={{ display: "grid", gap: spacing.md }}>
             <div className="scheduling-toolbar">
               <div className="scheduling-month-title">
                 <CalendarDays size={18} strokeWidth={2.2} aria-hidden="true" />
@@ -560,7 +602,7 @@ export default function SchedulingWorkspacePage() {
             </div>
           </Card>
 
-          <Card style={{ display: "grid", gap: spacing.md }}>
+          <Card className="scheduling-card" style={{ display: "grid", gap: spacing.md }}>
             <SectionHeader icon={FileText} title="Notes" />
             <div style={{ display: "grid", gap: spacing.sm }}>
               <strong>{formatDay(selectedDate)}</strong>
@@ -594,7 +636,7 @@ export default function SchedulingWorkspacePage() {
                 placeholder="Add another note for this day"
               />
               <div className="scheduling-note-actions">
-                <Button type="button" onClick={addNote} aria-label="Add note">
+                <Button type="button" className="scheduling-primary-action" onClick={addNote} aria-label="Add note">
                   <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
                     <Plus size={16} aria-hidden="true" />
                     Add note
@@ -638,7 +680,7 @@ export default function SchedulingWorkspacePage() {
             actionLabel="Open Screening"
           />
 
-          <Card style={{ display: "grid", gap: spacing.md }}>
+          <Card className="scheduling-card" style={{ display: "grid", gap: spacing.md }}>
             <SectionHeader icon={ListChecks} title="Screening Shortcuts" />
             <div className="scheduling-shortcuts">
               <Link to="/screening" className="scheduling-link-button">
@@ -650,7 +692,7 @@ export default function SchedulingWorkspacePage() {
             </div>
           </Card>
 
-          <Card style={{ display: "grid", gap: spacing.md }}>
+          <Card className="scheduling-card" style={{ display: "grid", gap: spacing.md }}>
             <SectionHeader icon={ListChecks} title="Scheduling Review" />
             <ul className="scheduling-review-list" aria-label="Read-only scheduling recommendations">
               {reviewItems.map((item) => (


### PR DESCRIPTION
## Summary
- warms the landlord account surfaces for delegated access and PM company management without touching shared UI primitives
- warms the scheduling workspace calendar, notes, shortcuts, and route cards with route-local styling
- hardens LandlordNav shell stacking so fixed workspace navigation stays above routed content after repeated navigation

## Mission audit
- /account/delegated-access and /account/property-manager-companies already use LandlordNav; the visible mismatch came from route-local inline/shared UI colors still using old white/blue token defaults.
- /scheduling already uses LandlordNav; the visible mismatch came from a route-local CSS block with white, blue-gray, and blue selected states.
- The nav overlap risk was shell stacking: route content had no explicit lower stacking layer under the fixed top nav/drawer. The fix isolates the landlord shell and assigns content below nav layers without changing offsets or routing.

## Scope notes
- Frontend-only.
- No backend, API, auth, routing, delegation logic, scheduling data, global token, or shared Ui.tsx changes.
- Tenant, contractor, admin, public/auth pages are not intentionally restyled.

## Validation
- npm run test -- LandlordNav passed: 24 tests.
- npm run test -- DelegatedAccess PropertyManagerCompany SchedulingWorkspace DashboardPage UnifiedInboxPage OperationalCommandCenterPage passed: 77 tests.
- npm run build passed.
- git diff --check passed.
- git diff --cached --check passed before commit.

## Manual QA required
Authenticated browser QA is still required before readiness:
- /account/delegated-access
- /account/property-manager-companies
- /scheduling
- /dashboard smoke
- /properties smoke
- /tenants smoke
- /leases smoke
- /landlord/unified-inbox smoke

Confirm nav does not overlap after repeated navigation, desktop 1440px and mobile/tablet if practical, no horizontal overflow, no console errors, status colors remain understandable, and /login, /, and /site/pricing do not mount .rc-landlord-shell.