### PR TITLE
polish/renewal-send-confirmation-scroll-position-v1

### DIFF
--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -15,6 +15,9 @@ const mocks = vi.hoisted(() => ({
   fetchReviewTimeline: vi.fn(),
 }));
 
+const scrollIntoViewMock = vi.fn();
+const focusMock = vi.fn();
+
 vi.mock("@/api/leasesApi", () => ({
   getLeaseById: mocks.getLeaseById,
 }));
@@ -125,6 +128,16 @@ function decisionQueueResponse(items: unknown[]) {
 
 describe("LandlordLeaseWorkflowPage", () => {
   beforeEach(() => {
+    scrollIntoViewMock.mockReset();
+    focusMock.mockReset();
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+    Object.defineProperty(HTMLElement.prototype, "focus", {
+      configurable: true,
+      value: focusMock,
+    });
     mocks.getLeaseById.mockReset();
     mocks.fetchExpiringLeaseRenewals.mockReset();
     mocks.saveLeaseRenewalInputs.mockReset();
@@ -1121,6 +1134,10 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText("Send confirmation checklist")).toHaveTextContent(
       "Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself."
     );
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+      expect(focusMock).toHaveBeenCalledWith({ preventScroll: true });
+    });
     expect(screen.getByRole("button", { name: "Send renewal email" })).toBeDisabled();
     expect(document.body).not.toHaveTextContent(/email sent|tenant notified by email provider acceptance|legal delivery/i);
   });

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -1134,8 +1134,16 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText("Send confirmation checklist")).toHaveTextContent(
       "Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself."
     );
+    expect(screen.getByRole("button", { name: "Continue to send confirmations" })).toBeInTheDocument();
     await waitFor(() => {
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+      expect(focusMock).toHaveBeenCalledWith({ preventScroll: true });
+    });
+    scrollIntoViewMock.mockClear();
+    focusMock.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Continue to send confirmations" }));
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
       expect(focusMock).toHaveBeenCalledWith({ preventScroll: true });
     });
     expect(screen.getByRole("button", { name: "Send renewal email" })).toBeDisabled();

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -1131,9 +1131,14 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Approved internally");
     expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Ready for confirmation");
     expect(screen.getByLabelText("Send-readiness checklist")).toHaveTextContent("Ready for send");
