### PR TITLE
Implement renewal communication send approval decision v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
@@ -245,12 +245,14 @@ describe("landlordDecisionQueueRoutes", () => {
         expect.objectContaining({
           landlordId: "landlord-1",
           sourceType: "decision_inbox",
+          persistence: "derived",
           workspace: "payments",
           severity: "warning",
         }),
         expect.objectContaining({
           landlordId: "landlord-1",
           sourceType: "message_unread_priority",
+          persistence: "derived",
           workspace: "tenant",
           severity: "warning",
         }),
@@ -295,6 +297,7 @@ describe("landlordDecisionQueueRoutes", () => {
     expect(res.body.items).toEqual([
       expect.objectContaining({
         id: "persisted-message-review",
+        persistence: "persisted",
         sourceType: "message_unread_priority",
         sourceId: "tenant-message-1",
         status: "deferred",
@@ -316,6 +319,7 @@ describe("landlordDecisionQueueRoutes", () => {
       url: "/decision-queue/items",
       body: {
         sourceType: "renewal_notice_send_review",
+        persistence: "persisted",
         sourceId: "lease-1:notice-review",
         workspace: "notices",
         severity: "needs_review",
@@ -347,6 +351,7 @@ describe("landlordDecisionQueueRoutes", () => {
       expect.objectContaining({
         landlordId: "landlord-1",
         sourceType: "renewal_notice_send_review",
+        persistence: "persisted",
         auditEventIds: ["canonical-event-1"],
       })
     );
@@ -414,6 +419,7 @@ describe("landlordDecisionQueueRoutes", () => {
       ok: true,
       item: expect.objectContaining({
         id: "existing-send-approval",
+        persistence: "persisted",
         sourceType: "renewal_notice_send_review",
         sourceId: "lease:lease-1:renewal_notice_send_review",
         auditEventIds: ["existing-audit-event"],
@@ -656,6 +662,7 @@ describe("landlordDecisionQueueRoutes", () => {
     expect(res.body.items).toEqual([
       expect.objectContaining({
         id: "send-approval-lease-1",
+        persistence: "persisted",
         sourceId: "lease:lease-1:renewal_notice_send_review",
         sourceRoute: "/leases/lease-1/workflows/notice",
       }),

--- a/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
@@ -369,6 +369,61 @@ describe("landlordDecisionQueueRoutes", () => {
     );
   });
 
+  it("reuses an existing source-matched approval decision instead of creating a duplicate", async () => {
+    seedDoc("landlordDecisionQueueItems", "existing-send-approval", {
+      id: "existing-send-approval",
+      landlordId: "landlord-1",
+      sourceType: "renewal_notice_send_review",
+      sourceId: "lease:lease-1:renewal_notice_send_review",
+      sourceRoute: "/leases/lease-1/workflows/notice",
+      workspace: "notices",
+      severity: "warning",
+      title: "Renewal tenant communication ready for approval",
+      description: "Saved renewal notice draft is ready for send approval review.",
+      recommendedActionLabel: "Open notice review",
+      recommendedActionHref: "/leases/lease-1/workflows/notice",
+      dueAt: null,
+      createdAt: "2026-07-10T00:00:00.000Z",
+      updatedAt: "2026-07-10T00:00:00.000Z",
+      status: "open",
+      leaseId: "lease-1",
+      dedupeKey: "lease:lease-1:renewal_notice_send_review",
+      auditEventIds: ["existing-audit-event"],
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/decision-queue/items",
+      body: {
+        sourceType: "renewal_notice_send_review",
+        sourceId: "lease:lease-1:renewal_notice_send_review",
+        sourceRoute: "/leases/lease-1/workflows/notice",
+        workspace: "notices",
+        severity: "warning",
+        title: "Renewal tenant communication ready for approval",
+        description: "Saved renewal notice draft is ready for send approval review.",
+        recommendedActionLabel: "Open notice review",
+        recommendedActionHref: "/leases/lease-1/workflows/notice",
+        leaseId: "lease-1",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      item: expect.objectContaining({
+        id: "existing-send-approval",
+        sourceType: "renewal_notice_send_review",
+        sourceId: "lease:lease-1:renewal_notice_send_review",
+        auditEventIds: ["existing-audit-event"],
+      }),
+      auditEventId: null,
+      created: false,
+    });
+    expect(writeCanonicalEventMock).not.toHaveBeenCalled();
+  });
+
   it("updates lifecycle status and assignment without creating send or notice behavior", async () => {
     seedDoc("landlordDecisionQueueItems", "decision-item-1", {
       id: "decision-item-1",
@@ -525,6 +580,9 @@ describe("landlordDecisionQueueRoutes", () => {
       severity: "warning",
       workspace: "tenant",
       status: null,
+      sourceType: null,
+      sourceId: null,
+      sourceRoute: null,
     });
     expect(res.body.total).toBe(1);
     expect(res.body.limit).toBe(1);
@@ -533,6 +591,73 @@ describe("landlordDecisionQueueRoutes", () => {
         sourceId: "message-1",
         sourceType: "message_unread_priority",
         sortKey: expect.any(String),
+      }),
+    ]);
+  });
+
+  it("filters persisted decision queue items by source context", async () => {
+    seedDoc("landlordDecisionQueueItems", "send-approval-lease-1", {
+      id: "send-approval-lease-1",
+      landlordId: "landlord-1",
+      sourceType: "renewal_notice_send_review",
+      sourceId: "lease:lease-1:renewal_notice_send_review",
+      sourceRoute: "/leases/lease-1/workflows/notice",
+      workspace: "notices",
+      severity: "warning",
+      title: "Renewal tenant communication ready for approval",
+      description: "Saved renewal notice draft is ready for send approval review.",
+      recommendedActionLabel: "Open notice review",
+      recommendedActionHref: "/leases/lease-1/workflows/notice",
+      dueAt: null,
+      createdAt: "2026-07-10T00:00:00.000Z",
+      updatedAt: "2026-07-10T00:00:00.000Z",
+      status: "open",
+      leaseId: "lease-1",
+      dedupeKey: "lease:lease-1:renewal_notice_send_review",
+      auditEventIds: [],
+    });
+    seedDoc("landlordDecisionQueueItems", "send-approval-lease-2", {
+      id: "send-approval-lease-2",
+      landlordId: "landlord-1",
+      sourceType: "renewal_notice_send_review",
+      sourceId: "lease:lease-2:renewal_notice_send_review",
+      sourceRoute: "/leases/lease-2/workflows/notice",
+      workspace: "notices",
+      severity: "warning",
+      title: "Other renewal tenant communication ready for approval",
+      description: "Saved renewal notice draft is ready for send approval review.",
+      recommendedActionLabel: "Open notice review",
+      recommendedActionHref: "/leases/lease-2/workflows/notice",
+      dueAt: null,
+      createdAt: "2026-07-10T00:00:00.000Z",
+      updatedAt: "2026-07-10T00:00:00.000Z",
+      status: "open",
+      leaseId: "lease-2",
+      dedupeKey: "lease:lease-2:renewal_notice_send_review",
+      auditEventIds: [],
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url:
+        "/decision-queue?sourceType=renewal_notice_send_review&sourceId=lease%3Alease-1%3Arenewal_notice_send_review&sourceRoute=%2Fleases%2Flease-1%2Fworkflows%2Fnotice",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.filters).toEqual({
+      severity: null,
+      workspace: null,
+      status: null,
+      sourceType: "renewal_notice_send_review",
+      sourceId: "lease:lease-1:renewal_notice_send_review",
+      sourceRoute: "/leases/lease-1/workflows/notice",
+    });
+    expect(res.body.items).toEqual([
+      expect.objectContaining({
+        id: "send-approval-lease-1",
+        sourceId: "lease:lease-1:renewal_notice_send_review",
+        sourceRoute: "/leases/lease-1/workflows/notice",
       }),
     ]);
   });
@@ -550,6 +675,9 @@ describe("landlordDecisionQueueRoutes", () => {
       severity: null,
       workspace: null,
       status: null,
+      sourceType: null,
+      sourceId: null,
+      sourceRoute: null,
     });
     expect(res.body.limit).toBe(50);
     expect(res.body.items.length).toBeGreaterThan(0);

--- a/rentchain-api/src/routes/landlordDecisionQueueRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionQueueRoutes.ts
@@ -10,6 +10,7 @@ import {
   applyLandlordDecisionQueueLifecycleOverlay,
   createLandlordDecisionQueueItem,
   deriveLandlordDecisionQueue,
+  findPersistedLandlordDecisionQueueItemBySource,
   LandlordDecisionQueueLifecycleError,
   loadPersistedLandlordDecisionQueueItems,
   summarizeLandlordDecisionQueueItems,
@@ -205,6 +206,9 @@ function applyFilters(
     severity: LandlordDecisionQueueSeverity | null;
     workspace: LandlordDecisionQueueWorkspace | null;
     status: LandlordDecisionQueueStatus | "open_state" | null;
+    sourceType: LandlordDecisionQueueSourceType | null;
+    sourceId: string | null;
+    sourceRoute: string | null;
   }
 ) {
   return items.filter((item) => {
@@ -212,6 +216,9 @@ function applyFilters(
     if (filters.workspace && item.workspace !== filters.workspace) return false;
     if (filters.status === "open_state" && (item.status === "resolved" || item.status === "dismissed")) return false;
     if (filters.status && filters.status !== "open_state" && item.status !== filters.status) return false;
+    if (filters.sourceType && item.sourceType !== filters.sourceType) return false;
+    if (filters.sourceId && item.sourceId !== filters.sourceId) return false;
+    if (filters.sourceRoute && item.sourceRoute !== filters.sourceRoute) return false;
     return true;
   });
 }
@@ -249,14 +256,20 @@ router.get("/decision-queue", requireAuth, requireLandlord, async (req: any, res
     const summary = summarizeLandlordDecisionQueueItems(queueItems);
 
     const statusRaw = asString(req.query?.status ?? req.query?.open, 80).toLowerCase();
-    const status =
+    const status: LandlordDecisionQueueStatus | "open_state" | null =
       statusRaw === "true" || statusRaw === "open_state"
         ? "open_state"
         : normalizeFilter(req.query?.status, STATUSES);
-    const filteredItems = applyFilters(queueItems, {
+    const filters = {
       severity: normalizeFilter(req.query?.severity, SEVERITIES),
       workspace: normalizeFilter(req.query?.workspace, WORKSPACES),
       status,
+      sourceType: normalizeFilter(req.query?.sourceType, SOURCE_TYPES),
+      sourceId: asString(req.query?.sourceId, 300) || null,
+      sourceRoute: asString(req.query?.sourceRoute, 700) || null,
+    };
+    const filteredItems = applyFilters(queueItems, {
+      ...filters,
     });
     const limit = parseLimit(req.query?.limit);
     const items = filteredItems.slice(0, limit);
@@ -269,9 +282,7 @@ router.get("/decision-queue", requireAuth, requireLandlord, async (req: any, res
       total: filteredItems.length,
       limit,
       filters: {
-        severity: normalizeFilter(req.query?.severity, SEVERITIES),
-        workspace: normalizeFilter(req.query?.workspace, WORKSPACES),
-        status,
+        ...filters,
       },
     });
   } catch (err: any) {
@@ -288,12 +299,24 @@ router.post("/decision-queue/items", requireAuth, requireLandlord, async (req: a
     }
     const body = bodyObject(req);
     const assignment = assignmentFromBody(body);
+    const sourceType = normalizeFilter(body.sourceType, SOURCE_TYPES) as LandlordDecisionQueueSourceType | null;
+    const sourceId = asString(body.sourceId, 300);
+    if (sourceType && sourceId) {
+      const existing = await findPersistedLandlordDecisionQueueItemBySource({
+        landlordId,
+        sourceType,
+        sourceId,
+      });
+      if (existing) {
+        return res.status(200).json({ ok: true, item: existing, auditEventId: null, created: false });
+      }
+    }
     const item = await createLandlordDecisionQueueItem({
       landlordId,
       actorId: actorId(req),
       actorEmail: actorEmail(req),
-      sourceType: normalizeFilter(body.sourceType, SOURCE_TYPES) as any,
-      sourceId: asString(body.sourceId, 300),
+      sourceType: sourceType as any,
+      sourceId,
       sourceRoute: asString(body.sourceRoute, 700) || null,
       workspace: normalizeFilter(body.workspace, WORKSPACES) as any,
       severity: normalizeFilter(body.severity, SEVERITIES) as any,
@@ -323,7 +346,7 @@ router.post("/decision-queue/items", requireAuth, requireLandlord, async (req: a
     const auditedItem = auditEventId
       ? await appendLandlordDecisionQueueAuditEventId(landlordId, item.id, auditEventId)
       : item;
-    return res.status(201).json({ ok: true, item: auditedItem || item, auditEventId });
+    return res.status(201).json({ ok: true, item: auditedItem || item, auditEventId, created: true });
   } catch (err: any) {
     if (err instanceof LandlordDecisionQueueLifecycleError) {
       return res.status(err.statusCode).json({ ok: false, error: err.code });

--- a/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueLifecycleService.ts
+++ b/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueLifecycleService.ts
@@ -291,6 +291,29 @@ export async function loadPersistedLandlordDecisionQueueItems(landlordId: string
   );
 }
 
+export async function findPersistedLandlordDecisionQueueItemBySource(params: {
+  landlordId: string;
+  sourceType: LandlordDecisionQueueSourceType;
+  sourceId: string;
+}): Promise<LandlordDecisionQueueItem | null> {
+  const landlordId = asString(params.landlordId, 240);
+  const sourceType = requireKnown(params.sourceType, SOURCE_TYPES, "source_type");
+  const sourceId = asString(params.sourceId, 300);
+  if (!landlordId || !sourceId) return null;
+  const snapshot = await db
+    .collection(LANDLORD_DECISION_QUEUE_ITEMS_COLLECTION)
+    .where("landlordId", "==", landlordId)
+    .where("sourceType", "==", sourceType)
+    .where("sourceId", "==", sourceId)
+    .get();
+  const items = sortLandlordDecisionQueueItems(
+    (snapshot.docs || [])
+      .map((doc: any) => normalizePersistedItem(doc.id, doc.data?.()))
+      .filter((item: LandlordDecisionQueueItem | null): item is LandlordDecisionQueueItem => Boolean(item))
+  );
+  return items[0] || null;
+}
+
 function overlayLifecycleFields(
   derived: LandlordDecisionQueueItem,
   persisted: LandlordDecisionQueueItem

--- a/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueLifecycleService.ts
+++ b/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueLifecycleService.ts
@@ -211,6 +211,7 @@ function normalizePersistedItem(id: string, raw: Record<string, unknown> | undef
     return buildLandlordDecisionQueueItem({
       id: asString(raw.id, 300) || id,
       landlordId,
+      persistence: "persisted",
       sourceType,
       sourceId,
       sourceRoute: asString(raw.sourceRoute, 700) || null,
@@ -246,6 +247,7 @@ function itemToDocument(item: LandlordDecisionQueueItem): Record<string, unknown
   return {
     id: item.id,
     landlordId: item.landlordId,
+    persistence: item.persistence || "persisted",
     sourceType: item.sourceType,
     sourceId: item.sourceId,
     sourceRoute: item.sourceRoute || null,
@@ -321,6 +323,7 @@ function overlayLifecycleFields(
   return buildLandlordDecisionQueueItem({
     ...derived,
     id: persisted.id,
+    persistence: "persisted",
     status: persisted.status,
     dueAt: persisted.dueAt || derived.dueAt,
     updatedAt: persisted.updatedAt || derived.updatedAt,
@@ -399,6 +402,7 @@ export async function createLandlordDecisionQueueItem(
   const item = buildLandlordDecisionQueueItem({
     id,
     landlordId,
+    persistence: "persisted",
     sourceType,
     sourceId,
     sourceRoute: asString(input.sourceRoute, 700) || null,

--- a/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueService.ts
+++ b/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueService.ts
@@ -170,6 +170,7 @@ export function buildLandlordDecisionQueueItem(input: Omit<LandlordDecisionQueue
   const dueOrDate = input.dueAt || input.updatedAt || input.createdAt || "";
   return {
     ...input,
+    persistence: input.persistence || "derived",
     priorityRank: rank,
     sortKey: [String(rank).padStart(2, "0"), dueOrDate || "9999-12-31T23:59:59.999Z", input.id].join("|"),
   };

--- a/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueTypes.ts
+++ b/rentchain-api/src/services/landlordDecisionQueue/landlordDecisionQueueTypes.ts
@@ -67,6 +67,7 @@ export type LandlordDecisionQueueRelatedRefs = {
 export type LandlordDecisionQueueItem = LandlordDecisionQueueRelatedRefs & {
   id: string;
   landlordId: string;
+  persistence?: "derived" | "persisted";
   sourceType: LandlordDecisionQueueSourceType;
   sourceId: string;
   sourceRoute?: string | null;

--- a/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
+++ b/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
@@ -30,6 +30,24 @@ export type LandlordDecisionQueueStatus =
   | "resolved"
   | "dismissed";
 
+export type LandlordDecisionQueueSourceType =
+  | "renewal_notice_send_review"
+  | "application_review"
+  | "evidence_review"
+  | "decision_inbox"
+  | "lease_state_coherence"
+  | "payment_obligation"
+  | "payment_readiness"
+  | "lease_lifecycle"
+  | "maintenance_readiness"
+  | "property_action_request"
+  | "message_thread"
+  | "message_unread_priority"
+  | "message_notice_relevance"
+  | "message_maintenance_follow_up"
+  | "message_support_escalation"
+  | "unified_inbox_event";
+
 export type LandlordDecisionQueueAssignment = {
   assignedToUserId: string | null;
   assignedToEmail: string | null;
@@ -94,6 +112,9 @@ export type LandlordDecisionQueueResponse = {
     severity: LandlordDecisionQueueSeverity | null;
     workspace: LandlordDecisionQueueWorkspace | null;
     status: LandlordDecisionQueueStatus | "open_state" | null;
+    sourceType?: LandlordDecisionQueueSourceType | null;
+    sourceId?: string | null;
+    sourceRoute?: string | null;
   };
 };
 
@@ -102,12 +123,77 @@ export async function fetchLandlordDecisionQueue(params?: {
   status?: LandlordDecisionQueueStatus | "open_state";
   workspace?: LandlordDecisionQueueWorkspace;
   severity?: LandlordDecisionQueueSeverity;
+  sourceType?: LandlordDecisionQueueSourceType;
+  sourceId?: string;
+  sourceRoute?: string;
 }): Promise<LandlordDecisionQueueResponse> {
   const search = new URLSearchParams();
   if (params?.limit) search.set("limit", String(params.limit));
   if (params?.status) search.set("status", params.status);
   if (params?.workspace) search.set("workspace", params.workspace);
   if (params?.severity) search.set("severity", params.severity);
+  if (params?.sourceType) search.set("sourceType", params.sourceType);
+  if (params?.sourceId) search.set("sourceId", params.sourceId);
+  if (params?.sourceRoute) search.set("sourceRoute", params.sourceRoute);
   const suffix = search.toString() ? `?${search.toString()}` : "";
   return apiFetch<LandlordDecisionQueueResponse>(`/landlord/decision-queue${suffix}`);
+}
+
+export type CreateLandlordDecisionQueueItemPayload = {
+  sourceType: LandlordDecisionQueueSourceType;
+  sourceId: string;
+  sourceRoute?: string | null;
+  workspace: LandlordDecisionQueueWorkspace;
+  severity: LandlordDecisionQueueSeverity;
+  title: string;
+  description: string;
+  recommendedActionLabel: string;
+  recommendedActionHref: string;
+  dueAt?: string | null;
+  status?: LandlordDecisionQueueStatus | null;
+  assignment?: LandlordDecisionQueueAssignment | null;
+  sourceSnapshot?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  dedupeKey?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  leaseId?: string | null;
+  maintenanceRequestId?: string | null;
+  noticeId?: string | null;
+};
+
+export type LandlordDecisionQueueMutationResponse = {
+  ok: true;
+  item: LandlordDecisionQueueItem;
+  auditEventId?: string | null;
+  created?: boolean;
+};
+
+export function createLandlordDecisionQueueItem(payload: CreateLandlordDecisionQueueItemPayload) {
+  return apiFetch<LandlordDecisionQueueMutationResponse>("/landlord/decision-queue/items", {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export function updateLandlordDecisionQueueItem(
+  decisionItemId: string,
+  payload: {
+    action?: string | null;
+    status?: LandlordDecisionQueueStatus | null;
+    assignment?: LandlordDecisionQueueAssignment | null;
+    clearAssignment?: boolean;
+    dueAt?: string | null;
+    clearDueAt?: boolean;
+    metadata?: Record<string, unknown> | null;
+  }
+) {
+  return apiFetch<LandlordDecisionQueueMutationResponse>(
+    `/landlord/decision-queue/items/${encodeURIComponent(decisionItemId)}`,
+    {
+      method: "PATCH",
+      body: payload,
+    }
+  );
 }

--- a/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
+++ b/rentchain-frontend/src/api/landlordDecisionQueueApi.ts
@@ -56,6 +56,7 @@ export type LandlordDecisionQueueAssignment = {
 
 export type LandlordDecisionQueueItem = {
   id: string;
+  persistence?: "derived" | "persisted";
   sourceType: string;
   sourceId: string;
   sourceRoute?: string | null;

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -400,7 +400,11 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(sendReview).toHaveTextContent("Renewal operator inputs saved");
     expect(sendReview).toHaveTextContent("Draft snapshot saved");
     expect(sendReview).toHaveTextContent("Tenant recipient reviewed");
-    expect(sendReview).toHaveTextContent("Delivery status model required before live send");
+    expect(sendReview).toHaveTextContent("Delivery status model");
+    expect(sendReview).toHaveTextContent("Deferred");
+    expect(screen.getByLabelText("Future send confirmation model")).toHaveTextContent(
+      "These confirmations will be required before live tenant communication is enabled."
+    );
     expect(sendReview).toHaveTextContent("Email delivery");
     expect(sendReview).toHaveTextContent("Not enabled");
     expect(sendReview).toHaveTextContent("Tenant notification");
@@ -831,7 +835,17 @@ describe("LandlordLeaseWorkflowPage", () => {
     });
     expect(await screen.findByText("Future send review approved internally. Send remains disabled.")).toBeInTheDocument();
     expect(approvalSection).toHaveTextContent("Approved");
-    expect(approvalSection).toHaveTextContent("Approved status does not enable tenant communication.");
+    expect(approvalSection).toHaveTextContent("Internal approval has been recorded. Send remains disabled");
+    expect(screen.queryByRole("button", { name: "Approve for future send review" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Approved internally");
+    expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Acknowledged for approval");
+    expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Still required before live send");
+    expect(screen.getByLabelText("Tenant communication send review")).toHaveTextContent(
+      "Checklist status reflects internal approval only. Live send confirmation remains deferred"
+    );
+    expect(screen.getByLabelText("Future send confirmation model")).toHaveTextContent(
+      "These confirmations will be required before live tenant communication is enabled."
+    );
     expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
     expect(document.body).not.toHaveTextContent(/email sent|tenant notified|notice served|legal delivery/i);
   });

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => ({
   fetchExpiringLeaseRenewals: vi.fn(),
   saveLeaseRenewalInputs: vi.fn(),
   saveRenewalNoticeDraftSnapshot: vi.fn(),
+  fetchLandlordDecisionQueue: vi.fn(),
+  createLandlordDecisionQueueItem: vi.fn(),
+  updateLandlordDecisionQueueItem: vi.fn(),
 }));
 
 vi.mock("@/api/leasesApi", () => ({
@@ -18,6 +21,12 @@ vi.mock("@/api/landlordLeaseRenewalApi", () => ({
   fetchExpiringLeaseRenewals: mocks.fetchExpiringLeaseRenewals,
   saveLeaseRenewalInputs: mocks.saveLeaseRenewalInputs,
   saveRenewalNoticeDraftSnapshot: mocks.saveRenewalNoticeDraftSnapshot,
+}));
+
+vi.mock("@/api/landlordDecisionQueueApi", () => ({
+  fetchLandlordDecisionQueue: mocks.fetchLandlordDecisionQueue,
+  createLandlordDecisionQueueItem: mocks.createLandlordDecisionQueueItem,
+  updateLandlordDecisionQueueItem: mocks.updateLandlordDecisionQueueItem,
 }));
 
 function renderWorkflow(path: string) {
@@ -43,12 +52,47 @@ function dateInputValueToMs(value: string) {
   return new Date(year, month - 1, day).getTime();
 }
 
+function approvalDecisionFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "decision-1",
+    sourceType: "renewal_notice_send_review",
+    sourceId: "lease:lease-1:renewal_notice_send_review",
+    sourceRoute: "/leases/lease-1/workflows/notice",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    leaseId: "lease-1",
+    workspace: "notices",
+    severity: "warning",
+    title: "Renewal tenant communication ready for approval",
+    description:
+      "Saved renewal notice draft is ready for send approval review. Email delivery remains disabled until approved send infrastructure is available.",
+    recommendedActionLabel: "Open notice review",
+    recommendedActionHref: "/leases/lease-1/workflows/notice",
+    dueAt: null,
+    createdAt: "2026-07-11T12:00:00.000Z",
+    updatedAt: "2026-07-11T12:00:00.000Z",
+    status: "open",
+    assignment: null,
+    sourceSnapshot: null,
+    auditEventIds: ["decision-audit-1"],
+    metadata: { noSendBehavior: true },
+    dedupeKey: "lease:lease-1:renewal_notice_send_review",
+    sortKey: "2026-07-11T12:00:00.000Z",
+    priorityRank: 2,
+    ...overrides,
+  };
+}
+
 describe("LandlordLeaseWorkflowPage", () => {
   beforeEach(() => {
     mocks.getLeaseById.mockReset();
     mocks.fetchExpiringLeaseRenewals.mockReset();
     mocks.saveLeaseRenewalInputs.mockReset();
     mocks.saveRenewalNoticeDraftSnapshot.mockReset();
+    mocks.fetchLandlordDecisionQueue.mockReset();
+    mocks.createLandlordDecisionQueueItem.mockReset();
+    mocks.updateLandlordDecisionQueueItem.mockReset();
     mocks.getLeaseById.mockResolvedValue({
       lease: {
         id: "lease-1",
@@ -222,6 +266,56 @@ describe("LandlordLeaseWorkflowPage", () => {
         canonicalEventId: "canonical-1",
       },
     });
+    mocks.fetchLandlordDecisionQueue.mockResolvedValue({
+      ok: true,
+      version: "landlord_decision_queue_v1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-07-11T12:00:00.000Z",
+      items: [],
+      summary: {
+        total: 0,
+        critical: 0,
+        warning: 0,
+        needsReview: 0,
+        upcoming: 0,
+        informational: 0,
+        open: 0,
+        blocked: 0,
+      },
+      total: 0,
+      limit: 5,
+      filters: {
+        severity: null,
+        workspace: null,
+        status: null,
+        sourceType: "renewal_notice_send_review",
+        sourceId: "lease:lease-1:renewal_notice_send_review",
+        sourceRoute: null,
+      },
+    });
+    mocks.createLandlordDecisionQueueItem.mockResolvedValue({
+      ok: true,
+      created: true,
+      auditEventId: "decision-audit-1",
+      item: approvalDecisionFixture(),
+    });
+    mocks.updateLandlordDecisionQueueItem.mockImplementation(async (_id: string, payload: { action?: string }) => ({
+      ok: true,
+      auditEventId: "decision-audit-2",
+      item: approvalDecisionFixture({
+        status:
+          payload.action === "approve"
+            ? "approved"
+            : payload.action === "return_to_draft"
+              ? "returned"
+              : payload.action === "defer"
+                ? "deferred"
+                : payload.action === "mark_not_required"
+                  ? "dismissed"
+                  : "acknowledged",
+        auditEventIds: ["decision-audit-1", "decision-audit-2"],
+      }),
+    }));
   });
 
   afterEach(() => {
@@ -314,6 +408,11 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(sendReview).toHaveTextContent("Not established");
     expect(sendReview).toHaveTextContent("Legal compliance");
     expect(sendReview).toHaveTextContent("Not determined by this workflow");
+    expect(sendReview).toHaveTextContent("Approval decision");
+    await waitFor(() => {
+      expect(sendReview).toHaveTextContent("Save a draft snapshot before creating a send approval decision.");
+    });
+    expect(screen.queryByRole("button", { name: "Create send approval decision" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
@@ -343,7 +442,7 @@ describe("LandlordLeaseWorkflowPage", () => {
           tenantId: "tenant-1",
           propertyId: "prop-1",
           propertyAddress: "12 Harbour Road",
-          unitId: "unit-1",
+          unitId: null,
           status: "active",
           leaseType: "fixed_term",
           province: "NS",
@@ -540,9 +639,80 @@ describe("LandlordLeaseWorkflowPage", () => {
     const sendReview = screen.getByLabelText("Tenant communication send review");
     expect(sendReview).toHaveTextContent("Prepared from saved renewal notice draft snapshot");
     expect(sendReview).toHaveTextContent("Draft snapshot captured");
+    expect(await screen.findByRole("button", { name: "Create send approval decision" })).toBeInTheDocument();
     expect(mocks.saveLeaseRenewalInputs).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/evidence saved|notice has been served|email sent/i);
+  });
+
+  it("creates and updates a send approval decision without enabling tenant communication", async () => {
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Tenant notice draft preview");
+    fireEvent.click(screen.getByRole("button", { name: "Save draft snapshot" }));
+    await screen.findByText("Audit event recorded.");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Create send approval decision" }));
+
+    await waitFor(() => {
+      expect(mocks.createLandlordDecisionQueueItem).toHaveBeenCalled();
+    });
+    const createPayload = mocks.createLandlordDecisionQueueItem.mock.calls[0][0];
+    expect(createPayload).toMatchObject({
+      sourceType: "renewal_notice_send_review",
+      sourceId: "lease:lease-1:renewal_notice_send_review",
+      sourceRoute: "/leases/lease-1/workflows/notice",
+      workspace: "notices",
+      severity: "warning",
+      title: "Renewal tenant communication ready for approval",
+      recommendedActionHref: "/leases/lease-1/workflows/notice",
+      leaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: null,
+      tenantId: "tenant-1",
+      dedupeKey: "lease:lease-1:renewal_notice_send_review",
+    });
+    expect(createPayload.description).toContain("Email delivery remains disabled");
+    expect(createPayload.sourceSnapshot).toMatchObject({
+      tenantLabel: "Jane Tenant",
+      propertyUnitLabel: "12 Harbour Road · Unit 101",
+      draftSnapshotId: "snapshot-1",
+      emailSent: false,
+      noticeServed: false,
+      tenantNotified: false,
+    });
+    expect(createPayload.metadata).toMatchObject({
+      noSendBehavior: true,
+      noTenantNotification: true,
+      noNoticeServed: true,
+      noLeaseLifecycleMutation: true,
+    });
+    const approvalSection = screen.getByLabelText("Send approval decision");
+    expect(await screen.findByText("Approval decision created.")).toBeInTheDocument();
+    expect(approvalSection).toHaveTextContent("Open");
+    expect(screen.getByRole("link", { name: "Open decision inbox" })).toHaveAttribute("href", "/decision-inbox");
+    expect(screen.getByRole("link", { name: "Open operations" })).toHaveAttribute("href", "/operations");
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve for future send review" }));
+    await waitFor(() => {
+      expect(mocks.updateLandlordDecisionQueueItem).toHaveBeenCalledWith(
+        "decision-1",
+        expect.objectContaining({
+          action: "approve",
+          metadata: expect.objectContaining({
+            noSendBehavior: true,
+            noTenantNotification: true,
+            noNoticeServed: true,
+            noLeaseLifecycleMutation: true,
+          }),
+        })
+      );
+    });
+    expect(await screen.findByText("Future send review approved internally. Send remains disabled.")).toBeInTheDocument();
+    expect(approvalSection).toHaveTextContent("Approved");
+    expect(approvalSection).toHaveTextContent("Approved status does not enable tenant communication.");
+    expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
+    expect(document.body).not.toHaveTextContent(/email sent|tenant notified|notice served|legal delivery/i);
   });
 
   it("shows a draft snapshot save error without implying audit persistence", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -80,6 +80,7 @@ function approvalDecisionFixture(overrides: Record<string, unknown> = {}) {
     dedupeKey: "lease:lease-1:renewal_notice_send_review",
     sortKey: "2026-07-11T12:00:00.000Z",
     priorityRank: 2,
+    persistence: "persisted",
     ...overrides,
   };
 }
@@ -413,6 +414,8 @@ describe("LandlordLeaseWorkflowPage", () => {
       expect(sendReview).toHaveTextContent("Save a draft snapshot before creating a send approval decision.");
     });
     expect(screen.queryByRole("button", { name: "Create send approval decision" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Acknowledge" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve for future send review" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
@@ -643,6 +646,124 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(mocks.saveLeaseRenewalInputs).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/evidence saved|notice has been served|email sent/i);
+  });
+
+  it("does not bind approval lifecycle controls to unrelated derived decision queue items", async () => {
+    mocks.fetchLandlordDecisionQueue.mockResolvedValue({
+      ok: true,
+      version: "landlord_decision_queue_v1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-07-11T12:00:00.000Z",
+      items: [
+        approvalDecisionFixture({
+          id: "decision_queue:decision_inbox:decision:review_overdue_rent:delinquency:overdue:pi_rent_3d25",
+          persistence: "derived",
+          sourceType: "decision_inbox",
+          sourceId: "decision:review_overdue_rent:delinquency:overdue:pi_rent_3d25",
+          sourceRoute: "/leases/lease-1/ledger",
+          workspace: "payments",
+          title: "Review Overdue Rent",
+          status: "pending",
+          dueAt: "2026-05-31T00:00:00.000Z",
+        }),
+      ],
+      summary: {
+        total: 1,
+        critical: 0,
+        warning: 1,
+        needsReview: 0,
+        upcoming: 0,
+        informational: 0,
+        open: 1,
+        blocked: 0,
+      },
+      total: 1,
+      limit: 5,
+      filters: {
+        severity: null,
+        workspace: null,
+        status: null,
+        sourceType: "renewal_notice_send_review",
+        sourceId: "lease:lease-1:renewal_notice_send_review",
+        sourceRoute: "/leases/lease-1/workflows/notice",
+      },
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Tenant notice draft preview");
+    expect(mocks.fetchLandlordDecisionQueue).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Send approval decision")).toHaveTextContent(
+      "Save a draft snapshot before creating a send approval decision."
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save draft snapshot" }));
+    await screen.findByText("Audit event recorded.");
+
+    expect(await screen.findByRole("button", { name: "Create send approval decision" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Send approval decision")).not.toHaveTextContent("Review Overdue Rent");
+    expect(screen.queryByRole("button", { name: "Acknowledge" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve for future send review" })).not.toBeInTheDocument();
+    expect(mocks.updateLandlordDecisionQueueItem).not.toHaveBeenCalled();
+  });
+
+  it("shows an existing persisted renewal approval decision only after the draft snapshot is saved", async () => {
+    mocks.fetchLandlordDecisionQueue.mockResolvedValue({
+      ok: true,
+      version: "landlord_decision_queue_v1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-07-11T12:00:00.000Z",
+      items: [
+        approvalDecisionFixture({
+          status: "in_review",
+          assignment: {
+            assignedToUserId: "manager-1",
+            assignedToEmail: "manager@example.com",
+            assignmentLabel: "Portfolio manager",
+          },
+          dueAt: "2026-07-18T00:00:00.000Z",
+        }),
+      ],
+      summary: {
+        total: 1,
+        critical: 0,
+        warning: 1,
+        needsReview: 0,
+        upcoming: 0,
+        informational: 0,
+        open: 1,
+        blocked: 0,
+      },
+      total: 1,
+      limit: 5,
+      filters: {
+        severity: null,
+        workspace: null,
+        status: null,
+        sourceType: "renewal_notice_send_review",
+        sourceId: "lease:lease-1:renewal_notice_send_review",
+        sourceRoute: "/leases/lease-1/workflows/notice",
+      },
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Tenant notice draft preview");
+    expect(screen.getByLabelText("Send approval decision")).toHaveTextContent(
+      "Save a draft snapshot before creating a send approval decision."
+    );
+    expect(mocks.fetchLandlordDecisionQueue).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save draft snapshot" }));
+
+    const approvalSection = await screen.findByLabelText("Send approval decision");
+    await waitFor(() => {
+      expect(approvalSection).toHaveTextContent("In review");
+    });
+    expect(approvalSection).toHaveTextContent("Portfolio manager");
+    expect(approvalSection).toHaveTextContent("Decision audit captured");
+    expect(screen.queryByRole("button", { name: "Create send approval decision" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve for future send review" })).toBeInTheDocument();
   });
 
   it("creates and updates a send approval decision without enabling tenant communication", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -753,6 +753,7 @@ function TenantCommunicationSendReview({
   const [decisionSubmitting, setDecisionSubmitting] = React.useState(false);
   const [decisionNotice, setDecisionNotice] = React.useState<string | null>(null);
   const [decisionError, setDecisionError] = React.useState<string | null>(null);
+  const approvalDecisionApproved = approvalDecision?.status === "approved";
 
   React.useEffect(() => {
     let active = true;
@@ -934,14 +935,33 @@ function TenantCommunicationSendReview({
         <SendChecklistItem label="Renewal operator inputs saved" status={readinessReady ? "Ready" : "Needs review"} />
         <SendChecklistItem label="Draft snapshot saved" status={savedSnapshot ? "Ready" : "Needs review"} />
         <SendChecklistItem label="Tenant recipient reviewed" status={recipientReady ? "Ready" : "Needs review"} />
-        <SendChecklistItem label="Draft body reviewed" status={draftAvailable ? "Needs review" : "Deferred"} />
+        <SendChecklistItem
+          label="Draft body review"
+          status={approvalDecisionApproved ? "Approved internally" : draftAvailable ? "Needs review" : "Deferred"}
+        />
         <SendChecklistItem label="Evidence/audit capture available" status={savedSnapshot ? "Ready" : "Needs review"} />
-        <SendChecklistItem label="Delivery status model required before live send" status="Deferred" />
-        <SendChecklistItem label="Legal-service separation acknowledged" status="Deferred" />
+        <SendChecklistItem
+          label="Delivery status model"
+          status={approvalDecisionApproved ? "Still required before live send" : "Deferred"}
+        />
+        <SendChecklistItem
+          label="Legal-service separation"
+          status={approvalDecisionApproved ? "Acknowledged for approval" : "Deferred"}
+        />
       </div>
 
-      <fieldset disabled style={confirmationPreviewStyle} aria-label="Confirmation model preview">
-        <legend style={sendReviewSubheadingStyle}>Confirmation required before future send</legend>
+      {approvalDecisionApproved ? (
+        <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
+          Checklist status reflects internal approval only. Live send confirmation remains deferred until tenant communication
+          infrastructure is enabled.
+        </div>
+      ) : null}
+
+      <fieldset disabled style={confirmationPreviewStyle} aria-label="Future send confirmation model">
+        <legend style={sendReviewSubheadingStyle}>Future send confirmation model</legend>
+        <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
+          These confirmations will be required before live tenant communication is enabled.
+        </div>
         <label style={checkboxLabelStyle}>
           <input type="checkbox" /> I have reviewed the recipient(s).
         </label>
@@ -1018,9 +1038,11 @@ function TenantCommunicationSendReview({
               </Link>
             </div>
             <div style={decisionActionGridStyle}>
-              <button type="button" onClick={() => void updateApprovalDecision("acknowledge", "Decision acknowledged.")} disabled={decisionSubmitting} style={buttonStyle}>
-                Acknowledge
-              </button>
+              {!approvalDecisionApproved ? (
+                <button type="button" onClick={() => void updateApprovalDecision("acknowledge", "Decision acknowledged.")} disabled={decisionSubmitting} style={buttonStyle}>
+                  Acknowledge
+                </button>
+              ) : null}
               <button type="button" onClick={() => void updateApprovalDecision("defer", "Decision deferred.")} disabled={decisionSubmitting} style={buttonStyle}>
                 Defer
               </button>
@@ -1030,12 +1052,16 @@ function TenantCommunicationSendReview({
               <button type="button" onClick={() => void updateApprovalDecision("mark_not_required", "Decision marked not required.")} disabled={decisionSubmitting} style={buttonStyle}>
                 Mark not required
               </button>
-              <button type="button" onClick={() => void updateApprovalDecision("approve", "Future send review approved internally.")} disabled={decisionSubmitting} style={primaryButtonStyle}>
-                Approve for future send review
-              </button>
+              {!approvalDecisionApproved ? (
+                <button type="button" onClick={() => void updateApprovalDecision("approve", "Future send review approved internally.")} disabled={decisionSubmitting} style={primaryButtonStyle}>
+                  Approve for future send review
+                </button>
+              ) : null}
             </div>
             <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
-              Approved status does not enable tenant communication. Future send infrastructure remains required.
+              {approvalDecisionApproved
+                ? "Internal approval has been recorded. Send remains disabled and future send infrastructure remains required."
+                : "Approved status does not enable tenant communication. Future send infrastructure remains required."}
             </div>
           </div>
         ) : null}
@@ -1053,8 +1079,21 @@ function TenantCommunicationSendReview({
   );
 }
 
-function SendChecklistItem({ label, status }: { label: string; status: "Ready" | "Needs review" | "Deferred" }) {
-  const tone = status === "Ready" ? "ready" : status === "Needs review" ? "warning" : "deferred";
+type SendChecklistStatus =
+  | "Ready"
+  | "Needs review"
+  | "Deferred"
+  | "Approved internally"
+  | "Acknowledged for approval"
+  | "Still required before live send";
+
+function SendChecklistItem({ label, status }: { label: string; status: SendChecklistStatus }) {
+  const tone =
+    status === "Ready" || status === "Approved internally" || status === "Acknowledged for approval"
+      ? "ready"
+      : status === "Needs review"
+        ? "warning"
+        : "deferred";
   return <NoticeStatus label={label} value={status} tone={tone} />;
 }
 

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -23,6 +23,12 @@ import {
   type RenewalPipelineItem,
   type RenewalPipelineTimingBucketKey,
 } from "@/lib/leases/renewalPipeline";
+import {
+  createLandlordDecisionQueueItem,
+  fetchLandlordDecisionQueue,
+  updateLandlordDecisionQueueItem,
+  type LandlordDecisionQueueItem,
+} from "@/api/landlordDecisionQueueApi";
 
 type WorkflowKey = "execution" | "rent-increase" | "notice" | "deposit" | "renewal" | "move-out";
 
@@ -740,6 +746,120 @@ function TenantCommunicationSendReview({
       ? "Prepared from current renewal draft"
       : "Draft unavailable";
   const hasMultipleTenants = Array.isArray(lease.tenantIds) && lease.tenantIds.length > 1;
+  const decisionSourceId = `lease:${lease.id}:renewal_notice_send_review`;
+  const decisionRoute = `/leases/${encodeURIComponent(lease.id)}/workflows/notice`;
+  const [approvalDecision, setApprovalDecision] = React.useState<LandlordDecisionQueueItem | null>(null);
+  const [decisionLoading, setDecisionLoading] = React.useState(false);
+  const [decisionSubmitting, setDecisionSubmitting] = React.useState(false);
+  const [decisionNotice, setDecisionNotice] = React.useState<string | null>(null);
+  const [decisionError, setDecisionError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let active = true;
+    async function loadApprovalDecision() {
+      setDecisionLoading(true);
+      setDecisionError(null);
+      try {
+        const response = await fetchLandlordDecisionQueue({
+          limit: 5,
+          sourceType: "renewal_notice_send_review",
+          sourceId: decisionSourceId,
+        });
+        if (!active) return;
+        setApprovalDecision(response.items[0] || null);
+      } catch {
+        if (active) setDecisionError("Approval decision could not be loaded.");
+      } finally {
+        if (active) setDecisionLoading(false);
+      }
+    }
+    void loadApprovalDecision();
+    return () => {
+      active = false;
+    };
+  }, [decisionSourceId]);
+
+  async function createApprovalDecision() {
+    if (!savedSnapshot || !reviewModel || decisionSubmitting) return;
+    setDecisionSubmitting(true);
+    setDecisionError(null);
+    setDecisionNotice(null);
+    try {
+      const response = await createLandlordDecisionQueueItem({
+        sourceType: "renewal_notice_send_review",
+        sourceId: decisionSourceId,
+        sourceRoute: decisionRoute,
+        workspace: "notices",
+        severity: "warning",
+        title: "Renewal tenant communication ready for approval",
+        description:
+          "Saved renewal notice draft is ready for send approval review. Email delivery remains disabled until approved send infrastructure is available.",
+        recommendedActionLabel: "Open notice review",
+        recommendedActionHref: decisionRoute,
+        status: "open",
+        leaseId: lease.id,
+        propertyId: lease.propertyId || null,
+        unitId: lease.unitId || null,
+        tenantId: lease.tenantId || (Array.isArray(lease.tenantIds) ? lease.tenantIds[0] : null) || null,
+        sourceSnapshot: {
+          leaseId: lease.id,
+          tenantLabel: reviewModel.tenantLabel,
+          propertyUnitLabel: reviewModel.propertyUnitLabel,
+          currentRentLabel: reviewModel.currentRentLabel,
+          renewalRentLabel: reviewModel.renewalRentLabel,
+          currentLeaseEndLabel: reviewModel.currentLeaseEndLabel,
+          proposedTermLabel: reviewModel.proposedTermLabel,
+          tenantResponseTargetDateLabel: reviewModel.tenantResponseTargetDateLabel,
+          draftSnapshotId: savedSnapshot.snapshotId,
+          draftSnapshotSavedAt: savedSnapshot.savedAt,
+          emailSent: false,
+          noticeServed: false,
+          tenantNotified: false,
+        },
+        metadata: {
+          approvalPurpose: "future_send_review",
+          draftSnapshotId: savedSnapshot.snapshotId,
+          noSendBehavior: true,
+          noTenantNotification: true,
+          noNoticeServed: true,
+          noLeaseLifecycleMutation: true,
+        },
+        dedupeKey: decisionSourceId,
+      });
+      setApprovalDecision(response.item);
+      setDecisionNotice(response.created === false ? "Existing approval decision loaded." : "Approval decision created.");
+    } catch {
+      setDecisionError("Approval decision could not be created.");
+    } finally {
+      setDecisionSubmitting(false);
+    }
+  }
+
+  async function updateApprovalDecision(action: string, successLabel: string) {
+    if (!approvalDecision || decisionSubmitting) return;
+    setDecisionSubmitting(true);
+    setDecisionError(null);
+    setDecisionNotice(null);
+    try {
+      const response = await updateLandlordDecisionQueueItem(approvalDecision.id, {
+        action,
+        metadata: {
+          approvalPurpose: "future_send_review",
+          lastApprovalDecisionAction: action,
+          noSendBehavior: true,
+          noTenantNotification: true,
+          noNoticeServed: true,
+          noLeaseLifecycleMutation: true,
+        },
+      });
+      setApprovalDecision(response.item);
+      setDecisionNotice(`${successLabel} Send remains disabled.`);
+    } catch {
+      setDecisionError("Approval decision could not be updated.");
+    } finally {
+      setDecisionSubmitting(false);
+    }
+  }
 
   return (
     <section style={sendReviewStyle} aria-label="Tenant communication send review">
@@ -820,6 +940,83 @@ function TenantCommunicationSendReview({
         <NoticeStatus label="Audit/evidence" value={savedSnapshot ? "Draft snapshot captured" : "Captured when snapshot is saved"} tone={savedSnapshot ? "ready" : "deferred"} />
       </div>
 
+      <section style={approvalDecisionStyle} aria-label="Send approval decision">
+        <div style={{ display: "grid", gap: 4 }}>
+          <h4 style={sendReviewSubheadingStyle}>Approval decision</h4>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+            Create an internal decision queue item for future send approval review. This does not send email, notify the tenant,
+            serve notice, or change lease lifecycle state.
+          </div>
+        </div>
+
+        {decisionLoading ? <div style={{ color: workflowTheme.muted }}>Loading approval decision…</div> : null}
+        {decisionError ? <div style={warningTextStyle}>{decisionError}</div> : null}
+        {decisionNotice ? <div style={successTextStyle}>{decisionNotice}</div> : null}
+
+        {!approvalDecision && !savedSnapshot && !decisionLoading ? (
+          <div style={warningPanelStyle}>Save a draft snapshot before creating a send approval decision.</div>
+        ) : null}
+
+        {!approvalDecision && savedSnapshot ? (
+          <div style={{ display: "grid", gap: 10 }}>
+            <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+              The saved draft snapshot can now be queued for internal send approval review.
+            </div>
+            <button
+              type="button"
+              onClick={() => void createApprovalDecision()}
+              disabled={decisionSubmitting}
+              style={primaryButtonStyle}
+            >
+              {decisionSubmitting ? "Creating approval decision…" : "Create send approval decision"}
+            </button>
+          </div>
+        ) : null}
+
+        {approvalDecision ? (
+          <div style={{ display: "grid", gap: 10 }}>
+            <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 10, margin: 0 }}>
+              <ReviewFact label="Decision" value={approvalDecision.title} />
+              <ReviewFact label="Status" value={decisionStatusLabel(approvalDecision.status)} />
+              <ReviewFact label="Assignment" value={decisionAssignmentLabel(approvalDecision)} />
+              <ReviewFact label="Due date" value={approvalDecision.dueAt ? formatDate(approvalDecision.dueAt) : "Not set"} />
+              <ReviewFact
+                label="Audit capture"
+                value={approvalDecision.auditEventIds?.length ? "Decision audit captured" : "Decision queue item recorded"}
+              />
+            </dl>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <Link to="/decision-inbox" style={buttonLinkStyle}>
+                Open decision inbox
+              </Link>
+              <Link to="/operations" style={buttonLinkStyle}>
+                Open operations
+              </Link>
+            </div>
+            <div style={decisionActionGridStyle}>
+              <button type="button" onClick={() => void updateApprovalDecision("acknowledge", "Decision acknowledged.")} disabled={decisionSubmitting} style={buttonStyle}>
+                Acknowledge
+              </button>
+              <button type="button" onClick={() => void updateApprovalDecision("defer", "Decision deferred.")} disabled={decisionSubmitting} style={buttonStyle}>
+                Defer
+              </button>
+              <button type="button" onClick={() => void updateApprovalDecision("return_to_draft", "Decision returned to draft review.")} disabled={decisionSubmitting} style={buttonStyle}>
+                Return to draft
+              </button>
+              <button type="button" onClick={() => void updateApprovalDecision("mark_not_required", "Decision marked not required.")} disabled={decisionSubmitting} style={buttonStyle}>
+                Mark not required
+              </button>
+              <button type="button" onClick={() => void updateApprovalDecision("approve", "Future send review approved internally.")} disabled={decisionSubmitting} style={primaryButtonStyle}>
+                Approve for future send review
+              </button>
+            </div>
+            <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
+              Approved status does not enable tenant communication. Future send infrastructure remains required.
+            </div>
+          </div>
+        ) : null}
+      </section>
+
       <button type="button" disabled style={sendDisabledButtonStyle}>
         Send tenant communication - not enabled yet
       </button>
@@ -835,6 +1032,27 @@ function TenantCommunicationSendReview({
 function SendChecklistItem({ label, status }: { label: string; status: "Ready" | "Needs review" | "Deferred" }) {
   const tone = status === "Ready" ? "ready" : status === "Needs review" ? "warning" : "deferred";
   return <NoticeStatus label={label} value={status} tone={tone} />;
+}
+
+function decisionStatusLabel(status: LandlordDecisionQueueItem["status"]) {
+  const labels: Record<LandlordDecisionQueueItem["status"], string> = {
+    open: "Open",
+    acknowledged: "Acknowledged",
+    in_review: "In review",
+    pending: "Pending",
+    blocked: "Blocked",
+    approved: "Approved",
+    returned: "Returned to draft",
+    deferred: "Deferred",
+    resolved: "Resolved",
+    dismissed: "Not required",
+  };
+  return labels[status] || status;
+}
+
+function decisionAssignmentLabel(item: LandlordDecisionQueueItem) {
+  const assignment = item.assignment;
+  return assignment?.assignmentLabel || assignment?.assignedToEmail || assignment?.assignedToUserId || "Unassigned";
 }
 
 function ReviewWorkspaceHeader({ renewalPath }: { renewalPath: string }) {
@@ -1173,6 +1391,22 @@ const confirmationPreviewStyle: React.CSSProperties = {
   background: "rgba(255, 250, 241, 0.72)",
   padding: 12,
   color: workflowTheme.muted,
+};
+
+const approvalDecisionStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 12,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 10,
+  background: workflowTheme.card,
+  padding: 12,
+};
+
+const decisionActionGridStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 8,
+  flexWrap: "wrap",
+  alignItems: "center",
 };
 
 const checkboxLabelStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -757,6 +757,13 @@ function TenantCommunicationSendReview({
   React.useEffect(() => {
     let active = true;
     async function loadApprovalDecision() {
+      if (!savedSnapshot) {
+        setApprovalDecision(null);
+        setDecisionLoading(false);
+        setDecisionError(null);
+        setDecisionNotice(null);
+        return;
+      }
       setDecisionLoading(true);
       setDecisionError(null);
       try {
@@ -764,9 +771,12 @@ function TenantCommunicationSendReview({
           limit: 5,
           sourceType: "renewal_notice_send_review",
           sourceId: decisionSourceId,
+          sourceRoute: decisionRoute,
         });
         if (!active) return;
-        setApprovalDecision(response.items[0] || null);
+        const matchedDecision =
+          response.items.find((item) => isPersistedApprovalDecisionItem(item, decisionSourceId, decisionRoute)) || null;
+        setApprovalDecision(matchedDecision);
       } catch {
         if (active) setDecisionError("Approval decision could not be loaded.");
       } finally {
@@ -777,7 +787,7 @@ function TenantCommunicationSendReview({
     return () => {
       active = false;
     };
-  }, [decisionSourceId]);
+  }, [decisionRoute, decisionSourceId, savedSnapshot]);
 
   async function createApprovalDecision() {
     if (!savedSnapshot || !reviewModel || decisionSubmitting) return;
@@ -826,6 +836,9 @@ function TenantCommunicationSendReview({
         },
         dedupeKey: decisionSourceId,
       });
+      if (!isPersistedApprovalDecisionItem(response.item, decisionSourceId, decisionRoute)) {
+        throw new Error("approval_decision_source_mismatch");
+      }
       setApprovalDecision(response.item);
       setDecisionNotice(response.created === false ? "Existing approval decision loaded." : "Approval decision created.");
     } catch {
@@ -837,6 +850,11 @@ function TenantCommunicationSendReview({
 
   async function updateApprovalDecision(action: string, successLabel: string) {
     if (!approvalDecision || decisionSubmitting) return;
+    if (!isPersistedApprovalDecisionItem(approvalDecision, decisionSourceId, decisionRoute)) {
+      setApprovalDecision(null);
+      setDecisionError("Approval decision could not be updated. Refresh the decision state or create a new approval decision.");
+      return;
+    }
     setDecisionSubmitting(true);
     setDecisionError(null);
     setDecisionNotice(null);
@@ -852,10 +870,16 @@ function TenantCommunicationSendReview({
           noLeaseLifecycleMutation: true,
         },
       });
+      if (!isPersistedApprovalDecisionItem(response.item, decisionSourceId, decisionRoute)) {
+        throw new Error("approval_decision_source_mismatch");
+      }
       setApprovalDecision(response.item);
       setDecisionNotice(`${successLabel} Send remains disabled.`);
-    } catch {
-      setDecisionError("Approval decision could not be updated.");
+    } catch (error) {
+      if (String((error as Error)?.message || error).includes("decision_item_not_found")) {
+        setApprovalDecision(null);
+      }
+      setDecisionError("Approval decision could not be updated. Refresh the decision state or create a new approval decision.");
     } finally {
       setDecisionSubmitting(false);
     }
@@ -957,7 +981,7 @@ function TenantCommunicationSendReview({
           <div style={warningPanelStyle}>Save a draft snapshot before creating a send approval decision.</div>
         ) : null}
 
-        {!approvalDecision && savedSnapshot ? (
+        {!approvalDecision && savedSnapshot && !decisionLoading ? (
           <div style={{ display: "grid", gap: 10 }}>
             <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
               The saved draft snapshot can now be queued for internal send approval review.
@@ -1032,6 +1056,20 @@ function TenantCommunicationSendReview({
 function SendChecklistItem({ label, status }: { label: string; status: "Ready" | "Needs review" | "Deferred" }) {
   const tone = status === "Ready" ? "ready" : status === "Needs review" ? "warning" : "deferred";
   return <NoticeStatus label={label} value={status} tone={tone} />;
+}
+
+function isPersistedApprovalDecisionItem(
+  item: LandlordDecisionQueueItem | null | undefined,
+  sourceId: string,
+  sourceRoute: string
+) {
+  if (!item) return false;
+  if (item.sourceType !== "renewal_notice_send_review") return false;
+  if (item.sourceId !== sourceId) return false;
+  if (item.sourceRoute && item.sourceRoute !== sourceRoute) return false;
+  if (item.persistence === "derived") return false;
+  if (item.id.startsWith("decision_queue:")) return false;
+  return true;
 }
 
 function decisionStatusLabel(status: LandlordDecisionQueueItem["status"]) {


### PR DESCRIPTION
## Summary
- adds an internal send approval decision section to /leases/:leaseId/workflows/notice after a renewal notice draft snapshot is saved
- extends the landlord decision queue client with source filters plus create/update helpers
- adds backend source filtering and source-matched idempotent create behavior so repeated approval creates reuse the existing queue item
- preserves disabled send state and no-delivery guardrails

## Guardrails
- no email/send behavior added
- no tenant notification added
- no notice creation or service added
- no lease lifecycle mutation added
- no legacy send-notice wiring added
- approval status does not enable tenant communication

## Validation
- npm run test -- LandlordLeaseWorkflowPage
- npm run test -- DecisionInboxPage OperationalCommandCenterPage DashboardPage
- npm run test -- landlordDecisionQueueRoutes
- npm run test -- landlordDecisionQueue
- npm run build (frontend)
- npm run build (backend)
- git diff --check
- git diff --cached --check