### PR TITLE
Implement Mailgun renewal communication webhook delivery status v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -98,6 +98,7 @@ import stripeScreeningOrdersWebhookRoutes, {
   stripeWebhookHandler,
 } from "./routes/stripeScreeningOrdersWebhookRoutes";
 import { transunionWebhookHandler } from "./routes/transunionWebhookRoutes";
+import { mailgunEventsWebhookHandler } from "./routes/mailgunWebhookRoutes";
 import { signingWebhookBrowserReturnHandler, signingWebhookHandler } from "./routes/webhooks/signingWebhookRoutes";
 import { requireAuth } from "./middleware/requireAuth";
 import { requirePermission } from "./middleware/requireAuthz";
@@ -241,6 +242,12 @@ app.post(
   express.raw({ type: "application/json" }),
   routeSource("transunionWebhookRoutes.ts"),
   transunionWebhookHandler
+);
+app.post(
+  "/api/webhooks/mailgun/events",
+  express.json({ type: "application/json", limit: "1mb" }),
+  routeSource("mailgunWebhookRoutes.ts"),
+  mailgunEventsWebhookHandler
 );
 app.post(
   "/webhooks/signing/:providerId?",

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -507,6 +507,75 @@ describe("deriveEvidencePack", () => {
     expect(JSON.stringify(pack)).not.toMatch(/provider-secret|notice served|legally delivered|tenant received|compliance achieved|statutory notice completed/i);
   });
 
+  it("renders renewal tenant communication delivery confirmations with safe provider-only labels", () => {
+    const cases: Array<{ status?: string; label: string; id: string }> = [
+      { id: "legacy", label: "Not tracked yet" },
+      { id: "not-tracked", status: "not_tracked", label: "Not tracked yet" },
+      { id: "accepted", status: "accepted_for_sending", label: "Accepted for sending" },
+      { id: "delivered", status: "delivered", label: "Delivered by email provider" },
+      { id: "bounced", status: "bounced", label: "Bounce detected by email provider" },
+      { id: "deferred", status: "deferred", label: "Temporary delivery issue detected by email provider" },
+      { id: "complained", status: "complained", label: "Complaint reported by email provider" },
+      { id: "failed", status: "failed", label: "Failed by email provider" },
+      { id: "rejected", status: "rejected", label: "Rejected by email provider" },
+    ];
+
+    for (const item of cases) {
+      const record: Record<string, any> = {
+        communicationId: `communication-${item.id}`,
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        snapshotId: `snapshot-${item.id}`,
+        approvalDecisionItemId: `decision-${item.id}`,
+        recipientEmail: "hello+tenant@rentchain.ai",
+        status: "email_sent",
+        attemptedAt: "2026-07-11T12:10:00.000Z",
+        sentAt: "2026-07-11T12:10:02.000Z",
+        tenantNotified: true,
+        noticeServed: false,
+        legalServiceEstablished: false,
+        confirmation: {
+          confirmationAccepted: true,
+          recipientReviewed: true,
+          bodyReviewed: true,
+          legalServiceAcknowledged: true,
+          noLegalServiceClaim: true,
+        },
+        generatedDraftText: "Hello Jane, private body text should not project.",
+        providerPayload: {
+          signature: "mailgun-signature-secret",
+          token: "mailgun-token-secret",
+          event: { raw: "raw-provider-body" },
+        },
+        webhookSigningKey: "mailgun-webhook-signing-key",
+      };
+      if (item.status) record.deliveryStatus = item.status;
+
+      const pack = deriveEvidencePack({
+        scope: "lease",
+        scopeId: "lease-1",
+        landlordId: "landlord-1",
+        generatedAt: "2026-07-11T12:00:00.000Z",
+        renewalNoticeCommunications: [record],
+        leases: [{ id: "lease-1", propertyName: "North Towers", unitNumber: "101", tenantName: "John Smith" }],
+      });
+
+      const evidenceText = JSON.stringify(pack);
+      expect(evidenceText).toContain(`Communication ID: communication-${item.id}.`);
+      expect(evidenceText).toContain("Context: North Towers · Unit 101 · John Smith.");
+      expect(evidenceText).toContain("Recipient email: hello+tenant@rentchain.ai.");
+      expect(evidenceText).toContain(`Delivery confirmation: ${item.label}.`);
+      expect(evidenceText).toContain(`Draft snapshot ID: snapshot-${item.id}.`);
+      expect(evidenceText).toContain(`Approval decision ID: decision-${item.id}.`);
+      expect(evidenceText).toContain("Confirmation/audit status: send confirmations captured.");
+      expect(evidenceText).toContain("Not served; legal service not established.");
+      expect(evidenceText).toContain("Legal compliance not determined by this workflow.");
+      expect(evidenceText).not.toMatch(
+        /private body text|raw-provider-body|mailgun-signature-secret|mailgun-token-secret|mailgun-webhook-signing-key|notice served|legally delivered|tenant received|tenant opened|delivery confirmed|compliance achieved|statutory notice completed/i,
+      );
+    }
+  });
+
   it("keeps raw provider, banking, debug, and private document fields out of evidence projections", () => {
     const pack = deriveEvidencePack({
       scope: "decision",

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -398,7 +398,7 @@ function renewalNoticeCommunicationDeliveryLabel(value: unknown): string {
   if (raw === "delivered") return "Delivered by email provider";
   if (raw === "bounced") return "Bounce detected by email provider";
   if (raw === "failed") return "Failed by email provider";
-  if (raw === "deferred") return "Deferred by email provider";
+  if (raw === "deferred") return "Temporary delivery issue detected by email provider";
   if (raw === "rejected") return "Rejected by email provider";
   if (raw === "complained") return "Complaint reported by email provider";
   if (raw === "opened") return "Open event recorded by provider";

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -373,4 +373,95 @@ describe("deriveCanonicalReviewTimeline", () => {
     );
     expect(JSON.stringify(timeline)).not.toMatch(/provider-secret|notice served|legally delivered|tenant received|compliance achieved|statutory notice completed/i);
   });
+
+  it("renders renewal communication delivery status updates with safe provider-only labels", () => {
+    const cases: Array<{ status?: string; label: string; id: string }> = [
+      { id: "legacy", label: "Not tracked yet" },
+      { id: "not-tracked", status: "not_tracked", label: "Not tracked yet" },
+      { id: "accepted", status: "accepted_for_sending", label: "Accepted for sending" },
+      { id: "delivered", status: "delivered", label: "Delivered by email provider" },
+      { id: "bounced", status: "bounced", label: "Bounce detected by email provider" },
+      { id: "deferred", status: "deferred", label: "Temporary delivery issue detected by email provider" },
+      { id: "complained", status: "complained", label: "Complaint reported by email provider" },
+      { id: "failed", status: "failed", label: "Failed by email provider" },
+      { id: "rejected", status: "rejected", label: "Rejected by email provider" },
+    ];
+
+    for (const item of cases) {
+      const communicationId = `rnc_${item.id}`;
+      const metadata: Record<string, any> = {
+        communicationId,
+        deliveryStatusSource: "mailgun_webhook",
+        providerMessageId: "<provider-message@mg.example.com>",
+        providerPayload: {
+          signature: "mailgun-signature-secret",
+          token: "mailgun-token-secret",
+          event: { raw: "raw-provider-body" },
+        },
+      };
+      if (item.status) metadata.deliveryStatus = item.status;
+
+      const timeline = deriveCanonicalReviewTimeline({
+        scope: "lease",
+        scopeId: "lease-1",
+        landlordId: "landlord-1",
+        renewalNoticeCommunications: [
+          {
+            communicationId,
+            leaseId: "lease-1",
+            snapshotId: `snapshot-${item.id}`,
+            approvalDecisionItemId: `decision-${item.id}`,
+            recipientEmail: "hello+tenant@rentchain.ai",
+            status: "email_sent",
+            deliveryStatus: item.status,
+            sentAt: "2026-07-11T12:10:02.000Z",
+            confirmation: {
+              confirmationAccepted: true,
+              recipientReviewed: true,
+              bodyReviewed: true,
+              legalServiceAcknowledged: true,
+              noLegalServiceClaim: true,
+            },
+            generatedDraftText: "Hello Jane, private body text should not project.",
+            providerPayload: { raw: "record-provider-secret" },
+          },
+        ],
+        canonicalEvents: [
+          {
+            id: `event-delivery-${item.id}`,
+            type: "renewal_notice_delivery_status_updated",
+            action: "renewal_notice_delivery_status_updated",
+            summary:
+              "Renewal tenant communication delivery confirmation updated from Mailgun webhook. Not served; legal service not established.",
+            leaseId: "lease-1",
+            resource: { id: "lease-1" },
+            actor: { type: "system", id: "mailgun" },
+            metadata,
+            occurredAt: "2026-07-11T12:12:00.000Z",
+          },
+        ],
+      });
+
+      const timelineText = JSON.stringify(timeline);
+      expect(timeline.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: "Renewal tenant communication delivery status updated",
+            description: expect.stringContaining(`Delivery confirmation: ${item.label}.`),
+          }),
+        ]),
+      );
+      expect(timelineText).toContain(`Communication ID: ${communicationId}.`);
+      expect(timelineText).toContain("Status: delivery status updated.");
+      expect(timelineText).toContain("Recipient email: hello+tenant@rentchain.ai.");
+      expect(timelineText).toContain(`Draft snapshot ID: snapshot-${item.id}.`);
+      expect(timelineText).toContain(`Approval decision ID: decision-${item.id}.`);
+      expect(timelineText).toContain("Confirmation/audit status: send confirmations captured.");
+      expect(timelineText).toContain("Not served; legal service not established.");
+      expect(timelineText).toContain("Legal compliance not determined by this workflow.");
+      expect(timelineText).not.toMatch(
+        /private body text|record-provider-secret|raw-provider-body|mailgun-signature-secret|mailgun-token-secret|provider-message@mg\.example\.com|notice served|legally delivered|tenant received|tenant opened|delivery confirmed|compliance achieved|statutory notice completed/i,
+      );
+    }
+  });
 });

--- a/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
+++ b/rentchain-api/src/lib/reviewTimeline/__tests__/deriveCanonicalReviewTimeline.test.ts
@@ -250,6 +250,24 @@ describe("deriveCanonicalReviewTimeline", () => {
           },
           occurredAt: "2026-07-11T12:10:00.000Z",
         },
+        {
+          id: "event-delivery-1",
+          type: "renewal_notice_delivery_status_updated",
+          action: "renewal_notice_delivery_status_updated",
+          summary:
+            "Renewal tenant communication delivery confirmation updated from Mailgun webhook. Not served; legal service not established.",
+          leaseId: "lease-1",
+          resource: { id: "lease-1" },
+          actor: { type: "system", id: "mailgun" },
+          metadata: {
+            communicationId: "rnc_test",
+            deliveryStatus: "delivered",
+            deliveryStatusSource: "mailgun_webhook",
+            providerMessageId: "<provider-message@mg.example.com>",
+            providerPayload: { raw: "provider-secret" },
+          },
+          occurredAt: "2026-07-11T12:12:00.000Z",
+        },
       ],
     });
 
