### PR TITLE
feat: add renewal notice draft workflow

### DIFF
--- a/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
+++ b/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
@@ -30,7 +30,7 @@ export type LandlordLeaseRenewalLease = {
   propertyLabel: string | null;
   renewalRentChangeMode: "no_change" | "increase" | "decrease" | "undecided" | null;
   renewalOfferedRent: number | null;
-  renewalDecisionDeadlineAt: number | null;
+  renewalDecisionDeadlineAt: string | number | null;
   renewalNewTermType: "fixed_term" | "year_to_year" | "month_to_month" | null;
   renewalNewLeaseStartDate: string | null;
   renewalNewLeaseEndDate: string | null;

--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -140,10 +140,7 @@ export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease)
   if (!lease.renewalNewLeaseStartDate) {
     missing.push("new lease start date");
   }
-  if (
-    (lease.renewalNewTermType === "fixed_term" || lease.renewalNewTermType === "year_to_year") &&
-    !lease.renewalNewLeaseEndDate
-  ) {
+  if (!lease.renewalNewLeaseEndDate) {
     missing.push("new lease end date");
   }
   if (!isValidDateValue(lease.renewalDecisionDeadlineAt)) {
@@ -161,18 +158,21 @@ export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease)
 export function buildRenewalNoticeDraftText(lease: LandlordLeaseRenewalLease) {
   const tenantName = tenantDisplayName(lease);
   const currentRent = formatRenewalCurrency(lease.currentRent, lease.currency) || "not available";
-  const proposedRent = proposedRentRequired(lease)
-    ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "not set"
-    : "no rent change currently proposed";
+  const renewalRent = typeof lease.renewalOfferedRent === "number" ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) : null;
   const startDate = formatDateOnly(lease.renewalNewLeaseStartDate);
-  const endDate = lease.renewalNewLeaseEndDate ? formatDateOnly(lease.renewalNewLeaseEndDate) : "open-ended";
+  const endDate = formatDateOnly(lease.renewalNewLeaseEndDate);
   const targetDate = formatTargetDate(lease.renewalDecisionDeadlineAt);
   const greeting = tenantName ? `Hello ${tenantName},` : "Hello,";
+  const termSentence =
+    lease.renewalNewTermType === "fixed_term"
+      ? `The new fixed term would begin on ${startDate} and end on ${endDate}.`
+      : `The renewal term details would begin on ${startDate} and end on ${endDate}.`;
+  const rentSentence = renewalRent ? ` The rent for the unit you occupy would be ${renewalRent}.` : "";
 
   return [
     greeting,
     "",
-    `We are preparing renewal details for ${propertyUnitLabel(lease)}. The current rent on file is ${currentRent}. The renewal rent entered for review is ${proposedRent}, with a term from ${startDate} to ${endDate}.`,
+    `We are preparing renewal details for ${propertyUnitLabel(lease)}. The current rent on file is ${currentRent}. ${termSentence}${rentSentence}`,
     "",
     `Please review these renewal details. The tenant response target date recorded for internal follow-up is ${targetDate}.`,
     "",

--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -66,10 +66,47 @@ function formatTermType(value: LandlordLeaseRenewalLease["renewalNewTermType"]) 
   }
 }
 
