### PR TITLE
polish: simplify operations command center

### DIFF
--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -640,7 +640,7 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getByText("Operational inbox bridge")).toBeInTheDocument();
     expect(screen.getByText(/Review messages and source-linked actions tied to applications, leases, maintenance, payments, or work orders/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open operational inbox" })).toHaveAttribute("href", "/landlord/unified-inbox");
-    expect(screen.getByRole("link", { name: "Open decision inbox" })).toHaveAttribute("href", "/decision-inbox");
+    expect(screen.getAllByRole("link", { name: "Open decision inbox" })[0]).toHaveAttribute("href", "/decision-inbox");
 
     await waitFor(() => {
       expect(mocks.fetchDecisionInbox).toHaveBeenCalled();
@@ -653,8 +653,12 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getByText("Today's operational summary")).toBeInTheDocument();
     expect(screen.getByText("Urgent / overdue work")).toBeInTheDocument();
     expect(screen.getByText("Urgent / blocked")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review urgent work:/i })).toHaveAttribute("href", "#operations-urgent-work");
     expect(screen.getByText("Needs landlord review")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review landlord-owned items:/i })).toHaveAttribute("href", "#operations-review-queue");
     expect(screen.getByText("Evidence/source attached")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open evidence-ready items:/i })).toHaveAttribute("href", "#operations-evidence-ready");
+    expect(screen.getByRole("link", { name: /Review upcoming deadlines:/i })).toHaveAttribute("href", "#operations-upcoming-work");
     expect(screen.getByTestId("operations-waiting-lanes")).toBeInTheDocument();
     expect(screen.getByText("Waiting lanes")).toBeInTheDocument();
     expect(screen.getByText("Waiting on tenant")).toBeInTheDocument();
@@ -673,32 +677,26 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getByText("Payments and arrears")).toBeInTheDocument();
     expect(screen.getByText("Tenant/application requests")).toBeInTheDocument();
     expect(screen.getByText("Contractor follow-ups")).toBeInTheDocument();
-    expect(screen.getByText("Evidence-ready items")).toBeInTheDocument();
+    expect(screen.getAllByText("Evidence-ready items").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Payments / obligations").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lease lifecycle").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Documents / workspace").length).toBeGreaterThan(0);
-    expect(screen.getByTestId("operations-summary-strip")).toHaveStyle({
-      gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 136px), 1fr))",
-    });
     expect(screen.getByTestId("operations-coordination-lanes")).toHaveStyle({
       display: "grid",
       gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
     });
     expect(screen.getByText("Advanced triage queue")).toBeInTheDocument();
-    expect(screen.getByText(/Search, saved views, manual review controls, and detailed priority lists/i)).toBeInTheDocument();
+    expect(screen.getByText(/Search, saved views, and compact manual review controls/i)).toBeInTheDocument();
+    expect(screen.getByText(/Showing 6 of 9 reviewable items/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View all in review queue" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show detailed priority lists" })).toBeInTheDocument();
     expect(screen.getAllByText("Critical").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Needs review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Upcoming").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Informational").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Context: North Towers · 101 · John Smith").length).toBeGreaterThan(0);