@@ -258,6 +276,7 @@ describe("deriveCanonicalReviewTimeline", () => {
         "Renewal tenant communication send confirmed",
         "Renewal tenant communication send attempted",
         "Renewal tenant communication email sent",
+        "Renewal tenant communication delivery status updated",
       ])
     );
     expect(timeline.entries).toEqual(
@@ -268,6 +287,11 @@ describe("deriveCanonicalReviewTimeline", () => {
           label: "Renewal tenant communication email sent",
           description:
             "Renewal tenant communication email sent at 2026-07-11 12:10 UTC. Communication ID: rnc_test. Status: email sent. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Accepted for sending. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+        }),
+        expect.objectContaining({
+          label: "Renewal tenant communication delivery status updated",
+          description:
+            "Renewal tenant communication delivery status updated at 2026-07-11 12:12 UTC. Communication ID: rnc_test. Status: delivery status updated. Recipient email: hello+tenant@rentchain.ai. Delivery confirmation: Delivered by email provider. Draft snapshot ID: snapshot-1. Approval decision ID: decision-1. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
         }),
         expect.objectContaining({
           label: "Renewal tenant communication send attempted",

--- a/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
+++ b/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
@@ -137,7 +137,7 @@ function renewalNoticeCommunicationDeliveryLabel(value: unknown): string {
   if (raw === "delivered") return "Delivered by email provider";
   if (raw === "bounced") return "Bounce detected by email provider";
   if (raw === "failed") return "Failed by email provider";
-  if (raw === "deferred") return "Deferred by email provider";
+  if (raw === "deferred") return "Temporary delivery issue detected by email provider";
   if (raw === "rejected") return "Rejected by email provider";
   if (raw === "complained") return "Complaint reported by email provider";
   if (raw === "opened") return "Open event recorded by provider";

--- a/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
+++ b/rentchain-api/src/lib/reviewTimeline/deriveCanonicalReviewTimeline.ts
@@ -78,6 +78,9 @@ function canonicalEventLabel(event: Record<string, any>): string {
   if (raw === "renewal_notice_email_failed" || raw === "lease.renewal_notice_email_failed") {
     return "Renewal tenant communication email failed";
   }
+  if (raw === "renewal_notice_delivery_status_updated" || raw === "lease.renewal_notice_delivery_status_updated") {
+    return "Renewal tenant communication delivery status updated";
+  }
   return raw || "Canonical event";
 }
 
@@ -91,7 +94,9 @@ function isRenewalNoticeCommunicationEvent(event: Record<string, any>): boolean 
     raw === "renewal_notice_email_sent" ||
     raw === "lease.renewal_notice_email_sent" ||
     raw === "renewal_notice_email_failed" ||
-    raw === "lease.renewal_notice_email_failed"
+    raw === "lease.renewal_notice_email_failed" ||
+    raw === "renewal_notice_delivery_status_updated" ||
+    raw === "lease.renewal_notice_delivery_status_updated"
   );
 }
 
@@ -105,6 +110,9 @@ function renewalNoticeCommunicationStatusText(event: Record<string, any>): strin
   const raw = asString(event.type || event.action, 160);
   if (raw === "renewal_notice_email_sent" || raw === "lease.renewal_notice_email_sent") return "email sent";
   if (raw === "renewal_notice_email_failed" || raw === "lease.renewal_notice_email_failed") return "email failed";
+  if (raw === "renewal_notice_delivery_status_updated" || raw === "lease.renewal_notice_delivery_status_updated") {
+    return "delivery status updated";
+  }
   if (raw === "renewal_notice_email_send_attempted" || raw === "lease.renewal_notice_email_send_attempted") return "send attempted";
   if (raw === "renewal_notice_send_confirmed" || raw === "lease.renewal_notice_send_confirmed") return "send confirmed internally";
   return "communication recorded";

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -16,6 +16,14 @@ const stripeMocks = vi.hoisted(() => ({
   constructEvent: vi.fn(),
 }));
 
+const mailgunWebhookMocks = vi.hoisted(() => ({
+  handleMailgunRenewalCommunicationWebhook: vi.fn(async () => ({
+    ok: false,
+    statusCode: 401,
+    error: "MAILGUN_WEBHOOK_SIGNATURE_REQUIRED",
+  })),
+}));
+
 const renewalNoticeCommunicationMocks = vi.hoisted(() => ({
   sendRenewalNoticeCommunication: vi.fn(async () => ({
     ok: true,
@@ -193,6 +201,10 @@ vi.mock("../../services/stripeScreeningProcessor", () => ({
   applyScreeningResultsFromOrder: vi.fn(async () => ({ ok: true })),
 }));
 
+vi.mock("../../services/renewalNoticeCommunicationDeliveryWebhookService", () => ({
+  handleMailgunRenewalCommunicationWebhook: mailgunWebhookMocks.handleMailgunRenewalCommunicationWebhook,
+}));
+
 vi.mock("../../services/screening/screeningOrchestrator", () => ({
   beginScreening: vi.fn(async () => ({ ok: true })),
 }));
@@ -320,10 +332,17 @@ async function buildRuntimeOwnershipApp() {
   const screeningJobsAdminRoutes = (await import("../screeningJobsAdminRoutes")).default;
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   const { transunionWebhookHandler } = await import("../transunionWebhookRoutes");
+  const { mailgunEventsWebhookHandler } = await import("../mailgunWebhookRoutes");
 
   const app = express();
   app.post("/api/webhooks/stripe", routeSource("stripeScreeningOrdersWebhookRoutes.ts"), stripeWebhookHandler);
   app.post("/api/webhooks/transunion", routeSource("transunionWebhookRoutes.ts"), transunionWebhookHandler);
+  app.post(
+    "/api/webhooks/mailgun/events",
+    express.json({ type: "application/json" }),
+    routeSource("mailgunWebhookRoutes.ts"),
+    mailgunEventsWebhookHandler
+  );
   app.get("/api/leases/:leaseId/document-url", routeSource("leaseRoutes.ts"), requireLandlord, handleLeaseDocumentUrl);
   app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
   app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
@@ -379,9 +398,11 @@ describe("API route ownership regression", () => {
     expect(source.indexOf('"/api/webhooks/stripe"')).toBeGreaterThan(-1);
     expect(source.indexOf('"/api/stripe/webhook"')).toBeGreaterThan(-1);
     expect(source.indexOf('"/api/webhooks/transunion"')).toBeGreaterThan(-1);
+    expect(source.indexOf('"/api/webhooks/mailgun/events"')).toBeGreaterThan(-1);
     expect(source.indexOf('"/api/webhooks/stripe"')).toBeLessThan(jsonParserIndex);
     expect(source.indexOf('"/api/stripe/webhook"')).toBeLessThan(jsonParserIndex);
     expect(source.indexOf('"/api/webhooks/transunion"')).toBeLessThan(jsonParserIndex);
+    expect(source.indexOf('"/api/webhooks/mailgun/events"')).toBeLessThan(jsonParserIndex);
   });
 
   it("keeps high-risk prefixed mounts ahead of broad fallback and screening job routes", () => {
@@ -981,6 +1002,23 @@ describe("API route ownership regression", () => {
     expect(transunionRes.status).toBe(400);
     expect(transunionRes.body).toMatchObject({ ok: false, error: "missing_request_id" });
     expect(transunionRes.headers["x-route-source"]).toBe("transunionWebhookRoutes.ts");
+
+    mailgunWebhookMocks.handleMailgunRenewalCommunicationWebhook.mockResolvedValueOnce({
+      ok: false,
+      statusCode: 401,
+      error: "MAILGUN_WEBHOOK_SIGNATURE_REQUIRED",
+    });
+    const mailgunRes = await invokeApp(app, {
+      method: "POST",
+      url: "/api/webhooks/mailgun/events",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: Buffer.from("{}"),
+    });
+    expect(mailgunRes.status).toBe(401);
+    expect(mailgunRes.body).toMatchObject({ ok: false, error: "MAILGUN_WEBHOOK_SIGNATURE_REQUIRED" });
+    expect(mailgunRes.headers["x-route-source"]).toBe("mailgunWebhookRoutes.ts");
   });
 
   it("keeps public-safe probes, gated diagnostics, and API catchall deterministic", async () => {

--- a/rentchain-api/src/routes/__tests__/mailgunWebhookRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/mailgunWebhookRoutes.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import { Readable } from "stream";
 
 const handleWebhookMock = vi.fn();
 
@@ -84,5 +86,45 @@ describe("mailgun webhook routes", () => {
 
     expect(res.status).toBe(401);
     expect(res.body).toEqual({ ok: false, error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID" });
+  });
+
+  it("falls back safely when replay-window env is invalid", async () => {
+    handleWebhookMock.mockResolvedValueOnce({
+      ok: true,
+      statusCode: 200,
+      matched: false,
+      updated: false,
+      receiptId: "receipt-1",
+    });
+
+    await invoke(
+      { signature: {}, "event-data": {} },
+      { MAILGUN_WEBHOOK_SIGNING_KEY: "secret", MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS: "not-a-number" }
+    );
+
+    expect(handleWebhookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signingKey: "secret",
+        replayWindowSeconds: undefined,
+      })
+    );
+  });
+
+  it("rejects malformed JSON in the route-local parser before processing", async () => {
+    const parser = express.json({ type: "application/json", limit: "1mb" });
+    const req = Readable.from(["{not-json"]) as any;
+    req.method = "POST";
+    req.url = "/api/webhooks/mailgun/events";
+    req.originalUrl = "/api/webhooks/mailgun/events";
+    req.headers = {
+      "content-type": "application/json",
+      "content-length": String("{not-json".length),
+    };
+    const parserError = await new Promise<any>((resolve) => {
+      parser(req, {} as any, (err: any) => resolve(err || null));
+    });
+
+    expect(parserError).toEqual(expect.objectContaining({ type: "entity.parse.failed" }));
+    expect(handleWebhookMock).not.toHaveBeenCalled();
   });
 });

--- a/rentchain-api/src/routes/__tests__/mailgunWebhookRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/mailgunWebhookRoutes.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handleWebhookMock = vi.fn();
+
+vi.mock("../../services/renewalNoticeCommunicationDeliveryWebhookService", () => ({
+  handleMailgunRenewalCommunicationWebhook: handleWebhookMock,
+}));
+
+async function invoke(body: any, env: Record<string, string | undefined> = {}) {
+  const original = { ...process.env };
+  process.env.MAILGUN_WEBHOOK_SIGNING_KEY = env.MAILGUN_WEBHOOK_SIGNING_KEY ?? "secret";
+  process.env.MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS = env.MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS;
+  const { mailgunEventsWebhookHandler } = await import("../mailgunWebhookRoutes");
+  return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    const req: any = { body, headers: {} };
+    const res: any = {
+      statusCode: 200,
+      setHeader(key: string, value: string) {
+        headers[key.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        process.env = original;
+        resolve({ status: this.statusCode, body: payload, headers });
+        return this;
+      },
+    };
+    mailgunEventsWebhookHandler(req, res).catch((err) => {
+      process.env = original;
+      reject(err);
+    });
+  });
+}
+
+describe("mailgun webhook routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts provider webhooks without Authorization when the service verifies the signature", async () => {
+    handleWebhookMock.mockResolvedValueOnce({
+      ok: true,
+      statusCode: 200,
+      matched: true,
+      updated: true,
+      communicationId: "rnc_test",
+      deliveryStatus: "delivered",
+      receiptId: "receipt-1",
+    });
+
+    const res = await invoke({ signature: {}, "event-data": {} });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-rentchain-mailgun-webhook"]).toBe("events-v1");
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        matched: true,
+        updated: true,
+        communicationId: "rnc_test",
+        deliveryStatus: "delivered",
+      })
+    );
+    expect(handleWebhookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signingKey: "secret",
+        replayWindowSeconds: undefined,
+      })
+    );
+  });
+
+  it("returns service validation errors without requiring landlord auth", async () => {
+    handleWebhookMock.mockResolvedValueOnce({
+      ok: false,
+      statusCode: 401,
+      error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID",
+    });
+
+    const res = await invoke({ signature: {}, "event-data": {} });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID" });
+  });
+});

--- a/rentchain-api/src/routes/mailgunWebhookRoutes.ts
+++ b/rentchain-api/src/routes/mailgunWebhookRoutes.ts
@@ -1,0 +1,33 @@
+import type { Request, Response } from "express";
+import {
+  handleMailgunRenewalCommunicationWebhook,
+} from "../services/renewalNoticeCommunicationDeliveryWebhookService";
+
+function replayWindowSeconds(): number | undefined {
+  const raw = String(process.env.MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS || "").trim();
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export async function mailgunEventsWebhookHandler(req: Request, res: Response) {
+  const result = await handleMailgunRenewalCommunicationWebhook({
+    body: req.body,
+    signingKey: process.env.MAILGUN_WEBHOOK_SIGNING_KEY || "",
+    replayWindowSeconds: replayWindowSeconds(),
+  });
+  if (!result.ok) {
+    return res.status(result.statusCode).json({ ok: false, error: result.error });
+  }
+  res.setHeader("x-rentchain-mailgun-webhook", "events-v1");
+  return res.status(result.statusCode).json({
+    ok: true,
+    duplicate: result.duplicate || undefined,
+    matched: result.matched || false,
+    updated: result.updated || false,
+    ignoredReason: result.ignoredReason || undefined,
+    communicationId: result.communicationId || undefined,
+    deliveryStatus: result.deliveryStatus || undefined,
+    receiptId: result.receiptId,
+  });
+}

--- a/rentchain-api/src/services/__tests__/emailService.mailgun.test.ts
+++ b/rentchain-api/src/services/__tests__/emailService.mailgun.test.ts
@@ -70,6 +70,34 @@ describe("emailService mailgun provider", () => {
     });
   });
 
+  it("passes safe Mailgun variables when metadata is provided", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: "<abc123@mg.example.com>" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock as any);
+
+    await sendEmail({
+      to: "tenant@example.com",
+      subject: "Test",
+      html: "<p>Hello</p>",
+      metadata: {
+        communicationId: "rnc_safe_123",
+        workflow: "renewal_notice_communication",
+        "unsafe key": "still-safe",
+        empty: "",
+      },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get("v:communicationId")).toBe("rnc_safe_123");
+    expect(body.get("v:workflow")).toBe("renewal_notice_communication");
+    expect(body.get("v:unsafekey")).toBe("still-safe");
+    expect(body.has("v:empty")).toBe(false);
+  });
+
   it("rejects when Mailgun responds with failure", async () => {
     const fetchMock = vi.fn(async () => ({
       ok: false,

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
@@ -172,6 +172,7 @@ describe("Mailgun renewal communication delivery webhooks", () => {
   });
 
   it("accepts a valid signature and updates a matching communication to delivered", async () => {
+    const before = collections.get("renewalNoticeCommunications")?.get("rnc_test");
     const result = await handle(signedBody(eventData()));
 
     expect(result).toEqual(expect.objectContaining({ ok: true, matched: true, updated: true, deliveryStatus: "delivered" }));
@@ -185,6 +186,27 @@ describe("Mailgun renewal communication delivery webhooks", () => {
         noticeServed: false,
         legalServiceEstablished: false,
         noLegalServiceClaim: true,
+      })
+    );
+    expect(record).toEqual(
+      expect.objectContaining({
+        communicationId: before.communicationId,
+        leaseId: before.leaseId,
+        landlordId: before.landlordId,
+        tenantId: before.tenantId,
+        propertyId: before.propertyId,
+        unitId: before.unitId,
+        snapshotId: before.snapshotId,
+        approvalDecisionItemId: before.approvalDecisionItemId,
+        idempotencyKeyHash: before.idempotencyKeyHash,
+        subject: before.subject,
+        recipientEmail: before.recipientEmail,
+        bodyHash: before.bodyHash,
+        status: before.status,
+        attemptedAt: before.attemptedAt,
+        sentAt: before.sentAt,
+        failedAt: before.failedAt,
+        tenantNotified: before.tenantNotified,
       })
     );
     expect(collections.get("events")?.size).toBe(1);
@@ -316,6 +338,102 @@ describe("Mailgun renewal communication delivery webhooks", () => {
     const result = await handle(body);
 
     expect(result).toEqual(expect.objectContaining({ ok: true, matched: true, updated: true, communicationId: "rnc_test" }));
+  });
+
+  it("prefers communicationId over providerMessageId when both are present", async () => {
+    seedDoc(
+      "renewalNoticeCommunications",
+      "rnc_other",
+      communication({
+        communicationId: "rnc_other",
+        deliveryStatus: "accepted_for_sending",
+        providerMessageId: "<conflicting-message@mg.example.com>",
+      })
+    );
+    const body = signedBody(
+      eventData({
+        id: "evt-priority",
+        "user-variables": { communicationId: "rnc_test" },
+        message: { headers: { "message-id": "conflicting-message@mg.example.com" } },
+      }),
+      "priority-token"
+    );
+
+    const result = await handle(body);
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, matched: true, updated: true, communicationId: "rnc_test" }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test")).toEqual(
+      expect.objectContaining({ deliveryStatus: "delivered" })
+    );
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_other")).toEqual(
+      expect.objectContaining({ deliveryStatus: "accepted_for_sending" })
+    );
+  });
+
+  it("does not update communications when both correlation fields are missing", async () => {
+    const before = { ...collections.get("renewalNoticeCommunications")?.get("rnc_test") };
+    const body = signedBody(
+      eventData({
+        id: "evt-no-correlation",
+        "user-variables": {},
+        message: { headers: {} },
+      }),
+      "no-correlation-token"
+    );
+
+    const result = await handle(body);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        matched: false,
+        updated: false,
+        ignoredReason: "communication_not_found",
+      })
+    );
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test")).toEqual(before);
+    const receipts = Array.from((collections.get("communicationProviderEventReceipts") || new Map()).values());
+    expect(receipts[0]).toEqual(expect.objectContaining({ reconciliationState: "unmatched" }));
+    expect(collections.get("events")).toBeUndefined();
+    expect(collections.get("canonicalEvents")).toBeUndefined();
+  });
+
+  it("does not update communications when providerMessageId matches multiple records", async () => {
+    seedDoc(
+      "renewalNoticeCommunications",
+      "rnc_other",
+      communication({
+        communicationId: "rnc_other",
+        providerMessageId: "<message-1@mg.example.com>",
+      })
+    );
+    const beforeFirst = { ...collections.get("renewalNoticeCommunications")?.get("rnc_test") };
+    const beforeSecond = { ...collections.get("renewalNoticeCommunications")?.get("rnc_other") };
+    const body = signedBody(
+      eventData({
+        id: "evt-ambiguous",
+        "user-variables": {},
+        message: { headers: { "message-id": "message-1@mg.example.com" } },
+      }),
+      "ambiguous-token"
+    );
+
+    const result = await handle(body);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        matched: false,
+        updated: false,
+        ignoredReason: "ambiguous_provider_message_id",
+      })
+    );
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test")).toEqual(beforeFirst);
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_other")).toEqual(beforeSecond);
+    const receipts = Array.from((collections.get("communicationProviderEventReceipts") || new Map()).values());
+    expect(receipts[0]).toEqual(expect.objectContaining({ reconciliationState: "ambiguous" }));
+    expect(collections.get("events")).toBeUndefined();
+    expect(collections.get("canonicalEvents")).toBeUndefined();
   });
 
   it("records unmatched provider events safely without updating communication records", async () => {

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
@@ -1,0 +1,292 @@
+import crypto from "crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+
+  function refFor(name: string, id?: string) {
+    const docId = id || `${name}_${++autoId}`;
+    return {
+      id: docId,
+      get: async () => ({
+        id: docId,
+        exists: ensureCollection(name).has(docId),
+        data: () => ensureCollection(name).get(docId),
+      }),
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = ensureCollection(name).get(docId) || {};
+        ensureCollection(name).set(docId, options?.merge ? { ...current, ...value } : value);
+      },
+    };
+  }
+
+  function queryFor(name: string, filters: Array<[string, unknown]> = [], max?: number) {
+    return {
+      where(field: string, _op: string, value: unknown) {
+        return queryFor(name, [...filters, [field, value]], max);
+      },
+      limit(value: number) {
+        return queryFor(name, filters, value);
+      },
+      async get() {
+        const docs = Array.from(ensureCollection(name).entries())
+          .filter(([, data]) => filters.every(([field, value]) => data?.[field] === value))
+          .slice(0, max || Number.MAX_SAFE_INTEGER)
+          .map(([id, data]) => ({ id, data: () => data }));
+        return { empty: docs.length === 0, docs };
+      },
+    };
+  }
+
+  const dbMock = {
+    collection: (name: string) => ({
+      doc: (id?: string) => refFor(name, id),
+      where(field: string, op: string, value: unknown) {
+        return queryFor(name).where(field, op, value);
+      },
+    }),
+    batch: () => {
+      const ops: Array<() => Promise<void>> = [];
+      return {
+        set(ref: any, value: any, options?: { merge?: boolean }) {
+          ops.push(() => ref.set(value, options));
+        },
+        async commit() {
+          for (const op of ops) await op();
+        },
+      };
+    },
+  };
+
+  return { collections, dbMock };
+});
+
+vi.mock("../../firebase", () => ({ db: dbMock }));
+
+const signingKey = "mailgun-signing-secret";
+const now = new Date("2026-07-13T12:00:00.000Z");
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) collections.set(collectionName, new Map());
+  collections.get(collectionName)!.set(id, data);
+}
+
+function communication(overrides: Record<string, any> = {}) {
+  return {
+    communicationId: "rnc_test",
+    leaseId: "lease-1",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    snapshotId: "snapshot-1",
+    approvalDecisionItemId: "decision-1",
+    idempotencyKeyHash: "hash",
+    subject: "Renewal details",
+    recipientEmail: "hello+tenant@rentchain.ai",
+    bodyHash: "body-hash",
+    status: "email_sent",
+    deliveryStatus: "accepted_for_sending",
+    deliveryStatusUpdatedAt: "2026-07-13T11:00:00.000Z",
+    deliveryStatusSource: "send_response",
+    deliveryStatusReason: "mailgun_accepted",
+    deliveryEventIds: [],
+    lastProviderEventAt: "2026-07-13T11:00:00.000Z",
+    provider: "mailgun",
+    providerMessageId: "<message-1@mg.example.com>",
+    attemptedAt: "2026-07-13T10:59:00.000Z",
+    sentAt: "2026-07-13T11:00:00.000Z",
+    failedAt: null,
+    tenantNotified: true,
+    noticeServed: false,
+    legalServiceEstablished: false,
+    noLegalServiceClaim: true,
+    confirmation: {
+      confirmationAccepted: true,
+      recipientReviewed: true,
+      bodyReviewed: true,
+      legalServiceAcknowledged: true,
+      noLegalServiceClaim: true,
+    },
+    actor: { id: "landlord-1", email: "landlord@example.com" },
+    source: "renewal_notice_communication_send_api",
+    createdAt: "2026-07-13T10:59:00.000Z",
+    updatedAt: "2026-07-13T11:00:00.000Z",
+    auditEventIds: [],
+    canonicalEventIds: [],
+    ...overrides,
+  };
+}
+
+function signedBody(eventData: Record<string, any>, token = "token-1", timestamp = "1783944000") {
+  const signature = crypto.createHmac("sha256", signingKey).update(`${timestamp}${token}`).digest("hex");
+  return {
+    signature: { timestamp, token, signature },
+    "event-data": eventData,
+  };
+}
+
+function eventData(overrides: Record<string, any> = {}) {
+  return {
+    id: "evt-1",
+    event: "delivered",
+    timestamp: 1783944000,
+    "user-variables": { communicationId: "rnc_test" },
+    message: { headers: { "message-id": "message-1@mg.example.com" } },
+    "raw-private-provider-payload": "must-not-project",
+    ...overrides,
+  };
+}
+
+async function handle(body: any) {
+  const { handleMailgunRenewalCommunicationWebhook } = await import("../renewalNoticeCommunicationDeliveryWebhookService");
+  return handleMailgunRenewalCommunicationWebhook({
+    body,
+    signingKey,
+    now,
+    replayWindowSeconds: 900,
+  });
+}
+
+describe("Mailgun renewal communication delivery webhooks", () => {
+  beforeEach(() => {
+    collections.clear();
+    vi.clearAllMocks();
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication());
+  });
+
+  it("accepts a valid signature and updates a matching communication to delivered", async () => {
+    const result = await handle(signedBody(eventData()));
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, matched: true, updated: true, deliveryStatus: "delivered" }));
+    const record = collections.get("renewalNoticeCommunications")?.get("rnc_test");
+    expect(record).toEqual(
+      expect.objectContaining({
+        deliveryStatus: "delivered",
+        deliveryStatusSource: "mailgun_webhook",
+        deliveryStatusReason: "mailgun_event_delivered",
+        providerMessageId: "<message-1@mg.example.com>",
+        noticeServed: false,
+        legalServiceEstablished: false,
+        noLegalServiceClaim: true,
+      })
+    );
+    expect(collections.get("events")?.size).toBe(1);
+    expect(collections.get("canonicalEvents")?.size).toBe(1);
+    expect(JSON.stringify(Array.from(collections.values()).map((items) => Array.from(items.values())))).not.toContain(
+      "must-not-project"
+    );
+    expect(collections.get("leaseNotices")).toBeUndefined();
+    expect(collections.get("leases")).toBeUndefined();
+  });
+
+  it("rejects missing, invalid, and stale signatures", async () => {
+    const missing = await handle({ "event-data": eventData() });
+    expect(missing).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_REQUIRED" });
+
+    const invalid = await handle({
+      ...signedBody(eventData(), "token-2"),
+      signature: { timestamp: "1783944000", token: "token-2", signature: "bad" },
+    });
+    expect(invalid).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID" });
+
+    const stale = await handle(signedBody(eventData(), "token-3", "1000"));
+    expect(stale).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_STALE" });
+  });
+
+  it("treats duplicate provider events as idempotent without duplicating audit events", async () => {
+    const body = signedBody(eventData({ id: "evt-dupe" }), "dupe-token");
+    const first = await handle(body);
+    const second = await handle(body);
+
+    expect(first).toEqual(expect.objectContaining({ ok: true, updated: true }));
+    expect(second).toEqual(expect.objectContaining({ ok: true, duplicate: true, updated: false }));
+    expect(collections.get("events")?.size).toBe(1);
+    expect(collections.get("canonicalEvents")?.size).toBe(1);
+  });
+
+  it.each([
+    ["failed", "permanent", "bounced", "mailgun_event_failed_permanent"],
+    ["failed", "temporary", "deferred", "mailgun_event_failed_temporary"],
+    ["complained", undefined, "complained", "mailgun_event_complained"],
+  ])("maps %s/%s to %s without legal-service state", async (event, severity, status, reason) => {
+    const body = signedBody(eventData({ id: `evt-${status}`, event, severity }), `token-${status}`);
+    const result = await handle(body);
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, updated: true, deliveryStatus: status }));
+    const record = collections.get("renewalNoticeCommunications")?.get("rnc_test");
+    expect(record).toEqual(
+      expect.objectContaining({
+        deliveryStatus: status,
+        deliveryStatusReason: reason,
+        noticeServed: false,
+        legalServiceEstablished: false,
+      })
+    );
+  });
+
+  it("does not let accepted events downgrade delivered or complaint states", async () => {
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "delivered" }));
+    const deliveredNoop = await handle(signedBody(eventData({ id: "evt-accepted", event: "accepted" }), "accepted-token"));
+    expect(deliveredNoop).toEqual(
+      expect.objectContaining({ ok: true, matched: true, updated: false, ignoredReason: "delivery_status_precedence_noop" })
+    );
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("delivered");
+
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "complained" }));
+    const complainedNoop = await handle(signedBody(eventData({ id: "evt-accepted-2", event: "accepted" }), "accepted-token-2"));
+    expect(complainedNoop).toEqual(expect.objectContaining({ ok: true, updated: false }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("complained");
+  });
+
+  it("matches by provider message id when the custom communication id is absent", async () => {
+    const body = signedBody(
+      eventData({
+        id: "evt-message-id",
+        "user-variables": {},
+        message: { headers: { "message-id": "message-1@mg.example.com" } },
+      }),
+      "message-token"
+    );
+    const result = await handle(body);
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, matched: true, updated: true, communicationId: "rnc_test" }));
+  });
+
+  it("records unmatched provider events safely without updating communication records", async () => {
+    collections.get("renewalNoticeCommunications")?.delete("rnc_test");
+    const result = await handle(signedBody(eventData({ id: "evt-unmatched" }), "unmatched-token"));
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        matched: false,
+        updated: false,
+        ignoredReason: "communication_not_found",
+      })
+    );
+    const receipts = Array.from((collections.get("communicationProviderEventReceipts") || new Map()).values());
+    expect(receipts[0]).toEqual(expect.objectContaining({ reconciliationState: "unmatched" }));
+    expect(collections.get("events")).toBeUndefined();
+  });
+
+  it("ignores unsupported open/click-style events for v1", async () => {
+    const result = await handle(signedBody(eventData({ id: "evt-opened", event: "opened" }), "opened-token"));
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        matched: false,
+        updated: false,
+        ignoredReason: "unsupported_event:opened",
+      })
+    );
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("accepted_for_sending");
+  });
+});

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
@@ -211,11 +211,18 @@ describe("Mailgun renewal communication delivery webhooks", () => {
     );
     expect(collections.get("events")?.size).toBe(1);
     expect(collections.get("canonicalEvents")?.size).toBe(1);
-    expect(JSON.stringify(Array.from(collections.values()).map((items) => Array.from(items.values())))).not.toContain(
-      "must-not-project"
-    );
+    const allStoredJson = JSON.stringify(Array.from(collections.values()).map((items) => Array.from(items.values())));
+    expect(allStoredJson).not.toContain("must-not-project");
+    expect(allStoredJson).not.toMatch(/notice served|legally delivered|tenant legally notified|tenant received notice|compliance achieved|statutory notice completed|enforceable notice/i);
+    expect(record).not.toHaveProperty("servedAt");
+    expect(record).not.toHaveProperty("legalComplianceEstablished");
+    expect(record).not.toHaveProperty("complianceStatus");
+    expect(record).not.toHaveProperty("lifecycleStatus");
     expect(collections.get("leaseNotices")).toBeUndefined();
     expect(collections.get("leases")).toBeUndefined();
+    expect(collections.get("leaseLifecycleEvents")).toBeUndefined();
+    expect(collections.get("tenantLegalNotifications")).toBeUndefined();
+    expect(collections.get("complianceEvents")).toBeUndefined();
   });
 
   it("rejects missing, invalid, and stale signatures", async () => {

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
@@ -293,10 +293,15 @@ describe("Mailgun renewal communication delivery webhooks", () => {
   });
 
   it.each([
+    ["accepted", undefined, "accepted_for_sending", "mailgun_event_accepted"],
+    ["delivered", undefined, "delivered", "mailgun_event_delivered"],
     ["failed", "permanent", "bounced", "mailgun_event_failed_permanent"],
     ["failed", "temporary", "deferred", "mailgun_event_failed_temporary"],
+    ["failed", undefined, "failed", "mailgun_event_failed"],
     ["complained", undefined, "complained", "mailgun_event_complained"],
+    ["rejected", undefined, "rejected", "mailgun_event_rejected"],
   ])("maps %s/%s to %s without legal-service state", async (event, severity, status, reason) => {
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "delivery_status_unknown", deliveryStatusUpdatedAt: null }));
     const body = signedBody(eventData({ id: `evt-${status}`, event, severity }), `token-${status}`);
     const result = await handle(body);
 
@@ -312,18 +317,95 @@ describe("Mailgun renewal communication delivery webhooks", () => {
     );
   });
 
