### PR TITLE
polish: surface renewal source context in workflow

### DIFF
--- a/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
@@ -170,7 +170,7 @@ export function mapRenewalValidationMessage(errorCode: string | null | undefined
     case "INVALID_NEW_LEASE_END_DATE":
       return "Enter a valid new lease end date.";
     case "INVALID_RESPONSE_DEADLINE":
-      return "Enter a valid response deadline.";
+      return "Enter a valid tenant response target date.";
     default:
       return null;
   }
@@ -383,8 +383,11 @@ export function LeaseRenewalOperatorInputsCard({
         </label>
 
         <label style={fieldStyle}>
-          <span>Response deadline</span>
+          <span>Tenant response target date</span>
           <input type="datetime-local" value={form.responseDeadlineAt} onChange={(event) => updateForm("responseDeadlineAt", event.target.value)} />
+          <span style={{ color: "#64748b", fontSize: 12 }}>
+            Planning date only. Does not send notice or determine legal deadlines.
+          </span>
         </label>
       </div>
 

--- a/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
@@ -1,0 +1,417 @@
+import React from "react";
+import {
+  saveLeaseRenewalInputs,
+  type LandlordLeaseRenewalLease,
+} from "@/api/landlordLeaseRenewalApi";
+
+export type LeaseRenewalFormState = {
+  rentChangeMode: "" | "no_change" | "increase" | "decrease" | "undecided";
+  proposedRent: string;
+  newTermType: "" | "fixed_term" | "year_to_year" | "month_to_month";
+  newLeaseStartDate: string;
+  newLeaseEndDate: string;
+  responseDeadlineAt: string;
+};
+
+export type LeaseRenewalValidationState = {
+  proposedRent?: string | null;
+};
+
+export type LeaseRenewalToast = {
+  message: string;
+  description?: string;
+  variant: "success" | "error" | "warning";
+};
+
+type LeaseRenewalOperatorInputsCardProps = {
+  lease: LandlordLeaseRenewalLease;
+  formState?: LeaseRenewalFormState;
+  onFormStateChange?: (leaseId: string, form: LeaseRenewalFormState) => void;
+  onSaved?: (lease: LandlordLeaseRenewalLease) => void;
+  notify?: (toast: LeaseRenewalToast) => void;
+};
+
+export function toDatetimeLocalInput(value: number | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+}
+
+export function fromDatetimeLocalInput(value: string) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function createLeaseRenewalFormState(lease: LandlordLeaseRenewalLease): LeaseRenewalFormState {
+  return {
+    rentChangeMode: lease.renewalRentChangeMode || "",
+    proposedRent: typeof lease.renewalOfferedRent === "number" ? String(lease.renewalOfferedRent) : "",
+    newTermType: lease.renewalNewTermType || "",
+    newLeaseStartDate: lease.renewalNewLeaseStartDate || "",
+    newLeaseEndDate: lease.renewalNewLeaseEndDate || "",
+    responseDeadlineAt: toDatetimeLocalInput(lease.renewalDecisionDeadlineAt),
+  };
+}
+
+export function formatLifecycleNextAction(
+  value:
+    | "review_expiring_lease"
+    | "prepare_renewal_notice"
+    | "follow_up_response"
+    | "review_renewal_outcome"
+    | "review_move_out"
+    | "none"
+    | undefined
+) {
+  switch (value) {
+    case "prepare_renewal_notice":
+      return "Prepare renewal notice";
+    case "follow_up_response":
+      return "Follow up on renewal response";
+    case "review_renewal_outcome":
+      return "Review renewal outcome";
+    case "review_move_out":
+      return "Review move-out follow-through";
+    case "review_expiring_lease":
+      return "Review expiring lease";
+    default:
+      return "No follow-up needed";
+  }
+}
+
+export function formatRenewalOutcome(
+  value:
+    | "not_started"
+    | "pending_response"
+    | "renewed"
+    | "tenant_quitting"
+    | "no_response"
+    | "not_applicable"
+    | undefined
+) {
+  switch (value) {
+    case "pending_response":
+      return "Pending response";
+    case "renewed":
+      return "Renewed";
+    case "tenant_quitting":
+      return "Tenant ending lease";
+    case "no_response":
+      return "No response";
+    case "not_started":
+      return "Not started";
+    default:
+      return "Not applicable";
+  }
+}
+
+export function canSetProposedRent(rentChangeMode: LeaseRenewalFormState["rentChangeMode"]) {
+  return rentChangeMode === "increase" || rentChangeMode === "decrease";
+}
+
+export function formatLeaseRenewalLocation(lease: LandlordLeaseRenewalLease) {
+  const propertyLabel = lease.propertyAddress || lease.propertyLabel || "Property";
+  return lease.unitLabel ? `${propertyLabel} • ${lease.unitLabel}` : propertyLabel;
+}
+
+export function formatLeaseExpiryBadge(lease: LandlordLeaseRenewalLease) {
+  return lease.leaseEndDate ? `Expires ${lease.leaseEndDate}` : "Expiry date unavailable";
+}
+
+export function hasSavedRenewalInputs(lease: LandlordLeaseRenewalLease) {
+  return Boolean(
+    lease.renewalRentChangeMode ||
+      lease.renewalOfferedRent != null ||
+      lease.renewalDecisionDeadlineAt ||
+      lease.renewalNewTermType ||
+      lease.renewalNewLeaseStartDate ||
+      lease.renewalNewLeaseEndDate
+  );
+}
+
+export function formatShortUpdateDate(value: string | number | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function formatRenewalUpdatedBadge(lease: LandlordLeaseRenewalLease) {
+  if (!hasSavedRenewalInputs(lease)) return null;
+  const updatedAt = formatShortUpdateDate(lease.renewalUpdatedAt || lease.updatedAt);
+  return updatedAt ? `Updated • ${updatedAt}` : "Updated";
+}
+
+export function mapRenewalValidationMessage(errorCode: string | null | undefined) {
+  switch (String(errorCode || "").trim()) {
+    case "RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT":
+      return "Choose Increase or Decrease before entering a proposed rent.";
+    case "PROPOSED_RENT_NOT_ALLOWED_FOR_RENT_CHANGE_MODE":
+      return "Proposed rent is only allowed when rent change mode is Increase or Decrease.";
+    case "INVALID_PROPOSED_RENT":
+      return "Enter a valid proposed rent amount.";
+    case "INVALID_NEW_TERM_TYPE":
+      return "Choose a valid renewal term type.";
+    case "INVALID_NEW_LEASE_START_DATE":
+      return "Enter a valid new lease start date.";
+    case "INVALID_NEW_LEASE_END_DATE":
+      return "Enter a valid new lease end date.";
+    case "INVALID_RESPONSE_DEADLINE":
+      return "Enter a valid response deadline.";
+    default:
+      return null;
+  }
+}
+
+export function LeaseRenewalOperatorInputsCard({
+  lease,
+  formState,
+  onFormStateChange,
+  onSaved,
+  notify,
+}: LeaseRenewalOperatorInputsCardProps) {
+  const [localLease, setLocalLease] = React.useState(lease);
+  const [internalForm, setInternalForm] = React.useState(() => createLeaseRenewalFormState(lease));
+  const [validation, setValidation] = React.useState<LeaseRenewalValidationState>({});
+  const [saving, setSaving] = React.useState(false);
+  const [statusMessage, setStatusMessage] = React.useState<{ variant: "success" | "error" | "warning"; text: string } | null>(null);
+
+  React.useEffect(() => {
+    setLocalLease(lease);
+    setInternalForm(createLeaseRenewalFormState(lease));
+    setValidation({});
+  }, [lease]);
+
+  const form = formState || internalForm;
+  const proposedRentAllowed = canSetProposedRent(form.rentChangeMode);
+  const updatedBadge = formatRenewalUpdatedBadge(localLease);
+
+  function updateForm(field: keyof LeaseRenewalFormState, value: string) {
+    const next = {
+      ...form,
+      [field]: value,
+    };
+    if (field === "rentChangeMode" && !canSetProposedRent(value as LeaseRenewalFormState["rentChangeMode"])) {
+      next.proposedRent = "";
+    }
+    if (onFormStateChange) {
+      onFormStateChange(lease.id, next);
+    } else {
+      setInternalForm(next);
+    }
+    setValidation((current) => ({
+      ...current,
+      proposedRent:
+        field === "rentChangeMode" && !canSetProposedRent(value as LeaseRenewalFormState["rentChangeMode"])
+          ? "Choose Increase or Decrease before entering a proposed rent."
+          : null,
+    }));
+    setStatusMessage(null);
+  }
+
+  async function handleSave() {
+    const nextValidation: LeaseRenewalValidationState = {};
+    if (form.proposedRent.trim() && !canSetProposedRent(form.rentChangeMode)) {
+      nextValidation.proposedRent = "Choose Increase or Decrease before entering a proposed rent.";
+      setValidation(nextValidation);
+      setStatusMessage({ variant: "warning", text: nextValidation.proposedRent });
+      notify?.({
+        message: "Review renewal inputs",
+        description: nextValidation.proposedRent,
+        variant: "warning",
+      });
+      return;
+    }
+
+    try {
+      setSaving(true);
+      setValidation({});
+      setStatusMessage(null);
+      const response = await saveLeaseRenewalInputs(lease.id, {
+        rentChangeMode: form.rentChangeMode || null,
+        proposedRent: form.proposedRent.trim() ? Number(form.proposedRent) : null,
+        newTermType: form.newTermType || null,
+        newLeaseStartDate: form.newLeaseStartDate || null,
+        newLeaseEndDate: form.newLeaseEndDate || null,
+        responseDeadlineAt: fromDatetimeLocalInput(form.responseDeadlineAt),
+      });
+      const savedForm = createLeaseRenewalFormState(response.lease);
+      setLocalLease(response.lease);
+      if (onFormStateChange) {
+        onFormStateChange(lease.id, savedForm);
+      } else {
+        setInternalForm(savedForm);
+      }
+      setValidation({});
+      onSaved?.(response.lease);
+      setStatusMessage({ variant: "success", text: "Lease renewal inputs saved." });
+      notify?.({
+        message: "Lease renewal inputs saved",
+        description: "Saved values will be picked up by lease notice readiness checks.",
+        variant: "success",
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Failed to save lease renewal inputs";
+      const payloadError = typeof (err as { payload?: { error?: unknown } })?.payload?.error === "string"
+        ? (err as { payload: { error: string } }).payload.error
+        : null;
+      const friendlyMessage = mapRenewalValidationMessage(message) || mapRenewalValidationMessage(payloadError) || message;
+      if (
+        friendlyMessage &&
+        (message.includes("PROPOSED_RENT") || message.includes("RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT"))
+      ) {
+        setValidation((current) => ({
+          ...current,
+          proposedRent: friendlyMessage,
+        }));
+      }
+      setStatusMessage({ variant: "error", text: `Failed to save renewal inputs: ${friendlyMessage}` });
+      notify?.({
+        message: "Failed to save lease renewal inputs",
+        description: friendlyMessage,
+        variant: "error",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={cardStyle}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, flexWrap: "wrap" }}>
+        <div style={{ display: "grid", gap: 2 }}>
+          <div style={{ fontWeight: 700 }}>{formatLeaseRenewalLocation(localLease)}</div>
+          <div style={{ color: "#475569", fontSize: 14 }}>
+            Lease ends {localLease.leaseEndDate || "unknown"}{localLease.tenantName ? ` • ${localLease.tenantName}` : ""}
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+          {updatedBadge ? <Badge tone="success">{updatedBadge}</Badge> : null}
+          <Badge tone="warning">{formatLeaseExpiryBadge(localLease)}</Badge>
+        </div>
+      </div>
+
+      {localLease.leaseLifecycleSummary ? (
+        <div style={{ display: "grid", gap: 6, color: "#334155", fontSize: 14 }}>
+          <div>
+            <strong>Lifecycle:</strong> {localLease.leaseLifecycleSummary.lifecycleLabel}
+          </div>
+          <div>
+            <strong>Outcome:</strong> {formatRenewalOutcome(localLease.leaseLifecycleSummary.renewalOutcome)}
+          </div>
+          <div>
+            <strong>Next step:</strong> {formatLifecycleNextAction(localLease.leaseLifecycleSummary.requiredNextAction)}
+          </div>
+          {localLease.leaseLifecycleSummary.history.length > 0 ? (
+            <div>
+              <strong>History:</strong>{" "}
+              {localLease.leaseLifecycleSummary.history.map((item) => item.label).join(" • ")}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+        <label style={fieldStyle}>
+          <span>Rent change mode</span>
+          <select value={form.rentChangeMode} onChange={(event) => updateForm("rentChangeMode", event.target.value)}>
+            <option value="">Unset</option>
+            <option value="no_change">No change</option>
+            <option value="increase">Increase</option>
+            <option value="decrease">Decrease</option>
+            <option value="undecided">Undecided</option>
+          </select>
+        </label>
+
+        <label style={fieldStyle}>
+          <span>Proposed rent</span>
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={form.proposedRent}
+            disabled={!proposedRentAllowed}
+            onChange={(event) => updateForm("proposedRent", event.target.value)}
+          />
+          <span style={{ color: validation.proposedRent ? "#b91c1c" : "#64748b", fontSize: 12 }}>
+            {validation.proposedRent || "Choose Increase or Decrease before entering a proposed rent."}
+          </span>
+        </label>
+
+        <label style={fieldStyle}>
+          <span>New term type</span>
+          <select value={form.newTermType} onChange={(event) => updateForm("newTermType", event.target.value)}>
+            <option value="">Unset</option>
+            <option value="fixed_term">Fixed term</option>
+            <option value="year_to_year">Year to year</option>
+            <option value="month_to_month">Month to month</option>
+          </select>
+        </label>
+
+        <label style={fieldStyle}>
+          <span>New lease start date</span>
+          <input type="date" value={form.newLeaseStartDate} onChange={(event) => updateForm("newLeaseStartDate", event.target.value)} />
+        </label>
+
+        <label style={fieldStyle}>
+          <span>New lease end date</span>
+          <input type="date" value={form.newLeaseEndDate} onChange={(event) => updateForm("newLeaseEndDate", event.target.value)} />
+        </label>
+
+        <label style={fieldStyle}>
+          <span>Response deadline</span>
+          <input type="datetime-local" value={form.responseDeadlineAt} onChange={(event) => updateForm("responseDeadlineAt", event.target.value)} />
+        </label>
+      </div>
+
+      {statusMessage ? (
+        <div style={{ color: statusMessage.variant === "error" ? "#b91c1c" : statusMessage.variant === "warning" ? "#92400e" : "#166534" }}>
+          {statusMessage.text}
+        </div>
+      ) : null}
+
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <button type="button" onClick={() => void handleSave()} disabled={saving}>
+          {saving ? "Saving…" : "Save renewal inputs"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Badge({ children, tone }: React.PropsWithChildren<{ tone: "success" | "warning" }>) {
+  const success = tone === "success";
+  return (
+    <div
+      style={{
+        padding: "5px 10px",
+        borderRadius: 999,
+        border: success ? "1px solid rgba(22,101,52,0.28)" : "1px solid rgba(245,158,11,0.35)",
+        background: success ? "rgba(22,101,52,0.10)" : "rgba(245,158,11,0.14)",
+        color: success ? "#166534" : "#92400e",
+        fontSize: 12,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 12,
+  padding: 16,
+  border: "1px solid #dbe4ee",
+  borderRadius: 12,
+  background: "#fff",
+};
+
+const fieldStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 4,
+};

--- a/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
@@ -112,6 +112,16 @@ export function canSetProposedRent(rentChangeMode: LeaseRenewalFormState["rentCh
   return rentChangeMode === "increase" || rentChangeMode === "decrease";
 }
 
+export function formatRenewalCurrency(value: number | null | undefined, currency = "CAD") {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency: currency || "CAD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
 export function formatLeaseRenewalLocation(lease: LandlordLeaseRenewalLease) {
   const propertyLabel = lease.propertyAddress || lease.propertyLabel || "Property";
   return lease.unitLabel ? `${propertyLabel} • ${lease.unitLabel}` : propertyLabel;
@@ -188,6 +198,7 @@ export function LeaseRenewalOperatorInputsCard({
   const form = formState || internalForm;
   const proposedRentAllowed = canSetProposedRent(form.rentChangeMode);
   const updatedBadge = formatRenewalUpdatedBadge(localLease);
+  const currentRentLabel = formatRenewalCurrency(localLease.currentRent, localLease.currency);
 
   function updateForm(field: keyof LeaseRenewalFormState, value: string) {
     const next = {
@@ -326,6 +337,16 @@ export function LeaseRenewalOperatorInputsCard({
           </select>
         </label>
 
+        <div style={fieldStyle} aria-label="Current rent">
+          <span>Current rent</span>
+          <div style={readonlyValueStyle}>{currentRentLabel || "Current rent unavailable"}</div>
+          <span style={{ color: "#64748b", fontSize: 12 }}>
+            {currentRentLabel
+              ? "Compare proposed rent against the current lease rent before saving renewal inputs."
+              : "Review lease terms before changing rent."}
+          </span>
+        </div>
+
         <label style={fieldStyle}>
           <span>Proposed rent</span>
           <input
@@ -414,4 +435,11 @@ const cardStyle: React.CSSProperties = {
 const fieldStyle: React.CSSProperties = {
   display: "grid",
   gap: 4,
+};
+
+const readonlyValueStyle: React.CSSProperties = {
+  minHeight: 22,
+  padding: "2px 0",
+  color: "#0f172a",
+  fontWeight: 800,
 };

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -261,13 +261,60 @@ describe("LandlordLeaseWorkflowPage", () => {
     );
     expect(await screen.findByLabelText(/Rent change mode/i)).toHaveValue("increase");
     expect(mocks.fetchExpiringLeaseRenewals).toHaveBeenCalledWith({ propertyId: "prop-1" });
+    expect(screen.getByLabelText("Current rent")).toHaveTextContent(/1,850/);
+    expect(screen.getByText("Compare proposed rent against the current lease rent before saving renewal inputs.")).toBeInTheDocument();
     expect(screen.getByLabelText(/Proposed rent/i)).toHaveValue(1975);
     expect(screen.getByLabelText(/New term type/i)).toHaveValue("fixed_term");
     expect(screen.getByLabelText(/New lease start date/i)).toHaveValue("2027-01-01");
     expect(screen.getByLabelText(/New lease end date/i)).toHaveValue("2027-12-31");
     expect(screen.getByLabelText(/Response deadline/i)).toHaveValue("2026-11-15T09:30");
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Tenant notice email workflow")).toHaveTextContent(
+      "Tenant-facing renewal notices are not sent from this workflow yet."
+    );
+    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
+  });
+
+  it("shows current rent unavailable when renewal projection rent is missing", async () => {
+    mocks.fetchExpiringLeaseRenewals.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          propertyAddress: "12 Harbour Road",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2026-01-01",
+          leaseEndDate: "2026-12-31",
+          currentRent: null,
+          currency: "CAD",
+          nextNoticeDueAt: null,
+          latestNoticeId: null,
+          tenantName: "Jane Tenant",
+          unitLabel: "Unit 101",
+          propertyLabel: "Harbour View",
+          renewalRentChangeMode: "undecided",
+          renewalOfferedRent: null,
+          renewalDecisionDeadlineAt: null,
+          renewalNewTermType: null,
+          renewalNewLeaseStartDate: null,
+          renewalNewLeaseEndDate: null,
+        },
+      ],
+      data: [],
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+
+    expect(await screen.findByLabelText("Current rent")).toHaveTextContent("Current rent unavailable");
+    expect(screen.getByText("Review lease terms before changing rent.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
   });
 
   it("saves renewal operator inputs through the existing lease renewal save behavior", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -156,13 +156,64 @@ describe("LandlordLeaseWorkflowPage", () => {
 
     expect(await screen.findByRole("heading", { name: "Renewal Review" })).toBeInTheDocument();
     expect(screen.getByText("Review lease end timing and renewal context before deciding on renewal, continuation, or move-out next steps.")).toBeInTheDocument();
-    expect(screen.getByText("Expiring soon")).toBeInTheDocument();
+    expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);
     expect(screen.getByText("30 days")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Renewal operator inputs" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Open renewal inputs" })).toHaveAttribute(
+    const sourceContext = screen.getByLabelText("Renewal source context");
+    expect(sourceContext).toHaveTextContent("Portfolio renewal context for this lease, scoped to the property source view.");
+    expect(sourceContext).toHaveTextContent("Harbour View");
+    expect(sourceContext).toHaveTextContent("Unit 101 · Jane Tenant");
+    expect(sourceContext).toHaveTextContent("December 31, 2026");
+    expect(sourceContext).toHaveTextContent("Next 30 days · 30 days to lease end");
+    expect(sourceContext).toHaveTextContent("Expiring soon");
+    expect(sourceContext).toHaveTextContent(/Review the renewal planning window and check jurisdiction requirements/i);
+    expect(screen.getByRole("link", { name: "Open portfolio renewal view" })).toHaveAttribute(
       "href",
       "/portfolio-health?entry=lease-renewals&propertyId=prop-1"
     );
+    expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
+  });
+
+  it("shows a compact unavailable renewal source state when the lease has no property link", async () => {
+    mocks.getLeaseById.mockResolvedValueOnce({
+      lease: {
+        id: "lease-missing-property",
+        propertyId: null,
+        propertyName: null,
+        propertyLabel: null,
+        propertyAddress: null,
+        unitNumber: "202",
+        monthlyRent: 1650,
+        startDate: "2026-01-01",
+        endDate: "2026-10-31",
+        status: "active",
+        tenantName: "No Property Tenant",
+        tenantEmail: "tenant@example.com",
+        leaseExecution: null,
+        paymentReadiness: null,
+        leaseLifecycleSummary: {
+          lifecycleStatus: "expiring_soon",
+          lifecycleLabel: "Expiring soon",
+          lifecycleDescription: "This lease is approaching renewal planning review.",
+          requiredNextAction: "prepare_renewal_notice",
+          renewalOutcome: "not_started",
+          daysUntilExpiry: 45,
+          history: [],
+        },
+        jurisdictionPolicies: [],
+      },
+    });
+
+    renderWorkflow("/leases/lease-missing-property/workflows/renewal");
+
+    expect(await screen.findByRole("heading", { name: "Renewal Review" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Renewal operator inputs" })).toBeInTheDocument();
+    const sourceContext = screen.getByLabelText("Renewal source context");
+    expect(sourceContext).toHaveTextContent(
+      "Portfolio renewal context is not available because this lease is not linked to a property."
+    );
+    expect(screen.queryByRole("link", { name: "Open portfolio renewal view" })).not.toBeInTheDocument();
+    expect(screen.getByText("45 days")).toBeInTheDocument();
   });
 
   it("uses lease end date fallback copy when lifecycle summary is absent", async () => {
@@ -187,7 +238,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     renderWorkflow("/leases/lease-no-summary/workflows/renewal");
 
     expect(await screen.findByRole("heading", { name: "Renewal Review" })).toBeInTheDocument();
-    expect(screen.getByText("December 31, 2099")).toBeInTheDocument();
+    expect(screen.getAllByText("December 31, 2099").length).toBeGreaterThan(0);
     expect(screen.getByText("Lifecycle summary pending")).toBeInTheDocument();
     expect(screen.getByText(/days$/)).toBeInTheDocument();
     expect(screen.queryByText("Not available")).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -1,14 +1,21 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import LandlordLeaseWorkflowPage from "./LandlordLeaseWorkflowPage";
 
 const mocks = vi.hoisted(() => ({
   getLeaseById: vi.fn(),
+  fetchExpiringLeaseRenewals: vi.fn(),
+  saveLeaseRenewalInputs: vi.fn(),
 }));
 
 vi.mock("@/api/leasesApi", () => ({
   getLeaseById: mocks.getLeaseById,
+}));
+
+vi.mock("@/api/landlordLeaseRenewalApi", () => ({
+  fetchExpiringLeaseRenewals: mocks.fetchExpiringLeaseRenewals,
+  saveLeaseRenewalInputs: mocks.saveLeaseRenewalInputs,
 }));
 
 function renderWorkflow(path: string) {
@@ -24,9 +31,12 @@ function renderWorkflow(path: string) {
 describe("LandlordLeaseWorkflowPage", () => {
   beforeEach(() => {
     mocks.getLeaseById.mockReset();
+    mocks.fetchExpiringLeaseRenewals.mockReset();
+    mocks.saveLeaseRenewalInputs.mockReset();
     mocks.getLeaseById.mockResolvedValue({
       lease: {
         id: "lease-1",
+        tenantId: "tenant-1",
         propertyId: "prop-1",
         propertyName: "Harbour View",
         unitNumber: "101",
@@ -105,6 +115,84 @@ describe("LandlordLeaseWorkflowPage", () => {
         ],
       },
     });
+    mocks.fetchExpiringLeaseRenewals.mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          propertyAddress: "12 Harbour Road",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2026-01-01",
+          leaseEndDate: "2026-12-31",
+          currentRent: 1850,
+          currency: "CAD",
+          nextNoticeDueAt: null,
+          latestNoticeId: null,
+          tenantName: "Jane Tenant",
+          unitLabel: "Unit 101",
+          propertyLabel: "Harbour View",
+          renewalRentChangeMode: "increase",
+          renewalOfferedRent: 1975,
+          renewalDecisionDeadlineAt: Date.UTC(2026, 10, 15, 13, 30, 0, 0),
+          renewalNewTermType: "fixed_term",
+          renewalNewLeaseStartDate: "2027-01-01",
+          renewalNewLeaseEndDate: "2027-12-31",
+          renewalUpdatedAt: "2026-07-01T12:00:00.000Z",
+          leaseLifecycleSummary: {
+            lifecycleStatus: "expiring_soon",
+            lifecycleLabel: "Expiring soon",
+            lifecycleDescription: "This lease is approaching notice timing.",
+            requiredNextAction: "prepare_renewal_notice",
+            renewalOutcome: "not_started",
+            daysUntilExpiry: 30,
+            history: [],
+          },
+        },
+      ],
+      data: [],
+    });
+    mocks.saveLeaseRenewalInputs.mockResolvedValue({
+      ok: true,
+      lease: {
+        id: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        propertyAddress: "12 Harbour Road",
+        unitId: "unit-1",
+        status: "active",
+        leaseType: "fixed_term",
+        province: "NS",
+        leaseStartDate: "2026-01-01",
+        leaseEndDate: "2026-12-31",
+        currentRent: 1850,
+        currency: "CAD",
+        nextNoticeDueAt: null,
+        latestNoticeId: null,
+        tenantName: "Jane Tenant",
+        unitLabel: "Unit 101",
+        propertyLabel: "Harbour View",
+        renewalRentChangeMode: "no_change",
+        renewalOfferedRent: null,
+        renewalDecisionDeadlineAt: Date.UTC(2026, 10, 20, 14, 0, 0, 0),
+        renewalNewTermType: "month_to_month",
+        renewalNewLeaseStartDate: "2027-01-01",
+        renewalNewLeaseEndDate: "",
+        renewalUpdatedAt: "2026-07-02T12:00:00.000Z",
+      },
+      renewalInputs: {
+        rentChangeMode: "no_change",
+        proposedRent: null,
+        newTermType: "month_to_month",
+        newLeaseStartDate: "2027-01-01",
+        newLeaseEndDate: null,
+        responseDeadlineAt: Date.UTC(2026, 10, 20, 14, 0, 0, 0),
+      },
+    });
   });
 
   afterEach(() => {
@@ -151,7 +239,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     });
   });
 
-  it("preserves the lease renewal workflow and links to portfolio renewal inputs", async () => {
+  it("renders editable renewal operator inputs with prefilled values and source link", async () => {
     renderWorkflow("/leases/lease-1/workflows/renewal");
 
     expect(await screen.findByRole("heading", { name: "Renewal Review" })).toBeInTheDocument();
@@ -171,7 +259,51 @@ describe("LandlordLeaseWorkflowPage", () => {
       "href",
       "/portfolio-health?entry=lease-renewals&propertyId=prop-1"
     );
+    expect(await screen.findByLabelText(/Rent change mode/i)).toHaveValue("increase");
+    expect(mocks.fetchExpiringLeaseRenewals).toHaveBeenCalledWith({ propertyId: "prop-1" });
+    expect(screen.getByLabelText(/Proposed rent/i)).toHaveValue(1975);
+    expect(screen.getByLabelText(/New term type/i)).toHaveValue("fixed_term");
+    expect(screen.getByLabelText(/New lease start date/i)).toHaveValue("2027-01-01");
+    expect(screen.getByLabelText(/New lease end date/i)).toHaveValue("2027-12-31");
+    expect(screen.getByLabelText(/Response deadline/i)).toHaveValue("2026-11-15T09:30");
+    expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
     expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
+  });
+
+  it("saves renewal operator inputs through the existing lease renewal save behavior", async () => {
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+
+    expect(await screen.findByLabelText(/Rent change mode/i)).toHaveValue("increase");
+    fireEvent.change(screen.getByLabelText(/Rent change mode/i), { target: { value: "no_change" } });
+    fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "month_to_month" } });
+    fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2027-01-01" } });
+    fireEvent.change(screen.getByLabelText(/New lease end date/i), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText(/Response deadline/i), { target: { value: "2026-11-20T10:00" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save renewal inputs" }));
+
+    await waitFor(() => {
+      expect(mocks.saveLeaseRenewalInputs).toHaveBeenCalledWith(
+        "lease-1",
+        expect.objectContaining({
+          rentChangeMode: "no_change",
+          proposedRent: null,
+          newTermType: "month_to_month",
+          newLeaseStartDate: "2027-01-01",
+          newLeaseEndDate: null,
+        })
+      );
+    });
+    expect(await screen.findByText("Lease renewal inputs saved.")).toBeInTheDocument();
+  });
+
+  it("shows a clear save failure state for renewal operator inputs", async () => {
+    mocks.saveLeaseRenewalInputs.mockRejectedValueOnce(new Error("INVALID_RESPONSE_DEADLINE"));
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+
+    expect(await screen.findByLabelText(/Rent change mode/i)).toHaveValue("increase");
+    fireEvent.click(screen.getByRole("button", { name: "Save renewal inputs" }));
+
+    expect(await screen.findByText("Failed to save renewal inputs: Enter a valid response deadline.")).toBeInTheDocument();
   });
 
   it("shows a compact unavailable renewal source state when the lease has no property link", async () => {
@@ -212,7 +344,10 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(sourceContext).toHaveTextContent(
       "Portfolio renewal context is not available because this lease is not linked to a property."
     );
+    expect(screen.getByText("Renewal operator inputs cannot be loaded until this lease is linked to a property.")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Open portfolio renewal view" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save renewal inputs" })).not.toBeInTheDocument();
+    expect(mocks.fetchExpiringLeaseRenewals).not.toHaveBeenCalled();
     expect(screen.getByText("45 days")).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -267,7 +267,9 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText(/New term type/i)).toHaveValue("fixed_term");
     expect(screen.getByLabelText(/New lease start date/i)).toHaveValue("2027-01-01");
     expect(screen.getByLabelText(/New lease end date/i)).toHaveValue("2027-12-31");
-    expect(screen.getByLabelText(/Response deadline/i)).toHaveValue("2026-11-15T09:30");
+    expect(screen.getByLabelText(/Tenant response target date/i)).toHaveValue("2026-11-15T09:30");
+    expect(screen.getByText("Planning date only. Does not send notice or determine legal deadlines.")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Response deadline/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Tenant notice email workflow")).toHaveTextContent(
       "Tenant-facing renewal notices are not sent from this workflow yet."
@@ -325,7 +327,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "month_to_month" } });
     fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2027-01-01" } });
     fireEvent.change(screen.getByLabelText(/New lease end date/i), { target: { value: "" } });
-    fireEvent.change(screen.getByLabelText(/Response deadline/i), { target: { value: "2026-11-20T10:00" } });
+    fireEvent.change(screen.getByLabelText(/Tenant response target date/i), { target: { value: "2026-11-20T10:00" } });
     fireEvent.click(screen.getByRole("button", { name: "Save renewal inputs" }));
 
     await waitFor(() => {
@@ -350,7 +352,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(await screen.findByLabelText(/Rent change mode/i)).toHaveValue("increase");
     fireEvent.click(screen.getByRole("button", { name: "Save renewal inputs" }));
 
-    expect(await screen.findByText("Failed to save renewal inputs: Enter a valid response deadline.")).toBeInTheDocument();
+    expect(await screen.findByText("Failed to save renewal inputs: Enter a valid tenant response target date.")).toBeInTheDocument();
   });
 
   it("shows a compact unavailable renewal source state when the lease has no property link", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -28,6 +28,12 @@ function renderWorkflow(path: string) {
   );
 }
 
+function datetimeLocalValue(value: number) {
+  const date = new Date(value);
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+}
+
 describe("LandlordLeaseWorkflowPage", () => {
   beforeEach(() => {
     mocks.getLeaseById.mockReset();
@@ -267,7 +273,9 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText(/New term type/i)).toHaveValue("fixed_term");
     expect(screen.getByLabelText(/New lease start date/i)).toHaveValue("2027-01-01");
     expect(screen.getByLabelText(/New lease end date/i)).toHaveValue("2027-12-31");
-    expect(screen.getByLabelText(/Tenant response target date/i)).toHaveValue("2026-11-15T09:30");
+    expect(screen.getByLabelText(/Tenant response target date/i)).toHaveValue(
+      datetimeLocalValue(Date.UTC(2026, 10, 15, 13, 30, 0, 0))
+    );
     expect(screen.getByText("Planning date only. Does not send notice or determine legal deadlines.")).toBeInTheDocument();
     expect(screen.queryByLabelText(/Response deadline/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import { Link, useParams } from "react-router-dom";
 import { getLeaseById, type JurisdictionPolicyGuidance, type LandlordActiveLease } from "@/api/leasesApi";
 import {
+  fetchExpiringLeaseRenewals,
+  type LandlordLeaseRenewalLease,
+} from "@/api/landlordLeaseRenewalApi";
+import { LeaseRenewalOperatorInputsCard } from "@/components/leases/LeaseRenewalOperatorInputsCard";
+import {
   RENEWAL_PIPELINE_BUCKETS,
   deriveRenewalPipelineItems,
   type RenewalPipelineItem,
@@ -231,16 +236,89 @@ function renewalSourceContextItem(lease: LandlordActiveLease): RenewalPipelineIt
   return deriveRenewalPipelineItems([lease])[0] || null;
 }
 
-function RenewalSourceContext({ lease }: { lease: LandlordActiveLease }) {
+function renewalProjectionFallbackFromLease(lease: LandlordActiveLease): LandlordLeaseRenewalLease {
+  const projectedLease = lease as LandlordActiveLease & Partial<LandlordLeaseRenewalLease>;
+  return {
+    id: lease.id,
+    tenantId: lease.tenantId || lease.primaryTenantId || "",
+    propertyId: lease.propertyId || null,
+    propertyAddress: lease.propertyAddress || null,
+    unitId: lease.unitId || null,
+    status: lease.status,
+    leaseType: projectedLease.leaseType || "fixed_term",
+    province: lease.jurisdictionProvince || projectedLease.province || "UNKNOWN",
+    leaseStartDate: lease.startDate || null,
+    leaseEndDate: lease.endDate || null,
+    currentRent: typeof lease.monthlyRent === "number" ? lease.monthlyRent : null,
+    currency: projectedLease.currency || "CAD",
+    nextNoticeDueAt: projectedLease.nextNoticeDueAt || null,
+    latestNoticeId: projectedLease.latestNoticeId || null,
+    tenantName: lease.tenantName || null,
+    unitLabel: lease.unitLabel || (lease.unitNumber ? `Unit ${lease.unitNumber}` : null),
+    propertyLabel: lease.propertyLabel || lease.propertyName || null,
+    renewalRentChangeMode: projectedLease.renewalRentChangeMode || null,
+    renewalOfferedRent: typeof projectedLease.renewalOfferedRent === "number" ? projectedLease.renewalOfferedRent : null,
+    renewalDecisionDeadlineAt: projectedLease.renewalDecisionDeadlineAt || null,
+    renewalNewTermType: projectedLease.renewalNewTermType || null,
+    renewalNewLeaseStartDate: projectedLease.renewalNewLeaseStartDate || null,
+    renewalNewLeaseEndDate: projectedLease.renewalNewLeaseEndDate || null,
+    renewalUpdatedAt: projectedLease.renewalUpdatedAt || null,
+    updatedAt: lease.updatedAt,
+    leaseLifecycleSummary: lease.leaseLifecycleSummary,
+  };
+}
+
+function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease }) {
   const propertyId = String(lease.propertyId || "").trim();
+  const [renewalLease, setRenewalLease] = React.useState<LandlordLeaseRenewalLease | null>(null);
+  const [loadingRenewalInputs, setLoadingRenewalInputs] = React.useState(false);
+  const [renewalInputsError, setRenewalInputsError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!propertyId) {
+      setRenewalLease(null);
+      setLoadingRenewalInputs(false);
+      setRenewalInputsError(null);
+      return;
+    }
+
+    let active = true;
+    (async () => {
+      try {
+        setLoadingRenewalInputs(true);
+        setRenewalInputsError(null);
+        const response = await fetchExpiringLeaseRenewals({ propertyId });
+        if (!active) return;
+        const renewalItems = response.items?.length ? response.items : response.data || [];
+        const projectedLease = renewalItems.find((item) => item.id === lease.id);
+        setRenewalLease(projectedLease || renewalProjectionFallbackFromLease(lease));
+      } catch (err: unknown) {
+        if (!active) return;
+        setRenewalLease(null);
+        setRenewalInputsError(errorMessage(err, "Failed to load renewal operator inputs."));
+      } finally {
+        if (active) setLoadingRenewalInputs(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [lease, propertyId]);
+
   if (!propertyId) {
     return (
-      <div style={sourceContextStyle} aria-label="Renewal source context">
-        <div style={sourceContextTitleStyle}>Renewal source context</div>
-        <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
-          Portfolio renewal context is not available because this lease is not linked to a property.
+      <>
+        <div style={sourceContextStyle} aria-label="Renewal source context">
+          <div style={sourceContextTitleStyle}>Renewal source context</div>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+            Portfolio renewal context is not available because this lease is not linked to a property.
+          </div>
         </div>
-      </div>
+        <div style={{ color: "#b91c1c", lineHeight: 1.55 }}>
+          Renewal operator inputs cannot be loaded until this lease is linked to a property.
+        </div>
+      </>
     );
   }
 
@@ -255,42 +333,53 @@ function RenewalSourceContext({ lease }: { lease: LandlordActiveLease }) {
     "Review renewal planning and source context before preparing next steps. Check jurisdiction requirements before acting.";
 
   return (
-    <div style={sourceContextStyle} aria-label="Renewal source context">
-      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
-        <div style={{ display: "grid", gap: 4 }}>
-          <div style={sourceContextTitleStyle}>Renewal source context</div>
-          <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
-            Portfolio renewal context for this lease, scoped to the property source view.
+    <>
+      <div style={sourceContextStyle} aria-label="Renewal source context">
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+          <div style={{ display: "grid", gap: 4 }}>
+            <div style={sourceContextTitleStyle}>Renewal source context</div>
+            <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+              Portfolio renewal context for this lease, scoped to the property source view.
+            </div>
           </div>
+          <Link to={sourcePath} style={{ ...buttonLinkStyle, width: "fit-content" }}>
+            Open portfolio renewal view
+          </Link>
         </div>
-        <Link to={sourcePath} style={{ ...buttonLinkStyle, width: "fit-content" }}>
-          Open portfolio renewal view
-        </Link>
+        <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12, margin: 0 }}>
+          <div style={{ display: "grid", gap: 4 }}>
+            <dt style={termStyle}>Property</dt>
+            <dd style={sourceValueStyle}>{lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property"}</dd>
+          </div>
+          <div style={{ display: "grid", gap: 4 }}>
+            <dt style={termStyle}>Lease</dt>
+            <dd style={sourceValueStyle}>{renewalSourceLeaseLabel(lease)}</dd>
+          </div>
+          <div style={{ display: "grid", gap: 4 }}>
+            <dt style={termStyle}>Lease end</dt>
+            <dd style={sourceValueStyle}>{formatDate(lease.endDate)}</dd>
+          </div>
+          <div style={{ display: "grid", gap: 4 }}>
+            <dt style={termStyle}>Review timing</dt>
+            <dd style={sourceValueStyle}>{timing}</dd>
+          </div>
+          <div style={{ display: "grid", gap: 4 }}>
+            <dt style={termStyle}>Renewal status</dt>
+            <dd style={sourceValueStyle}>{status}</dd>
+          </div>
+        </dl>
+        <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>{explanation}</div>
       </div>
-      <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12, margin: 0 }}>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Property</dt>
-          <dd style={sourceValueStyle}>{lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property"}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Lease</dt>
-          <dd style={sourceValueStyle}>{renewalSourceLeaseLabel(lease)}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Lease end</dt>
-          <dd style={sourceValueStyle}>{formatDate(lease.endDate)}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Review timing</dt>
-          <dd style={sourceValueStyle}>{timing}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Renewal status</dt>
-          <dd style={sourceValueStyle}>{status}</dd>
-        </div>
-      </dl>
-      <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>{explanation}</div>
-    </div>
+
+      {loadingRenewalInputs ? <div>Loading renewal operator inputs…</div> : null}
+      {!loadingRenewalInputs && renewalInputsError ? <div style={{ color: "#b91c1c" }}>{renewalInputsError}</div> : null}
+      {!loadingRenewalInputs && !renewalInputsError && renewalLease ? (
+        <LeaseRenewalOperatorInputsCard
+          lease={renewalLease}
+          onSaved={(updatedLease) => setRenewalLease(updatedLease)}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -394,10 +483,10 @@ export default function LandlordLeaseWorkflowPage() {
             <section style={panelStyle} aria-label="Renewal operator inputs">
               <h2 style={sectionHeadingStyle}>Renewal operator inputs</h2>
               <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
-                Use the portfolio renewal workbench to review unit-specific renewal inputs such as proposed rent,
-                term dates, response deadline, and renewal recommendation before preparing tenant-facing notices.
+                Review and save unit-specific renewal inputs such as proposed rent, term dates, and response deadline
+                before preparing tenant-facing notices.
               </div>
-              <RenewalSourceContext lease={lease} />
+              <RenewalOperatorInputsWorkspace lease={lease} />
             </section>
           ) : null}
 

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { Link, useParams } from "react-router-dom";
 import { getLeaseById, type JurisdictionPolicyGuidance, type LandlordActiveLease } from "@/api/leasesApi";
+import {
+  RENEWAL_PIPELINE_BUCKETS,
+  deriveRenewalPipelineItems,
+  type RenewalPipelineItem,
+  type RenewalPipelineTimingBucketKey,
+} from "@/lib/leases/renewalPipeline";
 
 type WorkflowKey = "execution" | "rent-increase" | "notice" | "deposit" | "renewal" | "move-out";
 
@@ -211,6 +217,83 @@ function portfolioRenewalInputsPath(lease: LandlordActiveLease) {
   return `/portfolio-health?${params.toString()}`;
 }
 
+function renewalPipelineBucketLabel(value: RenewalPipelineTimingBucketKey) {
+  return RENEWAL_PIPELINE_BUCKETS.find((bucket) => bucket.key === value)?.label || "Review timing";
+}
+
+function renewalSourceLeaseLabel(lease: LandlordActiveLease) {
+  const unit = lease.unitLabel || lease.unitNumber || "Unit not set";
+  const tenant = lease.tenantName || "Tenant not linked";
+  return `Unit ${unit} · ${tenant}`;
+}
+
+function renewalSourceContextItem(lease: LandlordActiveLease): RenewalPipelineItem | null {
+  return deriveRenewalPipelineItems([lease])[0] || null;
+}
+
+function RenewalSourceContext({ lease }: { lease: LandlordActiveLease }) {
+  const propertyId = String(lease.propertyId || "").trim();
+  if (!propertyId) {
+    return (
+      <div style={sourceContextStyle} aria-label="Renewal source context">
+        <div style={sourceContextTitleStyle}>Renewal source context</div>
+        <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+          Portfolio renewal context is not available because this lease is not linked to a property.
+        </div>
+      </div>
+    );
+  }
+
+  const contextItem = renewalSourceContextItem(lease);
+  const sourcePath = portfolioRenewalInputsPath(lease);
+  const timing = contextItem
+    ? `${renewalPipelineBucketLabel(contextItem.timingBucket)} · ${contextItem.timingLabel}`
+    : "Review timing unavailable";
+  const status = contextItem?.statusLabel || lifecycleStatusLabel(lease);
+  const explanation =
+    contextItem?.detail ||
+    "Review renewal planning and source context before preparing next steps. Check jurisdiction requirements before acting.";
+
+  return (
+    <div style={sourceContextStyle} aria-label="Renewal source context">
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <div style={sourceContextTitleStyle}>Renewal source context</div>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+            Portfolio renewal context for this lease, scoped to the property source view.
+          </div>
+        </div>
+        <Link to={sourcePath} style={{ ...buttonLinkStyle, width: "fit-content" }}>
+          Open portfolio renewal view
+        </Link>
+      </div>
+      <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12, margin: 0 }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Property</dt>
+          <dd style={sourceValueStyle}>{lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property"}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Lease</dt>
+          <dd style={sourceValueStyle}>{renewalSourceLeaseLabel(lease)}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Lease end</dt>
+          <dd style={sourceValueStyle}>{formatDate(lease.endDate)}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Review timing</dt>
+          <dd style={sourceValueStyle}>{timing}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Renewal status</dt>
+          <dd style={sourceValueStyle}>{status}</dd>
+        </div>
+      </dl>
+      <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>{explanation}</div>
+    </div>
+  );
+}
+
 function matchingPolicy(lease: LandlordActiveLease, config: WorkflowConfig): JurisdictionPolicyGuidance | null {
   const policies = Array.isArray(lease.jurisdictionPolicies) ? lease.jurisdictionPolicies : [];
   return policies.find((policy) => config.policyKeys.includes(policy.policyKey)) || null;
@@ -314,9 +397,7 @@ export default function LandlordLeaseWorkflowPage() {
                 Use the portfolio renewal workbench to review unit-specific renewal inputs such as proposed rent,
                 term dates, response deadline, and renewal recommendation before preparing tenant-facing notices.
               </div>
-              <Link to={portfolioRenewalInputsPath(lease)} style={{ ...buttonLinkStyle, width: "fit-content" }}>
-                Open renewal inputs
-              </Link>
+              <RenewalSourceContext lease={lease} />
             </section>
           ) : null}
 
@@ -386,6 +467,27 @@ const sectionHeadingStyle: React.CSSProperties = {
   color: workflowTheme.charcoal,
   fontSize: 18,
   letterSpacing: 0,
+};
+
+const sourceContextStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 12,
+  padding: 12,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 10,
+  background: workflowTheme.cardStrong,
+};
+
+const sourceContextTitleStyle: React.CSSProperties = {
+  color: workflowTheme.charcoal,
+  fontWeight: 900,
+};
+
+const sourceValueStyle: React.CSSProperties = {
+  margin: 0,
+  color: workflowTheme.charcoal,
+  fontWeight: 700,
+  lineHeight: 1.35,
 };
 
 const termStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -487,6 +487,13 @@ export default function LandlordLeaseWorkflowPage() {
                 before preparing tenant-facing notices.
               </div>
               <RenewalOperatorInputsWorkspace lease={lease} />
+              <div style={deferredNoticeStyle} aria-label="Tenant notice email workflow">
+                <div style={{ color: workflowTheme.charcoal, fontWeight: 900 }}>Tenant notice/email workflow</div>
+                <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+                  Tenant-facing renewal notices are not sent from this workflow yet. Review and save operator inputs here first;
+                  notice drafting, email delivery, and evidence tracking should be handled in a dedicated notice workflow.
+                </div>
+              </div>
             </section>
           ) : null}
 
@@ -570,6 +577,15 @@ const sourceContextStyle: React.CSSProperties = {
 const sourceContextTitleStyle: React.CSSProperties = {
   color: workflowTheme.charcoal,
   fontWeight: 900,
+};
+
+const deferredNoticeStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 6,
+  padding: 12,
+  border: `1px dashed ${workflowTheme.borderStrong}`,
+  borderRadius: 10,
+  background: "rgba(255, 246, 232, 0.72)",
 };
 
 const sourceValueStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -432,7 +432,7 @@ describe("PortfolioHealthSummaryPage", () => {
 
     expect((await screen.findAllByText(/Lease renewal operator inputs/i)).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Save renewal term and tenant response target choices/i).length).toBeGreaterThan(0);
-    expect(screen.queryByText(/deadline choices/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/deadline\s+choices/i)).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/Rent change mode/i), { target: { value: "no_change" } });
     fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "fixed_term" } });
     fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2026-07-01" } });

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -274,6 +274,7 @@ describe("PortfolioHealthSummaryPage", () => {
     expect((await screen.findAllByText(/Taylor Tenant/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("123 Harbour St • Unit 2")).length).toBeGreaterThan(0);
     expect(screen.getByText("Expires 2026-06-30")).toBeInTheDocument();
+    expect(screen.getByLabelText("Current rent")).toHaveTextContent(/1,800/);
     expect(screen.queryByText(/^Updated/)).not.toBeInTheDocument();
     expect(screen.getByText("Visible leases: 1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print / Save renewal view" })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -435,7 +435,7 @@ describe("PortfolioHealthSummaryPage", () => {
     fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "fixed_term" } });
     fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2026-07-01" } });
     fireEvent.change(screen.getByLabelText(/New lease end date/i), { target: { value: "2027-06-30" } });
-    fireEvent.change(screen.getByLabelText(/Response deadline/i), { target: { value: "2026-05-01T08:00" } });
+    fireEvent.change(screen.getByLabelText(/Tenant response target date/i), { target: { value: "2026-05-01T08:00" } });
     fireEvent.click(screen.getByRole("button", { name: /Save renewal inputs/i }));
 
     await waitFor(() => {

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -431,6 +431,8 @@ describe("PortfolioHealthSummaryPage", () => {
     );
 
     expect((await screen.findAllByText(/Lease renewal operator inputs/i)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Save renewal term and tenant response target choices/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/deadline choices/i)).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/Rent change mode/i), { target: { value: "no_change" } });
     fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "fixed_term" } });
     fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2026-07-01" } });

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -255,7 +255,7 @@ export default function PortfolioHealthSummaryPage() {
                       form.rentChangeMode ? `Mode: ${form.rentChangeMode.replace(/_/g, " ")}` : null,
                       form.proposedRent.trim() ? `Proposed rent: ${form.proposedRent}` : null,
                       form.newTermType ? `Term: ${form.newTermType.replace(/_/g, " ")}` : null,
-                      form.responseDeadlineAt ? `Deadline: ${form.responseDeadlineAt}` : null,
+                      form.responseDeadlineAt ? `Tenant response target: ${form.responseDeadlineAt}` : null,
                     ]
                       .filter(Boolean)
                       .join(" · ");

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -72,7 +72,7 @@ export default function PortfolioHealthSummaryPage() {
       ? "Showing leases with a sent notice that are still awaiting a tenant response."
       : entryStatus === "no-response"
       ? "Showing leases where the tenant response window has elapsed without a reply."
-      : "Save renewal term and deadline choices on the lease record so readiness checks can observe them canonically.";
+      : "Save renewal term and tenant response target choices on the lease record so readiness checks can observe them consistently.";
   const renewalDisplayItems = React.useMemo(() => renewalItems, [renewalItems]);
 
   React.useEffect(() => {

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -3,9 +3,16 @@ import { useLocation } from "react-router-dom";
 import { fetchLandlordPortfolioHealth, type LandlordPortfolioHealthSummaryV1 } from "../../api/landlordPortfolioHealthApi";
 import {
   fetchExpiringLeaseRenewals,
-  saveLeaseRenewalInputs,
   type LandlordLeaseRenewalLease,
 } from "../../api/landlordLeaseRenewalApi";
+import {
+  createLeaseRenewalFormState,
+  formatLeaseRenewalLocation,
+  formatLifecycleNextAction,
+  formatRenewalOutcome,
+  LeaseRenewalOperatorInputsCard,
+  type LeaseRenewalFormState,
+} from "@/components/leases/LeaseRenewalOperatorInputsCard";
 import { MacShell } from "../../components/layout/MacShell";
 import { Card, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
@@ -18,155 +25,7 @@ import PortfolioHealthDimensionList from "../../components/portfolioHealth/Portf
 import PortfolioHealthNextFocusList from "../../components/portfolioHealth/PortfolioHealthNextFocusList";
 import PortfolioFeedbackSummary from "../../components/portfolioHealth/PortfolioFeedbackSummary";
 
-type LeaseRenewalFormState = {
-  rentChangeMode: "" | "no_change" | "increase" | "decrease" | "undecided";
-  proposedRent: string;
-  newTermType: "" | "fixed_term" | "year_to_year" | "month_to_month";
-  newLeaseStartDate: string;
-  newLeaseEndDate: string;
-  responseDeadlineAt: string;
-};
-
-type LeaseRenewalValidationState = {
-  proposedRent?: string | null;
-};
-
 type LeaseRenewalStatusScope = "expiring" | "pending-response" | "no-response";
-
-function toDatetimeLocalInput(value: number | null) {
-  if (!value) return "";
-  const date = new Date(value);
-  const offset = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
-}
-
-function fromDatetimeLocalInput(value: string) {
-  const raw = String(value || "").trim();
-  if (!raw) return null;
-  const parsed = Date.parse(raw);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function createLeaseRenewalFormState(lease: LandlordLeaseRenewalLease): LeaseRenewalFormState {
-  return {
-    rentChangeMode: lease.renewalRentChangeMode || "",
-    proposedRent: typeof lease.renewalOfferedRent === "number" ? String(lease.renewalOfferedRent) : "",
-    newTermType: lease.renewalNewTermType || "",
-    newLeaseStartDate: lease.renewalNewLeaseStartDate || "",
-    newLeaseEndDate: lease.renewalNewLeaseEndDate || "",
-    responseDeadlineAt: toDatetimeLocalInput(lease.renewalDecisionDeadlineAt),
-  };
-}
-
-function formatLifecycleNextAction(
-  value:
-    | "review_expiring_lease"
-    | "prepare_renewal_notice"
-    | "follow_up_response"
-    | "review_renewal_outcome"
-    | "review_move_out"
-    | "none"
-    | undefined
-) {
-  switch (value) {
-    case "prepare_renewal_notice":
-      return "Prepare renewal notice";
-    case "follow_up_response":
-      return "Follow up on renewal response";
-    case "review_renewal_outcome":
-      return "Review renewal outcome";
-    case "review_move_out":
-      return "Review move-out follow-through";
-    case "review_expiring_lease":
-      return "Review expiring lease";
-    default:
-      return "No follow-up needed";
-  }
-}
-
-function formatRenewalOutcome(
-  value:
-    | "not_started"
-    | "pending_response"
-    | "renewed"
-    | "tenant_quitting"
-    | "no_response"
-    | "not_applicable"
-    | undefined
-) {
-  switch (value) {
-    case "pending_response":
-      return "Pending response";
-    case "renewed":
-      return "Renewed";
-    case "tenant_quitting":
-      return "Tenant ending lease";
-    case "no_response":
-      return "No response";
-    case "not_started":
-      return "Not started";
-    default:
-      return "Not applicable";
-  }
-}
-
-function canSetProposedRent(rentChangeMode: LeaseRenewalFormState["rentChangeMode"]) {
-  return rentChangeMode === "increase" || rentChangeMode === "decrease";
-}
-
-function formatLeaseRenewalLocation(lease: LandlordLeaseRenewalLease) {
-  const propertyLabel = lease.propertyAddress || lease.propertyLabel || "Property";
-  return lease.unitLabel ? `${propertyLabel} • ${lease.unitLabel}` : propertyLabel;
-}
-
-function formatLeaseExpiryBadge(lease: LandlordLeaseRenewalLease) {
-  return lease.leaseEndDate ? `Expires ${lease.leaseEndDate}` : "Expiry date unavailable";
-}
-
-function hasSavedRenewalInputs(lease: LandlordLeaseRenewalLease) {
-  return Boolean(
-    lease.renewalRentChangeMode ||
-      lease.renewalOfferedRent != null ||
-      lease.renewalDecisionDeadlineAt ||
-      lease.renewalNewTermType ||
-      lease.renewalNewLeaseStartDate ||
-      lease.renewalNewLeaseEndDate
-  );
-}
-
-function formatShortUpdateDate(value: string | number | null | undefined) {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
-
-function formatRenewalUpdatedBadge(lease: LandlordLeaseRenewalLease) {
-  if (!hasSavedRenewalInputs(lease)) return null;
-  const updatedAt = formatShortUpdateDate(lease.renewalUpdatedAt || lease.updatedAt);
-  return updatedAt ? `Updated • ${updatedAt}` : "Updated";
-}
-
-function mapRenewalValidationMessage(errorCode: string | null | undefined) {
-  switch (String(errorCode || "").trim()) {
-    case "RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT":
-      return "Choose Increase or Decrease before entering a proposed rent.";
-    case "PROPOSED_RENT_NOT_ALLOWED_FOR_RENT_CHANGE_MODE":
-      return "Proposed rent is only allowed when rent change mode is Increase or Decrease.";
-    case "INVALID_PROPOSED_RENT":
-      return "Enter a valid proposed rent amount.";
-    case "INVALID_NEW_TERM_TYPE":
-      return "Choose a valid renewal term type.";
-    case "INVALID_NEW_LEASE_START_DATE":
-      return "Enter a valid new lease start date.";
-    case "INVALID_NEW_LEASE_END_DATE":
-      return "Enter a valid new lease end date.";
-    case "INVALID_RESPONSE_DEADLINE":
-      return "Enter a valid response deadline.";
-    default:
-      return null;
-  }
-}
 
 export default function PortfolioHealthSummaryPage() {
   const location = useLocation();
@@ -184,8 +43,6 @@ export default function PortfolioHealthSummaryPage() {
   const [renewalForms, setRenewalForms] = React.useState<Record<string, LeaseRenewalFormState>>({});
   const [renewalLoading, setRenewalLoading] = React.useState(false);
   const [renewalError, setRenewalError] = React.useState<string | null>(null);
-  const [savingLeaseId, setSavingLeaseId] = React.useState<string | null>(null);
-  const [renewalValidation, setRenewalValidation] = React.useState<Record<string, LeaseRenewalValidationState>>({});
   const entryParams = React.useMemo(() => new URLSearchParams(location.search), [location.search]);
   const entry = entryParams.get("entry");
   const entryPropertyId = entryParams.get("propertyId");
@@ -268,7 +125,6 @@ export default function PortfolioHealthSummaryPage() {
             return acc;
           }, {})
         );
-        setRenewalValidation({});
       } catch (err: unknown) {
         if (!mounted) return;
         const message = err instanceof Error && err.message ? err.message : "Failed to load lease renewal inputs";
@@ -290,107 +146,6 @@ export default function PortfolioHealthSummaryPage() {
   const scorePlanLabel = resolveRequiredPlanLabel("portfolio_score") || "Pro";
   const recommendationsPlanLabel =
     resolveRequiredPlanLabel("portfolio_action_recommendations") || "Elite";
-
-  const handleRenewalFieldChange = React.useCallback(
-    (leaseId: string, field: keyof LeaseRenewalFormState, value: string) => {
-      setRenewalForms((current) => {
-        const next = {
-          ...(current[leaseId] || {
-            rentChangeMode: "",
-            proposedRent: "",
-            newTermType: "",
-            newLeaseStartDate: "",
-            newLeaseEndDate: "",
-            responseDeadlineAt: "",
-          }),
-          [field]: value,
-        };
-        if (field === "rentChangeMode" && !canSetProposedRent(value as LeaseRenewalFormState["rentChangeMode"])) {
-          next.proposedRent = "";
-        }
-        return {
-          ...current,
-          [leaseId]: next,
-        };
-      });
-      setRenewalValidation((current) => ({
-        ...current,
-        [leaseId]: {
-          ...current[leaseId],
-          proposedRent:
-            field === "rentChangeMode" && !canSetProposedRent(value as LeaseRenewalFormState["rentChangeMode"])
-              ? "Choose Increase or Decrease before entering a proposed rent."
-              : null,
-        },
-      }));
-    },
-    []
-  );
-
-  const handleSaveRenewalInputs = React.useCallback(
-    async (leaseId: string) => {
-      const form = renewalForms[leaseId];
-      if (!form) return;
-      const nextValidation: LeaseRenewalValidationState = {};
-      if (form.proposedRent.trim() && !canSetProposedRent(form.rentChangeMode)) {
-        nextValidation.proposedRent = "Choose Increase or Decrease before entering a proposed rent.";
-        setRenewalValidation((current) => ({ ...current, [leaseId]: nextValidation }));
-        showToast({
-          message: "Review renewal inputs",
-          description: nextValidation.proposedRent,
-          variant: "warning",
-        });
-        return;
-      }
-
-      try {
-        setSavingLeaseId(leaseId);
-        setRenewalValidation((current) => ({ ...current, [leaseId]: {} }));
-        const response = await saveLeaseRenewalInputs(leaseId, {
-          rentChangeMode: form.rentChangeMode || null,
-          proposedRent: form.proposedRent.trim() ? Number(form.proposedRent) : null,
-          newTermType: form.newTermType || null,
-          newLeaseStartDate: form.newLeaseStartDate || null,
-          newLeaseEndDate: form.newLeaseEndDate || null,
-          responseDeadlineAt: fromDatetimeLocalInput(form.responseDeadlineAt),
-        });
-        setRenewalItems((current) => current.map((item) => (item.id === leaseId ? response.lease : item)));
-        setRenewalForms((current) => ({
-          ...current,
-          [leaseId]: createLeaseRenewalFormState(response.lease),
-        }));
-        setRenewalValidation((current) => ({ ...current, [leaseId]: {} }));
-        showToast({
-          message: "Lease renewal inputs saved",
-          description: "Saved values will be picked up by lease notice readiness checks.",
-          variant: "success",
-        });
-      } catch (err: unknown) {
-        const message = err instanceof Error && err.message ? err.message : "Failed to save lease renewal inputs";
-        const friendlyMessage = mapRenewalValidationMessage(message) || mapRenewalValidationMessage((err as any)?.payload?.error) || message;
-        if (
-          friendlyMessage &&
-          (message.includes("PROPOSED_RENT") || message.includes("RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT"))
-        ) {
-          setRenewalValidation((current) => ({
-            ...current,
-            [leaseId]: {
-              ...current[leaseId],
-              proposedRent: friendlyMessage,
-            },
-          }));
-        }
-        showToast({
-          message: "Failed to save lease renewal inputs",
-          description: friendlyMessage,
-          variant: "error",
-        });
-      } finally {
-        setSavingLeaseId(null);
-      }
-    },
-    [renewalForms, showToast]
-  );
 
   return (
     <MacShell title="Portfolio health" showTopNav={false}>
@@ -528,163 +283,26 @@ export default function PortfolioHealthSummaryPage() {
 
             {!renewalLoading && !renewalError
               ? renewalDisplayItems.map((lease) => {
-                  const form = renewalForms[lease.id] || createLeaseRenewalFormState(lease);
-                  const validation = renewalValidation[lease.id] || {};
-                  const proposedRentAllowed = canSetProposedRent(form.rentChangeMode);
-                  const isSaving = savingLeaseId === lease.id;
-                  const updatedBadge = formatRenewalUpdatedBadge(lease);
                   return (
-                    <div
+                    <LeaseRenewalOperatorInputsCard
                       key={lease.id}
-                      style={{
-                        display: "grid",
-                        gap: 12,
-                        padding: 16,
-                        border: "1px solid #dbe4ee",
-                        borderRadius: 12,
-                        background: "#fff",
+                      lease={lease}
+                      formState={renewalForms[lease.id] || createLeaseRenewalFormState(lease)}
+                      onFormStateChange={(leaseId, form) => {
+                        setRenewalForms((current) => ({
+                          ...current,
+                          [leaseId]: form,
+                        }));
                       }}
-                    >
-                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, flexWrap: "wrap" }}>
-                        <div style={{ display: "grid", gap: 2 }}>
-                          <div style={{ fontWeight: 700 }}>
-                            {formatLeaseRenewalLocation(lease)}
-                          </div>
-                          <div style={{ color: "#475569", fontSize: 14 }}>
-                            Lease ends {lease.leaseEndDate || "unknown"}{lease.tenantName ? ` • ${lease.tenantName}` : ""}
-                          </div>
-                        </div>
-                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
-                          {updatedBadge ? (
-                            <div
-                              style={{
-                                padding: "5px 10px",
-                                borderRadius: 999,
-                                border: "1px solid rgba(22,101,52,0.28)",
-                                background: "rgba(22,101,52,0.10)",
-                                color: "#166534",
-                                fontSize: 12,
-                                fontWeight: 800,
-                                whiteSpace: "nowrap",
-                              }}
-                            >
-                              {updatedBadge}
-                            </div>
-                          ) : null}
-                          <div
-                            style={{
-                              padding: "5px 10px",
-                              borderRadius: 999,
-                              border: "1px solid rgba(245,158,11,0.35)",
-                              background: "rgba(245,158,11,0.14)",
-                              color: "#92400e",
-                              fontSize: 12,
-                              fontWeight: 800,
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            {formatLeaseExpiryBadge(lease)}
-                          </div>
-                        </div>
-                      </div>
-
-                      {lease.leaseLifecycleSummary ? (
-                        <div style={{ display: "grid", gap: 6, color: "#334155", fontSize: 14 }}>
-                          <div>
-                            <strong>Lifecycle:</strong> {lease.leaseLifecycleSummary.lifecycleLabel}
-                          </div>
-                          <div>
-                            <strong>Outcome:</strong> {formatRenewalOutcome(lease.leaseLifecycleSummary.renewalOutcome)}
-                          </div>
-                          <div>
-                            <strong>Next step:</strong> {formatLifecycleNextAction(lease.leaseLifecycleSummary.requiredNextAction)}
-                          </div>
-                          {lease.leaseLifecycleSummary.history.length > 0 ? (
-                            <div>
-                              <strong>History:</strong>{" "}
-                              {lease.leaseLifecycleSummary.history.map((item) => item.label).join(" • ")}
-                            </div>
-                          ) : null}
-                        </div>
-                      ) : null}
-
-                      <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
-                        <label style={{ display: "grid", gap: 4 }}>
-                          <span>Rent change mode</span>
-                          <select
-                            value={form.rentChangeMode}
-                            onChange={(event) => handleRenewalFieldChange(lease.id, "rentChangeMode", event.target.value)}
-                          >
-                            <option value="">Unset</option>
-                            <option value="no_change">No change</option>
-                            <option value="increase">Increase</option>
-                            <option value="decrease">Decrease</option>
-                            <option value="undecided">Undecided</option>
-                          </select>
-                        </label>
-
-                        <label style={{ display: "grid", gap: 4 }}>
-                          <span>Proposed rent</span>
-                          <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            value={form.proposedRent}
-                            disabled={!proposedRentAllowed}
-                            onChange={(event) => handleRenewalFieldChange(lease.id, "proposedRent", event.target.value)}
-                          />
-                          <span style={{ color: validation.proposedRent ? "#b91c1c" : "#64748b", fontSize: 12 }}>
-                            {validation.proposedRent || "Choose Increase or Decrease before entering a proposed rent."}
-                          </span>
-                        </label>
-
-                        <label style={{ display: "grid", gap: 4 }}>
-                          <span>New term type</span>
-                          <select
-                            value={form.newTermType}
-                            onChange={(event) => handleRenewalFieldChange(lease.id, "newTermType", event.target.value)}
-                          >
-                            <option value="">Unset</option>
-                            <option value="fixed_term">Fixed term</option>
-                            <option value="year_to_year">Year to year</option>
-                            <option value="month_to_month">Month to month</option>
-                          </select>
-                        </label>
-
-                        <label style={{ display: "grid", gap: 4 }}>
-                          <span>New lease start date</span>
-                          <input
-                            type="date"
-                            value={form.newLeaseStartDate}
-                            onChange={(event) => handleRenewalFieldChange(lease.id, "newLeaseStartDate", event.target.value)}
-                          />
-                        </label>
-
-                        <label style={{ display: "grid", gap: 4 }}>
-                          <span>New lease end date</span>
-                          <input
-                            type="date"
-                            value={form.newLeaseEndDate}
-                            onChange={(event) => handleRenewalFieldChange(lease.id, "newLeaseEndDate", event.target.value)}
-                          />
-                        </label>
-
-                        <label style={{ display: "grid", gap: 4 }}>
-                          <span>Response deadline</span>
-                          <input
-                            type="datetime-local"
-                            value={form.responseDeadlineAt}
-                            onChange={(event) => handleRenewalFieldChange(lease.id, "responseDeadlineAt", event.target.value)}
-                          />
-                        </label>
-                      </div>
-
-                      <div style={{ display: "flex", justifyContent: "flex-end" }}>
-                        <button type="button" onClick={() => void handleSaveRenewalInputs(lease.id)} disabled={isSaving}>
-                          {isSaving ? "Saving…" : "Save renewal inputs"}
-                        </button>
-                      </div>
-                    </div>
+                      onSaved={(updatedLease) => {
+                        setRenewalItems((current) => current.map((item) => (item.id === updatedLease.id ? updatedLease : item)));
+                        setRenewalForms((current) => ({
+                          ...current,
+                          [updatedLease.id]: createLeaseRenewalFormState(updatedLease),
+                        }));
+                      }}
+                      notify={showToast}
+                    />
                   );
                 })
               : null}


### PR DESCRIPTION
## Summary

Embeds compact renewal source context into `/leases/:leaseId/workflows/renewal` inside the existing Renewal operator inputs card.

- Shows property, unit/tenant, lease end date, review timing, renewal status, and operational explanation derived from the existing lease projection.
- Links to the existing source route as `Open portfolio renewal view` using `/portfolio-health?entry=lease-renewals&propertyId=<propertyId>` when a property link exists.
- Shows a clear unavailable state when the lease is not linked to a property.
- Keeps portfolio-health behavior, renewal pipeline, operations routing, backend/API/auth/data behavior, and lease lifecycle state unchanged.

## Audit findings

- `/leases/:leaseId/workflows/:workflowKey` is owned by `LandlordLeaseWorkflowPage.tsx`.
- The Renewal operator inputs card is rendered page-locally inside `LandlordLeaseWorkflowPage.tsx` when `workflow.key === "renewal"`.
- The workflow page already loads `LandlordActiveLease` via `getLeaseById`, including `propertyId`, property/unit/tenant labels, lease end date, lifecycle summary, and policy metadata.
- Portfolio-health lease-renewal operator inputs are page-local in `PortfolioHealthSummaryPage.tsx` and fetched only on `/portfolio-health?entry=lease-renewals` via existing APIs.
- V1 can safely embed useful source context from existing lease projection data without a new endpoint or backend change.

## Scope

Frontend-only. No backend/API/auth/data model/write behavior changed. No notices, legal deadlines, legal advice, lease lifecycle state changes, or portfolio-health behavior changes introduced.

## Validation

- `npm run test -- LandlordLeaseWorkflowPage`
- `npm run test -- LandlordLeaseSummaryPage`
- `npm run test -- LandlordActiveLeasesPage`
- `npm run test -- OperationalCommandCenterPage`
- `npm run test -- PortfolioHealthSummaryPage`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`

Build note: Vite printed the existing Node 20.11.1 warning but the production build completed successfully.

## QA hold

Keep this PR draft until preview landlord QA confirms the renewal workflow source context is useful, compact, and routes correctly.