### PR TITLE
feat: add lease credit allocation API

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -160,6 +160,7 @@ import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScore
 import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordDecisionQueueRoutes from "./routes/landlordDecisionQueueRoutes";
+import landlordLeaseCreditAllocationRoutes from "./routes/landlordLeaseCreditAllocationRoutes";
 import delegatedAccessInvitationRoutes, { delegatedAccessSelfRoutes } from "./routes/delegatedAccessInvitationRoutes";
 import propertyManagerCompanyRelationshipRoutes, {
   propertyManagerCompanyRoutes,
@@ -528,6 +529,8 @@ app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlord
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordDecisionQueueRoutes.ts"), landlordDecisionQueueRoutes);
 console.log("[route-mount] landlordDecisionQueueRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordLeaseCreditAllocationRoutes.ts"), landlordLeaseCreditAllocationRoutes);
+console.log("[route-mount] landlordLeaseCreditAllocationRoutes mounted at /api/landlord");
 app.use("/api/delegated-access", routeSource("delegatedAccessInvitationRoutes.ts:self"), delegatedAccessSelfRoutes);
 console.log("[route-mount] delegatedAccessSelfRoutes mounted at /api/delegated-access");
 app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), delegatedAccessInvitationRoutes);

--- a/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
+++ b/rentchain-api/src/routes/__tests__/apiRouteOwnershipRegression.test.ts
@@ -424,6 +424,9 @@ describe("API route ownership regression", () => {
       'app.use("/api/landlord/leases", routeSource("leaseNoticeLandlordRoutes.ts"), leaseNoticeLandlordRoutes)'
     );
     const landlordInboxMount = source.indexOf('app.use("/api/landlord", routeSource("landlordInboxRoutes.ts"), landlordInboxRoutes)');
+    const landlordCreditAllocationMount = source.indexOf(
+      'app.use("/api/landlord", routeSource("landlordLeaseCreditAllocationRoutes.ts"), landlordLeaseCreditAllocationRoutes)'
+    );
     const delegatedAccessLandlordMount = source.indexOf(
       'app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), delegatedAccessInvitationRoutes)'
     );
@@ -454,6 +457,7 @@ describe("API route ownership regression", () => {
     expect(evidencePackageMount).toBeGreaterThan(-1);
     expect(leaseNoticeLandlordMount).toBeGreaterThan(-1);
     expect(landlordInboxMount).toBeGreaterThan(-1);
+    expect(landlordCreditAllocationMount).toBeGreaterThan(-1);
     expect(delegatedAccessLandlordMount).toBeGreaterThan(-1);
     expect(landlordActivationMount).toBeGreaterThan(-1);
     expect(statusMount).toBeGreaterThan(-1);
@@ -488,6 +492,9 @@ describe("API route ownership regression", () => {
     expect(leaseNoticeLandlordMount).toBeLessThan(landlordActivationMount);
     expect(leaseNoticeLandlordMount).toBeLessThan(screeningJobsMount);
     expect(leaseNoticeLandlordMount).toBeLessThan(apiCatchall);
+    expect(landlordCreditAllocationMount).toBeLessThan(delegatedAccessLandlordMount);
+    expect(landlordCreditAllocationMount).toBeLessThan(screeningJobsMount);
+    expect(landlordCreditAllocationMount).toBeLessThan(apiCatchall);
     expect(buildProbeRoute).toBeLessThan(riskAgentMount);
     expect(tenantPortalMount).toBeLessThan(referralsMount);
     expect(tenantPortalMount).toBeLessThan(screeningJobsMount);

--- a/rentchain-api/src/routes/__tests__/landlordLeaseCreditAllocationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordLeaseCreditAllocationRoutes.test.ts
@@ -303,11 +303,71 @@ describe("landlordLeaseCreditAllocationRoutes", () => {
         obligationRowId: obligation.obligationRowId,
         allocationAmountCents: 200000,
         previewFingerprint: "stale",
+        idempotencyKey: "stale-fingerprint",
       },
     });
 
     expect(res.status).toBe(409);
     expect(res.body.error).toBe("CREDIT_ALLOCATION_STATE_STALE");
+  });
+
+  it("requires obligationRowId for apply requests", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        allocationAmountCents: 200000,
+        previewFingerprint: preview.body.previewFingerprint,
+        idempotencyKey: "missing-obligation",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_OBLIGATION_NOT_ELIGIBLE");
+  });
+
+  it("requires allocationAmountCents for apply requests", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+    const obligation = preview.body.eligibleObligations[0];
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: obligation.obligationRowId,
+        previewFingerprint: preview.body.previewFingerprint,
+        idempotencyKey: "missing-amount",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_AMOUNT_INVALID");
+  });
+
+  it("requires idempotencyKey for apply requests", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+    const obligation = preview.body.eligibleObligations[0];
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: obligation.obligationRowId,
+        allocationAmountCents: 200000,
+        previewFingerprint: preview.body.previewFingerprint,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_IDEMPOTENCY_KEY_REQUIRED");
   });
 
   it("rejects amounts exceeding available credit", async () => {
@@ -323,6 +383,7 @@ describe("landlordLeaseCreditAllocationRoutes", () => {
         obligationRowId: obligation.obligationRowId,
         allocationAmountCents: 150000,
         previewFingerprint: preview.body.previewFingerprint,
+        idempotencyKey: "exceeds-credit",
       },
     });
 
@@ -343,6 +404,7 @@ describe("landlordLeaseCreditAllocationRoutes", () => {
         obligationRowId: obligation.obligationRowId,
         allocationAmountCents: 200001,
         previewFingerprint: preview.body.previewFingerprint,
+        idempotencyKey: "exceeds-outstanding",
       },
     });
 
@@ -362,6 +424,7 @@ describe("landlordLeaseCreditAllocationRoutes", () => {
         obligationRowId: "not-this-lease",
         allocationAmountCents: 200000,
         previewFingerprint: preview.body.previewFingerprint,
+        idempotencyKey: "invalid-obligation",
       },
     });
 