-  it("does not let accepted events downgrade delivered or complaint states", async () => {
-    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "delivered" }));
+  it("normalizes event casing for supported statuses", async () => {
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "delivery_status_unknown", deliveryStatusUpdatedAt: null }));
+    const result = await handle(signedBody(eventData({ id: "evt-case", event: "DeLiVeReD" }), "case-token"));
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, updated: true, deliveryStatus: "delivered" }));
+  });
+
+  it("does not let lower-precedence events downgrade known statuses", async () => {
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "delivered", deliveryStatusUpdatedAt: "2026-07-13T11:10:00.000Z" }));
     const deliveredNoop = await handle(signedBody(eventData({ id: "evt-accepted", event: "accepted" }), "accepted-token"));
     expect(deliveredNoop).toEqual(
       expect.objectContaining({ ok: true, matched: true, updated: false, ignoredReason: "delivery_status_precedence_noop" })
     );
     expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("delivered");
 
-    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "complained" }));
-    const complainedNoop = await handle(signedBody(eventData({ id: "evt-accepted-2", event: "accepted" }), "accepted-token-2"));
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "bounced", deliveryStatusUpdatedAt: "2026-07-13T11:10:00.000Z" }));
+    const bouncedNoop = await handle(signedBody(eventData({ id: "evt-accepted-2", event: "accepted" }), "accepted-token-2"));
+    expect(bouncedNoop).toEqual(expect.objectContaining({ ok: true, updated: false }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("bounced");
+
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "failed", deliveryStatusUpdatedAt: "2026-07-13T11:10:00.000Z" }));
+    const failedNoop = await handle(signedBody(eventData({ id: "evt-accepted-3", event: "accepted" }), "accepted-token-3"));
+    expect(failedNoop).toEqual(expect.objectContaining({ ok: true, updated: false }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("failed");
+
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "complained", deliveryStatusUpdatedAt: "2026-07-13T11:10:00.000Z" }));
+    const complainedNoop = await handle(signedBody(eventData({ id: "evt-accepted-4", event: "accepted" }), "accepted-token-4"));
     expect(complainedNoop).toEqual(expect.objectContaining({ ok: true, updated: false }));
     expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("complained");
