### PR TITLE
polish: align legal pages and remaining nav surfaces with warm neutral theme

### DIFF
--- a/rentchain-frontend/src/components/help/AskRentChainWidget.tsx
+++ b/rentchain-frontend/src/components/help/AskRentChainWidget.tsx
@@ -19,6 +19,19 @@ type WidgetProps = {
   audience?: Audience;
   defaultOpen?: boolean;
   compact?: boolean;
+  tone?: "default" | "warmNeutral";
+};
+
+const warmWidgetTheme = {
+  card: "#fffaf1",
+  panel: "#fff8ed",
+  border: "rgba(105, 82, 49, 0.2)",
+  text: "#171411",
+  muted: "#5f5a51",
+  primary: "#171411",
+  primaryText: "#fffaf1",
+  secondary: "rgba(234, 223, 205, 0.72)",
+  accentSoft: "rgba(36, 88, 66, 0.14)",
 };
 
 const promptSuggestions = [
@@ -42,6 +55,7 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
   audience = "general",
   defaultOpen = false,
   compact = false,
+  tone = "default",
 }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [query, setQuery] = useState("");
@@ -105,6 +119,14 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
         padding: compact ? "6px 10px" : "8px 12px",
         fontSize: compact ? "0.8rem" : "0.85rem",
         borderRadius: radius.pill,
+        ...(tone === "warmNeutral"
+          ? {
+              background: warmWidgetTheme.secondary,
+              border: `1px solid ${warmWidgetTheme.border}`,
+              color: warmWidgetTheme.text,
+              boxShadow: "none",
+            }
+          : {}),
       }}
       onClick={() => handleSend(label, "prompt")}
       aria-label={`Search: ${label}`}
@@ -117,7 +139,9 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
     <Card
       style={{
         padding: compact ? spacing.md : spacing.lg,
-        background: colors.panel,
+        background: tone === "warmNeutral" ? warmWidgetTheme.card : colors.panel,
+        border: tone === "warmNeutral" ? `1px solid ${warmWidgetTheme.border}` : undefined,
+        color: tone === "warmNeutral" ? warmWidgetTheme.text : undefined,
       }}
     >
       <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: spacing.md }}>
@@ -136,6 +160,14 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
           style={{
             padding: compact ? "6px 10px" : "8px 12px",
             fontSize: compact ? "0.8rem" : "0.85rem",
+            ...(tone === "warmNeutral"
+              ? {
+                  background: warmWidgetTheme.secondary,
+                  border: `1px solid ${warmWidgetTheme.border}`,
+                  color: warmWidgetTheme.text,
+                  boxShadow: "none",
+                }
+              : {}),
           }}
           onClick={() => setIsOpen((prev) => !prev)}
           aria-label={isOpen ? "Collapse Ask RentChain widget" : "Expand Ask RentChain widget"}
@@ -152,9 +184,9 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
             role="log"
             aria-live="polite"
             style={{
-              background: colors.card,
+              background: tone === "warmNeutral" ? warmWidgetTheme.panel : colors.card,
               borderRadius: radius.md,
-              border: `1px solid ${colors.border}`,
+              border: `1px solid ${tone === "warmNeutral" ? warmWidgetTheme.border : colors.border}`,
               padding: spacing.md,
               display: "flex",
               flexDirection: "column",
@@ -165,7 +197,7 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
             }}
           >
             {messages.length === 0 && (
-              <div style={{ color: text.muted }}>
+              <div style={{ color: tone === "warmNeutral" ? warmWidgetTheme.muted : text.muted }}>
                 Ask a question and I will suggest the closest Help Center matches.
               </div>
             )}
@@ -181,29 +213,39 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
                     maxWidth: "88%",
                     padding: spacing.sm,
                     borderRadius: radius.md,
-                    background: isUser ? colors.accentSoft : colors.panel,
-                    border: `1px solid ${colors.border}`,
-                    color: text.primary,
+                    background:
+                      tone === "warmNeutral"
+                        ? isUser
+                          ? warmWidgetTheme.accentSoft
+                          : warmWidgetTheme.card
+                        : isUser
+                          ? colors.accentSoft
+                          : colors.panel,
+                    border: `1px solid ${tone === "warmNeutral" ? warmWidgetTheme.border : colors.border}`,
+                    color: tone === "warmNeutral" ? warmWidgetTheme.text : text.primary,
                   }}
                 >
                   <div style={{ fontWeight: 600, marginBottom: spacing.xxs }}>
                     {isUser ? "You" : "RentChain"}
                   </div>
-                  <div style={{ color: text.secondary }}>{message.text}</div>
+                  <div style={{ color: tone === "warmNeutral" ? warmWidgetTheme.text : text.secondary }}>{message.text}</div>
                   {!isUser && message.results && message.results.length > 0 && (
                     <div style={{ marginTop: spacing.sm, display: "grid", gap: spacing.sm }}>
                       {message.results.map((result) => (
                         <div
                           key={result.id}
                           style={{
-                            border: `1px solid ${colors.border}`,
+                            border: `1px solid ${tone === "warmNeutral" ? warmWidgetTheme.border : colors.border}`,
                             borderRadius: radius.sm,
                             padding: spacing.sm,
-                            background: "#ffffff",
+                            background: tone === "warmNeutral" ? warmWidgetTheme.panel : "#ffffff",
                           }}
                         >
                           <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
-                            <Link to={result.url} style={{ color: colors.accent, fontWeight: 600 }}>
+                            <Link
+                              to={result.url}
+                              style={{ color: tone === "warmNeutral" ? warmWidgetTheme.primary : colors.accent, fontWeight: 600 }}
+                            >
                               {result.title}
                             </Link>
                             {result.audience && (
@@ -212,18 +254,37 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
                               </Pill>
                             )}
                           </div>
-                          <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: "0.9rem" }}>
+                          <div
+                            style={{
+                              marginTop: spacing.xs,
+                              color: tone === "warmNeutral" ? warmWidgetTheme.muted : text.muted,
+                              fontSize: "0.9rem",
+                            }}
+                          >
                             {snippetFor(result, scopedQuery(message.text))}
                           </div>
                         </div>
                       ))}
                       <div style={{ display: "flex", alignItems: "center", gap: spacing.sm, flexWrap: "wrap" }}>
