### PR TITLE
polish: align account and billing pages with warm neutral theme

### DIFF
--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
@@ -35,6 +35,8 @@ describe("BillingPlansPanel", () => {
 
     expect(screen.getByText("Current")).toBeInTheDocument();
     expect(screen.getByText("Selected from pricing")).toBeInTheDocument();
+    expect(document.querySelector('.rc-billing-plan-card[data-selected="true"]')).toBeInTheDocument();
+    expect(document.querySelector('.rc-billing-plan-card[data-highlight="true"]')).toBeInTheDocument();
     expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
       screen.getByText(
@@ -67,6 +69,7 @@ describe("BillingPlansPanel", () => {
     );
 
     expect(screen.getByText("Recommended next step")).toBeInTheDocument();
+    expect(document.querySelector('.rc-billing-plan-card[data-recommended="true"]')).toBeInTheDocument();
     expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
       screen.getByText(

--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "../ui/Ui";
-import { colors, radius, text } from "../../styles/tokens";
+import { radius, text } from "../../styles/tokens";
 import { PlanIntervalToggle } from "./PlanIntervalToggle";
 import { getVisiblePlans, type PlanKey } from "@/billing/planVisibility";
 import { normalizePlan } from "@/lib/plan";
@@ -10,6 +10,7 @@ import {
   TIER_MATRIX_AREAS,
   type PricingPlanKey,
 } from "@/constants/pricingPlans";
+import "@/pages/account/accountBillingTheme.css";
 
 type Props = {
   pricing: any | null;
@@ -99,7 +100,7 @@ export function BillingPlansPanel({
   };
 
   return (
-    <div style={{ display: "grid", gap: 10 }}>
+    <div className="rc-billing-plans-panel" style={{ display: "grid", gap: 10 }}>
       <PlanIntervalToggle value={interval} onChange={onIntervalChange} />
 
       {visiblePlans.map((planId) => {
@@ -114,26 +115,30 @@ export function BillingPlansPanel({
         return (
           <div
             key={planId}
+            className="rc-billing-plan-card"
+            data-highlight={highlight ? "true" : "false"}
+            data-selected={selected ? "true" : "false"}
+            data-recommended={recommended ? "true" : "false"}
             style={{
               borderRadius: radius.lg,
               border: highlight
-                ? "1px solid rgba(59,130,246,0.45)"
+                ? "1px solid rgba(36,88,66,0.34)"
                 : selected
-                  ? "1px solid rgba(37,99,235,0.45)"
+                  ? "1px solid rgba(36,88,66,0.34)"
                   : recommended
-                    ? "1px solid rgba(14,116,144,0.42)"
-                  : "1px solid rgba(148,163,184,0.25)",
+                    ? "1px solid rgba(36,88,66,0.32)"
+                  : "1px solid rgba(91,70,48,0.18)",
               background: highlight
-                ? "rgba(59,130,246,0.08)"
+                ? "rgba(36,88,66,0.1)"
                 : selected
-                  ? "rgba(37,99,235,0.08)"
+                  ? "rgba(36,88,66,0.1)"
                   : recommended
-                    ? "rgba(14,116,144,0.08)"
-                  : "rgba(148,163,184,0.06)",
+                    ? "rgba(36,88,66,0.08)"
+                  : "rgba(91,70,48,0.06)",
               padding: 12,
               display: "grid",
               gap: 12,
-              boxShadow: recommended ? "0 14px 28px rgba(14,116,144,0.10)" : "none",
+              boxShadow: recommended ? "0 14px 28px rgba(36,88,66,0.1)" : "none",
             }}
           >
             <div
@@ -154,11 +159,11 @@ export function BillingPlansPanel({
                 </div>
               </div>
               {highlight ? (
-                <span style={{ fontSize: 12, fontWeight: 700, color: colors.accent }}>Current</span>
+                <span className="rc-account-status-pill" style={{ fontSize: 12, fontWeight: 700, color: "#245842", padding: "4px 10px" }}>Current</span>
               ) : selected ? (
-                <span style={{ fontSize: 12, fontWeight: 700, color: "#1d4ed8" }}>Selected from pricing</span>
+                <span className="rc-account-status-pill" style={{ fontSize: 12, fontWeight: 700, color: "#245842", padding: "4px 10px" }}>Selected from pricing</span>
               ) : recommended ? (
-                <span style={{ fontSize: 12, fontWeight: 700, color: "#0f766e" }}>Recommended next step</span>
+                <span className="rc-account-status-pill" style={{ fontSize: 12, fontWeight: 700, color: "#245842", padding: "4px 10px" }}>Recommended next step</span>
               ) : null}
             </div>
 
@@ -189,11 +194,12 @@ export function BillingPlansPanel({
               {topAreas.map((area) => (
                 <div
                   key={`${planId}-${area.key}`}
+                  className="rc-billing-plan-capability"
                   style={{
-                    border: "1px solid rgba(148,163,184,0.2)",
+                    border: "1px solid rgba(91,70,48,0.18)",
                     borderRadius: 12,
                     padding: "8px 10px",
-                    background: "rgba(255,255,255,0.5)",
+                    background: "rgba(255,250,241,0.72)",
                   }}
                 >
                   <div style={{ fontSize: 12, fontWeight: 700, color: text.secondary }}>{area.label}</div>
@@ -206,6 +212,7 @@ export function BillingPlansPanel({
 
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <Button
+                className={highlight ? "rc-account-secondary-action" : undefined}
                 type="button"
                 variant={highlight ? "secondary" : "primary"}
                 onClick={() => {

--- a/rentchain-frontend/src/pages/AccountPage.test.tsx
+++ b/rentchain-frontend/src/pages/AccountPage.test.tsx
@@ -74,5 +74,7 @@ describe("AccountPage", () => {
     expect(screen.getByRole("button", { name: "Manage delegates" })).toBeInTheDocument();
     expect(screen.getByText("PM Company Management")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Manage PM companies" })).toBeInTheDocument();
+    expect(document.querySelector(".rc-account-page")).toHaveClass("rc-account-billing-surface");
+    expect(screen.getByRole("button", { name: "Profile" })).toHaveClass("rc-account-secondary-action");
   });
 });

--- a/rentchain-frontend/src/pages/AccountPage.tsx
+++ b/rentchain-frontend/src/pages/AccountPage.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "../context/useAuth";
 import { useBillingStatus, billingTierLabel } from "@/hooks/useBillingStatus";
 import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import { useAccountSummary } from "./account/useAccountSummary";
+import "./account/accountBillingTheme.css";
 
 type HubCardProps = {
   title: string;
@@ -15,7 +16,7 @@ type HubCardProps = {
 
 function HubCard({ title, description, children }: HubCardProps) {
   return (
-    <Card style={{ display: "grid", gap: spacing.sm, border: `1px solid ${colors.border}` }}>
+    <Card className="rc-account-billing-card" style={{ display: "grid", gap: spacing.sm, border: `1px solid ${colors.border}` }}>
       <div style={{ fontWeight: 800, fontSize: "1rem" }}>{title}</div>
       <div style={{ color: text.muted, fontSize: "0.9rem" }}>{description}</div>
       <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>{children}</div>
@@ -36,8 +37,8 @@ const AccountPage: React.FC = () => {
     typeof amountCents === "number" ? `${(amountCents / 100).toFixed(2)} CAD` : "Unavailable";
 
   return (
-    <Section style={{ maxWidth: 1080, margin: "0 auto", display: "grid", gap: spacing.md }}>
-      <Card elevated>
+    <Section className="rc-account-billing-surface rc-account-page" style={{ maxWidth: 1080, margin: "0 auto", display: "grid", gap: spacing.md }}>
+      <Card elevated className="rc-account-billing-card rc-account-billing-card--strong">
         <div style={{ display: "grid", gap: 6 }}>
           <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 800 }}>My Account</h1>
           <p style={{ margin: 0, color: text.muted }}>
@@ -49,7 +50,7 @@ const AccountPage: React.FC = () => {
         </div>
       </Card>
 
-      <Card style={{ display: "grid", gap: spacing.sm, border: `1px solid ${colors.border}` }}>
+      <Card className="rc-account-billing-card" style={{ display: "grid", gap: spacing.sm, border: `1px solid ${colors.border}` }}>
         <div style={{ fontWeight: 800, fontSize: "1rem" }}>Account Summary</div>
         {summaryLoading ? (
           <div style={{ display: "grid", gap: 6, color: text.muted, fontSize: 13 }}>
@@ -95,7 +96,7 @@ const AccountPage: React.FC = () => {
         {summaryError ? (
           <div style={{ display: "flex", alignItems: "center", gap: spacing.sm, color: text.muted, fontSize: 13 }}>
             <span>{summaryError}</span>
-            <Button type="button" variant="secondary" onClick={() => navigate("/billing")}>
+            <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/billing")}>
               Go to Billing
             </Button>
           </div>
@@ -110,13 +111,13 @@ const AccountPage: React.FC = () => {
         }}
       >
         <HubCard title="Personal" description="Profile and notification preferences.">
-          <Button type="button" variant="secondary" onClick={() => navigate("/account/profile")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/account/profile")}>
             Profile
           </Button>
         </HubCard>
 
         <HubCard title="Security" description="Additional sign-in security controls will appear here when they are ready for landlord use.">
-          <Button type="button" variant="secondary" disabled>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" disabled>
             Security controls coming soon
           </Button>
         </HubCard>
@@ -137,11 +138,12 @@ const AccountPage: React.FC = () => {
           <Button type="button" onClick={() => navigate("/billing")}>
             Billing
           </Button>
-          <Button type="button" variant="secondary" onClick={() => navigate("/site/pricing")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/site/pricing")}>
             Pricing & plans
           </Button>
           <Button
             type="button"
+            className="rc-account-secondary-action"
             variant="secondary"
             onClick={() => {
               void openUpgradeFlow({ navigate, fallbackPath: "/pricing" });
@@ -158,16 +160,16 @@ const AccountPage: React.FC = () => {
         </HubCard>
 
         <HubCard title="Data management" description="Export your data and manage retention (coming soon).">
-          <Button type="button" variant="secondary" onClick={() => navigate("/account/data")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/account/data")}>
             Manage data
           </Button>
         </HubCard>
 
         <HubCard title="Legal" description="Privacy, Terms, and compliance documents.">
-          <Button type="button" variant="secondary" onClick={() => navigate("/privacy")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/privacy")}>
             Privacy
           </Button>
-          <Button type="button" variant="secondary" onClick={() => navigate("/terms")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/terms")}>
             Terms
           </Button>
         </HubCard>

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -95,6 +95,7 @@ describe("BillingPage", () => {
     );
 
     expect(screen.getAllByText("Loading...").length).toBeGreaterThan(0);
+    expect(document.querySelector(".rc-billing-page")).toHaveClass("rc-account-billing-surface");
     expect(screen.getByTestId("billing-plans-panel")).toHaveTextContent("none");
     expect(screen.getAllByRole("button", { name: "Continue to Starter checkout" })).toHaveLength(2);
     expect(
@@ -121,6 +122,7 @@ describe("BillingPage", () => {
     await waitFor(() =>
       expect(screen.getByText(/Pricing selection saved: Pro on the Yearly plan/i)).toBeInTheDocument()
     );
+    expect(document.querySelector(".rc-billing-page")).toHaveClass("rc-account-billing-surface");
     expect(screen.getByText(/Billing, plans, and upgrade review/i)).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -183,6 +185,7 @@ describe("BillingPage", () => {
     );
 
     await waitFor(() => expect(screen.getByText("Pro")).toBeInTheDocument());
+    expect(document.querySelector(".rc-billing-page")).toHaveClass("rc-account-billing-surface");
     expect(screen.getByTestId("billing-plans-panel")).toHaveTextContent("pro");
     expect(screen.getAllByRole("button", { name: "Manage subscription" })).toHaveLength(2);
     expect(

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -18,6 +18,7 @@ import { track } from "@/lib/analytics";
 import { billingTierLabel, useBillingStatus } from "@/hooks/useBillingStatus";
 import { refreshEntitlements } from "@/lib/entitlements";
 import { CANONICAL_TIER_MATRIX, TIER_POSITIONING_COPY } from "@/constants/pricingPlans";
+import "./account/accountBillingTheme.css";
 
 const formatAmount = (amountCents: number, currency: string) => {
   const amount = (amountCents || 0) / 100;
@@ -289,6 +290,7 @@ const BillingPage: React.FC = () => {
 
   return (
     <Section
+      className="rc-account-billing-surface rc-billing-page"
       style={{
         display: "flex",
         flexDirection: "column",
@@ -297,7 +299,7 @@ const BillingPage: React.FC = () => {
         margin: "0 auto",
       }}
     >
-      <Card elevated>
+      <Card elevated className="rc-account-billing-card rc-account-billing-card--strong">
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: spacing.sm }}>
           <div>
             <h1 style={{ margin: 0, fontSize: "1.3rem", fontWeight: 700 }}>Billing, plans, and upgrade review</h1>
@@ -326,7 +328,7 @@ const BillingPage: React.FC = () => {
             </div>
           </div>
           <div className="rc-wrap-row">
-            <Button type="button" variant="secondary" onClick={load} disabled={loading}>
+            <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={load} disabled={loading}>
               Refresh
             </Button>
             {isPaidPlan ? (
@@ -351,15 +353,15 @@ const BillingPage: React.FC = () => {
         </div>
       </Card>
 
-      <Card id="plan">
+      <Card id="plan" className="rc-account-billing-card">
         <div style={{ display: "grid", gap: spacing.md }}>
           <div style={{ display: "grid", gap: spacing.sm, gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
             <div
               style={{
-                border: "1px solid rgba(148,163,184,0.25)",
+                border: "1px solid rgba(91,70,48,0.18)",
                 borderRadius: 16,
                 padding: 16,
-                background: "rgba(148,163,184,0.06)",
+                background: "#fff6e8",
                 display: "grid",
                 gap: spacing.xs,
               }}
@@ -401,15 +403,15 @@ const BillingPage: React.FC = () => {
             {recommendedUpgradeTier ? (
               <div
                 style={{
-                  border: "1px solid rgba(14,116,144,0.28)",
+                  border: "1px solid rgba(36,88,66,0.28)",
                   borderRadius: 16,
                   padding: 16,
-                  background: "rgba(14,116,144,0.08)",
+                  background: "rgba(36,88,66,0.1)",
                   display: "grid",
                   gap: spacing.xs,
                 }}
               >
-                <div style={{ color: "#0f766e", fontSize: 12, fontWeight: 800 }}>
+                <div style={{ color: "#245842", fontSize: 12, fontWeight: 800 }}>
                   {requestedUpgradePlan ? "Selected from pricing" : "Recommended next plan"}
                 </div>
                 <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>
@@ -449,7 +451,7 @@ const BillingPage: React.FC = () => {
 
           <div className="rc-wrap-row" style={{ marginTop: spacing.xs }}>
             {isPaidPlan ? (
-              <Button type="button" variant="secondary" onClick={handlePortal} disabled={portalLoading}>
+              <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={handlePortal} disabled={portalLoading}>
                 {portalLoading ? "Opening..." : "Manage subscription"}
               </Button>
             ) : (
@@ -470,7 +472,7 @@ const BillingPage: React.FC = () => {
         </div>
       </Card>
 
-      <Card id="receipts">
+      <Card id="receipts" className="rc-account-billing-card">
         <div style={{ fontWeight: 700, fontSize: "1.05rem", marginBottom: 12 }}>Plans</div>
         <BillingPlansPanel
           pricing={pricing}
@@ -493,7 +495,7 @@ const BillingPage: React.FC = () => {
         />
       </Card>
 
-      <Card>
+      <Card className="rc-account-billing-card">
         {loading ? (
           <div style={{ color: text.muted }}>Loading...</div>
         ) : error ? (
@@ -504,7 +506,7 @@ const BillingPage: React.FC = () => {
           </div>
         ) : (
           <div style={{ width: "100%", overflowX: "auto" }}>
-            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+            <table className="rc-account-billing-table" style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
               <thead>
                 <tr style={{ textAlign: "left", borderBottom: `1px solid ${colors.border}` }}>
                   <th style={{ padding: "8px" }}>Date</th>
@@ -534,7 +536,7 @@ const BillingPage: React.FC = () => {
                     </td>
                     <td style={{ padding: "8px" }}>
                       {record.receiptUrl ? (
-                        <a href={record.receiptUrl} target="_blank" rel="noopener noreferrer" style={{ color: colors.accent }}>
+                        <a href={record.receiptUrl} target="_blank" rel="noopener noreferrer" style={{ color: "#245842" }}>
                           View
                         </a>
                       ) : (
@@ -549,16 +551,16 @@ const BillingPage: React.FC = () => {
         )}
       </Card>
 
-      <Card>
+      <Card className="rc-account-billing-card">
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: spacing.sm }}>
           <div style={{ color: text.secondary }}>
             Need a receipt or have billing questions? Email{" "}
-            <a href={`mailto:${SUPPORT_EMAIL}`} style={{ color: colors.accent }}>
+            <a href={`mailto:${SUPPORT_EMAIL}`} style={{ color: "#245842" }}>
               {SUPPORT_EMAIL}
             </a>
             .
           </div>
-          <Button variant="secondary" onClick={load} disabled={loading} className="rc-full-width-mobile">
+          <Button variant="secondary" onClick={load} disabled={loading} className="rc-full-width-mobile rc-account-secondary-action">
             Reload
           </Button>
         </div>

--- a/rentchain-frontend/src/pages/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.test.tsx
@@ -88,6 +88,8 @@ describe("PricingPage analytics", () => {
         /You do not need to pick a paid plan before you understand the workflow\. Use pricing to see what opens next after the basics are already working for you\./i
       )
     ).toBeInTheDocument();
+    expect(document.querySelector(".rc-auth-pricing-page")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Monthly" })).toHaveClass("rc-pricing-interval-button");
 
     fireEvent.click(screen.getByRole("button", { name: "Annual" }));
 

--- a/rentchain-frontend/src/pages/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.tsx
@@ -17,6 +17,7 @@ import {
 } from "../constants/pricingPlans";
 import { track } from "@/lib/analytics";
 import { normalizePlan } from "@/lib/plan";
+import "./account/accountBillingTheme.css";
 
 type PlanKey = PricingPlanKey;
 
@@ -74,9 +75,9 @@ const PLAN_CALLOUT_COPY: Partial<
 
 function pricingCardShadow(plan: PlanKey, hovered: boolean) {
   if (plan === "pro") {
-    return hovered ? "0 22px 42px rgba(37,99,235,0.16)" : "0 16px 34px rgba(37,99,235,0.12)";
+    return hovered ? "0 22px 42px rgba(59,44,28,0.16)" : "0 16px 34px rgba(59,44,28,0.12)";
   }
-  return hovered ? "0 16px 32px rgba(15,23,42,0.10)" : "0 10px 24px rgba(15,23,42,0.06)";
+  return hovered ? "0 16px 32px rgba(59,44,28,0.12)" : "0 10px 24px rgba(59,44,28,0.08)";
 }
 
 function buildBillingUpgradePath(target: Exclude<PlanKey, "free">, interval: PricingInterval) {
@@ -239,6 +240,7 @@ const PricingPage: React.FC = () => {
   return (
     <MacShell title="RentChain · Pricing" showTopNav={false}>
       <Section
+        className="rc-auth-pricing-page"
         style={{
           maxWidth: 1360,
           margin: "0 auto",
@@ -251,7 +253,7 @@ const PricingPage: React.FC = () => {
           boxSizing: "border-box",
         }}
       >
-        <Card elevated>
+        <Card elevated className="rc-auth-pricing-card rc-auth-pricing-card--strong">
           <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 800 }}>Pricing</h1>
           <p style={{ marginTop: spacing.sm, color: text.muted, maxWidth: 760, lineHeight: 1.65 }}>
             Start simple on Free, move into day-to-day rental operations on Starter, get stronger control on Pro, and step up to deeper portfolio oversight on Elite.
@@ -272,11 +274,12 @@ const PricingPage: React.FC = () => {
 
         <div
           style={{
-            background: "#f3f7ff",
+            background: "#f7f1e7",
             borderRadius: isMobile ? 20 : 24,
             padding: isMobile ? 12 : 20,
             boxSizing: "border-box",
           }}
+          className="rc-auth-pricing-panel"
         >
           <div
             style={{
@@ -287,10 +290,12 @@ const PricingPage: React.FC = () => {
               alignItems: "stretch",
             }}
           >
-          <Card style={{ gridColumn: "1 / -1" }}>
+          <Card className="rc-auth-pricing-card" style={{ gridColumn: "1 / -1" }}>
             <div style={{ display: "inline-flex", gap: 8, border: "1px solid rgba(15,23,42,0.12)", borderRadius: 999, padding: 4 }}>
               <Button
                 type="button"
+                className="rc-pricing-interval-button"
+                data-active={interval === "monthly" ? "true" : "false"}
                 variant={interval === "monthly" ? "primary" : "ghost"}
                 onClick={() => setInterval("monthly")}
                 style={{ padding: "6px 12px" }}
@@ -299,6 +304,8 @@ const PricingPage: React.FC = () => {
               </Button>
               <Button
                 type="button"
+                className="rc-pricing-interval-button"
+                data-active={interval === "yearly" ? "true" : "false"}
                 variant={interval === "yearly" ? "primary" : "ghost"}
                 onClick={() => setInterval("yearly")}
                 style={{ padding: "6px 12px" }}
@@ -310,6 +317,7 @@ const PricingPage: React.FC = () => {
           {PLAN_ORDER.map((plan) => (
             <Card
               key={plan}
+              className={`rc-auth-pricing-card${plan === "pro" ? " rc-auth-pricing-card--strong" : ""}`}
               elevated={plan === "pro"}
               style={{
                 display: "flex",
@@ -325,11 +333,11 @@ const PricingPage: React.FC = () => {
                 overflow: "visible",
                 transform: hoveredPlan === plan ? "translateY(-3px)" : "translateY(0)",
                 border:
-                  plan === "pro" ? "1px solid rgba(37,99,235,0.28)" : "1px solid rgba(15,23,42,0.08)",
+                  plan === "pro" ? "1px solid rgba(36,88,66,0.28)" : "1px solid rgba(91,70,48,0.18)",
                 background:
                   plan === "pro"
-                    ? "linear-gradient(180deg, rgba(37,99,235,0.06) 0%, #ffffff 28%)"
-                    : "#ffffff",
+                    ? "linear-gradient(180deg, rgba(36,88,66,0.1) 0%, #fffaf1 30%)"
+                    : "#fffaf1",
                 boxShadow: pricingCardShadow(plan, hoveredPlan === plan),
                 justifySelf: "stretch",
                 ...(plan === "pro"
@@ -350,25 +358,26 @@ const PricingPage: React.FC = () => {
                 </div>
                 {plan !== "free" ? (
                   <span
+                    className="rc-billing-plan-badge"
                     style={{
                       border:
                         plan === "pro" || plan === "elite"
-                          ? "1px solid rgba(37,99,235,0.4)"
-                          : "1px solid rgba(15,23,42,0.18)",
+                          ? "1px solid rgba(36,88,66,0.28)"
+                          : "1px solid rgba(91,70,48,0.18)",
                       borderRadius: 999,
                       padding: "4px 12px",
                       fontSize: 11,
                       fontWeight: 700,
-                      color: plan === "pro" || plan === "elite" ? "#1d4ed8" : text.primary,
+                      color: plan === "pro" || plan === "elite" ? "#245842" : text.primary,
                       background:
                         plan === "pro" || plan === "elite"
-                          ? "linear-gradient(180deg, rgba(37,99,235,0.14), rgba(37,99,235,0.08))"
-                          : "rgba(15,23,42,0.06)",
+                          ? "linear-gradient(180deg, rgba(36,88,66,0.14), rgba(36,88,66,0.08))"
+                          : "rgba(91,70,48,0.08)",
                       maxWidth: "100%",
                       overflowWrap: "anywhere",
                       letterSpacing: 0.2,
                       boxShadow:
-                        plan === "pro" || plan === "elite" ? "0 8px 20px rgba(37,99,235,0.12)" : "none",
+                        plan === "pro" || plan === "elite" ? "0 8px 20px rgba(36,88,66,0.12)" : "none",
                     }}
                   >
                     {TIER_POSITIONING_COPY[plan].badge}
@@ -407,8 +416,8 @@ const PricingPage: React.FC = () => {
                     lineHeight: 1.65,
                     padding: "10px 12px",
                     borderRadius: 12,
-                    background: "rgba(15,23,42,0.03)",
-                    border: "1px solid rgba(15,23,42,0.06)",
+                    background: "rgba(91,70,48,0.06)",
+                    border: "1px solid rgba(91,70,48,0.12)",
                     minWidth: 0,
                     flex: "0 0 auto",
                     ...wrappingTextStyle,
@@ -420,9 +429,9 @@ const PricingPage: React.FC = () => {
               {plan === "pro" || plan === "elite" ? (
                 <div
                   style={{
-                    border: "1px solid rgba(37,99,235,0.28)",
+                    border: "1px solid rgba(36,88,66,0.28)",
                     borderRadius: 12,
-                    background: "rgba(37,99,235,0.06)",
+                    background: "rgba(36,88,66,0.08)",
                     padding: "12px 14px",
                     display: "grid",
                     gap: 8,
@@ -463,7 +472,7 @@ const PricingPage: React.FC = () => {
               {plan !== "free" ? (
                 <div
                   style={{
-                    border: "1px solid rgba(15,23,42,0.12)",
+                    border: "1px solid rgba(91,70,48,0.18)",
                     borderRadius: 12,
                     padding: "12px 14px",
                     display: "grid",
@@ -481,7 +490,7 @@ const PricingPage: React.FC = () => {
               ) : null}
               <div style={{ marginTop: isMobile ? spacing.sm : "auto", paddingTop: 8, width: "100%" }}>
                 {plan === "free" ? (
-                  <Button type="button" variant="secondary" onClick={() => navigate("/dashboard")} style={{ width: "100%" }}>
+                  <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/dashboard")} style={{ width: "100%" }}>
                     Start your rental workflow
                   </Button>
                 ) : (
@@ -500,9 +509,9 @@ const PricingPage: React.FC = () => {
           </div>
         </div>
 
-        <Card>
+        <Card className="rc-auth-pricing-card">
           <h2 style={{ marginTop: 0 }}>FAQ</h2>
-          <details open style={{ border: "1px solid rgba(15,23,42,0.12)", borderRadius: 12, padding: "12px 14px" }}>
+          <details open className="rc-auth-pricing-card" style={{ border: "1px solid rgba(91,70,48,0.18)", borderRadius: 12, padding: "12px 14px" }}>
             <summary style={{ cursor: "pointer", fontWeight: 700 }}>
               Do I need a subscription to screen tenants?
             </summary>

--- a/rentchain-frontend/src/pages/account/AccountDataPage.test.tsx
+++ b/rentchain-frontend/src/pages/account/AccountDataPage.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AccountDataPage from "./AccountDataPage";
+
+const mocks = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+}));
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: mocks.useAuthMock,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AccountDataPage", () => {
+  beforeEach(() => {
+    mocks.useAuthMock.mockReturnValue({
+      user: {
+        id: "user-1",
+        email: "owner@example.com",
+        actorRole: "landlord",
+        actorLandlordId: "landlord-1",
+        plan: "elite",
+      },
+    });
+  });
+
+  it("keeps account export behavior while using the scoped warm account surface", () => {
+    const appendChild = vi.spyOn(document.body, "appendChild");
+    const createObjectURL = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:account-export");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter>
+        <AccountDataPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Data Management" })).toBeInTheDocument();
+    expect(screen.getByText("Automation Timeline: up to 24 months visible.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to My Account" })).toHaveClass("rc-account-secondary-action");
+    expect(document.querySelector(".rc-account-data-page")).toHaveClass("rc-account-billing-surface");
+
+    fireEvent.click(screen.getByRole("button", { name: "Export account JSON" }));
+
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(appendChild).toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/pages/account/AccountDataPage.tsx
+++ b/rentchain-frontend/src/pages/account/AccountDataPage.tsx
@@ -4,6 +4,7 @@ import { Button, Card, Section } from "../../components/ui/Ui";
 import { colors, spacing, text } from "../../styles/tokens";
 import { useAuth } from "../../context/useAuth";
 import { normalizeTimelinePlan } from "../../features/automation/timeline/timelineEntitlements";
+import "./accountBillingTheme.css";
 
 const AccountDataPage: React.FC = () => {
   const navigate = useNavigate();
@@ -43,15 +44,15 @@ const AccountDataPage: React.FC = () => {
   };
 
   return (
-    <Section style={{ maxWidth: 860, margin: "0 auto", display: "grid", gap: spacing.md }}>
-      <Card elevated style={{ display: "grid", gap: 8 }}>
+    <Section className="rc-account-billing-surface rc-account-data-page" style={{ maxWidth: 860, margin: "0 auto", display: "grid", gap: spacing.md }}>
+      <Card elevated className="rc-account-billing-card rc-account-billing-card--strong" style={{ display: "grid", gap: 8 }}>
         <h1 style={{ margin: 0, fontSize: "1.4rem", fontWeight: 800 }}>Data Management</h1>
         <p style={{ margin: 0, color: text.muted }}>
           Export account-level data and review retention policy information.
         </p>
       </Card>
 
-      <Card style={{ display: "grid", gap: spacing.md, border: `1px solid ${colors.border}` }}>
+      <Card className="rc-account-billing-card" style={{ display: "grid", gap: spacing.md, border: `1px solid ${colors.border}` }}>
         <div style={{ display: "grid", gap: 8 }}>
           <div style={{ fontWeight: 700 }}>Export options</div>
           <div style={{ color: text.muted, fontSize: 14 }}>
@@ -82,10 +83,10 @@ const AccountDataPage: React.FC = () => {
         </div>
 
         <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-          <Button type="button" variant="secondary" onClick={() => navigate("/account")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/account")}>
             Back to My Account
           </Button>
-          <Button type="button" variant="secondary" onClick={() => navigate("/billing#receipts")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/billing#receipts")}>
             View receipts
           </Button>
         </div>

--- a/rentchain-frontend/src/pages/account/AccountProfilePage.test.tsx
+++ b/rentchain-frontend/src/pages/account/AccountProfilePage.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AccountProfilePage from "./AccountProfilePage";
+
+const mocks = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+}));
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: mocks.useAuthMock,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AccountProfilePage", () => {
+  beforeEach(() => {
+    mocks.useAuthMock.mockReturnValue({
+      user: {
+        email: "owner@example.com",
+        id: "user-1",
+        actorRole: "landlord",
+        actorLandlordId: "landlord-1",
+      },
+    });
+  });
+
+  it("uses the scoped warm account surface without changing read-only profile fields", () => {
+    render(
+      <MemoryRouter>
+        <AccountProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Profile" })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("owner@example.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("user-1")).toBeInTheDocument();
+    expect(screen.getByText("Profile editing will be enabled in a future release.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to My Account" })).toHaveClass("rc-account-secondary-action");
+    expect(document.querySelector(".rc-account-profile-page")).toHaveClass("rc-account-billing-surface");
+  });
+});

--- a/rentchain-frontend/src/pages/account/AccountProfilePage.tsx
+++ b/rentchain-frontend/src/pages/account/AccountProfilePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Button, Card, Section } from "../../components/ui/Ui";
 import { colors, spacing, text } from "../../styles/tokens";
 import { useAuth } from "../../context/useAuth";
+import "./accountBillingTheme.css";
 
 function ReadOnlyField({ label, value }: { label: string; value: string }) {
   return (
@@ -29,15 +30,15 @@ const AccountProfilePage: React.FC = () => {
   const { user } = useAuth();
 
   return (
-    <Section style={{ maxWidth: 860, margin: "0 auto", display: "grid", gap: spacing.md }}>
-      <Card elevated style={{ display: "grid", gap: 8 }}>
+    <Section className="rc-account-billing-surface rc-account-profile-page" style={{ maxWidth: 860, margin: "0 auto", display: "grid", gap: spacing.md }}>
+      <Card elevated className="rc-account-billing-card rc-account-billing-card--strong" style={{ display: "grid", gap: 8 }}>
         <h1 style={{ margin: 0, fontSize: "1.4rem", fontWeight: 800 }}>Profile</h1>
         <p style={{ margin: 0, color: text.muted }}>
           Account identity and contact details for your workspace.
         </p>
       </Card>
 
-      <Card style={{ display: "grid", gap: spacing.md, border: `1px solid ${colors.border}` }}>
+      <Card className="rc-account-billing-card" style={{ display: "grid", gap: spacing.md, border: `1px solid ${colors.border}` }}>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: spacing.md }}>
           <ReadOnlyField label="Email" value={String(user?.email || "Not available")} />
           <ReadOnlyField label="User ID" value={String(user?.id || "Not available")} />
@@ -57,10 +58,10 @@ const AccountProfilePage: React.FC = () => {
           Profile editing will be enabled in a future release.
         </div>
         <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-          <Button type="button" variant="secondary" onClick={() => navigate("/account")}>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" onClick={() => navigate("/account")}>
             Back to My Account
           </Button>
-          <Button type="button" variant="secondary" disabled>
+          <Button className="rc-account-secondary-action" type="button" variant="secondary" disabled>
             Security controls coming soon
           </Button>
         </div>

--- a/rentchain-frontend/src/pages/account/accountBillingTheme.css
+++ b/rentchain-frontend/src/pages/account/accountBillingTheme.css
@@ -1,0 +1,156 @@
+.rc-account-billing-surface,
+.rc-auth-pricing-page {
+  --rc-account-paper: #f7f1e7;
+  --rc-account-card: #fffaf1;
+  --rc-account-card-strong: #fff6e8;
+  --rc-account-border: rgba(91, 70, 48, 0.18);
+  --rc-account-border-strong: rgba(91, 70, 48, 0.3);
+  --rc-account-text: #211c17;
+  --rc-account-muted: #63594d;
+  --rc-account-subtle: #7a6b5c;
+  --rc-account-pine: #245842;
+  --rc-account-pine-soft: rgba(36, 88, 66, 0.12);
+  --rc-account-amber-soft: rgba(184, 130, 62, 0.16);
+  --rc-account-danger: #a33a2f;
+  --rc-account-shadow: 0 16px 36px rgba(59, 44, 28, 0.12);
+  --rc-account-shadow-soft: 0 8px 18px rgba(59, 44, 28, 0.08);
+  background:
+    radial-gradient(circle at top left, rgba(184, 130, 62, 0.14) 0, rgba(247, 241, 231, 0) 34%),
+    linear-gradient(180deg, var(--rc-account-card) 0%, var(--rc-account-paper) 100%) !important;
+  border-color: var(--rc-account-border) !important;
+  color: var(--rc-account-text) !important;
+  box-shadow: var(--rc-account-shadow) !important;
+}
+
+.rc-account-billing-surface *,
+.rc-auth-pricing-page * {
+  letter-spacing: 0;
+}
+
+.rc-account-billing-surface h1,
+.rc-account-billing-surface h2,
+.rc-account-billing-surface h3,
+.rc-auth-pricing-page h1,
+.rc-auth-pricing-page h2,
+.rc-auth-pricing-page h3 {
+  color: var(--rc-account-text) !important;
+}
+
+.rc-account-billing-surface a,
+.rc-auth-pricing-page a {
+  color: var(--rc-account-pine) !important;
+}
+
+.rc-account-billing-card,
+.rc-account-billing-surface .rc-account-billing-card,
+.rc-auth-pricing-card,
+.rc-auth-pricing-page .rc-auth-pricing-card,
+.rc-billing-plan-card {
+  background: var(--rc-account-card) !important;
+  border: 1px solid var(--rc-account-border) !important;
+  box-shadow: var(--rc-account-shadow-soft) !important;
+  color: var(--rc-account-text) !important;
+}
+
+.rc-account-billing-card--strong,
+.rc-auth-pricing-card--strong,
+.rc-billing-plan-card[data-highlight="true"],
+.rc-billing-plan-card[data-selected="true"],
+.rc-billing-plan-card[data-recommended="true"] {
+  background: var(--rc-account-card-strong) !important;
+  border-color: var(--rc-account-border-strong) !important;
+}
+
+.rc-account-billing-panel,
+.rc-auth-pricing-panel,
+.rc-billing-plan-capability,
+.rc-billing-current-plan-panel,
+.rc-billing-recommended-panel {
+  background: var(--rc-account-card-strong) !important;
+  border: 1px solid var(--rc-account-border) !important;
+  box-shadow: var(--rc-account-shadow-soft) !important;
+  color: var(--rc-account-text) !important;
+}
+
+.rc-account-billing-surface input,
+.rc-account-billing-surface select,
+.rc-account-billing-surface textarea {
+  background: var(--rc-account-card-strong) !important;
+  border-color: var(--rc-account-border-strong) !important;
+  color: var(--rc-account-text) !important;
+}
+
+.rc-account-billing-surface input:focus-visible,
+.rc-account-billing-surface button:focus-visible,
+.rc-auth-pricing-page button:focus-visible,
+.rc-auth-pricing-page a:focus-visible {
+  outline: 3px solid rgba(184, 130, 62, 0.36) !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 0 4px rgba(36, 88, 66, 0.14) !important;
+}
+
+.rc-account-billing-surface button,
+.rc-auth-pricing-page button,
+.rc-billing-plan-card button {
+  background: var(--rc-account-pine) !important;
+  border: 1px solid rgba(36, 88, 66, 0.34) !important;
+  color: #fff !important;
+  box-shadow: var(--rc-account-shadow-soft) !important;
+}
+
+.rc-account-billing-surface button:not(:disabled):hover,
+.rc-auth-pricing-page button:not(:disabled):hover,
+.rc-billing-plan-card button:not(:disabled):hover {
+  background: #1f4f3b !important;
+  border-color: #1f4f3b !important;
+}
+
+.rc-account-billing-surface .rc-account-secondary-action,
+.rc-auth-pricing-page .rc-account-secondary-action,
+.rc-account-billing-surface .rc-pricing-interval-button[data-active="false"],
+.rc-auth-pricing-page .rc-pricing-interval-button[data-active="false"] {
+  background: var(--rc-account-card) !important;
+  color: var(--rc-account-pine) !important;
+  border: 1px solid var(--rc-account-border-strong) !important;
+}
+
+.rc-account-billing-surface button:disabled,
+.rc-auth-pricing-page button:disabled,
+.rc-billing-plan-card button:disabled {
+  background: var(--rc-account-card-strong) !important;
+  color: var(--rc-account-muted) !important;
+  border-color: var(--rc-account-border) !important;
+  box-shadow: none !important;
+}
+
+.rc-account-status-pill,
+.rc-billing-plan-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(36, 88, 66, 0.28) !important;
+  background: var(--rc-account-pine-soft) !important;
+  color: var(--rc-account-pine) !important;
+  box-shadow: none !important;
+}
+
+.rc-account-danger-panel {
+  background: rgba(163, 58, 47, 0.08) !important;
+  border-color: rgba(163, 58, 47, 0.3) !important;
+  color: var(--rc-account-danger) !important;
+}
+
+.rc-account-billing-table {
+  background: var(--rc-account-card) !important;
+}
+
+.rc-account-billing-table th,
+.rc-account-billing-table td {
+  border-color: var(--rc-account-border) !important;
+}
+
+.rc-account-billing-table th {
+  color: var(--rc-account-subtle) !important;
+  background: rgba(250, 243, 232, 0.72) !important;
+}


### PR DESCRIPTION
## Summary
- Adds a scoped authenticated account/billing theme layer for `/account`, `/account/profile`, `/account/data`, authenticated `/pricing`, `/billing`, and `/billing#receipts`.
- Warms account hub/profile/data panels, authenticated pricing plan cards, billing plan cards, receipt/support panels, actions, tables, inputs, and status pills without changing billing, payment, entitlement, auth, or data logic.
- Keeps public marketing/legal routes out of scope, including `/site/pricing`, `/privacy`, `/terms`, and `/site/legal`.

## Route and file mapping
- `/account`: `rentchain-frontend/src/pages/AccountPage.tsx`
- `/account/profile`: `rentchain-frontend/src/pages/account/AccountProfilePage.tsx`
- `/account/data`: `rentchain-frontend/src/pages/account/AccountDataPage.tsx`
- authenticated `/pricing`: `rentchain-frontend/src/pages/PricingPage.tsx`
- `/billing` and `/billing#receipts`: `rentchain-frontend/src/pages/BillingPage.tsx`, `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- scoped styling: `rentchain-frontend/src/pages/account/accountBillingTheme.css`

## Mission audit
- Confirmed `/site/pricing` is the public marketing pricing page and remains untouched.
- Confirmed authenticated `/pricing` is guarded by `PricingGate` and rendered inside `LandlordNav` for signed-in users.
- Confirmed `/account`, `/account/profile`, `/account/data`, and `/billing` are authenticated landlord-shell routes.
- Deferred public/legal old-theme surfaces to separate follow-up work.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- AccountPage AccountProfilePage AccountDataPage PricingPage BillingPage BillingPlansPanel`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- DashboardPage LandlordNav`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`
- `git diff --cached --check`

## Manual QA required
Use a valid authenticated landlord/admin-equivalent session and verify:
- `/account`, `/account/profile`, `/account/data`, authenticated `/pricing`, `/billing`, and `/billing#receipts` use warm neutral cards, panels, forms, tables, receipt rows, buttons, and status pills.
- No bright blue primary CTA, selected tab, selected border, focus ring, or status pill remains in the scoped surfaces.
- Billing plan selection, billing actions, receipts, export controls, and account profile/data behavior remain unchanged.
- `/dashboard`, `/landlord/unified-inbox`, `/properties`, `/tenants`, and `/leases` smoke checks remain acceptable.
- `/site/pricing`, `/privacy`, `/terms`, `/site/legal`, `/login`, `/`, and tenant/contractor/admin dashboards are not restyled by this PR.
- No console errors and no horizontal overflow.

## Deferred follow-ups
- `polish/public-legal-pages-warm-neutral-v1` for `/privacy`, `/terms`, `/site/legal`, and related public/legal pages.
- Additional authenticated billing/account polish only if QA finds route-local gaps beyond this scoped foundation.