+
+    const deliveredComplaintNoop = await handle(signedBody(eventData({ id: "evt-delivered-complaint", event: "delivered" }), "delivered-complaint-token"));
+    expect(deliveredComplaintNoop).toEqual(expect.objectContaining({ ok: true, updated: false }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("complained");
+  });
+
+  it("allows higher-precedence status transitions from accepted or deferred", async () => {
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "accepted_for_sending" }));
+    const delivered = await handle(signedBody(eventData({ id: "evt-accepted-delivered", event: "delivered" }), "accepted-delivered-token"));
+    expect(delivered).toEqual(expect.objectContaining({ ok: true, updated: true, deliveryStatus: "delivered" }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test")).toEqual(
+      expect.objectContaining({ deliveryStatus: "delivered" })
+    );
+
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "deferred" }));
+    const deferredDelivered = await handle(signedBody(eventData({ id: "evt-deferred-delivered", event: "delivered" }), "deferred-delivered-token"));
+    expect(deferredDelivered).toEqual(expect.objectContaining({ ok: true, updated: true, deliveryStatus: "delivered" }));
+
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "deferred" }));
+    const deferredBounced = await handle(
+      signedBody(eventData({ id: "evt-deferred-bounced", event: "failed", severity: "permanent" }), "deferred-bounced-token")
+    );
+    expect(deferredBounced).toEqual(expect.objectContaining({ ok: true, updated: true, deliveryStatus: "bounced" }));
+  });
+
+  it("does not let older same-rank provider events move timestamps backward", async () => {
+    seedDoc(
+      "renewalNoticeCommunications",
+      "rnc_test",
+      communication({
+        deliveryStatus: "delivered",
+        deliveryStatusUpdatedAt: "2026-07-13T11:30:00.000Z",
+        lastProviderEventAt: "2026-07-13T11:30:00.000Z",
+      })
+    );
+    const olderDelivered = await handle(
+      signedBody(eventData({ id: "evt-older-delivered", event: "delivered", timestamp: 1783941300 }), "older-delivered-token")
+    );
+
+    expect(olderDelivered).toEqual(expect.objectContaining({ ok: true, updated: false, ignoredReason: "delivery_status_precedence_noop" }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test")).toEqual(
+      expect.objectContaining({
+        deliveryStatus: "delivered",
+        deliveryStatusUpdatedAt: "2026-07-13T11:30:00.000Z",
+        lastProviderEventAt: "2026-07-13T11:30:00.000Z",
+      })
+    );
+  });
+
+  it("uses server processing time when provider event timestamp is missing", async () => {
+    seedDoc("renewalNoticeCommunications", "rnc_test", communication({ deliveryStatus: "accepted_for_sending" }));
+    const result = await handle(signedBody(eventData({ id: "evt-no-timestamp", event: "delivered", timestamp: undefined }), "no-timestamp-token"));
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, updated: true, deliveryStatus: "delivered" }));
+    expect(collections.get("renewalNoticeCommunications")?.get("rnc_test")).toEqual(
+      expect.objectContaining({
+        deliveryStatusUpdatedAt: now.toISOString(),
+        lastProviderEventAt: now.toISOString(),
+      })
+    );
   });
 
   it("matches by provider message id when the custom communication id is absent", async () => {
@@ -453,15 +535,16 @@ describe("Mailgun renewal communication delivery webhooks", () => {
     expect(collections.get("events")).toBeUndefined();
   });
 
-  it("ignores unsupported open/click-style events for v1", async () => {
-    const result = await handle(signedBody(eventData({ id: "evt-opened", event: "opened" }), "opened-token"));
+  it.each(["opened", "clicked", "stored", "mystery_event", ""])("ignores unsupported %s events for v1", async (event) => {
+    const eventId = event || "missing-event";
+    const result = await handle(signedBody(eventData({ id: `evt-${eventId}`, event }), `${eventId}-token`));
 
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,
         matched: false,
         updated: false,
-        ignoredReason: "unsupported_event:opened",
+        ignoredReason: event ? `unsupported_event:${event}` : "missing_event_type",
       })
     );
     expect(collections.get("renewalNoticeCommunications")?.get("rnc_test").deliveryStatus).toBe("accepted_for_sending");

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationDeliveryWebhookService.test.ts
@@ -154,6 +154,16 @@ async function handle(body: any) {
   });
 }
 
+async function handleWithOptions(body: any, options: { replayWindowSeconds?: number; now?: Date } = {}) {
+  const { handleMailgunRenewalCommunicationWebhook } = await import("../renewalNoticeCommunicationDeliveryWebhookService");
+  return handleMailgunRenewalCommunicationWebhook({
+    body,
+    signingKey,
+    now: options.now || now,
+    replayWindowSeconds: options.replayWindowSeconds,
+  });
+}
+
 describe("Mailgun renewal communication delivery webhooks", () => {
   beforeEach(() => {
     collections.clear();
@@ -198,6 +208,55 @@ describe("Mailgun renewal communication delivery webhooks", () => {
 
     const stale = await handle(signedBody(eventData(), "token-3", "1000"));
     expect(stale).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_STALE" });
+  });
+
+  it.each([
+    ["timestamp", { token: "token", signature: "abc" }],
+    ["token", { timestamp: "1783944000", signature: "abc" }],
+    ["signature", { timestamp: "1783944000", token: "token" }],
+  ])("rejects missing signature.%s without processing", async (_field, signature) => {
+    const result = await handle({ signature, "event-data": eventData() });
+
+    expect(result).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_REQUIRED" });
+    expect(collections.get("communicationProviderEventReceipts")).toBeUndefined();
+    expect(collections.get("events")).toBeUndefined();
+    expect(collections.get("canonicalEvents")).toBeUndefined();
+  });
+
+  it("rejects non-numeric, far-future, and invalid-format signatures safely", async () => {
+    const nonNumeric = await handle({
+      ...signedBody(eventData(), "token-nonnumeric", "not-a-time"),
+      signature: { timestamp: "not-a-time", token: "token-nonnumeric", signature: "abc123" },
+    });
+    expect(nonNumeric).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID" });
+
+    const future = await handle(signedBody(eventData(), "token-future", "9999999999"));
+    expect(future).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_STALE" });
+
+    const invalidHex = await handle({
+      ...signedBody(eventData(), "token-invalid-format"),
+      signature: { timestamp: "1783944000", token: "token-invalid-format", signature: "not-hex-signature" },
+    });
+    expect(invalidHex).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID" });
+    expect(collections.get("communicationProviderEventReceipts")).toBeUndefined();
+  });
+
+  it("uses the default replay window when none is supplied", async () => {
+    const staleByDefault = await handleWithOptions(signedBody(eventData(), "token-default-window", "1000"));
+
+    expect(staleByDefault).toEqual({ ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_STALE" });
+  });
+
+  it("rejects a valid signature with missing event-data without creating receipts", async () => {
+    const timestamp = "1783944000";
+    const token = "token-no-event-data";
+    const signature = crypto.createHmac("sha256", signingKey).update(`${timestamp}${token}`).digest("hex");
+    const result = await handle({ signature: { timestamp, token, signature } });
+
+    expect(result).toEqual({ ok: false, statusCode: 400, error: "MAILGUN_WEBHOOK_EVENT_DATA_REQUIRED" });
+    expect(collections.get("communicationProviderEventReceipts")).toBeUndefined();
+    expect(collections.get("events")).toBeUndefined();
+    expect(collections.get("canonicalEvents")).toBeUndefined();
   });
 
   it("treats duplicate provider events as idempotent without duplicating audit events", async () => {

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
@@ -185,6 +185,12 @@ describe("sendRenewalNoticeCommunication", () => {
     );
     expect(sendEmailMock.mock.calls[0]?.[0]?.metadata).not.toHaveProperty("leaseId");
     expect(sendEmailMock.mock.calls[0]?.[0]?.metadata).not.toHaveProperty("tenantEmail");
+    expect(sendEmailMock.mock.calls[0]?.[0]?.metadata).not.toHaveProperty("tenantName");
+    expect(sendEmailMock.mock.calls[0]?.[0]?.metadata).not.toHaveProperty("propertyId");
+    expect(Object.keys(sendEmailMock.mock.calls[0]?.[0]?.metadata || {}).sort()).toEqual([
+      "communicationId",
+      "workflow",
+    ]);
     const communications = Array.from((collections.get("renewalNoticeCommunications") || new Map()).values());
     expect(communications).toHaveLength(1);
     expect(communications[0]).toEqual(

--- a/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
+++ b/rentchain-api/src/services/__tests__/renewalNoticeCommunicationService.test.ts
@@ -177,8 +177,14 @@ describe("sendRenewalNoticeCommunication", () => {
         to: "tenant@example.com",
         subject: "Renewal details for Harbour View · Unit 101",
         text: expect.stringContaining("The new fixed term would begin"),
+        metadata: expect.objectContaining({
+          communicationId: expect.stringMatching(/^rnc_/),
+          workflow: "renewal_notice_communication",
+        }),
       })
     );
+    expect(sendEmailMock.mock.calls[0]?.[0]?.metadata).not.toHaveProperty("leaseId");
+    expect(sendEmailMock.mock.calls[0]?.[0]?.metadata).not.toHaveProperty("tenantEmail");
     const communications = Array.from((collections.get("renewalNoticeCommunications") || new Map()).values());
     expect(communications).toHaveLength(1);
     expect(communications[0]).toEqual(

--- a/rentchain-api/src/services/emailService.ts
+++ b/rentchain-api/src/services/emailService.ts
@@ -17,6 +17,7 @@ export type EmailMessage = {
   subject: string;
   text?: string;
   html?: string;
+  metadata?: Record<string, string | number | boolean | null | undefined>;
 };
 
 let lastEmailPreview: any = null;
@@ -40,6 +41,10 @@ function maskEmail(value: string): string {
 
 function getCorrelationId(): string {
   return `em_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function safeMailgunVariableKey(value: string): string {
+  return safeStr(value).replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 80);
 }
 
 export function parseMailgunMessageId(responseText: string): string | null {
@@ -84,6 +89,12 @@ async function sendViaMailgun(message: EmailMessage): Promise<EmailSendResult> {
   const bcc = toCsvRecipients(message.bcc);
   if (bcc) params.set("bcc", bcc);
   if (replyTo) params.set("h:Reply-To", replyTo);
+  for (const [rawKey, rawValue] of Object.entries(message.metadata || {})) {
+    const key = safeMailgunVariableKey(rawKey);
+    const value = safeStr(rawValue);
+    if (!key || !value) continue;
+    params.set(`v:${key}`, value.slice(0, 500));
+  }
 
   const auth = Buffer.from(`api:${apiKey}`).toString("base64");
   const url = `https://api.mailgun.net/v3/${domain}/messages`;

--- a/rentchain-api/src/services/renewalNoticeCommunicationDeliveryWebhookService.ts
+++ b/rentchain-api/src/services/renewalNoticeCommunicationDeliveryWebhookService.ts
@@ -256,11 +256,28 @@ function deliveryStatusRank(value: unknown): number {
   return 0;
 }
 
-function shouldApplyDeliveryStatus(current: unknown, next: RenewalNoticeDeliveryStatus): boolean {
+function timestampMillis(value: unknown): number | null {
+  const iso = toIsoTimestamp(value);
+  if (!iso) return null;
+  const millis = Date.parse(iso);
+  return Number.isFinite(millis) ? millis : null;
+}
+
+function shouldApplyDeliveryStatus(
+  current: unknown,
+  next: RenewalNoticeDeliveryStatus,
+  currentTimestamp?: unknown,
+  nextTimestamp?: unknown
+): boolean {
   const currentRank = deliveryStatusRank(current);
   const nextRank = deliveryStatusRank(next);
   if (nextRank === 0) return false;
-  return nextRank >= currentRank;
+  if (nextRank > currentRank) return true;
+  if (nextRank < currentRank) return false;
+  const currentMillis = timestampMillis(currentTimestamp);
+  const nextMillis = timestampMillis(nextTimestamp);
+  if (currentMillis == null || nextMillis == null) return true;
+  return nextMillis >= currentMillis;
 }
 
 async function findCommunication(input: {
@@ -508,7 +525,7 @@ export async function handleMailgunRenewalCommunicationWebhook(input: {
 
   const record = matched.record;
   const communicationId = record.communicationId || matched.record.id || normalized.communicationId || null;
-  if (!shouldApplyDeliveryStatus(record.deliveryStatus, normalized.deliveryStatus)) {
+  if (!shouldApplyDeliveryStatus(record.deliveryStatus, normalized.deliveryStatus, record.deliveryStatusUpdatedAt, eventTimestamp)) {
     await receiptRef.set(
       {
         ...receiptBase,

--- a/rentchain-api/src/services/renewalNoticeCommunicationDeliveryWebhookService.ts
+++ b/rentchain-api/src/services/renewalNoticeCommunicationDeliveryWebhookService.ts
@@ -1,0 +1,590 @@
+import crypto from "crypto";
+import { db } from "../firebase";
+import { CANONICAL_EVENTS_COLLECTION, buildEvent } from "../lib/events/buildEvent";
+import {
+  RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION,
+  type RenewalNoticeCommunicationRecord,
+  type RenewalNoticeDeliveryStatus,
+} from "./renewalNoticeCommunicationService";
+
+export const COMMUNICATION_PROVIDER_EVENT_RECEIPTS_COLLECTION = "communicationProviderEventReceipts";
+
+type MailgunWebhookBody = {
+  signature?: {
+    timestamp?: unknown;
+    token?: unknown;
+    signature?: unknown;
+  };
+  "event-data"?: Record<string, any>;
+};
+
+type MailgunDeliveryWebhookResult =
+  | {
+      ok: true;
+      statusCode: 200;
+      duplicate?: boolean;
+      matched?: boolean;
+      updated?: boolean;
+      ignoredReason?: string | null;
+      communicationId?: string | null;
+      deliveryStatus?: RenewalNoticeDeliveryStatus | null;
+      receiptId?: string;
+    }
+  | {
+      ok: false;
+      statusCode: number;
+      error: string;
+    };
+
+const DEFAULT_REPLAY_WINDOW_SECONDS = 24 * 60 * 60;
+
+function asString(value: unknown, max = 1000): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function safeReason(value: string): string {
+  return asString(value, 160).replace(/[^a-zA-Z0-9_.:-]/g, "_") || "mailgun_event";
+}
+
+function safeEventType(value: unknown): string {
+  return asString(value, 80).toLowerCase().replace(/[^a-z0-9_.:-]/g, "_");
+}
+
+function safeId(value: unknown, max = 240): string {
+  return asString(value, max).replace(/[^\w@.<>:+-]/g, "");
+}
+
+function normalizeProviderMessageId(value: unknown): string {
+  const raw = safeId(value, 320);
+  if (!raw) return "";
+  const bracketed = raw.match(/<[^>\s]+@[^>\s]+>/)?.[0];
+  if (bracketed) return bracketed;
+  if (raw.includes("@") && !raw.startsWith("<") && !raw.endsWith(">")) return `<${raw}>`;
+  return raw;
+}
+
+function toIsoTimestamp(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value * 1000).toISOString();
+  }
+  const raw = asString(value, 80);
+  if (!raw) return null;
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric)) return new Date(numeric * 1000).toISOString();
+  const parsed = Date.parse(raw);
+  if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  return null;
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  const left = Buffer.from(a, "hex");
+  const right = Buffer.from(b, "hex");
+  if (left.length !== right.length || left.length === 0) return false;
+  return crypto.timingSafeEqual(left, right);
+}
+
+export function verifyMailgunWebhookSignature(input: {
+  signature: MailgunWebhookBody["signature"];
+  signingKey: string;
+  now?: Date;
+  replayWindowSeconds?: number;
+}): { ok: true; timestamp: string; token: string } | { ok: false; error: string; statusCode: number } {
+  const timestamp = asString(input.signature?.timestamp, 80);
+  const token = asString(input.signature?.token, 240);
+  const signature = asString(input.signature?.signature, 240);
+  const signingKey = asString(input.signingKey, 500);
+  if (!signingKey) return { ok: false, statusCode: 503, error: "MAILGUN_WEBHOOK_SIGNING_KEY_REQUIRED" };
+  if (!timestamp || !token || !signature) {
+    return { ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_REQUIRED" };
+  }
+
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isFinite(timestampSeconds)) {
+    return { ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID" };
+  }
+  const replayWindowSeconds = input.replayWindowSeconds ?? DEFAULT_REPLAY_WINDOW_SECONDS;
+  const nowMs = (input.now || new Date()).getTime();
+  if (replayWindowSeconds > 0 && Math.abs(nowMs - timestampSeconds * 1000) > replayWindowSeconds * 1000) {
+    return { ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_STALE" };
+  }
+
+  const expected = crypto.createHmac("sha256", signingKey).update(`${timestamp}${token}`).digest("hex");
+  if (!timingSafeEqualHex(signature, expected)) {
+    return { ok: false, statusCode: 401, error: "MAILGUN_WEBHOOK_SIGNATURE_INVALID" };
+  }
+  return { ok: true, timestamp, token };
+}
+
+export function normalizeMailgunDeliveryEvent(eventData: Record<string, any>): {
+  eventType: string;
+  deliveryStatus: RenewalNoticeDeliveryStatus | null;
+  reason: string;
+  ignoredReason: string | null;
+  eventTimestamp: string | null;
+  providerEventId: string | null;
+  providerMessageId: string | null;
+  communicationId: string | null;
+} {
+  const eventType = safeEventType(eventData?.event);
+  const severity = safeEventType(eventData?.severity);
+  const userVariables = eventData?.["user-variables"] || eventData?.userVariables || {};
+  const communicationId =
+    safeId(userVariables.communicationId || userVariables.communication_id || eventData?.communicationId, 240) || null;
+  const providerMessageId =
+    normalizeProviderMessageId(
+      eventData?.message?.headers?.["message-id"] ||
+        eventData?.message?.headers?.["Message-Id"] ||
+        eventData?.message?.["message-id"] ||
+        eventData?.["message-id"]
+    ) || null;
+  const providerEventId = safeId(eventData?.id || eventData?.eventId || eventData?.["event-id"], 240) || null;
+  const eventTimestamp = toIsoTimestamp(eventData?.timestamp) || null;
+
+  if (eventType === "accepted") {
+    return {
+      eventType,
+      deliveryStatus: "accepted_for_sending",
+      reason: "mailgun_event_accepted",
+      ignoredReason: null,
+      eventTimestamp,
+      providerEventId,
+      providerMessageId,
+      communicationId,
+    };
+  }
+  if (eventType === "delivered") {
+    return {
+      eventType,
+      deliveryStatus: "delivered",
+      reason: "mailgun_event_delivered",
+      ignoredReason: null,
+      eventTimestamp,
+      providerEventId,
+      providerMessageId,
+      communicationId,
+    };
+  }
+  if (eventType === "failed" && severity === "temporary") {
+    return {
+      eventType,
+      deliveryStatus: "deferred",
+      reason: "mailgun_event_failed_temporary",
+      ignoredReason: null,
+      eventTimestamp,
+      providerEventId,
+      providerMessageId,
+      communicationId,
+    };
+  }
+  if (eventType === "failed" && severity === "permanent") {
+    return {
+      eventType,
+      deliveryStatus: "bounced",
+      reason: "mailgun_event_failed_permanent",
+      ignoredReason: null,
+      eventTimestamp,
+      providerEventId,
+      providerMessageId,
+      communicationId,
+    };
+  }
+  if (eventType === "failed") {
+    return {
+      eventType,
+      deliveryStatus: "failed",
+      reason: "mailgun_event_failed",
+      ignoredReason: null,
+      eventTimestamp,
+      providerEventId,
+      providerMessageId,
+      communicationId,
+    };
+  }
+  if (eventType === "complained") {
+    return {
+      eventType,
+      deliveryStatus: "complained",
+      reason: "mailgun_event_complained",
+      ignoredReason: null,
+      eventTimestamp,
+      providerEventId,
+      providerMessageId,
+      communicationId,
+    };
+  }
+  if (eventType === "rejected") {
+    return {
+      eventType,
+      deliveryStatus: "rejected",
+      reason: "mailgun_event_rejected",
+      ignoredReason: null,
+      eventTimestamp,
+      providerEventId,
+      providerMessageId,
+      communicationId,
+    };
+  }
+  return {
+    eventType: eventType || "unknown",
+    deliveryStatus: null,
+    reason: "mailgun_event_ignored",
+    ignoredReason: eventType ? `unsupported_event:${safeReason(eventType)}` : "missing_event_type",
+    eventTimestamp,
+    providerEventId,
+    providerMessageId,
+    communicationId,
+  };
+}
+
+function receiptIdFor(input: { eventId?: string | null; token: string; timestamp: string; eventType: string }): string {
+  const key = ["mailgun", input.eventId || "", input.timestamp, input.token, input.eventType].join(":");
+  return `mailgun_${sha256(key).slice(0, 64)}`;
+}
+
+function deliveryStatusRank(value: unknown): number {
+  const raw = asString(value, 80);
+  if (raw === "complained") return 6;
+  if (raw === "bounced" || raw === "failed" || raw === "rejected") return 5;
+  if (raw === "delivered") return 4;
+  if (raw === "deferred") return 3;
+  if (raw === "sent" || raw === "queued") return 2;
+  if (raw === "accepted_for_sending") return 1;
+  return 0;
+}
+
+function shouldApplyDeliveryStatus(current: unknown, next: RenewalNoticeDeliveryStatus): boolean {
+  const currentRank = deliveryStatusRank(current);
+  const nextRank = deliveryStatusRank(next);
+  if (nextRank === 0) return false;
+  return nextRank >= currentRank;
+}
+
+async function findCommunication(input: {
+  communicationId?: string | null;
+  providerMessageId?: string | null;
+}): Promise<{ ref: any; record: RenewalNoticeCommunicationRecord & { id?: string } } | null | "ambiguous"> {
+  if (input.communicationId) {
+    const ref = db.collection(RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION).doc(input.communicationId);
+    const snap = await ref.get();
+    if (!snap.exists) return null;
+    return { ref, record: { id: snap.id, ...(snap.data() as RenewalNoticeCommunicationRecord) } };
+  }
+  if (!input.providerMessageId) return null;
+
+  const query = await db
+    .collection(RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION)
+    .where("provider", "==", "mailgun")
+    .where("providerMessageId", "==", input.providerMessageId)
+    .limit(2)
+    .get();
+  if (query.empty || !query.docs?.length) return null;
+  if (query.docs.length > 1) return "ambiguous";
+  const doc = query.docs[0];
+  return {
+    ref: db.collection(RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION).doc(doc.id),
+    record: { id: doc.id, ...(doc.data() as RenewalNoticeCommunicationRecord) },
+  };
+}
+
+function deliveryStatusSummary(input: {
+  deliveryStatus: RenewalNoticeDeliveryStatus;
+  eventType: string;
+}): string {
+  if (input.deliveryStatus === "delivered") {
+    return "Renewal tenant communication delivery confirmation updated from Mailgun webhook. Not served; legal service not established.";
+  }
+  if (input.deliveryStatus === "complained") {
+    return "Renewal tenant communication complaint reported by email provider. Not served; legal service not established.";
+  }
+  if (input.deliveryStatus === "bounced" || input.deliveryStatus === "failed" || input.deliveryStatus === "rejected") {
+    return "Renewal tenant communication delivery issue reported by email provider. Not served; legal service not established.";
+  }
+  if (input.deliveryStatus === "deferred") {
+    return "Renewal tenant communication temporary delivery issue reported by email provider. Not served; legal service not established.";
+  }
+  return "Renewal tenant communication delivery status updated from Mailgun webhook. Not served; legal service not established.";
+}
+
+async function writeDeliveryStatusEvent(input: {
+  record: RenewalNoticeCommunicationRecord;
+  deliveryStatus: RenewalNoticeDeliveryStatus;
+  reason: string;
+  eventType: string;
+  providerEventId: string | null;
+  providerMessageId: string | null;
+  occurredAt: string;
+}) {
+  const eventRef = db.collection("events").doc();
+  const canonicalEventId = `renewal_notice_delivery_status_updated:${input.record.communicationId}:${input.occurredAt}:${input.deliveryStatus}`;
+  const summary = deliveryStatusSummary({ deliveryStatus: input.deliveryStatus, eventType: input.eventType });
+  const legacyEvent = {
+    id: eventRef.id,
+    landlordId: input.record.landlordId,
+    actorUserId: null,
+    type: "renewal_notice_delivery_status_updated",
+    leaseId: input.record.leaseId,
+    tenantId: input.record.tenantId || undefined,
+    propertyId: input.record.propertyId || undefined,
+    payload: {
+      communicationId: input.record.communicationId,
+      snapshotId: input.record.snapshotId,
+      approvalDecisionItemId: input.record.approvalDecisionItemId,
+      status: input.record.status,
+      deliveryStatus: input.deliveryStatus,
+      provider: "mailgun",
+      providerMessageId: input.providerMessageId || input.record.providerMessageId || null,
+      providerEventId: input.providerEventId,
+      providerEventType: input.eventType,
+      deliveryStatusSource: "mailgun_webhook",
+      deliveryStatusReason: input.reason,
+      deliveryStatusUpdatedAt: input.occurredAt,
+      lastProviderEventAt: input.occurredAt,
+      noLegalServiceClaim: true,
+      noticeServed: false,
+      tenantNotified: input.record.tenantNotified,
+      legalServiceEstablished: false,
+      summary,
+    },
+    summary,
+    occurredAt: input.occurredAt,
+    createdAt: input.occurredAt,
+  };
+  const canonicalEvent = buildEvent({
+    id: canonicalEventId,
+    type: "renewal_notice_delivery_status_updated",
+    domain: "lease",
+    action: "renewal_notice_delivery_status_updated",
+    status: "completed",
+    actor: { type: "system", id: "mailgun", role: "provider", displayName: "Mailgun" },
+    resource: {
+      type: "lease",
+      id: input.record.leaseId,
+      parentType: input.record.propertyId ? "property" : null,
+      parentId: input.record.propertyId,
+    },
+    occurredAt: input.occurredAt,
+    visibility: "landlord",
+    summary,
+    metadata: {
+      landlordId: input.record.landlordId,
+      leaseId: input.record.leaseId,
+      tenantId: input.record.tenantId,
+      propertyId: input.record.propertyId,
+      unitId: input.record.unitId,
+      communicationId: input.record.communicationId,
+      snapshotId: input.record.snapshotId,
+      approvalDecisionItemId: input.record.approvalDecisionItemId,
+      deliveryStatus: input.deliveryStatus,
+      provider: "mailgun",
+      providerMessageId: input.providerMessageId || input.record.providerMessageId || null,
+      providerEventId: input.providerEventId,
+      providerEventType: input.eventType,
+      deliveryStatusSource: "mailgun_webhook",
+      deliveryStatusReason: input.reason,
+      deliveryStatusUpdatedAt: input.occurredAt,
+      lastProviderEventAt: input.occurredAt,
+      noLegalServiceClaim: true,
+      noticeServed: false,
+      tenantNotified: input.record.tenantNotified,
+      legalServiceEstablished: false,
+    },
+    tags: ["renewal_notice", "tenant_communication", "delivery_status", "mailgun_webhook"],
+  });
+  const batch = db.batch();
+  batch.set(eventRef, legacyEvent);
+  batch.set(db.collection(CANONICAL_EVENTS_COLLECTION).doc(canonicalEvent.id), canonicalEvent);
+  await batch.commit();
+  return { auditEventId: eventRef.id, canonicalEventId };
+}
+
+export async function handleMailgunRenewalCommunicationWebhook(input: {
+  body: MailgunWebhookBody;
+  signingKey: string;
+  replayWindowSeconds?: number;
+  now?: Date;
+}): Promise<MailgunDeliveryWebhookResult> {
+  const verified = verifyMailgunWebhookSignature({
+    signature: input.body?.signature,
+    signingKey: input.signingKey,
+    replayWindowSeconds: input.replayWindowSeconds,
+    now: input.now,
+  });
+  if (!verified.ok) return verified;
+
+  const eventData = input.body?.["event-data"];
+  if (!eventData || typeof eventData !== "object") {
+    return { ok: false, statusCode: 400, error: "MAILGUN_WEBHOOK_EVENT_DATA_REQUIRED" };
+  }
+  const normalized = normalizeMailgunDeliveryEvent(eventData);
+  const receiptId = receiptIdFor({
+    eventId: normalized.providerEventId,
+    token: verified.token,
+    timestamp: verified.timestamp,
+    eventType: normalized.eventType,
+  });
+  const receiptRef = db.collection(COMMUNICATION_PROVIDER_EVENT_RECEIPTS_COLLECTION).doc(receiptId);
+  const existingReceipt = await receiptRef.get();
+  if (existingReceipt.exists) {
+    const existing = existingReceipt.data() || {};
+    return {
+      ok: true,
+      statusCode: 200,
+      duplicate: true,
+      matched: existing.reconciliationState === "matched",
+      updated: false,
+      ignoredReason: existing.ignoredReason || null,
+      communicationId: existing.communicationId || null,
+      deliveryStatus: existing.deliveryStatus || null,
+      receiptId,
+    };
+  }
+
+  const receivedAt = (input.now || new Date()).toISOString();
+  const eventTimestamp = normalized.eventTimestamp || receivedAt;
+  const payloadHash = sha256(JSON.stringify(eventData));
+  const receiptBase = {
+    receiptId,
+    provider: "mailgun",
+    providerEventId: normalized.providerEventId,
+    providerMessageId: normalized.providerMessageId,
+    eventType: normalized.eventType,
+    eventTimestamp,
+    receivedAt,
+    signatureVerified: true,
+    redactedPayloadHash: payloadHash,
+    deliveryStatus: normalized.deliveryStatus,
+    communicationId: normalized.communicationId,
+    reconciliationState: "received",
+    ignoredReason: normalized.ignoredReason,
+    createdAt: receivedAt,
+    updatedAt: receivedAt,
+  };
+
+  if (normalized.ignoredReason || !normalized.deliveryStatus) {
+    await receiptRef.set({ ...receiptBase, reconciliationState: "ignored" }, { merge: false });
+    return {
+      ok: true,
+      statusCode: 200,
+      matched: false,
+      updated: false,
+      ignoredReason: normalized.ignoredReason,
+      deliveryStatus: normalized.deliveryStatus,
+      receiptId,
+    };
+  }
+
+  const matched = await findCommunication({
+    communicationId: normalized.communicationId,
+    providerMessageId: normalized.providerMessageId,
+  });
+  if (matched === "ambiguous") {
+    await receiptRef.set({ ...receiptBase, reconciliationState: "ambiguous", ignoredReason: "ambiguous_provider_message_id" }, { merge: false });
+    return {
+      ok: true,
+      statusCode: 200,
+      matched: false,
+      updated: false,
+      ignoredReason: "ambiguous_provider_message_id",
+      deliveryStatus: normalized.deliveryStatus,
+      receiptId,
+    };
+  }
+  if (!matched) {
+    await receiptRef.set({ ...receiptBase, reconciliationState: "unmatched", ignoredReason: "communication_not_found" }, { merge: false });
+    return {
+      ok: true,
+      statusCode: 200,
+      matched: false,
+      updated: false,
+      ignoredReason: "communication_not_found",
+      deliveryStatus: normalized.deliveryStatus,
+      receiptId,
+    };
+  }
+
+  const record = matched.record;
+  const communicationId = record.communicationId || matched.record.id || normalized.communicationId || null;
+  if (!shouldApplyDeliveryStatus(record.deliveryStatus, normalized.deliveryStatus)) {
+    await receiptRef.set(
+      {
+        ...receiptBase,
+        communicationId,
+        reconciliationState: "ignored",
+        ignoredReason: "delivery_status_precedence_noop",
+      },
+      { merge: false }
+    );
+    return {
+      ok: true,
+      statusCode: 200,
+      matched: true,
+      updated: false,
+      ignoredReason: "delivery_status_precedence_noop",
+      communicationId,
+      deliveryStatus: normalized.deliveryStatus,
+      receiptId,
+    };
+  }
+
+  const eventIds = Array.from(new Set([...(record.deliveryEventIds || []), receiptId]));
+  const eventIdsForRecord = eventIds.slice(-50);
+  const eventResult = await writeDeliveryStatusEvent({
+    record,
+    deliveryStatus: normalized.deliveryStatus,
+    reason: normalized.reason,
+    eventType: normalized.eventType,
+    providerEventId: normalized.providerEventId,
+    providerMessageId: normalized.providerMessageId,
+    occurredAt: eventTimestamp,
+  });
+  await matched.ref.set(
+    {
+      deliveryStatus: normalized.deliveryStatus,
+      deliveryStatusUpdatedAt: eventTimestamp,
+      deliveryStatusSource: "mailgun_webhook",
+      deliveryStatusReason: normalized.reason,
+      providerMessageId: normalized.providerMessageId || record.providerMessageId || null,
+      lastProviderEventAt: eventTimestamp,
+      deliveryEventIds: eventIdsForRecord,
+      updatedAt: receivedAt,
+      auditEventIds: Array.from(new Set([...(record.auditEventIds || []), eventResult.auditEventId])),
+      canonicalEventIds: Array.from(new Set([...(record.canonicalEventIds || []), eventResult.canonicalEventId])),
+      noticeServed: false,
+      legalServiceEstablished: false,
+      noLegalServiceClaim: true,
+    },
+    { merge: true }
+  );
+  await receiptRef.set(
+    {
+      ...receiptBase,
+      communicationId,
+      reconciliationState: "matched",
+      ignoredReason: null,
+      updatedCommunication: true,
+      auditEventId: eventResult.auditEventId,
+      canonicalEventId: eventResult.canonicalEventId,
+    },
+    { merge: false }
+  );
+  return {
+    ok: true,
+    statusCode: 200,
+    matched: true,
+    updated: true,
+    communicationId,
+    deliveryStatus: normalized.deliveryStatus,
+    receiptId,
+  };
+}
+
+export const __testing = {
+  receiptIdFor,
+  deliveryStatusRank,
+  shouldApplyDeliveryStatus,
+  normalizeProviderMessageId,
+};

--- a/rentchain-api/src/services/renewalNoticeCommunicationService.ts
+++ b/rentchain-api/src/services/renewalNoticeCommunicationService.ts
@@ -7,7 +7,7 @@ import { LANDLORD_DECISION_QUEUE_ITEMS_COLLECTION } from "./landlordDecisionQueu
 
 export const RENEWAL_NOTICE_COMMUNICATIONS_COLLECTION = "renewalNoticeCommunications";
 
-type RenewalNoticeDeliveryStatus =
+export type RenewalNoticeDeliveryStatus =
   | "delivery_status_unknown"
   | "not_tracked"
   | "accepted_for_sending"
@@ -23,7 +23,7 @@ type RenewalNoticeDeliveryStatus =
   | "clicked"
   | "unknown";
 
-type RenewalNoticeDeliveryStatusSource =
+export type RenewalNoticeDeliveryStatusSource =
   | "not_tracked"
   | "send_response"
   | "mailgun_webhook"
@@ -50,7 +50,7 @@ type SendRenewalNoticeCommunicationParams = {
   input: SendRenewalNoticeCommunicationInput;
 };
 
-type RenewalNoticeCommunicationRecord = {
+export type RenewalNoticeCommunicationRecord = {
   communicationId: string;
   leaseId: string;
   landlordId: string;
@@ -515,6 +515,10 @@ export async function sendRenewalNoticeCommunication(
       subject,
       text: body,
       html: htmlFromText(body),
+      metadata: {
+        communicationId,
+        workflow: "renewal_notice_communication",
+      },
     })) as EmailSendResult | undefined;
     const sentAt = new Date().toISOString();
     const sentRecord: RenewalNoticeCommunicationRecord = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -256,7 +256,7 @@ function deliveryConfirmationLabel(status: RenewalNoticeCommunicationResponse["d
   if (status === "delivered") return "Delivered by email provider";
   if (status === "bounced") return "Bounce detected by email provider";
   if (status === "failed") return "Failed by email provider";
-  if (status === "deferred") return "Deferred by email provider";
+  if (status === "deferred") return "Temporary delivery issue detected by email provider";
   if (status === "rejected") return "Rejected by email provider";
   if (status === "complained") return "Complaint reported by email provider";
   if (status === "opened") return "Open event recorded by provider";
@@ -291,7 +291,13 @@ function communicationDeliveryLabel(value: string | null | undefined) {
   if (normalized === "delivered" || normalized === "delivered by email provider") return "Delivered by email provider";
   if (normalized === "bounced" || normalized === "bounce detected by email provider") return "Bounce detected by email provider";
   if (normalized === "failed" || normalized === "failed by email provider") return "Failed by email provider";
-  if (normalized === "deferred" || normalized === "deferred by email provider") return "Deferred by email provider";
+  if (
+    normalized === "deferred" ||
+    normalized === "deferred by email provider" ||
+    normalized === "temporary delivery issue detected by email provider"
+  ) {
+    return "Temporary delivery issue detected by email provider";
+  }
   if (normalized === "rejected" || normalized === "rejected by email provider") return "Rejected by email provider";
   if (normalized === "complained" || normalized === "complaint reported by email provider") return "Complaint reported by email provider";
   if (normalized === "opened" || normalized === "open event recorded by provider") return "Open event recorded by provider";


### PR DESCRIPTION
## Summary

Implements the backend Mailgun webhook foundation for renewal tenant communication delivery status updates.

- Adds public, signature-protected `POST /api/webhooks/mailgun/events`.
- Verifies Mailgun HMAC signatures using `MAILGUN_WEBHOOK_SIGNING_KEY` and enforces a replay window via `MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS` when configured.
- Records idempotent provider event receipts without storing raw provider payloads.
- Reconciles events to `renewalNoticeCommunications` by opaque `communicationId` user variable first, then Mailgun provider message ID.
- Updates delivery status with monotonic precedence and appends conservative landlord-visible audit/canonical timeline events.
- Adds minimal outbound Mailgun variables: `communicationId` and `workflow=renewal_notice_communication` only.
- Extends timeline/evidence derivation to label delivery-status webhook updates safely.

## Audit Findings

- Current send flow already persists `providerMessageId` when Mailgun returns it and stores delivery status fields from PR #1359.
- Existing evidence/timeline/frontend labels already cover tracked statuses such as delivered, bounced, deferred, failed, rejected, and complained.
- No Mailgun webhook route existed before this PR.
- Mailgun user variables are included in delivered MIME headers, so this PR avoids tenant/property/lease metadata and sends only the opaque communication ID plus workflow marker.
- Evidence projection reads communication records directly, and this PR adds coverage for each provider delivery status label.

## Webhook Behavior

Route added:

`POST /api/webhooks/mailgun/events`

Security and replay controls:

- Missing signatures reject with `MAILGUN_WEBHOOK_SIGNATURE_REQUIRED`.
- Invalid signatures reject with `MAILGUN_WEBHOOK_SIGNATURE_INVALID`.
- Stale signatures reject with `MAILGUN_WEBHOOK_SIGNATURE_STALE`.
- Missing `MAILGUN_WEBHOOK_SIGNING_KEY` fails closed.
- Duplicate event id/signature-token receipts return idempotently without duplicating audit/timeline events.

Event mapping:

- `accepted` -> `accepted_for_sending`
- `delivered` -> `delivered`
- `failed` + `permanent` -> `bounced`
- `failed` + `temporary` -> `deferred`
- `failed` -> `failed`
- `complained` -> `complained`
- `rejected` -> `rejected`
- unsupported events, including open/click-style events, are ignored for v1

Precedence:

`complained > bounced/failed/rejected > delivered > deferred > sent/queued > accepted_for_sending > unknown/not_tracked`

This prevents accepted/unknown events from downgrading delivered or complaint/failure states while allowing later stronger provider events to update the record.

## Legal / Product Guardrails

This PR does not:

- send emails
- add polling
- add open/click tracking
- create notice-served state
- establish legal service
- make compliance claims
- mutate lease lifecycle
- weaken approval/snapshot/idempotency send guardrails
- expose raw provider payloads in evidence/timeline/UI

Webhook-generated events preserve:

- `Not served; legal service not established.`
- `Legal compliance not determined by this workflow.`

Provider delivery status remains an operational provider signal only. It is not legal notice service, tenant legal receipt, statutory compliance, or lease lifecycle completion.

## Post-Merge Operational Setup

Do not configure Mailgun dashboard webhooks until this backend is merged, deployed, and configured with the webhook signing key.

Required backend runtime env/secret:

- `MAILGUN_WEBHOOK_SIGNING_KEY` - required. Use the Mailgun domain webhook signing key. Missing value fails closed and does not process webhook events.

Optional backend runtime env:

- `MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS` - optional. Defaults safely to 24 hours. Invalid values fall back to the safe default behavior already covered by tests.

Cloud Run / backend setup:

1. Merge PR #1360.
2. Deploy the backend and confirm the active Cloud Run revision/image for the merge commit.
3. Add `MAILGUN_WEBHOOK_SIGNING_KEY` to the landlord API Cloud Run/backend runtime secret/env configuration.
4. Optionally set `MAILGUN_WEBHOOK_REPLAY_WINDOW_SECONDS`.
5. Confirm `GET /health` and `GET /health/ready` return 200.
6. Confirm unsigned webhook requests are rejected in production.
7. If safe, confirm invalid-signature requests are rejected in production.

The webhook route is intentionally public because Mailgun cannot use landlord auth. It is protected by Mailgun signature verification and does not depend on a browser session, cookies, CORS, or CSRF behavior.

## Mailgun Dashboard Setup

Configure the active verified sending domain only after backend deploy and secret setup are complete.

Expected production webhook target:

`https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/api/webhooks/mailgun/events`

Route path:

`POST /api/webhooks/mailgun/events`

Active provider/domain notes:

- Confirm the active Mailgun sending domain, likely `mg.rentchain.ai` based on prior QA.
- Confirm the Mailgun domain is verified.
- Confirm SPF and DKIM are healthy.
- If the sending domain is EU-region, confirm whether the Mailgun API base URL/account settings differ before enabling webhooks.
- Open/click CNAME/tracking is not required for this v1 and should remain out of scope unless separately approved.

Recommended v1 events to enable if available in the Mailgun dashboard:

- accepted
- delivered
- permanent failure
- temporary failure
- complained
- rejected

Do not enable/use for v1:

- opened
- clicked

If Mailgun dashboard labels differ, map them as follows:

- permanent failure -> `failed` with `severity=permanent` -> `bounced`
- temporary failure -> `failed` with `severity=temporary` -> `deferred`
- complaint/complained -> `complained`
- rejected -> `rejected`

## Safe Production Smoke Plan

Do not use real tenant production notices for initial webhook validation.

Recommended smoke sequence:

1. Use an approved internal/safe tenant test inbox only.
2. Send one controlled renewal communication only after explicit operator approval.
3. Confirm `providerMessageId` was recorded on the renewal communication.
4. Confirm the Mailgun webhook event arrives.
5. Confirm delivery status updates only from a real Mailgun provider event.
6. Confirm evidence package, review timeline, and notice workflow history show provider delivery confirmation safely.
7. Confirm legal-service status remains `Not served; legal service not established.`
8. Confirm legal compliance remains `Not determined by this workflow.`

## Rollback / Failure Posture

- If `MAILGUN_WEBHOOK_SIGNING_KEY` is missing, existing send flow can still work, but webhook updates fail closed.
- If Mailgun webhooks are not configured, existing records remain at `accepted_for_sending` or `not_tracked` as applicable.
- If webhook delivery fails, no notice-served, legal-service, compliance, or lease lifecycle state is created.
- Duplicate webhooks are idempotent.
- Unmatched or ambiguous webhook events do not mutate renewal communications.
- Mailgun retries should not create duplicate status history.

## Validation

Passed with Node v20.20.2:

```bash
cd rentchain-api
npm run test -- emailService.mailgun renewalNoticeCommunicationService renewalNoticeCommunicationDeliveryWebhookService mailgunWebhookRoutes apiRouteOwnershipRegression deriveCanonicalReviewTimeline deriveEvidencePack
npm run build
```

Step 6 also passed:

```bash
cd rentchain-frontend
npm run test -- LandlordLeaseWorkflowPage
npm run build
```

Also passed:

```bash
git diff --check
git diff --cached --check
```

## Notes

Draft PR pending operational setup QA completion, CI, and final readiness approval. Do not configure Mailgun dashboard webhooks before deploy + env secret setup.
