### PR TITLE
feat: add renewal tenant communication send review UI

### DIFF
--- a/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseRenewalNoticeDraftCard.tsx
@@ -418,10 +418,12 @@ export function RenewalNoticeDraftSnapshotCapture({
   lease,
   draftText,
   reviewModel,
+  onSnapshotSaved,
 }: {
   lease: LandlordLeaseRenewalLease;
   draftText: string;
   reviewModel: RenewalNoticeReviewModel;
+  onSnapshotSaved?: (snapshot: RenewalNoticeDraftSnapshot) => void;
 }) {
   const [saveState, setSaveState] = React.useState<SnapshotSaveState>({ status: "idle", snapshot: null, error: null });
 
@@ -433,6 +435,7 @@ export function RenewalNoticeDraftSnapshotCapture({
         buildRenewalNoticeDraftSnapshotPayload(draftText, reviewModel)
       );
       setSaveState({ status: "saved", snapshot: response.snapshot, error: null });
+      onSnapshotSaved?.(response.snapshot);
     } catch (err) {
       const message = err instanceof Error && err.message ? err.message : "Draft snapshot could not be saved.";
       setSaveState({ status: "error", snapshot: null, error: message });

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -290,6 +290,29 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByRole("button", { name: "Copy draft text" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download draft" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save draft snapshot" })).toBeInTheDocument();
+    const sendReview = screen.getByLabelText("Tenant communication send review");
+    expect(sendReview).toHaveTextContent("Recipient preview");
+    expect(sendReview).toHaveTextContent("Jane Tenant");
+    expect(sendReview).toHaveTextContent("jane@example.com");
+    expect(sendReview).toHaveTextContent("Message preview");
+    expect(sendReview).toHaveTextContent("Renewal details for 12 Harbour Road · Unit 101");
+    expect(sendReview).toHaveTextContent("Prepared from current renewal draft");
+    expect((screen.getByLabelText("Tenant communication body preview") as HTMLTextAreaElement).value).toContain(
+      "Hello Jane Tenant,"
+    );
+    expect(sendReview).toHaveTextContent("Renewal operator inputs saved");
+    expect(sendReview).toHaveTextContent("Draft snapshot saved");
+    expect(sendReview).toHaveTextContent("Tenant recipient reviewed");
+    expect(sendReview).toHaveTextContent("Delivery status model required before live send");
+    expect(sendReview).toHaveTextContent("Email delivery");
+    expect(sendReview).toHaveTextContent("Not enabled");
+    expect(sendReview).toHaveTextContent("Tenant notification");
+    expect(sendReview).toHaveTextContent("Not sent");
+    expect(sendReview).toHaveTextContent("Notice service");
+    expect(sendReview).toHaveTextContent("Not established");
+    expect(sendReview).toHaveTextContent("Legal compliance");
+    expect(sendReview).toHaveTextContent("Not determined by this workflow");
+    expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/evidence saved|notice has been served|email sent/i);
@@ -355,6 +378,10 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Save draft snapshot" })).not.toBeInTheDocument();
+    const sendReview = screen.getByLabelText("Tenant communication send review");
+    expect(sendReview).toHaveTextContent("Draft unavailable");
+    expect(sendReview).toHaveTextContent("Draft body unavailable. Complete renewal inputs before future tenant communication review.");
+    expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
     expect(screen.getByRole("link", { name: "Return to renewal inputs" })).toHaveAttribute(
       "href",
       "/leases/lease-1/workflows/renewal"
@@ -410,7 +437,53 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.queryByRole("button", { name: "Copy draft text" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Download draft" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Save draft snapshot" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Tenant communication send review")).toHaveTextContent("Draft unavailable");
     expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
+  });
+
+  it("shows tenant communication send review with missing recipient email but no send behavior", async () => {
+    mocks.getLeaseById.mockResolvedValueOnce({
+      lease: {
+        id: "lease-missing-email",
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        propertyName: "Harbour View",
+        unitNumber: "101",
+        monthlyRent: 1850,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        status: "active",
+        tenantName: "Jane Tenant",
+        tenantEmail: null,
+        leaseExecution: null,
+        paymentReadiness: null,
+        leaseLifecycleSummary: {
+          lifecycleStatus: "expiring_soon",
+          lifecycleLabel: "Expiring soon",
+          lifecycleDescription: "This lease is approaching notice timing.",
+          requiredNextAction: "prepare_renewal_notice",
+          renewalOutcome: "not_started",
+          daysUntilExpiry: 30,
+          history: [],
+        },
+        jurisdictionPolicies: [],
+      },
+    });
+
+    renderWorkflow("/leases/lease-missing-email/workflows/notice");
+
+    const sendReview = await screen.findByLabelText("Tenant communication send review");
+    await waitFor(() => {
+      expect(sendReview).toHaveTextContent("Tenant email unavailable");
+    });
+    expect(sendReview).toHaveTextContent("Jane Tenant");
+    expect(sendReview).toHaveTextContent("Tenant recipient reviewed");
+    expect(sendReview).toHaveTextContent("Needs review");
+    const sendButton = screen.getByRole("button", { name: "Send tenant communication - not enabled yet" });
+    expect(sendButton).toBeDisabled();
+    fireEvent.click(sendButton);
+    expect(mocks.saveRenewalNoticeDraftSnapshot).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent(/email sent|notice served|legally compliant|tenant legally notified/i);
   });
 
   it("copies the notice review draft without sending or creating notice records", async () => {
@@ -462,6 +535,9 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText("Draft snapshot persistence")).toHaveTextContent("Draft snapshot saved");
     expect(screen.getByLabelText("Draft snapshot persistence")).toHaveTextContent("manager@example.com");
     expect(screen.getByLabelText("Draft snapshot persistence")).toHaveTextContent("Not sent · Not served · Tenant not notified");
+    const sendReview = screen.getByLabelText("Tenant communication send review");
+    expect(sendReview).toHaveTextContent("Prepared from saved renewal notice draft snapshot");
+    expect(sendReview).toHaveTextContent("Draft snapshot captured");
     expect(mocks.saveLeaseRenewalInputs).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/evidence saved|notice has been served|email sent/i);

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -754,7 +754,7 @@ function TenantCommunicationSendReview({
       </div>
 
       <div style={sendReviewGridStyle}>
-        <div style={sendReviewBlockStyle} aria-label="Recipient preview">
+        <div style={sendRecipientPreviewStyle} aria-label="Recipient preview">
           <div style={sendReviewSubheadingStyle}>Recipient preview</div>
           <dl style={{ display: "grid", gap: 8, margin: 0 }}>
             <ReviewFact label="Tenant" value={tenantName} />
@@ -767,7 +767,7 @@ function TenantCommunicationSendReview({
           </div>
         </div>
 
-        <div style={sendReviewBlockStyle} aria-label="Message preview">
+        <div style={sendMessagePreviewStyle} aria-label="Message preview">
           <div style={sendReviewSubheadingStyle}>Message preview</div>
           <dl style={{ display: "grid", gap: 8, margin: 0 }}>
             <ReviewFact label="Subject" value={subject} />
@@ -1134,18 +1134,32 @@ const sendReviewSubheadingStyle: React.CSSProperties = {
 };
 
 const sendReviewGridStyle: React.CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "stretch",
   gap: 12,
 };
 
 const sendReviewBlockStyle: React.CSSProperties = {
   display: "grid",
   gap: 10,
+  boxSizing: "border-box",
   border: `1px solid ${workflowTheme.border}`,
   borderRadius: 10,
   background: workflowTheme.card,
   padding: 12,
+};
+
+const sendRecipientPreviewStyle: React.CSSProperties = {
+  ...sendReviewBlockStyle,
+  flex: "1 1 220px",
+  minWidth: 220,
+};
+
+const sendMessagePreviewStyle: React.CSSProperties = {
+  ...sendReviewBlockStyle,
+  flex: "2 1 520px",
+  minWidth: "min(100%, 420px)",
 };
 
 const sendChecklistStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -4,6 +4,7 @@ import { getLeaseById, type JurisdictionPolicyGuidance, type LandlordActiveLease
 import {
   fetchExpiringLeaseRenewals,
   type LandlordLeaseRenewalLease,
+  type RenewalNoticeDraftSnapshot,
 } from "@/api/landlordLeaseRenewalApi";
 import {
   hasSavedRenewalInputs,
@@ -197,6 +198,15 @@ function prettyValue(value: string | null | undefined) {
 function propertyLabel(lease: LandlordActiveLease) {
   const property = lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property";
   return lease.unitNumber ? `${property} · Unit ${lease.unitNumber}` : property;
+}
+
+function tenantEmailLabel(lease: LandlordActiveLease) {
+  const email = String(lease.tenantEmail || "").trim();
+  return email || "Tenant email unavailable";
+}
+
+function hasTenantEmail(lease: LandlordActiveLease) {
+  return Boolean(String(lease.tenantEmail || "").trim());
 }
 
 function daysUntilDate(value: string | null | undefined) {
@@ -501,6 +511,7 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
 function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLease }) {
   const { propertyId, renewalLease, loadingRenewalInputs, renewalInputsError } = useRenewalLeaseProjection(lease);
   const [copyStatus, setCopyStatus] = React.useState<"idle" | "success" | "error">("idle");
+  const [savedDraftSnapshot, setSavedDraftSnapshot] = React.useState<RenewalNoticeDraftSnapshot | null>(null);
   const renewalPath = `/leases/${encodeURIComponent(lease.id)}/workflows/renewal`;
 
   async function copyDraft(draftText: string) {
@@ -549,6 +560,13 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
         <div style={warningPanelStyle}>
           Renewal notice review cannot load source inputs until this lease is linked to a property.
         </div>
+        <TenantCommunicationSendReview
+          lease={lease}
+          reviewModel={null}
+          draftText={null}
+          readinessReady={false}
+          savedSnapshot={null}
+        />
       </section>
     );
   }
@@ -575,6 +593,13 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
         <div style={warningPanelStyle}>
           Renewal inputs are not available yet. Return to the renewal workflow before reviewing notice preparation.
         </div>
+        <TenantCommunicationSendReview
+          lease={lease}
+          reviewModel={null}
+          draftText={null}
+          readinessReady={false}
+          savedSnapshot={null}
+        />
       </section>
     );
   }
@@ -637,8 +662,21 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
       </div>
 
       {draftText ? (
-        <RenewalNoticeDraftSnapshotCapture lease={renewalLease} draftText={draftText} reviewModel={reviewModel} />
+        <RenewalNoticeDraftSnapshotCapture
+          lease={renewalLease}
+          draftText={draftText}
+          reviewModel={reviewModel}
+          onSnapshotSaved={setSavedDraftSnapshot}
+        />
       ) : null}
+
+      <TenantCommunicationSendReview
+        lease={lease}
+        reviewModel={reviewModel}
+        draftText={draftText}
+        readinessReady={readiness.ready}
+        savedSnapshot={savedDraftSnapshot}
+      />
 
       <div style={noticeActionGridStyle}>
         {draftText ? (
@@ -674,6 +712,133 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
       </div>
     </section>
   );
+}
+
+function TenantCommunicationSendReview({
+  lease,
+  reviewModel,
+  draftText,
+  readinessReady,
+  savedSnapshot,
+}: {
+  lease: LandlordActiveLease;
+  reviewModel: ReturnType<typeof buildRenewalNoticeReviewModel> | null;
+  draftText: string | null;
+  readinessReady: boolean;
+  savedSnapshot: RenewalNoticeDraftSnapshot | null;
+}) {
+  const tenantName = reviewModel?.tenantLabel || workflowDisplayLabel(lease.tenantName, /^tenant$/i) || "Tenant name unavailable";
+  const recipientEmail = tenantEmailLabel(lease);
+  const recipientReady = hasTenantEmail(lease);
+  const draftAvailable = Boolean(readinessReady && draftText);
+  const subject = reviewModel?.propertyUnitLabel
+    ? `Renewal details for ${reviewModel.propertyUnitLabel}`
+    : "Renewal details for review";
+  const sourceLabel = savedSnapshot
+    ? "Prepared from saved renewal notice draft snapshot"
+    : draftAvailable
+      ? "Prepared from current renewal draft"
+      : "Draft unavailable";
+  const hasMultipleTenants = Array.isArray(lease.tenantIds) && lease.tenantIds.length > 1;
+
+  return (
+    <section style={sendReviewStyle} aria-label="Tenant communication send review">
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <h3 style={sendReviewHeadingStyle}>Tenant communication send review</h3>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
+            Review the future send model without sending email, notifying the tenant, or creating a notice record.
+          </div>
+        </div>
+        <span style={deferredBadgeStyle}>Send disabled</span>
+      </div>
+
+      <div style={sendReviewGridStyle}>
+        <div style={sendReviewBlockStyle} aria-label="Recipient preview">
+          <div style={sendReviewSubheadingStyle}>Recipient preview</div>
+          <dl style={{ display: "grid", gap: 8, margin: 0 }}>
+            <ReviewFact label="Tenant" value={tenantName} />
+            <ReviewFact label="Email" value={recipientEmail} />
+          </dl>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+            {hasMultipleTenants
+              ? "V1 is using the available tenant contact only. Multi-recipient review remains deferred."
+              : "V1 reviews the available tenant contact only."}
+          </div>
+        </div>
+
+        <div style={sendReviewBlockStyle} aria-label="Message preview">
+          <div style={sendReviewSubheadingStyle}>Message preview</div>
+          <dl style={{ display: "grid", gap: 8, margin: 0 }}>
+            <ReviewFact label="Subject" value={subject} />
+            <ReviewFact label="Source" value={sourceLabel} />
+          </dl>
+          {draftText ? (
+            <textarea
+              readOnly
+              rows={6}
+              value={draftText}
+              aria-label="Tenant communication body preview"
+              style={sendBodyPreviewStyle}
+            />
+          ) : (
+            <div style={warningPanelStyle}>Draft body unavailable. Complete renewal inputs before future tenant communication review.</div>
+          )}
+          <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
+            The exact message body must be reviewed and persisted before any future send.
+          </div>
+        </div>
+      </div>
+
+      <div style={sendChecklistStyle} aria-label="Send-readiness checklist">
+        <SendChecklistItem label="Renewal operator inputs saved" status={readinessReady ? "Ready" : "Needs review"} />
+        <SendChecklistItem label="Draft snapshot saved" status={savedSnapshot ? "Ready" : "Needs review"} />
+        <SendChecklistItem label="Tenant recipient reviewed" status={recipientReady ? "Ready" : "Needs review"} />
+        <SendChecklistItem label="Draft body reviewed" status={draftAvailable ? "Needs review" : "Deferred"} />
+        <SendChecklistItem label="Evidence/audit capture available" status={savedSnapshot ? "Ready" : "Needs review"} />
+        <SendChecklistItem label="Delivery status model required before live send" status="Deferred" />
+        <SendChecklistItem label="Legal-service separation acknowledged" status="Deferred" />
+      </div>
+
+      <fieldset disabled style={confirmationPreviewStyle} aria-label="Confirmation model preview">
+        <legend style={sendReviewSubheadingStyle}>Confirmation required before future send</legend>
+        <label style={checkboxLabelStyle}>
+          <input type="checkbox" /> I have reviewed the recipient(s).
+        </label>
+        <label style={checkboxLabelStyle}>
+          <input type="checkbox" /> I have reviewed the message body.
+        </label>
+        <label style={checkboxLabelStyle}>
+          <input type="checkbox" /> I understand this would send tenant communication only.
+        </label>
+        <label style={checkboxLabelStyle}>
+          <input type="checkbox" /> I understand this does not establish legal notice service by itself.
+        </label>
+      </fieldset>
+
+      <div style={noticeStatusGridStyle} aria-label="Delivery and legal status">
+        <NoticeStatus label="Email delivery" value="Not enabled" tone="deferred" />
+        <NoticeStatus label="Tenant notification" value="Not sent" tone="deferred" />
+        <NoticeStatus label="Notice service" value="Not established" tone="deferred" />
+        <NoticeStatus label="Legal compliance" value="Not determined by this workflow" tone="deferred" />
+        <NoticeStatus label="Audit/evidence" value={savedSnapshot ? "Draft snapshot captured" : "Captured when snapshot is saved"} tone={savedSnapshot ? "ready" : "deferred"} />
+      </div>
+
+      <button type="button" disabled style={sendDisabledButtonStyle}>
+        Send tenant communication - not enabled yet
+      </button>
+
+      <div style={deferredPanelStyle}>
+        Email delivery is not enabled in this workflow yet. Future send will require recipient confirmation, exact body
+        persistence, delivery status, audit capture, and legal-service separation.
+      </div>
+    </section>
+  );
+}
+
+function SendChecklistItem({ label, status }: { label: string; status: "Ready" | "Needs review" | "Deferred" }) {
+  const tone = status === "Ready" ? "ready" : status === "Needs review" ? "warning" : "deferred";
+  return <NoticeStatus label={label} value={status} tone={tone} />;
 }
 
 function ReviewWorkspaceHeader({ renewalPath }: { renewalPath: string }) {
@@ -942,6 +1107,104 @@ const noticeStatusStyle: React.CSSProperties = {
   borderRadius: 10,
   background: workflowTheme.cardStrong,
   padding: 10,
+};
+
+const sendReviewStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 12,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 12,
+  background: workflowTheme.cardStrong,
+  padding: 14,
+};
+
+const sendReviewHeadingStyle: React.CSSProperties = {
+  margin: 0,
+  color: workflowTheme.charcoal,
+  fontSize: 17,
+  letterSpacing: 0,
+};
+
+const sendReviewSubheadingStyle: React.CSSProperties = {
+  color: workflowTheme.charcoal,
+  fontSize: 14,
+  fontWeight: 900,
+  margin: 0,
+  letterSpacing: 0,
+};
+
+const sendReviewGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+  gap: 12,
+};
+
+const sendReviewBlockStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 10,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 10,
+  background: workflowTheme.card,
+  padding: 12,
+};
+
+const sendChecklistStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+  gap: 10,
+};
+
+const confirmationPreviewStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 8,
+  margin: 0,
+  border: `1px dashed ${workflowTheme.borderStrong}`,
+  borderRadius: 10,
+  background: "rgba(255, 250, 241, 0.72)",
+  padding: 12,
+  color: workflowTheme.muted,
+};
+
+const checkboxLabelStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  lineHeight: 1.45,
+  fontWeight: 700,
+};
+
+const sendBodyPreviewStyle: React.CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  resize: "vertical",
+  border: `1px solid ${workflowTheme.borderStrong}`,
+  borderRadius: 10,
+  padding: 10,
+  color: workflowTheme.charcoal,
+  background: "#fff",
+  lineHeight: 1.55,
+  minHeight: 130,
+};
+
+const deferredBadgeStyle: React.CSSProperties = {
+  border: `1px solid ${workflowTheme.borderStrong}`,
+  borderRadius: 999,
+  background: "rgba(91, 70, 48, 0.08)",
+  color: workflowTheme.subtle,
+  fontSize: 12,
+  fontWeight: 900,
+  padding: "5px 10px",
+  whiteSpace: "nowrap",
+};
+
+const sendDisabledButtonStyle: React.CSSProperties = {
+  ...buttonStyle,
+  width: "fit-content",
+  border: `1px solid ${workflowTheme.borderStrong}`,
+  background: "rgba(91, 70, 48, 0.12)",
+  color: workflowTheme.subtle,
+  cursor: "not-allowed",
+  boxShadow: "none",
 };
 
 const noticeActionGridStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- Adds a compact tenant communication send review section to /leases/:leaseId/workflows/notice.
- Shows recipient preview, subject/body preview, send-readiness checklist, disabled confirmation model, disabled send action, and delivery/legal separation status.
- Keeps draft snapshot save/copy/download behavior intact and updates the send review source after a snapshot save.

## Scope
- Frontend-only.
- No live send behavior.
- No tenant notification.
- No legacy send-notice wiring.
- No backend endpoint or send API client.
- No lease lifecycle mutation.
- No evidence/audit mutation beyond existing draft snapshot save behavior.

## Validation
- npm run test -- LandlordLeaseWorkflowPage
- npm run test -- LandlordLeaseSummaryPage
- npm run test -- OperationalCommandCenterPage
- npm run test -- EvidencePackPage
- npm run build (Node 20.11.1; Vite emitted its Node 20.19+ recommendation but build completed)
- git diff --check
- git diff --cached --check

## Browser QA
- Not run locally in this turn. PR should remain draft pending preview/live landlord QA and legal-copy review per mission.