### PR TITLE
Add renewal communication history to notice workflow

### DIFF
--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   fetchLandlordDecisionQueue: vi.fn(),
   createLandlordDecisionQueueItem: vi.fn(),
   updateLandlordDecisionQueueItem: vi.fn(),
+  fetchReviewTimeline: vi.fn(),
 }));
 
 vi.mock("@/api/leasesApi", () => ({
@@ -29,6 +30,11 @@ vi.mock("@/api/landlordDecisionQueueApi", () => ({
   fetchLandlordDecisionQueue: mocks.fetchLandlordDecisionQueue,
   createLandlordDecisionQueueItem: mocks.createLandlordDecisionQueueItem,
   updateLandlordDecisionQueueItem: mocks.updateLandlordDecisionQueueItem,
+}));
+
+vi.mock("@/api/reviewTimelineApi", () => ({
+  fetchReviewTimeline: mocks.fetchReviewTimeline,
+  reviewTimelinePath: ({ scope, scopeId }: { scope: string; scopeId: string }) => `/review-timeline?scope=${scope}&scopeId=${scopeId}`,
 }));
 
 function renderWorkflow(path: string) {
@@ -127,6 +133,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     mocks.fetchLandlordDecisionQueue.mockReset();
     mocks.createLandlordDecisionQueueItem.mockReset();
     mocks.updateLandlordDecisionQueueItem.mockReset();
+    mocks.fetchReviewTimeline.mockReset();
     mocks.getLeaseById.mockResolvedValue({
       lease: {
         id: "lease-1",
@@ -342,6 +349,18 @@ describe("LandlordLeaseWorkflowPage", () => {
         sourceRoute: null,
       },
     });
+    mocks.fetchReviewTimeline.mockResolvedValue({
+      timelineId: "timeline-lease-1",
+      scope: "lease",
+      scopeId: "lease-1",
+      generatedAt: "2026-07-13T12:00:00.000Z",
+      manualReviewRequired: true,
+      externalSharingEnabled: false,
+      certificationIssued: false,
+      entries: [],
+      filters: { entryType: [], status: [], source: [] },
+      summary: { total: 0, reviewRequired: 0, blocked: 0, completed: 0, redacted: 0 },
+    });
     mocks.createLandlordDecisionQueueItem.mockImplementation(async (payload) => ({
       ok: true,
       created: true,
@@ -470,6 +489,20 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(sendReview).toHaveTextContent("Not established");
     expect(sendReview).toHaveTextContent("Legal compliance");
     expect(sendReview).toHaveTextContent("Not determined by this workflow");
+    const communicationHistory = await screen.findByLabelText("Previous renewal communications");
+    await waitFor(() => {
+      expect(communicationHistory).toHaveTextContent("No renewal communications have been sent for this lease yet.");
+    });
+    expect(communicationHistory).toHaveTextContent("Renewal emails previously sent through this workflow");
+    expect(within(communicationHistory).getByRole("link", { name: "View in timeline" })).toHaveAttribute(
+      "href",
+      "/review-timeline?scope=lease&scopeId=lease-1"
+    );
+    expect(within(communicationHistory).getByRole("link", { name: "View evidence package" })).toHaveAttribute(
+      "href",
+      "/evidence-packs?scope=lease&scopeId=lease-1"
+    );
+    expect(mocks.fetchReviewTimeline).toHaveBeenCalledWith({ scope: "lease", scopeId: "lease-1" });
     expect(sendReview).toHaveTextContent("Approval decision");
     await waitFor(() => {
       expect(sendReview).toHaveTextContent("Save a draft snapshot before creating a send approval decision.");
@@ -495,6 +528,107 @@ describe("LandlordLeaseWorkflowPage", () => {
       background: "#fff6e8",
       borderRadius: "14px",
     });
+  });
+
+  it("shows previous renewal communications separately from current send readiness", async () => {
+    mocks.fetchReviewTimeline.mockResolvedValue({
+      timelineId: "timeline-lease-1",
+      scope: "lease",
+      scopeId: "lease-1",
+      generatedAt: "2026-07-13T12:00:00.000Z",
+      manualReviewRequired: true,
+      externalSharingEnabled: false,
+      certificationIssued: false,
+      entries: [
+        {
+          timelineEntryId: "renewal_notice_send_confirmed:rnc_prior",
+          entryType: "canonical_event",
+          timestamp: "2026-07-13T03:49:00.000Z",
+          label: "Renewal tenant communication send confirmed internally",
+          description:
+            "Renewal tenant communication send confirmed internally at 2026-07-13 03:49 UTC. Communication ID: rnc_prior. Status: send confirmed internally. Recipient email: jane@example.com. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-prior. Approval decision ID: decision-prior. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+          status: "completed",
+          actor: { type: "landlord", id: "landlord-1" },
+          source: "canonical_events",
+          sourceId: "rnc_prior",
+          destination: null,
+          redacted: false,
+          redactionReason: null,
+          blockedReason: null,
+          manualOnly: true,
+        },
+        {
+          timelineEntryId: "renewal_notice_send_attempted:rnc_prior",
+          entryType: "canonical_event",
+          timestamp: "2026-07-13T03:57:00.000Z",
+          label: "Renewal tenant communication send attempted",
+          description:
+            "Renewal tenant communication send attempted at 2026-07-13 03:57 UTC. Communication ID: rnc_prior. Status: send attempted. Recipient email: jane@example.com. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-prior. Approval decision ID: decision-prior. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+          status: "completed",
+          actor: { type: "landlord", id: "landlord-1" },
+          source: "canonical_events",
+          sourceId: "rnc_prior",
+          destination: null,
+          redacted: false,
+          redactionReason: null,
+          blockedReason: null,
+          manualOnly: true,
+        },
+        {
+          timelineEntryId: "renewal_notice_email_sent:rnc_prior",
+          entryType: "canonical_event",
+          timestamp: "2026-07-13T03:58:00.000Z",
+          label: "Renewal tenant communication email sent",
+          description:
+            "Renewal tenant communication email sent at 2026-07-13 03:58 UTC. Communication ID: rnc_prior. Status: email sent. Recipient email: jane@example.com. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-prior. Approval decision ID: decision-prior. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+          status: "completed",
+          actor: { type: "landlord", id: "landlord-1" },
+          source: "canonical_events",
+          sourceId: "rnc_prior",
+          destination: null,
+          redacted: false,
+          redactionReason: null,
+          blockedReason: null,
+          manualOnly: true,
+        },
+      ],
+      filters: { entryType: ["canonical_event"], status: ["completed"], source: ["canonical_events"] },
+      summary: { total: 3, reviewRequired: 0, blocked: 0, completed: 3, redacted: 0 },
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    const noticeReview = await screen.findByLabelText("Renewal notice review");
+    await screen.findByLabelText("Tenant notice draft preview");
+    expect(noticeReview).toHaveTextContent("Requires approval and confirmations");
+    const history = await screen.findByLabelText("Previous renewal communications");
+    await waitFor(() => {
+      expect(history).toHaveTextContent("1 recorded");
+    });
+    expect(history).toHaveTextContent("Renewal emails previously sent through this workflow");
+    expect(history).toHaveTextContent("Renewal email sent");
+    expect(history).toHaveTextContent("rnc_prior");
+    expect(screen.getByText("rnc_prior")).toHaveStyle({ overflowWrap: "anywhere" });
+    expect(history).toHaveTextContent("jane@example.com");
+    expect(history).toHaveTextContent("Email delivery");
+    expect(history).toHaveTextContent("Email sent");
+    expect(history).toHaveTextContent("Delivery confirmation");
+    expect(history).toHaveTextContent("Not tracked yet");
+    expect(history).toHaveTextContent("Not served; legal service not established");
+    expect(history).toHaveTextContent("Not determined by this workflow");
+    expect(history).toHaveTextContent("snapshot-prior");
+    expect(history).toHaveTextContent("decision-prior");
+    expect(within(history).getByRole("link", { name: "View in timeline" })).toHaveAttribute(
+      "href",
+      "/review-timeline?scope=lease&scopeId=lease-1"
+    );
+    expect(within(history).getByRole("link", { name: "View evidence package" })).toHaveAttribute(
+      "href",
+      "/evidence-packs?scope=lease&scopeId=lease-1"
+    );
+    expect(history).not.toHaveTextContent("Provider delivery status unknown");
+    expect(document.body).not.toHaveTextContent(/legally delivered|tenant opened|delivery confirmed|compliance achieved|statutory notice completed/i);
+    expect(mocks.sendRenewalNoticeCommunication).not.toHaveBeenCalled();
   });
 
   it("shows notice review inputs-needed state without draft actions", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -31,6 +31,8 @@ import {
   updateLandlordDecisionQueueItem,
   type LandlordDecisionQueueItem,
 } from "@/api/landlordDecisionQueueApi";
+import { fetchReviewTimeline, reviewTimelinePath, type ReviewTimelineEntry } from "@/api/reviewTimelineApi";
+import { evidencePackPath } from "@/api/evidencePackApi";
 
 type WorkflowKey = "execution" | "rent-increase" | "notice" | "deposit" | "renewal" | "move-out";
 
@@ -251,6 +253,21 @@ function deliveryConfirmationLabel(status: RenewalNoticeCommunicationResponse["d
   return "Not tracked yet";
 }
 
+function communicationDeliveryLabel(value: string | null | undefined) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized || normalized === "delivery_status_unknown" || normalized === "unknown") return "Not tracked yet";
+  if (normalized === "not tracked yet") return "Not tracked yet";
+  return value || "Not tracked yet";
+}
+
+function communicationEmailDeliveryLabel(value: string | null | undefined) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "email sent") return "Email sent";
+  if (normalized === "send attempted") return "Send attempted";
+  if (normalized === "send confirmed internally") return "Send confirmed internally";
+  return "Email sent";
+}
+
 function recordStringValue(record: Record<string, unknown> | null | undefined, key: string) {
   const value = record?.[key];
   return typeof value === "string" ? value.trim() : "";
@@ -263,6 +280,67 @@ function approvalDecisionDraftSnapshotId(decision: LandlordDecisionQueueItem | n
     recordStringValue(decision.sourceSnapshot, "draftSnapshotId") ||
     recordStringValue(decision.sourceSnapshot, "snapshotId")
   );
+}
+
+function extractSentenceValue(text: string, label: string) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}:\\s*(.*?)(?:\\.\\s+[A-Z][A-Za-z /-]+:|\\.$|$)`, "i").exec(text);
+  return match?.[1]?.trim().replace(/\.$/, "") || "";
+}
+
+type PreviousRenewalCommunication = {
+  communicationId: string;
+  recipientEmail: string;
+  sentTimestamp: string;
+  emailDelivery: string;
+  deliveryConfirmation: string;
+  draftSnapshotId: string;
+  approvalDecisionId: string;
+};
+
+function renewalCommunicationIdForEntry(entry: ReviewTimelineEntry) {
+  return extractSentenceValue(entry.description || "", "Communication ID") || entry.sourceId || "";
+}
+
+function isRenewalCommunicationTimelineEntry(entry: ReviewTimelineEntry) {
+  return /renewal tenant communication/i.test(`${entry.label} ${entry.description}`);
+}
+
+function renewalCommunicationRank(entry: ReviewTimelineEntry) {
+  const text = `${entry.label} ${entry.description}`.toLowerCase();
+  if (text.includes("email sent")) return 3;
+  if (text.includes("send attempted")) return 2;
+  if (text.includes("send confirmed")) return 1;
+  return 0;
+}
+
+function previousRenewalCommunicationsFromTimeline(entries: ReviewTimelineEntry[]) {
+  const grouped = new Map<string, ReviewTimelineEntry[]>();
+  entries.filter(isRenewalCommunicationTimelineEntry).forEach((entry) => {
+    const communicationId = renewalCommunicationIdForEntry(entry);
+    if (!communicationId) return;
+    grouped.set(communicationId, [...(grouped.get(communicationId) || []), entry]);
+  });
+
+  return Array.from(grouped.entries())
+    .map(([communicationId, group]): PreviousRenewalCommunication => {
+      const sorted = [...group].sort((left, right) => {
+        const rank = renewalCommunicationRank(right) - renewalCommunicationRank(left);
+        if (rank !== 0) return rank;
+        return new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime();
+      });
+      const primary = sorted[0];
+      return {
+        communicationId,
+        recipientEmail: extractSentenceValue(primary.description, "Recipient email") || "Recipient not available",
+        sentTimestamp: primary.timestamp,
+        emailDelivery: communicationEmailDeliveryLabel(extractSentenceValue(primary.description, "Status")),
+        deliveryConfirmation: communicationDeliveryLabel(extractSentenceValue(primary.description, "Delivery confirmation")),
+        draftSnapshotId: extractSentenceValue(primary.description, "Draft snapshot ID"),
+        approvalDecisionId: extractSentenceValue(primary.description, "Approval decision ID"),
+      };
+    })
+    .sort((left, right) => new Date(right.sentTimestamp).getTime() - new Date(left.sentTimestamp).getTime());
 }
 
 function daysUntilDate(value: string | null | undefined) {
@@ -656,6 +734,7 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
           readinessReady={false}
           savedSnapshot={null}
         />
+        <PreviousRenewalCommunicationsSection lease={lease} />
       </section>
     );
   }
@@ -739,6 +818,8 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
         savedSnapshot={savedDraftSnapshot}
       />
 
+      <PreviousRenewalCommunicationsSection lease={lease} />
+
       <div style={noticeActionGridStyle}>
         {draftText ? (
           <>
@@ -771,6 +852,104 @@ function RenewalNoticeDraftContextWorkspace({ lease }: { lease: LandlordActiveLe
       <div style={deferredPanelStyle}>
         Notice record creation remains separate. Saving a draft snapshot records audit context only; email delivery requires
         internal approval and explicit confirmations.
+      </div>
+    </section>
+  );
+}
+
+function PreviousRenewalCommunicationsSection({ lease }: { lease: LandlordActiveLease }) {
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [communications, setCommunications] = React.useState<PreviousRenewalCommunication[]>([]);
+  const timelineHref = reviewTimelinePath({ scope: "lease", scopeId: lease.id });
+  const evidenceHref = evidencePackPath({ scope: "lease", scopeId: lease.id });
+
+  React.useEffect(() => {
+    let active = true;
+    async function loadHistory() {
+      setLoading(true);
+      setError(null);
+      try {
+        const timeline = await fetchReviewTimeline({ scope: "lease", scopeId: lease.id });
+        if (!active) return;
+        setCommunications(previousRenewalCommunicationsFromTimeline(timeline.entries || []));
+      } catch {
+        if (!active) return;
+        setCommunications([]);
+        setError("Previous renewal communications could not be loaded.");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    void loadHistory();
+    return () => {
+      active = false;
+    };
+  }, [lease.id]);
+
+  return (
+    <section style={communicationHistoryStyle} aria-label="Previous renewal communications">
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <h3 style={sendReviewHeadingStyle}>Previous renewal communications</h3>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.6 }}>
+            Renewal emails previously sent through this workflow. These records are audit/evidence references only and do
+            not establish legal notice service.
+          </div>
+        </div>
+        <span style={communications.length ? readyBadgePillStyle : deferredBadgeStyle}>
+          {communications.length ? `${communications.length} recorded` : "No sends recorded"}
+        </span>
+      </div>
+
+      {loading ? <div style={{ color: workflowTheme.muted }}>Loading previous renewal communications…</div> : null}
+      {error ? <div style={warningPanelStyle}>{error}</div> : null}
+      {!loading && !error && communications.length === 0 ? (
+        <div style={deferredPanelStyle}>No renewal communications have been sent for this lease yet.</div>
+      ) : null}
+
+      {communications.length ? (
+        <div style={communicationHistoryListStyle}>
+          {communications.map((communication) => (
+            <article key={communication.communicationId} style={communicationHistoryCardStyle}>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "flex-start" }}>
+                <div style={{ display: "grid", gap: 4 }}>
+                  <div style={sendReviewSubheadingStyle}>Renewal email sent</div>
+                  <div style={{ color: workflowTheme.muted, lineHeight: 1.5 }}>{formatTimestamp(communication.sentTimestamp)}</div>
+                </div>
+                <span style={readyBadgePillStyle}>Audit/evidence record</span>
+              </div>
+              <dl style={communicationHistoryFactsStyle}>
+                <ReviewFact label="Recipient" value={communication.recipientEmail} valueStyle={communicationIdValueStyle} />
+                <ReviewFact
+                  label="Communication ID"
+                  value={communication.communicationId}
+                  containerStyle={communicationIdFactStyle}
+                  valueStyle={communicationIdValueStyle}
+                />
+                <ReviewFact label="Email delivery" value={communication.emailDelivery} />
+                <ReviewFact label="Delivery confirmation" value={communication.deliveryConfirmation} />
+                <ReviewFact label="Notice service" value="Not served; legal service not established" />
+                <ReviewFact label="Legal compliance" value="Not determined by this workflow" />
+                {communication.draftSnapshotId ? (
+                  <ReviewFact label="Draft snapshot ID" value={communication.draftSnapshotId} valueStyle={communicationIdValueStyle} />
+                ) : null}
+                {communication.approvalDecisionId ? (
+                  <ReviewFact label="Approval decision ID" value={communication.approvalDecisionId} valueStyle={communicationIdValueStyle} />
+                ) : null}
+              </dl>
+            </article>
+          ))}
+        </div>
+      ) : null}
+
+      <div style={noticeActionGridStyle}>
+        <Link to={timelineHref} style={buttonLinkStyle}>
+          View in timeline
+        </Link>
+        <Link to={evidenceHref} style={buttonLinkStyle}>
+          View evidence package
+        </Link>
       </div>
     </section>
   );
@@ -1895,6 +2074,38 @@ const sentStatusStyle: React.CSSProperties = {
   borderRadius: 10,
   background: "rgba(220, 252, 231, 0.42)",
   padding: 12,
+};
+
+const communicationHistoryStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 12,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 12,
+  background: workflowTheme.cardStrong,
+  padding: 14,
+};
+
+const communicationHistoryListStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 10,
+};
+
+const communicationHistoryCardStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 10,
+  border: `1px solid ${workflowTheme.border}`,
+  borderRadius: 10,
+  background: workflowTheme.card,
+  padding: 12,
+  minWidth: 0,
+};
+
+const communicationHistoryFactsStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))",
+  gap: 10,
+  margin: 0,
+  minWidth: 0,
 };
 
 const communicationIdFactStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- Adds a read-only `Previous renewal communications` section to `/leases/:leaseId/workflows/notice`.
- Reuses the existing authenticated lease-scoped review timeline API and groups renewal communication events by communication ID.
- Keeps current draft/send readiness separate from prior sent renewal communication history.

## Audit findings
- The notice workflow only displayed the current draft/send readiness and current-session send result.
- PR #1356 already enriches lease-scoped review timeline entries with renewal communication ID, recipient email, delivery confirmation, draft snapshot ID, approval decision ID, and legal guardrail wording.
- No new backend endpoint is needed for v1; the existing review timeline and evidence package routes remain the source links.

## Implementation
- Displays historical renewal email records with communication ID, recipient, sent timestamp, email delivery, delivery confirmation, notice-service status, legal-compliance status, draft snapshot ID, and approval decision ID when available.
- Shows an empty state for leases without prior renewal communications.
- Preserves links to the review timeline and evidence package.
- Long IDs wrap safely to avoid horizontal overflow.

## Validation
- `npm run test -- LandlordLeaseWorkflowPage` passed.
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` passed. Vite emitted its existing Node-version warning for 20.11.1 but completed successfully.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Guardrails
- Frontend-only.
- No send API behavior changed.
- No email sending was triggered.
- No delivery tracking or provider webhook handling added.
- No notice-served state or lease lifecycle mutation added.
- No legal-service, legal-delivery, or compliance claim added.