### PR TITLE
polish: align landlord workflow pages with warm neutral theme

### DIFF
--- a/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
@@ -2,6 +2,18 @@ import React from "react";
 import type { LandlordActiveLease } from "@/api/leasesApi";
 import { composeLeaseSummaryLegalDocument } from "@/lib/legalDocumentComposition";
 
+const leaseDocumentTheme = {
+  card: "#fffaf1",
+  cardStrong: "#fff6e8",
+  border: "rgba(91, 70, 48, 0.18)",
+  borderStrong: "rgba(91, 70, 48, 0.3)",
+  charcoal: "#211c17",
+  muted: "#63594d",
+  subtle: "#7a6b5c",
+  pine: "#245842",
+  pineSoft: "rgba(36, 88, 66, 0.12)",
+} as const;
+
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
   return amount.toLocaleString(undefined, { style: "currency", currency: "CAD" });
@@ -51,14 +63,14 @@ function Section({
         display: "grid",
         gap: 10,
         padding: highlighted ? "18px 14px 14px" : "18px 0 0",
-        borderTop: highlighted ? "2px solid #2563eb" : "1px solid #e2e8f0",
-        borderRadius: highlighted ? 8 : 0,
-        background: highlighted ? "#eff6ff" : "transparent",
+        borderTop: highlighted ? `2px solid ${leaseDocumentTheme.pine}` : `1px solid ${leaseDocumentTheme.border}`,
+        borderRadius: highlighted ? 12 : 0,
+        background: highlighted ? leaseDocumentTheme.pineSoft : "transparent",
         scrollMarginTop: 96,
         transition: "background-color 160ms ease, border-color 160ms ease",
       }}
     >
-      <h2 id={titleId} style={{ margin: 0, fontSize: 16, letterSpacing: 0, color: "#0f172a" }}>{title}</h2>
+      <h2 id={titleId} style={{ margin: 0, fontSize: 16, letterSpacing: 0, color: leaseDocumentTheme.charcoal }}>{title}</h2>
       <div style={{ display: "grid", gap: 8 }}>{children}</div>
     </section>
   );
@@ -67,10 +79,10 @@ function Section({
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div style={{ display: "grid", gap: 3 }}>
-      <dt aria-label={label} style={{ fontSize: 12, fontWeight: 700, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
+      <dt aria-label={label} style={{ fontSize: 12, fontWeight: 700, color: leaseDocumentTheme.subtle, textTransform: "uppercase", letterSpacing: 0 }}>
         {label}
       </dt>
-      <dd style={{ margin: 0, color: "#0f172a" }}>{value}</dd>
+      <dd style={{ margin: 0, color: leaseDocumentTheme.charcoal }}>{value}</dd>
     </div>
   );
 }
@@ -103,21 +115,21 @@ export function LeaseDocumentView({
         maxWidth: 860,
         margin: "0 auto",
         padding: "clamp(18px, 5vw, 32px) clamp(14px, 5vw, 52px)",
-        border: "1px solid #dbe4ee",
-        borderRadius: 6,
-        background: "#fff",
-        boxShadow: "0 14px 32px rgba(15,23,42,0.08)",
+        border: `1px solid ${leaseDocumentTheme.border}`,
+        borderRadius: 18,
+        background: `linear-gradient(180deg, ${leaseDocumentTheme.cardStrong} 0%, ${leaseDocumentTheme.card} 100%)`,
+        boxShadow: "0 14px 32px rgba(59, 44, 28, 0.12)",
         display: "grid",
         gap: 22,
         overflowWrap: "anywhere",
       }}
     >
       <header style={{ display: "grid", gap: 8, textAlign: "center" }}>
-        <div style={{ fontSize: 12, fontWeight: 800, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
+        <div style={{ fontSize: 12, fontWeight: 800, color: leaseDocumentTheme.subtle, textTransform: "uppercase", letterSpacing: 0 }}>
           {documentDefinition.eyebrow}
         </div>
-        <h1 id={titleId} style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{documentDefinition.title}</h1>
-        <div id={descriptionId} style={{ color: "#475569" }}>
+        <h1 id={titleId} style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: leaseDocumentTheme.charcoal }}>{documentDefinition.title}</h1>
+        <div id={descriptionId} style={{ color: leaseDocumentTheme.muted }}>
           {documentDefinition.description}
         </div>
       </header>
@@ -137,7 +149,7 @@ export function LeaseDocumentView({
               ))}
             </dl>
           ) : null}