--- a/rentchain-api/src/routes/__tests__/landlordLeaseCreditAllocationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordLeaseCreditAllocationRoutes.test.ts
@@ -1,0 +1,483 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let idSeq = 0;
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      if (op === "array-contains") return Array.isArray(actual) && actual.includes(value);
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      orderBy: () => makeQuery(name, filters),
+      limit: () => makeQuery(name, filters),
+      get: async () => {
+        const col = ensureCollection(name);
+        const docs = Array.from(col.values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, forEach: (fn: any) => docs.forEach(fn), size: docs.length };
+      },
+      doc: (id?: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id?: string) {
+    const actualId = id || `doc_${++idSeq}`;
+    const col = ensureCollection(name);
+    return {
+      id: actualId,
+      create: async (value: any) => {
+        if (col.has(actualId)) throw new Error("already exists");
+        col.set(actualId, { id: actualId, data: value });
+      },
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = col.get(actualId)?.data || {};
+        col.set(actualId, { id: actualId, data: options?.merge ? { ...current, ...value } : value });
+      },
+      get: async () => {
+        const entry = col.get(actualId);
+        return { id: actualId, exists: Boolean(entry), data: () => entry?.data };
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => {
+      store.clear();
+      idSeq = 0;
+    },
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
+    listDocs: (name: string) => Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, data: doc.data })),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        orderBy: () => makeQuery(name),
+        limit: () => makeQuery(name),
+        get: async () => makeQuery(name).get(),
+        doc: (id?: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+  FieldValue: { serverTimestamp: () => "SERVER_TIMESTAMP" },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user ||= { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "ll@example.com" };
+    next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const header = String(req.headers?.["x-test-user"] || "").trim();
+    req.user = header
+      ? JSON.parse(header)
+      : { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "ll@example.com" };
+    if (req.user.role !== "landlord" && req.user.role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    req.user.landlordId = req.user.landlordId || req.user.id;
+    next();
+  },
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, any> }>((resolve, reject) => {
+    const headers: Record<string, any> = {};
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+    };
+    const res: any = {
+      statusCode: 200,
+      setHeader: (key: string, value: any) => {
+        headers[key.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+      else resolve({ status: 404, body: { ok: false, error: "not_found" }, headers });
+    });
+  });
+}
+
+function seedLease(overrides: Record<string, any> = {}) {
+  seedDoc("leases", overrides.id || "lease-1", {
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    primaryTenantId: "tenant-1",
+    monthlyRent: 2000,
+    startDate: "2026-06-01",
+    endDate: "2027-05-31",
+    status: "active",
+    dueDay: 1,
+    ...overrides,
+  });
+}
+
+function seedBaileyCredit(overrides: Record<string, any> = {}) {
+  seedLease(overrides.lease || {});
+  seedDoc("ledgerEntries", overrides.ledgerId || "credit-adjustment-1", {
+    landlordId: "landlord-1",
+    leaseId: "lease-1",
+    entryType: "adjustment",
+    amountCents: -876900,
+    effectiveDate: "2026-06-15",
+    createdAt: "2026-06-15T00:00:00.000Z",
+    ...overrides.ledger,
+  });
+}
+
+async function loadPreview(router: any) {
+  return invokeRouter(router, { method: "GET", url: "/leases/lease-1/credit-allocation-preview" });
+}
+
+async function applyFirstSuggestion(router: any, overrides: Record<string, any> = {}) {
+  const preview = await loadPreview(router);
+  const obligation = preview.body.eligibleObligations[0];
+  return invokeRouter(router, {
+    method: "POST",
+    url: "/leases/lease-1/credit-allocations",
+    body: {
+      obligationRowId: obligation.obligationRowId,
+      allocationAmountCents: obligation.suggestedAllocationAmountCents,
+      previewFingerprint: preview.body.previewFingerprint,
+      idempotencyKey: "idem-1",
+      ...overrides,
+    },
+  });
+}
+
+describe("landlordLeaseCreditAllocationRoutes", () => {
+  beforeEach(() => {
+    resetFakeDb();
+  });
+
+  it("returns the Bailey-style credit allocation preview", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+
+    const res = await loadPreview(router);
+
+    expect(res.status).toBe(200);
+    expect(res.body.availableCreditCents).toBe(876900);
+    expect(res.body.eligibleObligations[0]).toEqual(
+      expect.objectContaining({
+        outstandingAmountCents: 200000,
+        suggestedAllocationAmountCents: 200000,
+        obligationOutstandingAfterCents: 0,
+      })
+    );
+    expect(res.body.suggestedAllocations[0]).toEqual(
+      expect.objectContaining({
+        allocationAmountCents: 200000,
+        afterAvailableCreditCents: 676900,
+      })
+    );
+    expect(res.body.noLegalOrLifecycleEffect).toBe(true);
+  });
+
+  it("returns blocked preview when there is no available credit", async () => {
+    seedLease();
+    seedDoc("ledgerEntries", "charge-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      entryType: "charge",
+      amountCents: 200000,
+      effectiveDate: "2026-06-01",
+    });
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+
+    const res = await loadPreview(router);
+
+    expect(res.status).toBe(200);
+    expect(res.body.allowed).toBe(false);
+    expect(res.body.availableCreditCents).toBe(0);
+    expect(res.body.blockedReasons).toContain("aggregate_balance_is_not_credit");
+  });
+
+  it("returns blocked preview when there is credit but no outstanding obligation", async () => {
+    seedBaileyCredit();
+    seedDoc("payments", "payment-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      amountCents: 200000,
+      status: "recorded",
+      effectiveDate: "2026-06-01",
+    });
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+
+    const res = await loadPreview(router);
+
+    expect(res.status).toBe(200);
+    expect(res.body.allowed).toBe(false);
+    expect(res.body.eligibleObligations).toEqual([]);
+    expect(res.body.blockedReasons).toContain("no_outstanding_obligations");
+  });
+
+  it("applies an allocation append-safely without mutating ledger, payments, or reconciliation records", async () => {
+    seedBaileyCredit();
+    seedDoc("payments", "unrelated-payment", { landlordId: "landlord-1", leaseId: "other-lease", amountCents: 1 });
+    seedDoc("paymentReconciliationRecords", "rec-1", { leaseId: "lease-1", reconciliationStatus: "not_started" });
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const ledgerBefore = listDocs("ledgerEntries");
+    const paymentsBefore = listDocs("payments");
+    const reconciliationBefore = listDocs("paymentReconciliationRecords");
+
+    const res = await applyFirstSuggestion(router);
+
+    expect(res.status).toBe(201);
+    expect(res.body.allocation).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        allocationAmountCents: 200000,
+        status: "active",
+        beforeAvailableCreditCents: 876900,
+        afterAvailableCreditCents: 676900,
+        afterOutstandingAmountCents: 0,
+      })
+    );
+    expect(res.body.preview.availableCreditCents).toBe(676900);
+    expect(listDocs("leaseCreditAllocationRecords")).toHaveLength(1);
+    expect(listDocs("canonicalEvents")).toHaveLength(1);
+    expect(listDocs("ledgerEntries")).toEqual(ledgerBefore);
+    expect(listDocs("payments")).toEqual(paymentsBefore);
+    expect(listDocs("paymentReconciliationRecords")).toEqual(reconciliationBefore);
+    expect(res.body.noLegalOrLifecycleEffect).toBe(true);
+  });
+
+  it("rejects stale preview fingerprints with a 409", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+    const obligation = preview.body.eligibleObligations[0];
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: obligation.obligationRowId,
+        allocationAmountCents: 200000,
+        previewFingerprint: "stale",
+      },
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_STATE_STALE");
+  });
+
+  it("rejects amounts exceeding available credit", async () => {
+    seedBaileyCredit({ ledger: { amountCents: -100000 } });
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+    const obligation = preview.body.eligibleObligations[0];
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: obligation.obligationRowId,
+        allocationAmountCents: 150000,
+        previewFingerprint: preview.body.previewFingerprint,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_AMOUNT_EXCEEDS_CREDIT");
+  });
+
+  it("rejects amounts exceeding selected obligation outstanding amount", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+    const obligation = preview.body.eligibleObligations[0];
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: obligation.obligationRowId,
+        allocationAmountCents: 200001,
+        previewFingerprint: preview.body.previewFingerprint,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_AMOUNT_EXCEEDS_OUTSTANDING");
+  });
+
+  it("rejects invalid obligations", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: "not-this-lease",
+        allocationAmountCents: 200000,
+        previewFingerprint: preview.body.previewFingerprint,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_OBLIGATION_NOT_ELIGIBLE");
+  });
+
+  it("returns idempotent replay for the same apply request", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+    const obligation = preview.body.eligibleObligations[0];
+    const body = {
+      obligationRowId: obligation.obligationRowId,
+      allocationAmountCents: 200000,
+      previewFingerprint: preview.body.previewFingerprint,
+      idempotencyKey: "idem-1",
+    };
+
+    const first = await invokeRouter(router, { method: "POST", url: "/leases/lease-1/credit-allocations", body });
+    const second = await invokeRouter(router, { method: "POST", url: "/leases/lease-1/credit-allocations", body });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(200);
+    expect(second.body.idempotentReplay).toBe(true);
+    expect(second.body.allocation.allocationId).toBe(first.body.allocation.allocationId);
+    expect(listDocs("leaseCreditAllocationRecords")).toHaveLength(1);
+  });
+
+  it("rejects conflicting idempotency replay", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const preview = await loadPreview(router);
+    const obligation = preview.body.eligibleObligations[0];
+    await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: obligation.obligationRowId,
+        allocationAmountCents: 200000,
+        previewFingerprint: preview.body.previewFingerprint,
+        idempotencyKey: "idem-1",
+      },
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/credit-allocations",
+      body: {
+        obligationRowId: obligation.obligationRowId,
+        allocationAmountCents: 100000,
+        previewFingerprint: preview.body.previewFingerprint,
+        idempotencyKey: "idem-1",
+      },
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_IDEMPOTENCY_CONFLICT");
+  });
+
+  it("blocks cross-landlord preview access", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/leases/lease-1/credit-allocation-preview",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-2", landlordId: "landlord-2", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("FORBIDDEN");
+  });
+
+  it("reduces available credit and obligation exposure for active allocations in the next preview", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    await applyFirstSuggestion(router, { allocationAmountCents: 100000 });
+
+    const res = await loadPreview(router);
+
+    expect(res.body.availableCreditCents).toBe(776900);
+    expect(res.body.eligibleObligations[0].outstandingAmountCents).toBe(100000);
+    expect(res.body.existingActiveAllocations).toHaveLength(1);
+  });
+
+  it("reverses an active allocation and excludes it from the next preview exposure", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const applied = await applyFirstSuggestion(router, { allocationAmountCents: 100000 });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: `/leases/lease-1/credit-allocations/${encodeURIComponent(applied.body.allocation.allocationId)}/reverse`,
+      body: { reason: "operator correction" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.allocation.status).toBe("reversed");
+    expect(res.body.allocation.reversalReason).toBe("operator correction");
+    expect(res.body.preview.availableCreditCents).toBe(876900);
+    expect(res.body.preview.eligibleObligations[0].outstandingAmountCents).toBe(200000);
+    expect(res.body.preview.reversedAllocations).toHaveLength(1);
+    expect(listDocs("ledgerEntries")).toHaveLength(1);
+  });
+
+  it("returns already reversed for repeated reversal", async () => {
+    seedBaileyCredit();
+    const router = (await import("../landlordLeaseCreditAllocationRoutes")).default;
+    const applied = await applyFirstSuggestion(router);
+    const url = `/leases/lease-1/credit-allocations/${encodeURIComponent(applied.body.allocation.allocationId)}/reverse`;
+    await invokeRouter(router, { method: "POST", url, body: { reason: "operator correction" } });
+
+    const res = await invokeRouter(router, { method: "POST", url, body: { reason: "repeat" } });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("CREDIT_ALLOCATION_ALREADY_REVERSED");
+  });
+});

