### PR TITLE
feat: add renewal tenant communication send API

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -513,6 +513,8 @@ app.use("/api", routeSource("landlordPortfolioScoreRoutes.ts"), landlordPortfoli
 console.log("[route-mount] landlordPortfolioScoreRoutes mounted at /api");
 app.use("/api", routeSource("landlordPortfolioScoreSharingRoutes.ts"), landlordPortfolioScoreSharingRoutes);
 console.log("[route-mount] landlordPortfolioScoreSharingRoutes mounted at /api");
+app.use("/api/landlord/leases", routeSource("leaseNoticeLandlordRoutes.ts"), leaseNoticeLandlordRoutes);
+console.log("[route-mount] leaseNoticeLandlordRoutes mounted at /api/landlord/leases");
 app.use("/api/landlord", routeSource("landlordInboxRoutes.ts"), landlordInboxRoutes);
 console.log("[route-mount] landlordInboxRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlordDecisionInboxRoutes);
@@ -653,7 +655,6 @@ app.use("/api", routeSource("tenantEventsRoutes"), tenantEventsRoutes);
 app.use("/api", routeSource("tenantEventsWriteRoutes"), tenantEventsWriteRoutes);
 app.use("/api", routeSource("ledgerAttachmentsRoutes"), ledgerAttachmentsRoutes);
 app.use("/api", routeSource("tenantNoticesRoutes"), tenantNoticesRoutes);
-app.use("/api/landlord/leases", routeSource("leaseNoticeLandlordRoutes.ts"), leaseNoticeLandlordRoutes);
 app.use("/api/tenant/lease-notices", routeSource("tenantLeaseNoticeRoutes.ts"), tenantLeaseNoticeRoutes);
 app.use("/api", routeSource("maintenanceRequestsRoutes"), maintenanceRequestsRoutes);
 app.use("/api", routeSource("usageBreakdownRoutes.ts"), usageBreakdownRoutes);

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -370,19 +370,68 @@ describe("deriveEvidencePack", () => {
           generatedDraftText: "Hello Jane, private body text should not project.",
           providerPayload: { raw: "provider-secret" },
         },
+        {
+          communicationId: "communication-1",
+          leaseId: "lease-1",
+          landlordId: "landlord-1",
+          snapshotId: "snapshot-1",
+          status: "send_attempted",
+          deliveryStatus: "delivery_status_unknown",
+          attemptedAt: "2026-07-11T12:10:00.000Z",
+          tenantNotified: false,
+          noticeServed: false,
+          legalServiceEstablished: false,
+        },
+      ],
+      canonicalEvents: [
+        {
+          id: "event-confirmed-1",
+          type: "renewal_notice_send_confirmed",
+          summary: "Renewal tenant communication send confirmed internally. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          metadata: { communicationId: "communication-1" },
+          occurredAt: "2026-07-11T12:09:58.000Z",
+        },
+        {
+          id: "event-attempted-1",
+          type: "renewal_notice_email_send_attempted",
+          summary: "Renewal tenant communication send attempted. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          metadata: { communicationId: "communication-1" },
+          occurredAt: "2026-07-11T12:10:00.000Z",
+        },
+        {
+          id: "event-sent-1",
+          type: "renewal_notice_email_sent",
+          summary: "Renewal tenant communication email sent. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          metadata: { communicationId: "communication-1" },
+          occurredAt: "2026-07-11T12:10:02.000Z",
+        },
       ],
       leases: [{ id: "lease-1", propertyName: "North Towers", unitNumber: "101", tenantName: "John Smith" }],
       properties: [{ id: "prop-1", name: "North Towers" }],
     });
 
     const auditSection = pack.sections.find((section) => section.sectionKey === "audit_events");
+    expect(auditSection?.items.filter((item) => item.itemType === "communication_record")).toHaveLength(1);
+    expect(auditSection?.items.map((item) => item.label)).not.toEqual(
+      expect.arrayContaining([
+        "Renewal tenant communication send confirmed",
+        "Renewal tenant communication send attempted",
+        "Renewal tenant communication email sent",
+      ])
+    );
     expect(auditSection?.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           itemType: "communication_record",
-          label: "Renewal tenant communication · Email sent",
+          label: "Renewal tenant communication email sent",
           description:
-            "Email sent at 2026-07-11 12:10 UTC. Tenant notified by email provider acceptance. Not served; legal service not established.",
+            "Email sent at 2026-07-11 12:10 UTC. Provider delivery status: unknown. Tenant notified by email provider acceptance. Not served; legal service not established. Communication ID: communication-1.",
           source: "renewal_notice_communications",
           sourceId: "communication-1",
         }),

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -348,6 +348,49 @@ describe("deriveEvidencePack", () => {
     expect(JSON.stringify(pack)).not.toMatch(/Notice sent|Tenant notified|Notice served/);
   });
 
