### PR TITLE
feat: add renewal notice evidence readiness

### DIFF
--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { evidencePackPath } from "@/api/evidencePackApi";
 import type { LandlordLeaseRenewalLease } from "@/api/landlordLeaseRenewalApi";
+import { reviewTimelinePath } from "@/api/reviewTimelineApi";
 import { formatRenewalCurrency } from "./LeaseRenewalOperatorInputsCard";
 
 type LeaseRenewalNoticeDraftCardProps = {
@@ -76,6 +78,12 @@ function formatTermType(value: LandlordLeaseRenewalLease["renewalNewTermType"]) 
     default:
       return "Not set";
   }
+}
+
+function formatEvidenceTermLabel(lease: LandlordLeaseRenewalLease) {
+  return `${formatTermType(lease.renewalNewTermType)} · ${formatDateOnly(lease.renewalNewLeaseStartDate)} to ${formatDateOnly(
+    lease.renewalNewLeaseEndDate
+  )}`;
 }
 
 function cleanDisplayLabel(value: string | null | undefined) {
@@ -194,6 +202,8 @@ export function LeaseRenewalNoticeDraftCard({
   const proposedRent = proposedRentRequired(lease)
     ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "Proposed rent not set"
     : "No rent change currently proposed";
+  const leaseEvidencePath = evidencePackPath({ scope: "lease", scopeId: lease.id });
+  const leaseTimelinePath = reviewTimelinePath({ scope: "lease", scopeId: lease.id });
 
   async function copyDraft() {
     try {
@@ -285,6 +295,49 @@ export function LeaseRenewalNoticeDraftCard({
         evidence tracking should be completed in the dedicated communication workflow when available.
       </div>
 
+      <section style={evidenceReadinessStyle} aria-label="Evidence readiness">
+        <div style={evidenceReadinessHeaderStyle}>
+          <div>
+            <h4 style={subheadingStyle}>Evidence readiness</h4>
+            <div style={mutedStyle}>Draft prepared from saved renewal inputs. Review values before tenant communication.</div>
+          </div>
+          <span style={evidenceBadgeStyle}>Operational record only</span>
+        </div>
+
+        <dl style={factsGridStyle}>
+          <Fact label="Tenant" value={tenantMetadataLabel(lease)} />
+          <Fact label="Property/unit" value={propertyUnitLabel(lease)} />
+          <Fact label="Current rent" value={currentRent} />
+          <Fact label="Renewal rent" value={proposedRent} />
+          <Fact label="Current lease end" value={formatDateOnly(lease.leaseEndDate)} />
+          <Fact label="Proposed term" value={formatEvidenceTermLabel(lease)} />
+          <Fact label="Tenant response target date" value={formatTargetDate(lease.renewalDecisionDeadlineAt)} />
+        </dl>
+
+        <div style={statusListStyle}>
+          <StatusItem label="Draft prepared from saved renewal inputs" tone="ready" />
+          <StatusItem label="Copy/download actions are available for review" tone="ready" />
+          <StatusItem label="Email delivery not enabled" tone="deferred" />
+          <StatusItem label="Draft evidence is not persisted yet" tone="deferred" />
+          <StatusItem label="Audit capture deferred" tone="deferred" />
+          <StatusItem label="Evidence package inclusion deferred" tone="deferred" />
+        </div>
+
+        <div style={noticeStyle}>
+          Current evidence preview and review timeline routes can show lease context, but this draft text is not saved to an
+          evidence package or audit trail yet.
+        </div>
+
+        <div style={actionsStyle}>
+          <Link to={leaseEvidencePath} style={linkButtonStyle}>
+            Open lease evidence preview
+          </Link>
+          <Link to={leaseTimelinePath} style={linkButtonStyle}>
+            Open lease review timeline
+          </Link>
+        </div>
+      </section>
+
       <div style={actionsStyle}>
         <button type="button" onClick={() => void copyDraft()} style={primaryButtonStyle}>
           Copy draft text
@@ -308,6 +361,16 @@ function Fact({ label, value }: { label: string; value: string }) {
     <div style={{ display: "grid", gap: 4 }}>
       <dt style={termStyle}>{label}</dt>
       <dd style={valueStyle}>{value}</dd>
+    </div>
+  );
+}
+
+function StatusItem({ label, tone }: { label: string; tone: "ready" | "deferred" }) {
+  const markerStyle = tone === "ready" ? readyMarkerStyle : deferredMarkerStyle;
+  return (
+    <div style={statusItemStyle}>
+      <span aria-hidden="true" style={markerStyle} />
+      <span>{label}</span>
     </div>
   );
 }
@@ -336,6 +399,13 @@ const headingStyle: React.CSSProperties = {
   letterSpacing: 0,
 };
 
+const subheadingStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 15,
+  color: "#211c17",
+  letterSpacing: 0,
+};
+
 const mutedStyle: React.CSSProperties = {
   color: "#63594d",
   lineHeight: 1.55,
@@ -357,6 +427,13 @@ const readyBadgeStyle: React.CSSProperties = {
   border: "1px solid rgba(22, 101, 52, 0.28)",
   background: "rgba(22, 101, 52, 0.10)",
   color: "#166534",
+};
+
+const evidenceBadgeStyle: React.CSSProperties = {
+  ...badgeStyle,
+  border: "1px solid rgba(91, 70, 48, 0.24)",
+  background: "rgba(255, 246, 232, 0.95)",
+  color: "#5b4630",
 };
 
 const factsGridStyle: React.CSSProperties = {
@@ -401,6 +478,55 @@ const noticeStyle: React.CSSProperties = {
   borderRadius: 10,
   background: "rgba(255, 246, 232, 0.72)",
   padding: 10,
+};
+
+const evidenceReadinessStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 12,
+  border: "1px solid rgba(91, 70, 48, 0.18)",
+  borderRadius: 10,
+  background: "rgba(255, 246, 232, 0.62)",
+  padding: 12,
+};
+
+const evidenceReadinessHeaderStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: 12,
+  flexWrap: "wrap",
+};
+
+const statusListStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))",
+  gap: 8,
+};
+
+const statusItemStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  color: "#211c17",
+  fontWeight: 700,
+  lineHeight: 1.4,
+};
+
+const statusMarkerBaseStyle: React.CSSProperties = {
+  width: 9,
+  height: 9,
+  borderRadius: 999,
+  flexShrink: 0,
+};
+
+const readyMarkerStyle: React.CSSProperties = {
+  ...statusMarkerBaseStyle,
+  background: "#166534",
+};
+
+const deferredMarkerStyle: React.CSSProperties = {
+  ...statusMarkerBaseStyle,
+  background: "#b45309",
 };
 
 const actionsStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -324,6 +324,32 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(draftPreview.value).not.toContain("Please review these proposed renewal details");
     expect((draftPreview.value.match(/\bproposed\b/gi) || []).length).toBeLessThanOrEqual(1);
     expect(screen.getByText(/Email delivery is not enabled from this workflow yet/i)).toBeInTheDocument();
+    const evidenceReadiness = screen.getByLabelText("Evidence readiness");
+    expect(evidenceReadiness).toHaveTextContent("Evidence readiness");
+    expect(evidenceReadiness).toHaveTextContent("Operational record only");
+    expect(evidenceReadiness).toHaveTextContent("Draft prepared from saved renewal inputs");
+    expect(evidenceReadiness).toHaveTextContent("Review values before tenant communication");
+    expect(evidenceReadiness).toHaveTextContent("Jane Tenant");
+    expect(evidenceReadiness).toHaveTextContent("12 Harbour Road · Unit 101");
+    expect(evidenceReadiness).toHaveTextContent("CA$1,850.00");
+    expect(evidenceReadiness).toHaveTextContent("CA$1,975.00");
+    expect(evidenceReadiness).toHaveTextContent("December 31, 2026");
+    expect(evidenceReadiness).toHaveTextContent("Fixed term · January 1, 2027 to December 31, 2027");
+    expect(evidenceReadiness).toHaveTextContent("Tenant response target date");
+    expect(evidenceReadiness).toHaveTextContent("Copy/download actions are available for review");
+    expect(evidenceReadiness).toHaveTextContent("Email delivery not enabled");
+    expect(evidenceReadiness).toHaveTextContent("Draft evidence is not persisted yet");
+    expect(evidenceReadiness).toHaveTextContent("Audit capture deferred");
+    expect(evidenceReadiness).toHaveTextContent("Evidence package inclusion deferred");
+    expect(evidenceReadiness).toHaveTextContent("this draft text is not saved to an evidence package or audit trail yet");
+    expect(screen.getByRole("link", { name: "Open lease evidence preview" })).toHaveAttribute(
+      "href",
+      "/evidence-packs?scope=lease&scopeId=lease-1"
+    );
+    expect(screen.getByRole("link", { name: "Open lease review timeline" })).toHaveAttribute(
+      "href",
+      "/review-timeline?scope=lease&scopeId=lease-1"
+    );
     expect(screen.getByRole("link", { name: "Open notice review workflow" })).toHaveAttribute(
       "href",
       "/leases/lease-1/workflows/notice"
@@ -333,6 +359,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
+    expect(document.body).not.toHaveTextContent(/audit event created|evidence saved|notice served|tenant notified|email sent/i);
     expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
   });
 
