### PR TITLE
feat: add renewal notice review workflow

### DIFF
--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -17,6 +17,18 @@ type DraftReadiness = {
   validationMessage?: string | null;
 };
 
+export type RenewalNoticeReviewModel = {
+  tenantLabel: string;
+  propertyUnitLabel: string;
+  currentRentLabel: string;
+  renewalRentLabel: string;
+  currentLeaseEndLabel: string;
+  proposedTermLabel: string;
+  tenantResponseTargetDateLabel: string;
+  leaseEvidencePath: string;
+  leaseTimelinePath: string;
+};
+
 function formatDateOnly(value: string | null | undefined) {
   const raw = String(value || "").trim();
   if (!raw) return "Not set";
@@ -133,6 +145,25 @@ function proposedRentRequired(lease: LandlordLeaseRenewalLease) {
   return lease.renewalRentChangeMode === "increase" || lease.renewalRentChangeMode === "decrease";
 }
 
+export function buildRenewalNoticeReviewModel(lease: LandlordLeaseRenewalLease): RenewalNoticeReviewModel {
+  const currentRentLabel = formatRenewalCurrency(lease.currentRent, lease.currency) || "Current rent unavailable";
+  const renewalRentLabel = proposedRentRequired(lease)
+    ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "Proposed rent not set"
+    : "No rent change currently proposed";
+
+  return {
+    tenantLabel: tenantMetadataLabel(lease),
+    propertyUnitLabel: propertyUnitLabel(lease),
+    currentRentLabel,
+    renewalRentLabel,
+    currentLeaseEndLabel: formatDateOnly(lease.leaseEndDate),
+    proposedTermLabel: formatEvidenceTermLabel(lease),
+    tenantResponseTargetDateLabel: formatTargetDate(lease.renewalDecisionDeadlineAt),
+    leaseEvidencePath: evidencePackPath({ scope: "lease", scopeId: lease.id }),
+    leaseTimelinePath: reviewTimelinePath({ scope: "lease", scopeId: lease.id }),
+  };
+}
+
 export function getRenewalNoticeDraftReadiness(lease: LandlordLeaseRenewalLease): DraftReadiness {
   const missing: string[] = [];
   let validationMessage: string | null = null;
@@ -198,12 +229,7 @@ export function LeaseRenewalNoticeDraftCard({
   const [copyStatus, setCopyStatus] = React.useState<"idle" | "success" | "error">("idle");
   const readiness = getRenewalNoticeDraftReadiness(lease);
   const draftText = React.useMemo(() => buildRenewalNoticeDraftText(lease), [lease]);
-  const currentRent = formatRenewalCurrency(lease.currentRent, lease.currency) || "Current rent unavailable";
-  const proposedRent = proposedRentRequired(lease)
-    ? formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "Proposed rent not set"
-    : "No rent change currently proposed";
-  const leaseEvidencePath = evidencePackPath({ scope: "lease", scopeId: lease.id });
-  const leaseTimelinePath = reviewTimelinePath({ scope: "lease", scopeId: lease.id });
+  const reviewModel = React.useMemo(() => buildRenewalNoticeReviewModel(lease), [lease]);
 
   async function copyDraft() {
     try {
@@ -271,18 +297,13 @@ export function LeaseRenewalNoticeDraftCard({
       </div>
 
       <dl style={factsGridStyle}>
-        <Fact label="Tenant" value={tenantMetadataLabel(lease)} />
-        <Fact label="Unit/property" value={propertyUnitLabel(lease)} />
-        <Fact label="Current rent" value={currentRent} />
-        <Fact label="Proposed rent" value={proposedRent} />
-        <Fact label="Current lease end" value={formatDateOnly(lease.leaseEndDate)} />
-        <Fact
-          label="Proposed term"
-          value={`${formatTermType(lease.renewalNewTermType)} · ${formatDateOnly(lease.renewalNewLeaseStartDate)} to ${
-            lease.renewalNewLeaseEndDate ? formatDateOnly(lease.renewalNewLeaseEndDate) : "open-ended"
-          }`}
-        />
-        <Fact label="Tenant response target date" value={formatTargetDate(lease.renewalDecisionDeadlineAt)} />
+        <Fact label="Tenant" value={reviewModel.tenantLabel} />
+        <Fact label="Unit/property" value={reviewModel.propertyUnitLabel} />
+        <Fact label="Current rent" value={reviewModel.currentRentLabel} />
+        <Fact label="Proposed rent" value={reviewModel.renewalRentLabel} />
+        <Fact label="Current lease end" value={reviewModel.currentLeaseEndLabel} />
+        <Fact label="Proposed term" value={reviewModel.proposedTermLabel} />
+        <Fact label="Tenant response target date" value={reviewModel.tenantResponseTargetDateLabel} />
       </dl>
 
       <label style={{ display: "grid", gap: 6 }}>
@@ -305,13 +326,13 @@ export function LeaseRenewalNoticeDraftCard({
         </div>
 
         <dl style={factsGridStyle}>
-          <Fact label="Tenant" value={tenantMetadataLabel(lease)} />
-          <Fact label="Property/unit" value={propertyUnitLabel(lease)} />
-          <Fact label="Current rent" value={currentRent} />
-          <Fact label="Renewal rent" value={proposedRent} />
-          <Fact label="Current lease end" value={formatDateOnly(lease.leaseEndDate)} />
-          <Fact label="Proposed term" value={formatEvidenceTermLabel(lease)} />
-          <Fact label="Tenant response target date" value={formatTargetDate(lease.renewalDecisionDeadlineAt)} />
+          <Fact label="Tenant" value={reviewModel.tenantLabel} />
+          <Fact label="Property/unit" value={reviewModel.propertyUnitLabel} />
+          <Fact label="Current rent" value={reviewModel.currentRentLabel} />
+          <Fact label="Renewal rent" value={reviewModel.renewalRentLabel} />
+          <Fact label="Current lease end" value={reviewModel.currentLeaseEndLabel} />
+          <Fact label="Proposed term" value={reviewModel.proposedTermLabel} />
+          <Fact label="Tenant response target date" value={reviewModel.tenantResponseTargetDateLabel} />
         </dl>
 
         <div style={statusListStyle}>
@@ -329,10 +350,10 @@ export function LeaseRenewalNoticeDraftCard({
         </div>
 
         <div style={actionsStyle}>
-          <Link to={leaseEvidencePath} style={linkButtonStyle}>
+          <Link to={reviewModel.leaseEvidencePath} style={linkButtonStyle}>
             Open lease evidence preview
           </Link>
-          <Link to={leaseTimelinePath} style={linkButtonStyle}>
+          <Link to={reviewModel.leaseTimelinePath} style={linkButtonStyle}>
             Open lease review timeline
           </Link>
         </div>

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -236,22 +236,43 @@ describe("LandlordLeaseWorkflowPage", () => {
     renderWorkflow("/leases/lease-1/workflows/notice");
     expect(await screen.findByRole("heading", { name: "Notice Workflow" })).toBeInTheDocument();
     expect(screen.getByText("Review notice-related lease status, lifecycle timing, and audit context before preparing a notice.")).toBeInTheDocument();
-    const renewalContext = await screen.findByLabelText("Renewal notice draft context");
-    expect(renewalContext).toHaveTextContent("Renewal operator inputs are available for this lease.");
-    expect(renewalContext).toHaveTextContent("Jane Tenant");
-    expect(renewalContext).toHaveTextContent("12 Harbour Road · Unit 101");
-    expect(renewalContext).toHaveTextContent("CA$1,850.00");
-    expect(renewalContext).toHaveTextContent("CA$1,975.00");
-    expect(renewalContext).toHaveTextContent("Tenant response target date");
-    expect((screen.getByLabelText("Draft preview from renewal workflow") as HTMLTextAreaElement).value).toContain(
+    const noticeReview = await screen.findByLabelText("Renewal notice review");
+    expect(noticeReview).toHaveTextContent("Review renewal notice preparation");
+    expect(noticeReview).toHaveTextContent("Draft ready");
+    expect(noticeReview).toHaveTextContent("Email delivery");
+    expect(noticeReview).toHaveTextContent("Deferred");
+    expect(noticeReview).toHaveTextContent("Evidence capture");
+    expect(noticeReview).toHaveTextContent("Audit capture");
+    expect(noticeReview).toHaveTextContent("Jane Tenant");
+    expect(noticeReview).toHaveTextContent("12 Harbour Road · Unit 101");
+    expect(noticeReview).toHaveTextContent("CA$1,850.00");
+    expect(noticeReview).toHaveTextContent("CA$1,975.00");
+    expect(noticeReview).toHaveTextContent("Fixed term · January 1, 2027 to December 31, 2027");
+    expect(noticeReview).toHaveTextContent("Tenant response target date");
+    expect((screen.getByLabelText("Tenant notice draft preview") as HTMLTextAreaElement).value).toContain(
       "This message is for renewal planning and review."
     );
     expect(screen.getByRole("link", { name: "Back to renewal workflow" })).toHaveAttribute(
       "href",
       "/leases/lease-1/workflows/renewal"
     );
+    expect(screen.getByRole("link", { name: "Return to renewal inputs" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/workflows/renewal"
+    );
+    expect(screen.getByRole("link", { name: "Open lease evidence preview" })).toHaveAttribute(
+      "href",
+      "/evidence-packs?scope=lease&scopeId=lease-1"
+    );
+    expect(screen.getByRole("link", { name: "Open lease review timeline" })).toHaveAttribute(
+      "href",
+      "/review-timeline?scope=lease&scopeId=lease-1"
+    );
+    expect(screen.getByRole("button", { name: "Copy draft text" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download draft" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/audit event created|evidence saved|notice served|tenant notified|email sent/i);
 
     cleanup();
     renderWorkflow("/leases/lease-1/workflows/execution");
@@ -266,6 +287,126 @@ describe("LandlordLeaseWorkflowPage", () => {
       background: "#fff6e8",
       borderRadius: "14px",
     });
+  });
+
+  it("shows notice review inputs-needed state without draft actions", async () => {
+    mocks.fetchExpiringLeaseRenewals.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          propertyAddress: "12 Harbour Road",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2026-01-01",
+          leaseEndDate: "2026-12-31",
+          currentRent: 1850,
+          currency: "CAD",
+          nextNoticeDueAt: null,
+          latestNoticeId: null,
+          tenantName: "Jane Tenant",
+          unitLabel: "Unit 101",
+          propertyLabel: "Harbour View",
+          renewalRentChangeMode: null,
+          renewalOfferedRent: null,
+          renewalDecisionDeadlineAt: null,
+          renewalNewTermType: null,
+          renewalNewLeaseStartDate: null,
+          renewalNewLeaseEndDate: null,
+          renewalUpdatedAt: null,
+        },
+      ],
+      data: [],
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    const noticeReview = await screen.findByLabelText("Renewal notice review");
+    expect(noticeReview).toHaveTextContent("Inputs needed");
+    expect(noticeReview).toHaveTextContent("Save renewal operator inputs before reviewing tenant-facing notice preparation.");
+    expect(noticeReview).toHaveTextContent("Missing: rent change mode, new term type, new lease start date, new lease end date, tenant response target date.");
+    expect(screen.queryByLabelText("Tenant notice draft preview")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Return to renewal inputs" })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/workflows/renewal"
+    );
+    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+  });
+
+  it("blocks notice review draft actions when renewal term dates are invalid", async () => {
+    mocks.fetchExpiringLeaseRenewals.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          propertyAddress: "12 Harbour Road",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2026-01-01",
+          leaseEndDate: "2026-12-31",
+          currentRent: 1850,
+          currency: "CAD",
+          nextNoticeDueAt: null,
+          latestNoticeId: null,
+          tenantName: "Jane Tenant",
+          unitLabel: "Unit 101",
+          propertyLabel: "Harbour View",
+          renewalRentChangeMode: "increase",
+          renewalOfferedRent: 1975,
+          renewalDecisionDeadlineAt: dateInputValueToMs("2026-11-20"),
+          renewalNewTermType: "fixed_term",
+          renewalNewLeaseStartDate: "2036-09-01",
+          renewalNewLeaseEndDate: "2027-08-31",
+          renewalUpdatedAt: "2026-07-02T12:00:00.000Z",
+        },
+      ],
+      data: [],
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    const noticeReview = await screen.findByLabelText("Renewal notice review");
+    expect(noticeReview).toHaveTextContent("Invalid renewal term dates");
+    expect(noticeReview).toHaveTextContent(
+      "Review renewal term dates before preparing a tenant notice draft. The new lease start date must be on or before the new lease end date."
+    );
+    expect(noticeReview).not.toHaveTextContent("Draft ready");
+    expect(screen.queryByLabelText("Tenant notice draft preview")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
+  });
+
+  it("copies the notice review draft without sending, saving, or creating notice records", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    const draftPreview = (await screen.findByLabelText("Tenant notice draft preview")) as HTMLTextAreaElement;
+    expect(draftPreview.value).toContain("Hello Jane Tenant,");
+    fireEvent.click(screen.getByRole("button", { name: "Copy draft text" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("This message is for renewal planning and review."));
+    });
+    expect(await screen.findByText("Draft text copied.")).toBeInTheDocument();
+    expect(mocks.saveLeaseRenewalInputs).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/audit event created|evidence saved|notice served|tenant notified|email sent/i);
   });
 
   it("renders editable renewal operator inputs with prefilled values and source link", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -237,8 +237,10 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(await screen.findByRole("heading", { name: "Notice Workflow" })).toBeInTheDocument();
     expect(screen.getByText("Review notice-related lease status, lifecycle timing, and audit context before preparing a notice.")).toBeInTheDocument();
     const noticeReview = await screen.findByLabelText("Renewal notice review");
+    await waitFor(() => {
+      expect(noticeReview).toHaveTextContent("Draft ready");
+    });
     expect(noticeReview).toHaveTextContent("Review renewal notice preparation");
-    expect(noticeReview).toHaveTextContent("Draft ready");
     expect(noticeReview).toHaveTextContent("Email delivery");
     expect(noticeReview).toHaveTextContent("Deferred");
     expect(noticeReview).toHaveTextContent("Evidence capture");
@@ -326,7 +328,9 @@ describe("LandlordLeaseWorkflowPage", () => {
     renderWorkflow("/leases/lease-1/workflows/notice");
 
     const noticeReview = await screen.findByLabelText("Renewal notice review");
-    expect(noticeReview).toHaveTextContent("Inputs needed");
+    await waitFor(() => {
+      expect(noticeReview).toHaveTextContent("Inputs needed");
+    });
     expect(noticeReview).toHaveTextContent("Save renewal operator inputs before reviewing tenant-facing notice preparation.");
     expect(noticeReview).toHaveTextContent("Missing: rent change mode, new term type, new lease start date, new lease end date, tenant response target date.");
     expect(screen.queryByLabelText("Tenant notice draft preview")).not.toBeInTheDocument();
@@ -376,7 +380,9 @@ describe("LandlordLeaseWorkflowPage", () => {
     renderWorkflow("/leases/lease-1/workflows/notice");
 
     const noticeReview = await screen.findByLabelText("Renewal notice review");
-    expect(noticeReview).toHaveTextContent("Invalid renewal term dates");
+    await waitFor(() => {
+      expect(noticeReview).toHaveTextContent("Invalid renewal term dates");
+    });
     expect(noticeReview).toHaveTextContent(
       "Review renewal term dates before preparing a tenant notice draft. The new lease start date must be on or before the new lease end date."
     );

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -6,11 +6,11 @@ import {
   type LandlordLeaseRenewalLease,
 } from "@/api/landlordLeaseRenewalApi";
 import {
-  formatRenewalCurrency,
   hasSavedRenewalInputs,
   LeaseRenewalOperatorInputsCard,
 } from "@/components/leases/LeaseRenewalOperatorInputsCard";
 import {
+  buildRenewalNoticeReviewModel,
   buildRenewalNoticeDraftText,
   getRenewalNoticeDraftReadiness,
   LeaseRenewalNoticeDraftCard,
@@ -374,46 +374,6 @@ function useRenewalLeaseProjection(lease: LandlordActiveLease) {
   return { propertyId, renewalLease, setRenewalLease, loadingRenewalInputs, renewalInputsError };
 }
 
-function formatRenewalWorkflowDate(value: string | null | undefined) {
-  return formatDate(value);
-}
-
-function formatRenewalTargetDate(value: string | number | null | undefined) {
-  if (!value) return "Not set";
-  if (typeof value === "string") return formatRenewalWorkflowDate(value);
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "Not set";
-  return date.toLocaleDateString("en-CA", { year: "numeric", month: "long", day: "numeric" });
-}
-
-function renewalProjectionLocationLabel(lease: LandlordLeaseRenewalLease) {
-  const property =
-    workflowDisplayLabel(lease.propertyAddress, /^property$/i) ||
-    workflowDisplayLabel(lease.propertyLabel, /^property$/i);
-  const unitRaw = workflowDisplayLabel(lease.unitLabel, /^unit$/i);
-  const unit = unitRaw ? (/^unit\b/i.test(unitRaw) ? unitRaw : `Unit ${unitRaw}`) : null;
-  if (property && unit) return `${property} · ${unit}`;
-  if (property) return property;
-  if (unit) return unit;
-  return "Property/unit unavailable";
-}
-
-function renewalProjectionTenantLabel(lease: LandlordLeaseRenewalLease) {
-  return workflowDisplayLabel(lease.tenantName, /^tenant$/i) || "Tenant name unavailable";
-}
-
-function renewalProjectionRentLabel(lease: LandlordLeaseRenewalLease) {
-  const requiresRent = lease.renewalRentChangeMode === "increase" || lease.renewalRentChangeMode === "decrease";
-  if (!requiresRent) return "No rent change currently proposed";
-  return formatRenewalCurrency(lease.renewalOfferedRent, lease.currency) || "Renewal rent not set";
-}
-
-function renewalProjectionTermLabel(lease: LandlordLeaseRenewalLease) {
-  const start = formatRenewalWorkflowDate(lease.renewalNewLeaseStartDate);
-  const end = lease.renewalNewLeaseEndDate ? formatRenewalWorkflowDate(lease.renewalNewLeaseEndDate) : "open-ended";
-  return `${start} to ${end}`;
-}
-
 function RenewalWorkflowStatusPanel({ lease }: { lease: LandlordLeaseRenewalLease }) {
   const readiness = getRenewalNoticeDraftReadiness(lease);
   const saved = hasSavedRenewalInputs(lease);
@@ -539,79 +499,214 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
 
 function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLease }) {
   const { propertyId, renewalLease, loadingRenewalInputs, renewalInputsError } = useRenewalLeaseProjection(lease);
+  const [copyStatus, setCopyStatus] = React.useState<"idle" | "success" | "error">("idle");
   const renewalPath = `/leases/${encodeURIComponent(lease.id)}/workflows/renewal`;
 
-  if (!propertyId) return null;
-  if (loadingRenewalInputs) return <div>Loading renewal notice draft context…</div>;
-  if (renewalInputsError) {
-    return <div style={{ color: "#b91c1c" }}>Renewal notice draft context could not be loaded.</div>;
+  async function copyDraft(draftText: string) {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(draftText);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = draftText;
+        textarea.setAttribute("readonly", "true");
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        const copied = document.execCommand("copy");
+        document.body.removeChild(textarea);
+        if (!copied) throw new Error("copy_failed");
+      }
+      setCopyStatus("success");
+    } catch {
+      setCopyStatus("error");
+    }
   }
-  if (!renewalLease || !hasSavedRenewalInputs(renewalLease)) return null;
+
+  function downloadDraft(draftText: string) {
+    const blob = new Blob([draftText], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `renewal-notice-review-${lease.id}.txt`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
+  if (!propertyId) {
+    return (
+      <section style={panelStyle} aria-label="Renewal notice review">
+        <ReviewWorkspaceHeader renewalPath={renewalPath} />
+        <div style={noticeStatusGridStyle}>
+          <NoticeStatus label="Draft readiness" value="Inputs needed" tone="warning" />
+          <NoticeStatus label="Email delivery" value="Deferred" tone="deferred" />
+          <NoticeStatus label="Evidence capture" value="Deferred" tone="deferred" />
+        </div>
+        <div style={warningPanelStyle}>
+          Renewal notice review cannot load source inputs until this lease is linked to a property.
+        </div>
+      </section>
+    );
+  }
+  if (loadingRenewalInputs) {
+    return (
+      <section style={panelStyle} aria-label="Renewal notice review">
+        <ReviewWorkspaceHeader renewalPath={renewalPath} />
+        <div>Loading renewal notice review…</div>
+      </section>
+    );
+  }
+  if (renewalInputsError) {
+    return (
+      <section style={panelStyle} aria-label="Renewal notice review">
+        <ReviewWorkspaceHeader renewalPath={renewalPath} />
+        <div style={{ color: "#b91c1c" }}>Renewal notice review could not be loaded.</div>
+      </section>
+    );
+  }
+  if (!renewalLease) {
+    return (
+      <section style={panelStyle} aria-label="Renewal notice review">
+        <ReviewWorkspaceHeader renewalPath={renewalPath} />
+        <div style={warningPanelStyle}>
+          Renewal inputs are not available yet. Return to the renewal workflow before reviewing notice preparation.
+        </div>
+      </section>
+    );
+  }
 
   const readiness = getRenewalNoticeDraftReadiness(renewalLease);
   const draftText = readiness.ready ? buildRenewalNoticeDraftText(renewalLease) : null;
+  const reviewModel = buildRenewalNoticeReviewModel(renewalLease);
+  const statusLabel = readiness.ready
+    ? "Draft ready"
+    : readiness.validationMessage
+      ? "Invalid renewal term dates"
+      : "Inputs needed";
 
   return (
-    <section style={panelStyle} aria-label="Renewal notice draft context">
-      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
-        <div style={{ display: "grid", gap: 4 }}>
-          <h2 style={sectionHeadingStyle}>Renewal notice draft context</h2>
-          <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
-            Renewal operator inputs are available for this lease. Review this context before preparing tenant-facing notice steps.
-          </div>
-        </div>
-        <Link to={renewalPath} style={buttonLinkStyle}>
-          Back to renewal workflow
-        </Link>
+    <section style={panelStyle} aria-label="Renewal notice review">
+      <ReviewWorkspaceHeader renewalPath={renewalPath} />
+
+      <div style={noticeStatusGridStyle}>
+        <NoticeStatus label="Draft readiness" value={statusLabel} tone={readiness.ready ? "ready" : "warning"} />
+        <NoticeStatus label="Email delivery" value="Deferred" tone="deferred" />
+        <NoticeStatus label="Evidence capture" value="Deferred" tone="deferred" />
+        <NoticeStatus label="Audit capture" value="Deferred" tone="deferred" />
       </div>
 
+      {!hasSavedRenewalInputs(renewalLease) ? (
+        <div style={warningPanelStyle}>
+          Save renewal operator inputs before reviewing tenant-facing notice preparation.
+        </div>
+      ) : null}
+
+      {readiness.validationMessage ? <div style={warningPanelStyle}>{readiness.validationMessage}</div> : null}
+      {!readiness.ready && readiness.missing.length > 0 ? (
+        <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>Missing: {readiness.missing.join(", ")}.</div>
+      ) : null}
+
       <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14, margin: 0 }}>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Tenant</dt>
-          <dd style={sourceValueStyle}>{renewalProjectionTenantLabel(renewalLease)}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Unit/property</dt>
-          <dd style={sourceValueStyle}>{renewalProjectionLocationLabel(renewalLease)}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Current rent</dt>
-          <dd style={sourceValueStyle}>{formatRenewalCurrency(renewalLease.currentRent, renewalLease.currency) || "Current rent unavailable"}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Renewal rent entered for review</dt>
-          <dd style={sourceValueStyle}>{renewalProjectionRentLabel(renewalLease)}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Current lease end</dt>
-          <dd style={sourceValueStyle}>{formatRenewalWorkflowDate(renewalLease.leaseEndDate)}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Proposed term</dt>
-          <dd style={sourceValueStyle}>{renewalProjectionTermLabel(renewalLease)}</dd>
-        </div>
-        <div style={{ display: "grid", gap: 4 }}>
-          <dt style={termStyle}>Tenant response target date</dt>
-          <dd style={sourceValueStyle}>{formatRenewalTargetDate(renewalLease.renewalDecisionDeadlineAt)}</dd>
-        </div>
+        <ReviewFact label="Tenant" value={reviewModel.tenantLabel} />
+        <ReviewFact label="Unit/property" value={reviewModel.propertyUnitLabel} />
+        <ReviewFact label="Current rent" value={reviewModel.currentRentLabel} />
+        <ReviewFact label="Renewal rent" value={reviewModel.renewalRentLabel} />
+        <ReviewFact label="Current lease end" value={reviewModel.currentLeaseEndLabel} />
+        <ReviewFact label="Proposed term" value={reviewModel.proposedTermLabel} />
+        <ReviewFact label="Tenant response target date" value={reviewModel.tenantResponseTargetDateLabel} />
       </dl>
 
       {draftText ? (
         <label style={{ display: "grid", gap: 6 }}>
-          <span style={termStyle}>Draft preview from renewal workflow</span>
+          <span style={termStyle}>Tenant notice draft preview</span>
           <textarea readOnly rows={7} value={draftText} style={draftPreviewStyle} />
         </label>
       ) : (
         <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
-          Renewal operator inputs are present, but the tenant notice draft still needs review in the renewal workflow before
-          tenant-facing notice steps are prepared.
+          The tenant notice draft is not ready yet. Return to the renewal workflow to complete or correct source inputs.
         </div>
       )}
 
       <div style={{ color: workflowTheme.subtle, lineHeight: 1.6 }}>
-        This is review context only. No notice record is created here, and email delivery remains deferred.
+        Renewal operator inputs are the source for this draft. Review official lease documents and current provincial
+        requirements before tenant communication. No notice record is created here, and email delivery remains deferred.
+      </div>
+
+      <div style={noticeActionGridStyle}>
+        {draftText ? (
+          <>
+            <button type="button" onClick={() => void copyDraft(draftText)} style={primaryButtonStyle}>
+              Copy draft text
+            </button>
+            <button type="button" onClick={() => downloadDraft(draftText)} style={buttonStyle}>
+              Download draft
+            </button>
+          </>
+        ) : null}
+        <Link to={renewalPath} style={buttonLinkStyle}>
+          Return to renewal inputs
+        </Link>
+        <Link to={reviewModel.leaseEvidencePath} style={buttonLinkStyle}>
+          Open lease evidence preview
+        </Link>
+        <Link to={reviewModel.leaseTimelinePath} style={buttonLinkStyle}>
+          Open lease review timeline
+        </Link>
+      </div>
+
+      {copyStatus === "success" ? <div style={successTextStyle}>Draft text copied.</div> : null}
+      {copyStatus === "error" ? <div style={warningTextStyle}>Draft text could not be copied. Select the preview text manually.</div> : null}
+
+      <div style={deferredPanelStyle}>
+        Draft persistence, audit capture, evidence package inclusion, notice record creation, and email delivery are deferred.
       </div>
     </section>
+  );
+}
+
+function ReviewWorkspaceHeader({ renewalPath }: { renewalPath: string }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+      <div style={{ display: "grid", gap: 4 }}>
+        <h2 style={sectionHeadingStyle}>Renewal notice review</h2>
+        <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
+          Review renewal notice preparation, source values, and safe handoff steps before any tenant communication.
+        </div>
+      </div>
+      <Link to={renewalPath} style={buttonLinkStyle}>
+        Back to renewal workflow
+      </Link>
+    </div>
+  );
+}
+
+function NoticeStatus({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: "ready" | "warning" | "deferred";
+}) {
+  const color = tone === "ready" ? "#166534" : tone === "warning" ? "#92400e" : workflowTheme.subtle;
+  return (
+    <div style={noticeStatusStyle}>
+      <div style={termStyle}>{label}</div>
+      <div style={{ ...sourceValueStyle, color }}>{value}</div>
+    </div>
+  );
+}
+
+function ReviewFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: "grid", gap: 4 }}>
+      <dt style={termStyle}>{label}</dt>
+      <dd style={sourceValueStyle}>{value}</dd>
+    </div>
   );
 }
 
@@ -751,6 +846,18 @@ const buttonLinkStyle: React.CSSProperties = {
   boxShadow: "0 6px 16px rgba(59, 44, 28, 0.08)",
 };
 
+const buttonStyle: React.CSSProperties = {
+  ...buttonLinkStyle,
+  cursor: "pointer",
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  ...buttonStyle,
+  border: `1px solid ${workflowTheme.pine}`,
+  background: workflowTheme.pine,
+  color: "#fff",
+};
+
 const workflowPageStyle: React.CSSProperties = {
   width: "100%",
   maxWidth: 1040,
@@ -811,6 +918,57 @@ const sourceValueStyle: React.CSSProperties = {
   color: workflowTheme.charcoal,
   fontWeight: 700,
   lineHeight: 1.35,
+};
+
+const noticeStatusGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+  gap: 10,
+};
+
+const noticeStatusStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 4,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 10,
+  background: workflowTheme.cardStrong,
+  padding: 10,
+};
+
+const noticeActionGridStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  alignItems: "center",
+};
+
+const warningPanelStyle: React.CSSProperties = {
+  color: "#92400e",
+  fontWeight: 700,
+  lineHeight: 1.55,
+  border: "1px solid rgba(146, 64, 14, 0.22)",
+  borderRadius: 10,
+  background: "rgba(254, 243, 199, 0.7)",
+  padding: 10,
+};
+
+const deferredPanelStyle: React.CSSProperties = {
+  color: workflowTheme.subtle,
+  lineHeight: 1.55,
+  border: `1px dashed ${workflowTheme.borderStrong}`,
+  borderRadius: 10,
+  background: "rgba(255, 250, 241, 0.65)",
+  padding: 10,
+};
+
+const successTextStyle: React.CSSProperties = {
+  color: "#166534",
+  fontWeight: 700,
+};
+
+const warningTextStyle: React.CSSProperties = {
+  color: "#92400e",
+  fontWeight: 700,
 };
 
 const draftPreviewStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

Implements Renewal Notice Review Workflow v1 for `/leases/:leaseId/workflows/notice` as a frontend-only review workspace.

## Audit findings

- Route/file ownership: `/leases/:leaseId/workflows/notice` is owned by `rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx` through the existing workflow route and `notice` workflow config.
- Renewal draft source ownership: tenant-facing draft copy/readiness logic lives in `rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx`; this PR extracts a shared review model from that component so renewal and notice review surfaces use the same labels, dates, routes, and source values.
- Data/source of truth: the workflow reads existing landlord active lease data and the existing landlord expiring lease renewal projection via `fetchExpiringLeaseRenewals({ propertyId })`. Saved renewal operator inputs remain the source for draft readiness and review values.
- Existing backend notice preview/send routes were not reused because v1 is review-only and must not create notice records, send email, trigger tenant notification, or persist evidence/audit records.

## Implementation

- Adds a `/notice` renewal notice review workspace with readiness statuses, source value facts, compact draft preview, copy/download actions, and links back to renewal inputs, lease evidence preview, and lease review timeline.
- Handles missing property, loading, fetch error, missing inputs, and invalid renewal term dates without generating draft-ready copy.
- Keeps draft persistence, audit capture, evidence package inclusion, notice record creation, and email delivery explicitly deferred.
- Adds tests for ready review state, inputs-needed state, invalid date blocking, and copy behavior without saving or sending.

## Route behavior

- `/leases/:leaseId/workflows/renewal` remains the source input and draft-preparation surface.
- `/leases/:leaseId/workflows/notice` now shows the notice review workspace using existing renewal inputs/projection data.
- Evidence preview link: `/evidence-packs?scope=lease&scopeId=<leaseId>`.
- Review timeline link: `/review-timeline?scope=lease&scopeId=<leaseId>`.

## Guardrails

- Frontend-only.
- No backend/API/auth/data model/write behavior changes.
- No notice creation, email delivery, tenant notification, audit capture, or evidence package persistence.
- No lease lifecycle state changes.
- No legal deadline engine, legal advice, compliance guarantee, delivery claim, or jurisdiction-specific legal claim.
- No tenant-facing route or signed-document behavior changes.

## Validation

- `npm run test -- LandlordLeaseWorkflowPage`
- `npm run test -- LandlordLeaseSummaryPage`
- `npm run test -- OperationalCommandCenterPage`
- `npm run test -- EvidencePackPage`
- `npm run test -- UnifiedInboxPage`
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` *(passes; Vite prints the existing Node 20.19+ advisory while building successfully under repo-required Node 20.11.1)*
- `git diff --check`
- `git diff --cached --check`

## QA status

Draft PR pending preview/live landlord QA and legal-copy review.