### PR TITLE
Polish renewal communication history delivery status

### DIFF
--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -631,6 +631,92 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(mocks.sendRenewalNoticeCommunication).not.toHaveBeenCalled();
   });
 
+  it("prefers the latest provider delivery status in previous renewal communications", async () => {
+    mocks.fetchReviewTimeline.mockResolvedValue({
+      timelineId: "timeline-lease-1",
+      scope: "lease",
+      scopeId: "lease-1",
+      generatedAt: "2026-07-14T03:00:00.000Z",
+      manualReviewRequired: true,
+      externalSharingEnabled: false,
+      certificationIssued: false,
+      entries: [
+        {
+          timelineEntryId: "renewal_notice_email_sent:rnc_delivered",
+          entryType: "canonical_event",
+          timestamp: "2026-07-14T02:56:04.240Z",
+          label: "Renewal tenant communication email sent",
+          description:
+            "Renewal tenant communication email sent at 2026-07-14 02:56 UTC. Communication ID: rnc_delivered. Status: email sent. Recipient email: jane@example.com. Delivery confirmation: Accepted for sending. Draft snapshot ID: snapshot-delivered. Approval decision ID: decision-delivered. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+          status: "completed",
+          actor: { type: "landlord", id: "landlord-1" },
+          source: "canonical_events",
+          sourceId: "rnc_delivered",
+          destination: null,
+          redacted: false,
+          redactionReason: null,
+          blockedReason: null,
+          manualOnly: true,
+        },
+        {
+          timelineEntryId: "renewal_notice_delivery_status_updated:rnc_delivered:accepted",
+          entryType: "canonical_event",
+          timestamp: "2026-07-14T02:56:04.193Z",
+          label: "Renewal tenant communication delivery status updated",
+          description:
+            "Renewal tenant communication delivery status updated at 2026-07-14 02:56 UTC. Communication ID: rnc_delivered. Status: delivery status updated. Recipient email: jane@example.com. Delivery confirmation: Accepted for sending. Draft snapshot ID: snapshot-delivered. Approval decision ID: decision-delivered. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+          status: "completed",
+          actor: { type: "system", id: "mailgun" },
+          source: "canonical_events",
+          sourceId: "rnc_delivered",
+          destination: null,
+          redacted: false,
+          redactionReason: null,
+          blockedReason: null,
+          manualOnly: true,
+        },
+        {
+          timelineEntryId: "renewal_notice_delivery_status_updated:rnc_delivered:delivered",
+          entryType: "canonical_event",
+          timestamp: "2026-07-14T02:56:04.944Z",
+          label: "Renewal tenant communication delivery status updated",
+          description:
+            "Renewal tenant communication delivery status updated at 2026-07-14 02:56 UTC. Communication ID: rnc_delivered. Status: delivery status updated. Recipient email: jane@example.com. Delivery confirmation: Delivered by email provider. Draft snapshot ID: snapshot-delivered. Approval decision ID: decision-delivered. Confirmation/audit status: send confirmations captured. Not served; legal service not established. Legal compliance not determined by this workflow.",
+          status: "completed",
+          actor: { type: "system", id: "mailgun" },
+          source: "canonical_events",
+          sourceId: "rnc_delivered",
+          destination: null,
+          redacted: false,
+          redactionReason: null,
+          blockedReason: null,
+          manualOnly: true,
+        },
+      ],
+      filters: { entryType: ["canonical_event"], status: ["completed"], source: ["canonical_events"] },
+      summary: { total: 3, reviewRequired: 0, blocked: 0, completed: 3, redacted: 0 },
+    });
+
+    renderWorkflow("/leases/lease-1/workflows/notice");
+
+    await screen.findByLabelText("Previous renewal communications");
+    await waitFor(() => {
+      expect(mocks.fetchReviewTimeline).toHaveBeenCalledWith({ scope: "lease", scopeId: "lease-1" });
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Previous renewal communications")).toHaveTextContent("1 recorded");
+    });
+    const history = screen.getByLabelText("Previous renewal communications");
+    expect(history).toHaveTextContent("rnc_delivered");
+    expect(history).toHaveTextContent("Email sent");
+    expect(history).toHaveTextContent("Delivered by email provider");
+    expect(history).not.toHaveTextContent("Delivery confirmation Accepted for sending");
+    expect(history).toHaveTextContent("Not served; legal service not established");
+    expect(history).toHaveTextContent("Not determined by this workflow");
+    expect(document.body).not.toHaveTextContent(/legally delivered|tenant legally notified|tenant received notice|tenant opened notice|compliance achieved|statutory notice completed/i);
+    expect(mocks.sendRenewalNoticeCommunication).not.toHaveBeenCalled();
+  });
+
   it("shows notice review inputs-needed state without draft actions", async () => {
     mocks.fetchExpiringLeaseRenewals.mockResolvedValueOnce({
       ok: true,

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -360,6 +360,16 @@ function renewalCommunicationRank(entry: ReviewTimelineEntry) {
   return 0;
 }
 
+function isRenewalCommunicationDeliveryUpdate(entry: ReviewTimelineEntry) {
+  return /delivery status updated/i.test(`${entry.label} ${entry.description}`);
+}
+
+function latestRenewalCommunicationDeliveryEntry(entries: ReviewTimelineEntry[]) {
+  return entries
+    .filter(isRenewalCommunicationDeliveryUpdate)
+    .sort((left, right) => new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime())[0];
+}
+
 function previousRenewalCommunicationsFromTimeline(entries: ReviewTimelineEntry[]) {
   const grouped = new Map<string, ReviewTimelineEntry[]>();
   entries.filter(isRenewalCommunicationTimelineEntry).forEach((entry) => {
@@ -376,12 +386,13 @@ function previousRenewalCommunicationsFromTimeline(entries: ReviewTimelineEntry[
         return new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime();
       });
       const primary = sorted[0];
+      const deliveryEntry = latestRenewalCommunicationDeliveryEntry(group) || primary;
       return {
         communicationId,
         recipientEmail: extractSentenceValue(primary.description, "Recipient email") || "Recipient not available",
         sentTimestamp: primary.timestamp,
         emailDelivery: communicationEmailDeliveryLabel(extractSentenceValue(primary.description, "Status")),
-        deliveryConfirmation: communicationDeliveryLabel(extractSentenceValue(primary.description, "Delivery confirmation")),
+        deliveryConfirmation: communicationDeliveryLabel(extractSentenceValue(deliveryEntry.description, "Delivery confirmation")),
         draftSnapshotId: extractSentenceValue(primary.description, "Draft snapshot ID"),
         approvalDecisionId: extractSentenceValue(primary.description, "Approval decision ID"),
       };


### PR DESCRIPTION
## Summary
- Previous renewal communication cards now prefer the latest provider delivery-status update for the visible Delivery confirmation value.
- Preserves the original email-sent record as the source for sent timestamp, recipient, communication ID, draft snapshot ID, and approval decision ID.
- Adds regression coverage for an email-sent Accepted for sending record followed by a later Delivered by email provider update.

## Audit findings
- The notice workflow history derives previous renewal communications from the lease review timeline.
- Existing grouping already collected all communication events by communication ID, but the display chose the email-sent event as the primary record, so later Mailgun delivery-status updates were not reflected in the card summary.
- Timeline data already contains the delivery-status update entries, so this is frontend-only.

## Guardrails
- No send API behavior changed.
- No webhook behavior changed.
- No backend/API files changed.
- No legal-service, notice-served, compliance, or lease lifecycle behavior changed.
- No raw provider payloads, signatures, tokens, or secrets are exposed.

## Validation
- npm run test -- LandlordLeaseWorkflowPage: passed
- source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build: passed
- git diff --check: passed
- git diff --cached --check: passed

Note: raw npm run build under shell Node v25.8.1 failed the repo Node preflight. Re-running with Node 20.11.1 passed.

## Manual QA
- Authenticated preview QA has not been run yet.
- Target route: /leases/oTmWc8UxDj9u7Asgaqe7/workflows/notice

Closes #1362