+  it("shows renewal tenant communication records without raw message bodies or legal-service claims", () => {
+    const pack = deriveEvidencePack({
+      scope: "lease",
+      scopeId: "lease-1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-07-11T12:00:00.000Z",
+      renewalNoticeCommunications: [
+        {
+          communicationId: "communication-1",
+          leaseId: "lease-1",
+          landlordId: "landlord-1",
+          snapshotId: "snapshot-1",
+          status: "email_sent",
+          deliveryStatus: "delivery_status_unknown",
+          attemptedAt: "2026-07-11T12:10:00.000Z",
+          sentAt: "2026-07-11T12:10:02.000Z",
+          tenantNotified: true,
+          noticeServed: false,
+          legalServiceEstablished: false,
+          generatedDraftText: "Hello Jane, private body text should not project.",
+          providerPayload: { raw: "provider-secret" },
+        },
+      ],
+      leases: [{ id: "lease-1", propertyName: "North Towers", unitNumber: "101", tenantName: "John Smith" }],
+      properties: [{ id: "prop-1", name: "North Towers" }],
+    });
+
+    const auditSection = pack.sections.find((section) => section.sectionKey === "audit_events");
+    expect(auditSection?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "communication_record",
+          label: "Renewal tenant communication · Email sent",
+          description:
+            "Email sent at 2026-07-11 12:10 UTC. Tenant notified by email provider acceptance. Not served; legal service not established.",
+          source: "renewal_notice_communications",
+          sourceId: "communication-1",
+        }),
+      ])
+    );
+    expect(JSON.stringify(pack)).not.toMatch(/private body text|provider-secret|legally served|legal delivery/i);
+  });
+
   it("keeps raw provider, banking, debug, and private document fields out of evidence projections", () => {
     const pack = deriveEvidencePack({
       scope: "decision",

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -98,6 +98,18 @@ function canonicalEventLabel(event: Record<string, any>): string {
   if (raw === "renewal_notice_draft_saved" || raw === "lease.renewal_notice_draft_saved") {
     return "Renewal notice draft snapshot";
   }
+  if (raw === "renewal_notice_send_confirmed" || raw === "lease.renewal_notice_send_confirmed") {
+    return "Renewal tenant communication send confirmed";
+  }
+  if (raw === "renewal_notice_email_send_attempted" || raw === "lease.renewal_notice_email_send_attempted") {
+    return "Renewal tenant communication send attempted";
+  }
+  if (raw === "renewal_notice_email_sent" || raw === "lease.renewal_notice_email_sent") {
+    return "Renewal tenant communication email sent";
+  }
+  if (raw === "renewal_notice_email_failed" || raw === "lease.renewal_notice_email_failed") {
+    return "Renewal tenant communication email failed";
+  }
   return raw || "Canonical event";
 }
 
@@ -315,9 +327,13 @@ function operatorReviewSection(input: DeriveEvidencePackInput): EvidencePackSect
 
 function canonicalEventsSection(input: DeriveEvidencePackInput): EvidencePackSection {
   const scopedEvents = arrayOf(input.canonicalEvents).filter((event) => isRelatedToScope(event, input.scope, input.scopeId));
+  const communicationItems = renewalNoticeCommunicationEvidenceItems(input);
   const renewalDraftItems = renewalNoticeDraftSnapshotEvidenceItem(scopedEvents);
-  const events = scopedEvents.filter((event) => !isRenewalNoticeDraftSavedEvent(event)).slice(0, 20 - renewalDraftItems.length);
+  const events = scopedEvents
+    .filter((event) => !isRenewalNoticeDraftSavedEvent(event))
+    .slice(0, Math.max(0, 20 - renewalDraftItems.length - communicationItems.length));
   const items = [
+    ...communicationItems,
     ...renewalDraftItems,
     ...events.map((event) =>
       evidenceItem({
@@ -336,6 +352,39 @@ function canonicalEventsSection(input: DeriveEvidencePackInput): EvidencePackSec
     items,
     missingEvidence: items.length ? [] : ["No landlord-scoped canonical events were available for this scope."],
   });
+}
+
+function renewalNoticeCommunicationStatusLabel(status: unknown): string {
+  const raw = asString(status, 80);
+  if (raw === "email_sent") return "Email sent";
+  if (raw === "email_failed") return "Email failed";
+  if (raw === "send_attempted") return "Send attempted";
+  return "Communication recorded";
+}
+
+function renewalNoticeCommunicationEvidenceItems(input: DeriveEvidencePackInput): EvidenceItem[] {
+  return arrayOf(input.renewalNoticeCommunications)
+    .filter((record) => isRelatedToScope(record, input.scope, input.scopeId))
+    .sort((a, b) =>
+      asString(b.sentAt || b.failedAt || b.attemptedAt || b.createdAt, 120).localeCompare(
+        asString(a.sentAt || a.failedAt || a.attemptedAt || a.createdAt, 120),
+      ),
+    )
+    .slice(0, 5)
+    .map((record) => {
+      const statusLabel = renewalNoticeCommunicationStatusLabel(record.status);
+      const timestamp = normalizeTimestamp(record.sentAt || record.failedAt || record.attemptedAt || record.createdAt);
+      const timestampLabel = formatEvidenceTimestamp(timestamp);
+      const tenantNotified = record.tenantNotified === true ? "Tenant notified by email provider acceptance." : "Tenant not notified.";
+      return evidenceItem({
+        itemType: "communication_record",
+        label: `Renewal tenant communication · ${statusLabel}`,
+        description: `${statusLabel} at ${timestampLabel}. ${tenantNotified} Not served; legal service not established.`,
+        source: "renewal_notice_communications",
+        sourceId: record.communicationId || record.id,
+        timestamp,
+      });
+    });
 }
 
 function exportSection(input: DeriveEvidencePackInput): EvidencePackSection {

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -118,6 +118,20 @@ function isRenewalNoticeDraftSavedEvent(event: Record<string, any>): boolean {
   return raw === "renewal_notice_draft_saved" || raw === "lease.renewal_notice_draft_saved";
 }
 
+function isRenewalNoticeCommunicationEvent(event: Record<string, any>): boolean {
+  const raw = asString(event.type || event.action, 160);
+  return (
+    raw === "renewal_notice_send_confirmed" ||
+    raw === "lease.renewal_notice_send_confirmed" ||
+    raw === "renewal_notice_email_send_attempted" ||
+    raw === "lease.renewal_notice_email_send_attempted" ||
+    raw === "renewal_notice_email_sent" ||
+    raw === "lease.renewal_notice_email_sent" ||
+    raw === "renewal_notice_email_failed" ||
+    raw === "lease.renewal_notice_email_failed"
+  );
+}
+
 function eventTimestamp(event: Record<string, any>): string | null {
   return normalizeTimestamp(event.occurredAt || event.recordedAt || event.createdAt);
 }
@@ -331,6 +345,7 @@ function canonicalEventsSection(input: DeriveEvidencePackInput): EvidencePackSec
   const renewalDraftItems = renewalNoticeDraftSnapshotEvidenceItem(scopedEvents);
   const events = scopedEvents
     .filter((event) => !isRenewalNoticeDraftSavedEvent(event))
+    .filter((event) => !(communicationItems.length && isRenewalNoticeCommunicationEvent(event)))
     .slice(0, Math.max(0, 20 - renewalDraftItems.length - communicationItems.length));
   const items = [
     ...communicationItems,
@@ -356,32 +371,80 @@ function canonicalEventsSection(input: DeriveEvidencePackInput): EvidencePackSec
 
 function renewalNoticeCommunicationStatusLabel(status: unknown): string {
   const raw = asString(status, 80);
+  if (raw === "email_sent") return "email sent";
+  if (raw === "email_failed") return "email failed";
+  if (raw === "send_attempted") return "send attempted";
+  return "communication recorded";
+}
+
+function renewalNoticeCommunicationRank(record: Record<string, any>): number {
+  const status = asString(record.status, 80);
+  if (status === "email_sent") return 3;
+  if (status === "email_failed") return 2;
+  if (status === "send_attempted") return 1;
+  return 0;
+}
+
+function renewalNoticeCommunicationTimestamp(record: Record<string, any>): string | null {
+  return normalizeTimestamp(record.sentAt || record.failedAt || record.attemptedAt || record.createdAt);
+}
+
+function renewalNoticeCommunicationDeliveryLabel(value: unknown): string {
+  const raw = asString(value, 120);
+  if (!raw || raw === "delivery_status_unknown") return "unknown";
+  return raw.replace(/_/g, " ");
+}
+
+function renewalNoticeCommunicationActionText(status: unknown): string {
+  const raw = asString(status, 80);
   if (raw === "email_sent") return "Email sent";
   if (raw === "email_failed") return "Email failed";
   if (raw === "send_attempted") return "Send attempted";
   return "Communication recorded";
 }
 
+function groupRenewalNoticeCommunications(records: Record<string, any>[]): Record<string, any>[] {
+  const byCommunicationId = new Map<string, Record<string, any>[]>();
+  for (const record of records) {
+    const key = asString(record.communicationId || record.id, 240) || `missing:${byCommunicationId.size}`;
+    byCommunicationId.set(key, [...(byCommunicationId.get(key) || []), record]);
+  }
+
+  return Array.from(byCommunicationId.entries()).map(([communicationId, group]) => {
+    const ordered = [...group].sort((a, b) => {
+      const rankDelta = renewalNoticeCommunicationRank(b) - renewalNoticeCommunicationRank(a);
+      if (rankDelta) return rankDelta;
+      return (renewalNoticeCommunicationTimestamp(b) || "").localeCompare(renewalNoticeCommunicationTimestamp(a) || "");
+    });
+    return { ...ordered[0], communicationId };
+  });
+}
+
 function renewalNoticeCommunicationEvidenceItems(input: DeriveEvidencePackInput): EvidenceItem[] {
-  return arrayOf(input.renewalNoticeCommunications)
+  const groupedRecords = groupRenewalNoticeCommunications(
+    arrayOf(input.renewalNoticeCommunications)
     .filter((record) => isRelatedToScope(record, input.scope, input.scopeId))
+  );
+
+  return groupedRecords
     .sort((a, b) =>
-      asString(b.sentAt || b.failedAt || b.attemptedAt || b.createdAt, 120).localeCompare(
-        asString(a.sentAt || a.failedAt || a.attemptedAt || a.createdAt, 120),
-      ),
+      (renewalNoticeCommunicationTimestamp(b) || "").localeCompare(renewalNoticeCommunicationTimestamp(a) || ""),
     )
     .slice(0, 5)
     .map((record) => {
       const statusLabel = renewalNoticeCommunicationStatusLabel(record.status);
-      const timestamp = normalizeTimestamp(record.sentAt || record.failedAt || record.attemptedAt || record.createdAt);
+      const actionText = renewalNoticeCommunicationActionText(record.status);
+      const timestamp = renewalNoticeCommunicationTimestamp(record);
       const timestampLabel = formatEvidenceTimestamp(timestamp);
+      const deliveryLabel = renewalNoticeCommunicationDeliveryLabel(record.deliveryStatus);
       const tenantNotified = record.tenantNotified === true ? "Tenant notified by email provider acceptance." : "Tenant not notified.";
+      const communicationId = asString(record.communicationId || record.id, 240);
       return evidenceItem({
         itemType: "communication_record",
-        label: `Renewal tenant communication · ${statusLabel}`,
-        description: `${statusLabel} at ${timestampLabel}. ${tenantNotified} Not served; legal service not established.`,
+        label: `Renewal tenant communication ${statusLabel}`,
+        description: `${actionText} at ${timestampLabel}. Provider delivery status: ${deliveryLabel}. ${tenantNotified} Not served; legal service not established.${communicationId ? ` Communication ID: ${communicationId}.` : ""}`,
         source: "renewal_notice_communications",
-        sourceId: record.communicationId || record.id,
+        sourceId: communicationId || record.id,
         timestamp,
       });
     });

--- a/rentchain-api/src/lib/evidencePacks/evidencePackTypes.ts
+++ b/rentchain-api/src/lib/evidencePacks/evidencePackTypes.ts
@@ -30,6 +30,7 @@ export type EvidenceItemType =
   | "readiness_check"
   | "lease_summary"
   | "property_summary"
+  | "communication_record"
   | "ledger_summary"
   | "maintenance_summary"
   | "redaction_note";
@@ -41,6 +42,7 @@ export type EvidenceItemSource =
   | "canonical_events"
   | "institution_exports"
   | "audit_compliance"
+  | "renewal_notice_communications"
   | "lease_ledger"
   | "maintenance"
   | "registry"
@@ -158,6 +160,7 @@ export type DeriveEvidencePackInput = {
   institutionExportPackage?: InstitutionExportPackage | null;
   auditComplianceReadiness?: AuditComplianceReadiness | null;
   canonicalEvents?: Array<Record<string, any>> | null;
+  renewalNoticeCommunications?: Array<Record<string, any>> | null;
   leases?: Array<Record<string, any>> | null;
   properties?: Array<Record<string, any>> | null;
   maintenanceRequests?: Array<Record<string, any>> | null;

--- a/rentchain-api/src/lib/evidencePacks/evidenceProjectionProfile.ts
+++ b/rentchain-api/src/lib/evidencePacks/evidenceProjectionProfile.ts
@@ -17,6 +17,7 @@ const SOURCE_COLLECTION_BY_ITEM_SOURCE: Record<EvidenceItemSource, string> = {
   lease_ledger: "leases",
   maintenance: "maintenanceRequests",
   operator_review: "operatorReviewSessions",
+  renewal_notice_communications: "renewalNoticeCommunications",
   registry: "properties",
   workflow_routing: "decisionItems",
   unknown: "unknown",

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -185,6 +185,36 @@ describe("deriveCanonicalReviewTimeline", () => {
       landlordId: "landlord-1",
       canonicalEvents: [
         {
+          id: "event-confirmed-1",
+          type: "renewal_notice_send_confirmed",
+          action: "renewal_notice_send_confirmed",
+          summary: "Renewal tenant communication send confirmed internally. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          actor: { type: "landlord", id: "landlord-1" },
+          metadata: {
+            communicationId: "rnc_test",
+            deliveryStatus: "delivery_status_unknown",
+            tenantNotified: false,
+          },
+          occurredAt: "2026-07-11T12:09:58.000Z",
+        },
+        {
+          id: "event-attempted-1",
+          type: "renewal_notice_email_send_attempted",
+          action: "renewal_notice_email_send_attempted",
+          summary: "Renewal tenant communication send attempted. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          actor: { type: "landlord", id: "landlord-1" },
+          metadata: {
+            communicationId: "rnc_test",
+            deliveryStatus: "delivery_status_unknown",
+            tenantNotified: false,
+          },
+          occurredAt: "2026-07-11T12:10:00.000Z",
+        },
+        {
           id: "event-send-1",
           type: "renewal_notice_email_sent",
           action: "renewal_notice_email_sent",
@@ -192,18 +222,41 @@ describe("deriveCanonicalReviewTimeline", () => {
           leaseId: "lease-1",
           resource: { id: "lease-1" },
           actor: { type: "landlord", id: "landlord-1" },
+          metadata: {
+            communicationId: "rnc_test",
+            deliveryStatus: "delivery_status_unknown",
+            tenantNotified: true,
+          },
           occurredAt: "2026-07-11T12:10:00.000Z",
         },
       ],
     });
 
+    expect(timeline.entries.map((entry) => entry.label)).toEqual(
+      expect.arrayContaining([
+        "Renewal tenant communication send confirmed",
+        "Renewal tenant communication send attempted",
+        "Renewal tenant communication email sent",
+      ])
+    );
     expect(timeline.entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           entryType: "canonical_event",
           source: "canonical_events",
           label: "Renewal tenant communication email sent",
-          description: "Renewal tenant communication email sent. Not served; legal service not established.",
+          description:
+            "Renewal tenant communication email sent at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: email sent. Provider delivery status: unknown. Tenant notified by email provider acceptance. Not served; legal service not established.",
+        }),
+        expect.objectContaining({
+          label: "Renewal tenant communication send attempted",
+          description:
+            "Renewal tenant communication send attempted at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: send attempted. Provider delivery status: unknown. Not served; legal service not established.",
+        }),
+        expect.objectContaining({
+          label: "Renewal tenant communication send confirmed",
+          description:
+            "Renewal tenant communication send confirmed internally at 2026-07-11 12:09 UTC. Communication ID: rnc_test. Status: send confirmed internally. Provider delivery status: unknown. Not served; legal service not established.",
         }),
       ])
     );

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -177,4 +177,36 @@ describe("deriveCanonicalReviewTimeline", () => {
     );
     expect(JSON.stringify(timeline)).not.toMatch(/Notice sent|Tenant notified|Notice served/);
   });
+
+  it("labels renewal tenant communication send events with legal-service guardrails", () => {
+    const timeline = deriveCanonicalReviewTimeline({
+      scope: "lease",
+      scopeId: "lease-1",
+      landlordId: "landlord-1",
+      canonicalEvents: [
+        {
+          id: "event-send-1",
+          type: "renewal_notice_email_sent",
+          action: "renewal_notice_email_sent",
+          summary: "Renewal tenant communication email sent. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          actor: { type: "landlord", id: "landlord-1" },
+          occurredAt: "2026-07-11T12:10:00.000Z",
+        },
+      ],
+    });
+
+    expect(timeline.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          entryType: "canonical_event",
+          source: "canonical_events",
+          label: "Renewal tenant communication email sent",
+          description: "Renewal tenant communication email sent. Not served; legal service not established.",
+        }),
+      ])
+    );
+    expect(JSON.stringify(timeline)).not.toMatch(/legally served|legal delivery|compliant notice/i);
+  });
 });

--- a/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
+++ b/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
@@ -66,6 +66,18 @@ function canonicalEventLabel(event: Record<string, any>): string {
   if (raw === "renewal_notice_draft_saved" || raw === "lease.renewal_notice_draft_saved") {
     return "Renewal notice draft saved";
   }
+  if (raw === "renewal_notice_send_confirmed" || raw === "lease.renewal_notice_send_confirmed") {
+    return "Renewal tenant communication send confirmed";
+  }
+  if (raw === "renewal_notice_email_send_attempted" || raw === "lease.renewal_notice_email_send_attempted") {
+    return "Renewal tenant communication send attempted";
+  }
+  if (raw === "renewal_notice_email_sent" || raw === "lease.renewal_notice_email_sent") {
+    return "Renewal tenant communication email sent";
+  }
+  if (raw === "renewal_notice_email_failed" || raw === "lease.renewal_notice_email_failed") {
+    return "Renewal tenant communication email failed";
+  }
   return raw || "Canonical event";
 }
 

--- a/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
+++ b/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
@@ -81,6 +81,53 @@ function canonicalEventLabel(event: Record<string, any>): string {
   return raw || "Canonical event";
 }
 
+function isRenewalNoticeCommunicationEvent(event: Record<string, any>): boolean {
+  const raw = asString(event.type || event.action, 160);
+  return (
+    raw === "renewal_notice_send_confirmed" ||
+    raw === "lease.renewal_notice_send_confirmed" ||
+    raw === "renewal_notice_email_send_attempted" ||
+    raw === "lease.renewal_notice_email_send_attempted" ||
+    raw === "renewal_notice_email_sent" ||
+    raw === "lease.renewal_notice_email_sent" ||
+    raw === "renewal_notice_email_failed" ||
+    raw === "lease.renewal_notice_email_failed"
+  );
+}
+
+function formatTimelineTimestamp(value: unknown): string {
+  const iso = toIso(value, "");
+  if (!iso) return "time unavailable";
+  return iso.replace("T", " ").slice(0, 16) + " UTC";
+}
+
+function renewalNoticeCommunicationStatusText(event: Record<string, any>): string {
+  const raw = asString(event.type || event.action, 160);
+  if (raw === "renewal_notice_email_sent" || raw === "lease.renewal_notice_email_sent") return "email sent";
+  if (raw === "renewal_notice_email_failed" || raw === "lease.renewal_notice_email_failed") return "email failed";
+  if (raw === "renewal_notice_email_send_attempted" || raw === "lease.renewal_notice_email_send_attempted") return "send attempted";
+  if (raw === "renewal_notice_send_confirmed" || raw === "lease.renewal_notice_send_confirmed") return "send confirmed internally";
+  return "communication recorded";
+}
+
+function renewalNoticeCommunicationTimelineDescription(event: Record<string, any>): string | null {
+  if (!isRenewalNoticeCommunicationEvent(event)) return null;
+  const metadata = event.metadata || {};
+  const communicationId = asString(metadata.communicationId || event.communicationId, 240);
+  const rawDeliveryStatus = asString(metadata.deliveryStatus || event.deliveryStatus, 120);
+  const deliveryStatus = !rawDeliveryStatus || rawDeliveryStatus === "delivery_status_unknown"
+    ? "unknown"
+    : rawDeliveryStatus.replace(/_/g, " ");
+  const occurredAt = formatTimelineTimestamp(event.occurredAt || event.recordedAt || event.createdAt);
+  const status = renewalNoticeCommunicationStatusText(event);
+  const idText = communicationId ? ` Communication ID: ${communicationId}.` : "";
+  const tenantNoticeText =
+    metadata.tenantNotified === true || event.tenantNotified === true
+      ? " Tenant notified by email provider acceptance."
+      : "";
+  return `Renewal tenant communication ${status} at ${occurredAt}.${idText} Status: ${status}. Provider delivery status: ${deliveryStatus}.${tenantNoticeText} Not served; legal service not established.`;
+}
+
 function normalizeActor(raw: any): ReviewTimelineActor {
   const type = asString(raw?.type || raw?.role, 80).toLowerCase();
   return {
@@ -266,7 +313,7 @@ function canonicalEventEntries(input: DeriveCanonicalReviewTimelineInput): Revie
         entryType: "canonical_event",
         timestamp: event.occurredAt || event.recordedAt,
         label: canonicalEventLabel(event),
-        description: event.summary || "Canonical event recorded.",
+        description: renewalNoticeCommunicationTimelineDescription(event) || event.summary || "Canonical event recorded.",
         status: event.status === "blocked" ? "blocked" : "info",
         actor: normalizeActor(event.actor),
         source: "canonical_events",

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -16,6 +16,24 @@ const stripeMocks = vi.hoisted(() => ({
   constructEvent: vi.fn(),
 }));
 
+const renewalNoticeCommunicationMocks = vi.hoisted(() => ({
+  sendRenewalNoticeCommunication: vi.fn(async () => ({
+    ok: true,
+    communicationId: "communication-mounted-success",
+    status: "email_sent",
+    deliveryStatus: "delivery_status_unknown",
+    attemptedAt: "2026-07-11T12:10:00.000Z",
+    sentAt: "2026-07-11T12:10:01.000Z",
+    providerMessageId: null,
+    auditEventId: "event-communication-mounted-success",
+    timelineEventId: "canonical-communication-mounted-success",
+    noLegalServiceClaim: true,
+    noticeServed: false,
+    tenantNotified: true,
+    legalServiceEstablished: false,
+  })),
+}));
+
 function buildEmptyQuery() {
   return {
     where: () => buildEmptyQuery(),
@@ -159,21 +177,7 @@ vi.mock("../../services/emailService", () => ({
 }));
 
 vi.mock("../../services/renewalNoticeCommunicationService", () => ({
-  sendRenewalNoticeCommunication: vi.fn(async () => ({
-    ok: true,
-    communicationId: "communication-mounted-success",
-    status: "email_sent",
-    deliveryStatus: "delivery_status_unknown",
-    attemptedAt: "2026-07-11T12:10:00.000Z",
-    sentAt: "2026-07-11T12:10:01.000Z",
-    providerMessageId: null,
-    auditEventId: "event-communication-mounted-success",
-    timelineEventId: "canonical-communication-mounted-success",
-    noLegalServiceClaim: true,
-    noticeServed: false,
-    tenantNotified: true,
-    legalServiceEstablished: false,
-  })),
+  sendRenewalNoticeCommunication: renewalNoticeCommunicationMocks.sendRenewalNoticeCommunication,
 }));
 
 function appBuildSource() {
@@ -646,6 +650,31 @@ describe("API route ownership regression", () => {
         legalServiceEstablished: false,
       })
     );
+
+    renewalNoticeCommunicationMocks.sendRenewalNoticeCommunication.mockResolvedValueOnce({
+      ok: false,
+      statusCode: 400,
+      error: "RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED",
+      details: ["snapshotId"],
+    });
+    const communicationValidationRes = await invokeApp(app, {
+      method: "POST",
+      url: "/api/landlord/leases/lease-mounted-success/renewal-notice-communications",
+      headers: { authorization: "Bearer landlord-token" },
+      body: {
+        approvalDecisionItemId: "decision-mounted-success",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-mounted-success",
+      },
+    });
+    expect(communicationValidationRes.status).toBe(400);
+    expect(communicationValidationRes.headers["x-route-source"]).toBe("leaseNoticeLandlordRoutes.ts");
+    expect(communicationValidationRes.body?.error).toBe("RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED");
+    expect(communicationValidationRes.body?.error).not.toBe("Not Found");
 
     const communicationMissingAuth = await invokeApp(app, {
       method: "POST",

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -158,6 +158,24 @@ vi.mock("../../services/emailService", () => ({
   sendEmail: vi.fn(async () => undefined),
 }));
 
+vi.mock("../../services/renewalNoticeCommunicationService", () => ({
+  sendRenewalNoticeCommunication: vi.fn(async () => ({
+    ok: true,
+    communicationId: "communication-mounted-success",
+    status: "email_sent",
+    deliveryStatus: "delivery_status_unknown",
+    attemptedAt: "2026-07-11T12:10:00.000Z",
+    sentAt: "2026-07-11T12:10:01.000Z",
+    providerMessageId: null,
+    auditEventId: "event-communication-mounted-success",
+    timelineEventId: "canonical-communication-mounted-success",
+    noLegalServiceClaim: true,
+    noticeServed: false,
+    tenantNotified: true,
+    legalServiceEstablished: false,
+  })),
+}));
+
 function appBuildSource() {
   return fs.readFileSync(path.resolve(__dirname, "../../app.build.ts"), "utf8");
 }
@@ -602,6 +620,59 @@ describe("API route ownership regression", () => {
     expect(draftSnapshotUnknownLease.headers["x-route-source"]).toBe("leaseNoticeLandlordRoutes.ts");
     expect(draftSnapshotUnknownLease.body?.error).toBe("LEASE_NOT_FOUND");
     expect(draftSnapshotUnknownLease.body?.error).not.toBe("Not Found");
+
+    const communicationRes = await invokeApp(app, {
+      method: "POST",
+      url: "/api/landlord/leases/lease-mounted-success/renewal-notice-communications",
+      headers: { authorization: "Bearer landlord-token" },
+      body: {
+        snapshotId: "snapshot-mounted-success",
+        approvalDecisionItemId: "decision-mounted-success",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-mounted-success",
+      },
+    });
+    expect(communicationRes.status).toBe(201);
+    expect(communicationRes.headers["x-route-source"]).toBe("leaseNoticeLandlordRoutes.ts");
+    expect(communicationRes.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        communicationId: "communication-mounted-success",
+        noticeServed: false,
+        legalServiceEstablished: false,
+      })
+    );
+
+    const communicationMissingAuth = await invokeApp(app, {
+      method: "POST",
+      url: "/api/landlord/leases/lease-mounted-success/renewal-notice-communications",
+      body: {},
+    });
+    expect(communicationMissingAuth.status).toBe(401);
+    expect(communicationMissingAuth.headers["x-route-source"]).toBe("leaseNoticeLandlordRoutes.ts");
+
+    const communicationUnknownLease = await invokeApp(app, {
+      method: "POST",
+      url: "/api/landlord/leases/lease-missing/renewal-notice-communications",
+      headers: { authorization: "Bearer landlord-token" },
+      body: {
+        snapshotId: "snapshot-mounted-success",
+        approvalDecisionItemId: "decision-mounted-success",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-mounted-success",
+      },
+    });
+    expect(communicationUnknownLease.status).toBe(404);
+    expect(communicationUnknownLease.headers["x-route-source"]).toBe("leaseNoticeLandlordRoutes.ts");
+    expect(communicationUnknownLease.body?.error).toBe("LEASE_NOT_FOUND");
 
     const internalRes = await invokeApp(app, {
       method: "POST",

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -32,6 +32,46 @@ const renewalNoticeCommunicationMocks = vi.hoisted(() => ({
     tenantNotified: true,
     legalServiceEstablished: false,
   })),
+  validateRenewalNoticeCommunicationInput: vi.fn((input: any) => {
+    if (!String(input?.snapshotId || "").trim()) {
+      return { ok: false, error: "RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED", details: ["snapshotId"] };
+    }
+    if (!String(input?.approvalDecisionItemId || "").trim()) {
+      return {
+        ok: false,
+        error: "RENEWAL_NOTICE_APPROVAL_DECISION_ITEM_ID_REQUIRED",
+        details: ["approvalDecisionItemId"],
+      };
+    }
+    if (input?.confirmationAccepted !== true) {
+      return { ok: false, error: "RENEWAL_NOTICE_CONFIRMATION_ACCEPTED_REQUIRED", details: ["confirmationAccepted"] };
+    }
+    if (input?.recipientReviewed !== true) {
+      return { ok: false, error: "RENEWAL_NOTICE_RECIPIENT_REVIEWED_REQUIRED", details: ["recipientReviewed"] };
+    }
+    if (input?.bodyReviewed !== true) {
+      return { ok: false, error: "RENEWAL_NOTICE_BODY_REVIEWED_REQUIRED", details: ["bodyReviewed"] };
+    }
+    if (input?.legalServiceAcknowledged !== true) {
+      return {
+        ok: false,
+        error: "RENEWAL_NOTICE_LEGAL_SERVICE_ACKNOWLEDGED_REQUIRED",
+        details: ["legalServiceAcknowledged"],
+      };
+    }
+    if (input?.noLegalServiceClaim !== true) {
+      return { ok: false, error: "RENEWAL_NOTICE_NO_LEGAL_SERVICE_CLAIM_REQUIRED", details: ["noLegalServiceClaim"] };
+    }
+    if (!String(input?.idempotencyKey || "").trim()) {
+      return { ok: false, error: "RENEWAL_NOTICE_IDEMPOTENCY_KEY_REQUIRED", details: ["idempotencyKey"] };
+    }
+    return {
+      ok: true,
+      snapshotId: String(input.snapshotId),
+      approvalDecisionItemId: String(input.approvalDecisionItemId),
+      idempotencyKey: String(input.idempotencyKey),
+    };
+  }),
 }));
 
 function buildEmptyQuery() {
@@ -178,6 +218,7 @@ vi.mock("../../services/emailService", () => ({
 
 vi.mock("../../services/renewalNoticeCommunicationService", () => ({
   sendRenewalNoticeCommunication: renewalNoticeCommunicationMocks.sendRenewalNoticeCommunication,
+  validateRenewalNoticeCommunicationInput: renewalNoticeCommunicationMocks.validateRenewalNoticeCommunicationInput,
 }));
 
 function appBuildSource() {
@@ -361,6 +402,11 @@ describe("API route ownership regression", () => {
     const leaseNoticeLandlordMount = source.indexOf(
       'app.use("/api/landlord/leases", routeSource("leaseNoticeLandlordRoutes.ts"), leaseNoticeLandlordRoutes)'
     );
+    const landlordInboxMount = source.indexOf('app.use("/api/landlord", routeSource("landlordInboxRoutes.ts"), landlordInboxRoutes)');
+    const delegatedAccessLandlordMount = source.indexOf(
+      'app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), delegatedAccessInvitationRoutes)'
+    );
+    const landlordActivationMount = source.indexOf('app.use("/api/landlord", routeSource("landlordActivationRoutes.ts"), landlordActivationRoutes)');
     const statusMount = source.indexOf('app.use("/api/status", statusRoutes)');
     const paymentsBroadMount = source.indexOf('app.use("/api", routeSource("paymentsRoutes.ts"), paymentsRoutes)');
     const publicPortfolioMount = source.indexOf('app.use("/api", routeSource("publicPortfolioScoreRoutes.ts"), publicPortfolioScoreRoutes)');
@@ -386,6 +432,9 @@ describe("API route ownership regression", () => {
     expect(screeningRoutesMount).toBeGreaterThan(-1);
     expect(evidencePackageMount).toBeGreaterThan(-1);
     expect(leaseNoticeLandlordMount).toBeGreaterThan(-1);
+    expect(landlordInboxMount).toBeGreaterThan(-1);
+    expect(delegatedAccessLandlordMount).toBeGreaterThan(-1);
+    expect(landlordActivationMount).toBeGreaterThan(-1);
     expect(statusMount).toBeGreaterThan(-1);
     expect(paymentsBroadMount).toBeGreaterThan(-1);
     expect(publicPortfolioMount).toBeGreaterThan(-1);
@@ -413,6 +462,9 @@ describe("API route ownership regression", () => {
     expect(telemetryMount).toBeLessThan(riskAgentMount);
     expect(screeningRoutesMount).toBeLessThan(riskAgentMount);
     expect(evidencePackageMount).toBeLessThan(screeningJobsMount);
+    expect(leaseNoticeLandlordMount).toBeLessThan(landlordInboxMount);
+    expect(leaseNoticeLandlordMount).toBeLessThan(delegatedAccessLandlordMount);
+    expect(leaseNoticeLandlordMount).toBeLessThan(landlordActivationMount);
     expect(leaseNoticeLandlordMount).toBeLessThan(screeningJobsMount);
     expect(leaseNoticeLandlordMount).toBeLessThan(apiCatchall);
     expect(buildProbeRoute).toBeLessThan(riskAgentMount);

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -112,7 +112,7 @@ const saveRenewalNoticeDraftSnapshot = vi.fn(async () => ({
     canonicalEventId: "canonical-1",
   },
 }));
-const sendRenewalNoticeCommunication = vi.fn(async () => ({
+const renewalNoticeCommunicationSuccess = {
   ok: true,
   communicationId: "communication-1",
   status: "email_sent",
@@ -126,7 +126,8 @@ const sendRenewalNoticeCommunication = vi.fn(async () => ({
   noticeServed: false,
   tenantNotified: true,
   legalServiceEstablished: false,
-}));
+};
+const sendRenewalNoticeCommunication = vi.fn(async () => renewalNoticeCommunicationSuccess);
 const sanitizeLeaseRenewalOperatorInput = vi.fn((body: any) => ({
   ok: true,
   data: {
@@ -247,6 +248,7 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
         summary: { title: "Lease notice preview", body: "Preview body" },
       },
     });
+    sendRenewalNoticeCommunication.mockResolvedValue(renewalNoticeCommunicationSuccess);
   });
 
   it("blocks lease notice preview when required legal inputs are missing", async () => {
@@ -460,6 +462,175 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
         input: body,
       })
     );
+    expect(performLeaseNoticeSendFromPreviewInput).not.toHaveBeenCalled();
+    expect(sendLeaseWorkflowEmail).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "missing snapshotId",
+      {
+        approvalDecisionItemId: "decision-1",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      400,
+      "RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED",
+    ],
+    [
+      "missing approvalDecisionItemId",
+      {
+        snapshotId: "snapshot-1",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      400,
+      "RENEWAL_NOTICE_APPROVAL_DECISION_ITEM_ID_REQUIRED",
+    ],
+    [
+      "missing confirmationAccepted",
+      {
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "decision-1",
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      400,
+      "RENEWAL_NOTICE_CONFIRMATION_ACCEPTED_REQUIRED",
+    ],
+    [
+      "missing recipientReviewed",
+      {
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "decision-1",
+        confirmationAccepted: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      400,
+      "RENEWAL_NOTICE_RECIPIENT_REVIEWED_REQUIRED",
+    ],
+    [
+      "missing bodyReviewed",
+      {
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "decision-1",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      400,
+      "RENEWAL_NOTICE_BODY_REVIEWED_REQUIRED",
+    ],
+    [
+      "missing legalServiceAcknowledged",
+      {
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "decision-1",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      400,
+      "RENEWAL_NOTICE_LEGAL_SERVICE_ACKNOWLEDGED_REQUIRED",
+    ],
+    [
+      "missing noLegalServiceClaim",
+      {
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "decision-1",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        idempotencyKey: "idem-1",
+      },
+      400,
+      "RENEWAL_NOTICE_NO_LEGAL_SERVICE_CLAIM_REQUIRED",
+    ],
+    [
+      "missing idempotencyKey",
+      {
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "decision-1",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+      },
+      400,
+      "RENEWAL_NOTICE_IDEMPOTENCY_KEY_REQUIRED",
+    ],
+    [
+      "invalid snapshotId",
+      {
+        snapshotId: "missing-snapshot",
+        approvalDecisionItemId: "decision-1",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      404,
+      "RENEWAL_NOTICE_DRAFT_SNAPSHOT_NOT_FOUND",
+    ],
+    [
+      "invalid approvalDecisionItemId",
+      {
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "missing-decision",
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey: "idem-1",
+      },
+      404,
+      "RENEWAL_NOTICE_APPROVAL_DECISION_NOT_FOUND",
+    ],
+  ])("returns route-specific validation/domain error for %s", async (_label, body, statusCode, error) => {
+    sendRenewalNoticeCommunication.mockResolvedValueOnce({
+      ok: false,
+      statusCode,
+      error,
+      details: statusCode === 400 ? ["validation"] : undefined,
+    });
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/renewal-notice-communications",
+      body,
+    });
+
+    expect(res.status).toBe(statusCode);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error,
+      })
+    );
+    expect(res.body?.error).not.toBe("Not Found");
     expect(performLeaseNoticeSendFromPreviewInput).not.toHaveBeenCalled();
     expect(sendLeaseWorkflowEmail).not.toHaveBeenCalled();
   });

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -128,6 +128,46 @@ const renewalNoticeCommunicationSuccess = {
   legalServiceEstablished: false,
 };
 const sendRenewalNoticeCommunication = vi.fn(async () => renewalNoticeCommunicationSuccess);
+const validateRenewalNoticeCommunicationInput = vi.fn((input: any) => {
+  if (!String(input?.snapshotId || "").trim()) {
+    return { ok: false, error: "RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED", details: ["snapshotId"] };
+  }
+  if (!String(input?.approvalDecisionItemId || "").trim()) {
+    return {
+      ok: false,
+      error: "RENEWAL_NOTICE_APPROVAL_DECISION_ITEM_ID_REQUIRED",
+      details: ["approvalDecisionItemId"],
+    };
+  }
+  if (input?.confirmationAccepted !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_CONFIRMATION_ACCEPTED_REQUIRED", details: ["confirmationAccepted"] };
+  }
+  if (input?.recipientReviewed !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_RECIPIENT_REVIEWED_REQUIRED", details: ["recipientReviewed"] };
+  }
+  if (input?.bodyReviewed !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_BODY_REVIEWED_REQUIRED", details: ["bodyReviewed"] };
+  }
+  if (input?.legalServiceAcknowledged !== true) {
+    return {
+      ok: false,
+      error: "RENEWAL_NOTICE_LEGAL_SERVICE_ACKNOWLEDGED_REQUIRED",
+      details: ["legalServiceAcknowledged"],
+    };
+  }
+  if (input?.noLegalServiceClaim !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_NO_LEGAL_SERVICE_CLAIM_REQUIRED", details: ["noLegalServiceClaim"] };
+  }
+  if (!String(input?.idempotencyKey || "").trim()) {
+    return { ok: false, error: "RENEWAL_NOTICE_IDEMPOTENCY_KEY_REQUIRED", details: ["idempotencyKey"] };
+  }
+  return {
+    ok: true,
+    snapshotId: String(input.snapshotId),
+    approvalDecisionItemId: String(input.approvalDecisionItemId),
+    idempotencyKey: String(input.idempotencyKey),
+  };
+});
 const sanitizeLeaseRenewalOperatorInput = vi.fn((body: any) => ({
   ok: true,
   data: {
@@ -173,6 +213,7 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
 
 vi.mock("../../services/renewalNoticeCommunicationService", () => ({
   sendRenewalNoticeCommunication,
+  validateRenewalNoticeCommunicationInput,
 }));
 
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
@@ -248,6 +289,7 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
         summary: { title: "Lease notice preview", body: "Preview body" },
       },
     });
+    sendRenewalNoticeCommunication.mockReset();
     sendRenewalNoticeCommunication.mockResolvedValue(renewalNoticeCommunicationSuccess);
   });
 
@@ -623,7 +665,7 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
       body,
     });
 
-    expect(res.status).toBe(statusCode);
+    expect(res.status, JSON.stringify(res.body)).toBe(statusCode);
     expect(res.body).toEqual(
       expect.objectContaining({
         ok: false,

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -112,6 +112,21 @@ const saveRenewalNoticeDraftSnapshot = vi.fn(async () => ({
     canonicalEventId: "canonical-1",
   },
 }));
+const sendRenewalNoticeCommunication = vi.fn(async () => ({
+  ok: true,
+  communicationId: "communication-1",
+  status: "email_sent",
+  deliveryStatus: "delivery_status_unknown",
+  attemptedAt: "2026-07-11T12:01:00.000Z",
+  sentAt: "2026-07-11T12:01:01.000Z",
+  providerMessageId: null,
+  auditEventId: "event-communication-1",
+  timelineEventId: "canonical-communication-1",
+  noLegalServiceClaim: true,
+  noticeServed: false,
+  tenantNotified: true,
+  legalServiceEstablished: false,
+}));
 const sanitizeLeaseRenewalOperatorInput = vi.fn((body: any) => ({
   ok: true,
   data: {
@@ -153,6 +168,10 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   saveRenewalNoticeDraftSnapshot,
   sanitizeLeaseRenewalOperatorInput,
   sendLeaseWorkflowEmail,
+}));
+
+vi.mock("../../services/renewalNoticeCommunicationService", () => ({
+  sendRenewalNoticeCommunication,
 }));
 
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
@@ -399,6 +418,46 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
         input: expect.objectContaining({
           draftText: expect.stringContaining("Draft renewal notice text"),
         }),
+      })
+    );
+    expect(performLeaseNoticeSendFromPreviewInput).not.toHaveBeenCalled();
+    expect(sendLeaseWorkflowEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends a renewal tenant communication through the gated API service without legacy notice send", async () => {
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const body = {
+      snapshotId: "snapshot-1",
+      approvalDecisionItemId: "decision-1",
+      confirmationAccepted: true,
+      recipientReviewed: true,
+      bodyReviewed: true,
+      legalServiceAcknowledged: true,
+      noLegalServiceClaim: true,
+      idempotencyKey: "idem-1",
+    };
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/renewal-notice-communications",
+      body,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        communicationId: "communication-1",
+        noticeServed: false,
+        tenantNotified: true,
+        legalServiceEstablished: false,
+      })
+    );
+    expect(sendRenewalNoticeCommunication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        actorId: "landlord-1",
+        input: body,
       })
     );
     expect(performLeaseNoticeSendFromPreviewInput).not.toHaveBeenCalled();

--- a/rentchain-api/src/routes/landlordEvidencePackRoutes.ts
+++ b/rentchain-api/src/routes/landlordEvidencePackRoutes.ts
@@ -98,7 +98,7 @@ router.get("/evidence-packs/preview", requireAuth, requireLandlord, async (req: 
     if (!scope || !scopeId) return res.status(400).json({ ok: false, error: "EVIDENCE_PACK_SCOPE_REQUIRED" });
 
     const packageType = requestedPackageType(req.query?.packageType);
-    const [properties, leases, units, maintenanceRequests, rentPayments, events, decisions, operatorReviewSessions] =
+    const [properties, leases, units, maintenanceRequests, rentPayments, events, renewalNoticeCommunications, decisions, operatorReviewSessions] =
       await Promise.all([
         loadLandlordCollection("properties", landlordId),
         loadLandlordCollection("leases", landlordId),
@@ -106,6 +106,7 @@ router.get("/evidence-packs/preview", requireAuth, requireLandlord, async (req: 
         loadLandlordCollection("maintenanceRequests", landlordId),
         loadLandlordCollection("rentPayments", landlordId),
         loadLandlordCollection("events", landlordId),
+        loadLandlordCollection("renewalNoticeCommunications", landlordId),
         loadLandlordDecisionItems(landlordId),
         loadOperatorReviewSessions(landlordId),
       ]);
@@ -143,6 +144,7 @@ router.get("/evidence-packs/preview", requireAuth, requireLandlord, async (req: 
       institutionExportPackage,
       auditComplianceReadiness,
       canonicalEvents: events,
+      renewalNoticeCommunications,
       leases,
       properties,
       maintenanceRequests,

--- a/rentchain-api/src/routes/landlordReviewTimelineRoutes.ts
+++ b/rentchain-api/src/routes/landlordReviewTimelineRoutes.ts
@@ -127,7 +127,7 @@ router.get("/review-timeline", requireAuth, requireLandlord, async (req: any, re
     if (!scope || !scopeId) return res.status(400).json({ ok: false, error: "REVIEW_TIMELINE_SCOPE_REQUIRED" });
 
     const packageType = requestedPackageType(queryValue(req, "packageType"));
-    const [properties, leases, units, maintenanceRequests, rentPayments, events, canonicalEvents, decisions, operatorReviewSessions] =
+    const [properties, leases, units, maintenanceRequests, rentPayments, events, canonicalEvents, renewalNoticeCommunications, decisions, operatorReviewSessions] =
       await Promise.all([
         loadLandlordCollection("properties", landlordId),
         loadLandlordCollection("leases", landlordId),
@@ -136,6 +136,7 @@ router.get("/review-timeline", requireAuth, requireLandlord, async (req: any, re
         loadLandlordCollection("rentPayments", landlordId),
         loadLandlordCollection("events", landlordId),
         loadLandlordCanonicalEvents(landlordId),
+        loadLandlordCollection("renewalNoticeCommunications", landlordId),
         loadLandlordDecisionItems(landlordId),
         loadOperatorReviewSessions(landlordId),
       ]);
@@ -173,6 +174,7 @@ router.get("/review-timeline", requireAuth, requireLandlord, async (req: any, re
       institutionExportPackage,
       auditComplianceReadiness,
       canonicalEvents: auditEvents,
+      renewalNoticeCommunications,
       leases,
       properties,
       maintenanceRequests,

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -22,7 +22,10 @@ import {
   sanitizeLeaseRenewalOperatorInput,
   sendLeaseWorkflowEmail,
 } from "../services/leaseNoticeWorkflowService";
-import { sendRenewalNoticeCommunication } from "../services/renewalNoticeCommunicationService";
+import {
+  sendRenewalNoticeCommunication,
+  validateRenewalNoticeCommunicationInput,
+} from "../services/renewalNoticeCommunicationService";
 import { deriveLeaseLifecycleSummary } from "../services/leaseLifecycle/deriveLeaseLifecycleSummary";
 import { executeAutomation } from "../lib/automation/automationExecutor";
 import { buildLeaseNoticePolicyRequest } from "../lib/policy/policyAdapters";
@@ -259,6 +262,11 @@ router.post("/:id/renewal-notice-communications", async (req: any, res) => {
     const actorId = String(req.user?.id || landlordId || "").trim() || null;
     const actorEmail = String(req.user?.email || req.user?.claims?.email || "").trim() || null;
     const leaseId = String(req.params?.id || "").trim();
+    const validation = validateRenewalNoticeCommunicationInput(req.body || {});
+    if (!validation.ok) {
+      return res.status(400).json({ ok: false, error: validation.error, details: validation.details || [] });
+    }
+
     const leaseResult = await getLeaseForLandlordWorkflow(leaseId, landlordId);
     if (!leaseResult.ok) {
       return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -22,6 +22,7 @@ import {
   sanitizeLeaseRenewalOperatorInput,
   sendLeaseWorkflowEmail,
 } from "../services/leaseNoticeWorkflowService";
+import { sendRenewalNoticeCommunication } from "../services/renewalNoticeCommunicationService";
 import { deriveLeaseLifecycleSummary } from "../services/leaseLifecycle/deriveLeaseLifecycleSummary";
 import { executeAutomation } from "../lib/automation/automationExecutor";
 import { buildLeaseNoticePolicyRequest } from "../lib/policy/policyAdapters";
@@ -249,6 +250,36 @@ router.post("/:id/renewal-notice-draft-snapshots", async (req: any, res) => {
   } catch (err: any) {
     console.error("[lease-notice] renewal draft snapshot save failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "LEASE_RENEWAL_DRAFT_SNAPSHOT_SAVE_FAILED" });
+  }
+});
+
+router.post("/:id/renewal-notice-communications", async (req: any, res) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const actorId = String(req.user?.id || landlordId || "").trim() || null;
+    const actorEmail = String(req.user?.email || req.user?.claims?.email || "").trim() || null;
+    const leaseId = String(req.params?.id || "").trim();
+    const leaseResult = await getLeaseForLandlordWorkflow(leaseId, landlordId);
+    if (!leaseResult.ok) {
+      return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
+    }
+
+    const result = await sendRenewalNoticeCommunication({
+      leaseId,
+      landlordId,
+      actorId,
+      actorEmail,
+      lease: normalizeLeaseRecord(leaseId, leaseResult.lease),
+      input: req.body || {},
+    });
+    if (!result.ok) {
+      const { statusCode, ...payload } = result;
+      return res.status(statusCode).json(payload);
+    }
+    return res.status(result.idempotent ? 200 : 201).json(result);
+  } catch (err: any) {
+    console.error("[lease-notice] renewal tenant communication send failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "RENEWAL_NOTICE_COMMUNICATION_SEND_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock, sendEmailMock, lookupUserEmailMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+
+  const dbMock = {
+    collection: (name: string) => ({
+      doc: (id?: string) => {
+        const docId = id || `${name}_${++autoId}`;
+        return {
+          id: docId,
+          get: async () => ({
+            id: docId,
+            exists: ensureCollection(name).has(docId),
+            data: () => ensureCollection(name).get(docId),
+          }),
+          set: async (value: any, options?: { merge?: boolean }) => {
+            const current = ensureCollection(name).get(docId) || {};
+            ensureCollection(name).set(docId, options?.merge ? { ...current, ...value } : value);
+          },
+        };
+      },
+    }),
+    batch: () => {
+      const ops: Array<() => Promise<void>> = [];
+      return {
+        set(ref: any, value: any, options?: { merge?: boolean }) {
+          ops.push(() => ref.set(value, options));
+        },
+        async commit() {
+          for (const op of ops) await op();
+        },
+      };
+    },
+  };
+
+  return {
+    collections,
+    dbMock,
+    sendEmailMock: vi.fn(async () => undefined),
+    lookupUserEmailMock: vi.fn(async () => "tenant@example.com"),
+  };
+});
+
+vi.mock("../../firebase", () => ({ db: dbMock }));
+vi.mock("../emailService", () => ({ sendEmail: sendEmailMock }));
+vi.mock("../leaseNoticeWorkflowService", () => ({ lookupUserEmail: lookupUserEmailMock }));
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) collections.set(collectionName, new Map());
+  collections.get(collectionName)!.set(id, data);
+}
+
+function baseLease(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "lease-1",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    propertyLabel: "Harbour View",
+    propertyAddress: "12 Harbour Road",
+    unitLabel: "Unit 101",
+    status: "active",
+    leaseType: "fixed_term",
+    province: "NS",
+    leaseStartDate: "2026-01-01",
+    leaseEndDate: "2026-12-31",
+    currentRent: 1850,
+    currency: "CAD",
+    ...overrides,
+  } as any;
+}
+
+function baseSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    snapshotId: "snapshot-1",
+    leaseId: "lease-1",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    propertyUnitLabel: "Harbour View · Unit 101",
+    generatedDraftText: "Hello Jane,\n\nThe new fixed term would begin on January 1, 2027.",
+    generatedAt: "2026-07-11T12:00:00.000Z",
+    savedAt: "2026-07-11T12:01:00.000Z",
+    source: "renewal_notice_draft",
+    status: "draft_saved",
+    emailSent: false,
+    noticeServed: false,
+    tenantNotified: false,
+    ...overrides,
+  };
+}
+
+function baseDecision(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "decision-1",
+    landlordId: "landlord-1",
+    sourceType: "renewal_notice_send_review",
+    sourceId: "lease:lease-1:renewal_notice_send_review",
+    sourceRoute: "/leases/lease-1/workflows/notice",
+    status: "approved",
+    leaseId: "lease-1",
+    propertyId: "property-1",
+    tenantId: "tenant-1",
+    sourceSnapshot: { draftSnapshotId: "snapshot-1", leaseId: "lease-1" },
+    metadata: { draftSnapshotId: "snapshot-1" },
+    ...overrides,
+  };
+}
+
+const confirmationPayload = {
+  snapshotId: "snapshot-1",
+  approvalDecisionItemId: "decision-1",
+  confirmationAccepted: true,
+  recipientReviewed: true,
+  bodyReviewed: true,
+  legalServiceAcknowledged: true,
+  noLegalServiceClaim: true,
+  idempotencyKey: "idem-1",
+};
+
+async function send(overrides: Record<string, unknown> = {}) {
+  const { sendRenewalNoticeCommunication } = await import("../renewalNoticeCommunicationService");
+  return sendRenewalNoticeCommunication({
+    leaseId: "lease-1",
+    landlordId: "landlord-1",
+    actorId: "landlord-1",
+    actorEmail: "manager@example.com",
+    lease: baseLease(),
+    input: { ...confirmationPayload, ...overrides },
+  });
+}
+
+describe("sendRenewalNoticeCommunication", () => {
+  beforeEach(() => {
+    collections.clear();
+    vi.clearAllMocks();
+    lookupUserEmailMock.mockResolvedValue("tenant@example.com");
+    sendEmailMock.mockResolvedValue(undefined);
+    seedDoc("renewalNoticeDraftSnapshots", "snapshot-1", baseSnapshot());
+    seedDoc("landlordDecisionQueueItems", "decision-1", baseDecision());
+  });
+
+  it("sends from the saved snapshot after approval and confirmation without creating notices or lease lifecycle changes", async () => {
+    const result = await send();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        status: "email_sent",
+        deliveryStatus: "delivery_status_unknown",
+        noticeServed: false,
+        tenantNotified: true,
+        legalServiceEstablished: false,
+        noLegalServiceClaim: true,
+      })
+    );
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "tenant@example.com",
+        subject: "Renewal details for Harbour View · Unit 101",
+        text: expect.stringContaining("The new fixed term would begin"),
+      })
+    );
+    const communications = Array.from((collections.get("renewalNoticeCommunications") || new Map()).values());
+    expect(communications).toHaveLength(1);
+    expect(communications[0]).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        snapshotId: "snapshot-1",
+        approvalDecisionItemId: "decision-1",
+        status: "email_sent",
+        tenantNotified: true,
+        noticeServed: false,
+        legalServiceEstablished: false,
+      })
+    );
+    expect(collections.get("leaseNotices")).toBeUndefined();
+    expect(collections.get("leases")).toBeUndefined();
+  });
+
+  it.each([
+    "confirmationAccepted",
+    "recipientReviewed",
+    "bodyReviewed",
+    "legalServiceAcknowledged",
+    "noLegalServiceClaim",
+  ])("requires %s before attempting send", async (field) => {
+    const result = await send({ [field]: false });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        statusCode: 400,
+        error: "RENEWAL_NOTICE_SEND_CONFIRMATION_REQUIRED",
+        details: expect.arrayContaining([field]),
+      })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("requires an idempotency key", async () => {
+    const result = await send({ idempotencyKey: "" });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        statusCode: 400,
+        error: "RENEWAL_NOTICE_SEND_CONFIRMATION_REQUIRED",
+        details: expect.arrayContaining(["idempotencyKey"]),
+      })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing or mismatched snapshots", async () => {
+    const missing = await send({ snapshotId: "missing-snapshot" });
+    expect(missing).toEqual(expect.objectContaining({ ok: false, statusCode: 404, error: "RENEWAL_NOTICE_DRAFT_SNAPSHOT_NOT_FOUND" }));
+
+    seedDoc("renewalNoticeDraftSnapshots", "snapshot-2", baseSnapshot({ snapshotId: "snapshot-2", leaseId: "lease-2" }));
+    const mismatch = await send({ snapshotId: "snapshot-2", idempotencyKey: "idem-2" });
+    expect(mismatch).toEqual(expect.objectContaining({ ok: false, statusCode: 403, error: "RENEWAL_NOTICE_DRAFT_SNAPSHOT_SCOPE_MISMATCH" }));
+  });
+
+  it("rejects missing, unapproved, wrong-source, or snapshot-mismatched approval decisions", async () => {
+    const missing = await send({ approvalDecisionItemId: "missing-decision" });
+    expect(missing).toEqual(expect.objectContaining({ ok: false, statusCode: 404, error: "RENEWAL_NOTICE_APPROVAL_DECISION_NOT_FOUND" }));
+
+    seedDoc("landlordDecisionQueueItems", "decision-open", baseDecision({ id: "decision-open", status: "open" }));
+    const notApproved = await send({ approvalDecisionItemId: "decision-open", idempotencyKey: "idem-2" });
+    expect(notApproved).toEqual(expect.objectContaining({ ok: false, statusCode: 409, error: "RENEWAL_NOTICE_APPROVAL_DECISION_NOT_APPROVED" }));
+
+    seedDoc("landlordDecisionQueueItems", "decision-source", baseDecision({ id: "decision-source", sourceType: "payment_readiness" }));
+    const wrongSource = await send({ approvalDecisionItemId: "decision-source", idempotencyKey: "idem-3" });
+    expect(wrongSource).toEqual(expect.objectContaining({ ok: false, statusCode: 400, error: "RENEWAL_NOTICE_APPROVAL_DECISION_SOURCE_TYPE_INVALID" }));
+
+    seedDoc("landlordDecisionQueueItems", "decision-snapshot", baseDecision({ id: "decision-snapshot", metadata: { draftSnapshotId: "other" } }));
+    const mismatch = await send({ approvalDecisionItemId: "decision-snapshot", idempotencyKey: "idem-4" });
+    expect(mismatch).toEqual(expect.objectContaining({ ok: false, statusCode: 409, error: "RENEWAL_NOTICE_APPROVAL_SNAPSHOT_MISMATCH" }));
+  });
+
+  it("requires a tenant email before calling the provider", async () => {
+    lookupUserEmailMock.mockResolvedValue(null);
+    const result = await send();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false, statusCode: 400, error: "RENEWAL_NOTICE_TENANT_EMAIL_REQUIRED" }));
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an idempotent response without sending a duplicate email", async () => {
+    const first = await send();
+    const second = await send();
+
+    expect(first.ok).toBe(true);
+    expect(second).toEqual(expect.objectContaining({ ok: true, idempotent: true, communicationId: (first as any).communicationId }));
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores a failed communication safely when the provider rejects the email", async () => {
+    sendEmailMock.mockRejectedValue(new Error("mailgun_send_failed:500"));
+    const result = await send();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        statusCode: 502,
+        error: "RENEWAL_NOTICE_EMAIL_SEND_FAILED",
+        status: "email_failed",
+        tenantNotified: false,
+        noticeServed: false,
+        legalServiceEstablished: false,
+      })
+    );
+    const communications = Array.from((collections.get("renewalNoticeCommunications") || new Map()).values());
+    expect(communications[0]).toEqual(
+      expect.objectContaining({
+        status: "email_failed",
+        tenantNotified: false,
+        noticeServed: false,
+        legalServiceEstablished: false,
+        errorCode: "EMAIL_SEND_FAILED",
+      })
+    );
+    expect(collections.get("leaseNotices")).toBeUndefined();
+    expect(collections.get("leases")).toBeUndefined();
+  });
+
+  it("writes landlord-visible audit and canonical events for attempted and final states", async () => {
+    await send();
+
+    const legacyEvents = Array.from((collections.get("events") || new Map()).values());
+    const canonicalEvents = Array.from((collections.get("canonicalEvents") || new Map()).values());
+    expect(legacyEvents.map((event: any) => event.type)).toEqual([
+      "renewal_notice_send_confirmed",
+      "renewal_notice_email_send_attempted",
+      "renewal_notice_email_sent",
+    ]);
+    expect(canonicalEvents.map((event: any) => event.type)).toEqual([
+      "renewal_notice_send_confirmed",
+      "renewal_notice_email_send_attempted",
+      "renewal_notice_email_sent",
+    ]);
+    expect(canonicalEvents[2]).toEqual(
+      expect.objectContaining({
+        visibility: "landlord",
+        summary: "Renewal tenant communication email sent. Not served; legal service not established.",
+        metadata: expect.objectContaining({
+          tenantNotified: true,
+          noticeServed: false,
+          legalServiceEstablished: false,
+        }),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
@@ -189,19 +189,36 @@ describe("sendRenewalNoticeCommunication", () => {
   });
 
   it.each([
-    "confirmationAccepted",
-    "recipientReviewed",
-    "bodyReviewed",
-    "legalServiceAcknowledged",
-    "noLegalServiceClaim",
-  ])("requires %s before attempting send", async (field) => {
+    ["confirmationAccepted", "RENEWAL_NOTICE_CONFIRMATION_ACCEPTED_REQUIRED"],
+    ["recipientReviewed", "RENEWAL_NOTICE_RECIPIENT_REVIEWED_REQUIRED"],
+    ["bodyReviewed", "RENEWAL_NOTICE_BODY_REVIEWED_REQUIRED"],
+    ["legalServiceAcknowledged", "RENEWAL_NOTICE_LEGAL_SERVICE_ACKNOWLEDGED_REQUIRED"],
+    ["noLegalServiceClaim", "RENEWAL_NOTICE_NO_LEGAL_SERVICE_CLAIM_REQUIRED"],
+  ])("requires %s before attempting send", async (field, error) => {
     const result = await send({ [field]: false });
 
     expect(result).toEqual(
       expect.objectContaining({
         ok: false,
         statusCode: 400,
-        error: "RENEWAL_NOTICE_SEND_CONFIRMATION_REQUIRED",
+        error,
+        details: expect.arrayContaining([field]),
+      })
+    );
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["snapshotId", "RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED"],
+    ["approvalDecisionItemId", "RENEWAL_NOTICE_APPROVAL_DECISION_ITEM_ID_REQUIRED"],
+  ])("requires %s before attempting send", async (field, error) => {
+    const result = await send({ [field]: "" });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: false,
+        statusCode: 400,
+        error,
         details: expect.arrayContaining([field]),
       })
     );
@@ -215,7 +232,7 @@ describe("sendRenewalNoticeCommunication", () => {
       expect.objectContaining({
         ok: false,
         statusCode: 400,
-        error: "RENEWAL_NOTICE_SEND_CONFIRMATION_REQUIRED",
+        error: "RENEWAL_NOTICE_IDEMPOTENCY_KEY_REQUIRED",
         details: expect.arrayContaining(["idempotencyKey"]),
       })
     );

--- a/rentchain-api/src/services/renewalNoticeCommunicationService.ts
+++ b/rentchain-api/src/services/renewalNoticeCommunicationService.ts
@@ -1,0 +1,524 @@
+import crypto from "crypto";
+import { db } from "../firebase";
+import { CANONICAL_EVENTS_COLLECTION, buildEvent } from "../lib/events/buildEvent";
+import { sendEmail } from "./emailService";
+import { lookupUserEmail, type LeaseWorkflowLease } from "./leaseNoticeWorkflowService";
+import { LANDLORD_DECISION_QUEUE_ITEMS_COLLECTION } from "./landlordDecisionQueue/landlordDecisionQueueLifecycleService";
+
+export const RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION = "renewalNoticeCommunications";
+
+type SendRenewalNoticeCommunicationInput = {
+  snapshotId?: unknown;
+  approvalDecisionItemId?: unknown;
+  confirmationAccepted?: unknown;
+  recipientReviewed?: unknown;
+  bodyReviewed?: unknown;
+  legalServiceAcknowledged?: unknown;
+  noLegalServiceClaim?: unknown;
+  idempotencyKey?: unknown;
+};
+
+type SendRenewalNoticeCommunicationParams = {
+  leaseId: string;
+  landlordId: string;
+  actorId?: string | null;
+  actorEmail?: string | null;
+  lease: LeaseWorkflowLease;
+  input: SendRenewalNoticeCommunicationInput;
+};
+
+type RenewalNoticeCommunicationRecord = {
+  communicationId: string;
+  leaseId: string;
+  landlordId: string;
+  tenantId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  snapshotId: string;
+  approvalDecisionItemId: string;
+  idempotencyKeyHash: string;
+  subject: string;
+  recipientEmail: string;
+  bodyHash: string;
+  status: "send_attempted" | "email_sent" | "email_failed";
+  deliveryStatus: "delivery_status_unknown";
+  provider: "mailgun";
+  providerMessageId: null;
+  attemptedAt: string;
+  sentAt: string | null;
+  failedAt: string | null;
+  tenantNotified: boolean;
+  noticeServed: false;
+  legalServiceEstablished: false;
+  noLegalServiceClaim: true;
+  confirmation: {
+    confirmationAccepted: true;
+    recipientReviewed: true;
+    bodyReviewed: true;
+    legalServiceAcknowledged: true;
+    noLegalServiceClaim: true;
+  };
+  actor: { id: string | null; email: string | null };
+  source: "renewal_notice_communication_send_api";
+  createdAt: string;
+  updatedAt: string;
+  auditEventIds: string[];
+  canonicalEventIds: string[];
+  errorCode?: string | null;
+  errorMessage?: string | null;
+};
+
+type SendRenewalNoticeCommunicationResult =
+  | {
+      ok: true;
+      idempotent?: boolean;
+      communicationId: string;
+      status: RenewalNoticeCommunicationRecord["status"];
+      deliveryStatus: RenewalNoticeCommunicationRecord["deliveryStatus"];
+      attemptedAt: string;
+      sentAt: string | null;
+      providerMessageId: null;
+      auditEventId: string | null;
+      timelineEventId: string | null;
+      noLegalServiceClaim: true;
+      noticeServed: false;
+      tenantNotified: boolean;
+      legalServiceEstablished: false;
+    }
+  | {
+      ok: false;
+      statusCode: number;
+      error: string;
+      details?: string[];
+      communicationId?: string;
+      status?: RenewalNoticeCommunicationRecord["status"];
+      deliveryStatus?: RenewalNoticeCommunicationRecord["deliveryStatus"];
+      attemptedAt?: string;
+      sentAt?: string | null;
+      providerMessageId?: null;
+      auditEventId?: string | null;
+      timelineEventId?: string | null;
+      noLegalServiceClaim?: true;
+      noticeServed?: false;
+      tenantNotified?: boolean;
+      legalServiceEstablished?: false;
+    };
+
+function asString(value: unknown, max = 1000): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function communicationIdFor(input: {
+  landlordId: string;
+  leaseId: string;
+  snapshotId: string;
+  idempotencyKey: string;
+}): string {
+  return `rnc_${sha256([input.landlordId, input.leaseId, input.snapshotId, input.idempotencyKey].join(":")).slice(0, 40)}`;
+}
+
+function htmlFromText(text: string): string {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+  return `<div style="white-space:pre-line;font-family:Arial,sans-serif;line-height:1.5;color:#111827;">${escaped}</div>`;
+}
+
+function safeErrorMessage(error: unknown): string {
+  return asString((error as any)?.message || error || "email_send_failed", 240).replace(/\bhttps?:\/\/\S+/gi, "[url]");
+}
+
+function validateConfirmation(input: SendRenewalNoticeCommunicationInput): {
+  ok: true;
+  snapshotId: string;
+  approvalDecisionItemId: string;
+  idempotencyKey: string;
+} | {
+  ok: false;
+  error: string;
+  details: string[];
+} {
+  const details: string[] = [];
+  const snapshotId = asString(input?.snapshotId, 240);
+  const approvalDecisionItemId = asString(input?.approvalDecisionItemId, 240);
+  const idempotencyKey = asString(input?.idempotencyKey, 240);
+  if (!snapshotId) details.push("snapshotId");
+  if (!approvalDecisionItemId) details.push("approvalDecisionItemId");
+  if (!idempotencyKey) details.push("idempotencyKey");
+  for (const field of [
+    "confirmationAccepted",
+    "recipientReviewed",
+    "bodyReviewed",
+    "legalServiceAcknowledged",
+    "noLegalServiceClaim",
+  ] as const) {
+    if (input?.[field] !== true) details.push(field);
+  }
+  if (details.length) return { ok: false, error: "RENEWAL_NOTICE_SEND_CONFIRMATION_REQUIRED", details };
+  return { ok: true, snapshotId, approvalDecisionItemId, idempotencyKey };
+}
+
+function toResponse(record: RenewalNoticeCommunicationRecord, idempotent = false): Extract<SendRenewalNoticeCommunicationResult, { ok: true }> {
+  return {
+    ok: true,
+    idempotent: idempotent || undefined,
+    communicationId: record.communicationId,
+    status: record.status,
+    deliveryStatus: record.deliveryStatus,
+    attemptedAt: record.attemptedAt,
+    sentAt: record.sentAt,
+    providerMessageId: record.providerMessageId,
+    auditEventId: record.auditEventIds[record.auditEventIds.length - 1] || null,
+    timelineEventId: record.canonicalEventIds[record.canonicalEventIds.length - 1] || null,
+    noLegalServiceClaim: true,
+    noticeServed: false,
+    tenantNotified: record.tenantNotified,
+    legalServiceEstablished: false,
+  };
+}
+
+function communicationSummary(record: RenewalNoticeCommunicationRecord): string {
+  if (record.status === "send_attempted") {
+    return "Renewal tenant communication send attempted. Not served; legal service not established.";
+  }
+  if (record.status === "email_sent") {
+    return "Renewal tenant communication email sent. Not served; legal service not established.";
+  }
+  if (record.status === "email_failed") {
+    return "Renewal tenant communication email failed. Tenant not notified; not served; legal service not established.";
+  }
+  return "Renewal tenant communication send attempted. Not served; legal service not established.";
+}
+
+function communicationEvent(input: {
+  id: string;
+  type:
+    | "renewal_notice_send_confirmed"
+    | "renewal_notice_email_send_attempted"
+    | "renewal_notice_email_sent"
+    | "renewal_notice_email_failed";
+  status: string;
+  summary: string;
+  record: RenewalNoticeCommunicationRecord;
+  occurredAt: string;
+}) {
+  return buildEvent({
+    id: input.id,
+    type: input.type,
+    domain: "lease",
+    action: input.type,
+    status: input.status,
+    actor: {
+      type: "landlord",
+      id: input.record.actor.id,
+      role: "landlord",
+      displayName: input.record.actor.email,
+    },
+    resource: {
+      type: "lease",
+      id: input.record.leaseId,
+      parentType: input.record.propertyId ? "property" : null,
+      parentId: input.record.propertyId,
+    },
+    occurredAt: input.occurredAt,
+    visibility: "landlord",
+    summary: input.summary,
+    metadata: {
+      landlordId: input.record.landlordId,
+      leaseId: input.record.leaseId,
+      tenantId: input.record.tenantId,
+      propertyId: input.record.propertyId,
+      unitId: input.record.unitId,
+      communicationId: input.record.communicationId,
+      snapshotId: input.record.snapshotId,
+      approvalDecisionItemId: input.record.approvalDecisionItemId,
+      deliveryStatus: input.record.deliveryStatus,
+      provider: input.record.provider,
+      providerMessageId: input.record.providerMessageId,
+      noLegalServiceClaim: true,
+      noticeServed: false,
+      tenantNotified: input.record.tenantNotified,
+      legalServiceEstablished: false,
+    },
+    tags: ["renewal_notice", "tenant_communication", "send_api"],
+  });
+}
+
+async function writeCommunicationEvent(input: {
+  record: RenewalNoticeCommunicationRecord;
+  type:
+    | "renewal_notice_send_confirmed"
+    | "renewal_notice_email_send_attempted"
+    | "renewal_notice_email_sent"
+    | "renewal_notice_email_failed";
+  status: string;
+  occurredAt: string;
+  summary?: string;
+}) {
+  const eventRef = db.collection("events").doc();
+  const canonicalEventId = `${input.type}:${input.record.communicationId}:${input.occurredAt}`;
+  const summary = input.summary || communicationSummary(input.record);
+  const legacyEvent = {
+    id: eventRef.id,
+    landlordId: input.record.landlordId,
+    actorUserId: input.record.actor.id || undefined,
+    type: input.type,
+    leaseId: input.record.leaseId,
+    tenantId: input.record.tenantId || undefined,
+    propertyId: input.record.propertyId || undefined,
+    payload: {
+      communicationId: input.record.communicationId,
+      snapshotId: input.record.snapshotId,
+      approvalDecisionItemId: input.record.approvalDecisionItemId,
+      status: input.record.status,
+      deliveryStatus: input.record.deliveryStatus,
+      provider: input.record.provider,
+      noLegalServiceClaim: true,
+      noticeServed: false,
+      tenantNotified: input.record.tenantNotified,
+      legalServiceEstablished: false,
+      summary,
+    },
+    summary,
+    occurredAt: input.occurredAt,
+    createdAt: input.occurredAt,
+  };
+  const canonicalEvent = communicationEvent({
+    id: canonicalEventId,
+    type: input.type,
+    status: input.status,
+    summary,
+    record: input.record,
+    occurredAt: input.occurredAt,
+  });
+  const batch = db.batch();
+  batch.set(eventRef, legacyEvent);
+  batch.set(db.collection(CANONICAL_EVENTS_COLLECTION).doc(canonicalEvent.id), canonicalEvent);
+  await batch.commit();
+  return { auditEventId: eventRef.id, canonicalEventId };
+}
+
+function approvalSnapshotId(decision: any): string {
+  return (
+    asString(decision?.metadata?.draftSnapshotId, 240) ||
+    asString(decision?.sourceSnapshot?.draftSnapshotId, 240) ||
+    asString(decision?.sourceSnapshot?.snapshotId, 240)
+  );
+}
+
+export async function sendRenewalNoticeCommunication(
+  params: SendRenewalNoticeCommunicationParams
+): Promise<SendRenewalNoticeCommunicationResult> {
+  const leaseId = asString(params.leaseId, 240);
+  const landlordId = asString(params.landlordId, 240);
+  if (!leaseId || !landlordId) return { ok: false, statusCode: 401, error: "UNAUTHORIZED" };
+
+  const confirmation = validateConfirmation(params.input);
+  if (!confirmation.ok) {
+    return { ok: false, statusCode: 400, error: confirmation.error, details: confirmation.details };
+  }
+
+  const communicationId = communicationIdFor({
+    landlordId,
+    leaseId,
+    snapshotId: confirmation.snapshotId,
+    idempotencyKey: confirmation.idempotencyKey,
+  });
+  const communicationRef = db.collection(RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION).doc(communicationId);
+  const existingCommunication = await communicationRef.get();
+  if (existingCommunication.exists) {
+    const existing = existingCommunication.data() as RenewalNoticeCommunicationRecord;
+    if (existing.status === "email_failed") {
+      return {
+        ok: false,
+        statusCode: 502,
+        error: "RENEWAL_NOTICE_EMAIL_SEND_FAILED",
+        communicationId: existing.communicationId,
+        status: existing.status,
+        deliveryStatus: existing.deliveryStatus,
+        attemptedAt: existing.attemptedAt,
+        sentAt: null,
+        providerMessageId: null,
+        auditEventId: existing.auditEventIds[existing.auditEventIds.length - 1] || null,
+        timelineEventId: existing.canonicalEventIds[existing.canonicalEventIds.length - 1] || null,
+        noLegalServiceClaim: true,
+        noticeServed: false,
+        tenantNotified: false,
+        legalServiceEstablished: false,
+      };
+    }
+    return toResponse(existing, true);
+  }
+
+  const snapshotSnap = await db.collection("renewalNoticeDraftSnapshots").doc(confirmation.snapshotId).get();
+  if (!snapshotSnap.exists) return { ok: false, statusCode: 404, error: "RENEWAL_NOTICE_DRAFT_SNAPSHOT_NOT_FOUND" };
+  const snapshot = snapshotSnap.data() as any;
+  if (asString(snapshot?.landlordId, 240) !== landlordId || asString(snapshot?.leaseId, 240) !== leaseId) {
+    return { ok: false, statusCode: 403, error: "RENEWAL_NOTICE_DRAFT_SNAPSHOT_SCOPE_MISMATCH" };
+  }
+  if (asString(snapshot?.status, 80) !== "draft_saved" || !asString(snapshot?.generatedDraftText, 20_000)) {
+    return { ok: false, statusCode: 400, error: "RENEWAL_NOTICE_DRAFT_SNAPSHOT_NOT_SEND_READY" };
+  }
+  if (snapshot?.emailSent === true || snapshot?.noticeServed === true || snapshot?.tenantNotified === true) {
+    return { ok: false, statusCode: 400, error: "RENEWAL_NOTICE_DRAFT_SNAPSHOT_DELIVERY_STATE_INVALID" };
+  }
+
+  const decisionSnap = await db.collection(LANDLORD_DECISION_QUEUE_ITEMS_COLLECTION).doc(confirmation.approvalDecisionItemId).get();
+  if (!decisionSnap.exists) return { ok: false, statusCode: 404, error: "RENEWAL_NOTICE_APPROVAL_DECISION_NOT_FOUND" };
+  const decision = { id: decisionSnap.id, ...((decisionSnap.data() as any) || {}) };
+  if (asString(decision.landlordId, 240) !== landlordId || asString(decision.leaseId, 240) !== leaseId) {
+    return { ok: false, statusCode: 403, error: "RENEWAL_NOTICE_APPROVAL_DECISION_SCOPE_MISMATCH" };
+  }
+  if (asString(decision.sourceType, 120) !== "renewal_notice_send_review") {
+    return { ok: false, statusCode: 400, error: "RENEWAL_NOTICE_APPROVAL_DECISION_SOURCE_TYPE_INVALID" };
+  }
+  if (asString(decision.status, 80) !== "approved") {
+    return { ok: false, statusCode: 409, error: "RENEWAL_NOTICE_APPROVAL_DECISION_NOT_APPROVED" };
+  }
+  if (approvalSnapshotId(decision) !== confirmation.snapshotId) {
+    return { ok: false, statusCode: 409, error: "RENEWAL_NOTICE_APPROVAL_SNAPSHOT_MISMATCH" };
+  }
+
+  const tenantEmail = await lookupUserEmail(params.lease.tenantId, ["tenants", "users"]);
+  if (!tenantEmail) return { ok: false, statusCode: 400, error: "RENEWAL_NOTICE_TENANT_EMAIL_REQUIRED" };
+
+  const nowIso = new Date().toISOString();
+  const actorId = asString(params.actorId, 240) || null;
+  const actorEmail = asString(params.actorEmail, 320) || null;
+  const body = asString(snapshot.generatedDraftText, 20_000);
+  const subjectContext = asString(snapshot.propertyUnitLabel || params.lease.propertyLabel || params.lease.propertyAddress, 120);
+  const subject = subjectContext ? `Renewal details for ${subjectContext}` : "Renewal details for your lease";
+  const attemptedRecord: RenewalNoticeCommunicationRecord = {
+    communicationId,
+    leaseId,
+    landlordId,
+    tenantId: params.lease.tenantId || snapshot.tenantId || null,
+    propertyId: params.lease.propertyId || snapshot.propertyId || null,
+    unitId: params.lease.unitId || snapshot.unitId || null,
+    snapshotId: confirmation.snapshotId,
+    approvalDecisionItemId: confirmation.approvalDecisionItemId,
+    idempotencyKeyHash: sha256(confirmation.idempotencyKey),
+    subject,
+    recipientEmail: tenantEmail,
+    bodyHash: sha256(body),
+    status: "send_attempted",
+    deliveryStatus: "delivery_status_unknown",
+    provider: "mailgun",
+    providerMessageId: null,
+    attemptedAt: nowIso,
+    sentAt: null,
+    failedAt: null,
+    tenantNotified: false,
+    noticeServed: false,
+    legalServiceEstablished: false,
+    noLegalServiceClaim: true,
+    confirmation: {
+      confirmationAccepted: true,
+      recipientReviewed: true,
+      bodyReviewed: true,
+      legalServiceAcknowledged: true,
+      noLegalServiceClaim: true,
+    },
+    actor: { id: actorId, email: actorEmail },
+    source: "renewal_notice_communication_send_api",
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    auditEventIds: [],
+    canonicalEventIds: [],
+  };
+
+  const confirmedEvent = await writeCommunicationEvent({
+    record: attemptedRecord,
+    type: "renewal_notice_send_confirmed",
+    status: "completed",
+    occurredAt: nowIso,
+    summary: "Renewal tenant communication send confirmed internally. Not served; legal service not established.",
+  });
+  const attemptedEvent = await writeCommunicationEvent({
+    record: attemptedRecord,
+    type: "renewal_notice_email_send_attempted",
+    status: "attempted",
+    occurredAt: nowIso,
+  });
+  const attemptedWithAudit = {
+    ...attemptedRecord,
+    auditEventIds: [confirmedEvent.auditEventId, attemptedEvent.auditEventId],
+    canonicalEventIds: [confirmedEvent.canonicalEventId, attemptedEvent.canonicalEventId],
+  };
+  await communicationRef.set(attemptedWithAudit, { merge: false });
+
+  try {
+    await sendEmail({
+      to: tenantEmail,
+      subject,
+      text: body,
+      html: htmlFromText(body),
+    });
+    const sentAt = new Date().toISOString();
+    const sentRecord: RenewalNoticeCommunicationRecord = {
+      ...attemptedWithAudit,
+      status: "email_sent",
+      sentAt,
+      tenantNotified: true,
+      updatedAt: sentAt,
+    };
+    const sentEvent = await writeCommunicationEvent({
+      record: sentRecord,
+      type: "renewal_notice_email_sent",
+      status: "completed",
+      occurredAt: sentAt,
+    });
+    const finalRecord = {
+      ...sentRecord,
+      auditEventIds: [...sentRecord.auditEventIds, sentEvent.auditEventId],
+      canonicalEventIds: [...sentRecord.canonicalEventIds, sentEvent.canonicalEventId],
+    };
+    await communicationRef.set(finalRecord, { merge: true });
+    return toResponse(finalRecord);
+  } catch (err: any) {
+    const failedAt = new Date().toISOString();
+    const failedRecord: RenewalNoticeCommunicationRecord = {
+      ...attemptedWithAudit,
+      status: "email_failed",
+      failedAt,
+      updatedAt: failedAt,
+      errorCode: "EMAIL_SEND_FAILED",
+      errorMessage: safeErrorMessage(err),
+    };
+    const failedEvent = await writeCommunicationEvent({
+      record: failedRecord,
+      type: "renewal_notice_email_failed",
+      status: "failed",
+      occurredAt: failedAt,
+    });
+    const finalRecord = {
+      ...failedRecord,
+      auditEventIds: [...failedRecord.auditEventIds, failedEvent.auditEventId],
+      canonicalEventIds: [...failedRecord.canonicalEventIds, failedEvent.canonicalEventId],
+    };
+    await communicationRef.set(finalRecord, { merge: true });
+    return {
+      ok: false,
+      statusCode: 502,
+      error: "RENEWAL_NOTICE_EMAIL_SEND_FAILED",
+      communicationId: finalRecord.communicationId,
+      status: finalRecord.status,
+      deliveryStatus: finalRecord.deliveryStatus,
+      attemptedAt: finalRecord.attemptedAt,
+      sentAt: null,
+      providerMessageId: null,
+      auditEventId: failedEvent.auditEventId,
+      timelineEventId: failedEvent.canonicalEventId,
+      noLegalServiceClaim: true,
+      noticeServed: false,
+      tenantNotified: false,
+      legalServiceEstablished: false,
+    };
+  }
+}

--- a/rentchain-api/src/services/renewalNoticeCommunicationService.ts
+++ b/rentchain-api/src/services/renewalNoticeCommunicationService.ts
@@ -142,25 +142,39 @@ function validateConfirmation(input: SendRenewalNoticeCommunicationInput): {
 } | {
   ok: false;
   error: string;
-  details: string[];
+  details?: string[];
 } {
-  const details: string[] = [];
   const snapshotId = asString(input?.snapshotId, 240);
   const approvalDecisionItemId = asString(input?.approvalDecisionItemId, 240);
   const idempotencyKey = asString(input?.idempotencyKey, 240);
-  if (!snapshotId) details.push("snapshotId");
-  if (!approvalDecisionItemId) details.push("approvalDecisionItemId");
-  if (!idempotencyKey) details.push("idempotencyKey");
-  for (const field of [
-    "confirmationAccepted",
-    "recipientReviewed",
-    "bodyReviewed",
-    "legalServiceAcknowledged",
-    "noLegalServiceClaim",
-  ] as const) {
-    if (input?.[field] !== true) details.push(field);
+  if (!snapshotId) return { ok: false, error: "RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED", details: ["snapshotId"] };
+  if (!approvalDecisionItemId) {
+    return {
+      ok: false,
+      error: "RENEWAL_NOTICE_APPROVAL_DECISION_ITEM_ID_REQUIRED",
+      details: ["approvalDecisionItemId"],
+    };
   }
-  if (details.length) return { ok: false, error: "RENEWAL_NOTICE_SEND_CONFIRMATION_REQUIRED", details };
+  if (input?.confirmationAccepted !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_CONFIRMATION_ACCEPTED_REQUIRED", details: ["confirmationAccepted"] };
+  }
+  if (input?.recipientReviewed !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_RECIPIENT_REVIEWED_REQUIRED", details: ["recipientReviewed"] };
+  }
+  if (input?.bodyReviewed !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_BODY_REVIEWED_REQUIRED", details: ["bodyReviewed"] };
+  }
+  if (input?.legalServiceAcknowledged !== true) {
+    return {
+      ok: false,
+      error: "RENEWAL_NOTICE_LEGAL_SERVICE_ACKNOWLEDGED_REQUIRED",
+      details: ["legalServiceAcknowledged"],
+    };
+  }
+  if (input?.noLegalServiceClaim !== true) {
+    return { ok: false, error: "RENEWAL_NOTICE_NO_LEGAL_SERVICE_CLAIM_REQUIRED", details: ["noLegalServiceClaim"] };
+  }
+  if (!idempotencyKey) return { ok: false, error: "RENEWAL_NOTICE_IDEMPOTENCY_KEY_REQUIRED", details: ["idempotencyKey"] };
   return { ok: true, snapshotId, approvalDecisionItemId, idempotencyKey };
 }
 

--- a/rentchain-api/src/services/renewalNoticeCommunicationService.ts
+++ b/rentchain-api/src/services/renewalNoticeCommunicationService.ts
@@ -134,7 +134,7 @@ function safeErrorMessage(error: unknown): string {
   return asString((error as any)?.message || error || "email_send_failed", 240).replace(/\bhttps?:\/\/\S+/gi, "[url]");
 }
 
-function validateConfirmation(input: SendRenewalNoticeCommunicationInput): {
+export function validateRenewalNoticeCommunicationInput(input: SendRenewalNoticeCommunicationInput): {
   ok: true;
   snapshotId: string;
   approvalDecisionItemId: string;
@@ -333,7 +333,7 @@ export async function sendRenewalNoticeCommunication(
   const landlordId = asString(params.landlordId, 240);
   if (!leaseId || !landlordId) return { ok: false, statusCode: 401, error: "UNAUTHORIZED" };
 
-  const confirmation = validateConfirmation(params.input);
+  const confirmation = validateRenewalNoticeCommunicationInput(params.input);
   if (!confirmation.ok) {
     return { ok: false, statusCode: 400, error: confirmation.error, details: confirmation.details };
   }

--- a/rentchain-frontend/api/[...path].ts
+++ b/rentchain-frontend/api/[...path].ts
@@ -1,0 +1,107 @@
+import { getApiBaseUrl } from "./getApiBaseUrl.js";
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const RESPONSE_HEADERS_TO_FORWARD = [
+  "content-type",
+  "cache-control",
+  "x-route-source",
+  "x-landlord-decision-queue-route-version",
+];
+
+export default async function handler(req: any, res: any) {
+  let upstream = "";
+  try {
+    upstream = getApiBaseUrl();
+  } catch (err: any) {
+    console.error("[vercel] missing api proxy base", err?.message || err);
+    return res.status(500).json({
+      ok: false,
+      error: "API_PROXY_BASE_MISSING",
+      detail: String(err?.message || err),
+    });
+  }
+
+  const targetUrl = buildUpstreamUrl(req, upstream);
+  const headers = forwardRequestHeaders(req.headers || {});
+  const body = requestBodyForProxy(req);
+
+  try {
+    const upstreamResponse = await fetch(targetUrl, {
+      method: req.method || "GET",
+      headers,
+      body,
+      redirect: "manual",
+    });
+    const text = await upstreamResponse.text();
+
+    for (const headerName of RESPONSE_HEADERS_TO_FORWARD) {
+      const value = upstreamResponse.headers.get(headerName);
+      if (value) res.setHeader(headerName, value);
+    }
+    res.setHeader("x-rentchain-api-proxy", "vercel-catchall");
+
+    return res.status(upstreamResponse.status).send(text);
+  } catch (err: any) {
+    console.error("[vercel] api proxy failed", { message: err?.message || "failed" });
+    return res.status(502).json({ ok: false, error: "API_PROXY_FAILED" });
+  }
+}
+
+export function buildUpstreamUrl(req: any, upstream: string): string {
+  const base = String(upstream || "").trim().replace(/\/$/, "").replace(/\/api$/i, "");
+  const requestUrl = typeof req?.url === "string" ? req.url : "";
+  const [rawPath, rawQuery = ""] = requestUrl.split("?");
+  const path = rawPath.startsWith("/api/")
+    ? rawPath
+    : `/api/${pathSegments(req).join("/")}`;
+  return `${base}${path}${rawQuery ? `?${rawQuery}` : ""}`;
+}
+
+function pathSegments(req: any): string[] {
+  const rawPath = req?.query?.path;
+  const segments = Array.isArray(rawPath) ? rawPath : rawPath ? [rawPath] : [];
+  return segments
+    .map((segment) => String(segment || "").trim())
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment));
+}
+
+function forwardRequestHeaders(input: Record<string, unknown>): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input)) {
+    const normalizedKey = key.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(normalizedKey)) continue;
+    if (Array.isArray(value)) {
+      headers[key] = value.join(", ");
+    } else if (typeof value === "string") {
+      headers[key] = value;
+    }
+  }
+  headers["x-rentchain-api-proxy"] = "vercel-catchall";
+  return headers;
+}
+
+function requestBodyForProxy(req: any): BodyInit | undefined {
+  const method = String(req?.method || "GET").toUpperCase();
+  if (method === "GET" || method === "HEAD") return undefined;
+
+  const body = req?.body;
+  if (body == null) return undefined;
+  if (typeof body === "string") return body;
+  if (body instanceof ArrayBuffer || body instanceof Blob || body instanceof FormData) return body;
+  if (ArrayBuffer.isView(body)) return body as BodyInit;
+
+  return JSON.stringify(body);
+}

--- a/rentchain-frontend/src/platform/securityHeaders.test.ts
+++ b/rentchain-frontend/src/platform/securityHeaders.test.ts
@@ -87,7 +87,7 @@ describe("frontend Vercel security headers", () => {
     expect(csp).toContain("script-src 'self' https://vercel.live");
     expect(csp).toContain("style-src 'self' 'unsafe-inline'");
     expect(csp).toContain("connect-src 'self'");
-    expect(csp).toContain("https://rentchain-landlord-api-915921057662.us-central1.run.app");
+    expect(csp).toContain("https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app");
     expect(csp).toContain("https://*.a.run.app");
     expect(csp).toContain("https://*.rentchain.ai");
     expect(csp).toContain("https://*.googleapis.com");
@@ -106,7 +106,7 @@ describe("frontend Vercel security headers", () => {
     expect(apiRewrite).toEqual({
       source: "/api/:path*",
       destination:
-        "https://rentchain-landlord-api-915921057662.us-central1.run.app/api/:path*",
+        "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/api/:path*",
     });
     expect(rewriteSources.indexOf("/api/:path*")).toBeGreaterThan(-1);
     expect(rewriteSources.indexOf("/:path*")).toBeGreaterThan(rewriteSources.indexOf("/api/:path*"));

--- a/rentchain-frontend/src/platform/vercelApiProxy.test.ts
+++ b/rentchain-frontend/src/platform/vercelApiProxy.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import handler, { buildUpstreamUrl } from "../../api/[...path]";
+
+function createResponse() {
+  const headers = new Map<string, string>();
+  return {
+    statusCode: 200,
+    body: "",
+    headers,
+    setHeader: vi.fn((key: string, value: string) => {
+      headers.set(key.toLowerCase(), value);
+    }),
+    status: vi.fn(function status(this: any, code: number) {
+      this.statusCode = code;
+      return this;
+    }),
+    send: vi.fn(function send(this: any, body: string) {
+      this.body = body;
+      return this;
+    }),
+    json: vi.fn(function json(this: any, body: unknown) {
+      this.body = JSON.stringify(body);
+      return this;
+    }),
+  };
+}
+
+describe("Vercel API catch-all proxy", () => {
+  const originalApiBase = process.env.VITE_API_BASE_URL;
+
+  beforeEach(() => {
+    process.env.VITE_API_BASE_URL = "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalApiBase == null) {
+      delete process.env.VITE_API_BASE_URL;
+    } else {
+      process.env.VITE_API_BASE_URL = originalApiBase;
+    }
+  });
+
+  it("builds the exact Cloud Run URL for relative app-context API paths", () => {
+    expect(
+      buildUpstreamUrl(
+        {
+          url: "/api/landlord/leases/lease-1/renewal-notice-communications?debug=1",
+          query: { path: ["landlord", "leases", "lease-1", "renewal-notice-communications"] },
+        },
+        "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app",
+      ),
+    ).toBe(
+      "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/api/landlord/leases/lease-1/renewal-notice-communications?debug=1",
+    );
+  });
+
+  it("forwards authenticated invalid payloads to Cloud Run instead of returning Vercel Not Found", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(_url).toBe(
+        "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/api/landlord/leases/lease-1/renewal-notice-communications",
+      );
+      expect(init.method).toBe("POST");
+      expect(init.body).toBe(JSON.stringify({ confirmationAccepted: true }));
+      expect((init.headers as Record<string, string>).authorization).toBe("Bearer test-token");
+      return new Response(
+        JSON.stringify({ ok: false, error: "RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED" }),
+        {
+          status: 400,
+          headers: {
+            "content-type": "application/json",
+            "x-route-source": "leaseNoticeLandlordRoutes.ts",
+          },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      url: "/api/landlord/leases/lease-1/renewal-notice-communications",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+        host: "preview.example.vercel.app",
+      },
+      body: { confirmationAccepted: true },
+      query: { path: ["landlord", "leases", "lease-1", "renewal-notice-communications"] },
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.body).toContain("RENEWAL_NOTICE_SNAPSHOT_ID_REQUIRED");
+    expect(res.headers.get("x-route-source")).toBe("leaseNoticeLandlordRoutes.ts");
+    expect(res.headers.get("x-rentchain-api-proxy")).toBe("vercel-catchall");
+  });
+});

--- a/rentchain-frontend/vercel.json
+++ b/rentchain-frontend/vercel.json
@@ -24,7 +24,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-915921057662.us-central1.run.app https://*.a.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app https://*.a.run.app https://*.rentchain.ai https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.gstatic.com https://*.stripe.com wss://*.firebaseio.com; frame-src 'self' blob: data: https:; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob: data:; form-action 'self'; upgrade-insecure-requests"
         },
         {
           "key": "X-Frame-Options",
@@ -84,11 +84,11 @@
   "rewrites": [
     {
       "source": "/health",
-      "destination": "https://rentchain-landlord-api-915921057662.us-central1.run.app/health"
+      "destination": "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/health"
     },
     {
       "source": "/api/:path*",
-      "destination": "https://rentchain-landlord-api-915921057662.us-central1.run.app/api/:path*"
+      "destination": "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/api/:path*"
     },
     {
       "source": "/sample/:path*",


### PR DESCRIPTION
## Summary

Implements the backend Renewal Tenant Communication Send API v1 at `POST /api/landlord/leases/:leaseId/renewal-notice-communications`.

The endpoint is confirmation-gated and sends only from a saved renewal notice draft snapshot after a matching approved `renewal_notice_send_review` decision exists. It creates append-safe communication/audit records and keeps legal-service boundaries explicit.

## Key behavior

- Adds `renewalNoticeCommunications` records with deterministic idempotency by landlord, lease, snapshot, and idempotency key.
- Requires `snapshotId`, `approvalDecisionItemId`, `confirmationAccepted`, `recipientReviewed`, `bodyReviewed`, `legalServiceAcknowledged`, `noLegalServiceClaim`, and `idempotencyKey`.
- Derives email body from the saved draft snapshot and tenant recipient server-side.
- Validates landlord/lease/snapshot/decision scope server-side.
- Rejects missing snapshot, mismatched snapshot, missing/unapproved/wrong-source decision, missing tenant email, and missing confirmation fields.
- Sends through the existing email provider adapter without using legacy `send-notice`.
- Records `renewal_notice_send_confirmed`, `renewal_notice_email_send_attempted`, `renewal_notice_email_sent`, and `renewal_notice_email_failed` audit/canonical events.
- Adds evidence/timeline projection labels for renewal tenant communication records/events without exposing raw message bodies or provider payloads.

## Guardrails

- No legacy `send-notice` wiring.
- No `leaseNotices` creation.
- No lease lifecycle mutation.
- No notice-served state.
- No legal delivery/compliance/enforceability claim.
- No frontend live-send enablement.

## Validation

Backend, with Node 20.20.2:

- `npm run test -- renewalNoticeCommunication`
- `npm run test -- leaseNoticeLandlordRoutes`
- `npm run test -- landlordDecisionQueueRoutes`
- `npm run test -- landlordDecisionQueue`
- `npm run test -- deriveCanonicalReviewTimeline`
- `npm run test -- deriveEvidencePack`
- `npm run test -- apiRouteOwnershipRegression`
- `npm run build`

Frontend, with Node 20.20.2:

- `npm run test -- LandlordLeaseWorkflowPage`
- `npm run build`

Checks:

- `git diff --check`
- `git diff --cached --check`

Note: The frontend test initially failed under Node 20.11.1 before loading tests due a Vitest/jsdom dependency ESM worker issue. It passed under Node 20.20.2, which also satisfies Vite's Node 20.19+ requirement.