### PR TITLE
feat: add embedded signed document workspace

### DIFF
--- a/rentchain-frontend/src/components/leases/SignedDocumentWorkspace.tsx
+++ b/rentchain-frontend/src/components/leases/SignedDocumentWorkspace.tsx
@@ -1,0 +1,248 @@
+import React from "react";
+
+const signedDocumentWorkspaceTheme = {
+  card: "#fffaf1",
+  cardStrong: "#fff6e8",
+  border: "rgba(91, 70, 48, 0.18)",
+  borderStrong: "rgba(91, 70, 48, 0.32)",
+  charcoal: "#211c17",
+  muted: "#63594d",
+  pine: "#245842",
+  pineSoft: "rgba(36, 88, 66, 0.12)",
+  amberSoft: "rgba(146, 64, 14, 0.1)",
+} as const;
+
+type SignedDocumentWorkspaceAudience = "landlord" | "tenant";
+
+export type SignedDocumentWorkspaceProps = {
+  audience: SignedDocumentWorkspaceAudience;
+  title?: string;
+  statusLabel: string;
+  documentLabel?: string | null;
+  documentUrl?: string | null;
+  sourceLabel?: string | null;
+  signedAt?: string | number | null;
+  completedAt?: string | number | null;
+  evidenceLabel?: string | null;
+  warnings?: string[];
+  opening?: boolean;
+  openError?: string | null;
+  onOpenDocument?: () => void;
+  unavailableMessage?: string;
+  providerMetadataVisible?: boolean;
+};
+
+function formatWorkspaceDate(value?: string | number | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+function canEmbedPdf(value: string | null | undefined) {
+  const raw = String(value || "").trim();
+  if (!raw || typeof window === "undefined") return false;
+  try {
+    const url = new URL(raw, window.location.origin);
+    return url.origin === window.location.origin && /\.pdf$/i.test(url.pathname);
+  } catch {
+    return /^\/[^?#]+\.pdf(?:$|[?#])/i.test(raw);
+  }
+}
+
+function normalizedDocumentUrl(value?: string | null) {
+  return String(value || "").trim();
+}
+
+export function SignedDocumentWorkspace({
+  audience,
+  title,
+  statusLabel,
+  documentLabel,
+  documentUrl,
+  sourceLabel,
+  signedAt,
+  completedAt,
+  evidenceLabel,
+  warnings = [],
+  opening = false,
+  openError = null,
+  onOpenDocument,
+  unavailableMessage,
+  providerMetadataVisible = true,
+}: SignedDocumentWorkspaceProps) {
+  const safeDocumentUrl = normalizedDocumentUrl(documentUrl);
+  const hasDocument = Boolean(safeDocumentUrl);
+  const embedAllowed = canEmbedPdf(safeDocumentUrl);
+  const signedDate = formatWorkspaceDate(signedAt) || formatWorkspaceDate(completedAt);
+  const heading = title || (audience === "tenant" ? "Signed document workspace" : "Signed Document Workspace");
+  const fallbackMessage =
+    unavailableMessage ||
+    (hasDocument
+      ? "This signed document is available through a secure external source. Open it in a new tab if the preview cannot be embedded safely."
+      : "No signed document is available in this workspace yet.");
+
+  return (
+    <section
+      id="signed-document"
+      aria-labelledby="signed-document-heading"
+      style={{
+        border: `1px solid ${signedDocumentWorkspaceTheme.borderStrong}`,
+        borderRadius: 14,
+        background: `linear-gradient(180deg, ${signedDocumentWorkspaceTheme.cardStrong} 0%, ${signedDocumentWorkspaceTheme.card} 100%)`,
+        boxShadow: "0 14px 30px rgba(59, 44, 28, 0.08)",
+        padding: 16,
+        display: "grid",
+        gap: 14,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 14, flexWrap: "wrap" }}>
+        <div style={{ display: "grid", gap: 5, minWidth: 240 }}>
+          <div style={{ fontSize: 12, fontWeight: 800, color: signedDocumentWorkspaceTheme.muted, textTransform: "uppercase", letterSpacing: 0 }}>
+            Secure document review
+          </div>
+          <h2 id="signed-document-heading" style={{ margin: 0, fontSize: 20, color: signedDocumentWorkspaceTheme.charcoal }}>
+            {heading}
+          </h2>
+          <div style={{ color: signedDocumentWorkspaceTheme.muted, lineHeight: 1.5 }}>
+            {audience === "tenant"
+              ? "Review your tenant-safe signed lease access without exposing landlord-only workflow metadata."
+              : "Review the executed lease document alongside landlord lease context and evidence package readiness."}
+          </div>
+        </div>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            whiteSpace: "nowrap",
+            borderRadius: 999,
+            border: `1px solid ${signedDocumentWorkspaceTheme.borderStrong}`,
+            background: hasDocument ? signedDocumentWorkspaceTheme.pineSoft : signedDocumentWorkspaceTheme.amberSoft,
+            color: hasDocument ? signedDocumentWorkspaceTheme.pine : "#92400e",
+            padding: "7px 10px",
+            fontSize: 12,
+            fontWeight: 800,
+          }}
+        >
+          {statusLabel}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 10,
+        }}
+      >
+        <WorkspaceFact label="Document" value={documentLabel || (hasDocument ? "Signed lease document" : "Unavailable")} />
+        <WorkspaceFact label="Signed" value={signedDate || "Pending"} />
+        {providerMetadataVisible ? <WorkspaceFact label="Source" value={sourceLabel || (hasDocument ? "Secure document source" : "Pending")} /> : null}
+        <WorkspaceFact label="Evidence" value={evidenceLabel || (hasDocument ? "Ready for lease evidence package" : "Awaiting signed document")} />
+      </div>
+
+      {embedAllowed ? (
+        <div
+          style={{
+            border: `1px solid ${signedDocumentWorkspaceTheme.border}`,
+            borderRadius: 12,
+            overflow: "hidden",
+            background: "#ffffff",
+            minHeight: 420,
+          }}
+        >
+          <object
+            data={safeDocumentUrl}
+            type="application/pdf"
+            title="Signed lease document preview"
+            style={{ width: "100%", minHeight: 420, display: "block" }}
+          >
+            <div style={{ padding: 16, color: signedDocumentWorkspaceTheme.muted }}>{fallbackMessage}</div>
+          </object>
+        </div>
+      ) : (
+        <div
+          style={{
+            border: `1px solid ${signedDocumentWorkspaceTheme.border}`,
+            borderRadius: 12,
+            background: "#fffdf8",
+            padding: 14,
+            display: "grid",
+            gap: 6,
+            color: signedDocumentWorkspaceTheme.muted,
+          }}
+        >
+          <div style={{ fontWeight: 800, color: signedDocumentWorkspaceTheme.charcoal }}>
+            {hasDocument ? "External preview fallback" : "Document unavailable"}
+          </div>
+          <div>{fallbackMessage}</div>
+          {warnings.length ? <div>{warnings[0]}</div> : null}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+        {onOpenDocument ? (
+          <button
+            type="button"
+            onClick={onOpenDocument}
+            disabled={opening}
+            style={workspaceActionStyle("primary")}
+          >
+            {opening ? "Opening..." : "View signed document"}
+          </button>
+        ) : null}
+        {hasDocument ? (
+          <a
+            href={safeDocumentUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open signed document in a new tab"
+            style={workspaceActionStyle("secondary")}
+          >
+            Open in new tab
+          </a>
+        ) : null}
+      </div>
+
+      {openError ? <div role="alert" style={{ color: "#b91c1c", fontWeight: 700 }}>{openError}</div> : null}
+    </section>
+  );
+}
+
+function WorkspaceFact({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        border: `1px solid ${signedDocumentWorkspaceTheme.border}`,
+        borderRadius: 10,
+        padding: "10px 12px",
+        background: "#fffdf8",
+        display: "grid",
+        gap: 4,
+        minWidth: 0,
+      }}
+    >
+      <div style={{ fontSize: 12, color: signedDocumentWorkspaceTheme.muted, fontWeight: 800, textTransform: "uppercase", letterSpacing: 0 }}>
+        {label}
+      </div>
+      <div style={{ color: signedDocumentWorkspaceTheme.charcoal, fontWeight: 800, overflowWrap: "anywhere" }}>{value}</div>
+    </div>
+  );
+}
+
+function workspaceActionStyle(variant: "primary" | "secondary"): React.CSSProperties {
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 38,
+    padding: "8px 12px",
+    borderRadius: 10,
+    border: `1px solid ${signedDocumentWorkspaceTheme.borderStrong}`,
+    background: variant === "primary" ? signedDocumentWorkspaceTheme.pine : signedDocumentWorkspaceTheme.card,
+    color: variant === "primary" ? "#fffaf1" : signedDocumentWorkspaceTheme.pine,
+    textDecoration: "none",
+    fontWeight: 800,
+    cursor: "pointer",
+  };
+}

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -6,6 +6,7 @@ import { buildLeaseSummaryPdfSource } from "@/utils/leaseSummaryPdf";
 
 const mocks = vi.hoisted(() => ({
   getLeaseById: vi.fn(),
+  downloadSignedLease: vi.fn(),
   printSummaryDocument: vi.fn(),
   downloadAuthenticatedExport: vi.fn(),
 }));