-function locationLabel(lease: LandlordLeaseRenewalLease) {
-  const property = String(lease.propertyAddress || lease.propertyLabel || "Property").trim();
-  const unit = String(lease.unitLabel || "").trim();
-  return unit ? `${property} / ${unit}` : property;
+function cleanDisplayLabel(value: string | null | undefined) {
+  return String(value || "").trim();
+}
+
+function looksLikeRawIdentifier(value: string) {
+  const raw = value.trim();
+  if (raw.length < 12 || /\s/.test(raw)) return false;
+  return /^[A-Za-z0-9_-]+$/.test(raw) && /[A-Za-z]/.test(raw) && /\d/.test(raw);
+}
+
+function usableDisplayLabel(value: string | null | undefined, genericPattern?: RegExp) {
+  const label = cleanDisplayLabel(value);
+  if (!label) return null;
+  if (genericPattern?.test(label)) return null;
+  if (looksLikeRawIdentifier(label)) return null;
+  return label;
+}
+
+function tenantDisplayName(lease: LandlordLeaseRenewalLease) {
+  return usableDisplayLabel(lease.tenantName, /^tenant$/i);
+}
+
+function tenantMetadataLabel(lease: LandlordLeaseRenewalLease) {
+  return tenantDisplayName(lease) || "Tenant name unavailable";
+}
+
+function unitDisplayLabel(lease: LandlordLeaseRenewalLease) {
+  const unit = usableDisplayLabel(lease.unitLabel, /^unit$/i);
+  if (!unit) return null;
+  return /^unit\b/i.test(unit) ? unit : `Unit ${unit}`;
+}
+
+function propertyUnitLabel(lease: LandlordLeaseRenewalLease) {
+  const property =
+    usableDisplayLabel(lease.propertyAddress, /^property$/i) ||
+    usableDisplayLabel(lease.propertyLabel, /^property$/i);
+  const unit = unitDisplayLabel(lease);
+  if (property && unit) return `${property} · ${unit}`;
+  if (property) return property;
+  if (unit) return unit;
+  return "Property/unit unavailable";
 }
 
 function proposedRentRequired(lease: LandlordLeaseRenewalLease) {
@@ -103,7 +140,7 @@ export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease)
 }
 
 export function buildRenewalNoticeDraftText(lease: LandlordLeaseRenewalLease) {
-  const tenantName = String(lease.tenantName || "").trim() || "Tenant";
+  const tenantName = tenantDisplayName(lease);
   const currentRent = formatRenewalCurrency(lease.currentRent, lease.currency) || "not available";
   const proposedRent = proposedRentRequired(lease)
     ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "not set"
@@ -111,13 +148,14 @@ export function buildRenewalNoticeDraftText(lease: LandlordLeaseRenewalLease) {
   const startDate = formatDateOnly(lease.renewalNewLeaseStartDate);
   const endDate = lease.renewalNewLeaseEndDate ? formatDateOnly(lease.renewalNewLeaseEndDate) : "open-ended";
   const targetDate = formatTargetDate(lease.renewalDecisionDeadlineAt);
+  const greeting = tenantName ? `Hello ${tenantName},` : "Hello,";
 
   return [
-    `Hello ${tenantName},`,
+    greeting,
     "",
-    `We are preparing the renewal details for ${locationLabel(lease)}. The current rent on file is ${currentRent}. The proposed renewal rent is ${proposedRent}, with a proposed term of ${startDate} to ${endDate}.`,
+    `We are preparing the renewal details for ${propertyUnitLabel(lease)}. The current rent on file is ${currentRent}. The proposed renewal rent is ${proposedRent}, with a proposed term of ${startDate} to ${endDate}.`,
     "",
-    `Please review these proposed renewal details. The tenant response target date currently recorded for internal follow-up is ${targetDate}`,
+    `Please review these proposed renewal details. The tenant response target date currently recorded for internal follow-up is ${targetDate}.`,
     "",
     "This message is for renewal planning and review. Please refer to the official lease documents and current provincial requirements before relying on any notice or timing requirement.",
     "",
@@ -202,8 +240,8 @@ export function LeaseRenewalNoticeDraftCard({
       </div>
 
       <dl style={factsGridStyle}>
-        <Fact label="Tenant" value={lease.tenantName || "Tenant"} />
-        <Fact label="Unit/property" value={locationLabel(lease)} />
+        <Fact label="Tenant" value={tenantMetadataLabel(lease)} />
+        <Fact label="Unit/property" value={propertyUnitLabel(lease)} />
         <Fact label="Current rent" value={currentRent} />
         <Fact label="Proposed rent" value={proposedRent} />
         <Fact label="Current lease end" value={formatDateOnly(lease.leaseEndDate)} />

--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -12,6 +12,7 @@ type LeaseRenewalNoticeDraftCardProps = {
 type DraftReadiness = {
   ready: boolean;
   missing: string[];
+  validationMessage?: string | null;
 };
 
 function formatDateOnly(value: string | null | undefined) {
@@ -51,6 +52,17 @@ function formatTargetDate(value: string | number | null | undefined) {
     month: "long",
     day: "numeric",
   });
+}
+
+function dateOnlySortValue(value: string | null | undefined) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  const date = dateOnly
+    ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+    : new Date(raw);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.getTime();
 }
 
 function formatTermType(value: LandlordLeaseRenewalLease["renewalNewTermType"]) {
@@ -115,6 +127,7 @@ function proposedRentRequired(lease: LandlordLeaseRenewalLease) {
 
 export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease): DraftReadiness {
   const missing: string[] = [];
+  let validationMessage: string | null = null;
   if (!lease.renewalRentChangeMode || lease.renewalRentChangeMode === "undecided") {
     missing.push("rent change mode");
   }
@@ -136,7 +149,13 @@ export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease)
   if (!isValidDateValue(lease.renewalDecisionDeadlineAt)) {
     missing.push("tenant response target date");
   }
-  return { ready: missing.length === 0, missing };
+  const startValue = dateOnlySortValue(lease.renewalNewLeaseStartDate);
+  const endValue = dateOnlySortValue(lease.renewalNewLeaseEndDate);
+  if (startValue != null && endValue != null && startValue > endValue) {
+    validationMessage =
+      "Review renewal term dates before preparing a tenant notice draft. The new lease start date must be on or before the new lease end date.";
+  }
+  return { ready: missing.length === 0 && !validationMessage, missing, validationMessage };
 }
 
 export function buildRenewalNoticeDraftText(lease: LandlordLeaseRenewalLease) {
@@ -153,9 +172,9 @@ export function buildRenewalNoticeDraftText(lease: LandlordLeaseRenewalLease) {
   return [
     greeting,
     "",
-    `We are preparing the renewal details for ${propertyUnitLabel(lease)}. The current rent on file is ${currentRent}. The proposed renewal rent is ${proposedRent}, with a proposed term of ${startDate} to ${endDate}.`,
+    `We are preparing renewal details for ${propertyUnitLabel(lease)}. The current rent on file is ${currentRent}. The renewal rent entered for review is ${proposedRent}, with a term from ${startDate} to ${endDate}.`,
     "",
-    `Please review these proposed renewal details. The tenant response target date currently recorded for internal follow-up is ${targetDate}.`,
+    `Please review these renewal details. The tenant response target date recorded for internal follow-up is ${targetDate}.`,
     "",
     "This message is for renewal planning and review. Please refer to the official lease documents and current provincial requirements before relying on any notice or timing requirement.",
     "",
@@ -220,8 +239,10 @@ export function LeaseRenewalNoticeDraftCard({
           </div>
           <span style={badgeStyle}>Inputs needed</span>
         </div>
-        <div style={warningStyle}>Save renewal operator inputs before preparing a tenant notice draft.</div>
-        <div style={mutedStyle}>Missing: {readiness.missing.join(", ")}.</div>
+        <div style={warningStyle}>
+          {readiness.validationMessage || "Save renewal operator inputs before preparing a tenant notice draft."}
+        </div>
+        {readiness.missing.length > 0 ? <div style={mutedStyle}>Missing: {readiness.missing.join(", ")}.</div> : null}
         <button type="button" onClick={onReviewInputs} style={secondaryButtonStyle}>
           Review renewal operator inputs
         </button>

--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -31,16 +31,25 @@ function formatDateOnly(value: string | null | undefined) {
   return parsed.toLocaleDateString("en-CA", { year: "numeric", month: "long", day: "numeric" });
 }
 
-function formatDateTime(value: number | null | undefined) {
+function isValidDateValue(value: string | number | null | undefined) {
+  if (value == null || value === "") return false;
+  if (typeof value === "number") return Number.isFinite(value) && value > 0;
+  const raw = String(value || "").trim();
+  if (!raw) return false;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return true;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed);
+}
+
+function formatTargetDate(value: string | number | null | undefined) {
   if (!value) return "Not set";
+  if (typeof value === "string") return formatDateOnly(value);
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Not set";
-  return date.toLocaleString("en-CA", {
+  return date.toLocaleDateString("en-CA", {
     year: "numeric",
     month: "long",
     day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
   });
 }
 
@@ -87,7 +96,7 @@ export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease)
   ) {
     missing.push("new lease end date");
   }
-  if (!lease.renewalDecisionDeadlineAt) {
+  if (!isValidDateValue(lease.renewalDecisionDeadlineAt)) {
     missing.push("tenant response target date");
   }
   return { ready: missing.length === 0, missing };
@@ -101,7 +110,7 @@ export function buildRenewalNoticeDraftText(lease: LandlordLeaseRenewalLease) {
     : "no rent change currently proposed";
   const startDate = formatDateOnly(lease.renewalNewLeaseStartDate);
   const endDate = lease.renewalNewLeaseEndDate ? formatDateOnly(lease.renewalNewLeaseEndDate) : "open-ended";
-  const targetDate = formatDateTime(lease.renewalDecisionDeadlineAt);
+  const targetDate = formatTargetDate(lease.renewalDecisionDeadlineAt);
 
   return [
     `Hello ${tenantName},`,
@@ -204,7 +213,7 @@ export function LeaseRenewalNoticeDraftCard({
             lease.renewalNewLeaseEndDate ? formatDateOnly(lease.renewalNewLeaseEndDate) : "open-ended"
           }`}
         />
-        <Fact label="Tenant response target date" value={formatDateTime(lease.renewalDecisionDeadlineAt)} />
+        <Fact label="Tenant response target date" value={formatTargetDate(lease.renewalDecisionDeadlineAt)} />
       </dl>
 
       <label style={{ display: "grid", gap: 6 }}>

--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -1,0 +1,380 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { LandlordLeaseRenewalLease } from "@/api/landlordLeaseRenewalApi";
+import { formatRenewalCurrency } from "./LeaseRenewalOperatorInputsCard";
+
+type LeaseRenewalNoticeDraftCardProps = {
+  lease: LandlordLeaseRenewalLease;
+  noticeWorkflowPath: string;
+  onReviewInputs?: () => void;
+};
+
+type DraftReadiness = {
+  ready: boolean;
+  missing: string[];
+};
+
+function formatDateOnly(value: string | null | undefined) {
+  const raw = String(value || "").trim();
+  if (!raw) return "Not set";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-CA", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return raw;
+  return parsed.toLocaleDateString("en-CA", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function formatDateTime(value: number | null | undefined) {
+  if (!value) return "Not set";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not set";
+  return date.toLocaleString("en-CA", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatTermType(value: LandlordLeaseRenewalLease["renewalNewTermType"]) {
+  switch (value) {
+    case "fixed_term":
+      return "Fixed term";
+    case "year_to_year":
+      return "Year to year";
+    case "month_to_month":
+      return "Month to month";
+    default:
+      return "Not set";
+  }
+}
+
+function locationLabel(lease: LandlordLeaseRenewalLease) {
+  const property = String(lease.propertyAddress || lease.propertyLabel || "Property").trim();
+  const unit = String(lease.unitLabel || "").trim();
+  return unit ? `${property} / ${unit}` : property;
+}
+
+function proposedRentRequired(lease: LandlordLeaseRenewalLease) {
+  return lease.renewalRentChangeMode === "increase" || lease.renewalRentChangeMode === "decrease";
+}
+
+export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease): DraftReadiness {
+  const missing: string[] = [];
+  if (!lease.renewalRentChangeMode || lease.renewalRentChangeMode === "undecided") {
+    missing.push("rent change mode");
+  }
+  if (proposedRentRequired(lease) && typeof lease.renewalOfferedRent !== "number") {
+    missing.push("proposed rent");
+  }
+  if (!lease.renewalNewTermType) {
+    missing.push("new term type");
+  }
+  if (!lease.renewalNewLeaseStartDate) {
+    missing.push("new lease start date");
+  }
+  if (
+    (lease.renewalNewTermType === "fixed_term" || lease.renewalNewTermType === "year_to_year") &&
+    !lease.renewalNewLeaseEndDate
+  ) {
+    missing.push("new lease end date");
+  }
+  if (!lease.renewalDecisionDeadlineAt) {
+    missing.push("tenant response target date");
+  }
+  return { ready: missing.length === 0, missing };
+}
+
+export function buildRenewalNoticeDraftText(lease: LandlordLeaseRenewalLease) {
+  const tenantName = String(lease.tenantName || "").trim() || "Tenant";
+  const currentRent = formatRenewalCurrency(lease.currentRent, lease.currency) || "not available";
+  const proposedRent = proposedRentRequired(lease)
+    ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "not set"
+    : "no rent change currently proposed";
+  const startDate = formatDateOnly(lease.renewalNewLeaseStartDate);
+  const endDate = lease.renewalNewLeaseEndDate ? formatDateOnly(lease.renewalNewLeaseEndDate) : "open-ended";
+  const targetDate = formatDateTime(lease.renewalDecisionDeadlineAt);
+
+  return [
+    `Hello ${tenantName},`,
+    "",
+    `We are preparing the renewal details for ${locationLabel(lease)}. The current rent on file is ${currentRent}. The proposed renewal rent is ${proposedRent}, with a proposed term of ${startDate} to ${endDate}.`,
+    "",
+    `Please review these proposed renewal details. The tenant response target date currently recorded for internal follow-up is ${targetDate}`,
+    "",
+    "This message is for renewal planning and review. Please refer to the official lease documents and current provincial requirements before relying on any notice or timing requirement.",
+    "",
+    "Thank you.",
+  ].join("\n");
+}
+
+export function LeaseRenewalNoticeDraftCard({
+  lease,
+  noticeWorkflowPath,
+  onReviewInputs,
+}: LeaseRenewalNoticeDraftCardProps) {
+  const [copyStatus, setCopyStatus] = React.useState<"idle" | "success" | "error">("idle");
+  const readiness = getRenewalNoticeDraftReadiness(lease);
+  const draftText = React.useMemo(() => buildRenewalNoticeDraftText(lease), [lease]);
+  const currentRent = formatRenewalCurrency(lease.currentRent, lease.currency) || "Current rent unavailable";
+  const proposedRent = proposedRentRequired(lease)
+    ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "Proposed rent not set"
+    : "No rent change currently proposed";
+
+  async function copyDraft() {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(draftText);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = draftText;
+        textarea.setAttribute("readonly", "true");
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        const copied = document.execCommand("copy");
+        document.body.removeChild(textarea);
+        if (!copied) throw new Error("copy_failed");
+      }
+      setCopyStatus("success");
+    } catch {
+      setCopyStatus("error");
+    }
+  }
+
+  function downloadDraft() {
+    const blob = new Blob([draftText], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `renewal-notice-draft-${lease.id}.txt`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
+  if (!readiness.ready) {
+    return (
+      <div style={cardStyle} aria-label="Tenant renewal notice draft">
+        <div style={headerStyle}>
+          <div>
+            <h3 style={headingStyle}>Tenant renewal notice draft</h3>
+            <div style={mutedStyle}>Prepare tenant-facing draft copy after the saved renewal inputs are complete.</div>
+          </div>
+          <span style={badgeStyle}>Inputs needed</span>
+        </div>
+        <div style={warningStyle}>Save renewal operator inputs before preparing a tenant notice draft.</div>
+        <div style={mutedStyle}>Missing: {readiness.missing.join(", ")}.</div>
+        <button type="button" onClick={onReviewInputs} style={secondaryButtonStyle}>
+          Review renewal operator inputs
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={cardStyle} aria-label="Tenant renewal notice draft">
+      <div style={headerStyle}>
+        <div>
+          <h3 style={headingStyle}>Tenant renewal notice draft</h3>
+          <div style={mutedStyle}>Review conservative draft copy before using any tenant communication workflow.</div>
+        </div>
+        <span style={readyBadgeStyle}>Draft ready</span>
+      </div>
+
+      <dl style={factsGridStyle}>
+        <Fact label="Tenant" value={lease.tenantName || "Tenant"} />
+        <Fact label="Unit/property" value={locationLabel(lease)} />
+        <Fact label="Current rent" value={currentRent} />
+        <Fact label="Proposed rent" value={proposedRent} />
+        <Fact label="Current lease end" value={formatDateOnly(lease.leaseEndDate)} />
+        <Fact
+          label="Proposed term"
+          value={`${formatTermType(lease.renewalNewTermType)} · ${formatDateOnly(lease.renewalNewLeaseStartDate)} to ${
+            lease.renewalNewLeaseEndDate ? formatDateOnly(lease.renewalNewLeaseEndDate) : "open-ended"
+          }`}
+        />
+        <Fact label="Tenant response target date" value={formatDateTime(lease.renewalDecisionDeadlineAt)} />
+      </dl>
+
+      <label style={{ display: "grid", gap: 6 }}>
+        <span style={termStyle}>Draft message preview</span>
+        <textarea readOnly value={draftText} rows={9} style={draftPreviewStyle} />
+      </label>
+
+      <div style={noticeStyle}>
+        Email delivery is not enabled from this workflow yet. Use this draft for review; notice drafting, delivery, and
+        evidence tracking should be completed in the dedicated communication workflow when available.
+      </div>
+
+      <div style={actionsStyle}>
+        <button type="button" onClick={() => void copyDraft()} style={primaryButtonStyle}>
+          Copy draft text
+        </button>
+        <button type="button" onClick={downloadDraft} style={secondaryButtonStyle}>
+          Download draft
+        </button>
+        <Link to={noticeWorkflowPath} style={linkButtonStyle}>
+          Open notice review workflow
+        </Link>
+      </div>
+
+      {copyStatus === "success" ? <div style={successStyle}>Draft text copied.</div> : null}
+      {copyStatus === "error" ? <div style={warningStyle}>Draft text could not be copied. Select the preview text manually.</div> : null}
+    </div>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: "grid", gap: 4 }}>
+      <dt style={termStyle}>{label}</dt>
+      <dd style={valueStyle}>{value}</dd>
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 12,
+  padding: 14,
+  border: "1px solid rgba(91, 70, 48, 0.18)",
+  borderRadius: 12,
+  background: "#fffaf1",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: 12,
+  flexWrap: "wrap",
+};
+
+const headingStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 16,
+  color: "#211c17",
+  letterSpacing: 0,
+};
+
+const mutedStyle: React.CSSProperties = {
+  color: "#63594d",
+  lineHeight: 1.55,
+};
+
+const badgeStyle: React.CSSProperties = {
+  border: "1px solid rgba(245, 158, 11, 0.35)",
+  borderRadius: 999,
+  background: "rgba(245, 158, 11, 0.14)",
+  color: "#92400e",
+  fontSize: 12,
+  fontWeight: 800,
+  padding: "5px 10px",
+  whiteSpace: "nowrap",
+};
+
+const readyBadgeStyle: React.CSSProperties = {
+  ...badgeStyle,
+  border: "1px solid rgba(22, 101, 52, 0.28)",
+  background: "rgba(22, 101, 52, 0.10)",
+  color: "#166534",
+};
+
+const factsGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))",
+  gap: 12,
+  margin: 0,
+};
+
+const termStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 800,
+  color: "#7a6b5c",
+  textTransform: "uppercase",
+  letterSpacing: 0,
+};
+
+const valueStyle: React.CSSProperties = {
+  margin: 0,
+  color: "#211c17",
+  fontWeight: 700,
+  lineHeight: 1.35,
+};
+
+const draftPreviewStyle: React.CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  border: "1px solid rgba(91, 70, 48, 0.22)",
+  borderRadius: 10,
+  background: "#fff",
+  color: "#211c17",
+  font: "inherit",
+  lineHeight: 1.5,
+  padding: 12,
+  resize: "vertical",
+};
+
+const noticeStyle: React.CSSProperties = {
+  color: "#63594d",
+  lineHeight: 1.55,
+  border: "1px dashed rgba(91, 70, 48, 0.3)",
+  borderRadius: 10,
+  background: "rgba(255, 246, 232, 0.72)",
+  padding: 10,
+};
+
+const actionsStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+};
+
+const baseButtonStyle: React.CSSProperties = {
+  borderRadius: 8,
+  cursor: "pointer",
+  fontWeight: 800,
+  padding: "8px 10px",
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  ...baseButtonStyle,
+  border: "1px solid #245842",
+  background: "#245842",
+  color: "#fff",
+};
+
+const secondaryButtonStyle: React.CSSProperties = {
+  ...baseButtonStyle,
+  border: "1px solid rgba(91, 70, 48, 0.3)",
+  background: "#fffaf1",
+  color: "#245842",
+};
+
+const linkButtonStyle: React.CSSProperties = {
+  ...secondaryButtonStyle,
+  display: "inline-flex",
+  alignItems: "center",
+  textDecoration: "none",
+};
+
+const successStyle: React.CSSProperties = {
+  color: "#166534",
+  fontWeight: 700,
+};
+
+const warningStyle: React.CSSProperties = {
+  color: "#92400e",
+  fontWeight: 700,
+};

--- a/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
@@ -31,16 +31,31 @@ type LeaseRenewalOperatorInputsCardProps = {
   notify?: (toast: LeaseRenewalToast) => void;
 };
 
-export function toDatetimeLocalInput(value: number | null) {
-  if (!value) return "";
-  const date = new Date(value);
-  const offset = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+function toLocalDateInputFromDate(date: Date) {
+  if (Number.isNaN(date.getTime())) return "";
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
-export function fromDatetimeLocalInput(value: string) {
+export function toDateInput(value: string | number | null | undefined) {
+  if (!value) return "";
+  const raw = String(value || "").trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  const date = new Date(value);
+  return toLocalDateInputFromDate(date);
+}
+
+export function fromDateInput(value: string) {
   const raw = String(value || "").trim();
   if (!raw) return null;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    const parsed = new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+    return Number.isFinite(parsed) ? parsed : null;
+  }
   const parsed = Date.parse(raw);
   return Number.isFinite(parsed) ? parsed : null;
 }
@@ -52,7 +67,7 @@ export function createLeaseRenewalFormState(lease: LandlordLeaseRenewalLease): L
     newTermType: lease.renewalNewTermType || "",
     newLeaseStartDate: lease.renewalNewLeaseStartDate || "",
     newLeaseEndDate: lease.renewalNewLeaseEndDate || "",
-    responseDeadlineAt: toDatetimeLocalInput(lease.renewalDecisionDeadlineAt),
+    responseDeadlineAt: toDateInput(lease.renewalDecisionDeadlineAt),
   };
 }
 
@@ -247,17 +262,21 @@ export function LeaseRenewalOperatorInputsCard({
         newTermType: form.newTermType || null,
         newLeaseStartDate: form.newLeaseStartDate || null,
         newLeaseEndDate: form.newLeaseEndDate || null,
-        responseDeadlineAt: fromDatetimeLocalInput(form.responseDeadlineAt),
+        responseDeadlineAt: fromDateInput(form.responseDeadlineAt),
       });
-      const savedForm = createLeaseRenewalFormState(response.lease);
-      setLocalLease(response.lease);
+      const savedLease = {
+        ...response.lease,
+        renewalDecisionDeadlineAt: response.lease.renewalDecisionDeadlineAt ?? response.renewalInputs?.responseDeadlineAt ?? null,
+      };
+      const savedForm = createLeaseRenewalFormState(savedLease);
+      setLocalLease(savedLease);
       if (onFormStateChange) {
         onFormStateChange(lease.id, savedForm);
       } else {
         setInternalForm(savedForm);
       }
       setValidation({});
-      onSaved?.(response.lease);
+      onSaved?.(savedLease);
       setStatusMessage({ variant: "success", text: "Lease renewal inputs saved." });
       notify?.({
         message: "Lease renewal inputs saved",
@@ -384,7 +403,7 @@ export function LeaseRenewalOperatorInputsCard({
 
         <label style={fieldStyle}>
           <span>Tenant response target date</span>
-          <input type="datetime-local" value={form.responseDeadlineAt} onChange={(event) => updateForm("responseDeadlineAt", event.target.value)} />
+          <input type="date" value={form.responseDeadlineAt} onChange={(event) => updateForm("responseDeadlineAt", event.target.value)} />
           <span style={{ color: "#64748b", fontSize: 12 }}>
             Planning date only. Does not send notice or determine legal deadlines.
           </span>

--- a/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalOperatorInputsCard.tsx
@@ -29,6 +29,7 @@ type LeaseRenewalOperatorInputsCardProps = {
   onFormStateChange?: (leaseId: string, form: LeaseRenewalFormState) => void;
   onSaved?: (lease: LandlordLeaseRenewalLease) => void;
   notify?: (toast: LeaseRenewalToast) => void;
+  showLifecycleSummary?: boolean;
 };
 
 function toLocalDateInputFromDate(date: Date) {
@@ -197,6 +198,7 @@ export function LeaseRenewalOperatorInputsCard({
   onFormStateChange,
   onSaved,
   notify,
+  showLifecycleSummary = true,
 }: LeaseRenewalOperatorInputsCardProps) {
   const [localLease, setLocalLease] = React.useState(lease);
   const [internalForm, setInternalForm] = React.useState(() => createLeaseRenewalFormState(lease));
@@ -324,7 +326,7 @@ export function LeaseRenewalOperatorInputsCard({
         </div>
       </div>
 
-      {localLease.leaseLifecycleSummary ? (
+      {showLifecycleSummary && localLease.leaseLifecycleSummary ? (
         <div style={{ display: "grid", gap: 6, color: "#334155", fontSize: 14 }}>
           <div>
             <strong>Lifecycle:</strong> {localLease.leaseLifecycleSummary.lifecycleLabel}

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -293,9 +293,13 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("CA$1,975.00");
     const draftPreview = screen.getByLabelText("Draft message preview") as HTMLTextAreaElement;
     expect(draftPreview.value).toContain("Hello Jane Tenant,");
-    expect(draftPreview.value).toContain("We are preparing the renewal details for 12 Harbour Road · Unit 101.");
-    expect(draftPreview.value).toContain("tenant response target date currently recorded for internal follow-up");
-    expect(draftPreview.value).toMatch(/tenant response target date currently recorded for internal follow-up is .*?\./);
+    expect(draftPreview.value).toContain("We are preparing renewal details for 12 Harbour Road · Unit 101.");
+    expect(draftPreview.value).toContain("The renewal rent entered for review is CA$1,975.00");
+    expect(draftPreview.value).toContain("with a term from January 1, 2027 to December 31, 2027.");
+    expect(draftPreview.value).toContain("tenant response target date recorded for internal follow-up");
+    expect(draftPreview.value).toMatch(/tenant response target date recorded for internal follow-up is .*?\./);
+    expect(draftPreview.value).not.toContain("Please review these proposed renewal details");
+    expect((draftPreview.value.match(/\bproposed\b/gi) || []).length).toBeLessThanOrEqual(1);
     expect(screen.getByText(/Email delivery is not enabled from this workflow yet/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open notice review workflow" })).toHaveAttribute(
       "href",
@@ -380,13 +384,63 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(draftCard).not.toHaveTextContent("36DDfE1QldevOrw9wVyR");
 
     const draftPreview = screen.getByLabelText("Draft message preview") as HTMLTextAreaElement;
-    expect(draftPreview.value).toContain("Hello,\n\nWe are preparing the renewal details for 32 central road · Unit 4.");
+    expect(draftPreview.value).toContain("Hello,\n\nWe are preparing renewal details for 32 central road · Unit 4.");
     expect(draftPreview.value).not.toContain("Hello Tenant,");
     expect(draftPreview.value).not.toContain("36DDfE1QldevOrw9wVyR");
-    expect(draftPreview.value).toMatch(/tenant response target date currently recorded for internal follow-up is November 20, 2026\./);
+    expect(draftPreview.value).toMatch(/tenant response target date recorded for internal follow-up is November 20, 2026\./);
     expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+  });
+
+  it("blocks the tenant renewal notice draft when renewal term dates are invalid", async () => {
+    mocks.fetchExpiringLeaseRenewals.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          propertyAddress: "12 Harbour Road",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2026-01-01",
+          leaseEndDate: "2026-12-31",
+          currentRent: 1850,
+          currency: "CAD",
+          nextNoticeDueAt: null,
+          latestNoticeId: null,
+          tenantName: "Jane Tenant",
+          unitLabel: "Unit 101",
+          propertyLabel: "Harbour View",
+          renewalRentChangeMode: "increase",
+          renewalOfferedRent: 1975,
+          renewalDecisionDeadlineAt: dateInputValueToMs("2026-11-20"),
+          renewalNewTermType: "fixed_term",
+          renewalNewLeaseStartDate: "2036-09-01",
+          renewalNewLeaseEndDate: "2027-08-31",
+          renewalUpdatedAt: "2026-07-02T12:00:00.000Z",
+        },
+      ],
+      data: [],
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+
+    const draftCard = await screen.findByLabelText("Tenant renewal notice draft");
+    expect(draftCard).toHaveTextContent("Inputs needed");
+    expect(draftCard).toHaveTextContent(
+      "Review renewal term dates before preparing a tenant notice draft. The new lease start date must be on or before the new lease end date."
+    );
+    expect(draftCard).not.toHaveTextContent("Draft ready");
+    expect(screen.queryByLabelText("Draft message preview")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
   });
 
   it("copies the renewal notice draft without sending or saving a notice", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -288,12 +288,14 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Draft ready");
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Jane Tenant");
-    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("12 Harbour Road / Unit 101");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("12 Harbour Road · Unit 101");
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("CA$1,850.00");
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("CA$1,975.00");
     const draftPreview = screen.getByLabelText("Draft message preview") as HTMLTextAreaElement;
     expect(draftPreview.value).toContain("Hello Jane Tenant,");
+    expect(draftPreview.value).toContain("We are preparing the renewal details for 12 Harbour Road · Unit 101.");
     expect(draftPreview.value).toContain("tenant response target date currently recorded for internal follow-up");
+    expect(draftPreview.value).toMatch(/tenant response target date currently recorded for internal follow-up is .*?\./);
     expect(screen.getByText(/Email delivery is not enabled from this workflow yet/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open notice review workflow" })).toHaveAttribute(
       "href",
@@ -305,6 +307,86 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
     expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
+  });
+
+  it("uses safe draft fallbacks when tenant name is missing and projection labels are raw", async () => {
+    mocks.getLeaseById.mockResolvedValueOnce({
+      lease: {
+        id: "lease-raw-labels",
+        tenantId: "tenant-raw",
+        propertyId: "36DDfE1QldevOrw9wVyR",
+        propertyName: "center suites",
+        propertyAddress: "32 central road",
+        unitNumber: "4",
+        monthlyRent: 1850,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        status: "active",
+        tenantName: null,
+        tenantEmail: null,
+        leaseExecution: null,
+        paymentReadiness: null,
+        leaseLifecycleSummary: {
+          lifecycleStatus: "expiring_soon",
+          lifecycleLabel: "Expiring soon",
+          lifecycleDescription: "This lease is approaching notice timing.",
+          requiredNextAction: "prepare_renewal_notice",
+          renewalOutcome: "not_started",
+          daysUntilExpiry: 30,
+          history: [],
+        },
+        jurisdictionPolicies: [],
+      },
+    });
+    mocks.fetchExpiringLeaseRenewals.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          id: "lease-raw-labels",
+          tenantId: "tenant-raw",
+          propertyId: "36DDfE1QldevOrw9wVyR",
+          propertyAddress: null,
+          unitId: "36DDfE1QldevOrw9wVyR",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2026-01-01",
+          leaseEndDate: "2026-12-31",
+          currentRent: 1850,
+          currency: "CAD",
+          nextNoticeDueAt: null,
+          latestNoticeId: null,
+          tenantName: null,
+          unitLabel: "36DDfE1QldevOrw9wVyR",
+          propertyLabel: null,
+          renewalRentChangeMode: "no_change",
+          renewalOfferedRent: null,
+          renewalDecisionDeadlineAt: dateInputValueToMs("2026-11-20"),
+          renewalNewTermType: "month_to_month",
+          renewalNewLeaseStartDate: "2027-01-01",
+          renewalNewLeaseEndDate: "",
+          renewalUpdatedAt: "2026-07-02T12:00:00.000Z",
+        },
+      ],
+      data: [],
+    });
+
+    renderWorkflow("/leases/lease-raw-labels/workflows/renewal");
+
+    const draftCard = await screen.findByLabelText("Tenant renewal notice draft");
+    expect(draftCard).toHaveTextContent("Draft ready");
+    expect(draftCard).toHaveTextContent("Tenant name unavailable");
+    expect(draftCard).toHaveTextContent("32 central road · Unit 4");
+    expect(draftCard).not.toHaveTextContent("36DDfE1QldevOrw9wVyR");
+
+    const draftPreview = screen.getByLabelText("Draft message preview") as HTMLTextAreaElement;
+    expect(draftPreview.value).toContain("Hello,\n\nWe are preparing the renewal details for 32 central road · Unit 4.");
+    expect(draftPreview.value).not.toContain("Hello Tenant,");
+    expect(draftPreview.value).not.toContain("36DDfE1QldevOrw9wVyR");
+    expect(draftPreview.value).toMatch(/tenant response target date currently recorded for internal follow-up is November 20, 2026\./);
+    expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
+    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
   });
 
   it("copies the renewal notice draft without sending or saving a notice", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -279,12 +279,45 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByText("Planning date only. Does not send notice or determine legal deadlines.")).toBeInTheDocument();
     expect(screen.queryByLabelText(/Response deadline/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Tenant notice email workflow")).toHaveTextContent(
-      "Tenant-facing renewal notices are not sent from this workflow yet."
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Draft ready");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Jane Tenant");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("12 Harbour Road / Unit 101");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("CA$1,850.00");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("CA$1,975.00");
+    const draftPreview = screen.getByLabelText("Draft message preview") as HTMLTextAreaElement;
+    expect(draftPreview.value).toContain("Hello Jane Tenant,");
+    expect(draftPreview.value).toContain("tenant response target date currently recorded for internal follow-up");
+    expect(screen.getByText(/Email delivery is not enabled from this workflow yet/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open notice review workflow" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/workflows/notice"
     );
+    expect(screen.getByRole("button", { name: "Copy draft text" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download draft" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
     expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
+  });
+
+  it("copies the renewal notice draft without sending or saving a notice", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+
+    const draftPreview = (await screen.findByLabelText("Draft message preview")) as HTMLTextAreaElement;
+    expect(draftPreview.value).toContain("Hello Jane Tenant,");
+    fireEvent.click(screen.getByRole("button", { name: "Copy draft text" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("This message is for renewal planning and review."));
+    });
+    expect(await screen.findByText("Draft text copied.")).toBeInTheDocument();
+    expect(mocks.saveLeaseRenewalInputs).not.toHaveBeenCalled();
   });
 
   it("shows current rent unavailable when renewal projection rent is missing", async () => {
@@ -325,6 +358,12 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(await screen.findByLabelText("Current rent")).toHaveTextContent("Current rent unavailable");
     expect(screen.getByText("Review lease terms before changing rent.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Inputs needed");
+    expect(screen.getByText("Save renewal operator inputs before preparing a tenant notice draft.")).toBeInTheDocument();
+    expect(screen.getByText(/Missing: rent change mode, new term type, new lease start date, tenant response target date/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
   });
 
   it("saves renewal operator inputs through the existing lease renewal save behavior", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -28,10 +28,17 @@ function renderWorkflow(path: string) {
   );
 }
 
-function datetimeLocalValue(value: number) {
+function dateInputValue(value: number) {
   const date = new Date(value);
-  const offset = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function dateInputValueToMs(value: string) {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, month - 1, day).getTime();
 }
 
 describe("LandlordLeaseWorkflowPage", () => {
@@ -274,7 +281,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText(/New lease start date/i)).toHaveValue("2027-01-01");
     expect(screen.getByLabelText(/New lease end date/i)).toHaveValue("2027-12-31");
     expect(screen.getByLabelText(/Tenant response target date/i)).toHaveValue(
-      datetimeLocalValue(Date.UTC(2026, 10, 15, 13, 30, 0, 0))
+      dateInputValue(Date.UTC(2026, 10, 15, 13, 30, 0, 0))
     );
     expect(screen.getByText("Planning date only. Does not send notice or determine legal deadlines.")).toBeInTheDocument();
     expect(screen.queryByLabelText(/Response deadline/i)).not.toBeInTheDocument();
@@ -367,6 +374,44 @@ describe("LandlordLeaseWorkflowPage", () => {
   });
 
   it("saves renewal operator inputs through the existing lease renewal save behavior", async () => {
+    mocks.saveLeaseRenewalInputs.mockResolvedValueOnce({
+      ok: true,
+      lease: {
+        id: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        propertyAddress: "12 Harbour Road",
+        unitId: "unit-1",
+        status: "active",
+        leaseType: "fixed_term",
+        province: "NS",
+        leaseStartDate: "2026-01-01",
+        leaseEndDate: "2026-12-31",
+        currentRent: 1850,
+        currency: "CAD",
+        nextNoticeDueAt: null,
+        latestNoticeId: null,
+        tenantName: "Jane Tenant",
+        unitLabel: "Unit 101",
+        propertyLabel: "Harbour View",
+        renewalRentChangeMode: "no_change",
+        renewalOfferedRent: null,
+        renewalDecisionDeadlineAt: null,
+        renewalNewTermType: "month_to_month",
+        renewalNewLeaseStartDate: "2027-01-01",
+        renewalNewLeaseEndDate: "",
+        renewalUpdatedAt: "2026-07-02T12:00:00.000Z",
+      },
+      renewalInputs: {
+        rentChangeMode: "no_change",
+        proposedRent: null,
+        newTermType: "month_to_month",
+        newLeaseStartDate: "2027-01-01",
+        newLeaseEndDate: null,
+        responseDeadlineAt: dateInputValueToMs("2026-11-20"),
+      },
+    });
+
     renderWorkflow("/leases/lease-1/workflows/renewal");
 
     expect(await screen.findByLabelText(/Rent change mode/i)).toHaveValue("increase");
@@ -374,7 +419,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "month_to_month" } });
     fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2027-01-01" } });
     fireEvent.change(screen.getByLabelText(/New lease end date/i), { target: { value: "" } });
-    fireEvent.change(screen.getByLabelText(/Tenant response target date/i), { target: { value: "2026-11-20T10:00" } });
+    fireEvent.change(screen.getByLabelText(/Tenant response target date/i), { target: { value: "2026-11-20" } });
     fireEvent.click(screen.getByRole("button", { name: "Save renewal inputs" }));
 
     await waitFor(() => {
@@ -386,10 +431,16 @@ describe("LandlordLeaseWorkflowPage", () => {
           newTermType: "month_to_month",
           newLeaseStartDate: "2027-01-01",
           newLeaseEndDate: null,
+          responseDeadlineAt: dateInputValueToMs("2026-11-20"),
         })
       );
     });
     expect(await screen.findByText("Lease renewal inputs saved.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Draft ready");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).not.toHaveTextContent("Missing: tenant response target date");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("November 20, 2026");
+    expect(screen.queryByLabelText(/Response deadline/i)).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/deadline choices/i);
   });
 
   it("shows a clear save failure state for renewal operator inputs", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -236,6 +236,22 @@ describe("LandlordLeaseWorkflowPage", () => {
     renderWorkflow("/leases/lease-1/workflows/notice");
     expect(await screen.findByRole("heading", { name: "Notice Workflow" })).toBeInTheDocument();
     expect(screen.getByText("Review notice-related lease status, lifecycle timing, and audit context before preparing a notice.")).toBeInTheDocument();
+    const renewalContext = await screen.findByLabelText("Renewal notice draft context");
+    expect(renewalContext).toHaveTextContent("Renewal operator inputs are available for this lease.");
+    expect(renewalContext).toHaveTextContent("Jane Tenant");
+    expect(renewalContext).toHaveTextContent("12 Harbour Road · Unit 101");
+    expect(renewalContext).toHaveTextContent("CA$1,850.00");
+    expect(renewalContext).toHaveTextContent("CA$1,975.00");
+    expect(renewalContext).toHaveTextContent("Tenant response target date");
+    expect((screen.getByLabelText("Draft preview from renewal workflow") as HTMLTextAreaElement).value).toContain(
+      "This message is for renewal planning and review."
+    );
+    expect(screen.getByRole("link", { name: "Back to renewal workflow" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/workflows/renewal"
+    );
+    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
 
     cleanup();
     renderWorkflow("/leases/lease-1/workflows/execution");
@@ -286,6 +302,10 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByText("Planning date only. Does not send notice or determine legal deadlines.")).toBeInTheDocument();
     expect(screen.queryByLabelText(/Response deadline/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Renewal workflow status")).toHaveTextContent("Operator inputs saved");
+    expect(screen.getByLabelText("Renewal workflow status")).toHaveTextContent("Tenant notice draft ready");
+    expect(screen.getByLabelText("Renewal workflow status")).toHaveTextContent("Notice review pending");
+    expect(screen.getByLabelText("Renewal workflow status")).toHaveTextContent("Email delivery deferred");
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Draft ready");
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Jane Tenant");
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("12 Harbour Road · Unit 101");
@@ -311,6 +331,62 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
     expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
+  });
+
+  it("uses workflow-local renewal status instead of stale no-follow-up lifecycle copy", async () => {
+    mocks.fetchExpiringLeaseRenewals.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          propertyAddress: "12 Harbour Road",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2026-01-01",
+          leaseEndDate: "2026-12-31",
+          currentRent: 1850,
+          currency: "CAD",
+          nextNoticeDueAt: null,
+          latestNoticeId: null,
+          tenantName: "Jane Tenant",
+          unitLabel: "Unit 101",
+          propertyLabel: "Harbour View",
+          renewalRentChangeMode: "increase",
+          renewalOfferedRent: 1975,
+          renewalDecisionDeadlineAt: dateInputValueToMs("2026-11-20"),
+          renewalNewTermType: "fixed_term",
+          renewalNewLeaseStartDate: "2027-01-01",
+          renewalNewLeaseEndDate: "2027-12-31",
+          renewalUpdatedAt: "2026-07-02T12:00:00.000Z",
+          leaseLifecycleSummary: {
+            lifecycleStatus: "active",
+            lifecycleLabel: "Active",
+            lifecycleDescription: "Lease is active.",
+            requiredNextAction: "none",
+            renewalOutcome: "not_applicable",
+            daysUntilExpiry: 30,
+            history: [{ type: "lease_started", label: "Lease started", at: "2026-01-01" }],
+          },
+        },
+      ],
+      data: [],
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+
+    const statusPanel = await screen.findByLabelText("Renewal workflow status");
+    expect(statusPanel).toHaveTextContent("Operator inputs saved");
+    expect(statusPanel).toHaveTextContent("Tenant notice draft ready");
+    expect(statusPanel).toHaveTextContent("Notice review pending");
+    expect(statusPanel).toHaveTextContent("Email delivery deferred");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Draft ready");
+    expect(document.body).not.toHaveTextContent("Outcome: Not applicable");
+    expect(document.body).not.toHaveTextContent("Next step: No follow-up needed");
+    expect(document.body).not.toHaveTextContent("History: Lease started");
   });
 
   it("uses safe draft fallbacks when tenant name is missing and projection labels are raw", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -314,8 +314,11 @@ describe("LandlordLeaseWorkflowPage", () => {
     const draftPreview = screen.getByLabelText("Draft message preview") as HTMLTextAreaElement;
     expect(draftPreview.value).toContain("Hello Jane Tenant,");
     expect(draftPreview.value).toContain("We are preparing renewal details for 12 Harbour Road · Unit 101.");
-    expect(draftPreview.value).toContain("The renewal rent entered for review is CA$1,975.00");
-    expect(draftPreview.value).toContain("with a term from January 1, 2027 to December 31, 2027.");
+    expect(draftPreview.value).toContain("The new fixed term would begin on January 1, 2027 and end on December 31, 2027.");
+    expect(draftPreview.value).toContain("The rent for the unit you occupy would be CA$1,975.00.");
+    expect(draftPreview.value).not.toMatch(/\bwill be\b/i);
+    expect(draftPreview.value).not.toContain("renewal rent entered for review");
+    expect(draftPreview.value).not.toContain("with a term from");
     expect(draftPreview.value).toContain("tenant response target date recorded for internal follow-up");
     expect(draftPreview.value).toMatch(/tenant response target date recorded for internal follow-up is .*?\./);
     expect(draftPreview.value).not.toContain("Please review these proposed renewal details");
@@ -444,7 +447,7 @@ describe("LandlordLeaseWorkflowPage", () => {
           renewalDecisionDeadlineAt: dateInputValueToMs("2026-11-20"),
           renewalNewTermType: "month_to_month",
           renewalNewLeaseStartDate: "2027-01-01",
-          renewalNewLeaseEndDate: "",
+          renewalNewLeaseEndDate: "2027-12-31",
           renewalUpdatedAt: "2026-07-02T12:00:00.000Z",
         },
       ],
@@ -461,6 +464,7 @@ describe("LandlordLeaseWorkflowPage", () => {
 
     const draftPreview = screen.getByLabelText("Draft message preview") as HTMLTextAreaElement;
     expect(draftPreview.value).toContain("Hello,\n\nWe are preparing renewal details for 32 central road · Unit 4.");
+    expect(draftPreview.value).toContain("The renewal term details would begin on January 1, 2027 and end on December 31, 2027.");
     expect(draftPreview.value).not.toContain("Hello Tenant,");
     expect(draftPreview.value).not.toContain("36DDfE1QldevOrw9wVyR");
     expect(draftPreview.value).toMatch(/tenant response target date recorded for internal follow-up is November 20, 2026\./);
@@ -579,7 +583,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByRole("button", { name: "Save renewal inputs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Inputs needed");
     expect(screen.getByText("Save renewal operator inputs before preparing a tenant notice draft.")).toBeInTheDocument();
-    expect(screen.getByText(/Missing: rent change mode, new term type, new lease start date, tenant response target date/i)).toBeInTheDocument();
+    expect(screen.getByText(/Missing: rent change mode, new term type, new lease start date, new lease end date, tenant response target date/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
@@ -648,9 +652,10 @@ describe("LandlordLeaseWorkflowPage", () => {
       );
     });
     expect(await screen.findByText("Lease renewal inputs saved.")).toBeInTheDocument();
-    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Draft ready");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Inputs needed");
     expect(screen.getByLabelText("Tenant renewal notice draft")).not.toHaveTextContent("Missing: tenant response target date");
-    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("November 20, 2026");
+    expect(screen.getByLabelText("Tenant renewal notice draft")).toHaveTextContent("Missing: new lease end date");
+    expect(screen.queryByLabelText("Draft message preview")).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Response deadline/i)).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/deadline choices/i);
   });

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -6,6 +6,7 @@ import {
   type LandlordLeaseRenewalLease,
 } from "@/api/landlordLeaseRenewalApi";
 import { LeaseRenewalOperatorInputsCard } from "@/components/leases/LeaseRenewalOperatorInputsCard";
+import { LeaseRenewalNoticeDraftCard } from "@/components/leases/LeaseRenewalNoticeDraftCard";
 import {
   RENEWAL_PIPELINE_BUCKETS,
   deriveRenewalPipelineItems,
@@ -273,6 +274,7 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
   const [renewalLease, setRenewalLease] = React.useState<LandlordLeaseRenewalLease | null>(null);
   const [loadingRenewalInputs, setLoadingRenewalInputs] = React.useState(false);
   const [renewalInputsError, setRenewalInputsError] = React.useState<string | null>(null);
+  const inputsRef = React.useRef<HTMLDivElement | null>(null);
 
   React.useEffect(() => {
     if (!propertyId) {
@@ -374,10 +376,22 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
       {loadingRenewalInputs ? <div>Loading renewal operator inputs…</div> : null}
       {!loadingRenewalInputs && renewalInputsError ? <div style={{ color: "#b91c1c" }}>{renewalInputsError}</div> : null}
       {!loadingRenewalInputs && !renewalInputsError && renewalLease ? (
-        <LeaseRenewalOperatorInputsCard
-          lease={renewalLease}
-          onSaved={(updatedLease) => setRenewalLease(updatedLease)}
-        />
+        <>
+          <div ref={inputsRef} tabIndex={-1} style={{ outline: "none" }}>
+            <LeaseRenewalOperatorInputsCard
+              lease={renewalLease}
+              onSaved={(updatedLease) => setRenewalLease(updatedLease)}
+            />
+          </div>
+          <LeaseRenewalNoticeDraftCard
+            lease={renewalLease}
+            noticeWorkflowPath={`/leases/${encodeURIComponent(lease.id)}/workflows/notice`}
+            onReviewInputs={() => {
+              inputsRef.current?.focus();
+              inputsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+            }}
+          />
+        </>
       ) : null}
     </>
   );
@@ -483,17 +497,10 @@ export default function LandlordLeaseWorkflowPage() {
             <section style={panelStyle} aria-label="Renewal operator inputs">
               <h2 style={sectionHeadingStyle}>Renewal operator inputs</h2>
               <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
-                Review and save unit-specific renewal inputs such as proposed rent, term dates, and response deadline
+                Review and save unit-specific renewal inputs such as proposed rent, term dates, and tenant response target date
                 before preparing tenant-facing notices.
               </div>
               <RenewalOperatorInputsWorkspace lease={lease} />
-              <div style={deferredNoticeStyle} aria-label="Tenant notice email workflow">
-                <div style={{ color: workflowTheme.charcoal, fontWeight: 900 }}>Tenant notice/email workflow</div>
-                <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
-                  Tenant-facing renewal notices are not sent from this workflow yet. Review and save operator inputs here first;
-                  notice drafting, email delivery, and evidence tracking should be handled in a dedicated notice workflow.
-                </div>
-              </div>
             </section>
           ) : null}
 
@@ -577,15 +584,6 @@ const sourceContextStyle: React.CSSProperties = {
 const sourceContextTitleStyle: React.CSSProperties = {
   color: workflowTheme.charcoal,
   fontWeight: 900,
-};
-
-const deferredNoticeStyle: React.CSSProperties = {
-  display: "grid",
-  gap: 6,
-  padding: 12,
-  border: `1px dashed ${workflowTheme.borderStrong}`,
-  borderRadius: 10,
-  background: "rgba(255, 246, 232, 0.72)",
 };
 
 const sourceValueStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -5,8 +5,16 @@ import {
   fetchExpiringLeaseRenewals,
   type LandlordLeaseRenewalLease,
 } from "@/api/landlordLeaseRenewalApi";
-import { LeaseRenewalOperatorInputsCard } from "@/components/leases/LeaseRenewalOperatorInputsCard";
-import { LeaseRenewalNoticeDraftCard } from "@/components/leases/LeaseRenewalNoticeDraftCard";
+import {
+  formatRenewalCurrency,
+  hasSavedRenewalInputs,
+  LeaseRenewalOperatorInputsCard,
+} from "@/components/leases/LeaseRenewalOperatorInputsCard";
+import {
+  buildRenewalNoticeDraftText,
+  getRenewalNoticeDraftReadiness,
+  LeaseRenewalNoticeDraftCard,
+} from "@/components/leases/LeaseRenewalNoticeDraftCard";
 import {
   RENEWAL_PIPELINE_BUCKETS,
   deriveRenewalPipelineItems,
@@ -321,12 +329,11 @@ function renewalProjectionFallbackFromLease(lease: LandlordActiveLease): Landlor
   };
 }
 
-function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease }) {
+function useRenewalLeaseProjection(lease: LandlordActiveLease) {
   const propertyId = String(lease.propertyId || "").trim();
   const [renewalLease, setRenewalLease] = React.useState<LandlordLeaseRenewalLease | null>(null);
   const [loadingRenewalInputs, setLoadingRenewalInputs] = React.useState(false);
   const [renewalInputsError, setRenewalInputsError] = React.useState<string | null>(null);
-  const inputsRef = React.useRef<HTMLDivElement | null>(null);
 
   React.useEffect(() => {
     if (!propertyId) {
@@ -363,6 +370,81 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
       active = false;
     };
   }, [lease, propertyId]);
+
+  return { propertyId, renewalLease, setRenewalLease, loadingRenewalInputs, renewalInputsError };
+}
+
+function formatRenewalWorkflowDate(value: string | null | undefined) {
+  return formatDate(value);
+}
+
+function formatRenewalTargetDate(value: string | number | null | undefined) {
+  if (!value) return "Not set";
+  if (typeof value === "string") return formatRenewalWorkflowDate(value);
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not set";
+  return date.toLocaleDateString("en-CA", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function renewalProjectionLocationLabel(lease: LandlordLeaseRenewalLease) {
+  const property =
+    workflowDisplayLabel(lease.propertyAddress, /^property$/i) ||
+    workflowDisplayLabel(lease.propertyLabel, /^property$/i);
+  const unitRaw = workflowDisplayLabel(lease.unitLabel, /^unit$/i);
+  const unit = unitRaw ? (/^unit\b/i.test(unitRaw) ? unitRaw : `Unit ${unitRaw}`) : null;
+  if (property && unit) return `${property} · ${unit}`;
+  if (property) return property;
+  if (unit) return unit;
+  return "Property/unit unavailable";
+}
+
+function renewalProjectionTenantLabel(lease: LandlordLeaseRenewalLease) {
+  return workflowDisplayLabel(lease.tenantName, /^tenant$/i) || "Tenant name unavailable";
+}
+
+function renewalProjectionRentLabel(lease: LandlordLeaseRenewalLease) {
+  const requiresRent = lease.renewalRentChangeMode === "increase" || lease.renewalRentChangeMode === "decrease";
+  if (!requiresRent) return "No rent change currently proposed";
+  return formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "Renewal rent not set";
+}
+
+function renewalProjectionTermLabel(lease: LandlordLeaseRenewalLease) {
+  const start = formatRenewalWorkflowDate(lease.renewalNewLeaseStartDate);
+  const end = lease.renewalNewLeaseEndDate ? formatRenewalWorkflowDate(lease.renewalNewLeaseEndDate) : "open-ended";
+  return `${start} to ${end}`;
+}
+
+function RenewalWorkflowStatusPanel({ lease }: { lease: LandlordLeaseRenewalLease }) {
+  const readiness = getRenewalNoticeDraftReadiness(lease);
+  const saved = hasSavedRenewalInputs(lease);
+  return (
+    <div style={sourceContextStyle} aria-label="Renewal workflow status">
+      <div style={sourceContextTitleStyle}>Renewal workflow status</div>
+      <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 12, margin: 0 }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Operator inputs</dt>
+          <dd style={sourceValueStyle}>{saved ? "Operator inputs saved" : "Operator inputs pending"}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Tenant notice draft</dt>
+          <dd style={sourceValueStyle}>{readiness.ready ? "Tenant notice draft ready" : "Review inputs before draft"}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Notice review</dt>
+          <dd style={sourceValueStyle}>Notice review pending</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Email delivery</dt>
+          <dd style={sourceValueStyle}>Email delivery deferred</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease }) {
+  const { propertyId, renewalLease, setRenewalLease, loadingRenewalInputs, renewalInputsError } = useRenewalLeaseProjection(lease);
+  const inputsRef = React.useRef<HTMLDivElement | null>(null);
 
   if (!propertyId) {
     return (
@@ -433,10 +515,12 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
       {!loadingRenewalInputs && renewalInputsError ? <div style={{ color: "#b91c1c" }}>{renewalInputsError}</div> : null}
       {!loadingRenewalInputs && !renewalInputsError && renewalLease ? (
         <>
+          <RenewalWorkflowStatusPanel lease={renewalLease} />
           <div ref={inputsRef} tabIndex={-1} style={{ outline: "none" }}>
             <LeaseRenewalOperatorInputsCard
               lease={renewalLease}
               onSaved={(updatedLease) => setRenewalLease(updatedLease)}
+              showLifecycleSummary={false}
             />
           </div>
           <LeaseRenewalNoticeDraftCard
@@ -450,6 +534,84 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
         </>
       ) : null}
     </>
+  );
+}
+
+function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLease }) {
+  const { propertyId, renewalLease, loadingRenewalInputs, renewalInputsError } = useRenewalLeaseProjection(lease);
+  const renewalPath = `/leases/${encodeURIComponent(lease.id)}/workflows/renewal`;
+
+  if (!propertyId) return null;
+  if (loadingRenewalInputs) return <div>Loading renewal notice draft context…</div>;
+  if (renewalInputsError) {
+    return <div style={{ color: "#b91c1c" }}>Renewal notice draft context could not be loaded.</div>;
+  }
+  if (!renewalLease || !hasSavedRenewalInputs(renewalLease)) return null;
+
+  const readiness = getRenewalNoticeDraftReadiness(renewalLease);
+  const draftText = readiness.ready ? buildRenewalNoticeDraftText(renewalLease) : null;
+
+  return (
+    <section style={panelStyle} aria-label="Renewal notice draft context">
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <h2 style={sectionHeadingStyle}>Renewal notice draft context</h2>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
+            Renewal operator inputs are available for this lease. Review this context before preparing tenant-facing notice steps.
+          </div>
+        </div>
+        <Link to={renewalPath} style={buttonLinkStyle}>
+          Back to renewal workflow
+        </Link>
+      </div>
+
+      <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14, margin: 0 }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Tenant</dt>
+          <dd style={sourceValueStyle}>{renewalProjectionTenantLabel(renewalLease)}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Unit/property</dt>
+          <dd style={sourceValueStyle}>{renewalProjectionLocationLabel(renewalLease)}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Current rent</dt>
+          <dd style={sourceValueStyle}>{formatRenewalCurrency(renewalLease.currentRent, renewalLease.currency) || "Current rent unavailable"}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Renewal rent entered for review</dt>
+          <dd style={sourceValueStyle}>{renewalProjectionRentLabel(renewalLease)}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Current lease end</dt>
+          <dd style={sourceValueStyle}>{formatRenewalWorkflowDate(renewalLease.leaseEndDate)}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Proposed term</dt>
+          <dd style={sourceValueStyle}>{renewalProjectionTermLabel(renewalLease)}</dd>
+        </div>
+        <div style={{ display: "grid", gap: 4 }}>
+          <dt style={termStyle}>Tenant response target date</dt>
+          <dd style={sourceValueStyle}>{formatRenewalTargetDate(renewalLease.renewalDecisionDeadlineAt)}</dd>
+        </div>
+      </dl>
+
+      {draftText ? (
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={termStyle}>Draft preview from renewal workflow</span>
+          <textarea readOnly rows={7} value={draftText} style={draftPreviewStyle} />
+        </label>
+      ) : (
+        <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
+          Renewal operator inputs are present, but the tenant notice draft still needs review in the renewal workflow before
+          tenant-facing notice steps are prepared.
+        </div>
+      )}
+
+      <div style={{ color: workflowTheme.subtle, lineHeight: 1.6 }}>
+        This is review context only. No notice record is created here, and email delivery remains deferred.
+      </div>
+    </section>
   );
 }
 
@@ -549,6 +711,8 @@ export default function LandlordLeaseWorkflowPage() {
             </ul>
           </section>
 
+          {workflow.key === "notice" ? <RenewalNoticeDraftContextWorkspace lease={lease} /> : null}
+
           {workflow.key === "renewal" ? (
             <section style={panelStyle} aria-label="Renewal operator inputs">
               <h2 style={sectionHeadingStyle}>Renewal operator inputs</h2>
@@ -647,6 +811,19 @@ const sourceValueStyle: React.CSSProperties = {
   color: workflowTheme.charcoal,
   fontWeight: 700,
   lineHeight: 1.35,
+};
+
+const draftPreviewStyle: React.CSSProperties = {
+  width: "100%",
+  minHeight: 160,
+  boxSizing: "border-box",
+  resize: "vertical",
+  border: `1px solid ${workflowTheme.borderStrong}`,
+  borderRadius: 10,
+  padding: 10,
+  color: workflowTheme.charcoal,
+  background: "#fff",
+  lineHeight: 1.55,
 };
 
 const termStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -237,13 +237,65 @@ function renewalSourceContextItem(lease: LandlordActiveLease): RenewalPipelineIt
   return deriveRenewalPipelineItems([lease])[0] || null;
 }
 
+function looksLikeWorkflowRawIdentifier(value: string) {
+  const raw = value.trim();
+  if (raw.length < 12 || /\s/.test(raw)) return false;
+  return /^[A-Za-z0-9_-]+$/.test(raw) && /[A-Za-z]/.test(raw) && /\d/.test(raw);
+}
+
+function workflowDisplayLabel(value: string | null | undefined, genericPattern?: RegExp) {
+  const label = String(value || "").trim();
+  if (!label) return null;
+  if (genericPattern?.test(label)) return null;
+  if (looksLikeWorkflowRawIdentifier(label)) return null;
+  return label;
+}
+
+function workflowUnitLabel(lease: LandlordActiveLease) {
+  const unitNumber = workflowDisplayLabel(lease.unitNumber, /^unit$/i);
+  if (unitNumber) return /^unit\b/i.test(unitNumber) ? unitNumber : `Unit ${unitNumber}`;
+  const unitLabel = workflowDisplayLabel(lease.unitLabel, /^unit$/i);
+  if (!unitLabel) return null;
+  return /^unit\b/i.test(unitLabel) ? unitLabel : `Unit ${unitLabel}`;
+}
+
+function workflowPropertyLabel(lease: LandlordActiveLease) {
+  return (
+    workflowDisplayLabel(lease.propertyName, /^property$/i) ||
+    workflowDisplayLabel(lease.propertyLabel, /^property$/i) ||
+    workflowDisplayLabel(lease.propertyAddress, /^property$/i)
+  );
+}
+
+function renewalProjectionWithLeaseContext(
+  projectedLease: LandlordLeaseRenewalLease,
+  sourceLease: LandlordActiveLease
+): LandlordLeaseRenewalLease {
+  return {
+    ...projectedLease,
+    tenantName: workflowDisplayLabel(projectedLease.tenantName, /^tenant$/i) || workflowDisplayLabel(sourceLease.tenantName, /^tenant$/i),
+    propertyAddress:
+      workflowDisplayLabel(projectedLease.propertyAddress, /^property$/i) ||
+      workflowDisplayLabel(sourceLease.propertyAddress, /^property$/i) ||
+      null,
+    propertyLabel:
+      workflowDisplayLabel(projectedLease.propertyLabel, /^property$/i) ||
+      workflowPropertyLabel(sourceLease) ||
+      null,
+    unitLabel:
+      workflowDisplayLabel(projectedLease.unitLabel, /^unit$/i) ||
+      workflowUnitLabel(sourceLease) ||
+      null,
+  };
+}
+
 function renewalProjectionFallbackFromLease(lease: LandlordActiveLease): LandlordLeaseRenewalLease {
   const projectedLease = lease as LandlordActiveLease & Partial<LandlordLeaseRenewalLease>;
   return {
     id: lease.id,
     tenantId: lease.tenantId || lease.primaryTenantId || "",
     propertyId: lease.propertyId || null,
-    propertyAddress: lease.propertyAddress || null,
+    propertyAddress: workflowDisplayLabel(lease.propertyAddress, /^property$/i),
     unitId: lease.unitId || null,
     status: lease.status,
     leaseType: projectedLease.leaseType || "fixed_term",
@@ -254,9 +306,9 @@ function renewalProjectionFallbackFromLease(lease: LandlordActiveLease): Landlor
     currency: projectedLease.currency || "CAD",
     nextNoticeDueAt: projectedLease.nextNoticeDueAt || null,
     latestNoticeId: projectedLease.latestNoticeId || null,
-    tenantName: lease.tenantName || null,
-    unitLabel: lease.unitLabel || (lease.unitNumber ? `Unit ${lease.unitNumber}` : null),
-    propertyLabel: lease.propertyLabel || lease.propertyName || null,
+    tenantName: workflowDisplayLabel(lease.tenantName, /^tenant$/i),
+    unitLabel: workflowUnitLabel(lease),
+    propertyLabel: workflowPropertyLabel(lease),
     renewalRentChangeMode: projectedLease.renewalRentChangeMode || null,
     renewalOfferedRent: typeof projectedLease.renewalOfferedRent === "number" ? projectedLease.renewalOfferedRent : null,
     renewalDecisionDeadlineAt: projectedLease.renewalDecisionDeadlineAt || null,
@@ -293,7 +345,11 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
         if (!active) return;
         const renewalItems = response.items?.length ? response.items : response.data || [];
         const projectedLease = renewalItems.find((item) => item.id === lease.id);
-        setRenewalLease(projectedLease || renewalProjectionFallbackFromLease(lease));
+        setRenewalLease(
+          projectedLease
+            ? renewalProjectionWithLeaseContext(projectedLease, lease)
+            : renewalProjectionFallbackFromLease(lease)
+        );
       } catch (err: unknown) {
         if (!active) return;
         setRenewalLease(null);

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -437,7 +437,7 @@ describe("PortfolioHealthSummaryPage", () => {
     fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "fixed_term" } });
     fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2026-07-01" } });
     fireEvent.change(screen.getByLabelText(/New lease end date/i), { target: { value: "2027-06-30" } });
-    fireEvent.change(screen.getByLabelText(/Tenant response target date/i), { target: { value: "2026-05-01T08:00" } });
+    fireEvent.change(screen.getByLabelText(/Tenant response target date/i), { target: { value: "2026-05-01" } });
     fireEvent.click(screen.getByRole("button", { name: /Save renewal inputs/i }));
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Adds a frontend-only Tenant renewal notice draft section to /leases/:leaseId/workflows/renewal after saved renewal operator inputs.
- Generates conservative draft copy from existing renewal projection data, including tenant, property/unit, current rent, proposed rent, proposed term, lease end, and tenant response target date.
- Adds copy/download actions and an existing-route link to /leases/:leaseId/workflows/notice without creating, saving, or sending notices.
- Keeps renewal input save behavior unchanged and removes the remaining visible response deadline wording from the renewal workflow intro.

## Audit Findings
- Existing landlord tenant-notices API creates notices and attempts email immediately; it is not a safe renewal draft persistence path for this workflow.
- Existing lease notice landlord routes support preview/send and audit events, but send is a backend write/delivery path with policy and notice state behavior; v1 does not embed that path.
- Existing tenant lease notice routes are tenant-safe read/respond routes and are not landlord draft creation routes.
- Existing landlord messages workspace can send conversation messages, but there is no route-safe renewal draft prefill or draft lifecycle to reuse here.
- Evidence package support can include lease notices after records exist, but this PR does not create false evidence/audit claims.

## Boundaries
- Frontend-only.
- No backend/API/auth/data-model/write path changes.
- No email delivery, notice sending, statutory notice creation, lease lifecycle state change, legal deadline engine, or jurisdiction-specific legal rule was introduced.
- Existing signed-document and renewal input save behavior are untouched.

## Validation
- npm run test -- LandlordLeaseWorkflowPage PortfolioHealthSummaryPage LandlordActiveLeasesPage OperationalCommandCenterPage
- npm run build
- git diff --check
- git diff --cached --check