-          {section.note ? <div style={{ color: "#475569", lineHeight: 1.6 }}>{section.note}</div> : null}
+          {section.note ? <div style={{ color: leaseDocumentTheme.muted, lineHeight: 1.6 }}>{section.note}</div> : null}
         </Section>
       ))}
     </article>

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -121,6 +121,10 @@ describe("LandlordLeaseSummaryPage", () => {
 
     expect(await screen.findByText("Lease summary")).toBeInTheDocument();
     expect(screen.getAllByTestId("lease-document-view").length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId("lease-document-view")[0]).toHaveStyle({
+      background: "linear-gradient(180deg, #fff6e8 0%, #fffaf1 100%)",
+      borderRadius: "18px",
+    });
     expect(screen.getAllByRole("article", { name: "Residential Lease Pack" }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("term", { name: "Property" }).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Residential Lease Pack").length).toBeGreaterThan(0);
@@ -158,6 +162,9 @@ describe("LandlordLeaseSummaryPage", () => {
     );
 
     expect(await screen.findByText("Lease summary")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.getElementById("lease-section-rent-payment")).toBeTruthy();
+    });
     const target = document.getElementById("lease-section-rent-payment");
 
     expect(screen.getByRole("status")).toHaveTextContent("Rent and Payment workflow focus");
@@ -169,7 +176,8 @@ describe("LandlordLeaseSummaryPage", () => {
       expect(focus).toHaveBeenCalledWith({ preventScroll: true });
       expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
     });
-    expect(target).toHaveStyle({ background: "#eff6ff" });
+    expect(target).toHaveStyle({ background: "rgba(36, 88, 66, 0.12)" });
+    expect(target).toHaveStyle({ borderTop: "2px solid #245842" });
   });
 
   it("renders a non-empty printable lease summary source for browser print preview", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -7,6 +7,15 @@ import { triggerDocumentDownload } from "@/lib/documentRendering";
 import { downloadLeaseSummaryPdf } from "@/utils/leaseSummaryPdf";
 import { printSummaryDocument } from "@/utils/printSummary";
 
+const leaseSummaryTheme = {
+  card: "#fffaf1",
+  borderStrong: "rgba(91, 70, 48, 0.3)",
+  charcoal: "#211c17",
+  muted: "#63594d",
+  pine: "#245842",
+  pineSoft: "rgba(36, 88, 66, 0.12)",
+} as const;
+
 function errorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) return error.message;
   return fallback;
@@ -134,8 +143,8 @@ export default function LandlordLeaseSummaryPage() {
   return (
     <div style={{ display: "grid", gap: 16 }}>
       <div style={{ display: "grid", gap: 6 }}>
-        <div style={{ fontSize: 24, fontWeight: 800 }}>Lease summary</div>
-        <div style={{ color: "#475569", fontSize: 14 }}>
+        <div style={{ fontSize: 24, fontWeight: 800, color: leaseSummaryTheme.charcoal }}>Lease summary</div>
+        <div style={{ color: leaseSummaryTheme.muted, fontSize: 14 }}>
           Review the current landlord-visible lease details when a separate lease document is not attached.
         </div>
       </div>
@@ -143,7 +152,7 @@ export default function LandlordLeaseSummaryPage() {
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
         <Link
           to={ledgerPath}
-          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+          style={leaseSummaryActionStyle}
         >
           Open payment ledger
         </Link>
@@ -151,7 +160,7 @@ export default function LandlordLeaseSummaryPage() {
             type="button"
             onClick={() => void handlePrintOrSavePdf()}
           disabled={!lease}
-          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+          style={leaseSummaryActionStyle}
         >
           Print / Save PDF
         </button>
@@ -159,19 +168,19 @@ export default function LandlordLeaseSummaryPage() {
           type="button"
           onClick={() => void handleDownloadEvidencePackage()}
           disabled={!lease}
-          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+          style={leaseSummaryActionStyle}
         >
           Download evidence package
         </button>
         <Link
           to="/leases"
-          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+          style={leaseSummaryActionStyle}
         >
           Back to leases
         </Link>
         <Link
           to="/operations"
-          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+          style={leaseSummaryActionStyle}
         >
           Open operations
         </Link>
@@ -185,17 +194,18 @@ export default function LandlordLeaseSummaryPage() {
           role="status"
           aria-live="polite"
           style={{
-            border: "1px solid #bfdbfe",
+            border: `1px solid ${leaseSummaryTheme.borderStrong}`,
             borderRadius: 10,
-            background: "#eff6ff",
-            color: "#1e3a8a",
+            background: leaseSummaryTheme.pineSoft,
+            color: leaseSummaryTheme.pine,
             padding: "10px 12px",
             display: "grid",
             gap: 3,
+            boxShadow: "0 8px 18px rgba(59, 44, 28, 0.07)",
           }}
         >
           <div style={{ fontWeight: 800 }}>{workflowFocus.title}</div>
-          <div style={{ fontSize: 13, color: "#334155" }}>{workflowFocus.description}</div>
+          <div style={{ fontSize: 13, color: leaseSummaryTheme.muted }}>{workflowFocus.description}</div>
         </div>
       ) : null}
 
@@ -210,3 +220,13 @@ export default function LandlordLeaseSummaryPage() {
     </div>
   );
 }
+
+const leaseSummaryActionStyle: React.CSSProperties = {
+  padding: "8px 10px",
+  borderRadius: 10,
+  border: `1px solid ${leaseSummaryTheme.borderStrong}`,
+  background: leaseSummaryTheme.card,
+  color: leaseSummaryTheme.pine,
+  textDecoration: "none",
+  fontWeight: 700,
+};

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -146,8 +146,8 @@ describe("LandlordLeaseWorkflowPage", () => {
       boxSizing: "border-box",
     });
     expect(screen.getByLabelText("Workflow overview")).toHaveStyle({
-      background: "#f8fafc",
-      borderRadius: "8px",
+      background: "#fff6e8",
+      borderRadius: "14px",
     });
   });
 

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -17,6 +17,18 @@ type WorkflowConfig = {
   }>;
 };
 
+const workflowTheme = {
+  paper: "#f7f1e7",
+  card: "#fffaf1",
+  cardStrong: "#fff6e8",
+  border: "rgba(91, 70, 48, 0.18)",
+  borderStrong: "rgba(91, 70, 48, 0.3)",
+  charcoal: "#211c17",
+  muted: "#63594d",
+  subtle: "#7a6b5c",
+  pine: "#245842",
+} as const;
+
 const WORKFLOWS: Record<WorkflowKey, WorkflowConfig> = {
   execution: {
     key: "execution",
@@ -249,11 +261,11 @@ export default function LandlordLeaseWorkflowPage() {
     <div data-testid="lease-workflow-page" style={workflowPageStyle}>
       <section style={workflowOverviewStyle} aria-label="Workflow overview">
         <div style={{ display: "grid", gap: 6 }}>
-          <div style={{ fontSize: 12, color: "#2563eb", fontWeight: 800, textTransform: "uppercase", letterSpacing: 0 }}>
+          <div style={{ fontSize: 12, color: workflowTheme.pine, fontWeight: 800, textTransform: "uppercase", letterSpacing: 0 }}>
             {workflow.eyebrow}
           </div>
-          <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{workflow.title}</h1>
-          <div style={{ color: "#475569", lineHeight: 1.6 }}>{workflow.purpose}</div>
+          <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: workflowTheme.charcoal }}>{workflow.title}</h1>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>{workflow.purpose}</div>
         </div>
 
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
@@ -280,7 +292,7 @@ export default function LandlordLeaseWorkflowPage() {
               {workflow.facts.map((fact) => (
                 <div key={fact.label} style={{ display: "grid", gap: 4 }}>
                   <dt style={termStyle}>{fact.label}</dt>
-                  <dd style={{ margin: 0, color: "#0f172a" }}>{fact.value(lease)}</dd>
+                  <dd style={{ margin: 0, color: workflowTheme.charcoal }}>{fact.value(lease)}</dd>
                 </div>
               ))}
             </dl>
@@ -288,7 +300,7 @@ export default function LandlordLeaseWorkflowPage() {
 
           <section style={panelStyle} aria-label="Workflow review checklist">
             <h2 style={sectionHeadingStyle}>Review before action</h2>
-            <ul style={{ margin: 0, paddingLeft: 20, display: "grid", gap: 8, color: "#334155", lineHeight: 1.55 }}>
+            <ul style={{ margin: 0, paddingLeft: 20, display: "grid", gap: 8, color: workflowTheme.muted, lineHeight: 1.55 }}>
               {workflow.reviewItems.map((item) => (
                 <li key={item}>{item}</li>
               ))}
@@ -298,7 +310,7 @@ export default function LandlordLeaseWorkflowPage() {
           {workflow.key === "renewal" ? (
             <section style={panelStyle} aria-label="Renewal operator inputs">
               <h2 style={sectionHeadingStyle}>Renewal operator inputs</h2>
-              <div style={{ color: "#334155", lineHeight: 1.6 }}>
+              <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
                 Use the portfolio renewal workbench to review unit-specific renewal inputs such as proposed rent,
                 term dates, response deadline, and renewal recommendation before preparing tenant-facing notices.
               </div>
@@ -310,10 +322,10 @@ export default function LandlordLeaseWorkflowPage() {
 
           <section style={panelStyle} aria-label="Jurisdiction context">
             <h2 style={sectionHeadingStyle}>Jurisdiction context</h2>
-            <div style={{ color: "#334155", lineHeight: 1.6 }}>
+            <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
               {policy ? policy.recommendation : "No specific jurisdiction policy is available for this workflow yet."}
             </div>
-            <div style={{ marginTop: 10, color: "#475569", lineHeight: 1.6 }}>
+            <div style={{ marginTop: 10, color: workflowTheme.subtle, lineHeight: 1.6 }}>
               Workflow guidance is operational only. Verify current provincial requirements and official forms before acting.
               RentChain does not provide legal advice or guarantee enforceability.
             </div>
@@ -327,44 +339,51 @@ export default function LandlordLeaseWorkflowPage() {
 const buttonLinkStyle: React.CSSProperties = {
   padding: "8px 10px",
   borderRadius: 8,
-  border: "1px solid #cbd5e1",
+  border: `1px solid ${workflowTheme.borderStrong}`,
   textDecoration: "none",
-  color: "#0f172a",
-  background: "#fff",
+  color: workflowTheme.pine,
+  background: workflowTheme.card,
   fontWeight: 700,
+  boxShadow: "0 6px 16px rgba(59, 44, 28, 0.08)",
 };
 
 const workflowPageStyle: React.CSSProperties = {
   width: "100%",
   maxWidth: 1040,
   margin: "0 auto",
-  padding: "0 16px 24px",
+  padding: "16px",
   boxSizing: "border-box",
   display: "grid",
   gap: 16,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 20,
+  background: `radial-gradient(circle at top left, rgba(184, 130, 62, 0.14) 0, rgba(247, 241, 231, 0) 34%), linear-gradient(180deg, ${workflowTheme.card} 0%, ${workflowTheme.paper} 100%)`,
+  boxShadow: "0 16px 36px rgba(59, 44, 28, 0.12)",
 };
 
 const workflowOverviewStyle: React.CSSProperties = {
-  border: "1px solid #dbe4ee",
-  borderRadius: 8,
-  background: "#f8fafc",
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 14,
+  background: workflowTheme.cardStrong,
   padding: 18,
   display: "grid",
   gap: 14,
+  boxShadow: "0 10px 24px rgba(59, 44, 28, 0.08)",
 };
 
 const panelStyle: React.CSSProperties = {
-  border: "1px solid #dbe4ee",
-  borderRadius: 8,
-  background: "#fff",
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 14,
+  background: workflowTheme.card,
   padding: 16,
   display: "grid",
   gap: 12,
+  boxShadow: "0 8px 18px rgba(59, 44, 28, 0.07)",
 };
 
 const sectionHeadingStyle: React.CSSProperties = {
   margin: 0,
-  color: "#0f172a",
+  color: workflowTheme.charcoal,
   fontSize: 18,
   letterSpacing: 0,
 };
@@ -372,7 +391,7 @@ const sectionHeadingStyle: React.CSSProperties = {
 const termStyle: React.CSSProperties = {
   fontSize: 12,
   fontWeight: 800,
-  color: "#64748b",
+  color: workflowTheme.subtle,
   textTransform: "uppercase",
   letterSpacing: 0,
 };

--- a/rentchain-frontend/src/pages/PropertiesPage.css
+++ b/rentchain-frontend/src/pages/PropertiesPage.css
@@ -115,6 +115,31 @@
   color: #211c17 !important;
 }
 
+.rc-properties-page .rc-action-request-filter-button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 4px 10px !important;
+  border-radius: 999px !important;
+  font-size: 12px !important;
+  font-weight: 700 !important;
+  line-height: 1 !important;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.rc-properties-page .rc-action-request-filter-button:focus-visible {
+  outline: 3px solid rgba(184, 130, 62, 0.35);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(36, 88, 66, 0.14) !important;
+}
+
 .rc-properties-page .rc-properties-action-button,
 .rc-properties-page button,
 .rc-properties-page a[role="button"] {

--- a/rentchain-frontend/src/pages/PropertiesPage.css
+++ b/rentchain-frontend/src/pages/PropertiesPage.css
@@ -100,6 +100,21 @@
   border-radius: 14px;
 }
 
+.rc-properties-page .rc-action-request-filter-button[data-active="true"],
+.rc-properties-page .rc-action-request-filter-button[data-active="true"]:not(:disabled):hover {
+  background: #245842 !important;
+  border-color: #245842 !important;
+  color: #fff !important;
+  box-shadow: 0 6px 16px rgba(36, 88, 66, 0.18) !important;
+}
+
+.rc-properties-page .rc-action-request-filter-button[data-active="false"],
+.rc-properties-page .rc-action-request-filter-button[data-active="false"]:not(:disabled):hover {
+  background: #fffaf1 !important;
+  border-color: rgba(91, 70, 48, 0.3) !important;
+  color: #211c17 !important;
+}
+
 .rc-properties-page .rc-properties-action-button,
 .rc-properties-page button,
 .rc-properties-page a[role="button"] {

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -239,13 +239,25 @@ describe("PropertiesPage", () => {
     expect(filterButtons).toHaveLength(4);
     expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("data-active", "true");
     expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "All" })).toHaveStyle({
+      background: "#245842",
+      color: "#fff",
+    });
     expect(screen.getByRole("button", { name: "New" })).toHaveAttribute("data-active", "false");
     expect(screen.getByRole("button", { name: "New" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "New" })).toHaveStyle({
+      background: "#fffaf1",
+      color: "#211c17",
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Resolved" }));
 
     expect(screen.getByRole("button", { name: "Resolved" })).toHaveAttribute("data-active", "true");
     expect(screen.getByRole("button", { name: "Resolved" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Resolved" })).toHaveStyle({
+      background: "#245842",
+      color: "#fff",
+    });
     expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("data-active", "false");
   });
 

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -238,11 +238,14 @@ describe("PropertiesPage", () => {
     const filterButtons = Array.from(document.querySelectorAll(".rc-action-request-filter-button"));
     expect(filterButtons).toHaveLength(4);
     expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("data-active", "true");
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "New" })).toHaveAttribute("data-active", "false");
+    expect(screen.getByRole("button", { name: "New" })).toHaveAttribute("aria-pressed", "false");
 
     fireEvent.click(screen.getByRole("button", { name: "Resolved" }));
 
     expect(screen.getByRole("button", { name: "Resolved" })).toHaveAttribute("data-active", "true");
+    expect(screen.getByRole("button", { name: "Resolved" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("data-active", "false");
   });
 

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -226,6 +226,26 @@ describe("PropertiesPage", () => {
     expect(screen.getAllByRole("button", { name: "Upgrade to Starter" }).length).toBeGreaterThan(0);
   });
 
+  it("renders action request filters with route-local warm active states", async () => {
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Free tier property workflow")).toBeInTheDocument();
+
+    const filterButtons = Array.from(document.querySelectorAll(".rc-action-request-filter-button"));
+    expect(filterButtons).toHaveLength(4);
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("data-active", "true");
+    expect(screen.getByRole("button", { name: "New" })).toHaveAttribute("data-active", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Resolved" }));
+
+    expect(screen.getByRole("button", { name: "Resolved" })).toHaveAttribute("data-active", "true");
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("data-active", "false");
+  });
+
   it("shows a print action when a property is selected", async () => {
     render(
       <MemoryRouter>

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -56,6 +56,27 @@ const landlordWorkspaceTheme = {
   warmPanel: "#fbf6ed",
 };
 
+function actionRequestFilterButtonStyle(active: boolean): React.CSSProperties {
+  return {
+    appearance: "none",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 30,
+    padding: "4px 10px",
+    borderRadius: 999,
+    fontSize: 12,
+    fontWeight: 700,
+    lineHeight: 1,
+    cursor: "pointer",
+    background: active ? landlordWorkspaceTheme.pine : landlordWorkspaceTheme.card,
+    color: active ? "#fff" : landlordWorkspaceTheme.charcoal,
+    border: `1px solid ${active ? landlordWorkspaceTheme.pine : landlordWorkspaceTheme.borderStrong}`,
+    boxShadow: active ? "0 6px 16px rgba(36, 88, 66, 0.18)" : "none",
+    transition: "background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease",
+  };
+}
+
 function isPersistedUnitIdValue(value: any) {
   const id = String(value || "").trim();
   return Boolean(id) && !/^placeholder-/i.test(id);
@@ -1293,6 +1314,7 @@ const PropertiesPage: React.FC = () => {
                     className="rc-action-request-filter-button"
                     aria-pressed={actionFilter === status}
                     data-active={actionFilter === status ? "true" : "false"}
+                    style={actionRequestFilterButtonStyle(actionFilter === status)}
                     onClick={() =>
                       setActionFilter(
                         status as ActionRequestStatus | "all"

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -1287,29 +1287,22 @@ const PropertiesPage: React.FC = () => {
               <div style={{ fontWeight: 600 }}>Action Requests</div>
               <div className="rc-action-requests-filters" style={{ display: "flex", gap: 8 }}>
                 {["all", "new", "acknowledged", "resolved"].map((status) => (
-                  <Button
+                  <button
+                    type="button"
                     key={status}
                     className="rc-action-request-filter-button"
+                    aria-pressed={actionFilter === status}
                     data-active={actionFilter === status ? "true" : "false"}
-                    variant="ghost"
                     onClick={() =>
                       setActionFilter(
                         status as ActionRequestStatus | "all"
                       )
                     }
-                    style={{
-                      padding: "4px 10px",
-                      fontSize: 12,
-                      background: actionFilter === status ? landlordWorkspaceTheme.pine : landlordWorkspaceTheme.card,
-                      color: actionFilter === status ? "#fff" : landlordWorkspaceTheme.charcoal,
-                      border: `1px solid ${actionFilter === status ? landlordWorkspaceTheme.pine : landlordWorkspaceTheme.borderStrong}`,
-                      boxShadow: actionFilter === status ? "0 6px 16px rgba(36, 88, 66, 0.18)" : "none",
-                    }}
                   >
                     {status === "all"
                       ? "All"
                       : status.charAt(0).toUpperCase() + status.slice(1)}
-                  </Button>
+                  </button>
                 ))}
               </div>
             </div>

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -1289,13 +1289,22 @@ const PropertiesPage: React.FC = () => {
                 {["all", "new", "acknowledged", "resolved"].map((status) => (
                   <Button
                     key={status}
-                    variant={actionFilter === status ? "primary" : "ghost"}
+                    className="rc-action-request-filter-button"
+                    data-active={actionFilter === status ? "true" : "false"}
+                    variant="ghost"
                     onClick={() =>
                       setActionFilter(
                         status as ActionRequestStatus | "all"
                       )
                     }
-                    style={{ padding: "4px 10px", fontSize: 12 }}
+                    style={{
+                      padding: "4px 10px",
+                      fontSize: 12,
+                      background: actionFilter === status ? landlordWorkspaceTheme.pine : landlordWorkspaceTheme.card,
+                      color: actionFilter === status ? "#fff" : landlordWorkspaceTheme.charcoal,
+                      border: `1px solid ${actionFilter === status ? landlordWorkspaceTheme.pine : landlordWorkspaceTheme.borderStrong}`,
+                      boxShadow: actionFilter === status ? "0 6px 16px rgba(36, 88, 66, 0.18)" : "none",
+                    }}
                   >
                     {status === "all"
                       ? "All"


### PR DESCRIPTION
## Summary
- Aligns the remaining scoped landlord workflow surfaces with the warm neutral landlord foundation.
- Updates `/properties` action-request filter buttons to use warm inactive states and pine active states instead of the shared bright primary treatment.
- Warms lease workflow guidance pages and related lease-summary workflow focus/actions without changing workflow logic, routing, API calls, PDF/export behavior, or lease data.

## Mission Audit
- `/properties` action request filters are rendered inline in `rentchain-frontend/src/pages/PropertiesPage.tsx` and styled by `PropertiesPage.css`.
- Lease workflow pages are rendered by `LandlordLeaseWorkflowPage` at `/leases/:leaseId/workflows/:workflowKey`.
- Supported workflow keys in that page include `execution`, `renewal`, `rent-increase`, `notice`, `deposit`, and `move-out`.
- `/leases/:leaseId` is not an app route; lease summary is `/leases/:leaseId/summary` and is rendered by `LandlordLeaseSummaryPage`.
- The prompt's `/workflows/renewal/leases/:leaseId/workflows/rent-increase` path is not registered in `App.tsx`; the actual rent increase route is `/leases/:leaseId/workflows/rent-increase`.
- Fixes were made route-locally. No global tokens or shared `Ui.tsx` primitives were changed.

## Implementation
- `/properties`: action request filters now always use `variant="ghost"` with route-local active/inactive styling and data-state attributes for test coverage.
- `LandlordLeaseWorkflowPage`: replaced old blue/white panels, links, headings, and cards with local warm theme constants.
- `LandlordLeaseSummaryPage`: warmed the workflow-focus handoff banner and action buttons used by the lease-summary workflow path.
- Tests now assert the warm action-request filter state and lease workflow overview styling.

## Preserved Behavior
- No backend/API/auth/routing/data-fetching changes.
- No lease execution/signing, renewal, rent-increase, notice, deposit, payment/import, or PDF/export behavior changes.
- No tenant/contractor/admin styling changes.
- No global token migration or broad shared UI changes.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- PropertiesPage` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- LandlordLeaseSummaryPage` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- LandlordLeaseWorkflowPage` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- Lease` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- DashboardPage` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- LandlordNav` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Manual QA Required
Authenticated browser QA still needs to be completed in preview/live with a landlord/admin session:
- `/properties`
- `/leases/:leaseId/summary`
- `/leases/:leaseId/workflows/execution`
- `/leases/:leaseId/workflows/renewal`
- `/leases/:leaseId/workflows/rent-increase`
- `/leases/:leaseId/workflows/notice`
- `/leases/:leaseId/workflows/deposit`
- `/dashboard` smoke
- `/tenants` smoke
- `/leases` smoke

QA checks:
- `/properties` action request filter buttons are warm neutral/pine, not bright blue.
- Lease workflow pages no longer show old blue button/panel/pill theme in the scoped guidance surfaces.
- Workflow statuses remain understandable.
- Workflow buttons still work or route correctly.
- No console errors or horizontal overflow.
- No workflow/data/routing behavior changed.
- `/login`, `/`, and `/site/pricing` do not mount `.rc-landlord-shell`.

## Deferred
- `/account`, `/account/profile`, `/billing`, `/billing#receipts`, `/privacy`, `/terms`, and `/site/legal` remain out of scope for separate follow-up PRs.