--- a/rentchain-api/src/routes/landlordLeaseCreditAllocationRoutes.ts
+++ b/rentchain-api/src/routes/landlordLeaseCreditAllocationRoutes.ts
@@ -181,6 +181,15 @@ function routeErrorFromValidation(error: LeaseCreditAllocationValidationError): 
   return { status: 400, code: "CREDIT_ALLOCATION_AMOUNT_INVALID", message: error.message };
 }
 
+function routeValidationError(res: Response, code: string, preview?: ReturnType<typeof previewResponse>) {
+  return res.status(400).json({
+    ok: false,
+    error: code,
+    code,
+    ...(preview ? { preview } : {}),
+  });
+}
+
 async function loadLeaseForLandlord(leaseId: string, landlordId: string) {
   const snap = await db.collection("leases").doc(leaseId).get();
   if (!snap.exists) return { ok: false as const, status: 404, code: "LEASE_NOT_FOUND" };
@@ -427,13 +436,31 @@ router.post("/leases/:leaseId/credit-allocations", requireAuth, requireLandlord,
     if (isAllocationContextError(context)) {
       return res.status(context.status).json({ ok: false, error: context.code, code: context.code });
     }
-    const obligationRef = cleanString(req.body?.obligationRowId || req.body?.obligationKey, 500);
+    const currentPreview = previewResponse(context.preview, context.allocationRecords);
+    const obligationRef = cleanString(req.body?.obligationRowId, 500);
+    if (!obligationRef) {
+      return routeValidationError(res, "CREDIT_ALLOCATION_OBLIGATION_NOT_ELIGIBLE", currentPreview);
+    }
+    if (!Object.prototype.hasOwnProperty.call(req.body || {}, "allocationAmountCents")) {
+      return routeValidationError(res, "CREDIT_ALLOCATION_AMOUNT_INVALID", currentPreview);
+    }
+    if (!cleanString(req.body?.previewFingerprint, 240)) {
+      return res.status(409).json({
+        ok: false,
+        error: "CREDIT_ALLOCATION_STATE_STALE",
+        code: "CREDIT_ALLOCATION_STATE_STALE",
+        preview: currentPreview,
+      });
+    }
     const idempotencyKey = cleanString(req.body?.idempotencyKey, 500);
+    if (!idempotencyKey) {
+      return routeValidationError(res, "CREDIT_ALLOCATION_IDEMPOTENCY_KEY_REQUIRED", currentPreview);
+    }
     const existingForIdempotency = idempotencyKey
       ? context.allocationRecords.find((record: LeaseCreditAllocationRecord) => record.idempotencyKey === idempotencyKey)
       : null;
     const selectedObligation = context.preview.obligations.find(
-      (obligation) => obligation.obligationRowId === obligationRef || obligation.obligationKey === obligationRef
+      (obligation) => obligation.obligationRowId === obligationRef
     );
     const obligationKey = selectedObligation?.obligationKey || existingForIdempotency?.obligationKey;
     if (!obligationKey) {

--- a/rentchain-api/src/routes/landlordLeaseCreditAllocationRoutes.ts
+++ b/rentchain-api/src/routes/landlordLeaseCreditAllocationRoutes.ts
@@ -1,0 +1,551 @@
+import { Router, Response } from "express";
+import { db } from "../firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
+import {
+  buildPaymentObligationLedgerRows,
+  type PaymentObligationLedgerRow,
+} from "../lib/payments/paymentObligationLedger";
+import {
+  buildCanonicalPaymentEvidenceFromLedgerEntries,
+  loadLeaseCanonicalPaymentsForObligationLedger,
+} from "../lib/payments/leasePaymentObligationEvidence";
+import {
+  applyLeaseCreditAllocation,
+  buildLeaseCreditAllocationPreview,
+  CREDIT_ALLOCATION_STATE_STALE,
+  LEASE_CREDIT_ALLOCATION_RECORDS_COLLECTION,
+  listLeaseCreditAllocationRecords,
+  reverseLeaseCreditAllocation,
+  type LeaseCreditAllocationPreview,
+  type LeaseCreditAllocationRecord,
+  type LeaseCreditAllocationValidationError,
+} from "../services/leaseCreditAllocationService";
+import type { RentPaymentRecord } from "../services/rentPayments/rentPaymentService";
+
+const router = Router();
+const LEDGER_COLLECTION = "ledgerEntries";
+const NO_LEGAL_OR_LIFECYCLE_EFFECT = true;
+
+type LeaseAllocationContext = {
+  landlordId: string;
+  leaseId: string;
+  lease: Record<string, any>;
+  entries: any[];
+  aggregateBalanceCents: number;
+  obligationRows: PaymentObligationLedgerRow[];
+  allocationRecords: LeaseCreditAllocationRecord[];
+  preview: LeaseCreditAllocationPreview;
+};
+
+type LeaseAllocationContextError = { ok: false; status: number; code: string };
+
+function cleanString(value: unknown, max = 500): string | null {
+  const text = String(value ?? "").trim().slice(0, max);
+  return text || null;
+}
+
+function normalizeAmountCents(value: unknown): number {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) return 0;
+  return Math.round(amount);
+}
+
+function normalizeLeaseRentAmountCents(lease: Record<string, any>): number {
+  const amountCents = normalizeAmountCents(lease?.amountCents);
+  if (amountCents > 0) return amountCents;
+  const monthlyRent = Number(lease?.monthlyRent ?? lease?.currentRent ?? lease?.rent);
+  if (!Number.isFinite(monthlyRent) || monthlyRent <= 0) return 0;
+  return Math.round(monthlyRent * 100);
+}
+
+function signedLedgerAmountCents(entry: any): number {
+  const entryType = String(entry?.entryType || entry?.type || "").trim().toLowerCase();
+  if (entryType === "payment") return -Math.abs(Number(entry?.amountCents || 0));
+  if (entryType === "adjustment") return Math.round(Number(entry?.amountCents || 0));
+  return Math.abs(Math.round(Number(entry?.amountCents || 0)));
+}
+
+function actorTypeForRole(role: unknown): "admin" | "landlord" | "user" {
+  const normalized = String(role || "").trim().toLowerCase();
+  if (normalized === "admin") return "admin";
+  if (normalized === "landlord") return "landlord";
+  return "user";
+}
+
+function getActor(req: any, landlordId: string) {
+  return {
+    id: cleanString(req.user?.id, 240) || cleanString(req.user?.uid, 240) || landlordId,
+    email: cleanString(req.user?.email, 320),
+    role: cleanString(req.user?.role, 80) || "landlord",
+  };
+}
+
+function allocationSummary(record: LeaseCreditAllocationRecord) {
+  return {
+    allocationId: record.allocationId,
+    landlordId: record.landlordId,
+    leaseId: record.leaseId,
+    propertyId: record.propertyId,
+    unitId: record.unitId,
+    tenantId: record.tenantId,
+    obligationRowId: record.obligationRowId,
+    obligationKey: record.obligationKey,
+    allocationAmountCents: record.allocationAmountCents,
+    currency: record.currency,
+    status: record.status,
+    createdAt: record.createdAt,
+    createdBy: record.createdBy,
+    createdByEmail: record.createdByEmail,
+    reason: record.reason,
+    note: record.note,
+    beforeAvailableCreditCents: record.beforeAvailableCreditCents,
+    beforeOutstandingAmountCents: record.beforeOutstandingAmountCents,
+    afterAvailableCreditCents: record.afterAvailableCreditCents,
+    afterOutstandingAmountCents: record.afterOutstandingAmountCents,
+    previewFingerprint: record.previewFingerprint,
+    idempotencyKey: record.idempotencyKey,
+    reversedAt: record.reversedAt,
+    reversedBy: record.reversedBy,
+    reversedByEmail: record.reversedByEmail,
+    reversalReason: record.reversalReason,
+    sourceType: record.sourceType,
+  };
+}
+
+function previewResponse(preview: LeaseCreditAllocationPreview, allocationRecords: LeaseCreditAllocationRecord[]) {
+  const active = allocationRecords.filter((record) => record.status === "active").map(allocationSummary);
+  const reversed = allocationRecords.filter((record) => record.status === "reversed").map(allocationSummary);
+  return {
+    leaseId: preview.leaseId,
+    landlordId: preview.landlordId,
+    sourceType: preview.sourceType,
+    aggregateBalanceCents: preview.aggregateBalanceCents,
+    sourceBalanceBeforeCents: preview.sourceBalanceBeforeCents,
+    grossAvailableCreditCents: preview.grossAvailableCreditCents,
+    activeAllocationAmountCents: preview.activeAllocationAmountCents,
+    availableCreditCents: preview.availableCreditCents,
+    eligibleObligations: preview.obligations,
+    obligations: preview.obligations,
+    suggestedAllocations: preview.obligations
+      .filter((obligation) => obligation.suggestedAllocationAmountCents > 0)
+      .map((obligation) => ({
+        obligationRowId: obligation.obligationRowId,
+        obligationKey: obligation.obligationKey,
+        allocationAmountCents: obligation.suggestedAllocationAmountCents,
+        beforeAvailableCreditCents: preview.availableCreditCents,
+        beforeOutstandingAmountCents: obligation.outstandingAmountCents,
+        afterAvailableCreditCents: obligation.afterAvailableCreditCents,
+        afterOutstandingAmountCents: obligation.obligationOutstandingAfterCents,
+      })),
+    totalOutstandingAmountCents: preview.totalOutstandingAmountCents,
+    totalSuggestedAllocationAmountCents: preview.totalSuggestedAllocationAmountCents,
+    remainingAvailableCreditCents: preview.remainingAvailableCreditCents,
+    previewFingerprint: preview.previewFingerprint,
+    blockedReasons: preview.blockedReasons,
+    allowed: preview.allowed,
+    existingActiveAllocations: active,
+    reversedAllocations: reversed,
+    noLegalOrLifecycleEffect: NO_LEGAL_OR_LIFECYCLE_EFFECT,
+  };
+}
+
+function routeErrorFromValidation(error: LeaseCreditAllocationValidationError): { status: number; code: string; message: string } {
+  const code = error.code;
+  if (code === CREDIT_ALLOCATION_STATE_STALE) {
+    return { status: 409, code: "CREDIT_ALLOCATION_STATE_STALE", message: error.message };
+  }
+  if (code === "LEASE_CREDIT_ALLOCATION_AMOUNT_REQUIRED") {
+    return { status: 400, code: "CREDIT_ALLOCATION_AMOUNT_INVALID", message: error.message };
+  }
+  if (code === "LEASE_CREDIT_ALLOCATION_AMOUNT_EXCEEDS_AVAILABLE_CREDIT") {
+    return { status: 400, code: "CREDIT_ALLOCATION_AMOUNT_EXCEEDS_CREDIT", message: error.message };
+  }
+  if (code === "LEASE_CREDIT_ALLOCATION_AMOUNT_EXCEEDS_OUTSTANDING") {
+    return { status: 400, code: "CREDIT_ALLOCATION_AMOUNT_EXCEEDS_OUTSTANDING", message: error.message };
+  }
+  if (code === "LEASE_CREDIT_ALLOCATION_OBLIGATION_NOT_FOUND") {
+    return { status: 400, code: "CREDIT_ALLOCATION_OBLIGATION_NOT_ELIGIBLE", message: error.message };
+  }
+  if (code === "LEASE_CREDIT_ALLOCATION_DUPLICATE_CONFLICT") {
+    return { status: 409, code: "CREDIT_ALLOCATION_IDEMPOTENCY_CONFLICT", message: error.message };
+  }
+  if (code === "LEASE_CREDIT_ALLOCATION_NO_CREDIT") {
+    return { status: 400, code: "CREDIT_ALLOCATION_AMOUNT_EXCEEDS_CREDIT", message: error.message };
+  }
+  if (code === "LEASE_CREDIT_ALLOCATION_NO_OUTSTANDING_OBLIGATION") {
+    return { status: 400, code: "CREDIT_ALLOCATION_OBLIGATION_NOT_ELIGIBLE", message: error.message };
+  }
+  return { status: 400, code: "CREDIT_ALLOCATION_AMOUNT_INVALID", message: error.message };
+}
+
+async function loadLeaseForLandlord(leaseId: string, landlordId: string) {
+  const snap = await db.collection("leases").doc(leaseId).get();
+  if (!snap.exists) return { ok: false as const, status: 404, code: "LEASE_NOT_FOUND" };
+  const lease = (snap.data() as any) || {};
+  if (String(lease?.landlordId || "").trim() !== landlordId) {
+    return { ok: false as const, status: 403, code: "FORBIDDEN" };
+  }
+  return { ok: true as const, lease };
+}
+
+async function loadLedgerEntries(leaseId: string, landlordId: string) {
+  const snap = await db
+    .collection(LEDGER_COLLECTION)
+    .where("landlordId", "==", landlordId)
+    .where("leaseId", "==", leaseId)
+    .get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+async function loadLeaseRentPaymentsForObligationLedger(leaseId: string, landlordId: string): Promise<RentPaymentRecord[]> {
+  const snap = await db
+    .collection("rentPayments")
+    .where("leaseId", "==", leaseId)
+    .get()
+    .catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => String(record?.landlordId || "").trim() === landlordId)
+    .map((record: any) => ({
+      id: cleanString(record?.id || record?.rentPaymentId || record?.paymentId || "", 240) || cleanString(record?.id, 240) || "",
+      leaseId: cleanString(record?.leaseId, 240) || "",
+      tenantId: cleanString(record?.tenantId, 240) || "",
+      landlordId: cleanString(record?.landlordId, 240) || "",
+      propertyId: cleanString(record?.propertyId, 240),
+      unitId: cleanString(record?.unitId, 240),
+      paymentIntentId: cleanString(record?.paymentIntentId, 240),
+      amountCents: normalizeAmountCents(record?.amountCents),
+      currency: "cad" as const,
+      status: cleanString(record?.status, 80) as RentPaymentRecord["status"] || "setup_required",
+      processor: "stripe" as const,
+      processorCheckoutSessionId: cleanString(record?.processorCheckoutSessionId, 240),
+      processorPaymentIntentId: cleanString(record?.processorPaymentIntentId, 240),
+      createdAt: cleanString(record?.createdAt, 120) || "",
+      updatedAt: cleanString(record?.updatedAt, 120) || "",
+      paidAt: cleanString(record?.paidAt, 120),
+    }));
+}
+
+async function loadLeasePaymentIntentsForObligationLedger(leaseId: string, landlordId: string) {
+  const snap = await db
+    .collection("paymentIntents")
+    .where("leaseId", "==", leaseId)
+    .get()
+    .catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ paymentIntentId: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => String(record?.landlordId || "").trim() === landlordId);
+}
+
+async function loadLeaseReconciliationRecordsForObligationLedger(params: {
+  leaseId: string;
+  paymentIntentIds: string[];
+  rentPaymentIds: string[];
+}) {
+  const records = new Map<string, any>();
+  async function collect(field: string, value: string) {
+    const normalizedValue = cleanString(value, 240);
+    if (!normalizedValue) return;
+    const snap = await db
+      .collection("paymentReconciliationRecords")
+      .where(field, "==", normalizedValue)
+      .get()
+      .catch(() => null);
+    for (const doc of snap?.docs || []) {
+      records.set(doc.id, { reconciliationId: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+  await collect("leaseId", params.leaseId);
+  await collect("subjectId", params.leaseId);
+  for (const paymentIntentId of params.paymentIntentIds) await collect("paymentIntentId", paymentIntentId);
+  for (const rentPaymentId of params.rentPaymentIds) {
+    await collect("rentPaymentId", rentPaymentId);
+    await collect("subjectId", rentPaymentId);
+  }
+  return Array.from(records.values());
+}
+
+function isAllocationContextError(value: LeaseAllocationContext | LeaseAllocationContextError): value is LeaseAllocationContextError {
+  return (value as LeaseAllocationContextError).ok === false;
+}
+
+async function loadAllocationContext(leaseId: string, landlordId: string): Promise<LeaseAllocationContext | LeaseAllocationContextError> {
+  const leaseResult = await loadLeaseForLandlord(leaseId, landlordId);
+  if (!leaseResult.ok) return leaseResult;
+  const lease = leaseResult.lease;
+  const [entries, rentPayments, paymentIntents, canonicalPayments] = await Promise.all([
+    loadLedgerEntries(leaseId, landlordId),
+    loadLeaseRentPaymentsForObligationLedger(leaseId, landlordId),
+    loadLeasePaymentIntentsForObligationLedger(leaseId, landlordId),
+    loadLeaseCanonicalPaymentsForObligationLedger(leaseId, landlordId),
+  ]);
+  const ledgerPaymentEvidence = buildCanonicalPaymentEvidenceFromLedgerEntries(entries, canonicalPayments);
+  const reconciliationRecords = await loadLeaseReconciliationRecordsForObligationLedger({
+    leaseId,
+    paymentIntentIds: paymentIntents.map((record: any) => cleanString(record?.paymentIntentId, 240)).filter(Boolean) as string[],
+    rentPaymentIds: rentPayments.map((record) => cleanString(record?.id, 240)).filter(Boolean) as string[],
+  });
+  const lifecycle = deriveLeaseLifecycleState({ id: leaseId, ...lease });
+  const obligationRows = buildPaymentObligationLedgerRows({
+    leases: [
+      {
+        id: leaseId,
+        ...lease,
+        amountCents: normalizeLeaseRentAmountCents(lease),
+        derivedLifecycleState: lifecycle.state,
+      },
+    ],
+    paymentIntents,
+    rentPayments,
+    canonicalPayments: [...canonicalPayments, ...ledgerPaymentEvidence],
+    reconciliationRecords,
+  });
+  const allocationRecords = await listLeaseCreditAllocationRecords({ landlordId, leaseId });
+  const aggregateBalanceCents = entries.reduce((sum, entry) => sum + signedLedgerAmountCents(entry), 0);
+  const preview = buildLeaseCreditAllocationPreview({
+    landlordId,
+    leaseId,
+    aggregateBalanceCents,
+    obligationRows,
+    allocationRecords,
+  });
+  return {
+    landlordId,
+    leaseId,
+    lease,
+    entries,
+    aggregateBalanceCents,
+    obligationRows,
+    allocationRecords,
+    preview,
+  };
+}
+
+async function recordAllocationEvent(input: {
+  action: "lease_credit_allocation_created" | "lease_credit_allocation_reversed";
+  req: any;
+  landlordId: string;
+  leaseId: string;
+  record: LeaseCreditAllocationRecord;
+}) {
+  const actor = getActor(input.req, input.landlordId);
+  await writeCanonicalEvent({
+    domain: "payment",
+    action: input.action,
+    status: input.record.status,
+    actor: {
+      type: actorTypeForRole(actor.role),
+      id: actor.id,
+      role: actor.role,
+      displayName: actor.email,
+    },
+    resource: {
+      type: "lease_credit_allocation",
+      id: input.record.allocationId,
+      parentType: "lease",
+      parentId: input.leaseId,
+    },
+    visibility: "internal",
+    summary:
+      input.action === "lease_credit_allocation_reversed"
+        ? "Lease credit allocation was reversed by an operator."
+        : "Lease credit was allocated to an eligible obligation by an operator.",
+    metadata: {
+      landlordId: input.landlordId,
+      leaseId: input.leaseId,
+      obligationRowId: input.record.obligationRowId,
+      obligationKey: input.record.obligationKey,
+      allocationAmountCents: input.record.allocationAmountCents,
+      beforeAvailableCreditCents: input.record.beforeAvailableCreditCents,
+      beforeOutstandingAmountCents: input.record.beforeOutstandingAmountCents,
+      afterAvailableCreditCents: input.record.afterAvailableCreditCents,
+      afterOutstandingAmountCents: input.record.afterOutstandingAmountCents,
+      noLegalOrLifecycleEffect: NO_LEGAL_OR_LIFECYCLE_EFFECT,
+    },
+    tags: ["lease_credit_allocation"],
+  });
+}
+
+async function tryRecordAllocationEvent(input: Parameters<typeof recordAllocationEvent>[0]): Promise<boolean> {
+  try {
+    await recordAllocationEvent(input);
+    return true;
+  } catch (err) {
+    console.warn("[landlordLeaseCreditAllocationRoutes] canonical event write skipped", {
+      action: input.action,
+      leaseId: input.leaseId,
+      allocationId: input.record.allocationId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+function mergeAllocationRecords(records: LeaseCreditAllocationRecord[], next: LeaseCreditAllocationRecord) {
+  const byId = new Map(records.map((record) => [record.allocationId, record]));
+  byId.set(next.allocationId, next);
+  return Array.from(byId.values());
+}
+
+function nextPreviewForContext(context: LeaseAllocationContext, allocationRecords: LeaseCreditAllocationRecord[]) {
+  return buildLeaseCreditAllocationPreview({
+    landlordId: context.landlordId,
+    leaseId: context.leaseId,
+    aggregateBalanceCents: context.aggregateBalanceCents,
+    obligationRows: context.obligationRows,
+    allocationRecords,
+  });
+}
+
+router.get("/leases/:leaseId/credit-allocation-preview", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = cleanString(req.user?.landlordId || req.user?.id, 240);
+    const leaseId = cleanString(req.params?.leaseId, 240);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized", code: "UNAUTHORIZED" });
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required", code: "LEASE_ID_REQUIRED" });
+    const context = await loadAllocationContext(leaseId, landlordId);
+    if (isAllocationContextError(context)) {
+      return res.status(context.status).json({ ok: false, error: context.code, code: context.code });
+    }
+    return res.status(200).json({ ok: true, ...previewResponse(context.preview, context.allocationRecords) });
+  } catch (err) {
+    console.error("[landlordLeaseCreditAllocationRoutes] preview failed", err);
+    return res.status(500).json({ ok: false, error: "CREDIT_ALLOCATION_PREVIEW_FAILED", code: "CREDIT_ALLOCATION_PREVIEW_FAILED" });
+  }
+});
+
+router.post("/leases/:leaseId/credit-allocations", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = cleanString(req.user?.landlordId || req.user?.id, 240);
+    const leaseId = cleanString(req.params?.leaseId, 240);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized", code: "UNAUTHORIZED" });
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required", code: "LEASE_ID_REQUIRED" });
+    const context = await loadAllocationContext(leaseId, landlordId);
+    if (isAllocationContextError(context)) {
+      return res.status(context.status).json({ ok: false, error: context.code, code: context.code });
+    }
+    const obligationRef = cleanString(req.body?.obligationRowId || req.body?.obligationKey, 500);
+    const idempotencyKey = cleanString(req.body?.idempotencyKey, 500);
+    const existingForIdempotency = idempotencyKey
+      ? context.allocationRecords.find((record: LeaseCreditAllocationRecord) => record.idempotencyKey === idempotencyKey)
+      : null;
+    const selectedObligation = context.preview.obligations.find(
+      (obligation) => obligation.obligationRowId === obligationRef || obligation.obligationKey === obligationRef
+    );
+    const obligationKey = selectedObligation?.obligationKey || existingForIdempotency?.obligationKey;
+    if (!obligationKey) {
+      return res.status(400).json({
+        ok: false,
+        error: "CREDIT_ALLOCATION_OBLIGATION_NOT_ELIGIBLE",
+        code: "CREDIT_ALLOCATION_OBLIGATION_NOT_ELIGIBLE",
+        preview: previewResponse(context.preview, context.allocationRecords),
+      });
+    }
+    const actor = getActor(req, landlordId);
+    const result = await applyLeaseCreditAllocation({
+      landlordId,
+      leaseId,
+      aggregateBalanceCents: context.aggregateBalanceCents,
+      obligationRows: context.obligationRows,
+      allocationRecords: context.allocationRecords,
+      obligationKey,
+      allocationAmountCents: Number(req.body?.allocationAmountCents),
+      expectedPreviewFingerprint: cleanString(req.body?.previewFingerprint, 240) || "",
+      createdBy: actor.id,
+      createdByEmail: actor.email,
+      note: cleanString(req.body?.note, 1000),
+      reason: "operator_credit_allocation",
+      idempotencyKey,
+      firestore: db as any,
+    });
+    if (!result.ok) {
+      const routeError = routeErrorFromValidation(result.error);
+      return res.status(routeError.status).json({
+        ok: false,
+        error: routeError.code,
+        code: routeError.code,
+        message: routeError.message,
+        preview: previewResponse(result.preview, context.allocationRecords),
+      });
+    }
+    if (!result.idempotentReplay) {
+      await tryRecordAllocationEvent({ action: "lease_credit_allocation_created", req, landlordId, leaseId, record: result.record });
+    }
+    const nextRecords = mergeAllocationRecords(context.allocationRecords, result.record);
+    const nextPreview = nextPreviewForContext(context, nextRecords);
+    return res.status(result.idempotentReplay ? 200 : 201).json({
+      ok: true,
+      allocation: allocationSummary(result.record),
+      idempotentReplay: result.idempotentReplay,
+      beforePreview: previewResponse(result.preview, context.allocationRecords),
+      preview: previewResponse(nextPreview, nextRecords),
+      noLegalOrLifecycleEffect: NO_LEGAL_OR_LIFECYCLE_EFFECT,
+    });
+  } catch (err: any) {
+    if (String(err?.message || "") === "lease_credit_allocation_record_exists") {
+      return res.status(409).json({
+        ok: false,
+        error: "CREDIT_ALLOCATION_IDEMPOTENCY_CONFLICT",
+        code: "CREDIT_ALLOCATION_IDEMPOTENCY_CONFLICT",
+      });
+    }
+    console.error("[landlordLeaseCreditAllocationRoutes] apply failed", err);
+    return res.status(500).json({ ok: false, error: "CREDIT_ALLOCATION_APPLY_FAILED", code: "CREDIT_ALLOCATION_APPLY_FAILED" });
+  }
+});
+
+router.post("/leases/:leaseId/credit-allocations/:allocationId/reverse", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = cleanString(req.user?.landlordId || req.user?.id, 240);
+    const leaseId = cleanString(req.params?.leaseId, 240);
+    const allocationId = cleanString(req.params?.allocationId, 500);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized", code: "UNAUTHORIZED" });
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required", code: "LEASE_ID_REQUIRED" });
+    if (!allocationId) {
+      return res.status(400).json({ ok: false, error: "CREDIT_ALLOCATION_NOT_FOUND", code: "CREDIT_ALLOCATION_NOT_FOUND" });
+    }
+    const context = await loadAllocationContext(leaseId, landlordId);
+    if (isAllocationContextError(context)) {
+      return res.status(context.status).json({ ok: false, error: context.code, code: context.code });
+    }
+    const record = context.allocationRecords.find((allocation: LeaseCreditAllocationRecord) => allocation.allocationId === allocationId);
+    if (!record) {
+      return res.status(404).json({ ok: false, error: "CREDIT_ALLOCATION_NOT_FOUND", code: "CREDIT_ALLOCATION_NOT_FOUND" });
+    }
+    if (record.status !== "active") {
+      return res.status(409).json({
+        ok: false,
+        error: "CREDIT_ALLOCATION_ALREADY_REVERSED",
+        code: "CREDIT_ALLOCATION_ALREADY_REVERSED",
+        allocation: allocationSummary(record),
+        preview: previewResponse(context.preview, context.allocationRecords),
+        noLegalOrLifecycleEffect: NO_LEGAL_OR_LIFECYCLE_EFFECT,
+      });
+    }
+    const actor = getActor(req, landlordId);
+    const reversed = await reverseLeaseCreditAllocation({
+      record,
+      reversedBy: actor.id,
+      reversedByEmail: actor.email,
+      reversalReason: cleanString(req.body?.reason || req.body?.reversalReason, 1000) || "operator_reversal",
+      firestore: db as any,
+    });
+    await tryRecordAllocationEvent({ action: "lease_credit_allocation_reversed", req, landlordId, leaseId, record: reversed });
+    const nextRecords = mergeAllocationRecords(context.allocationRecords, reversed);
+    const nextPreview = nextPreviewForContext(context, nextRecords);
+    return res.status(200).json({
+      ok: true,
+      allocation: allocationSummary(reversed),
+      preview: previewResponse(nextPreview, nextRecords),
+      noLegalOrLifecycleEffect: NO_LEGAL_OR_LIFECYCLE_EFFECT,
+    });
+  } catch (err) {
+    console.error("[landlordLeaseCreditAllocationRoutes] reverse failed", err);
+    return res.status(500).json({ ok: false, error: "CREDIT_ALLOCATION_REVERSE_FAILED", code: "CREDIT_ALLOCATION_REVERSE_FAILED" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Adds landlord-scoped lease credit allocation API endpoints backed by `leaseCreditAllocationService`.
- Adds preview, apply, and reverse flows for operator-confirmed lease credit allocation records.
- Mounts the backend/API-only route under `/api/landlord`.

## API Endpoints
- `GET /api/landlord/leases/:leaseId/credit-allocation-preview`
- `POST /api/landlord/leases/:leaseId/credit-allocations`
- `POST /api/landlord/leases/:leaseId/credit-allocations/:allocationId/reverse`

## Behavior
- Preview derives current aggregate credit, eligible obligations, suggested allocations, before/after values, active allocations, reversed allocations, blocked reasons, and a preview fingerprint.
- Apply requires landlord-scoped lease access, selected eligible obligation, positive amount, matching preview fingerprint, available credit, outstanding exposure, and idempotency-safe replay/conflict handling.
- Reverse requires the allocation to belong to the same landlord and lease and be active; reversed records are preserved and no longer reduce current preview exposure.
- Successful apply/reverse writes conservative canonical events on a best-effort basis.

## Guardrails
- No UI added.
- No visible allocation button added.
- No auto-allocation added.
- No ledgerEntries mutation added.
- No payment record mutation added.
- No paymentReconciliationRecords reuse/mutation added.
- No collection, legal, compliance, or lease lifecycle behavior added.

## Validation
- `npm run test -- landlordLeaseCreditAllocationRoutes` passed, 14 tests.
- `npm run test -- leaseCreditAllocationService` passed, 15 tests.
- `npm run test -- paymentObligationLedger landlordDecisionInboxRoutes landlordDecisionQueueRoutes` passed, 55 tests.
- `npm run build` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Next PR
- `feat/ledger-credit-allocation-ui-v1` once this API is reviewed and accepted.
