### PR TITLE
Strengthen renewal communication evidence inclusion

### DIFF
--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -360,6 +360,8 @@ describe("deriveEvidencePack", () => {
           leaseId: "lease-1",
           landlordId: "landlord-1",
           snapshotId: "snapshot-1",
+          approvalDecisionItemId: "decision-1",
+          recipientEmail: "hello+tenant@rentchain.ai",
           status: "email_sent",
           deliveryStatus: "delivery_status_unknown",
           attemptedAt: "2026-07-11T12:10:00.000Z",
@@ -367,6 +369,13 @@ describe("deriveEvidencePack", () => {
           tenantNotified: true,
           noticeServed: false,
           legalServiceEstablished: false,
+          confirmation: {
+            confirmationAccepted: true,
+            recipientReviewed: true,
+            bodyReviewed: true,
+            legalServiceAcknowledged: true,
+            noLegalServiceClaim: true,
+          },
           generatedDraftText: "Hello Jane, private body text should not project.",
           providerPayload: { raw: "provider-secret" },
         },
@@ -375,6 +384,8 @@ describe("deriveEvidencePack", () => {
           leaseId: "lease-1",
           landlordId: "landlord-1",
           snapshotId: "snapshot-1",
+          approvalDecisionItemId: "decision-1",
+          recipientEmail: "hello+tenant@rentchain.ai",
           status: "send_attempted",
           deliveryStatus: "delivery_status_unknown",
           attemptedAt: "2026-07-11T12:10:00.000Z",
@@ -431,13 +442,13 @@ describe("deriveEvidencePack", () => {
           itemType: "communication_record",
           label: "Renewal tenant communication email sent",
           description:
-            "Email sent at 2026-07-11 12:10 UTC. Provider delivery status: unknown. Tenant notified by email provider acceptance. Not served; legal service not established. Communication ID: communication-1.",
+            "Email accepted for sending at 2026-07-11 12:10 UTC. Communication ID: communication-1. Lease ID: lease-1. Context: North Towers · Unit 101 · John Smith. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
           source: "renewal_notice_communications",
           sourceId: "communication-1",
         }),
       ])
     );
-    expect(JSON.stringify(pack)).not.toMatch(/private body text|provider-secret|legally served|legal delivery/i);
+    expect(JSON.stringify(pack)).not.toMatch(/private body text|provider-secret|legally served|legal delivery|provider delivery confirmed|statutory compliance/i);
   });
 
   it("keeps raw provider, banking, debug, and private document fields out of evidence projections", () => {

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -391,16 +391,49 @@ function renewalNoticeCommunicationTimestamp(record: Record<string, any>): strin
 
 function renewalNoticeCommunicationDeliveryLabel(value: unknown): string {
   const raw = asString(value, 120);
-  if (!raw || raw === "delivery_status_unknown") return "unknown";
+  if (!raw || raw === "delivery_status_unknown") return "Not tracked yet";
   return raw.replace(/_/g, " ");
 }
 
 function renewalNoticeCommunicationActionText(status: unknown): string {
   const raw = asString(status, 80);
-  if (raw === "email_sent") return "Email sent";
+  if (raw === "email_sent") return "Email accepted for sending";
   if (raw === "email_failed") return "Email failed";
   if (raw === "send_attempted") return "Send attempted";
   return "Communication recorded";
+}
+
+function renewalNoticeCommunicationContextLabel(record: Record<string, any>, input: DeriveEvidencePackInput): string {
+  const leaseId = asString(record.leaseId, 240);
+  const lease = arrayOf(input.leases).find((item) => asString(item.id || item.leaseId, 240) === leaseId);
+  if (lease) return leaseContextLabel(lease);
+  const propertyId = asString(record.propertyId, 240);
+  const property = arrayOf(input.properties).find((item) => asString(item.id || item.propertyId, 240) === propertyId);
+  if (property) return propertyContextLabel(property);
+  return "";
+}
+
+function renewalNoticeCommunicationDetails(record: Record<string, any>, input: DeriveEvidencePackInput): string {
+  const parts: string[] = [];
+  const communicationId = asString(record.communicationId || record.id, 240);
+  const leaseId = asString(record.leaseId, 240);
+  const contextLabel = renewalNoticeCommunicationContextLabel(record, input);
+  const recipientEmail = asString(record.recipientEmail, 320);
+  const snapshotId = asString(record.snapshotId, 240);
+  const approvalDecisionItemId = asString(record.approvalDecisionItemId, 240);
+  const deliveryLabel = renewalNoticeCommunicationDeliveryLabel(record.deliveryStatus);
+
+  if (communicationId) parts.push(`Communication ID: ${communicationId}.`);
+  if (leaseId) parts.push(`Lease ID: ${leaseId}.`);
+  if (contextLabel) parts.push(`Context: ${contextLabel}.`);
+  if (recipientEmail) parts.push(`Recipient email: ${recipientEmail}.`);
+  parts.push(`Delivery confirmation: ${deliveryLabel}.`);
+  if (snapshotId) parts.push(`Draft snapshot ID: ${snapshotId}.`);
+  if (approvalDecisionItemId) parts.push(`Approval decision ID: ${approvalDecisionItemId}.`);
+  if (record.confirmation) parts.push("Confirmation/audit status: send confirmations captured.");
+  parts.push("Not served; legal service not established.");
+  parts.push("Legal compliance not determined by this workflow.");
+  return parts.join(" ");
 }
 
 function groupRenewalNoticeCommunications(records: Record<string, any>[]): Record<string, any>[] {
@@ -436,13 +469,11 @@ function renewalNoticeCommunicationEvidenceItems(input: DeriveEvidencePackInput)
       const actionText = renewalNoticeCommunicationActionText(record.status);
       const timestamp = renewalNoticeCommunicationTimestamp(record);
       const timestampLabel = formatEvidenceTimestamp(timestamp);
-      const deliveryLabel = renewalNoticeCommunicationDeliveryLabel(record.deliveryStatus);
-      const tenantNotified = record.tenantNotified === true ? "Tenant notified by email provider acceptance." : "Tenant not notified.";
       const communicationId = asString(record.communicationId || record.id, 240);
       return evidenceItem({
         itemType: "communication_record",
         label: `Renewal tenant communication ${statusLabel}`,
-        description: `${actionText} at ${timestampLabel}. Provider delivery status: ${deliveryLabel}. ${tenantNotified} Not served; legal service not established.${communicationId ? ` Communication ID: ${communicationId}.` : ""}`,
+        description: `${actionText} at ${timestampLabel}. ${renewalNoticeCommunicationDetails(record, input)}`,
         source: "renewal_notice_communications",
         sourceId: communicationId || record.id,
         timestamp,

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -213,7 +213,7 @@ describe("deriveCanonicalReviewTimeline", () => {
           leaseId: "lease-1",
           resource: { id: "lease-1" },
           actor: { type: "landlord", id: "landlord-1" },
-          metadata: {
+          payload: {
             communicationId: "rnc_test",
             deliveryStatus: "delivery_status_unknown",
             tenantNotified: false,
@@ -228,7 +228,7 @@ describe("deriveCanonicalReviewTimeline", () => {
           leaseId: "lease-1",
           resource: { id: "lease-1" },
           actor: { type: "landlord", id: "landlord-1" },
-          metadata: {
+          payload: {
             communicationId: "rnc_test",
             deliveryStatus: "delivery_status_unknown",
             tenantNotified: false,

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -183,6 +183,27 @@ describe("deriveCanonicalReviewTimeline", () => {
       scope: "lease",
       scopeId: "lease-1",
       landlordId: "landlord-1",
+      renewalNoticeCommunications: [
+        {
+          communicationId: "rnc_test",
+          leaseId: "lease-1",
+          snapshotId: "snapshot-1",
+          approvalDecisionItemId: "decision-1",
+          recipientEmail: "hello+tenant@rentchain.ai",
+          status: "email_sent",
+          deliveryStatus: "delivery_status_unknown",
+          sentAt: "2026-07-11T12:10:00.000Z",
+          confirmation: {
+            confirmationAccepted: true,
+            recipientReviewed: true,
+            bodyReviewed: true,
+            legalServiceAcknowledged: true,
+            noLegalServiceClaim: true,
+          },
+          generatedDraftText: "Hello Jane, private body text should not project.",
+          providerPayload: { raw: "provider-secret" },
+        },
+      ],
       canonicalEvents: [
         {
           id: "event-confirmed-1",
@@ -246,20 +267,20 @@ describe("deriveCanonicalReviewTimeline", () => {
           source: "canonical_events",
           label: "Renewal tenant communication email sent",
           description:
-            "Renewal tenant communication email sent at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: email sent. Provider delivery status: unknown. Tenant notified by email provider acceptance. Not served; legal service not established.",
+            "Renewal tenant communication email sent at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: email sent. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
         }),
         expect.objectContaining({
           label: "Renewal tenant communication send attempted",
           description:
-            "Renewal tenant communication send attempted at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: send attempted. Provider delivery status: unknown. Not served; legal service not established.",
+            "Renewal tenant communication send attempted at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: send attempted. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
         }),
         expect.objectContaining({
           label: "Renewal tenant communication send confirmed",
           description:
-            "Renewal tenant communication send confirmed internally at 2026-07-11 12:09 UTC. Communication ID: rnc_test. Status: send confirmed internally. Provider delivery status: unknown. Not served; legal service not established.",
+            "Renewal tenant communication send confirmed internally at 2026-07-11 12:09 UTC. Communication ID: rnc_test. Status: send confirmed internally. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
         }),
       ])
     );
-    expect(JSON.stringify(timeline)).not.toMatch(/legally served|legal delivery|compliant notice/i);
+    expect(JSON.stringify(timeline)).not.toMatch(/private body text|provider-secret|legally served|legal delivery|compliant notice|provider delivery confirmed/i);
   });
 });

--- a/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
+++ b/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
@@ -110,22 +110,46 @@ function renewalNoticeCommunicationStatusText(event: Record<string, any>): strin
   return "communication recorded";
 }
 
-function renewalNoticeCommunicationTimelineDescription(event: Record<string, any>): string | null {
-  if (!isRenewalNoticeCommunicationEvent(event)) return null;
+function renewalNoticeCommunicationRecordFor(
+  event: Record<string, any>,
+  records: Record<string, any>[] | null | undefined
+): Record<string, any> | null {
   const metadata = event.metadata || {};
   const communicationId = asString(metadata.communicationId || event.communicationId, 240);
-  const rawDeliveryStatus = asString(metadata.deliveryStatus || event.deliveryStatus, 120);
+  if (!communicationId) return null;
+  return (records || []).find((record) => asString(record.communicationId || record.id, 240) === communicationId) || null;
+}
+
+function renewalNoticeCommunicationTimelineDescriptionForInput(
+  event: Record<string, any>,
+  input: DeriveCanonicalReviewTimelineInput
+): string | null {
+  if (!isRenewalNoticeCommunicationEvent(event)) return null;
+  const metadata = event.metadata || {};
+  const record = renewalNoticeCommunicationRecordFor(event, input.renewalNoticeCommunications);
+  const communicationId = asString(metadata.communicationId || event.communicationId || record?.communicationId || record?.id, 240);
+  const rawDeliveryStatus = asString(metadata.deliveryStatus || event.deliveryStatus || record?.deliveryStatus, 120);
   const deliveryStatus = !rawDeliveryStatus || rawDeliveryStatus === "delivery_status_unknown"
-    ? "unknown"
+    ? "Not tracked yet"
     : rawDeliveryStatus.replace(/_/g, " ");
-  const occurredAt = formatTimelineTimestamp(event.occurredAt || event.recordedAt || event.createdAt);
+  const occurredAt = formatTimelineTimestamp(event.occurredAt || event.recordedAt || event.createdAt || record?.sentAt || record?.attemptedAt);
   const status = renewalNoticeCommunicationStatusText(event);
-  const idText = communicationId ? ` Communication ID: ${communicationId}.` : "";
-  const tenantNoticeText =
-    metadata.tenantNotified === true || event.tenantNotified === true
-      ? " Tenant notified by email provider acceptance."
-      : "";
-  return `Renewal tenant communication ${status} at ${occurredAt}.${idText} Status: ${status}. Provider delivery status: ${deliveryStatus}.${tenantNoticeText} Not served; legal service not established.`;
+  const parts = [
+    `Renewal tenant communication ${status} at ${occurredAt}.`,
+    communicationId ? `Communication ID: ${communicationId}.` : "",
+    `Status: ${status}.`,
+  ];
+  const recipientEmail = asString(record?.recipientEmail, 320);
+  const snapshotId = asString(metadata.snapshotId || record?.snapshotId, 240);
+  const approvalDecisionItemId = asString(metadata.approvalDecisionItemId || record?.approvalDecisionItemId, 240);
+  if (recipientEmail) parts.push(`Recipient email: ${recipientEmail}.`);
+  parts.push(`Delivery confirmation: ${deliveryStatus}.`);
+  if (snapshotId) parts.push(`Draft snapshot ID: ${snapshotId}.`);
+  if (approvalDecisionItemId) parts.push(`Approval decision ID: ${approvalDecisionItemId}.`);
+  if (record?.confirmation) parts.push("Confirmation/audit status: send confirmations captured.");
+  parts.push("Not served; legal service not established.");
+  parts.push("Legal compliance not determined by this workflow.");
+  return parts.filter(Boolean).join(" ");
 }
 
 function normalizeActor(raw: any): ReviewTimelineActor {
@@ -313,7 +337,7 @@ function canonicalEventEntries(input: DeriveCanonicalReviewTimelineInput): Revie
         entryType: "canonical_event",
         timestamp: event.occurredAt || event.recordedAt,
         label: canonicalEventLabel(event),
-        description: renewalNoticeCommunicationTimelineDescription(event) || event.summary || "Canonical event recorded.",
+        description: renewalNoticeCommunicationTimelineDescriptionForInput(event, input) || event.summary || "Canonical event recorded.",
         status: event.status === "blocked" ? "blocked" : "info",
         actor: normalizeActor(event.actor),
         source: "canonical_events",

--- a/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
+++ b/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
@@ -114,7 +114,7 @@ function renewalNoticeCommunicationRecordFor(
   event: Record<string, any>,
   records: Record<string, any>[] | null | undefined
 ): Record<string, any> | null {
-  const metadata = event.metadata || {};
+  const metadata = { ...(event.payload || {}), ...(event.metadata || {}) };
   const communicationId = asString(metadata.communicationId || event.communicationId, 240);
   if (!communicationId) return null;
   return (records || []).find((record) => asString(record.communicationId || record.id, 240) === communicationId) || null;
@@ -125,7 +125,7 @@ function renewalNoticeCommunicationTimelineDescriptionForInput(
   input: DeriveCanonicalReviewTimelineInput
 ): string | null {
   if (!isRenewalNoticeCommunicationEvent(event)) return null;
-  const metadata = event.metadata || {};
+  const metadata = { ...(event.payload || {}), ...(event.metadata || {}) };
   const record = renewalNoticeCommunicationRecordFor(event, input.renewalNoticeCommunications);
   const communicationId = asString(metadata.communicationId || event.communicationId || record?.communicationId || record?.id, 240);
   const rawDeliveryStatus = asString(metadata.deliveryStatus || event.deliveryStatus || record?.deliveryStatus, 120);

--- a/rentchain-api/src/lib/reviewTimeline/reviewTimelineTypes.ts
+++ b/rentchain-api/src/lib/reviewTimeline/reviewTimelineTypes.ts
@@ -93,6 +93,7 @@ export type DeriveCanonicalReviewTimelineInput = {
   institutionExportPackage?: Record<string, any> | null;
   auditComplianceReadiness?: Record<string, any> | null;
   canonicalEvents?: Array<Record<string, any>> | null;
+  renewalNoticeCommunications?: Array<Record<string, any>> | null;
   recoveryLogs?: Array<Record<string, unknown>> | null;
   filters?: {
     entryType?: unknown;

--- a/rentchain-api/src/routes/landlordReviewTimelineRoutes.ts
+++ b/rentchain-api/src/routes/landlordReviewTimelineRoutes.ts
@@ -190,6 +190,7 @@ router.get("/review-timeline", requireAuth, requireLandlord, async (req: any, re
       institutionExportPackage,
       auditComplianceReadiness,
       canonicalEvents: auditEvents,
+      renewalNoticeCommunications,
       filters: {
         entryType: queryValue(req, "entryType"),
         status: queryValue(req, "status"),


### PR DESCRIPTION
## Summary
- Enrich lease evidence pack renewal tenant communication items with communication ID, lease/context, recipient email, sent timestamp, draft snapshot ID, approval decision ID, confirmation/audit status, delivery confirmation, and legal-service guardrails.
- Enrich review timeline renewal communication event descriptions by matching canonical send events to stored renewal communication records when available.
- Preserve grouped evidence behavior and historical timeline events without changing send behavior.

## Audit findings
- Evidence preview already loads `renewalNoticeCommunications` and derives grouped communication evidence items in `deriveEvidencePack`.
- Review timeline already loads `renewalNoticeCommunications`, but the derivation helper did not receive them, so timeline entries could not include recipient/snapshot/approval details from the stored communication record.
- Renewal draft snapshots were already grouped in evidence; this change does not alter draft snapshot grouping.
- Communication records are already stored in `renewalNoticeCommunications`; this PR only improves read-model projection and tests.

## Guardrails
- No send API behavior changed.
- No email send path changed.
- No delivery tracking or provider webhook handling added.
- No notice-served or legal-service claim added.
- No lease lifecycle mutation added.

## Validation
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test -- deriveEvidencePack deriveCanonicalReviewTimeline`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build`
- `git diff --check`
- `git diff --cached --check`

Frontend was not touched.