-    expect(screen.getByText("Why: Lease is active but occupancy state conflicts.")).toBeInTheDocument();
-    expect(screen.getByText("Workflow status: New")).toBeInTheDocument();
-    expect(screen.getByText("Review status: Open")).toBeInTheDocument();
-    expect(screen.getAllByText("Financial status: Review required").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Assignment: Operations owned").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Escalation: Critical").length).toBeGreaterThan(0);
-    expect(screen.getByText("Next action: Open payment ledger")).toBeInTheDocument();
+    expect(screen.getAllByText("North Towers · 101 · John Smith").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Next: Open payment ledger").length).toBeGreaterThan(0);
     expect(screen.getByTestId("operational-review-queue")).toBeInTheDocument();
     expect(screen.getByText("Operational review queue")).toBeInTheDocument();
     expect(screen.getByText(/does not create workspaces, route work automatically, or change source records/i)).toBeInTheDocument();
@@ -708,6 +706,7 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(1);
     expect(screen.getAllByText("Payment Ledger Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Delinquency or payment evidence review").length).toBeGreaterThan(0);
+    expect(document.body.textContent).not.toContain("/leases/lease-1/ledger");
     expect(screen.queryByRole("button", { name: /create review workspace/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/tenant-visible review/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/institutional sharing/i)).not.toBeInTheDocument();
@@ -874,12 +873,10 @@ describe("OperationalCommandCenterPage", () => {
 
     await waitFor(() => expect(mocks.fetchOperatorReviewManualMetadata).toHaveBeenCalled());
 
-    expect(screen.getAllByText("Review status: In review").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Assignment: Finance reviewer").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Review status: Blocked").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Assignment: Property manager").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual status: In review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Assigned reviewer: Finance reviewer").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual status: Blocked").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Assigned reviewer: Property manager").length).toBeGreaterThan(0);
   });
 
   it("persists manual review status and assigned reviewer changes from Operations controls", async () => {
@@ -911,7 +908,7 @@ describe("OperationalCommandCenterPage", () => {
     );
 
     await waitFor(() => expect(screen.getAllByText("Manual status: In review").length).toBeGreaterThan(0));
-    expect(screen.getAllByText("Assignment: Finance reviewer").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Assigned reviewer: Finance reviewer").length).toBeGreaterThan(0);
   });
 
   it("supports combined triage facets while preserving search and reset behavior", async () => {

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -649,6 +649,26 @@ describe("OperationalCommandCenterPage", () => {
       expect(mocks.fetchProperties).toHaveBeenCalledWith({ status: "active" });
     });
 
+    expect(screen.getByTestId("operations-daily-summary")).toBeInTheDocument();
+    expect(screen.getByText("Today's operational summary")).toBeInTheDocument();
+    expect(screen.getByText("Urgent / overdue work")).toBeInTheDocument();
+    expect(screen.getByText("Urgent / blocked")).toBeInTheDocument();
+    expect(screen.getByText("Needs landlord review")).toBeInTheDocument();
+    expect(screen.getByText("Evidence/source attached")).toBeInTheDocument();
+    expect(screen.getByTestId("operations-waiting-lanes")).toBeInTheDocument();
+    expect(screen.getByText("Waiting lanes")).toBeInTheDocument();
+    expect(screen.getByText("Waiting on tenant")).toBeInTheDocument();
+    expect(screen.getByText("Waiting on landlord")).toBeInTheDocument();
+    expect(screen.getByText("Waiting on contractor")).toBeInTheDocument();
+    expect(screen.getByTestId("operations-work-buckets")).toBeInTheDocument();
+    expect(screen.getByText("Main work buckets")).toBeInTheDocument();
+    expect(screen.getByText("Maintenance and repairs")).toBeInTheDocument();
+    expect(screen.getByText("Lease actions")).toBeInTheDocument();
+    expect(screen.getByText("Notices and compliance")).toBeInTheDocument();
+    expect(screen.getByText("Payments and arrears")).toBeInTheDocument();
+    expect(screen.getByText("Tenant/application requests")).toBeInTheDocument();
+    expect(screen.getByText("Contractor follow-ups")).toBeInTheDocument();
+    expect(screen.getByText("Evidence-ready items")).toBeInTheDocument();
     expect(screen.getAllByText("Payments / obligations").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lease lifecycle").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Documents / workspace").length).toBeGreaterThan(0);
@@ -659,8 +679,8 @@ describe("OperationalCommandCenterPage", () => {
       display: "grid",
       gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
     });
-    expect(screen.getByText("Priority routing queue")).toBeInTheDocument();
-    expect(screen.getByText(/Highest priority first by urgency, severity, and source workflow/i)).toBeInTheDocument();
+    expect(screen.getByText("Advanced triage queue")).toBeInTheDocument();
+    expect(screen.getByText(/Search, saved views, manual review controls, and detailed priority lists/i)).toBeInTheDocument();
     expect(screen.getAllByText("Critical").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Needs review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Upcoming").length).toBeGreaterThan(0);
@@ -674,7 +694,6 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Assignment: Operations owned").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Escalation: Critical").length).toBeGreaterThan(0);
     expect(screen.getByText("Next action: Open payment ledger")).toBeInTheDocument();
-    expect(screen.getAllByText("Review workspace readiness").length).toBeGreaterThan(0);
     expect(screen.getByTestId("operational-review-queue")).toBeInTheDocument();
     expect(screen.getByText("Operational review queue")).toBeInTheDocument();
     expect(screen.getByText(/does not create workspaces, route work automatically, or change source records/i)).toBeInTheDocument();
@@ -682,7 +701,6 @@ describe("OperationalCommandCenterPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Details and manual controls for Review missing payment/i }));
     expect(screen.getAllByText("Related resource context").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Review missing payment").length).toBeGreaterThan(1);
-    expect(screen.getAllByText(/does not create a workspace, route work automatically, or change source records/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Payment Ledger Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Delinquency or payment evidence review").length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /create review workspace/i })).not.toBeInTheDocument();
@@ -856,7 +874,7 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getAllByText("Review status: Blocked").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Assignment: Property manager").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual status: In review").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Manual assignment: Finance reviewer").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Assigned reviewer: Finance reviewer").length).toBeGreaterThan(0);
   });
 
   it("persists manual review status and assigned reviewer changes from Operations controls", async () => {

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -660,6 +660,11 @@ describe("OperationalCommandCenterPage", () => {
     expect(screen.getByText("Waiting on tenant")).toBeInTheDocument();
     expect(screen.getByText("Waiting on landlord")).toBeInTheDocument();
     expect(screen.getByText("Waiting on contractor")).toBeInTheDocument();
+    expect(screen.getByTestId("operations-waiting-lane-count-tenant")).toHaveStyle({
+      whiteSpace: "nowrap",
+      flex: "0 0 auto",
+      minWidth: "max-content",
+    });
     expect(screen.getByTestId("operations-work-buckets")).toBeInTheDocument();
     expect(screen.getByText("Main work buckets")).toBeInTheDocument();
     expect(screen.getByText("Maintenance and repairs")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -80,6 +80,8 @@ type WorkBucketKey =
   | "contractor_followups"
   | "evidence_ready";
 
+type SummaryActionKey = "urgent" | "landlord_review" | "upcoming" | "evidence";
+
 type CommandCenterFilterOptions = {
   search?: string;
   filter?: CommandCenterFilter;
@@ -335,6 +337,55 @@ const WORK_BUCKET_CONFIG: Array<{
     helper: "Items with scoped source workflow evidence or manual review handoff context.",
     destination: "/decision-inbox",
     icon: ShieldCheck,
+  },
+];
+
+const REVIEW_QUEUE_PREVIEW_LIMIT = 6;
+
+const SUMMARY_ACTION_CONFIG: Array<{
+  key: SummaryActionKey;
+  label: string;
+  issue: string;
+  nextAction: string;
+  actionLabel: string;
+  href: string;
+  severity: CommandCenterSeverity;
+}> = [
+  {
+    key: "urgent",
+    label: "Urgent / blocked",
+    issue: "Blocked, critical, delinquent, or escalated source work.",
+    nextAction: "Start with the highest-risk operational items.",
+    actionLabel: "Review urgent work",
+    href: "#operations-urgent-work",
+    severity: "critical",
+  },
+  {
+    key: "landlord_review",
+    label: "Needs landlord review",
+    issue: "Manual decisions, assignments, approvals, and review-needed items.",
+    nextAction: "Review landlord-owned items before source workflows move forward.",
+    actionLabel: "Review landlord-owned items",
+    href: "#operations-review-queue",
+    severity: "warning",
+  },
+  {
+    key: "upcoming",
+    label: "Upcoming",
+    issue: "Forward-looking lease, renewal, occupancy, or dated workflow timing.",
+    nextAction: "Check deadlines that need scheduling, notice, or renewal follow-up.",
+    actionLabel: "Review upcoming deadlines",
+    href: "#operations-upcoming-work",
+    severity: "info",
+  },
+  {
+    key: "evidence",
+    label: "Evidence/source attached",
+    issue: "Items with source routing and manual review handoff context.",
+    nextAction: "Open source-backed items that are ready for review context.",
+    actionLabel: "Open evidence-ready items",
+    href: "#operations-evidence-ready",
+    severity: "info",
   },
 ];
 
@@ -1254,37 +1305,52 @@ function Badge({ children, severity }: { children: React.ReactNode; severity: Co
   );
 }
 
-function DailyMetricCard({
-  label: metricLabel,
+function SummaryActionCard({
+  config,
   value,
-  helper,
-  severity = "info",
 }: {
-  label: string;
+  config: (typeof SUMMARY_ACTION_CONFIG)[number];
   value: number;
-  helper: string;
-  severity?: CommandCenterSeverity;
 }) {
-  const tone = severityTone(severity);
+  const tone = severityTone(value > 0 ? config.severity : "info");
   return (
-    <Card
+    <a
+      href={config.href}
+      aria-label={`${config.actionLabel}: ${value} ${config.label.toLowerCase()} item${value === 1 ? "" : "s"}`}
       style={{
-        ...operationsCardSurface,
-        border: `1px solid ${tone.border}`,
-        borderRadius: 12,
-        padding: 14,
-        boxSizing: "border-box",
+        color: "inherit",
+        textDecoration: "none",
+        display: "flex",
         minWidth: 0,
-        minHeight: 118,
-        display: "grid",
-        gap: 6,
-        alignContent: "start",
       }}
     >
-      <div style={{ color: "#63594d", fontSize: 12, fontWeight: 900 }}>{metricLabel}</div>
-      <strong style={{ color: "#211c17", fontSize: 30, lineHeight: 1 }}>{value}</strong>
-      <span style={{ color: "#3f382f", fontSize: 13, lineHeight: 1.45 }}>{helper}</span>
-    </Card>
+      <Card
+        data-testid={`operations-summary-action-${config.key}`}
+        style={{
+          ...operationsCardSurface,
+          border: `1px solid ${tone.border}`,
+          borderRadius: 12,
+          padding: 14,
+          boxSizing: "border-box",
+          minWidth: 0,
+          minHeight: 150,
+          display: "grid",
+          gap: 8,
+          alignContent: "start",
+          width: "100%",
+        }}
+      >
+        <div style={{ color: "#63594d", fontSize: 12, fontWeight: 900 }}>{config.label}</div>
+        <div style={{ display: "flex", alignItems: "start", justifyContent: "space-between", gap: 12, minWidth: 0 }}>
+          <strong style={{ color: "#211c17", fontSize: 32, lineHeight: 1, whiteSpace: "nowrap" }}>{value}</strong>
+          <span style={{ color: "#245842", fontSize: 13, fontWeight: 900, textAlign: "right", lineHeight: 1.3 }}>
+            {config.actionLabel}
+          </span>
+        </div>
+        <span style={{ color: "#3f382f", fontSize: 13, lineHeight: 1.45 }}>{config.issue}</span>
+        <span style={{ color: "#211c17", fontSize: 13, lineHeight: 1.45, fontWeight: 900 }}>Next: {config.nextAction}</span>
+      </Card>
+    </a>
   );
 }
 
@@ -1396,6 +1462,8 @@ export default function OperationalCommandCenterPage() {
   const [assignment, setAssignment] = React.useState<AssignmentFilter>("all");
   const [escalation, setEscalation] = React.useState<EscalationFilter>("all");
   const [timingRisk, setTimingRisk] = React.useState<TimingRiskFilter>("all");
+  const [showFullReviewQueue, setShowFullReviewQueue] = React.useState(false);
+  const [showPriorityDetails, setShowPriorityDetails] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -1455,6 +1523,10 @@ export default function OperationalCommandCenterPage() {
     [activeFilter, assignment, escalation, reviewStatus, search, signals, timingRisk, workflowType]
   );
   const reviewQueueItems = React.useMemo(() => deriveOperationalReviewQueueItems(visibleSignals), [visibleSignals]);
+  const displayedReviewQueueItems = React.useMemo(
+    () => (showFullReviewQueue ? reviewQueueItems : reviewQueueItems.slice(0, REVIEW_QUEUE_PREVIEW_LIMIT)),
+    [reviewQueueItems, showFullReviewQueue]
+  );
   const categorySummary = React.useMemo(() => summarizeByCategory(visibleSignals), [visibleSignals]);
   const prioritySummary = React.useMemo(() => summarizeByPriority(visibleSignals), [visibleSignals]);
   const urgentSignals = React.useMemo(() => visibleSignals.filter(isBlockedOrUrgent), [visibleSignals]);
@@ -1480,8 +1552,12 @@ export default function OperationalCommandCenterPage() {
       })),
     [visibleSignals]
   );
-  const criticalCount = signals.filter((signal) => signal.severity === "critical").length;
-  const warningCount = signals.filter((signal) => signal.severity === "warning").length;
+  const summaryActionCounts: Record<SummaryActionKey, number> = {
+    urgent: urgentSignals.length,
+    landlord_review: landlordReviewSignals.length,
+    upcoming: upcomingSignals.length,
+    evidence: evidenceReadySignals.length,
+  };
   const activeFilterCopy = filterCopy({ search, filter: activeFilter, workflowType, reviewStatus, assignment, escalation, timingRisk });
 
   function applySavedView(view: SavedOperationalView) {
@@ -1615,46 +1691,73 @@ export default function OperationalCommandCenterPage() {
               minWidth: 0,
             }}
           >
-            <DailyMetricCard
-              label="Urgent / blocked"
-              value={urgentSignals.length}
-              helper="Critical, blocked, delinquent, or escalated source work."
-              severity={urgentSignals.length ? "critical" : "info"}
-            />
-            <DailyMetricCard
-              label="Needs landlord review"
-              value={landlordReviewSignals.length}
-              helper="Manual decisions, assignments, approvals, and review-needed items."
-              severity={landlordReviewSignals.length ? "warning" : "info"}
-            />
-            <DailyMetricCard
-              label="Upcoming"
-              value={upcomingSignals.length}
-              helper="Forward-looking lease, renewal, occupancy, or dated workflow timing."
-            />
-            <DailyMetricCard
-              label="Evidence/source attached"
-              value={evidenceReadySignals.length}
-              helper="Items with source routing and manual review handoff context."
-            />
+            {SUMMARY_ACTION_CONFIG.map((config) => (
+              <SummaryActionCard key={config.key} config={config} value={summaryActionCounts[config.key]} />
+            ))}
           </div>
-          <Card
+          <div
             style={{
-              ...operationsCardSurface,
-              borderRadius: 12,
-              padding: 14,
               display: "grid",
-              gap: 10,
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
+              gap: 12,
               minWidth: 0,
             }}
           >
-            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-              <AlertTriangle size={18} />
-              <strong style={sectionTitleStyle}>Urgent / overdue work</strong>
-              <span style={helperTextStyle}>Highest-priority items appear here before the full queue.</span>
-            </div>
-            <SignalMiniList signals={urgentSignals} empty="No urgent or blocked operational items are visible." />
-          </Card>
+            <Card
+              id="operations-urgent-work"
+              style={{
+                ...operationsCardSurface,
+                borderRadius: 12,
+                padding: 14,
+                display: "grid",
+                gap: 10,
+                minWidth: 0,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <AlertTriangle size={18} />
+                <strong style={sectionTitleStyle}>Urgent / overdue work</strong>
+                <span style={helperTextStyle}>Top items only.</span>
+              </div>
+              <SignalMiniList signals={urgentSignals} empty="No urgent or blocked operational items are visible." />
+            </Card>
+            <Card
+              id="operations-upcoming-work"
+              style={{
+                ...operationsCardSurface,
+                borderRadius: 12,
+                padding: 14,
+                display: "grid",
+                gap: 10,
+                minWidth: 0,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <ClipboardList size={18} />
+                <strong style={sectionTitleStyle}>Upcoming deadlines</strong>
+                <span style={helperTextStyle}>Top dated work only.</span>
+              </div>
+              <SignalMiniList signals={upcomingSignals} empty="No upcoming deadline items are visible." />
+            </Card>
+            <Card
+              id="operations-evidence-ready"
+              style={{
+                ...operationsCardSurface,
+                borderRadius: 12,
+                padding: 14,
+                display: "grid",
+                gap: 10,
+                minWidth: 0,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <ShieldCheck size={18} />
+                <strong style={sectionTitleStyle}>Evidence-ready items</strong>
+                <span style={helperTextStyle}>Top source-backed items only.</span>
+              </div>
+              <SignalMiniList signals={evidenceReadySignals} empty="No evidence-ready items are visible." />
+            </Card>
+          </div>
         </Section>
 
         <Section
@@ -1733,36 +1836,6 @@ export default function OperationalCommandCenterPage() {
               <WorkBucketCard key={bucket.key} config={bucket} signals={bucket.signals} />
             ))}
           </div>
-        </Section>
-
-        <Section
-          data-testid="operations-summary-strip"
-          style={{
-            ...operationsSectionSurface,
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 136px), 1fr))",
-            gap: 8,
-            minWidth: 0,
-            boxSizing: "border-box",
-          }}
-        >
-          {[
-            ["Signals", signals.length],
-            ["Critical", criticalCount],
-            ["Warnings", warningCount],
-            ["Needs review", signals.filter((signal) => signal.priorityGroup === "needs_review").length],
-            ["Upcoming", signals.filter((signal) => signal.priorityGroup === "upcoming").length],
-            ["Open decisions", decisionData?.summary?.open ?? 0],
-            ["Delinquent", dashboardData?.kpis?.delinquentCount ?? 0],
-          ].map(([name, value]) => (
-            <Card
-              key={String(name)}
-              style={{ ...operationsCardSurface, borderRadius: 12, padding: 12, boxSizing: "border-box", minWidth: 0, minHeight: 86 }}
-            >
-              <div style={{ color: "#63594d", fontSize: 12, fontWeight: 900 }}>{name}</div>
-              <strong style={{ color: "#211c17", fontSize: 24 }}>{value}</strong>
-            </Card>
-          ))}
         </Section>
 
         <Section style={{ ...operationsSectionSurface, display: "grid", gap: 12, minWidth: 0 }}>
@@ -1866,7 +1939,9 @@ export default function OperationalCommandCenterPage() {
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             <Building2 size={18} />
             <strong style={sectionTitleStyle}>Advanced triage queue</strong>
-            <span style={helperTextStyle}>Search, saved views, manual review controls, and detailed priority lists.</span>
+            <span style={helperTextStyle}>
+              Search, saved views, and compact manual review controls. Open decisions: {decisionData?.summary?.open ?? 0}. Delinquent: {dashboardData?.kpis?.delinquentCount ?? 0}.
+            </span>
           </div>
           <Card
             data-testid="operations-filter-panel"
@@ -2056,107 +2131,185 @@ export default function OperationalCommandCenterPage() {
             </Card>
           ) : null}
           {!loading && !error && visibleSignals.length ? (
-            <OperationalReviewQueue
-              items={reviewQueueItems}
-              onManualReviewChange={(item, next) =>
-                persistManualReviewChange(item.manualReviewScope as OperatorReviewScope, item.manualReviewScopeId, next)
-              }
-            />
+            <div id="operations-review-queue" style={{ display: "grid", gap: 10, minWidth: 0 }}>
+              <Card
+                style={{
+                  ...operationsCardSurface,
+                  borderRadius: 10,
+                  padding: 12,
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 10,
+                  flexWrap: "wrap",
+                  alignItems: "center",
+                  minWidth: 0,
+                }}
+              >
+                <span style={{ ...helperTextStyle, fontWeight: 900 }}>
+                  Showing {displayedReviewQueueItems.length} of {reviewQueueItems.length} reviewable item{reviewQueueItems.length === 1 ? "" : "s"}.
+                </span>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                  {reviewQueueItems.length > REVIEW_QUEUE_PREVIEW_LIMIT ? (
+                    <button
+                      type="button"
+                      onClick={() => setShowFullReviewQueue((current) => !current)}
+                      style={{
+                        border: "1px solid rgba(91,70,48,0.24)",
+                        background: showFullReviewQueue ? "#fffaf1" : "#211c17",
+                        color: showFullReviewQueue ? "#3f382f" : "#fffaf1",
+                        borderRadius: 8,
+                        padding: "8px 10px",
+                        fontSize: 13,
+                        fontWeight: 900,
+                        cursor: "pointer",
+                        minHeight: 36,
+                      }}
+                    >
+                      {showFullReviewQueue ? "Show compact preview" : "View all in review queue"}
+                    </button>
+                  ) : null}
+                  <Link to="/decision-inbox" style={compactActionLinkStyle}>
+                    Open decision inbox
+                  </Link>
+                </div>
+              </Card>
+              <OperationalReviewQueue
+                items={displayedReviewQueueItems}
+                onManualReviewChange={(item, next) =>
+                  persistManualReviewChange(item.manualReviewScope as OperatorReviewScope, item.manualReviewScopeId, next)
+                }
+              />
+            </div>
           ) : null}
           {!loading && !error && visibleSignals.length ? (
-            <div style={{ display: "grid", gap: 16 }}>
-              {prioritySummary.map((group) => (
-                <div key={group.group} style={{ display: "grid", gap: 10, minWidth: 0 }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
-                    <div style={{ display: "grid", gap: 3 }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                        <Badge severity={group.tone}>{group.label}</Badge>
-                        <strong style={{ color: "#211c17" }}>{group.signals.length} item{group.signals.length === 1 ? "" : "s"}</strong>
+            <Card
+              style={{
+                ...operationsCardSurface,
+                borderRadius: 10,
+                padding: 12,
+                display: "grid",
+                gap: 10,
+                minWidth: 0,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+                <span style={{ ...helperTextStyle, fontWeight: 900 }}>
+                  Detailed priority lists are collapsed by default to keep this page focused on daily action.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setShowPriorityDetails((current) => !current)}
+                  style={{
+                    border: "1px solid rgba(91,70,48,0.24)",
+                    background: showPriorityDetails ? "#fffaf1" : "#211c17",
+                    color: showPriorityDetails ? "#3f382f" : "#fffaf1",
+                    borderRadius: 8,
+                    padding: "8px 10px",
+                    fontSize: 13,
+                    fontWeight: 900,
+                    cursor: "pointer",
+                    minHeight: 36,
+                  }}
+                >
+                  {showPriorityDetails ? "Hide detailed priority lists" : "Show detailed priority lists"}
+                </button>
+              </div>
+              {showPriorityDetails ? (
+                <div style={{ display: "grid", gap: 16 }}>
+                  {prioritySummary.map((group) => (
+                    <div key={group.group} style={{ display: "grid", gap: 10, minWidth: 0 }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+                        <div style={{ display: "grid", gap: 3 }}>
+                          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                            <Badge severity={group.tone}>{group.label}</Badge>
+                            <strong style={{ color: "#211c17" }}>{group.signals.length} item{group.signals.length === 1 ? "" : "s"}</strong>
+                          </div>
+                          <span style={{ color: "#63594d", fontSize: 13 }}>{group.description}</span>
+                        </div>
                       </div>
-                      <span style={{ color: "#63594d", fontSize: 13 }}>{group.description}</span>
-                    </div>
-                  </div>
-                  {group.signals.length ? (
-                    <div style={{ display: "grid", gap: 10 }}>
-                      {group.signals.map((signal) => (
-                        <Card
-                          key={signal.id}
-                          style={{
-                            borderRadius: 12,
-                            padding: 14,
-                            display: "grid",
-                            gap: 10,
-                            minWidth: 0,
-                            boxSizing: "border-box",
-                            overflowWrap: "anywhere",
-                            ...operationsCardSurface,
-                            border: signal.severity === "critical" ? "1px solid #fecaca" : operationsCardSurface.border,
-                          }}
-                        >
-                          <div
-                            style={{
-                              display: "grid",
-                              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 260px), 1fr))",
-                              gap: 10,
-                              alignItems: "start",
-                              minWidth: 0,
-                            }}
-                          >
-                            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-                              <Badge severity={signal.severity}>{signal.severity}</Badge>
-                              <span style={{ color: "#63594d", fontSize: 13, fontWeight: 800 }}>
-                                {CATEGORY_CONFIG[signal.category].label}
-                              </span>
-                              <span style={{ color: "#63594d", fontSize: 13 }}>{signal.source}</span>
-                            </div>
-                            <Link
-                              to={signal.destination}
+                      {group.signals.length ? (
+                        <div style={{ display: "grid", gap: 10 }}>
+                          {group.signals.map((signal) => (
+                            <Card
+                              key={signal.id}
                               style={{
-                                color: "#245842",
-                                fontWeight: 900,
-                                whiteSpace: "nowrap",
-                                alignSelf: "start",
+                                borderRadius: 12,
+                                padding: 14,
+                                display: "grid",
+                                gap: 10,
+                                minWidth: 0,
+                                boxSizing: "border-box",
+                                overflowWrap: "anywhere",
+                                ...operationsCardSurface,
+                                border: signal.severity === "critical" ? "1px solid #fecaca" : operationsCardSurface.border,
                               }}
                             >
-                              Open source workflow
-                            </Link>
-                          </div>
-                          <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
-                            <strong style={{ color: "#211c17", fontSize: 16 }}>{signal.title}</strong>
-                            <span style={{ color: "#63594d", fontSize: 13 }}>Context: {signal.contextLabel}</span>
-                            <span style={{ color: "#3f382f", lineHeight: 1.5 }}>Why: {signal.description}</span>
-                            <span style={{ color: "#211c17", fontSize: 13, fontWeight: 900 }}>
-                              Next action: {signal.nextActionLabel}
-                            </span>
-                          </div>
-                          <div
-                            style={{
-                              display: "grid",
-                              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 180px), 1fr))",
-                              gap: 8,
-                              color: "#3f382f",
-                              fontSize: 12,
-                              fontWeight: 800,
-                              minWidth: 0,
-                            }}
-                          >
-                            <span>Workflow status: {signal.workflowStatus}</span>
-                            <span>Review status: {signal.reviewStatus}</span>
-                            {signal.financialStatus ? <span>Financial status: {signal.financialStatus}</span> : null}
-                            <span>Assignment: {signal.assignmentLabel || "Unassigned"}</span>
-                            <span>Escalation: {signal.escalationLabel || "Not escalated"}</span>
-                          </div>
+                              <div
+                                style={{
+                                  display: "grid",
+                                  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 260px), 1fr))",
+                                  gap: 10,
+                                  alignItems: "start",
+                                  minWidth: 0,
+                                }}
+                              >
+                                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                                  <Badge severity={signal.severity}>{signal.severity}</Badge>
+                                  <span style={{ color: "#63594d", fontSize: 13, fontWeight: 800 }}>
+                                    {CATEGORY_CONFIG[signal.category].label}
+                                  </span>
+                                  <span style={{ color: "#63594d", fontSize: 13 }}>{signal.source}</span>
+                                </div>
+                                <Link
+                                  to={scopedSourceDestinationForSignal(signal)}
+                                  style={{
+                                    color: "#245842",
+                                    fontWeight: 900,
+                                    whiteSpace: "nowrap",
+                                    alignSelf: "start",
+                                  }}
+                                >
+                                  Open source workflow
+                                </Link>
+                              </div>
+                              <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+                                <strong style={{ color: "#211c17", fontSize: 16 }}>{signal.title}</strong>
+                                <span style={{ color: "#63594d", fontSize: 13 }}>Context: {signal.contextLabel}</span>
+                                <span style={{ color: "#3f382f", lineHeight: 1.5 }}>Why: {signal.description}</span>
+                                <span style={{ color: "#211c17", fontSize: 13, fontWeight: 900 }}>
+                                  Next action: {signal.nextActionLabel}
+                                </span>
+                              </div>
+                              <div
+                                style={{
+                                  display: "grid",
+                                  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 180px), 1fr))",
+                                  gap: 8,
+                                  color: "#3f382f",
+                                  fontSize: 12,
+                                  fontWeight: 800,
+                                  minWidth: 0,
+                                }}
+                              >
+                                <span>Workflow status: {signal.workflowStatus}</span>
+                                <span>Review status: {signal.reviewStatus}</span>
+                                {signal.financialStatus ? <span>Financial status: {signal.financialStatus}</span> : null}
+                                <span>Assignment: {signal.assignmentLabel || "Unassigned"}</span>
+                                <span>Escalation: {signal.escalationLabel || "Not escalated"}</span>
+                              </div>
+                            </Card>
+                          ))}
+                        </div>
+                      ) : (
+                        <Card style={{ ...operationsCardSurface, color: "#63594d", borderRadius: 8, boxSizing: "border-box" }}>
+                          No {group.label.toLowerCase()} items currently visible.
                         </Card>
-                      ))}
+                      )}
                     </div>
-                  ) : (
-                    <Card style={{ ...operationsCardSurface, color: "#63594d", borderRadius: 8, boxSizing: "border-box" }}>
-                      No {group.label.toLowerCase()} items currently visible.
-                    </Card>
-                  )}
+                  ))}
                 </div>
-              ))}
-            </div>
+              ) : null}
+            </Card>
           ) : null}
         </Section>
       </div>

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -1524,7 +1524,7 @@ export default function OperationalCommandCenterPage() {
           display: "grid",
           gap: 18,
           width: "100%",
-          maxWidth: 1280,
+          maxWidth: 1360,
           margin: "0 auto",
           minWidth: 0,
           padding: 18,
@@ -1686,12 +1686,26 @@ export default function OperationalCommandCenterPage() {
                   alignContent: "start",
                 }}
               >