-    expect(screen.getByLabelText("Send confirmation checklist")).toHaveTextContent(
+    const sendConfirmationArea = screen.getByLabelText("Send confirmation and action area");
+    expect(within(sendConfirmationArea).getByLabelText("Send confirmation checklist")).toHaveTextContent(
       "Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself."
     );
+    expect(within(sendConfirmationArea).getByLabelText("Send renewal email action")).toHaveTextContent(
+      "The send button unlocks only after all confirmations are checked."
+    );
+    expect(within(sendConfirmationArea).getByRole("button", { name: "Send renewal email" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Continue to send confirmations" })).toBeInTheDocument();
     await waitFor(() => {
       expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
@@ -1163,12 +1168,13 @@ describe("LandlordLeaseWorkflowPage", () => {
     await screen.findByText("Future send review approved internally. Send requires the confirmation checklist.");
 
     const confirmationChecklist = screen.getByLabelText("Send confirmation checklist");
+    const sendConfirmationArea = screen.getByLabelText("Send confirmation and action area");
     expect(confirmationChecklist).toHaveTextContent("I have reviewed the recipient(s).");
     expect(confirmationChecklist).toHaveTextContent("I have reviewed the message body.");
     expect(confirmationChecklist).toHaveTextContent("I understand this sends tenant communication only.");
     expect(confirmationChecklist).toHaveTextContent("I understand this does not establish legal notice service by itself.");
 
-    const sendButton = screen.getByRole("button", { name: "Send renewal email" });
+    const sendButton = within(sendConfirmationArea).getByRole("button", { name: "Send renewal email" });
     expect(sendButton).toBeDisabled();
     fireEvent.click(screen.getByLabelText("I have reviewed the recipient(s)."));
     fireEvent.click(screen.getByLabelText("I have reviewed the message body."));

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -1183,6 +1183,8 @@ describe("LandlordLeaseWorkflowPage", () => {
     fireEvent.click(screen.getByLabelText("I understand this does not establish legal notice service by itself."));
     expect(sendButton).toBeEnabled();
 
+    scrollIntoViewMock.mockClear();
+    focusMock.mockClear();
     fireEvent.click(sendButton);
 
     await waitFor(() => {
@@ -1200,17 +1202,21 @@ describe("LandlordLeaseWorkflowPage", () => {
         })
       );
     });
-    expect(await screen.findByLabelText("Renewal email sent status")).toHaveTextContent("Renewal email sent");
-    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Delivery confirmation");
-    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Accepted for sending");
-    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent(
+    const sentStatus = await screen.findByLabelText("Renewal email sent status");
+    expect(sentStatus).toHaveTextContent("Renewal email sent");
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+      expect(focusMock).toHaveBeenCalledWith({ preventScroll: true });
+    });
+    expect(sentStatus).toHaveTextContent("Delivery confirmation");
+    expect(sentStatus).toHaveTextContent("Accepted for sending");
+    expect(sentStatus).toHaveTextContent(
       "Email was accepted for sending. Delivery confirmation beyond provider acceptance is not tracked yet."
     );
-    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("Not served; legal service not established");
-    expect(screen.getByLabelText("Renewal email sent status")).not.toHaveTextContent("Delivery status unknown");
-    expect(screen.getByLabelText("Renewal email sent status")).toHaveTextContent("rnc_test");
+    expect(sentStatus).toHaveTextContent("Not served; legal service not established");
+    expect(sentStatus).not.toHaveTextContent("Delivery status unknown");
+    expect(sentStatus).toHaveTextContent("rnc_test");
     expect(screen.getByText("rnc_test")).toHaveStyle({ overflowWrap: "anywhere" });
-    const sentStatus = screen.getByLabelText("Renewal email sent status");
     expect(within(sentStatus).getByRole("link", { name: "Open lease review timeline" })).toHaveAttribute(
       "href",
       "/review-timeline?scope=lease&scopeId=lease-1"

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1054,6 +1054,7 @@ function TenantCommunicationSendReview({
   const [decisionError, setDecisionError] = React.useState<string | null>(null);
   const [sendConfirmationFocusRequested, setSendConfirmationFocusRequested] = React.useState(false);
   const sendConfirmationActionAreaRef = React.useRef<HTMLDivElement | null>(null);
+  const sendSuccessConfirmationRef = React.useRef<HTMLElement | null>(null);
   const [confirmation, setConfirmation] = React.useState<Record<ConfirmationKey, boolean>>({
     recipientReviewed: false,
     bodyReviewed: false,
@@ -1075,6 +1076,7 @@ function TenantCommunicationSendReview({
   const sendContextKey =
     savedSnapshot && approvalDecision ? `${savedSnapshot.snapshotId}:${approvalDecision.id}:${lease.id}` : null;
   const sendSucceeded = sendState.status === "success";
+  const sentCommunicationId = sendState.status === "success" ? sendState.result.communicationId : null;
 
   const focusSendConfirmationChecklist = React.useCallback(() => {
     const actionArea = sendConfirmationActionAreaRef.current;
@@ -1084,6 +1086,18 @@ function TenantCommunicationSendReview({
       if (!currentActionArea) return;
       currentActionArea.scrollIntoView({ behavior: "smooth", block: "center" });
       currentActionArea.focus({ preventScroll: true });
+    }, 0);
+    return true;
+  }, []);
+
+  const focusSendSuccessConfirmation = React.useCallback(() => {
+    const successCard = sendSuccessConfirmationRef.current;
+    if (!successCard) return false;
+    window.setTimeout(() => {
+      const currentSuccessCard = sendSuccessConfirmationRef.current;
+      if (!currentSuccessCard) return;
+      currentSuccessCard.scrollIntoView({ behavior: "smooth", block: "center" });
+      currentSuccessCard.focus({ preventScroll: true });
     }, 0);
     return true;
   }, []);
@@ -1154,6 +1168,11 @@ function TenantCommunicationSendReview({
       setSendConfirmationFocusRequested(false);
     }
   }, [focusSendConfirmationChecklist, sendConfirmationFocusRequested, sendPrerequisitesMet, sendSucceeded]);
+
+  React.useEffect(() => {
+    if (sendState.status !== "success") return;
+    focusSendSuccessConfirmation();
+  }, [focusSendSuccessConfirmation, sendState.status, sentCommunicationId]);
 
   function setConfirmationValue(key: ConfirmationKey, value: boolean) {
     setConfirmation((current) => ({ ...current, [key]: value }));
@@ -1616,7 +1635,12 @@ function TenantCommunicationSendReview({
       </section>
 
       {sendState.status === "success" ? (
-        <section style={sentStatusStyle} aria-label="Renewal email sent status">
+        <section
+          ref={sendSuccessConfirmationRef}
+          style={sentStatusStyle}
+          aria-label="Renewal email sent status"
+          tabIndex={-1}
+        >
           <h4 style={sendReviewSubheadingStyle}>Renewal email sent</h4>
           <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 10, margin: 0 }}>
             <ReviewFact label="Sent at" value={formatTimestamp(sendState.result.sentAt || sendState.result.attemptedAt)} />

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1053,7 +1053,7 @@ function TenantCommunicationSendReview({
   const [decisionNotice, setDecisionNotice] = React.useState<string | null>(null);
   const [decisionError, setDecisionError] = React.useState<string | null>(null);
   const [sendConfirmationFocusRequested, setSendConfirmationFocusRequested] = React.useState(false);
-  const sendConfirmationChecklistRef = React.useRef<HTMLFieldSetElement | null>(null);
+  const sendConfirmationActionAreaRef = React.useRef<HTMLDivElement | null>(null);
   const [confirmation, setConfirmation] = React.useState<Record<ConfirmationKey, boolean>>({
     recipientReviewed: false,
     bodyReviewed: false,
@@ -1077,13 +1077,13 @@ function TenantCommunicationSendReview({
   const sendSucceeded = sendState.status === "success";
 
   const focusSendConfirmationChecklist = React.useCallback(() => {
-    const checklist = sendConfirmationChecklistRef.current;
-    if (!checklist) return false;
+    const actionArea = sendConfirmationActionAreaRef.current;
+    if (!actionArea) return false;
     window.setTimeout(() => {
-      const currentChecklist = sendConfirmationChecklistRef.current;
-      if (!currentChecklist) return;
-      currentChecklist.scrollIntoView({ behavior: "smooth", block: "center" });
-      currentChecklist.focus({ preventScroll: true });
+      const currentActionArea = sendConfirmationActionAreaRef.current;
+      if (!currentActionArea) return;
+      currentActionArea.scrollIntoView({ behavior: "smooth", block: "center" });
+      currentActionArea.focus({ preventScroll: true });
     }, 0);
     return true;
   }, []);
@@ -1425,49 +1425,75 @@ function TenantCommunicationSendReview({
       ) : null}
 
       {sendPrerequisitesMet && !sendSucceeded ? (
-        <fieldset
-          ref={sendConfirmationChecklistRef}
-          style={confirmationPreviewStyle}
-          aria-label="Send confirmation checklist"
+        <section
+          ref={sendConfirmationActionAreaRef}
+          style={sendConfirmationActionPanelStyle}
+          aria-label="Send confirmation and action area"
           tabIndex={-1}
         >
-          <legend style={sendReviewSubheadingStyle}>Send confirmation checklist</legend>
-          <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
-            Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself.
+          <fieldset
+            style={{ ...confirmationPreviewStyle, flex: "2 1 360px", minWidth: "min(100%, 280px)", boxSizing: "border-box" }}
+            aria-label="Send confirmation checklist"
+          >
+            <legend style={sendReviewSubheadingStyle}>Send confirmation checklist</legend>
+            <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
+              Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself.
+            </div>
+            <label style={checkboxLabelStyle}>
+              <input
+                type="checkbox"
+                checked={confirmation.recipientReviewed}
+                onChange={(event) => setConfirmationValue("recipientReviewed", event.currentTarget.checked)}
+              />{" "}
+              I have reviewed the recipient(s).
+            </label>
+            <label style={checkboxLabelStyle}>
+              <input
+                type="checkbox"
+                checked={confirmation.bodyReviewed}
+                onChange={(event) => setConfirmationValue("bodyReviewed", event.currentTarget.checked)}
+              />{" "}
+              I have reviewed the message body.
+            </label>
+            <label style={checkboxLabelStyle}>
+              <input
+                type="checkbox"
+                checked={confirmation.communicationOnly}
+                onChange={(event) => setConfirmationValue("communicationOnly", event.currentTarget.checked)}
+              />{" "}
+              I understand this sends tenant communication only.
+            </label>
+            <label style={checkboxLabelStyle}>
+              <input
+                type="checkbox"
+                checked={confirmation.legalService}
+                onChange={(event) => setConfirmationValue("legalService", event.currentTarget.checked)}
+              />{" "}
+              I understand this does not establish legal notice service by itself.
+            </label>
+          </fieldset>
+          <div style={sendActionPanelStyle} aria-label="Send renewal email action">
+            <div style={{ display: "grid", gap: 4 }}>
+              <h4 style={sendReviewSubheadingStyle}>Send renewal email</h4>
+              <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
+                The send button unlocks only after all confirmations are checked.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void sendRenewalEmail()}
+              disabled={!allConfirmationsChecked || sendState.status === "sending"}
+              style={allConfirmationsChecked ? primaryButtonStyle : sendDisabledButtonStyle}
+            >
+              {sendState.status === "sending" ? "Sending renewal email…" : "Send renewal email"}
+            </button>
+            {sendState.status === "error" ? <div style={warningPanelStyle}>{sendState.message}</div> : null}
+            <div style={deferredPanelStyle}>
+              Renewal email sends use the controlled communication endpoint only. This workflow does not create lease notice
+              records, mark notice served, establish legal service, or change lease lifecycle state.
+            </div>
           </div>
-          <label style={checkboxLabelStyle}>
-            <input
-              type="checkbox"
-              checked={confirmation.recipientReviewed}
-              onChange={(event) => setConfirmationValue("recipientReviewed", event.currentTarget.checked)}
-            />{" "}
-            I have reviewed the recipient(s).
-          </label>
-          <label style={checkboxLabelStyle}>
-            <input
-              type="checkbox"
-              checked={confirmation.bodyReviewed}
-              onChange={(event) => setConfirmationValue("bodyReviewed", event.currentTarget.checked)}
-            />{" "}
-            I have reviewed the message body.
-          </label>
-          <label style={checkboxLabelStyle}>
-            <input
-              type="checkbox"
-              checked={confirmation.communicationOnly}
-              onChange={(event) => setConfirmationValue("communicationOnly", event.currentTarget.checked)}
-            />{" "}
-            I understand this sends tenant communication only.
-          </label>
-          <label style={checkboxLabelStyle}>
-            <input
-              type="checkbox"
-              checked={confirmation.legalService}
-              onChange={(event) => setConfirmationValue("legalService", event.currentTarget.checked)}
-            />{" "}
-            I understand this does not establish legal notice service by itself.
-          </label>
-        </fieldset>
+        </section>
       ) : null}
 
       <div style={noticeStatusGridStyle} aria-label="Delivery and legal status">
@@ -1616,7 +1642,7 @@ function TenantCommunicationSendReview({
             </Link>
           </div>
         </section>
-      ) : (
+      ) : !sendPrerequisitesMet ? (
         <button
           type="button"
           onClick={() => void sendRenewalEmail()}
@@ -1625,14 +1651,16 @@ function TenantCommunicationSendReview({
         >
           {sendState.status === "sending" ? "Sending renewal email…" : "Send renewal email"}
         </button>
-      )}
+      ) : null}
 
-      {sendState.status === "error" ? <div style={warningPanelStyle}>{sendState.message}</div> : null}
+      {sendState.status === "error" && !sendPrerequisitesMet ? <div style={warningPanelStyle}>{sendState.message}</div> : null}
 
-      <div style={deferredPanelStyle}>
-        Renewal email sends use the controlled communication endpoint only. This workflow does not create lease notice
-        records, mark notice served, establish legal service, or change lease lifecycle state.
-      </div>
+      {!sendPrerequisitesMet || sendSucceeded ? (
+        <div style={deferredPanelStyle}>
+          Renewal email sends use the controlled communication endpoint only. This workflow does not create lease notice
+          records, mark notice served, establish legal service, or change lease lifecycle state.
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -2110,6 +2138,25 @@ const confirmationPreviewStyle: React.CSSProperties = {
   background: "rgba(255, 250, 241, 0.72)",
   padding: 12,
   color: workflowTheme.muted,
+};
+
+const sendConfirmationActionPanelStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 12,
+  alignItems: "stretch",
+  border: `1px solid ${workflowTheme.borderStrong}`,
+  borderRadius: 10,
+  background: workflowTheme.cardStrong,
+  padding: 12,
+};
+
+const sendActionPanelStyle: React.CSSProperties = {
+  display: "grid",
+  alignContent: "start",
+  gap: 10,
+  flex: "1 1 260px",
+  minWidth: 0,
 };
 
 const approvalDecisionStyle: React.CSSProperties = {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1076,6 +1076,18 @@ function TenantCommunicationSendReview({
     savedSnapshot && approvalDecision ? `${savedSnapshot.snapshotId}:${approvalDecision.id}:${lease.id}` : null;
   const sendSucceeded = sendState.status === "success";
 
+  const focusSendConfirmationChecklist = React.useCallback(() => {
+    const checklist = sendConfirmationChecklistRef.current;
+    if (!checklist) return false;
+    window.setTimeout(() => {
+      const currentChecklist = sendConfirmationChecklistRef.current;
+      if (!currentChecklist) return;
+      currentChecklist.scrollIntoView({ behavior: "smooth", block: "center" });
+      currentChecklist.focus({ preventScroll: true });
+    }, 0);
+    return true;
+  }, []);
+
   React.useEffect(() => {
     let active = true;
     async function loadApprovalDecision() {
@@ -1138,12 +1150,10 @@ function TenantCommunicationSendReview({
 
   React.useEffect(() => {
     if (!sendConfirmationFocusRequested || !sendPrerequisitesMet || sendSucceeded) return;
-    const checklist = sendConfirmationChecklistRef.current;
-    if (!checklist) return;
-    checklist.scrollIntoView({ behavior: "smooth", block: "start" });
-    checklist.focus({ preventScroll: true });
-    setSendConfirmationFocusRequested(false);
-  }, [sendConfirmationFocusRequested, sendPrerequisitesMet, sendSucceeded]);
+    if (focusSendConfirmationChecklist()) {
+      setSendConfirmationFocusRequested(false);
+    }
+  }, [focusSendConfirmationChecklist, sendConfirmationFocusRequested, sendPrerequisitesMet, sendSucceeded]);
 
   function setConfirmationValue(key: ConfirmationKey, value: boolean) {
     setConfirmation((current) => ({ ...current, [key]: value }));
@@ -1568,6 +1578,13 @@ function TenantCommunicationSendReview({
                 ? "Internal approval has been recorded. Send still requires explicit confirmation before tenant communication."
                 : "Approved status is required before tenant communication can be sent."}
             </div>
+            {sendPrerequisitesMet && !sendSucceeded ? (
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <button type="button" onClick={focusSendConfirmationChecklist} style={primaryButtonStyle}>
+                  Continue to send confirmations
+                </button>
+              </div>
+            ) : null}
           </div>
         ) : null}
       </section>

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1052,6 +1052,8 @@ function TenantCommunicationSendReview({
   const [decisionSubmitting, setDecisionSubmitting] = React.useState(false);
   const [decisionNotice, setDecisionNotice] = React.useState<string | null>(null);
   const [decisionError, setDecisionError] = React.useState<string | null>(null);
+  const [sendConfirmationFocusRequested, setSendConfirmationFocusRequested] = React.useState(false);
+  const sendConfirmationChecklistRef = React.useRef<HTMLFieldSetElement | null>(null);
   const [confirmation, setConfirmation] = React.useState<Record<ConfirmationKey, boolean>>({
     recipientReviewed: false,
     bodyReviewed: false,
@@ -1133,6 +1135,15 @@ function TenantCommunicationSendReview({
     });
     setSendState({ status: "idle" });
   }, [activeSendContext, approvalDecision, lease.id, savedSnapshot, sendContextKey]);
+
+  React.useEffect(() => {
+    if (!sendConfirmationFocusRequested || !sendPrerequisitesMet || sendSucceeded) return;
+    const checklist = sendConfirmationChecklistRef.current;
+    if (!checklist) return;
+    checklist.scrollIntoView({ behavior: "smooth", block: "start" });
+    checklist.focus({ preventScroll: true });
+    setSendConfirmationFocusRequested(false);
+  }, [sendConfirmationFocusRequested, sendPrerequisitesMet, sendSucceeded]);
 
   function setConfirmationValue(key: ConfirmationKey, value: boolean) {
     setConfirmation((current) => ({ ...current, [key]: value }));
@@ -1225,6 +1236,9 @@ function TenantCommunicationSendReview({
       }
       setApprovalDecision(response.item);
       setDecisionNotice(`${successLabel} Send requires the confirmation checklist.`);
+      if (action === "approve") {
+        setSendConfirmationFocusRequested(true);
+      }
     } catch (error) {
       if (String((error as Error)?.message || error).includes("decision_item_not_found")) {
         setApprovalDecision(null);
@@ -1401,7 +1415,12 @@ function TenantCommunicationSendReview({
       ) : null}
 
       {sendPrerequisitesMet && !sendSucceeded ? (
-        <fieldset style={confirmationPreviewStyle} aria-label="Send confirmation checklist">
+        <fieldset
+          ref={sendConfirmationChecklistRef}
+          style={confirmationPreviewStyle}
+          aria-label="Send confirmation checklist"
+          tabIndex={-1}
+        >
           <legend style={sendReviewSubheadingStyle}>Send confirmation checklist</legend>
           <div style={{ color: workflowTheme.subtle, lineHeight: 1.55 }}>
             Sending emails the tenant using the approved renewal draft. This does not establish legal notice service by itself.


### PR DESCRIPTION
## Summary

- Adds a focused scroll/focus handoff to the send confirmation checklist after the internal approval decision is approved.
- Keeps the existing snapshot, approval, confirmation, and send guardrails unchanged.
- Adds test coverage that approval brings the confirmation checklist into view while the send button remains disabled until confirmations are checked.

## Scope

- Frontend-only route-local polish for `/leases/:leaseId/workflows/notice`.
- No backend/API changes.
- No send behavior changes.
- No email, tenant notification, notice service, evidence, audit, legal-service, compliance, or lease lifecycle behavior changes.

## Validation

- `npm run test -- LandlordLeaseWorkflowPage` in `rentchain-frontend` with Node v20.20.2
- `npm run build` in `rentchain-frontend` with Node v20.20.2
- `git diff --check`
- `git diff --cached --check`

## Notes

- The first build attempt under the shell default Node v25.8.1 failed the repo preflight, which requires Node 20. The same build passed under Node v20.20.2.
- Tracks #1361.
