### PR TITLE
Polish ledger print evidence signal reason copy

### DIFF
--- a/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
@@ -100,4 +100,29 @@ describe("decisionContext", () => {
     );
     expect(items.map((item) => item.value)).not.toContain("undefined");
   });
+
+  it("formats signal reasons as operator-readable evidence copy", () => {
+    const items = buildDecisionEvidenceItems(decision, {
+      delinquencySignals: [
+        {
+          signalId: "signal-1",
+          leaseId: "lease-1",
+          paymentIntentId: "pi-1",
+          propertyId: "property-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 0,
+          outstandingAmountCents: 145000,
+          signalType: "overdue",
+          severity: "critical",
+          detectedAt: "2026-05-05T12:00:00.000Z",
+          reasons: ["obligation_pending_after_due_date"],
+        },
+      ],
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([{ label: "Signal reason", value: "Obligation remains unmatched after due date" }])
+    );
+    expect(items.map((item) => item.value)).not.toContain("obligation_pending_after_due_date");
+  });
 });

--- a/rentchain-frontend/src/lib/decisions/decisionContext.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.ts
@@ -62,6 +62,26 @@ function titleCase(value: unknown): string {
   return text.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+const signalReasonDisplayCopy: Record<string, string> = {
+  aggregate_credit_balance_with_unmatched_obligations: "Aggregate credit balance with unmatched obligations",
+  manual_review_required: "Manual review required",
+  obligation_pending_after_due_date: "Obligation remains unmatched after due date",
+  provider_received: "Provider received payment evidence",
+  rent_payment_checkout_created: "Provider checkout was created",
+};
+
+export function formatSignalReason(value: unknown): string {
+  const reason = cleanString(value);
+  if (!reason) return "Not specified";
+  return signalReasonDisplayCopy[reason] || titleCase(reason);
+}
+
+function formatSignalReasons(values: unknown[] | null | undefined): string | null {
+  if (!values?.length) return null;
+  const labels = values.map((reason) => formatSignalReason(reason)).filter((reason) => reason !== "Not specified");
+  return labels.length ? labels.join(", ") : null;
+}
+
 function datesMatch(a: unknown, b: unknown): boolean {
   const left = cleanString(a);
   const right = cleanString(b);
@@ -177,12 +197,13 @@ export function buildDecisionEvidenceItems(
     (relatedRow
       ? Math.max(0, Number(relatedRow.expectedAmountCents || 0) - Number(relatedRow.paidAmountCents || 0))
       : null);
-  const signalType = relatedSignal?.signalType || metadataString(decision, "signalType");
-  const signalReasons = relatedSignal?.reasons?.length
-    ? relatedSignal.reasons.join(", ")
+  const signalType = metadataString(decision, "signalType") || relatedSignal?.signalType;
+  const signalReasonValues = relatedSignal?.reasons?.length
+    ? relatedSignal.reasons
     : Array.isArray(decision.metadata?.signalReasons)
-    ? (decision.metadata.signalReasons as unknown[]).map((reason) => String(reason)).join(", ")
+    ? (decision.metadata.signalReasons as unknown[])
     : null;
+  const signalReasons = formatSignalReasons(signalReasonValues);
   const lifecycleState = metadataString(decision, "lifecycleState");
   const lifecycleReasons = Array.isArray(decision.metadata?.lifecycleReasons)
     ? (decision.metadata.lifecycleReasons as unknown[]).map((reason) => String(reason)).join(", ")

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -627,6 +627,8 @@ describe("LeaseLedgerPage", () => {
     expect(screen.queryByText("Review / resolve")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Mark reviewed:/ })).not.toBeInTheDocument();
     expect(screen.getAllByText("Payments exceed charges in aggregate, but this obligation remains unmatched.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Obligation remains unmatched after due date")).toBeInTheDocument();
+    expect(screen.queryByText("obligation_pending_after_due_date")).not.toBeInTheDocument();
     expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
     expect(screen.getByText(/reviewed or resolved status does not mark rent paid/i)).toBeInTheDocument();
     expect(screen.queryByText("Overdue Rent")).not.toBeInTheDocument();
@@ -699,11 +701,12 @@ describe("LeaseLedgerPage", () => {
     expect(await screen.findByText("$4,250.00")).toBeInTheDocument();
     expect(screen.queryByText("425000")).not.toBeInTheDocument();
 
-    expect(screen.getAllByText("Overdue — Rent past due date (obligation missing after due date)").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Missing — No rent payment found after due date (missing rent payment after due date)").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Underpaid — Partial payment received (obligation partially paid)").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Failed — Payment did not complete (obligation payment failed)").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Manual review required — Payment mismatch or incomplete evidence (obligation requires manual review)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Overdue — Rent past due date (Obligation Missing After Due Date)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Missing — No rent payment found after due date (Missing Rent Payment After Due Date)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Underpaid — Partial payment received (Obligation Partially Paid)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Failed — Payment did not complete (Obligation Payment Failed)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual review required — Payment mismatch or incomplete evidence (Obligation Requires Manual Review)").length).toBeGreaterThan(0);
+    expect(screen.queryByText("obligation missing after due date")).not.toBeInTheDocument();
   });
 
   it("renders read-only lease decisions derived from delinquency signals", async () => {
@@ -924,6 +927,37 @@ describe("LeaseLedgerPage", () => {
     );
     expect(document.querySelector('[data-print-root="true"].lease-ledger-print-root')).not.toBeInTheDocument();
     expect(document.body.hasAttribute("data-print-root-active")).toBe(false);
+    printSpy.mockRestore();
+  });
+
+  it("prints allocation-review signal reasons as readable evidence copy", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "resolved"));
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {
+      const printRoot = document.querySelector('[data-print-root="true"].lease-ledger-print-root');
+      const printText = printRoot?.textContent || "";
+      expect(printText).toContain("Review payment allocation");
+      expect(printText).toContain("Allocation review");
+      expect(printText).toContain("Payments exceed charges in aggregate, but one or more obligations remain unmatched.");
+      expect(printText).toContain("Review and allocate unmatched payments before taking any overdue-rent action.");
+      expect(printText).toContain("Signal reason: Obligation remains unmatched after due date");
+      expect(printText).not.toContain("obligation_pending_after_due_date");
+      window.dispatchEvent(new Event("afterprint"));
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Review payment allocation");
+    fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
+
+    await waitFor(() => expect(printSpy).toHaveBeenCalled());
     printSpy.mockRestore();
   });
 

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -41,7 +41,7 @@ import {
   type DecisionSeverity,
   type DecisionStatus,
 } from "@/lib/decisions/decisionDisplay";
