### PR TITLE
Implement renewal tenant communication delivery status v1

### DIFF
--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -363,7 +363,7 @@ describe("deriveEvidencePack", () => {
           approvalDecisionItemId: "decision-1",
           recipientEmail: "hello+tenant@rentchain.ai",
           status: "email_sent",
-          deliveryStatus: "delivery_status_unknown",
+          deliveryStatus: "accepted_for_sending",
           attemptedAt: "2026-07-11T12:10:00.000Z",
           sentAt: "2026-07-11T12:10:02.000Z",
           tenantNotified: true,
@@ -442,7 +442,7 @@ describe("deriveEvidencePack", () => {
           itemType: "communication_record",
           label: "Renewal tenant communication email sent",
           description:
-            "Email accepted for sending at 2026-07-11 12:10 UTC. Communication ID: communication-1. Lease ID: lease-1. Context: North Towers · Unit 101 · John Smith. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+            "Email accepted for sending at 2026-07-11 12:10 UTC. Communication ID: communication-1. Lease ID: lease-1. Context: North Towers · Unit 101 · John Smith. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Accepted for sending. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
           source: "renewal_notice_communications",
           sourceId: "communication-1",
         }),

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -451,6 +451,62 @@ describe("deriveEvidencePack", () => {
     expect(JSON.stringify(pack)).not.toMatch(/private body text|provider-secret|legally served|legal delivery|provider delivery confirmed|statutory compliance/i);
   });
 
+  it("renders failed and legacy renewal tenant communication delivery status safely", () => {
+    const pack = deriveEvidencePack({
+      scope: "lease",
+      scopeId: "lease-1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-07-11T12:00:00.000Z",
+      renewalNoticeCommunications: [
+        {
+          communicationId: "communication-failed",
+          leaseId: "lease-1",
+          landlordId: "landlord-1",
+          snapshotId: "snapshot-failed",
+          approvalDecisionItemId: "decision-failed",
+          recipientEmail: "hello+tenant@rentchain.ai",
+          status: "email_failed",
+          deliveryStatus: "failed",
+          attemptedAt: "2026-07-11T12:20:00.000Z",
+          failedAt: "2026-07-11T12:20:02.000Z",
+          tenantNotified: false,
+          noticeServed: false,
+          legalServiceEstablished: false,
+          providerPayload: { raw: "provider-secret" },
+        },
+        {
+          communicationId: "communication-legacy",
+          leaseId: "lease-1",
+          landlordId: "landlord-1",
+          snapshotId: "snapshot-legacy",
+          approvalDecisionItemId: "decision-legacy",
+          recipientEmail: "hello+tenant@rentchain.ai",
+          status: "email_sent",
+          attemptedAt: "2026-07-11T12:10:00.000Z",
+          sentAt: "2026-07-11T12:10:02.000Z",
+          tenantNotified: true,
+          noticeServed: false,
+          legalServiceEstablished: false,
+        },
+      ],
+    });
+
+    const auditSection = pack.sections.find((section) => section.sectionKey === "audit_events");
+    expect(auditSection?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Renewal tenant communication email failed",
+          description: expect.stringContaining("Delivery confirmation: Failed by email provider."),
+        }),
+        expect.objectContaining({
+          label: "Renewal tenant communication email sent",
+          description: expect.stringContaining("Delivery confirmation: Not tracked yet."),
+        }),
+      ])
+    );
+    expect(JSON.stringify(pack)).not.toMatch(/provider-secret|notice served|legally delivered|tenant received|compliance achieved|statutory notice completed/i);
+  });
+
   it("keeps raw provider, banking, debug, and private document fields out of evidence projections", () => {
     const pack = deriveEvidencePack({
       scope: "decision",

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -391,7 +391,19 @@ function renewalNoticeCommunicationTimestamp(record: Record<string, any>): strin
 
 function renewalNoticeCommunicationDeliveryLabel(value: unknown): string {
   const raw = asString(value, 120);
-  if (!raw || raw === "delivery_status_unknown") return "Not tracked yet";
+  if (!raw || raw === "delivery_status_unknown" || raw === "not_tracked") return "Not tracked yet";
+  if (raw === "accepted_for_sending") return "Accepted for sending";
+  if (raw === "queued") return "Queued by email provider";
+  if (raw === "sent") return "Sent by email provider";
+  if (raw === "delivered") return "Delivered by email provider";
+  if (raw === "bounced") return "Bounce detected by email provider";
+  if (raw === "failed") return "Failed by email provider";
+  if (raw === "deferred") return "Deferred by email provider";
+  if (raw === "rejected") return "Rejected by email provider";
+  if (raw === "complained") return "Complaint reported by email provider";
+  if (raw === "opened") return "Open event recorded by provider";
+  if (raw === "clicked") return "Click event recorded by provider";
+  if (raw === "unknown") return "Unknown";
   return raw.replace(/_/g, " ");
 }
 

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -283,4 +283,70 @@ describe("deriveCanonicalReviewTimeline", () => {
     );
     expect(JSON.stringify(timeline)).not.toMatch(/private body text|provider-secret|legally served|legal delivery|compliant notice|provider delivery confirmed/i);
   });
+
+  it("labels failed and legacy renewal tenant communication events without legal-service claims", () => {
+    const timeline = deriveCanonicalReviewTimeline({
+      scope: "lease",
+      scopeId: "lease-1",
+      landlordId: "landlord-1",
+      renewalNoticeCommunications: [
+        {
+          communicationId: "rnc_failed",
+          leaseId: "lease-1",
+          snapshotId: "snapshot-failed",
+          approvalDecisionItemId: "decision-failed",
+          recipientEmail: "hello+tenant@rentchain.ai",
+          status: "email_failed",
+          deliveryStatus: "failed",
+          failedAt: "2026-07-11T12:20:02.000Z",
+          providerPayload: { raw: "provider-secret" },
+        },
+        {
+          communicationId: "rnc_legacy",
+          leaseId: "lease-1",
+          snapshotId: "snapshot-legacy",
+          approvalDecisionItemId: "decision-legacy",
+          recipientEmail: "hello+tenant@rentchain.ai",
+          status: "email_sent",
+          sentAt: "2026-07-11T12:10:02.000Z",
+        },
+      ],
+      canonicalEvents: [
+        {
+          id: "event-failed-1",
+          type: "renewal_notice_email_failed",
+          action: "renewal_notice_email_failed",
+          summary: "Renewal tenant communication email failed. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          metadata: { communicationId: "rnc_failed", deliveryStatus: "failed" },
+          occurredAt: "2026-07-11T12:20:02.000Z",
+        },
+        {
+          id: "event-legacy-1",
+          type: "renewal_notice_email_sent",
+          action: "renewal_notice_email_sent",
+          summary: "Renewal tenant communication email sent. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          metadata: { communicationId: "rnc_legacy" },
+          occurredAt: "2026-07-11T12:10:02.000Z",
+        },
+      ],
+    });
+
+    expect(timeline.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Renewal tenant communication email failed",
+          description: expect.stringContaining("Delivery confirmation: Failed by email provider."),
+        }),
+        expect.objectContaining({
+          label: "Renewal tenant communication email sent",
+          description: expect.stringContaining("Delivery confirmation: Not tracked yet."),
+        }),
+      ])
+    );
+    expect(JSON.stringify(timeline)).not.toMatch(/provider-secret|notice served|legally delivered|tenant received|compliance achieved|statutory notice completed/i);
+  });
 });

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -191,7 +191,7 @@ describe("deriveCanonicalReviewTimeline", () => {
           approvalDecisionItemId: "decision-1",
           recipientEmail: "hello+tenant@rentchain.ai",
           status: "email_sent",
-          deliveryStatus: "delivery_status_unknown",
+          deliveryStatus: "accepted_for_sending",
           sentAt: "2026-07-11T12:10:00.000Z",
           confirmation: {
             confirmationAccepted: true,
@@ -245,7 +245,7 @@ describe("deriveCanonicalReviewTimeline", () => {
           actor: { type: "landlord", id: "landlord-1" },
           metadata: {
             communicationId: "rnc_test",
-            deliveryStatus: "delivery_status_unknown",
+            deliveryStatus: "accepted_for_sending",
             tenantNotified: true,
           },
           occurredAt: "2026-07-11T12:10:00.000Z",
@@ -267,7 +267,7 @@ describe("deriveCanonicalReviewTimeline", () => {
           source: "canonical_events",
           label: "Renewal tenant communication email sent",
           description:
-            "Renewal tenant communication email sent at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: email sent. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Not tracked yet. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+            "Renewal tenant communication email sent at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: email sent. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Accepted for sending. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
         }),
         expect.objectContaining({
           label: "Renewal tenant communication send attempted",

--- a/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
+++ b/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
@@ -120,6 +120,24 @@ function renewalNoticeCommunicationRecordFor(
   return (records || []).find((record) => asString(record.communicationId || record.id, 240) === communicationId) || null;
 }
 
+function renewalNoticeCommunicationDeliveryLabel(value: unknown): string {
+  const raw = asString(value, 120);
+  if (!raw || raw === "delivery_status_unknown" || raw === "not_tracked") return "Not tracked yet";
+  if (raw === "accepted_for_sending") return "Accepted for sending";
+  if (raw === "queued") return "Queued by email provider";
+  if (raw === "sent") return "Sent by email provider";
+  if (raw === "delivered") return "Delivered by email provider";
+  if (raw === "bounced") return "Bounce detected by email provider";
+  if (raw === "failed") return "Failed by email provider";
+  if (raw === "deferred") return "Deferred by email provider";
+  if (raw === "rejected") return "Rejected by email provider";
+  if (raw === "complained") return "Complaint reported by email provider";
+  if (raw === "opened") return "Open event recorded by provider";
+  if (raw === "clicked") return "Click event recorded by provider";
+  if (raw === "unknown") return "Unknown";
+  return raw.replace(/_/g, " ");
+}
+
 function renewalNoticeCommunicationTimelineDescriptionForInput(
   event: Record<string, any>,
   input: DeriveCanonicalReviewTimelineInput
@@ -128,10 +146,9 @@ function renewalNoticeCommunicationTimelineDescriptionForInput(
   const metadata = { ...(event.payload || {}), ...(event.metadata || {}) };
   const record = renewalNoticeCommunicationRecordFor(event, input.renewalNoticeCommunications);
   const communicationId = asString(metadata.communicationId || event.communicationId || record?.communicationId || record?.id, 240);
-  const rawDeliveryStatus = asString(metadata.deliveryStatus || event.deliveryStatus || record?.deliveryStatus, 120);
-  const deliveryStatus = !rawDeliveryStatus || rawDeliveryStatus === "delivery_status_unknown"
-    ? "Not tracked yet"
-    : rawDeliveryStatus.replace(/_/g, " ");
+  const deliveryStatus = renewalNoticeCommunicationDeliveryLabel(
+    metadata.deliveryStatus || event.deliveryStatus || record?.deliveryStatus
+  );
   const occurredAt = formatTimelineTimestamp(event.occurredAt || event.recordedAt || event.createdAt || record?.sentAt || record?.attemptedAt);
   const status = renewalNoticeCommunicationStatusText(event);
   const parts = [

--- a/rentchain-api/src/services/__tests__/emailService.mailgun.test.ts
+++ b/rentchain-api/src/services/__tests__/emailService.mailgun.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { sendEmail } from "../emailService";
+import { parseMailgunMessageId, sendEmail } from "../emailService";
 
 describe("emailService mailgun provider", () => {
   const envBackup = { ...process.env };
@@ -21,7 +21,7 @@ describe("emailService mailgun provider", () => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       status: 200,
-      text: async () => "queued",
+      text: async () => JSON.stringify({ id: "<abc123@mg.example.com>", message: "Queued. Thank you." }),
     }));
     vi.stubGlobal("fetch", fetchMock as any);
 
@@ -31,12 +31,22 @@ describe("emailService mailgun provider", () => {
         subject: "Test",
         html: "<p>Hello</p>",
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({
+      provider: "mailgun",
+      providerMessageId: "<abc123@mg.example.com>",
+      providerResponseId: "<abc123@mg.example.com>",
+    });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0];
     expect(init.method).toBe("POST");
     expect(init.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+  });
+
+  it("parses Mailgun message ids from json or plain text responses", () => {
+    expect(parseMailgunMessageId(JSON.stringify({ id: "<json-id@mg.example.com>" }))).toBe("<json-id@mg.example.com>");
+    expect(parseMailgunMessageId("Queued. Thank you. <plain-id@mg.example.com>")).toBe("<plain-id@mg.example.com>");
+    expect(parseMailgunMessageId("queued")).toBeNull();
   });
 
   it("rejects when Mailgun responds with failure", async () => {
@@ -56,4 +66,3 @@ describe("emailService mailgun provider", () => {
     ).rejects.toThrow("mailgun_send_failed:401");
   });
 });
-

--- a/rentchain-api/src/services/__tests__/emailService.mailgun.test.ts
+++ b/rentchain-api/src/services/__tests__/emailService.mailgun.test.ts
@@ -49,6 +49,27 @@ describe("emailService mailgun provider", () => {
     expect(parseMailgunMessageId("queued")).toBeNull();
   });
 
+  it("does not fail a successful send when Mailgun omits a message id", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ message: "Queued. Thank you." }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as any);
+
+    await expect(
+      sendEmail({
+        to: "tenant@example.com",
+        subject: "Test",
+        html: "<p>Hello</p>",
+      })
+    ).resolves.toEqual({
+      provider: "mailgun",
+      providerMessageId: null,
+      providerResponseId: null,
+    });
+  });
+
   it("rejects when Mailgun responds with failure", async () => {
     const fetchMock = vi.fn(async () => ({
       ok: false,

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
@@ -43,7 +43,11 @@ const { collections, dbMock, sendEmailMock, lookupUserEmailMock } = vi.hoisted((
   return {
     collections,
     dbMock,
-    sendEmailMock: vi.fn(async () => undefined),
+    sendEmailMock: vi.fn(async () => ({
+      provider: "mailgun",
+      providerMessageId: "<provider-message@mg.example.com>",
+      providerResponseId: "<provider-message@mg.example.com>",
+    })),
     lookupUserEmailMock: vi.fn(async () => "tenant@example.com"),
   };
 });
@@ -144,7 +148,11 @@ describe("sendRenewalNoticeCommunication", () => {
     collections.clear();
     vi.clearAllMocks();
     lookupUserEmailMock.mockResolvedValue("tenant@example.com");
-    sendEmailMock.mockResolvedValue(undefined);
+    sendEmailMock.mockResolvedValue({
+      provider: "mailgun",
+      providerMessageId: "<provider-message@mg.example.com>",
+      providerResponseId: "<provider-message@mg.example.com>",
+    });
     seedDoc("renewalNoticeDraftSnapshots", "snapshot-1", baseSnapshot());
     seedDoc("landlordDecisionQueueItems", "decision-1", baseDecision());
   });
@@ -156,7 +164,8 @@ describe("sendRenewalNoticeCommunication", () => {
       expect.objectContaining({
         ok: true,
         status: "email_sent",
-        deliveryStatus: "delivery_status_unknown",
+        deliveryStatus: "accepted_for_sending",
+        providerMessageId: "<provider-message@mg.example.com>",
         noticeServed: false,
         tenantNotified: true,
         legalServiceEstablished: false,
@@ -179,6 +188,10 @@ describe("sendRenewalNoticeCommunication", () => {
         snapshotId: "snapshot-1",
         approvalDecisionItemId: "decision-1",
         status: "email_sent",
+        deliveryStatus: "accepted_for_sending",
+        deliveryStatusSource: "send_response",
+        deliveryStatusReason: "mailgun_accepted",
+        providerMessageId: "<provider-message@mg.example.com>",
         tenantNotified: true,
         noticeServed: false,
         legalServiceEstablished: false,
@@ -292,6 +305,7 @@ describe("sendRenewalNoticeCommunication", () => {
         statusCode: 502,
         error: "RENEWAL_NOTICE_EMAIL_SEND_FAILED",
         status: "email_failed",
+        deliveryStatus: "failed",
         tenantNotified: false,
         noticeServed: false,
         legalServiceEstablished: false,
@@ -301,6 +315,9 @@ describe("sendRenewalNoticeCommunication", () => {
     expect(communications[0]).toEqual(
       expect.objectContaining({
         status: "email_failed",
+        deliveryStatus: "failed",
+        deliveryStatusSource: "send_response",
+        deliveryStatusReason: "mailgun_send_failed:500",
         tenantNotified: false,
         noticeServed: false,
         legalServiceEstablished: false,
@@ -331,6 +348,9 @@ describe("sendRenewalNoticeCommunication", () => {
         visibility: "landlord",
         summary: "Renewal tenant communication email sent. Not served; legal service not established.",
         metadata: expect.objectContaining({
+          deliveryStatus: "accepted_for_sending",
+          deliveryStatusSource: "send_response",
+          providerMessageId: "<provider-message@mg.example.com>",
           tenantNotified: true,
           noticeServed: false,
           legalServiceEstablished: false,

--- a/rentchain-api/src/services/emailService.ts
+++ b/rentchain-api/src/services/emailService.ts
@@ -2,6 +2,12 @@ import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemp
 
 type SendResult = { ok: true } | { ok: false; error: string };
 
+export type EmailSendResult = {
+  provider: "mailgun";
+  providerMessageId: string | null;
+  providerResponseId: string | null;
+};
+
 export type EmailMessage = {
   to: string | string[];
   from?: string;
@@ -36,7 +42,20 @@ function getCorrelationId(): string {
   return `em_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-async function sendViaMailgun(message: EmailMessage): Promise<void> {
+export function parseMailgunMessageId(responseText: string): string | null {
+  const raw = safeStr(responseText);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const id = safeStr(parsed?.id || parsed?.messageId || parsed?.message_id);
+    return id || null;
+  } catch {
+    const match = raw.match(/<[^>\s]+@[^>\s]+>/);
+    return match?.[0] || null;
+  }
+}
+
+async function sendViaMailgun(message: EmailMessage): Promise<EmailSendResult> {
   const correlationId = getCorrelationId();
   const apiKey = safeStr(process.env.MAILGUN_API_KEY);
   const domain = safeStr(process.env.MAILGUN_DOMAIN);
@@ -88,12 +107,19 @@ async function sendViaMailgun(message: EmailMessage): Promise<void> {
     throw new Error(`mailgun_send_failed:${response.status}`);
   }
 
+  const providerMessageId = parseMailgunMessageId(responseText);
   lastEmailPreview = {
     provider: "mailgun",
     correlationId,
+    providerMessageId,
     to: to.split(",").map(maskEmail),
     subject,
     sentAt: new Date().toISOString(),
+  };
+  return {
+    provider: "mailgun",
+    providerMessageId,
+    providerResponseId: providerMessageId,
   };
 }
 
@@ -199,10 +225,10 @@ export async function sendLandlordWelcomeEmail(params: {
   }
 }
 
-export async function sendEmail(message: EmailMessage) {
+export async function sendEmail(message: EmailMessage): Promise<EmailSendResult> {
   const provider = safeStr(process.env.EMAIL_PROVIDER || "mailgun").toLowerCase();
   if (provider !== "mailgun") {
     throw new Error(`EMAIL_PROVIDER_UNSUPPORTED:${provider || "unset"}`);
   }
-  await sendViaMailgun(message);
+  return sendViaMailgun(message);
 }

--- a/rentchain-api/src/services/renewalNoticeCommunicationService.ts
+++ b/rentchain-api/src/services/renewalNoticeCommunicationService.ts
@@ -1,11 +1,34 @@
 import crypto from "crypto";
 import { db } from "../firebase";
 import { CANONICAL_EVENTS_COLLECTION, buildEvent } from "../lib/events/buildEvent";
-import { sendEmail } from "./emailService";
+import { sendEmail, type EmailSendResult } from "./emailService";
 import { lookupUserEmail, type LeaseWorkflowLease } from "./leaseNoticeWorkflowService";
 import { LANDLORD_DECISION_QUEUE_ITEMS_COLLECTION } from "./landlordDecisionQueue/landlordDecisionQueueLifecycleService";
 
 export const RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION = "renewalNoticeCommunications";
+
+type RenewalNoticeDeliveryStatus =
+  | "delivery_status_unknown"
+  | "not_tracked"
+  | "accepted_for_sending"
+  | "queued"
+  | "sent"
+  | "delivered"
+  | "bounced"
+  | "failed"
+  | "deferred"
+  | "rejected"
+  | "complained"
+  | "opened"
+  | "clicked"
+  | "unknown";
+
+type RenewalNoticeDeliveryStatusSource =
+  | "not_tracked"
+  | "send_response"
+  | "mailgun_webhook"
+  | "mailgun_events_api"
+  | "manual_reconciliation";
 
 type SendRenewalNoticeCommunicationInput = {
   snapshotId?: unknown;
@@ -41,9 +64,14 @@ type RenewalNoticeCommunicationRecord = {
   recipientEmail: string;
   bodyHash: string;
   status: "send_attempted" | "email_sent" | "email_failed";
-  deliveryStatus: "delivery_status_unknown";
+  deliveryStatus: RenewalNoticeDeliveryStatus;
+  deliveryStatusUpdatedAt: string | null;
+  deliveryStatusSource: RenewalNoticeDeliveryStatusSource;
+  deliveryStatusReason: string | null;
+  deliveryEventIds: string[];
+  lastProviderEventAt: string | null;
   provider: "mailgun";
-  providerMessageId: null;
+  providerMessageId: string | null;
   attemptedAt: string;
   sentAt: string | null;
   failedAt: string | null;
@@ -77,7 +105,7 @@ type SendRenewalNoticeCommunicationResult =
       deliveryStatus: RenewalNoticeCommunicationRecord["deliveryStatus"];
       attemptedAt: string;
       sentAt: string | null;
-      providerMessageId: null;
+      providerMessageId: string | null;
       auditEventId: string | null;
       timelineEventId: string | null;
       noLegalServiceClaim: true;
@@ -95,7 +123,7 @@ type SendRenewalNoticeCommunicationResult =
       deliveryStatus?: RenewalNoticeCommunicationRecord["deliveryStatus"];
       attemptedAt?: string;
       sentAt?: string | null;
-      providerMessageId?: null;
+      providerMessageId?: string | null;
       auditEventId?: string | null;
       timelineEventId?: string | null;
       noLegalServiceClaim?: true;
@@ -255,6 +283,10 @@ function communicationEvent(input: {
       deliveryStatus: input.record.deliveryStatus,
       provider: input.record.provider,
       providerMessageId: input.record.providerMessageId,
+      deliveryStatusSource: input.record.deliveryStatusSource,
+      deliveryStatusReason: input.record.deliveryStatusReason,
+      deliveryStatusUpdatedAt: input.record.deliveryStatusUpdatedAt,
+      lastProviderEventAt: input.record.lastProviderEventAt,
       noLegalServiceClaim: true,
       noticeServed: false,
       tenantNotified: input.record.tenantNotified,
@@ -293,6 +325,11 @@ async function writeCommunicationEvent(input: {
       status: input.record.status,
       deliveryStatus: input.record.deliveryStatus,
       provider: input.record.provider,
+      providerMessageId: input.record.providerMessageId,
+      deliveryStatusSource: input.record.deliveryStatusSource,
+      deliveryStatusReason: input.record.deliveryStatusReason,
+      deliveryStatusUpdatedAt: input.record.deliveryStatusUpdatedAt,
+      lastProviderEventAt: input.record.lastProviderEventAt,
       noLegalServiceClaim: true,
       noticeServed: false,
       tenantNotified: input.record.tenantNotified,
@@ -358,7 +395,7 @@ export async function sendRenewalNoticeCommunication(
         deliveryStatus: existing.deliveryStatus,
         attemptedAt: existing.attemptedAt,
         sentAt: null,
-        providerMessageId: null,
+        providerMessageId: existing.providerMessageId || null,
         auditEventId: existing.auditEventIds[existing.auditEventIds.length - 1] || null,
         timelineEventId: existing.canonicalEventIds[existing.canonicalEventIds.length - 1] || null,
         noLegalServiceClaim: true,
@@ -423,6 +460,11 @@ export async function sendRenewalNoticeCommunication(
     bodyHash: sha256(body),
     status: "send_attempted",
     deliveryStatus: "delivery_status_unknown",
+    deliveryStatusUpdatedAt: null,
+    deliveryStatusSource: "not_tracked",
+    deliveryStatusReason: null,
+    deliveryEventIds: [],
+    lastProviderEventAt: null,
     provider: "mailgun",
     providerMessageId: null,
     attemptedAt: nowIso,
@@ -468,16 +510,22 @@ export async function sendRenewalNoticeCommunication(
   await communicationRef.set(attemptedWithAudit, { merge: false });
 
   try {
-    await sendEmail({
+    const emailResult = (await sendEmail({
       to: tenantEmail,
       subject,
       text: body,
       html: htmlFromText(body),
-    });
+    })) as EmailSendResult | undefined;
     const sentAt = new Date().toISOString();
     const sentRecord: RenewalNoticeCommunicationRecord = {
       ...attemptedWithAudit,
       status: "email_sent",
+      deliveryStatus: "accepted_for_sending",
+      deliveryStatusUpdatedAt: sentAt,
+      deliveryStatusSource: "send_response",
+      deliveryStatusReason: "mailgun_accepted",
+      lastProviderEventAt: sentAt,
+      providerMessageId: emailResult?.providerMessageId || null,
       sentAt,
       tenantNotified: true,
       updatedAt: sentAt,
@@ -500,6 +548,11 @@ export async function sendRenewalNoticeCommunication(
     const failedRecord: RenewalNoticeCommunicationRecord = {
       ...attemptedWithAudit,
       status: "email_failed",
+      deliveryStatus: "failed",
+      deliveryStatusUpdatedAt: failedAt,
+      deliveryStatusSource: "send_response",
+      deliveryStatusReason: safeErrorMessage(err),
+      lastProviderEventAt: failedAt,
       failedAt,
       updatedAt: failedAt,
       errorCode: "EMAIL_SEND_FAILED",
@@ -526,7 +579,7 @@ export async function sendRenewalNoticeCommunication(
       deliveryStatus: finalRecord.deliveryStatus,
       attemptedAt: finalRecord.attemptedAt,
       sentAt: null,
-      providerMessageId: null,
+      providerMessageId: finalRecord.providerMessageId || null,
       auditEventId: failedEvent.auditEventId,
       timelineEventId: failedEvent.canonicalEventId,
       noLegalServiceClaim: true,

--- a/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
+++ b/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
@@ -95,10 +95,24 @@ export type RenewalNoticeCommunicationResponse = {
   idempotent?: boolean;
   communicationId: string;
   status: "send_attempted" | "email_sent" | "email_failed";
-  deliveryStatus: "delivery_status_unknown";
+  deliveryStatus:
+    | "delivery_status_unknown"
+    | "not_tracked"
+    | "accepted_for_sending"
+    | "queued"
+    | "sent"
+    | "delivered"
+    | "bounced"
+    | "failed"
+    | "deferred"
+    | "rejected"
+    | "complained"
+    | "opened"
+    | "clicked"
+    | "unknown";
   attemptedAt: string;
   sentAt: string | null;
-  providerMessageId: null;
+  providerMessageId: string | null;
   auditEventId: string | null;
   timelineEventId: string | null;
   noLegalServiceClaim: true;

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -311,10 +311,10 @@ describe("LandlordLeaseWorkflowPage", () => {
       ok: true,
       communicationId: "rnc_test",
       status: "email_sent",
-      deliveryStatus: "delivery_status_unknown",
+      deliveryStatus: "accepted_for_sending",
       attemptedAt: "2026-07-13T12:00:00.000Z",
       sentAt: "2026-07-13T12:00:01.000Z",
-      providerMessageId: null,
+      providerMessageId: "<provider-message@mg.example.com>",
       auditEventId: "communication-audit-1",
       timelineEventId: "renewal_notice_email_sent:rnc_test:2026-07-13T12:00:01.000Z",
       noLegalServiceClaim: true,
@@ -1085,9 +1085,9 @@ describe("LandlordLeaseWorkflowPage", () => {
     });
     expect(await screen.findByLabelText("Renewal email sent status")).toHaveTextContent("Renewal email sent");
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Delivery confirmation");
-    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Not tracked yet");
+    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Accepted for sending");
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent(
-      "Email was accepted for sending. Provider delivery, bounce, and open tracking are not enabled yet."
+      "Email was accepted for sending. Delivery confirmation beyond provider acceptance is not tracked yet."
     );
     expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Not served; legal service not established");
     expect(screen.getByLabelText("Renewal email sent status")).not.toHaveTextContent("Delivery status unknown");
@@ -1200,10 +1200,10 @@ describe("LandlordLeaseWorkflowPage", () => {
         idempotent: true,
         communicationId: "rnc_retry",
         status: "email_sent",
-        deliveryStatus: "delivery_status_unknown",
+        deliveryStatus: "accepted_for_sending",
         attemptedAt: "2026-07-13T12:00:00.000Z",
         sentAt: "2026-07-13T12:00:01.000Z",
-        providerMessageId: null,
+        providerMessageId: "<provider-message@mg.example.com>",
         auditEventId: "communication-audit-2",
         timelineEventId: "renewal_notice_email_sent:rnc_retry:2026-07-13T12:00:01.000Z",
         noLegalServiceClaim: true,

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -249,14 +249,54 @@ function communicationStatusLabel(status: RenewalNoticeCommunicationResponse["st
 }
 
 function deliveryConfirmationLabel(status: RenewalNoticeCommunicationResponse["deliveryStatus"] | null | undefined) {
-  if (status === "delivery_status_unknown") return "Not tracked yet";
+  if (!status || status === "delivery_status_unknown" || status === "not_tracked") return "Not tracked yet";
+  if (status === "accepted_for_sending") return "Accepted for sending";
+  if (status === "queued") return "Queued by email provider";
+  if (status === "sent") return "Sent by email provider";
+  if (status === "delivered") return "Delivered by email provider";
+  if (status === "bounced") return "Bounce detected by email provider";
+  if (status === "failed") return "Failed by email provider";
+  if (status === "deferred") return "Deferred by email provider";
+  if (status === "rejected") return "Rejected by email provider";
+  if (status === "complained") return "Complaint reported by email provider";
+  if (status === "opened") return "Open event recorded by provider";
+  if (status === "clicked") return "Click event recorded by provider";
+  if (status === "unknown") return "Unknown";
   return "Not tracked yet";
+}
+
+function deliveryConfirmationDetail(status: RenewalNoticeCommunicationResponse["deliveryStatus"] | null | undefined) {
+  if (status === "accepted_for_sending") {
+    return "Email was accepted for sending. Delivery confirmation beyond provider acceptance is not tracked yet. This does not establish legal notice service by itself.";
+  }
+  if (status === "delivered") {
+    return "Email provider reported delivery. This does not establish legal notice service by itself.";
+  }
+  if (status === "bounced") {
+    return "Email provider reported a bounce. Review the recipient before any future communication attempt.";
+  }
+  if (status === "failed" || status === "rejected") {
+    return "Email provider reported a send failure. Review the recipient and message state before any future communication attempt.";
+  }
+  return "Email was accepted for sending. Provider delivery, bounce, and open tracking are not enabled yet. This does not establish legal notice service by itself.";
 }
 
 function communicationDeliveryLabel(value: string | null | undefined) {
   const normalized = String(value || "").trim().toLowerCase();
-  if (!normalized || normalized === "delivery_status_unknown" || normalized === "unknown") return "Not tracked yet";
+  if (!normalized || normalized === "delivery_status_unknown" || normalized === "not_tracked") return "Not tracked yet";
   if (normalized === "not tracked yet") return "Not tracked yet";
+  if (normalized === "accepted_for_sending" || normalized === "accepted for sending") return "Accepted for sending";
+  if (normalized === "queued" || normalized === "queued by email provider") return "Queued by email provider";
+  if (normalized === "sent" || normalized === "sent by email provider") return "Sent by email provider";
+  if (normalized === "delivered" || normalized === "delivered by email provider") return "Delivered by email provider";
+  if (normalized === "bounced" || normalized === "bounce detected by email provider") return "Bounce detected by email provider";
+  if (normalized === "failed" || normalized === "failed by email provider") return "Failed by email provider";
+  if (normalized === "deferred" || normalized === "deferred by email provider") return "Deferred by email provider";
+  if (normalized === "rejected" || normalized === "rejected by email provider") return "Rejected by email provider";
+  if (normalized === "complained" || normalized === "complaint reported by email provider") return "Complaint reported by email provider";
+  if (normalized === "opened" || normalized === "open event recorded by provider") return "Open event recorded by provider";
+  if (normalized === "clicked" || normalized === "click event recorded by provider") return "Click event recorded by provider";
+  if (normalized === "unknown") return "Unknown";
   return value || "Not tracked yet";
 }
 
@@ -1512,8 +1552,7 @@ function TenantCommunicationSendReview({
           </dl>
           <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
             {sendState.result.idempotent ? "Idempotent retry returned the existing communication record. " : ""}
-            Email was accepted for sending. Provider delivery, bounce, and open tracking are not enabled yet. This does
-            not establish legal notice service by itself.
+            {deliveryConfirmationDetail(sendState.result.deliveryStatus)}
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <Link to={reviewModel?.leaseTimelinePath || `/review-timeline?scope=lease&scopeId=${encodeURIComponent(lease.id)}`} style={buttonLinkStyle}>


### PR DESCRIPTION
## Summary

Foundation-only implementation for renewal tenant communication delivery status.

- Parses the Mailgun send response for a provider message id when available.
- Persists provider delivery-status metadata on `renewalNoticeCommunications` records.
- Marks successful controlled sends as `accepted_for_sending` from the Mailgun send response.
- Marks provider send failures as `failed` from the send response failure path.
- Keeps legacy/unknown communications compatible as `Not tracked yet`.
- Updates evidence package and review timeline projection labels for safe delivery-confirmation wording.
- Updates the notice workflow success/history UI to display the same delivery-confirmation model.

This PR intentionally does not implement Mailgun webhook delivery/bounce tracking.

## Mailgun Requirements Audit

Current RentChain assumptions:

- Current code sends via `EMAIL_PROVIDER=mailgun`, `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`, and `EMAIL_FROM` / `FROM_EMAIL`.
- Current Mailgun send path uses `https://api.mailgun.net`; if the sending domain is EU-region, a future `MAILGUN_API_BASE_URL` or equivalent config will be needed.
- Active sending domain appears to be `mg.rentchain.ai` based on prior QA, but Mailgun dashboard verification was not directly confirmed in this PR.
- Mailgun domain verification should be confirmed in the Mailgun dashboard before production delivery tracking work.
- SPF/DKIM verification is required for normal production sending posture.
- CNAME/tracking setup is only needed for tracking features such as open/click/unsubscribe; open/click should remain out of v1 unless explicitly approved.
- Mailgun send API returns `id` / `message`; `providerMessageId` correlation is plausible but should be verified with one real webhook sample before automatic status updates.
- Mailgun webhook signature verification requires timestamp/token/signature validation using the Mailgun Webhook Signing Key.
- Future env var needed for webhook work: `MAILGUN_WEBHOOK_SIGNING_KEY`.
- Possible future env/config: `MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS` and `MAILGUN_API_BASE_URL`.
- Event dedupe should use Mailgun event id plus replay-token protections where appropriate.

## Delivery Status Model

Supported statuses now include:

- `not_tracked`
- `accepted_for_sending`
- `queued`
- `sent`
- `delivered`
- `bounced`
- `failed`
- `deferred`
- `rejected`
- `complained`
- `opened`
- `clicked`
- `unknown`
- legacy `delivery_status_unknown`

User-facing wording stays legally separated, for example:

- `Delivery confirmation: Not tracked yet`
- `Delivery confirmation: Accepted for sending`
- `Delivery confirmation: Failed by email provider`
- `Delivery confirmation: Delivered by email provider` only if a future provider event supplies real delivery confirmation
- `Not served; legal service not established`
- `Legal compliance not determined by this workflow`

## Deferred Follow-Up

Recommended follow-up PR: `feat/mailgun-renewal-communication-webhook-delivery-status-v1`.

That follow-up should include:

- Mailgun webhook route.
- Raw/public webhook mount order review.
- HMAC signature verification.
- Replay/dedupe handling.
- Event-to-communication correlation using `communicationId` custom variable and/or `providerMessageId`.
- Delivered/bounced/failed/deferred/complained mapping.
- Evidence/timeline projection for real provider events.
- UI projection for real provider events.
- Tests for delivered, failed, bounced/deferred, complained, replay, duplicate events, and missing communication matches.
- No legal-service/compliance/lifecycle claims.

## Validation

Backend, Node v20.20.2:

- `npm run test -- emailService.mailgun renewalNoticeCommunicationService deriveEvidencePack deriveCanonicalReviewTimeline`
- `npm run build`

Frontend, Node v20.20.2:

- `npm run test -- LandlordLeaseWorkflowPage`
- `npm run build`

Repo:

- `git diff --check`
- `git diff --cached --check`

## Guardrails

- No Mailgun webhook route was added.
- No signature verification path was added.
- No replay/dedupe receipt collection was added.
- No event-to-communication webhook reconciliation was added.
- No delivered/bounced/deferred/complained automatic updates were added.
- No open/click tracking was added.
- No dashboard setup assumptions are encoded in runtime behavior.
- No additional emails are sent by this PR.
- No raw provider payloads are projected to evidence/timeline/frontend.
- No notice-served state was created.
- No legal-service/legal-delivery/compliance claim was added.
- No lease lifecycle mutation was added.