### PR TITLE
Fix dashboard credit balance action labeling

### DIFF
--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -557,6 +557,90 @@ describe("landlordDecisionInboxRoutes", () => {
     );
   });
 
+  it("labels aggregate credit plus outstanding obligations as payment allocation review", async () => {
+    seedLease({
+      id: "y7XM6BFXIzWW0fV3mu1L",
+      monthlyRent: 2000,
+      dueDate: "2026-04-01",
+      startDate: "2026-04-01",
+      endDate: "2027-03-31",
+    });
+    seedDoc("ledgerEntries", "ledger-credit-adjustment", {
+      leaseId: "y7XM6BFXIzWW0fV3mu1L",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "adjustment",
+      amountCents: -876900,
+      effectiveDate: "2026-05-31",
+      source: "manual_credit_adjustment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "lease_ledger",
+          type: "billing",
+          title: "Review payment allocation",
+          destination: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+          dueAt: "2026-04-01T00:00:00.000Z",
+          description: "Lease has an aggregate credit balance of -$8,769.00, but $2,000.00 remains outstanding on specific obligations. Review payment allocation before taking overdue-rent action.",
+        }),
+      ])
+    );
+    expect(res.body.items.map((item: any) => item.title)).not.toContain("Review Overdue Rent");
+    expect(res.body.items.map((item: any) => item.title)).not.toContain("Review Missing Payment");
+    expect(JSON.stringify(res.body)).not.toContain("tenant owes");
+  });
+
+  it("does not emit overdue payment actions for neutral settled ledger balances", async () => {
+    seedLease({
+      id: "lease-neutral",
+      monthlyRent: 2000,
+      dueDate: "2026-04-01",
+      startDate: "2026-04-01",
+      endDate: "2027-03-31",
+    });
+    seedDoc("ledgerEntries", "ledger-neutral-charge", {
+      leaseId: "lease-neutral",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "charge",
+      amountCents: 200000,
+      effectiveDate: "2026-04-01",
+      source: "manual_ledger_charge",
+    });
+    seedDoc("ledgerEntries", "ledger-neutral-payment", {
+      leaseId: "lease-neutral",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      entryType: "payment",
+      amountCents: 200000,
+      effectiveDate: "2026-04-01",
+      source: "manual_ledger_payment",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox?type=billing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+    expect(JSON.stringify(res.body)).not.toContain("Review Overdue Rent");
+    expect(JSON.stringify(res.body)).not.toContain("Review payment allocation");
+  });
+
   it("does not expose another landlord's lease decisions", async () => {
     seedLease({ id: "lease-other", landlordId: "landlord-2" });
     loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });

--- a/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionQueueRoutes.test.ts
@@ -779,6 +779,93 @@ describe("landlordDecisionQueueRoutes", () => {
     expect(JSON.stringify(res.body)).not.toContain("76c2961b-eae5-4574-9f51-66096976b5dc");
   });
 
+  it("returns allocation-safe dashboard payment decisions from the settled-payment-aware inbox", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      decisions: {
+        items: [
+          analyticsDecision({
+            id: "stale_overdue_rent:y7XM6BFXIzWW0fV3mu1L",
+            decisionType: "review_overdue_rent",
+            actionLabel: "Review Overdue Rent",
+            recommendedAction: "Review Overdue Rent",
+            destination: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+            executionMapping: { resourceType: "lease", resourceId: "y7XM6BFXIzWW0fV3mu1L" },
+          }),
+        ],
+      },
+    });
+    derivePaymentConsistentDecisionInbox.mockResolvedValue({
+      items: [
+        {
+          id: "decision:review_overdue_rent:delinquency:overdue:y7XM6BFXIzWW0fV3mu1L",
+          title: "Review payment allocation",
+          description:
+            "Lease has an aggregate credit balance of -$8,769.00, but $2,000.00 remains outstanding on specific obligations. Review payment allocation before taking overdue-rent action.",
+          severity: "critical",
+          status: "open",
+          type: "billing",
+          source: "lease_ledger",
+          relatedEntity: { kind: "lease", id: "y7XM6BFXIzWW0fV3mu1L", label: "Lease y7XM6BFXIzWW0fV3mu1L" },
+          destination: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+          automationEligible: false,
+          dueAt: "2026-05-31T00:00:00.000Z",
+          createdAt: "2026-06-18T12:00:00.000Z",
+          updatedAt: "2026-06-19T12:00:00.000Z",
+          workflow: {
+            queue: "delinquency_review",
+            workflowState: "new",
+            ownershipType: "landlord",
+            reviewPriority: "critical",
+            escalationLevel: "critical",
+            manualOnly: true,
+          },
+        },
+      ],
+      filters: { severity: [], status: [], type: [], queue: [], workflowState: [], escalationLevel: [] },
+      summary: { total: 1, critical: 1, high: 0, open: 1, blocked: 0 },
+      workflowSummary: { new: 1, underReview: 0, escalated: 0, critical: 1 },
+      automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+      agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
+    });
+    getUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: [],
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
+    const router = (await import("../landlordDecisionQueueRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-queue?status=open_state&limit=6" });
+
+    expect(res.status).toBe(200);
+    expect(derivePaymentConsistentDecisionInbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        analyticsDecisions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "stale_overdue_rent:y7XM6BFXIzWW0fV3mu1L",
+            actionLabel: "Review Overdue Rent",
+          }),
+        ]),
+      })
+    );
+    expect(res.body.items).toEqual([
+      expect.objectContaining({
+        title: "Review payment allocation",
+        workspace: "payments",
+        recommendedActionHref: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+        dueAt: "2026-05-31T00:00:00.000Z",
+        description: expect.stringContaining("aggregate credit balance of -$8,769.00"),
+      }),
+    ]);
+    expect(JSON.stringify(res.body)).not.toContain("Review Overdue Rent");
+    expect(JSON.stringify(res.body)).not.toContain("tenant owes");
+    expect(JSON.stringify(res.body)).not.toContain("Record payment or contact the tenant");
+  });
+
   it("does not show overpaid up-to-date leases as dashboard missing-payment decisions after inbox suppression", async () => {
     loadLandlordAnalyticsSnapshot.mockResolvedValue({
       decisions: {

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -221,19 +221,93 @@ function isActivePaymentDecisionItem(item: DecisionInboxItem): boolean {
 }
 
 type LeasePaymentObligationState = "settled" | "unsettled" | "unknown";
+type LeasePaymentObligationReview = {
+  state: LeasePaymentObligationState;
+  aggregateBalanceCents: number | null;
+  outstandingAmountCents: number | null;
+  allocationReviewRequired: boolean;
+};
 
-async function getLeasePaymentObligationState(leaseId: string, landlordId: string): Promise<LeasePaymentObligationState> {
+function signedLedgerEntryAmountCents(entry: any): number {
+  const amount = Number(entry?.amountCents || 0);
+  if (!Number.isFinite(amount)) return 0;
+  const entryType = asString(entry?.entryType, 80);
+  if (entryType === "payment") return -Math.abs(Math.round(amount));
+  if (entryType === "adjustment") return Math.round(amount);
+  return Math.abs(Math.round(amount));
+}
+
+async function loadLeaseAggregateLedgerBalanceCents(leaseId: string, landlordId: string): Promise<number | null> {
+  const snap = await db.collection("ledgerEntries").where("leaseId", "==", leaseId).get().catch(() => null);
+  if (!snap) return null;
+  const entries = (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((entry: any) => asString(entry?.landlordId, 240) === landlordId);
+  if (entries.length === 0) return null;
+  return entries.reduce((sum: number, entry: any) => sum + signedLedgerEntryAmountCents(entry), 0);
+}
+
+function formatSignedCurrencyCents(value: number | null | undefined): string {
+  const cents = Number(value);
+  if (!Number.isFinite(cents)) return "not available";
+  const prefix = cents < 0 ? "-" : "";
+  return `${prefix}$${(Math.abs(Math.round(cents)) / 100).toLocaleString("en-CA", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function allocationReviewDecisionItem(item: DecisionInboxItem, review: LeasePaymentObligationReview): DecisionInboxItem {
+  const credit = formatSignedCurrencyCents(review.aggregateBalanceCents);
+  const outstanding = formatSignedCurrencyCents(review.outstandingAmountCents);
+  return {
+    ...item,
+    title: "Review payment allocation",
+    description:
+      `Lease has an aggregate credit balance of ${credit}, but ${outstanding} remains outstanding on specific obligations. ` +
+      "Review payment allocation before taking overdue-rent action.",
+  };
+}
+
+async function getLeasePaymentObligationReview(leaseId: string, landlordId: string): Promise<LeasePaymentObligationReview> {
   const lease = await loadLeaseForLandlord(leaseId, landlordId);
-  if (!lease) return "unknown";
+  if (!lease) {
+    return {
+      state: "unknown",
+      aggregateBalanceCents: null,
+      outstandingAmountCents: null,
+      allocationReviewRequired: false,
+    };
+  }
   const obligationRows = await buildLeaseObligationRowsForDecisionInbox(lease, landlordId);
-  if (obligationRows.length === 0) return "unknown";
+  if (obligationRows.length === 0) {
+    return {
+      state: "unknown",
+      aggregateBalanceCents: null,
+      outstandingAmountCents: null,
+      allocationReviewRequired: false,
+    };
+  }
   const summary = summarizePaymentObligationLedger(obligationRows);
-  if (summary.outstandingAmountCents > 0) return "unsettled";
-  return deriveDelinquencySignals(obligationRows).length === 0 ? "settled" : "unsettled";
+  const aggregateBalanceCents = await loadLeaseAggregateLedgerBalanceCents(leaseId, landlordId);
+  if (summary.outstandingAmountCents > 0) {
+    return {
+      state: "unsettled",
+      aggregateBalanceCents,
+      outstandingAmountCents: summary.outstandingAmountCents,
+      allocationReviewRequired: aggregateBalanceCents != null && aggregateBalanceCents < 0,
+    };
+  }
+  return {
+    state: deriveDelinquencySignals(obligationRows).length === 0 ? "settled" : "unsettled",
+    aggregateBalanceCents,
+    outstandingAmountCents: summary.outstandingAmountCents,
+    allocationReviewRequired: false,
+  };
 }
 
 async function suppressSettledPaymentDecisionItems(landlordId: string, items: DecisionInboxItem[]) {
-  const obligationStateByLeaseId = new Map<string, LeasePaymentObligationState>();
+  const obligationStateByLeaseId = new Map<string, LeasePaymentObligationReview>();
   const result: DecisionInboxItem[] = [];
   for (const item of items) {
     if (!isActivePaymentDecisionItem(item)) {
@@ -243,17 +317,19 @@ async function suppressSettledPaymentDecisionItems(landlordId: string, items: De
     const leaseIds = leaseIdsFromDecisionItem(item);
     let settled = false;
     let unsettled = false;
+    let allocationReview: LeasePaymentObligationReview | null = null;
     for (const leaseId of leaseIds) {
       if (!obligationStateByLeaseId.has(leaseId)) {
-        obligationStateByLeaseId.set(leaseId, await getLeasePaymentObligationState(leaseId, landlordId));
+        obligationStateByLeaseId.set(leaseId, await getLeasePaymentObligationReview(leaseId, landlordId));
       }
-      const state = obligationStateByLeaseId.get(leaseId);
-      settled = settled || state === "settled";
-      unsettled = unsettled || state === "unsettled";
+      const review = obligationStateByLeaseId.get(leaseId);
+      settled = settled || review?.state === "settled";
+      unsettled = unsettled || review?.state === "unsettled";
+      if (review?.allocationReviewRequired) allocationReview = review;
     }
     if (settled) continue;
     if (item.source === "analytics" && !unsettled) continue;
-    result.push(item);
+    result.push(allocationReview ? allocationReviewDecisionItem(item, allocationReview) : item);
   }
   return result;
 }

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -454,8 +454,9 @@ describe("DashboardPage", () => {
     renderDashboard();
 
     expect(await screen.findByTestId("upcoming-actions-section")).toHaveTextContent("Review payment allocation");
-    expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Payments");
+    expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Payments · Allocation review");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review payment allocation");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Payments · Allocation review");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("aggregate credit balance of -$8,769.00");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review payment allocation before taking overdue-rent action.");
     expect(screen.getByRole("link", { name: /Open payment ledger: Review payment allocation/i })).toHaveAttribute(
@@ -465,6 +466,59 @@ describe("DashboardPage", () => {
     expect(screen.queryByText("Review Overdue Rent")).not.toBeInTheDocument();
     expect(screen.queryByText("Review overdue rent")).not.toBeInTheDocument();
     expect(screen.queryByText("tenant owes")).not.toBeInTheDocument();
+  });
+
+  it("defensively relabels legacy overdue-rent dashboard titles when allocation context is present", async () => {
+    mocks.fetchLandlordDecisionQueueMock.mockResolvedValue(
+      queueResponse({
+        total: 1,
+        summary: {
+          total: 1,
+          critical: 1,
+          warning: 0,
+          needsReview: 0,
+          upcoming: 0,
+          informational: 0,
+          open: 1,
+          blocked: 0,
+        },
+        items: [
+          {
+            id: "decision-credit-allocation-legacy-title",
+            sourceType: "decision_inbox",
+            sourceId: "decision:review_overdue_rent:delinquency:overdue:y7XM6BFXIzWW0fV3mu1L",
+            workspace: "payments",
+            severity: "critical",
+            title: "Review Overdue Rent",
+            description:
+              "Lease has an aggregate credit balance of -$8,769.00, but $2,000.00 remains outstanding on specific obligations. Review payment allocation before taking overdue-rent action.",
+            recommendedActionLabel: "Review",
+            recommendedActionHref: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+            dueAt: "2026-05-31T00:00:00.000Z",
+            createdAt: "2026-06-18T12:00:00.000Z",
+            updatedAt: "2026-06-19T12:00:00.000Z",
+            status: "open",
+            leaseId: "y7XM6BFXIzWW0fV3mu1L",
+            dedupeKey: "payment-allocation:y7XM6BFXIzWW0fV3mu1L",
+            sortKey: "1",
+            priorityRank: 1,
+          },
+        ],
+      })
+    );
+
+    renderDashboard();
+
+    expect(await screen.findByTestId("upcoming-actions-section")).toHaveTextContent("Review payment allocation");
+    expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Payments · Allocation review");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review payment allocation");
+    expect(screen.getByRole("link", { name: /Open payment ledger: Review payment allocation/i })).toHaveAttribute(
+      "href",
+      "/leases/y7XM6BFXIzWW0fV3mu1L/ledger"
+    );
+    expect(screen.queryByText("Review Overdue Rent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rent obligation is overdue.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Record payment or contact the tenant")).not.toBeInTheDocument();
   });
 
   it("stacks Dashboard decision card actions below content on mobile", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -412,6 +412,61 @@ describe("DashboardPage", () => {
     );
   });
 
+  it("labels credit-balance obligation decisions as payment allocation review on the dashboard", async () => {
+    mocks.fetchLandlordDecisionQueueMock.mockResolvedValue(
+      queueResponse({
+        total: 1,
+        summary: {
+          total: 1,
+          critical: 1,
+          warning: 0,
+          needsReview: 0,
+          upcoming: 0,
+          informational: 0,
+          open: 1,
+          blocked: 0,
+        },
+        items: [
+          {
+            id: "decision-credit-allocation",
+            sourceType: "decision_inbox",
+            sourceId: "decision:review_overdue_rent:delinquency:overdue:y7XM6BFXIzWW0fV3mu1L",
+            workspace: "payments",
+            severity: "critical",
+            title: "Review payment allocation",
+            description:
+              "Lease has an aggregate credit balance of -$8,769.00, but $2,000.00 remains outstanding on specific obligations. Review payment allocation before taking overdue-rent action.",
+            recommendedActionLabel: "Review",
+            recommendedActionHref: "/leases/y7XM6BFXIzWW0fV3mu1L/ledger",
+            dueAt: "2026-05-31T00:00:00.000Z",
+            createdAt: "2026-06-18T12:00:00.000Z",
+            updatedAt: "2026-06-19T12:00:00.000Z",
+            status: "open",
+            leaseId: "y7XM6BFXIzWW0fV3mu1L",
+            dedupeKey: "payment-allocation:y7XM6BFXIzWW0fV3mu1L",
+            sortKey: "1",
+            priorityRank: 1,
+          },
+        ],
+      })
+    );
+
+    renderDashboard();
+
+    expect(await screen.findByTestId("upcoming-actions-section")).toHaveTextContent("Review payment allocation");
+    expect(screen.getByTestId("upcoming-actions-section")).toHaveTextContent("Payments");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review payment allocation");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("aggregate credit balance of -$8,769.00");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review payment allocation before taking overdue-rent action.");
+    expect(screen.getByRole("link", { name: /Open payment ledger: Review payment allocation/i })).toHaveAttribute(
+      "href",
+      "/leases/y7XM6BFXIzWW0fV3mu1L/ledger"
+    );
+    expect(screen.queryByText("Review Overdue Rent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Review overdue rent")).not.toBeInTheDocument();
+    expect(screen.queryByText("tenant owes")).not.toBeInTheDocument();
+  });
+
   it("stacks Dashboard decision card actions below content on mobile", async () => {
     installMatchMedia(true);
 

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -224,6 +224,9 @@ function decisionDestinationCopy(item: LandlordDecisionQueueItem): { meta: strin
     return { meta: "Lease renewals · Review operator inputs", action: "Review renewals" };
   }
   if (href.includes("/ledger")) {
+    if (isPaymentAllocationReviewItem(item)) {
+      return { meta: "Payments · Allocation review", action: "Open payment ledger" };
+    }
     return {
       meta: "Payment ledger · Review obligation",
       action: label && !isGenericActionLabel(label) && !isLegacyLedgerActionLabel(label) ? label : "Open payment ledger",
@@ -249,8 +252,40 @@ function decisionContextLabel(item: LandlordDecisionQueueItem): string {
   return decisionDestinationCopy(item).meta;
 }
 
+function isPaymentAllocationReviewItem(item: LandlordDecisionQueueItem): boolean {
+  const href = String(item.recommendedActionHref || "").toLowerCase();
+  if (!href.includes("/ledger")) return false;
+  const haystack = [
+    item.title,
+    item.description,
+    item.recommendedActionLabel,
+    item.sourceSnapshot?.title,
+    item.sourceSnapshot?.description,
+  ]
+    .map((value) => String(value || "").toLowerCase())
+    .join(" ");
+  return (
+    haystack.includes("review payment allocation") ||
+    haystack.includes("aggregate credit balance") ||
+    haystack.includes("unmatched obligations") ||
+    haystack.includes("unmatched payments")
+  );
+}
+
+function decisionTitle(item: LandlordDecisionQueueItem): string {
+  if (isPaymentAllocationReviewItem(item)) return "Review payment allocation";
+  return item.title || "Review required";
+}
+
 function decisionReason(item: LandlordDecisionQueueItem): string {
   const description = String(item.description || "").replace(/\s+/g, " ").trim();
+  if (isPaymentAllocationReviewItem(item)) {
+    const hasSafeAllocationContext =
+      /aggregate credit balance|unmatched obligations|unmatched payments|payment allocation/i.test(description);
+    return hasSafeAllocationContext
+      ? description
+      : "Lease has an aggregate credit balance, but one or more obligations remain unmatched. Review payment allocation before taking overdue-rent action.";
+  }
   return description || "Review the recommended next step for this operational decision.";
 }
 
@@ -695,6 +730,7 @@ function DecisionQueuePreview({ queue }: { queue: LandlordDecisionQueueResponse 
 
 function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
   const destinationLabel = decisionDestinationLabel(item);
+  const title = decisionTitle(item);
   const isMobileDecisionCard = useMediaQuery("(max-width: 640px)");
   return (
     <div
@@ -711,7 +747,7 @@ function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
       }}
     >
       <div style={{ display: "grid", gap: 7, minWidth: 0 }}>
-        <div style={{ fontWeight: 850, color: text.primary, overflowWrap: "anywhere" }}>{item.title || "Review required"}</div>
+        <div style={{ fontWeight: 850, color: text.primary, overflowWrap: "anywhere" }}>{title}</div>
         <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.35, overflowWrap: "anywhere" }}>
           {decisionContextLabel(item)}
         </div>
@@ -729,7 +765,7 @@ function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
       </div>
       <Link
         to={operationalHref(item)}
-        aria-label={`${destinationLabel}: ${item.title || "Review required"}`}
+        aria-label={`${destinationLabel}: ${title}`}
         style={{
           ...compactButton,
           width: isMobileDecisionCard ? "100%" : "fit-content",
@@ -769,10 +805,12 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
           {actions.map((item) => (
             <div key={item.id} style={{ display: "flex", justifyContent: "space-between", gap: 12, borderBottom: `1px solid ${colors.border}`, paddingBottom: 10, alignItems: "center" }}>
               <div style={{ minWidth: 0 }}>
-                <div style={{ fontWeight: 800, overflowWrap: "anywhere" }}>{item.title}</div>
-                <div style={{ color: text.muted, fontSize: 13 }}>{workspaceLabel(item.workspace)} · {formatDate(item.dueAt)}</div>
+                <div style={{ fontWeight: 800, overflowWrap: "anywhere" }}>{decisionTitle(item)}</div>
+                <div style={{ color: text.muted, fontSize: 13 }}>
+                  {isPaymentAllocationReviewItem(item) ? "Payments · Allocation review" : `${workspaceLabel(item.workspace)} · ${formatDate(item.dueAt)}`}
+                </div>
               </div>
-              <Link to={operationalHref(item)} aria-label={`Open ${item.title}`} style={{ ...compactButton, flex: "0 0 auto" }}>
+              <Link to={operationalHref(item)} aria-label={`Open ${decisionTitle(item)}`} style={{ ...compactButton, flex: "0 0 auto" }}>
                 <ArrowRight size={16} />
               </Link>
             </div>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -615,8 +615,16 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText(/aggregate credit balance of -\$8,769.00/i)).toBeInTheDocument();
     expect(screen.getByText(/but \$2,000.00 remains outstanding on specific obligations/i)).toBeInTheDocument();
     expect(screen.getByText("Review the obligation rows before resolving overdue decisions.")).toBeInTheDocument();
+    expect(screen.getByText("Review payment allocation")).toBeInTheDocument();
+    expect(screen.getAllByText("Allocation review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Payments exceed charges in aggregate, but one or more obligations remain unmatched.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Review and allocate unmatched payments before taking any overdue-rent action.")).toBeInTheDocument();
+    expect(screen.getAllByText("Payments exceed charges in aggregate, but this obligation remains unmatched.").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
     expect(screen.getByText(/reviewed or resolved status does not mark rent paid/i)).toBeInTheDocument();
+    expect(screen.queryByText("Overdue Rent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rent obligation is overdue.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Record payment or contact the tenant, then resolve once the ledger is updated.")).not.toBeInTheDocument();
   });
 
   it("keeps the payment CSV import collapsed until the landlord opens it", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -107,6 +107,10 @@ function totalOutstandingObligationCents(
   return obligationRows.reduce((sum, row) => sum + obligationOutstandingCents(row), 0);
 }
 
+function hasCreditBalanceAllocationReview(balanceCents: number, outstandingObligationCents: number): boolean {
+  return Number(balanceCents || 0) < 0 && Number(outstandingObligationCents || 0) > 0;
+}
+
 const obligationStatusCopy: Record<PaymentObligationStatus, { label: string; bg: string; color: string; border: string }> = {
   expected: { label: "Expected", bg: "#fffaf1", color: "#63594d", border: "rgba(91,70,48,0.18)" },
   pending: { label: "Pending", bg: "#fef9c3", color: "#854d0e", border: "#fde68a" },
@@ -333,13 +337,34 @@ function recommendedDecisionAction(decision: DecisionItem): { label: string; cta
   }
 }
 
+function allocationReviewRecommendedAction(): { label: string; cta: "resolve"; helper: string } {
+  return {
+    label: "Review and allocate unmatched payments before taking any overdue-rent action.",
+    cta: "resolve",
+    helper: "Marks the operational review item resolved only after allocation review is complete.",
+  };
+}
+
+function allocationReviewDecision(decision: DecisionItem): DecisionItem {
+  return {
+    ...decision,
+    reason: "Payments exceed charges in aggregate, but one or more obligations remain unmatched.",
+    metadata: {
+      ...(decision.metadata || {}),
+      signalType: "allocation_review",
+      signalReasons: ["aggregate_credit_balance_with_unmatched_obligations"],
+    },
+  };
+}
+
 function buildDecisionSummaryFacts(
   decision: DecisionItem,
   lease: LandlordActiveLease | null,
   obligationRows: LeaseObligationLedgerRow[],
-  delinquencySignals: LeaseDelinquencySignal[]
+  delinquencySignals: LeaseDelinquencySignal[],
+  allocationReviewRequired: boolean
 ) {
-  const displayDecision = withDecisionReviewContext(decision, lease);
+  const displayDecision = withDecisionReviewContext(allocationReviewRequired ? allocationReviewDecision(decision) : decision, lease);
   const reviewContext = displayDecision.metadata?.reviewContext as Record<string, string | undefined> | undefined;
   const relatedRow = findRelatedObligationRow(displayDecision, obligationRows);
   const relatedSignal = findRelatedDelinquencySignal(displayDecision, delinquencySignals);
@@ -361,7 +386,7 @@ function buildDecisionSummaryFacts(
     outstandingAmount: outstandingAmountCents != null ? formatCurrencyCents(outstandingAmountCents) : "Not available",
     dueDate: dueDate ? formatDate(dueDate) : "Not available",
     obligationStatus: readableText(obligationStatus),
-    recommendedAction: recommendedDecisionAction(displayDecision),
+    recommendedAction: allocationReviewRequired ? allocationReviewRecommendedAction() : recommendedDecisionAction(displayDecision),
   };
 }
 
@@ -408,6 +433,7 @@ function DecisionRow({
   lease,
   obligationRows,
   delinquencySignals,
+  allocationReviewRequired,
   pending,
   onAction,
   onRecordPayment,
@@ -416,20 +442,24 @@ function DecisionRow({
   lease: LandlordActiveLease | null;
   obligationRows: LeaseObligationLedgerRow[];
   delinquencySignals: LeaseDelinquencySignal[];
+  allocationReviewRequired: boolean;
   pending: boolean;
   onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
   onRecordPayment: () => void;
 }) {
   const copy = decisionDisplayCopy[decision.decisionType];
-  const summary = buildDecisionSummaryFacts(decision, lease, obligationRows, delinquencySignals);
+  const displayCopy = allocationReviewRequired
+    ? { label: "Review payment allocation", badge: "Allocation review" }
+    : copy;
+  const summary = buildDecisionSummaryFacts(decision, lease, obligationRows, delinquencySignals, allocationReviewRequired);
   return (
     <div className="lease-ledger-decision-card">
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-        <strong>{copy.label}</strong>
+        <strong>{displayCopy.label}</strong>
       </div>
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
         <span style={{ color: "#63594d", fontSize: 12, fontWeight: 800 }}>Financial signal</span>
-        <DecisionBadge severity={decision.severity} label={copy.badge} />
+        <DecisionBadge severity={allocationReviewRequired ? "warning" : decision.severity} label={displayCopy.badge} />
         <span style={{ color: "#63594d", fontSize: 12, fontWeight: 800 }}>Workflow status</span>
         <span style={{ border: "1px solid rgba(91,70,48,0.18)", background: "#fffaf1", borderRadius: 999, padding: "3px 8px", fontSize: 12, fontWeight: 800 }}>
           {decisionStatusCopy[decision.status || "detected"]}
@@ -438,7 +468,7 @@ function DecisionRow({
       <div className="lease-ledger-decision-summary">
         <div className="lease-ledger-decision-primary">
           <span>Issue</span>
-          <strong>{decision.reason}</strong>
+          <strong>{summary.displayDecision.reason}</strong>
         </div>
         <div>
           <span>Tenant</span>
@@ -520,11 +550,23 @@ function signalMatchesRow(signal: LeaseDelinquencySignal, row: LeaseObligationLe
 function DelinquencyIndicators({
   row,
   signals,
+  allocationReviewRequired = false,
 }: {
   row: LeaseObligationLedgerRow;
   signals: LeaseDelinquencySignal[];
+  allocationReviewRequired?: boolean;
 }) {
   const matchingSignals = signals.filter((signal) => signalMatchesRow(signal, row));
+  if (allocationReviewRequired && matchingSignals.length > 0) {
+    return (
+      <div style={{ display: "grid", gap: 4 }}>
+        <span style={{ color: "#854d0e", fontWeight: 800 }}>Allocation review</span>
+        <span style={{ color: "#475569", fontSize: 12 }}>
+          Payments exceed charges in aggregate, but this obligation remains unmatched.
+        </span>
+      </div>
+    );
+  }
   if (matchingSignals.length === 0) {
     const status = row.obligationStatus || "unknown";
     const copy = obligationStatusCopy[status] || obligationStatusCopy.unknown;
@@ -554,9 +596,11 @@ function DelinquencyIndicators({
 function ObligationMobileCard({
   row,
   signals,
+  allocationReviewRequired,
 }: {
   row: LeaseObligationLedgerRow;
   signals: LeaseDelinquencySignal[];
+  allocationReviewRequired: boolean;
 }) {
   return (
     <article className="lease-ledger-obligation-card">
@@ -587,7 +631,7 @@ function ObligationMobileCard({
       </div>
       <div className="lease-ledger-obligation-card-section">
         <span>Financial signal</span>
-        <DelinquencyIndicators row={row} signals={signals} />
+        <DelinquencyIndicators row={row} signals={signals} allocationReviewRequired={allocationReviewRequired} />
       </div>
       <div className="lease-ledger-obligation-card-section">
         <span>Evidence</span>
@@ -724,7 +768,7 @@ export default function LeaseLedgerPage() {
     () => totalOutstandingObligationCents(obligationRows, obligationSummary),
     [obligationRows, obligationSummary]
   );
-  const hasUnallocatedCreditNotice = totals.balanceCents < 0 && outstandingObligationCents > 0;
+  const hasUnallocatedCreditNotice = hasCreditBalanceAllocationReview(totals.balanceCents, outstandingObligationCents);
 
   const monthlyRows = useMemo(() => {
     return Object.entries(monthlyTotals).sort((a, b) => (a[0] < b[0] ? 1 : -1));
@@ -1142,6 +1186,7 @@ export default function LeaseLedgerPage() {
                   lease={lease}
                   obligationRows={obligationRows}
                   delinquencySignals={delinquencySignals}
+                  allocationReviewRequired={hasUnallocatedCreditNotice}
                   pending={decisionActionPendingId === decision.decisionId}
                   onAction={handleDecisionAction}
                   onRecordPayment={() => setShowPaymentModal(true)}
@@ -1239,7 +1284,7 @@ export default function LeaseLedgerPage() {
                       <ObligationStatusBadge status={row.obligationStatus || "unknown"} />
                     </td>
                     <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)", minWidth: 220 }}>
-                      <DelinquencyIndicators row={row} signals={delinquencySignals} />
+                      <DelinquencyIndicators row={row} signals={delinquencySignals} allocationReviewRequired={hasUnallocatedCreditNotice} />
                     </td>
                     <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)", color: "#3f382f" }}>{prettyEvidenceStatus(row)}</td>
                   </tr>
@@ -1249,7 +1294,12 @@ export default function LeaseLedgerPage() {
           </div>
           <div className="lease-ledger-obligation-cards" aria-label="Payment obligation cards">
             {obligationRows.map((row) => (
-              <ObligationMobileCard key={row.rowId} row={row} signals={delinquencySignals} />
+              <ObligationMobileCard
+                key={row.rowId}
+                row={row}
+                signals={delinquencySignals}
+                allocationReviewRequired={hasUnallocatedCreditNotice}
+              />
             ))}
           </div>
           </>


### PR DESCRIPTION
## Summary
- Relabels active payment decision inbox items as payment allocation review when the lease has an aggregate credit balance but specific obligations still show outstanding amounts.
- Keeps true positive outstanding-balance decisions on the existing overdue/missing payment path.
- Adds dashboard rendering coverage so `/dashboard` Upcoming Actions no longer shows the credit-balance allocation case as `Review Overdue Rent`.

## Audit findings
- `/dashboard` Upcoming Actions renders items from `GET /api/landlord/decision-queue?status=open_state&limit=6`.
- The decision queue normalizes `DecisionInboxItem` records from `derivePaymentConsistentDecisionInbox`.
- The ledger warning is frontend-rendered when `totals.balanceCents < 0` and `obligationSummary.outstandingAmountCents > 0`.
- The existing payment-consistency layer already suppresses fully settled stale payment decisions, but it treated aggregate-credit + unmatched-obligation cases as ordinary active delinquency decisions.
- The dashboard did not receive enough context to distinguish allocation review from true overdue rent, so the smallest safe fix is backend decision-label logic plus dashboard contract coverage.

## Implementation
- Added read-only aggregate ledger balance derivation in the landlord decision inbox route.
- When outstanding obligations remain but aggregate ledger balance is a credit, the decision item title becomes `Review payment allocation`.
- Description now explains the allocation problem: aggregate credit exists, but specific obligations remain outstanding and should be reviewed before overdue-rent action.
- No payment math, ledger records, allocation state, decision lifecycle, or ledger destination changed.

## Validation
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run test -- landlordDecisionInboxRoutes landlordDecisionQueueRoutes` passed in `rentchain-api`.
- `npm run test -- DashboardPage LeaseLedgerPage` passed in `rentchain-frontend`.
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` passed in `rentchain-api`.
- `source ~/.nvm/nvm.sh && nvm use 20.11.1 && npm run build` passed in `rentchain-frontend`.
- `git diff --check` passed.
- `git diff --cached --check` passed.

Note: backend test/build commands require Node 20.11.1 because the repo preflight rejects the shell Node v25.8.1.

## Guardrails
- No payment math changed.
- No ledger mutation added.
- No auto-allocation added.
- No collection action added.
- No legal claim added.
- No lease lifecycle mutation added.
- True positive outstanding balances remain on the existing payment review path.

## Manual QA
- Authenticated preview QA has not been run yet.
- Target route: `/dashboard`.
- Expected observed case for lease `y7XM6BFXIzWW0fV3mu1L`: dashboard action should read `Review payment allocation` and still route to `/leases/y7XM6BFXIzWW0fV3mu1L/ledger`.