### PR TITLE
Polish ledger reviewed decision action state

### DIFF
--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -3,6 +3,101 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LeaseLedgerPage from "./LeaseLedgerPage";
 
+function buildCreditAllocationLedgerResponse(baseLedgerResponse: any, status: "reviewed" | "resolved" = "reviewed") {
+  return {
+    ...baseLedgerResponse,
+    totals: { chargesCents: 217300, paymentsCents: 1094200, balanceCents: -876900 },
+    obligationRows: [
+      {
+        rowId: "obligation-pending-credit",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        tenantId: "tenant-1",
+        dueDate: "2026-06-01T00:00:00.000Z",
+        expectedAmountCents: 200000,
+        paidAmountCents: 0,
+        currency: "cad",
+        obligationStatus: "pending",
+        evidenceStatus: "pending",
+        source: "payment_intent",
+        reasons: ["payment_pending"],
+      },
+    ],
+    obligationSummary: {
+      totalRows: 1,
+      expectedAmountCents: 200000,
+      paidAmountCents: 0,
+      outstandingAmountCents: 200000,
+      manualReviewCount: 0,
+      statusCounts: {
+        expected: 0,
+        pending: 1,
+        paid: 0,
+        underpaid: 0,
+        overpaid: 0,
+        failed: 0,
+        missing: 0,
+        manual_review_required: 0,
+        unknown: 0,
+      },
+    },
+    delinquencySignals: [
+      {
+        signalId: "delinquency:overdue:obligation-pending-credit",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        tenantId: "tenant-1",
+        dueDate: "2026-06-01T00:00:00.000Z",
+        expectedAmountCents: 200000,
+        paidAmountCents: 0,
+        outstandingAmountCents: 200000,
+        signalType: "overdue",
+        severity: "critical",
+        detectedAt: "2026-07-02T00:00:00.000Z",
+        reasons: ["obligation_pending_after_due_date"],
+      },
+    ],
+    delinquencySummary: {
+      totalSignals: 1,
+      overdueCount: 1,
+      partiallyPaidCount: 0,
+      failedCount: 0,
+      missingCount: 0,
+      manualReviewCount: 0,
+      totalOutstandingCents: 200000,
+    },
+    decisions: [
+      {
+        decisionId: "decision-reviewed-overdue",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        tenantId: "tenant-1",
+        decisionType: "review_overdue_rent",
+        severity: "critical",
+        status,
+        reason: "Rent obligation is overdue.",
+        metadata: {
+          signalId: "delinquency:overdue:obligation-pending-credit",
+          signalType: "overdue",
+          outstandingAmountCents: 200000,
+          obligationStatus: "pending",
+        },
+        latestAction: {
+          actionId: `action-${status}`,
+          decisionId: "decision-reviewed-overdue",
+          actionType: status,
+          previousStatus: status === "resolved" ? "reviewed" : "detected",
+          nextStatus: status,
+          createdAt: "2026-07-02T12:00:00.000Z",
+        },
+      },
+    ],
+  };
+}
+
 const mocks = vi.hoisted(() => ({
   fetchLeaseLedger: vi.fn(),
   addLeaseCharge: vi.fn(),
@@ -510,98 +605,7 @@ describe("LeaseLedgerPage", () => {
   it("explains aggregate credit balances when specific obligations remain outstanding", async () => {
     const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
     mocks.fetchLeaseLedger.mockClear();
-    mocks.fetchLeaseLedger.mockResolvedValueOnce({
-      ...baseLedgerResponse,
-      totals: { chargesCents: 217300, paymentsCents: 1094200, balanceCents: -876900 },
-      obligationRows: [
-        {
-          rowId: "obligation-pending-credit",
-          leaseId: "lease-1",
-          propertyId: "prop-1",
-          unitId: "unit-1",
-          tenantId: "tenant-1",
-          dueDate: "2026-06-01T00:00:00.000Z",
-          expectedAmountCents: 200000,
-          paidAmountCents: 0,
-          currency: "cad",
-          obligationStatus: "pending",
-          evidenceStatus: "pending",
-          source: "payment_intent",
-          reasons: ["payment_pending"],
-        },
-      ],
-      obligationSummary: {
-        totalRows: 1,
-        expectedAmountCents: 200000,
-        paidAmountCents: 0,
-        outstandingAmountCents: 200000,
-        manualReviewCount: 0,
-        statusCounts: {
-          expected: 0,
-          pending: 1,
-          paid: 0,
-          underpaid: 0,
-          overpaid: 0,
-          failed: 0,
-          missing: 0,
-          manual_review_required: 0,
-          unknown: 0,
-        },
-      },
-      delinquencySignals: [
-        {
-          signalId: "delinquency:overdue:obligation-pending-credit",
-          leaseId: "lease-1",
-          propertyId: "prop-1",
-          unitId: "unit-1",
-          tenantId: "tenant-1",
-          dueDate: "2026-06-01T00:00:00.000Z",
-          expectedAmountCents: 200000,
-          paidAmountCents: 0,
-          outstandingAmountCents: 200000,
-          signalType: "overdue",
-          severity: "critical",
-          detectedAt: "2026-07-02T00:00:00.000Z",
-          reasons: ["obligation_pending_after_due_date"],
-        },
-      ],
-      delinquencySummary: {
-        totalSignals: 1,
-        overdueCount: 1,
-        partiallyPaidCount: 0,
-        failedCount: 0,
-        missingCount: 0,
-        manualReviewCount: 0,
-        totalOutstandingCents: 200000,
-      },
-      decisions: [
-        {
-          decisionId: "decision-reviewed-overdue",
-          leaseId: "lease-1",
-          propertyId: "prop-1",
-          unitId: "unit-1",
-          tenantId: "tenant-1",
-          decisionType: "review_overdue_rent",
-          severity: "critical",
-          status: "reviewed",
-          reason: "Rent obligation is overdue.",
-          metadata: {
-            signalId: "delinquency:overdue:obligation-pending-credit",
-            signalType: "overdue",
-            outstandingAmountCents: 200000,
-            obligationStatus: "pending",
-          },
-          latestAction: {
-            actionId: "action-reviewed",
-            decisionId: "decision-reviewed-overdue",
-            actionType: "reviewed",
-            previousStatus: "detected",
-            nextStatus: "reviewed",
-            createdAt: "2026-07-02T12:00:00.000Z",
-          },
-        },
-      ],
-    });
+    mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
 
     render(
       <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
@@ -619,12 +623,42 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText("Allocation review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Payments exceed charges in aggregate, but one or more obligations remain unmatched.").length).toBeGreaterThan(0);
     expect(screen.getByText("Review and allocate unmatched payments before taking any overdue-rent action.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
+    expect(screen.queryByText("Review / resolve")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Mark reviewed:/ })).not.toBeInTheDocument();
     expect(screen.getAllByText("Payments exceed charges in aggregate, but this obligation remains unmatched.").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
     expect(screen.getByText(/reviewed or resolved status does not mark rent paid/i)).toBeInTheDocument();
     expect(screen.queryByText("Overdue Rent")).not.toBeInTheDocument();
     expect(screen.queryByText("Rent obligation is overdue.")).not.toBeInTheDocument();
     expect(screen.queryByText("Record payment or contact the tenant, then resolve once the ledger is updated.")).not.toBeInTheDocument();
+  });
+
+  it("renders resolved allocation-review decisions as passive workflow state", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "resolved"));
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Credit balance needs allocation review")).toBeInTheDocument();
+    expect(screen.getByText("Review payment allocation")).toBeInTheDocument();
+    expect(screen.getAllByText("Allocation review").length).toBeGreaterThan(0);
+    expect(screen.getByText("Review and allocate unmatched payments before taking any overdue-rent action.")).toBeInTheDocument();
+    expect(screen.getAllByText("Already resolved").length).toBeGreaterThan(0);
+    expect(screen.getByText("Last action: Resolved")).toBeInTheDocument();
+    expect(screen.queryByText("Review / resolve")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Resolve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Mark reviewed:/ })).not.toBeInTheDocument();
+    expect(mocks.patchDecisionAction).not.toHaveBeenCalled();
+    expect(screen.queryByText("Overdue Rent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rent obligation is overdue.")).not.toBeInTheDocument();
   });
 
   it("keeps the payment CSV import collapsed until the landlord opens it", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -39,6 +39,7 @@ import {
   type DecisionActionType,
   type DecisionItem,
   type DecisionSeverity,
+  type DecisionStatus,
 } from "@/lib/decisions/decisionDisplay";
 import { findRelatedDelinquencySignal, findRelatedObligationRow } from "@/lib/decisions/decisionContext";
 import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
@@ -210,17 +211,46 @@ function DecisionBadge({ severity, label }: { severity: DecisionSeverity; label:
   );
 }
 
+function statusForDecisionAction(actionType: DecisionActionType): DecisionStatus {
+  if (actionType === "reviewed") return "reviewed";
+  if (actionType === "snoozed") return "snoozed";
+  if (actionType === "assigned") return "assigned";
+  if (actionType === "dismissed") return "dismissed";
+  return "resolved";
+}
+
+function currentDecisionStatus(decision: DecisionItem): DecisionStatus {
+  return decision.status || "detected";
+}
+
+function decisionActionChangesStatus(decision: DecisionItem, actionType: DecisionActionType): boolean {
+  return statusForDecisionAction(actionType) !== currentDecisionStatus(decision);
+}
+
+function isTerminalDecisionStatus(status: DecisionStatus): boolean {
+  return status === "resolved" || status === "dismissed";
+}
+
+function decisionPassiveLabel(decision: DecisionItem): string {
+  const status = currentDecisionStatus(decision);
+  if (status === "resolved") return "Already resolved";
+  if (status === "dismissed") return "Dismissed";
+  return decisionStatusCopy[status];
+}
+
+function DecisionWorkflowPassiveState({ decision }: { decision: DecisionItem }) {
+  return (
+    <div style={{ border: "1px solid rgba(91,70,48,0.16)", background: "#fffaf1", borderRadius: 10, padding: "8px 10px", color: "#3f382f" }}>
+      <strong>{decisionPassiveLabel(decision)}</strong>
+      <div style={{ color: "#63594d", fontSize: 12, marginTop: 2 }}>
+        No state-changing decision action is currently available.
+      </div>
+    </div>
+  );
+}
+
 function decisionWithStatus(decision: DecisionItem, actionType: DecisionActionType): DecisionItem {
-  const nextStatus =
-    actionType === "reviewed"
-      ? "reviewed"
-      : actionType === "snoozed"
-      ? "snoozed"
-      : actionType === "assigned"
-      ? "assigned"
-      : actionType === "dismissed"
-      ? "dismissed"
-      : "resolved";
+  const nextStatus = statusForDecisionAction(actionType);
   return {
     ...decision,
     status: nextStatus,
@@ -239,10 +269,12 @@ function DecisionActionControls({
   decision,
   pending,
   onAction,
+  primaryActionType,
 }: {
   decision: DecisionItem;
   pending: boolean;
   onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
+  primaryActionType?: DecisionActionType | null;
 }) {
   const actions: Array<{ actionType: DecisionActionType; label: string; description: string }> = [
     {
@@ -271,9 +303,15 @@ function DecisionActionControls({
       description: "Marks the operational review task as resolved. Does not automatically modify balances or obligations.",
     },
   ];
+  const status = currentDecisionStatus(decision);
+  if (isTerminalDecisionStatus(status)) return null;
+  const availableActions = actions.filter(
+    (action) => action.actionType !== primaryActionType && decisionActionChangesStatus(decision, action.actionType)
+  );
+  if (availableActions.length === 0) return <DecisionWorkflowPassiveState decision={decision} />;
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-      {actions.map((action) => (
+      {availableActions.map((action) => (
         <button
           key={action.actionType}
           type="button"
@@ -452,6 +490,9 @@ function DecisionRow({
     ? { label: "Review payment allocation", badge: "Allocation review" }
     : copy;
   const summary = buildDecisionSummaryFacts(decision, lease, obligationRows, delinquencySignals, allocationReviewRequired);
+  const currentStatus = currentDecisionStatus(decision);
+  const hasTerminalStatus = isTerminalDecisionStatus(currentStatus);
+  const primaryActionType = summary.recommendedAction.cta === "resolve" && !hasTerminalStatus ? "resolved" : null;
   return (
     <div className="lease-ledger-decision-card">
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
@@ -496,13 +537,15 @@ function DecisionRow({
           <span>Recommended next action</span>
           <strong>{summary.recommendedAction.label}</strong>
         </div>
-        {summary.recommendedAction.cta === "record_payment" ? (
+        {hasTerminalStatus ? (
+          <DecisionWorkflowPassiveState decision={decision} />
+        ) : summary.recommendedAction.cta === "record_payment" ? (
           <button type="button" onClick={onRecordPayment} title={summary.recommendedAction.helper}>
             Record payment
           </button>
         ) : (
           <button type="button" disabled={pending} onClick={() => onAction(decision, "resolved")} title={summary.recommendedAction.helper}>
-            {pending ? "Saving..." : "Review / resolve"}
+            {pending ? "Saving..." : "Resolve"}
           </button>
         )}
       </div>
@@ -515,7 +558,7 @@ function DecisionRow({
         delinquencySignals={delinquencySignals}
         internalEvidenceMode="advanced"
       />
-      <DecisionActionControls decision={decision} pending={pending} onAction={onAction} />
+      <DecisionActionControls decision={decision} pending={pending} onAction={onAction} primaryActionType={primaryActionType} />
     </div>
   );
 }
@@ -798,6 +841,7 @@ export default function LeaseLedgerPage() {
 
   const handleDecisionAction = async (decision: DecisionItem, actionType: DecisionActionType) => {
     if (!leaseId) return;
+    if (!decisionActionChangesStatus(decision, actionType)) return;
     setDecisionActionPendingId(decision.decisionId);
     const snoozedUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
     try {


### PR DESCRIPTION
## Summary
- Updates the lease ledger decision card so terminal decisions render passive workflow state instead of active no-op decision CTAs.
- Changes the reviewed allocation-review path to show a clear `Resolve` action only when it can change status.
- Keeps PR #1364 allocation-safe credit-balance wording intact for aggregate-credit + unmatched-obligation cases.

## Audit Findings
- `LeaseLedgerPage` rendered the primary `Review / resolve` CTA without checking the decision workflow status.
- The lower decision action row also rendered all actions unconditionally, so already reviewed/resolved decisions could expose no-op buttons.
- The existing PATCH response handling can return `previousStatus === nextStatus`; a frontend-only guard is sufficient because the UI already receives decision status.
- No backend decision contract or payment math change was needed.

## Implementation
- Added local status helpers for decision action target status and no-op detection.
- Suppressed terminal-state controls for `resolved` and `dismissed` decisions and rendered passive state such as `Already resolved`.
- Filtered action buttons that would not change the current status, such as `Mark reviewed` on reviewed cards.
- Added a handler guard to avoid sending no-op PATCH requests if a stale UI event reaches the action handler.
- Updated ledger tests for reviewed and resolved allocation-review decisions.

## Validation
- `npm run test -- LeaseLedgerPage` passed under Node v20.20.2.
- `npm run build` passed under Node v20.20.2.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Guardrails
- Frontend-only change.
- No payment math changed.
- No ledger records mutated.
- No auto-allocation added.
- No collection action added.
- No legal claim added.
- No lifecycle mutation added.

Manual authenticated QA remains pending on `/leases/y7XM6BFXIzWW0fV3mu1L/ledger`.