-                        <span style={{ color: text.muted, fontSize: "0.85rem" }}>Was this helpful?</span>
+                        <span style={{ color: tone === "warmNeutral" ? warmWidgetTheme.muted : text.muted, fontSize: "0.85rem" }}>
+                          Was this helpful?
+                        </span>
                         <Button
                           variant="ghost"
                           disabled={feedbackLocked}
                           aria-label="Helpful response"
-                          style={{ padding: "6px 10px", opacity: feedbackLocked ? 0.6 : 1 }}
+                          style={{
+                            padding: "6px 10px",
+                            opacity: feedbackLocked ? 0.6 : 1,
+                            ...(tone === "warmNeutral"
+                              ? {
+                                  background: warmWidgetTheme.secondary,
+                                  border: `1px solid ${warmWidgetTheme.border}`,
+                                  color: warmWidgetTheme.text,
+                                  boxShadow: "none",
+                                }
+                              : {}),
+                          }}
                           onClick={() => {
                             if (feedbackLocked) {
                               return;
@@ -238,7 +299,18 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
                           variant="ghost"
                           disabled={feedbackLocked}
                           aria-label="Not helpful response"
-                          style={{ padding: "6px 10px", opacity: feedbackLocked ? 0.6 : 1 }}
+                          style={{
+                            padding: "6px 10px",
+                            opacity: feedbackLocked ? 0.6 : 1,
+                            ...(tone === "warmNeutral"
+                              ? {
+                                  background: warmWidgetTheme.secondary,
+                                  border: `1px solid ${warmWidgetTheme.border}`,
+                                  color: warmWidgetTheme.text,
+                                  boxShadow: "none",
+                                }
+                              : {}),
+                          }}
                           onClick={() => {
                             if (feedbackLocked) {
                               return;
@@ -275,7 +347,16 @@ export const AskRentChainWidget: React.FC<WidgetProps> = ({
             <Button
               onClick={() => handleSend(query, "button")}
               aria-label="Send search query"
-              style={{ padding: compact ? "8px 12px" : "10px 16px" }}
+              style={{
+                padding: compact ? "8px 12px" : "10px 16px",
+                ...(tone === "warmNeutral"
+                  ? {
+                      background: warmWidgetTheme.primary,
+                      color: warmWidgetTheme.primaryText,
+                      boxShadow: "0 14px 26px rgba(23, 20, 17, 0.16)",
+                    }
+                  : {}),
+              }}
             >
               Send
             </Button>

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -105,6 +105,24 @@ describe("WorkspaceDrawer", () => {
     });
   });
 
+  it("uses warm neutral active drawer states instead of blue selection styling", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" userEmail="owner@example.com" />
+      </MemoryRouter>
+    );
+
+    const dashboard = within(screen.getByRole("dialog")).getByRole("button", { name: "Dashboard" });
+
+    expect(dashboard).toHaveStyle({
+      background: "rgba(36, 88, 66, 0.13)",
+      color: "#245842",
+    });
+    expect(dashboard).not.toHaveStyle({
+      background: "rgba(37,99,235,0.08)",
+    });
+  });
+
   it("uses the same mobile breakpoint as the landlord shell", () => {
     render(
       <MemoryRouter initialEntries={["/dashboard"]}>

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useLocation, useNavigate } from "react-router-dom";
-import { colors, radius, spacing, text, shadows } from "../../styles/tokens";
+import { radius, spacing } from "../../styles/tokens";
 import { getVisibleNavItems } from "./navConfig";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -15,6 +15,20 @@ type WorkspaceDrawerProps = {
 };
 
 export const WORKSPACE_DRAWER_MOBILE_QUERY = "(max-width: 820px)";
+
+const workspaceDrawerTheme = {
+  card: "#fffaf1",
+  panel: "#fff8ed",
+  border: "rgba(91, 70, 48, 0.18)",
+  borderStrong: "rgba(91, 70, 48, 0.3)",
+  activeBorder: "rgba(36, 88, 66, 0.38)",
+  activeBg: "rgba(36, 88, 66, 0.13)",
+  activeText: "#245842",
+  text: "#211c17",
+  muted: "#63594d",
+  scrim: "rgba(33, 28, 23, 0.42)",
+  shadow: "0 22px 52px rgba(59, 44, 28, 0.18)",
+};
 
 export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
   open,
@@ -83,6 +97,18 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
     onClose();
   };
   const mobileBottomNavOffset = "var(--rc-mobile-drawer-bottom-offset, calc(104px + env(safe-area-inset-bottom, 0px)))";
+  const drawerNavButtonStyle = (active: boolean): React.CSSProperties => ({
+    textAlign: isMobile ? "center" : "left",
+    padding: isMobile ? "10px 8px" : "10px 12px",
+    minHeight: isMobile ? 48 : undefined,
+    borderRadius: radius.md,
+    border: `1px solid ${active ? workspaceDrawerTheme.activeBorder : workspaceDrawerTheme.border}`,
+    background: active ? workspaceDrawerTheme.activeBg : workspaceDrawerTheme.card,
+    color: active ? workspaceDrawerTheme.activeText : workspaceDrawerTheme.text,
+    fontWeight: active ? 750 : 650,
+    cursor: "pointer",
+    boxShadow: active ? "inset 0 -2px 0 rgba(36, 88, 66, 0.22)" : "none",
+  });
   const footerContent = (
     <>
       {onSignOut ? (
@@ -91,8 +117,9 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           onClick={onSignOut}
           style={{
             borderRadius: radius.md,
-            border: `1px solid ${colors.border}`,
-            background: colors.panel,
+            border: `1px solid ${workspaceDrawerTheme.border}`,
+            background: workspaceDrawerTheme.panel,
+            color: workspaceDrawerTheme.text,
             padding: "8px 12px",
             cursor: "pointer",
             fontWeight: 700,
@@ -102,7 +129,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           Sign out
         </button>
       ) : null}
-      {userEmail ? <div style={{ fontSize: 12, color: text.muted }}>{userEmail}</div> : null}
+      {userEmail ? <div style={{ fontSize: 12, color: workspaceDrawerTheme.muted }}>{userEmail}</div> : null}
     </>
   );
 
@@ -131,7 +158,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
         style={{
           position: "absolute",
           inset: 0,
-          background: "rgba(0,0,0,0.35)",
+          background: workspaceDrawerTheme.scrim,
           touchAction: isMobile ? "auto" : "none",
           overscrollBehavior: "none",
           pointerEvents: "auto",
@@ -151,11 +178,11 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           margin: isMobile ? "0 auto 8px" : 0,
           minHeight: 0,
           minWidth: 0,
-          background: colors.card,
-          border: isMobile ? `1px solid ${colors.border}` : undefined,
-          borderLeft: isMobile ? undefined : `1px solid ${colors.border}`,
+          background: workspaceDrawerTheme.card,
+          border: isMobile ? `1px solid ${workspaceDrawerTheme.border}` : undefined,
+          borderLeft: isMobile ? undefined : `1px solid ${workspaceDrawerTheme.border}`,
           borderRadius: isMobile ? 20 : 0,
-          boxShadow: shadows.lg,
+          boxShadow: workspaceDrawerTheme.shadow,
           display: "flex",
           flexDirection: "column",
           zIndex: 1,
@@ -177,19 +204,20 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
             position: "sticky",
             top: 0,
             flex: "0 0 auto",
-            background: colors.card,
+            background: workspaceDrawerTheme.card,
             padding: `${spacing.lg} ${spacing.lg} ${spacing.sm}`,
             zIndex: 1,
-            borderBottom: `1px solid ${colors.border}`,
+            borderBottom: `1px solid ${workspaceDrawerTheme.border}`,
           }}
         >
-          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: text.primary }}>Workspace</div>
+          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: workspaceDrawerTheme.text }}>Workspace</div>
           <button
             type="button"
             onClick={onClose}
             style={{
-              border: `1px solid ${colors.border}`,
-              background: colors.panel,
+              border: `1px solid ${workspaceDrawerTheme.border}`,
+              background: workspaceDrawerTheme.panel,
+              color: workspaceDrawerTheme.text,
               borderRadius: radius.pill,
               padding: "6px 10px",
               cursor: "pointer",
@@ -212,7 +240,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
             maxHeight: "100%",
           }}
         >
-          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.02em", color: text.muted, marginBottom: spacing.sm }}>Pages</div>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.02em", color: workspaceDrawerTheme.muted, marginBottom: spacing.sm }}>Pages</div>
           <div
             style={{
               display: "grid",
@@ -226,9 +254,9 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
                   textAlign: "left",
                   padding: "10px 12px",
                   borderRadius: radius.md,
-                  border: `1px solid ${colors.border}`,
-                  background: colors.card,
-                  color: text.muted,
+                  border: `1px solid ${workspaceDrawerTheme.border}`,
+                  background: workspaceDrawerTheme.card,
+                  color: workspaceDrawerTheme.muted,
                   fontWeight: 600,
                 }}
               >
@@ -242,17 +270,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
                   key={link.to}
                   type="button"
                   onClick={() => handleNav(link.to)}
-                  style={{
-                    textAlign: isMobile ? "center" : "left",
-                    padding: isMobile ? "10px 8px" : "10px 12px",
-                    minHeight: isMobile ? 48 : undefined,
-                    borderRadius: radius.md,
-                    border: `1px solid ${active ? colors.accent : colors.border}`,
-                    background: active ? "rgba(37,99,235,0.08)" : colors.card,
-                    color: text.primary,
-                    fontWeight: active ? 700 : 600,
-                    cursor: "pointer",
-                  }}
+                  style={drawerNavButtonStyle(active)}
                 >
                   {link.label}
                 </button>
@@ -262,7 +280,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
               <div
                 style={{
                   height: 1,
-                  background: colors.border,
+                  background: workspaceDrawerTheme.border,
                   margin: `${spacing.xs} 0`,
                   gridColumn: isMobile ? "1 / -1" : undefined,
                 }}
@@ -275,17 +293,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
                   key={link.to}
                   type="button"
                   onClick={() => handleNav(link.to)}
-                  style={{
-                    textAlign: isMobile ? "center" : "left",
-                    padding: isMobile ? "10px 8px" : "10px 12px",
-                    minHeight: isMobile ? 48 : undefined,
-                    borderRadius: radius.md,
-                    border: `1px solid ${active ? colors.accent : colors.border}`,
-                    background: active ? "rgba(37,99,235,0.08)" : colors.card,
-                    color: text.primary,
-                    fontWeight: active ? 700 : 600,
-                    cursor: "pointer",
-                  }}
+                  style={drawerNavButtonStyle(active)}
                 >
                   {link.label}
                 </button>
@@ -296,7 +304,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
             <div
               style={{
                 marginTop: spacing.md,
-                borderTop: `1px solid ${colors.border}`,
+                borderTop: `1px solid ${workspaceDrawerTheme.border}`,
                 paddingTop: spacing.sm,
                 display: "grid",
                 gap: 8,
@@ -311,8 +319,8 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
           <div
             style={{
               flex: "0 0 auto",
-              background: colors.card,
-              borderTop: `1px solid ${colors.border}`,
+              background: workspaceDrawerTheme.card,
+              borderTop: `1px solid ${workspaceDrawerTheme.border}`,
               padding: `${spacing.sm} ${spacing.lg} calc(${spacing.sm} + env(safe-area-inset-bottom))`,
               display: "grid",
               gap: 8,

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.test.tsx
@@ -76,10 +76,18 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
     expect(mocks.listVerifiedScreenings).toHaveBeenCalledWith("landlord");
     expect(screen.getByPlaceholderText("Search applicant or email")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /Phil Jones/i }));
+    const queueItem = screen.getByRole("button", { name: /Phil Jones/i });
+    expect(queueItem).toHaveStyle({
+      background: "#fffaf1",
+    });
+
+    fireEvent.click(queueItem);
 
     await waitFor(() => {
       expect(screen.getByText("Result summary")).toBeInTheDocument();
+    });
+    expect(queueItem).toHaveStyle({
+      background: "rgba(36, 88, 66, 0.13)",
     });
     expect(screen.getByText("Screening review completed.")).toBeInTheDocument();
     expect(screen.getByText("Approve")).toBeInTheDocument();
@@ -100,6 +108,22 @@ describe("AdminVerifiedScreeningsPage landlord mode", () => {
     expect(screen.queryByText(/Unit ID/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unit_raw_123/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Internal-only note/i)).not.toBeInTheDocument();
+  });
+
+  it("uses warm neutral landlord buttons and cards for empty states", async () => {
+    mocks.listVerifiedScreenings.mockResolvedValueOnce([]);
+
+    render(
+      <MemoryRouter>
+        <AdminVerifiedScreeningsPage audience="landlord" shell="none" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No verified screenings yet.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Run a screening" })).toHaveStyle({
+      background: "#171411",
+      color: "#fffaf1",
+    });
   });
 
   it("reloads through the admin endpoint when the route audience changes", async () => {

--- a/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
+++ b/rentchain-frontend/src/pages/AdminVerifiedScreeningsPage.tsx
@@ -30,6 +30,54 @@ type AdminVerifiedScreeningsPageProps = {
   shell?: VerifiedScreeningsShell;
 };
 
+const landlordVerifiedTheme = {
+  page: "#f7f1e7",
+  card: "#fffaf1",
+  panel: "#fff8ed",
+  border: "rgba(91, 70, 48, 0.18)",
+  borderStrong: "rgba(91, 70, 48, 0.3)",
+  activeBg: "rgba(36, 88, 66, 0.13)",
+  activeBorder: "rgba(36, 88, 66, 0.38)",
+  primary: "#171411",
+  primaryText: "#fffaf1",
+  pine: "#245842",
+  text: "#211c17",
+  muted: "#63594d",
+  shadow: "0 18px 42px rgba(59, 44, 28, 0.12)",
+};
+
+const landlordVerifiedCardStyle: React.CSSProperties = {
+  background: landlordVerifiedTheme.card,
+  border: `1px solid ${landlordVerifiedTheme.border}`,
+  boxShadow: landlordVerifiedTheme.shadow,
+  color: landlordVerifiedTheme.text,
+};
+
+const landlordVerifiedButtonStyle: React.CSSProperties = {
+  background: landlordVerifiedTheme.primary,
+  color: landlordVerifiedTheme.primaryText,
+  boxShadow: "0 14px 26px rgba(23, 20, 17, 0.16)",
+};
+
+const landlordVerifiedSecondaryButtonStyle: React.CSSProperties = {
+  background: "rgba(234, 223, 205, 0.72)",
+  color: landlordVerifiedTheme.text,
+  border: `1px solid ${landlordVerifiedTheme.border}`,
+  boxShadow: "none",
+};
+
+const landlordVerifiedPillStyle: React.CSSProperties = {
+  background: landlordVerifiedTheme.activeBg,
+  borderColor: landlordVerifiedTheme.activeBorder,
+  color: landlordVerifiedTheme.pine,
+};
+
+const landlordVerifiedInputStyle: React.CSSProperties = {
+  background: "#fffdf8",
+  border: `1px solid ${landlordVerifiedTheme.border}`,
+  color: landlordVerifiedTheme.text,
+};
+
 function formatVerifiedScreeningStatus(value?: string | null) {
   const normalized = String(value || "").trim().toUpperCase();
   const labels: Record<string, string> = {
@@ -93,8 +141,8 @@ function ScreeningSummaryDetail({ item }: { item: VerifiedScreeningQueueItem }) 
           </div>
         </div>
         <div className="rc-wrap-row">
-          <Pill>{verifiedScreeningPackageDisplay(item)}</Pill>
-          <Pill>{verifiedScreeningStatusDisplay(item)}</Pill>
+          <Pill style={landlordVerifiedPillStyle}>{verifiedScreeningPackageDisplay(item)}</Pill>
+          <Pill style={landlordVerifiedPillStyle}>{verifiedScreeningStatusDisplay(item)}</Pill>
         </div>
       </div>
 
@@ -155,6 +203,7 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
   const isAdminAudience = audience === "admin";
   const adminAccessDenied = isAdminAudience && !isAdmin;
   const pageTitle = isAdminAudience ? "Admin · Verified Screenings" : "Verified Screenings";
+  const landlordMode = !isAdminAudience;
 
   const load = useCallback(async () => {
     if (adminAccessDenied) {
@@ -242,7 +291,20 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
     shell === "mac" ? (
       <MacShell title={pageTitle}>{children}</MacShell>
     ) : (
-      <div style={{ display: "grid", gap: spacing.lg }}>{children}</div>
+      <div
+        style={{
+          display: "grid",
+          gap: spacing.lg,
+          ...(landlordMode
+            ? {
+                background: landlordVerifiedTheme.page,
+                color: landlordVerifiedTheme.text,
+              }
+            : {}),
+        }}
+      >
+        {children}
+      </div>
     );
 
   const handleSave = async () => {
@@ -297,21 +359,46 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
               ? "You do not have access to this queue."
               : "Unable to load verified screenings.";
     return renderShell(
-        <Section>
-          <Card elevated style={{ display: "grid", gap: 12 }}>
+        <Section
+          style={
+            landlordMode
+              ? {
+                  background: "transparent",
+                  border: "none",
+                  boxShadow: "none",
+                  padding: 0,
+                }
+              : undefined
+          }
+        >
+          <Card elevated style={{ display: "grid", gap: 12, ...(landlordMode ? landlordVerifiedCardStyle : {}) }}>
             <h1 style={{ margin: 0, fontSize: "1.2rem" }}>{heading}</h1>
-            {viewMessage ? <div style={{ color: text.muted }}>{viewMessage}</div> : null}
+            {viewMessage ? <div style={{ color: landlordMode ? landlordVerifiedTheme.muted : text.muted }}>{viewMessage}</div> : null}
             <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-              <Button type="button" onClick={() => navigate("/applications")}>
+              <Button
+                type="button"
+                onClick={() => navigate("/applications")}
+                style={landlordMode ? landlordVerifiedButtonStyle : undefined}
+              >
                 Run a screening
               </Button>
               {viewState === "upgrade_required" ? (
-                <Button type="button" variant="secondary" onClick={() => navigate("/billing")}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => navigate("/billing")}
+                  style={landlordMode ? landlordVerifiedSecondaryButtonStyle : undefined}
+                >
                   Upgrade plan
                 </Button>
               ) : null}
               {viewState === "error" ? (
-                <Button type="button" variant="secondary" onClick={load}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={load}
+                  style={landlordMode ? landlordVerifiedSecondaryButtonStyle : undefined}
+                >
                   Retry
                 </Button>
               ) : null}
@@ -322,17 +409,36 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
   }
 
   return renderShell(
-      <Section style={{ display: "grid", gap: spacing.md }}>
+      <Section
+        style={{
+          display: "grid",
+          gap: spacing.md,
+          ...(landlordMode
+            ? {
+                background: "transparent",
+                border: "none",
+                boxShadow: "none",
+                padding: 0,
+              }
+            : {}),
+        }}
+      >
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: spacing.sm }}>
           <h1 style={{ margin: 0, fontSize: "1.3rem" }}>Verified Screening Queue</h1>
           <div style={{ display: "flex", gap: spacing.sm }}>
-            <Button type="button" variant="secondary" onClick={load} disabled={loading}>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={load}
+              disabled={loading}
+              style={landlordMode ? landlordVerifiedSecondaryButtonStyle : undefined}
+            >
               Refresh
             </Button>
           </div>
         </div>
 
-        <Card elevated>
+        <Card elevated style={landlordMode ? landlordVerifiedCardStyle : undefined}>
           <ResponsiveMasterDetail
             title={undefined}
             searchSlot={
@@ -340,16 +446,16 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder={isAdminAudience ? "Search applicant or application ID" : "Search applicant or email"}
-                style={{ width: "100%" }}
+                style={{ width: "100%", ...(landlordMode ? landlordVerifiedInputStyle : {}) }}
               />
             }
             masterTitle="Queue"
             master={
               <div style={{ display: "grid", gap: 8 }}>
                 {loading ? (
-                  <div style={{ color: text.muted }}>Loading queue...</div>
+                  <div style={{ color: landlordMode ? landlordVerifiedTheme.muted : text.muted }}>Loading queue...</div>
                 ) : filtered.length === 0 ? (
-                  <div style={{ color: text.muted }}>No verified screenings.</div>
+                  <div style={{ color: landlordMode ? landlordVerifiedTheme.muted : text.muted }}>No verified screenings.</div>
                 ) : (
                   filtered.map((item, index) => {
                     const itemKey = verifiedScreeningListKey(item, index);
@@ -360,22 +466,45 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
                       onClick={() => setSelectedId(itemKey)}
                       style={{
                         textAlign: "left",
-                        border: `1px solid ${itemKey === selectedId ? colors.accent : colors.border}`,
-                        background: itemKey === selectedId ? "rgba(37,99,235,0.08)" : colors.card,
+                        border: `1px solid ${
+                          landlordMode
+                            ? itemKey === selectedId
+                              ? landlordVerifiedTheme.activeBorder
+                              : landlordVerifiedTheme.border
+                            : itemKey === selectedId
+                              ? colors.accent
+                              : colors.border
+                        }`,
+                        background: landlordMode
+                          ? itemKey === selectedId
+                            ? landlordVerifiedTheme.activeBg
+                            : landlordVerifiedTheme.card
+                          : itemKey === selectedId
+                            ? "rgba(37,99,235,0.08)"
+                            : colors.card,
                         borderRadius: radius.md,
                         padding: "10px 12px",
                         cursor: "pointer",
                         display: "grid",
                         gap: 4,
+                        boxShadow: landlordMode && itemKey === selectedId ? "inset 0 -2px 0 rgba(36, 88, 66, 0.22)" : "none",
                       }}
                     >
-                      <div style={{ fontWeight: 700, color: text.primary }}>{item.applicant?.name || "Applicant"}</div>
-                      <div style={{ color: text.muted, fontSize: 12 }}>{item.applicant?.email || "No email"}</div>
-                      <div className="rc-wrap-row">
-                        <Pill>{isAdminAudience ? item.status : verifiedScreeningStatusDisplay(item)}</Pill>
-                        <Pill>{isAdminAudience ? item.serviceLevel : verifiedScreeningPackageDisplay(item)}</Pill>
+                      <div style={{ fontWeight: 700, color: landlordMode ? landlordVerifiedTheme.text : text.primary }}>
+                        {item.applicant?.name || "Applicant"}
                       </div>
-                      <div style={{ fontSize: 12, color: text.muted }}>
+                      <div style={{ color: landlordMode ? landlordVerifiedTheme.muted : text.muted, fontSize: 12 }}>
+                        {item.applicant?.email || "No email"}
+                      </div>
+                      <div className="rc-wrap-row">
+                        <Pill style={landlordMode ? landlordVerifiedPillStyle : undefined}>
+                          {isAdminAudience ? item.status : verifiedScreeningStatusDisplay(item)}
+                        </Pill>
+                        <Pill style={landlordMode ? landlordVerifiedPillStyle : undefined}>
+                          {isAdminAudience ? item.serviceLevel : verifiedScreeningPackageDisplay(item)}
+                        </Pill>
+                      </div>
+                      <div style={{ fontSize: 12, color: landlordMode ? landlordVerifiedTheme.muted : text.muted }}>
                         ${(item.totalAmountCents / 100).toFixed(2)} {item.currency}
                       </div>
                     </button>
@@ -404,7 +533,7 @@ const AdminVerifiedScreeningsPage: React.FC<AdminVerifiedScreeningsPageProps> = 
             selectedLabel={(isAdminAudience ? detail?.applicant?.name : selectedSummary?.applicant?.name) || "Screening"}
             onClearSelection={() => setSelectedId(null)}
             detail={
-              <Card>
+              <Card style={landlordMode ? landlordVerifiedCardStyle : undefined}>
                 {isAdminAudience && !detail ? (
                   <div style={{ color: text.muted }}>Select a queue item.</div>
                 ) : !isAdminAudience && !selectedSummary ? (

--- a/rentchain-frontend/src/pages/legal/PrivacyPage.test.tsx
+++ b/rentchain-frontend/src/pages/legal/PrivacyPage.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LanguageProvider } from "../../context/LanguageContext";
+import PrivacyPage from "./PrivacyPage";
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+function renderPrivacyPage() {
+  return render(
+    <MemoryRouter>
+      <LanguageProvider>
+        <PrivacyPage />
+      </LanguageProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("PrivacyPage", () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("renders the privacy policy in the warm neutral public legal shell", () => {
+    const { container } = renderPrivacyPage();
+
+    expect(screen.getByRole("heading", { name: "Privacy Policy" })).toBeInTheDocument();
+    expect(screen.getByText("Effective date: 2026-01-21")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveStyle({
+      background: "#f4efe6",
+      color: "#171411",
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/legal/PrivacyPage.tsx
+++ b/rentchain-frontend/src/pages/legal/PrivacyPage.tsx
@@ -8,7 +8,7 @@ const PrivacyPage: React.FC = () => {
   }, []);
 
   return (
-    <MarketingLayout>
+    <MarketingLayout tone="warmNeutral">
       <div style={{ display: "flex", flexDirection: "column", gap: spacing.md, maxWidth: 760 }}>
         <div>
           <h1 style={{ margin: 0 }}>Privacy Policy</h1>

--- a/rentchain-frontend/src/pages/legal/TermsPage.test.tsx
+++ b/rentchain-frontend/src/pages/legal/TermsPage.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LanguageProvider } from "../../context/LanguageContext";
+import TermsPage from "./TermsPage";
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+function renderTermsPage() {
+  return render(
+    <MemoryRouter>
+      <LanguageProvider>
+        <TermsPage />
+      </LanguageProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("TermsPage", () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("renders the terms in the warm neutral public legal shell without changing copy", () => {
+    const { container } = renderTermsPage();
+
+    expect(screen.getByRole("heading", { name: "Terms of Service" })).toBeInTheDocument();
+    expect(screen.getByText("Effective date: 2026-01-21")).toBeInTheDocument();
+    expect(screen.getByText(/RentChain provides governed operational infrastructure/)).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveStyle({
+      background: "#f4efe6",
+      color: "#171411",
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/legal/TermsPage.tsx
+++ b/rentchain-frontend/src/pages/legal/TermsPage.tsx
@@ -8,7 +8,7 @@ const TermsPage: React.FC = () => {
   }, []);
 
   return (
-    <MarketingLayout>
+    <MarketingLayout tone="warmNeutral">
       <div style={{ display: "flex", flexDirection: "column", gap: spacing.md, maxWidth: 760 }}>
         <div>
           <h1 style={{ margin: 0 }}>Terms of Service</h1>

--- a/rentchain-frontend/src/pages/marketing/LegalHelpPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/LegalHelpPage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LanguageProvider } from "../../context/LanguageContext";
+import LegalHelpPage from "./LegalHelpPage";
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+vi.mock("../../lib/analytics", () => ({
+  track: vi.fn(),
+}));
+
+function renderLegalHelpPage() {
+  return render(
+    <MemoryRouter initialEntries={["/site/legal"]}>
+      <LanguageProvider>
+        <LegalHelpPage />
+      </LanguageProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("LegalHelpPage", () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("renders the public legal hub in the warm neutral shell", () => {
+    const { container } = renderLegalHelpPage();
+
+    expect(screen.getByRole("heading", { name: "Legal" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Terms of Service" })).toHaveAttribute("href", "/terms");
+    expect(screen.getByRole("link", { name: "Privacy Policy" })).toHaveAttribute("href", "/privacy");
+    expect(screen.getByRole("button", { name: "Expand Ask RentChain widget" })).toHaveStyle({
+      background: "rgba(234, 223, 205, 0.72)",
+      color: "#171411",
+    });
+    expect(container.firstElementChild).toHaveStyle({
+      background: "#f4efe6",
+      color: "#171411",
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/marketing/LegalHelpPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/LegalHelpPage.tsx
@@ -7,6 +7,19 @@ import { MarketingLayout } from "./MarketingLayout";
 import { useLanguage } from "../../context/LanguageContext";
 import { marketingCopy } from "../../content/marketingCopy";
 
+const legalWarmCardStyle: React.CSSProperties = {
+  background: "#fffaf1",
+  border: "1px solid rgba(105, 82, 49, 0.2)",
+  boxShadow: "0 18px 42px rgba(69, 55, 33, 0.12)",
+  color: "#171411",
+};
+
+const legalWarmLinkStyle: React.CSSProperties = {
+  color: "#245842",
+  fontWeight: 700,
+  textUnderlineOffset: 3,
+};
+
 const LegalHelpPage: React.FC = () => {
   const { locale } = useLanguage();
   const copy = marketingCopy[locale];
@@ -16,39 +29,39 @@ const LegalHelpPage: React.FC = () => {
   }, [copy.legal.headline]);
 
   return (
-    <MarketingLayout>
+    <MarketingLayout tone="warmNeutral">
       <div style={{ display: "flex", flexDirection: "column", gap: spacing.lg }}>
         <div>
           <h1 style={{ margin: 0 }}>{copy.legal.headline}</h1>
-          <p style={{ marginTop: spacing.sm, marginBottom: 0, color: text.muted }}>{copy.legal.intro}</p>
+          <p style={{ marginTop: spacing.sm, marginBottom: 0, color: "#5f5a51" }}>{copy.legal.intro}</p>
         </div>
 
-        <Card>
+        <Card style={legalWarmCardStyle}>
           <div style={{ display: "flex", flexDirection: "column", gap: spacing.md }}>
             {copy.legal.sections.map((section) => (
               <div key={section.title}>
                 <h2 style={{ marginTop: 0 }}>{section.title}</h2>
-                <p style={{ margin: 0, color: text.muted }}>{section.body}</p>
+                <p style={{ margin: 0, color: "#5f5a51" }}>{section.body}</p>
               </div>
             ))}
           </div>
         </Card>
 
-        <Card>
+        <Card style={legalWarmCardStyle}>
           <h2 style={{ marginTop: 0 }}>{copy.legal.policyTitle}</h2>
-          <ul style={{ margin: 0, paddingLeft: "1.1rem", color: text.muted }}>
+          <ul style={{ margin: 0, paddingLeft: "1.1rem", color: "#5f5a51" }}>
             <li>
-              <Link to="/terms" style={{ color: text.secondary }}>
+              <Link to="/terms" style={legalWarmLinkStyle}>
                 {copy.legal.policyTerms}
               </Link>
             </li>
             <li>
-              <Link to="/privacy" style={{ color: text.secondary }}>
+              <Link to="/privacy" style={legalWarmLinkStyle}>
                 {copy.legal.policyPrivacy}
               </Link>
             </li>
             <li>
-              <Link to="/acceptable-use" style={{ color: text.secondary }}>
+              <Link to="/acceptable-use" style={legalWarmLinkStyle}>
                 {copy.legal.policyAcceptableUse}
               </Link>
             </li>
@@ -57,7 +70,7 @@ const LegalHelpPage: React.FC = () => {
 
         <div>
           <h2 style={{ marginTop: 0 }}>{copy.legal.assistanceTitle}</h2>
-          <AskRentChainWidget compact defaultOpen={false} />
+          <AskRentChainWidget compact defaultOpen={false} tone="warmNeutral" />
         </div>
       </div>
     </MarketingLayout>

--- a/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
+++ b/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
@@ -1,16 +1,58 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { colors, layout, radius, shadows, spacing, text, typography } from "../../styles/tokens";
+import {
+  colors as baseColors,
+  layout,
+  radius,
+  shadows as baseShadows,
+  spacing,
+  text as baseText,
+  typography,
+} from "../../styles/tokens";
 import { useAuth } from "../../context/useAuth";
 import { useLanguage } from "../../context/LanguageContext";
 import { RentChainLogo } from "../../components/brand/RentChainLogo";
 import { marketingCopy } from "../../content/marketingCopy";
 
+type MarketingLayoutTone = "default" | "warmNeutral";
+
 interface MarketingLayoutProps {
   children: React.ReactNode;
+  tone?: MarketingLayoutTone;
 }
 
-export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) => {
+const warmMarketingColors = {
+  ...baseColors,
+  bg: "#f4efe6",
+  bgAmbient:
+    "radial-gradient(circle at 12% 10%, rgba(215, 173, 107, 0.18), transparent 30%), linear-gradient(135deg, #f4efe6 0%, #efe6d7 48%, #f8f3ea 100%)",
+  panel: "#fffaf1",
+  card: "#fffaf1",
+  bgElevated: "#fff7ea",
+  border: "rgba(105, 82, 49, 0.2)",
+  borderStrong: "rgba(105, 82, 49, 0.34)",
+  accent: "#171411",
+  accentSoft: "rgba(36, 88, 66, 0.14)",
+  navy: "#245842",
+  navySoft: "rgba(36, 88, 66, 0.14)",
+};
+
+const warmMarketingText = {
+  ...baseText,
+  primary: "#171411",
+  secondary: "#2c2924",
+  muted: "#5f5a51",
+  subtle: "#756f64",
+};
+
+const warmMarketingShadows = {
+  ...baseShadows,
+  sm: "0 8px 18px rgba(69, 55, 33, 0.09)",
+  md: "0 22px 52px rgba(69, 55, 33, 0.14)",
+  focus: "0 0 0 3px rgba(105, 82, 49, 0.22)",
+};
+
+export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children, tone = "default" }) => {
   const [isMobile, setIsMobile] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -21,6 +63,9 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
   const { locale, setLocale, t } = useLanguage();
   const copy = marketingCopy[locale];
   const isAuthed = Boolean(user?.id);
+  const colors = tone === "warmNeutral" ? warmMarketingColors : baseColors;
+  const text = tone === "warmNeutral" ? warmMarketingText : baseText;
+  const shadows = tone === "warmNeutral" ? warmMarketingShadows : baseShadows;
 
   const localeButtonStyle = (active: boolean) => ({
     border: "none",


### PR DESCRIPTION
## Summary
- Adds a scoped warm-neutral variant to `MarketingLayout` and opts `/privacy` and `/terms` into it without changing legal copy.
- Warms the landlord `WorkspaceDrawer` surface, scrim, close/sign-out controls, and active drawer states so the remaining drawer selection styling no longer uses bright blue.
- Adds focused tests for the legal page warm shell and drawer active-state styling.

## Mission audit
- `/terms` is rendered by `rentchain-frontend/src/pages/legal/TermsPage.tsx` through `MarketingLayout`; it was inheriting the older blue/white marketing shell and could be warmed without touching legal copy.
- `/privacy` is rendered by `rentchain-frontend/src/pages/legal/PrivacyPage.tsx` through `MarketingLayout`; it had the same older inherited shell and could be warmed without touching legal copy.
- Login save-password appears to be browser-native password-manager UI. The app renders only the normal `LoginPage`/`LoginForm` password field with `autoComplete="current-password"`, so this PR does not try to style browser-managed UI.
- The app-rendered drawer found with old theme styling was `rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx`; it still used blue active-state styling (`rgba(37,99,235,0.08)`) and token-blue borders via `colors.accent`.

## Implementation notes
- `MarketingLayout` now supports `tone="warmNeutral"`; default behavior remains unchanged for other shared marketing/help pages.
- `/privacy` and `/terms` pass `tone="warmNeutral"` and keep their legal text unchanged.
- `WorkspaceDrawer` now uses route-local warm neutral/pine styling for cards, panel, backdrop, borders, active states, footer actions, and labels.
- No backend, auth logic, route behavior, legal copy, billing/account/workflow/data behavior, global token migration, or shared `Ui.tsx` changes.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test -- PrivacyPage TermsPage LoginForm LoginPage LandlordNav WorkspaceDrawer`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`
- `git diff --cached --check`

## Browser QA notes
- Attempted localhost browser smoke for `/privacy`, `/terms`, `/login`, `/`, and `/site/pricing` at desktop/mobile viewports.
- The local app rendered the dev-access gate, so route-level visual verification is preview/live gated.
- The automated gated-page check still showed no console errors and no horizontal overflow for those route loads.

## Manual QA required
- `/privacy`: warm neutral public/legal theme, copy unchanged, no console errors, no horizontal overflow.
- `/terms`: warm neutral public/legal theme, copy unchanged, no console errors, no horizontal overflow.
- `/login`: login remains functional; password manager/autofill compatibility preserved where practical. Browser-native save-password prompt is not app-styleable.
- Affected workspace drawer: opens/closes cleanly, no overlap, no click-through, warm neutral active states, close button usable.
- `/`, `/site/pricing`, and `/dashboard` smoke if the workspace drawer is checked in an authenticated session.

## Deferred
- Browser-native save-password prompts remain outside app styling control.
- Other pages still using `MarketingLayout` keep the existing default shell unless a later mission opts them into the warm variant.