-                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "start" }}>
-                  <div style={{ display: "grid", gap: 4 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start", minWidth: 0 }}>
+                  <div style={{ display: "grid", gap: 4, flex: "1 1 auto", minWidth: 0 }}>
                     <strong style={{ color: "#211c17" }}>{lane.label}</strong>
                     <span style={{ color: "#63594d", fontSize: 13, lineHeight: 1.45 }}>{lane.helper}</span>
                   </div>
-                  <strong style={{ color: "#211c17", fontSize: 24, lineHeight: 1 }}>{lane.signals.length}</strong>
+                  <strong
+                    data-testid={`operations-waiting-lane-count-${lane.key}`}
+                    style={{
+                      color: "#211c17",
+                      fontSize: 24,
+                      lineHeight: 1,
+                      whiteSpace: "nowrap",
+                      flex: "0 0 auto",
+                      minWidth: "max-content",
+                      fontVariantNumeric: "tabular-nums",
+                      textAlign: "right",
+                    }}
+                  >
+                    {lane.signals.length}
+                  </strong>
                 </div>
                 <SignalMiniList signals={lane.signals} empty={lane.empty} />
               </Card>

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -1,6 +1,19 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { AlertTriangle, Building2, ClipboardList, FileText, Home, Inbox, ReceiptText, ShieldCheck } from "lucide-react";
+import {
+  AlertTriangle,
+  Building2,
+  ClipboardList,
+  FileCheck2,
+  FileText,
+  Hammer,
+  Home,
+  Inbox,
+  ReceiptText,
+  ShieldCheck,
+  UserRoundCheck,
+  Wrench,
+} from "lucide-react";
 import { fetchDashboardSummary, type DashboardSummaryData } from "@/api/dashboard";
 import {
   fetchDecisionInbox,
@@ -27,7 +40,7 @@ import {
   type ReviewAssignmentTarget,
   type ReviewLifecycleStatus,
 } from "@/components/reviewWorkspaces/ReviewAssignmentStatusControls";
-import { ReviewWorkspacePanel, type ReviewWorkspaceUiModel } from "@/components/reviewWorkspaces/ReviewWorkspacePanel";
+import { type ReviewWorkspaceUiModel } from "@/components/reviewWorkspaces/ReviewWorkspacePanel";
 import { Card, Section } from "@/components/ui/Ui";
 import { useEntitlements } from "@/hooks/useEntitlements";
 import { isUpgradeRequiredError } from "@/lib/gatedFeatureErrors";
@@ -57,6 +70,15 @@ type ReviewStatusFilter = "all" | "open" | "review_needed" | "informational";
 type AssignmentFilter = "all" | "assigned" | "unassigned";
 type EscalationFilter = "all" | "escalated" | "not_escalated";
 type TimingRiskFilter = "all" | "delinquent" | "upcoming" | "high_risk";
+type WaitingLaneKey = "tenant" | "landlord" | "contractor";
+type WorkBucketKey =
+  | "maintenance"
+  | "lease_actions"
+  | "notices"
+  | "payments"
+  | "tenant_requests"
+  | "contractor_followups"
+  | "evidence_ready";
 
 type CommandCenterFilterOptions = {
   search?: string;
@@ -230,6 +252,90 @@ const TIMING_RISK_OPTIONS: Array<{ value: TimingRiskFilter; label: string }> = [
   { value: "delinquent", label: "Delinquent" },
   { value: "upcoming", label: "Upcoming / deadline" },
   { value: "high_risk", label: "High risk" },
+];
+
+const WAITING_LANE_CONFIG: Array<{
+  key: WaitingLaneKey;
+  label: string;
+  helper: string;
+  empty: string;
+}> = [
+  {
+    key: "tenant",
+    label: "Waiting on tenant",
+    helper: "Tenant, applicant, signature, screening, and response-dependent work.",
+    empty: "No tenant-waiting items visible.",
+  },
+  {
+    key: "landlord",
+    label: "Waiting on landlord",
+    helper: "Manual review, assignment, approval, payment, lease, and document decisions.",
+    empty: "No landlord-owned waiting items visible.",
+  },
+  {
+    key: "contractor",
+    label: "Waiting on contractor",
+    helper: "Maintenance, repair, work order, and contractor follow-up signals when present.",
+    empty: "No contractor-waiting items visible.",
+  },
+];
+
+const WORK_BUCKET_CONFIG: Array<{
+  key: WorkBucketKey;
+  label: string;
+  helper: string;
+  destination: string;
+  icon: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+}> = [
+  {
+    key: "maintenance",
+    label: "Maintenance and repairs",
+    helper: "Maintenance, repair, property condition, and work-order source signals.",
+    destination: "/properties",
+    icon: Wrench,
+  },
+  {
+    key: "lease_actions",
+    label: "Lease actions",
+    helper: "Execution, renewal, document, signature, and lease lifecycle work.",
+    destination: "/leases",
+    icon: ClipboardList,
+  },
+  {
+    key: "notices",
+    label: "Notices and compliance",
+    helper: "Jurisdiction, notice, policy, and compliance review signals.",
+    destination: "/leases",
+    icon: FileCheck2,
+  },
+  {
+    key: "payments",
+    label: "Payments and arrears",
+    helper: "Delinquency, payment readiness, ledger, and obligation review work.",
+    destination: "/payments",
+    icon: ReceiptText,
+  },
+  {
+    key: "tenant_requests",
+    label: "Tenant/application requests",
+    helper: "Screening, application, applicant, tenant, and inbox-driven requests.",
+    destination: "/tenants",
+    icon: UserRoundCheck,
+  },
+  {
+    key: "contractor_followups",
+    label: "Contractor follow-ups",
+    helper: "Contractor and work-order follow-up work when source signals exist.",
+    destination: "/properties",
+    icon: Hammer,
+  },
+  {
+    key: "evidence_ready",
+    label: "Evidence-ready items",
+    helper: "Items with scoped source workflow evidence or manual review handoff context.",
+    destination: "/decision-inbox",
+    icon: ShieldCheck,
+  },
 ];
 
 function label(value: string) {
@@ -880,6 +986,95 @@ function summarizeByPriority(signals: CommandCenterSignal[]) {
   }));
 }
 
+function signalOperationalText(signal: CommandCenterSignal) {
+  return [
+    signal.title,
+    signal.description,
+    signal.contextLabel,
+    signal.source,
+    signal.workflowStatus,
+    signal.reviewStatus,
+    signal.nextActionLabel,
+    signal.assignmentLabel,
+    signal.escalationLabel,
+    CATEGORY_CONFIG[signal.category].label,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function signalMatches(signal: CommandCenterSignal, pattern: RegExp) {
+  return pattern.test(signalOperationalText(signal));
+}
+
+function isBlockedOrUrgent(signal: CommandCenterSignal) {
+  return (
+    signal.priorityGroup === "critical" ||
+    signal.severity === "critical" ||
+    signal.escalationState === "escalated" ||
+    /blocked|critical|urgent|delinquent|arrear/i.test(`${signal.workflowStatus} ${signal.reviewStatus} ${signal.source}`)
+  );
+}
+
+function isReviewReady(signal: CommandCenterSignal) {
+  return (
+    signal.priorityGroup === "needs_review" ||
+    /review|open|blocked|awaiting|manual/i.test(`${signal.reviewStatus} ${signal.workflowStatus} ${signal.source}`)
+  );
+}
+
+function waitingLaneSignals(signals: CommandCenterSignal[], lane: WaitingLaneKey) {
+  if (lane === "tenant") {
+    return signals.filter((signal) =>
+      signalMatches(signal, /\b(tenant|applicant|application|screening|signature|awaiting tenant|tenant response)\b/i)
+    );
+  }
+  if (lane === "contractor") {
+    return signals.filter((signal) => signalMatches(signal, /\b(contractor|maintenance|repair|work order|work-order)\b/i));
+  }
+  return signals.filter((signal) => {
+    const tenant = signalMatches(signal, /\b(tenant response|applicant|application|screening)\b/i);
+    const contractor = signalMatches(signal, /\b(contractor|maintenance|repair|work order|work-order)\b/i);
+    return !tenant && !contractor && isReviewReady(signal);
+  });
+}
+
+function workBucketSignals(signals: CommandCenterSignal[], bucket: WorkBucketKey) {
+  if (bucket === "maintenance") {
+    return signals.filter((signal) => signalMatches(signal, /\b(maintenance|repair|work order|work-order|condition|vacant)\b/i));
+  }
+  if (bucket === "lease_actions") {
+    return signals.filter(
+      (signal) =>
+        signal.category === "lease_lifecycle" ||
+        signal.category === "documents" ||
+        signalMatches(signal, /\b(lease|renewal|signature|document|execution)\b/i)
+    );
+  }
+  if (bucket === "notices") {
+    return signals.filter((signal) => signalMatches(signal, /\b(notice|compliance|jurisdiction|policy|legal|renewal)\b/i));
+  }
+  if (bucket === "payments") {
+    return signals.filter((signal) => signal.category === "payments" || signalMatches(signal, /\b(payment|rent|arrear|delinquen|ledger|obligation)\b/i));
+  }
+  if (bucket === "tenant_requests") {
+    return signals.filter(
+      (signal) =>
+        signal.category === "screening" ||
+        signalMatches(signal, /\b(tenant|applicant|application|screening|inbox|message|request)\b/i)
+    );
+  }
+  if (bucket === "contractor_followups") {
+    return signals.filter((signal) => signalMatches(signal, /\b(contractor|work order|work-order|repair vendor|maintenance vendor)\b/i));
+  }
+  return signals.filter((signal) => Boolean(signal.manualReviewScope && signal.manualReviewScopeId));
+}
+
+function limitedSignals(signals: CommandCenterSignal[], limit = 3) {
+  return prioritizeOperationalItems(signals).slice(0, limit);
+}
+
 function normalizeSearchText(value: string) {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim();
 }
@@ -1024,6 +1219,21 @@ const operationsInputStyle: React.CSSProperties = {
   boxShadow: "inset 0 1px 0 rgba(255,255,255,0.65)",
 };
 
+const compactActionLinkStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: 8,
+  padding: "8px 10px",
+  background: "#fffaf1",
+  border: "1px solid rgba(91,70,48,0.2)",
+  color: "#245842",
+  fontSize: 13,
+  fontWeight: 900,
+  textDecoration: "none",
+  minHeight: 36,
+};
+
 function Badge({ children, severity }: { children: React.ReactNode; severity: CommandCenterSeverity }) {
   const tone = severityTone(severity);
   return (
@@ -1041,6 +1251,126 @@ function Badge({ children, severity }: { children: React.ReactNode; severity: Co
     >
       {label(String(children))}
     </span>
+  );
+}
+
+function DailyMetricCard({
+  label: metricLabel,
+  value,
+  helper,
+  severity = "info",
+}: {
+  label: string;
+  value: number;
+  helper: string;
+  severity?: CommandCenterSeverity;
+}) {
+  const tone = severityTone(severity);
+  return (
+    <Card
+      style={{
+        ...operationsCardSurface,
+        border: `1px solid ${tone.border}`,
+        borderRadius: 12,
+        padding: 14,
+        boxSizing: "border-box",
+        minWidth: 0,
+        minHeight: 118,
+        display: "grid",
+        gap: 6,
+        alignContent: "start",
+      }}
+    >
+      <div style={{ color: "#63594d", fontSize: 12, fontWeight: 900 }}>{metricLabel}</div>
+      <strong style={{ color: "#211c17", fontSize: 30, lineHeight: 1 }}>{value}</strong>
+      <span style={{ color: "#3f382f", fontSize: 13, lineHeight: 1.45 }}>{helper}</span>
+    </Card>
+  );
+}
+
+function SignalMiniList({ signals, empty }: { signals: CommandCenterSignal[]; empty: string }) {
+  const items = limitedSignals(signals, 3);
+  if (!items.length) {
+    return <span style={{ color: "#63594d", fontSize: 13 }}>{empty}</span>;
+  }
+  return (
+    <div style={{ display: "grid", gap: 8, minWidth: 0 }}>
+      {items.map((signal) => (
+        <div
+          key={signal.id}
+          style={{
+            display: "grid",
+            gap: 4,
+            minWidth: 0,
+            padding: "8px 0",
+            borderTop: "1px solid rgba(91,70,48,0.12)",
+          }}
+        >
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+            <Badge severity={signal.severity}>{signal.severity}</Badge>
+            <strong style={{ color: "#211c17", fontSize: 14, overflowWrap: "anywhere" }}>{signal.title}</strong>
+          </div>
+          <span style={{ color: "#63594d", fontSize: 12, lineHeight: 1.4 }}>{signal.contextLabel}</span>
+          <span style={{ color: "#3f382f", fontSize: 12, fontWeight: 800 }}>Next: {signal.nextActionLabel}</span>
+          <Link to={scopedSourceDestinationForSignal(signal)} style={{ color: "#245842", fontSize: 13, fontWeight: 900 }}>
+            Open source workflow
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function WorkBucketCard({
+  config,
+  signals,
+}: {
+  config: (typeof WORK_BUCKET_CONFIG)[number];
+  signals: CommandCenterSignal[];
+}) {
+  const Icon = config.icon;
+  const critical = signals.filter(isBlockedOrUrgent).length;
+  const preview = limitedSignals(signals, 2);
+  return (
+    <Card
+      data-testid={`operations-work-bucket-${config.key}`}
+      style={{
+        ...operationsCardSurface,
+        borderRadius: 12,
+        padding: 14,
+        display: "grid",
+        gap: 10,
+        minWidth: 0,
+        alignContent: "start",
+        boxSizing: "border-box",
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center", minWidth: 0 }}>
+        <Icon size={18} />
+        <strong style={{ color: "#211c17", overflowWrap: "anywhere" }}>{config.label}</strong>
+      </div>
+      <span style={{ color: "#63594d", fontSize: 13, lineHeight: 1.45 }}>{config.helper}</span>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#3f382f", fontSize: 12, fontWeight: 900 }}>
+        <span>{signals.length} item{signals.length === 1 ? "" : "s"}</span>
+        <span>{critical} urgent</span>
+      </div>
+      {preview.length ? (
+        <div style={{ display: "grid", gap: 6, minWidth: 0 }}>
+          {preview.map((signal) => (
+            <div key={signal.id} style={{ display: "grid", gap: 3, minWidth: 0 }}>
+              <strong style={{ color: "#211c17", fontSize: 13, overflowWrap: "anywhere" }}>{signal.title}</strong>
+              <span style={{ color: "#63594d", fontSize: 12, lineHeight: 1.35 }}>{signal.contextLabel}</span>
+              <span style={{ color: "#3f382f", fontSize: 12, lineHeight: 1.35 }}>Status: {signal.reviewStatus}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <span style={{ color: "#63594d", fontSize: 13 }}>No visible source items in this bucket.</span>
+      )}
+      <Link to={config.destination} style={compactActionLinkStyle}>
+        Open workspace
+      </Link>
+    </Card>
   );
 }
 
@@ -1127,6 +1457,29 @@ export default function OperationalCommandCenterPage() {
   const reviewQueueItems = React.useMemo(() => deriveOperationalReviewQueueItems(visibleSignals), [visibleSignals]);
   const categorySummary = React.useMemo(() => summarizeByCategory(visibleSignals), [visibleSignals]);
   const prioritySummary = React.useMemo(() => summarizeByPriority(visibleSignals), [visibleSignals]);
+  const urgentSignals = React.useMemo(() => visibleSignals.filter(isBlockedOrUrgent), [visibleSignals]);
+  const landlordReviewSignals = React.useMemo(() => visibleSignals.filter(isReviewReady), [visibleSignals]);
+  const upcomingSignals = React.useMemo(() => visibleSignals.filter((signal) => signal.priorityGroup === "upcoming"), [visibleSignals]);
+  const evidenceReadySignals = React.useMemo(
+    () => visibleSignals.filter((signal) => Boolean(signal.manualReviewScope && signal.manualReviewScopeId)),
+    [visibleSignals]
+  );
+  const waitingLanes = React.useMemo(
+    () =>
+      WAITING_LANE_CONFIG.map((lane) => ({
+        ...lane,
+        signals: waitingLaneSignals(visibleSignals, lane.key),
+      })),
+    [visibleSignals]
+  );
+  const workBuckets = React.useMemo(
+    () =>
+      WORK_BUCKET_CONFIG.map((bucket) => ({
+        ...bucket,
+        signals: workBucketSignals(visibleSignals, bucket.key),
+      })),
+    [visibleSignals]
+  );
   const criticalCount = signals.filter((signal) => signal.severity === "critical").length;
   const warningCount = signals.filter((signal) => signal.severity === "warning").length;
   const activeFilterCopy = filterCopy({ search, filter: activeFilter, workflowType, reviewStatus, assignment, escalation, timingRisk });
@@ -1244,6 +1597,131 @@ export default function OperationalCommandCenterPage() {
         </Section>
 
         <Section
+          data-testid="operations-daily-summary"
+          style={{ ...operationsSectionSurface, display: "grid", gap: 14, minWidth: 0 }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "end" }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={sectionTitleStyle}>Today's operational summary</div>
+              <div style={helperTextStyle}>Daily work is grouped by urgency, review ownership, upcoming timing, and evidence/source readiness.</div>
+            </div>
+            <div style={{ ...helperTextStyle, fontWeight: 900 }}>{visibleSignals.length} visible source signal{visibleSignals.length === 1 ? "" : "s"}</div>
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 180px), 1fr))",
+              gap: 10,
+              minWidth: 0,
+            }}
+          >
+            <DailyMetricCard
+              label="Urgent / blocked"
+              value={urgentSignals.length}
+              helper="Critical, blocked, delinquent, or escalated source work."
+              severity={urgentSignals.length ? "critical" : "info"}
+            />
+            <DailyMetricCard
+              label="Needs landlord review"
+              value={landlordReviewSignals.length}
+              helper="Manual decisions, assignments, approvals, and review-needed items."
+              severity={landlordReviewSignals.length ? "warning" : "info"}
+            />
+            <DailyMetricCard
+              label="Upcoming"
+              value={upcomingSignals.length}
+              helper="Forward-looking lease, renewal, occupancy, or dated workflow timing."
+            />
+            <DailyMetricCard
+              label="Evidence/source attached"
+              value={evidenceReadySignals.length}
+              helper="Items with source routing and manual review handoff context."
+            />
+          </div>
+          <Card
+            style={{
+              ...operationsCardSurface,
+              borderRadius: 12,
+              padding: 14,
+              display: "grid",
+              gap: 10,
+              minWidth: 0,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              <AlertTriangle size={18} />
+              <strong style={sectionTitleStyle}>Urgent / overdue work</strong>
+              <span style={helperTextStyle}>Highest-priority items appear here before the full queue.</span>
+            </div>
+            <SignalMiniList signals={urgentSignals} empty="No urgent or blocked operational items are visible." />
+          </Card>
+        </Section>
+
+        <Section
+          data-testid="operations-waiting-lanes"
+          style={{ ...operationsSectionSurface, display: "grid", gap: 14, minWidth: 0 }}
+        >
+          <div style={{ display: "grid", gap: 4 }}>
+            <div style={sectionTitleStyle}>Waiting lanes</div>
+            <div style={helperTextStyle}>These lanes use existing source signal text and review metadata only; they do not create new workflow state.</div>
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
+              gap: 12,
+              minWidth: 0,
+            }}
+          >
+            {waitingLanes.map((lane) => (
+              <Card
+                key={lane.key}
+                style={{
+                  ...operationsCardSurface,
+                  borderRadius: 12,
+                  padding: 14,
+                  display: "grid",
+                  gap: 10,
+                  minWidth: 0,
+                  alignContent: "start",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "start" }}>
+                  <div style={{ display: "grid", gap: 4 }}>
+                    <strong style={{ color: "#211c17" }}>{lane.label}</strong>
+                    <span style={{ color: "#63594d", fontSize: 13, lineHeight: 1.45 }}>{lane.helper}</span>
+                  </div>
+                  <strong style={{ color: "#211c17", fontSize: 24, lineHeight: 1 }}>{lane.signals.length}</strong>
+                </div>
+                <SignalMiniList signals={lane.signals} empty={lane.empty} />
+              </Card>
+            ))}
+          </div>
+        </Section>
+
+        <Section
+          data-testid="operations-work-buckets"
+          style={{ ...operationsSectionSurface, display: "grid", gap: 14, minWidth: 0 }}
+        >
+          <div style={{ display: "grid", gap: 4 }}>
+            <div style={sectionTitleStyle}>Main work buckets</div>
+            <div style={helperTextStyle}>Buckets keep source-workspace links visible without merging dashboard, inbox, lease, or property workflows into this page.</div>
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 260px), 1fr))",
+              gap: 12,
+              minWidth: 0,
+            }}
+          >
+            {workBuckets.map((bucket) => (
+              <WorkBucketCard key={bucket.key} config={bucket} signals={bucket.signals} />
+            ))}
+          </div>
+        </Section>
+
+        <Section
           data-testid="operations-summary-strip"
           style={{
             ...operationsSectionSurface,
@@ -1276,10 +1754,10 @@ export default function OperationalCommandCenterPage() {
         <Section style={{ ...operationsSectionSurface, display: "grid", gap: 12, minWidth: 0 }}>
           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
             <div>
-              <div style={sectionTitleStyle}>Coordination lanes</div>
-              <div style={helperTextStyle}>Each lane links back to the source workflow for manual review.</div>
+              <div style={sectionTitleStyle}>Source workspaces</div>
+              <div style={helperTextStyle}>Use these shortcuts when the daily board points back to a source workflow.</div>
             </div>
-            <div style={{ ...helperTextStyle, fontWeight: 800 }}>Read-only coordination layer</div>
+            <div style={{ ...helperTextStyle, fontWeight: 800 }}>Read-only source routing</div>
           </div>
           <div
             data-testid="operations-coordination-lanes"
@@ -1373,8 +1851,8 @@ export default function OperationalCommandCenterPage() {
         <Section style={{ ...operationsSectionSurface, display: "grid", gap: 14, minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             <Building2 size={18} />
-            <strong style={sectionTitleStyle}>Priority routing queue</strong>
-            <span style={helperTextStyle}>Highest priority first by urgency, severity, and source workflow.</span>
+            <strong style={sectionTitleStyle}>Advanced triage queue</strong>
+            <span style={helperTextStyle}>Search, saved views, manual review controls, and detailed priority lists.</span>
           </div>
           <Card
             data-testid="operations-filter-panel"
@@ -1654,16 +2132,6 @@ export default function OperationalCommandCenterPage() {
                             <span>Assignment: {signal.assignmentLabel || "Unassigned"}</span>
                             <span>Escalation: {signal.escalationLabel || "Not escalated"}</span>
                           </div>
-                          <ReviewWorkspacePanel
-                            workspace={reviewWorkspacePreviewForSignal(signal)}
-                            onManualReviewChange={(workspace, next) =>
-                              persistManualReviewChange(
-                                workspace.manualReviewScope as OperatorReviewScope,
-                                workspace.manualReviewScopeId,
-                                next
-                              )
-                            }
-                          />
                         </Card>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary

Simplifies `/operations` into a daily landlord command center while preserving existing frontend data sources, source routing, manual review metadata controls, and API/auth behavior.

Changes include:
- Adds a first-viewport daily operational summary focused on urgent/blocked work, landlord review, upcoming timing, and evidence/source readiness.
- Adds waiting lanes for tenant, landlord, and contractor-oriented work using existing signal text and metadata only.
- Adds main work buckets for maintenance, lease actions, notices/compliance, payments/arrears, tenant/application requests, contractor follow-ups, and evidence-ready items.
- Keeps source workspace links and moves search/saved views/manual review controls into an advanced triage queue lower on the page.
- Removes repeated embedded review panels from every priority card so manual controls stay in the dedicated operational review queue.

## Scope

Frontend-only. Backend/API/auth/data models were not changed.

## Validation

- `npm run test -- OperationalCommandCenterPage`
- `npm run test -- OperationsPage OperationalCommandCenterPage`
- `npm run test -- DashboardPage DecisionInboxPage`
- `npm run build` under Node 20.11.1: passed, with Vite warning that 20.19+ is preferred
- `git diff --check`
- `git diff --cached --check`

## Browser QA

Local Vite server was started under Node 20.20.2 because Vite dev requires newer Node 20.x APIs than the repo `.nvmrc` version. Headless browser smoke reached the protected dev-access screen for `/operations`, `/dashboard`, `/decision-inbox`, `/landlord/unified-inbox`, `/properties`, `/tenants`, `/leases`, and `/scheduling` with no console errors and no horizontal overflow at that boundary.

Full authenticated landlord/admin preview QA was not completed because this environment does not have the dev access password or a valid landlord/admin-equivalent session.