### PR TITLE
feat: add renewal pipeline visibility

### DIFF
--- a/rentchain-frontend/src/components/leases/RenewalPipelinePanel.tsx
+++ b/rentchain-frontend/src/components/leases/RenewalPipelinePanel.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { LandlordActiveLease } from "@/api/leasesApi";
+import {
+  countRenewalPipelineBuckets,
+  deriveRenewalPipelineItems,
+  isRenewalPipelineActionable,
+  type RenewalPipelineItem,
+} from "@/lib/leases/renewalPipeline";
+
+const MAX_VISIBLE_PIPELINE_ITEMS = 6;
+
+function RenewalPipelineRow({ item }: { item: RenewalPipelineItem }) {
+  return (
+    <div className="rc-renewal-pipeline-row">
+      <div className="rc-renewal-pipeline-main">
+        <div className="rc-renewal-pipeline-lease">
+          {item.propertyLabel} · Unit {item.unitLabel}
+        </div>
+        <div className="rc-renewal-pipeline-context">
+          {item.tenantLabel} · Ends {item.endDateLabel} · {item.timingLabel}
+        </div>
+        <div className="rc-renewal-pipeline-detail">{item.detail}</div>
+      </div>
+      <div className="rc-renewal-pipeline-side">
+        <span className="rc-renewal-pipeline-badge">{item.category}</span>
+        <span className="rc-renewal-pipeline-status">{item.statusLabel}</span>
+        <Link
+          className="rc-renewal-pipeline-action"
+          to={item.href}
+          aria-label={`${item.nextActionLabel} for ${item.propertyLabel} unit ${item.unitLabel}`}
+        >
+          {item.nextActionLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default function RenewalPipelinePanel({ leases }: { leases: LandlordActiveLease[] }) {
+  const items = React.useMemo(() => deriveRenewalPipelineItems(leases), [leases]);
+  const bucketCounts = React.useMemo(() => countRenewalPipelineBuckets(items), [items]);
+  const actionableItems = items.filter(isRenewalPipelineActionable);
+  const visibleItems = actionableItems.slice(0, MAX_VISIBLE_PIPELINE_ITEMS);
+  const hiddenCount = Math.max(0, actionableItems.length - visibleItems.length);
+
+  return (
+    <section
+      id="renewal-pipeline"
+      className="rc-renewal-pipeline"
+      aria-labelledby="renewal-pipeline-title"
+    >
+      <div className="rc-renewal-pipeline-header">
+        <div>
+          <div id="renewal-pipeline-title" className="rc-renewal-pipeline-title">
+            Renewal pipeline
+          </div>
+          <div className="rc-renewal-pipeline-helper">
+            Upcoming lease lifecycle review windows, renewal planning, rent increase review, notice timing review, and move-out preparation.
+          </div>
+        </div>
+        <Link className="rc-renewal-pipeline-summary-link" to="/operations#operations-upcoming-work">
+          Open operations view
+        </Link>
+      </div>
+
+      <div className="rc-renewal-pipeline-buckets" aria-label="Renewal pipeline timing buckets">
+        {bucketCounts.map((bucket) => (
+          <div key={bucket.key} className="rc-renewal-pipeline-bucket">
+            <span>{bucket.label}</span>
+            <strong>{bucket.count}</strong>
+          </div>
+        ))}
+      </div>
+
+      {visibleItems.length > 0 ? (
+        <div className="rc-renewal-pipeline-list">
+          {visibleItems.map((item) => (
+            <RenewalPipelineRow key={`${item.leaseId}:${item.category}:${item.timingBucket}`} item={item} />
+          ))}
+        </div>
+      ) : (
+        <div className="rc-renewal-pipeline-empty">
+          No lease lifecycle items need immediate renewal pipeline action from current lease data.
+        </div>
+      )}
+
+      {hiddenCount > 0 ? (
+        <div className="rc-renewal-pipeline-more">
+          {hiddenCount} more renewal pipeline item{hiddenCount === 1 ? "" : "s"} are available in the lease list below.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/rentchain-frontend/src/lib/leases/renewalPipeline.ts
+++ b/rentchain-frontend/src/lib/leases/renewalPipeline.ts
@@ -1,0 +1,313 @@
+import type { LandlordActiveLease, LeaseAutomationTask } from "@/api/leasesApi";
+
+export type RenewalPipelineTimingBucketKey =
+  | "past_due"
+  | "next_30"
+  | "next_60"
+  | "next_90"
+  | "later"
+  | "missing_date";
+
+export type RenewalPipelineCategory =
+  | "Ending soon"
+  | "Renewal review"
+  | "Rent increase review"
+  | "Notice timing review"
+  | "Move-out preparation"
+  | "Execution/signing review"
+  | "Healthy/no immediate action";
+
+export type RenewalPipelineRouteKind = "summary" | "renewal" | "rent-increase" | "notice" | "move-out";
+
+export type RenewalPipelineItem = {
+  leaseId: string;
+  propertyLabel: string;
+  unitLabel: string;
+  tenantLabel: string;
+  endDateLabel: string;
+  daysUntilEnd: number | null;
+  timingBucket: RenewalPipelineTimingBucketKey;
+  timingLabel: string;
+  category: RenewalPipelineCategory;
+  statusLabel: string;
+  nextActionLabel: string;
+  href: string;
+  routeKind: RenewalPipelineRouteKind;
+  detail: string;
+  sortRank: number;
+};
+
+export const RENEWAL_PIPELINE_BUCKETS: Array<{
+  key: RenewalPipelineTimingBucketKey;
+  label: string;
+}> = [
+  { key: "past_due", label: "Past due / needs immediate review" },
+  { key: "next_30", label: "Next 30 days" },
+  { key: "next_60", label: "Next 60 days" },
+  { key: "next_90", label: "Next 90 days" },
+  { key: "later", label: "Later" },
+  { key: "missing_date", label: "Missing date / needs review" },
+];
+
+const BUCKET_RANK: Record<RenewalPipelineTimingBucketKey, number> = {
+  past_due: 0,
+  missing_date: 1,
+  next_30: 2,
+  next_60: 3,
+  next_90: 4,
+  later: 5,
+};
+
+function workflowHref(leaseId: string, routeKind: RenewalPipelineRouteKind) {
+  const base = `/leases/${encodeURIComponent(leaseId)}`;
+  if (routeKind === "summary") return `${base}/summary`;
+  return `${base}/workflows/${routeKind}`;
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "Not set";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-CA", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Date needs review";
+  return parsed.toLocaleDateString("en-CA", { year: "numeric", month: "short", day: "numeric" });
+}
+
+function daysUntilDate(value: string | null | undefined, now: Date) {
+  if (!value) return null;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  const parsed = dateOnly
+    ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+    : new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const todayDay = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  const endDay = Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+  return Math.ceil((endDay - todayDay) / 86_400_000);
+}
+
+function timingBucket(daysUntilEnd: number | null): RenewalPipelineTimingBucketKey {
+  if (daysUntilEnd == null) return "missing_date";
+  if (daysUntilEnd < 0) return "past_due";
+  if (daysUntilEnd <= 30) return "next_30";
+  if (daysUntilEnd <= 60) return "next_60";
+  if (daysUntilEnd <= 90) return "next_90";
+  return "later";
+}
+
+function timingLabel(daysUntilEnd: number | null, bucket: RenewalPipelineTimingBucketKey) {
+  if (daysUntilEnd == null) return "Lease end date needs review";
+  if (daysUntilEnd < 0) return "Lease end date has passed";
+  if (daysUntilEnd === 0) return "Lease ends today";
+  if (daysUntilEnd === 1) return "1 day to lease end";
+  if (bucket === "later") return `${daysUntilEnd} days to lease end`;
+  return `${daysUntilEnd} days to lease end`;
+}
+
+function taskKinds(lease: LandlordActiveLease) {
+  return (lease.automationTasks || [])
+    .map((task: LeaseAutomationTask) => String(task.kind || "").trim())
+    .filter(Boolean);
+}
+
+function hasReviewPolicy(lease: LandlordActiveLease, pattern: RegExp) {
+  return (lease.jurisdictionPolicies || []).some((policy) => {
+    return policy.status === "review" && pattern.test(String(policy.policyKey || ""));
+  });
+}
+
+function deriveCategory(lease: LandlordActiveLease, bucket: RenewalPipelineTimingBucketKey): {
+  category: RenewalPipelineCategory;
+  routeKind: RenewalPipelineRouteKind;
+  nextActionLabel: string;
+  statusLabel: string;
+  detail: string;
+} {
+  const lifecycle = lease.leaseLifecycleSummary;
+  const requiredAction = String(lifecycle?.requiredNextAction || "").trim();
+  const lifecycleStatus = String(lifecycle?.lifecycleStatus || "").trim();
+  const tasks = taskKinds(lease);
+  const executionStatus = String(lease.leaseExecution?.executionStatus || "").trim();
+  const signatureStatus = String(lease.signatureStatus || "").trim();
+
+  if (
+    String(lease.status || "") === "move_out_pending" ||
+    lifecycleStatus === "ending" ||
+    requiredAction === "review_move_out" ||
+    tasks.some((kind) => kind.startsWith("move_out_"))
+  ) {
+    return {
+      category: "Move-out preparation",
+      routeKind: "move-out",
+      nextActionLabel: "Review move-out preparation",
+      statusLabel: lifecycle?.lifecycleLabel || "Move-out preparation",
+      detail: "Review move-out preparation and check jurisdiction requirements before taking action.",
+    };
+  }
+
+  if (
+    tasks.includes("rent_increase_eligibility_check") ||
+    hasReviewPolicy(lease, /rent_increase/)
+  ) {
+    return {
+      category: "Rent increase review",
+      routeKind: "rent-increase",
+      nextActionLabel: "Review rent increase workflow",
+      statusLabel: "Rent increase review",
+      detail: "Review rent increase context and check jurisdiction requirements before preparing any notice.",
+    };
+  }
+
+  if (hasReviewPolicy(lease, /notice/)) {
+    return {
+      category: "Notice timing review",
+      routeKind: "notice",
+      nextActionLabel: "Review notice timing",
+      statusLabel: "Notice timing review",
+      detail: "Review notice timing context and check jurisdiction requirements before preparing notices.",
+    };
+  }
+
+  if (
+    requiredAction === "prepare_renewal_notice" ||
+    requiredAction === "follow_up_response" ||
+    requiredAction === "review_renewal_outcome" ||
+    lifecycleStatus === "renewal_pending" ||
+    lifecycleStatus === "no_response" ||
+    tasks.includes("renewal_reminder") ||
+    tasks.includes("renewal_offer_draft") ||
+    hasReviewPolicy(lease, /renewal/)
+  ) {
+    return {
+      category: "Renewal review",
+      routeKind: "renewal",
+      nextActionLabel: "Review renewal workflow",
+      statusLabel: lifecycle?.lifecycleLabel || "Renewal planning",
+      detail: "Review the renewal planning window and check jurisdiction requirements before preparing next steps.",
+    };
+  }
+
+  if (
+    executionStatus &&
+    executionStatus !== "fully_executed" &&
+    executionStatus !== "landlord_signed"
+  ) {
+    return {
+      category: "Execution/signing review",
+      routeKind: "summary",
+      nextActionLabel: "Open lease summary",
+      statusLabel: lease.leaseExecution?.executionLabel || "Execution review",
+      detail: "Review signing and document readiness before relying on renewal planning.",
+    };
+  }
+
+  if (signatureStatus && signatureStatus !== "signed" && signatureStatus !== "unavailable") {
+    return {
+      category: "Execution/signing review",
+      routeKind: "summary",
+      nextActionLabel: "Open lease summary",
+      statusLabel: lease.signatureReadinessLabel || "Signature review",
+      detail: "Review signing and document readiness before relying on renewal planning.",
+    };
+  }
+
+  if (bucket === "missing_date") {
+    return {
+      category: "Renewal review",
+      routeKind: "summary",
+      nextActionLabel: "Confirm lease end date",
+      statusLabel: "Missing lease end date",
+      detail: "Confirm the lease end date before renewal planning or notice timing review.",
+    };
+  }
+
+  if (bucket === "past_due" || bucket === "next_30" || bucket === "next_60" || bucket === "next_90") {
+    return {
+      category: "Ending soon",
+      routeKind: "renewal",
+      nextActionLabel: "Review renewal workflow",
+      statusLabel: lifecycle?.lifecycleLabel || "Review window",
+      detail: "Review renewal planning, notice timing, and move-out preparation options; check jurisdiction requirements.",
+    };
+  }
+
+  return {
+    category: "Healthy/no immediate action",
+    routeKind: "summary",
+    nextActionLabel: "Open lease summary",
+    statusLabel: lifecycle?.lifecycleLabel || "No immediate review",
+    detail: "No immediate renewal pipeline action is visible from current lease dates.",
+  };
+}
+
+function actionRank(category: RenewalPipelineCategory) {
+  switch (category) {
+    case "Rent increase review":
+    case "Notice timing review":
+    case "Move-out preparation":
+    case "Renewal review":
+      return 0;
+    case "Execution/signing review":
+    case "Ending soon":
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+function leaseLabels(lease: LandlordActiveLease) {
+  const propertyLabel = lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property";
+  const unitLabel = lease.unitLabel || lease.unitNumber || "Unit not set";
+  const tenantLabel = lease.tenantName || "Tenant not linked";
+  return { propertyLabel, unitLabel, tenantLabel };
+}
+
+export function deriveRenewalPipelineItems(
+  leases: LandlordActiveLease[],
+  now = new Date()
+): RenewalPipelineItem[] {
+  return leases
+    .map((lease) => {
+      const summaryDays = lease.leaseLifecycleSummary?.daysUntilExpiry;
+      const daysUntilEnd = typeof summaryDays === "number" ? summaryDays : daysUntilDate(lease.endDate, now);
+      const bucket = timingBucket(daysUntilEnd);
+      const categoryMeta = deriveCategory(lease, bucket);
+      const labels = leaseLabels(lease);
+      return {
+        leaseId: lease.id,
+        ...labels,
+        endDateLabel: formatDate(lease.endDate),
+        daysUntilEnd,
+        timingBucket: bucket,
+        timingLabel: timingLabel(daysUntilEnd, bucket),
+        ...categoryMeta,
+        href: workflowHref(lease.id, categoryMeta.routeKind),
+        sortRank: BUCKET_RANK[bucket] * 10 + actionRank(categoryMeta.category),
+      };
+    })
+    .sort((a, b) => {
+      return (
+        a.sortRank - b.sortRank ||
+        (a.daysUntilEnd ?? Number.POSITIVE_INFINITY) - (b.daysUntilEnd ?? Number.POSITIVE_INFINITY) ||
+        a.propertyLabel.localeCompare(b.propertyLabel) ||
+        a.unitLabel.localeCompare(b.unitLabel)
+      );
+    });
+}
+
+export function countRenewalPipelineBuckets(items: RenewalPipelineItem[]) {
+  return RENEWAL_PIPELINE_BUCKETS.map((bucket) => ({
+    ...bucket,
+    count: items.filter((item) => item.timingBucket === bucket.key).length,
+  }));
+}
+
+export function isRenewalPipelineActionable(item: RenewalPipelineItem) {
+  return item.category !== "Healthy/no immediate action" || item.timingBucket !== "later";
+}

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.css
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.css
@@ -41,9 +41,172 @@
   color: #fffaf1 !important;
 }
 
+.rc-renewal-pipeline {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(91, 70, 48, 0.18);
+  border-radius: 12px;
+  background: #fffaf1;
+}
+
+.rc-renewal-pipeline-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.rc-renewal-pipeline-title {
+  color: #211c17;
+  font-size: 18px;
+  font-weight: 900;
+}
+
+.rc-renewal-pipeline-helper {
+  max-width: 760px;
+  color: #63594d;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.rc-renewal-pipeline-summary-link,
+.rc-renewal-pipeline-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 1px solid rgba(91, 70, 48, 0.3);
+  border-radius: 8px;
+  background: #fff6e8;
+  color: #245842;
+  font-size: 13px;
+  font-weight: 900;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.rc-renewal-pipeline-buckets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
+  gap: 8px;
+}
+
+.rc-renewal-pipeline-bucket {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid rgba(91, 70, 48, 0.16);
+  border-radius: 8px;
+  background: #fff6e8;
+  color: #63594d;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.rc-renewal-pipeline-bucket strong {
+  flex-shrink: 0;
+  color: #211c17;
+  font-size: 18px;
+  white-space: nowrap;
+}
+
+.rc-renewal-pipeline-list {
+  display: grid;
+  gap: 10px;
+}
+
+.rc-renewal-pipeline-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, max-content);
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid rgba(91, 70, 48, 0.16);
+  border-radius: 8px;
+  background: #fffdfa;
+}
+
+.rc-renewal-pipeline-main {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.rc-renewal-pipeline-lease {
+  color: #211c17;
+  font-weight: 900;
+}
+
+.rc-renewal-pipeline-context,
+.rc-renewal-pipeline-detail,
+.rc-renewal-pipeline-status,
+.rc-renewal-pipeline-more,
+.rc-renewal-pipeline-empty {
+  color: #63594d;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.rc-renewal-pipeline-side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.rc-renewal-pipeline-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 8px;
+  border: 1px solid rgba(36, 88, 66, 0.22);
+  border-radius: 999px;
+  background: #eef7f0;
+  color: #245842;
+  font-size: 12px;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.rc-renewal-pipeline-status {
+  font-weight: 800;
+}
+
+.rc-renewal-pipeline-action:focus-visible,
+.rc-renewal-pipeline-summary-link:focus-visible {
+  outline: 3px solid rgba(36, 88, 66, 0.24);
+  outline-offset: 2px;
+}
+
 @media (max-width: 768px) {
   .rc-leases-page {
     padding: 14px;
     border-radius: 12px;
+  }
+
+  .rc-renewal-pipeline {
+    padding: 12px;
+  }
+
+  .rc-renewal-pipeline-row {
+    grid-template-columns: 1fr;
+  }
+
+  .rc-renewal-pipeline-side {
+    justify-content: flex-start;
+  }
+
+  .rc-renewal-pipeline-action,
+  .rc-renewal-pipeline-summary-link {
+    width: 100%;
+    white-space: normal;
   }
 }

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -293,6 +293,19 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.queryByText("Lease execution review recommended")).not.toBeInTheDocument();
     expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);
     expect(screen.getByText(/Prepare renewal notice/i)).toBeInTheDocument();
+    const renewalPipeline = document.querySelector("#renewal-pipeline") as HTMLElement;
+    expect(renewalPipeline).toBeInTheDocument();
+    expect(within(renewalPipeline).getByText("Renewal pipeline")).toBeInTheDocument();
+    expect(within(renewalPipeline).getByText("Next 30 days")).toBeInTheDocument();
+    expect(within(renewalPipeline).getByText("Renewal review")).toBeInTheDocument();
+    expect(within(renewalPipeline).getByText(/check jurisdiction requirements/i)).toBeInTheDocument();
+    expect(
+      within(renewalPipeline).getByRole("link", { name: /Review renewal workflow for Harbour View unit 101/i })
+    ).toHaveAttribute("href", "/leases/lease-1/workflows/renewal");
+    expect(within(renewalPipeline).getByRole("link", { name: "Open operations view" })).toHaveAttribute(
+      "href",
+      "/operations#operations-upcoming-work"
+    );
     expect(screen.getByText("NS Workflow Guidance:")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Renewal Review" })).toHaveAttribute(
       "href",
@@ -336,6 +349,80 @@ describe("LandlordActiveLeasesPage", () => {
     await waitFor(() => expect(mocks.archiveLeaseRecord).toHaveBeenCalledWith("lease-1"));
     fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
+  });
+
+  it("routes renewal pipeline review actions to existing workflow and summary routes", async () => {
+    mocks.getLeaseReconciliationCandidates.mockResolvedValue({ candidates: [] });
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-missing-date",
+          propertyId: "prop-1",
+          propertyName: "North Court",
+          unitNumber: "4A",
+          monthlyRent: 1550,
+          startDate: "2026-01-01",
+          endDate: null,
+          status: "active",
+          tenantName: "Mina Tenant",
+        },
+        {
+          id: "lease-rent-review",
+          propertyId: "prop-2",
+          propertyName: "Market Lofts",
+          unitNumber: "8",
+          monthlyRent: 2200,
+          startDate: "2026-01-01",
+          endDate: "2026-09-30",
+          status: "active",
+          tenantName: "Raj Tenant",
+          leaseLifecycleSummary: {
+            lifecycleStatus: "active",
+            lifecycleLabel: "Active",
+            lifecycleDescription: "Lease lifecycle is active.",
+            requiredNextAction: "none",
+            renewalOutcome: "not_started",
+            daysUntilExpiry: 45,
+            history: [],
+          },
+          jurisdictionPolicies: [
+            {
+              jurisdiction: "NS",
+              policyKey: "rent_increase_workflow_availability",
+              status: "review",
+              severity: "info",
+              label: "Rent increase workflow review",
+              reason: "Rent review metadata is available.",
+              recommendation: "Review current requirements before preparing any notice.",
+              sourceRuleKey: "NS.rent_increase_workflow",
+              confidence: "medium",
+              legalAdvice: false,
+              disclaimer:
+                "RentChain provides operational workflow guidance only. It does not provide legal advice.",
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Renewal pipeline");
+    const renewalPipeline = document.querySelector("#renewal-pipeline") as HTMLElement;
+    expect(within(renewalPipeline).getByText("Missing date / needs review")).toBeInTheDocument();
+    expect(within(renewalPipeline).getAllByText("Rent increase review").length).toBeGreaterThan(0);
+    expect(
+      within(renewalPipeline).getByRole("link", { name: /Confirm lease end date for North Court unit 4A/i })
+    ).toHaveAttribute("href", "/leases/lease-missing-date/summary");
+    expect(
+      within(renewalPipeline).getByRole("link", { name: /Review rent increase workflow for Market Lofts unit 8/i })
+    ).toHaveAttribute("href", "/leases/lease-rent-review/workflows/rent-increase");
+    expect(renewalPipeline).not.toHaveTextContent("lease-missing-date");
+    expect(renewalPipeline).not.toHaveTextContent("lease-rent-review");
   });
 
   it("shows a staged rent-terms action instead of enablement when payment setup is not ready", async () => {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/payments/paymentStatusGuidance";
 import { isTargetedHiddenLeaseId } from "@/lib/testDataVisibilityTargets";
 import LeaseSigningDashboard from "@/components/LeaseSigningDashboard";
+import RenewalPipelinePanel from "@/components/leases/RenewalPipelinePanel";
 import { downloadLeaseSummaryPdf } from "@/utils/leaseSummaryPdf";
 import { printSummaryDocument } from "@/utils/printSummary";
 import { LockedFeature } from "@/components/billing/LockedFeature";
@@ -995,6 +996,10 @@ export default function LandlordActiveLeasesPage() {
         >
           {view === "archived" ? "No archived leases yet." : "No active leases were found for this landlord yet."}
         </div>
+      ) : null}
+
+      {!entitlements.loading && leasesEnabled && !loading && !error && view === "active" && leases.length > 0 ? (
+        <RenewalPipelinePanel leases={leases} />
       ) : null}
 
       {!entitlements.loading && leasesEnabled && !loading && !error && leases.length > 0 && filteredLeases.length === 0 ? (

--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.tsx
@@ -129,7 +129,7 @@ const CATEGORY_CONFIG: Record<CommandCenterCategory, CategoryConfig> = {
     label: "Lease lifecycle",
     description: "Lease execution, ending-soon, and readiness signals.",
     icon: ClipboardList,
-    destination: "/leases",
+    destination: "/leases#renewal-pipeline",
   },
   payments: {
     label: "Payments / obligations",
@@ -960,7 +960,7 @@ export function deriveCommandCenterSignals(input: {
         severity: endingIn <= 30 ? "warning" : "info",
         priorityGroup: "upcoming",
         title: "Lease ending soon",
-        description: `Lease ends ${formatDate(lease.endDate)}. Review renewal, notice, or move-out workflow timing.`,
+        description: `Lease ends ${formatDate(lease.endDate)}. Review renewal planning, notice timing review, or move-out preparation.`,
         contextLabel: baseLabel,
         destination: leaseRenewalWorkflowDestination(lease.id),
         source: "Lease operations · lifecycle timing",


### PR DESCRIPTION
## Summary

Implements Renewal Pipeline Visibility v1 as a frontend-only addition.

- Adds a compact Renewal pipeline section on `/leases` with timing buckets, capped actionable rows, jurisdiction-safe copy, and links to existing lease summary/workflow routes.
- Derives pipeline state from existing landlord active lease projections only: end dates, lifecycle summaries, automation tasks, signing/execution state, and jurisdiction policy review signals.
- Keeps `/operations` compact by routing lease lifecycle source shortcuts to `/leases#renewal-pipeline` instead of duplicating a long queue.
- Adds tests for renewal pipeline routing, missing end-date fallback, and avoiding raw lease IDs as visible text.

## Scope

Frontend-only. No backend, API, auth, data model, lifecycle writes, notice creation, signing lifecycle, or legal-rule behavior changed.

## Validation

- `npm run test -- LeasesPage LandlordActiveLeasesPage`
- `npm run test -- LandlordLeaseSummaryPage`
- `npm run test -- OperationalCommandCenterPage`
- `npm run test -- DashboardPage DecisionInboxPage`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`

Build note: Vite printed the existing Node 20.11.1 warning but the production build completed successfully.