@@ -14,6 +15,7 @@ const originalWindowPrintDescriptor = Object.getOwnPropertyDescriptor(window, "p
 
 vi.mock("@/api/leasesApi", () => ({
   getLeaseById: mocks.getLeaseById,
+  downloadSignedLease: mocks.downloadSignedLease,
 }));
 
 vi.mock("@/api/exportDownload", () => ({
@@ -27,6 +29,12 @@ vi.mock("@/utils/printSummary", () => ({
 describe("LandlordLeaseSummaryPage", () => {
   beforeEach(() => {
     mocks.getLeaseById.mockReset();
+    mocks.downloadSignedLease.mockReset();
+    mocks.downloadSignedLease.mockResolvedValue({
+      documentUrl: "https://example.com/signed-lease.pdf",
+      signingStatus: "signed",
+      signedAt: "2026-01-02T00:00:00.000Z",
+    });
     mocks.printSummaryDocument.mockReset();
     mocks.printSummaryDocument.mockResolvedValue(undefined);
     mocks.downloadAuthenticatedExport.mockReset();
@@ -147,6 +155,64 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getByRole("button", { name: "Download evidence package" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
     expect(screen.getByRole("link", { name: "Open operations" })).toHaveAttribute("href", "/operations");
+    expect(screen.getByRole("heading", { name: "Signed Document Workspace" })).toBeInTheDocument();
+    expect(screen.getAllByText("Document unavailable").length).toBeGreaterThan(0);
+  });
+
+  it("renders a signed document workspace without exposing raw URLs and opens a refreshed signed document", async () => {
+    mocks.getLeaseById.mockResolvedValue({
+      lease: {
+        id: "lease-signed",
+        propertyId: "prop-1",
+        propertyName: "Coburg Rd",
+        unitNumber: "3",
+        monthlyRent: 2100,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        status: "active",
+        tenantName: "Tony Wenpeng",
+        tenantEmail: "tony@example.com",
+        documentUrl: "https://storage.googleapis.com/rentchain-documents-prod/signed.pdf?X-Goog-Signature=hidden",
+        signingStatus: "signed",
+        leaseExecution: {
+          executionStatus: "fully_executed",
+          executionLabel: "Lease fully executed",
+          executionDescription: "The signing workflow is complete.",
+          requiredNextAction: "none",
+          tenantSignatureStatus: "completed",
+          landlordSignatureStatus: "completed",
+          pdfStatus: "generated",
+          completedAt: "2026-01-02T00:00:00.000Z",
+        },
+      },
+    });
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-signed/summary"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Signed Document Workspace" })).toBeInTheDocument();
+    expect(screen.getByText("Signed document available")).toBeInTheDocument();
+    expect(screen.getByText("Included in lease evidence package")).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("X-Goog-Signature");
+
+    const fallbackLink = screen.getByRole("link", { name: "Open signed document in a new tab" });
+    expect(fallbackLink).toHaveAttribute(
+      "href",
+      "https://storage.googleapis.com/rentchain-documents-prod/signed.pdf?X-Goog-Signature=hidden"
+    );
+    expect(fallbackLink).toHaveAttribute("target", "_blank");
+    expect(fallbackLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    fireEvent.click(screen.getByRole("button", { name: "View signed document" }));
+
+    await waitFor(() => expect(mocks.downloadSignedLease).toHaveBeenCalledWith("lease-signed"));
+    expect(open).toHaveBeenCalledWith("https://example.com/signed-lease.pdf", "_blank", "noopener,noreferrer");
   });
 
   it("scrolls to and highlights requested lease summary workflow sections after data loads", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -151,6 +151,7 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(screen.getAllByText("Tony Wenpeng").length).toBeGreaterThan(0);
     expect(screen.queryByText(/gs:\/\//i)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open payment ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Signed document workspace" })).toHaveAttribute("href", "#signed-document");
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download evidence package" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
@@ -197,6 +198,7 @@ describe("LandlordLeaseSummaryPage", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "Signed Document Workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Signed document workspace" })).toHaveAttribute("href", "#signed-document");
     expect(screen.getByText("Signed document available")).toBeInTheDocument();
     expect(screen.getByText("Included in lease evidence package")).toBeInTheDocument();
     expect(document.body).not.toHaveTextContent("X-Goog-Signature");

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 import { downloadAuthenticatedExport } from "@/api/exportDownload";
-import { getLeaseById, type LandlordActiveLease } from "@/api/leasesApi";
+import { downloadSignedLease, getLeaseById, type LandlordActiveLease } from "@/api/leasesApi";
 import { LeaseDocumentView } from "@/components/leases/LeaseDocumentView";
+import { SignedDocumentWorkspace } from "@/components/leases/SignedDocumentWorkspace";
 import { triggerDocumentDownload } from "@/lib/documentRendering";
 import { downloadLeaseSummaryPdf } from "@/utils/leaseSummaryPdf";
 import { printSummaryDocument } from "@/utils/printSummary";
@@ -62,12 +63,61 @@ function workflowFocusForSection(sectionId: string | null) {
   return null;
 }
 
+function isSignedLeaseSummaryRecord(lease: LandlordActiveLease) {
+  const signingStatus = String((lease as any).currentSigningStatus || (lease as any).signingStatus || "").trim().toLowerCase();
+  const executionStatus = String(lease.leaseExecution?.executionStatus || "").trim().toLowerCase();
+  return signingStatus === "signed" || executionStatus === "fully_executed" || lease.signatureStatus === "signed";
+}
+
+function signedDocumentStatusLabel(lease: LandlordActiveLease) {
+  if (isSignedLeaseSummaryRecord(lease) && lease.documentUrl) return "Signed document available";
+  if (isSignedLeaseSummaryRecord(lease)) return "Signed document pending";
+  if (lease.documentUrl) return "Lease document available";
+  return "Document unavailable";
+}
+
+function signedDocumentSourceLabel(lease: LandlordActiveLease) {
+  const source = String((lease as any).signedDocumentSource || (lease as any).documentSource || "").trim();
+  if (!source) return lease.documentUrl ? "Secure signed document source" : null;
+  return source
+    .replace(/[./-]+/g, " ")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function isGoogleStorageSignedUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.hostname === "storage.googleapis.com" || url.hostname === "storage.cloud.google.com" || url.hostname.endsWith(".storage.googleapis.com");
+  } catch {
+    return false;
+  }
+}
+
+function isAppDomainLeasePdfFallback(value: string) {
+  if (!value) return false;
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.origin === window.location.origin && /^\/leases\/.+\.pdf$/i.test(url.pathname);
+  } catch {
+    return /^\/leases\/.+\.pdf(?:$|\?)/i.test(value);
+  }
+}
+
+function canUseLegacyDocumentFallback(value: string) {
+  const next = String(value || "").trim();
+  return Boolean(next) && !isGoogleStorageSignedUrl(next) && !isAppDomainLeasePdfFallback(next);
+}
+
 export default function LandlordLeaseSummaryPage() {
   const { leaseId = "" } = useParams();
   const location = useLocation();
   const [lease, setLease] = React.useState<LandlordActiveLease | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [openingSignedDocument, setOpeningSignedDocument] = React.useState(false);
+  const [signedDocumentError, setSignedDocumentError] = React.useState<string | null>(null);
+  const [signedDocumentUrl, setSignedDocumentUrl] = React.useState<string | null>(null);
   const activeSectionId = sectionTargetFromLocation(location);
   const workflowFocus = workflowFocusForSection(activeSectionId);
 
@@ -87,10 +137,12 @@ export default function LandlordLeaseSummaryPage() {
         const response = await getLeaseById(leaseId);
         if (!active) return;
         setLease(response.lease || null);
+        setSignedDocumentUrl(String(response.lease?.documentUrl || "").trim() || null);
       } catch (err: unknown) {
         if (!active) return;
         setError(errorMessage(err, "Failed to load lease summary."));
         setLease(null);
+        setSignedDocumentUrl(null);
       } finally {
         if (active) setLoading(false);
       }
@@ -137,6 +189,28 @@ export default function LandlordLeaseSummaryPage() {
       triggerDocumentDownload({ blob, filename, urlApi: URL });
     } catch (err: unknown) {
       setError(errorMessage(err, "Failed to download evidence package."));
+    }
+  }
+
+  async function handleOpenSignedDocument() {
+    if (!lease) return;
+    setOpeningSignedDocument(true);
+    setSignedDocumentError(null);
+    try {
+      const signedDocument = await downloadSignedLease(lease.id);
+      const nextUrl = String(signedDocument?.documentUrl || "").trim();
+      if (!nextUrl) throw new Error("Signed document is not available yet.");
+      setSignedDocumentUrl(nextUrl);
+      window.open(nextUrl, "_blank", "noopener,noreferrer");
+    } catch (err: unknown) {
+      const fallbackUrl = String(signedDocumentUrl || lease.documentUrl || "").trim();
+      if (canUseLegacyDocumentFallback(fallbackUrl)) {
+        window.open(fallbackUrl, "_blank", "noopener,noreferrer");
+        return;
+      }
+      setSignedDocumentError(errorMessage(err, "Signed document is not available yet."));
+    } finally {
+      setOpeningSignedDocument(false);
     }
   }
 
@@ -211,6 +285,25 @@ export default function LandlordLeaseSummaryPage() {
 
       {lease ? (
         <>
+          <SignedDocumentWorkspace
+            audience="landlord"
+            statusLabel={signedDocumentStatusLabel(lease)}
+            documentLabel={isSignedLeaseSummaryRecord(lease) ? "Signed lease document" : lease.leasePdfLabel || "Lease document"}
+            documentUrl={signedDocumentUrl || lease.documentUrl || null}
+            sourceLabel={signedDocumentSourceLabel(lease)}
+            signedAt={(lease as any).providerSignedAt || lease.leaseExecution?.completedAt || lease.tenantSignature?.signedAt || null}
+            completedAt={lease.leaseExecution?.completedAt || null}
+            evidenceLabel={isSignedLeaseSummaryRecord(lease) ? "Included in lease evidence package" : "Evidence package pending signed document"}
+            warnings={[]}
+            opening={openingSignedDocument}
+            openError={signedDocumentError}
+            onOpenDocument={() => void handleOpenSignedDocument()}
+            unavailableMessage={
+              isSignedLeaseSummaryRecord(lease)
+                ? "Signing appears complete, but no signed document URL is available in this workspace yet."
+                : "A signed document will appear here after the lease signing workflow is complete."
+            }
+          />
           <LeaseDocumentView lease={lease} activeSectionId={activeSectionId} />
           <div className="print-only print-only-summary" aria-hidden="true">
             <LeaseDocumentView lease={lease} anchorIds={false} />

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -230,9 +230,12 @@ export default function LandlordLeaseSummaryPage() {
         >
           Open payment ledger
         </Link>
-          <button
-            type="button"
-            onClick={() => void handlePrintOrSavePdf()}
+        <a href="#signed-document" style={leaseSummaryActionStyle}>
+          Signed document workspace
+        </a>
+        <button
+          type="button"
+          onClick={() => void handlePrintOrSavePdf()}
           disabled={!lease}
           style={leaseSummaryActionStyle}
         >

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -277,7 +277,7 @@ describe("TenantsPage", () => {
     expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
     const leaseLinks = screen.getAllByRole("link", { name: "Main Street · Unit 4 · Lease" });
     expect(leaseLinks.length).toBeGreaterThan(0);
-    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-1/summary#signed-document");
     expect(screen.queryByText("lease-1")).not.toBeInTheDocument();
     expect(screen.getByText("Payment ledger")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open payment ledger" })).toBeEnabled();
@@ -333,12 +333,12 @@ describe("TenantsPage", () => {
     expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
     const leaseLinks = screen.getAllByRole("link", { name: "Main Street · Unit 4 · Lease" });
     expect(leaseLinks.length).toBeGreaterThan(0);
-    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-active-1/summary");
+    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-active-1/summary#signed-document");
     expect(screen.queryByText("lease-active-1")).not.toBeInTheDocument();
     expect(screen.queryByText("No current lease linked")).not.toBeInTheDocument();
   });
 
-  it("prefers the signed lease document URL for tenant profile lease links when available", async () => {
+  it("keeps signed lease document links inside the lease summary workspace when a lease id is available", async () => {
     mocks.useCapabilitiesMock.mockReturnValue({
       features: { tenant_invites: true },
     });
@@ -389,11 +389,8 @@ describe("TenantsPage", () => {
     expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
     const leaseLinks = screen.getAllByRole("link", { name: "Main Street · Unit 4 · Lease" });
     expect(leaseLinks.length).toBeGreaterThan(0);
-    expect(leaseLinks[0]).toHaveAttribute(
-      "href",
-      "https://storage.googleapis.com/rentchain-documents-prod/lease-signing/1?X-Goog-Signature=safe"
-    );
-    expect(leaseLinks[0]).toHaveAttribute("target", "_blank");
+    expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-signed-1/summary#signed-document");
+    expect(leaseLinks[0]).not.toHaveAttribute("target", "_blank");
   });
 
   it("uses the current lease as the active unit link when tenancy registration is stale", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -393,6 +393,66 @@ describe("TenantsPage", () => {
     expect(leaseLinks[0]).not.toHaveAttribute("target", "_blank");
   });
 
+  it("preserves the signed document URL fallback only when no lease id is available", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyName: "Main Street",
+        propertyId: "property-1",
+        unit: "Unit 4",
+        unitId: "unit-4",
+        currentLeaseId: null,
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([
+      { id: "tenancy-1", tenantId: "tenant-1", status: "active", unitLabel: "Unit 4" },
+    ]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      bundle: {
+        tenant: { id: "tenant-1", fullName: "Taylor Tenant" },
+        currentLease: {
+          id: "",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          propertyName: "Main Street",
+          unitId: "unit-4",
+          unit: "Unit 4",
+          leaseStart: "2026-01-01",
+          leaseEnd: null,
+          monthlyRent: 1850,
+          status: "active",
+          signedDocumentUrl: "https://storage.googleapis.com/rentchain-documents-prod/lease-signing/1?X-Goog-Signature=safe",
+          signedDocumentExpiresInSeconds: 1800,
+          signedDocumentSource: "signedDocument",
+        },
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    const leaseLinks = screen.getAllByRole("link", { name: "No current lease linked" });
+    expect(leaseLinks.length).toBeGreaterThan(0);
+    expect(leaseLinks[0]).toHaveAttribute(
+      "href",
+      "https://storage.googleapis.com/rentchain-documents-prod/lease-signing/1?X-Goog-Signature=safe"
+    );
+    expect(leaseLinks[0]).toHaveAttribute("target", "_blank");
+    expect(leaseLinks[0]).toHaveAttribute("rel", "noreferrer");
+    expect(document.body).not.toHaveTextContent("X-Goog-Signature");
+  });
+
   it("uses the current lease as the active unit link when tenancy registration is stale", async () => {
     mocks.useCapabilitiesMock.mockReturnValue({
       features: { tenant_invites: true },

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -209,20 +209,21 @@ function buildTenantLeaseLink(
   tenant?: TenantApiModel | null,
   currentLease?: TenantLeaseSummary | null
 ) {
+  const currentLeaseId = getTenantCurrentLeaseId(tenant, currentLease);
   const signedDocumentUrl = String(currentLease?.signedDocumentUrl || "").trim();
+  if (currentLeaseId) {
+    return {
+      href: `/leases/${encodeURIComponent(currentLeaseId)}/summary#signed-document`,
+      external: false,
+    };
+  }
   if (signedDocumentUrl) {
     return {
       href: signedDocumentUrl,
       external: true,
     };
   }
-  const currentLeaseId = getTenantCurrentLeaseId(tenant, currentLease);
-  return currentLeaseId
-    ? {
-        href: `/leases/${encodeURIComponent(currentLeaseId)}/summary`,
-        external: false,
-      }
-    : null;
+  return null;
 }
 
 function TenantLeaseLink({

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -49,6 +49,25 @@ function canUseLegacyDocumentFallback(value: string) {
   return Boolean(next) && !isGoogleStorageSignedUrl(next) && !isAppDomainLeasePdfFallback(next);
 }
 
+function tenantDocumentOpenErrorMessage(err: any, documentKind: "lease" | "schedule-a") {
+  const code = String(err?.payload?.error || err?.message || "").trim();
+  const isMissingDocument =
+    err?.status === 404 ||
+    code === "lease_document_not_found" ||
+    code === "schedule_a_document_not_found";
+  if (isMissingDocument) {
+    return documentKind === "schedule-a"
+      ? "Schedule A is not available in this tenant workspace yet."
+      : "Signed document is not available in this tenant workspace yet. If signing was completed, the tenant-safe copy may still be preparing.";
+  }
+  return (
+    code ||
+    (documentKind === "schedule-a"
+      ? "Schedule A link expired and needs regeneration."
+      : "Lease document link expired and needs regeneration.")
+  );
+}
+
 function isScheduleADocumentUrl(value: unknown) {
   const normalized = String(value || "").trim().toLowerCase();
   return Boolean(normalized) && (normalized.includes("schedule-a") || normalized.includes("schedule_a"));
@@ -152,7 +171,7 @@ export default function TenantLeasePage() {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
-      setDocumentOpenError(err?.payload?.error || err?.message || (documentKind === "schedule-a" ? "Schedule A link expired and needs regeneration." : "Lease document link expired and needs regeneration."));
+      setDocumentOpenError(tenantDocumentOpenErrorMessage(err, documentKind));
     } finally {
       setOpeningDocument(false);
     }

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -49,13 +49,18 @@ function canUseLegacyDocumentFallback(value: string) {
   return Boolean(next) && !isGoogleStorageSignedUrl(next) && !isAppDomainLeasePdfFallback(next);
 }
 
-function tenantDocumentOpenErrorMessage(err: any, documentKind: "lease" | "schedule-a") {
+function isMissingTenantDocumentRefreshError(err: any) {
   const code = String(err?.payload?.error || err?.message || "").trim();
-  const isMissingDocument =
+  return (
     err?.status === 404 ||
     code === "lease_document_not_found" ||
-    code === "schedule_a_document_not_found";
-  if (isMissingDocument) {
+    code === "schedule_a_document_not_found"
+  );
+}
+
+function tenantDocumentOpenErrorMessage(err: any, documentKind: "lease" | "schedule-a") {
+  const code = String(err?.payload?.error || err?.message || "").trim();
+  if (isMissingTenantDocumentRefreshError(err)) {
     return documentKind === "schedule-a"
       ? "Schedule A is not available in this tenant workspace yet."
       : "Signed document is not available in this tenant workspace yet. If signing was completed, the tenant-safe copy may still be preparing.";
@@ -163,10 +168,13 @@ export default function TenantLeasePage() {
       if (!nextUrl) throw new Error("Lease document is not available.");
       window.open(nextUrl, "_blank", "noreferrer");
     } catch (err: any) {
+      const canUseProjectedFallback =
+        Boolean(fallbackUrl) &&
+        (documentKind === "schedule-a" || !isScheduleADocumentUrl(fallbackUrl)) &&
+        (canUseLegacyDocumentFallback(fallbackUrl) || isMissingTenantDocumentRefreshError(err));
       if (
         !primaryRefreshReturnedScheduleA &&
-        canUseLegacyDocumentFallback(fallbackUrl) &&
-        (documentKind === "schedule-a" || !isScheduleADocumentUrl(fallbackUrl))
+        canUseProjectedFallback
       ) {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -6,6 +6,7 @@ import {
   refreshTenantLeaseDocumentUrl,
   signTenantLease,
 } from "../../api/tenantPortal";
+import { SignedDocumentWorkspace } from "../../components/leases/SignedDocumentWorkspace";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -63,6 +64,7 @@ export default function TenantLeasePage() {
   const [paying, setPaying] = React.useState(false);
   const [openingDocument, setOpeningDocument] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [documentOpenError, setDocumentOpenError] = React.useState<string | null>(null);
 
   const load = React.useCallback(async () => {
     setLoading(true);
@@ -128,7 +130,7 @@ export default function TenantLeasePage() {
     const fallbackUrl = String(context?.documentUrl || (documentKind === "lease" ? data?.documentUrl : "") || "").trim();
     let primaryRefreshReturnedScheduleA = false;
     setOpeningDocument(true);
-    setError(null);
+    setDocumentOpenError(null);
     try {
       const refreshed =
         documentKind === "schedule-a"
@@ -150,7 +152,7 @@ export default function TenantLeasePage() {
         window.open(fallbackUrl, "_blank", "noreferrer");
         return;
       }
-      setError(err?.payload?.error || err?.message || (documentKind === "schedule-a" ? "Schedule A link expired and needs regeneration." : "Lease document link expired and needs regeneration."));
+      setDocumentOpenError(err?.payload?.error || err?.message || (documentKind === "schedule-a" ? "Schedule A link expired and needs regeneration." : "Lease document link expired and needs regeneration."));
     } finally {
       setOpeningDocument(false);
     }
@@ -177,6 +179,7 @@ export default function TenantLeasePage() {
   const execution = data?.leaseExecution || null;
   const providerSigningStatus = String(data?.providerSigningStatus || "not_started");
   const providerSigningComplete = providerSigningStatus === "signed";
+  const signedDocumentComplete = providerSigningComplete || data?.signatureStatus === "signed";
   const providerSigningAvailable = data?.providerSigningAvailable === true || providerSigningStatus === "pending_signature";
   const leaseDocumentContext = data?.leaseDocumentContext || null;
   const scheduleADocumentContext = data?.scheduleADocumentContext || null;
@@ -399,33 +402,34 @@ export default function TenantLeasePage() {
             </TenantInfoCard>
           ) : null}
 
-          <TenantInfoCard heading="Lease Document" accent="#0f766e">
-            {leaseDocumentLabel ? (
-              <div style={{ display: "grid", gap: 6 }}>
-                <div style={{ fontWeight: 800 }}>{leaseDocumentLabel}</div>
-                {data.leasePdfDescription ? (
-                  <div style={{ color: "var(--text-muted, #64748b)" }}>{data.leasePdfDescription}</div>
-                ) : null}
-                {leaseDocumentContext?.documentStatus ? (
-                  <div style={{ color: "var(--text-muted, #64748b)" }}>
-                    Document status: {prettyStatus(leaseDocumentContext.documentStatus)}
-                  </div>
-                ) : null}
-                {leaseDocumentWarnings.length > 0 ? (
-                  <div style={{ color: "var(--text-muted, #64748b)" }}>{leaseDocumentWarnings[0]}</div>
-                ) : null}
-              </div>
-            ) : null}
-            {leaseDocumentUrl ? (
-              <button type="button" onClick={() => void handleOpenLeaseDocument()} disabled={openingDocument}>
-                {openingDocument ? "Opening..." : "View lease"}
-              </button>
-            ) : (
-              <div style={{ color: "var(--text-muted, #64748b)" }}>
-                No approved lease document link is available in this workspace yet.
-              </div>
-            )}
-          </TenantInfoCard>
+          <SignedDocumentWorkspace
+            audience="tenant"
+            title="Signed lease document workspace"
+            statusLabel={
+              leaseDocumentUrl
+                ? signedDocumentComplete
+                  ? "Signed document available"
+                  : "Lease document available"
+                : signedCopyPending
+                ? "Signed copy pending"
+                : "Document unavailable"
+            }
+            documentLabel={leaseDocumentLabel || "Signed lease document"}
+            documentUrl={leaseDocumentUrl}
+            signedAt={data.providerSignedAt || data.tenantSignature?.signedAt || null}
+            completedAt={execution?.completedAt || null}
+            evidenceLabel={signedDocumentComplete && leaseDocumentUrl ? "Lease record ready" : "Tenant-safe document access pending"}
+            warnings={leaseDocumentWarnings}
+            opening={openingDocument}
+            openError={documentOpenError}
+            onOpenDocument={leaseDocumentUrl ? () => void handleOpenLeaseDocument() : undefined}
+            providerMetadataVisible={false}
+            unavailableMessage={
+              signedCopyPending
+                ? "Signing is complete, but no tenant-safe signed lease document link is available yet."
+                : "No approved lease document link is available in this workspace yet."
+            }
+          />
 
           {scheduleAUrl ? (
             <TenantInfoCard heading="Schedule A / attachment" accent="#0891b2">

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2423,11 +2423,13 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText("refresh failed")).toBeInTheDocument();
   });
 
-  it("handles tenant signed document 404 responses as an unavailable state", async () => {
+  it("uses the projected signed document fallback when tenant refresh returns 404", async () => {
     const missingDocumentError = Object.assign(new Error("lease_document_not_found"), {
       status: 404,
       payload: { ok: false, error: "lease_document_not_found" },
     });
+    const fallbackUrl =
+      "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-missing-document-url/signed.pdf?X-Goog-Expires=1";
     tenantPortalApi.refreshTenantLeaseDocumentUrl.mockRejectedValueOnce(missingDocumentError);
     tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
       leaseId: "lease-missing-document-url",
@@ -2435,12 +2437,10 @@ describe("tenant workspace frontend shell", () => {
       endDate: "2027-02-28",
       monthlyRent: 1800,
       status: "active",
-      documentUrl:
-        "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-missing-document-url/signed.pdf?X-Goog-Expires=1",
+      documentUrl: fallbackUrl,
       leaseDocumentContext: {
         leaseId: "lease-missing-document-url",
-        documentUrl:
-          "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-missing-document-url/signed.pdf?X-Goog-Expires=1",
+        documentUrl: fallbackUrl,
         displayLabel: "Signed lease document",
         documentStatus: "signed",
         source: "lease.documentUrl",
@@ -2477,15 +2477,17 @@ describe("tenant workspace frontend shell", () => {
       </MemoryRouter>
     );
 
+    expect(await screen.findByText(/^Signed document available$/i)).toBeInTheDocument();
+    const newTabLink = screen.getByRole("link", { name: "Open signed document in a new tab" });
+    expect(newTabLink).toHaveAttribute("href", fallbackUrl);
+    expect(newTabLink).toHaveAttribute("target", "_blank");
+    expect(newTabLink).toHaveAttribute("rel", "noopener noreferrer");
+
     vi.mocked(window.open).mockClear();
     fireEvent.click(await screen.findByRole("button", { name: /View signed document/i }));
     await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith());
-    expect(window.open).not.toHaveBeenCalled();
-    expect(
-      await screen.findByText(
-        "Signed document is not available in this tenant workspace yet. If signing was completed, the tenant-safe copy may still be preparing."
-      )
-    ).toBeInTheDocument();
+    expect(window.open).toHaveBeenCalledWith(fallbackUrl, "_blank", "noreferrer");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent("lease_document_not_found");
     expect(document.body).not.toHaveTextContent("X-Goog-Expires");
   });
@@ -2541,6 +2543,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getAllByText(/no tenant-safe signed lease document link is available yet/i).length).toBeGreaterThan(0);
     expect(screen.queryByText(/^Signature workflow not started$/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /View signed document/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Open signed document in a new tab" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("does not open Schedule A when the tenant primary lease refresh path returns it", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2335,14 +2335,16 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/\$1,800/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease signing complete$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Signed lease document$/i)).toBeInTheDocument();
-    expect(screen.getByText(/Document status: Signed/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Signed lease document workspace/i })).toBeInTheDocument();
+    expect(screen.getByText(/^Signed document available$/i)).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("https://example.com/lease.pdf");
     expect(screen.getByText(/^Lease fully executed$/i)).toBeInTheDocument();
     expect(screen.getByText(/Rent terms ready for future setup/i)).toBeInTheDocument();
     expect(screen.getByText(/Payment processed by Stripe\. RentChain does not store card or bank payment details\./i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Pay rent/i })).toBeInTheDocument();
     expect(screen.getByText(/^Drawn signature$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Taylor Tenant$/i)).toBeInTheDocument();
-    const openLeaseButton = screen.getByRole("button", { name: /View lease/i });
+    const openLeaseButton = screen.getByRole("button", { name: /View signed document/i });
     expect(openLeaseButton).toBeInTheDocument();
     fireEvent.click(openLeaseButton);
     await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalled());
@@ -2411,7 +2413,7 @@ describe("tenant workspace frontend shell", () => {
     );
 
     vi.mocked(window.open).mockClear();
-    expect(screen.queryByRole("button", { name: /Open lease document/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View signed document/i })).not.toBeInTheDocument();
     expect(await screen.findByText(/Schedule A \/ attachment/i)).toBeInTheDocument();
     fireEvent.click(await screen.findByRole("button", { name: /Open Schedule A/i }));
     await waitFor(() =>
@@ -2471,7 +2473,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/^Signing complete; signed copy pending$/i)).toBeInTheDocument();
     expect(screen.getAllByText(/no tenant-safe signed lease document link is available yet/i).length).toBeGreaterThan(0);
     expect(screen.queryByText(/^Signature workflow not started$/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /View lease/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /View signed document/i })).not.toBeInTheDocument();
   });
 
   it("does not open Schedule A when the tenant primary lease refresh path returns it", async () => {
@@ -2528,7 +2530,7 @@ describe("tenant workspace frontend shell", () => {
     );
 
     vi.mocked(window.open).mockClear();
-    fireEvent.click(await screen.findByRole("button", { name: /View lease/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /View signed document/i }));
     await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith());
     expect(window.open).not.toHaveBeenCalled();
   });

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -2423,6 +2423,73 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText("refresh failed")).toBeInTheDocument();
   });
 
+  it("handles tenant signed document 404 responses as an unavailable state", async () => {
+    const missingDocumentError = Object.assign(new Error("lease_document_not_found"), {
+      status: 404,
+      payload: { ok: false, error: "lease_document_not_found" },
+    });
+    tenantPortalApi.refreshTenantLeaseDocumentUrl.mockRejectedValueOnce(missingDocumentError);
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-missing-document-url",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1800,
+      status: "active",
+      documentUrl:
+        "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-missing-document-url/signed.pdf?X-Goog-Expires=1",
+      leaseDocumentContext: {
+        leaseId: "lease-missing-document-url",
+        documentUrl:
+          "https://storage.googleapis.com/lease-documents/leases/landlord-1/lease-missing-document-url/signed.pdf?X-Goog-Expires=1",
+        displayLabel: "Signed lease document",
+        documentStatus: "signed",
+        source: "lease.documentUrl",
+        confidence: "high",
+        warnings: [],
+      },
+      signatureStatus: "signed",
+      signatureReadinessLabel: "Lease signing complete",
+      signatureReadinessDescription: "The visible lease record shows the current signing stage as complete.",
+      providerSigningStatus: "signed",
+      tenantSignature: {
+        signedAt: "2026-03-02T12:00:00.000Z",
+        signatureMethod: "typed",
+        signatureDisplayName: "Taylor Tenant",
+      },
+      leasePdfStatus: "available",
+      leasePdfLabel: "Lease document available",
+      leasePdfDescription: "A tenant-safe lease document is available in this workspace.",
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "The lease is fully executed.",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "generated",
+        completedAt: "2026-03-02T12:00:00.000Z",
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <TenantLeasePage />
+      </MemoryRouter>
+    );
+
+    vi.mocked(window.open).mockClear();
+    fireEvent.click(await screen.findByRole("button", { name: /View signed document/i }));
+    await waitFor(() => expect(tenantPortalApi.refreshTenantLeaseDocumentUrl).toHaveBeenCalledWith());
+    expect(window.open).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(
+        "Signed document is not available in this tenant workspace yet. If signing was completed, the tenant-safe copy may still be preparing."
+      )
+    ).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("lease_document_not_found");
+    expect(document.body).not.toHaveTextContent("X-Goog-Expires");
+  });
+
   it("shows provider-signed leases without documents as signed-copy pending instead of not started", async () => {
     tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
       leaseId: "lease-provider-signed",


### PR DESCRIPTION
## Summary
- Adds a reusable signed document workspace for landlord and tenant lease surfaces.
- Adds the workspace to /leases/:leaseId/summary with signed status, source summary, signed timestamp, evidence package readiness copy, safe fallback preview, and open actions.
- Replaces the tenant lease document card with a tenant-safe signed lease workspace that preserves the existing tenant document refresh/open behavior.
- Keeps landlord tenant-profile lease links inside /leases/:leaseId/summary#signed-document when a canonical lease id exists.

Refs #1182

## Audit findings
- signedDocumentUrl/documentUrl data is already returned through existing lease projections and tenant-safe lease document context.
- Landlord signed document refresh/download already exists through /api/leases/:leaseId/download-signed and /api/leases/:leaseId/document-url.
- Tenant signed document refresh already exists through /api/tenant/lease/document-url.
- Existing source URLs can be provider or Google Cloud Storage signed URLs and are not reliably iframe-embeddable.
- A safe v1 can be frontend-only by rendering an in-app workspace shell and only embedding same-origin PDFs; external/provider/GCS URLs use intentional new-tab fallback.

## Security notes
- No backend/API/auth/data model changes.
- No storage permission, CORS, provider webhook, signing lifecycle, lease status, or evidence generation changes.
- Raw storage/provider URLs are not rendered as visible page text.
- External document targets use safe new-tab behavior.
- Tenant workspace hides provider/source metadata to preserve tenant-safe projection boundaries.

## Evidence/audit notes
- The landlord workspace labels signed leases as included in the existing lease evidence package when the lease appears executed.
- No new audit events were created because no existing view/download event endpoint was wired for this exact action in this mission.
- Future event capture and evidence timeline sidebars remain deferred.

## Validation
- npm run test -- LandlordLeaseSummaryPage TenantWorkspacePage TenantsPage
- npm run test -- LandlordLeaseSummaryPage TenantWorkspacePage TenantDashboardPage TenantsPage ApplicationReviewSummaryPage EvidencePackPage LandlordActiveLeasesPage
- npm run build
- git diff --check
- git diff --cached --check

## Browser QA
- Not yet performed. Keep draft until preview/live landlord QA passes and tenant QA passes.

## Deferred
- Secure PDF proxy or provider-specific embed support.
- Signed document viewed/downloaded audit event capture.
- Evidence package timeline/sidebar integration.
- Print action inside the workspace.
- Browser QA with authenticated landlord and tenant sessions.