### PR TITLE
feat: enable renewal tenant communication send confirmation UI

### DIFF
--- a/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
+++ b/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
@@ -79,6 +79,34 @@ export type RenewalNoticeDraftSnapshot = {
   canonicalEventId?: string | null;
 };
 
+export type SendRenewalNoticeCommunicationPayload = {
+  snapshotId: string;
+  approvalDecisionItemId: string;
+  confirmationAccepted: true;
+  recipientReviewed: true;
+  bodyReviewed: true;
+  legalServiceAcknowledged: true;
+  noLegalServiceClaim: true;
+  idempotencyKey: string;
+};
+
+export type RenewalNoticeCommunicationResponse = {
+  ok: true;
+  idempotent?: boolean;
+  communicationId: string;
+  status: "send_attempted" | "email_sent" | "email_failed";
+  deliveryStatus: "delivery_status_unknown";
+  attemptedAt: string;
+  sentAt: string | null;
+  providerMessageId: null;
+  auditEventId: string | null;
+  timelineEventId: string | null;
+  noLegalServiceClaim: true;
+  noticeServed: false;
+  tenantNotified: boolean;
+  legalServiceEstablished: false;
+};
+
 export function fetchExpiringLeaseRenewals(params?: {
   propertyId?: string | null;
   withinDays?: number;
@@ -93,6 +121,19 @@ export function fetchExpiringLeaseRenewals(params?: {
   const suffix = search.size ? `?${search.toString()}` : "";
   return apiFetch<{ ok: true; items: LandlordLeaseRenewalLease[]; data: LandlordLeaseRenewalLease[] }>(
     `/landlord/leases/expiring${suffix}`
+  );
+}
+
+export function sendRenewalNoticeCommunication(
+  leaseId: string,
+  payload: SendRenewalNoticeCommunicationPayload
+) {
+  return apiFetch<RenewalNoticeCommunicationResponse>(
+    `/landlord/leases/${encodeURIComponent(leaseId)}/renewal-notice-communications`,
+    {
+      method: "POST",
+      body: payload,
+    }
   );
 }
 

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -953,6 +953,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Delivery status unknown");
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Not served; legal service not established");
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("rnc_test");
+    expect(screen.getByText("rnc_test")).toHaveStyle({ overflowWrap: "anywhere" });
     const sentStatus = screen.getByLabelText("Renewal email sent status");
     expect(within(sentStatus).getByRole("link", { name: "Open lease review timeline" })).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import LandlordLeaseWorkflowPage from "./LandlordLeaseWorkflowPage";
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   fetchExpiringLeaseRenewals: vi.fn(),
   saveLeaseRenewalInputs: vi.fn(),
   saveRenewalNoticeDraftSnapshot: vi.fn(),
+  sendRenewalNoticeCommunication: vi.fn(),
   fetchLandlordDecisionQueue: vi.fn(),
   createLandlordDecisionQueueItem: vi.fn(),
   updateLandlordDecisionQueueItem: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("@/api/landlordLeaseRenewalApi", () => ({
   fetchExpiringLeaseRenewals: mocks.fetchExpiringLeaseRenewals,
   saveLeaseRenewalInputs: mocks.saveLeaseRenewalInputs,
   saveRenewalNoticeDraftSnapshot: mocks.saveRenewalNoticeDraftSnapshot,
+  sendRenewalNoticeCommunication: mocks.sendRenewalNoticeCommunication,
 }));
 
 vi.mock("@/api/landlordDecisionQueueApi", () => ({
@@ -66,7 +68,7 @@ function approvalDecisionFixture(overrides: Record<string, unknown> = {}) {
     severity: "warning",
     title: "Renewal tenant communication ready for approval",
     description:
-      "Saved renewal notice draft is ready for send approval review. Email delivery remains disabled until approved send infrastructure is available.",
+      "Saved renewal notice draft is ready for send approval review. Email delivery is available only after approval and explicit send confirmations.",
     recommendedActionLabel: "Open notice review",
     recommendedActionHref: "/leases/lease-1/workflows/notice",
     dueAt: null,
@@ -76,7 +78,7 @@ function approvalDecisionFixture(overrides: Record<string, unknown> = {}) {
     assignment: null,
     sourceSnapshot: null,
     auditEventIds: ["decision-audit-1"],
-    metadata: { noSendBehavior: true },
+    metadata: { noSendBehavior: false },
     dedupeKey: "lease:lease-1:renewal_notice_send_review",
     sortKey: "2026-07-11T12:00:00.000Z",
     priorityRank: 2,
@@ -91,6 +93,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     mocks.fetchExpiringLeaseRenewals.mockReset();
     mocks.saveLeaseRenewalInputs.mockReset();
     mocks.saveRenewalNoticeDraftSnapshot.mockReset();
+    mocks.sendRenewalNoticeCommunication.mockReset();
     mocks.fetchLandlordDecisionQueue.mockReset();
     mocks.createLandlordDecisionQueueItem.mockReset();
     mocks.updateLandlordDecisionQueueItem.mockReset();
@@ -267,6 +270,21 @@ describe("LandlordLeaseWorkflowPage", () => {
         canonicalEventId: "canonical-1",
       },
     });
+    mocks.sendRenewalNoticeCommunication.mockResolvedValue({
+      ok: true,
+      communicationId: "rnc_test",
+      status: "email_sent",
+      deliveryStatus: "delivery_status_unknown",
+      attemptedAt: "2026-07-13T12:00:00.000Z",
+      sentAt: "2026-07-13T12:00:01.000Z",
+      providerMessageId: null,
+      auditEventId: "communication-audit-1",
+      timelineEventId: "renewal_notice_email_sent:rnc_test:2026-07-13T12:00:01.000Z",
+      noLegalServiceClaim: true,
+      noticeServed: false,
+      tenantNotified: true,
+      legalServiceEstablished: false,
+    });
     mocks.fetchLandlordDecisionQueue.mockResolvedValue({
       ok: true,
       version: "landlord_decision_queue_v1",
@@ -394,19 +412,24 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(sendReview).toHaveTextContent("Prepared from current renewal draft");
     expect(screen.queryByLabelText("Tenant communication body preview")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Tenant communication body reference")).toHaveTextContent(
-      "Uses the renewal notice draft shown above. Exact body must be reviewed and persisted before any future send."
+      "Uses the renewal notice draft shown above. Exact body must be reviewed before sending."
     );
     expect(screen.getAllByLabelText("Tenant notice draft preview")).toHaveLength(1);
+    expect(screen.getByLabelText("Renewal send steps")).toHaveTextContent("Step 1");
+    expect(screen.getByLabelText("Renewal send steps")).toHaveTextContent("Draft snapshot");
+    expect(screen.getByLabelText("Renewal send steps")).toHaveTextContent("Approval decision");
+    expect(screen.getByLabelText("Renewal send steps")).toHaveTextContent("Send confirmation");
     expect(sendReview).toHaveTextContent("Renewal operator inputs saved");
     expect(sendReview).toHaveTextContent("Draft snapshot saved");
     expect(sendReview).toHaveTextContent("Tenant recipient reviewed");
     expect(sendReview).toHaveTextContent("Delivery status model");
     expect(sendReview).toHaveTextContent("Deferred");
-    expect(screen.getByLabelText("Future send confirmation model")).toHaveTextContent(
-      "These confirmations will be required before live tenant communication is enabled."
+    expect(screen.queryByLabelText("Send confirmation checklist")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Send requirements")).toHaveTextContent(
+      "Send renewal email unlocks after the draft snapshot is saved"
     );
     expect(sendReview).toHaveTextContent("Email delivery");
-    expect(sendReview).toHaveTextContent("Not enabled");
+    expect(sendReview).toHaveTextContent("Not sent");
     expect(sendReview).toHaveTextContent("Tenant notification");
     expect(sendReview).toHaveTextContent("Not sent");
     expect(sendReview).toHaveTextContent("Notice service");
@@ -420,8 +443,8 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.queryByRole("button", { name: "Create send approval decision" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Acknowledge" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Approve for future send review" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
-    expect(screen.queryByRole("button", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send renewal email" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /serve notice|send legal notice|complete renewal/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /email renewal notice|send renewal notice/i })).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent(/evidence saved|notice has been served|email sent/i);
 
@@ -488,8 +511,8 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.queryByRole("button", { name: "Save draft snapshot" })).not.toBeInTheDocument();
     const sendReview = screen.getByLabelText("Tenant communication send review");
     expect(sendReview).toHaveTextContent("Draft unavailable");
-    expect(sendReview).toHaveTextContent("Draft body unavailable. Complete renewal inputs before future tenant communication review.");
-    expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
+    expect(sendReview).toHaveTextContent("Draft body unavailable. Fill in renewal inputs before tenant communication review.");
+    expect(screen.getByRole("button", { name: "Send renewal email" })).toBeDisabled();
     expect(screen.getByRole("link", { name: "Return to renewal inputs" })).toHaveAttribute(
       "href",
       "/leases/lease-1/workflows/renewal"
@@ -587,11 +610,12 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(sendReview).toHaveTextContent("Jane Tenant");
     expect(sendReview).toHaveTextContent("Tenant recipient reviewed");
     expect(sendReview).toHaveTextContent("Needs review");
-    const sendButton = screen.getByRole("button", { name: "Send tenant communication - not enabled yet" });
+    const sendButton = screen.getByRole("button", { name: "Send renewal email" });
     expect(sendButton).toBeDisabled();
     fireEvent.click(sendButton);
     expect(mocks.saveRenewalNoticeDraftSnapshot).not.toHaveBeenCalled();
-    expect(document.body).not.toHaveTextContent(/email sent|notice served|legally compliant|tenant legally notified/i);
+    expect(mocks.sendRenewalNoticeCommunication).not.toHaveBeenCalled();
+    expect(document.body).not.toHaveTextContent(/email sent|notice has been served|legally compliant|tenant legally notified/i);
   });
 
   it("copies the notice review draft without sending or creating notice records", async () => {
@@ -770,7 +794,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByRole("button", { name: "Approve for future send review" })).toBeInTheDocument();
   });
 
-  it("creates and updates a send approval decision without enabling tenant communication", async () => {
+  it("creates and approves a send approval decision before enabling confirmations", async () => {
     renderWorkflow("/leases/lease-1/workflows/notice");
 
     await screen.findByLabelText("Tenant notice draft preview");
@@ -797,7 +821,7 @@ describe("LandlordLeaseWorkflowPage", () => {
       tenantId: "tenant-1",
       dedupeKey: "lease:lease-1:renewal_notice_send_review",
     });
-    expect(createPayload.description).toContain("Email delivery remains disabled");
+    expect(createPayload.description).toContain("Email delivery is available only after approval and explicit send confirmations");
     expect(createPayload.sourceSnapshot).toMatchObject({
       tenantLabel: "Jane Tenant",
       propertyUnitLabel: "12 Harbour Road · Unit 101",
@@ -807,7 +831,7 @@ describe("LandlordLeaseWorkflowPage", () => {
       tenantNotified: false,
     });
     expect(createPayload.metadata).toMatchObject({
-      noSendBehavior: true,
+      noSendBehavior: false,
       noTenantNotification: true,
       noNoticeServed: true,
       noLeaseLifecycleMutation: true,
@@ -825,7 +849,7 @@ describe("LandlordLeaseWorkflowPage", () => {
         expect.objectContaining({
           action: "approve",
           metadata: expect.objectContaining({
-            noSendBehavior: true,
+            noSendBehavior: false,
             noTenantNotification: true,
             noNoticeServed: true,
             noLeaseLifecycleMutation: true,
@@ -833,21 +857,126 @@ describe("LandlordLeaseWorkflowPage", () => {
         })
       );
     });
-    expect(await screen.findByText("Future send review approved internally. Send remains disabled.")).toBeInTheDocument();
+    expect(await screen.findByText("Future send review approved internally. Send requires the confirmation checklist.")).toBeInTheDocument();
     expect(approvalSection).toHaveTextContent("Approved");
-    expect(approvalSection).toHaveTextContent("Internal approval has been recorded. Send remains disabled");
+    expect(approvalSection).toHaveTextContent("Internal approval has been recorded. Send still requires explicit confirmation");
     expect(screen.queryByRole("button", { name: "Approve for future send review" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Approved internally");
-    expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Acknowledged for approval");
-    expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Still required before live send");
-    expect(screen.getByLabelText("Tenant communication send review")).toHaveTextContent(
-      "Checklist status reflects internal approval only. Live send confirmation remains deferred"
+    expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Ready for confirmation");
+    expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Ready for send");
+    expect(screen.getByLabelText("Send confirmation checklist")).toHaveTextContent(
+      "Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself."
     );
-    expect(screen.getByLabelText("Future send confirmation model")).toHaveTextContent(
-      "These confirmations will be required before live tenant communication is enabled."
+    expect(screen.getByRole("button", { name: "Send renewal email" })).toBeDisabled();
+    expect(document.body).not.toHaveTextContent(/email sent|tenant notified by email provider acceptance|legal delivery/i);
+  });
+
+  it("requires all send confirmations before calling the renewal communication API", async () => {
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Tenant notice draft preview");
+    expect(screen.queryByLabelText("Send confirmation checklist")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Save draft snapshot" }));
+    await screen.findByText("Audit event recorded.");
+    fireEvent.click(await screen.findByRole("button", { name: "Create send approval decision" }));
+    await screen.findByText("Approval decision created.");
+    fireEvent.click(screen.getByRole("button", { name: "Approve for future send review" }));
+    await screen.findByText("Future send review approved internally. Send requires the confirmation checklist.");
+
+    const confirmationChecklist = screen.getByLabelText("Send confirmation checklist");
+    expect(confirmationChecklist).toHaveTextContent("I have reviewed the recipient(s).");
+    expect(confirmationChecklist).toHaveTextContent("I have reviewed the message body.");
+    expect(confirmationChecklist).toHaveTextContent("I understand this sends tenant communication only.");
+    expect(confirmationChecklist).toHaveTextContent("I understand this does not establish legal notice service by itself.");
+
+    const sendButton = screen.getByRole("button", { name: "Send renewal email" });
+    expect(sendButton).toBeDisabled();
+    fireEvent.click(screen.getByLabelText("I have reviewed the recipient(s)."));
+    fireEvent.click(screen.getByLabelText("I have reviewed the message body."));
+    fireEvent.click(screen.getByLabelText("I understand this sends tenant communication only."));
+    expect(sendButton).toBeDisabled();
+    fireEvent.click(screen.getByLabelText("I understand this does not establish legal notice service by itself."));
+    expect(sendButton).toBeEnabled();
+
+    fireEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(mocks.sendRenewalNoticeCommunication).toHaveBeenCalledWith(
+        "lease-1",
+        expect.objectContaining({
+          snapshotId: "snapshot-1",
+          approvalDecisionItemId: "decision-1",
+          confirmationAccepted: true,
+          recipientReviewed: true,
+          bodyReviewed: true,
+          legalServiceAcknowledged: true,
+          noLegalServiceClaim: true,
+          idempotencyKey: expect.stringMatching(/^renewal-email:lease-1:snapshot-1:decision-1:/),
+        })
+      );
+    });
+    expect(await screen.findByLabelText("Renewal email sent status")).toHaveTextContent("Renewal email sent");
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Delivery status unknown");
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Not served; legal service not established");
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("rnc_test");
+    const sentStatus = screen.getByLabelText("Renewal email sent status");
+    expect(within(sentStatus).getByRole("link", { name: "Open lease review timeline" })).toHaveAttribute(
+      "href",
+      "/review-timeline?scope=lease&scopeId=lease-1"
     );
-    expect(screen.getByRole("button", { name: "Send tenant communication - not enabled yet" })).toBeDisabled();
-    expect(document.body).not.toHaveTextContent(/email sent|tenant notified|notice served|legal delivery/i);
+    expect(within(sentStatus).getByRole("link", { name: "Open lease evidence preview" })).toHaveAttribute(
+      "href",
+      "/evidence-packs?scope=lease&scopeId=lease-1"
+    );
+    expect(screen.queryByRole("button", { name: "Send renewal email" })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/legal notice sent|legally delivered|legally compliant|enforceable|statutory notice satisfied|must respond by|must serve by/i);
+  });
+
+  it("shows a safe send error while reusing the same idempotency key for retry", async () => {
+    mocks.sendRenewalNoticeCommunication
+      .mockRejectedValueOnce(new Error("RENEWAL_NOTICE_DRAFT_SNAPSHOT_NOT_FOUND"))
+      .mockResolvedValueOnce({
+        ok: true,
+        idempotent: true,
+        communicationId: "rnc_retry",
+        status: "email_sent",
+        deliveryStatus: "delivery_status_unknown",
+        attemptedAt: "2026-07-13T12:00:00.000Z",
+        sentAt: "2026-07-13T12:00:01.000Z",
+        providerMessageId: null,
+        auditEventId: "communication-audit-2",
+        timelineEventId: "renewal_notice_email_sent:rnc_retry:2026-07-13T12:00:01.000Z",
+        noLegalServiceClaim: true,
+        noticeServed: false,
+        tenantNotified: true,
+        legalServiceEstablished: false,
+      });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Tenant notice draft preview");
+    fireEvent.click(screen.getByRole("button", { name: "Save draft snapshot" }));
+    await screen.findByText("Audit event recorded.");
+    fireEvent.click(await screen.findByRole("button", { name: "Create send approval decision" }));
+    await screen.findByText("Approval decision created.");
+    fireEvent.click(screen.getByRole("button", { name: "Approve for future send review" }));
+    await screen.findByText("Future send review approved internally. Send requires the confirmation checklist.");
+
+    fireEvent.click(screen.getByLabelText("I have reviewed the recipient(s)."));
+    fireEvent.click(screen.getByLabelText("I have reviewed the message body."));
+    fireEvent.click(screen.getByLabelText("I understand this sends tenant communication only."));
+    fireEvent.click(screen.getByLabelText("I understand this does not establish legal notice service by itself."));
+
+    fireEvent.click(screen.getByRole("button", { name: "Send renewal email" }));
+    expect(await screen.findByText("RENEWAL_NOTICE_DRAFT_SNAPSHOT_NOT_FOUND")).toBeInTheDocument();
+    const firstPayload = mocks.sendRenewalNoticeCommunication.mock.calls[0][1];
+
+    fireEvent.click(screen.getByRole("button", { name: "Send renewal email" }));
+    await screen.findByLabelText("Renewal email sent status");
+    const secondPayload = mocks.sendRenewalNoticeCommunication.mock.calls[1][1];
+    expect(secondPayload.idempotencyKey).toBe(firstPayload.idempotencyKey);
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Idempotent retry returned the existing communication record.");
+    expect(document.body).not.toHaveTextContent(/stack trace|provider payload|notice has been served|legal delivery/i);
   });
 
   it("shows a draft snapshot save error without implying audit persistence", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -87,6 +87,36 @@ function approvalDecisionFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function decisionQueueResponse(items: unknown[]) {
+  return {
+    ok: true,
+    version: "landlord_decision_queue_v1",
+    landlordId: "landlord-1",
+    generatedAt: "2026-07-11T12:00:00.000Z",
+    items,
+    summary: {
+      total: items.length,
+      critical: 0,
+      warning: items.length,
+      needsReview: 0,
+      upcoming: 0,
+      informational: 0,
+      open: 0,
+      blocked: 0,
+    },
+    total: items.length,
+    limit: 5,
+    filters: {
+      severity: null,
+      workspace: null,
+      status: null,
+      sourceType: "renewal_notice_send_review",
+      sourceId: "lease:lease-1:renewal_notice_send_review",
+      sourceRoute: null,
+    },
+  };
+}
+
 describe("LandlordLeaseWorkflowPage", () => {
   beforeEach(() => {
     mocks.getLeaseById.mockReset();
@@ -312,13 +342,16 @@ describe("LandlordLeaseWorkflowPage", () => {
         sourceRoute: null,
       },
     });
-    mocks.createLandlordDecisionQueueItem.mockResolvedValue({
+    mocks.createLandlordDecisionQueueItem.mockImplementation(async (payload) => ({
       ok: true,
       created: true,
       auditEventId: "decision-audit-1",
-      item: approvalDecisionFixture(),
-    });
-    mocks.updateLandlordDecisionQueueItem.mockImplementation(async (_id: string, payload: { action?: string }) => ({
+      item: approvalDecisionFixture({
+        sourceSnapshot: payload.sourceSnapshot,
+        metadata: payload.metadata,
+      }),
+    }));
+    mocks.updateLandlordDecisionQueueItem.mockImplementation(async (_id: string, payload: { action?: string; metadata?: Record<string, unknown> }) => ({
       ok: true,
       auditEventId: "decision-audit-2",
       item: approvalDecisionFixture({
@@ -333,6 +366,7 @@ describe("LandlordLeaseWorkflowPage", () => {
                   ? "dismissed"
                   : "acknowledged",
         auditEventIds: ["decision-audit-1", "decision-audit-2"],
+        metadata: payload.metadata || { noSendBehavior: false },
       }),
     }));
   });
@@ -929,6 +963,92 @@ describe("LandlordLeaseWorkflowPage", () => {
       "/evidence-packs?scope=lease&scopeId=lease-1"
     );
     expect(screen.queryByRole("button", { name: "Send renewal email" })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/legal notice sent|legally delivered|legally compliant|enforceable|statutory notice satisfied|must respond by|must serve by/i);
+  });
+
+  it("blocks send when approval decision belongs to an older draft snapshot", async () => {
+    mocks.fetchLandlordDecisionQueue.mockResolvedValue(
+      decisionQueueResponse([
+        approvalDecisionFixture({
+          status: "approved",
+          sourceSnapshot: { draftSnapshotId: "older-snapshot", leaseId: "lease-1" },
+          metadata: { draftSnapshotId: "older-snapshot", noSendBehavior: false },
+        }),
+      ])
+    );
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Tenant notice draft preview");
+    fireEvent.click(screen.getByRole("button", { name: "Save draft snapshot" }));
+    expect(await screen.findByText("Audit event recorded.")).toBeInTheDocument();
+
+    expect(await screen.findByText(/Approval decision is tied to an older draft snapshot/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Send requirements")).toHaveTextContent(
+      "Approval decision is tied to an older draft snapshot. Save and approve the current draft snapshot before sending."
+    );
+    expect(screen.queryByLabelText("Send confirmation checklist")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send renewal email" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Send renewal email" }));
+    expect(mocks.sendRenewalNoticeCommunication).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Update approval decision for current draft" }));
+    await waitFor(() => {
+      expect(mocks.updateLandlordDecisionQueueItem).toHaveBeenCalledWith(
+        "decision-1",
+        expect.objectContaining({
+          action: "return_to_draft",
+          metadata: expect.objectContaining({
+            draftSnapshotId: "snapshot-1",
+            noSendBehavior: false,
+            noNoticeServed: true,
+            noLeaseLifecycleMutation: true,
+          }),
+        })
+      );
+    });
+    expect(await screen.findByText("Approval decision updated for the current draft snapshot. Send requires the confirmation checklist.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve for future send review" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve for future send review" }));
+    await waitFor(() => {
+      expect(mocks.updateLandlordDecisionQueueItem).toHaveBeenLastCalledWith(
+        "decision-1",
+        expect.objectContaining({
+          action: "approve",
+          metadata: expect.objectContaining({
+            draftSnapshotId: "snapshot-1",
+          }),
+        })
+      );
+    });
+    expect(await screen.findByLabelText("Send confirmation checklist")).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(/legal notice sent|legally delivered|legally compliant|enforceable|statutory notice satisfied|must respond by|must serve by/i);
+  });
+
+  it("shows a friendly approval snapshot mismatch error if the backend rejects send", async () => {
+    mocks.sendRenewalNoticeCommunication.mockRejectedValueOnce(new Error("RENEWAL_NOTICE_APPROVAL_SNAPSHOT_MISMATCH"));
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Tenant notice draft preview");
+    fireEvent.click(screen.getByRole("button", { name: "Save draft snapshot" }));
+    await screen.findByText("Audit event recorded.");
+    fireEvent.click(await screen.findByRole("button", { name: "Create send approval decision" }));
+    await screen.findByText("Approval decision created.");
+    fireEvent.click(screen.getByRole("button", { name: "Approve for future send review" }));
+    await screen.findByText("Future send review approved internally. Send requires the confirmation checklist.");
+
+    fireEvent.click(screen.getByLabelText("I have reviewed the recipient(s)."));
+    fireEvent.click(screen.getByLabelText("I have reviewed the message body."));
+    fireEvent.click(screen.getByLabelText("I understand this sends tenant communication only."));
+    fireEvent.click(screen.getByLabelText("I understand this does not establish legal notice service by itself."));
+    fireEvent.click(screen.getByRole("button", { name: "Send renewal email" }));
+
+    expect(
+      await screen.findByText("This approval belongs to an earlier draft snapshot. Save the current draft snapshot and approve it again before sending.")
+    ).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("RENEWAL_NOTICE_APPROVAL_SNAPSHOT_MISMATCH");
     expect(document.body).not.toHaveTextContent(/legal notice sent|legally delivered|legally compliant|enforceable|statutory notice satisfied|must respond by|must serve by/i);
   });
 

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -950,8 +950,13 @@ describe("LandlordLeaseWorkflowPage", () => {
       );
     });
     expect(await screen.findByLabelText("Renewal email sent status")).toHaveTextContent("Renewal email sent");
-    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Delivery status unknown");
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Delivery confirmation");
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Not tracked yet");
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent(
+      "Email was accepted for sending. Provider delivery, bounce, and open tracking are not enabled yet."
+    );
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Not served; legal service not established");
+    expect(screen.getByLabelText("Renewal email sent status")).not.toHaveTextContent("Delivery status unknown");
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("rnc_test");
     expect(screen.getByText("rnc_test")).toHaveStyle({ overflowWrap: "anywhere" });
     const sentStatus = screen.getByLabelText("Renewal email sent status");

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -3,7 +3,9 @@ import { Link, useParams } from "react-router-dom";
 import { getLeaseById, type JurisdictionPolicyGuidance, type LandlordActiveLease } from "@/api/leasesApi";
 import {
   fetchExpiringLeaseRenewals,
+  sendRenewalNoticeCommunication,
   type LandlordLeaseRenewalLease,
+  type RenewalNoticeCommunicationResponse,
   type RenewalNoticeDraftSnapshot,
 } from "@/api/landlordLeaseRenewalApi";
 import {
@@ -213,6 +215,40 @@ function tenantEmailLabel(lease: LandlordActiveLease) {
 
 function hasTenantEmail(lease: LandlordActiveLease) {
   return Boolean(String(lease.tenantEmail || "").trim());
+}
+
+function generateSendIdempotencyKey(leaseId: string, snapshotId: string, decisionId: string) {
+  const random =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `renewal-email:${leaseId}:${snapshotId}:${decisionId}:${random}`;
+}
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) return "Not available";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString("en-CA", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function communicationStatusLabel(status: RenewalNoticeCommunicationResponse["status"] | null | undefined) {
+  if (status === "email_sent") return "Email sent";
+  if (status === "email_failed") return "Email failed";
+  if (status === "send_attempted") return "Send attempted";
+  return "Not sent";
+}
+
+function deliveryStatusLabel(status: RenewalNoticeCommunicationResponse["deliveryStatus"] | null | undefined) {
+  if (status === "delivery_status_unknown") return "Delivery status unknown";
+  return "Delivery status pending";
 }
 
 function daysUntilDate(value: string | null | undefined) {
@@ -625,7 +661,11 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
 
       <div style={noticeStatusGridStyle}>
         <NoticeStatus label="Draft readiness" value={statusLabel} tone={readiness.ready ? "ready" : "warning"} />
-        <NoticeStatus label="Email delivery" value="Deferred" tone="deferred" />
+        <NoticeStatus
+          label="Email delivery"
+          value={readiness.ready ? "Requires approval and confirmations" : "Inputs needed"}
+          tone={readiness.ready ? "warning" : "deferred"}
+        />
         <NoticeStatus label="Evidence capture" value={readiness.ready ? "Available after snapshot save" : "Inputs needed"} tone={readiness.ready ? "ready" : "warning"} />
         <NoticeStatus label="Audit capture" value={readiness.ready ? "Available after snapshot save" : "Inputs needed"} tone={readiness.ready ? "ready" : "warning"} />
       </div>
@@ -664,7 +704,8 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
 
       <div style={{ color: workflowTheme.subtle, lineHeight: 1.6 }}>
         Renewal operator inputs are the source for this draft. Review official lease documents and current provincial
-        requirements before tenant communication. No notice record is created here, and email delivery remains deferred.
+        requirements before tenant communication. No notice record is created here. Email delivery requires a saved snapshot,
+        internal approval, and explicit confirmations below.
       </div>
 
       {draftText ? (
@@ -714,7 +755,8 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
       {copyStatus === "error" ? <div style={warningTextStyle}>Draft text could not be copied. Select the preview text manually.</div> : null}
 
       <div style={deferredPanelStyle}>
-        Notice record creation and email delivery are deferred. Saving a draft snapshot records audit context only.
+        Notice record creation remains separate. Saving a draft snapshot records audit context only; email delivery requires
+        internal approval and explicit confirmations.
       </div>
     </section>
   );
@@ -733,6 +775,13 @@ function TenantCommunicationSendReview({
   readinessReady: boolean;
   savedSnapshot: RenewalNoticeDraftSnapshot | null;
 }) {
+  type ConfirmationKey = "recipientReviewed" | "bodyReviewed" | "communicationOnly" | "legalService";
+  type SendState =
+    | { status: "idle" }
+    | { status: "sending" }
+    | { status: "success"; result: RenewalNoticeCommunicationResponse }
+    | { status: "error"; message: string };
+
   const tenantName = reviewModel?.tenantLabel || workflowDisplayLabel(lease.tenantName, /^tenant$/i) || "Tenant name unavailable";
   const recipientEmail = tenantEmailLabel(lease);
   const recipientReady = hasTenantEmail(lease);
@@ -753,7 +802,21 @@ function TenantCommunicationSendReview({
   const [decisionSubmitting, setDecisionSubmitting] = React.useState(false);
   const [decisionNotice, setDecisionNotice] = React.useState<string | null>(null);
   const [decisionError, setDecisionError] = React.useState<string | null>(null);
+  const [confirmation, setConfirmation] = React.useState<Record<ConfirmationKey, boolean>>({
+    recipientReviewed: false,
+    bodyReviewed: false,
+    communicationOnly: false,
+    legalService: false,
+  });
+  const [idempotencyKey, setIdempotencyKey] = React.useState<string | null>(null);
+  const [activeSendContext, setActiveSendContext] = React.useState<string | null>(null);
+  const [sendState, setSendState] = React.useState<SendState>({ status: "idle" });
   const approvalDecisionApproved = approvalDecision?.status === "approved";
+  const sendPrerequisitesMet = Boolean(savedSnapshot && approvalDecisionApproved && recipientReady && draftAvailable && approvalDecision);
+  const allConfirmationsChecked = Object.values(confirmation).every(Boolean);
+  const sendContextKey =
+    savedSnapshot && approvalDecision ? `${savedSnapshot.snapshotId}:${approvalDecision.id}:${lease.id}` : null;
+  const sendSucceeded = sendState.status === "success";
 
   React.useEffect(() => {
     let active = true;
@@ -790,6 +853,35 @@ function TenantCommunicationSendReview({
     };
   }, [decisionRoute, decisionSourceId, savedSnapshot]);
 
+  React.useEffect(() => {
+    if (!sendContextKey || !savedSnapshot || !approvalDecision) {
+      setActiveSendContext(null);
+      setIdempotencyKey(null);
+      setConfirmation({
+        recipientReviewed: false,
+        bodyReviewed: false,
+        communicationOnly: false,
+        legalService: false,
+      });
+      setSendState({ status: "idle" });
+      return;
+    }
+    if (activeSendContext === sendContextKey) return;
+    setActiveSendContext(sendContextKey);
+    setIdempotencyKey(generateSendIdempotencyKey(lease.id, savedSnapshot.snapshotId, approvalDecision.id));
+    setConfirmation({
+      recipientReviewed: false,
+      bodyReviewed: false,
+      communicationOnly: false,
+      legalService: false,
+    });
+    setSendState({ status: "idle" });
+  }, [activeSendContext, approvalDecision, lease.id, savedSnapshot, sendContextKey]);
+
+  function setConfirmationValue(key: ConfirmationKey, value: boolean) {
+    setConfirmation((current) => ({ ...current, [key]: value }));
+  }
+
   async function createApprovalDecision() {
     if (!savedSnapshot || !reviewModel || decisionSubmitting) return;
     setDecisionSubmitting(true);
@@ -804,7 +896,7 @@ function TenantCommunicationSendReview({
         severity: "warning",
         title: "Renewal tenant communication ready for approval",
         description:
-          "Saved renewal notice draft is ready for send approval review. Email delivery remains disabled until approved send infrastructure is available.",
+          "Saved renewal notice draft is ready for send approval review. Email delivery is available only after approval and explicit send confirmations.",
         recommendedActionLabel: "Open notice review",
         recommendedActionHref: decisionRoute,
         status: "open",
@@ -830,7 +922,7 @@ function TenantCommunicationSendReview({
         metadata: {
           approvalPurpose: "future_send_review",
           draftSnapshotId: savedSnapshot.snapshotId,
-          noSendBehavior: true,
+          noSendBehavior: false,
           noTenantNotification: true,
           noNoticeServed: true,
           noLeaseLifecycleMutation: true,
@@ -865,7 +957,7 @@ function TenantCommunicationSendReview({
         metadata: {
           approvalPurpose: "future_send_review",
           lastApprovalDecisionAction: action,
-          noSendBehavior: true,
+          noSendBehavior: false,
           noTenantNotification: true,
           noNoticeServed: true,
           noLeaseLifecycleMutation: true,
@@ -875,7 +967,7 @@ function TenantCommunicationSendReview({
         throw new Error("approval_decision_source_mismatch");
       }
       setApprovalDecision(response.item);
-      setDecisionNotice(`${successLabel} Send remains disabled.`);
+      setDecisionNotice(`${successLabel} Send requires the confirmation checklist.`);
     } catch (error) {
       if (String((error as Error)?.message || error).includes("decision_item_not_found")) {
         setApprovalDecision(null);
@@ -886,16 +978,91 @@ function TenantCommunicationSendReview({
     }
   }
 
+  async function sendRenewalEmail() {
+    if (!savedSnapshot || !approvalDecision || !idempotencyKey || !sendPrerequisitesMet || !allConfirmationsChecked) {
+      setSendState({ status: "error", message: "Complete the send requirements and confirmations before sending." });
+      return;
+    }
+    setSendState({ status: "sending" });
+    try {
+      const result = await sendRenewalNoticeCommunication(lease.id, {
+        snapshotId: savedSnapshot.snapshotId,
+        approvalDecisionItemId: approvalDecision.id,
+        confirmationAccepted: true,
+        recipientReviewed: true,
+        bodyReviewed: true,
+        legalServiceAcknowledged: true,
+        noLegalServiceClaim: true,
+        idempotencyKey,
+      });
+      setSendState({ status: "success", result });
+    } catch (error) {
+      setSendState({
+        status: "error",
+        message: errorMessage(error, "Renewal email could not be sent. Review the saved draft, approval decision, and recipient."),
+      });
+    }
+  }
+
   return (
     <section style={sendReviewStyle} aria-label="Tenant communication send review">
       <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
         <div style={{ display: "grid", gap: 4 }}>
           <h3 style={sendReviewHeadingStyle}>Tenant communication send review</h3>
           <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
-            Review the future send model without sending email, notifying the tenant, or creating a notice record.
+            Confirm the saved draft, internal approval, recipient, and legal-service separation before sending a renewal email.
           </div>
         </div>
-        <span style={deferredBadgeStyle}>Send disabled</span>
+        <span style={sendSucceeded ? readyBadgePillStyle : sendPrerequisitesMet ? readyBadgePillStyle : deferredBadgeStyle}>
+          {sendSucceeded ? "Email sent" : sendPrerequisitesMet ? "Ready for confirmation" : "Send gated"}
+        </span>
+      </div>
+
+      <div style={sendStepsStyle} aria-label="Renewal send steps">
+        <SendStepCard
+          step="Step 1"
+          title="Renewal inputs"
+          status={readinessReady ? "Ready" : "Needs review"}
+          description={readinessReady ? "Saved renewal inputs are available." : "Fill in renewal inputs before preparing a tenant email."}
+          actionLabel={!readinessReady ? "Open renewal workflow" : undefined}
+          actionHref={!readinessReady ? `/leases/${encodeURIComponent(lease.id)}/workflows/renewal` : undefined}
+        />
+        <SendStepCard
+          step="Step 2"
+          title="Draft snapshot"
+          status={savedSnapshot ? "Ready" : "Needs review"}
+          description={savedSnapshot ? "Draft snapshot is saved for audit and send review." : "Save the draft snapshot above before approval."}
+        />
+        <SendStepCard
+          step="Step 3"
+          title="Approval decision"
+          status={approvalDecisionApproved ? "Approved" : approvalDecision ? "Needs approval" : "Needs review"}
+          description={
+            approvalDecisionApproved
+              ? "Internal approval is recorded."
+              : approvalDecision
+                ? "Approve the decision before send confirmation."
+                : "Create a send approval decision after the draft snapshot is saved."
+          }
+        />
+        <SendStepCard
+          step="Step 4"
+          title="Send confirmation"
+          status={sendSucceeded ? "Complete" : sendPrerequisitesMet ? "Ready" : "Locked"}
+          description={
+            sendSucceeded
+              ? "Renewal email was sent through the controlled communication endpoint."
+              : sendPrerequisitesMet
+                ? "Review and check all confirmations to enable sending."
+                : "Unlocks after snapshot, approval, recipient, and draft are ready."
+          }
+        />
+        <SendStepCard
+          step="Step 5"
+          title="Sent status / evidence"
+          status={sendSucceeded ? "Ready" : "Deferred"}
+          description={sendSucceeded ? "Evidence and timeline links are available below." : "Available after a successful send."}
+        />
       </div>
 
       <div style={sendReviewGridStyle}>
@@ -920,13 +1087,13 @@ function TenantCommunicationSendReview({
           </dl>
           {draftText ? (
             <div style={sendBodyReferenceStyle} aria-label="Tenant communication body reference">
-              Uses the renewal notice draft shown above. Exact body must be reviewed and persisted before any future send.
+              Uses the renewal notice draft shown above. Exact body must be reviewed before sending.
             </div>
           ) : (
-            <div style={warningPanelStyle}>Draft body unavailable. Complete renewal inputs before future tenant communication review.</div>
+            <div style={warningPanelStyle}>Draft body unavailable. Fill in renewal inputs before tenant communication review.</div>
           )}
           <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
-            The exact message body must be reviewed and persisted before any future send.
+            The saved draft snapshot is the source for the outgoing renewal email.
           </div>
         </div>
       </div>
@@ -942,43 +1109,74 @@ function TenantCommunicationSendReview({
         <SendChecklistItem label="Evidence/audit capture available" status={savedSnapshot ? "Ready" : "Needs review"} />
         <SendChecklistItem
           label="Delivery status model"
-          status={approvalDecisionApproved ? "Still required before live send" : "Deferred"}
+          status={sendSucceeded ? "Ready" : approvalDecisionApproved ? "Ready for send" : "Deferred"}
         />
         <SendChecklistItem
           label="Legal-service separation"
-          status={approvalDecisionApproved ? "Acknowledged for approval" : "Deferred"}
+          status={sendSucceeded ? "Acknowledged" : approvalDecisionApproved ? "Ready for confirmation" : "Deferred"}
         />
       </div>
 
-      {approvalDecisionApproved ? (
-        <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
-          Checklist status reflects internal approval only. Live send confirmation remains deferred until tenant communication
-          infrastructure is enabled.
+      {!sendPrerequisitesMet && !sendSucceeded ? (
+        <div style={warningPanelStyle} aria-label="Send requirements">
+          Send renewal email unlocks after the draft snapshot is saved, the approval decision is approved, the tenant email
+          is available, and the draft body is ready.
         </div>
       ) : null}
 
-      <fieldset disabled style={confirmationPreviewStyle} aria-label="Future send confirmation model">
-        <legend style={sendReviewSubheadingStyle}>Future send confirmation model</legend>
-        <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
-          These confirmations will be required before live tenant communication is enabled.
-        </div>
-        <label style={checkboxLabelStyle}>
-          <input type="checkbox" /> I have reviewed the recipient(s).
-        </label>
-        <label style={checkboxLabelStyle}>
-          <input type="checkbox" /> I have reviewed the message body.
-        </label>
-        <label style={checkboxLabelStyle}>
-          <input type="checkbox" /> I understand this would send tenant communication only.
-        </label>
-        <label style={checkboxLabelStyle}>
-          <input type="checkbox" /> I understand this does not establish legal notice service by itself.
-        </label>
-      </fieldset>
+      {sendPrerequisitesMet && !sendSucceeded ? (
+        <fieldset style={confirmationPreviewStyle} aria-label="Send confirmation checklist">
+          <legend style={sendReviewSubheadingStyle}>Send confirmation checklist</legend>
+          <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
+            Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself.
+          </div>
+          <label style={checkboxLabelStyle}>
+            <input
+              type="checkbox"
+              checked={confirmation.recipientReviewed}
+              onChange={(event) => setConfirmationValue("recipientReviewed", event.currentTarget.checked)}
+            />{" "}
+            I have reviewed the recipient(s).
+          </label>
+          <label style={checkboxLabelStyle}>
+            <input
+              type="checkbox"
+              checked={confirmation.bodyReviewed}
+              onChange={(event) => setConfirmationValue("bodyReviewed", event.currentTarget.checked)}
+            />{" "}
+            I have reviewed the message body.
+          </label>
+          <label style={checkboxLabelStyle}>
+            <input
+              type="checkbox"
+              checked={confirmation.communicationOnly}
+              onChange={(event) => setConfirmationValue("communicationOnly", event.currentTarget.checked)}
+            />{" "}
+            I understand this sends tenant communication only.
+          </label>
+          <label style={checkboxLabelStyle}>
+            <input
+              type="checkbox"
+              checked={confirmation.legalService}
+              onChange={(event) => setConfirmationValue("legalService", event.currentTarget.checked)}
+            />{" "}
+            I understand this does not establish legal notice service by itself.
+          </label>
+        </fieldset>
+      ) : null}
 
       <div style={noticeStatusGridStyle} aria-label="Delivery and legal status">
-        <NoticeStatus label="Email delivery" value="Not enabled" tone="deferred" />
-        <NoticeStatus label="Tenant notification" value="Not sent" tone="deferred" />
+        <NoticeStatus
+          label="Email delivery"
+          value={sendSucceeded ? communicationStatusLabel(sendState.result.status) : "Not sent"}
+          tone={sendSucceeded ? "ready" : "deferred"}
+        />
+        <NoticeStatus
+          label="Delivery status"
+          value={sendSucceeded ? deliveryStatusLabel(sendState.result.deliveryStatus) : "Not available yet"}
+          tone={sendSucceeded ? "warning" : "deferred"}
+        />
+        <NoticeStatus label="Tenant notification" value={sendSucceeded ? "Tenant notified by email provider acceptance" : "Not sent"} tone={sendSucceeded ? "ready" : "deferred"} />
         <NoticeStatus label="Notice service" value="Not established" tone="deferred" />
         <NoticeStatus label="Legal compliance" value="Not determined by this workflow" tone="deferred" />
         <NoticeStatus label="Audit/evidence" value={savedSnapshot ? "Draft snapshot captured" : "Captured when snapshot is saved"} tone={savedSnapshot ? "ready" : "deferred"} />
@@ -988,8 +1186,8 @@ function TenantCommunicationSendReview({
         <div style={{ display: "grid", gap: 4 }}>
           <h4 style={sendReviewSubheadingStyle}>Approval decision</h4>
           <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
-            Create an internal decision queue item for future send approval review. This does not send email, notify the tenant,
-            serve notice, or change lease lifecycle state.
+            Create or review the internal approval decision before enabling send confirmations. Approval does not serve notice
+            or change lease lifecycle state.
           </div>
         </div>
 
@@ -1060,20 +1258,51 @@ function TenantCommunicationSendReview({
             </div>
             <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
               {approvalDecisionApproved
-                ? "Internal approval has been recorded. Send remains disabled and future send infrastructure remains required."
-                : "Approved status does not enable tenant communication. Future send infrastructure remains required."}
+                ? "Internal approval has been recorded. Send still requires explicit confirmation before tenant communication."
+                : "Approved status is required before tenant communication can be sent."}
             </div>
           </div>
         ) : null}
       </section>
 
-      <button type="button" disabled style={sendDisabledButtonStyle}>
-        Send tenant communication - not enabled yet
-      </button>
+      {sendState.status === "success" ? (
+        <section style={sentStatusStyle} aria-label="Renewal email sent status">
+          <h4 style={sendReviewSubheadingStyle}>Renewal email sent</h4>
+          <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 10, margin: 0 }}>
+            <ReviewFact label="Sent at" value={formatTimestamp(sendState.result.sentAt || sendState.result.attemptedAt)} />
+            <ReviewFact label="Delivery status" value={deliveryStatusLabel(sendState.result.deliveryStatus)} />
+            <ReviewFact label="Communication ID" value={sendState.result.communicationId} />
+            <ReviewFact label="Legal-service status" value="Not served; legal service not established" />
+          </dl>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+            {sendState.result.idempotent ? "Idempotent retry returned the existing communication record. " : ""}
+            Email was accepted by the communication endpoint. This does not establish legal notice service by itself.
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Link to={reviewModel?.leaseTimelinePath || `/review-timeline?scope=lease&scopeId=${encodeURIComponent(lease.id)}`} style={buttonLinkStyle}>
+              Open lease review timeline
+            </Link>
+            <Link to={reviewModel?.leaseEvidencePath || `/evidence-packs?scope=lease&scopeId=${encodeURIComponent(lease.id)}`} style={buttonLinkStyle}>
+              Open lease evidence preview
+            </Link>
+          </div>
+        </section>
+      ) : (
+        <button
+          type="button"
+          onClick={() => void sendRenewalEmail()}
+          disabled={!sendPrerequisitesMet || !allConfirmationsChecked || sendState.status === "sending"}
+          style={sendPrerequisitesMet && allConfirmationsChecked ? primaryButtonStyle : sendDisabledButtonStyle}
+        >
+          {sendState.status === "sending" ? "Sending renewal email…" : "Send renewal email"}
+        </button>
+      )}
+
+      {sendState.status === "error" ? <div style={warningPanelStyle}>{sendState.message}</div> : null}
 
       <div style={deferredPanelStyle}>
-        Email delivery is not enabled in this workflow yet. Future send will require recipient confirmation, exact body
-        persistence, delivery status, audit capture, and legal-service separation.
+        Renewal email sends use the controlled communication endpoint only. This workflow does not create lease notice
+        records, mark notice served, establish legal service, or change lease lifecycle state.
       </div>
     </section>
   );
@@ -1085,16 +1314,59 @@ type SendChecklistStatus =
   | "Deferred"
   | "Approved internally"
   | "Acknowledged for approval"
-  | "Still required before live send";
+  | "Still required before live send"
+  | "Ready for send"
+  | "Ready for confirmation"
+  | "Acknowledged";
 
 function SendChecklistItem({ label, status }: { label: string; status: SendChecklistStatus }) {
   const tone =
-    status === "Ready" || status === "Approved internally" || status === "Acknowledged for approval"
+    status === "Ready" ||
+    status === "Approved internally" ||
+    status === "Acknowledged for approval" ||
+    status === "Ready for send" ||
+    status === "Ready for confirmation" ||
+    status === "Acknowledged"
       ? "ready"
       : status === "Needs review"
         ? "warning"
         : "deferred";
   return <NoticeStatus label={label} value={status} tone={tone} />;
+}
+
+function SendStepCard({
+  step,
+  title,
+  status,
+  description,
+  actionLabel,
+  actionHref,
+}: {
+  step: string;
+  title: string;
+  status: string;
+  description: string;
+  actionLabel?: string;
+  actionHref?: string;
+}) {
+  const ready = ["Ready", "Approved", "Complete"].includes(status);
+  return (
+    <div style={sendStepCardStyle}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "flex-start" }}>
+        <div style={{ display: "grid", gap: 2 }}>
+          <div style={termStyle}>{step}</div>
+          <div style={{ color: workflowTheme.charcoal, fontWeight: 900 }}>{title}</div>
+        </div>
+        <span style={ready ? readyBadgePillStyle : deferredBadgeStyle}>{status}</span>
+      </div>
+      <div style={{ color: workflowTheme.muted, lineHeight: 1.5 }}>{description}</div>
+      {actionHref && actionLabel ? (
+        <Link to={actionHref} style={buttonLinkStyle}>
+          {actionLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
 }
 
 function isPersistedApprovalDecisionItem(
@@ -1459,6 +1731,21 @@ const sendChecklistStyle: React.CSSProperties = {
   gap: 10,
 };
 
+const sendStepsStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+  gap: 10,
+};
+
+const sendStepCardStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 8,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 10,
+  background: workflowTheme.card,
+  padding: 10,
+};
+
 const confirmationPreviewStyle: React.CSSProperties = {
   display: "grid",
   gap: 8,
@@ -1516,6 +1803,13 @@ const deferredBadgeStyle: React.CSSProperties = {
   whiteSpace: "nowrap",
 };
 
+const readyBadgePillStyle: React.CSSProperties = {
+  ...deferredBadgeStyle,
+  border: "1px solid rgba(22, 101, 52, 0.24)",
+  background: "rgba(220, 252, 231, 0.78)",
+  color: "#166534",
+};
+
 const sendDisabledButtonStyle: React.CSSProperties = {
   ...buttonStyle,
   width: "fit-content",
@@ -1524,6 +1818,15 @@ const sendDisabledButtonStyle: React.CSSProperties = {
   color: workflowTheme.subtle,
   cursor: "not-allowed",
   boxShadow: "none",
+};
+
+const sentStatusStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 10,
+  border: "1px solid rgba(22, 101, 52, 0.22)",
+  borderRadius: 10,
+  background: "rgba(220, 252, 231, 0.42)",
+  padding: 12,
 };
 
 const noticeActionGridStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1323,7 +1323,12 @@ function TenantCommunicationSendReview({
           <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 10, margin: 0 }}>
             <ReviewFact label="Sent at" value={formatTimestamp(sendState.result.sentAt || sendState.result.attemptedAt)} />
             <ReviewFact label="Delivery status" value={deliveryStatusLabel(sendState.result.deliveryStatus)} />
-            <ReviewFact label="Communication ID" value={sendState.result.communicationId} />
+            <ReviewFact
+              label="Communication ID"
+              value={sendState.result.communicationId}
+              containerStyle={communicationIdFactStyle}
+              valueStyle={communicationIdValueStyle}
+            />
             <ReviewFact label="Legal-service status" value="Not served; legal service not established" />
           </dl>
           <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
@@ -1490,11 +1495,21 @@ function NoticeStatus({
   );
 }
 
-function ReviewFact({ label, value }: { label: string; value: string }) {
+function ReviewFact({
+  label,
+  value,
+  containerStyle,
+  valueStyle,
+}: {
+  label: string;
+  value: string;
+  containerStyle?: React.CSSProperties;
+  valueStyle?: React.CSSProperties;
+}) {
   return (
-    <div style={{ display: "grid", gap: 4 }}>
+    <div style={{ display: "grid", gap: 4, ...containerStyle }}>
       <dt style={termStyle}>{label}</dt>
-      <dd style={sourceValueStyle}>{value}</dd>
+      <dd style={{ ...sourceValueStyle, ...valueStyle }}>{value}</dd>
     </div>
   );
 }
@@ -1879,6 +1894,17 @@ const sentStatusStyle: React.CSSProperties = {
   borderRadius: 10,
   background: "rgba(220, 252, 231, 0.42)",
   padding: 12,
+};
+
+const communicationIdFactStyle: React.CSSProperties = {
+  minWidth: 0,
+  gridColumn: "span 2",
+};
+
+const communicationIdValueStyle: React.CSSProperties = {
+  minWidth: 0,
+  overflowWrap: "anywhere",
+  wordBreak: "break-word",
 };
 
 const noticeActionGridStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -251,6 +251,20 @@ function deliveryStatusLabel(status: RenewalNoticeCommunicationResponse["deliver
   return "Delivery status pending";
 }
 
+function recordStringValue(record: Record<string, unknown> | null | undefined, key: string) {
+  const value = record?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function approvalDecisionDraftSnapshotId(decision: LandlordDecisionQueueItem | null | undefined) {
+  if (!decision) return "";
+  return (
+    recordStringValue(decision.metadata, "draftSnapshotId") ||
+    recordStringValue(decision.sourceSnapshot, "draftSnapshotId") ||
+    recordStringValue(decision.sourceSnapshot, "snapshotId")
+  );
+}
+
 function daysUntilDate(value: string | null | undefined) {
   if (!value) return null;
   const parsed = new Date(value);
@@ -812,7 +826,13 @@ function TenantCommunicationSendReview({
   const [activeSendContext, setActiveSendContext] = React.useState<string | null>(null);
   const [sendState, setSendState] = React.useState<SendState>({ status: "idle" });
   const approvalDecisionApproved = approvalDecision?.status === "approved";
-  const sendPrerequisitesMet = Boolean(savedSnapshot && approvalDecisionApproved && recipientReady && draftAvailable && approvalDecision);
+  const approvalDecisionSnapshotId = approvalDecisionDraftSnapshotId(approvalDecision);
+  const approvalSnapshotMatches =
+    Boolean(savedSnapshot && approvalDecision) && approvalDecisionSnapshotId === savedSnapshot?.snapshotId;
+  const approvalSnapshotMismatch = Boolean(savedSnapshot && approvalDecision && !approvalSnapshotMatches);
+  const sendPrerequisitesMet = Boolean(
+    savedSnapshot && approvalDecisionApproved && approvalSnapshotMatches && recipientReady && draftAvailable && approvalDecision
+  );
   const allConfirmationsChecked = Object.values(confirmation).every(Boolean);
   const sendContextKey =
     savedSnapshot && approvalDecision ? `${savedSnapshot.snapshotId}:${approvalDecision.id}:${lease.id}` : null;
@@ -956,6 +976,7 @@ function TenantCommunicationSendReview({
         action,
         metadata: {
           approvalPurpose: "future_send_review",
+          draftSnapshotId: savedSnapshot?.snapshotId || null,
           lastApprovalDecisionAction: action,
           noSendBehavior: false,
           noTenantNotification: true,
@@ -980,7 +1001,12 @@ function TenantCommunicationSendReview({
 
   async function sendRenewalEmail() {
     if (!savedSnapshot || !approvalDecision || !idempotencyKey || !sendPrerequisitesMet || !allConfirmationsChecked) {
-      setSendState({ status: "error", message: "Complete the send requirements and confirmations before sending." });
+      setSendState({
+        status: "error",
+        message: approvalSnapshotMismatch
+          ? "This approval belongs to an earlier draft snapshot. Save the current draft snapshot and approve it again before sending."
+          : "Complete the send requirements and confirmations before sending.",
+      });
       return;
     }
     setSendState({ status: "sending" });
@@ -997,9 +1023,12 @@ function TenantCommunicationSendReview({
       });
       setSendState({ status: "success", result });
     } catch (error) {
+      const rawMessage = String((error as Error)?.message || error || "");
       setSendState({
         status: "error",
-        message: errorMessage(error, "Renewal email could not be sent. Review the saved draft, approval decision, and recipient."),
+        message: rawMessage.includes("RENEWAL_NOTICE_APPROVAL_SNAPSHOT_MISMATCH")
+          ? "This approval belongs to an earlier draft snapshot. Save the current draft snapshot and approve it again before sending."
+          : errorMessage(error, "Renewal email could not be sent. Review the saved draft, approval decision, and recipient."),
       });
     }
   }
@@ -1036,9 +1065,19 @@ function TenantCommunicationSendReview({
         <SendStepCard
           step="Step 3"
           title="Approval decision"
-          status={approvalDecisionApproved ? "Approved" : approvalDecision ? "Needs approval" : "Needs review"}
+          status={
+            approvalSnapshotMismatch
+              ? "Needs current draft"
+              : approvalDecisionApproved
+                ? "Approved"
+                : approvalDecision
+                  ? "Needs approval"
+                  : "Needs review"
+          }
           description={
-            approvalDecisionApproved
+            approvalSnapshotMismatch
+              ? "Approval is tied to an older draft snapshot."
+              : approvalDecisionApproved
               ? "Internal approval is recorded."
               : approvalDecision
                 ? "Approve the decision before send confirmation."
@@ -1119,8 +1158,9 @@ function TenantCommunicationSendReview({
 
       {!sendPrerequisitesMet && !sendSucceeded ? (
         <div style={warningPanelStyle} aria-label="Send requirements">
-          Send renewal email unlocks after the draft snapshot is saved, the approval decision is approved, the tenant email
-          is available, and the draft body is ready.
+          {approvalSnapshotMismatch
+            ? "Approval decision is tied to an older draft snapshot. Save and approve the current draft snapshot before sending."
+            : "Send renewal email unlocks after the draft snapshot is saved, the approval decision is approved, the tenant email is available, and the draft body is ready."}
         </div>
       ) : null}
 
@@ -1236,6 +1276,16 @@ function TenantCommunicationSendReview({
               </Link>
             </div>
             <div style={decisionActionGridStyle}>
+              {approvalSnapshotMismatch ? (
+                <button
+                  type="button"
+                  onClick={() => void updateApprovalDecision("return_to_draft", "Approval decision updated for the current draft snapshot.")}
+                  disabled={decisionSubmitting}
+                  style={primaryButtonStyle}
+                >
+                  Update approval decision for current draft
+                </button>
+              ) : null}
               {!approvalDecisionApproved ? (
                 <button type="button" onClick={() => void updateApprovalDecision("acknowledge", "Decision acknowledged.")} disabled={decisionSubmitting} style={buttonStyle}>
                   Acknowledge
@@ -1257,7 +1307,9 @@ function TenantCommunicationSendReview({
               ) : null}
             </div>
             <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
-              {approvalDecisionApproved
+              {approvalSnapshotMismatch
+                ? "This approval belongs to an earlier draft snapshot. Update the approval decision for the current draft, then approve it again before sending."
+                : approvalDecisionApproved
                 ? "Internal approval has been recorded. Send still requires explicit confirmation before tenant communication."
                 : "Approved status is required before tenant communication can be sent."}
             </div>

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -246,9 +246,9 @@ function communicationStatusLabel(status: RenewalNoticeCommunicationResponse["st
   return "Not sent";
 }
 
-function deliveryStatusLabel(status: RenewalNoticeCommunicationResponse["deliveryStatus"] | null | undefined) {
-  if (status === "delivery_status_unknown") return "Delivery status unknown";
-  return "Delivery status pending";
+function deliveryConfirmationLabel(status: RenewalNoticeCommunicationResponse["deliveryStatus"] | null | undefined) {
+  if (status === "delivery_status_unknown") return "Not tracked yet";
+  return "Not tracked yet";
 }
 
 function recordStringValue(record: Record<string, unknown> | null | undefined, key: string) {
@@ -1212,8 +1212,8 @@ function TenantCommunicationSendReview({
           tone={sendSucceeded ? "ready" : "deferred"}
         />
         <NoticeStatus
-          label="Delivery status"
-          value={sendSucceeded ? deliveryStatusLabel(sendState.result.deliveryStatus) : "Not available yet"}
+          label="Delivery confirmation"
+          value={sendSucceeded ? deliveryConfirmationLabel(sendState.result.deliveryStatus) : "Not available yet"}
           tone={sendSucceeded ? "warning" : "deferred"}
         />
         <NoticeStatus label="Tenant notification" value={sendSucceeded ? "Tenant notified by email provider acceptance" : "Not sent"} tone={sendSucceeded ? "ready" : "deferred"} />
@@ -1322,7 +1322,7 @@ function TenantCommunicationSendReview({
           <h4 style={sendReviewSubheadingStyle}>Renewal email sent</h4>
           <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 10, margin: 0 }}>
             <ReviewFact label="Sent at" value={formatTimestamp(sendState.result.sentAt || sendState.result.attemptedAt)} />
-            <ReviewFact label="Delivery status" value={deliveryStatusLabel(sendState.result.deliveryStatus)} />
+            <ReviewFact label="Delivery confirmation" value={deliveryConfirmationLabel(sendState.result.deliveryStatus)} />
             <ReviewFact
               label="Communication ID"
               value={sendState.result.communicationId}
@@ -1333,7 +1333,8 @@ function TenantCommunicationSendReview({
           </dl>
           <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
             {sendState.result.idempotent ? "Idempotent retry returned the existing communication record. " : ""}
-            Email was accepted by the communication endpoint. This does not establish legal notice service by itself.
+            Email was accepted for sending. Provider delivery, bounce, and open tracking are not enabled yet. This does
+            not establish legal notice service by itself.
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <Link to={reviewModel?.leaseTimelinePath || `/review-timeline?scope=lease&scopeId=${encodeURIComponent(lease.id)}`} style={buttonLinkStyle}>


### PR DESCRIPTION
## Summary
- Adds the landlord renewal communication send confirmation UI on `/leases/:leaseId/workflows/notice`.
- Wires the frontend to the controlled renewal communication endpoint from PR #1354.
- Requires saved draft snapshot, approved send decision, tenant email, ready draft body, and four explicit confirmations before enabling `Send renewal email`.
- Shows sent status with timestamp, delivery status, communication ID, timeline/evidence links, and legal-service guardrails after a successful response.

## Guardrails
- No backend/API changes in this PR.
- No legacy `send-notice` wiring.
- No `leaseNotices` creation.
- No notice-served state.
- No legal-service or compliance claim.
- No lease lifecycle mutation.

## Validation
- `npm run test -- LandlordLeaseWorkflowPage`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`

Draft until safe preview/live QA confirms the send confirmation flow against the internal test tenant inbox.