@@ -516,6 +543,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     );
     expect(draftCard).not.toHaveTextContent("Draft ready");
     expect(screen.queryByLabelText("Draft message preview")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Evidence readiness")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Add a compact Evidence readiness section to the renewal notice draft card on `/leases/:leaseId/workflows/renewal`.
- Show the saved renewal-input source values used for the draft: tenant, property/unit, current rent, renewal rent, current lease end, proposed term, and tenant response target date.
- Link to existing read-only lease evidence preview and review timeline routes while clearly stating the draft text itself is not persisted or included in evidence yet.
- Preserve copy, download, and notice review workflow actions without adding live email/send behavior.

## Audit findings
- Existing evidence pack API is preview/read-only: `/landlord/evidence-packs/preview` derives a current evidence projection but does not persist draft snapshots.
- Existing review timeline API is read-only: `/landlord/review-timeline` can show lease timeline context but does not record this renewal draft.
- Existing lease notice routes support renewal input save, notice preview, and send notice. The preview/send paths create workflow events tied to notice preview/send semantics and are not a safe standalone draft-snapshot persistence API for this frontend draft.
- Existing canonical/event infrastructure exists, but no safe landlord renewal draft prepared/copied/downloaded endpoint is exposed for this v1 without inventing backend behavior.

## Decision
Frontend-only readiness v1. No backend/API/auth/data-model/write changes. Draft persistence, audit capture, and evidence package inclusion remain explicitly deferred.

## Guardrails
- No live email/send action.
- No notice record creation.
- No legal deadline logic.
- No lease lifecycle state change.
- No tenant-facing behavior change.
- No signed-document logic change.
- No raw URLs or raw IDs as visible labels.
- No claims that evidence was saved or audit events were recorded.

## Validation
- `npm run test -- LandlordLeaseWorkflowPage` passed.
- `npm run test -- LandlordLeaseSummaryPage` passed, with existing Firebase/auth telemetry test-environment warnings.
- `npm run test -- OperationalCommandCenterPage` passed.
- `npm run test -- EvidencePackPage` passed.
- `npm run test -- LandlordUnifiedInboxPage` has no matching test file; closest existing `npm run test -- UnifiedInboxPage` passed.
- `npm run build` passed, with existing Vite Node-version warning under Node 20.11.1.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Browser QA
Not completed in this run. Keep PR draft pending preview/live landlord QA and legal-copy review.

## Deferred
- live email send
- notice record creation
- draft persistence
- audit event recording
- evidence package inclusion of the draft text
- tenant response workflow
- jurisdiction-aware notice template/rules