-import { findRelatedDelinquencySignal, findRelatedObligationRow } from "@/lib/decisions/decisionContext";
+import { findRelatedDelinquencySignal, findRelatedObligationRow, formatSignalReason } from "@/lib/decisions/decisionContext";
 import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
 import { PaymentCsvImportPreviewCard } from "@/components/ledger/PaymentCsvImportPreviewCard";
 import "./LeaseLedgerPage.css";
@@ -582,8 +582,8 @@ function DecisionRow({
 
 function reasonTextFromSignal(signal: LeaseDelinquencySignal): string {
   const copy = delinquencySignalCopy[signal.signalType];
-  const reason = (signal.reasons || [])[0]?.replace(/_/g, " ");
-  return `${copy.label} — ${copy.reason}${reason ? ` (${reason})` : ""}`;
+  const reason = (signal.reasons || [])[0];
+  return `${copy.label} — ${copy.reason}${reason ? ` (${formatSignalReason(reason)})` : ""}`;
 }
 
 function comparableDate(value: string | null | undefined): string | null {
@@ -773,6 +773,22 @@ function printFinancialSignalText(
     return `${copy.label} — ${obligationFallbackReason[status] || obligationFallbackReason.unknown}`;
   }
   return matchingSignals.map((signal) => reasonTextFromSignal(signal)).join("; ");
+}
+
+function printSignalReasonText(row: LeaseObligationLedgerRow, signals: LeaseDelinquencySignal[]): string | null {
+  const labels = signals
+    .filter((signal) => signalMatchesRow(signal, row))
+    .flatMap((signal) => signal.reasons || [])
+    .map((reason) => formatSignalReason(reason))
+    .filter((reason) => reason !== "Not specified");
+  const uniqueLabels = Array.from(new Set(labels));
+  return uniqueLabels.length ? uniqueLabels.join("; ") : null;
+}
+
+function printEvidenceText(row: LeaseObligationLedgerRow, signals: LeaseDelinquencySignal[]): string {
+  const signalReason = printSignalReasonText(row, signals);
+  const evidence = prettyEvidenceStatus(row);
+  return signalReason ? `${evidence}. Signal reason: ${signalReason}` : evidence;
 }
 
 function printLedgerEntryDescription(entry: LeaseLedgerEntry): string {
@@ -1033,7 +1049,7 @@ function LeaseLedgerPrintExport({
               </div>
               <div className="lease-ledger-print-obligation-card-wide">
                 <span>Evidence</span>
-                <strong>{prettyEvidenceStatus(singleObligationRow)}</strong>
+                <strong>{printEvidenceText(singleObligationRow, delinquencySignals)}</strong>
               </div>
             </article>
           ) : (
@@ -1061,7 +1077,7 @@ function LeaseLedgerPrintExport({
                       <td>{formatCurrencyCents(obligationOutstandingCents(row))}</td>
                       <td>{obligationStatusCopy[row.obligationStatus || "unknown"]?.label || obligationStatusCopy.unknown.label}</td>
                       <td>{printFinancialSignalText(row, delinquencySignals, hasUnallocatedCreditNotice)}</td>
-                      <td>{prettyEvidenceStatus(row)}</td>
+                      <td>{printEvidenceText(row, delinquencySignals)}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary
- Formats ledger decision signal reasons with operator-facing copy instead of raw internal reason codes.
- Adds the mapped signal reason to ledger print/PDF evidence text for matched obligation signals.
- Preserves allocation-safe decision summary and recommended next-action wording for aggregate-credit allocation review cases.

## Validation
- `npm run test -- LeaseLedgerPage` under Node v20.20.2
- `npm run test -- decisionContext` under Node v20.20.2
- `npm run build` under Node v20.20.2
- `git diff --check`
- `git diff --cached --check`

## Safety
- Frontend display-copy only.
- No backend/API changes.
- No payment math changes.
- No ledger mutation or auto-allocation.
- No collection action, legal claim, or lifecycle mutation added.